### PR TITLE
refactor(vscode): lift viewport tracker out of behavior.ts

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -14,6 +14,7 @@
 
 import { getVsCodeApi } from "../shared/vscode";
 import { previewStore } from "./previewStore";
+import { ViewportTracker } from "./viewportTracker";
 
 export function setupPreviewBehavior(
     initialEarlyFeaturesEnabled: boolean,
@@ -2233,8 +2234,7 @@ export function setupPreviewBehavior(
         for (const [id, card] of existingCards) {
             if (!newIds.has(id)) {
                 cardCaptures.delete(id);
-                intersecting.delete(id);
-                if (intersectionObserver) intersectionObserver.unobserve(card);
+                viewport.forget(id, card);
                 card.remove();
             }
         }
@@ -2693,141 +2693,26 @@ export function setupPreviewBehavior(
     }
 
     // ----- Viewport tracking (daemon scroll-ahead, PREDICTIVE.md § 7) -----
-    // Webview owns the geometry. Extension's daemon scheduler consumes
-    // the published snapshot; when the daemon path is off the extension
-    // simply ignores these messages.
-    const intersecting = new Set();
-    let lastScrollTop = 0;
-    let lastScrollAt = 0;
-    let scrollVelocity = 0; // px/ms, +ve = scrolling down
-    let viewportDebounce = null;
-
-    const intersectionObserver =
-        "IntersectionObserver" in window
-            ? new IntersectionObserver(
-                  (entries) => {
-                      for (const entry of entries) {
-                          const id = entry.target.dataset.previewId;
-                          if (!id) continue;
-                          if (entry.isIntersecting) {
-                              intersecting.add(id);
-                          } else {
-                              intersecting.delete(id);
-                              // Auto-stop interactive mode when a live preview scrolls out of view —
-                              // keeps the daemon from accumulating warm scenes the user can't see and
-                              // matches the "follow what the user is looking at" UX. Re-entering view
-                              // doesn't auto-resume; the user re-clicks if they want it back.
-                              if (interactivePreviewIds.has(id)) {
-                                  interactivePreviewIds.delete(id);
-                                  vscode.postMessage({
-                                      command: "setInteractive",
-                                      previewId: id,
-                                      enabled: false,
-                                  });
-                                  applyLiveBadge();
-                                  applyInteractiveButtonState();
-                              }
-                          }
-                      }
-                      scheduleViewportPublish();
-                  },
-                  { root: null, rootMargin: "0px", threshold: 0.1 },
-              )
-            : null;
+    // The actual machinery lives in `./viewportTracker.ts`. The auto-stop-
+    // interactive-on-scroll-out rule stays here because the live set lives
+    // here; the tracker just notifies us via `onCardLeftViewport`.
+    const viewport = new ViewportTracker({
+        vscode,
+        onCardLeftViewport: (id) => {
+            if (!interactivePreviewIds.has(id)) return;
+            interactivePreviewIds.delete(id);
+            vscode.postMessage({
+                command: "setInteractive",
+                previewId: id,
+                enabled: false,
+            });
+            applyLiveBadge();
+            applyInteractiveButtonState();
+        },
+    });
 
     function observeCardForViewport(card) {
-        if (intersectionObserver) intersectionObserver.observe(card);
-    }
-
-    function unobserveAllCards() {
-        if (!intersectionObserver) return;
-        intersecting.clear();
-        document
-            .querySelectorAll(".preview-card")
-            .forEach((c) => intersectionObserver.unobserve(c));
-    }
-
-    // Coalesce viewport publishes — IntersectionObserver fires per-card
-    // during a scroll burst; don't drown the daemon in setVisible spam.
-    function scheduleViewportPublish() {
-        if (viewportDebounce) return;
-        viewportDebounce = setTimeout(() => {
-            viewportDebounce = null;
-            publishViewport();
-        }, 120);
-    }
-
-    document.addEventListener(
-        "scroll",
-        () => {
-            const now = performance.now();
-            const top =
-                window.scrollY || document.documentElement.scrollTop || 0;
-            const dt = Math.max(1, now - lastScrollAt);
-            const dy = top - lastScrollTop;
-            // Light EMA so a single jittery frame doesn't flip the predicted set.
-            scrollVelocity = scrollVelocity * 0.4 + (dy / dt) * 0.6;
-            lastScrollAt = now;
-            lastScrollTop = top;
-            scheduleViewportPublish();
-        },
-        { passive: true },
-    );
-
-    // Project the next-page IDs based on scroll direction. Velocity is
-    // signed (px/ms): positive = scrolling down → predict cards below
-    // the lowest currently-visible card; negative = predict above.
-    function predictNextIds() {
-        if (Math.abs(scrollVelocity) < 0.05) return [];
-        const visibleCards = Array.from(
-            document.querySelectorAll(".preview-card"),
-        ).filter(
-            (c) =>
-                intersecting.has(c.dataset.previewId) &&
-                !c.classList.contains("filtered-out"),
-        );
-        if (visibleCards.length === 0) return [];
-        const allCards = Array.from(
-            document.querySelectorAll(".preview-card"),
-        ).filter((c) => !c.classList.contains("filtered-out"));
-        // Cards are in DOM order; pick the ones immediately ahead of the
-        // last visible (or before the first) up to a bounded count.
-        const PREDICT_AHEAD = 4;
-        const ids = [];
-        if (scrollVelocity > 0) {
-            const lastVisibleIdx = allCards.indexOf(
-                visibleCards[visibleCards.length - 1],
-            );
-            for (
-                let i = lastVisibleIdx + 1;
-                i < allCards.length && ids.length < PREDICT_AHEAD;
-                i++
-            ) {
-                const id = allCards[i].dataset.previewId;
-                if (id && !intersecting.has(id)) ids.push(id);
-            }
-        } else {
-            const firstVisibleIdx = allCards.indexOf(visibleCards[0]);
-            for (
-                let i = firstVisibleIdx - 1;
-                i >= 0 && ids.length < PREDICT_AHEAD;
-                i--
-            ) {
-                const id = allCards[i].dataset.previewId;
-                if (id && !intersecting.has(id)) ids.push(id);
-            }
-        }
-        return ids;
-    }
-
-    function publishViewport() {
-        const visible = Array.from(intersecting);
-        const predicted = predictNextIds();
-        vscode.postMessage({
-            command: "viewportUpdated",
-            visible,
-            predicted,
-        });
+        viewport.observe(card);
     }
 
     window.addEventListener("message", (event) => {

--- a/vscode-extension/src/webview/preview/viewportTracker.ts
+++ b/vscode-extension/src/webview/preview/viewportTracker.ts
@@ -1,0 +1,171 @@
+// Viewport tracking for the preview grid.
+//
+// Lifted verbatim from `behavior.ts`'s `IntersectionObserver` /
+// `predictNextIds` / `publishViewport` / `scheduleViewportPublish` /
+// scroll-velocity EMA block. See PREDICTIVE.md § 7 — the webview owns
+// the geometry, the daemon's scroll-ahead scheduler consumes the
+// `viewportUpdated` snapshots; when the daemon path is off the
+// extension simply ignores them.
+//
+// The class is a thin lifecycle wrapper. Per-event work is unchanged:
+//
+//  - `IntersectionObserver` callback adds / removes ids from
+//    `intersecting`, calls back to the host when a previously-live
+//    preview leaves the viewport, then `scheduleViewportPublish`s.
+//  - A `passive` document `scroll` listener feeds the signed
+//    velocity EMA so `predictNextIds` can project the next-page set.
+//  - A 120ms `setTimeout` coalesces the publish so a scroll burst
+//    doesn't fan out per-card `viewportUpdated` posts.
+//
+// The host hands in an `onLiveCardScrolledOut` callback for the
+// "auto-stop interactive when out of view" rule — keeping the live-set
+// mutation in `behavior.ts` (where the rest of the live-state lives)
+// rather than copying it over. Re-entering the viewport doesn't
+// auto-resume — the user re-clicks if they want it back.
+
+import type { VsCodeApi } from "../shared/vscode";
+
+export interface ViewportTrackerConfig {
+    vscode: VsCodeApi<unknown>;
+    /**
+     * Fired when a card with `previewId` leaves the viewport. The host
+     * is expected to check whether that preview is currently in the
+     * live set and, if so, toggle live mode off (post setInteractive,
+     * update local sets, refresh badges/buttons).
+     */
+    onCardLeftViewport(previewId: string): void;
+}
+
+export class ViewportTracker {
+    private readonly intersecting = new Set<string>();
+    private readonly observer: IntersectionObserver | null;
+    private lastScrollTop = 0;
+    private lastScrollAt = 0;
+    private scrollVelocity = 0; // px/ms, positive = scrolling down
+    private debounce: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(private readonly config: ViewportTrackerConfig) {
+        this.observer =
+            "IntersectionObserver" in window
+                ? new IntersectionObserver(
+                      (entries) => this.onIntersect(entries),
+                      { root: null, rootMargin: "0px", threshold: 0.1 },
+                  )
+                : null;
+        document.addEventListener("scroll", this.onScroll, { passive: true });
+    }
+
+    observe(card: HTMLElement): void {
+        this.observer?.observe(card);
+    }
+
+    /**
+     * Drop a card from the tracker — removes its id from `intersecting`
+     * and unhooks the observer. Called when a card is removed from the
+     * grid (e.g. its preview was deleted on a re-discovery pass) so the
+     * tracker's snapshot doesn't keep referring to detached DOM.
+     */
+    forget(previewId: string, card: HTMLElement): void {
+        this.intersecting.delete(previewId);
+        this.observer?.unobserve(card);
+    }
+
+    unobserveAll(): void {
+        if (!this.observer) return;
+        this.intersecting.clear();
+        for (const card of document.querySelectorAll<HTMLElement>(
+            ".preview-card",
+        )) {
+            this.observer.unobserve(card);
+        }
+    }
+
+    private readonly onScroll = (): void => {
+        const now = performance.now();
+        const top = window.scrollY || document.documentElement.scrollTop || 0;
+        const dt = Math.max(1, now - this.lastScrollAt);
+        const dy = top - this.lastScrollTop;
+        // Light EMA so a single jittery frame doesn't flip the predicted set.
+        this.scrollVelocity = this.scrollVelocity * 0.4 + (dy / dt) * 0.6;
+        this.lastScrollAt = now;
+        this.lastScrollTop = top;
+        this.schedulePublish();
+    };
+
+    private onIntersect(entries: IntersectionObserverEntry[]): void {
+        for (const entry of entries) {
+            const id = (entry.target as HTMLElement).dataset.previewId;
+            if (!id) continue;
+            if (entry.isIntersecting) {
+                this.intersecting.add(id);
+            } else {
+                this.intersecting.delete(id);
+                this.config.onCardLeftViewport(id);
+            }
+        }
+        this.schedulePublish();
+    }
+
+    private schedulePublish(): void {
+        if (this.debounce) return;
+        this.debounce = setTimeout(() => {
+            this.debounce = null;
+            this.publish();
+        }, 120);
+    }
+
+    private publish(): void {
+        const visible = Array.from(this.intersecting);
+        const predicted = this.predictNextIds();
+        this.config.vscode.postMessage({
+            command: "viewportUpdated",
+            visible,
+            predicted,
+        });
+    }
+
+    /**
+     * Project the next-page IDs based on scroll direction. Velocity is
+     * signed (px/ms): positive = scrolling down → predict cards below
+     * the lowest currently-visible card; negative = predict above.
+     */
+    private predictNextIds(): string[] {
+        if (Math.abs(this.scrollVelocity) < 0.05) return [];
+        const allCards = Array.from(
+            document.querySelectorAll<HTMLElement>(".preview-card"),
+        ).filter((c) => !c.classList.contains("filtered-out"));
+        const visibleCards = allCards.filter((c) => {
+            const id = c.dataset.previewId;
+            return !!id && this.intersecting.has(id);
+        });
+        if (visibleCards.length === 0) return [];
+        // Cards are in DOM order; pick the ones immediately ahead of the
+        // last visible (or before the first) up to a bounded count.
+        const PREDICT_AHEAD = 4;
+        const ids: string[] = [];
+        if (this.scrollVelocity > 0) {
+            const lastVisibleIdx = allCards.indexOf(
+                visibleCards[visibleCards.length - 1],
+            );
+            for (
+                let i = lastVisibleIdx + 1;
+                i < allCards.length && ids.length < PREDICT_AHEAD;
+                i++
+            ) {
+                const id = allCards[i].dataset.previewId;
+                if (id && !this.intersecting.has(id)) ids.push(id);
+            }
+        } else {
+            const firstVisibleIdx = allCards.indexOf(visibleCards[0]);
+            for (
+                let i = firstVisibleIdx - 1;
+                i >= 0 && ids.length < PREDICT_AHEAD;
+                i--
+            ) {
+                const id = allCards[i].dataset.previewId;
+                if (id && !this.intersecting.has(id)) ids.push(id);
+            }
+        }
+        return ids;
+    }
+}


### PR DESCRIPTION
Slice of #767. Extracts the `IntersectionObserver` + scroll-velocity EMA + debounced `viewportUpdated` publisher out of `behavior.ts`'s `@ts-nocheck` body and into a typed `ViewportTracker` class.

## Summary

- New `viewportTracker.ts` — class wrapping the observer, scroll listener, debounce timer, and the predict-ahead logic. Public surface is `observe(card)`, `forget(previewId, card)`, `unobserveAll()`. Hands a single `onCardLeftViewport(id)` callback back to the host.
- `behavior.ts` keeps the auto-stop-interactive-on-scroll-out rule (because that's where the live set lives) — the tracker just notifies via the callback. Same 0.1 IO threshold, same 120ms debounce, same EMA factors (0.4 / 0.6), same `PREDICT_AHEAD = 4` bound.
- The renderPreviews removal path that previously wrote `intersecting.delete(id); intersectionObserver.unobserve(card)` becomes a single `viewport.forget(id, card)`.

`behavior.ts` shrinks from 3208 → 3093 lines (−115 LOC). No behaviour change.

Built from `main`, independent of #769 and #770.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 320/320 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke: open the preview panel against a workspace with enough previews to scroll, verify daemon receives `viewportUpdated` with both `visible` and `predicted` ids during scroll bursts (single coalesced post per ~120ms), and that LIVE auto-stops when a live card scrolls fully out of view.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTv9gnHTdY5MzDfGdnSpBn)_