### PR TITLE
feat(mcp): register compose-preview-mcp with every detected agent host

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentMcpConfig.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentMcpConfig.kt
@@ -1,0 +1,152 @@
+package ee.schimke.composeai.cli
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Pure helpers that produce the on-disk representation each agent host expects for the
+ * `compose-preview-mcp` MCP server entry, given the absolute launcher path and project dir.
+ *
+ * - Antigravity: JSON file at `~/.gemini/antigravity/mcp_config.json`, merged into `mcpServers`.
+ * - Codex: TOML file at `~/.codex/config.toml`, with a `[mcp_servers.compose-preview-mcp]` table
+ *   replaced in place (or appended when absent). Hand-rolled because the rest of the codebase
+ *   doesn't pull in a TOML library, and our table is a fixed, small shape so a section-level edit
+ *   is safe enough.
+ * - Claude Code: not a config file — invoked via `claude mcp add --scope user`. We expose the argv
+ *   here so the caller can shell out and tests can assert the construction.
+ */
+internal object AgentMcpConfig {
+
+  const val SERVER_NAME = "compose-preview-mcp"
+
+  private val JSON: Json = Json { prettyPrint = true }
+
+  /** Merge a `compose-preview-mcp` entry into Antigravity's `mcpServers` map. */
+  fun mergeAntigravityConfig(existing: String?, launcher: String, projectAbsPath: String): String {
+    val parsed: JsonObject =
+      if (existing.isNullOrBlank()) JsonObject(emptyMap())
+      else Json.parseToJsonElement(existing).jsonObject
+
+    val existingServers = parsed["mcpServers"]?.jsonObject ?: JsonObject(emptyMap())
+    val server = buildJsonObject {
+      put("command", JsonPrimitive(launcher))
+      put(
+        "args",
+        JsonArray(
+          listOf(
+            JsonPrimitive("mcp"),
+            JsonPrimitive("serve"),
+            JsonPrimitive("--project=$projectAbsPath"),
+          )
+        ),
+      )
+    }
+    val mergedServers = JsonObject(existingServers + (SERVER_NAME to server))
+    val merged = JsonObject(parsed + ("mcpServers" to mergedServers))
+    return JSON.encodeToString(JsonObject.serializer(), merged) + "\n"
+  }
+
+  /**
+   * Replace (or append) the `[mcp_servers.compose-preview-mcp]` table in a Codex `config.toml`,
+   * preserving every other line verbatim. Idempotent: a second call with the same inputs yields the
+   * same file contents (modulo a trailing newline). When `existing` is null/empty, returns a file
+   * containing only our table.
+   */
+  fun mergeCodexConfig(existing: String?, launcher: String, projectAbsPath: String): String {
+    val block = buildString {
+      appendLine("[mcp_servers.$SERVER_NAME]")
+      appendLine("command = ${tomlString(launcher)}")
+      appendLine("args = [\"mcp\", \"serve\", ${tomlString("--project=$projectAbsPath")}]")
+    }
+
+    if (existing.isNullOrBlank()) return block
+
+    val lines = existing.lines()
+    val out = StringBuilder()
+    var i = 0
+    var replaced = false
+    while (i < lines.size) {
+      val line = lines[i]
+      if (line.trim() == "[mcp_servers.$SERVER_NAME]") {
+        // Skip our existing block: from this header up to the next top-level header (a line
+        // starting with "[" with no leading whitespace) or EOF. Trailing blank lines inside the
+        // block are dropped along with it.
+        i++
+        while (i < lines.size && !lines[i].startsWith("[")) i++
+        // Insert the fresh block where the old one stood. Match the surrounding spacing: ensure
+        // a single blank line before it if there was content above.
+        if (out.isNotEmpty() && !out.endsWith("\n\n")) {
+          if (!out.endsWith("\n")) out.append('\n')
+          out.append('\n')
+        }
+        out.append(block)
+        replaced = true
+        // The next line (if any) starts a new section header, not part of our block.
+        continue
+      }
+      out.append(line)
+      if (i < lines.size - 1) out.append('\n')
+      i++
+    }
+
+    if (!replaced) {
+      val base = out.toString()
+      val joiner =
+        when {
+          base.isEmpty() -> ""
+          base.endsWith("\n\n") -> ""
+          base.endsWith("\n") -> "\n"
+          else -> "\n\n"
+        }
+      return base + joiner + block
+    }
+    return out.toString()
+  }
+
+  /**
+   * Argv for `claude mcp add --scope user compose-preview-mcp -- <launcher> mcp serve --project=…`.
+   */
+  fun claudeMcpAddCommand(launcher: String, projectAbsPath: String): List<String> =
+    listOf(
+      "claude",
+      "mcp",
+      "add",
+      "--scope",
+      "user",
+      SERVER_NAME,
+      "--",
+      launcher,
+      "mcp",
+      "serve",
+      "--project=$projectAbsPath",
+    )
+
+  /** Argv for `claude mcp remove --scope user compose-preview-mcp` (used to upsert). */
+  fun claudeMcpRemoveCommand(): List<String> =
+    listOf("claude", "mcp", "remove", "--scope", "user", SERVER_NAME)
+
+  /**
+   * TOML basic-string encoding. Codex `config.toml` paths are absolute, so this is conservative.
+   */
+  private fun tomlString(value: String): String {
+    val escaped = buildString {
+      append('"')
+      for (c in value) {
+        when (c) {
+          '\\' -> append("\\\\")
+          '"' -> append("\\\"")
+          '\n' -> append("\\n")
+          '\r' -> append("\\r")
+          '\t' -> append("\\t")
+          else -> append(c)
+        }
+      }
+      append('"')
+    }
+    return escaped
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -70,10 +70,25 @@ internal class McpCommand(args: List<String>) {
         --project <path>     Project root containing settings.gradle[.kts] (default: cwd)
         --module <gradlePath> Limit to one or more module paths (repeatable)
         --json               Emit a structured envelope on stdout (install, doctor)
-        --antigravity        install: write Antigravity's mcp_config.json
-                             (auto-enabled when running inside Antigravity)
+
+      install: agent host registration (each defaults to "on" when the host is detected
+      locally; opt out with --no-<host>):
+        --claude / --no-claude
+                             Run `claude mcp add --scope user` for compose-preview-mcp
+                             (idempotent: re-runs `mcp remove` first). Detected when
+                             `claude` is on PATH or ~/.claude/ exists.
+        --codex / --no-codex
+                             Merge a [mcp_servers.compose-preview-mcp] table into Codex's
+                             config.toml. Detected when `codex` is on PATH or ~/.codex/
+                             exists.
+        --codex-config <path>
+                             Override the Codex config path (default ~/.codex/config.toml).
+        --antigravity / --no-antigravity
+                             Merge into Antigravity's mcp_config.json. Detected via
+                             __CFBundleIdentifier=com.google.antigravity, ANTIGRAVITY_CLI_ALIAS,
+                             or ~/.gemini/antigravity/.
         --antigravity-config <path>
-                             install: override Antigravity config path
+                             Override the Antigravity config path.
 
       See skills/compose-preview/design/MCP.md for the full agent flow.
       """
@@ -94,8 +109,17 @@ internal class McpCommand(args: List<String>) {
 
   private fun install(args: List<String>) {
     val emitJson = "--json" in args
+
     val antigravityDetected = isAntigravityEnvironment()
-    val installAntigravity = "--antigravity" in args || antigravityDetected
+    val claudeDetected = isClaudeEnvironment()
+    val codexDetected = isCodexEnvironment()
+
+    // Per-host: default to "on if detected", opt-in via --<host>, opt-out via --no-<host>.
+    val installAntigravity =
+      "--no-antigravity" !in args && ("--antigravity" in args || antigravityDetected)
+    val installClaude = "--no-claude" !in args && ("--claude" in args || claudeDetected)
+    val installCodex = "--no-codex" !in args && ("--codex" in args || codexDetected)
+
     val projectDir = resolveProjectDir(args)
     val moduleFilter = args.flagValuesAll("--module").map { it.removePrefix(":") }.toSet()
 
@@ -159,33 +183,86 @@ internal class McpCommand(args: List<String>) {
 
       // CLAUDE_CLOUD users need an absolute path because `~/.claude/skills/.../bin/compose-preview`
       // is the canonical launcher; we don't know how `compose-preview` is on the consumer's PATH.
+      val needAbsoluteLauncher = installAntigravity || installCodex || installClaude
       val launcher =
         locateHostLauncher()
-          ?: if (installAntigravity) {
+          ?: if (needAbsoluteLauncher) {
             System.err.println(
               "compose-preview mcp install: cannot locate an absolute compose-preview launcher " +
-                "for Antigravity config"
+                "for agent host config"
             )
             exitProcess(1)
           } else {
             "compose-preview"
           }
+      val projectAbs = projectDir.absolutePath
       val claudeMcpAdd =
-        "claude mcp add compose-preview-mcp -- $launcher mcp serve --project=${projectDir.absolutePath}"
+        "claude mcp add --scope user ${AgentMcpConfig.SERVER_NAME} -- " +
+          "$launcher mcp serve --project=$projectAbs"
+
       val antigravityConfig =
         args.flagValue("--antigravity-config")?.let(::File) ?: defaultAntigravityConfig()
+      val codexConfig = args.flagValue("--codex-config")?.let(::File) ?: defaultCodexConfig()
+
+      val results = mutableListOf<HostResult>()
+
       if (installAntigravity) {
-        writeAntigravityConfig(antigravityConfig, launcher, projectDir)
+        results +=
+          runCatching {
+              writeAntigravityConfig(antigravityConfig, launcher, projectDir)
+              HostResult("antigravity", true, antigravityConfig.absolutePath, null)
+            }
+            .getOrElse { e ->
+              HostResult("antigravity", false, antigravityConfig.absolutePath, e.message)
+            }
+      }
+      if (installCodex) {
+        results +=
+          runCatching {
+              writeCodexConfig(codexConfig, launcher, projectDir)
+              HostResult("codex", true, codexConfig.absolutePath, null)
+            }
+            .getOrElse { e -> HostResult("codex", false, codexConfig.absolutePath, e.message) }
+      }
+      if (installClaude) {
+        val claudeOnPath = locateOnPath("claude") != null
+        if (!claudeOnPath) {
+          results +=
+            HostResult(
+              "claude",
+              false,
+              null,
+              "`claude` not on PATH; copy/paste the printed command instead",
+            )
+        } else {
+          results += runClaudeMcpAdd(launcher, projectDir)
+        }
       }
 
       if (emitJson) {
         val payload = buildJsonObject {
           put("schema", JsonPrimitive("compose-preview-mcp-install/v1"))
-          put("projectRoot", JsonPrimitive(projectDir.absolutePath))
+          put("projectRoot", JsonPrimitive(projectAbs))
           put("launcher", JsonPrimitive(launcher))
           put("claudeMcpAdd", JsonPrimitive(claudeMcpAdd))
           put("antigravityConfig", JsonPrimitive(antigravityConfig.absolutePath))
           put("antigravityInstalled", JsonPrimitive(installAntigravity))
+          put("codexConfig", JsonPrimitive(codexConfig.absolutePath))
+          put("codexInstalled", JsonPrimitive(installCodex))
+          put("claudeInstalled", JsonPrimitive(installClaude))
+          put(
+            "hosts",
+            kotlinx.serialization.json.JsonArray(
+              results.map {
+                buildJsonObject {
+                  put("name", JsonPrimitive(it.name))
+                  put("ok", JsonPrimitive(it.ok))
+                  it.path?.let { p -> put("path", JsonPrimitive(p)) }
+                  it.error?.let { e -> put("error", JsonPrimitive(e)) }
+                }
+              }
+            ),
+          )
           put(
             "modules",
             kotlinx.serialization.json.JsonArray(
@@ -207,25 +284,55 @@ internal class McpCommand(args: List<String>) {
           System.err.println("    :${d.gradlePath}  ${d.descriptor}  (enabled=true)")
         }
         System.err.println()
-        System.err.println("Attach an MCP-aware agent host with:")
-        println(claudeMcpAdd)
-        if (installAntigravity) {
-          System.err.println()
-          System.err.println(
-            if (antigravityDetected) "Antigravity detected; MCP config updated:"
-            else "Antigravity MCP config updated:"
-          )
-          System.err.println("    ${antigravityConfig.absolutePath}")
+        if (results.isEmpty()) {
+          System.err.println("No agent host detected. To attach one manually, copy/paste:")
+          println(claudeMcpAdd)
         } else {
-          System.err.println()
-          System.err.println(
-            "For Antigravity, re-run with `--antigravity` to update " +
-              antigravityConfig.absolutePath
-          )
+          System.err.println("Agent hosts configured:")
+          results.forEach { r ->
+            val tag = if (r.ok) "ok" else "failed"
+            val where = r.path?.let { "  (${it})" } ?: ""
+            System.err.println("    [$tag] ${r.name}$where")
+            if (!r.ok && r.error != null) System.err.println("           ${r.error}")
+          }
+          if (results.none { it.name == "claude" && it.ok }) {
+            System.err.println()
+            System.err.println("To attach Claude Code manually, run:")
+            println(claudeMcpAdd)
+          }
         }
       }
     }
   }
+
+  private data class HostResult(
+    val name: String,
+    val ok: Boolean,
+    val path: String?,
+    val error: String?,
+  )
+
+  private fun runClaudeMcpAdd(launcher: String, projectDir: File): HostResult {
+    // Upsert: `claude mcp add` errors if the name already exists, so remove first (suppressing
+    // failure when it's not present) and add fresh. Both invocations stream to stderr so the
+    // user sees Claude's own messaging.
+    runProcess(AgentMcpConfig.claudeMcpRemoveCommand())
+    val add = AgentMcpConfig.claudeMcpAddCommand(launcher, projectDir.absolutePath)
+    val exit = runProcess(add)
+    return if (exit == 0) {
+      HostResult("claude", true, "${System.getProperty("user.home")}/.claude.json", null)
+    } else {
+      HostResult("claude", false, null, "claude mcp add exited with status $exit")
+    }
+  }
+
+  private fun runProcess(argv: List<String>): Int =
+    try {
+      ProcessBuilder(argv).inheritIO().start().waitFor()
+    } catch (e: Exception) {
+      System.err.println("compose-preview mcp install: ${argv.first()} failed: ${e.message}")
+      127
+    }
 
   // -- doctor ------------------------------------------------------------------------------------
 
@@ -339,46 +446,55 @@ internal class McpCommand(args: List<String>) {
   private fun defaultAntigravityConfig(): File =
     File(System.getProperty("user.home"), ".gemini/antigravity/mcp_config.json")
 
+  private fun defaultCodexConfig(): File =
+    File(System.getProperty("user.home"), ".codex/config.toml")
+
   private fun isAntigravityEnvironment(): Boolean =
     System.getenv("__CFBundleIdentifier") == "com.google.antigravity" ||
-      !System.getenv("ANTIGRAVITY_CLI_ALIAS").isNullOrBlank()
+      !System.getenv("ANTIGRAVITY_CLI_ALIAS").isNullOrBlank() ||
+      File(System.getProperty("user.home"), ".gemini/antigravity").isDirectory
+
+  private fun isClaudeEnvironment(): Boolean =
+    locateOnPath("claude") != null || File(System.getProperty("user.home"), ".claude").isDirectory
+
+  private fun isCodexEnvironment(): Boolean =
+    locateOnPath("codex") != null || File(System.getProperty("user.home"), ".codex").isDirectory
 
   private fun writeAntigravityConfig(file: File, launcher: String, projectDir: File) {
     val existing =
       if (file.isFile) {
         try {
-          JSON.parseToJsonElement(file.readText()).jsonObject
+          file.readText()
         } catch (e: Exception) {
-          System.err.println(
-            "compose-preview mcp install: Antigravity MCP config is not valid JSON: " +
-              "${file.absolutePath}: ${e.message}"
+          throw IllegalStateException(
+            "Antigravity MCP config unreadable: ${file.absolutePath}: ${e.message}"
           )
-          exitProcess(1)
         }
-      } else {
-        JsonObject(emptyMap())
+      } else null
+    val merged =
+      try {
+        AgentMcpConfig.mergeAntigravityConfig(existing, launcher, projectDir.absolutePath)
+      } catch (e: Exception) {
+        throw IllegalStateException(
+          "Antigravity MCP config is not valid JSON: ${file.absolutePath}: ${e.message}"
+        )
       }
-
-    val existingServers = existing["mcpServers"]?.jsonObject ?: JsonObject(emptyMap())
-    val composePreviewServer = buildJsonObject {
-      put("command", JsonPrimitive(launcher))
-      put(
-        "args",
-        kotlinx.serialization.json.JsonArray(
-          listOf(
-            JsonPrimitive("mcp"),
-            JsonPrimitive("serve"),
-            JsonPrimitive("--project=${projectDir.absolutePath}"),
-          )
-        ),
-      )
-    }
-
-    val mergedServers =
-      JsonObject(existingServers + ("compose-preview-mcp" to composePreviewServer))
-    val merged = JsonObject(existing + ("mcpServers" to mergedServers))
     file.parentFile?.mkdirs()
-    file.writeText(JSON.encodeToString(JsonObject.serializer(), merged) + "\n")
+    file.writeText(merged)
+  }
+
+  private fun writeCodexConfig(file: File, launcher: String, projectDir: File) {
+    val existing =
+      if (file.isFile) {
+        try {
+          file.readText()
+        } catch (e: Exception) {
+          throw IllegalStateException("Codex config unreadable: ${file.absolutePath}: ${e.message}")
+        }
+      } else null
+    val merged = AgentMcpConfig.mergeCodexConfig(existing, launcher, projectDir.absolutePath)
+    file.parentFile?.mkdirs()
+    file.writeText(merged)
   }
 
   /**
@@ -422,7 +538,13 @@ internal class McpCommand(args: List<String>) {
     val JSON: Json = Json { prettyPrint = true }
 
     private val VALUE_FLAGS =
-      setOf("--project", "--module", "--replicas-per-daemon", "--antigravity-config")
+      setOf(
+        "--project",
+        "--module",
+        "--replicas-per-daemon",
+        "--antigravity-config",
+        "--codex-config",
+      )
 
     private fun parseSubcommand(args: List<String>): Pair<String, List<String>> {
       var i = 0

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AgentMcpConfigTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AgentMcpConfigTest.kt
@@ -1,0 +1,132 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The Codex writer hand-rolls a section-level TOML edit (no TOML library on the classpath), so
+ * exercise the boundary cases: empty file, append, replace-in-place, and idempotent re-write. The
+ * Claude argv has no file I/O — assert the exact shape so a typo can't slip past review.
+ */
+class AgentMcpConfigTest {
+
+  private val launcher = "/abs/bin/compose-preview"
+  private val project = "/abs/repo"
+
+  @Test
+  fun `codex empty file produces only our table`() {
+    val out = AgentMcpConfig.mergeCodexConfig(null, launcher, project)
+    assertEquals(
+      """
+      [mcp_servers.compose-preview-mcp]
+      command = "/abs/bin/compose-preview"
+      args = ["mcp", "serve", "--project=/abs/repo"]
+
+      """
+        .trimIndent(),
+      out,
+    )
+  }
+
+  @Test
+  fun `codex appends our table without touching prior content`() {
+    val existing =
+      """
+      # Codex config
+      model = "gpt-5"
+
+      [model_providers.openai]
+      base_url = "https://api.openai.com/v1"
+      """
+        .trimIndent()
+    val out = AgentMcpConfig.mergeCodexConfig(existing, launcher, project)
+    assertTrue(out.startsWith(existing), "prior content preserved verbatim:\n$out")
+    assertTrue(out.contains("[mcp_servers.compose-preview-mcp]"), "appended our table:\n$out")
+    assertTrue(
+      out.contains("args = [\"mcp\", \"serve\", \"--project=/abs/repo\"]"),
+      "appended args line:\n$out",
+    )
+  }
+
+  @Test
+  fun `codex replaces existing table in place`() {
+    val existing =
+      """
+      # Codex config
+      model = "gpt-5"
+
+      [mcp_servers.compose-preview-mcp]
+      command = "/old/path/compose-preview"
+      args = ["mcp", "serve", "--project=/old/repo"]
+
+      [mcp_servers.other]
+      command = "/usr/bin/other"
+      """
+        .trimIndent()
+    val out = AgentMcpConfig.mergeCodexConfig(existing, launcher, project)
+    assertFalse(out.contains("/old/path/compose-preview"), "old path replaced:\n$out")
+    assertFalse(out.contains("/old/repo"), "old project replaced:\n$out")
+    assertTrue(out.contains(launcher), "new launcher present:\n$out")
+    assertTrue(out.contains("[mcp_servers.other]"), "sibling table preserved:\n$out")
+    assertEquals(
+      1,
+      Regex("\\[mcp_servers\\.compose-preview-mcp]").findAll(out).count(),
+      "exactly one of our tables: $out",
+    )
+  }
+
+  @Test
+  fun `codex is idempotent`() {
+    val first = AgentMcpConfig.mergeCodexConfig(null, launcher, project)
+    val second = AgentMcpConfig.mergeCodexConfig(first, launcher, project)
+    assertEquals(first, second)
+  }
+
+  @Test
+  fun `codex escapes special characters in launcher path`() {
+    val odd = "/abs/with \"quote\"/compose-preview"
+    val out = AgentMcpConfig.mergeCodexConfig(null, odd, project)
+    // The escaped form `\"quote\"` must appear; the raw `"quote"` must not break the TOML string.
+    assertTrue(out.contains("\\\"quote\\\""), "quote escaped:\n$out")
+  }
+
+  @Test
+  fun `antigravity merges into mcpServers without dropping siblings`() {
+    val existing = """{"mcpServers":{"other-mcp":{"command":"/usr/bin/other"}},"theme":"dark"}"""
+    val out = AgentMcpConfig.mergeAntigravityConfig(existing, launcher, project)
+    assertTrue(out.contains("\"other-mcp\""), "sibling preserved:\n$out")
+    assertTrue(out.contains("\"compose-preview-mcp\""), "ours added:\n$out")
+    assertTrue(out.contains("\"theme\""), "top-level keys preserved:\n$out")
+  }
+
+  @Test
+  fun `claude mcp add argv is the documented shape`() {
+    val argv = AgentMcpConfig.claudeMcpAddCommand(launcher, project)
+    assertEquals(
+      listOf(
+        "claude",
+        "mcp",
+        "add",
+        "--scope",
+        "user",
+        "compose-preview-mcp",
+        "--",
+        "/abs/bin/compose-preview",
+        "mcp",
+        "serve",
+        "--project=/abs/repo",
+      ),
+      argv,
+    )
+  }
+
+  @Test
+  fun `claude mcp remove argv targets the same scope and name`() {
+    assertEquals(
+      listOf("claude", "mcp", "remove", "--scope", "user", "compose-preview-mcp"),
+      AgentMcpConfig.claudeMcpRemoveCommand(),
+    )
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents.kt
@@ -7,10 +7,9 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
 /**
  * Keyboard `record_preview` script events. One descriptor — `input.keyboard` — advertising
  * `input.keyDown` and `input.keyUp` as **roadmap** (`supported = false`) on every host today.
- * Desktop's `ImageComposeScene.sendKeyEvent` and Android's held-rule
- * `KeyEvent.dispatchKeyEvent` are both wirable but neither is implemented yet — the existing
- * input handlers register these as unsupported so the wire shape is documented while the
- * dispatch side remains a follow-up.
+ * Desktop's `ImageComposeScene.sendKeyEvent` and Android's held-rule `KeyEvent.dispatchKeyEvent`
+ * are both wirable but neither is implemented yet — the existing input handlers register these as
+ * unsupported so the wire shape is documented while the dispatch side remains a follow-up.
  *
  * Lives in `:daemon:core` because the descriptor is renderer-agnostic — both backends will
  * eventually advertise it from `recordingScriptEventDescriptors()` with `supported = true` once

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt
@@ -14,16 +14,16 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
  * - `input.pointerMove` — `PointerEventType.Move` with the primary button held.
  * - `input.pointerUp` — `PointerEventType.Release`.
  *
- * Lives in `:daemon:core` because both `DesktopHost` and `RobolectricHost` dispatch this
- * extension. Each host advertises the same descriptor from `recordingScriptEventDescriptors()`;
- * the dispatch end is host-specific (Skiko `sendPointerEvent` on desktop, the held-rule's
- * pointer pipeline on Android), but the descriptor advertisement is uniform.
+ * Lives in `:daemon:core` because both `DesktopHost` and `RobolectricHost` dispatch this extension.
+ * Each host advertises the same descriptor from `recordingScriptEventDescriptors()`; the dispatch
+ * end is host-specific (Skiko `sendPointerEvent` on desktop, the held-rule's pointer pipeline on
+ * Android), but the descriptor advertisement is uniform.
  *
- * **Why split from `input.keyboard` and `input.rsb`.** Per-axis splits let each host advertise
- * the exact subset it dispatches: desktop carries `input.touch` + `input.keyboard` (latter as
- * roadmap); RobolectricHost carries `input.touch` + `input.keyboard` + `input.rsb`. One blanket
- * `input` extension would force per-host descriptor variants with different `supported` flags
- * — the per-axis split keeps the descriptors uniform across hosts and the per-host advertisement
+ * **Why split from `input.keyboard` and `input.rsb`.** Per-axis splits let each host advertise the
+ * exact subset it dispatches: desktop carries `input.touch` + `input.keyboard` (latter as roadmap);
+ * RobolectricHost carries `input.touch` + `input.keyboard` + `input.rsb`. One blanket `input`
+ * extension would force per-host descriptor variants with different `supported` flags — the
+ * per-axis split keeps the descriptors uniform across hosts and the per-host advertisement
  * trivially additive.
  */
 object InputTouchRecordingScriptEvents {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -138,8 +138,8 @@ fun String.toInteractiveInputKindOrNull(): InteractiveInputKind? =
  * Naming follows the per-extension `<extension>.<event>` convention: `input.click`,
  * `input.pointerDown`, etc. Three input extensions advertise these ids — see
  * `InputTouchRecordingScriptEvents`, `InputKeyboardRecordingScriptEvents`, and
- * `InputRsbRecordingScriptEvents`. The MCP `validateRecordingScriptKinds` checks every kind
- * against the daemon's advertised set — no special-case branch for input kinds anymore.
+ * `InputRsbRecordingScriptEvents`. The MCP `validateRecordingScriptKinds` checks every kind against
+ * the daemon's advertised set — no special-case branch for input kinds anymore.
  */
 val INTERACTIVE_INPUT_KIND_BY_WIRE_NAME: Map<String, InteractiveInputKind> =
   mapOf(

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1024,12 +1024,11 @@ data class RecordingScriptEvent(
   /** Agent-supplied checkpoint id for save/restore state markers. */
   val checkpointId: String? = null,
   /**
-   * Vestigial after compose-ai-tools#754: the legacy `kind = "lifecycle.event"` /
-   * `lifecycleEvent: <transition>` shape was split into per-id events (`lifecycle.pause` /
-   * `lifecycle.resume` / `lifecycle.stop`), so no handler reads this field anymore. Retained on
-   * the wire as a free-form passthrough — agents that set it for trace context still see it
-   * round-trip into [RecordingScriptEvidence.lifecycleEvent]. Future cleanup may remove the
-   * field entirely.
+   * Vestigial after compose-ai-tools#754: the legacy `kind = "lifecycle.event"` / `lifecycleEvent:
+   * <transition>` shape was split into per-id events (`lifecycle.pause` / `lifecycle.resume` /
+   * `lifecycle.stop`), so no handler reads this field anymore. Retained on the wire as a free-form
+   * passthrough — agents that set it for trace context still see it round-trip into
+   * [RecordingScriptEvidence.lifecycleEvent]. Future cleanup may remove the field entirely.
    */
   val lifecycleEvent: String? = null,
   /** Optional free-form tags copied into script evidence. */

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InputRecordingScriptEventsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InputRecordingScriptEventsTest.kt
@@ -73,9 +73,7 @@ class InputRecordingScriptEventsTest {
     // through to the unsupported branch.
     val advertisedTouchIds = InputTouchRecordingScriptEvents.WIRED_EVENTS
     val advertisedKeyboardIds =
-      InputKeyboardRecordingScriptEvents.descriptor.recordingScriptEvents
-        .map { it.id }
-        .toSet()
+      InputKeyboardRecordingScriptEvents.descriptor.recordingScriptEvents.map { it.id }.toSet()
     // input.rotaryScroll is advertised by the Android-only `input.rsb` extension; check it via
     // the wire-name table without depending on the Android module here.
     val rotaryWireName = "input.rotaryScroll"

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
@@ -110,8 +110,8 @@ class DesktopHostTest {
   /**
    * With a resolver wired, `recordingScriptEventDescriptors()` advertises three extensions:
    * `recording` (probe, supported), `input.touch` (4 pointer events, supported), and
-   * `input.keyboard` (2 key events, roadmap). The Wear-only `input.rsb` lives on the Android
-   * host; desktop daemons skip it.
+   * `input.keyboard` (2 key events, roadmap). The Wear-only `input.rsb` lives on the Android host;
+   * desktop daemons skip it.
    */
   @Test
   fun recordingScriptEventDescriptorsAdvertiseSupportedExtensions() {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -526,8 +526,8 @@ class DesktopRecordingSessionTest {
       try {
         val thrown =
           runCatching {
-            session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "input.click")))
-          }
+              session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "input.click")))
+            }
             .exceptionOrNull()
         assertTrue(
           "postScript on a live session must throw IllegalStateException; got ${thrown?.javaClass}",

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -37,31 +37,34 @@ in [`docs/daemon/MCP-KOTLIN.md`](../docs/daemon/MCP-KOTLIN.md).
 
 ## Quick start
 
-The CLI bundles `:mcp` so the consumer-facing path is two commands —
-`compose-preview mcp install` then `claude mcp add`. The standalone
-`:mcp:installDist` launcher is the alternative path for embedders that
-don't ship the CLI.
+The CLI bundles `:mcp` so the consumer-facing path is one command —
+`compose-preview mcp install` registers the server with every locally
+installed agent host it detects (Claude Code, Codex, Antigravity). The
+standalone `:mcp:installDist` launcher is the alternative path for embedders
+that don't ship the CLI.
 
 ### Path A: via the bundled CLI (recommended)
 
 ```bash
-# Run from the project root. Bootstrap descriptors + previews.json for every
-# plugin-applied module. When run inside Antigravity, this also installs the
-# MCP server into Antigravity's config. Outside Antigravity, pass --antigravity.
+# Run from the project root. Bootstraps descriptors + previews.json for every
+# plugin-applied module, then registers compose-preview-mcp with every locally
+# installed agent host. Idempotent — re-running upserts each registration.
 compose-preview mcp install
 
 # Verify per-module state.
 compose-preview mcp doctor
-
-# `mcp install` printed the exact `claude mcp add` line; copy/paste it.
-claude mcp add compose-preview-mcp -- compose-preview mcp serve \
-  --project=/abs/path/to/your-repo
 ```
+
+Per-host opt-in/out flags: `--claude` / `--no-claude`, `--codex` /
+`--no-codex` / `--codex-config <path>`, `--antigravity` / `--no-antigravity`
+/ `--antigravity-config <path>`. Defaults to "on if detected" for each host;
+detection rules are documented in
+[`skills/compose-preview/design/MCP.md`](../skills/compose-preview/design/MCP.md#setup).
 
 `compose-preview mcp serve` runs the MCP server in-process; status goes
 to stderr and stdout is reserved for JSON-RPC framing. If no `--project` is
-passed, it defaults to the current Gradle root. Generated Antigravity config
-still includes an absolute `--project=...` because Antigravity's launch
+passed, it defaults to the current Gradle root. Generated host config files
+still include an absolute `--project=...` because each host's launch
 directory is not project-scoped.
 
 The consumer-facing skill doc is

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -2639,8 +2639,8 @@ class DaemonMcpServer(
    * - **`supported = true`** — accepted; the daemon will dispatch.
    * - **`supported = false`** — rejected with a precise diagnostic that points at
    *   `list_data_products` so the agent sees the roadmap shape rather than a quiet `unsupported`
-   *   evidence trail. (The daemon-side fallback that emits `unsupported` evidence stays in
-   *   place as defense-in-depth for older MCP servers + direct daemon clients.)
+   *   evidence trail. (The daemon-side fallback that emits `unsupported` evidence stays in place as
+   *   defense-in-depth for older MCP servers + direct daemon clients.)
    * - **Not advertised** — rejected with "not advertised by this daemon".
    *
    * Input kinds (`input.click`, `input.pointerDown`, …) are advertised through

--- a/skills/compose-preview/design/MCP.md
+++ b/skills/compose-preview/design/MCP.md
@@ -29,27 +29,35 @@ hand.
 
 ```bash
 # Run from the project root. Bootstraps descriptors + previews.json for every
-# plugin-applied module. When run inside Antigravity, also installs the MCP
-# server into Antigravity's config.
+# plugin-applied module, then registers the MCP server with every locally
+# installed agent host it detects (Claude Code, Codex, Antigravity).
 compose-preview mcp install
 
-# Outside Antigravity, force the same config write explicitly.
-compose-preview mcp install --antigravity
+# Force a specific host even if it's not auto-detected, or opt out.
+compose-preview mcp install --antigravity        # force Antigravity write
+compose-preview mcp install --no-claude          # skip claude mcp add
+compose-preview mcp install --codex              # force Codex write
+compose-preview mcp install --codex-config /path/to/config.toml
 
 # Verify per-module state (descriptor present, enabled=true).
 compose-preview mcp doctor
-
-# For Claude Code, copy/paste the command that `mcp install` printed:
-claude mcp add compose-preview-mcp -- compose-preview mcp serve \
-  --project=/abs/path/to/your-repo
 ```
 
-`compose-preview mcp serve` also defaults `--project` to the current Gradle
-root when run from a project checkout. Antigravity auto-detection uses
-`__CFBundleIdentifier=com.google.antigravity` or `ANTIGRAVITY_CLI_ALIAS`. When
-Antigravity config is written, it still uses absolute paths because
-Antigravity may launch the server from a different working directory. `mcp
-install` does three things behind the scenes:
+`compose-preview mcp serve` defaults `--project` to the current Gradle root
+when run from a project checkout. Detection per host:
+
+- **Claude Code**: `claude` on PATH, or `~/.claude/` exists. Registered via
+  `claude mcp add --scope user` (idempotent — the install upserts).
+- **Codex**: `codex` on PATH, or `~/.codex/` exists. The
+  `[mcp_servers.compose-preview-mcp]` table is replaced in place (or appended)
+  in `~/.codex/config.toml`.
+- **Antigravity**: `__CFBundleIdentifier=com.google.antigravity`,
+  `ANTIGRAVITY_CLI_ALIAS`, or `~/.gemini/antigravity/` exists. The MCP server
+  entry is merged into `~/.gemini/antigravity/mcp_config.json`.
+
+All three host writers store the absolute launcher path because the host may
+launch the server from a different working directory than the Gradle root.
+Beyond host registration, `mcp install` does three things behind the scenes:
 
 1. Runs `composePreviewDaemonStart` for every module that applies the plugin,
    so each `<module>/build/compose-previews/daemon-launch.json` exists.


### PR DESCRIPTION
## Summary

- `compose-preview mcp install` now detects Claude Code (`claude` on PATH or `~/.claude/`), Codex (`codex` on PATH or `~/.codex/`), and Antigravity (`__CFBundleIdentifier`, `ANTIGRAVITY_CLI_ALIAS`, or `~/.gemini/antigravity/`), and registers `compose-preview-mcp` with each — defaults to "on if detected", with `--<host>` / `--no-<host>` opt-in/out plus `--codex-config` / `--antigravity-config` overrides.
- New `cli/.../AgentMcpConfig.kt` with three pure writers: Antigravity JSON merge (factored from existing), Codex TOML section replace-or-append, and the `claude mcp add --scope user` argv (Claude is upserted via `mcp remove` + `mcp add` so re-runs are idempotent).
- New `AgentMcpConfigTest` covering the Codex TOML edge cases (empty / append / replace-in-place / idempotent / quote escaping) plus the Claude argv shape.
- Docs in `mcp/README.md` and `skills/compose-preview/design/MCP.md` updated to reflect the multi-host install.

The first commit (`chore(format)`) is pre-existing ktfmt violations from #762 that the pre-commit hook flagged separately; kept distinct from the feature so the diff is reviewable.

Closes #768. Tracks #772 for publishing to public registries (Smithery, mcp.so, etc.) instead.

## Test plan

- [x] `./gradlew :cli:test` — green, including 8 new `AgentMcpConfigTest` cases.
- [ ] Manual: run `compose-preview mcp install` in a project on a host with all three of Claude / Codex / Antigravity present, and confirm each config file / `claude mcp list` shows the entry.
- [ ] Manual: re-run to confirm idempotency on each host (no duplicates, no clobber of sibling tables / servers).
- [ ] Manual: `--no-claude` / `--no-codex` / `--no-antigravity` skip the respective writer.

---
_Generated by [Claude Code](https://claude.ai/code/session_014K4JuhqBRUAtywaGKNSjv9)_