### PR TITLE
refactor(vscode): lift stale badge + loading overlay out of behavior.ts

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -22,7 +22,9 @@ import {
 import { PreviewGrid } from "./components/PreviewGrid";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
 import { attachInteractiveInputHandlers } from "./interactiveInput";
+import { LoadingOverlay } from "./loadingOverlay";
 import { previewStore } from "./previewStore";
+import { StaleBadgeController } from "./staleBadge";
 import { ViewportTracker } from "./viewportTracker";
 
 export function setupPreviewBehavior(
@@ -152,6 +154,9 @@ export function setupPreviewBehavior(
             vscode.setState(state);
         },
     };
+
+    const staleBadge = new StaleBadgeController(vscode);
+    const loadingOverlay = new LoadingOverlay();
 
     // Restore layout preference
     if (
@@ -1234,7 +1239,7 @@ export function setupPreviewBehavior(
         // already known to be stale at setPreviews time. updateStaleBadges
         // also adds/removes it on subsequent renders. Placed before the
         // header is appended so its DOM order stays predictable.
-        applyStaleBadge(card, false);
+        staleBadge.apply(card, false);
 
         header.appendChild(titleRow);
         card.appendChild(header);
@@ -1266,7 +1271,7 @@ export function setupPreviewBehavior(
             if (card.classList.contains("is-stale")) {
                 evt.preventDefault();
                 evt.stopPropagation();
-                requestHeavyRefresh(card);
+                staleBadge.requestHeavyRefresh(card);
                 return;
             }
             enterInteractiveOnCard(card, evt.shiftKey);
@@ -1761,122 +1766,6 @@ export function setupPreviewBehavior(
         }
     }
 
-    /**
-     * Toggles the "stale render — click to refresh" affordance on a card.
-     *
-     * Called both at card creation time (so cards born stale have the
-     * badge from the start) and from updateStaleBadges after each
-     * setPreviews (state can flip when the user toggles between fast
-     * and full saves). Idempotent: skips if the desired state already
-     * matches the DOM, so re-running on an unchanged card is cheap.
-     *
-     * Why a button rather than a static badge: clicking it is the only
-     * way the user can recover a fresh GIF/long-scroll image without
-     * editing source. Keeping it inside the title row puts it in the
-     * same affordance band as the open-source buttons.
-     */
-    function requestHeavyRefresh(card) {
-        const previewId = card.dataset.previewId;
-        if (!previewId) return;
-        vscode.postMessage({
-            command: "refreshHeavy",
-            previewId,
-        });
-    }
-
-    function applyStaleBadge(card, isStale) {
-        const titleRow = card.querySelector(".card-title-row");
-        if (!titleRow) return;
-        const existing = card.querySelector(".card-stale-btn");
-        if (isStale && !existing) {
-            const btn = document.createElement("button");
-            btn.className = "icon-button card-stale-btn";
-            btn.title =
-                "Stale heavy capture — click to keep fresh while focused";
-            btn.setAttribute("aria-label", "Keep stale capture fresh");
-            btn.innerHTML =
-                '<i class="codicon codicon-warning" aria-hidden="true"></i>';
-            btn.addEventListener("click", (evt) => {
-                evt.preventDefault();
-                evt.stopPropagation();
-                requestHeavyRefresh(card);
-            });
-            titleRow.appendChild(btn);
-            card.classList.add("is-stale");
-        } else if (!isStale && existing) {
-            existing.remove();
-            card.classList.remove("is-stale");
-        }
-    }
-
-    /**
-     * Apply the heavy-stale badge state across all cards after
-     * setPreviews fires. The extension passes a list of preview IDs
-     * whose heavy captures weren't refreshed this run; everything else
-     * gets its badge cleared.
-     */
-    function updateStaleBadges(heavyStaleIds) {
-        const stale = new Set(heavyStaleIds || []);
-        grid.querySelectorAll(".preview-card").forEach((card) => {
-            applyStaleBadge(card, stale.has(card.dataset.previewId));
-        });
-    }
-
-    // Two-stage overlay during stealth refresh:
-    //   stage 1 (0–500ms): tiny corner spinner, no dim, no blur. Most
-    //     daemon hits land in this window — image swap reads as a clean
-    //     update, no "dim → undim" flicker.
-    //   stage 2 (>500ms):  classic subtle (dim + blur + corner spinner).
-    //     The build is taking real time, escalate so the user sees the
-    //     panel is actually working.
-    // Cards whose updateImage arrives during stage 1 never see stage 2.
-    const OVERLAY_ESCALATE_MS = 500;
-    let overlayEscalationTimer = null;
-
-    function markAllLoading() {
-        document.querySelectorAll(".preview-card").forEach((card) => {
-            const container = card.querySelector(".image-container");
-            if (!container) return;
-            // Skip if already has an overlay (e.g. previous refresh still running)
-            if (container.querySelector(".loading-overlay")) return;
-            // Don't add overlay if there's just a skeleton (nothing useful to cover)
-            if (
-                container.querySelector(".skeleton") &&
-                !container.querySelector("img")
-            )
-                return;
-            const overlay = document.createElement("div");
-            overlay.className = "loading-overlay minimal";
-            overlay.innerHTML =
-                '<div class="spinner" aria-label="Refreshing"></div>';
-            container.appendChild(overlay);
-        });
-        scheduleOverlayEscalation();
-    }
-
-    function scheduleOverlayEscalation() {
-        if (overlayEscalationTimer) clearTimeout(overlayEscalationTimer);
-        overlayEscalationTimer = setTimeout(() => {
-            overlayEscalationTimer = null;
-            // Promote every still-present minimal overlay to subtle.
-            // Cards whose images already arrived have removed their
-            // overlays, so this only touches cards still waiting.
-            document
-                .querySelectorAll(".loading-overlay.minimal")
-                .forEach((o) => {
-                    o.classList.remove("minimal");
-                    o.classList.add("subtle");
-                });
-        }, OVERLAY_ESCALATE_MS);
-    }
-
-    function cancelOverlayEscalation() {
-        if (overlayEscalationTimer) {
-            clearTimeout(overlayEscalationTimer);
-            overlayEscalationTimer = null;
-        }
-    }
-
     function updateImage(previewId, captureIndex, imageData) {
         const card = document.getElementById(
             "preview-" + sanitizeId(previewId),
@@ -2086,7 +1975,7 @@ export function setupPreviewBehavior(
                 // *after* renderPreviews so the badge attaches to cards
                 // that were just inserted, not stripped by a stale-state
                 // diff from the previous setPreviews.
-                updateStaleBadges(msg.heavyStaleIds);
+                staleBadge.updateAll(grid, msg.heavyStaleIds);
 
                 const fns = [
                     ...new Set(msg.previews.map((p) => p.functionName)),
@@ -2119,7 +2008,7 @@ export function setupPreviewBehavior(
             }
 
             case "markAllLoading":
-                markAllLoading();
+                loadingOverlay.markAll();
                 break;
 
             case "clearAll":
@@ -2134,7 +2023,7 @@ export function setupPreviewBehavior(
                 // Cards are gone — escalation timer has nothing left to
                 // promote. Avoids a stray timer firing after the next
                 // refresh has installed fresh minimal overlays.
-                cancelOverlayEscalation();
+                loadingOverlay.cancel();
                 // Don't clear the message here — if it came with a
                 // follow-up showMessage (the usual pattern) it'll be
                 // replaced; if not, ensureNotBlank will backstop a

--- a/vscode-extension/src/webview/preview/loadingOverlay.ts
+++ b/vscode-extension/src/webview/preview/loadingOverlay.ts
@@ -1,0 +1,81 @@
+// Two-stage per-card loading overlay during stealth refresh.
+//
+// Lifted verbatim from `behavior.ts`'s `markAllLoading` /
+// `scheduleOverlayEscalation` / `cancelOverlayEscalation` cluster.
+//
+//   stage 1 (0–500 ms): `loading-overlay minimal` — tiny corner
+//     spinner, no dim, no blur. Most daemon hits land in this
+//     window — image swap reads as a clean update, no
+//     "dim → undim" flicker.
+//   stage 2 (>500 ms):  `loading-overlay subtle` — dim + blur +
+//     corner spinner. The build is taking real time, escalate so
+//     the user sees the panel is actually working.
+//
+// Cards whose `updateImage` arrives during stage 1 never see stage 2.
+// `cancel()` cuts the timer when the extension explicitly clears
+// loading state (e.g. an empty-state notice took over the panel).
+//
+// Held as a class so the escalation timer doesn't need a module-
+// global. Constructor takes nothing — all state is per-instance.
+
+const ESCALATE_MS = 500;
+
+export class LoadingOverlay {
+    private escalationTimer: ReturnType<typeof setTimeout> | null = null;
+
+    /**
+     * Drop a `.loading-overlay.minimal` onto every card that has
+     * existing pixels (skip cards still showing the skeleton — there's
+     * nothing useful to cover yet). Then arm the 500ms timer that
+     * promotes any still-present minimal overlays to `subtle`.
+     */
+    markAll(): void {
+        for (const card of document.querySelectorAll<HTMLElement>(
+            ".preview-card",
+        )) {
+            const container =
+                card.querySelector<HTMLElement>(".image-container");
+            if (!container) continue;
+            // Skip if already has an overlay (e.g. previous refresh still running)
+            if (container.querySelector(".loading-overlay")) continue;
+            // Don't add overlay if there's just a skeleton (nothing useful to cover)
+            if (
+                container.querySelector(".skeleton") &&
+                !container.querySelector("img")
+            )
+                continue;
+            const overlay = document.createElement("div");
+            overlay.className = "loading-overlay minimal";
+            overlay.innerHTML =
+                '<div class="spinner" aria-label="Refreshing"></div>';
+            container.appendChild(overlay);
+        }
+        this.scheduleEscalation();
+    }
+
+    /** Cut the escalation timer — called from the extension's
+     *  `clearLoading` path so cards don't visibly flip to `subtle`
+     *  after the loading state has been cleared. */
+    cancel(): void {
+        if (this.escalationTimer) {
+            clearTimeout(this.escalationTimer);
+            this.escalationTimer = null;
+        }
+    }
+
+    private scheduleEscalation(): void {
+        if (this.escalationTimer) clearTimeout(this.escalationTimer);
+        this.escalationTimer = setTimeout(() => {
+            this.escalationTimer = null;
+            // Promote every still-present minimal overlay to subtle.
+            // Cards whose images already arrived have removed their
+            // overlays, so this only touches cards still waiting.
+            for (const o of document.querySelectorAll(
+                ".loading-overlay.minimal",
+            )) {
+                o.classList.remove("minimal");
+                o.classList.add("subtle");
+            }
+        }, ESCALATE_MS);
+    }
+}

--- a/vscode-extension/src/webview/preview/staleBadge.ts
+++ b/vscode-extension/src/webview/preview/staleBadge.ts
@@ -1,0 +1,85 @@
+// Per-card "stale heavy capture" badge.
+//
+// Lifted verbatim from `behavior.ts`'s `requestHeavyRefresh` /
+// `applyStaleBadge` / `updateStaleBadges` trio. The badge is the only
+// way the user can recover a fresh GIF / long-scroll image without
+// editing source — clicking it posts `refreshHeavy` so the extension
+// re-runs the heavy render path. Living inside the title row puts it
+// in the same affordance band as the open-source button.
+//
+// `applyStaleBadge` is idempotent: it skips when the desired state
+// already matches the DOM, so re-running on an unchanged card is
+// cheap. Called both at card-creation time (so cards born stale have
+// the badge from the start) and from `updateStaleBadges` after each
+// `setPreviews` (state can flip when the user toggles fast↔full
+// saves).
+//
+// The module is shaped as a single `StaleBadgeController` so the
+// `vscode` handle stays scoped — none of the three helpers need to
+// reach into closure.
+
+import type { VsCodeApi } from "../shared/vscode";
+
+export class StaleBadgeController {
+    constructor(private readonly vscode: VsCodeApi<unknown>) {}
+
+    /** Posts `refreshHeavy` for [card]'s preview id. No-op when the
+     *  card has no `data-preview-id` (shouldn't happen in practice
+     *  but stays defensive — the imperative copy did the same). */
+    requestHeavyRefresh(card: HTMLElement): void {
+        const previewId = card.dataset.previewId;
+        if (!previewId) return;
+        this.vscode.postMessage({
+            command: "refreshHeavy",
+            previewId,
+        });
+    }
+
+    /**
+     * Toggles the "stale render — click to refresh" affordance on a
+     * single card. Idempotent — skips when the desired state already
+     * matches the DOM.
+     */
+    apply(card: HTMLElement, isStale: boolean): void {
+        const titleRow = card.querySelector(".card-title-row");
+        if (!titleRow) return;
+        const existing = card.querySelector(".card-stale-btn");
+        if (isStale && !existing) {
+            const btn = document.createElement("button");
+            btn.className = "icon-button card-stale-btn";
+            btn.title =
+                "Stale heavy capture — click to keep fresh while focused";
+            btn.setAttribute("aria-label", "Keep stale capture fresh");
+            btn.innerHTML =
+                '<i class="codicon codicon-warning" aria-hidden="true"></i>';
+            btn.addEventListener("click", (evt) => {
+                evt.preventDefault();
+                evt.stopPropagation();
+                this.requestHeavyRefresh(card);
+            });
+            titleRow.appendChild(btn);
+            card.classList.add("is-stale");
+        } else if (!isStale && existing) {
+            existing.remove();
+            card.classList.remove("is-stale");
+        }
+    }
+
+    /**
+     * Apply the heavy-stale badge state across all cards inside [grid]
+     * after `setPreviews` fires. The extension passes a list of preview
+     * ids whose heavy captures weren't refreshed this run; everything
+     * else gets its badge cleared.
+     */
+    updateAll(
+        grid: ParentNode,
+        heavyStaleIds: readonly string[] | null | undefined,
+    ): void {
+        const stale = new Set(heavyStaleIds ?? []);
+        for (const card of grid.querySelectorAll<HTMLElement>(
+            ".preview-card",
+        )) {
+            this.apply(card, stale.has(card.dataset.previewId ?? ""));
+        }
+    }
+}


### PR DESCRIPTION
Slice of #767. Two small per-card overlay state machines lifted into typed modules.

## Summary

- `staleBadge.ts` — `StaleBadgeController` with `requestHeavyRefresh(card)`, `apply(card, isStale)`, `updateAll(grid, heavyStaleIds)`. Idempotent badge add/remove on the card title row; click posts `refreshHeavy` to the extension.
- `loadingOverlay.ts` — `LoadingOverlay` class owning the two-stage spinner: 0–500 ms `loading-overlay minimal` (corner spinner only), >500 ms `loading-overlay subtle` (dim + blur + spinner). `markAll()` arms the escalation timer; `cancel()` cuts it for `clearAll`-style resets.

Both replace free-standing `function foo(...) {}` blocks shielded by `@ts-nocheck`. No semantics change — same DOM classes, same 500 ms escalation threshold, same idempotency rules. `behavior.ts` shrinks from 3208 → 3097 lines (−111 LOC).

Built from `main`, independent of #769 / #770 / #771 / #773 / #774.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 320/320 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke:
  - Trigger a fast-tier save (heavy captures dropped). Verify the warning badge appears in the card title row, clicking it triggers a heavy refresh, and that successful refresh removes the badge.
  - Trigger a refresh with a fast daemon hit (<500 ms): verify only the minimal corner spinner appears, no dim/blur flicker.
  - Trigger a refresh with a slow build (>500 ms): verify cards still waiting escalate to the subtle (dim+blur) overlay.
  - Send the panel a `clearAll` message during a slow refresh and verify the escalation timer is cut (no stray subtle promotion afterwards).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTv9gnHTdY5MzDfGdnSpBn)_