### PR TITLE
fix(vscode): republish state on webviewReady so the panel populates after late resolution

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -19,30 +19,27 @@ import java.nio.file.Path
 /**
  * Entry point for the preview daemon JVM — see docs/daemon/DESIGN.md § 4.
  *
- * The Gradle plugin's `composePreviewDaemonStart` task points its launch
- * descriptor at `ee.schimke.composeai.daemon.DaemonMain` (see
+ * The Gradle plugin's `composePreviewDaemonStart` task points its launch descriptor at
+ * `ee.schimke.composeai.daemon.DaemonMain` (see
  * [`AndroidPreviewSupport.kt:974`](../../../../../../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt#L974)),
  * which the JVM resolves via the file-level [JvmName] annotation above.
  *
  * Lifecycle:
  *
  * 1. Print a hello banner to stderr (free-form log per PROTOCOL.md § 1).
- * 2. Build a [RobolectricHost] (B1.3 — holds the Robolectric sandbox open
- *    across renders). Implements the renderer-agnostic [RenderHost] from
- *    `:daemon:core`. **D-harness.v2:** when
- *    `composeai.harness.previewsManifest=<path>` is set, wrap with
- *    [PreviewManifestRouter] so the harness's `previewId=<id>` payload
- *    resolves to a parseable [RenderSpec]. Mirrors
- *    `:daemon:desktop`'s wireup. Production launches don't pass the
- *    sysprop, so production behaviour is unchanged.
- * 3. Build a [JsonRpcServer] (B1.5 — JSON-RPC 2.0 over stdio with LSP-style
- *    Content-Length framing). Lives in `:daemon:core`; binds to any
- *    [RenderHost] implementation.
- * 4. [JsonRpcServer.run] blocks until the client sends `shutdown` + `exit`
- *    or stdin closes; it calls `System.exit` itself.
+ * 2. Build a [RobolectricHost] (B1.3 — holds the Robolectric sandbox open across renders).
+ *    Implements the renderer-agnostic [RenderHost] from `:daemon:core`. **D-harness.v2:** when
+ *    `composeai.harness.previewsManifest=<path>` is set, wrap with [PreviewManifestRouter] so the
+ *    harness's `previewId=<id>` payload resolves to a parseable [RenderSpec]. Mirrors
+ *    `:daemon:desktop`'s wireup. Production launches don't pass the sysprop, so production
+ *    behaviour is unchanged.
+ * 3. Build a [JsonRpcServer] (B1.5 — JSON-RPC 2.0 over stdio with LSP-style Content-Length
+ *    framing). Lives in `:daemon:core`; binds to any [RenderHost] implementation.
+ * 4. [JsonRpcServer.run] blocks until the client sends `shutdown` + `exit` or stdin closes; it
+ *    calls `System.exit` itself.
  *
- * `args` is currently unused; future flags (e.g. `--detect-leaks=heavy`,
- * `--foreground`) will be parsed here.
+ * `args` is currently unused; future flags (e.g. `--detect-leaks=heavy`, `--foreground`) will be
+ * parsed here.
  */
 fun main(args: Array<String>) {
   // D-harness.v2 — capture the real stdout *before* swapping. Robolectric (and Roborazzi) write
@@ -80,7 +77,8 @@ fun main(args: Array<String>) {
   // descriptor was introduced, but the Android daemon previously ignored it and came up with a
   // single sandbox unless the experimental sandbox-count property was set manually. Held
   // interactive sessions need slot 1 pinned while slot 0 continues normal renders, so default the
-  // pool to two sandboxes when warmSpare is on. Explicit `composeai.daemon.sandboxCount` still wins.
+  // pool to two sandboxes when warmSpare is on. Explicit `composeai.daemon.sandboxCount` still
+  // wins.
   val warmSpareEnabled = System.getProperty(WARM_SPARE_PROP)?.toBooleanStrictOrNull() ?: true
   val defaultSandboxCount = if (warmSpareEnabled) 2 else 1
 
@@ -88,8 +86,7 @@ fun main(args: Array<String>) {
   // the warm-spare-derived default above so production Android daemons have the second sandbox
   // required for held interactive sessions.
   val sandboxCount =
-    (System.getProperty(SANDBOX_COUNT_PROP)?.toIntOrNull() ?: defaultSandboxCount)
-      .coerceAtLeast(1)
+    (System.getProperty(SANDBOX_COUNT_PROP)?.toIntOrNull() ?: defaultSandboxCount).coerceAtLeast(1)
 
   // Per-slot child loaders. The factory closes over the URL list and constructs one holder per
   // slot, parented to the slot's own sandbox classloader. The
@@ -139,19 +136,21 @@ fun main(args: Array<String>) {
       val productionManifestRoute = previewIndex.size > 0 || hasUserClasses
       val routerSandboxCount = if (productionManifestRoute) sandboxCount else 1
       val singletonHolder: UserClassLoaderHolder? =
-        if (routerSandboxCount == 1) userClassloaderHolderFactory?.let { factory ->
-          UserClassLoaderHolder(
-            urls = userClassUrls,
-            parentSupplier = {
-              DaemonHostBridge.currentSandboxClassLoader()
-                ?: error(
-                  "DaemonHostBridge.sandboxClassLoaderRef is null — sandbox prologue didn't run. " +
-                    "Did SandboxHoldingRunner.holdSandboxOpen execute setSandboxClassLoader before " +
-                    "the host called publishChildLoader?"
-                )
-            },
-          )
-        } else null
+        if (routerSandboxCount == 1)
+          userClassloaderHolderFactory?.let { factory ->
+            UserClassLoaderHolder(
+              urls = userClassUrls,
+              parentSupplier = {
+                DaemonHostBridge.currentSandboxClassLoader()
+                  ?: error(
+                    "DaemonHostBridge.sandboxClassLoaderRef is null — sandbox prologue didn't run. " +
+                      "Did SandboxHoldingRunner.holdSandboxOpen execute setSandboxClassLoader before " +
+                      "the host called publishChildLoader?"
+                  )
+              },
+            )
+          }
+        else null
       if (routerSandboxCount > 1) {
         System.err.println(
           "compose-ai-tools daemon: sandbox pool active (sandboxCount=$routerSandboxCount)"
@@ -182,18 +181,20 @@ fun main(args: Array<String>) {
   // construction shape — cheap-signal set from `composeai.daemon.cheapSignalFiles`, authoritative
   // hash from this JVM's `java.class.path`. Sysprop unset → null fingerprint → pre-B2.1 no-op.
   val classpathFingerprint: ClasspathFingerprint? =
-    ClasspathFingerprint.parseCheapSignalFilesSysprop().takeIf { it.isNotEmpty() }?.let { cheap ->
-      val classpath =
-        (System.getProperty("java.class.path") ?: "")
-          .split(File.pathSeparator)
-          .filter { it.isNotBlank() }
-          .map { File(it) }
-      System.err.println(
-        "compose-ai-tools daemon: ClasspathFingerprint active " +
-          "(cheap=${cheap.size}, classpath=${classpath.size})"
-      )
-      ClasspathFingerprint(cheapSignalFiles = cheap, classpathEntries = classpath)
-    }
+    ClasspathFingerprint.parseCheapSignalFilesSysprop()
+      .takeIf { it.isNotEmpty() }
+      ?.let { cheap ->
+        val classpath =
+          (System.getProperty("java.class.path") ?: "")
+            .split(File.pathSeparator)
+            .filter { it.isNotBlank() }
+            .map { File(it) }
+        System.err.println(
+          "compose-ai-tools daemon: ClasspathFingerprint active " +
+            "(cheap=${cheap.size}, classpath=${classpath.size})"
+        )
+        ClasspathFingerprint(cheapSignalFiles = cheap, classpathEntries = classpath)
+      }
 
   // B2.2 phase 2 — wire the incremental rescan path. Mirrors `:daemon:desktop`'s wireup; the
   // ClassGraph scan happens against this JVM's `java.class.path` and is scoped to the smallest
@@ -226,21 +227,20 @@ fun main(args: Array<String>) {
   val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
   // H4 — prune config from sysprops (defaults: 50 entries / 14 days / 500 MB / 1h auto interval).
   val pruneConfig = HistoryPruneConfig.fromSysprops()
-  val historyManager: HistoryManager? =
-    historyDirProp?.let { dir ->
-      System.err.println(
-        "compose-ai-tools daemon: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs}, " +
-          "pruneConfig=$pruneConfig)"
-      )
-      HistoryManager.forLocalFsAndGitRefs(
-        historyDir = Path.of(dir),
-        module = System.getProperty(MODULE_ID_PROP) ?: "",
-        gitProvenance = gitProvenance,
-        gitRefs = gitRefHistoryRefs,
-        repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
-        pruneConfig = pruneConfig,
-      )
-    }
+  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
+    System.err.println(
+      "compose-ai-tools daemon: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs}, " +
+        "pruneConfig=$pruneConfig)"
+    )
+    HistoryManager.forLocalFsAndGitRefs(
+      historyDir = Path.of(dir),
+      module = System.getProperty(MODULE_ID_PROP) ?: "",
+      gitProvenance = gitProvenance,
+      gitRefs = gitRefHistoryRefs,
+      repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
+      pruneConfig = pruneConfig,
+    )
+  }
 
   // D2 — wire data-product registries. `compose/semantics` is default-mode data emitted by the
   // Android render loop whenever a render output dir exists. A11y is selected through the generic
@@ -262,7 +262,9 @@ fun main(args: Array<String>) {
         System.err.println("compose-ai-tools daemon: ThemeDataProductRegistry active")
         add(ThemeDataProductRegistry())
         if (historyManager != null) {
-          System.err.println("compose-ai-tools daemon: HistoryDiffRegionsDataProductRegistry active")
+          System.err.println(
+            "compose-ai-tools daemon: HistoryDiffRegionsDataProductRegistry active"
+          )
           add(HistoryDiffRegionsDataProductRegistry(historyManager = historyManager))
         }
         if (renderOutputDir != null) {
@@ -303,29 +305,26 @@ fun main(args: Array<String>) {
             )
             add(AccessibilityDataProductRegistry(rootDir = dataRoot))
           } else {
-            System.err.println(
-              "compose-ai-tools daemon: a11y data product plugin disabled"
-            )
+            System.err.println("compose-ai-tools daemon: a11y data product plugin disabled")
           }
         }
       }
       .let(::CompositeDataProductRegistry)
-  val previewExtensions =
-    buildList {
-      add(RenderPreviewExtension.deviceClipDescriptor)
-      add(RenderPreviewExtension.deviceBackgroundDescriptor)
-      add(RenderPreviewExtension.renderTraceDescriptor)
-      if (composeTraceEnabled) {
-        add(RenderPreviewExtension.composeTraceDescriptor)
-      }
-      add(RenderPreviewExtension.overlayLegendDescriptor)
-      if (a11yPreviewExtensionEnabled) {
-        add(AccessibilitySemanticsPreviewExtension.descriptor)
-        add(AtfChecksPreviewExtension.descriptor)
-        add(AccessibilityOverlayPreviewExtension.descriptor)
-        add(AccessibilityAnnotatedPreviewExtension.descriptor)
-      }
+  val previewExtensions = buildList {
+    add(RenderPreviewExtension.deviceClipDescriptor)
+    add(RenderPreviewExtension.deviceBackgroundDescriptor)
+    add(RenderPreviewExtension.renderTraceDescriptor)
+    if (composeTraceEnabled) {
+      add(RenderPreviewExtension.composeTraceDescriptor)
     }
+    add(RenderPreviewExtension.overlayLegendDescriptor)
+    if (a11yPreviewExtensionEnabled) {
+      add(AccessibilitySemanticsPreviewExtension.descriptor)
+      add(AtfChecksPreviewExtension.descriptor)
+      add(AccessibilityOverlayPreviewExtension.descriptor)
+      add(AccessibilityAnnotatedPreviewExtension.descriptor)
+    }
+  }
 
   val server =
     JsonRpcServer(
@@ -408,9 +407,9 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
 }
 
 /**
- * SANDBOX-POOL.md (Layer 3) — sandbox-pool size knob. Set by [DaemonSupervisor] from
- * `1 + replicasPerDaemon`. Default 1 preserves the pre-pool single-sandbox behaviour. Values < 1
- * are coerced to 1.
+ * SANDBOX-POOL.md (Layer 3) — sandbox-pool size knob. Set by [DaemonSupervisor] from `1 +
+ * replicasPerDaemon`. Default 1 preserves the pre-pool single-sandbox behaviour. Values < 1 are
+ * coerced to 1.
  */
 private const val SANDBOX_COUNT_PROP = "composeai.daemon.sandboxCount"
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -331,6 +331,7 @@ fun main(args: Array<String>) {
       input = System.`in`,
       output = realOut,
       host = host,
+      daemonVersion = DaemonVersion.value,
       classpathFingerprint = classpathFingerprint,
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -37,6 +37,24 @@ dependencies {
   testImplementation(libs.junit)
 }
 
+// Bake the daemon's own version into a resource so `JsonRpcServer.initialize` can report the
+// real release back to VS Code instead of the `0.0.0-dev` fallback. Mirrors
+// `gradle-plugin/build.gradle.kts`'s `generatePluginVersionResource` and `cli/build.gradle.kts`'s
+// `generateCliVersionResource`.
+val generateDaemonVersionResource by tasks.registering {
+  val outputDir = layout.buildDirectory.dir("generated/daemon-version-resource")
+  val daemonVersion = project.version.toString()
+  inputs.property("version", daemonVersion)
+  outputs.dir(outputDir)
+  doLast {
+    val file = outputDir.get().file("ee/schimke/composeai/daemon/daemon-version.properties").asFile
+    file.parentFile.mkdirs()
+    file.writeText("version=$daemonVersion\n")
+  }
+}
+
+sourceSets.main.get().resources.srcDir(generateDaemonVersionResource)
+
 // GitHub Packages mirror — same shape as `:renderer-android` and `:preview-annotations`.
 
 composeAiMavenPublishing {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DaemonVersion.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DaemonVersion.kt
@@ -1,0 +1,28 @@
+package ee.schimke.composeai.daemon
+
+import java.util.Properties
+
+/**
+ * Daemon version baked into the jar by `generateDaemonVersionResource` in
+ * [daemon/core/build.gradle.kts]. Surfaced via the `initialize` response's `daemonVersion` field so
+ * VS Code's `[daemon] ready ...` line and remote-bug-report dumps record the actual release. Falls
+ * back to `0.0.0-dev` when the resource is missing (e.g. running tests with a partial classpath);
+ * production [DaemonMain] entry points pass [value] explicitly to [JsonRpcServer]'s constructor.
+ *
+ * Mirrors `gradle-plugin`'s [PluginVersion] / `cli`'s `BUNDLE_VERSION` — the version the build
+ * baked in is the same one downstream artifacts publish, so embedders can reason about
+ * compatibility without a separate compile-time literal.
+ */
+object DaemonVersion {
+  val value: String by lazy {
+    val stream =
+      DaemonVersion::class
+        .java
+        .classLoader
+        .getResourceAsStream("ee/schimke/composeai/daemon/daemon-version.properties")
+        ?: return@lazy "0.0.0-dev"
+    val props = Properties()
+    stream.use { props.load(it) }
+    props.getProperty("version") ?: "0.0.0-dev"
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents.kt
@@ -7,10 +7,9 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
 /**
  * Keyboard `record_preview` script events. One descriptor — `input.keyboard` — advertising
  * `input.keyDown` and `input.keyUp` as **roadmap** (`supported = false`) on every host today.
- * Desktop's `ImageComposeScene.sendKeyEvent` and Android's held-rule
- * `KeyEvent.dispatchKeyEvent` are both wirable but neither is implemented yet — the existing
- * input handlers register these as unsupported so the wire shape is documented while the
- * dispatch side remains a follow-up.
+ * Desktop's `ImageComposeScene.sendKeyEvent` and Android's held-rule `KeyEvent.dispatchKeyEvent`
+ * are both wirable but neither is implemented yet — the existing input handlers register these as
+ * unsupported so the wire shape is documented while the dispatch side remains a follow-up.
  *
  * Lives in `:daemon:core` because the descriptor is renderer-agnostic — both backends will
  * eventually advertise it from `recordingScriptEventDescriptors()` with `supported = true` once

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt
@@ -14,16 +14,16 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
  * - `input.pointerMove` — `PointerEventType.Move` with the primary button held.
  * - `input.pointerUp` — `PointerEventType.Release`.
  *
- * Lives in `:daemon:core` because both `DesktopHost` and `RobolectricHost` dispatch this
- * extension. Each host advertises the same descriptor from `recordingScriptEventDescriptors()`;
- * the dispatch end is host-specific (Skiko `sendPointerEvent` on desktop, the held-rule's
- * pointer pipeline on Android), but the descriptor advertisement is uniform.
+ * Lives in `:daemon:core` because both `DesktopHost` and `RobolectricHost` dispatch this extension.
+ * Each host advertises the same descriptor from `recordingScriptEventDescriptors()`; the dispatch
+ * end is host-specific (Skiko `sendPointerEvent` on desktop, the held-rule's pointer pipeline on
+ * Android), but the descriptor advertisement is uniform.
  *
- * **Why split from `input.keyboard` and `input.rsb`.** Per-axis splits let each host advertise
- * the exact subset it dispatches: desktop carries `input.touch` + `input.keyboard` (latter as
- * roadmap); RobolectricHost carries `input.touch` + `input.keyboard` + `input.rsb`. One blanket
- * `input` extension would force per-host descriptor variants with different `supported` flags
- * — the per-axis split keeps the descriptors uniform across hosts and the per-host advertisement
+ * **Why split from `input.keyboard` and `input.rsb`.** Per-axis splits let each host advertise the
+ * exact subset it dispatches: desktop carries `input.touch` + `input.keyboard` (latter as roadmap);
+ * RobolectricHost carries `input.touch` + `input.keyboard` + `input.rsb`. One blanket `input`
+ * extension would force per-host descriptor variants with different `supported` flags — the
+ * per-axis split keeps the descriptors uniform across hosts and the per-host advertisement
  * trivially additive.
  */
 object InputTouchRecordingScriptEvents {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -138,8 +138,8 @@ fun String.toInteractiveInputKindOrNull(): InteractiveInputKind? =
  * Naming follows the per-extension `<extension>.<event>` convention: `input.click`,
  * `input.pointerDown`, etc. Three input extensions advertise these ids — see
  * `InputTouchRecordingScriptEvents`, `InputKeyboardRecordingScriptEvents`, and
- * `InputRsbRecordingScriptEvents`. The MCP `validateRecordingScriptKinds` checks every kind
- * against the daemon's advertised set — no special-case branch for input kinds anymore.
+ * `InputRsbRecordingScriptEvents`. The MCP `validateRecordingScriptKinds` checks every kind against
+ * the daemon's advertised set — no special-case branch for input kinds anymore.
  */
 val INTERACTIVE_INPUT_KIND_BY_WIRE_NAME: Map<String, InteractiveInputKind> =
   mapOf(

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1024,12 +1024,11 @@ data class RecordingScriptEvent(
   /** Agent-supplied checkpoint id for save/restore state markers. */
   val checkpointId: String? = null,
   /**
-   * Vestigial after compose-ai-tools#754: the legacy `kind = "lifecycle.event"` /
-   * `lifecycleEvent: <transition>` shape was split into per-id events (`lifecycle.pause` /
-   * `lifecycle.resume` / `lifecycle.stop`), so no handler reads this field anymore. Retained on
-   * the wire as a free-form passthrough — agents that set it for trace context still see it
-   * round-trip into [RecordingScriptEvidence.lifecycleEvent]. Future cleanup may remove the
-   * field entirely.
+   * Vestigial after compose-ai-tools#754: the legacy `kind = "lifecycle.event"` / `lifecycleEvent:
+   * <transition>` shape was split into per-id events (`lifecycle.pause` / `lifecycle.resume` /
+   * `lifecycle.stop`), so no handler reads this field anymore. Retained on the wire as a free-form
+   * passthrough — agents that set it for trace context still see it round-trip into
+   * [RecordingScriptEvidence.lifecycleEvent]. Future cleanup may remove the field entirely.
    */
   val lifecycleEvent: String? = null,
   /** Optional free-form tags copied into script evidence. */

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DaemonVersionTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DaemonVersionTest.kt
@@ -1,0 +1,24 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the contract that [DaemonVersion.value] resolves to whatever version `daemon/core`'s build
+ * baked into `daemon-version.properties`, not the `0.0.0-dev` literal that was the only thing
+ * showing up in `[daemon] ready ...` lines on released installs because [DaemonMain] never threaded
+ * the version through to [JsonRpcServer].
+ */
+class DaemonVersionTest {
+  @Test
+  fun bakedValueIsNotTheFallback() {
+    val v = DaemonVersion.value
+    assertNotEquals(
+      "DaemonVersion.value resolved to the fallback — `daemon-version.properties` missing or empty",
+      "0.0.0-dev",
+      v,
+    )
+    assertTrue("expected non-blank version, got '$v'", v.isNotBlank())
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InputRecordingScriptEventsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InputRecordingScriptEventsTest.kt
@@ -73,9 +73,7 @@ class InputRecordingScriptEventsTest {
     // through to the unsupported branch.
     val advertisedTouchIds = InputTouchRecordingScriptEvents.WIRED_EVENTS
     val advertisedKeyboardIds =
-      InputKeyboardRecordingScriptEvents.descriptor.recordingScriptEvents
-        .map { it.id }
-        .toSet()
+      InputKeyboardRecordingScriptEvents.descriptor.recordingScriptEvents.map { it.id }.toSet()
     // input.rotaryScroll is advertised by the Android-only `input.rsb` extension; check it via
     // the wire-name table without depending on the Android module here.
     val rotaryWireName = "input.rotaryScroll"

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -252,6 +252,7 @@ fun main(args: Array<String>) {
       input = System.`in`,
       output = realOut,
       host = host,
+      daemonVersion = DaemonVersion.value,
       classpathFingerprint = classpathFingerprint,
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
@@ -110,8 +110,8 @@ class DesktopHostTest {
   /**
    * With a resolver wired, `recordingScriptEventDescriptors()` advertises three extensions:
    * `recording` (probe, supported), `input.touch` (4 pointer events, supported), and
-   * `input.keyboard` (2 key events, roadmap). The Wear-only `input.rsb` lives on the Android
-   * host; desktop daemons skip it.
+   * `input.keyboard` (2 key events, roadmap). The Wear-only `input.rsb` lives on the Android host;
+   * desktop daemons skip it.
    */
   @Test
   fun recordingScriptEventDescriptorsAdvertiseSupportedExtensions() {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -526,8 +526,8 @@ class DesktopRecordingSessionTest {
       try {
         val thrown =
           runCatching {
-            session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "input.click")))
-          }
+              session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "input.click")))
+            }
             .exceptionOrNull()
         assertTrue(
           "postScript on a live session must throw IllegalStateException; got ${thrown?.javaClass}",

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -2639,8 +2639,8 @@ class DaemonMcpServer(
    * - **`supported = true`** — accepted; the daemon will dispatch.
    * - **`supported = false`** — rejected with a precise diagnostic that points at
    *   `list_data_products` so the agent sees the roadmap shape rather than a quiet `unsupported`
-   *   evidence trail. (The daemon-side fallback that emits `unsupported` evidence stays in
-   *   place as defense-in-depth for older MCP servers + direct daemon clients.)
+   *   evidence trail. (The daemon-side fallback that emits `unsupported` evidence stays in place as
+   *   defense-in-depth for older MCP servers + direct daemon clients.)
    * - **Not advertised** — rejected with "not advertised by this daemon".
    *
    * Input kinds (`input.click`, `input.pointerDown`, …) are advertised through

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3091,6 +3091,17 @@ function handleWebviewMessage(msg: WebviewToExtension) {
     // webview's untyped postMessage could deliver a structurally-broken
     // payload (e.g. arrays that aren't actually arrays).
     switch (msg.command) {
+        case "webviewReady":
+            // Webview just loaded — extension may have already tried to post
+            // `setPreviews` / `setModules` while the view was unresolved (panel
+            // hidden when `onLanguage:kotlin` activated us). Replay the
+            // stateful messages from current state so the grid populates even
+            // when the user opens the panel after the first refresh ran.
+            sendModuleList();
+            if (currentScopeFile) {
+                void refresh(false, currentScopeFile);
+            }
+            break;
         case "openFile":
             openPreviewSource(msg.className, msg.functionName);
             break;

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -501,6 +501,20 @@ export type ExtensionToWebview =
 
 /** Messages from webview to extension */
 export type WebviewToExtension =
+    /**
+     * Webview signals it has loaded and is ready to receive state messages.
+     * Sent once per webview lifecycle from `<preview-app>`'s `firstUpdated`,
+     * after the message listener in `behavior.ts` is installed. The extension
+     * responds by republishing the current session's stateful messages
+     * (`setPreviews`, `setModules`, `setEarlyFeatures`, daemon availability,
+     * etc.) so a panel that resolved after the initial refresh — e.g. user
+     * activated the extension by opening a `.kt` file before clicking the
+     * Compose Preview activity-bar icon — doesn't end up with an empty grid
+     * because the only `setPreviews` was sent before the webview existed.
+     * `view?.webview.postMessage` silently drops messages until the
+     * webviewView is resolved.
+     */
+    | { command: "webviewReady" }
     | { command: "openFile"; className: string; functionName: string }
     | { command: "selectModule"; value: string }
     /**

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -11,6 +11,7 @@
 import { LitElement, html, type TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 import { setupPreviewBehavior } from "./behavior";
+import { getVsCodeApi } from "../shared/vscode";
 import "./components/CompileErrorsBanner";
 import "./components/FilterToolbar";
 import "./components/MessageBanner";
@@ -173,5 +174,12 @@ export class PreviewApp extends LitElement {
     protected firstUpdated(): void {
         const initialEarlyFeatures = this.dataset.earlyFeatures === "true";
         setupPreviewBehavior(initialEarlyFeatures);
+        // Tell the extension we exist. The host posts `setPreviews` /
+        // `setModules` / etc. as soon as it has data — but `postMessage`
+        // silently drops messages while the webview view is unresolved
+        // (panel hidden when the extension activated on `onLanguage:kotlin`).
+        // Replying to this signal is the host's cue to republish the latest
+        // stateful messages so the grid isn't permanently empty.
+        getVsCodeApi().postMessage({ command: "webviewReady" });
     }
 }


### PR DESCRIPTION
## Summary

Investigating an empty-grid report on a marketplace install of `compose-preview 0.9.2` (Antigravity) where the daemon was clearly rendering (output panel showed all 25 `[render] …` lines) but the webview only displayed the toolbar with default `"all"` / `"all"` / `"grid"` selectors and no preview cards.

PR #761's changes don't ship in any release artifact (`vscode-extension/.vscode/tasks.json` is excluded by `.vscodeignore`, `gradle-plugin/gradle.properties` is build-time-only and isn't bundled into the published plugin JAR), so a different root cause was at work. Investigation surfaced four issues, all addressed here.

### `fix(vscode): republish state on webviewReady` — the empty-grid root cause

`PreviewPanel.postMessage` is `this.view?.webview.postMessage(msg)`. When the WebviewView isn't resolved yet (panel hidden when the extension activated on `onLanguage:kotlin` — e.g. the user opens a `.kt` file before clicking the Compose Preview activity-bar icon) the optional chain silently drops every host→webview message. The first `refresh()` runs immediately on activation and posts `setPreviews` into a void; by the time the user opens the panel there's no republish, so the grid stays empty even though the daemon is rendering and `<filter-toolbar>`'s default `@state` is rendering correctly.

`<preview-app>`'s `firstUpdated` now sends `{command: "webviewReady"}` after `behavior.ts` installs its message listener, and the host responds by re-running `sendModuleList()` and `refresh(false, currentScopeFile)`. State that was lost during the unresolved window — module list, preview cards — reappears the moment the webview tells us it exists. Also covers re-resolutions after the view-container is collapsed/expanded.

### `fix(daemon): report real version in initialize response`

Both `DaemonMain` entry points instantiated `JsonRpcServer` without the `daemonVersion` arg, so released JARs reported `0.0.0-dev` (the constructor default) instead of the published version. The `[daemon] ready …` line and any remote bug-report dump that snapshots the `initialize` response were therefore useless for diagnosing version-specific issues.

Bake the daemon version into a `daemon-version.properties` resource via `generateDaemonVersionResource` (mirrors `gradle-plugin`'s `generatePluginVersionResource` and `cli`'s `generateCliVersionResource`), expose it via `DaemonVersion.value`, and pass it explicitly from both `DaemonMain` (android + desktop) into `JsonRpcServer`.

### `test(vscode): assert webview consumed setPreviews end-to-end`

The e2e test asserted on `postedMessageLog` only — that captures the host's *attempt* to post `setPreviews`, before `view?.webview.postMessage` runs. A resolved-late webview that drops messages silently passed the test cleanly while users saw an empty grid. So even when the e2e ran, it couldn't have caught this regression.

Add a `webviewPreviewsRendered` signal sent from `behavior.ts` after `renderPreviews` paints the grid, exposed on the test API via `getReceivedMessages()`. The e2e test now waits for this inbound signal and asserts `count >= previews.length`, regression-locking the full host→webview→DOM loop.

### `ci: trigger vscode-extension-e2e on push to main, drop workflow_run gate`

The previous `workflow_run` + gate setup silently gated *every* e2e run to a 1-14s skip across the last ~60 commits — `:samples:cmp` rendering through the real Gradle plugin was unverified for that whole window even though the workflow list reported every run as success.

Mechanism: e2e fired on `workflow_run: [completed]` for both CI and Integration. The first firing (whichever upstream finished first) saw the other still `in_progress` and skipped via the gate. The second firing (the slower upstream completing) had `workflow_run.conclusion != 'success'` often enough — re-runs, cancelled sibling jobs in the same workflow, or other quirks of GitHub's `[completed]` semantics — that the job-level `if` rejected it before the gate even ran. Net: e2e never proceeded.

Switched to `push: branches: [main]`, dropped the gate. e2e runs alongside CI / Integration on every main push. PRs are still excluded by the branch filter, preserving the original "not on every PR" property.

### `chore: ktfmtFormatAll for accumulated drift`

The pre-commit gate caught accumulated drift in 9 files outside the scope of these fixes (`mcp/DaemonMcpServer.kt`, `daemon/core` input/recording sources, `daemon/desktop` test fixtures, `daemon/android/DaemonMain.kt`). Cleaned in a separate chore commit so the fix commits stay focused.

## Test plan

- [x] `npm run test` — 320 vscode-extension tests pass
- [x] `tsc -p ./` and `tsc -p tsconfig.webview.json` clean, prettier clean
- [x] `:daemon:core:assemble`, `:daemon:android:compileDebugKotlin`, `:daemon:desktop:compileKotlin` green with the new resource generator + `DaemonVersion` wiring
- [x] Verified `daemon-version.properties` is in the built `daemon-core.jar` with the resolved project version
- [x] Workflow YAML parses and the e2e job will trigger on the next push to main
- [ ] After merge: confirm `VS Code Extension E2E` actually runs (not gate-skipped) on the merge commit, and that the new `webviewPreviewsRendered` assertion passes
- [ ] Manual: install the new VSIX into Antigravity, open the meshcore-mobile project, confirm cards populate without manually clicking refresh, and confirm `[daemon] ready for wear (daemonVersion=…)` reports the real release
- [ ] New `DaemonVersionTest` — gated on the unrelated `InteractiveInputKind` regression in `InputRecordingScriptEventsTest.kt` being resolved (pre-existing on `main`; blocks `:daemon:core:compileTestKotlin`)
