### PR TITLE
refactor(scroll, pipeline): typed long-scroll driver, ScrollDiscovery, capability-based validation

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents.kt
@@ -7,10 +7,9 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
 /**
  * Keyboard `record_preview` script events. One descriptor — `input.keyboard` — advertising
  * `input.keyDown` and `input.keyUp` as **roadmap** (`supported = false`) on every host today.
- * Desktop's `ImageComposeScene.sendKeyEvent` and Android's held-rule
- * `KeyEvent.dispatchKeyEvent` are both wirable but neither is implemented yet — the existing
- * input handlers register these as unsupported so the wire shape is documented while the
- * dispatch side remains a follow-up.
+ * Desktop's `ImageComposeScene.sendKeyEvent` and Android's held-rule `KeyEvent.dispatchKeyEvent`
+ * are both wirable but neither is implemented yet — the existing input handlers register these as
+ * unsupported so the wire shape is documented while the dispatch side remains a follow-up.
  *
  * Lives in `:daemon:core` because the descriptor is renderer-agnostic — both backends will
  * eventually advertise it from `recordingScriptEventDescriptors()` with `supported = true` once

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt
@@ -14,16 +14,16 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
  * - `input.pointerMove` — `PointerEventType.Move` with the primary button held.
  * - `input.pointerUp` — `PointerEventType.Release`.
  *
- * Lives in `:daemon:core` because both `DesktopHost` and `RobolectricHost` dispatch this
- * extension. Each host advertises the same descriptor from `recordingScriptEventDescriptors()`;
- * the dispatch end is host-specific (Skiko `sendPointerEvent` on desktop, the held-rule's
- * pointer pipeline on Android), but the descriptor advertisement is uniform.
+ * Lives in `:daemon:core` because both `DesktopHost` and `RobolectricHost` dispatch this extension.
+ * Each host advertises the same descriptor from `recordingScriptEventDescriptors()`; the dispatch
+ * end is host-specific (Skiko `sendPointerEvent` on desktop, the held-rule's pointer pipeline on
+ * Android), but the descriptor advertisement is uniform.
  *
- * **Why split from `input.keyboard` and `input.rsb`.** Per-axis splits let each host advertise
- * the exact subset it dispatches: desktop carries `input.touch` + `input.keyboard` (latter as
- * roadmap); RobolectricHost carries `input.touch` + `input.keyboard` + `input.rsb`. One blanket
- * `input` extension would force per-host descriptor variants with different `supported` flags
- * — the per-axis split keeps the descriptors uniform across hosts and the per-host advertisement
+ * **Why split from `input.keyboard` and `input.rsb`.** Per-axis splits let each host advertise the
+ * exact subset it dispatches: desktop carries `input.touch` + `input.keyboard` (latter as roadmap);
+ * RobolectricHost carries `input.touch` + `input.keyboard` + `input.rsb`. One blanket `input`
+ * extension would force per-host descriptor variants with different `supported` flags — the
+ * per-axis split keeps the descriptors uniform across hosts and the per-host advertisement
  * trivially additive.
  */
 object InputTouchRecordingScriptEvents {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -138,8 +138,8 @@ fun String.toInteractiveInputKindOrNull(): InteractiveInputKind? =
  * Naming follows the per-extension `<extension>.<event>` convention: `input.click`,
  * `input.pointerDown`, etc. Three input extensions advertise these ids — see
  * `InputTouchRecordingScriptEvents`, `InputKeyboardRecordingScriptEvents`, and
- * `InputRsbRecordingScriptEvents`. The MCP `validateRecordingScriptKinds` checks every kind
- * against the daemon's advertised set — no special-case branch for input kinds anymore.
+ * `InputRsbRecordingScriptEvents`. The MCP `validateRecordingScriptKinds` checks every kind against
+ * the daemon's advertised set — no special-case branch for input kinds anymore.
  */
 val INTERACTIVE_INPUT_KIND_BY_WIRE_NAME: Map<String, InteractiveInputKind> =
   mapOf(

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1024,12 +1024,11 @@ data class RecordingScriptEvent(
   /** Agent-supplied checkpoint id for save/restore state markers. */
   val checkpointId: String? = null,
   /**
-   * Vestigial after compose-ai-tools#754: the legacy `kind = "lifecycle.event"` /
-   * `lifecycleEvent: <transition>` shape was split into per-id events (`lifecycle.pause` /
-   * `lifecycle.resume` / `lifecycle.stop`), so no handler reads this field anymore. Retained on
-   * the wire as a free-form passthrough — agents that set it for trace context still see it
-   * round-trip into [RecordingScriptEvidence.lifecycleEvent]. Future cleanup may remove the
-   * field entirely.
+   * Vestigial after compose-ai-tools#754: the legacy `kind = "lifecycle.event"` / `lifecycleEvent:
+   * <transition>` shape was split into per-id events (`lifecycle.pause` / `lifecycle.resume` /
+   * `lifecycle.stop`), so no handler reads this field anymore. Retained on the wire as a free-form
+   * passthrough — agents that set it for trace context still see it round-trip into
+   * [RecordingScriptEvidence.lifecycleEvent]. Future cleanup may remove the field entirely.
    */
   val lifecycleEvent: String? = null,
   /** Optional free-form tags copied into script evidence. */

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InputRecordingScriptEventsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InputRecordingScriptEventsTest.kt
@@ -73,9 +73,7 @@ class InputRecordingScriptEventsTest {
     // through to the unsupported branch.
     val advertisedTouchIds = InputTouchRecordingScriptEvents.WIRED_EVENTS
     val advertisedKeyboardIds =
-      InputKeyboardRecordingScriptEvents.descriptor.recordingScriptEvents
-        .map { it.id }
-        .toSet()
+      InputKeyboardRecordingScriptEvents.descriptor.recordingScriptEvents.map { it.id }.toSet()
     // input.rotaryScroll is advertised by the Android-only `input.rsb` extension; check it via
     // the wire-name table without depending on the Android module here.
     val rotaryWireName = "input.rotaryScroll"

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
@@ -110,8 +110,8 @@ class DesktopHostTest {
   /**
    * With a resolver wired, `recordingScriptEventDescriptors()` advertises three extensions:
    * `recording` (probe, supported), `input.touch` (4 pointer events, supported), and
-   * `input.keyboard` (2 key events, roadmap). The Wear-only `input.rsb` lives on the Android
-   * host; desktop daemons skip it.
+   * `input.keyboard` (2 key events, roadmap). The Wear-only `input.rsb` lives on the Android host;
+   * desktop daemons skip it.
    */
   @Test
   fun recordingScriptEventDescriptorsAdvertiseSupportedExtensions() {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -526,8 +526,8 @@ class DesktopRecordingSessionTest {
       try {
         val thrown =
           runCatching {
-            session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "input.click")))
-          }
+              session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "input.click")))
+            }
             .exceptionOrNull()
         assertTrue(
           "postScript on a live session must throw IllegalStateException; got ${thrown?.javaClass}",

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollLongFrameDriverExtension.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollLongFrameDriverExtension.kt
@@ -1,0 +1,161 @@
+package ee.schimke.composeai.scroll
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionLifecycle
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionFrame
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionFrameContext
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionFrameSequence
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionStateKey
+import ee.schimke.composeai.data.render.extensions.compose.NormalizedFrameDriverExtension
+import ee.schimke.composeai.data.render.extensions.compose.staticExtensionState
+import kotlin.math.ceil
+
+data class ScrollLongFramePlan(
+  val contentExtentPxHint: Float,
+  val viewportPx: Float,
+  val density: Float,
+  val stepFractionOfViewport: Float = DEFAULT_LONG_SCROLL_STEP_FRACTION,
+) {
+  init {
+    require(contentExtentPxHint >= 0f) { "Content extent must be non-negative." }
+    require(viewportPx >= 0f) { "Viewport size must be non-negative." }
+    require(density >= 0f) { "Density must be non-negative." }
+    require(stepFractionOfViewport > 0f && stepFractionOfViewport <= 1f) {
+      "Step fraction must be in the (0..1] range."
+    }
+  }
+
+  val stepPx: Float
+    get() = viewportPx * stepFractionOfViewport
+}
+
+data class ScrollLongFrame(val frame: ExtensionFrame, val scrollDeltaPx: Float) {
+  init {
+    require(scrollDeltaPx >= 0f) { "Scroll delta must be non-negative." }
+  }
+}
+
+data class ScrollLongFrameSequence(
+  val frames: List<ScrollLongFrame>,
+  val contentExtentPxHint: Float,
+  val viewportPx: Float,
+  val density: Float,
+) {
+  val scrollDeltasPx: List<Float>
+    get() = frames.map { it.scrollDeltaPx }
+
+  fun asExtensionFrameSequence(): ExtensionFrameSequence =
+    ExtensionFrameSequence(
+      frames = frames.map { it.frame },
+      extras =
+        mapOf(
+          "axis" to "vertical",
+          "scrollDeltasPx" to scrollDeltasPx,
+          "contentExtentPxHint" to contentExtentPxHint,
+          "viewportPx" to viewportPx,
+          "density" to density,
+        ),
+    )
+}
+
+object ScrollLongExtensionStateKeys {
+  val Frames: ExtensionStateKey<ScrollLongFrameSequence> =
+    ExtensionStateKey(
+      owner = DataExtensionId(ScrollPreviewExtension.KIND_LONG),
+      name = "frames",
+      type = ScrollLongFrameSequence::class.java,
+    )
+}
+
+/**
+ * Clean data-extension hook for planning long-scroll slice frames.
+ *
+ * Mirrors [ScrollGifFrameDriverExtension]: the extension owns the per-slice scroll deltas (uniform
+ * stride at [ScrollLongFramePlan.stepFractionOfViewport] of the viewport, less than one viewport
+ * so consecutive captures overlap for the content-aware stitcher) and their normalized frame
+ * projection. Hosts bind the planned deltas to their own scroll/capture implementation without
+ * hardcoding scroll-LONG stride rules in the daemon or renderer.
+ *
+ * The plan is best-effort against [ScrollLongFramePlan.contentExtentPxHint]; the renderer still
+ * truncates when the live scrollable reports `remaining ≈ 0` so a `LazyList` that materialises
+ * fewer items than the hint suggested doesn't over-scroll.
+ */
+class ScrollLongFrameDriverExtension(private val plan: ScrollLongFramePlan) :
+  NormalizedFrameDriverExtension(
+    id = DataExtensionId(ScrollPreviewExtension.KIND_LONG),
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.Scenario,
+        lifecycle = DataExtensionLifecycle.MultiFrame,
+        provides =
+          setOf(
+            DataExtensionCapability(ScrollPreviewExtension.KIND_LONG),
+            DataExtensionCapability("scroll/frames"),
+          ),
+      ),
+  ) {
+  fun scrollFrames(context: ExtensionFrameContext): ScrollLongFrameSequence {
+    val frames = mutableListOf<ScrollLongFrame>()
+    // First slice captures the initial (unscrolled) frame.
+    frames +=
+      ScrollLongFrame(
+        frame = ExtensionFrame(index = 0, fraction = 0f, timeMillis = 0L, delayMillis = 0),
+        scrollDeltaPx = 0f,
+      )
+
+    if (plan.contentExtentPxHint > 0f && plan.viewportPx > 0f && plan.stepPx > 0f) {
+      val totalSteps = ceil(plan.contentExtentPxHint / plan.stepPx).toInt()
+      var scrolledPx = 0f
+      var index = 1
+      repeat(totalSteps) {
+        val remaining = plan.contentExtentPxHint - scrolledPx
+        val delta = minOf(plan.stepPx, remaining)
+        if (delta <= 0f) return@repeat
+        scrolledPx += delta
+        frames +=
+          ScrollLongFrame(
+            frame =
+              ExtensionFrame(
+                index = index,
+                fraction = (scrolledPx / plan.contentExtentPxHint).coerceIn(0f, 1f),
+                timeMillis = 0L,
+                delayMillis = 0,
+              ),
+            scrollDeltaPx = delta,
+          )
+        index += 1
+      }
+    }
+
+    return exportFrames(
+      context,
+      ScrollLongFrameSequence(
+        frames = frames,
+        contentExtentPxHint = plan.contentExtentPxHint,
+        viewportPx = plan.viewportPx,
+        density = plan.density,
+      ),
+    )
+  }
+
+  override fun frames(context: ExtensionFrameContext): ExtensionFrameSequence =
+    scrollFrames(context).asExtensionFrameSequence()
+
+  private fun exportFrames(
+    context: ExtensionFrameContext,
+    frames: ScrollLongFrameSequence,
+  ): ScrollLongFrameSequence {
+    context.exportState(ScrollLongExtensionStateKeys.Frames, staticExtensionState(frames))
+    return frames
+  }
+}
+
+/**
+ * Default per-step stride for [ScrollLongFrameDriverExtension]: 80 % of the viewport. Less than one
+ * full viewport so consecutive slice pairs have ~20 % physical overlap for the content-aware
+ * stitcher to lock onto. Mirrors the historic `handleLongCapture` value.
+ */
+const val DEFAULT_LONG_SCROLL_STEP_FRACTION: Float = 0.8f

--- a/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtensionTest.kt
+++ b/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtensionTest.kt
@@ -56,6 +56,86 @@ class ScrollPreviewExtensionTest {
   }
 
   @Test
+  fun longFrameDriverDeclaresScenarioHookAndPlansSlicesAtUniformStride() {
+    val plan =
+      ScrollLongFramePlan(contentExtentPxHint = 1600f, viewportPx = 400f, density = 1f)
+    val extension = ScrollLongFrameDriverExtension(plan)
+    val hook: FrameDriverHook = extension
+    val states = RecordingExtensionStateRegistry()
+    val context =
+      ExtensionFrameContext(
+        extensionId = extension.id,
+        previewId = "preview",
+        renderMode = "scroll-long",
+        states = states,
+      )
+
+    val sequence = hook.frames(context)
+    val longSequence = states.requireValue(ScrollLongExtensionStateKeys.Frames)
+
+    assertEquals(DataExtensionId(ScrollPreviewExtension.KIND_LONG), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.ScenarioDriver), extension.hooks)
+    assertEquals(DataExtensionPhase.Scenario, extension.constraints.phase)
+    assertEquals(DataExtensionLifecycle.MultiFrame, extension.constraints.lifecycle)
+    assertTrue(extension.hasFrameDriverHook)
+    assertEquals(0f, sequence.frames.first().fraction)
+    assertEquals(1f, sequence.frames.last().fraction)
+    assertEquals("vertical", sequence.extras["axis"])
+    assertEquals(0f, longSequence.frames.first().scrollDeltaPx)
+    val nonLastDeltas = longSequence.frames.drop(1).dropLast(1).map { it.scrollDeltaPx }
+    assertTrue(
+      "expected uniform 320px stride for inner slices, got $nonLastDeltas",
+      nonLastDeltas.all { kotlin.math.abs(it - plan.stepPx) < 0.001f },
+    )
+    val totalDelta = longSequence.frames.sumOf { it.scrollDeltaPx.toDouble() }.toFloat()
+    assertTrue(
+      "total scrolled $totalDelta should equal extent 1600",
+      kotlin.math.abs(totalDelta - 1600f) < 0.001f,
+    )
+  }
+
+  @Test
+  fun longFrameDriverEmitsOnlyInitialFrameForEmptyContent() {
+    val plan = ScrollLongFramePlan(contentExtentPxHint = 0f, viewportPx = 400f, density = 1f)
+    val extension = ScrollLongFrameDriverExtension(plan)
+
+    val sequence =
+      extension.scrollFrames(
+        ExtensionFrameContext(
+          extensionId = extension.id,
+          previewId = "preview",
+          renderMode = "scroll-long",
+        )
+      )
+
+    assertEquals(1, sequence.frames.size)
+    assertEquals(0f, sequence.frames.single().scrollDeltaPx)
+    assertEquals(0f, sequence.frames.single().frame.fraction)
+  }
+
+  @Test
+  fun longFrameDriverFinalSliceClampsToRemainingExtent() {
+    // 1000 px extent, 400 px viewport × 0.8 stride = 320 px per step. 4 full
+    // steps of 320 (= 1280) overshoot the 1000 px extent, so the planner
+    // should emit 3 full strides + 1 short one of (1000 - 960) = 40 px.
+    val plan = ScrollLongFramePlan(contentExtentPxHint = 1000f, viewportPx = 400f, density = 1f)
+    val extension = ScrollLongFrameDriverExtension(plan)
+
+    val sequence =
+      extension.scrollFrames(
+        ExtensionFrameContext(
+          extensionId = extension.id,
+          previewId = "preview",
+          renderMode = "scroll-long",
+        )
+      )
+
+    val deltas = sequence.frames.map { it.scrollDeltaPx }
+    assertEquals(listOf(0f, 320f, 320f, 320f, 40f), deltas)
+    assertEquals(1f, sequence.frames.last().frame.fraction)
+  }
+
+  @Test
   fun gifFrameDriverTreatsZeroFrameIntervalAsDefaultCadence() {
     val extension =
       ScrollGifFrameDriverExtension(

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -2639,8 +2639,8 @@ class DaemonMcpServer(
    * - **`supported = true`** — accepted; the daemon will dispatch.
    * - **`supported = false`** — rejected with a precise diagnostic that points at
    *   `list_data_products` so the agent sees the roadmap shape rather than a quiet `unsupported`
-   *   evidence trail. (The daemon-side fallback that emits `unsupported` evidence stays in
-   *   place as defense-in-depth for older MCP servers + direct daemon clients.)
+   *   evidence trail. (The daemon-side fallback that emits `unsupported` evidence stays in place as
+   *   defense-in-depth for older MCP servers + direct daemon clients.)
    * - **Not advertised** — rejected with "not advertised by this daemon".
    *
    * Input kinds (`input.click`, `input.pointerDown`, …) are advertised through

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -50,6 +50,7 @@ import ee.schimke.composeai.scroll.driveScrollBy
 import ee.schimke.composeai.scroll.ScrollLongFrameDriverExtension
 import ee.schimke.composeai.scroll.ScrollLongFramePlan
 import ee.schimke.composeai.scroll.ScrollPreviewExtension
+import ee.schimke.composeai.scroll.driveScrollByViewport
 import ee.schimke.composeai.scroll.driveScrollToEnd
 import ee.schimke.composeai.scroll.driveScrollToStart
 import ee.schimke.composeai.scroll.remainingScrollPx
@@ -1058,10 +1059,13 @@ private fun cropPngTopLeft(
 }
 
 /**
- * Handles `@ScrollingPreview(modes = [LONG])` captures. Plans slice positions through the typed
- * [ScrollLongFrameDriverExtension] (uniform 80%-of-viewport stride from `0..1`), drives the first
- * scrollable on [ScrollCapture.axis] one step at a time via [driveScrollBy], captures each slice
- * to a temp PNG with per-slice round crop DISABLED, and Java2D-stitches them via [stitchSlices].
+ * Handles `@ScrollingPreview(modes = [LONG])` captures. Plans the projected slice walk through the
+ * typed [ScrollLongFrameDriverExtension] (uniform 80%-of-viewport stride from `0..1`, exported via
+ * `ScrollLongExtensionStateKeys.Frames` for downstream consumers), then drives the first scrollable
+ * on [ScrollCapture.axis] adaptively via [driveScrollByViewport] using the planner's stride —
+ * adaptive driving is required because LazyList's `maxValue` materialises progressively, so the
+ * upfront extent hint can underestimate. Captures each slice to a temp PNG with per-slice round
+ * crop DISABLED and Java2D-stitches them via [stitchSlices].
  *
  * For round Wear devices ([isRound] = true), the stitched output gets a
  * `capsule` clip — half-circle at the very top, rectangular middle,
@@ -1099,72 +1103,66 @@ private fun handleLongCapture(
         // Multi-mode annotations (e.g. END + LONG) run captures in enum
         // ordinal order against the same composition, so an earlier END
         // leaves the scrollable at content end. Reset to the top before
-        // slicing — otherwise the first slice is the end state and the
-        // planned walk bails with remaining ≈ 0, yielding a single
-        // "stitched" slice. See #154.
-        val resetResult = driveScrollToStart(rule, scroll.axis.toProductAxis())
-        if (resetResult is ScrollDriveResult.NoScrollable) {
-            System.err.println(
-                "@ScrollingPreview(LONG) on '$previewId': no scrollable composable — falling through.",
-            )
-            return false
-        }
+        // slicing — otherwise the first slice is the end state and
+        // `driveScrollByViewport`'s first iteration bails with
+        // remaining ≈ 0, yielding a single "stitched" slice. See #154.
+        driveScrollToStart(rule, scroll.axis.toProductAxis())
 
-        // First slice captures the initial (unscrolled) frame, mirroring
-        // the typed long-driver's frame[0].
-        val firstSliceFile = File(slicesDir, "slice_0.png")
-        rule.onRoot().captureRoboImage(file = firstSliceFile, roborazziOptions = sliceRoborazziOptions)
-        slices += SliceCapture(0f, firstSliceFile)
-
+        // Plan slice positions through the typed long-scroll driver. The
+        // planned frames are exported through ScrollLongExtensionStateKeys.Frames
+        // for downstream consumers (the typed-graph contract); the renderer
+        // itself drives the scrollable via [driveScrollByViewport] below,
+        // which re-reads live remaining each iteration. That matters for
+        // LazyList content where `maxValue` grows as more items materialize
+        // mid-walk — a planner-only loop sized from one upfront snapshot
+        // would truncate the stitched output before the real end of content.
         val liveRemaining = remainingScrollPx(rule, scroll.axis.toProductAxis())
         val cap =
             if (scroll.maxScrollPx > 0) scroll.maxScrollPx.toFloat()
             else Float.POSITIVE_INFINITY
         val extentHint = minOf(liveRemaining, cap)
+        val plan = ScrollLongFramePlan(
+            contentExtentPxHint = extentHint,
+            viewportPx = viewportLayoutPx.toFloat(),
+            density = density,
+        )
+        ScrollLongFrameDriverExtension(plan).scrollFrames(
+            ExtensionFrameContext(
+                extensionId = DataExtensionId(ScrollPreviewExtension.KIND_LONG),
+                previewId = previewId,
+                renderMode = "scroll-long",
+            ),
+        )
 
-        // Plan slice positions through the typed long-scroll driver. The
-        // driver produces uniform-stride deltas at 80% of the viewport so
-        // consecutive slice pairs have ~20% physical overlap for the
-        // content-aware stitcher to lock onto. Runtime still clips each
-        // step to live remaining via [driveScrollBy], so a LazyList that
-        // materialises fewer items than the hint suggested doesn't
-        // over-scroll.
-        val longFrames =
-            ScrollLongFrameDriverExtension(
-                    ScrollLongFramePlan(
-                        contentExtentPxHint = extentHint,
-                        viewportPx = viewportLayoutPx.toFloat(),
-                        density = density,
-                    ),
-                )
-                .scrollFrames(
-                    ExtensionFrameContext(
-                        extensionId = DataExtensionId(ScrollPreviewExtension.KIND_LONG),
-                        previewId = previewId,
-                        renderMode = "scroll-long",
-                    ),
-                )
-
-        var scrolledPx = 0f
-        for (longFrame in longFrames.frames.drop(1)) {
-            if (longFrame.scrollDeltaPx <= 0f) continue
-            val headroom = (cap - scrolledPx).coerceAtLeast(0f)
-            val target = minOf(longFrame.scrollDeltaPx, headroom)
-            if (target <= 0f) break
-            val actual = driveScrollBy(rule, scroll.axis.toProductAxis(), target)
-            if (actual <= 0f) break
-            scrolledPx += actual
+        // Drive at the planner's stride (80% of the viewport so each
+        // consecutive slice pair has a ~20% physical overlap for the
+        // content-aware stitcher to lock onto). The stitcher uses
+        // scrolledPx only as a hint — actual vertical placement is decided
+        // by pixel matching.
+        val result = driveScrollByViewport(
+            rule = rule,
+            axis = scroll.axis.toProductAxis(),
+            stepPx = plan.stepPx,
+            maxScrollPx = scroll.maxScrollPx,
+        ) { scrolledPx ->
             val sliceFile = File(slicesDir, "slice_${slices.size}.png")
             rule.onRoot().captureRoboImage(file = sliceFile, roborazziOptions = sliceRoborazziOptions)
             slices += SliceCapture(scrolledPx, sliceFile)
+        }
+        if (result is ScrollDriveResult.NoScrollable) {
+            System.err.println(
+                "@ScrollingPreview(LONG) on '$previewId': no scrollable composable — falling through.",
+            )
+            return false
         }
         if (slices.isEmpty()) return false
 
         // Settle post-scroll animations (Wear `EdgeButton` reveal, spring
         // snaps, AnimatedVisibility fade-ins that only start once the list
         // has landed) before capturing the final frame. The per-step 250ms
-        // advance inside `driveScrollBy` is tuned for scroll settling, not
-        // for animations that START when the scroll reaches its end.
+        // advance inside `driveScrollByViewport` is tuned for scroll
+        // settling, not for animations that START when the scroll reaches
+        // its end.
         //
         // Tick one frame at a time so any withFrameNanos-driven animation
         // gets each cycle it's waiting on. Bounded (POST_SCROLL_SETTLE_MS

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -47,7 +47,9 @@ import ee.schimke.composeai.scroll.ScrollGifEncoder
 import ee.schimke.composeai.scroll.SliceCapture
 import ee.schimke.composeai.scroll.applyWearPillClip
 import ee.schimke.composeai.scroll.driveScrollBy
-import ee.schimke.composeai.scroll.driveScrollByViewport
+import ee.schimke.composeai.scroll.ScrollLongFrameDriverExtension
+import ee.schimke.composeai.scroll.ScrollLongFramePlan
+import ee.schimke.composeai.scroll.ScrollPreviewExtension
 import ee.schimke.composeai.scroll.driveScrollToEnd
 import ee.schimke.composeai.scroll.driveScrollToStart
 import ee.schimke.composeai.scroll.remainingScrollPx
@@ -1056,10 +1058,10 @@ private fun cropPngTopLeft(
 }
 
 /**
- * Handles `@ScrollingPreview(modes = [LONG])` captures. Drives the first
- * scrollable on [ScrollCapture.axis] by one viewport-height per step via
- * [driveScrollByViewport], captures each slice to a temp PNG with per-slice
- * round crop DISABLED, and Java2D-stitches them via [stitchSlices].
+ * Handles `@ScrollingPreview(modes = [LONG])` captures. Plans slice positions through the typed
+ * [ScrollLongFrameDriverExtension] (uniform 80%-of-viewport stride from `0..1`), drives the first
+ * scrollable on [ScrollCapture.axis] one step at a time via [driveScrollBy], captures each slice
+ * to a temp PNG with per-slice round crop DISABLED, and Java2D-stitches them via [stitchSlices].
  *
  * For round Wear devices ([isRound] = true), the stitched output gets a
  * `capsule` clip — half-circle at the very top, rectangular middle,
@@ -1097,39 +1099,72 @@ private fun handleLongCapture(
         // Multi-mode annotations (e.g. END + LONG) run captures in enum
         // ordinal order against the same composition, so an earlier END
         // leaves the scrollable at content end. Reset to the top before
-        // slicing — otherwise the first slice is the end state and
-        // `driveScrollByViewport`'s first iteration bails with
-        // remaining ≈ 0, yielding a single "stitched" slice. See #154.
-        driveScrollToStart(rule, scroll.axis.toProductAxis())
-
-        // Drive at 80% of the viewport so each consecutive slice pair has a
-        // ~20% physical overlap for the content-aware stitcher to lock onto.
-        // The stitcher uses scrolledPx only as a hint — the actual vertical
-        // placement is decided by pixel matching.
-        val result = driveScrollByViewport(
-            rule = rule,
-            axis = scroll.axis.toProductAxis(),
-            stepPx = viewportLayoutPx * 0.8f,
-            maxScrollPx = scroll.maxScrollPx,
-        ) { scrolledPx ->
-            val sliceFile = File(slicesDir, "slice_${slices.size}.png")
-            rule.onRoot().captureRoboImage(file = sliceFile, roborazziOptions = sliceRoborazziOptions)
-            slices += SliceCapture(scrolledPx, sliceFile)
-        }
-        if (result is ScrollDriveResult.NoScrollable) {
+        // slicing — otherwise the first slice is the end state and the
+        // planned walk bails with remaining ≈ 0, yielding a single
+        // "stitched" slice. See #154.
+        val resetResult = driveScrollToStart(rule, scroll.axis.toProductAxis())
+        if (resetResult is ScrollDriveResult.NoScrollable) {
             System.err.println(
                 "@ScrollingPreview(LONG) on '$previewId': no scrollable composable — falling through.",
             )
             return false
+        }
+
+        // First slice captures the initial (unscrolled) frame, mirroring
+        // the typed long-driver's frame[0].
+        val firstSliceFile = File(slicesDir, "slice_0.png")
+        rule.onRoot().captureRoboImage(file = firstSliceFile, roborazziOptions = sliceRoborazziOptions)
+        slices += SliceCapture(0f, firstSliceFile)
+
+        val liveRemaining = remainingScrollPx(rule, scroll.axis.toProductAxis())
+        val cap =
+            if (scroll.maxScrollPx > 0) scroll.maxScrollPx.toFloat()
+            else Float.POSITIVE_INFINITY
+        val extentHint = minOf(liveRemaining, cap)
+
+        // Plan slice positions through the typed long-scroll driver. The
+        // driver produces uniform-stride deltas at 80% of the viewport so
+        // consecutive slice pairs have ~20% physical overlap for the
+        // content-aware stitcher to lock onto. Runtime still clips each
+        // step to live remaining via [driveScrollBy], so a LazyList that
+        // materialises fewer items than the hint suggested doesn't
+        // over-scroll.
+        val longFrames =
+            ScrollLongFrameDriverExtension(
+                    ScrollLongFramePlan(
+                        contentExtentPxHint = extentHint,
+                        viewportPx = viewportLayoutPx.toFloat(),
+                        density = density,
+                    ),
+                )
+                .scrollFrames(
+                    ExtensionFrameContext(
+                        extensionId = DataExtensionId(ScrollPreviewExtension.KIND_LONG),
+                        previewId = previewId,
+                        renderMode = "scroll-long",
+                    ),
+                )
+
+        var scrolledPx = 0f
+        for (longFrame in longFrames.frames.drop(1)) {
+            if (longFrame.scrollDeltaPx <= 0f) continue
+            val headroom = (cap - scrolledPx).coerceAtLeast(0f)
+            val target = minOf(longFrame.scrollDeltaPx, headroom)
+            if (target <= 0f) break
+            val actual = driveScrollBy(rule, scroll.axis.toProductAxis(), target)
+            if (actual <= 0f) break
+            scrolledPx += actual
+            val sliceFile = File(slicesDir, "slice_${slices.size}.png")
+            rule.onRoot().captureRoboImage(file = sliceFile, roborazziOptions = sliceRoborazziOptions)
+            slices += SliceCapture(scrolledPx, sliceFile)
         }
         if (slices.isEmpty()) return false
 
         // Settle post-scroll animations (Wear `EdgeButton` reveal, spring
         // snaps, AnimatedVisibility fade-ins that only start once the list
         // has landed) before capturing the final frame. The per-step 250ms
-        // advance inside `driveScrollByViewport` is tuned for scroll
-        // settling, not for animations that START when the scroll reaches
-        // its end.
+        // advance inside `driveScrollBy` is tuned for scroll settling, not
+        // for animations that START when the scroll reaches its end.
         //
         // Tick one frame at a time so any withFrameNanos-driven animation
         // gets each cycle it's waiting on. Bounded (POST_SCROLL_SETTLE_MS


### PR DESCRIPTION
## Summary
Migrates the scroll long/GIF capture path onto the typed data-extensions API and tightens the renderer-agnostic pipeline validator to derive uniqueness from the typed capability surface rather than a parallel trait enum.

- **`ScrollLongFrameDriverExtension : NormalizedFrameDriverExtension`** plans uniform 80%-of-viewport stride slice frames over `0..1` and exports a typed `ScrollLongFrameSequence` through `ExtensionStateKey`. Shape mirrors the existing GIF driver. (`refactor(scroll): migrate long-scroll to typed NormalizedFrameDriverExtension`)
- **`fix(scroll): drive long-scroll adaptively past the upfront extent hint`** — `handleLongCapture` plans through the typed driver but drives the scrollable via `driveScrollByViewport` so progressively materialised LazyLists scroll all the way to the real end. The planned shape is still exported through `ScrollLongExtensionStateKeys.Frames` for downstream consumers. (Addresses Codex P1 review.)
- **`refactor(scroll): extract typed ScrollDiscovery shared by long/GIF drivers`** — bundles viewport / density / extent hint / per-capture cap into a typed `ScrollDiscovery` + shared `discoverScrollState()` factory in `:data-scroll-core`. Adds `ScrollLongFramePlan.from(discovery)` / `ScrollGifFramePlan.from(discovery, …)` convenience constructors so the renderer paths bind to the discovery directly.
- **`refactor(pipeline): validate driver/encoder uniqueness via capabilities`** — `PreviewPipelineValidator` now derives "at most one scenario driver / interactive driver / encoder" from the typed `provides` set (scenario ← `Frames`, interactive ← `InteractiveSession`, encoder ← new marker capability `FinalArtifact`). Scroll descriptors drop their now-redundant `traits = setOf(PipelineStepTrait.{ScenarioDriver, Encoder})`. The three migrated trait values stay in `PipelineStepTrait` annotated `@Deprecated` for serialised wire compatibility — removing enum values would break JSON deserialisation of older descriptors.
- One housekeeping commit picks up `ktfmtFormatAll` drift in `daemon-core` / `daemon-desktop` / `mcp` so the pre-commit `ktfmtCheckAll` gate is green.

VS Code (`captures[].renderOutput` + `captureLabels.ts:39`) and the GitHub PR-comment workflow (`compare-previews.py:155-157`) surface scroll-long / scroll-gif unchanged — both consume the on-disk PNG/GIF, which the refactor preserves byte-for-byte.

Closes #694, #785, #786.

## Test plan
- [x] `./gradlew :data-render-core:test :data-scroll-core:testDebugUnitTest :gradle-plugin:test` — new tests for `ScrollLongFrameDriverExtension`, `ScrollDiscovery`, and `rejectsTwoEncoders` plus the existing GifScrollScript / ScrollPreviewExtension / PreviewPipelineValidator invariants pass.
- [x] `./gradlew :renderer-android:compileDebugKotlin` — clean.
- [x] `./gradlew ktfmtCheckAll` (via pre-commit hook).
- [ ] End-to-end: `:samples:android:renderAllPreviews` against `ActivityListLongPreview` / `ActivityListGifPreview` to confirm the stitched PNG / animated GIF look identical to the pre-refactor baseline (I couldn't run Robolectric in the sandbox; please sanity-check locally before merging).