### PR TITLE
ci: unbreak Format Check + wear-os integration on main

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,29 +66,19 @@ jobs:
         # so the new daemon round-trip step (further down the matrix) can
         # spawn a daemon JVM for an external-consumer module without falling
         # back to remote (where the SNAPSHOT version doesn't exist).
+        #
+        # Root-level abbreviation fans out to every subproject applying
+        # `composeai.maven-publishing` (same pattern as snapshot.yml /
+        # release.yml — see #766). `:gradle-plugin` is an `includeBuild` and
+        # needs an explicit address. Without the abbreviation each new
+        # publishable module (e.g. `:data-a11y-hierarchy-android`,
+        # `:data-recomposition-connector`) had to be added by hand and the
+        # render step silently fell through to the SNAPSHOT version on remote
+        # when one was missed.
         run: |
           ./gradlew \
             :gradle-plugin:publishToMavenLocal \
-            :data-a11y-core:publishToMavenLocal \
-            :data-a11y-connector:publishToMavenLocal \
-            :data-fonts-core:publishToMavenLocal \
-            :data-fonts-connector:publishToMavenLocal \
-            :data-history-connector:publishToMavenLocal \
-            :data-layoutinspector-core:publishToMavenLocal \
-            :data-layoutinspector-connector:publishToMavenLocal \
-            :data-render-compose:publishToMavenLocal \
-            :data-render-core:publishToMavenLocal \
-            :data-render-connector:publishToMavenLocal \
-            :data-resources-core:publishToMavenLocal \
-            :data-resources-connector:publishToMavenLocal \
-            :data-scroll-core:publishToMavenLocal \
-            :data-strings-core:publishToMavenLocal \
-            :data-strings-connector:publishToMavenLocal \
-            :data-theme-connector:publishToMavenLocal \
-            :renderer-android:publishToMavenLocal \
-            :daemon:core:publishToMavenLocal \
-            :daemon:desktop:publishToMavenLocal \
-            :daemon:android:publishToMavenLocal \
+            publishToMavenLocal \
             --stacktrace
 
       - name: Install CLI

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents.kt
@@ -7,10 +7,9 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
 /**
  * Keyboard `record_preview` script events. One descriptor — `input.keyboard` — advertising
  * `input.keyDown` and `input.keyUp` as **roadmap** (`supported = false`) on every host today.
- * Desktop's `ImageComposeScene.sendKeyEvent` and Android's held-rule
- * `KeyEvent.dispatchKeyEvent` are both wirable but neither is implemented yet — the existing
- * input handlers register these as unsupported so the wire shape is documented while the
- * dispatch side remains a follow-up.
+ * Desktop's `ImageComposeScene.sendKeyEvent` and Android's held-rule `KeyEvent.dispatchKeyEvent`
+ * are both wirable but neither is implemented yet — the existing input handlers register these as
+ * unsupported so the wire shape is documented while the dispatch side remains a follow-up.
  *
  * Lives in `:daemon:core` because the descriptor is renderer-agnostic — both backends will
  * eventually advertise it from `recordingScriptEventDescriptors()` with `supported = true` once

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt
@@ -14,16 +14,16 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
  * - `input.pointerMove` — `PointerEventType.Move` with the primary button held.
  * - `input.pointerUp` — `PointerEventType.Release`.
  *
- * Lives in `:daemon:core` because both `DesktopHost` and `RobolectricHost` dispatch this
- * extension. Each host advertises the same descriptor from `recordingScriptEventDescriptors()`;
- * the dispatch end is host-specific (Skiko `sendPointerEvent` on desktop, the held-rule's
- * pointer pipeline on Android), but the descriptor advertisement is uniform.
+ * Lives in `:daemon:core` because both `DesktopHost` and `RobolectricHost` dispatch this extension.
+ * Each host advertises the same descriptor from `recordingScriptEventDescriptors()`; the dispatch
+ * end is host-specific (Skiko `sendPointerEvent` on desktop, the held-rule's pointer pipeline on
+ * Android), but the descriptor advertisement is uniform.
  *
- * **Why split from `input.keyboard` and `input.rsb`.** Per-axis splits let each host advertise
- * the exact subset it dispatches: desktop carries `input.touch` + `input.keyboard` (latter as
- * roadmap); RobolectricHost carries `input.touch` + `input.keyboard` + `input.rsb`. One blanket
- * `input` extension would force per-host descriptor variants with different `supported` flags
- * — the per-axis split keeps the descriptors uniform across hosts and the per-host advertisement
+ * **Why split from `input.keyboard` and `input.rsb`.** Per-axis splits let each host advertise the
+ * exact subset it dispatches: desktop carries `input.touch` + `input.keyboard` (latter as roadmap);
+ * RobolectricHost carries `input.touch` + `input.keyboard` + `input.rsb`. One blanket `input`
+ * extension would force per-host descriptor variants with different `supported` flags — the
+ * per-axis split keeps the descriptors uniform across hosts and the per-host advertisement
  * trivially additive.
  */
 object InputTouchRecordingScriptEvents {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -138,8 +138,8 @@ fun String.toInteractiveInputKindOrNull(): InteractiveInputKind? =
  * Naming follows the per-extension `<extension>.<event>` convention: `input.click`,
  * `input.pointerDown`, etc. Three input extensions advertise these ids — see
  * `InputTouchRecordingScriptEvents`, `InputKeyboardRecordingScriptEvents`, and
- * `InputRsbRecordingScriptEvents`. The MCP `validateRecordingScriptKinds` checks every kind
- * against the daemon's advertised set — no special-case branch for input kinds anymore.
+ * `InputRsbRecordingScriptEvents`. The MCP `validateRecordingScriptKinds` checks every kind against
+ * the daemon's advertised set — no special-case branch for input kinds anymore.
  */
 val INTERACTIVE_INPUT_KIND_BY_WIRE_NAME: Map<String, InteractiveInputKind> =
   mapOf(

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1024,12 +1024,11 @@ data class RecordingScriptEvent(
   /** Agent-supplied checkpoint id for save/restore state markers. */
   val checkpointId: String? = null,
   /**
-   * Vestigial after compose-ai-tools#754: the legacy `kind = "lifecycle.event"` /
-   * `lifecycleEvent: <transition>` shape was split into per-id events (`lifecycle.pause` /
-   * `lifecycle.resume` / `lifecycle.stop`), so no handler reads this field anymore. Retained on
-   * the wire as a free-form passthrough — agents that set it for trace context still see it
-   * round-trip into [RecordingScriptEvidence.lifecycleEvent]. Future cleanup may remove the
-   * field entirely.
+   * Vestigial after compose-ai-tools#754: the legacy `kind = "lifecycle.event"` / `lifecycleEvent:
+   * <transition>` shape was split into per-id events (`lifecycle.pause` / `lifecycle.resume` /
+   * `lifecycle.stop`), so no handler reads this field anymore. Retained on the wire as a free-form
+   * passthrough — agents that set it for trace context still see it round-trip into
+   * [RecordingScriptEvidence.lifecycleEvent]. Future cleanup may remove the field entirely.
    */
   val lifecycleEvent: String? = null,
   /** Optional free-form tags copied into script evidence. */

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InputRecordingScriptEventsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InputRecordingScriptEventsTest.kt
@@ -73,9 +73,7 @@ class InputRecordingScriptEventsTest {
     // through to the unsupported branch.
     val advertisedTouchIds = InputTouchRecordingScriptEvents.WIRED_EVENTS
     val advertisedKeyboardIds =
-      InputKeyboardRecordingScriptEvents.descriptor.recordingScriptEvents
-        .map { it.id }
-        .toSet()
+      InputKeyboardRecordingScriptEvents.descriptor.recordingScriptEvents.map { it.id }.toSet()
     // input.rotaryScroll is advertised by the Android-only `input.rsb` extension; check it via
     // the wire-name table without depending on the Android module here.
     val rotaryWireName = "input.rotaryScroll"

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
@@ -110,8 +110,8 @@ class DesktopHostTest {
   /**
    * With a resolver wired, `recordingScriptEventDescriptors()` advertises three extensions:
    * `recording` (probe, supported), `input.touch` (4 pointer events, supported), and
-   * `input.keyboard` (2 key events, roadmap). The Wear-only `input.rsb` lives on the Android
-   * host; desktop daemons skip it.
+   * `input.keyboard` (2 key events, roadmap). The Wear-only `input.rsb` lives on the Android host;
+   * desktop daemons skip it.
    */
   @Test
   fun recordingScriptEventDescriptorsAdvertiseSupportedExtensions() {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -526,8 +526,8 @@ class DesktopRecordingSessionTest {
       try {
         val thrown =
           runCatching {
-            session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "input.click")))
-          }
+              session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "input.click")))
+            }
             .exceptionOrNull()
         assertTrue(
           "postScript on a live session must throw IllegalStateException; got ${thrown?.javaClass}",

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -2639,8 +2639,8 @@ class DaemonMcpServer(
    * - **`supported = true`** — accepted; the daemon will dispatch.
    * - **`supported = false`** — rejected with a precise diagnostic that points at
    *   `list_data_products` so the agent sees the roadmap shape rather than a quiet `unsupported`
-   *   evidence trail. (The daemon-side fallback that emits `unsupported` evidence stays in
-   *   place as defense-in-depth for older MCP servers + direct daemon clients.)
+   *   evidence trail. (The daemon-side fallback that emits `unsupported` evidence stays in place as
+   *   defense-in-depth for older MCP servers + direct daemon clients.)
    * - **Not advertised** — rejected with "not advertised by this daemon".
    *
    * Input kinds (`input.click`, `input.pointerDown`, …) are advertised through


### PR DESCRIPTION
## Summary

Fixes the three checks currently red on `main` after fa2f12c:

- **Format Check / ktfmt (Google style)** — `./gradlew ktfmtFormatAll` across 8 files in `:daemon:core`, `:daemon:desktop`, `:mcp` (the kotlin-jvm modules ncorti's plugin actually scans). PRs #760 and #762 introduced kdoc reflow + import-sort drift that's been red on every push to main since #762 merged. No behaviour change.
- **Integration / wear-os-samples (ComposeStarter)** and **(WearTilesKotlin)** — `integration.yml`'s `Build plugin + CLI` step listed each `:publishToMavenLocal` target by hand and missed `:data-a11y-hierarchy-android` (added in #724, became a `:renderer-android` `implementation` dep in #751) and `:data-recomposition-connector`. The renderer-android AAR resolved fine from mavenLocal but its transitive `ee.schimke.composeai:data-a11y-hierarchy-android:0.1.0-SNAPSHOT` fell through to remote (which doesn't have it) and broke `composePreviewAndroidRenderer<Variant>` resolution at `renderPreviews` time. Switched to the same root-level `publishToMavenLocal` abbreviation that `snapshot.yml` / `release.yml` already use post-#766; `:gradle-plugin` keeps its explicit address since it's an `includeBuild`.

## Test plan

- [x] `./gradlew ktfmtCheckAll` passes locally
- [ ] Format Check goes green on this PR
- [ ] Integration / wear-os-samples (ComposeStarter) goes green
- [ ] Integration / wear-os-samples (WearTilesKotlin) goes green

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsRrkVUSBAC4AztGPFZw8G)_