### PR TITLE
ci(vscode): unbreak vscode-extension-e2e and assert webview consumes setPreviews

### DIFF
--- a/.github/workflows/vscode-extension-e2e.yml
+++ b/.github/workflows/vscode-extension-e2e.yml
@@ -10,87 +10,32 @@ name: VS Code Extension E2E
 # and the prototype is more flake-prone than the stub-driven path.
 #
 # Triggers:
-#   workflow_dispatch — manual one-off runs (any branch).
-#   workflow_run      — fires after CI or Integration finish on `main`. Each
-#                       completion fires this workflow once, so the `gate`
-#                       job below short-circuits unless the *other* upstream
-#                       has also already succeeded on the same head_sha.
-#                       Net effect: e2e runs once per main push, after both
-#                       gating workflows are green.
+#   push (main)       — runs in parallel with CI / Integration so e2e
+#                       results land on the commit alongside everything
+#                       else. The previous workflow_run + gate setup
+#                       silently gated *every* run to a 1-14s skip
+#                       (workflow_run conclusion races, see git history)
+#                       and CMP went unverified for ~60 commits.
+#   workflow_dispatch — manual one-off runs (any branch), e.g. to
+#                       reproduce a regression on a feature branch.
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["CI", "Integration"]
-    types: [completed]
+  push:
     branches: [main]
 
 permissions:
   contents: read
-  actions: read
 
 concurrency:
-  # Group on the head SHA so the CI-completion run and the
-  # Integration-completion run for the same commit dedupe to a single
-  # attempt. Manual dispatches get their own slot via run_id.
-  group: vscode-extension-e2e-${{ github.event.workflow_run.head_sha || github.run_id }}
+  # One in-flight e2e per commit; manual dispatches get their own slot
+  # via run_id.
+  group: vscode-extension-e2e-${{ github.sha }}-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
-  gate:
-    name: Gate on upstream workflows
-    runs-on: ubuntu-latest
-    # workflow_run can fire after a *failed* upstream too; `if` weeds those
-    # out so the gate job itself only runs in the proceed-eligible cases.
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success')
-    outputs:
-      proceed: ${{ steps.check.outputs.proceed }}
-    steps:
-      - id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          TRIGGERING_WORKFLOW: ${{ github.event.workflow_run.name }}
-        run: |
-          set -euo pipefail
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "Manual dispatch — proceeding."
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Sibling gating workflows beyond the one that triggered us.
-          REQUIRED=(CI Integration)
-          for wf in "${REQUIRED[@]}"; do
-            if [ "$wf" = "$TRIGGERING_WORKFLOW" ]; then
-              continue
-            fi
-            echo "Checking '$wf' status for $HEAD_SHA"
-            STATE=$(gh run list \
-              --workflow "$wf" \
-              --commit "$HEAD_SHA" \
-              --limit 1 \
-              --json conclusion,status \
-              --jq '.[0] | "\(.status):\(.conclusion // "")"' \
-              || true)
-            echo "  $wf -> ${STATE:-(no run found)}"
-            if [ "$STATE" != "completed:success" ]; then
-              echo "::notice::Skipping e2e — '$wf' is '${STATE:-missing}' on $HEAD_SHA. Re-runs once it goes green."
-              echo "proceed=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          done
-          echo "All required upstream workflows are green for $HEAD_SHA."
-          echo "proceed=true" >> "$GITHUB_OUTPUT"
-
   e2e:
     name: VS Code Extension E2E (real Gradle)
-    needs: gate
-    if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     # 60 minutes ceiling — local cold runs land closer to 5-10 min, but a
     # CI runner with no Gradle/Compose caches warm and a fresh
@@ -100,10 +45,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          # workflow_run sets github.sha to the workflow file's own commit,
-          # not the head_sha that fired it. Pin to head_sha so we test the
-          # same tree CI / Integration just verified.
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: ./.github/actions/setup
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -265,13 +265,24 @@ export interface ComposePreviewTestApi {
     ): Promise<void>;
     /** Snapshot of every panel message posted since [resetMessages]. */
     getPostedMessages(): unknown[];
-    /** Drop the captured-messages buffer. */
+    /**
+     * Snapshot of every webview→extension message received since
+     * [resetMessages]. Lets e2e tests assert that the webview actually
+     * consumed a host post (`postedMessageLog` only proves the host called
+     * `postMessage`, not that a resolved webview ever received it).
+     */
+    getReceivedMessages(): unknown[];
+    /** Drop both message buffers (posted + received). */
     resetMessages(): void;
 }
 
 /** Captured messages for [ComposePreviewTestApi.getPostedMessages]. Only
  *  populated when running under `COMPOSE_PREVIEW_TEST_MODE=1`. */
 const postedMessageLog: unknown[] = [];
+
+/** Captured messages for [ComposePreviewTestApi.getReceivedMessages]. Only
+ *  populated when running under `COMPOSE_PREVIEW_TEST_MODE=1`. */
+const receivedMessageLog: unknown[] = [];
 
 /**
  * D2 — routes daemon-attached `a11y/atf` + `a11y/hierarchy` data products into the
@@ -579,7 +590,17 @@ export async function activate(
     interactiveStatusItem.command = "workbench.action.output.toggleOutput";
     context.subscriptions.push(interactiveStatusItem);
 
-    panel = new PreviewPanel(context.extensionUri, handleWebviewMessage, () =>
+    // In test mode we wrap the webview-message handler so the test API can
+    // also assert on inbound traffic (e.g. `webviewPreviewsRendered`, which
+    // proves the resolved webview actually consumed a `setPreviews` post —
+    // postedMessageLog alone only captures the host's *attempt* to send).
+    const onMessage = isTestMode
+        ? (msg: WebviewToExtension) => {
+              receivedMessageLog.push(msg);
+              handleWebviewMessage(msg);
+          }
+        : handleWebviewMessage;
+    panel = new PreviewPanel(context.extensionUri, onMessage, () =>
         earlyFeaturesEnabled(),
     );
     if (isTestMode) {
@@ -1053,8 +1074,12 @@ export async function activate(
             getPostedMessages(): unknown[] {
                 return [...postedMessageLog];
             },
+            getReceivedMessages(): unknown[] {
+                return [...receivedMessageLog];
+            },
             resetMessages(): void {
                 postedMessageLog.length = 0;
+                receivedMessageLog.length = 0;
             },
         };
         return testApi;
@@ -3101,6 +3126,11 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             if (currentScopeFile) {
                 void refresh(false, currentScopeFile);
             }
+            break;
+        case "webviewPreviewsRendered":
+            // No production action — this message is a test-only signal that
+            // proves the webview consumed a `setPreviews` post and populated
+            // the grid. The test API's `getReceivedMessages()` snapshots it.
             break;
         case "openFile":
             openPreviewSource(msg.className, msg.functionName);

--- a/vscode-extension/src/test/electron/suite/e2e.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2e.test.ts
@@ -171,5 +171,32 @@ describeE2E("Compose Preview e2e (real Gradle)", function () {
             pngs.length >= 2,
             `expected at least 2 rendered PNGs in ${renderDir}, found ${pngs.length}`,
         );
+
+        // `postedMessageLog` only proves the host *attempted* to post. Wait
+        // for `webviewPreviewsRendered` from the resolved webview to confirm
+        // the message landed and `renderPreviews` actually painted cards.
+        // Regression-locks the empty-grid bug where a host post into an
+        // unresolved view was silently dropped — assertions on
+        // `postedMessageLog` alone passed cleanly while users saw an empty
+        // panel.
+        const renderedSignal = await waitFor(
+            "webviewPreviewsRendered from the live webview",
+            this.timeout(),
+            500,
+            () => {
+                const inbound = api.getReceivedMessages();
+                const m = inbound.find(
+                    (raw) =>
+                        (raw as PostedMessage).command ===
+                        "webviewPreviewsRendered",
+                ) as { command: string; count: number } | undefined;
+                if (!m || m.count <= 0) return undefined;
+                return m;
+            },
+        );
+        assert.ok(
+            renderedSignal.count >= previews.length,
+            `webview rendered ${renderedSignal.count} cards but ${previews.length} previews were sent`,
+        );
     });
 });

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -515,6 +515,17 @@ export type WebviewToExtension =
      * webviewView is resolved.
      */
     | { command: "webviewReady" }
+    /**
+     * Webview reports it has finished applying a `setPreviews` payload to the
+     * grid — sent from `behavior.ts` after `renderPreviews` and the filter-
+     * toolbar/option update. `count` is the number of cards now in the grid.
+     *
+     * Drives the e2e test's "the host posted AND the webview consumed" check:
+     * `postedMessageLog` only proves the host called `postMessage`, not that a
+     * resolved webview ever received it. This signal closes that gap so the
+     * full host→webview→DOM loop is regression-locked.
+     */
+    | { command: "webviewPreviewsRendered"; count: number }
     | { command: "openFile"; className: string; functionName: string }
     | { command: "selectModule"; value: string }
     /**

--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -2115,6 +2115,14 @@ export function setupPreviewBehavior(
                 });
                 applyLiveBadge();
                 applyInteractiveButtonState();
+                // Tell the extension the cards reached the grid. Powers the
+                // e2e test's "real webview consumed setPreviews" assertion —
+                // postedMessageLog alone only proves the host posted the
+                // message, not that a resolved webview ever received it.
+                vscode.postMessage({
+                    command: "webviewPreviewsRendered",
+                    count: grid.querySelectorAll(".preview-card").length,
+                });
                 break;
             }
 


### PR DESCRIPTION
Follow-up to #778 — fixes the two issues that PR identified but didn't ship in the merged scope:

## Summary

### `ci: trigger vscode-extension-e2e on push to main, drop workflow_run gate`

The previous `workflow_run` + gate setup silently gated *every* e2e run to a 1-14s skip across the last ~60 commits — `:samples:cmp` rendering through the real Gradle plugin was unverified for that whole window even though the workflow list reported every run as success.

Mechanism: e2e fired on `workflow_run: [completed]` for both CI and Integration. The first firing (whichever upstream finished first) saw the other still `in_progress` and skipped via the gate (verified on individual run annotations: `Skipping e2e — 'Integration' is 'in_progress:' on <sha>`). The second firing (the slower upstream completing) had `workflow_run.conclusion != 'success'` often enough — re-runs, cancelled sibling jobs in the same workflow, or other quirks of GitHub's `[completed]` semantics — that the job-level `if` rejected it before the gate even ran. Net: e2e never proceeded, but every run reported as a successful skip.

Switched to `push: branches: [main]`, dropped the gate. e2e runs alongside CI / Integration on every main push. PRs are still excluded by the branch filter, preserving the original "not on every PR" property. ~70 lines of gate logic and the `actions: read` permission go away with it.

### `test(vscode): assert webview consumed setPreviews end-to-end`

The e2e test asserted on `postedMessageLog` only — that captures the host's *attempt* to post `setPreviews`, before `view?.webview.postMessage` runs. A resolved-late webview that drops messages silently passed the test cleanly while users saw an empty grid (the bug fixed in #778). So even when the e2e ran, it couldn't have caught that regression.

Add a `webviewPreviewsRendered` signal sent from `behavior.ts` after `renderPreviews` paints the grid, exposed on the test API via `getReceivedMessages()` (a new wrapper on the inbound `onMessage` callback in test mode, paired with the existing outbound `postedMessageLog`). The e2e test now waits for this inbound signal and asserts `count >= previews.length`, regression-locking the full host→webview→DOM loop.

## Test plan

- [x] `npm run test` — 320 vscode-extension tests pass
- [x] `tsc -p ./` and `tsc -p tsconfig.webview.json` clean, prettier clean
- [x] Cherry-picked cleanly from the merged #778 branch onto fresh `origin/main` (which has #769's `<preview-grid>` lift; the inline `grid.querySelectorAll(".preview-card")` count still works because the custom element inherits DOM query methods)
- [x] Workflow YAML parses
- [ ] After merge: confirm `VS Code Extension E2E` actually runs (not gate-skipped) on the merge commit, and that the new `webviewPreviewsRendered` assertion passes against `:samples:cmp`

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtWrzDWrGnAuQGbi5Lbmzv)_