### PR TITLE
refactor(vscode): lift frame carousel out of behavior.ts

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -31,6 +31,7 @@ import {
 import { PreviewGrid } from "./components/PreviewGrid";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
 import { buildErrorPanel } from "./errorPanel";
+import { FrameCarouselController } from "./frameCarousel";
 import { attachInteractiveInputHandlers } from "./interactiveInput";
 import { LoadingOverlay } from "./loadingOverlay";
 import { previewStore } from "./previewStore";
@@ -167,6 +168,18 @@ export function setupPreviewBehavior(
 
     const staleBadge = new StaleBadgeController(vscode);
     const loadingOverlay = new LoadingOverlay();
+
+    // Per-preview carousel runtime state — imageData / errorMessage per
+    // capture. Populated from updateImage / setImageError messages so
+    // prev/next navigation can swap the visible <img> without a fresh
+    // extension round-trip.
+    // Map<previewId, CapturePresentation[]>
+    const cardCaptures = new Map();
+    const frameCarousel = new FrameCarouselController({
+        vscode,
+        cardCaptures,
+        interactiveInputConfig,
+    });
 
     // Restore layout preference
     if (
@@ -1128,13 +1141,6 @@ export function setupPreviewBehavior(
     // `<filter-toolbar>`'s reactive state retains `fnValue` / `grpValue`
     // when only `fnOptions` / `grpOptions` change.
 
-    // Per-preview carousel runtime state — imageData / errorMessage per
-    // capture. Populated from updateImage / setImageError messages so
-    // prev/next navigation can swap the visible <img> without a fresh
-    // extension round-trip.
-    // Map<previewId, [{ label, imageData, errorMessage }]>
-    const cardCaptures = new Map();
-
     function createCard(p) {
         const animated = isAnimatedPreview(p);
         const captures = p.captures;
@@ -1281,149 +1287,11 @@ export function setupPreviewBehavior(
         }
 
         if (animated) {
-            card.appendChild(buildFrameControls(card));
+            card.appendChild(frameCarousel.buildControls(card));
         }
 
         observeCardForViewport(card);
         return card;
-    }
-
-    function buildFrameControls(card) {
-        const bar = document.createElement("div");
-        bar.className = "frame-controls";
-
-        const prev = document.createElement("button");
-        prev.className = "icon-button frame-prev";
-        prev.setAttribute("aria-label", "Previous capture");
-        prev.title = "Previous capture";
-        prev.innerHTML =
-            '<i class="codicon codicon-chevron-left" aria-hidden="true"></i>';
-        prev.addEventListener("click", () => stepFrame(card, -1));
-
-        const indicator = document.createElement("span");
-        indicator.className = "frame-indicator";
-        indicator.setAttribute("aria-live", "polite");
-
-        const next = document.createElement("button");
-        next.className = "icon-button frame-next";
-        next.setAttribute("aria-label", "Next capture");
-        next.title = "Next capture";
-        next.innerHTML =
-            '<i class="codicon codicon-chevron-right" aria-hidden="true"></i>';
-        next.addEventListener("click", () => stepFrame(card, 1));
-
-        bar.appendChild(prev);
-        bar.appendChild(indicator);
-        bar.appendChild(next);
-
-        // Arrow keys when the carousel has focus. Stop propagation so
-        // the document-level focus-mode nav doesn't also advance the card.
-        bar.tabIndex = 0;
-        bar.addEventListener("keydown", (e) => {
-            if (e.key === "ArrowLeft") {
-                stepFrame(card, -1);
-                e.preventDefault();
-                e.stopPropagation();
-            } else if (e.key === "ArrowRight") {
-                stepFrame(card, 1);
-                e.preventDefault();
-                e.stopPropagation();
-            }
-        });
-
-        // Seed indicator text so it's not blank before any image arrives.
-        requestAnimationFrame(() => updateFrameIndicator(card));
-        return bar;
-    }
-
-    function stepFrame(card, delta) {
-        const caps = cardCaptures.get(card.dataset.previewId);
-        if (!caps) return;
-        const cur = parseInt(card.dataset.currentIndex || "0", 10);
-        const next = Math.max(0, Math.min(caps.length - 1, cur + delta));
-        if (next === cur) return;
-        card.dataset.currentIndex = String(next);
-        showFrame(card, next);
-    }
-
-    function showFrame(card, index) {
-        const caps = cardCaptures.get(card.dataset.previewId);
-        if (!caps) return;
-        const capture = caps[index];
-        if (!capture) return;
-        const container = card.querySelector(".image-container");
-        if (!container) return;
-
-        if (capture.imageData) {
-            const skeleton = container.querySelector(".skeleton");
-            const errorMsg = container.querySelector(".error-message");
-            if (skeleton) skeleton.remove();
-            if (errorMsg) errorMsg.remove();
-            let img = container.querySelector("img");
-            if (!img) {
-                img = document.createElement("img");
-                img.alt = card.dataset.function + " preview";
-                container.appendChild(img);
-            }
-            img.src =
-                "data:" +
-                mimeFor(capture.renderOutput) +
-                ";base64," +
-                capture.imageData;
-            img.className = "fade-in";
-            attachInteractiveInputHandlers(card, img, interactiveInputConfig);
-            if (capture.errorMessage || capture.renderError) {
-                container.appendChild(
-                    buildErrorPanel(
-                        vscode,
-                        capture.errorMessage,
-                        capture.renderError,
-                        card.dataset.className,
-                    ),
-                );
-                card.classList.add("has-error");
-            } else {
-                card.classList.remove("has-error");
-            }
-        } else if (capture.errorMessage || capture.renderError) {
-            const existingErr = container.querySelector(".error-message");
-            if (existingErr) existingErr.remove();
-            container.appendChild(
-                buildErrorPanel(
-                    capture.errorMessage,
-                    capture.renderError,
-                    card.dataset.className,
-                ),
-            );
-            card.classList.add("has-error");
-        } else {
-            // No data for this capture yet — render will fill it in later.
-            const existing = container.querySelector("img");
-            if (existing) existing.remove();
-            if (!container.querySelector(".skeleton")) {
-                const s = document.createElement("div");
-                s.className = "skeleton";
-                s.setAttribute("aria-label", "Loading capture");
-                container.appendChild(s);
-            }
-        }
-        updateFrameIndicator(card);
-    }
-
-    function updateFrameIndicator(card) {
-        const indicator = card.querySelector(".frame-indicator");
-        const prevBtn = card.querySelector(".frame-prev");
-        const nextBtn = card.querySelector(".frame-next");
-        if (!indicator) return;
-        const caps = cardCaptures.get(card.dataset.previewId);
-        if (!caps) return;
-        const idx = parseInt(card.dataset.currentIndex || "0", 10);
-        const capture = caps[idx];
-        const label = capture && capture.label ? capture.label : "\u2014";
-        indicator.textContent =
-            idx + 1 + " / " + caps.length + " \u00B7 " + label;
-        if (prevBtn) prevBtn.disabled = idx === 0;
-        if (nextBtn) nextBtn.disabled = idx === caps.length - 1;
     }
 
     function updateCardMetadata(card, p) {
@@ -1461,7 +1329,7 @@ export function setupPreviewBehavior(
                 Math.max(0, mergedCaps.length - 1),
             );
         }
-        if (isAnimatedPreview(p)) updateFrameIndicator(card);
+        if (isAnimatedPreview(p)) frameCarousel.updateIndicator(card);
         const variantLabel = buildVariantLabel(p);
         let badge = card.querySelector(".variant-badge");
         if (variantLabel) {
@@ -1640,7 +1508,7 @@ export function setupPreviewBehavior(
         // prev/next.
         const cur = parseInt(card.dataset.currentIndex || "0", 10);
         if (cur !== captureIndex) {
-            if (caps) updateFrameIndicator(card);
+            if (caps) frameCarousel.updateIndicator(card);
             return;
         }
 
@@ -1675,7 +1543,7 @@ export function setupPreviewBehavior(
         img.className = isLive ? "live-frame" : "fade-in";
         attachInteractiveInputHandlers(card, img, interactiveInputConfig);
 
-        if (caps) updateFrameIndicator(card);
+        if (caps) frameCarousel.updateIndicator(card);
 
         // If a diff overlay is open on this card and uses the live render
         // as its left anchor (head / main / current), the bytes the

--- a/vscode-extension/src/webview/preview/frameCarousel.ts
+++ b/vscode-extension/src/webview/preview/frameCarousel.ts
@@ -1,0 +1,215 @@
+// Per-card frame carousel for animated / multi-capture previews.
+//
+// Lifted verbatim from `behavior.ts`'s `buildFrameControls` /
+// `stepFrame` / `showFrame` / `updateFrameIndicator` cluster. The DOM
+// shape is unchanged — same `<div class="frame-controls">` with prev /
+// indicator / next, same arrow-key handling, same per-capture image
+// swap and error-panel attach.
+//
+// Carousel state lives outside this module: `cardCaptures` is the
+// shared `Map<previewId, CapturePresentation[]>` owned by `behavior.ts`
+// (populated from `setPreviews`, mutated by `updateImage` /
+// `setImageError`, drained by `renderPreviews`'s removal pass), and
+// `card.dataset.currentIndex` tracks the visible frame as a string.
+// Both are passed in via `FrameCarouselConfig` so this module never
+// needs to reach into closures in `behavior.ts`.
+//
+// Held as a `FrameCarouselController` so the dependencies (vscode,
+// the captures Map, the interactive-input config used when swapping
+// to a fresh `<img>`) bind once at panel boot rather than threading
+// through every call site.
+
+import { mimeFor } from "./cardData";
+import { buildErrorPanel } from "./errorPanel";
+import {
+    attachInteractiveInputHandlers,
+    type InteractiveInputConfig,
+} from "./interactiveInput";
+import type { PreviewRenderError } from "../shared/types";
+import type { VsCodeApi } from "../shared/vscode";
+
+/** Per-capture state shared with `behavior.ts`. */
+export interface CapturePresentation {
+    /** Pre-formatted human-readable label of the capture's non-null
+     *  dimensions — `'500ms'`, `'scrolled end'`, etc. */
+    label: string;
+    /** Module-relative output path; drives the image MIME type. */
+    renderOutput: string;
+    /** Latest base64 image bytes, or `null` until the renderer has
+     *  produced a result for this capture. */
+    imageData: string | null;
+    /** One-line error message when the capture failed without a
+     *  structured sidecar. */
+    errorMessage: string | null;
+    /** Structured render-error sidecar when available. */
+    renderError: PreviewRenderError | null;
+}
+
+export interface FrameCarouselConfig {
+    vscode: VsCodeApi<unknown>;
+    cardCaptures: Map<string, CapturePresentation[]>;
+    interactiveInputConfig: InteractiveInputConfig;
+}
+
+export class FrameCarouselController {
+    constructor(private readonly config: FrameCarouselConfig) {}
+
+    /**
+     * Builds the prev / indicator / next strip placed under the image
+     * on multi-capture cards. Caller (`createCard`) appends the result
+     * to the card. Indicator text is seeded one frame later via
+     * `requestAnimationFrame` so the label matches the carousel's
+     * post-mount state.
+     */
+    buildControls(card: HTMLElement): HTMLElement {
+        const bar = document.createElement("div");
+        bar.className = "frame-controls";
+
+        const prev = document.createElement("button");
+        prev.className = "icon-button frame-prev";
+        prev.setAttribute("aria-label", "Previous capture");
+        prev.title = "Previous capture";
+        prev.innerHTML =
+            '<i class="codicon codicon-chevron-left" aria-hidden="true"></i>';
+        prev.addEventListener("click", () => this.step(card, -1));
+
+        const indicator = document.createElement("span");
+        indicator.className = "frame-indicator";
+        indicator.setAttribute("aria-live", "polite");
+
+        const next = document.createElement("button");
+        next.className = "icon-button frame-next";
+        next.setAttribute("aria-label", "Next capture");
+        next.title = "Next capture";
+        next.innerHTML =
+            '<i class="codicon codicon-chevron-right" aria-hidden="true"></i>';
+        next.addEventListener("click", () => this.step(card, 1));
+
+        bar.appendChild(prev);
+        bar.appendChild(indicator);
+        bar.appendChild(next);
+
+        // Arrow keys when the carousel has focus. Stop propagation so
+        // the document-level focus-mode nav doesn't also advance the card.
+        bar.tabIndex = 0;
+        bar.addEventListener("keydown", (e) => {
+            if (e.key === "ArrowLeft") {
+                this.step(card, -1);
+                e.preventDefault();
+                e.stopPropagation();
+            } else if (e.key === "ArrowRight") {
+                this.step(card, 1);
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        });
+
+        // Seed indicator text so it's not blank before any image arrives.
+        requestAnimationFrame(() => this.updateIndicator(card));
+        return bar;
+    }
+
+    /**
+     * Update the `idx / total · label` indicator and disable the
+     * boundary buttons. Called from `behavior.ts` whenever capture
+     * state churn might shift what's visible (`updateCardMetadata`,
+     * `updateImage`, `setImageError`) — outside those points this
+     * module updates the indicator itself after `step` / `show`.
+     */
+    updateIndicator(card: HTMLElement): void {
+        const indicator = card.querySelector<HTMLElement>(".frame-indicator");
+        const prevBtn = card.querySelector<HTMLButtonElement>(".frame-prev");
+        const nextBtn = card.querySelector<HTMLButtonElement>(".frame-next");
+        if (!indicator) return;
+        const previewId = card.dataset.previewId ?? "";
+        const caps = this.config.cardCaptures.get(previewId);
+        if (!caps) return;
+        const idx = parseInt(card.dataset.currentIndex || "0", 10);
+        const capture = caps[idx];
+        const label = capture && capture.label ? capture.label : "—";
+        indicator.textContent = idx + 1 + " / " + caps.length + " · " + label;
+        if (prevBtn) prevBtn.disabled = idx === 0;
+        if (nextBtn) nextBtn.disabled = idx === caps.length - 1;
+    }
+
+    private step(card: HTMLElement, delta: number): void {
+        const previewId = card.dataset.previewId ?? "";
+        const caps = this.config.cardCaptures.get(previewId);
+        if (!caps) return;
+        const cur = parseInt(card.dataset.currentIndex || "0", 10);
+        const next = Math.max(0, Math.min(caps.length - 1, cur + delta));
+        if (next === cur) return;
+        card.dataset.currentIndex = String(next);
+        this.show(card, next);
+    }
+
+    private show(card: HTMLElement, index: number): void {
+        const previewId = card.dataset.previewId ?? "";
+        const caps = this.config.cardCaptures.get(previewId);
+        if (!caps) return;
+        const capture = caps[index];
+        if (!capture) return;
+        const container = card.querySelector<HTMLElement>(".image-container");
+        if (!container) return;
+
+        if (capture.imageData) {
+            const skeleton = container.querySelector(".skeleton");
+            const errorMsg = container.querySelector(".error-message");
+            if (skeleton) skeleton.remove();
+            if (errorMsg) errorMsg.remove();
+            let img = container.querySelector<HTMLImageElement>("img");
+            if (!img) {
+                img = document.createElement("img");
+                img.alt = (card.dataset.function ?? "") + " preview";
+                container.appendChild(img);
+            }
+            img.src =
+                "data:" +
+                mimeFor(capture.renderOutput) +
+                ";base64," +
+                capture.imageData;
+            img.className = "fade-in";
+            attachInteractiveInputHandlers(
+                card,
+                img,
+                this.config.interactiveInputConfig,
+            );
+            if (capture.errorMessage || capture.renderError) {
+                container.appendChild(
+                    buildErrorPanel(
+                        this.config.vscode,
+                        capture.errorMessage,
+                        capture.renderError,
+                        card.dataset.className,
+                    ),
+                );
+                card.classList.add("has-error");
+            } else {
+                card.classList.remove("has-error");
+            }
+        } else if (capture.errorMessage || capture.renderError) {
+            const existingErr = container.querySelector(".error-message");
+            if (existingErr) existingErr.remove();
+            container.appendChild(
+                buildErrorPanel(
+                    this.config.vscode,
+                    capture.errorMessage,
+                    capture.renderError,
+                    card.dataset.className,
+                ),
+            );
+            card.classList.add("has-error");
+        } else {
+            // No data for this capture yet — render will fill it in later.
+            const existing = container.querySelector("img");
+            if (existing) existing.remove();
+            if (!container.querySelector(".skeleton")) {
+                const s = document.createElement("div");
+                s.className = "skeleton";
+                s.setAttribute("aria-label", "Loading capture");
+                container.appendChild(s);
+            }
+        }
+        this.updateIndicator(card);
+    }
+}


### PR DESCRIPTION
Slice of #767. Extracts the per-card frame carousel for animated / multi-capture previews — `buildFrameControls`, `stepFrame`, `showFrame`, `updateFrameIndicator` — into a typed `FrameCarouselController` class.

## Summary

- New `frameCarousel.ts` exports `FrameCarouselController` plus the `CapturePresentation` shape (so the carousel module and `behavior.ts` agree on the per-capture state — `label` / `renderOutput` / `imageData` / `errorMessage` / `renderError`). Public surface is `buildControls(card)` and `updateIndicator(card)`; `step` and `show` stay private (only used by the click / keydown handlers built into the controls bar).
- The shared `cardCaptures` Map (populated from `setPreviews`, mutated by `updateImage` / `setImageError`, drained on card removal) stays in `behavior.ts` and is handed to the controller via the constructor. Same DOM shape (`.frame-controls`, `.frame-indicator`, `.frame-prev`, `.frame-next`), same arrow-key handling (Left/Right while bar is focused, with `stopPropagation` so document-level focus-mode nav doesn't double-step), same per-capture image swap and error-panel attach.

**Drive-by bug fix:** The no-imageData-but-error branch of `showFrame` was calling `buildErrorPanel(message, renderError, className)` — the pre-#770 signature. The other branch in the same function had been updated to the typed signature `buildErrorPanel(vscode, message, renderError, className)` but this one was missed, and `@ts-nocheck` on `behavior.ts` hid it. Caught when copying the body into the typed module; both call sites now agree.

`behavior.ts` shrinks from 2217 → 2085 lines (−132 LOC). No behaviour change beyond the bug fix.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 320/320 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke: render an animated `@Preview` with multiple captures (e.g. `@ScrollingPreview` or paused-clock animation). Verify the carousel bar appears with `1 / N · label`, the prev/next buttons disable at boundaries, arrow keys advance frames without escaping focus mode, and a per-capture render error renders the structured error panel (not just the one-line message).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTv9gnHTdY5MzDfGdnSpBn)_