### PR TITLE
refactor(vscode): lift focus-toolbar button-state quartet out of behavior.ts

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -31,6 +31,11 @@ import {
 import { PreviewGrid } from "./components/PreviewGrid";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
 import { buildErrorPanel } from "./errorPanel";
+import {
+    FocusToolbarController,
+    isFocusedInteractiveSupported,
+    isFocusedModuleReady,
+} from "./focusToolbar";
 import { FrameCarouselController } from "./frameCarousel";
 import { attachInteractiveInputHandlers } from "./interactiveInput";
 import { LoadingOverlay } from "./loadingOverlay";
@@ -79,6 +84,20 @@ export function setupPreviewBehavior(
     const btnRecording = document.getElementById("btn-recording");
     const recordingFormat = document.getElementById("recording-format");
     const btnExitFocus = document.getElementById("btn-exit-focus");
+    const focusToolbar = new FocusToolbarController({
+        btnPrev,
+        btnNext,
+        btnDiffHead,
+        btnDiffMain,
+        btnLaunchDevice,
+        btnA11yOverlay,
+        btnInteractive,
+        btnStopInteractive,
+        btnRecording,
+        btnExitFocus,
+        recordingFormat,
+        focusInspector,
+    });
     // D2 — focus-mode a11y overlay toggle. Off by default; turning it on subscribes the
     // focused preview to a11y/atf + a11y/hierarchy via the extension, off unsubscribes.
     // Also gates the panel-side hierarchy overlay so the existing finding overlay (which
@@ -230,142 +249,53 @@ export function setupPreviewBehavior(
     // resolve fine.
 
     function applyEarlyFeatureVisibility() {
-        btnDiffHead.hidden = !earlyFeatures();
-        btnDiffMain.hidden = !earlyFeatures();
-        btnLaunchDevice.hidden = !earlyFeatures();
-        btnA11yOverlay.hidden =
-            !earlyFeatures() || filterToolbar.getLayoutValue() !== "focus";
-        btnRecording.hidden =
-            !earlyFeatures() || filterToolbar.getLayoutValue() !== "focus";
-        recordingFormat.hidden =
-            !earlyFeatures() || filterToolbar.getLayoutValue() !== "focus";
-        if (!earlyFeatures()) {
-            focusInspector.hidden = true;
-        }
-    }
-
-    function isFocusedDaemonReady() {
-        // The webview doesn't know moduleId per preview today. We fall
-        // back to "any module ready" because the extension-side panel
-        // is single-module-scoped (it only ever holds one module's
-        // previews at a time) — so the readiness of the sole module is
-        // also the readiness for whatever's focused. If the panel ever
-        // shows multiple modules at once, swap this to lookup by the
-        // focused card's data-module-id.
-        for (const ready of moduleDaemonReady.values()) {
-            if (ready) return true;
-        }
-        return false;
-    }
-
-    function isFocusedInteractiveSupported() {
-        for (const [moduleId, ready] of moduleDaemonReady.entries()) {
-            if (ready && moduleInteractiveSupported.get(moduleId) === true)
-                return true;
-        }
-        return false;
+        focusToolbar.applyEarlyFeatureVisibility({
+            earlyFeatures: earlyFeatures(),
+            inFocus: filterToolbar.getLayoutValue() === "focus",
+        });
     }
 
     function applyInteractiveButtonState() {
         const inFocus = filterToolbar.getLayoutValue() === "focus";
-        // Hide outright when not in focus mode — the toolbar already
-        // hides itself, but this keeps aria-pressed correct for tests
-        // that snapshot the button in either layout.
-        btnInteractive.hidden = !inFocus;
-        const hasLive = interactivePreviewIds.size > 0;
-        btnStopInteractive.hidden = !inFocus || !hasLive;
-        btnStopInteractive.disabled = !hasLive;
-        if (!inFocus) {
-            // Cheap fast-path: applyLayout fires this on every layout
-            // change (filter tweaks, focus nav, every setPreviews). In
-            // non-focus modes the focus-controls strip is hidden by CSS,
-            // so nothing visible would change — skip the getVisibleCards
-            // DOM walk and the per-attribute writes. State on re-entry to
-            // focus mode is rebuilt fresh by the full path below.
-            btnInteractive.setAttribute("aria-pressed", "false");
-            btnInteractive.classList.remove("live-on");
-            return;
-        }
-        const visible = getVisibleCards();
-        const card = visible[focusIndex];
-        if (!card) {
-            btnInteractive.disabled = true;
-            btnInteractive.setAttribute("aria-pressed", "false");
-            btnInteractive.title = "Daemon not ready — live mode unavailable";
-            btnInteractive.innerHTML =
-                '<i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>';
-            return;
-        }
-        const previewId = card.dataset.previewId;
-        const ready = isFocusedDaemonReady();
-        const supported = isFocusedInteractiveSupported();
-        const live = !!previewId && interactivePreviewIds.has(previewId);
-        const otherLiveCount = interactivePreviewIds.size - (live ? 1 : 0);
-        btnInteractive.disabled = !ready && !live;
-        btnInteractive.setAttribute("aria-pressed", live ? "true" : "false");
-        btnInteractive.classList.toggle("live-on", live);
-        btnInteractive.title = !ready
-            ? "Daemon not ready — live mode unavailable"
-            : live
-              ? "Live · click to exit · Shift+click to leave others on"
-              : !supported
-                ? "Live v1 fallback — renders refresh, but clicks do not preserve Compose state"
-                : otherLiveCount > 0
-                  ? otherLiveCount +
-                    " other live · click to make this one live too · " +
-                    "Shift+click to add without unsubscribing the rest"
-                  : "Enter live mode (stream renders) · Shift+click to add to multi-stream";
-        btnInteractive.innerHTML = live
-            ? '<i class="codicon codicon-record" aria-hidden="true"></i>'
-            : '<i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>';
+        const card = inFocus ? getVisibleCards()[focusIndex] : null;
+        const previewId = card?.dataset.previewId ?? null;
+        const isLive = !!previewId && interactivePreviewIds.has(previewId);
+        focusToolbar.applyInteractiveButtonState({
+            inFocus,
+            focusedPreviewId: previewId,
+            isLive,
+            otherLiveCount: interactivePreviewIds.size - (isLive ? 1 : 0),
+            hasLive: interactivePreviewIds.size > 0,
+            daemonReady: isFocusedModuleReady(moduleDaemonReady),
+            interactiveSupported: isFocusedInteractiveSupported(
+                moduleDaemonReady,
+                moduleInteractiveSupported,
+            ),
+        });
     }
 
     function applyRecordingButtonState() {
         const inFocus = filterToolbar.getLayoutValue() === "focus";
-        btnRecording.hidden = !earlyFeatures() || !inFocus;
-        recordingFormat.hidden = !earlyFeatures() || !inFocus;
-        if (!earlyFeatures() || !inFocus) {
-            btnRecording.setAttribute("aria-pressed", "false");
-            btnRecording.classList.remove("recording-on");
-            recordingFormat.disabled = true;
-            return;
-        }
-        const card = getVisibleCards()[focusIndex];
-        const previewId = card ? card.dataset.previewId : null;
-        const ready = isFocusedDaemonReady();
-        const recording = !!previewId && recordingPreviewIds.has(previewId);
-        btnRecording.disabled = !ready && !recording;
-        recordingFormat.disabled = recording || (!ready && !recording);
-        btnRecording.setAttribute("aria-pressed", recording ? "true" : "false");
-        btnRecording.classList.toggle("recording-on", recording);
-        btnRecording.title = !ready
-            ? "Daemon not ready — recording unavailable"
-            : recording
-              ? "Stop recording focused preview"
-              : "Record focused preview";
-        btnRecording.innerHTML = recording
-            ? '<i class="codicon codicon-debug-stop" aria-hidden="true"></i>'
-            : '<i class="codicon codicon-record-keys" aria-hidden="true"></i>';
+        const card = inFocus ? getVisibleCards()[focusIndex] : null;
+        const previewId = card?.dataset.previewId ?? null;
+        focusToolbar.applyRecordingButtonState({
+            inFocus,
+            earlyFeatures: earlyFeatures(),
+            focusedPreviewId: previewId,
+            daemonReady: isFocusedModuleReady(moduleDaemonReady),
+            isRecording: !!previewId && recordingPreviewIds.has(previewId),
+        });
     }
 
-    // D2 — keep the a11y-overlay toggle in lockstep with focus-mode + the focused card
-    // identity. Outside focus mode the button hides; inside focus mode aria-pressed
-    // tracks whether the currently focused preview has the overlay subscription on.
     function applyA11yOverlayButtonState() {
         const inFocus = filterToolbar.getLayoutValue() === "focus";
-        btnA11yOverlay.hidden = !earlyFeatures() || !inFocus;
-        if (!earlyFeatures() || !inFocus) {
-            btnA11yOverlay.setAttribute("aria-pressed", "false");
-            return;
-        }
-        const card = getVisibleCards()[focusIndex];
-        const previewId = card ? card.dataset.previewId : null;
-        const on = previewId !== null && previewId === a11yOverlay();
-        btnA11yOverlay.setAttribute("aria-pressed", on ? "true" : "false");
-        btnA11yOverlay.title = on
-            ? "Hide accessibility overlay"
-            : "Show accessibility overlay";
-        btnA11yOverlay.classList.toggle("a11y-overlay-on", on);
+        const card = inFocus ? getVisibleCards()[focusIndex] : null;
+        focusToolbar.applyA11yOverlayButtonState({
+            inFocus,
+            earlyFeatures: earlyFeatures(),
+            focusedPreviewId: card?.dataset.previewId ?? null,
+            a11yOverlayId: a11yOverlay(),
+        });
     }
 
     // D2 — clicking the a11y toggle subscribes/unsubscribes via the extension. When

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -1,0 +1,232 @@
+// Focus-mode toolbar — the 10-button strip rendered above the
+// preview grid when layout is `focus`.
+//
+// Lifted verbatim from `behavior.ts`'s
+// `applyEarlyFeatureVisibility` / `applyInteractiveButtonState` /
+// `applyRecordingButtonState` / `applyA11yOverlayButtonState` quartet
+// that drives `disabled` / `hidden` / `aria-pressed` / `title` / icon
+// across the focus-mode controls. The HTML structure of the toolbar
+// is still rendered by `<preview-app>` in `main.ts`; this module just
+// owns the typed state machinery.
+//
+// Each `applyXxx` takes a typed state object — `behavior.ts` computes
+// the inputs from its closures (filter toolbar layout, focus index,
+// live / recording sets, daemon readiness Maps, the `a11yOverlay`
+// store field) and hands them in. Click handlers on the buttons stay
+// in `behavior.ts` because they reach into `setInteractiveForCard` /
+// `toggleRecording` / `toggleA11yOverlay` etc.; that's a bigger lift
+// for a follow-up.
+//
+// The two `isFocused*` helpers also live here so behavior.ts can
+// import a typed predicate over the daemon-readiness Maps rather than
+// inlining the same `.values()` / `.entries()` walk at each call
+// site.
+
+export interface FocusToolbarElements {
+    btnPrev: HTMLButtonElement;
+    btnNext: HTMLButtonElement;
+    btnDiffHead: HTMLButtonElement;
+    btnDiffMain: HTMLButtonElement;
+    btnLaunchDevice: HTMLButtonElement;
+    btnA11yOverlay: HTMLButtonElement;
+    btnInteractive: HTMLButtonElement;
+    btnStopInteractive: HTMLButtonElement;
+    btnRecording: HTMLButtonElement;
+    btnExitFocus: HTMLButtonElement;
+    recordingFormat: HTMLSelectElement;
+    focusInspector: HTMLElement;
+}
+
+export interface EarlyFeatureVisibilityState {
+    earlyFeatures: boolean;
+    inFocus: boolean;
+}
+
+export interface InteractiveButtonState {
+    inFocus: boolean;
+    /** `previewId` of the focused card, or `null` when no card is in focus. */
+    focusedPreviewId: string | null;
+    /** Whether the focused preview is currently in the live set. */
+    isLive: boolean;
+    /** Live-set size minus the focused preview if it's live — used to
+     *  switch the title between "click to make this one live too" and
+     *  the multi-stream variants. */
+    otherLiveCount: number;
+    /** Whether ANY card is currently live (controls the stop-all
+     *  button's hidden / disabled state). */
+    hasLive: boolean;
+    /** Daemon readiness for the focused module. */
+    daemonReady: boolean;
+    /** Whether the focused module supports v2 live mode (vs the v1
+     *  fallback where renders refresh but pointer state is lost). */
+    interactiveSupported: boolean;
+}
+
+export interface RecordingButtonState {
+    inFocus: boolean;
+    earlyFeatures: boolean;
+    focusedPreviewId: string | null;
+    daemonReady: boolean;
+    isRecording: boolean;
+}
+
+export interface A11yOverlayButtonState {
+    inFocus: boolean;
+    earlyFeatures: boolean;
+    focusedPreviewId: string | null;
+    /** `previewId` whose accessibility-overlay subscription is on, or
+     *  `null` when no overlay is active. */
+    a11yOverlayId: string | null;
+}
+
+export class FocusToolbarController {
+    constructor(private readonly el: FocusToolbarElements) {}
+
+    applyEarlyFeatureVisibility(s: EarlyFeatureVisibilityState): void {
+        this.el.btnDiffHead.hidden = !s.earlyFeatures;
+        this.el.btnDiffMain.hidden = !s.earlyFeatures;
+        this.el.btnLaunchDevice.hidden = !s.earlyFeatures;
+        this.el.btnA11yOverlay.hidden = !s.earlyFeatures || !s.inFocus;
+        this.el.btnRecording.hidden = !s.earlyFeatures || !s.inFocus;
+        this.el.recordingFormat.hidden = !s.earlyFeatures || !s.inFocus;
+        if (!s.earlyFeatures) {
+            this.el.focusInspector.hidden = true;
+        }
+    }
+
+    applyInteractiveButtonState(s: InteractiveButtonState): void {
+        // Hide outright when not in focus mode — the toolbar already
+        // hides itself, but this keeps aria-pressed correct for tests
+        // that snapshot the button in either layout.
+        this.el.btnInteractive.hidden = !s.inFocus;
+        this.el.btnStopInteractive.hidden = !s.inFocus || !s.hasLive;
+        this.el.btnStopInteractive.disabled = !s.hasLive;
+        if (!s.inFocus) {
+            // Cheap fast-path: applyLayout fires this on every layout
+            // change (filter tweaks, focus nav, every setPreviews). In
+            // non-focus modes the focus-controls strip is hidden by CSS,
+            // so nothing visible would change — skip the per-attribute
+            // writes. State on re-entry to focus mode is rebuilt fresh
+            // by the full path below.
+            this.el.btnInteractive.setAttribute("aria-pressed", "false");
+            this.el.btnInteractive.classList.remove("live-on");
+            return;
+        }
+        if (!s.focusedPreviewId) {
+            this.el.btnInteractive.disabled = true;
+            this.el.btnInteractive.setAttribute("aria-pressed", "false");
+            this.el.btnInteractive.title =
+                "Daemon not ready — live mode unavailable";
+            this.el.btnInteractive.innerHTML =
+                '<i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>';
+            return;
+        }
+        this.el.btnInteractive.disabled = !s.daemonReady && !s.isLive;
+        this.el.btnInteractive.setAttribute(
+            "aria-pressed",
+            s.isLive ? "true" : "false",
+        );
+        this.el.btnInteractive.classList.toggle("live-on", s.isLive);
+        this.el.btnInteractive.title = !s.daemonReady
+            ? "Daemon not ready — live mode unavailable"
+            : s.isLive
+              ? "Live · click to exit · Shift+click to leave others on"
+              : !s.interactiveSupported
+                ? "Live v1 fallback — renders refresh, but clicks do not preserve Compose state"
+                : s.otherLiveCount > 0
+                  ? s.otherLiveCount +
+                    " other live · click to make this one live too · " +
+                    "Shift+click to add without unsubscribing the rest"
+                  : "Enter live mode (stream renders) · Shift+click to add to multi-stream";
+        this.el.btnInteractive.innerHTML = s.isLive
+            ? '<i class="codicon codicon-record" aria-hidden="true"></i>'
+            : '<i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>';
+    }
+
+    applyRecordingButtonState(s: RecordingButtonState): void {
+        this.el.btnRecording.hidden = !s.earlyFeatures || !s.inFocus;
+        this.el.recordingFormat.hidden = !s.earlyFeatures || !s.inFocus;
+        if (!s.earlyFeatures || !s.inFocus) {
+            this.el.btnRecording.setAttribute("aria-pressed", "false");
+            this.el.btnRecording.classList.remove("recording-on");
+            this.el.recordingFormat.disabled = true;
+            return;
+        }
+        this.el.btnRecording.disabled = !s.daemonReady && !s.isRecording;
+        this.el.recordingFormat.disabled =
+            s.isRecording || (!s.daemonReady && !s.isRecording);
+        this.el.btnRecording.setAttribute(
+            "aria-pressed",
+            s.isRecording ? "true" : "false",
+        );
+        this.el.btnRecording.classList.toggle("recording-on", s.isRecording);
+        this.el.btnRecording.title = !s.daemonReady
+            ? "Daemon not ready — recording unavailable"
+            : s.isRecording
+              ? "Stop recording focused preview"
+              : "Record focused preview";
+        this.el.btnRecording.innerHTML = s.isRecording
+            ? '<i class="codicon codicon-debug-stop" aria-hidden="true"></i>'
+            : '<i class="codicon codicon-record-keys" aria-hidden="true"></i>';
+    }
+
+    /**
+     * D2 — keep the a11y-overlay toggle in lockstep with focus-mode +
+     * the focused card identity. Outside focus mode the button hides;
+     * inside focus mode `aria-pressed` tracks whether the currently
+     * focused preview has the overlay subscription on.
+     */
+    applyA11yOverlayButtonState(s: A11yOverlayButtonState): void {
+        this.el.btnA11yOverlay.hidden = !s.earlyFeatures || !s.inFocus;
+        if (!s.earlyFeatures || !s.inFocus) {
+            this.el.btnA11yOverlay.setAttribute("aria-pressed", "false");
+            return;
+        }
+        const on =
+            s.focusedPreviewId !== null &&
+            s.focusedPreviewId === s.a11yOverlayId;
+        this.el.btnA11yOverlay.setAttribute(
+            "aria-pressed",
+            on ? "true" : "false",
+        );
+        this.el.btnA11yOverlay.title = on
+            ? "Hide accessibility overlay"
+            : "Show accessibility overlay";
+        this.el.btnA11yOverlay.classList.toggle("a11y-overlay-on", on);
+    }
+}
+
+/**
+ * Daemon-ready predicate for the focused module. The webview doesn't
+ * know moduleId per preview today; we fall back to "any module ready"
+ * because the extension-side panel is single-module-scoped (it only
+ * ever holds one module's previews at a time) — so the readiness of
+ * the sole module is also the readiness for whatever's focused. If
+ * the panel ever shows multiple modules at once, swap this to lookup
+ * by the focused card's `data-module-id`.
+ */
+export function isFocusedModuleReady(
+    moduleDaemonReady: ReadonlyMap<string, boolean>,
+): boolean {
+    for (const ready of moduleDaemonReady.values()) {
+        if (ready) return true;
+    }
+    return false;
+}
+
+/**
+ * Whether the focused module supports full v2 live mode (with
+ * preserved Compose state) vs the v1 fallback where pointer events
+ * round-trip through the daemon but renders refresh from scratch.
+ * Same module-scoping caveat as [isFocusedModuleReady].
+ */
+export function isFocusedInteractiveSupported(
+    moduleDaemonReady: ReadonlyMap<string, boolean>,
+    moduleInteractiveSupported: ReadonlyMap<string, boolean>,
+): boolean {
+    for (const [moduleId, ready] of moduleDaemonReady.entries()) {
+        if (ready && moduleInteractiveSupported.get(moduleId) === true)
+            return true;
+    }
+    return false;
+}


### PR DESCRIPTION
Slice of #767. Extracts the four `apply*ButtonState` / `apply*Visibility` functions that drive `disabled` / `hidden` / `aria-pressed` / `title` / icon across the focus-mode toolbar into a typed `FocusToolbarController`.

The HTML structure of the toolbar is still rendered by `<preview-app>` in `main.ts`; this change is just the typed state machinery.

## Summary

- `FocusToolbarController` owns the button DOM references and exposes `applyEarlyFeatureVisibility(s)`, `applyInteractiveButtonState(s)`, `applyRecordingButtonState(s)`, `applyA11yOverlayButtonState(s)`. Each takes a typed state object — `behavior.ts` computes the inputs (filter-toolbar layout, focus index → focused preview id, live / recording sets, daemon-readiness Maps, `a11yOverlay()` store field) and hands them in.
- `isFocusedModuleReady` / `isFocusedInteractiveSupported` lift to the same module as standalone helpers over the daemon-readiness Maps — same `.values()` / `.entries()` walk, just typed.

Click handlers on the buttons stay in `behavior.ts` because they reach into `setInteractiveForCard` / `toggleRecording` / `toggleA11yOverlay` etc.; that's a bigger lift for a follow-up.

`behavior.ts` shrinks from 2085 → 2015 lines (−70 LOC). No behaviour change.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 320/320 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke: open the panel against a workspace with previews, switch into focus mode. Verify:
  - With `composePreview.earlyFeatures` off: diff buttons / launch-device / a11y-overlay / recording controls are hidden, focus inspector hidden.
  - With `composePreview.earlyFeatures` on and the daemon ready: live button enables; click toggles `aria-pressed=true` and the icon flips to `codicon-record`; Shift+click adds without unsubscribing others; "stop interactive" appears when ≥1 live and disables/hides when none. Recording button enables, ` aria-pressed` flips while recording. A11y overlay toggle reflects the focused card's subscription state.
  - With the daemon stopped: live button disables and shows the v1-fallback / not-ready titles depending on `interactiveSupported`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTv9gnHTdY5MzDfGdnSpBn)_