### PR TITLE
feat(data/wallpaper): use material-kolor for seed → ColorScheme derivation

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -394,10 +394,12 @@ data class PreviewOverrides(
 /**
  * Single-color seed for the wallpaper data extension.
  *
- * The renderer treats this like a tiny dynamic-color scheme: derive primary/secondary/tertiary
- * tonal palettes from [seedColor], pick the brightness from [isDark] (when null, inherits the host
- * theme's surface luminance), and apply the resulting [androidx.compose.material3.ColorScheme] as a
- * `MaterialTheme` wrapper around the preview.
+ * The renderer derives a Material 3 [androidx.compose.material3.ColorScheme] from [seedColor] via
+ * Google's Material Color Utilities (HCT tonal palettes), picks the brightness from [isDark] (when
+ * null, inherits the host theme's surface luminance), and wraps the preview in a
+ * `MaterialTheme(colorScheme = …)`. [paletteStyle] selects the algorithm variant the wallpaper
+ * picker exposes (Tonal Spot / Vibrant / Expressive / etc.) and [contrastLevel] threads through the
+ * accessibility contrast control (`-1.0` → reduced, `0.0` → default, `0.5` → medium, `1.0` → high).
  */
 @Serializable
 data class WallpaperOverride(
@@ -405,7 +407,36 @@ data class WallpaperOverride(
   val seedColor: String,
   /** When non-null, forces the dark variant of the derived scheme. */
   val isDark: Boolean? = null,
+  /**
+   * Algorithm variant. Mirrors the styles the Android wallpaper picker exposes; null falls back to
+   * the connector's default (`TONAL_SPOT`).
+   */
+  val paletteStyle: WallpaperPaletteStyle? = null,
+  /**
+   * Material 3 contrast level in `[-1.0, 1.0]` — `0.0` is the default, `0.5` is medium, `1.0` is
+   * high contrast. Null falls back to `0.0`.
+   */
+  val contrastLevel: Double? = null,
 )
+
+/**
+ * Style of palette derivation for [WallpaperOverride].
+ *
+ * Mirrors `com.materialkolor.PaletteStyle` so the protocol stays free of an external dependency;
+ * the wallpaper connector maps each value to the upstream enum.
+ */
+@Serializable
+enum class WallpaperPaletteStyle {
+  @SerialName("tonalSpot") TONAL_SPOT,
+  @SerialName("neutral") NEUTRAL,
+  @SerialName("vibrant") VIBRANT,
+  @SerialName("expressive") EXPRESSIVE,
+  @SerialName("rainbow") RAINBOW,
+  @SerialName("fruitSalad") FRUIT_SALAD,
+  @SerialName("monochrome") MONOCHROME,
+  @SerialName("fidelity") FIDELITY,
+  @SerialName("content") CONTENT,
+}
 
 @Serializable
 data class Material3ThemeOverrides(

--- a/data/wallpaper/connector/build.gradle.kts
+++ b/data/wallpaper/connector/build.gradle.kts
@@ -12,6 +12,10 @@ dependencies {
   implementation(compose.runtime)
   implementation(compose.ui)
   implementation(compose.material3)
+  // KMP port of Material Color Utilities — `dynamicColorScheme(seed, isDark, style, contrast)`
+  // returns the canonical Material 3 dynamic ColorScheme from a single seed color, matching what
+  // Android's wallpaper-derived theming produces.
+  implementation(libs.material.kolor)
   testImplementation(libs.junit)
   testImplementation(compose.desktop.currentOs)
   testImplementation(compose.runtime)

--- a/data/wallpaper/connector/src/main/kotlin/ee/schimke/composeai/daemon/WallpaperColorScheme.kt
+++ b/data/wallpaper/connector/src/main/kotlin/ee/schimke/composeai/daemon/WallpaperColorScheme.kt
@@ -1,113 +1,56 @@
 package ee.schimke.composeai.daemon
 
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import kotlin.math.abs
+import com.materialkolor.PaletteStyle
+import com.materialkolor.dynamicColorScheme
+import ee.schimke.composeai.daemon.protocol.WallpaperPaletteStyle
 
 /**
- * Lightweight seed-color → Material 3 [ColorScheme] derivation used by the wallpaper data
- * extension.
+ * Wallpaper-seed → Material 3 [ColorScheme] derivation, backed by Material Color Utilities (KMP
+ * port via `com.materialkolor:material-kolor`).
  *
- * The algorithm intentionally avoids a Material Color Utilities dependency. Primary, secondary, and
- * tertiary roles are derived from the seed in HSL space (secondary at +30° hue, tertiary at +60°),
- * with light/dark luminance ramps tuned to roughly match the Material 3 tonal palette buckets.
- * Surface and neutral roles fall back to [lightColorScheme] / [darkColorScheme] defaults — clients
- * that need a fully wallpaper-derived neutral palette can layer a `material3Theme` override on top
- * of this one.
+ * The upstream library implements Google's HCT-based tonal-palette algorithm — the same one
+ * Android's wallpaper-derived dynamic theming uses — so the resulting scheme matches what users see
+ * when "Themed icons" is on. Style and contrast level pass through to expose the same knobs the
+ * Android wallpaper picker exposes.
  */
 object WallpaperColorScheme {
   /**
    * Derive a Material 3 [ColorScheme] from a seed color.
    *
-   * @param seed wallpaper seed color (any alpha is dropped — only the hue/saturation matter).
-   * @param isDark whether the dark variant should be returned. Surface tokens follow.
+   * @param seed wallpaper seed color (alpha is ignored — only hue/saturation matter).
+   * @param isDark whether to return the dark variant.
+   * @param style palette algorithm. Defaults to [WallpaperPaletteStyle.TONAL_SPOT] — the same
+   *   default the Android wallpaper picker uses.
+   * @param contrastLevel Material 3 contrast level in `[-1.0, 1.0]`. Defaults to `0.0` (standard).
    */
-  fun from(seed: Color, isDark: Boolean): ColorScheme {
-    val (h, s, _) = seed.toHsl()
-    // Force a minimum saturation so achromatic seeds (white/black/grey) still produce a visible
-    // tint instead of collapsing to the neutral defaults.
-    val chroma = s.coerceAtLeast(0.35f)
+  fun from(
+    seed: Color,
+    isDark: Boolean,
+    style: WallpaperPaletteStyle = WallpaperPaletteStyle.TONAL_SPOT,
+    contrastLevel: Double = 0.0,
+  ): ColorScheme =
+    dynamicColorScheme(
+      seedColor = seed,
+      isDark = isDark,
+      style = style.toMaterialKolor(),
+      contrastLevel = contrastLevel,
+    )
+}
 
-    return if (isDark) {
-      darkColorScheme(
-        primary = hsl(h, chroma, 0.78f),
-        onPrimary = hsl(h, chroma * 0.5f, 0.18f),
-        primaryContainer = hsl(h, chroma * 0.7f, 0.32f),
-        onPrimaryContainer = hsl(h, chroma * 0.4f, 0.90f),
-        secondary = hsl(h + 30f, chroma * 0.7f, 0.78f),
-        onSecondary = hsl(h + 30f, chroma * 0.4f, 0.18f),
-        secondaryContainer = hsl(h + 30f, chroma * 0.5f, 0.32f),
-        onSecondaryContainer = hsl(h + 30f, chroma * 0.3f, 0.90f),
-        tertiary = hsl(h + 60f, chroma * 0.7f, 0.78f),
-        onTertiary = hsl(h + 60f, chroma * 0.4f, 0.18f),
-        tertiaryContainer = hsl(h + 60f, chroma * 0.5f, 0.32f),
-        onTertiaryContainer = hsl(h + 60f, chroma * 0.3f, 0.90f),
-      )
-    } else {
-      lightColorScheme(
-        primary = hsl(h, chroma, 0.40f),
-        onPrimary = hsl(h, chroma * 0.4f, 0.98f),
-        primaryContainer = hsl(h, chroma * 0.6f, 0.86f),
-        onPrimaryContainer = hsl(h, chroma * 0.6f, 0.18f),
-        secondary = hsl(h + 30f, chroma * 0.7f, 0.42f),
-        onSecondary = hsl(h + 30f, chroma * 0.3f, 0.98f),
-        secondaryContainer = hsl(h + 30f, chroma * 0.4f, 0.86f),
-        onSecondaryContainer = hsl(h + 30f, chroma * 0.5f, 0.18f),
-        tertiary = hsl(h + 60f, chroma * 0.7f, 0.42f),
-        onTertiary = hsl(h + 60f, chroma * 0.3f, 0.98f),
-        tertiaryContainer = hsl(h + 60f, chroma * 0.4f, 0.86f),
-        onTertiaryContainer = hsl(h + 60f, chroma * 0.5f, 0.18f),
-      )
-    }
+internal fun WallpaperPaletteStyle.toMaterialKolor(): PaletteStyle =
+  when (this) {
+    WallpaperPaletteStyle.TONAL_SPOT -> PaletteStyle.TonalSpot
+    WallpaperPaletteStyle.NEUTRAL -> PaletteStyle.Neutral
+    WallpaperPaletteStyle.VIBRANT -> PaletteStyle.Vibrant
+    WallpaperPaletteStyle.EXPRESSIVE -> PaletteStyle.Expressive
+    WallpaperPaletteStyle.RAINBOW -> PaletteStyle.Rainbow
+    WallpaperPaletteStyle.FRUIT_SALAD -> PaletteStyle.FruitSalad
+    WallpaperPaletteStyle.MONOCHROME -> PaletteStyle.Monochrome
+    WallpaperPaletteStyle.FIDELITY -> PaletteStyle.Fidelity
+    WallpaperPaletteStyle.CONTENT -> PaletteStyle.Content
   }
-}
-
-internal data class Hsl(val hue: Float, val saturation: Float, val luminance: Float)
-
-internal fun Color.toHsl(): Hsl {
-  val r = red
-  val g = green
-  val b = blue
-  val max = maxOf(r, g, b)
-  val min = minOf(r, g, b)
-  val l = (max + min) / 2f
-  if (abs(max - min) < 1e-6f) return Hsl(0f, 0f, l)
-  val d = max - min
-  val s = if (l > 0.5f) d / (2f - max - min) else d / (max + min)
-  val h =
-    when (max) {
-      r -> ((g - b) / d + if (g < b) 6f else 0f)
-      g -> ((b - r) / d + 2f)
-      else -> ((r - g) / d + 4f)
-    } * 60f
-  return Hsl(h, s, l)
-}
-
-internal fun hsl(hueDegrees: Float, saturation: Float, luminance: Float): Color {
-  val h = ((hueDegrees % 360f) + 360f) % 360f / 360f
-  val s = saturation.coerceIn(0f, 1f)
-  val l = luminance.coerceIn(0f, 1f)
-  if (s == 0f) return Color(l, l, l)
-  val q = if (l < 0.5f) l * (1f + s) else l + s - l * s
-  val p = 2f * l - q
-  return Color(
-    red = hueToRgb(p, q, h + 1f / 3f),
-    green = hueToRgb(p, q, h),
-    blue = hueToRgb(p, q, h - 1f / 3f),
-  )
-}
-
-private fun hueToRgb(p: Float, q: Float, hue: Float): Float {
-  val t = ((hue % 1f) + 1f) % 1f
-  return when {
-    t < 1f / 6f -> p + (q - p) * 6f * t
-    t < 1f / 2f -> q
-    t < 2f / 3f -> p + (q - p) * (2f / 3f - t) * 6f
-    else -> p
-  }
-}
 
 internal fun Color.toHexArgb(): String = "#%08X".format(toArgb())

--- a/data/wallpaper/connector/src/main/kotlin/ee/schimke/composeai/daemon/WallpaperDataProduct.kt
+++ b/data/wallpaper/connector/src/main/kotlin/ee/schimke/composeai/daemon/WallpaperDataProduct.kt
@@ -9,6 +9,7 @@ import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.WallpaperOverride
+import ee.schimke.composeai.daemon.protocol.WallpaperPaletteStyle
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtension
 import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
@@ -50,7 +51,13 @@ class WallpaperOverrideExtension(private val override: WallpaperOverride?) :
     }
     val seed = ComposeColorSpec.resolve(override.seedColor)
     val isDark = override.isDark ?: isMaterialThemeDark()
-    val scheme = WallpaperColorScheme.from(seed, isDark)
+    val scheme =
+      WallpaperColorScheme.from(
+        seed = seed,
+        isDark = isDark,
+        style = override.paletteStyle ?: WallpaperPaletteStyle.TONAL_SPOT,
+        contrastLevel = override.contrastLevel ?: 0.0,
+      )
     MaterialTheme(
       colorScheme = scheme,
       typography = MaterialTheme.typography,
@@ -167,7 +174,7 @@ class WallpaperDataProductRegistry : DataProductRegistry {
       val seed = runCatching { ComposeColorSpec.resolve(applied.seedColor) }.getOrNull()
       if (seed != null) {
         val isDark = applied.isDark ?: previewContextIsDark(previewContext)
-        capture(previewId, payloadFor(seed, applied.seedColor, isDark))
+        capture(previewId, payloadFor(seed, applied, isDark))
         return
       }
     }
@@ -179,11 +186,25 @@ class WallpaperDataProductRegistry : DataProductRegistry {
     }
   }
 
-  private fun payloadFor(seed: Color, rawSeed: String, isDark: Boolean): WallpaperPayload {
-    val scheme = WallpaperColorScheme.from(seed, isDark)
+  private fun payloadFor(
+    seed: Color,
+    applied: WallpaperOverride,
+    isDark: Boolean,
+  ): WallpaperPayload {
+    val style = applied.paletteStyle ?: WallpaperPaletteStyle.TONAL_SPOT
+    val contrast = applied.contrastLevel ?: 0.0
+    val scheme =
+      WallpaperColorScheme.from(
+        seed = seed,
+        isDark = isDark,
+        style = style,
+        contrastLevel = contrast,
+      )
     return WallpaperPayload(
-      seedColor = canonicalSeedColor(rawSeed, seed),
+      seedColor = canonicalSeedColor(applied.seedColor, seed),
       isDark = isDark,
+      paletteStyle = style,
+      contrastLevel = contrast,
       derivedColorScheme =
         linkedMapOf(
           "primary" to scheme.primary.toHexArgb(),
@@ -259,6 +280,10 @@ data class WallpaperPayload(
   val seedColor: String,
   /** Whether the derived scheme is the dark variant. */
   val isDark: Boolean,
+  /** Palette algorithm the connector applied. */
+  val paletteStyle: WallpaperPaletteStyle = WallpaperPaletteStyle.TONAL_SPOT,
+  /** Effective contrast level in `[-1.0, 1.0]`. */
+  val contrastLevel: Double = 0.0,
   /** Material 3 color roles derived from [seedColor]; matches the schema of `compose/theme`. */
   val derivedColorScheme: Map<String, String>,
 )

--- a/data/wallpaper/connector/src/test/kotlin/ee/schimke/composeai/daemon/WallpaperColorSchemeTest.kt
+++ b/data/wallpaper/connector/src/test/kotlin/ee/schimke/composeai/daemon/WallpaperColorSchemeTest.kt
@@ -1,11 +1,18 @@
 package ee.schimke.composeai.daemon
 
 import androidx.compose.ui.graphics.Color
+import com.materialkolor.PaletteStyle
+import ee.schimke.composeai.daemon.protocol.WallpaperPaletteStyle
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
+/**
+ * Smoke tests for the wallpaper-seed → ColorScheme derivation. The heavy lifting (HCT, tonal
+ * palettes) lives in `com.materialkolor:material-kolor`; these tests pin our connector's
+ * style/contrast plumbing and the `WallpaperPaletteStyle` ↔ upstream-enum mapping rather than
+ * re-asserting Google's algorithm.
+ */
 class WallpaperColorSchemeTest {
 
   @Test
@@ -14,51 +21,67 @@ class WallpaperColorSchemeTest {
     val light = WallpaperColorScheme.from(seed, isDark = false)
     val dark = WallpaperColorScheme.from(seed, isDark = true)
     assertNotEquals(light.primary, dark.primary)
-    // Light primary is darker than dark primary in luminance.
-    val lightL = light.primary.toHsl().luminance
-    val darkL = dark.primary.toHsl().luminance
-    assertTrue("light L=$lightL dark L=$darkL", lightL < darkL)
+    assertNotEquals(light.background, dark.background)
   }
 
   @Test
-  fun seed_drives_primary_hue() {
-    val red = WallpaperColorScheme.from(Color(0xFFFF0000), isDark = false).primary.toHsl()
-    val blue = WallpaperColorScheme.from(Color(0xFF0000FF), isDark = false).primary.toHsl()
-    // A red seed should produce a primary near 0°/360°; blue near 240°.
-    assertTrue("red hue=${red.hue}", red.hue < 30f || red.hue > 330f)
-    assertTrue("blue hue=${blue.hue}", blue.hue in 200f..280f)
+  fun different_palette_styles_produce_different_schemes() {
+    val seed = Color(0xFF3366FF)
+    val tonal =
+      WallpaperColorScheme.from(seed, isDark = false, style = WallpaperPaletteStyle.TONAL_SPOT)
+    val vibrant =
+      WallpaperColorScheme.from(seed, isDark = false, style = WallpaperPaletteStyle.VIBRANT)
+    val mono =
+      WallpaperColorScheme.from(seed, isDark = false, style = WallpaperPaletteStyle.MONOCHROME)
+    assertNotEquals(
+      "tonalSpot vs vibrant should differ on at least one role",
+      tonal.primary,
+      vibrant.primary,
+    )
+    assertNotEquals(
+      "tonalSpot vs monochrome should differ on at least one role",
+      tonal.primary,
+      mono.primary,
+    )
   }
 
   @Test
-  fun secondary_and_tertiary_rotate_off_primary() {
-    val scheme = WallpaperColorScheme.from(Color(0xFF3366FF), isDark = false)
-    val primary = scheme.primary.toHsl().hue
-    val secondary = scheme.secondary.toHsl().hue
-    val tertiary = scheme.tertiary.toHsl().hue
-    fun rotation(a: Float, b: Float): Float {
-      val d = ((b - a) % 360f + 360f) % 360f
-      return d
-    }
-    assertEquals(30f, rotation(primary, secondary), 5f)
-    assertEquals(60f, rotation(primary, tertiary), 5f)
+  fun high_contrast_changes_role_luminance() {
+    val seed = Color(0xFF3366FF)
+    val standard = WallpaperColorScheme.from(seed, isDark = false, contrastLevel = 0.0)
+    val high = WallpaperColorScheme.from(seed, isDark = false, contrastLevel = 1.0)
+    val standardRoles =
+      listOf(
+        standard.primary,
+        standard.onSurface,
+        standard.onSurfaceVariant,
+        standard.outline,
+        standard.surfaceVariant,
+      )
+    val highRoles =
+      listOf(high.primary, high.onSurface, high.onSurfaceVariant, high.outline, high.surfaceVariant)
+    assertNotEquals(
+      "high-contrast scheme should differ from the default on at least one role",
+      standardRoles,
+      highRoles,
+    )
   }
 
   @Test
-  fun achromatic_seed_still_produces_visible_chroma() {
-    val grey = WallpaperColorScheme.from(Color(0xFF808080), isDark = false).primary.toHsl()
-    // Grey would normally collapse to saturation 0. The algorithm clamps the chroma floor so the
-    // derived primary is still visibly tinted.
-    assertTrue("primary saturation=${grey.saturation}", grey.saturation > 0.2f)
-  }
-
-  @Test
-  fun hsl_round_trips_through_color_constructor() {
-    val original = Color(0xFF80C040)
-    val (h, s, l) = original.toHsl()
-    val rebuilt = hsl(h, s, l)
-    fun close(a: Float, b: Float): Boolean = kotlin.math.abs(a - b) < 0.01f
-    assertTrue(close(rebuilt.red, original.red))
-    assertTrue(close(rebuilt.green, original.green))
-    assertTrue(close(rebuilt.blue, original.blue))
+  fun palette_style_enum_maps_to_upstream_one_to_one() {
+    assertEquals(PaletteStyle.TonalSpot, WallpaperPaletteStyle.TONAL_SPOT.toMaterialKolor())
+    assertEquals(PaletteStyle.Neutral, WallpaperPaletteStyle.NEUTRAL.toMaterialKolor())
+    assertEquals(PaletteStyle.Vibrant, WallpaperPaletteStyle.VIBRANT.toMaterialKolor())
+    assertEquals(PaletteStyle.Expressive, WallpaperPaletteStyle.EXPRESSIVE.toMaterialKolor())
+    assertEquals(PaletteStyle.Rainbow, WallpaperPaletteStyle.RAINBOW.toMaterialKolor())
+    assertEquals(PaletteStyle.FruitSalad, WallpaperPaletteStyle.FRUIT_SALAD.toMaterialKolor())
+    assertEquals(PaletteStyle.Monochrome, WallpaperPaletteStyle.MONOCHROME.toMaterialKolor())
+    assertEquals(PaletteStyle.Fidelity, WallpaperPaletteStyle.FIDELITY.toMaterialKolor())
+    assertEquals(PaletteStyle.Content, WallpaperPaletteStyle.CONTENT.toMaterialKolor())
+    assertEquals(
+      "every protocol enum entry must map to an upstream value",
+      WallpaperPaletteStyle.entries.size,
+      PaletteStyle.entries.size,
+    )
   }
 }

--- a/data/wallpaper/connector/src/test/kotlin/ee/schimke/composeai/daemon/WallpaperDataProductTest.kt
+++ b/data/wallpaper/connector/src/test/kotlin/ee/schimke/composeai/daemon/WallpaperDataProductTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.WallpaperOverride
+import ee.schimke.composeai.daemon.protocol.WallpaperPaletteStyle
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
@@ -13,6 +14,7 @@ import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -86,9 +88,67 @@ class WallpaperDataProductTest {
     val payload = (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
     assertEquals("#FF3366FF", payload["seedColor"]!!.jsonPrimitive.content)
     assertEquals(false, payload["isDark"]!!.jsonPrimitive.boolean)
+    assertEquals("tonalSpot", payload["paletteStyle"]!!.jsonPrimitive.content)
+    assertEquals(0.0, payload["contrastLevel"]!!.jsonPrimitive.content.toDouble(), 0.0001)
     val derived = payload["derivedColorScheme"]!!.jsonObject
     assertNotNull(derived["primary"])
     assertTrue(derived["primary"]!!.jsonPrimitive.content.matches(Regex("#[0-9A-F]{8}")))
+  }
+
+  @Test
+  fun on_render_propagates_palette_style_and_contrast_into_payload() {
+    val registry = WallpaperDataProductRegistry()
+    val tonalResult = stubRenderResult()
+    val vibrantResult = stubRenderResult()
+
+    registry.onRender(
+      "preview-1",
+      tonalResult,
+      PreviewOverrides(
+        wallpaper =
+          WallpaperOverride(
+            seedColor = "#FF3366FF",
+            paletteStyle = WallpaperPaletteStyle.TONAL_SPOT,
+            contrastLevel = 0.0,
+          )
+      ),
+      previewContext = null,
+    )
+    val tonalPrimary =
+      ((registry.fetch("preview-1", "compose/wallpaper", null, true)
+          as DataProductRegistry.Outcome.Ok)
+        .result
+        .payload!!
+        .jsonObject["derivedColorScheme"]!!
+        .jsonObject["primary"]!!
+        .jsonPrimitive
+        .content)
+
+    registry.onRender(
+      "preview-1",
+      vibrantResult,
+      PreviewOverrides(
+        wallpaper =
+          WallpaperOverride(
+            seedColor = "#FF3366FF",
+            paletteStyle = WallpaperPaletteStyle.VIBRANT,
+            contrastLevel = 1.0,
+          )
+      ),
+      previewContext = null,
+    )
+    val vibrantOutcome =
+      registry.fetch("preview-1", "compose/wallpaper", null, true) as DataProductRegistry.Outcome.Ok
+    val vibrantPayload = vibrantOutcome.result.payload!!.jsonObject
+    assertEquals("vibrant", vibrantPayload["paletteStyle"]!!.jsonPrimitive.content)
+    assertEquals(1.0, vibrantPayload["contrastLevel"]!!.jsonPrimitive.content.toDouble(), 0.0001)
+    val vibrantPrimary =
+      vibrantPayload["derivedColorScheme"]!!.jsonObject["primary"]!!.jsonPrimitive.content
+    assertNotEquals(
+      "vibrant + high contrast should produce a different primary than tonalSpot/default",
+      tonalPrimary,
+      vibrantPrimary,
+    )
   }
 
   @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,6 +87,11 @@ android-compose-screenshot = "0.0.1-alpha14"
 # warning without exporting the annotation to consumers (it's marker-only;
 # zero runtime impact).
 checker-qual = "4.0.0"
+# KMP port of Google's Material Color Utilities. Powers the wallpaper data
+# extension's seed → ColorScheme derivation (HCT tonal palettes, palette
+# styles, contrast level) so the result matches what Android's wallpaper-
+# derived dynamic theming actually produces.
+material-kolor = "4.1.1"
 
 [libraries]
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
@@ -139,6 +144,7 @@ truth = { module = "com.google.truth:truth", version.ref = "truth" }
 # files the test can't differentiate "stale" from "fresh".
 asm = { module = "org.ow2.asm:asm", version = "9.7" }
 asm-commons = { module = "org.ow2.asm:asm-commons", version = "9.7" }
+material-kolor = { module = "com.materialkolor:material-kolor", version.ref = "material-kolor" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Follow-up to #780.

## Summary

- Drops the in-tree HSL approximation in the wallpaper connector and delegates to `com.materialkolor:material-kolor:4.1.1` (KMP port of Google's Material Color Utilities). Resulting schemes match what Android's wallpaper-derived dynamic theming produces — HCT tonal palettes, full Material 3 role coverage, and the same per-style behaviour the wallpaper picker exposes.
- Protocol `WallpaperOverride` gains `paletteStyle: WallpaperPaletteStyle?` (TonalSpot / Neutral / Vibrant / Expressive / Rainbow / FruitSalad / Monochrome / Fidelity / Content — 1:1 with the upstream enum) and `contrastLevel: Double?` for the M3 contrast control. Both default to TonalSpot / 0.0. The protocol enum stays free of any external dependency; the connector carries the mapping (`WallpaperPaletteStyle.toMaterialKolor()`).
- `WallpaperColorScheme.from(seed, isDark, style, contrastLevel)` is a thin facade over `com.materialkolor.dynamicColorScheme(...)`. The HSL helpers are gone.
- `WallpaperPayload` echoes the applied `paletteStyle` and `contrastLevel` so clients can read what scheme was actually derived.

## Test plan

- [x] `:data-wallpaper-connector:test` (4 + 12 cases) green — covers the full enum mapping, light/dark divergence, palette-style divergence, contrast-level divergence, and the new payload fields.
- [x] `:daemon:desktop:test` (60 tests) still green; the existing `OverrideIntegrationTest.wallpaperOverrideDrivesAmbientPrimaryColor` exercises the upstream algorithm end-to-end via `PreviewManifestRouter`.
- [x] `:daemon:android:compileDebugKotlin` clean.
- [x] `./gradlew ktfmtCheckAll` clean.
- [ ] Manual smoke through the desktop daemon: drive `renderNow.overrides.wallpaper` against `WallpaperDemoPreview` with a few `paletteStyle` / `contrastLevel` combos and confirm the rendered PNG's primary tracks the expected wallpaper-picker output.

---
_Generated by [Claude Code](https://claude.ai/code/session_016F4ZRCBbgDv3J7WiFuoBx3)_