### PR TITLE
fix(vscode): surface @ScrollingPreview LONG/GIF data products in the panel

### DIFF
--- a/vscode-extension/src/captureLabels.ts
+++ b/vscode-extension/src/captureLabels.ts
@@ -1,4 +1,4 @@
-import { Capture, PreviewInfo } from "./types";
+import { Capture, PreviewDataProduct, PreviewInfo } from "./types";
 
 /**
  * Human-readable label for one capture of a preview, used in the carousel
@@ -51,4 +51,38 @@ export function isAnimatedPreview(p: PreviewInfo): boolean {
         return c.advanceTimeMillis != null || c.scroll != null;
     }
     return false;
+}
+
+/** Image-bearing data product? `render/scroll/long` lands at .png and
+ *  `render/scroll/gif` at .gif; non-image kinds (a11y/atf, a11y/hierarchy)
+ *  carry JSON paths and are filtered out. */
+function isImageDataProduct(p: PreviewDataProduct): boolean {
+    if (!p.output) return false;
+    const lower = p.output.toLowerCase();
+    return lower.endsWith(".png") || lower.endsWith(".gif");
+}
+
+function dataProductToCapture(p: PreviewDataProduct): Capture {
+    const cap: Capture = {
+        advanceTimeMillis: p.advanceTimeMillis,
+        scroll: p.scroll,
+        renderOutput: p.output,
+    };
+    if (p.cost != null) cap.cost = p.cost;
+    cap.label = captureLabel(cap);
+    return cap;
+}
+
+/** Returns a copy of [preview] with image-bearing data products folded into
+ *  the captures list as additional carousel frames. The webview only renders
+ *  `captures`; surfacing `@ScrollingPreview(LONG/GIF)` requires moving those
+ *  entries across the boundary so the panel actually paints them. Order:
+ *  base captures first, then data products in declaration order. */
+export function withDataProductCaptures(preview: PreviewInfo): PreviewInfo {
+    const products = (preview.dataProducts ?? []).filter(isImageDataProduct);
+    if (products.length === 0) return preview;
+    return {
+        ...preview,
+        captures: [...preview.captures, ...products.map(dataProductToCapture)],
+    };
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -23,7 +23,7 @@ import {
     WebviewToExtension,
 } from "./types";
 import { formatRenderErrorMessage } from "./renderError";
-import { captureLabel } from "./captureLabels";
+import { captureLabel, withDataProductCaptures } from "./captureLabels";
 import { DaemonGate } from "./daemon/daemonGate";
 import { DataProductAttachment } from "./daemon/daemonProtocol";
 import {
@@ -1514,15 +1514,17 @@ async function preloadCachedPreviews(filePath: string): Promise<boolean> {
         previewModuleMap.set(p.id, module);
     }
 
+    const displayPreviews = visiblePreviews.map(withDataProductCaptures);
+
     panel.postMessage({
         command: "setPreviews",
-        previews: visiblePreviews,
+        previews: displayPreviews,
         moduleDir: module,
         heavyStaleIds: [],
     });
 
     const imageJobs: Promise<void>[] = [];
-    for (const preview of visiblePreviews) {
+    for (const preview of displayPreviews) {
         for (let idx = 0; idx < preview.captures.length; idx++) {
             const capture = preview.captures[idx];
             if (!capture.renderOutput) {
@@ -1896,7 +1898,7 @@ async function reconcilePreviewManifest(
         : [];
     panel.postMessage({
         command: "setPreviews",
-        previews: visiblePreviews,
+        previews: visiblePreviews.map(withDataProductCaptures),
         moduleDir: module,
         heavyStaleIds,
     });
@@ -2002,7 +2004,7 @@ async function reconcilePreviewManifestAfterDaemonReady(
             : [];
         panel.postMessage({
             command: "setPreviews",
-            previews: visiblePreviews,
+            previews: visiblePreviews.map(withDataProductCaptures),
             moduleDir: module,
             heavyStaleIds,
         });
@@ -2855,9 +2857,11 @@ async function refresh(
             ? visiblePreviews.filter(hasHeavyCapture).map((p) => p.id)
             : [];
 
+        const displayPreviews = visiblePreviews.map(withDataProductCaptures);
+
         panel.postMessage({
             command: "setPreviews",
-            previews: visiblePreviews,
+            previews: displayPreviews,
             moduleDir: modules.join(","),
             heavyStaleIds,
         });
@@ -2912,7 +2916,7 @@ async function refresh(
             ));
         if (!sourceIsStale) {
             const imageJobs: Promise<void>[] = [];
-            for (const preview of visiblePreviews) {
+            for (const preview of displayPreviews) {
                 const captures = preview.captures;
                 if (captures.length === 0) {
                     continue;

--- a/vscode-extension/src/test/captureLabels.test.ts
+++ b/vscode-extension/src/test/captureLabels.test.ts
@@ -1,0 +1,167 @@
+import * as assert from "assert";
+import {
+    captureLabel,
+    isAnimatedPreview,
+    withDataProductCaptures,
+} from "../captureLabels";
+import { PreviewInfo } from "../types";
+
+const baseParams: PreviewInfo["params"] = {
+    name: null,
+    device: null,
+    widthDp: 0,
+    heightDp: 0,
+    fontScale: 1.0,
+    showSystemUi: false,
+    showBackground: false,
+    backgroundColor: 0,
+    uiMode: 0,
+    locale: null,
+    group: null,
+};
+
+function makePreview(overrides: Partial<PreviewInfo> = {}): PreviewInfo {
+    return {
+        id: "com.example.PreviewsKt.LongPreview",
+        functionName: "LongPreview",
+        className: "com.example.PreviewsKt",
+        sourceFile: "Previews.kt",
+        params: baseParams,
+        captures: [
+            {
+                advanceTimeMillis: null,
+                scroll: null,
+                renderOutput: "renders/com.example.LongPreview.png",
+            },
+        ],
+        ...overrides,
+    };
+}
+
+describe("captureLabel", () => {
+    it("returns empty for static captures", () => {
+        assert.strictEqual(
+            captureLabel({
+                advanceTimeMillis: null,
+                scroll: null,
+                renderOutput: "x.png",
+            }),
+            "",
+        );
+    });
+
+    it("labels scroll modes via the outcome", () => {
+        assert.strictEqual(
+            captureLabel({
+                advanceTimeMillis: null,
+                scroll: {
+                    mode: "LONG",
+                    axis: "VERTICAL",
+                    maxScrollPx: 0,
+                    reduceMotion: false,
+                    atEnd: false,
+                    reachedPx: null,
+                },
+                renderOutput: "x.png",
+            }),
+            "scroll long",
+        );
+    });
+});
+
+describe("withDataProductCaptures", () => {
+    it("returns the same preview when there are no data products", () => {
+        const preview = makePreview();
+        assert.strictEqual(withDataProductCaptures(preview), preview);
+    });
+
+    it("returns the same preview when data products are non-image", () => {
+        const preview = makePreview({
+            dataProducts: [
+                {
+                    kind: "a11y/atf",
+                    advanceTimeMillis: null,
+                    scroll: null,
+                    output: "data/atf/x.json",
+                },
+            ],
+        });
+        assert.strictEqual(withDataProductCaptures(preview), preview);
+    });
+
+    it("appends LONG/GIF data products as carousel captures", () => {
+        const longScroll = {
+            mode: "LONG",
+            axis: "VERTICAL",
+            maxScrollPx: 0,
+            reduceMotion: false,
+            atEnd: true,
+            reachedPx: null,
+        };
+        const gifScroll = { ...longScroll, mode: "GIF", atEnd: false };
+        const preview = makePreview({
+            dataProducts: [
+                {
+                    kind: "render/scroll/long",
+                    advanceTimeMillis: null,
+                    scroll: longScroll,
+                    output: "data/scroll/long/x.png",
+                    cost: 20,
+                },
+                {
+                    kind: "render/scroll/gif",
+                    advanceTimeMillis: null,
+                    scroll: gifScroll,
+                    output: "data/scroll/gif/x.gif",
+                    cost: 40,
+                },
+                {
+                    kind: "a11y/atf",
+                    advanceTimeMillis: null,
+                    scroll: null,
+                    output: "data/atf/x.json",
+                },
+            ],
+        });
+        const merged = withDataProductCaptures(preview);
+        assert.strictEqual(merged.captures.length, 3);
+        assert.strictEqual(
+            merged.captures[1].renderOutput,
+            "data/scroll/long/x.png",
+        );
+        assert.strictEqual(merged.captures[1].label, "scrolled end");
+        assert.strictEqual(merged.captures[1].cost, 20);
+        assert.strictEqual(
+            merged.captures[2].renderOutput,
+            "data/scroll/gif/x.gif",
+        );
+        assert.strictEqual(merged.captures[2].label, "scroll gif");
+        assert.notStrictEqual(merged, preview);
+        assert.strictEqual(preview.captures.length, 1);
+    });
+
+    it("makes a single-capture preview animated when a data product is added", () => {
+        const preview = makePreview({
+            dataProducts: [
+                {
+                    kind: "render/scroll/long",
+                    advanceTimeMillis: null,
+                    scroll: {
+                        mode: "LONG",
+                        axis: "VERTICAL",
+                        maxScrollPx: 0,
+                        reduceMotion: false,
+                        atEnd: false,
+                        reachedPx: null,
+                    },
+                    output: "data/scroll/long/x.png",
+                },
+            ],
+        });
+        assert.strictEqual(isAnimatedPreview(preview), false);
+        assert.strictEqual(
+            isAnimatedPreview(withDataProductCaptures(preview)),
+            true,
+        );
+    });
+});


### PR DESCRIPTION
## Summary

The webview only renders `PreviewInfo.captures`, so `@ScrollingPreview(LONG)` and `@ScrollingPreview(GIF)` outputs — emitted into `PreviewInfo.dataProducts` under `data/scroll/{long,gif}/` — were rendered to disk but never displayed. Cards for these previews showed only the base scroll-top capture, identical to the non-scrolling sibling.

Add a `withDataProductCaptures` helper that folds image-bearing data products (`.png` / `.gif` outputs) into the captures list as additional carousel frames, applied at the extension boundary on every `setPreviews` post and matched in the image-load loops so the merged `captureIndex` lines up. The webview keeps its existing capture-only contract.

After this, `ActivityListLongPreview` shows the base capture at carousel index 0 and the stitched LONG render at index 1 (label: `scrolled end` / `scroll long`); arrow keys / carousel buttons flip between them.

## Test plan

- [x] `npm run compile` clean
- [x] `npm run format:check` clean
- [x] `npx mocha out/test/captureLabels.test.js` — 6 new tests pass (no-op fast path, JSON-only filter, LONG+GIF append + label, single-capture → animated flip)
- [x] Full host suite: 326 passing
- [ ] Manual: open a Wear sample with `@ScrollingPreview(modes = [LONG])` in VS Code, confirm the carousel now exposes the stitched long render

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kog3LqDvBVQgUp2pCuKYbP)_