### PR TITLE
refactor(vscode): lift focus inspector out of behavior.ts

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -31,6 +31,7 @@ import {
 import { PreviewGrid } from "./components/PreviewGrid";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
 import { buildErrorPanel } from "./errorPanel";
+import { FocusInspectorController } from "./focusInspector";
 import {
     FocusToolbarController,
     isFocusedInteractiveSupported,
@@ -111,9 +112,15 @@ export function setupPreviewBehavior(
     const setA11yOverlay = (id: string | null): void => {
         previewStore.setState({ a11yOverlayPreviewId: id });
     };
-    const enabledFocusProducts = new Set();
-    let focusProductPickerOpen = false;
-    let focusHistoryOpen = false;
+    // previewId -> findings. Populated from setPreviews so updateImage can
+    // re-read the list on every image (re)load without re-querying the
+    // DOM for data attributes.
+    const cardA11yFindings = new Map();
+    // D2 — previewId -> nodes for the daemon-attached a11y/hierarchy payload. Drives
+    // the local hierarchy overlay (translucent rectangles + label/role/states tooltip
+    // on hover) drawn on top of the existing finding overlay. Populated by
+    // applyA11yUpdate and re-read on each image (re)load via applyHierarchyOverlay.
+    const cardA11yNodes = new Map();
     const focusPosition = document.getElementById("focus-position");
     // Progress bar is owned by `<progress-bar>` — see
     // `components/ProgressBar.ts`. It listens for `setProgress` /
@@ -159,6 +166,27 @@ export function setupPreviewBehavior(
     const moduleInteractiveSupported = new Map();
     const interactivePreviewIds = new Set();
     const recordingPreviewIds = new Set();
+
+    const inspector = new FocusInspectorController({
+        el: focusInspector,
+        earlyFeatures,
+        getPreview: (id) => allPreviews.find((p) => p.id === id),
+        getA11yFindings: (id) =>
+            cardA11yFindings.get(id) ||
+            allPreviews.find((p) => p.id === id)?.a11yFindings ||
+            [],
+        getA11yNodes: (id) =>
+            cardA11yNodes.get(id) ||
+            allPreviews.find((p) => p.id === id)?.a11yNodes ||
+            [],
+        getA11yOverlayId: a11yOverlay,
+        isLive: (id) => interactivePreviewIds.has(id),
+        onToggleA11yOverlay: () => toggleA11yOverlay(),
+        onToggleInteractive: (shift) => toggleInteractive(shift),
+        onToggleRecording: () => toggleRecording(),
+        onRequestFocusedDiff: (against) => requestFocusedDiff(against),
+        onRequestLaunchOnDevice: () => requestLaunchOnDevice(),
+    });
 
     // Config for the interactive-input pointer machine. The predicate
     // unifies live/recording state — both forward pointer/wheel input
@@ -323,7 +351,7 @@ export function setupPreviewBehavior(
             enabled: turningOn,
         });
         applyA11yOverlayButtonState();
-        renderFocusInspector(card);
+        inspector.render(card);
     }
 
     function applyLiveBadge() {
@@ -449,7 +477,7 @@ export function setupPreviewBehavior(
         });
         applyLiveBadge();
         applyInteractiveButtonState();
-        renderFocusInspector(card);
+        inspector.render(card);
     }
 
     function toggleRecording() {
@@ -488,7 +516,7 @@ export function setupPreviewBehavior(
             format: recordingFormat.value,
         });
         applyRecordingButtonState();
-        renderFocusInspector(card);
+        inspector.render(card);
     }
 
     /**
@@ -597,7 +625,7 @@ export function setupPreviewBehavior(
             const visible = getVisibleCards();
             if (visible.length === 0) {
                 focusPosition.textContent = "0 / 0";
-                renderFocusInspector(null);
+                inspector.render(null);
                 publishScopedPreview();
                 return;
             }
@@ -607,10 +635,10 @@ export function setupPreviewBehavior(
             focusPosition.textContent = focusIndex + 1 + " / " + visible.length;
             btnPrev.disabled = focusIndex === 0;
             btnNext.disabled = focusIndex === visible.length - 1;
-            renderFocusInspector(visible[focusIndex]);
+            inspector.render(visible[focusIndex]);
         } else {
             grid.applyFocusVisibility(null);
-            renderFocusInspector(null);
+            inspector.render(null);
         }
         document
             .querySelectorAll(".image-container")
@@ -721,311 +749,6 @@ export function setupPreviewBehavior(
         state.layout = previousLayout;
         vscode.setState(state);
         applyLayout();
-    }
-
-    function renderFocusInspector(card) {
-        focusInspector.innerHTML = "";
-        focusInspector.hidden = !earlyFeatures() || !card;
-        if (!earlyFeatures() || !card) return;
-        const previewId = card.dataset.previewId;
-        const p = allPreviews.find((pp) => pp.id === previewId);
-        if (!previewId || !p) return;
-
-        const inspect = document.createElement("section");
-        inspect.className = "focus-panel focus-inspect-panel";
-        inspect.appendChild(sectionHeader("search", "Inspect"));
-        const findings =
-            cardA11yFindings.get(previewId) || p.a11yFindings || [];
-        const nodes = cardA11yNodes.get(previewId) || p.a11yNodes || [];
-        inspect.appendChild(
-            productPicker([
-                {
-                    icon: "eye",
-                    label: "Accessibility",
-                    value:
-                        findings.length > 0
-                            ? findings.length +
-                              " finding" +
-                              (findings.length === 1 ? "" : "s")
-                            : "Overlay",
-                    enabled: previewId === a11yOverlay(),
-                    state: findings.length > 0 ? "warn" : "idle",
-                    onToggle: () => toggleA11yOverlay(),
-                },
-                {
-                    icon: "list-tree",
-                    label: "Layout",
-                    value:
-                        nodes.length > 0
-                            ? nodes.length +
-                              " node" +
-                              (nodes.length === 1 ? "" : "s")
-                            : "Placeholder",
-                    enabled: enabledFocusProducts.has("layout"),
-                    state: nodes.length > 0 ? "ok" : "idle",
-                    onToggle: () => toggleFocusProduct("layout"),
-                },
-                productSpec("symbol-string", "Strings", "strings"),
-                productSpec("file-code", "Resources", "resources"),
-                productSpec("text-size", "Fonts", "fonts"),
-                productSpec("pulse", "Render", "render"),
-                productSpec("symbol-color", "Theme", "theme"),
-                {
-                    icon: "sync",
-                    label: "Recomposition",
-                    value: interactivePreviewIds.has(previewId)
-                        ? "Live"
-                        : "Placeholder",
-                    enabled:
-                        enabledFocusProducts.has("recomposition") ||
-                        interactivePreviewIds.has(previewId),
-                    state: interactivePreviewIds.has(previewId) ? "ok" : "idle",
-                    onToggle: () => toggleFocusProduct("recomposition"),
-                },
-            ]),
-        );
-        const controls = document.createElement("section");
-        controls.className = "focus-panel focus-controls-panel";
-        controls.appendChild(sectionHeader("settings-gear", "Tools"));
-        const toolActions = document.createElement("div");
-        toolActions.className = "focus-actions";
-        toolActions.appendChild(
-            actionButton("eye", "A11y", "Toggle accessibility overlay", () => {
-                toggleA11yOverlay();
-            }),
-        );
-        toolActions.appendChild(
-            actionButton(
-                "device-mobile",
-                "Device",
-                "Launch on connected Android device",
-                () => {
-                    requestLaunchOnDevice();
-                },
-            ),
-        );
-        toolActions.appendChild(
-            actionButton(
-                "circle-large-outline",
-                "Live",
-                "Toggle live preview",
-                () => {
-                    toggleInteractive(false);
-                },
-            ),
-        );
-        toolActions.appendChild(
-            actionButton(
-                "record-keys",
-                "Record",
-                "Record focused preview",
-                () => {
-                    toggleRecording();
-                },
-            ),
-        );
-        controls.appendChild(toolActions);
-        focusInspector.appendChild(inspect);
-        focusInspector.appendChild(historyPanel());
-        focusInspector.appendChild(controls);
-        const placeholders = buildFocusPlaceholders();
-        if (placeholders) inspect.appendChild(placeholders);
-    }
-
-    function sectionHeader(icon, label) {
-        const header = document.createElement("div");
-        header.className = "focus-panel-header";
-        header.innerHTML =
-            '<i class="codicon codicon-' + icon + '" aria-hidden="true"></i>';
-        const span = document.createElement("span");
-        span.textContent = label;
-        header.appendChild(span);
-        return header;
-    }
-
-    function actionButton(icon, label, title, onClick) {
-        const btn = document.createElement("button");
-        btn.type = "button";
-        btn.className = "focus-action";
-        btn.title = title;
-        btn.innerHTML =
-            '<i class="codicon codicon-' + icon + '" aria-hidden="true"></i>';
-        const span = document.createElement("span");
-        span.textContent = label;
-        btn.appendChild(span);
-        btn.addEventListener("click", onClick);
-        return btn;
-    }
-
-    function historyPanel() {
-        const history = document.createElement("details");
-        history.className = "focus-panel focus-history-panel";
-        history.open = focusHistoryOpen;
-        history.addEventListener("toggle", () => {
-            focusHistoryOpen = history.open;
-        });
-        const summary = document.createElement("summary");
-        summary.className = "focus-panel-header focus-history-summary";
-        summary.innerHTML =
-            '<i class="codicon codicon-history" aria-hidden="true"></i>';
-        const label = document.createElement("span");
-        label.textContent = "History";
-        summary.appendChild(label);
-        const chevron = document.createElement("i");
-        chevron.className =
-            "codicon codicon-chevron-down focus-summary-chevron";
-        chevron.setAttribute("aria-hidden", "true");
-        summary.appendChild(chevron);
-        history.appendChild(summary);
-        const historyActions = document.createElement("div");
-        historyActions.className = "focus-actions";
-        historyActions.appendChild(
-            actionButton(
-                "git-compare",
-                "HEAD",
-                "Diff vs last archived render",
-                () => {
-                    requestFocusedDiff("head");
-                },
-            ),
-        );
-        historyActions.appendChild(
-            actionButton(
-                "source-control",
-                "main",
-                "Diff vs latest archived main render",
-                () => {
-                    requestFocusedDiff("main");
-                },
-            ),
-        );
-        history.appendChild(historyActions);
-        return history;
-    }
-
-    function productSpec(icon, label, id) {
-        return {
-            icon,
-            label,
-            value: "Placeholder",
-            enabled: enabledFocusProducts.has(id),
-            state: "idle",
-            onToggle: () => toggleFocusProduct(id),
-        };
-    }
-
-    function productPicker(products) {
-        const picker = document.createElement("details");
-        picker.className = "focus-product-picker";
-        picker.open = focusProductPickerOpen;
-        picker.addEventListener("toggle", () => {
-            focusProductPickerOpen = picker.open;
-        });
-        const summary = document.createElement("summary");
-        summary.className = "focus-product-summary";
-        const selected = products.filter((product) => product.enabled);
-        const summaryText = document.createElement("span");
-        summaryText.textContent =
-            selected.length === 0
-                ? "Choose inspection layers"
-                : selected.length === 1
-                  ? selected[0].label
-                  : selected.length + " layers selected";
-        summary.appendChild(summaryText);
-        const chevron = document.createElement("i");
-        chevron.className =
-            "codicon codicon-chevron-down focus-summary-chevron";
-        chevron.setAttribute("aria-hidden", "true");
-        summary.appendChild(chevron);
-        picker.appendChild(summary);
-
-        const menu = document.createElement("div");
-        menu.className = "focus-product-menu";
-        products.forEach((product) => {
-            menu.appendChild(productOption(product));
-        });
-        picker.appendChild(menu);
-        return picker;
-    }
-
-    function productOption(product) {
-        const option = document.createElement("label");
-        option.className = "focus-product-option";
-        option.dataset.state = product.state || "idle";
-        const input = document.createElement("input");
-        input.type = "checkbox";
-        input.checked = product.enabled;
-        input.addEventListener("change", product.onToggle);
-        option.appendChild(input);
-        const icon = document.createElement("i");
-        icon.className = "codicon codicon-" + product.icon;
-        icon.setAttribute("aria-hidden", "true");
-        option.appendChild(icon);
-        const text = document.createElement("div");
-        text.className = "focus-product-text";
-        const name = document.createElement("span");
-        name.className = "focus-product-name";
-        name.textContent = product.label;
-        const val = document.createElement("span");
-        val.className = "focus-product-value";
-        val.textContent = product.value;
-        text.appendChild(name);
-        text.appendChild(val);
-        option.appendChild(text);
-        return option;
-    }
-
-    function toggleFocusProduct(id) {
-        if (enabledFocusProducts.has(id)) {
-            enabledFocusProducts.delete(id);
-        } else {
-            enabledFocusProducts.add(id);
-        }
-        const card = getVisibleCards()[focusIndex];
-        if (filterToolbar.getLayoutValue() === "focus" && card)
-            renderFocusInspector(card);
-    }
-
-    function buildFocusPlaceholders() {
-        const defs = [
-            ["layout", "Layout", "layout tree and bounds"],
-            ["strings", "Strings", "text/strings and i18n/translations"],
-            ["resources", "Resources", "resources/used"],
-            ["fonts", "Fonts", "fonts/used"],
-            ["render", "Render", "render/trace and render/composeAiTrace"],
-            ["theme", "Theme", "compose/theme"],
-            ["recomposition", "Recomposition", "compose/recomposition"],
-        ].filter(([id]) => enabledFocusProducts.has(id));
-        if (defs.length === 0) return null;
-        const wrapper = document.createElement("div");
-        wrapper.className = "focus-placeholder-list";
-        defs.forEach(([id, label, kind]) => {
-            const details = document.createElement("details");
-            details.className = "focus-placeholder";
-            details.dataset.product = id;
-            const summary = document.createElement("summary");
-            summary.textContent = label;
-            details.appendChild(summary);
-            const body = document.createElement("div");
-            body.className = "focus-placeholder-body";
-            body.textContent = kind;
-            details.appendChild(body);
-            wrapper.appendChild(details);
-        });
-        return wrapper;
-    }
-
-    function renderSummary(p) {
-        const captures = p.captures ? p.captures.length : 0;
-        if (captures > 1) return captures + " captures";
-        const c = p.captures && p.captures[0];
-        if (c && c.label) return c.label;
-        return "Static";
-    }
-
-    function themeSummary(p) {
-        if (p.params.backgroundColor) return "Background";
-        return p.params.showSystemUi ? "System UI" : "Preview";
     }
 
     // Live-panel diff: only meaningful when one preview is focused. Pulls
@@ -1520,17 +1243,6 @@ export function setupPreviewBehavior(
         }
     }
 
-    // previewId -> findings. Populated from setPreviews so updateImage can
-    // re-read the list on every image (re)load without re-querying the
-    // DOM for data attributes.
-    const cardA11yFindings = new Map();
-
-    // D2 — previewId -> nodes for the daemon-attached a11y/hierarchy payload. Drives
-    // the local hierarchy overlay (translucent rectangles + label/role/states tooltip
-    // on hover) drawn on top of the existing finding overlay. Populated by
-    // applyA11yUpdate and re-read on each image (re)load via applyHierarchyOverlay.
-    const cardA11yNodes = new Map();
-
     // D2 — handles updateA11y from the extension (daemon-attached a11y data products).
     // Updates the per-preview caches and re-applies whichever overlays are now relevant
     // without rebuilding the whole card. Findings -> legend + finding overlay; nodes ->
@@ -1587,7 +1299,7 @@ export function setupPreviewBehavior(
         }
         if (filterToolbar.getLayoutValue() === "focus") {
             const focused = getVisibleCards()[focusIndex];
-            if (focused === card) renderFocusInspector(card);
+            if (focused === card) inspector.render(card);
         }
     }
 
@@ -1980,7 +1692,7 @@ export function setupPreviewBehavior(
                         .forEach((el) => el.remove());
                     cardA11yFindings.clear();
                     cardA11yNodes.clear();
-                    enabledFocusProducts.clear();
+                    inspector.clearProducts();
                     if (a11yOverlay()) {
                         vscode.postMessage({
                             command: "setA11yOverlay",

--- a/vscode-extension/src/webview/preview/focusInspector.ts
+++ b/vscode-extension/src/webview/preview/focusInspector.ts
@@ -1,0 +1,392 @@
+// Focus-mode inspector — the side panel that appears when a single
+// preview is focused. Three sections: an Inspect product picker (a11y
+// / Layout / Strings / Resources / Fonts / Render / Theme /
+// Recomposition), a History accordion (diff vs HEAD, diff vs main),
+// and a Tools strip (a11y, device, live, record action buttons).
+//
+// Lifted verbatim from `behavior.ts`'s `renderFocusInspector` cluster
+// (`sectionHeader` / `actionButton` / `historyPanel` / `productSpec` /
+// `productPicker` / `productOption` / `toggleFocusProduct` /
+// `buildFocusPlaceholders`). Same DOM structure, same CSS classes,
+// same accordion-open persistence (`focusProductPickerOpen` /
+// `focusHistoryOpen`) — those flags and the `enabledFocusProducts`
+// Set live as private state on the controller now rather than free
+// variables in `setupPreviewBehavior`.
+//
+// Action callbacks (toggleA11yOverlay / toggleInteractive /
+// toggleRecording / requestFocusedDiff / requestLaunchOnDevice) and
+// the per-preview state queries (a11y findings / nodes, live set,
+// store-backed `a11yOverlayId`) are passed in via `FocusInspectorConfig`
+// so the module doesn't need closure access to the rest of
+// `behavior.ts`. `clearAll` resets the `enabledFocusProducts` Set.
+//
+// `renderSummary` and `themeSummary` from the imperative copy were
+// dead code (defined but never called) and are dropped; behaviour
+// unchanged.
+
+import type {
+    AccessibilityFinding,
+    AccessibilityNode,
+    PreviewInfo,
+} from "../shared/types";
+
+export interface FocusInspectorConfig {
+    /** The `<div id="focus-inspector">` element rendered by `<preview-app>`. */
+    el: HTMLElement;
+    /** Whether `composePreview.earlyFeatures` is on — when off the
+     *  inspector hides and the caller's `clear` path clears it. */
+    earlyFeatures(): boolean;
+    /** Look up the manifest entry for a preview, or `undefined` when
+     *  the preview is unknown to this panel (e.g. transient state
+     *  during a `setPreviews` swap). */
+    getPreview(previewId: string): PreviewInfo | undefined;
+    /** Latest a11y findings for a preview. Reads the runtime cache
+     *  populated from `setPreviews` / `updateA11y`. */
+    getA11yFindings(previewId: string): readonly AccessibilityFinding[];
+    /** Latest a11y hierarchy nodes for a preview. */
+    getA11yNodes(previewId: string): readonly AccessibilityNode[];
+    /** `previewId` whose a11y overlay subscription is currently on, or
+     *  `null` when no card is subscribed. */
+    getA11yOverlayId(): string | null;
+    /** Whether [previewId] is currently in the live (interactive) set. */
+    isLive(previewId: string): boolean;
+    /** Click handlers shared with the focus toolbar — pressed from
+     *  the inspector's product-picker rows / tools strip. */
+    onToggleA11yOverlay(): void;
+    /** `shift = false` matches the toolbar Live button — single-target. */
+    onToggleInteractive(shift: boolean): void;
+    onToggleRecording(): void;
+    onRequestFocusedDiff(against: string): void;
+    onRequestLaunchOnDevice(): void;
+}
+
+interface ProductOptionSpec {
+    icon: string;
+    label: string;
+    value: string;
+    enabled: boolean;
+    state: "ok" | "warn" | "idle";
+    onToggle(): void;
+}
+
+export class FocusInspectorController {
+    private readonly enabled = new Set<string>();
+    private productPickerOpen = false;
+    private historyOpen = false;
+    /** Last card we rendered. Held so `toggleProduct` can re-render
+     *  the panel on the same card after flipping a checkbox. */
+    private lastCard: HTMLElement | null = null;
+
+    constructor(private readonly config: FocusInspectorConfig) {}
+
+    /** Repaint the inspector for [card], or clear it when [card] is
+     *  `null` / earlyFeatures is off. Called by `applyLayout`,
+     *  `setInteractiveForCard`, `toggleRecording`, etc. */
+    render(card: HTMLElement | null): void {
+        const el = this.config.el;
+        el.innerHTML = "";
+        const visible = !!card && this.config.earlyFeatures();
+        el.hidden = !visible;
+        if (!visible || !card) {
+            this.lastCard = null;
+            return;
+        }
+        const previewId = card.dataset.previewId ?? "";
+        const p = previewId ? this.config.getPreview(previewId) : undefined;
+        if (!previewId || !p) {
+            this.lastCard = null;
+            return;
+        }
+        this.lastCard = card;
+
+        const inspect = document.createElement("section");
+        inspect.className = "focus-panel focus-inspect-panel";
+        inspect.appendChild(sectionHeader("search", "Inspect"));
+        const findings = this.config.getA11yFindings(previewId);
+        const nodes = this.config.getA11yNodes(previewId);
+        inspect.appendChild(
+            this.productPicker([
+                {
+                    icon: "eye",
+                    label: "Accessibility",
+                    value:
+                        findings.length > 0
+                            ? findings.length +
+                              " finding" +
+                              (findings.length === 1 ? "" : "s")
+                            : "Overlay",
+                    enabled: previewId === this.config.getA11yOverlayId(),
+                    state: findings.length > 0 ? "warn" : "idle",
+                    onToggle: () => this.config.onToggleA11yOverlay(),
+                },
+                {
+                    icon: "list-tree",
+                    label: "Layout",
+                    value:
+                        nodes.length > 0
+                            ? nodes.length +
+                              " node" +
+                              (nodes.length === 1 ? "" : "s")
+                            : "Placeholder",
+                    enabled: this.enabled.has("layout"),
+                    state: nodes.length > 0 ? "ok" : "idle",
+                    onToggle: () => this.toggleProduct("layout"),
+                },
+                this.productSpec("symbol-string", "Strings", "strings"),
+                this.productSpec("file-code", "Resources", "resources"),
+                this.productSpec("text-size", "Fonts", "fonts"),
+                this.productSpec("pulse", "Render", "render"),
+                this.productSpec("symbol-color", "Theme", "theme"),
+                {
+                    icon: "sync",
+                    label: "Recomposition",
+                    value: this.config.isLive(previewId)
+                        ? "Live"
+                        : "Placeholder",
+                    enabled:
+                        this.enabled.has("recomposition") ||
+                        this.config.isLive(previewId),
+                    state: this.config.isLive(previewId) ? "ok" : "idle",
+                    onToggle: () => this.toggleProduct("recomposition"),
+                },
+            ]),
+        );
+        const controls = document.createElement("section");
+        controls.className = "focus-panel focus-controls-panel";
+        controls.appendChild(sectionHeader("settings-gear", "Tools"));
+        const toolActions = document.createElement("div");
+        toolActions.className = "focus-actions";
+        toolActions.appendChild(
+            actionButton("eye", "A11y", "Toggle accessibility overlay", () =>
+                this.config.onToggleA11yOverlay(),
+            ),
+        );
+        toolActions.appendChild(
+            actionButton(
+                "device-mobile",
+                "Device",
+                "Launch on connected Android device",
+                () => this.config.onRequestLaunchOnDevice(),
+            ),
+        );
+        toolActions.appendChild(
+            actionButton(
+                "circle-large-outline",
+                "Live",
+                "Toggle live preview",
+                () => this.config.onToggleInteractive(false),
+            ),
+        );
+        toolActions.appendChild(
+            actionButton(
+                "record-keys",
+                "Record",
+                "Record focused preview",
+                () => this.config.onToggleRecording(),
+            ),
+        );
+        controls.appendChild(toolActions);
+        el.appendChild(inspect);
+        el.appendChild(this.historyPanel());
+        el.appendChild(controls);
+        const placeholders = this.buildPlaceholders();
+        if (placeholders) inspect.appendChild(placeholders);
+    }
+
+    /**
+     * Reset the per-preview product-enable Set. Called by `behavior.ts`
+     * on the `clearAll` message path (panel scope changed) so the
+     * inspector doesn't carry stale "Layout enabled" / "Render enabled"
+     * checkboxes into the new module's previews.
+     */
+    clearProducts(): void {
+        this.enabled.clear();
+    }
+
+    private toggleProduct(id: string): void {
+        if (this.enabled.has(id)) {
+            this.enabled.delete(id);
+        } else {
+            this.enabled.add(id);
+        }
+        if (this.lastCard) this.render(this.lastCard);
+    }
+
+    private productSpec(
+        icon: string,
+        label: string,
+        id: string,
+    ): ProductOptionSpec {
+        return {
+            icon,
+            label,
+            value: "Placeholder",
+            enabled: this.enabled.has(id),
+            state: "idle",
+            onToggle: () => this.toggleProduct(id),
+        };
+    }
+
+    private productPicker(products: ProductOptionSpec[]): HTMLElement {
+        const picker = document.createElement("details");
+        picker.className = "focus-product-picker";
+        picker.open = this.productPickerOpen;
+        picker.addEventListener("toggle", () => {
+            this.productPickerOpen = picker.open;
+        });
+        const summary = document.createElement("summary");
+        summary.className = "focus-product-summary";
+        const selected = products.filter((product) => product.enabled);
+        const summaryText = document.createElement("span");
+        summaryText.textContent =
+            selected.length === 0
+                ? "Choose inspection layers"
+                : selected.length === 1
+                  ? selected[0].label
+                  : selected.length + " layers selected";
+        summary.appendChild(summaryText);
+        const chevron = document.createElement("i");
+        chevron.className =
+            "codicon codicon-chevron-down focus-summary-chevron";
+        chevron.setAttribute("aria-hidden", "true");
+        summary.appendChild(chevron);
+        picker.appendChild(summary);
+
+        const menu = document.createElement("div");
+        menu.className = "focus-product-menu";
+        for (const product of products) {
+            menu.appendChild(productOption(product));
+        }
+        picker.appendChild(menu);
+        return picker;
+    }
+
+    private historyPanel(): HTMLElement {
+        const history = document.createElement("details");
+        history.className = "focus-panel focus-history-panel";
+        history.open = this.historyOpen;
+        history.addEventListener("toggle", () => {
+            this.historyOpen = history.open;
+        });
+        const summary = document.createElement("summary");
+        summary.className = "focus-panel-header focus-history-summary";
+        summary.innerHTML =
+            '<i class="codicon codicon-history" aria-hidden="true"></i>';
+        const label = document.createElement("span");
+        label.textContent = "History";
+        summary.appendChild(label);
+        const chevron = document.createElement("i");
+        chevron.className =
+            "codicon codicon-chevron-down focus-summary-chevron";
+        chevron.setAttribute("aria-hidden", "true");
+        summary.appendChild(chevron);
+        history.appendChild(summary);
+        const historyActions = document.createElement("div");
+        historyActions.className = "focus-actions";
+        historyActions.appendChild(
+            actionButton(
+                "git-compare",
+                "HEAD",
+                "Diff vs last archived render",
+                () => this.config.onRequestFocusedDiff("head"),
+            ),
+        );
+        historyActions.appendChild(
+            actionButton(
+                "source-control",
+                "main",
+                "Diff vs latest archived main render",
+                () => this.config.onRequestFocusedDiff("main"),
+            ),
+        );
+        history.appendChild(historyActions);
+        return history;
+    }
+
+    private buildPlaceholders(): HTMLElement | null {
+        const defs: ReadonlyArray<readonly [string, string, string]> = [
+            ["layout", "Layout", "layout tree and bounds"],
+            ["strings", "Strings", "text/strings and i18n/translations"],
+            ["resources", "Resources", "resources/used"],
+            ["fonts", "Fonts", "fonts/used"],
+            ["render", "Render", "render/trace and render/composeAiTrace"],
+            ["theme", "Theme", "compose/theme"],
+            ["recomposition", "Recomposition", "compose/recomposition"],
+        ];
+        const active = defs.filter(([id]) => this.enabled.has(id));
+        if (active.length === 0) return null;
+        const wrapper = document.createElement("div");
+        wrapper.className = "focus-placeholder-list";
+        for (const [id, label, kind] of active) {
+            const details = document.createElement("details");
+            details.className = "focus-placeholder";
+            details.dataset.product = id;
+            const summary = document.createElement("summary");
+            summary.textContent = label;
+            details.appendChild(summary);
+            const body = document.createElement("div");
+            body.className = "focus-placeholder-body";
+            body.textContent = kind;
+            details.appendChild(body);
+            wrapper.appendChild(details);
+        }
+        return wrapper;
+    }
+}
+
+function sectionHeader(icon: string, label: string): HTMLElement {
+    const header = document.createElement("div");
+    header.className = "focus-panel-header";
+    header.innerHTML =
+        '<i class="codicon codicon-' + icon + '" aria-hidden="true"></i>';
+    const span = document.createElement("span");
+    span.textContent = label;
+    header.appendChild(span);
+    return header;
+}
+
+function actionButton(
+    icon: string,
+    label: string,
+    title: string,
+    onClick: () => void,
+): HTMLElement {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "focus-action";
+    btn.title = title;
+    btn.innerHTML =
+        '<i class="codicon codicon-' + icon + '" aria-hidden="true"></i>';
+    const span = document.createElement("span");
+    span.textContent = label;
+    btn.appendChild(span);
+    btn.addEventListener("click", onClick);
+    return btn;
+}
+
+function productOption(product: ProductOptionSpec): HTMLElement {
+    const option = document.createElement("label");
+    option.className = "focus-product-option";
+    option.dataset.state = product.state;
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = product.enabled;
+    input.addEventListener("change", product.onToggle);
+    option.appendChild(input);
+    const icon = document.createElement("i");
+    icon.className = "codicon codicon-" + product.icon;
+    icon.setAttribute("aria-hidden", "true");
+    option.appendChild(icon);
+    const text = document.createElement("div");
+    text.className = "focus-product-text";
+    const name = document.createElement("span");
+    name.className = "focus-product-name";
+    name.textContent = product.label;
+    const val = document.createElement("span");
+    val.className = "focus-product-value";
+    val.textContent = product.value;
+    text.appendChild(name);
+    text.appendChild(val);
+    option.appendChild(text);
+    return option;
+}


### PR DESCRIPTION
Slice of #767. Extracts the side panel that appears in focus mode — Inspect product picker (a11y / Layout / Strings / Resources / Fonts / Render / Theme / Recomposition), History accordion (diff vs HEAD, diff vs main), Tools strip (a11y / device / live / record action buttons) — into a typed `FocusInspectorController`.

## Summary

- New `focusInspector.ts` exports `FocusInspectorController` with public `render(card)` and `clearProducts()`. The eight imperative helpers (`sectionHeader`, `actionButton`, `historyPanel`, `productSpec`, `productPicker`, `productOption`, `toggleFocusProduct`, `buildFocusPlaceholders`) move into the same module as private functions / methods.
- The persistent UI state (`enabledFocusProducts` Set, `focusProductPickerOpen` / `focusHistoryOpen` flags) becomes private state on the controller — they were three free-standing variables in `setupPreviewBehavior` before.
- Action callbacks (`toggleA11yOverlay` / `toggleInteractive` / `toggleRecording` / `requestFocusedDiff` / `requestLaunchOnDevice`) and per-preview state queries (a11y findings / nodes, live set, store-backed `a11yOverlayId`) come in via `FocusInspectorConfig`. The `clearAll` message path now calls `inspector.clearProducts()` to reset the Set when the panel scope changes.

**Drive-by cleanup:** `renderSummary` and `themeSummary` from the imperative copy were dead code — defined but never called. Dropped.

`behavior.ts` shrinks from 2015 → 1727 lines (−288 LOC). No behaviour change beyond the dead-code removal.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 320/320 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke (with `composePreview.earlyFeatures` on): focus a preview, verify the inspector side panel opens with three sections; toggle product-picker checkboxes and confirm placeholder details appear / disappear and the picker's open/closed state survives re-render; expand the History accordion and click "HEAD" / "main" diff buttons; click each Tools strip button and verify it triggers the same action as the focus toolbar; switch panel scope (open a different module) and verify the inspector forgets its enabled products.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTv9gnHTdY5MzDfGdnSpBn)_