### PR TITLE
refactor(vscode): lift live + recording state controller out of behavior.ts

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -39,6 +39,7 @@ import {
 } from "./focusToolbar";
 import { FrameCarouselController } from "./frameCarousel";
 import { attachInteractiveInputHandlers } from "./interactiveInput";
+import { LiveStateController } from "./liveState";
 import { LoadingOverlay } from "./loadingOverlay";
 import { previewStore } from "./previewStore";
 import { StaleBadgeController } from "./staleBadge";
@@ -147,25 +148,20 @@ export function setupPreviewBehavior(
         state.layout && state.layout !== "focus" ? state.layout : "grid";
 
     // Interactive (live-stream) mode state. Declared up here — *before*
-    // the first applyLayout() call below — because applyLayout reads
-    // interactivePreviewIds via the early-exit-on-focus-change path.
+    // the first applyLayout() call below — because applyLayout reaches
+    // through `liveState` on the early-exit-on-focus-change path.
     // moduleDaemonReady tracks per-module daemon readiness pushed by the
     // extension via setInteractiveAvailability; the button enables only
     // when the focused card's owning module is ready. moduleInteractiveSupported
     // distinguishes full v2 live mode from the Android/v1 fallback where
     // renders refresh but pointer input doesn't mutate held composition state.
     //
-    // interactivePreviewIds is a Set so Shift+click on the LIVE toggle
-    // can add/remove a preview without disturbing others (multi-stream
-    // UI). The wire and daemon already support concurrent streams
-    // (INTERACTIVE.md § 8); the panel just exposes it under a modifier
-    // key. Default un-modified click stays single-target — clearing the
-    // set before adding the new one — so casual users don't accidentally
-    // pile up live streams.
+    // The live + recording sets and their state machine live in
+    // `./liveState.ts` — see `LiveStateController`. Constructed below,
+    // after `interactiveInputConfig` so the controller can hand the
+    // config to `attachInteractiveInputHandlers`.
     const moduleDaemonReady = new Map();
     const moduleInteractiveSupported = new Map();
-    const interactivePreviewIds = new Set();
-    const recordingPreviewIds = new Set();
 
     const inspector = new FocusInspectorController({
         el: focusInspector,
@@ -180,10 +176,10 @@ export function setupPreviewBehavior(
             allPreviews.find((p) => p.id === id)?.a11yNodes ||
             [],
         getA11yOverlayId: a11yOverlay,
-        isLive: (id) => interactivePreviewIds.has(id),
+        isLive: (id) => liveState.isLive(id),
         onToggleA11yOverlay: () => toggleA11yOverlay(),
-        onToggleInteractive: (shift) => toggleInteractive(shift),
-        onToggleRecording: () => toggleRecording(),
+        onToggleInteractive: (shift) => liveState.toggleInteractive(shift),
+        onToggleRecording: () => liveState.toggleRecording(),
         onRequestFocusedDiff: (against) => requestFocusedDiff(against),
         onRequestLaunchOnDevice: () => requestLaunchOnDevice(),
     });
@@ -191,12 +187,29 @@ export function setupPreviewBehavior(
     // Config for the interactive-input pointer machine. The predicate
     // unifies live/recording state — both forward pointer/wheel input
     // to the daemon — so the module doesn't need direct access to
-    // either Set.
+    // either Set. `liveState` is initialised right below and only read
+    // when a real pointer event fires, so the closure access can never
+    // hit before the controller is bound.
+    let liveState!: LiveStateController;
     const interactiveInputConfig = {
-        isLive: (id) =>
-            interactivePreviewIds.has(id) || recordingPreviewIds.has(id),
+        isLive: (id) => liveState.isLive(id) || liveState.isRecording(id),
         vscode,
     };
+
+    liveState = new LiveStateController({
+        vscode,
+        recordingFormat,
+        interactiveInputConfig,
+        earlyFeatures,
+        inFocus: () => filterToolbar.getLayoutValue() === "focus",
+        focusedCard: () =>
+            filterToolbar.getLayoutValue() === "focus"
+                ? (getVisibleCards()[focusIndex] ?? null)
+                : null,
+        applyInteractiveButtonState: () => applyInteractiveButtonState(),
+        applyRecordingButtonState: () => applyRecordingButtonState(),
+        renderInspector: (card) => inspector.render(card),
+    });
 
     // Config for `showDiffOverlay` — reads/writes the persisted Side/
     // Overlay/Onion mode through the same `state` object that holds the
@@ -264,17 +277,13 @@ export function setupPreviewBehavior(
     // remove just this one. Plain click keeps the single-target single-card UX casual users
     // expect.
     btnInteractive.addEventListener("click", (e) =>
-        toggleInteractive(e.shiftKey),
+        liveState.toggleInteractive(e.shiftKey),
     );
-    btnStopInteractive.addEventListener("click", () => stopAllInteractive());
-    btnRecording.addEventListener("click", () => toggleRecording());
+    btnStopInteractive.addEventListener("click", () =>
+        liveState.stopAllInteractive(),
+    );
+    btnRecording.addEventListener("click", () => liveState.toggleRecording());
     btnExitFocus.addEventListener("click", () => exitFocus());
-
-    // ----- Interactive (live-stream) mode helpers -----
-    // State (moduleDaemonReady, interactivePreviewIds) is declared
-    // earlier so the first applyLayout() can reach it. The function
-    // declarations below are hoisted, so call sites above this block
-    // resolve fine.
 
     function applyEarlyFeatureVisibility() {
         focusToolbar.applyEarlyFeatureVisibility({
@@ -287,13 +296,13 @@ export function setupPreviewBehavior(
         const inFocus = filterToolbar.getLayoutValue() === "focus";
         const card = inFocus ? getVisibleCards()[focusIndex] : null;
         const previewId = card?.dataset.previewId ?? null;
-        const isLive = !!previewId && interactivePreviewIds.has(previewId);
+        const isLive = !!previewId && liveState.isLive(previewId);
         focusToolbar.applyInteractiveButtonState({
             inFocus,
             focusedPreviewId: previewId,
             isLive,
-            otherLiveCount: interactivePreviewIds.size - (isLive ? 1 : 0),
-            hasLive: interactivePreviewIds.size > 0,
+            otherLiveCount: liveState.liveCount - (isLive ? 1 : 0),
+            hasLive: liveState.liveCount > 0,
             daemonReady: isFocusedModuleReady(moduleDaemonReady),
             interactiveSupported: isFocusedInteractiveSupported(
                 moduleDaemonReady,
@@ -311,7 +320,7 @@ export function setupPreviewBehavior(
             earlyFeatures: earlyFeatures(),
             focusedPreviewId: previewId,
             daemonReady: isFocusedModuleReady(moduleDaemonReady),
-            isRecording: !!previewId && recordingPreviewIds.has(previewId),
+            isRecording: !!previewId && liveState.isRecording(previewId),
         });
     }
 
@@ -354,185 +363,10 @@ export function setupPreviewBehavior(
         inspector.render(card);
     }
 
-    function applyLiveBadge() {
-        // Tear down every prior live decoration first — a removal from interactivePreviewIds
-        // (Shift+click off, set-cleared on daemon-not-ready, etc.) needs the badge to come
-        // off the now-not-live card. Then re-stamp every still-live preview.
-        document.querySelectorAll(".preview-card.live").forEach((c) => {
-            c.classList.remove("live");
-            c.querySelector(".card-live-stop-btn")?.remove();
-        });
-        if (interactivePreviewIds.size === 0) return;
-        interactivePreviewIds.forEach((previewId) => {
-            const card = document.getElementById(
-                "preview-" + sanitizeId(previewId),
-            );
-            if (!card) return;
-            card.classList.add("live");
-            ensureLiveCardControls(card);
-        });
-    }
-
-    function ensureLiveCardControls(card) {
-        const container = card.querySelector(".image-container");
-        if (!container) return;
-        if (!container.querySelector(".card-live-stop-btn")) {
-            const btn = document.createElement("button");
-            btn.type = "button";
-            btn.className = "icon-button card-live-stop-btn";
-            btn.title = "Stop live preview";
-            btn.setAttribute("aria-label", "Stop live preview");
-            btn.innerHTML =
-                '<i class="codicon codicon-debug-stop" aria-hidden="true"></i>';
-            btn.addEventListener("click", (evt) => {
-                evt.preventDefault();
-                evt.stopPropagation();
-                stopInteractiveForCard(card);
-            });
-            container.appendChild(btn);
-        }
-        const img = container.querySelector("img");
-        if (img)
-            attachInteractiveInputHandlers(card, img, interactiveInputConfig);
-    }
-
-    function stopAllInteractive() {
-        if (interactivePreviewIds.size === 0) return;
-        const ids = Array.from(interactivePreviewIds);
-        interactivePreviewIds.clear();
-        ids.forEach((previewId) => {
-            vscode.postMessage({
-                command: "setInteractive",
-                previewId,
-                enabled: false,
-            });
-        });
-        applyLiveBadge();
-        applyInteractiveButtonState();
-    }
-
-    function stopInteractiveForCard(card) {
-        const previewId = card.dataset.previewId;
-        if (!previewId || !interactivePreviewIds.has(previewId)) return;
-        interactivePreviewIds.delete(previewId);
-        vscode.postMessage({
-            command: "setInteractive",
-            previewId,
-            enabled: false,
-        });
-        applyLiveBadge();
-        applyInteractiveButtonState();
-    }
-
-    function toggleInteractive(shift) {
-        // Drives the LIVE button in the focus-mode toolbar — operates on the currently
-        // focused card. Body factored into setInteractiveForCard so the in-card click handler
-        // (any layout) can reuse the same plain-vs-Shift logic.
-        if (filterToolbar.getLayoutValue() !== "focus") return;
-        const visible = getVisibleCards();
-        const card = visible[focusIndex];
-        if (!card) return;
-        setInteractiveForCard(card, shift);
-    }
-
-    /**
-     * Toggle interactive mode for [card] honouring plain/Shift semantics:
-     *  - Plain: single-target. Drop every prior live target before adding (or re-removing)
-     *    this one — keeps the casual UX matching v1's "one card live at a time" mental model.
-     *  - Shift: multi-target. Toggle just this preview in/out of the live set without
-     *    touching the others.
-     */
-    function setInteractiveForCard(card, shift) {
-        const previewId = card.dataset.previewId;
-        if (!previewId) return;
-        const wasLive = interactivePreviewIds.has(previewId);
-        if (!shift) {
-            interactivePreviewIds.forEach((prior) => {
-                if (prior === previewId) return;
-                vscode.postMessage({
-                    command: "setInteractive",
-                    previewId: prior,
-                    enabled: false,
-                });
-            });
-            interactivePreviewIds.clear();
-        }
-        const turnOn = !wasLive;
-        if (turnOn) {
-            interactivePreviewIds.add(previewId);
-            const img = card.querySelector(".image-container img");
-            if (img)
-                attachInteractiveInputHandlers(
-                    card,
-                    img,
-                    interactiveInputConfig,
-                );
-        } else {
-            interactivePreviewIds.delete(previewId);
-        }
-        vscode.postMessage({
-            command: "setInteractive",
-            previewId,
-            enabled: turnOn,
-        });
-        applyLiveBadge();
-        applyInteractiveButtonState();
-        inspector.render(card);
-    }
-
-    function toggleRecording() {
-        if (!earlyFeatures()) return;
-        if (filterToolbar.getLayoutValue() !== "focus") return;
-        const card = getVisibleCards()[focusIndex];
-        const previewId = card ? card.dataset.previewId : null;
-        if (!card || !previewId) return;
-        const turnOn = !recordingPreviewIds.has(previewId);
-        if (turnOn) {
-            recordingPreviewIds.forEach((prior) => {
-                if (prior === previewId) return;
-                vscode.postMessage({
-                    command: "setRecording",
-                    previewId: prior,
-                    enabled: false,
-                    format: recordingFormat.value,
-                });
-            });
-            recordingPreviewIds.clear();
-            recordingPreviewIds.add(previewId);
-            const img = card.querySelector(".image-container img");
-            if (img)
-                attachInteractiveInputHandlers(
-                    card,
-                    img,
-                    interactiveInputConfig,
-                );
-        } else {
-            recordingPreviewIds.delete(previewId);
-        }
-        vscode.postMessage({
-            command: "setRecording",
-            previewId,
-            enabled: turnOn,
-            format: recordingFormat.value,
-        });
-        applyRecordingButtonState();
-        inspector.render(card);
-    }
-
-    /**
-     * Single-click-to-LIVE entry point from the in-card image click handler. Ensures
-     * image clicks land here in any layout (focus, grid, flow, column) — the focus-mode
-     * LIVE button is a redundant affordance for the focus-mode user, this lets every layout
-     * reach interactive mode in one click. Subsequent clicks while LIVE forward to the
-     * daemon via the per-image handler in updateImage; that is a separate code path and
-     * the click here short-circuits.
-     */
-    function enterInteractiveOnCard(card, shift) {
-        setInteractiveForCard(card, shift);
-    }
-
-    // Pointer + wheel state machine for live previews lives in
-    // `./interactiveInput.ts` — see `attachInteractiveInputHandlers`.
+    // Live + recording state (toolbar/per-card buttons, badge re-stamping,
+    // single-target follow-focus, viewport auto-stop) lives in
+    // `./liveState.ts` — see `LiveStateController`. The pointer + wheel
+    // state machine the live cards use lives in `./interactiveInput.ts`.
 
     // Document-level Left/Right in focus mode steps between cards. The
     // animated-carousel frame-controls handler stops propagation so
@@ -644,25 +478,11 @@ export function setupPreviewBehavior(
             .querySelectorAll(".image-container")
             .forEach((c) => c.removeAttribute("title"));
         publishScopedPreview();
-        // Single-target follow-focus: when there's exactly one live stream and the user
-        // navigates off it, drop the stream so the LIVE chip follows the focused card.
-        // Multi-target (size > 1) is treated as an explicit opt-in via Shift+click — those
-        // streams persist across focus navigation until the user explicitly toggles them off
-        // (or daemon dies, or the webview disposes).
-        if (interactivePreviewIds.size === 1) {
-            const visible = getVisibleCards();
-            const card = mode === "focus" ? visible[focusIndex] : null;
-            const lone = interactivePreviewIds.values().next().value;
-            if (!card || card.dataset.previewId !== lone) {
-                vscode.postMessage({
-                    command: "setInteractive",
-                    previewId: lone,
-                    enabled: false,
-                });
-                interactivePreviewIds.clear();
-                applyLiveBadge();
-            }
-        }
+        // Single-target follow-focus teardown — see
+        // `LiveStateController.enforceSingleTargetFollowFocus`.
+        liveState.enforceSingleTargetFollowFocus(
+            mode === "focus" ? (getVisibleCards()[focusIndex] ?? null) : null,
+        );
         // D2 — same teardown for the a11y overlay: navigating off the previewed card
         // (or exiting focus mode) unsubscribes so the wire stays quiet for cards the
         // user isn't looking at.
@@ -907,14 +727,14 @@ export function setupPreviewBehavior(
             // handler routes to recordInteractiveInput. Check before the
             // stale-card branch so interactive clicks do not also queue a
             // heavyweight refresh for stale captures.
-            if (interactivePreviewIds.has(previewId)) return;
+            if (liveState.isLive(previewId)) return;
             if (card.classList.contains("is-stale")) {
                 evt.preventDefault();
                 evt.stopPropagation();
                 staleBadge.requestHeavyRefresh(card);
                 return;
             }
-            enterInteractiveOnCard(card, evt.shiftKey);
+            liveState.enterInteractiveOnCard(card, evt.shiftKey);
         });
 
         // ATF legend + overlay layer — rendered in the webview (not
@@ -1192,7 +1012,7 @@ export function setupPreviewBehavior(
         // In live mode the new bytes are a frame, not a card reload —
         // skip the fade-in so successive frames read as a stream rather
         // than a sequence of independent renders. See INTERACTIVE.md § 3.
-        const isLive = interactivePreviewIds.has(previewId);
+        const isLive = liveState.isLive(previewId);
         img.className = isLive ? "live-frame" : "fade-in";
         attachInteractiveInputHandlers(card, img, interactiveInputConfig);
 
@@ -1305,21 +1125,11 @@ export function setupPreviewBehavior(
 
     // ----- Viewport tracking (daemon scroll-ahead, PREDICTIVE.md § 7) -----
     // The actual machinery lives in `./viewportTracker.ts`. The auto-stop-
-    // interactive-on-scroll-out rule stays here because the live set lives
-    // here; the tracker just notifies us via `onCardLeftViewport`.
+    // interactive-on-scroll-out rule lives in `liveState`; the tracker
+    // forwards the leave event via `onCardLeftViewport`.
     const viewport = new ViewportTracker({
         vscode,
-        onCardLeftViewport: (id) => {
-            if (!interactivePreviewIds.has(id)) return;
-            interactivePreviewIds.delete(id);
-            vscode.postMessage({
-                command: "setInteractive",
-                previewId: id,
-                enabled: false,
-            });
-            applyLiveBadge();
-            applyInteractiveButtonState();
-        },
+        onCardLeftViewport: (id) => liveState.onCardLeftViewport(id),
     });
 
     function observeCardForViewport(card) {
@@ -1363,10 +1173,8 @@ export function setupPreviewBehavior(
                 // bother sending interactive/stop because the preview no
                 // longer exists for the daemon to dispatch into anyway.
                 const newIds = new Set(msg.previews.map((p) => p.id));
-                interactivePreviewIds.forEach((id) => {
-                    if (!newIds.has(id)) interactivePreviewIds.delete(id);
-                });
-                applyLiveBadge();
+                liveState.pruneLive((id) => newIds.has(id));
+                liveState.applyLiveBadge();
                 applyInteractiveButtonState();
                 // Tell the extension the cards reached the grid. Powers the
                 // e2e test's "real webview consumed setPreviews" assertion —
@@ -1609,40 +1417,21 @@ export function setupPreviewBehavior(
                 // to every live preview; if the panel ever shows multi-
                 // module previews simultaneously, this needs scoping by
                 // each preview's owning module.
-                if (!msg.ready && interactivePreviewIds.size > 0) {
-                    interactivePreviewIds.clear();
-                    applyLiveBadge();
+                if (!msg.ready) liveState.handleDaemonLost();
+                else {
+                    applyInteractiveButtonState();
+                    applyRecordingButtonState();
                 }
-                if (!msg.ready && recordingPreviewIds.size > 0) {
-                    recordingPreviewIds.clear();
-                }
-                applyInteractiveButtonState();
-                applyRecordingButtonState();
                 break;
             }
             case "clearInteractive": {
-                // Extension flushed daemon-side streams (e.g. user moved focus to a
-                // different editor). Drop our UI-side bookkeeping in lockstep — the
-                // extension already stopped the streams server-side, so we MUST NOT post
-                // setInteractive messages back; that would race the flush.
-                if (msg.previewId) {
-                    interactivePreviewIds.delete(msg.previewId);
-                    applyLiveBadge();
-                    applyInteractiveButtonState();
-                } else if (interactivePreviewIds.size > 0) {
-                    interactivePreviewIds.clear();
-                    applyLiveBadge();
-                    applyInteractiveButtonState();
-                }
+                liveState.handleExtensionClearInteractive(
+                    msg.previewId ?? null,
+                );
                 break;
             }
             case "clearRecording": {
-                if (msg.previewId) {
-                    recordingPreviewIds.delete(msg.previewId);
-                } else if (recordingPreviewIds.size > 0) {
-                    recordingPreviewIds.clear();
-                }
-                applyRecordingButtonState();
+                liveState.handleExtensionClearRecording(msg.previewId ?? null);
                 break;
             }
             case "previewMainRefChanged": {
@@ -1701,17 +1490,7 @@ export function setupPreviewBehavior(
                         });
                         setA11yOverlay(null);
                     }
-                    if (recordingPreviewIds.size > 0) {
-                        recordingPreviewIds.forEach((previewId) => {
-                            vscode.postMessage({
-                                command: "setRecording",
-                                previewId,
-                                enabled: false,
-                                format: recordingFormat.value,
-                            });
-                        });
-                        recordingPreviewIds.clear();
-                    }
+                    liveState.handleEarlyFeaturesDisabled();
                 }
                 applyLayout();
                 break;

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -1,0 +1,364 @@
+// Live (interactive) + recording state controller for the preview panel.
+//
+// Lifted verbatim from `behavior.ts`'s `applyLiveBadge` / `ensureLiveCardControls`
+// / `stopAllInteractive` / `stopInteractiveForCard` / `toggleInteractive` /
+// `setInteractiveForCard` / `enterInteractiveOnCard` / `toggleRecording`
+// cluster, plus the lone-stream follow-focus teardown that used to live inline
+// in `applyLayout` and the ad-hoc Set manipulations spread across the
+// `setInteractiveAvailability` / `clearInteractive` / `clearRecording` /
+// `setEarlyFeatures` / `setPreviews` message handlers.
+//
+// Owns two Sets:
+//  - `interactivePreviewIds` — cards currently in v2 live (interactive) mode.
+//  - `recordingPreviewIds` — cards currently capturing a recording.
+//
+// Both sets forward pointer / wheel input to the daemon (predicate exposed via
+// `isLive` / `isRecording`); `attachInteractiveInputHandlers` from
+// `./interactiveInput.ts` consults them through `interactiveInputConfig.isLive`.
+//
+// Plain click on the LIVE button is single-target — drop every prior stream
+// before adding (or re-removing) this one. Shift+click is multi-target — toggle
+// just this preview without disturbing the others. Recording is currently
+// single-target only (Shift modifier intentionally not wired through).
+//
+// The controller posts the `setInteractive` / `setRecording` wire commands and
+// then re-runs the supplied button-state hooks so the toolbar reflects the new
+// truth synchronously. Silent variants (`handleDaemonLost`,
+// `handleExtensionClearInteractive`, `handleExtensionClearRecording`,
+// `pruneLive`) drop UI bookkeeping without posting back — those paths are
+// triggered after the extension or daemon has already torn the streams down,
+// and re-posting would race the flush.
+
+import { attachInteractiveInputHandlers } from "./interactiveInput";
+import type { InteractiveInputConfig } from "./interactiveInput";
+import type { VsCodeApi } from "../shared/vscode";
+import { sanitizeId } from "./cardData";
+
+export interface LiveStateConfig {
+    vscode: VsCodeApi<unknown>;
+    /** Selected recording format (`mp4` / `webm`). Read fresh on every
+     *  recording action so format-dropdown changes take effect on the
+     *  next gesture. */
+    recordingFormat: HTMLSelectElement;
+    /** Predicate config handed through to `attachInteractiveInputHandlers`
+     *  for the per-card pointer/wheel listeners. The `isLive` it carries
+     *  is expected to consult this controller (`isLive(id) || isRecording(id)`). */
+    interactiveInputConfig: InteractiveInputConfig;
+    /** Whether `composePreview.earlyFeatures` is on — recording is gated on it. */
+    earlyFeatures(): boolean;
+    /** Whether the panel is currently in focus layout. The Live / Recording
+     *  toolbar buttons only act when one card is focused. */
+    inFocus(): boolean;
+    /** The currently-focused preview card, or null when none is focused. */
+    focusedCard(): HTMLElement | null;
+    /** Re-run focus-toolbar button-state hooks after a state change. */
+    applyInteractiveButtonState(): void;
+    applyRecordingButtonState(): void;
+    /** Re-render the focus inspector for [card] — the inspector reads
+     *  `isLive` / `isRecording` to keep its Tools strip in sync. */
+    renderInspector(card: HTMLElement | null): void;
+}
+
+export class LiveStateController {
+    private readonly interactivePreviewIds = new Set<string>();
+    private readonly recordingPreviewIds = new Set<string>();
+
+    constructor(private readonly cfg: LiveStateConfig) {}
+
+    isLive(previewId: string): boolean {
+        return this.interactivePreviewIds.has(previewId);
+    }
+
+    isRecording(previewId: string): boolean {
+        return this.recordingPreviewIds.has(previewId);
+    }
+
+    get liveCount(): number {
+        return this.interactivePreviewIds.size;
+    }
+
+    get recordingCount(): number {
+        return this.recordingPreviewIds.size;
+    }
+
+    /** Re-stamp every `.preview-card.live` decoration from the current set.
+     *  Tear-down first so removals (Shift+click off, daemon-not-ready,
+     *  setPreviews dropping a previewId) cleanly wipe the prior decoration. */
+    applyLiveBadge(): void {
+        document.querySelectorAll(".preview-card.live").forEach((c) => {
+            c.classList.remove("live");
+            c.querySelector(".card-live-stop-btn")?.remove();
+        });
+        if (this.interactivePreviewIds.size === 0) return;
+        this.interactivePreviewIds.forEach((previewId) => {
+            const card = document.getElementById(
+                "preview-" + sanitizeId(previewId),
+            );
+            if (!card) return;
+            card.classList.add("live");
+            this.ensureLiveCardControls(card);
+        });
+    }
+
+    /** Toolbar `<i class="codicon codicon-debug-stop">` button — stop every
+     *  live stream at once. */
+    stopAllInteractive(): void {
+        if (this.interactivePreviewIds.size === 0) return;
+        const ids = Array.from(this.interactivePreviewIds);
+        this.interactivePreviewIds.clear();
+        ids.forEach((previewId) => {
+            this.cfg.vscode.postMessage({
+                command: "setInteractive",
+                previewId,
+                enabled: false,
+            });
+        });
+        this.applyLiveBadge();
+        this.cfg.applyInteractiveButtonState();
+    }
+
+    /** Per-card stop button (the codicon overlay) — stop only [card]. */
+    stopInteractiveForCard(card: HTMLElement): void {
+        const previewId = card.dataset.previewId;
+        if (!previewId || !this.interactivePreviewIds.has(previewId)) return;
+        this.interactivePreviewIds.delete(previewId);
+        this.cfg.vscode.postMessage({
+            command: "setInteractive",
+            previewId,
+            enabled: false,
+        });
+        this.applyLiveBadge();
+        this.cfg.applyInteractiveButtonState();
+    }
+
+    /** Focus-mode LIVE button — operates on the currently focused card. */
+    toggleInteractive(shift: boolean): void {
+        if (!this.cfg.inFocus()) return;
+        const card = this.cfg.focusedCard();
+        if (!card) return;
+        this.setInteractiveForCard(card, shift);
+    }
+
+    /**
+     * Toggle interactive mode for [card] honouring plain/Shift semantics:
+     *  - Plain: single-target. Drop every prior live target before adding (or
+     *    re-removing) this one — keeps the casual UX matching v1's "one card
+     *    live at a time" mental model.
+     *  - Shift: multi-target. Toggle just this preview in/out of the live set
+     *    without touching the others.
+     */
+    setInteractiveForCard(card: HTMLElement, shift: boolean): void {
+        const previewId = card.dataset.previewId;
+        if (!previewId) return;
+        const wasLive = this.interactivePreviewIds.has(previewId);
+        if (!shift) {
+            this.interactivePreviewIds.forEach((prior) => {
+                if (prior === previewId) return;
+                this.cfg.vscode.postMessage({
+                    command: "setInteractive",
+                    previewId: prior,
+                    enabled: false,
+                });
+            });
+            this.interactivePreviewIds.clear();
+        }
+        const turnOn = !wasLive;
+        if (turnOn) {
+            this.interactivePreviewIds.add(previewId);
+            const img = card.querySelector(".image-container img");
+            if (img instanceof HTMLImageElement) {
+                attachInteractiveInputHandlers(
+                    card,
+                    img,
+                    this.cfg.interactiveInputConfig,
+                );
+            }
+        } else {
+            this.interactivePreviewIds.delete(previewId);
+        }
+        this.cfg.vscode.postMessage({
+            command: "setInteractive",
+            previewId,
+            enabled: turnOn,
+        });
+        this.applyLiveBadge();
+        this.cfg.applyInteractiveButtonState();
+        this.cfg.renderInspector(card);
+    }
+
+    /** Single-click-to-LIVE entry point from the in-card image click handler.
+     *  Same effect as `setInteractiveForCard` — alias kept so the call site
+     *  documents intent. */
+    enterInteractiveOnCard(card: HTMLElement, shift: boolean): void {
+        this.setInteractiveForCard(card, shift);
+    }
+
+    /** Focus-mode REC button — operates on the currently focused card.
+     *  Recording is currently single-target; no Shift modifier. */
+    toggleRecording(): void {
+        if (!this.cfg.earlyFeatures()) return;
+        if (!this.cfg.inFocus()) return;
+        const card = this.cfg.focusedCard();
+        const previewId = card ? card.dataset.previewId : null;
+        if (!card || !previewId) return;
+        const turnOn = !this.recordingPreviewIds.has(previewId);
+        const format = this.cfg.recordingFormat.value;
+        if (turnOn) {
+            this.recordingPreviewIds.forEach((prior) => {
+                if (prior === previewId) return;
+                this.cfg.vscode.postMessage({
+                    command: "setRecording",
+                    previewId: prior,
+                    enabled: false,
+                    format,
+                });
+            });
+            this.recordingPreviewIds.clear();
+            this.recordingPreviewIds.add(previewId);
+            const img = card.querySelector(".image-container img");
+            if (img instanceof HTMLImageElement) {
+                attachInteractiveInputHandlers(
+                    card,
+                    img,
+                    this.cfg.interactiveInputConfig,
+                );
+            }
+        } else {
+            this.recordingPreviewIds.delete(previewId);
+        }
+        this.cfg.vscode.postMessage({
+            command: "setRecording",
+            previewId,
+            enabled: turnOn,
+            format,
+        });
+        this.cfg.applyRecordingButtonState();
+        this.cfg.renderInspector(card);
+    }
+
+    /**
+     * Single-target follow-focus teardown: when there is exactly one live
+     * stream and the user navigates off it, drop the stream so the LIVE chip
+     * follows the focused card. Multi-target (size > 1) is treated as an
+     * explicit opt-in via Shift+click — those streams persist across focus
+     * navigation until the user explicitly toggles them off.
+     */
+    enforceSingleTargetFollowFocus(focusedCard: HTMLElement | null): void {
+        if (this.interactivePreviewIds.size !== 1) return;
+        const lone = this.interactivePreviewIds.values().next().value;
+        if (lone === undefined) return;
+        if (focusedCard && focusedCard.dataset.previewId === lone) return;
+        this.cfg.vscode.postMessage({
+            command: "setInteractive",
+            previewId: lone,
+            enabled: false,
+        });
+        this.interactivePreviewIds.clear();
+        this.applyLiveBadge();
+    }
+
+    /** Viewport callback — auto-stop a live stream once its card has scrolled
+     *  fully out of view. */
+    onCardLeftViewport(previewId: string): void {
+        if (!this.interactivePreviewIds.has(previewId)) return;
+        this.interactivePreviewIds.delete(previewId);
+        this.cfg.vscode.postMessage({
+            command: "setInteractive",
+            previewId,
+            enabled: false,
+        });
+        this.applyLiveBadge();
+        this.cfg.applyInteractiveButtonState();
+    }
+
+    /** Drop live previewIds that are gone from a fresh setPreviews manifest.
+     *  Silent — the preview no longer exists for the daemon to dispatch into
+     *  anyway. Caller is expected to follow up with `applyLiveBadge` +
+     *  `applyInteractiveButtonState`. */
+    pruneLive(stillExists: (previewId: string) => boolean): void {
+        this.interactivePreviewIds.forEach((id) => {
+            if (!stillExists(id)) this.interactivePreviewIds.delete(id);
+        });
+    }
+
+    /** Daemon-not-ready — drop UI bookkeeping silently. */
+    handleDaemonLost(): void {
+        if (this.interactivePreviewIds.size > 0) {
+            this.interactivePreviewIds.clear();
+            this.applyLiveBadge();
+        }
+        if (this.recordingPreviewIds.size > 0) {
+            this.recordingPreviewIds.clear();
+        }
+        this.cfg.applyInteractiveButtonState();
+        this.cfg.applyRecordingButtonState();
+    }
+
+    /** Extension-driven `clearInteractive` — silent, the extension already
+     *  stopped the streams server-side. */
+    handleExtensionClearInteractive(previewId: string | null): void {
+        if (previewId) {
+            this.interactivePreviewIds.delete(previewId);
+            this.applyLiveBadge();
+            this.cfg.applyInteractiveButtonState();
+        } else if (this.interactivePreviewIds.size > 0) {
+            this.interactivePreviewIds.clear();
+            this.applyLiveBadge();
+            this.cfg.applyInteractiveButtonState();
+        }
+    }
+
+    handleExtensionClearRecording(previewId: string | null): void {
+        if (previewId) {
+            this.recordingPreviewIds.delete(previewId);
+        } else if (this.recordingPreviewIds.size > 0) {
+            this.recordingPreviewIds.clear();
+        }
+        this.cfg.applyRecordingButtonState();
+    }
+
+    /** Early-features flag flipped off — explicitly stop every recording
+     *  (live is implicitly torn down by the daemon-side teardown earlier in
+     *  the same setEarlyFeatures path). */
+    handleEarlyFeaturesDisabled(): void {
+        if (this.recordingPreviewIds.size === 0) return;
+        const format = this.cfg.recordingFormat.value;
+        this.recordingPreviewIds.forEach((previewId) => {
+            this.cfg.vscode.postMessage({
+                command: "setRecording",
+                previewId,
+                enabled: false,
+                format,
+            });
+        });
+        this.recordingPreviewIds.clear();
+    }
+
+    private ensureLiveCardControls(card: HTMLElement): void {
+        const container = card.querySelector(".image-container");
+        if (!container) return;
+        if (!container.querySelector(".card-live-stop-btn")) {
+            const btn = document.createElement("button");
+            btn.type = "button";
+            btn.className = "icon-button card-live-stop-btn";
+            btn.title = "Stop live preview";
+            btn.setAttribute("aria-label", "Stop live preview");
+            btn.innerHTML =
+                '<i class="codicon codicon-debug-stop" aria-hidden="true"></i>';
+            btn.addEventListener("click", (evt) => {
+                evt.preventDefault();
+                evt.stopPropagation();
+                this.stopInteractiveForCard(card);
+            });
+            container.appendChild(btn);
+        }
+        const img = container.querySelector("img");
+        if (img instanceof HTMLImageElement) {
+            attachInteractiveInputHandlers(
+                card,
+                img,
+                this.cfg.interactiveInputConfig,
+            );
+        }
+    }
+}


### PR DESCRIPTION
Slice of #767. Extracts the live (interactive) and recording state machine that drives the LIVE / REC focus-mode toolbar buttons, the per-card LIVE badge + stop button, the lone-stream follow-focus teardown, the viewport-leave auto-stop, and the silent UI cleanup paths driven by the extension's `setInteractiveAvailability` / `clearInteractive` / `clearRecording` / `setEarlyFeatures` messages.

## Summary

- New `liveState.ts` exports `LiveStateController` plus `LiveStateConfig`. Owns two private Sets (`interactivePreviewIds`, `recordingPreviewIds`) — both forward pointer/wheel input to the daemon — exposed externally only as `isLive(id)` / `isRecording(id)` / `liveCount` / `recordingCount`.
- Public mutators (`toggleInteractive(shift)`, `setInteractiveForCard`, `stopAllInteractive`, `stopInteractiveForCard`, `toggleRecording`, `enterInteractiveOnCard`, `applyLiveBadge`, `enforceSingleTargetFollowFocus`, `onCardLeftViewport`) post the wire commands and run the supplied button-state hooks. Silent variants (`handleDaemonLost`, `handleExtensionClearInteractive`, `handleExtensionClearRecording`, `pruneLive`, `handleEarlyFeaturesDisabled`) drop UI bookkeeping without re-posting — those paths are triggered after the extension or daemon has already torn the streams down, and re-posting would race the flush.
- `applyLayout`'s inline lone-stream follow-focus block becomes one call to `liveState.enforceSingleTargetFollowFocus(focusedCard)`. The viewport tracker's `onCardLeftViewport` callback collapses to `liveState.onCardLeftViewport(id)`.
- The construction order is `interactiveInputConfig` (forward-refs `liveState` in its `isLive` predicate) → `liveState`. The closure access is safe because the predicate is only called by pointer events, which fire later than module init.

`behavior.ts` shrinks from 1727 → 1506 lines (−221 LOC). No behaviour change.

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 326/326 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke: open the panel, focus a preview. Verify:
  - Plain click LIVE: chip appears on focused card, prior live cards drop their chip and receive `setInteractive enabled=false`.
  - Shift+click LIVE: prior live cards keep their chip, the new card joins the live set, "stop interactive" button appears.
  - Stop interactive button stops every live stream at once.
  - Per-card stop button (codicon overlay) stops only that card.
  - Navigate off the lone live card: stream drops automatically, LIVE chip follows the focused card on next toggle.
  - Two+ live (Shift) and navigate: streams persist across focus navigation.
  - Scroll a live card fully out of view: stream auto-stops.
  - Toggle REC: format-dropdown changes apply to the next gesture; one recording at a time.
  - Daemon goes not-ready: every LIVE chip + active recording disappears silently.
  - Toggle off `composePreview.earlyFeatures`: every active recording receives an explicit `setRecording enabled=false`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_