### PR TITLE
Defer debugUnitTestRuntimeClasspath resolution to fix concurrent variant resolution

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -16,6 +16,8 @@
 // § 19 for the captureToImage fallback if Roborazzi's API ever does break).
 // Pre-1.0; expect API breakage across minor versions.
 
+import java.util.concurrent.Callable
+
 plugins {
   id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
@@ -203,8 +205,16 @@ afterEvaluate {
   if (testRuntimeCfg == null || mainBundleTask == null || tfBundleTask == null) {
     return@afterEvaluate
   }
-  val testRuntimeJars =
+  // Wrap the artifactView's lazy `FileCollection` in a `Callable`-backed `project.files(...)` so
+  // resolution of `debugUnitTestRuntimeClasspath` is deferred until task execution rather than
+  // happening during task-graph build. Mirrors the pattern in
+  // `gradle-plugin/.../AndroidPreviewSupport.kt`'s rendererJars wireup. Without this, Gradle
+  // queries the artifactView while computing `writeDaemonClasspath`'s task dependencies, which
+  // races with concurrent variant resolution under `org.gradle.parallel=true` and throws
+  // `ConcurrentModificationException` from inside AGP's variant attribute machinery.
+  val testRuntimeJarsView =
     testRuntimeCfg.incoming.artifactView { attributes { attribute(artifactTypeAttr, "jar") } }.files
+  val testRuntimeJars = project.files(Callable { testRuntimeJarsView })
   val mainBundleFiles = mainBundleTask.outputs.files
   val tfBundleFiles = tfBundleTask.outputs.files
   // AGP-generated R.jar containing the transitive AAR's R.id classes (e.g.


### PR DESCRIPTION
## Summary
Fixed a race condition in the Gradle build that occurs when `org.gradle.parallel=true` is enabled. The issue was caused by eager resolution of the `debugUnitTestRuntimeClasspath` artifact view during task-graph construction, which could race with concurrent variant resolution in AGP's attribute machinery.

## Changes
- Added import for `java.util.concurrent.Callable`
- Wrapped the `artifactView`'s lazy `FileCollection` in a `Callable`-backed `project.files(...)` call to defer resolution until task execution time rather than during task-graph build
- This mirrors the existing pattern used in `gradle-plugin/.../AndroidPreviewSupport.kt`'s `rendererJars` wireup

## Implementation Details
The fix prevents `ConcurrentModificationException` errors that were thrown from inside AGP's variant attribute machinery when Gradle queried the artifact view while computing `writeDaemonClasspath`'s task dependencies under parallel execution. By deferring the resolution via `Callable`, the artifact view is only resolved during task execution, avoiding the race condition with concurrent variant resolution.

https://claude.ai/code/session_01WpDztoPkrYGLyvz6QL64qN