### PR TITLE
refactor(data-history): lift diff payload schema to data-history-core

### DIFF
--- a/data/history/connector/build.gradle.kts
+++ b/data/history/connector/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 dependencies {
   api(project(":daemon:core"))
+  api(project(":data-history-core"))
   testImplementation(libs.junit)
 }
 

--- a/data/history/connector/src/main/kotlin/ee/schimke/composeai/daemon/HistoryDiffRegionsDataProduct.kt
+++ b/data/history/connector/src/main/kotlin/ee/schimke/composeai/daemon/HistoryDiffRegionsDataProduct.kt
@@ -6,10 +6,13 @@ import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.history.HistoryDiffAverageDelta
+import ee.schimke.composeai.data.history.HistoryDiffPayload
+import ee.schimke.composeai.data.history.HistoryDiffRegion
+import ee.schimke.composeai.data.history.HistoryDiffRegionsProduct
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import javax.imageio.ImageIO
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -28,8 +31,8 @@ class HistoryDiffRegionsDataProductRegistry(private val historyManager: HistoryM
   override val capabilities: List<DataProductCapability> =
     listOf(
       DataProductCapability(
-        kind = KIND,
-        schemaVersion = SCHEMA_VERSION,
+        kind = HistoryDiffRegionsProduct.KIND,
+        schemaVersion = HistoryDiffRegionsProduct.SCHEMA_VERSION,
         transport = DataProductTransport.INLINE,
         attachable = true,
         fetchable = true,
@@ -43,7 +46,7 @@ class HistoryDiffRegionsDataProductRegistry(private val historyManager: HistoryM
     params: JsonElement?,
     inline: Boolean,
   ): DataProductRegistry.Outcome {
-    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    if (kind != HistoryDiffRegionsProduct.KIND) return DataProductRegistry.Outcome.Unknown
     val diffParams =
       parseParams(params)
         ?: return DataProductRegistry.Outcome.FetchFailed(
@@ -53,27 +56,27 @@ class HistoryDiffRegionsDataProductRegistry(private val historyManager: HistoryM
   }
 
   override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
-    if (KIND !in kinds) return emptyList()
+    if (HistoryDiffRegionsProduct.KIND !in kinds) return emptyList()
     val params = subscriptions[previewId] ?: return emptyList()
     val outcome = fetchDiff(previewId, params)
     if (outcome !is DataProductRegistry.Outcome.Ok) return emptyList()
     return listOf(
       DataProductAttachment(
-        kind = KIND,
-        schemaVersion = SCHEMA_VERSION,
+        kind = HistoryDiffRegionsProduct.KIND,
+        schemaVersion = HistoryDiffRegionsProduct.SCHEMA_VERSION,
         payload = outcome.result.payload,
       )
     )
   }
 
   override fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {
-    if (kind != KIND) return
+    if (kind != HistoryDiffRegionsProduct.KIND) return
     val parsed = parseParams(params) ?: return
     subscriptions[previewId] = parsed
   }
 
   override fun onUnsubscribe(previewId: String, kind: String) {
-    if (kind == KIND) subscriptions.remove(previewId)
+    if (kind == HistoryDiffRegionsProduct.KIND) subscriptions.remove(previewId)
   }
 
   private fun fetchDiff(previewId: String, params: DiffParams): DataProductRegistry.Outcome {
@@ -112,9 +115,9 @@ class HistoryDiffRegionsDataProductRegistry(private val historyManager: HistoryM
     val payload = diff(params.baselineHistoryId, latestImage, baselineImage, params.threshold)
     return DataProductRegistry.Outcome.Ok(
       DataFetchResult(
-        kind = KIND,
-        schemaVersion = SCHEMA_VERSION,
-        payload = json.encodeToJsonElement(DiffPayload.serializer(), payload),
+        kind = HistoryDiffRegionsProduct.KIND,
+        schemaVersion = HistoryDiffRegionsProduct.SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(HistoryDiffPayload.serializer(), payload),
       )
     )
   }
@@ -124,7 +127,7 @@ class HistoryDiffRegionsDataProductRegistry(private val historyManager: HistoryM
     latest: java.awt.image.BufferedImage,
     baseline: java.awt.image.BufferedImage,
     threshold: Int,
-  ): DiffPayload {
+  ): HistoryDiffPayload {
     val width = latest.width
     val height = latest.height
     val changed = BooleanArray(width * height)
@@ -166,7 +169,7 @@ class HistoryDiffRegionsDataProductRegistry(private val historyManager: HistoryM
       regions += region
     }
     val totalPixels = width.toLong() * height.toLong()
-    return DiffPayload(
+    return HistoryDiffPayload(
       baselineHistoryId = baselineHistoryId,
       totalPixelsChanged = totalChanged,
       changedFraction = if (totalPixels == 0L) 0.0 else totalChanged.toDouble() / totalPixels,
@@ -197,12 +200,12 @@ class HistoryDiffRegionsDataProductRegistry(private val historyManager: HistoryM
       sumB += channel(latestArgb, 0) - channel(baselineArgb, 0)
     }
 
-    fun toRegion(): DiffRegion =
-      DiffRegion(
+    fun toRegion(): HistoryDiffRegion =
+      HistoryDiffRegion(
         bounds = "$minX,$minY,${maxX + 1},${maxY + 1}",
         pixelCount = pixelCount,
         avgDelta =
-          AverageDelta(
+          HistoryDiffAverageDelta(
             r = sumR.toDouble() / pixelCount,
             g = sumG.toDouble() / pixelCount,
             b = sumB.toDouble() / pixelCount,
@@ -223,22 +226,7 @@ class HistoryDiffRegionsDataProductRegistry(private val historyManager: HistoryM
 
   private data class DiffParams(val baselineHistoryId: String, val threshold: Int)
 
-  @Serializable
-  data class DiffPayload(
-    val baselineHistoryId: String,
-    val totalPixelsChanged: Long,
-    val changedFraction: Double,
-    val regions: List<DiffRegion>,
-  )
-
-  @Serializable
-  data class DiffRegion(val bounds: String, val pixelCount: Long, val avgDelta: AverageDelta)
-
-  @Serializable data class AverageDelta(val r: Double, val g: Double, val b: Double, val a: Double)
-
-  companion object {
-    const val KIND: String = "history/diff/regions"
-    const val SCHEMA_VERSION: Int = 1
+  private companion object {
     private const val DEFAULT_THRESHOLD = 4
     private const val MAX_REGIONS = 50
 

--- a/data/history/connector/src/test/kotlin/ee/schimke/composeai/daemon/HistoryDiffRegionsDataProductRegistryTest.kt
+++ b/data/history/connector/src/test/kotlin/ee/schimke/composeai/daemon/HistoryDiffRegionsDataProductRegistryTest.kt
@@ -3,6 +3,8 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.history.HistoryManager
 import ee.schimke.composeai.daemon.history.LocalFsHistorySource
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.history.HistoryDiffPayload
+import ee.schimke.composeai.data.history.HistoryDiffRegionsProduct
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.nio.file.Files
@@ -45,7 +47,7 @@ class HistoryDiffRegionsDataProductRegistryTest {
     val registry = HistoryDiffRegionsDataProductRegistry(historyManager)
     val cap = registry.capabilities.single()
 
-    assertEquals(HistoryDiffRegionsDataProductRegistry.KIND, cap.kind)
+    assertEquals(HistoryDiffRegionsProduct.KIND, cap.kind)
     assertEquals(1, cap.schemaVersion)
     assertEquals(DataProductTransport.INLINE, cap.transport)
     assertTrue(cap.attachable)
@@ -82,7 +84,7 @@ class HistoryDiffRegionsDataProductRegistryTest {
       HistoryDiffRegionsDataProductRegistry(historyManager)
         .fetch(
           previewId = "com.example.Preview",
-          kind = HistoryDiffRegionsDataProductRegistry.KIND,
+          kind = HistoryDiffRegionsProduct.KIND,
           params = params(baseline.id),
           inline = false,
         )
@@ -91,11 +93,7 @@ class HistoryDiffRegionsDataProductRegistryTest {
     val result = (outcome as DataProductRegistry.Outcome.Ok).result
     assertNotNull(result.payload)
     assertNull(result.path)
-    val payload =
-      Json.decodeFromJsonElement(
-        HistoryDiffRegionsDataProductRegistry.DiffPayload.serializer(),
-        result.payload!!,
-      )
+    val payload = Json.decodeFromJsonElement(HistoryDiffPayload.serializer(), result.payload!!)
 
     assertEquals(baseline.id, payload.baselineHistoryId)
     assertEquals(5, payload.totalPixelsChanged)
@@ -126,12 +124,11 @@ class HistoryDiffRegionsDataProductRegistryTest {
     )
     val registry = HistoryDiffRegionsDataProductRegistry(historyManager)
 
-    registry.onSubscribe("preview", HistoryDiffRegionsDataProductRegistry.KIND, params(baseline.id))
-    val attachments =
-      registry.attachmentsFor("preview", setOf(HistoryDiffRegionsDataProductRegistry.KIND))
+    registry.onSubscribe("preview", HistoryDiffRegionsProduct.KIND, params(baseline.id))
+    val attachments = registry.attachmentsFor("preview", setOf(HistoryDiffRegionsProduct.KIND))
 
     assertEquals(1, attachments.size)
-    assertEquals(HistoryDiffRegionsDataProductRegistry.KIND, attachments.single().kind)
+    assertEquals(HistoryDiffRegionsProduct.KIND, attachments.single().kind)
     assertNotNull(attachments.single().payload)
   }
 
@@ -148,7 +145,7 @@ class HistoryDiffRegionsDataProductRegistryTest {
     val outcome =
       registry.fetch(
         previewId = "preview",
-        kind = HistoryDiffRegionsDataProductRegistry.KIND,
+        kind = HistoryDiffRegionsProduct.KIND,
         params = params("missing"),
         inline = false,
       )

--- a/data/history/core/build.gradle.kts
+++ b/data/history/core/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  api(libs.kotlinx.serialization.json)
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-history-core",
+    displayName = "Compose Preview - History Data Product Core",
+    description = "Shared history data-product model classes for Compose Preview.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/history/core/src/main/kotlin/ee/schimke/composeai/data/history/HistoryDiffModels.kt
+++ b/data/history/core/src/main/kotlin/ee/schimke/composeai/data/history/HistoryDiffModels.kt
@@ -1,0 +1,31 @@
+package ee.schimke.composeai.data.history
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Stable identity of the `history/diff/regions` data product. Lifted out of
+ * `HistoryDiffRegionsDataProductRegistry` so MCP clients and other connectors can depend on the
+ * payload schema without pulling in the daemon-side history manager.
+ */
+object HistoryDiffRegionsProduct {
+  const val KIND: String = "history/diff/regions"
+  const val SCHEMA_VERSION: Int = 1
+}
+
+@Serializable
+data class HistoryDiffPayload(
+  val baselineHistoryId: String,
+  val totalPixelsChanged: Long,
+  val changedFraction: Double,
+  val regions: List<HistoryDiffRegion>,
+)
+
+@Serializable
+data class HistoryDiffRegion(
+  val bounds: String,
+  val pixelCount: Long,
+  val avgDelta: HistoryDiffAverageDelta,
+)
+
+@Serializable
+data class HistoryDiffAverageDelta(val r: Double, val g: Double, val b: Double, val a: Double)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -94,6 +94,10 @@ include(":data-scroll-core")
 
 project(":data-scroll-core").projectDir = file("data/scroll/core")
 
+include(":data-history-core")
+
+project(":data-history-core").projectDir = file("data/history/core")
+
 include(":data-history-connector")
 
 project(":data-history-connector").projectDir = file("data/history/connector")


### PR DESCRIPTION
## Summary

- New `data-history-core` module holds the `history/diff/regions` payload schema (`HistoryDiffPayload`, `HistoryDiffRegion`, `HistoryDiffAverageDelta`) and its `KIND` / `SCHEMA_VERSION` identity in `HistoryDiffRegionsProduct`.
- `HistoryDiffRegionsDataProductRegistry` now imports those types instead of nesting them; the registry stays in `data-history-connector` because it depends on the daemon-side `HistoryManager`.
- Mirrors the core/connector split that `fonts`, `strings`, `layoutinspector`, `resources`, and `a11y` already use, so MCP clients and other connectors can depend on the schema without pulling in the daemon.

No behavior change.

Renames callers should be aware of:
- `HistoryDiffRegionsDataProductRegistry.KIND` → `HistoryDiffRegionsProduct.KIND`
- `HistoryDiffRegionsDataProductRegistry.DiffPayload` → `HistoryDiffPayload` (similarly `DiffRegion`, `AverageDelta`)

In-tree call sites (`DaemonMain` desktop + android, the registry test) are updated.

## Test plan

- [x] `./gradlew :data-history-core:compileKotlin :data-history-connector:compileKotlin :data-history-connector:test` — green
- [x] `./gradlew :data-history-core:ktfmtFormatMain :data-history-connector:ktfmtFormatMain :data-history-connector:ktfmtFormatTest` — clean
- [ ] CI `check`


---
_Generated by [Claude Code](https://claude.ai/code/session_018xiW9hpADkmVm3GyFMXrap)_