### PR TITLE
refactor(data-theme): lift compose/theme payload schema to data-theme-core

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -33,6 +33,7 @@ import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
 import ee.schimke.composeai.data.render.extensions.compose.ComposeDataExtensionPipeline
 import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionCompositionSink
+import ee.schimke.composeai.data.theme.ThemePayload
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.render.extensions.ExtensionContextData

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -17,6 +17,9 @@ import ee.schimke.composeai.data.render.PreviewDeviceContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
 import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
+import ee.schimke.composeai.data.theme.ResolvedThemeTokens
+import ee.schimke.composeai.data.theme.ThemePayload
+import ee.schimke.composeai.data.theme.TypographyToken
 import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
 import ee.schimke.composeai.daemon.bridge.InteractiveCommand
 import ee.schimke.composeai.daemon.bridge.SandboxSlot

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -33,6 +33,7 @@ import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
 import ee.schimke.composeai.data.render.extensions.compose.ComposeDataExtensionPipeline
 import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionCompositionSink
+import ee.schimke.composeai.data.theme.ThemePayload
 import java.io.File
 import java.util.Base64
 import java.util.Collections

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/ThemeDataProductRegistryTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/ThemeDataProductRegistryTest.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.theme.ResolvedThemeTokens
+import ee.schimke.composeai.data.theme.ThemePayload
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject

--- a/data/theme/connector/build.gradle.kts
+++ b/data/theme/connector/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 dependencies {
   api(project(":daemon:core"))
   api(project(":data-render-compose"))
+  api(project(":data-theme-core"))
   implementation(compose.runtime)
   implementation(compose.ui)
   implementation(compose.material3)

--- a/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
+++ b/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
@@ -34,9 +34,12 @@ import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExten
 import ee.schimke.composeai.data.render.extensions.compose.ComposableExtractorExtension
 import ee.schimke.composeai.data.render.extensions.compose.ComposeColorSpec
 import ee.schimke.composeai.data.render.extensions.compose.ExtensionCompositionSink
+import ee.schimke.composeai.data.theme.Material3ThemeProduct
+import ee.schimke.composeai.data.theme.ResolvedThemeTokens
+import ee.schimke.composeai.data.theme.ThemePayload
+import ee.schimke.composeai.data.theme.TypographyToken
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
@@ -194,8 +197,8 @@ class ThemeDataProductRegistry : DataProductRegistry {
   }
 
   companion object {
-    const val KIND = "compose/theme"
-    const val SCHEMA_VERSION = 1
+    const val KIND: String = Material3ThemeProduct.KIND
+    const val SCHEMA_VERSION: Int = Material3ThemeProduct.SCHEMA_VERSION
     const val RENDER_MODE = "theme"
 
     private val json = Json {
@@ -249,34 +252,6 @@ class ThemeCaptureExtension :
       )
   }
 }
-
-@Serializable
-data class ThemePayload(
-  val resolvedTokens: ResolvedThemeTokens,
-  val consumers: List<ThemeConsumer> = emptyList(),
-)
-
-@Serializable
-data class ResolvedThemeTokens(
-  val colorScheme: Map<String, String>,
-  val typography: Map<String, TypographyToken>,
-  val shapes: Map<String, String>,
-)
-
-@Serializable data class ThemeConsumer(val nodeId: String, val tokens: List<String>)
-
-@Serializable
-data class TypographyToken(
-  val fontFamily: String? = null,
-  val fontSize: Float? = null,
-  val fontSizeUnit: String? = null,
-  val fontWeight: String? = null,
-  val fontStyle: String? = null,
-  val lineHeight: Float? = null,
-  val lineHeightUnit: String? = null,
-  val letterSpacing: Float? = null,
-  val letterSpacingUnit: String? = null,
-)
 
 fun themePayloadFromMaterialTheme(
   colorScheme: ColorScheme,

--- a/data/theme/core/build.gradle.kts
+++ b/data/theme/core/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  api(libs.kotlinx.serialization.json)
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-theme-core",
+    displayName = "Compose Preview - Theme Data Product Core",
+    description = "Shared theme data-product model classes for Compose Preview.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/theme/core/src/main/kotlin/ee/schimke/composeai/data/theme/Material3ThemeModels.kt
+++ b/data/theme/core/src/main/kotlin/ee/schimke/composeai/data/theme/Material3ThemeModels.kt
@@ -1,0 +1,41 @@
+package ee.schimke.composeai.data.theme
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Stable identity of the `compose/theme` data product. Lifted out of `ThemeDataProductRegistry` so
+ * MCP clients and other connectors can depend on the payload schema without pulling in the
+ * daemon-side registry or Compose runtime.
+ */
+object Material3ThemeProduct {
+  const val KIND: String = "compose/theme"
+  const val SCHEMA_VERSION: Int = 1
+}
+
+@Serializable
+data class ThemePayload(
+  val resolvedTokens: ResolvedThemeTokens,
+  val consumers: List<ThemeConsumer> = emptyList(),
+)
+
+@Serializable
+data class ResolvedThemeTokens(
+  val colorScheme: Map<String, String>,
+  val typography: Map<String, TypographyToken>,
+  val shapes: Map<String, String>,
+)
+
+@Serializable data class ThemeConsumer(val nodeId: String, val tokens: List<String>)
+
+@Serializable
+data class TypographyToken(
+  val fontFamily: String? = null,
+  val fontSize: Float? = null,
+  val fontSizeUnit: String? = null,
+  val fontWeight: String? = null,
+  val fontStyle: String? = null,
+  val lineHeight: Float? = null,
+  val lineHeightUnit: String? = null,
+  val letterSpacing: Float? = null,
+  val letterSpacingUnit: String? = null,
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -122,6 +122,10 @@ include(":data-strings-core")
 
 project(":data-strings-core").projectDir = file("data/strings/core")
 
+include(":data-theme-core")
+
+project(":data-theme-core").projectDir = file("data/theme/core")
+
 include(":data-theme-connector")
 
 project(":data-theme-connector").projectDir = file("data/theme/connector")


### PR DESCRIPTION
## Summary

- New `data-theme-core` module holds the `compose/theme` payload schema (`ThemePayload`, `ResolvedThemeTokens`, `ThemeConsumer`, `TypographyToken`) and its `KIND` / `SCHEMA_VERSION` identity in `Material3ThemeProduct`. No Compose dep — pure kotlinx-serialization.
- `data-theme-connector` keeps the daemon-side registry, override planner, and Compose Material3 wiring; it now imports the moved types via a new `api(project(":data-theme-core"))` dep.
- `ThemeDataProductRegistry.KIND` / `.SCHEMA_VERSION` remain as forwarding constants pointing at `Material3ThemeProduct`, so existing in-tree call sites (`ThemeCaptureExtension`, `MaterialThemeTokenCaptureTest`) keep working without churn. `RENDER_MODE` stays in the registry — it's a runtime trigger, not part of the wire schema.
- Cross-module consumers (`daemon/desktop` `RenderEngine`, `daemon/android` `RenderEngine` + `RobolectricHost`, `daemon/desktop` `ThemeDataProductRegistryTest`) gain explicit imports for the moved types — they previously resolved them via same-package `ee.schimke.composeai.daemon` visibility.

Mirrors the `core/connector` split that fonts, strings, layoutinspector, resources, a11y, and (after #804) history already use.

No behavior change.

## Test plan

- [x] `./gradlew :data-theme-core:compileKotlin :data-theme-connector:compileKotlin` — green
- [x] `./gradlew :daemon:desktop:compileKotlin :daemon:android:compileDebugKotlin` — green
- [x] `./gradlew :data-theme-connector:test :data-theme-core:test :daemon:desktop:test` — green
- [x] `./gradlew :data-theme-core:ktfmtFormatMain :data-theme-connector:ktfmtFormat :daemon:desktop:ktfmtFormat :daemon:android:ktfmtFormat` — clean
- [ ] CI `check`
- [ ] `:daemon:android:testDebugUnitTest` — not run locally; `AndroidRecordingSessionTest` fails to compile on `origin/main` (unrelated `StateRecreateRecordingScriptEvents` reference). Confirmed pre-existing via `git stash` before my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_018xiW9hpADkmVm3GyFMXrap)_