### PR TITLE
refactor(vscode): dedupe parseBounds + diff-mode bar across webview

### DIFF
--- a/vscode-extension/src/webview/history/behavior.ts
+++ b/vscode-extension/src/webview/history/behavior.ts
@@ -11,6 +11,7 @@
 // rendered its skeleton into light DOM, so `document.getElementById(...)`
 // queries below resolve.
 
+import { buildDiffModeBar, type DiffMode } from "../shared/diffModeBar";
 import type {
     HistoryDiffSummary,
     HistoryEntry,
@@ -328,8 +329,6 @@ export function setupHistoryBehavior(): void {
         rightImage: string;
     }
 
-    type DiffMode = "side" | "overlay" | "onion";
-
     interface PersistedHistoryState {
         diffMode?: DiffMode;
     }
@@ -367,7 +366,7 @@ export function setupHistoryBehavior(): void {
         header.className = "diff-header";
         const body = document.createElement("div");
         body.className = "diff-body";
-        const modeBar = buildHistoryDiffModeBar(initialMode, (mode) => {
+        const modeBar = buildDiffModeBar(initialMode, (mode) => {
             const cur: PersistedHistoryState =
                 (vscode.getState() as PersistedHistoryState | undefined) ?? {};
             cur.diffMode = mode;
@@ -548,44 +547,6 @@ export function setupHistoryBehavior(): void {
             "×" +
             s.h;
         el.dataset.state = "changed";
-    }
-
-    function buildHistoryDiffModeBar(
-        initialMode: DiffMode,
-        onChange: (mode: DiffMode) => void,
-    ): HTMLElement {
-        const bar = document.createElement("div");
-        bar.className = "diff-mode-bar";
-        bar.setAttribute("role", "tablist");
-        const modes: { id: DiffMode; label: string }[] = [
-            { id: "side", label: "Side" },
-            { id: "overlay", label: "Overlay" },
-            { id: "onion", label: "Onion" },
-        ];
-        for (const m of modes) {
-            const btn = document.createElement("button");
-            btn.type = "button";
-            btn.textContent = m.label;
-            btn.dataset.mode = m.id;
-            btn.setAttribute("role", "tab");
-            btn.setAttribute(
-                "aria-selected",
-                m.id === initialMode ? "true" : "false",
-            );
-            if (m.id === initialMode) btn.classList.add("active");
-            btn.addEventListener("click", () => {
-                bar.querySelectorAll("button").forEach((b) => {
-                    b.classList.toggle("active", b.dataset.mode === m.id);
-                    b.setAttribute(
-                        "aria-selected",
-                        b.dataset.mode === m.id ? "true" : "false",
-                    );
-                });
-                onChange(m.id);
-            });
-            bar.appendChild(btn);
-        }
-        return bar;
     }
 
     function renderHistoryDiffMode(

--- a/vscode-extension/src/webview/preview/a11yOverlay.ts
+++ b/vscode-extension/src/webview/preview/a11yOverlay.ts
@@ -23,6 +23,7 @@ import type {
     AccessibilityNode,
     PreviewInfo,
 } from "../shared/types";
+import { parseBounds } from "./cardData";
 
 /**
  * Builds the per-card legend (one row per finding) shown beneath the
@@ -201,23 +202,4 @@ function highlightA11yFinding(card: HTMLElement, idx: number | null): void {
     )) {
         el.classList.add("a11y-active");
     }
-}
-
-interface ParsedBounds {
-    left: number;
-    top: number;
-    right: number;
-    bottom: number;
-}
-
-function parseBounds(s: string | null | undefined): ParsedBounds | null {
-    if (!s) return null;
-    const parts = s.split(",").map((x) => parseInt(x.trim(), 10));
-    if (parts.length !== 4 || parts.some(isNaN)) return null;
-    return {
-        left: parts[0],
-        top: parts[1],
-        right: parts[2],
-        bottom: parts[3],
-    };
 }

--- a/vscode-extension/src/webview/preview/diffOverlay.ts
+++ b/vscode-extension/src/webview/preview/diffOverlay.ts
@@ -21,9 +21,10 @@
 // daemon-side pixel mode (with SSIM, etc.) can plug in here later via
 // a different code path.
 
+import { buildDiffModeBar, type DiffMode } from "../shared/diffModeBar";
 import type { VsCodeApi } from "../shared/vscode";
 
-export type DiffMode = "side" | "overlay" | "onion";
+export type { DiffMode };
 
 export interface DiffPayload {
     leftLabel: string;
@@ -113,44 +114,6 @@ export function showDiffOverlay(
     computeDiffStats(payload.leftImage, payload.rightImage).then((s) => {
         applyDiffStats(stats, s);
     });
-}
-
-function buildDiffModeBar(
-    initialMode: DiffMode,
-    onChange: (mode: DiffMode) => void,
-): HTMLElement {
-    const bar = document.createElement("div");
-    bar.className = "diff-mode-bar";
-    bar.setAttribute("role", "tablist");
-    const modes: { id: DiffMode; label: string }[] = [
-        { id: "side", label: "Side" },
-        { id: "overlay", label: "Overlay" },
-        { id: "onion", label: "Onion" },
-    ];
-    for (const m of modes) {
-        const btn = document.createElement("button");
-        btn.type = "button";
-        btn.textContent = m.label;
-        btn.dataset.mode = m.id;
-        btn.setAttribute("role", "tab");
-        btn.setAttribute(
-            "aria-selected",
-            m.id === initialMode ? "true" : "false",
-        );
-        if (m.id === initialMode) btn.classList.add("active");
-        btn.addEventListener("click", () => {
-            for (const b of bar.querySelectorAll<HTMLButtonElement>("button")) {
-                b.classList.toggle("active", b.dataset.mode === m.id);
-                b.setAttribute(
-                    "aria-selected",
-                    b.dataset.mode === m.id ? "true" : "false",
-                );
-            }
-            onChange(m.id);
-        });
-        bar.appendChild(btn);
-    }
-    return bar;
 }
 
 function renderPreviewDiffMode(

--- a/vscode-extension/src/webview/shared/diffModeBar.ts
+++ b/vscode-extension/src/webview/shared/diffModeBar.ts
@@ -1,0 +1,62 @@
+// Shared Side / Overlay / Onion mode-bar widget for the diff overlays in the
+// preview and history panels. Same DOM shape (`role=tablist` + 3 buttons),
+// same `aria-selected` toggle behaviour, same CSS class (`.diff-mode-bar`).
+//
+// Lifted out of `preview/diffOverlay.ts` and `history/behavior.ts`'s
+// `buildHistoryDiffModeBar` — both panels were carrying the same ~30-line
+// function with only the persistence wiring different. The stack / pane
+// builders are not shared because the two panels intentionally use different
+// CSS class prefixes (`preview-diff-pane` vs `diff-pane`) to scope styling.
+
+export type DiffMode = "side" | "overlay" | "onion";
+
+interface DiffModeSpec {
+    id: DiffMode;
+    label: string;
+}
+
+const DIFF_MODES: readonly DiffModeSpec[] = [
+    { id: "side", label: "Side" },
+    { id: "overlay", label: "Overlay" },
+    { id: "onion", label: "Onion" },
+];
+
+/**
+ * Build the Side / Overlay / Onion tablist for a diff overlay. The active tab
+ * is marked with both the `.active` class (for styling) and `aria-selected`
+ * (for screen readers). [onChange] fires with the new mode each time a tab
+ * is clicked; the caller is expected to persist the choice and re-render the
+ * diff body.
+ */
+export function buildDiffModeBar(
+    initialMode: DiffMode,
+    onChange: (mode: DiffMode) => void,
+): HTMLElement {
+    const bar = document.createElement("div");
+    bar.className = "diff-mode-bar";
+    bar.setAttribute("role", "tablist");
+    for (const m of DIFF_MODES) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.textContent = m.label;
+        btn.dataset.mode = m.id;
+        btn.setAttribute("role", "tab");
+        btn.setAttribute(
+            "aria-selected",
+            m.id === initialMode ? "true" : "false",
+        );
+        if (m.id === initialMode) btn.classList.add("active");
+        btn.addEventListener("click", () => {
+            for (const b of bar.querySelectorAll<HTMLButtonElement>("button")) {
+                b.classList.toggle("active", b.dataset.mode === m.id);
+                b.setAttribute(
+                    "aria-selected",
+                    b.dataset.mode === m.id ? "true" : "false",
+                );
+            }
+            onChange(m.id);
+        });
+        bar.appendChild(btn);
+    }
+    return bar;
+}


### PR DESCRIPTION
Two follow-ups flagged in earlier PRs (#774 / the migration audit) — both were "the same helper exists in two places, fix when convenient".

## `parseBounds` dedup

Was duplicated between `cardData.ts` (exported, 11 lines) and a private copy in `a11yOverlay.ts` (same body). The cardData copy is the canonical one; `a11yOverlay.ts` now imports from it and drops the local re-implementation.

`a11yOverlay.ts`: 223 → 205 lines (−18).

## `buildDiffModeBar` lift to shared

Was duplicated between `preview/diffOverlay.ts` (`buildDiffModeBar`) and `history/behavior.ts` (`buildHistoryDiffModeBar`). Same DOM shape, same CSS class (`.diff-mode-bar`), same `aria-selected` toggle pattern, same 3-tab Side / Overlay / Onion list — only the persistence wiring differed and that already lives outside the function via the `onChange` callback. The only meaningful semantic difference was that the preview copy used a typed `for` loop and the history copy used `forEach` for the click handler's selectAll walk; standardised on the `for` form.

Lifts both into `shared/diffModeBar.ts` (62 lines) exporting `buildDiffModeBar(initialMode, onChange) → HTMLElement` plus the `DiffMode = "side" | "overlay" | "onion"` union. `preview/diffOverlay.ts` re-exports `DiffMode` from the shared module so existing imports (`import { DiffMode } from "./diffOverlay"`) keep working without a ripple-edit.

The stack / pane builders (`buildDiffStack` / `buildPreviewDiffPane` / `buildHistoryDiffStack` / `buildDiffPane`) intentionally **not** deduped — they use different CSS class prefixes (`preview-diff-pane` vs `diff-pane`) so the two panels' diff overlays can be styled independently, and there's no shared CSS truth to collapse them around.

`preview/diffOverlay.ts`: 378 → 341 lines (−37).
`history/behavior.ts`: 841 → 802 lines (−39).

**Net: −32 LOC across the webview tree (94 saved minus 62 new).**

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 326/326 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke:
  - Live panel: open a focused diff (Diff vs HEAD / vs main), cycle Side → Overlay → Onion tabs, verify persisted-mode survives a panel reload.
  - History panel: expand a row's "Diff vs previous" / "Diff vs current" and cycle the same three tabs, verify persisted-mode survives a panel reload.
  - Verify the a11y overlay still paints — `parseBounds` fires for each finding/node and the overlay layer renders boxes at percentage coordinates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_