### PR TITLE
refactor(data-wallpaper): lift compose/wallpaper payload schema to data-wallpaper-core

### DIFF
--- a/data/wallpaper/connector/build.gradle.kts
+++ b/data/wallpaper/connector/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 dependencies {
   api(project(":daemon:core"))
   api(project(":data-render-compose"))
+  api(project(":data-wallpaper-core"))
   implementation(compose.runtime)
   implementation(compose.ui)
   implementation(compose.material3)

--- a/data/wallpaper/connector/src/main/kotlin/ee/schimke/composeai/daemon/WallpaperDataProduct.kt
+++ b/data/wallpaper/connector/src/main/kotlin/ee/schimke/composeai/daemon/WallpaperDataProduct.kt
@@ -19,8 +19,9 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
 import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
 import ee.schimke.composeai.data.render.extensions.compose.ComposeColorSpec
+import ee.schimke.composeai.data.wallpaper.Material3WallpaperProduct
+import ee.schimke.composeai.data.wallpaper.WallpaperPayload
 import java.util.concurrent.ConcurrentHashMap
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
@@ -253,8 +254,8 @@ class WallpaperDataProductRegistry : DataProductRegistry {
     else parsed.toHexArgb()
 
   companion object {
-    const val KIND: String = "compose/wallpaper"
-    const val SCHEMA_VERSION: Int = 1
+    const val KIND: String = Material3WallpaperProduct.KIND
+    const val SCHEMA_VERSION: Int = Material3WallpaperProduct.SCHEMA_VERSION
 
     /**
      * Inspection-context key the theme connector publishes its payload under. Hard-coded here to
@@ -272,18 +273,3 @@ class WallpaperDataProductRegistry : DataProductRegistry {
     }
   }
 }
-
-/** Wire-shape returned by `data/fetch?kind=compose/wallpaper`. */
-@Serializable
-data class WallpaperPayload(
-  /** Canonical seed color hex string (`#AARRGGBB`). */
-  val seedColor: String,
-  /** Whether the derived scheme is the dark variant. */
-  val isDark: Boolean,
-  /** Palette algorithm the connector applied. */
-  val paletteStyle: WallpaperPaletteStyle = WallpaperPaletteStyle.TONAL_SPOT,
-  /** Effective contrast level in `[-1.0, 1.0]`. */
-  val contrastLevel: Double = 0.0,
-  /** Material 3 color roles derived from [seedColor]; matches the schema of `compose/theme`. */
-  val derivedColorScheme: Map<String, String>,
-)

--- a/data/wallpaper/connector/src/main/kotlin/ee/schimke/composeai/daemon/WallpaperDataProduct.kt
+++ b/data/wallpaper/connector/src/main/kotlin/ee/schimke/composeai/daemon/WallpaperDataProduct.kt
@@ -20,12 +20,17 @@ import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
 import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
 import ee.schimke.composeai.data.render.extensions.compose.ComposeColorSpec
 import ee.schimke.composeai.data.wallpaper.Material3WallpaperProduct
-import ee.schimke.composeai.data.wallpaper.WallpaperPayload
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 const val WALLPAPER_PAYLOAD_CONTEXT_KEY: String = "compose.wallpaper.payload"
+
+// Source/binary-compat shim. WallpaperPayload moved to :data-wallpaper-core in the
+// ee.schimke.composeai.data.wallpaper package; downstream consumers that imported it under the
+// old ee.schimke.composeai.daemon name continue to resolve via this alias. Mirrors the same
+// pattern used in :data-fonts-connector.
+typealias WallpaperPayload = ee.schimke.composeai.data.wallpaper.WallpaperPayload
 
 /**
  * Compose-side connector that wraps preview content in a Material 3 [MaterialTheme] whose color

--- a/data/wallpaper/core/build.gradle.kts
+++ b/data/wallpaper/core/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // `daemon:core` is the protocol definitions module. WallpaperPayload references the
+  // protocol-level WallpaperPaletteStyle enum, so the core schema module needs it on the
+  // classpath. MCP clients in other languages already consume the protocol module; pulling
+  // `data-wallpaper-core` adds the wallpaper payload schema alongside.
+  api(project(":daemon:core"))
+  api(libs.kotlinx.serialization.json)
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-wallpaper-core",
+    displayName = "Compose Preview - Wallpaper Data Product Core",
+    description = "Shared wallpaper data-product model classes for Compose Preview.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/wallpaper/core/src/main/kotlin/ee/schimke/composeai/data/wallpaper/WallpaperModels.kt
+++ b/data/wallpaper/core/src/main/kotlin/ee/schimke/composeai/data/wallpaper/WallpaperModels.kt
@@ -1,0 +1,29 @@
+package ee.schimke.composeai.data.wallpaper
+
+import ee.schimke.composeai.daemon.protocol.WallpaperPaletteStyle
+import kotlinx.serialization.Serializable
+
+/**
+ * Stable identity of the `compose/wallpaper` data product. Lifted out of
+ * `WallpaperDataProductRegistry` so MCP clients and other connectors can depend on the payload
+ * schema without pulling in the daemon-side registry, Compose Material3, or material-kolor.
+ */
+object Material3WallpaperProduct {
+  const val KIND: String = "compose/wallpaper"
+  const val SCHEMA_VERSION: Int = 1
+}
+
+/** Wire-shape returned by `data/fetch?kind=compose/wallpaper`. */
+@Serializable
+data class WallpaperPayload(
+  /** Canonical seed color hex string (`#AARRGGBB`). */
+  val seedColor: String,
+  /** Whether the derived scheme is the dark variant. */
+  val isDark: Boolean,
+  /** Palette algorithm the connector applied. */
+  val paletteStyle: WallpaperPaletteStyle = WallpaperPaletteStyle.TONAL_SPOT,
+  /** Effective contrast level in `[-1.0, 1.0]`. */
+  val contrastLevel: Double = 0.0,
+  /** Material 3 color roles derived from [seedColor]; matches the schema of `compose/theme`. */
+  val derivedColorScheme: Map<String, String>,
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -126,6 +126,10 @@ include(":data-theme-connector")
 
 project(":data-theme-connector").projectDir = file("data/theme/connector")
 
+include(":data-wallpaper-core")
+
+project(":data-wallpaper-core").projectDir = file("data/wallpaper/core")
+
 include(":data-wallpaper-connector")
 
 project(":data-wallpaper-connector").projectDir = file("data/wallpaper/connector")


### PR DESCRIPTION
## Summary

- New `data-wallpaper-core` module holds the `compose/wallpaper` payload schema (`WallpaperPayload`) and its `KIND` / `SCHEMA_VERSION` identity in `Material3WallpaperProduct`.
- `data-wallpaper-connector` keeps the daemon-side registry, Compose Material3 wiring, and material-kolor seed-color derivation; it now imports the moved types via `api(project(":data-wallpaper-core"))`.
- `WallpaperDataProductRegistry.KIND` / `.SCHEMA_VERSION` remain as forwarding constants pointing at `Material3WallpaperProduct`, so in-tree call sites (`WallpaperOverrideExtension.ID`, the connector tests) keep working without churn.
- `data-wallpaper-core` `api`-depends on `:daemon:core` because `WallpaperPayload` references the protocol-level `WallpaperPaletteStyle` enum. MCP clients already consume the protocol module, so this just makes the wallpaper schema reachable alongside it.

Mirrors the `core/connector` split that fonts, strings, layoutinspector, resources, a11y, and (after #804 / #806) history and theme already use. Recomposition is the last connector-only feature still pending the same lift.

No behavior change.

## Test plan

- [x] `./gradlew :data-wallpaper-core:compileKotlin :data-wallpaper-connector:compileKotlin :data-wallpaper-connector:test` — green
- [x] `./gradlew :data-wallpaper-core:ktfmtFormatMain :data-wallpaper-connector:ktfmtFormat` — clean
- [ ] CI `check`


---
_Generated by [Claude Code](https://claude.ai/code/session_018xiW9hpADkmVm3GyFMXrap)_