### PR TITLE
refactor(data-recomposition): lift compose/recomposition payload schema to data-recomposition-core

### DIFF
--- a/data/recomposition/connector/build.gradle.kts
+++ b/data/recomposition/connector/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 dependencies {
   api(project(":daemon:core"))
   api(project(":data-render-compose"))
+  api(project(":data-recomposition-core"))
   implementation(compose.runtime)
   implementation(compose.ui)
   testImplementation(libs.junit)

--- a/data/recomposition/connector/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
+++ b/data/recomposition/connector/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
@@ -16,6 +16,9 @@ import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.recomposition.RecompositionNode
+import ee.schimke.composeai.data.recomposition.RecompositionPayload
+import ee.schimke.composeai.data.recomposition.RecompositionProduct
 import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
 import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
 import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
@@ -27,7 +30,6 @@ import ee.schimke.composeai.data.render.extensions.compose.CompositionObserverHo
 import ee.schimke.composeai.data.render.extensions.compose.ExtensionComposeContext
 import ee.schimke.composeai.data.render.extensions.compose.ExtensionCompositionSink
 import java.util.concurrent.ConcurrentHashMap
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -444,16 +446,16 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
 
   companion object {
     /** The single kind this producer surfaces. */
-    const val KIND: String = "compose/recomposition"
+    const val KIND: String = RecompositionProduct.KIND
 
     /** Wire-format schema version pinned alongside [RecompositionPayload]. */
-    const val SCHEMA_VERSION: Int = 1
+    const val SCHEMA_VERSION: Int = RecompositionProduct.SCHEMA_VERSION
 
     /** Subscribe-time mode value: per-input deltas, requires a live interactive session. */
-    const val MODE_DELTA: String = "delta"
+    const val MODE_DELTA: String = RecompositionProduct.MODE_DELTA
 
     /** Subscribe-time mode value: one-shot snapshot of initial-composition counts. */
-    const val MODE_SNAPSHOT: String = "snapshot"
+    const val MODE_SNAPSHOT: String = RecompositionProduct.MODE_SNAPSHOT
 
     /**
      * Render mode tag the dispatcher forwards to the renderer-agnostic seam when this producer
@@ -565,32 +567,3 @@ internal object DesktopSceneRecomposer {
     throw NoSuchFieldException("$name not found on $start or any superclass")
   }
 }
-
-/**
- * Wire shape for `compose/recomposition` payloads (schemaVersion=1). Mirrors the JSON the VS Code
- * panel's heat-map overlay decodes. See
- * [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) §
- * "Recomposition + interactive mode".
- *
- * [sinceFrameStreamId] / [inputSeq] are populated only in delta mode — the snapshot mode is a
- * one-shot answer to "what recomposed during the initial composition" with no temporal baseline to
- * track.
- */
-@Serializable
-data class RecompositionPayload(
-  val mode: String,
-  val sinceFrameStreamId: String? = null,
-  val inputSeq: Long? = null,
-  val nodes: List<RecompositionNode> = emptyList(),
-)
-
-@Serializable
-data class RecompositionNode(
-  /**
-   * Identity-hashcode-of-RecomposeScope encoded as base-16 — stable for the duration of one
-   * interactive session. NOT stable across sessions. See [RecompositionDataProductRegistry] KDoc
-   * for the v2 followup (slot-table-derived `(file:line:column)` keys).
-   */
-  val nodeId: String,
-  val count: Int,
-)

--- a/data/recomposition/core/build.gradle.kts
+++ b/data/recomposition/core/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  api(libs.kotlinx.serialization.json)
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-recomposition-core",
+    displayName = "Compose Preview - Recomposition Data Product Core",
+    description = "Shared recomposition data-product model classes for Compose Preview.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/recomposition/core/src/main/kotlin/ee/schimke/composeai/data/recomposition/RecompositionModels.kt
+++ b/data/recomposition/core/src/main/kotlin/ee/schimke/composeai/data/recomposition/RecompositionModels.kt
@@ -1,0 +1,47 @@
+package ee.schimke.composeai.data.recomposition
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Stable identity of the `compose/recomposition` data product. Lifted out of
+ * `RecompositionDataProductRegistry` so MCP clients and other connectors can depend on the payload
+ * schema without pulling in the daemon-side registry, the Compose runtime, or the desktop scene
+ * recomposer reflection.
+ */
+object RecompositionProduct {
+  const val KIND: String = "compose/recomposition"
+  const val SCHEMA_VERSION: Int = 1
+
+  /** Subscribe-time mode: per-input deltas, requires a live interactive session. */
+  const val MODE_DELTA: String = "delta"
+
+  /** Subscribe-time mode: one-shot snapshot of initial-composition counts. */
+  const val MODE_SNAPSHOT: String = "snapshot"
+}
+
+/**
+ * Wire shape for `compose/recomposition` payloads. Mirrors the JSON the VS Code panel's heat-map
+ * overlay decodes. See `docs/daemon/DATA-PRODUCTS.md` § "Recomposition + interactive mode".
+ *
+ * [sinceFrameStreamId] / [inputSeq] are populated only in delta mode — the snapshot mode is a
+ * one-shot answer to "what recomposed during the initial composition" with no temporal baseline to
+ * track.
+ */
+@Serializable
+data class RecompositionPayload(
+  val mode: String,
+  val sinceFrameStreamId: String? = null,
+  val inputSeq: Long? = null,
+  val nodes: List<RecompositionNode> = emptyList(),
+)
+
+@Serializable
+data class RecompositionNode(
+  /**
+   * Identity-hashcode-of-RecomposeScope encoded as base-16 — stable for the duration of one
+   * interactive session. NOT stable across sessions. See `RecompositionDataProductRegistry` KDoc
+   * for the v2 followup (slot-table-derived `(file:line:column)` keys).
+   */
+  val nodeId: String,
+  val count: Int,
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -130,6 +130,10 @@ include(":data-wallpaper-connector")
 
 project(":data-wallpaper-connector").projectDir = file("data/wallpaper/connector")
 
+include(":data-recomposition-core")
+
+project(":data-recomposition-core").projectDir = file("data/recomposition/core")
+
 include(":data-recomposition-connector")
 
 project(":data-recomposition-connector").projectDir = file("data/recomposition/connector")


### PR DESCRIPTION
## Summary

- New `data-recomposition-core` module holds the `compose/recomposition` payload schema (`RecompositionPayload`, `RecompositionNode`) and its `KIND` / `SCHEMA_VERSION` / `MODE_DELTA` / `MODE_SNAPSHOT` identity in `RecompositionProduct`. Pure kotlinx-serialization, no Compose dep.
- `data-recomposition-connector` keeps the daemon-side registry, the experimental `CompositionObserver` install path, and the desktop `ImageComposeScene` reflection facade; it now imports the moved types via `api(project(":data-recomposition-core"))`.
- `RecompositionDataProductRegistry.KIND` / `.SCHEMA_VERSION` / `.MODE_DELTA` / `.MODE_SNAPSHOT` remain as forwarding constants pointing at `RecompositionProduct`, so in-tree call sites keep working without churn.

With this landed, every connector-only feature (theme, wallpaper, recomposition, history) now has the same `core/connector` split that fonts, strings, layoutinspector, resources, and a11y use. The only intentional outlier left is `data/scroll`, which has only a `core/` (renderer-side scenario steps, no daemon registration) — that gets a doc note in the next PR.

No behavior change.

## Test plan

- [x] `./gradlew :data-recomposition-core:compileKotlin :data-recomposition-connector:compileKotlin :data-recomposition-connector:test` — green
- [x] `./gradlew :data-recomposition-core:ktfmtFormatMain :data-recomposition-connector:ktfmtFormat` — clean
- [ ] CI `check`


---
_Generated by [Claude Code](https://claude.ai/code/session_018xiW9hpADkmVm3GyFMXrap)_