### PR TITLE
docs(data-products): index payload schema modules; document scroll/no-connector

### DIFF
--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtension.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtension.kt
@@ -7,7 +7,15 @@ import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionUsageMode
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelineStep
 
-/** Pipeline metadata for the scroll preview extension. */
+/**
+ * Pipeline metadata for the scroll preview extension.
+ *
+ * Unlike most `data/<feature>/`, scroll has only a `core/` module — there is no
+ * `data-scroll-connector`. Scroll produces image artifacts (long PNG, GIF) via the renderer's
+ * pipeline-step seam, not a JSON payload exposed on `data/fetch`. It never appears on
+ * `initialize.capabilities.dataProducts`. See `docs/daemon/DATA-PRODUCTS.md` § "`data/scroll` is
+ * renderer-side only".
+ */
 object ScrollPreviewExtension {
   const val ID: String = "scroll"
   const val ANNOTATION_ID: String = "scrolling-preview-annotation"

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -292,7 +292,10 @@ Compose runtime, daemon, or AndroidX:
 
 | Kind | Schema module | Schema type |
 |---|---|---|
-| `a11y/*` | `:data-a11y-core` | `AccessibilityReport`, `AccessibilityEntry` |
+| `a11y/atf` | `:data-a11y-core` | `AccessibilityFindingsPayload`, `AccessibilityFinding` |
+| `a11y/hierarchy` | `:data-a11y-core` | `AccessibilityHierarchyPayload`, `AccessibilityNode` |
+| `a11y/touchTargets` | `:data-a11y-core` | `AccessibilityTouchTargetsPayload`, `AccessibilityTouchTarget` |
+| `a11y/overlay` | `:data-a11y-core` | `AccessibilityOverlayArtifact` (path-only) |
 | `compose/recomposition` | `:data-recomposition-core` | `RecompositionPayload`, `RecompositionNode` |
 | `compose/semantics` | `:data-layoutinspector-core` | `ComposeSemanticsPayload`, `ComposeSemanticsNode` |
 | `compose/theme` | `:data-theme-core` | `ThemePayload`, `ResolvedThemeTokens`, `TypographyToken` |

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -276,8 +276,46 @@ Each data product is a **pair of modules** under `data/<product>/`:
   to the daemon process.
 
 Why split: cores are reusable in non-daemon contexts (`:gradle-plugin`,
-`:cli`, third-party Robolectric tests). Connectors are thin adapters
-that depend on `:daemon:core`.
+`:cli`, third-party Robolectric tests, MCP clients in any language that
+pull just the schema artifact). Connectors are thin adapters that
+depend on `:daemon:core`.
 
 The `ImageProcessor` interface lives in `:daemon:core` so every
 connector can implement it without circular module dependencies.
+
+### Schema source-of-truth
+
+Each on-the-wire payload kind has exactly one `@Serializable` definition,
+in the corresponding `data-<product>-core` module. MCP clients in other
+languages can generate parsers from these without depending on the
+Compose runtime, daemon, or AndroidX:
+
+| Kind | Schema module | Schema type |
+|---|---|---|
+| `a11y/*` | `:data-a11y-core` | `AccessibilityReport`, `AccessibilityEntry` |
+| `compose/recomposition` | `:data-recomposition-core` | `RecompositionPayload`, `RecompositionNode` |
+| `compose/semantics` | `:data-layoutinspector-core` | `ComposeSemanticsPayload`, `ComposeSemanticsNode` |
+| `compose/theme` | `:data-theme-core` | `ThemePayload`, `ResolvedThemeTokens`, `TypographyToken` |
+| `compose/wallpaper` | `:data-wallpaper-core` | `WallpaperPayload` |
+| `fonts/used` | `:data-fonts-core` | `FontsUsedPayload`, `FontUsedEntry` |
+| `history/diff/regions` | `:data-history-core` | `HistoryDiffPayload`, `HistoryDiffRegion` |
+| `i18n/translations` | `:data-strings-core` | `I18nTranslationsPayload`, `I18nVisibleString` |
+| `layout/inspector` | `:data-layoutinspector-core` | `LayoutInspectorPayload`, `LayoutInspectorNode` |
+| `resources/used` | `:data-resources-core` | `ResourcesUsedPayload`, `ResourceUsedReference` |
+| `text/strings` | `:data-strings-core` | `TextStringsPayload`, `TextStringEntry` |
+
+Each `core` module advertises its kind identity and schemaVersion via a
+`<Feature>Product` object (`HistoryDiffRegionsProduct.KIND`,
+`Material3ThemeProduct.SCHEMA_VERSION`, etc.). Connectors and consumers
+both refer to those constants — never inline the string literals.
+
+### `data/scroll` is renderer-side only
+
+`data/scroll/core` carries scroll-scenario drivers (`ScrollDriver`,
+`ScrollGifEncoder`, `ScrollPreviewExtension`) that the renderer
+composes through the regular extension pipeline. There is no
+`data-scroll-connector` because scroll is not a daemon-side data
+product — it produces image artifacts (GIFs, long PNGs), not a JSON
+payload, so it has no `kind` and never appears on the
+`initialize.capabilities.dataProducts` list. The renderer drives it
+directly via the `PreviewPipelineStep` / scenario-driver hooks.


### PR DESCRIPTION
## Summary

Closes the doc-side of the data-history-core / data-theme-core / data-wallpaper-core / data-recomposition-core schema lifts (#804, #806, #808, #809):

- New "Schema source-of-truth" subsection in `docs/daemon/DATA-PRODUCTS.md` with a per-kind table pointing at each `data-<feature>-core` module and the `@Serializable` types it owns. MCP clients in any language can generate parsers from those without pulling in the Compose runtime, daemon, or AndroidX.
- Module-level KDoc on `data/scroll/core`'s `ScrollPreviewExtension` explaining why scroll has only a `core/` and no `connector/` — it produces image artifacts (long PNG, GIF) via the renderer pipeline, not a JSON `kind` exposed on `data/fetch`. Same rationale lives in `DATA-PRODUCTS.md` § "`data/scroll` is renderer-side only".

No code changes beyond the comment.

## Test plan

- [x] `./gradlew :data-scroll-core:ktfmtFormat :data-scroll-core:compileDebugKotlin` — green
- [x] Manual review of the schema-source-of-truth table — type names spot-checked against each `data-<feature>-core` source
- [ ] CI `check`


---
_Generated by [Claude Code](https://claude.ai/code/session_018xiW9hpADkmVm3GyFMXrap)_