### PR TITLE
refactor(vscode): lift updateCardMetadata + applyRelativeSizing into cardBuilder

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -23,16 +23,12 @@ import {
     buildA11yOverlay,
     ensureHierarchyOverlay,
 } from "./a11yOverlay";
-import { buildPreviewCard } from "./cardBuilder";
 import {
-    buildTooltip,
-    buildVariantLabel,
-    isAnimatedPreview,
-    isWearPreview,
-    mimeFor,
-    parseBounds,
-    sanitizeId,
-} from "./cardData";
+    applyRelativeSizing,
+    buildPreviewCard,
+    updateCardMetadata,
+} from "./cardBuilder";
+import { mimeFor, parseBounds, sanitizeId } from "./cardData";
 import { FilterToolbar } from "./components/FilterToolbar";
 import { MessageBanner, type MessageOwner } from "./components/MessageBanner";
 import { PreviewGrid } from "./components/PreviewGrid";
@@ -308,8 +304,7 @@ export function setupPreviewBehavior(
     // capture. Populated from updateImage / setImageError messages so
     // prev/next navigation can swap the visible <img> without a fresh
     // extension round-trip.
-    // Map<previewId, CapturePresentation[]>
-    const cardCaptures = new Map();
+    const cardCaptures = new Map<string, CapturePresentation[]>();
     const frameCarousel = new FrameCarouselController({
         vscode,
         cardCaptures,
@@ -712,117 +707,13 @@ export function setupPreviewBehavior(
         return buildPreviewCard(p, cardBuilderConfig);
     }
 
-    function updateCardMetadata(card: HTMLElement, p: PreviewInfo): void {
-        card.dataset.function = p.functionName;
-        card.dataset.group = p.params.group || "";
-        card.dataset.wearPreview = isWearPreview(p) ? "1" : "0";
-        const title = card.querySelector<HTMLButtonElement>(".card-title");
-        if (title) {
-            title.textContent =
-                p.functionName + (p.params.name ? " — " + p.params.name : "");
-            title.title = buildTooltip(p);
-        }
-        // Refresh capture labels in place. If the capture count changed
-        // (e.g. user edited @RoboComposePreviewOptions) we preserve
-        // already-received imageData for renderOutputs that carry over.
-        const newCaps = p.captures.map((c) => ({
-            renderOutput: c.renderOutput,
-            label: c.label || "",
-        }));
-        const prior = cardCaptures.get(p.id) ?? [];
-        // Match by index rather than renderOutput since filenames may
-        // legitimately change (e.g. a preview gains a @RoboComposePreviewOptions
-        // annotation). Mismatched positions just reset to null-image.
-        const mergedCaps = newCaps.map(
-            (nc, i): CapturePresentation => ({
-                label: nc.label,
-                renderOutput: nc.renderOutput || "",
-                imageData: prior[i]?.imageData ?? null,
-                errorMessage: prior[i]?.errorMessage ?? null,
-                renderError: prior[i]?.renderError ?? null,
-            }),
-        );
-        cardCaptures.set(p.id, mergedCaps);
-        const curIdx = parseInt(card.dataset.currentIndex || "0", 10);
-        if (curIdx >= mergedCaps.length) {
-            card.dataset.currentIndex = String(
-                Math.max(0, mergedCaps.length - 1),
-            );
-        }
-        if (isAnimatedPreview(p)) frameCarousel.updateIndicator(card);
-        const variantLabel = buildVariantLabel(p);
-        let badge = card.querySelector(".variant-badge");
-        if (variantLabel) {
-            if (!badge) {
-                badge = document.createElement("div");
-                badge.className = "variant-badge";
-                card.appendChild(badge);
-            }
-            badge.textContent = variantLabel;
-        } else if (badge) {
-            badge.remove();
-        }
-
-        // Refresh the a11y legend + overlay in place when findings
-        // change (e.g. toggling a11y on turns findings from null → list,
-        // or a fresh render updates the set). Tear down the old nodes
-        // and rebuild: simpler than reconciling row-by-row for what is
-        // a rare event.
-        const existingLegend = card.querySelector(".a11y-legend");
-        const existingOverlay = card.querySelector(".a11y-overlay");
-        if (existingLegend) existingLegend.remove();
-        if (existingOverlay) existingOverlay.innerHTML = "";
-        if (earlyFeatures() && p.a11yFindings && p.a11yFindings.length > 0) {
-            const container = card.querySelector(".image-container");
-            if (container && !container.querySelector(".a11y-overlay")) {
-                const overlay = document.createElement("div");
-                overlay.className = "a11y-overlay";
-                overlay.setAttribute("aria-hidden", "true");
-                container.appendChild(overlay);
-            }
-            const legend = buildA11yLegend(card, p);
-            card.appendChild(legend);
-            // Repopulate box geometry if the image is already loaded —
-            // otherwise updateImage's load handler will pick it up on
-            // the next render cycle.
-            const img = card.querySelector<HTMLImageElement>(
-                ".image-container img",
-            );
-            if (img && img.complete && img.naturalWidth > 0) {
-                buildA11yOverlay(card, p.a11yFindings, img);
-            }
-        } else if (existingOverlay) {
-            // No findings or feature off — drop any leftover overlay
-            // div so cards stay clean when the user toggles
-            // earlyFeatures off mid-session.
-            existingOverlay.remove();
-        }
-    }
-
-    // Scale image containers so preview variants at different device sizes
-    // (e.g. wearos_large_round 227dp vs wearos_small_round 192dp) render at
-    // relative sizes in fixed-layout modes. Only applied when we have real
-    // widthDp/heightDp — variants without known dimensions fall back to
-    // the default CSS (full card width, auto aspect).
-    function applyRelativeSizing(previews: readonly PreviewInfo[]): void {
-        const widths = previews
-            .map((p) => p.params.widthDp ?? 0)
-            .filter((w) => w > 0);
-        const maxW = widths.length > 0 ? Math.max(...widths) : 0;
-        for (const p of previews) {
-            const card = document.getElementById("preview-" + sanitizeId(p.id));
-            if (!card) continue;
-            const w = p.params.widthDp;
-            const h = p.params.heightDp;
-            if (w && h && maxW > 0) {
-                card.style.setProperty("--size-ratio", (w / maxW).toFixed(4));
-                card.style.setProperty("--aspect-ratio", w + " / " + h);
-            } else {
-                card.style.removeProperty("--size-ratio");
-                card.style.removeProperty("--aspect-ratio");
-            }
-        }
-    }
+    // `updateCardMetadata` and `applyRelativeSizing` live in
+    // `./cardBuilder.ts` alongside `buildPreviewCard`.
+    const cardUpdateConfig = {
+        cardCaptures,
+        frameCarousel,
+        earlyFeatures,
+    };
 
     /**
      * Incremental diff: update existing cards, add new ones, remove missing.
@@ -871,7 +762,7 @@ export function setupPreviewBehavior(
         for (const p of previews) {
             const existing = existingCards.get(p.id);
             if (existing) {
-                updateCardMetadata(existing, p);
+                updateCardMetadata(existing, p, cardUpdateConfig);
                 // Ensure correct position
                 if (lastInsertedCard) {
                     if (lastInsertedCard.nextSibling !== existing) {

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -1,21 +1,17 @@
-// Initial DOM build for a single `<div class="preview-card">`.
+// Lifecycle DOM operations for a single `<div class="preview-card">`:
+// initial build (`buildPreviewCard`), metadata refresh on a fresh
+// `setPreviews` (`updateCardMetadata`), and the grid-wide relative-sizing
+// pass (`applyRelativeSizing`).
 //
-// Lifted verbatim from `behavior.ts`'s `createCard` so the imperative DOM
-// construction stops needing closure access to the rest of the panel. The
-// dynamic update paths (`updateCardMetadata`, `updateImage`, `applyA11yUpdate`)
-// still live in `behavior.ts` for now — they query the card via
-// `document.getElementById("preview-" + sanitizeId(id))` and patch in place,
-// independent of the initial build path.
-//
-// The eventual `<preview-card>` Lit component will fold both the initial
-// build and the dynamic updates into one reactive `render()`. This module is
-// the bridge: it captures every closed-over collaborator
-// (`vscode`, `liveState`, `staleBadge`, `frameCarousel`, viewport observer,
-// the `cardCaptures` map, the `interactiveInputConfig`) into a typed config
-// so the same logic can move into the component without re-resolving each
-// dependency through `setupPreviewBehavior`.
+// Lifted verbatim from `behavior.ts`'s `createCard` / `updateCardMetadata` /
+// `applyRelativeSizing` so the imperative DOM operations stop needing
+// closure access to the rest of the panel. The remaining update paths —
+// `updateImage` (per-frame image swap) and `applyA11yUpdate` (daemon-
+// attached a11y refresh) — still live in `behavior.ts` and patch the card
+// in place via `document.getElementById`. The eventual `<preview-card>`
+// Lit component will fold all five into a single reactive `render()`.
 
-import { buildA11yLegend } from "./a11yOverlay";
+import { buildA11yLegend, buildA11yOverlay } from "./a11yOverlay";
 import {
     buildTooltip,
     buildVariantLabel,
@@ -225,4 +221,141 @@ export function buildPreviewCard(
 
     config.observeForViewport(card);
     return card;
+}
+
+/** Subset of `CardBuilderConfig` that `updateCardMetadata` actually
+ *  reaches for. Kept narrow so callers — and the eventual reactive
+ *  Lit component — only have to satisfy what's used. */
+export type CardUpdateConfig = Pick<
+    CardBuilderConfig,
+    "cardCaptures" | "frameCarousel" | "earlyFeatures"
+>;
+
+/**
+ * Refresh an existing card after a `setPreviews` for an id we already
+ * have in the grid. Patches the card's dataset, title text, capture cache
+ * (preserving already-received `imageData` for surviving renderOutputs),
+ * variant badge, and a11y legend / overlay layer.
+ *
+ * Caller is responsible for finding the card — `renderPreviews` walks the
+ * grid once and dispatches to `updateCardMetadata` vs `buildPreviewCard`
+ * based on whether the previewId existed previously.
+ */
+export function updateCardMetadata(
+    card: HTMLElement,
+    p: PreviewInfo,
+    config: CardUpdateConfig,
+): void {
+    card.dataset.function = p.functionName;
+    card.dataset.group = p.params.group || "";
+    card.dataset.wearPreview = isWearPreview(p) ? "1" : "0";
+    const title = card.querySelector<HTMLButtonElement>(".card-title");
+    if (title) {
+        title.textContent =
+            p.functionName + (p.params.name ? " — " + p.params.name : "");
+        title.title = buildTooltip(p);
+    }
+    // Refresh capture labels in place. If the capture count changed
+    // (e.g. user edited @RoboComposePreviewOptions) we preserve
+    // already-received imageData for renderOutputs that carry over.
+    const newCaps = p.captures.map((c) => ({
+        renderOutput: c.renderOutput,
+        label: c.label || "",
+    }));
+    const prior = config.cardCaptures.get(p.id) ?? [];
+    // Match by index rather than renderOutput since filenames may
+    // legitimately change (e.g. a preview gains a @RoboComposePreviewOptions
+    // annotation). Mismatched positions just reset to null-image.
+    const mergedCaps = newCaps.map(
+        (nc, i): CapturePresentation => ({
+            label: nc.label,
+            renderOutput: nc.renderOutput || "",
+            imageData: prior[i]?.imageData ?? null,
+            errorMessage: prior[i]?.errorMessage ?? null,
+            renderError: prior[i]?.renderError ?? null,
+        }),
+    );
+    config.cardCaptures.set(p.id, mergedCaps);
+    const curIdx = parseInt(card.dataset.currentIndex || "0", 10);
+    if (curIdx >= mergedCaps.length) {
+        card.dataset.currentIndex = String(Math.max(0, mergedCaps.length - 1));
+    }
+    if (isAnimatedPreview(p)) config.frameCarousel.updateIndicator(card);
+    const variantLabel = buildVariantLabel(p);
+    let badge = card.querySelector(".variant-badge");
+    if (variantLabel) {
+        if (!badge) {
+            badge = document.createElement("div");
+            badge.className = "variant-badge";
+            card.appendChild(badge);
+        }
+        badge.textContent = variantLabel;
+    } else if (badge) {
+        badge.remove();
+    }
+
+    // Refresh the a11y legend + overlay in place when findings
+    // change (e.g. toggling a11y on turns findings from null → list,
+    // or a fresh render updates the set). Tear down the old nodes
+    // and rebuild: simpler than reconciling row-by-row for what is
+    // a rare event.
+    const existingLegend = card.querySelector(".a11y-legend");
+    const existingOverlay = card.querySelector(".a11y-overlay");
+    if (existingLegend) existingLegend.remove();
+    if (existingOverlay) existingOverlay.innerHTML = "";
+    if (config.earlyFeatures() && p.a11yFindings && p.a11yFindings.length > 0) {
+        const container = card.querySelector(".image-container");
+        if (container && !container.querySelector(".a11y-overlay")) {
+            const overlay = document.createElement("div");
+            overlay.className = "a11y-overlay";
+            overlay.setAttribute("aria-hidden", "true");
+            container.appendChild(overlay);
+        }
+        const legend = buildA11yLegend(card, p);
+        card.appendChild(legend);
+        // Repopulate box geometry if the image is already loaded —
+        // otherwise updateImage's load handler will pick it up on
+        // the next render cycle.
+        const img = card.querySelector<HTMLImageElement>(
+            ".image-container img",
+        );
+        if (img && img.complete && img.naturalWidth > 0) {
+            buildA11yOverlay(card, p.a11yFindings, img);
+        }
+    } else if (existingOverlay) {
+        // No findings or feature off — drop any leftover overlay
+        // div so cards stay clean when the user toggles
+        // earlyFeatures off mid-session.
+        existingOverlay.remove();
+    }
+}
+
+/**
+ * Scale image containers so preview variants at different device sizes
+ * (e.g. wearos_large_round 227dp vs wearos_small_round 192dp) render at
+ * relative sizes in fixed-layout modes. Only applied when we have real
+ * widthDp/heightDp — variants without known dimensions fall back to the
+ * default CSS (full card width, auto aspect).
+ *
+ * Walks all of [previews] once; idempotent — subsequent calls overwrite
+ * the CSS custom properties cleanly.
+ */
+export function applyRelativeSizing(previews: readonly PreviewInfo[]): void {
+    const widths = previews
+        .map((p) => p.params.widthDp ?? 0)
+        .filter((w) => w > 0);
+    const maxW = widths.length > 0 ? Math.max(...widths) : 0;
+    for (const p of previews) {
+        const card = document.getElementById("preview-" + sanitizeId(p.id));
+        if (!card) continue;
+        const w = p.params.widthDp;
+        const h = p.params.heightDp;
+        if (w && h && maxW > 0) {
+            card.style.setProperty("--size-ratio", (w / maxW).toFixed(4));
+            card.style.setProperty("--aspect-ratio", w + " / " + h);
+        } else {
+            card.style.removeProperty("--size-ratio");
+            card.style.removeProperty("--aspect-ratio");
+        }
+    }
 }


### PR DESCRIPTION
Continues the card-lifecycle extraction from #814. Lifts the remaining two metadata-side functions out of `behavior.ts` into `cardBuilder.ts`, where they sit alongside `buildPreviewCard`. The eventual `<preview-card>` Lit component will fold all of these (build, update, relative-sizing, plus the still-imperative `updateImage` and `applyA11yUpdate`) into one reactive `render()`.

## Summary

New `cardBuilder.ts` exports:
- `updateCardMetadata(card, p, config)` — refresh dataset, title, capture cache (preserving in-flight imageData), variant badge, and a11y legend / overlay. Takes a narrow `CardUpdateConfig` (a `Pick` of `CardBuilderConfig` covering `cardCaptures`, `frameCarousel`, `earlyFeatures`).
- `applyRelativeSizing(previews)` — pure DOM walk over all cards in the grid, sets `--size-ratio` / `--aspect-ratio` CSS vars from each preview's `widthDp` / `heightDp`. No config needed.

`behavior.ts` calls the new functions from `renderPreviews` (existing card path) and `setPreviews` (post-render relative-sizing pass), with the per-call config built once at panel boot. Same DOM, same side effects. No behaviour change.

## Drive-by

- Drops the now-unused `buildTooltip`, `buildVariantLabel`, `isAnimatedPreview`, `isWearPreview` imports from `behavior.ts` — all four were only referenced from `updateCardMetadata` and lifted along with it.
- Replaces a stale comment with a real type annotation on `cardCaptures`: was `// Map<previewId, CapturePresentation[]>` followed by `new Map()`; now `new Map<string, CapturePresentation[]>()`.
- Updates the `cardBuilder.ts` header comment to reflect the wider scope (lifecycle, not just initial build).

`behavior.ts`: 1141 → 1032 lines (**−109 LOC**).
`cardBuilder.ts`: 224 → 361 lines (+137 LOC).

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 350/350 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke: open the panel, edit a `@Preview` to trigger a fresh `setPreviews` for an existing previewId. Verify:
  - Title updates if `functionName` / `params.name` changed.
  - Variant badge appears / updates / disappears for changing `device` / `widthDp` / `heightDp` / `fontScale` / `uiMode` / `locale`.
  - In-flight imageData survives a metadata-only refresh.
  - Capture-count change clamps `currentIndex`.
  - Toggle `composePreview.earlyFeatures` mid-session — a11y legend + overlay appear / disappear without a full re-render.
  - Mixed widthDp/heightDp cards size proportionally in `flow` / `column` layouts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_