### PR TITLE
refactor(vscode): lift updateImage + applyA11yUpdate into cardBuilder

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -18,17 +18,13 @@ import type {
 } from "../shared/types";
 import { getVsCodeApi } from "../shared/vscode";
 import {
-    applyHierarchyOverlay,
-    buildA11yLegend,
-    buildA11yOverlay,
-    ensureHierarchyOverlay,
-} from "./a11yOverlay";
-import {
+    applyA11yUpdate,
     applyRelativeSizing,
     buildPreviewCard,
+    type CardBuilderConfig,
     updateCardMetadata,
+    updateImage,
 } from "./cardBuilder";
-import { mimeFor, parseBounds, sanitizeId } from "./cardData";
 import { FilterToolbar } from "./components/FilterToolbar";
 import { MessageBanner, type MessageOwner } from "./components/MessageBanner";
 import { PreviewGrid } from "./components/PreviewGrid";
@@ -43,7 +39,6 @@ import {
     FrameCarouselController,
     type CapturePresentation,
 } from "./frameCarousel";
-import { attachInteractiveInputHandlers } from "./interactiveInput";
 import { LiveStateController } from "./liveState";
 import { LoadingOverlay } from "./loadingOverlay";
 import {
@@ -685,20 +680,29 @@ export function setupPreviewBehavior(
     // `<filter-toolbar>`'s reactive state retains `fnValue` / `grpValue`
     // when only `fnOptions` / `grpOptions` change.
 
-    // Initial card construction lives in `./cardBuilder.ts` — see
-    // `buildPreviewCard`. The dynamic update paths (`updateCardMetadata`,
-    // `updateImage`, `applyA11yUpdate`) still live here for now and patch
-    // the card in place via `document.getElementById`. The eventual
-    // `<preview-card>` Lit component will fold both into a single reactive
-    // `render()`.
-    const cardBuilderConfig = {
+    // Card lifecycle lives in `./cardBuilder.ts` — see `buildPreviewCard`,
+    // `updateCardMetadata`, `applyRelativeSizing`, `updateImage`,
+    // `applyA11yUpdate`. The eventual `<preview-card>` Lit component will
+    // fold all five into a single reactive `render()` and consume the same
+    // `CardBuilderConfig` shape for its collaborator surface.
+    const cardBuilderConfig: CardBuilderConfig = {
         vscode,
         cardCaptures,
+        cardA11yFindings,
+        cardA11yNodes,
         staleBadge,
         frameCarousel,
         liveState,
+        interactiveInputConfig,
+        diffOverlayConfig,
+        inspector,
+        getAllPreviews: () => allPreviews,
         earlyFeatures,
         inFocus: () => filterToolbar.getLayoutValue() === "focus",
+        focusedCard: () =>
+            filterToolbar.getLayoutValue() === "focus"
+                ? (getVisibleCards()[focusIndex] ?? null)
+                : null,
         enterFocus: focusOnCard,
         exitFocus,
         observeForViewport: observeCardForViewport,
@@ -706,14 +710,6 @@ export function setupPreviewBehavior(
     function createCard(p: PreviewInfo): HTMLElement {
         return buildPreviewCard(p, cardBuilderConfig);
     }
-
-    // `updateCardMetadata` and `applyRelativeSizing` live in
-    // `./cardBuilder.ts` alongside `buildPreviewCard`.
-    const cardUpdateConfig = {
-        cardCaptures,
-        frameCarousel,
-        earlyFeatures,
-    };
 
     /**
      * Incremental diff: update existing cards, add new ones, remove missing.
@@ -762,7 +758,7 @@ export function setupPreviewBehavior(
         for (const p of previews) {
             const existing = existingCards.get(p.id);
             if (existing) {
-                updateCardMetadata(existing, p, cardUpdateConfig);
+                updateCardMetadata(existing, p, cardBuilderConfig);
                 // Ensure correct position
                 if (lastInsertedCard) {
                     if (lastInsertedCard.nextSibling !== existing) {
@@ -799,179 +795,6 @@ export function setupPreviewBehavior(
         const owner = messageBanner.getOwner();
         if (owner && owner !== "extension") {
             setMessage("", owner);
-        }
-    }
-
-    function updateImage(
-        previewId: string,
-        captureIndex: number,
-        imageData: string,
-    ): void {
-        const card = document.getElementById(
-            "preview-" + sanitizeId(previewId),
-        );
-        if (!card) return;
-
-        // Cache so carousel navigation can restore this capture without
-        // a fresh extension round-trip.
-        const caps = cardCaptures.get(previewId);
-        const capture =
-            caps && captureIndex >= 0 && captureIndex < caps.length
-                ? caps[captureIndex]
-                : null;
-        if (capture) {
-            capture.imageData = imageData;
-            capture.errorMessage = null;
-            capture.renderError = null;
-        }
-
-        // Only paint the <img> if the currently-displayed capture is the
-        // one that just arrived. Otherwise the cached bytes wait for
-        // prev/next.
-        const cur = parseInt(card.dataset.currentIndex || "0", 10);
-        if (cur !== captureIndex) {
-            if (caps) frameCarousel.updateIndicator(card);
-            return;
-        }
-
-        const container = card.querySelector<HTMLElement>(".image-container");
-        if (!container) return;
-        // Tear down every prior state before showing the new image.
-        // Leftover .error-message divs here are what caused the
-        // "Render pending — save the file to trigger a render" banner
-        // to stay visible forever even after a successful render.
-        container.querySelector(".skeleton")?.remove();
-        container.querySelector(".loading-overlay")?.remove();
-        container.querySelector(".error-message")?.remove();
-        card.classList.remove("has-error");
-
-        const ro = capture ? capture.renderOutput : "";
-        const newSrc = "data:" + mimeFor(ro) + ";base64," + imageData;
-
-        let img = container.querySelector("img");
-        if (!img) {
-            img = document.createElement("img");
-            img.alt = (card.dataset.function ?? "") + " preview";
-            container.appendChild(img);
-        }
-        img.src = newSrc;
-        // In live mode the new bytes are a frame, not a card reload —
-        // skip the fade-in so successive frames read as a stream rather
-        // than a sequence of independent renders. See INTERACTIVE.md § 3.
-        const isLive = liveState.isLive(previewId);
-        img.className = isLive ? "live-frame" : "fade-in";
-        attachInteractiveInputHandlers(card, img, interactiveInputConfig);
-
-        if (caps) frameCarousel.updateIndicator(card);
-
-        // If a diff overlay is open on this card and uses the live render
-        // as its left anchor (head / main / current), the bytes the
-        // overlay is showing just went stale. Re-issue so the user sees
-        // the new render without clicking — symmetric with the
-        // compose-preview/main ref watcher's auto-refresh on the right anchor.
-        const openDiff = container.querySelector<HTMLElement>(
-            ".preview-diff-overlay",
-        );
-        if (earlyFeatures() && openDiff) {
-            const against = openDiff.dataset.against;
-            if (against === "head" || against === "main") {
-                showDiffOverlay(card, against, null, null, diffOverlayConfig);
-                vscode.postMessage({
-                    command: "requestPreviewDiff",
-                    previewId,
-                    against,
-                });
-            }
-        }
-
-        // Re-build the a11y overlay once the image natural dimensions
-        // are known. Data-URL srcs may resolve synchronously; in that
-        // case img.complete is true and load will not fire, so we
-        // check both. Findings are stashed at setPreviews time via the
-        // renderPreviews pipeline. Gated on earlyFeatures so the
-        // overlay only paints when the user has opted into the
-        // accessibility-overlay feature surface.
-        const findings = cardA11yFindings.get(previewId);
-        const nodes = cardA11yNodes.get(previewId);
-        if (
-            earlyFeatures() &&
-            ((findings && findings.length > 0) || (nodes && nodes.length > 0))
-        ) {
-            const apply = () => {
-                if (findings && findings.length > 0)
-                    buildA11yOverlay(card, findings, img);
-                if (nodes && nodes.length > 0)
-                    applyHierarchyOverlay(card, nodes, img);
-            };
-            if (img.complete && img.naturalWidth > 0) {
-                apply();
-            } else {
-                img.addEventListener("load", apply, { once: true });
-            }
-        }
-    }
-
-    // D2 — handles updateA11y from the extension (daemon-attached a11y data products).
-    // Updates the per-preview caches and re-applies whichever overlays are now relevant
-    // without rebuilding the whole card. Findings -> legend + finding overlay; nodes ->
-    // hierarchy overlay. Either argument may be omitted to leave that side untouched.
-    // Gated on earlyFeatures so daemon-attached a11y data is dropped silently when the
-    // user has not opted into the accessibility-overlay feature surface.
-    function applyA11yUpdate(
-        previewId: string,
-        findings: readonly AccessibilityFinding[] | null | undefined,
-        nodes: readonly AccessibilityNode[] | null | undefined,
-    ): void {
-        if (!earlyFeatures()) return;
-        const card = document.getElementById(
-            "preview-" + sanitizeId(previewId),
-        );
-        if (!card) return;
-        const container = card.querySelector(".image-container");
-        const img = container && container.querySelector("img");
-        if (findings !== undefined) {
-            if (findings && findings.length > 0) {
-                cardA11yFindings.set(previewId, findings);
-                if (container && !container.querySelector(".a11y-overlay")) {
-                    const overlay = document.createElement("div");
-                    overlay.className = "a11y-overlay";
-                    overlay.setAttribute("aria-hidden", "true");
-                    container.appendChild(overlay);
-                }
-                const existingLegend = card.querySelector(".a11y-legend");
-                if (existingLegend) existingLegend.remove();
-                const p = allPreviews.find((pp) => pp.id === previewId);
-                if (p) {
-                    p.a11yFindings = [...findings];
-                    card.appendChild(buildA11yLegend(card, p));
-                }
-                if (img && img.complete && img.naturalWidth > 0) {
-                    buildA11yOverlay(card, findings, img);
-                }
-            } else {
-                cardA11yFindings.delete(previewId);
-                const overlay = card.querySelector(".a11y-overlay");
-                if (overlay) overlay.remove();
-                const legend = card.querySelector(".a11y-legend");
-                if (legend) legend.remove();
-            }
-        }
-        if (nodes !== undefined) {
-            if (nodes && nodes.length > 0) {
-                cardA11yNodes.set(previewId, nodes);
-                ensureHierarchyOverlay(container);
-                if (img && img.complete && img.naturalWidth > 0) {
-                    applyHierarchyOverlay(card, nodes, img);
-                }
-            } else {
-                cardA11yNodes.delete(previewId);
-                const layer = card.querySelector(".a11y-hierarchy-overlay");
-                if (layer) layer.remove();
-            }
-        }
-        if (filterToolbar.getLayoutValue() === "focus") {
-            const focused = getVisibleCards()[focusIndex];
-            if (focused === card) inspector.render(card);
         }
     }
 
@@ -1022,8 +845,10 @@ export function setupPreviewBehavior(
         saveFilterState,
         restoreFilterState,
         ensureNotBlank,
-        updateImage,
-        applyA11yUpdate,
+        updateImage: (previewId, captureIndex, imageData) =>
+            updateImage(previewId, captureIndex, imageData, cardBuilderConfig),
+        applyA11yUpdate: (previewId, findings, nodes) =>
+            applyA11yUpdate(previewId, findings, nodes, cardBuilderConfig),
         focusOnCard,
     };
     window.addEventListener("message", (event) => {

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -1,31 +1,48 @@
 // Lifecycle DOM operations for a single `<div class="preview-card">`:
 // initial build (`buildPreviewCard`), metadata refresh on a fresh
-// `setPreviews` (`updateCardMetadata`), and the grid-wide relative-sizing
-// pass (`applyRelativeSizing`).
+// `setPreviews` (`updateCardMetadata`), grid-wide relative-sizing
+// (`applyRelativeSizing`), per-frame image swap (`updateImage`), and
+// daemon-attached a11y refresh (`applyA11yUpdate`).
 //
-// Lifted verbatim from `behavior.ts`'s `createCard` / `updateCardMetadata` /
-// `applyRelativeSizing` so the imperative DOM operations stop needing
-// closure access to the rest of the panel. The remaining update paths —
-// `updateImage` (per-frame image swap) and `applyA11yUpdate` (daemon-
-// attached a11y refresh) — still live in `behavior.ts` and patch the card
-// in place via `document.getElementById`. The eventual `<preview-card>`
-// Lit component will fold all five into a single reactive `render()`.
+// Lifted verbatim from `behavior.ts` so the imperative DOM operations
+// stop needing closure access to the rest of the panel. Each function
+// takes a narrow `Pick` of `CardBuilderConfig` covering only the fields
+// it touches — the shared interface is the single source of truth for
+// the card's collaborator surface, and the eventual `<preview-card>`
+// Lit component will reach for those collaborators through the same
+// shape.
 
-import { buildA11yLegend, buildA11yOverlay } from "./a11yOverlay";
+import {
+    applyHierarchyOverlay,
+    buildA11yLegend,
+    buildA11yOverlay,
+    ensureHierarchyOverlay,
+} from "./a11yOverlay";
 import {
     buildTooltip,
     buildVariantLabel,
     isAnimatedPreview,
     isWearPreview,
+    mimeFor,
     sanitizeId,
 } from "./cardData";
+import { showDiffOverlay, type DiffOverlayConfig } from "./diffOverlay";
+import type { FocusInspectorController } from "./focusInspector";
 import type {
     CapturePresentation,
     FrameCarouselController,
 } from "./frameCarousel";
+import {
+    attachInteractiveInputHandlers,
+    type InteractiveInputConfig,
+} from "./interactiveInput";
 import type { LiveStateController } from "./liveState";
 import type { StaleBadgeController } from "./staleBadge";
-import type { PreviewInfo } from "../shared/types";
+import type {
+    AccessibilityFinding,
+    AccessibilityNode,
+    PreviewInfo,
+} from "../shared/types";
 import type { VsCodeApi } from "../shared/vscode";
 
 export interface CardBuilderConfig {
@@ -33,15 +50,43 @@ export interface CardBuilderConfig {
     /** Per-preview carousel runtime state — populated here on creation,
      *  read by `updateImage` / `setImageError` / `frameCarousel` later. */
     cardCaptures: Map<string, CapturePresentation[]>;
+    /** Per-preview a11y findings cache — populated by
+     *  `applyA11yUpdate` from daemon `a11y/atf` payloads, re-read on
+     *  every image (re)load to repaint the finding overlay. */
+    cardA11yFindings: Map<string, readonly AccessibilityFinding[]>;
+    /** Per-preview a11y hierarchy nodes cache — same shape, populated
+     *  from `a11y/hierarchy` payloads. */
+    cardA11yNodes: Map<string, readonly AccessibilityNode[]>;
     staleBadge: StaleBadgeController;
     frameCarousel: FrameCarouselController;
     liveState: LiveStateController;
-    /** Whether `composePreview.earlyFeatures` is on — gates the a11y legend
-     *  + overlay layer that the build path attaches up front. */
+    /** Pointer-input config for live cards — handed to
+     *  `attachInteractiveInputHandlers` whenever a fresh `<img>` lands
+     *  via `updateImage`. */
+    interactiveInputConfig: InteractiveInputConfig;
+    /** Diff overlay persistence + vscode handle — passed through to
+     *  `showDiffOverlay` when an open diff needs auto-refresh on a new
+     *  render. */
+    diffOverlayConfig: DiffOverlayConfig;
+    /** Focus-inspector handle so `applyA11yUpdate` can re-render when
+     *  a11y data lands for the focused card. */
+    inspector: FocusInspectorController;
+    /** Latest `setPreviews` manifest — `applyA11yUpdate` mutates the
+     *  matching entry's `a11yFindings` so legend rebuilds via
+     *  `buildA11yLegend(card, p)` see the fresh findings without a
+     *  separate parameter. */
+    getAllPreviews(): readonly PreviewInfo[];
+    /** Whether `composePreview.earlyFeatures` is on — gates the a11y
+     *  legend / overlay rebuild and the diff-overlay auto-refresh. */
     earlyFeatures(): boolean;
     /** Predicate for "panel is currently in focus layout" — keeps the
-     *  per-card focus button's enter/exit toggle in sync with the toolbar. */
+     *  per-card focus button's enter/exit toggle in sync with the toolbar
+     *  and gates the inspector re-render in `applyA11yUpdate`. */
     inFocus(): boolean;
+    /** The currently-focused preview card, or null when none is focused.
+     *  `applyA11yUpdate` uses it to decide whether to re-render the
+     *  inspector. */
+    focusedCard(): HTMLElement | null;
     /** Imperative actions the builder hands back to `behavior.ts` rather
      *  than reaching for them at construction time. */
     enterFocus(card: HTMLElement): void;
@@ -357,5 +402,227 @@ export function applyRelativeSizing(previews: readonly PreviewInfo[]): void {
             card.style.removeProperty("--size-ratio");
             card.style.removeProperty("--aspect-ratio");
         }
+    }
+}
+
+/** Subset `updateImage` reaches for — every per-frame paint dependency. */
+export type UpdateImageConfig = Pick<
+    CardBuilderConfig,
+    | "vscode"
+    | "cardCaptures"
+    | "cardA11yFindings"
+    | "cardA11yNodes"
+    | "frameCarousel"
+    | "liveState"
+    | "interactiveInputConfig"
+    | "diffOverlayConfig"
+    | "earlyFeatures"
+>;
+
+/**
+ * Paint a fresh capture image into the matching card. Idempotent — if the
+ * currently-displayed capture index doesn't match the arriving bytes, the
+ * cache is updated and the carousel indicator refreshed but no `<img>` is
+ * touched (the bytes wait for prev/next).
+ *
+ * Side effects (when [captureIndex] matches the displayed capture):
+ *  - Updates / mutates the per-capture cache entry on `cardCaptures`.
+ *  - Replaces the card's `<img>` `src` (or creates one if missing).
+ *  - Re-attaches the live pointer/wheel handlers via
+ *    `attachInteractiveInputHandlers`.
+ *  - If a diff overlay is open against `head` / `main`, re-issues the
+ *    diff request so the user sees the new bytes without clicking.
+ *  - Repaints the a11y finding / hierarchy overlays once the image's
+ *    natural dimensions are known.
+ */
+export function updateImage(
+    previewId: string,
+    captureIndex: number,
+    imageData: string,
+    config: UpdateImageConfig,
+): void {
+    const card = document.getElementById("preview-" + sanitizeId(previewId));
+    if (!card) return;
+
+    // Cache so carousel navigation can restore this capture without
+    // a fresh extension round-trip.
+    const caps = config.cardCaptures.get(previewId);
+    const capture =
+        caps && captureIndex >= 0 && captureIndex < caps.length
+            ? caps[captureIndex]
+            : null;
+    if (capture) {
+        capture.imageData = imageData;
+        capture.errorMessage = null;
+        capture.renderError = null;
+    }
+
+    // Only paint the <img> if the currently-displayed capture is the
+    // one that just arrived. Otherwise the cached bytes wait for
+    // prev/next.
+    const cur = parseInt(card.dataset.currentIndex || "0", 10);
+    if (cur !== captureIndex) {
+        if (caps) config.frameCarousel.updateIndicator(card);
+        return;
+    }
+
+    const container = card.querySelector<HTMLElement>(".image-container");
+    if (!container) return;
+    // Tear down every prior state before showing the new image.
+    // Leftover .error-message divs here are what caused the
+    // "Render pending — save the file to trigger a render" banner
+    // to stay visible forever even after a successful render.
+    container.querySelector(".skeleton")?.remove();
+    container.querySelector(".loading-overlay")?.remove();
+    container.querySelector(".error-message")?.remove();
+    card.classList.remove("has-error");
+
+    const ro = capture ? capture.renderOutput : "";
+    const newSrc = "data:" + mimeFor(ro) + ";base64," + imageData;
+
+    let img = container.querySelector("img");
+    if (!img) {
+        img = document.createElement("img");
+        img.alt = (card.dataset.function ?? "") + " preview";
+        container.appendChild(img);
+    }
+    img.src = newSrc;
+    // In live mode the new bytes are a frame, not a card reload —
+    // skip the fade-in so successive frames read as a stream rather
+    // than a sequence of independent renders. See INTERACTIVE.md § 3.
+    const isLive = config.liveState.isLive(previewId);
+    img.className = isLive ? "live-frame" : "fade-in";
+    attachInteractiveInputHandlers(card, img, config.interactiveInputConfig);
+
+    if (caps) config.frameCarousel.updateIndicator(card);
+
+    // If a diff overlay is open on this card and uses the live render
+    // as its left anchor (head / main / current), the bytes the
+    // overlay is showing just went stale. Re-issue so the user sees
+    // the new render without clicking — symmetric with the
+    // compose-preview/main ref watcher's auto-refresh on the right anchor.
+    const openDiff = container.querySelector<HTMLElement>(
+        ".preview-diff-overlay",
+    );
+    if (config.earlyFeatures() && openDiff) {
+        const against = openDiff.dataset.against;
+        if (against === "head" || against === "main") {
+            showDiffOverlay(
+                card,
+                against,
+                null,
+                null,
+                config.diffOverlayConfig,
+            );
+            config.vscode.postMessage({
+                command: "requestPreviewDiff",
+                previewId,
+                against,
+            });
+        }
+    }
+
+    // Re-build the a11y overlay once the image natural dimensions
+    // are known. Data-URL srcs may resolve synchronously; in that
+    // case img.complete is true and load will not fire, so we
+    // check both. Findings are stashed at setPreviews time via the
+    // renderPreviews pipeline. Gated on earlyFeatures so the
+    // overlay only paints when the user has opted into the
+    // accessibility-overlay feature surface.
+    const findings = config.cardA11yFindings.get(previewId);
+    const nodes = config.cardA11yNodes.get(previewId);
+    if (
+        config.earlyFeatures() &&
+        ((findings && findings.length > 0) || (nodes && nodes.length > 0))
+    ) {
+        const paintedImg = img;
+        const apply = (): void => {
+            if (findings && findings.length > 0)
+                buildA11yOverlay(card, findings, paintedImg);
+            if (nodes && nodes.length > 0)
+                applyHierarchyOverlay(card, nodes, paintedImg);
+        };
+        if (paintedImg.complete && paintedImg.naturalWidth > 0) {
+            apply();
+        } else {
+            paintedImg.addEventListener("load", apply, { once: true });
+        }
+    }
+}
+
+/** Subset `applyA11yUpdate` reaches for. */
+export type A11yUpdateConfig = Pick<
+    CardBuilderConfig,
+    | "cardA11yFindings"
+    | "cardA11yNodes"
+    | "getAllPreviews"
+    | "inspector"
+    | "earlyFeatures"
+    | "inFocus"
+    | "focusedCard"
+>;
+
+/**
+ * D2 — handles `updateA11y` from the extension (daemon-attached a11y data
+ * products). Updates the per-preview caches and re-applies whichever
+ * overlays are now relevant without rebuilding the whole card. Findings
+ * → legend + finding overlay; nodes → hierarchy overlay. Either argument
+ * may be omitted to leave that side untouched. Gated on `earlyFeatures()`
+ * so daemon-attached a11y data is dropped silently when the user has not
+ * opted into the accessibility-overlay feature surface.
+ */
+export function applyA11yUpdate(
+    previewId: string,
+    findings: readonly AccessibilityFinding[] | null | undefined,
+    nodes: readonly AccessibilityNode[] | null | undefined,
+    config: A11yUpdateConfig,
+): void {
+    if (!config.earlyFeatures()) return;
+    const card = document.getElementById("preview-" + sanitizeId(previewId));
+    if (!card) return;
+    const container = card.querySelector(".image-container");
+    const img = container?.querySelector<HTMLImageElement>("img") ?? null;
+    if (findings !== undefined) {
+        if (findings && findings.length > 0) {
+            config.cardA11yFindings.set(previewId, findings);
+            if (container && !container.querySelector(".a11y-overlay")) {
+                const overlay = document.createElement("div");
+                overlay.className = "a11y-overlay";
+                overlay.setAttribute("aria-hidden", "true");
+                container.appendChild(overlay);
+            }
+            const existingLegend = card.querySelector(".a11y-legend");
+            if (existingLegend) existingLegend.remove();
+            const p = config.getAllPreviews().find((pp) => pp.id === previewId);
+            if (p) {
+                p.a11yFindings = [...findings];
+                card.appendChild(buildA11yLegend(card, p));
+            }
+            if (img && img.complete && img.naturalWidth > 0) {
+                buildA11yOverlay(card, findings, img);
+            }
+        } else {
+            config.cardA11yFindings.delete(previewId);
+            const overlay = card.querySelector(".a11y-overlay");
+            if (overlay) overlay.remove();
+            const legend = card.querySelector(".a11y-legend");
+            if (legend) legend.remove();
+        }
+    }
+    if (nodes !== undefined) {
+        if (nodes && nodes.length > 0) {
+            config.cardA11yNodes.set(previewId, nodes);
+            ensureHierarchyOverlay(container);
+            if (img && img.complete && img.naturalWidth > 0) {
+                applyHierarchyOverlay(card, nodes, img);
+            }
+        } else {
+            config.cardA11yNodes.delete(previewId);
+            const layer = card.querySelector(".a11y-hierarchy-overlay");
+            if (layer) layer.remove();
+        }
+    }
+    if (config.inFocus() && config.focusedCard() === card) {
+        config.inspector.render(card);
     }
 }


### PR DESCRIPTION
Completes the card-lifecycle extraction started in #814 and continued in #815. Lifts the last two imperative card-update functions out of `behavior.ts` and into `cardBuilder.ts`, where all five lifecycle operations (initial build, metadata refresh, relative-sizing, image swap, a11y refresh) now live as siblings.

## Summary

New `cardBuilder.ts` exports:
- `updateImage(previewId, captureIndex, imageData, config)` — per-frame image swap. Updates the per-capture cache, paints a fresh `<img>` (or reuses the existing one), re-attaches live pointer/wheel handlers, auto-refreshes any open diff overlay against `head` / `main`, and repaints a11y finding / hierarchy overlays once the image's natural dimensions are known.
- `applyA11yUpdate(previewId, findings, nodes, config)` — daemon-attached `a11y/atf` + `a11y/hierarchy` payloads. Updates the per-preview caches, rebuilds the legend / overlay / hierarchy layer in place, and re-renders the focus inspector when the focused card is the one that just got updated.
- `UpdateImageConfig` / `A11yUpdateConfig` — narrow `Pick`s of `CardBuilderConfig` covering only the fields each function reaches for. Same pattern as #815's `CardUpdateConfig`.

`CardBuilderConfig` grows to cover the new collaborator surface: `cardA11yFindings`, `cardA11yNodes`, `interactiveInputConfig`, `diffOverlayConfig`, `inspector`, `getAllPreviews()`, `focusedCard()`. `behavior.ts` builds the unified `cardBuilderConfig` object once at panel boot and passes it (or its narrow `Pick` view) to all five lifecycle functions. The previous two-config split (`cardBuilderConfig` + `cardUpdateConfig`) collapses to one.

`messageHandlers.ts` continues to receive `updateImage` / `applyA11yUpdate` via its `PreviewMessageContext` callbacks; `behavior.ts` wraps the cardBuilder exports with thin arrow functions that bind the config so the dispatcher's call shape (no config arg) stays unchanged.

## Drive-by

Drops eight now-unused imports from `behavior.ts`:
- `applyHierarchyOverlay`, `buildA11yLegend`, `buildA11yOverlay`, `ensureHierarchyOverlay` from `./a11yOverlay`.
- `mimeFor`, `parseBounds`, `sanitizeId` from `./cardData`.
- `attachInteractiveInputHandlers` from `./interactiveInput`.

`behavior.ts`: 1032 → 857 lines (**−175 LOC**).
`cardBuilder.ts`: 361 → 628 lines (+267 LOC).

**`behavior.ts` is now down 73% from its 3208-line `@ts-nocheck` starting point**, with all five card-lifecycle DOM operations isolated in `cardBuilder.ts` ready to fold into the eventual `<preview-card>` Lit component.

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 350/350 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke:
  - `updateImage` for a static preview: image lands, fade-in class applied.
  - `updateImage` while LIVE: subsequent frames carry `live-frame` class (no fade-in).
  - `updateImage` for a non-displayed capture: cache updates, no `<img>` swap; carousel indicator still refreshes.
  - `updateImage` while a Diff vs HEAD / vs main overlay is open: overlay auto-refreshes with the new bytes.
  - `updateA11y` with findings: legend + overlay layer appear; with nodes: hierarchy overlay paints; with both null: layers tear down.
  - `updateA11y` for the focused card: focus inspector re-renders.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_