### PR TITLE
Implement wall-clock-accurate animation timing for live preview

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -118,6 +118,15 @@ internal constructor(
   private val lastUsedAtMs: AtomicLong = AtomicLong(System.currentTimeMillis())
 
   /**
+   * Wall-clock millis at the most recent [render] call, or `-1L` until the first render lands.
+   * Drives the wall-clock-accurate auto-advance in [render]: when the caller passes
+   * `advanceTimeMs = null`, the held composition's clock advances by the wall-clock delta since
+   * this timestamp (clamped — see [render]). Single-writer (`render` is serialised by
+   * `JsonRpcServer`) but `AtomicLong` for memory-visibility symmetry with [lastUsedAtMs].
+   */
+  private val lastRenderAtMs: AtomicLong = AtomicLong(-1L)
+
+  /**
    * Set to a non-null human-readable string when the watchdog auto-closes. Surfaced via
    * [autoClosedReason] so PR C's panel-side handler can distinguish "host force-closed because
    * idle" from "client hit interactive/stop".
@@ -432,12 +441,32 @@ internal constructor(
 
   override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {
     check(!closed) { "AndroidInteractiveSession.render() called after close()" }
-    lastUsedAtMs.set(System.currentTimeMillis())
+    val nowMs = System.currentTimeMillis()
+    lastUsedAtMs.set(nowMs)
+    // Wall-clock-accurate mode for live preview. JsonRpcServer.submitInteractiveRenderAsync calls
+    // render(hostId) without an explicit advance, in which case RobolectricHost defaults to a
+    // fixed 32ms per render — so a 200ms-per-render Robolectric capture only walks 32ms of
+    // animation per iteration and animations appear ~6× slower than wall-clock. Substitute the
+    // wall-clock delta since the previous render so the held composition's clock tracks real
+    // time; if the daemon falls behind, the next render covers the missed interval in one tick
+    // (i.e. animation skips frames forward to the correct wall-clock target). Floored at the
+    // existing settle window so first-render and back-to-back renders still get the recompose
+    // tick they need; capped at MAX_AUTO_ADVANCE_MS so a paused session doesn't lurch animations
+    // forward by minutes when the user returns. Recording callers pass an explicit delta and
+    // bypass this substitution entirely.
+    val previousRenderAtMs = lastRenderAtMs.getAndSet(nowMs)
+    val resolvedAdvance =
+      advanceTimeMs
+        ?: if (previousRenderAtMs < 0L) {
+          AUTO_ADVANCE_FLOOR_MS
+        } else {
+          (nowMs - previousRenderAtMs).coerceIn(AUTO_ADVANCE_FLOOR_MS, MAX_AUTO_ADVANCE_MS)
+        }
     slot.interactiveCommands.put(
       InteractiveCommand.Render(
         streamId = streamId,
         requestId = requestId,
-        advanceTimeMs = advanceTimeMs,
+        advanceTimeMs = resolvedAdvance,
       )
     )
     val resultQueue =
@@ -550,5 +579,38 @@ internal constructor(
      * `JsonRpcServer.onChannelClosed`.
      */
     const val DEFAULT_IDLE_LEASE_MS: Long = 60_000L
+
+    /**
+     * Floor for the wall-clock-derived advance applied in [render] when the caller leaves
+     * `advanceTimeMs` null. Matches `RobolectricHost.HELD_CAPTURE_ADVANCE_MS` — the same
+     * fixed-delta the held loop used unconditionally before the wall-clock substitution landed.
+     * Two reasons to floor at this value:
+     * - **First render** has no previous timestamp to subtract from, so `previousRenderAtMs <
+     *   0L`; the floor preserves the existing settle window the held loop relies on to flush
+     *   the initial composition.
+     * - **Back-to-back renders** (delta < 32ms — possible when the daemon batches a dispatch +
+     *   render arriving within a few ms of each other) still want at least one full recompose
+     *   tick before capture, otherwise effects scheduled by the dispatch may not have applied
+     *   yet.
+     */
+    private const val AUTO_ADVANCE_FLOOR_MS: Long = 32L
+
+    /**
+     * Cap on the wall-clock-derived advance applied in [render] when the caller leaves
+     * `advanceTimeMs` null. A session that's been idle for many seconds (user switched
+     * windows, network lag, etc.) shouldn't lurch animations forward by that whole gap on the
+     * next render — `rememberInfiniteTransition`-style animations would jump phase, and any
+     * `LaunchedEffect(Unit) { delay(...); ... }` that happens to straddle the gap could fire
+     * far past its intended trigger point.
+     *
+     * 1000ms picks the largest jump a user might plausibly tolerate as "the animation just
+     * caught up": one second of skipped wall-clock applied in a single tick lands the
+     * composition at a sensible mid-animation frame for typical Material / Wear motion
+     * (durations ≤ 600ms), without the multi-second phase jumps that frustrate diagnosis.
+     * Beyond that the held clock simply lags real time — animations resume from where they
+     * left off, accepting that the live preview is showing "the animation 2s ago" rather
+     * than skipping ahead unpredictably.
+     */
+    private const val MAX_AUTO_ADVANCE_MS: Long = 1_000L
   }
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionWallClockTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionWallClockTest.kt
@@ -1,0 +1,186 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
+import ee.schimke.composeai.daemon.bridge.InteractiveCommand
+import ee.schimke.composeai.daemon.bridge.SandboxSlot
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Wall-clock substitution coverage for [AndroidInteractiveSession.render]. The held-rule loop in
+ * `RobolectricHost` advances the held composition's `mainClock` by whatever `advanceTimeMs` the
+ * Render command carries (defaulting to 32ms when null). Live-preview callers
+ * (`JsonRpcServer.submitInteractiveRenderAsync`) leave the field null, so the historical 32ms
+ * default produced animations that walked ~6× slower than wall-clock when each Robolectric capture
+ * took ~200ms. The session-level substitution covered here keeps animations on real time:
+ *
+ *  * **Null advance, first render** → floored at the recompose-settle window so the initial
+ *    capture still flushes the post-`setContent` recomposition pass.
+ *  * **Null advance, subsequent render** → wall-clock delta since the previous render, clamped
+ *    into `[floor, cap]`.
+ *  * **Null advance after a long idle** → capped so a paused session doesn't lurch animations
+ *    forward when the user returns.
+ *  * **Explicit advance** → preserved verbatim (recording sessions pace frames themselves).
+ *
+ * The test runs on plain JUnit (no Robolectric sandbox boot) by driving `slot.interactiveCommands`
+ * directly: a poller thread drains each Render envelope and posts a synthetic [RenderResult] back
+ * through `DaemonHostBridge.results` so the foreground `render()` call returns. That sidesteps the
+ * minute-long `RENDER_TIMEOUT_SEC` blocking wait without changing production code.
+ */
+class AndroidInteractiveSessionWallClockTest {
+
+  private lateinit var slot: SandboxSlot
+  private lateinit var activeStreamRef: AtomicReference<String?>
+  private lateinit var session: AndroidInteractiveSession
+
+  @Before
+  fun setUp() {
+    DaemonHostBridge.reset()
+    slot = DaemonHostBridge.slot(0)
+    activeStreamRef = AtomicReference(STREAM_ID)
+    session =
+      AndroidInteractiveSession(
+        previewId = "preview-wall-clock",
+        streamId = STREAM_ID,
+        slot = slot,
+        activeStreamRef = activeStreamRef,
+        // Disable the watchdog — these tests don't exercise the idle-lease path and we don't want
+        // a scheduled close() racing with the fake reply harness.
+        idleLeaseMs = 0L,
+      )
+  }
+
+  @After
+  fun tearDown() {
+    DaemonHostBridge.reset()
+  }
+
+  @Test
+  fun firstRenderWithNullAdvanceUsesFloor() {
+    val cmd = renderAndCaptureCommand(advanceTimeMs = null, requestId = 1L)
+    assertNotNull("expected an advanceTimeMs to be substituted", cmd.advanceTimeMs)
+    assertEquals(
+      "first render with null advance must substitute the floor (no previous render to subtract)",
+      32L,
+      cmd.advanceTimeMs,
+    )
+  }
+
+  @Test
+  fun secondRenderWithNullAdvanceTracksWallClockDelta() {
+    renderAndCaptureCommand(advanceTimeMs = null, requestId = 1L)
+    val gapMs = 200L
+    Thread.sleep(gapMs)
+    val cmd = renderAndCaptureCommand(advanceTimeMs = null, requestId = 2L)
+    val advance =
+      cmd.advanceTimeMs
+        ?: error("second render must substitute a wall-clock advance, not leave it null")
+    assertTrue(
+      "expected substituted advance ≈ ${gapMs}ms, got ${advance}ms — wall-clock delta should " +
+        "drive the held mainClock so animations track real time",
+      advance in (gapMs - 50L)..(gapMs + 200L),
+    )
+  }
+
+  @Test
+  fun explicitAdvanceIsPreservedAndDoesNotPokeWallClockBookkeeping() {
+    val explicit = renderAndCaptureCommand(advanceTimeMs = 333L, requestId = 1L)
+    assertEquals(
+      "explicit advanceTimeMs must round-trip unchanged for recording-style callers",
+      333L,
+      explicit.advanceTimeMs,
+    )
+    // The first explicit-advance call should still seed `lastRenderAtMs`, otherwise the next
+    // null-advance render would get the floor instead of a wall-clock delta. Sleep a known gap
+    // and observe the substituted advance to confirm.
+    Thread.sleep(150L)
+    val followup = renderAndCaptureCommand(advanceTimeMs = null, requestId = 2L)
+    val advance = followup.advanceTimeMs ?: error("expected null-advance to substitute a delta")
+    assertTrue(
+      "expected substituted advance ≈ 150ms after an explicit-advance render, got ${advance}ms",
+      advance in 100L..400L,
+    )
+  }
+
+  @Test
+  fun longIdleClampsToTheCap() {
+    renderAndCaptureCommand(advanceTimeMs = null, requestId = 1L)
+    // Simulate a paused session by manually backdating the bookkeeping rather than sleeping for
+    // the cap interval — keeps the test fast. We assert the cap by reading
+    // `lastUsedAtMs` indirectly through the next render's advance.
+    //
+    // The session's render() reads `lastRenderAtMs` and substitutes `now - lastRenderAtMs`,
+    // clamped to MAX. We can't poke the field directly without reflection, so instead we verify
+    // the cap by sleeping past it. 1000ms is the production cap; 1100ms gives us 100ms of slack.
+    Thread.sleep(1_100L)
+    val cmd = renderAndCaptureCommand(advanceTimeMs = null, requestId = 2L)
+    val advance = cmd.advanceTimeMs ?: error("expected null-advance to substitute a delta")
+    assertTrue(
+      "expected advance to be clamped to the 1000ms cap after a 1100ms idle, got ${advance}ms",
+      advance <= 1_000L,
+    )
+    assertTrue(
+      "expected the clamped advance to still reflect the cap (≥ 900ms), got ${advance}ms",
+      advance >= 900L,
+    )
+  }
+
+  /**
+   * Drive `session.render()` from a worker thread, drain the resulting [InteractiveCommand.Render]
+   * off `slot.interactiveCommands`, post a synthetic [RenderResult] reply onto
+   * `DaemonHostBridge.results`, then join the worker and return the captured command. The session
+   * blocks on the reply queue with a 60s timeout in production; the harness completes the round
+   * trip in milliseconds without changing production code paths.
+   */
+  private fun renderAndCaptureCommand(
+    advanceTimeMs: Long?,
+    requestId: Long,
+  ): InteractiveCommand.Render {
+    val captured = AtomicReference<InteractiveCommand.Render?>(null)
+    val workerError = AtomicReference<Throwable?>(null)
+    val worker =
+      Thread({
+          try {
+            session.render(requestId = requestId, advanceTimeMs = advanceTimeMs)
+          } catch (t: Throwable) {
+            workerError.set(t)
+          }
+        })
+        .apply {
+          isDaemon = true
+          name = "AndroidInteractiveSessionWallClockTest-render-$requestId"
+        }
+    worker.start()
+    val cmd =
+      slot.interactiveCommands.poll(5, TimeUnit.SECONDS) as? InteractiveCommand.Render
+        ?: error(
+          "expected an InteractiveCommand.Render on the slot's queue within 5s; got nothing — " +
+            "session.render() may not have enqueued"
+        )
+    captured.set(cmd)
+    DaemonHostBridge.results.computeIfAbsent(requestId) { LinkedBlockingQueue() }.put(FAKE_RESULT)
+    worker.join(5_000)
+    workerError.get()?.let { throw AssertionError("render() worker failed", it) }
+    return cmd
+  }
+
+  private companion object {
+    const val STREAM_ID: String = "stream-wall-clock"
+
+    val FAKE_RESULT: RenderResult =
+      RenderResult(
+        id = 0L,
+        classLoaderHashCode = 0,
+        classLoaderName = "test",
+        pngPath = "/tmp/fake-render.png",
+        metrics = mapOf("test" to 1L),
+      )
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -1003,7 +1003,7 @@ class AndroidRecordingSessionTest {
         listOf(
           RecordingScriptEvent(
             tMs = 0L,
-            kind = StateRecreateRecordingScriptEvents.STATE_RECREATE_EVENT,
+            kind = StateRecordingScriptEvents.STATE_RECREATE_EVENT,
           )
         )
       )
@@ -1060,7 +1060,7 @@ class AndroidRecordingSessionTest {
         listOf(
           RecordingScriptEvent(
             tMs = 0L,
-            kind = StateRecreateRecordingScriptEvents.STATE_RECREATE_EVENT,
+            kind = StateRecordingScriptEvents.STATE_RECREATE_EVENT,
           )
         )
       )


### PR DESCRIPTION
## Summary
Adds wall-clock-accurate animation timing to live preview renders by substituting the composition's clock advance based on real elapsed time rather than a fixed 32ms default. This ensures animations play at normal speed during live preview instead of appearing ~6× slower when Robolectric captures take ~200ms each.

## Key Changes

- **Wall-clock substitution in `AndroidInteractiveSession.render()`**: When callers pass `advanceTimeMs = null` (live preview mode), the session now calculates the advance as the wall-clock delta since the previous render, clamped to `[32ms, 1000ms]`:
  - First render uses the 32ms floor (preserves initial composition settle window)
  - Subsequent renders use actual elapsed time (clamped to prevent animation jumps after idle periods)
  - Explicit advances from recording sessions are preserved unchanged

- **New `lastRenderAtMs` field**: Tracks the wall-clock timestamp of the most recent render call to enable delta calculation. Uses `AtomicLong` for memory visibility consistency with existing `lastUsedAtMs`.

- **Constants for timing bounds**:
  - `AUTO_ADVANCE_FLOOR_MS = 32L`: Matches the historical fixed advance, ensures first render and back-to-back renders get proper recompose ticks
  - `MAX_AUTO_ADVANCE_MS = 1000L`: Caps idle-induced jumps to prevent multi-second animation phase shifts when the session pauses

- **Comprehensive test coverage** (`AndroidInteractiveSessionWallClockTest`): Tests all four timing scenarios:
  - First render with null advance uses floor
  - Subsequent renders track wall-clock delta
  - Explicit advances bypass wall-clock logic but still seed bookkeeping
  - Long idle periods are clamped to the cap
  - Uses a worker thread + fake result harness to avoid the 60s production timeout

- **Minor test fix**: Corrected class name references in `AndroidRecordingSessionTest` from `StateRecreateRecordingScriptEvents` to `StateRecordingScriptEvents`

## Implementation Details

The wall-clock substitution is applied at the session level (not in `RobolectricHost`) to keep the fix localized and avoid changing the held-loop's internal clock mechanics. The clamping strategy balances responsiveness (animations catch up to real time) with stability (no jarring jumps after network lag or user inattention).

https://claude.ai/code/session_017KxnY6UJyNWCsX1vrmy9WV