### PR TITLE
test(vscode): lift history pure helpers + add unit tests

### DIFF
--- a/vscode-extension/src/test/historyData.test.ts
+++ b/vscode-extension/src/test/historyData.test.ts
@@ -1,0 +1,180 @@
+import * as assert from "assert";
+import {
+    cssEscape,
+    escapeHtml,
+    findLatestMainHash,
+    formatAbsolute,
+    formatRelative,
+} from "../webview/history/historyData";
+import type { HistoryEntry } from "../types";
+
+describe("escapeHtml", () => {
+    it("escapes the five HTML-significant characters", () => {
+        assert.strictEqual(
+            escapeHtml(`<a href="x">'foo' & "bar"</a>`),
+            "&lt;a href=&quot;x&quot;&gt;&#39;foo&#39; &amp; &quot;bar&quot;&lt;/a&gt;",
+        );
+    });
+
+    it("returns an empty string for null / undefined", () => {
+        assert.strictEqual(escapeHtml(null), "");
+        assert.strictEqual(escapeHtml(undefined), "");
+    });
+
+    it("coerces non-string inputs via String()", () => {
+        assert.strictEqual(escapeHtml(42), "42");
+        assert.strictEqual(escapeHtml(false), "false");
+    });
+
+    it("encodes & before the more specific entities so '&amp;' isn't double-escaped", () => {
+        assert.strictEqual(escapeHtml("&"), "&amp;");
+        assert.strictEqual(escapeHtml("<&>"), "&lt;&amp;&gt;");
+    });
+});
+
+describe("cssEscape", () => {
+    it('escapes quotes and backslashes for use in a `[data-id="..."]` selector', () => {
+        assert.strictEqual(cssEscape(`a"b'c\\d`), `a\\"b\\'c\\\\d`);
+    });
+
+    it("returns plain ids unchanged", () => {
+        assert.strictEqual(cssEscape("simple-id_1"), "simple-id_1");
+    });
+
+    it("coerces non-string inputs via String()", () => {
+        assert.strictEqual(cssEscape(42 as unknown as string), "42");
+    });
+});
+
+describe("formatRelative", () => {
+    // Use a fixed `now` so the bucket boundaries are deterministic.
+    const NOW = Date.parse("2026-05-01T12:00:00Z");
+
+    it("returns '(no timestamp)' for empty input", () => {
+        assert.strictEqual(formatRelative("", NOW), "(no timestamp)");
+        assert.strictEqual(formatRelative(undefined, NOW), "(no timestamp)");
+    });
+
+    it("returns the input verbatim for unparseable ISO strings", () => {
+        assert.strictEqual(formatRelative("not-a-date", NOW), "not-a-date");
+    });
+
+    it("returns 'just now' under 5s", () => {
+        const ts = new Date(NOW - 3_000).toISOString();
+        assert.strictEqual(formatRelative(ts, NOW), "just now");
+    });
+
+    it("returns 'Ns ago' for under a minute", () => {
+        const ts = new Date(NOW - 30_000).toISOString();
+        assert.strictEqual(formatRelative(ts, NOW), "30s ago");
+    });
+
+    it("returns 'Nm ago' for under an hour", () => {
+        const ts = new Date(NOW - 5 * 60_000).toISOString();
+        assert.strictEqual(formatRelative(ts, NOW), "5m ago");
+    });
+
+    it("returns 'Nh ago' for under a day", () => {
+        const ts = new Date(NOW - 3 * 60 * 60_000).toISOString();
+        assert.strictEqual(formatRelative(ts, NOW), "3h ago");
+    });
+
+    it("returns 'Nd ago' for under a month", () => {
+        const ts = new Date(NOW - 2 * 24 * 60 * 60_000).toISOString();
+        assert.strictEqual(formatRelative(ts, NOW), "2d ago");
+    });
+
+    it("returns 'Nmo ago' for under a year", () => {
+        const ts = new Date(NOW - 90 * 24 * 60 * 60_000).toISOString();
+        assert.strictEqual(formatRelative(ts, NOW), "3mo ago");
+    });
+
+    it("returns 'Ny ago' for ages over a year", () => {
+        const ts = new Date(NOW - 730 * 24 * 60 * 60_000).toISOString();
+        assert.strictEqual(formatRelative(ts, NOW), "2y ago");
+    });
+});
+
+describe("formatAbsolute", () => {
+    it("returns an empty string for empty / unparseable input", () => {
+        assert.strictEqual(formatAbsolute(""), "");
+        assert.strictEqual(formatAbsolute(undefined), "");
+        assert.strictEqual(formatAbsolute("nope"), "");
+    });
+
+    it("returns a non-empty localised label for a valid ISO timestamp", () => {
+        // Locale output is environment-dependent — assert the shape rather
+        // than the literal string. The 4-field format with a comma is the
+        // common output for the en-US default options.
+        const out = formatAbsolute("2026-05-01T12:00:00Z");
+        assert.ok(out.length > 0, "non-empty output expected, got " + out);
+    });
+});
+
+const baseEntry: HistoryEntry = {};
+
+describe("findLatestMainHash", () => {
+    it("returns null when no entries match", () => {
+        assert.strictEqual(findLatestMainHash([]), null);
+        assert.strictEqual(
+            findLatestMainHash([
+                { ...baseEntry, git: { branch: "feature/x" } },
+            ]),
+            null,
+        );
+    });
+
+    it("ignores entries whose branch is not main", () => {
+        const entries: HistoryEntry[] = [
+            {
+                ...baseEntry,
+                pngHash: "abc",
+                timestamp: "2026-05-01T10:00:00Z",
+                git: { branch: "feature/x" },
+            },
+        ];
+        assert.strictEqual(findLatestMainHash(entries), null);
+    });
+
+    it("ignores main-branch entries that lack pngHash", () => {
+        const entries: HistoryEntry[] = [
+            {
+                ...baseEntry,
+                git: { branch: "main" },
+                timestamp: "2026-05-01T10:00:00Z",
+            },
+        ];
+        assert.strictEqual(findLatestMainHash(entries), null);
+    });
+
+    it("picks the latest main entry by ISO timestamp string-compare", () => {
+        const entries: HistoryEntry[] = [
+            {
+                ...baseEntry,
+                pngHash: "old",
+                timestamp: "2026-04-01T10:00:00Z",
+                git: { branch: "main" },
+            },
+            {
+                ...baseEntry,
+                pngHash: "new",
+                timestamp: "2026-05-01T10:00:00Z",
+                git: { branch: "main" },
+            },
+        ];
+        assert.strictEqual(findLatestMainHash(entries), "new");
+    });
+
+    it("treats missing timestamps as the empty string (oldest possible)", () => {
+        const entries: HistoryEntry[] = [
+            { ...baseEntry, pngHash: "first", git: { branch: "main" } },
+            {
+                ...baseEntry,
+                pngHash: "stamped",
+                timestamp: "2026-05-01T10:00:00Z",
+                git: { branch: "main" },
+            },
+        ];
+        assert.strictEqual(findLatestMainHash(entries), "stamped");
+    });
+});

--- a/vscode-extension/src/webview/history/behavior.ts
+++ b/vscode-extension/src/webview/history/behavior.ts
@@ -18,6 +18,13 @@ import type {
     HistoryToWebview,
 } from "../shared/types";
 import { getVsCodeApi } from "../shared/vscode";
+import {
+    cssEscape,
+    escapeHtml,
+    findLatestMainHash,
+    formatAbsolute,
+    formatRelative,
+} from "./historyData";
 
 /** Look up a known-present DOM element. Used for the static ids that
  *  `<history-app>` has already rendered into the light DOM. Throws so a
@@ -492,21 +499,6 @@ export function setupHistoryBehavior(): void {
         });
     }
 
-    function findLatestMainHash(es: readonly HistoryEntry[]): string | null {
-        let bestTs = "";
-        let bestHash: string | null = null;
-        for (const e of es) {
-            if (!e || (e.git && e.git.branch) !== "main") continue;
-            if (!e.pngHash) continue;
-            const ts = e.timestamp || "";
-            if (ts > bestTs) {
-                bestTs = ts;
-                bestHash = e.pngHash;
-            }
-        }
-        return bestHash;
-    }
-
     function applyDiffStats(el: HTMLElement, s: DiffStats | null): void {
         if (!s) {
             el.textContent = "";
@@ -666,49 +658,6 @@ export function setupHistoryBehavior(): void {
         timelineEl.insertBefore(block, timelineEl.firstChild);
         // Auto-clear after 12s so the panel doesn't accumulate stale diffs.
         setTimeout(() => block.remove(), 12_000);
-    }
-
-    function escapeHtml(text: unknown): string {
-        const div = document.createElement("div");
-        div.textContent = String(text ?? "");
-        return div.innerHTML;
-    }
-    function cssEscape(s: string): string {
-        return String(s).replace(/[\\"']/g, "\\$&");
-    }
-
-    function formatRelative(iso: string | undefined): string {
-        if (!iso) return "(no timestamp)";
-        const t = Date.parse(iso);
-        if (isNaN(t)) return iso;
-        const s = Math.round((Date.now() - t) / 1000);
-        if (s < 5) return "just now";
-        if (s < 60) return s + "s ago";
-        const m = Math.round(s / 60);
-        if (m < 60) return m + "m ago";
-        const h = Math.round(m / 60);
-        if (h < 24) return h + "h ago";
-        const d = Math.round(h / 24);
-        if (d < 30) return d + "d ago";
-        const mo = Math.round(d / 30);
-        if (mo < 12) return mo + "mo ago";
-        return Math.round(mo / 12) + "y ago";
-    }
-
-    function formatAbsolute(iso: string | undefined): string {
-        if (!iso) return "";
-        const t = Date.parse(iso);
-        if (isNaN(t)) return "";
-        try {
-            return new Date(t).toLocaleString(undefined, {
-                month: "short",
-                day: "numeric",
-                hour: "2-digit",
-                minute: "2-digit",
-            });
-        } catch (_) {
-            return "";
-        }
     }
 
     window.addEventListener("message", (event: MessageEvent) => {

--- a/vscode-extension/src/webview/history/historyData.ts
+++ b/vscode-extension/src/webview/history/historyData.ts
@@ -1,0 +1,98 @@
+// Pure data helpers for the History panel.
+//
+// Lifted out of `behavior.ts`'s `escapeHtml` / `cssEscape` /
+// `formatRelative` / `formatAbsolute` / `findLatestMainHash` so the
+// timestamp / escape / "latest main hash" logic is unit-testable in
+// isolation. None of these reach into the DOM or the vscode handle —
+// everything is a pure string / number / Date computation.
+//
+// `escapeHtml` is reimplemented as a regex-based escape rather than
+// the previous `div.textContent → div.innerHTML` round-trip so the
+// helper can run under the host tsconfig (no DOM lib) and so tests
+// don't have to spin up a DOM.
+
+import type { HistoryEntry } from "../shared/types";
+
+/** HTML-escape arbitrary text for safe interpolation into an
+ *  `innerHTML` string. Returns the empty string for null / undefined. */
+export function escapeHtml(text: unknown): string {
+    return String(text ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+/** Escape characters that would break out of a CSS attribute selector
+ *  string (`'`, `"`, `\`). Used when building dynamic `[data-id="..."]`
+ *  selectors from untrusted history-entry ids. */
+export function cssEscape(s: string): string {
+    return String(s).replace(/[\\"']/g, "\\$&");
+}
+
+/** Render an ISO timestamp as a relative duration ("just now", "5m
+ *  ago", "3d ago", "2y ago"). Returns the original string when the
+ *  input doesn't parse as a date, and "(no timestamp)" for empty
+ *  input. Uses `Date.now()` so callers needing deterministic output
+ *  in tests should pass a [now] snapshot. */
+export function formatRelative(
+    iso: string | undefined,
+    now: number = Date.now(),
+): string {
+    if (!iso) return "(no timestamp)";
+    const t = Date.parse(iso);
+    if (isNaN(t)) return iso;
+    const s = Math.round((now - t) / 1000);
+    if (s < 5) return "just now";
+    if (s < 60) return s + "s ago";
+    const m = Math.round(s / 60);
+    if (m < 60) return m + "m ago";
+    const h = Math.round(m / 60);
+    if (h < 24) return h + "h ago";
+    const d = Math.round(h / 24);
+    if (d < 30) return d + "d ago";
+    const mo = Math.round(d / 30);
+    if (mo < 12) return mo + "mo ago";
+    return Math.round(mo / 12) + "y ago";
+}
+
+/** Render an ISO timestamp as a localised absolute label (e.g.
+ *  "Mar 4, 14:32"). Returns the empty string for empty / unparseable
+ *  input. */
+export function formatAbsolute(iso: string | undefined): string {
+    if (!iso) return "";
+    const t = Date.parse(iso);
+    if (isNaN(t)) return "";
+    try {
+        return new Date(t).toLocaleString(undefined, {
+            month: "short",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+        });
+    } catch (_) {
+        return "";
+    }
+}
+
+/** Pick the `pngHash` of the most recent main-branch render in
+ *  [entries]. Used by the timeline's "vs main" indicator dot — entries
+ *  whose own `pngHash` differs from this value get a dot. Returns
+ *  `null` when no main-branch entry has a `pngHash`. */
+export function findLatestMainHash(
+    entries: readonly HistoryEntry[],
+): string | null {
+    let bestTs = "";
+    let bestHash: string | null = null;
+    for (const e of entries) {
+        if (!e || (e.git && e.git.branch) !== "main") continue;
+        if (!e.pngHash) continue;
+        const ts = e.timestamp || "";
+        if (ts > bestTs) {
+            bestTs = ts;
+            bestHash = e.pngHash;
+        }
+    }
+    return bestHash;
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -14,5 +14,9 @@
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules", "src/webview/**"],
-    "files": ["src/webview/preview/cardData.ts", "src/webview/shared/types.ts"]
+    "files": [
+        "src/webview/preview/cardData.ts",
+        "src/webview/history/historyData.ts",
+        "src/webview/shared/types.ts"
+    ]
 }


### PR DESCRIPTION
Same playbook as #812 (cardData unit tests) for the History panel. Lifts the pure data helpers out of `history/behavior.ts` into a new sibling `historyData.ts`, then adds 23 unit tests covering every function. Brings the total test count from 350 → 373.

## Summary

New `historyData.ts` exports:
- `escapeHtml(text)` — HTML-escape arbitrary text. Reimplemented as a pure regex-based escape (was previously a `div.textContent → div.innerHTML` round-trip) so it runs under the host tsconfig without needing a DOM.
- `cssEscape(s)` — escape `'`, `"`, `\` for CSS attribute selectors.
- `formatRelative(iso, now?)` — render an ISO timestamp as a relative duration (`just now` / `Ns` / `Nm` / `Nh` / `Nd` / `Nmo` / `Ny` ago). Now takes an optional `now` parameter (defaults to `Date.now()`) so tests can assert deterministic bucket boundaries.
- `formatAbsolute(iso)` — render an ISO timestamp as a localised absolute label.
- `findLatestMainHash(entries)` — pick the `pngHash` of the most recent main-branch entry; null when none.

`tsconfig.json` adds `historyData.ts` to its `files` list (parallel to `cardData.ts` from #812) so the host build emits the file into `out/` and Mocha picks up the test via the existing `out/test/**/*.test.js` glob.

## Drive-by

The `escapeHtml` reimplementation is a behaviour-equivalent rewrite, **not** verbatim. The previous DOM round-trip and the new regex pipeline produce identical output for the inputs the History panel passes (plain text from sidecar JSON), but pre-encoded entities behave differently — `escapeHtml("&amp;")` returned `"&amp;"` under the old implementation (the textContent decoded the entity then innerHTML re-encoded just the bare `&`), and now returns `"&amp;amp;"` under the new implementation (the regex encodes the existing `&` so we get `&amp;amp;` from `&amp;`). The History panel never feeds it pre-encoded HTML so the observable behaviour is unchanged; worth flagging for future regression.

`history/behavior.ts`: 802 → 751 lines (−51 LOC).
`historyData.ts`: +98 lines (new file).

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 373/373 passing (350 prior + 23 new)
- [x] `npm run format:check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_