### PR TITLE
Infer preview target composables from bytecode analysis

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -33,6 +33,9 @@ gradlePlugin {
 dependencies {
   implementation(libs.classgraph)
   implementation(libs.kotlinx.serialization.json)
+  // ASM walks the preview method's bytecode to extract @Composable call targets — ClassGraph only
+  // surfaces annotations + signatures, not method-body invocations. Used by PreviewTargetInference.
+  implementation(libs.asm)
   compileOnly("com.android.tools.build:gradle:${libs.versions.agp.get()}")
 
   testImplementation(libs.junit)

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -1089,6 +1089,179 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
+  fun `discoverPreviews infers cross-file target composable`() {
+    // Idiomatic preview-file layout: production composable `HomeScreen` lives in `HomeScreen.kt`,
+    // its `@Preview` lives in a sibling `Previews.kt`. PreviewTargetInference walks the preview
+    // method's bytecode, finds the single project-local @Composable call into HomeScreen, and
+    // attaches it as a target.
+    val projectDir = createCmpTestProject()
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    File(srcDir, "Previews.kt").delete()
+
+    File(srcDir, "HomeScreen.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.unit.dp
+
+        @Composable
+        fun HomeScreen() {
+            Box(modifier = Modifier.size(100.dp).background(Color.Red)) {
+                Text("home")
+            }
+        }
+        """
+          .trimIndent()
+      )
+
+    File(srcDir, "Previews.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+
+        @Preview
+        @Composable
+        fun HomeScreenPreview() {
+            HomeScreen()
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val preview = manifest.previews.single { it.functionName == "HomeScreenPreview" }
+    val target = preview.targets.single()
+    assertThat(target.className).isEqualTo("test.HomeScreenKt")
+    assertThat(target.functionName).isEqualTo("HomeScreen")
+    // Single project-local composable call + matching name + cross-file → HIGH confidence.
+    assertThat(target.confidence).isEqualTo(TargetConfidence.HIGH)
+    assertThat(target.signals)
+      .containsAtLeast(
+        TargetSignal.SINGLE_PROJECT_COMPOSABLE_CALL,
+        TargetSignal.NAME_MATCH,
+        TargetSignal.CROSS_FILE,
+      )
+    // Source path resolves to the production file, not the preview file.
+    assertThat(target.sourceFile).contains("HomeScreen.kt")
+  }
+
+  @Test
+  fun `discoverPreviews emits no target when preview body is purely framework`() {
+    // A preview that only calls AndroidX Compose primitives (no project-local composable) gets no
+    // target — the inference should not invent one from theming / layout calls.
+    val projectDir = createCmpTestProject()
+
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
+
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.tooling.preview.Preview
+      import androidx.compose.ui.unit.dp
+
+      @Preview
+      @Composable
+      fun PrimitivesOnlyPreview() {
+          Box(modifier = Modifier.size(40.dp).background(Color.Red))
+      }
+      """
+        .trimIndent()
+    )
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("discoverPreviews", "--stacktrace")
+      .withPluginClasspath()
+      .build()
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    assertThat(manifest.previews.single().targets).isEmpty()
+  }
+
+  @Test
+  fun `discoverPreviews skips other previews as candidate targets`() {
+    // A preview function that calls a *sibling* preview (instead of the production composable)
+    // should not surface that sibling as a target.
+    val projectDir = createCmpTestProject()
+
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
+
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.tooling.preview.Preview
+      import androidx.compose.ui.unit.dp
+
+      @Preview
+      @Composable
+      fun FirstPreview() {
+          Box(modifier = Modifier.size(40.dp).background(Color.Red))
+      }
+
+      @Preview
+      @Composable
+      fun WrapperPreview() {
+          FirstPreview()
+      }
+      """
+        .trimIndent()
+    )
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("discoverPreviews", "--stacktrace")
+      .withPluginClasspath()
+      .build()
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val wrapper = manifest.previews.single { it.functionName == "WrapperPreview" }
+    // FirstPreview itself is annotated @Preview, so it must be filtered out — no target emitted.
+    assertThat(wrapper.targets).isEmpty()
+  }
+
+  @Test
   fun `failOnEmpty fails the build and emits diagnostics when no previews exist`() {
     val projectDir = createCmpTestProject()
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -175,6 +175,20 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         .scan()
         .use { scanResult ->
           reachablePreviewFqns = PREVIEW_FQNS.filter { scanResult.getClassInfo(it) != null }
+          // Project-local class FQNs — only classes loaded from the project's own
+          // class output directories, never from a dependency JAR. Powers the
+          // "is this @Composable call into project code?" filter inside
+          // PreviewTargetInference; computed once per scan and passed through.
+          val classDirPaths = existingClassDirs.map { it.absolutePath }.toSet()
+          val projectClassFqns =
+            scanResult.allClasses
+              .asSequence()
+              .filter { ci ->
+                val element = ci.classpathElementFile ?: return@filter false
+                element.isDirectory && element.absolutePath in classDirPaths
+              }
+              .map { it.name }
+              .toSet()
           for (classInfo in scanResult.allClasses) {
             scanClassCount++
             for (method in classInfo.methodInfo) {
@@ -183,7 +197,14 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
               for (ann in annotations) {
                 annotationFqnCounts.merge(ann.name, 1, Int::plus)
               }
-              discoverFromMethod(classInfo, method, annotations.toList(), scanResult, previews)
+              discoverFromMethod(
+                classInfo,
+                method,
+                annotations.toList(),
+                scanResult,
+                projectClassFqns,
+                previews,
+              )
             }
           }
         }
@@ -448,6 +469,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     method: MethodInfo,
     annotations: List<AnnotationInfo>,
     scanResult: ScanResult,
+    projectClassFqns: Set<String>,
     previews: MutableList<PreviewInfo>,
   ) {
     // @PreviewWrapper and @ScrollingPreview are both non-repeatable and apply
@@ -484,6 +506,8 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             animationSpec,
             timings,
             previewParameter,
+            scanResult,
+            projectClassFqns,
           )
         )
       }
@@ -503,6 +527,8 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             animationSpec,
             timings,
             previewParameter,
+            scanResult,
+            projectClassFqns,
           )
         )
       }
@@ -884,20 +910,42 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     animation: AnimationCapture?,
     timings: List<Long>,
     previewParameter: Pair<String, Int>?,
+    scanResult: ScanResult,
+    projectClassFqns: Set<String>,
   ): PreviewInfo {
     val params = extractPreviewParams(ann, wrapperClassName, previewParameter)
     val fqn = "${classInfo.name}.${method.name}"
     val suffix = buildVariantSuffix(params)
     val id = fqn + suffix
     val outputPlan = buildOutputPlan(ann, id, scrolls, animation, timings)
+    val previewSourceFile = sourceFilePath(classInfo)
+    val targets =
+      // Tile previews don't go through @Composable invocations — they return a `TilePreviewData`
+      // and the renderer reflects them directly. Skip target inference for that kind so we don't
+      // emit nonsense entries from the bytecode walk picking up `TileRenderer` / View calls.
+      if (params.kind == PreviewKind.TILE) emptyList()
+      else
+        PreviewTargetInference.infer(
+          previewClassInfo = classInfo,
+          previewMethod = method,
+          scanResult = scanResult,
+          projectClassFqns = projectClassFqns,
+          previewSourceFile = previewSourceFile,
+          resolveSourceFile = { ownerFqn ->
+            scanResult.getClassInfo(ownerFqn)?.let { sourceFilePath(it) }
+          },
+          variantName = variantName.get(),
+          hasPreviewParameter = previewParameter != null,
+        )
     return PreviewInfo(
       id = id,
       functionName = method.name,
       className = classInfo.name,
-      sourceFile = sourceFilePath(classInfo),
+      sourceFile = previewSourceFile,
       params = params,
       captures = outputPlan.captures,
       dataProducts = outputPlan.dataProducts,
+      targets = targets,
     )
   }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -278,7 +278,67 @@ data class PreviewInfo(
    * screenshots; clients fetch or surface them through the data-product path.
    */
   val dataProducts: List<PreviewDataProduct> = emptyList(),
+  /**
+   * Composables this preview is presumed to render. Discovery infers this by walking the preview
+   * function's bytecode for project-local `@Composable` calls, filtering theme/layout wrappers, and
+   * scoring the remaining candidates against the preview's name and source-set context. Empty when
+   * no candidate cleared the confidence threshold; ordered most-confident first.
+   *
+   * v1 emits at most one entry; the list shape is reserved for future multi-target inference (e.g.
+   * `Row { Foo(); Bar() }` returning both `Foo` and `Bar`).
+   */
+  val targets: List<PreviewTarget> = emptyList(),
 )
+
+/**
+ * A composable that a `@Preview` function is presumed to render. Attached to [PreviewInfo.targets]
+ * when discovery finds a high-enough-confidence match.
+ *
+ * The target is keyed by FQN + simple method name so consumers can correlate the rendered PNG back
+ * to the production composable's source — the canonical use case is "this UI PR changed
+ * `HomeScreen` in `src/main`, did its preview in `src/debug` change too?". [signals] makes the
+ * inference auditable: tooling that wants to be strict can require `CROSS_FILE` + `NAME_MATCH`,
+ * while best-effort consumers can use the [confidence] tier directly.
+ */
+@Serializable
+data class PreviewTarget(
+  /** Owner class FQN (synthetic `…Kt` for top-level functions). */
+  val className: String,
+  /** Composable function name on [className]. */
+  val functionName: String,
+  /** Module-relative source path of the target's owning file, when resolvable. */
+  val sourceFile: String? = null,
+  val confidence: TargetConfidence,
+  val signals: List<TargetSignal> = emptyList(),
+)
+
+@Serializable
+enum class TargetConfidence {
+  HIGH,
+  MEDIUM,
+  LOW,
+}
+
+@Serializable
+enum class TargetSignal {
+  /** Preview file lives in a non-shipping source set (debug, screenshotTest, test, …). */
+  NON_SHIPPING_SOURCE_SET,
+  /** Preview file's name and contents look dedicated to previews (e.g. `*Previews.kt`). */
+  DEDICATED_PREVIEW_FILE,
+  /** Exactly one project-local non-wrapper `@Composable` call survived filtering. */
+  SINGLE_PROJECT_COMPOSABLE_CALL,
+  /** Stripping `Preview`/`Preview_` from the preview function name yields the candidate. */
+  NAME_MATCH,
+  /** Candidate is declared in a different source file than the preview. */
+  CROSS_FILE,
+  /** `@PreviewParameter` value was forwarded into the candidate call. */
+  PARAMETER_FORWARDED,
+  /**
+   * Discovery recursed through a project-local theming/wrapper composable (single `@Composable ()
+   * -> Unit` parameter) before landing on the candidate.
+   */
+  WRAPPER_UNWRAPPED,
+}
 
 @Serializable
 data class PreviewManifest(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewTargetInference.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewTargetInference.kt
@@ -1,0 +1,376 @@
+package ee.schimke.composeai.plugin
+
+import io.github.classgraph.ClassInfo
+import io.github.classgraph.MethodInfo
+import io.github.classgraph.ScanResult
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+/**
+ * Infers which production `@Composable` a `@Preview` function is presumed to render. The preview's
+ * bytecode is walked for `INVOKE*` instructions; calls into project-local `@Composable` functions
+ * are kept (theming / layout primitives are filtered out by FQN), then scored against signals like
+ * "preview is in a debug/screenshotTest source set" or "preview's name matches the call's simple
+ * name once the `Preview` suffix is stripped".
+ *
+ * v1 emits at most one [PreviewTarget] per preview. The output type is a list because the schema is
+ * forward-compatible with later multi-target inference (e.g. `Row { Foo(); Bar() }` returning
+ * both), but the current scoring pass keeps only the top-scored candidate.
+ *
+ * Wrapper detection is FQN-prefix based. Project-local theme wrappers (e.g. `MyAppTheme { … }`) are
+ * intentionally **not** unwrapped here — that needs reading the lambda's synthetic `invoke` class
+ * and is reserved for a follow-up. The [TargetSignal.WRAPPER_UNWRAPPED] enum value is declared for
+ * that future use.
+ */
+internal object PreviewTargetInference {
+
+  // FQN prefixes whose @Composable functions are theming / layout / runtime scaffolding
+  // rather than the production UI under preview. Anything matching one of these is dropped
+  // from the candidate set before scoring. Prefix-match keeps the list short and lets us
+  // reach into deeper packages (e.g. `androidx.compose.foundation.layout.Box`) without
+  // enumerating every leaf.
+  private val WRAPPER_FQN_PREFIXES =
+    listOf(
+      "androidx.compose.material.",
+      "androidx.compose.material3.",
+      "androidx.compose.foundation.",
+      "androidx.compose.runtime.",
+      "androidx.compose.ui.",
+      "androidx.compose.animation.",
+      "androidx.wear.compose.material.",
+      "androidx.wear.compose.material3.",
+      "androidx.wear.compose.foundation.",
+      "org.jetbrains.compose.",
+    )
+
+  // Stdlib / JVM / Kotlin-runtime owners. Filtered explicitly so we never attempt to look
+  // them up as project-local @Composable methods.
+  private val STDLIB_FQN_PREFIXES = listOf("java.", "javax.", "kotlin.", "kotlinx.", "sun.", "jdk.")
+
+  // Source-set / variant names that signal the preview file is non-shipping. These are the
+  // standard AGP / Kotlin source set names; the check is conservative — anything not in the
+  // shipping set is treated as non-shipping for scoring purposes only.
+  private val NON_SHIPPING_SOURCE_SETS =
+    setOf(
+      "debug",
+      "test",
+      "androidTest",
+      "screenshotTest",
+      "debugAndroidTest",
+      "debugUnitTest",
+      "release", // not shipping in the sense relevant here, but production builds; keep neutral
+    )
+
+  // Filename heuristic for "this file is dedicated to previews" — case-insensitive.
+  private val DEDICATED_FILE_REGEX = Regex(""".*Previews?\.kt$""", RegexOption.IGNORE_CASE)
+
+  private const val PREVIEW_FQN = "androidx.compose.ui.tooling.preview.Preview"
+  private const val DESKTOP_PREVIEW_FQN = "androidx.compose.desktop.ui.tooling.preview.Preview"
+  private const val TILE_PREVIEW_FQN = "androidx.wear.tiles.tooling.preview.Preview"
+  private const val COMPOSABLE_FQN = "androidx.compose.runtime.Composable"
+
+  /** Single bytecode call site, as captured from the preview method body. */
+  internal data class Invocation(
+    val ownerFqn: String,
+    val methodName: String,
+    val descriptor: String,
+  )
+
+  private data class Candidate(
+    val classFqn: String,
+    val methodName: String,
+    val sourceFile: String?,
+    val score: Int,
+    val signals: List<TargetSignal>,
+  )
+
+  /**
+   * @param previewClassInfo the class containing the `@Preview` method.
+   * @param previewMethod the `@Preview`-annotated method.
+   * @param scanResult the active ClassGraph result; used to look up call targets.
+   * @param projectClassFqns FQNs of every class compiled from the project's own source dirs (i.e.
+   *   not pulled from a dependency JAR). The "is this call project-local?" filter keys off this
+   *   set.
+   * @param previewSourceFile module-relative source path of the preview file, when known.
+   * @param resolveSourceFile maps a target class FQN to its module-relative source path. Returns
+   *   `null` when the source file isn't wired into the discovery task's `sourceFiles` input.
+   * @param variantName the AGP/Kotlin source set the preview was discovered under (used for the
+   *   `NON_SHIPPING_SOURCE_SET` signal).
+   * @param hasPreviewParameter `true` when the preview function has a `@PreviewParameter`-annotated
+   *   parameter; enables the `PARAMETER_FORWARDED` signal when the candidate consumes a value of
+   *   the right shape.
+   */
+  fun infer(
+    previewClassInfo: ClassInfo,
+    previewMethod: MethodInfo,
+    scanResult: ScanResult,
+    projectClassFqns: Set<String>,
+    previewSourceFile: String?,
+    resolveSourceFile: (String) -> String?,
+    variantName: String,
+    hasPreviewParameter: Boolean,
+  ): List<PreviewTarget> {
+    val calls =
+      try {
+        extractCalls(previewClassInfo, previewMethod)
+      } catch (_: Throwable) {
+        // Bytecode unavailable / unreadable — discovery should still succeed without target
+        // inference. The preview is still emitted; consumers see `targets = []` and fall back
+        // to whatever signal they had before.
+        return emptyList()
+      }
+
+    val previewFqn = previewClassInfo.name
+    val previewMethodName = previewMethod.name
+
+    val candidates =
+      calls
+        .asSequence()
+        .filterNot { it.ownerFqn == previewFqn && it.methodName == previewMethodName }
+        .filterNot { isStdlib(it.ownerFqn) }
+        .filterNot { isWrapperFqn(it.ownerFqn) }
+        .filter { it.ownerFqn in projectClassFqns }
+        .mapNotNull { resolveCandidate(it, scanResult) }
+        .distinctBy { it.ownerFqn to it.method.name }
+        .toList()
+
+    if (candidates.isEmpty()) return emptyList()
+
+    val survivors = candidates.size
+    val scored = candidates.map { (callerOwner, callerMethod, callerClassInfo) ->
+      score(
+        callerOwner = callerOwner,
+        callerMethod = callerMethod,
+        callerClassInfo = callerClassInfo,
+        previewClassFqn = previewFqn,
+        previewMethodName = previewMethodName,
+        previewSourceFile = previewSourceFile,
+        variantName = variantName,
+        hasPreviewParameter = hasPreviewParameter,
+        callerMethodHasComposableParam =
+          callerMethod.parameterInfo?.any { p ->
+            // Heuristic for "this candidate consumes a value of the same shape as the preview's
+            // @PreviewParameter" — a non-`@Composable () -> Unit` parameter on the candidate.
+            // Cheap stand-in for proper data-flow analysis; good enough to flag the common
+            // `@PreviewParameter color: Long → Foo(color)` pattern.
+            p.annotationInfo?.none { it.name == COMPOSABLE_FQN } ?: true
+          } == true,
+        totalSurvivors = survivors,
+        resolveSourceFile = resolveSourceFile,
+      )
+    }
+
+    val best = scored.maxByOrNull { it.score } ?: return emptyList()
+    if (best.score < MIN_EMIT_SCORE) return emptyList()
+
+    val confidence =
+      when {
+        best.score >= HIGH_THRESHOLD -> TargetConfidence.HIGH
+        best.score >= MEDIUM_THRESHOLD -> TargetConfidence.MEDIUM
+        else -> TargetConfidence.LOW
+      }
+    return listOf(
+      PreviewTarget(
+        className = best.classFqn,
+        functionName = best.methodName,
+        sourceFile = best.sourceFile,
+        confidence = confidence,
+        signals = best.signals,
+      )
+    )
+  }
+
+  private const val MIN_EMIT_SCORE = 1
+  private const val MEDIUM_THRESHOLD = 2
+  private const val HIGH_THRESHOLD = 4
+
+  private fun isStdlib(fqn: String): Boolean = STDLIB_FQN_PREFIXES.any { fqn.startsWith(it) }
+
+  private fun isWrapperFqn(fqn: String): Boolean = WRAPPER_FQN_PREFIXES.any { fqn.startsWith(it) }
+
+  /**
+   * Reads [previewClassInfo]'s class file via ClassGraph and walks [previewMethod]'s body for
+   * `INVOKE*` instructions. Method matching is by name + descriptor so overloads don't bleed into
+   * each other; ClassGraph's `MethodInfo.typeDescriptorStr` is the JVM signature.
+   */
+  internal fun extractCalls(
+    previewClassInfo: ClassInfo,
+    previewMethod: MethodInfo,
+  ): List<Invocation> {
+    val resource = previewClassInfo.resource ?: return emptyList()
+    val targetName = previewMethod.name
+    val targetDescriptor = previewMethod.typeDescriptorStr
+    val collected = mutableListOf<Invocation>()
+    resource.open().use { stream ->
+      ClassReader(stream)
+        .accept(
+          object : ClassVisitor(Opcodes.ASM9) {
+            override fun visitMethod(
+              access: Int,
+              name: String,
+              descriptor: String,
+              signature: String?,
+              exceptions: Array<out String>?,
+            ): MethodVisitor? {
+              if (name != targetName) return null
+              if (descriptor != targetDescriptor) return null
+              return object : MethodVisitor(Opcodes.ASM9) {
+                override fun visitMethodInsn(
+                  opcode: Int,
+                  owner: String,
+                  name: String,
+                  descriptor: String,
+                  isInterface: Boolean,
+                ) {
+                  collected += Invocation(owner.replace('/', '.'), name, descriptor)
+                }
+              }
+            }
+          },
+          ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES,
+        )
+    }
+    return collected
+  }
+
+  private data class ResolvedCandidate(
+    val ownerFqn: String,
+    val method: MethodInfo,
+    val classInfo: ClassInfo,
+  )
+
+  private fun resolveCandidate(call: Invocation, scanResult: ScanResult): ResolvedCandidate? {
+    val classInfo = scanResult.getClassInfo(call.ownerFqn) ?: return null
+    val candidateMethods = classInfo.methodInfo?.filter { it.name == call.methodName }.orEmpty()
+    if (candidateMethods.isEmpty()) return null
+    val composable =
+      candidateMethods.firstOrNull { it.hasAnnotation(COMPOSABLE_FQN) } ?: return null
+    // Skip composables that themselves carry a @Preview — those are sibling previews, not the
+    // production target.
+    if (
+      composable.hasAnnotation(PREVIEW_FQN) ||
+        composable.hasAnnotation(DESKTOP_PREVIEW_FQN) ||
+        composable.hasAnnotation(TILE_PREVIEW_FQN)
+    ) {
+      return null
+    }
+    return ResolvedCandidate(call.ownerFqn, composable, classInfo)
+  }
+
+  private data class ScoredCandidate(
+    val classFqn: String,
+    val methodName: String,
+    val sourceFile: String?,
+    val score: Int,
+    val signals: List<TargetSignal>,
+  )
+
+  @Suppress("LongParameterList")
+  private fun score(
+    callerOwner: String,
+    callerMethod: MethodInfo,
+    callerClassInfo: ClassInfo,
+    previewClassFqn: String,
+    previewMethodName: String,
+    previewSourceFile: String?,
+    variantName: String,
+    hasPreviewParameter: Boolean,
+    callerMethodHasComposableParam: Boolean,
+    totalSurvivors: Int,
+    resolveSourceFile: (String) -> String?,
+  ): ScoredCandidate {
+    var score = 0
+    val signals = mutableListOf<TargetSignal>()
+
+    // +3 if this is the only project-local non-wrapper composable left after filtering.
+    if (totalSurvivors == 1) {
+      score += 3
+      signals += TargetSignal.SINGLE_PROJECT_COMPOSABLE_CALL
+    } else {
+      // Multiple survivors penalise *each* candidate by (n-1) so the top one still has a
+      // chance to clear the threshold when it independently matches by name.
+      score -= (totalSurvivors - 1)
+    }
+
+    // +2 if `FooPreview` / `PreviewFoo` / `Foo_*_Preview` strips down to the candidate's name.
+    if (nameMatches(previewMethodName, callerMethod.name)) {
+      score += 2
+      signals += TargetSignal.NAME_MATCH
+    }
+
+    // +1 if the candidate lives in a different .class file than the preview. Top-level functions
+    // share an owner only when declared in the same source file (Kotlin's `<File>Kt` synthetic),
+    // so this is a clean proxy for "cross-file".
+    val crossFile = callerOwner != previewClassFqn
+    if (crossFile) {
+      score += 1
+      signals += TargetSignal.CROSS_FILE
+    }
+
+    // +1 if the preview is in a non-shipping source set (debug / test / screenshotTest).
+    if (variantName in NON_SHIPPING_SOURCE_SETS) {
+      score += 1
+      signals += TargetSignal.NON_SHIPPING_SOURCE_SET
+    }
+
+    // +1 if the preview file looks dedicated to previews (file name `*Previews?.kt`).
+    if (
+      previewSourceFile != null &&
+        DEDICATED_FILE_REGEX.matches(previewSourceFile.substringAfterLast('/'))
+    ) {
+      score += 1
+      signals += TargetSignal.DEDICATED_PREVIEW_FILE
+    }
+
+    // +1 when the preview takes a @PreviewParameter and the candidate has a non-composable param
+    // it could plausibly receive. Approximate but cheap.
+    if (hasPreviewParameter && callerMethodHasComposableParam) {
+      score += 1
+      signals += TargetSignal.PARAMETER_FORWARDED
+    }
+
+    return ScoredCandidate(
+      classFqn = callerOwner,
+      methodName = callerMethod.name,
+      sourceFile = resolveSourceFile(callerOwner) ?: packageQualifiedSourcePath(callerClassInfo),
+      score = score,
+      signals = signals,
+    )
+  }
+
+  /**
+   * `FooPreview` ↔ `Foo`, `PreviewFoo` ↔ `Foo`, `Foo_Light_Preview` ↔ `Foo`, `FooScreenPreview` ↔
+   * `FooScreen`. Internal-mangled JVM names (`InternalPreview$module`) are stripped first.
+   */
+  internal fun nameMatches(previewMethodName: String, candidateName: String): Boolean {
+    // Strip the JVM `internal fun` mangle (`name$module`) before any name-shape work.
+    val cleaned = previewMethodName.substringBefore('$')
+    // Order matters: try the more specific affixes (`_Preview` / `Preview_`) before the bare ones,
+    // so `Foo_Preview` becomes `Foo`, not `Foo_`. Final `_` trim catches any residue.
+    val stripped =
+      cleaned
+        .removeSuffix("_Preview")
+        .removeSuffix("Preview")
+        .removePrefix("Preview_")
+        .removePrefix("Preview")
+        .trim('_')
+    if (stripped.isBlank()) return false
+    if (stripped == candidateName) return true
+    // Allow `Foo_Light_Preview` → `Foo_Light` → match `Foo` by the leading segment.
+    val leadingSegment = stripped.substringBefore('_')
+    return leadingSegment.isNotBlank() && leadingSegment == candidateName
+  }
+
+  /**
+   * Mirror of `DiscoverPreviewsTask.packageQualifiedSourcePath`: builds a `<pkg>/<File>.kt`-shaped
+   * fallback for when the source file isn't wired into the task. Used as the second leg of source
+   * resolution so consumers always see *something*.
+   */
+  private fun packageQualifiedSourcePath(classInfo: ClassInfo): String? {
+    val simpleName = classInfo.sourceFile ?: return null
+    val pkg = classInfo.packageName.orEmpty()
+    return if (pkg.isEmpty()) simpleName else "${pkg.replace('.', '/')}/$simpleName"
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
@@ -67,6 +67,55 @@ class PreviewDataTest {
   }
 
   @Test
+  fun `manifest serialization round-trips PreviewTarget`() {
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "screenshotTest",
+        previews =
+          listOf(
+            PreviewInfo(
+              id = "com.example.PreviewsKt.HomeScreenPreview",
+              functionName = "HomeScreenPreview",
+              className = "com.example.PreviewsKt",
+              sourceFile = "src/screenshotTest/kotlin/com/example/Previews.kt",
+              targets =
+                listOf(
+                  PreviewTarget(
+                    className = "com.example.HomeScreenKt",
+                    functionName = "HomeScreen",
+                    sourceFile = "src/main/kotlin/com/example/HomeScreen.kt",
+                    confidence = TargetConfidence.HIGH,
+                    signals =
+                      listOf(
+                        TargetSignal.SINGLE_PROJECT_COMPOSABLE_CALL,
+                        TargetSignal.NAME_MATCH,
+                        TargetSignal.CROSS_FILE,
+                        TargetSignal.NON_SHIPPING_SOURCE_SET,
+                      ),
+                  )
+                ),
+            )
+          ),
+      )
+
+    val serialized = json.encodeToString(manifest)
+    val deserialized = json.decodeFromString<PreviewManifest>(serialized)
+
+    assertThat(deserialized).isEqualTo(manifest)
+    val target = deserialized.previews.single().targets.single()
+    assertThat(target.className).isEqualTo("com.example.HomeScreenKt")
+    assertThat(target.confidence).isEqualTo(TargetConfidence.HIGH)
+    assertThat(target.signals).contains(TargetSignal.CROSS_FILE)
+  }
+
+  @Test
+  fun `targets defaults to empty list`() {
+    val info = PreviewInfo(id = "x", functionName = "x", className = "x")
+    assertThat(info.targets).isEmpty()
+  }
+
+  @Test
   fun `default params have sensible values`() {
     val params = PreviewParams()
     assertThat(params.widthDp).isNull()

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewTargetInferenceTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewTargetInferenceTest.kt
@@ -1,0 +1,44 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PreviewTargetInferenceTest {
+
+  @Test
+  fun `nameMatches strips Preview suffix`() {
+    assertThat(PreviewTargetInference.nameMatches("FooPreview", "Foo")).isTrue()
+    assertThat(PreviewTargetInference.nameMatches("FooScreenPreview", "FooScreen")).isTrue()
+  }
+
+  @Test
+  fun `nameMatches strips Preview prefix`() {
+    assertThat(PreviewTargetInference.nameMatches("PreviewFoo", "Foo")).isTrue()
+    assertThat(PreviewTargetInference.nameMatches("Preview_Foo", "Foo")).isTrue()
+  }
+
+  @Test
+  fun `nameMatches matches leading segment when separators present`() {
+    // `Foo_Light_Preview` → strip `_Preview` → `Foo_Light` → leading `Foo` matches.
+    assertThat(PreviewTargetInference.nameMatches("Foo_Light_Preview", "Foo")).isTrue()
+    assertThat(PreviewTargetInference.nameMatches("Foo_Dark_Preview", "Foo")).isTrue()
+  }
+
+  @Test
+  fun `nameMatches strips internal-fun JVM mangle`() {
+    // `internal fun InternalFooPreview` compiles to `InternalFooPreview$<module>`.
+    assertThat(PreviewTargetInference.nameMatches("InternalFooPreview\$test_module", "InternalFoo"))
+      .isTrue()
+  }
+
+  @Test
+  fun `nameMatches rejects unrelated names`() {
+    assertThat(PreviewTargetInference.nameMatches("FooPreview", "Bar")).isFalse()
+    assertThat(PreviewTargetInference.nameMatches("FooPreview", "FooBar")).isFalse()
+  }
+
+  @Test
+  fun `nameMatches rejects bare Preview when nothing left after strip`() {
+    assertThat(PreviewTargetInference.nameMatches("Preview", "Anything")).isFalse()
+  }
+}


### PR DESCRIPTION
## Summary
Add automatic inference of which production `@Composable` a `@Preview` function renders by analyzing the preview's bytecode for calls to project-local composables. The inference walks `INVOKE*` instructions, filters out framework/theming wrappers, and scores candidates based on signals like name matching and source-set context.

## Key Changes

- **New `PreviewTargetInference` object**: Core inference engine that:
  - Extracts method invocations from preview bytecode using ASM
  - Filters out stdlib, framework (androidx.compose.*), and wrapper composables
  - Scores remaining project-local `@Composable` candidates against multiple signals
  - Emits at most one `PreviewTarget` per preview (v1 limitation; schema supports multi-target)

- **New data types in `PreviewData.kt`**:
  - `PreviewTarget`: Represents an inferred target composable with className, functionName, sourceFile, confidence tier, and supporting signals
  - `TargetConfidence`: Enum (HIGH/MEDIUM/LOW) based on score thresholds
  - `TargetSignal`: Enum documenting why a target was selected (e.g., `SINGLE_PROJECT_COMPOSABLE_CALL`, `NAME_MATCH`, `CROSS_FILE`, `NON_SHIPPING_SOURCE_SET`, `DEDICATED_PREVIEW_FILE`, `PARAMETER_FORWARDED`, `WRAPPER_UNWRAPPED`)

- **Updated `DiscoverPreviewsTask`**:
  - Computes `projectClassFqns` set (classes from project source dirs, not dependencies) during ClassGraph scan
  - Passes `projectClassFqns` and `ScanResult` to preview creation methods
  - Invokes `PreviewTargetInference.infer()` for each preview and attaches results to `PreviewInfo.targets`

- **Scoring logic**:
  - +3 points: Single project-local composable call (after filtering)
  - +2 points: Preview name matches candidate (e.g., `FooPreview` → `Foo`)
  - +1 point each: Cross-file call, non-shipping source set, dedicated preview file, parameter forwarding
  - Penalty: Multiple survivors reduce each candidate's score by (n-1)
  - Thresholds: HIGH ≥4, MEDIUM ≥2, LOW ≥1 (minimum emit: 1)

- **Name matching heuristic**: Strips `Preview`/`Preview_` prefix/suffix and internal-fun JVM mangling (`$module`), then matches full name or leading segment before `_`

- **Filtering strategy**:
  - Excludes stdlib/JVM packages (java.*, kotlin.*, etc.)
  - Excludes framework composables by FQN prefix (androidx.compose.*, androidx.wear.compose.*, org.jetbrains.compose.*)
  - Excludes sibling previews (composables with `@Preview` annotation)
  - Requires project-local classification (in `projectClassFqns`)

## Notable Implementation Details

- Bytecode reading is wrapped in try-catch; discovery succeeds with empty targets if bytecode is unavailable
- Source file resolution uses two-leg fallback: explicit mapping first, then package-qualified path from ClassInfo
- Wrapper detection is FQN-prefix based; project-local theme wrappers are intentionally not unwrapped (reserved for future work via `WRAPPER_UNWRAPPED` signal)
- Functional tests verify cross-file inference, framework-only previews (no target), and sibling preview filtering
- Unit tests cover name-matching edge cases (prefixes, suffixes, segments, JVM mangling)

https://claude.ai/code/session_017Ejy1SBQYGwddRA6JvPXgy