### PR TITLE
feat: index preview targets and surface them in VS Code

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -493,6 +493,27 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     // @Preview drove the fan-out.
     val previewParameter = extractPreviewParameter(method)
 
+    // Target inference is identical across every @Preview expansion on a single function — the
+    // bytecode and signals don't change between (e.g.) the Light and Dark variants of a
+    // `@LightAndDark` multi-preview. Wrap in `lazy` so a multi-preview function with N expansions
+    // walks the bytecode once instead of N times; tile previews skip the inference entirely
+    // (handled in `makePreview`) and the lazy never forces.
+    val previewSourceFile = sourceFilePath(classInfo)
+    val inferredTargets = lazy {
+      PreviewTargetInference.infer(
+        previewClassInfo = classInfo,
+        previewMethod = method,
+        scanResult = scanResult,
+        projectClassFqns = projectClassFqns,
+        previewSourceFile = previewSourceFile,
+        resolveSourceFile = { ownerFqn ->
+          scanResult.getClassInfo(ownerFqn)?.let { sourceFilePath(it) }
+        },
+        variantName = variantName.get(),
+        hasPreviewParameter = previewParameter != null,
+      )
+    }
+
     val directPreviews = collectDirectPreviews(annotations)
     if (directPreviews.isNotEmpty()) {
       for (ann in directPreviews) {
@@ -506,8 +527,8 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             animationSpec,
             timings,
             previewParameter,
-            scanResult,
-            projectClassFqns,
+            previewSourceFile,
+            inferredTargets,
           )
         )
       }
@@ -527,8 +548,8 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             animationSpec,
             timings,
             previewParameter,
-            scanResult,
-            projectClassFqns,
+            previewSourceFile,
+            inferredTargets,
           )
         )
       }
@@ -910,33 +931,18 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     animation: AnimationCapture?,
     timings: List<Long>,
     previewParameter: Pair<String, Int>?,
-    scanResult: ScanResult,
-    projectClassFqns: Set<String>,
+    previewSourceFile: String?,
+    inferredTargets: Lazy<List<PreviewTarget>>,
   ): PreviewInfo {
     val params = extractPreviewParams(ann, wrapperClassName, previewParameter)
     val fqn = "${classInfo.name}.${method.name}"
     val suffix = buildVariantSuffix(params)
     val id = fqn + suffix
     val outputPlan = buildOutputPlan(ann, id, scrolls, animation, timings)
-    val previewSourceFile = sourceFilePath(classInfo)
-    val targets =
-      // Tile previews don't go through @Composable invocations — they return a `TilePreviewData`
-      // and the renderer reflects them directly. Skip target inference for that kind so we don't
-      // emit nonsense entries from the bytecode walk picking up `TileRenderer` / View calls.
-      if (params.kind == PreviewKind.TILE) emptyList()
-      else
-        PreviewTargetInference.infer(
-          previewClassInfo = classInfo,
-          previewMethod = method,
-          scanResult = scanResult,
-          projectClassFqns = projectClassFqns,
-          previewSourceFile = previewSourceFile,
-          resolveSourceFile = { ownerFqn ->
-            scanResult.getClassInfo(ownerFqn)?.let { sourceFilePath(it) }
-          },
-          variantName = variantName.get(),
-          hasPreviewParameter = previewParameter != null,
-        )
+    // Tile previews don't go through @Composable invocations — they return a `TilePreviewData`
+    // and the renderer reflects them directly. Skipping the lazy means the bytecode walk never
+    // runs for tile-only methods.
+    val targets = if (params.kind == PreviewKind.TILE) emptyList() else inferredTargets.value
     return PreviewInfo(
       id = id,
       functionName = method.name,

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -653,6 +653,14 @@ body {
     border-color: var(--vscode-focusBorder);
 }
 
+/* Referenced previews live in another file but target the active one (idiomatic
+   XxxPreviews.kt / screenshotTest layout). A subtle dashed left edge is enough
+   to telegraph "this is from somewhere else"; the tooltip carries the source
+   path. Theme tokens keep it readable on both light and dark themes. */
+.preview-card.referenced {
+    border-left: 3px dashed var(--vscode-textLink-foreground);
+}
+
 /* Header overlays the image, hidden until hover/focus. */
 .card-header {
     position: absolute;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,6 +15,7 @@ import { AndroidManifestCodeLensProvider } from "./androidManifestCodeLensProvid
 import { PreviewA11yDiagnostics } from "./previewA11yDiagnostics";
 import { PreviewDoctorDiagnostics } from "./previewDoctorDiagnostics";
 import { moduleRelativeSourcePath, previewSourceMatches } from "./sourcePath";
+import { visiblePreviewsForFile } from "./previewScope";
 import {
     AccessibilityFinding,
     AccessibilityNode,
@@ -1867,13 +1868,16 @@ function previewsForFile(
     if (!gradleService) {
         return [];
     }
-    return previews.filter((preview) =>
-        previewSourceMatches(
-            preview.sourceFile,
-            filePath,
-            gradleService!.workspaceRoot,
-            module,
-        ),
+    // Primary first (previews authored in this file), then referenced
+    // (previews authored elsewhere whose inferred target points back at this
+    // file — idiomatic `XxxPreviews.kt` / `screenshotTest` layout). Referenced
+    // entries carry `referenced = true` so the webview can group them under a
+    // "from elsewhere" header without touching the cached manifest.
+    return visiblePreviewsForFile(
+        previews,
+        gradleService.workspaceRoot,
+        module,
+        filePath,
     );
 }
 

--- a/vscode-extension/src/previewScope.ts
+++ b/vscode-extension/src/previewScope.ts
@@ -1,0 +1,77 @@
+import { PreviewInfo } from "./types";
+import { previewSourceMatches } from "./sourcePath";
+
+/**
+ * Splits a module's previews into two buckets relative to [filePath]:
+ *
+ * - **primary** — previews whose own `sourceFile` matches the file (the file
+ *   contains the `@Preview` annotations). Same set the panel always showed.
+ * - **referenced** — previews from *other* files in the module whose inferred
+ *   `targets[i].sourceFile` matches the file. These surface when the user
+ *   opens a production composable that has its `@Preview`s in a sibling file
+ *   (idiomatic `XxxPreviews.kt` / `screenshotTest` layout). Each entry is a
+ *   shallow copy with `referenced = true` so the webview can render them
+ *   under a "from elsewhere" treatment without touching the cached
+ *   `PreviewInfo` on `moduleManifestCache`.
+ *
+ * Previews that match both (a preview that lives in the file *and* targets
+ * the file) are reported as primary only — `referenced` would be redundant.
+ */
+export function partitionPreviewsForFile(
+    previews: PreviewInfo[],
+    workspaceRoot: string,
+    module: string,
+    filePath: string,
+): { primary: PreviewInfo[]; referenced: PreviewInfo[] } {
+    const primary: PreviewInfo[] = [];
+    const referenced: PreviewInfo[] = [];
+    const primaryIds = new Set<string>();
+    for (const preview of previews) {
+        if (
+            previewSourceMatches(
+                preview.sourceFile,
+                filePath,
+                workspaceRoot,
+                module,
+            )
+        ) {
+            primary.push(preview);
+            primaryIds.add(preview.id);
+        }
+    }
+    for (const preview of previews) {
+        if (primaryIds.has(preview.id)) {
+            continue;
+        }
+        const targets = preview.targets;
+        if (!targets || targets.length === 0) {
+            continue;
+        }
+        const matchesByTarget = targets.some((t) =>
+            previewSourceMatches(t.sourceFile, filePath, workspaceRoot, module),
+        );
+        if (matchesByTarget) {
+            referenced.push({ ...preview, referenced: true });
+        }
+    }
+    return { primary, referenced };
+}
+
+/**
+ * Convenience wrapper that returns `[...primary, ...referenced]` — the order
+ * the panel renders so primary previews stay at the top.
+ */
+export function visiblePreviewsForFile(
+    previews: PreviewInfo[],
+    workspaceRoot: string,
+    module: string,
+    filePath: string,
+): PreviewInfo[] {
+    const { primary, referenced } = partitionPreviewsForFile(
+        previews,
+        workspaceRoot,
+        module,
+        filePath,
+    );
+    return [...primary, ...referenced];
+}

--- a/vscode-extension/src/test/previewScope.test.ts
+++ b/vscode-extension/src/test/previewScope.test.ts
@@ -1,0 +1,181 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { partitionPreviewsForFile } from "../previewScope";
+import { PreviewInfo } from "../types";
+
+function makePreview(
+    overrides: Partial<PreviewInfo> & Pick<PreviewInfo, "id">,
+): PreviewInfo {
+    return {
+        functionName: "Stub",
+        className: "test.PreviewsKt",
+        sourceFile: null,
+        params: {
+            name: null,
+            device: null,
+            widthDp: null,
+            heightDp: null,
+            fontScale: 1.0,
+            showSystemUi: false,
+            showBackground: false,
+            backgroundColor: 0,
+            uiMode: 0,
+            locale: null,
+            group: null,
+        },
+        captures: [],
+        ...overrides,
+    };
+}
+
+function withTempProject(
+    fn: (workspaceRoot: string, module: string, homeScreenFile: string) => void,
+): void {
+    const workspaceRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), "compose-preview-scope-"),
+    );
+    try {
+        const module = "app";
+        const homeScreenFile = path.join(
+            workspaceRoot,
+            module,
+            "src",
+            "main",
+            "kotlin",
+            "test",
+            "HomeScreen.kt",
+        );
+        fs.mkdirSync(path.dirname(homeScreenFile), { recursive: true });
+        // Real package declaration so packageQualifiedSourcePath resolves the
+        // same shape the manifest stores.
+        fs.writeFileSync(homeScreenFile, "package test\n");
+        fn(workspaceRoot, module, homeScreenFile);
+    } finally {
+        fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+}
+
+describe("partitionPreviewsForFile", () => {
+    it("returns previews authored in the active file as primary", () => {
+        withTempProject((workspaceRoot, module, file) => {
+            const inFile = makePreview({
+                id: "p1",
+                functionName: "PreviewA",
+                sourceFile: "src/main/kotlin/test/HomeScreen.kt",
+            });
+            const elsewhere = makePreview({
+                id: "p2",
+                sourceFile: "src/main/kotlin/test/Other.kt",
+            });
+            const { primary, referenced } = partitionPreviewsForFile(
+                [inFile, elsewhere],
+                workspaceRoot,
+                module,
+                file,
+            );
+            assert.deepStrictEqual(
+                primary.map((p) => p.id),
+                ["p1"],
+            );
+            assert.deepStrictEqual(referenced, []);
+        });
+    });
+
+    it("surfaces previews from other files whose target points at the active file", () => {
+        withTempProject((workspaceRoot, module, file) => {
+            const targeting = makePreview({
+                id: "p2",
+                functionName: "HomeScreenPreview",
+                sourceFile: "src/main/kotlin/test/Previews.kt",
+                targets: [
+                    {
+                        className: "test.HomeScreenKt",
+                        functionName: "HomeScreen",
+                        sourceFile: "src/main/kotlin/test/HomeScreen.kt",
+                        confidence: "HIGH",
+                        signals: ["NAME_MATCH", "CROSS_FILE"],
+                    },
+                ],
+            });
+            const unrelated = makePreview({
+                id: "p3",
+                sourceFile: "src/main/kotlin/test/Other.kt",
+                targets: [
+                    {
+                        className: "test.OtherKt",
+                        functionName: "Other",
+                        sourceFile: "src/main/kotlin/test/Other.kt",
+                        confidence: "HIGH",
+                    },
+                ],
+            });
+            const { primary, referenced } = partitionPreviewsForFile(
+                [targeting, unrelated],
+                workspaceRoot,
+                module,
+                file,
+            );
+            assert.deepStrictEqual(primary, []);
+            assert.deepStrictEqual(
+                referenced.map((p) => p.id),
+                ["p2"],
+            );
+            assert.strictEqual(referenced[0].referenced, true);
+        });
+    });
+
+    it("does not double-list a preview that is both in the file and targets it", () => {
+        withTempProject((workspaceRoot, module, file) => {
+            // Edge case: a preview authored in HomeScreen.kt that also targets
+            // a composable in HomeScreen.kt — should only show up once, in
+            // the primary list.
+            const both = makePreview({
+                id: "p1",
+                functionName: "InlinePreview",
+                sourceFile: "src/main/kotlin/test/HomeScreen.kt",
+                targets: [
+                    {
+                        className: "test.HomeScreenKt",
+                        functionName: "HomeScreen",
+                        sourceFile: "src/main/kotlin/test/HomeScreen.kt",
+                        confidence: "HIGH",
+                    },
+                ],
+            });
+            const { primary, referenced } = partitionPreviewsForFile(
+                [both],
+                workspaceRoot,
+                module,
+                file,
+            );
+            assert.deepStrictEqual(
+                primary.map((p) => p.id),
+                ["p1"],
+            );
+            assert.deepStrictEqual(referenced, []);
+            // The primary copy should not have `referenced` set.
+            assert.strictEqual(primary[0].referenced, undefined);
+        });
+    });
+
+    it("skips previews with no targets", () => {
+        withTempProject((workspaceRoot, module, file) => {
+            const sibling = makePreview({
+                id: "p2",
+                sourceFile: "src/main/kotlin/test/Other.kt",
+                // No targets at all — discovery couldn't pin one. Don't surface.
+                targets: undefined,
+            });
+            const { primary, referenced } = partitionPreviewsForFile(
+                [sibling],
+                workspaceRoot,
+                module,
+                file,
+            );
+            assert.deepStrictEqual(primary, []);
+            assert.deepStrictEqual(referenced, []);
+        });
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -142,6 +142,35 @@ export interface PreviewInfo {
      * `docs/daemon/DATA-PRODUCTS.md` § "Worked example".
      */
     a11yNodes?: AccessibilityNode[] | null;
+    /**
+     * Composables this preview is presumed to render. Inferred by the Gradle
+     * plugin from the preview's bytecode (see `PreviewTargetInference.kt`); v1
+     * emits 0 or 1 entries. The extension uses this to surface previews from
+     * elsewhere when the user opens the production composable file — see
+     * `previewsReferencingFile` in `extension.ts`.
+     */
+    targets?: PreviewTarget[];
+    /**
+     * Set by the extension (not the manifest) when this preview is being
+     * displayed in the panel because one of its [targets] points at the active
+     * file, rather than because its own [sourceFile] matches. Lets the webview
+     * render a "from elsewhere" treatment without changing the message shape.
+     */
+    referenced?: boolean;
+}
+
+/**
+ * Mirrors the plugin-side `PreviewTarget`. Only the fields the panel/webview
+ * actually consume are typed; signal/confidence enums are treated as strings
+ * because the panel never enumerates them — they're surfaced verbatim in
+ * tooltips when present.
+ */
+export interface PreviewTarget {
+    className: string;
+    functionName: string;
+    sourceFile: string | null;
+    confidence: "HIGH" | "MEDIUM" | "LOW";
+    signals?: string[];
 }
 
 /**

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -118,7 +118,14 @@ export function buildPreviewCard(
     const captures = p.captures;
 
     const card = document.createElement("div");
-    card.className = "preview-card" + (animated ? " animated-card" : "");
+    // `referenced` previews live in another file but target the active one
+    // (idiomatic `XxxPreviews.kt` / `screenshotTest` layout). The CSS hook lets
+    // the panel render them under a "from elsewhere" treatment without changing
+    // the message shape.
+    card.className =
+        "preview-card" +
+        (animated ? " animated-card" : "") +
+        (p.referenced ? " referenced" : "");
     card.id = "preview-" + sanitizeId(p.id);
     card.setAttribute("role", "listitem");
     card.dataset.function = p.functionName;
@@ -127,6 +134,9 @@ export function buildPreviewCard(
     card.dataset.className = p.className;
     card.dataset.wearPreview = isWearPreview(p) ? "1" : "0";
     card.dataset.currentIndex = "0";
+    if (p.referenced) {
+        card.dataset.referenced = "1";
+    }
     config.cardCaptures.set(
         p.id,
         captures.map(

--- a/vscode-extension/src/webview/preview/cardData.ts
+++ b/vscode-extension/src/webview/preview/cardData.ts
@@ -107,6 +107,9 @@ export function buildTooltip(p: PreviewInfo): string {
     if (p.params.uiMode) parts.push("uiMode=" + p.params.uiMode);
     if (p.params.locale) parts.push(p.params.locale);
     if (p.params.group) parts.push("group: " + p.params.group);
+    if (p.referenced && p.sourceFile) {
+        parts.push("from " + p.sourceFile);
+    }
     return parts.length ? base + "\\n" + parts.join(" · ") : base;
 }
 


### PR DESCRIPTION
## Summary

Closes #795.

- **Plugin**: walk each `@Preview` function's bytecode (ASM), keep
  project-local `@Composable` calls, filter AndroidX/CMP theming and
  layout primitives by FQN, and score the survivors against signals
  (single survivor, name match `FooPreview`↔`Foo`, cross-file,
  non-shipping source set, dedicated `*Previews.kt` filename,
  `@PreviewParameter` forwarding). The top-scored candidate (HIGH ≥ 4,
  MEDIUM 2–3, LOW = 1) lands on `PreviewInfo.targets` with a confidence
  tier and the signals that drove the pick. The list shape is
  forward-compatible with multi-target inference; v1 emits 0 or 1
  entries.
- **Inference cache**: a single `lazy {}` per `(classInfo, method)` so a
  6-expansion `@WearPreviewDevices` walks the bytecode once instead of
  six times. Tile previews skip the lazy entirely (`TilePreviewData`
  isn't a `@Composable` invocation).
- **VS Code**: when the active file has no `@Preview` of its own but is
  the inferred target of previews elsewhere in the module, the panel
  surfaces those previews under the same scope. Primary previews
  (authored in the file) come first; referenced previews follow with a
  dashed left border and a tooltip noting their origin. The
  render-on-save flow inherits this wider scope automatically — every
  call site uses `previewsForFile` — so editing the production file
  repaints the referenced cards live.

## Test plan

- [x] `./gradlew :gradle-plugin:check ktfmtCheckAll` — green (unit +
      functional + format).
- [x] `:gradle-plugin:test` — new `PreviewTargetInferenceTest`,
      extended `PreviewDataTest` covering the manifest round-trip with
      `targets`.
- [x] `:gradle-plugin:functionalTest` — three new `DiscoveryFunctionalTest`
      cases: cross-file happy path, framework-only emits no target, and
      sibling-`@Preview` is filtered out as a candidate.
- [x] `vscode-extension`: `npm test` (330 passing) including new
      `previewScope.test.ts` covering primary/referenced partition and
      the no-double-list edge case.
- [ ] Manual smoke: F5 the extension, open
      `samples/android-screenshot-test/` in the dev host, and confirm
      the production composable file shows referenced previews from its
      sibling preview file.


---
_Generated by [Claude Code](https://claude.ai/code/session_017Ejy1SBQYGwddRA6JvPXgy)_