### PR TITLE
refactor(vscode): dedupe pixel-diff between preview and history panels

### DIFF
--- a/vscode-extension/src/webview/history/historyDiffView.ts
+++ b/vscode-extension/src/webview/history/historyDiffView.ts
@@ -11,17 +11,16 @@
 // orchestration — message dispatch, filter / scope plumbing, the
 // initial render kickoff.
 //
-// The pixel-diff helper (`computeDiffStats`) is duplicated semantically
-// from the live preview panel's `diffOverlay.ts`. Keeping the two
-// copies for now since the History panel is webview-self-contained
-// (no Lit dependency); a future shared module under
-// `webview/shared/pixelDiff.ts` could collapse them once the
-// component story stabilises.
+// The pixel-diff helper lives in `webview/shared/pixelDiff.ts` — the
+// preview panel's diff overlay reaches for the same algorithm.
 
 import { buildDiffModeBar, type DiffMode } from "../shared/diffModeBar";
+import { computeDiffStats, type DiffStats } from "../shared/pixelDiff";
 import type { HistoryDiffSummary } from "../shared/types";
 import type { VsCodeApi } from "../shared/vscode";
 import { cssEscape } from "./historyData";
+
+export type { DiffStats };
 
 interface DiffPayload {
     leftLabel: string;
@@ -33,24 +32,6 @@ interface DiffPayload {
 interface PersistedHistoryState {
     diffMode?: DiffMode;
 }
-
-export type DiffStats =
-    | { error: string }
-    | {
-          sameSize: false;
-          leftW: number;
-          leftH: number;
-          rightW: number;
-          rightH: number;
-      }
-    | {
-          sameSize: true;
-          w: number;
-          h: number;
-          diffPx: number;
-          total: number;
-          percent: number;
-      };
 
 export interface HistoryDiffViewConfig {
     /** Untyped vscode handle — `fillDiff` casts the persisted state to
@@ -120,100 +101,6 @@ export function fillDiff(
     renderHistoryDiffMode(body, initialMode, payload);
     computeDiffStats(payload.leftImage, payload.rightImage).then((s) => {
         applyDiffStats(stats, s);
-    });
-}
-
-/**
- * Async client-side pixel diff between two base64 PNG images. Resolves
- * a typed `DiffStats` discriminated union — error / size mismatch /
- * pixel count + same-size dimensions. Doesn't reject: every failure
- * mode lands as a `{ error }` variant so callers don't have to wrap
- * the call in a try/catch.
- *
- * Duplicated from `webview/preview/diffOverlay.ts`; same algorithm.
- */
-export function computeDiffStats(
-    leftBase64: string,
-    rightBase64: string,
-): Promise<DiffStats> {
-    return new Promise<DiffStats>((resolve) => {
-        const left = new Image();
-        const right = new Image();
-        let loaded = 0;
-        const onErr = (): void => resolve({ error: "image failed to load" });
-        const onOk = (): void => {
-            if (++loaded < 2) return;
-            try {
-                if (
-                    left.naturalWidth !== right.naturalWidth ||
-                    left.naturalHeight !== right.naturalHeight
-                ) {
-                    resolve({
-                        sameSize: false,
-                        leftW: left.naturalWidth,
-                        leftH: left.naturalHeight,
-                        rightW: right.naturalWidth,
-                        rightH: right.naturalHeight,
-                    });
-                    return;
-                }
-                const w = left.naturalWidth;
-                const h = left.naturalHeight;
-                const c1 = document.createElement("canvas");
-                c1.width = w;
-                c1.height = h;
-                const ctx1 = c1.getContext("2d");
-                if (!ctx1) {
-                    resolve({ error: "canvas 2d context unavailable" });
-                    return;
-                }
-                ctx1.drawImage(left, 0, 0);
-                const d1 = ctx1.getImageData(0, 0, w, h).data;
-                const c2 = document.createElement("canvas");
-                c2.width = w;
-                c2.height = h;
-                const ctx2 = c2.getContext("2d");
-                if (!ctx2) {
-                    resolve({ error: "canvas 2d context unavailable" });
-                    return;
-                }
-                ctx2.drawImage(right, 0, 0);
-                const d2 = ctx2.getImageData(0, 0, w, h).data;
-                let diff = 0;
-                const len = d1.length;
-                for (let i = 0; i < len; i += 4) {
-                    if (
-                        d1[i] !== d2[i] ||
-                        d1[i + 1] !== d2[i + 1] ||
-                        d1[i + 2] !== d2[i + 2] ||
-                        d1[i + 3] !== d2[i + 3]
-                    )
-                        diff++;
-                }
-                const total = w * h;
-                resolve({
-                    sameSize: true,
-                    w,
-                    h,
-                    diffPx: diff,
-                    total,
-                    percent: total > 0 ? diff / total : 0,
-                });
-            } catch (err) {
-                resolve({
-                    error:
-                        err instanceof Error
-                            ? err.message
-                            : "stats unavailable",
-                });
-            }
-        };
-        left.onload = onOk;
-        left.onerror = onErr;
-        right.onload = onOk;
-        right.onerror = onErr;
-        left.src = "data:image/png;base64," + leftBase64;
-        right.src = "data:image/png;base64," + rightBase64;
     });
 }
 

--- a/vscode-extension/src/webview/preview/diffOverlay.ts
+++ b/vscode-extension/src/webview/preview/diffOverlay.ts
@@ -22,9 +22,10 @@
 // a different code path.
 
 import { buildDiffModeBar, type DiffMode } from "../shared/diffModeBar";
+import { computeDiffStats, type DiffStats } from "../shared/pixelDiff";
 import type { VsCodeApi } from "../shared/vscode";
 
-export type { DiffMode };
+export type { DiffMode, DiffStats };
 
 export interface DiffPayload {
     leftLabel: string;
@@ -209,104 +210,6 @@ function buildPreviewDiffPane(
         pane.appendChild(empty);
     }
     return pane;
-}
-
-export type DiffStats =
-    | { error: string }
-    | {
-          sameSize: false;
-          leftW: number;
-          leftH: number;
-          rightW: number;
-          rightH: number;
-      }
-    | {
-          sameSize: true;
-          w: number;
-          h: number;
-          diffPx: number;
-          total: number;
-          percent: number;
-      };
-
-/**
- * Client-side pixel diff: load both base64 PNGs into `<img>`s, draw to
- * canvases, walk the `ImageData` buffers in parallel. Resolves to one
- * of three shapes — error, size-mismatch, or identical/changed stats.
- * Always resolves; never rejects.
- */
-function computeDiffStats(
-    leftBase64: string,
-    rightBase64: string,
-): Promise<DiffStats> {
-    return new Promise((resolve) => {
-        const left = new Image();
-        const right = new Image();
-        let loaded = 0;
-        const onErr = (): void => resolve({ error: "image failed to load" });
-        const onOk = (): void => {
-            if (++loaded < 2) return;
-            try {
-                if (
-                    left.naturalWidth !== right.naturalWidth ||
-                    left.naturalHeight !== right.naturalHeight
-                ) {
-                    resolve({
-                        sameSize: false,
-                        leftW: left.naturalWidth,
-                        leftH: left.naturalHeight,
-                        rightW: right.naturalWidth,
-                        rightH: right.naturalHeight,
-                    });
-                    return;
-                }
-                const w = left.naturalWidth;
-                const h = left.naturalHeight;
-                const c1 = document.createElement("canvas");
-                c1.width = w;
-                c1.height = h;
-                c1.getContext("2d")!.drawImage(left, 0, 0);
-                const d1 = c1.getContext("2d")!.getImageData(0, 0, w, h).data;
-                const c2 = document.createElement("canvas");
-                c2.width = w;
-                c2.height = h;
-                c2.getContext("2d")!.drawImage(right, 0, 0);
-                const d2 = c2.getContext("2d")!.getImageData(0, 0, w, h).data;
-                let diff = 0;
-                const len = d1.length;
-                for (let i = 0; i < len; i += 4) {
-                    if (
-                        d1[i] !== d2[i] ||
-                        d1[i + 1] !== d2[i + 1] ||
-                        d1[i + 2] !== d2[i + 2] ||
-                        d1[i + 3] !== d2[i + 3]
-                    )
-                        diff++;
-                }
-                const total = w * h;
-                resolve({
-                    sameSize: true,
-                    w,
-                    h,
-                    diffPx: diff,
-                    total,
-                    percent: total > 0 ? diff / total : 0,
-                });
-            } catch (err) {
-                resolve({
-                    error:
-                        (err instanceof Error && err.message) ||
-                        "stats unavailable",
-                });
-            }
-        };
-        left.onload = onOk;
-        left.onerror = onErr;
-        right.onload = onOk;
-        right.onerror = onErr;
-        left.src = "data:image/png;base64," + leftBase64;
-        right.src = "data:image/png;base64," + rightBase64;
-    });
 }
 
 function applyDiffStats(el: HTMLElement, s: DiffStats): void {

--- a/vscode-extension/src/webview/shared/pixelDiff.ts
+++ b/vscode-extension/src/webview/shared/pixelDiff.ts
@@ -1,0 +1,121 @@
+// Client-side pixel diff for the History panel + the live preview panel's
+// per-card diff overlay. Same algorithm in both call sites; lifted out of
+// `preview/diffOverlay.ts` and `history/historyDiffView.ts` so the two
+// copies stop drifting (the preview copy used `getContext("2d")!`
+// non-null assertions; the history copy guarded explicitly — this module
+// keeps the explicit guards).
+//
+// Loads both base64 PNGs into hidden `<img>`s, draws each to a canvas,
+// walks the two `ImageData` buffers in parallel comparing RGBA quads. The
+// resolved `DiffStats` is a discriminated union so callers (`applyDiffStats`
+// label renderer, both panels) narrow correctly via `"error" in s` and
+// `s.sameSize`.
+//
+// Always resolves; never rejects. Every failure mode (image load error,
+// canvas-2d-unavailable, runtime exception during the byte walk) lands as
+// an `{ error }` variant so callers don't have to wrap the call in a
+// try/catch.
+
+/** Outcome of a pixel diff between two base64 PNGs. */
+export type DiffStats =
+    | { error: string }
+    | {
+          sameSize: false;
+          leftW: number;
+          leftH: number;
+          rightW: number;
+          rightH: number;
+      }
+    | {
+          sameSize: true;
+          w: number;
+          h: number;
+          diffPx: number;
+          total: number;
+          percent: number;
+      };
+
+export function computeDiffStats(
+    leftBase64: string,
+    rightBase64: string,
+): Promise<DiffStats> {
+    return new Promise<DiffStats>((resolve) => {
+        const left = new Image();
+        const right = new Image();
+        let loaded = 0;
+        const onErr = (): void => resolve({ error: "image failed to load" });
+        const onOk = (): void => {
+            if (++loaded < 2) return;
+            try {
+                if (
+                    left.naturalWidth !== right.naturalWidth ||
+                    left.naturalHeight !== right.naturalHeight
+                ) {
+                    resolve({
+                        sameSize: false,
+                        leftW: left.naturalWidth,
+                        leftH: left.naturalHeight,
+                        rightW: right.naturalWidth,
+                        rightH: right.naturalHeight,
+                    });
+                    return;
+                }
+                const w = left.naturalWidth;
+                const h = left.naturalHeight;
+                const c1 = document.createElement("canvas");
+                c1.width = w;
+                c1.height = h;
+                const ctx1 = c1.getContext("2d");
+                if (!ctx1) {
+                    resolve({ error: "canvas 2d context unavailable" });
+                    return;
+                }
+                ctx1.drawImage(left, 0, 0);
+                const d1 = ctx1.getImageData(0, 0, w, h).data;
+                const c2 = document.createElement("canvas");
+                c2.width = w;
+                c2.height = h;
+                const ctx2 = c2.getContext("2d");
+                if (!ctx2) {
+                    resolve({ error: "canvas 2d context unavailable" });
+                    return;
+                }
+                ctx2.drawImage(right, 0, 0);
+                const d2 = ctx2.getImageData(0, 0, w, h).data;
+                let diff = 0;
+                const len = d1.length;
+                for (let i = 0; i < len; i += 4) {
+                    if (
+                        d1[i] !== d2[i] ||
+                        d1[i + 1] !== d2[i + 1] ||
+                        d1[i + 2] !== d2[i + 2] ||
+                        d1[i + 3] !== d2[i + 3]
+                    )
+                        diff++;
+                }
+                const total = w * h;
+                resolve({
+                    sameSize: true,
+                    w,
+                    h,
+                    diffPx: diff,
+                    total,
+                    percent: total > 0 ? diff / total : 0,
+                });
+            } catch (err) {
+                resolve({
+                    error:
+                        err instanceof Error
+                            ? err.message
+                            : "stats unavailable",
+                });
+            }
+        };
+        left.onload = onOk;
+        left.onerror = onErr;
+        right.onload = onOk;
+        right.onerror = onErr;
+        left.src = "data:image/png;base64," + leftBase64;
+        right.src = "data:image/png;base64," + rightBase64;
+    });
+}


### PR DESCRIPTION
Same playbook as #807 (parseBounds + diffModeBar dedup): the `computeDiffStats` algorithm — async client-side pixel diff between two base64 PNGs — was identical between `preview/diffOverlay.ts` and `history/historyDiffView.ts`, with the same ~90 LOC body and the same `DiffStats` discriminated union shape. Lift both into a new `webview/shared/pixelDiff.ts`.

The two prior copies had drifted slightly in defensive style:
- The preview copy used non-null `getContext("2d")!` assertions.
- The history copy guarded with `if (!ctx) resolve({ error: ... })`.

The shared module keeps the explicit guards (history-style) — they catch a real failure mode (canvas-2d unavailable in some sandboxed embeddings) and resolve cleanly instead of throwing inside the load handler.

The history copy's flagged TODO from #822 ("a future shared module under `webview/shared/pixelDiff.ts` could collapse them once the component story stabilises") is now addressed.

`preview/diffOverlay.ts` and `history/historyDiffView.ts` re-export `DiffStats` so existing imports (`import { DiffStats } from "./diffOverlay"` etc.) keep working without ripple-edits.

`preview/diffOverlay.ts`: 341 → 244 lines (−97 LOC).
`history/historyDiffView.ts`: 379 → 266 lines (−113 LOC).
`webview/shared/pixelDiff.ts`: +121 lines (new file).

**Net: −89 LOC across the webview tree.**

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 377/377 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke:
  - Live preview: focus a card, click Diff vs HEAD / Diff vs main — pixel-diff stats label renders (identical / changed / sizes differ).
  - History: shift+click two rows + toolbar Diff — inline diff banner shows `bytes identical` / `pixels differ`.
  - History: per-row "Diff vs previous" / "Diff vs current" — diff expansion's stats label transitions from "computing…" to a populated label.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_