### PR TITLE
test(vscode): extract pure formatDiffStatsLabel + add unit tests

### DIFF
--- a/vscode-extension/src/test/diffStatsLabel.test.ts
+++ b/vscode-extension/src/test/diffStatsLabel.test.ts
@@ -1,0 +1,106 @@
+import * as assert from "assert";
+import {
+    formatDiffStatsLabel,
+    type DiffStats,
+} from "../webview/shared/diffStatsLabel";
+
+describe("formatDiffStatsLabel", () => {
+    it("returns empty text + null state for null stats (still computing)", () => {
+        assert.deepStrictEqual(formatDiffStatsLabel(null), {
+            text: "",
+            state: null,
+        });
+    });
+
+    it("renders the error text for an error variant, no state", () => {
+        const stats: DiffStats = { error: "image failed to load" };
+        assert.deepStrictEqual(formatDiffStatsLabel(stats), {
+            text: "image failed to load",
+            state: null,
+        });
+    });
+
+    it("renders 'sizes differ' for size-mismatch", () => {
+        const stats: DiffStats = {
+            sameSize: false,
+            leftW: 100,
+            leftH: 200,
+            rightW: 110,
+            rightH: 210,
+        };
+        assert.deepStrictEqual(formatDiffStatsLabel(stats), {
+            text: "sizes differ — 100×200 vs 110×210",
+            state: "size-mismatch",
+        });
+    });
+
+    it("renders 'identical · WxH' when diffPx is 0", () => {
+        const stats: DiffStats = {
+            sameSize: true,
+            w: 360,
+            h: 640,
+            diffPx: 0,
+            total: 230_400,
+            percent: 0,
+        };
+        assert.deepStrictEqual(formatDiffStatsLabel(stats), {
+            text: "identical · 360×640",
+            state: "identical",
+        });
+    });
+
+    it("uses 2-decimal percent for >= 0.01% diffs", () => {
+        // 1000 px out of 100_000 = 1% — comfortably above 0.01.
+        const stats: DiffStats = {
+            sameSize: true,
+            w: 200,
+            h: 500,
+            diffPx: 1000,
+            total: 100_000,
+            percent: 0.01, // 1.00 after × 100
+        };
+        const out = formatDiffStatsLabel(stats);
+        assert.strictEqual(out.state, "changed");
+        assert.match(out.text, /1,000 px \(1\.00%\) · 200×500/);
+    });
+
+    it("uses 3-decimal percent for sub-0.01% diffs", () => {
+        // 1 px out of 1_000_000 = 0.0001%.
+        const stats: DiffStats = {
+            sameSize: true,
+            w: 1000,
+            h: 1000,
+            diffPx: 1,
+            total: 1_000_000,
+            percent: 0.000_001, // 0.0001 after × 100
+        };
+        const out = formatDiffStatsLabel(stats);
+        assert.strictEqual(out.state, "changed");
+        assert.match(out.text, /1 px \(0\.000%\) · 1000×1000/);
+        // Sanity: 3-decimal precision means we get "0.000" not "0.00".
+        assert.ok(
+            out.text.includes("0.000%"),
+            "expected 3-decimal pct, got " + out.text,
+        );
+    });
+
+    it("uses locale formatting on diffPx (thousands separators)", () => {
+        const stats: DiffStats = {
+            sameSize: true,
+            w: 1000,
+            h: 1000,
+            diffPx: 12_345,
+            total: 1_000_000,
+            percent: 0.012_345, // 1.2345% after × 100
+        };
+        const out = formatDiffStatsLabel(stats);
+        // toLocaleString defaults to en-US-ish thousands separators in
+        // most environments — accept either "12,345" or "12.345" so the
+        // test is locale-tolerant.
+        assert.ok(
+            /12[,.]345 px/.test(out.text),
+            "expected locale-formatted diffPx, got " + out.text,
+        );
+        assert.match(out.text, /1\.23%/);
+    });
+});

--- a/vscode-extension/src/webview/history/historyDiffView.ts
+++ b/vscode-extension/src/webview/history/historyDiffView.ts
@@ -15,7 +15,11 @@
 // preview panel's diff overlay reaches for the same algorithm.
 
 import { buildDiffModeBar, type DiffMode } from "../shared/diffModeBar";
-import { computeDiffStats, type DiffStats } from "../shared/pixelDiff";
+import {
+    applyDiffStats,
+    computeDiffStats,
+    type DiffStats,
+} from "../shared/pixelDiff";
 import type { HistoryDiffSummary } from "../shared/types";
 import type { VsCodeApi } from "../shared/vscode";
 import { cssEscape } from "./historyData";
@@ -102,47 +106,6 @@ export function fillDiff(
     computeDiffStats(payload.leftImage, payload.rightImage).then((s) => {
         applyDiffStats(stats, s);
     });
-}
-
-/**
- * Render the stats label for a completed `computeDiffStats`. Sets a
- * `data-state` attribute on [el] so the CSS can colour the label by
- * outcome (`identical`, `changed`, `size-mismatch`).
- */
-export function applyDiffStats(el: HTMLElement, s: DiffStats | null): void {
-    if (!s) {
-        el.textContent = "";
-        el.removeAttribute("data-state");
-        return;
-    }
-    if ("error" in s) {
-        el.textContent = s.error;
-        el.removeAttribute("data-state");
-        return;
-    }
-    if (!s.sameSize) {
-        el.textContent =
-            "sizes differ — " +
-            s.leftW +
-            "×" +
-            s.leftH +
-            " vs " +
-            s.rightW +
-            "×" +
-            s.rightH;
-        el.dataset.state = "size-mismatch";
-        return;
-    }
-    if (s.diffPx === 0) {
-        el.textContent = "identical · " + s.w + "×" + s.h;
-        el.dataset.state = "identical";
-        return;
-    }
-    const p = s.percent * 100;
-    const pct = p < 0.01 ? p.toFixed(3) : p.toFixed(2);
-    el.textContent =
-        s.diffPx.toLocaleString() + " px (" + pct + "%) · " + s.w + "×" + s.h;
-    el.dataset.state = "changed";
 }
 
 function renderHistoryDiffMode(

--- a/vscode-extension/src/webview/preview/diffOverlay.ts
+++ b/vscode-extension/src/webview/preview/diffOverlay.ts
@@ -22,7 +22,11 @@
 // a different code path.
 
 import { buildDiffModeBar, type DiffMode } from "../shared/diffModeBar";
-import { computeDiffStats, type DiffStats } from "../shared/pixelDiff";
+import {
+    applyDiffStats,
+    computeDiffStats,
+    type DiffStats,
+} from "../shared/pixelDiff";
 import type { VsCodeApi } from "../shared/vscode";
 
 export type { DiffMode, DiffStats };
@@ -210,35 +214,4 @@ function buildPreviewDiffPane(
         pane.appendChild(empty);
     }
     return pane;
-}
-
-function applyDiffStats(el: HTMLElement, s: DiffStats): void {
-    if ("error" in s) {
-        el.textContent = s.error;
-        el.removeAttribute("data-state");
-        return;
-    }
-    if (!s.sameSize) {
-        el.textContent =
-            "sizes differ — " +
-            s.leftW +
-            "×" +
-            s.leftH +
-            " vs " +
-            s.rightW +
-            "×" +
-            s.rightH;
-        el.dataset.state = "size-mismatch";
-        return;
-    }
-    if (s.diffPx === 0) {
-        el.textContent = "identical · " + s.w + "×" + s.h;
-        el.dataset.state = "identical";
-        return;
-    }
-    const p = s.percent * 100;
-    const pct = p < 0.01 ? p.toFixed(3) : p.toFixed(2);
-    el.textContent =
-        s.diffPx.toLocaleString() + " px (" + pct + "%) · " + s.w + "×" + s.h;
-    el.dataset.state = "changed";
 }

--- a/vscode-extension/src/webview/shared/diffStatsLabel.ts
+++ b/vscode-extension/src/webview/shared/diffStatsLabel.ts
@@ -1,0 +1,93 @@
+// Pure label-formatting for the pixel-diff stats line shown beneath the
+// Side / Overlay / Onion mode bar in both the live preview panel's
+// per-card diff overlay and the History panel's row-level diff
+// expansion. Lifted from the duplicated `applyDiffStats` bodies so the
+// formatting is unit-testable without a DOM, and so the two consumer
+// modules share one source of truth for the wording.
+//
+// `DiffStats` lives here (rather than in `./pixelDiff.ts`) so this
+// module has no DOM type dependencies — the host tsconfig can compile
+// it alongside `cardData.ts` / `historyData.ts` and pick it up via the
+// `files` list for unit tests. `pixelDiff.ts` re-exports `DiffStats`
+// for callers that already imported it from there.
+
+/** Outcome of a pixel diff between two base64 PNGs.
+ *  Discriminated by `"error" in s` and `s.sameSize`. */
+export type DiffStats =
+    | { error: string }
+    | {
+          sameSize: false;
+          leftW: number;
+          leftH: number;
+          rightW: number;
+          rightH: number;
+      }
+    | {
+          sameSize: true;
+          w: number;
+          h: number;
+          diffPx: number;
+          total: number;
+          percent: number;
+      };
+
+/** What the stats line should display: the visible text plus a tag the
+ *  CSS uses to colour the line. `state === null` means "no styling
+ *  state" (matches `removeAttribute("data-state")`). */
+export interface DiffStatsLabel {
+    text: string;
+    state: "size-mismatch" | "identical" | "changed" | null;
+}
+
+/**
+ * Render [stats] as a `{ text, state }` pair. Mirrors the previous
+ * `applyDiffStats` branches:
+ *
+ *  - `null` → empty label, no state (used while the diff is still
+ *    streaming — the host has set `"computing…"` and just received
+ *    the result before the formatter ran).
+ *  - `{ error }` → error message, no state.
+ *  - size-mismatch → `"sizes differ — WxH vs WxH"`, `state="size-mismatch"`.
+ *  - same size, zero diff → `"identical · WxH"`, `state="identical"`.
+ *  - same size, non-zero diff → `"<diffPx> px (<percent>%) · WxH"`,
+ *    `state="changed"`. Percent uses 3 decimal places below 0.01%
+ *    (so a single-pixel diff on a megapixel render reads as
+ *    `0.0001%` rather than `0.00%`), 2 decimal places otherwise.
+ */
+export function formatDiffStatsLabel(stats: DiffStats | null): DiffStatsLabel {
+    if (!stats) return { text: "", state: null };
+    if ("error" in stats) return { text: stats.error, state: null };
+    if (!stats.sameSize) {
+        return {
+            text:
+                "sizes differ — " +
+                stats.leftW +
+                "×" +
+                stats.leftH +
+                " vs " +
+                stats.rightW +
+                "×" +
+                stats.rightH,
+            state: "size-mismatch",
+        };
+    }
+    if (stats.diffPx === 0) {
+        return {
+            text: "identical · " + stats.w + "×" + stats.h,
+            state: "identical",
+        };
+    }
+    const p = stats.percent * 100;
+    const pct = p < 0.01 ? p.toFixed(3) : p.toFixed(2);
+    return {
+        text:
+            stats.diffPx.toLocaleString() +
+            " px (" +
+            pct +
+            "%) · " +
+            stats.w +
+            "×" +
+            stats.h,
+        state: "changed",
+    };
+}

--- a/vscode-extension/src/webview/shared/pixelDiff.ts
+++ b/vscode-extension/src/webview/shared/pixelDiff.ts
@@ -7,33 +7,27 @@
 //
 // Loads both base64 PNGs into hidden `<img>`s, draws each to a canvas,
 // walks the two `ImageData` buffers in parallel comparing RGBA quads. The
-// resolved `DiffStats` is a discriminated union so callers (`applyDiffStats`
-// label renderer, both panels) narrow correctly via `"error" in s` and
+// resolved `DiffStats` is a discriminated union so callers (the
+// `applyDiffStats` label renderer + the pure `formatDiffStatsLabel` in
+// `./diffStatsLabel.ts`) narrow correctly via `"error" in s` and
 // `s.sameSize`.
 //
 // Always resolves; never rejects. Every failure mode (image load error,
 // canvas-2d-unavailable, runtime exception during the byte walk) lands as
 // an `{ error }` variant so callers don't have to wrap the call in a
 // try/catch.
+//
+// The label-formatting logic lives in `./diffStatsLabel.ts` so the host
+// tsconfig can compile it alongside `cardData.ts` / `historyData.ts` and
+// unit-test it without a DOM.
 
-/** Outcome of a pixel diff between two base64 PNGs. */
-export type DiffStats =
-    | { error: string }
-    | {
-          sameSize: false;
-          leftW: number;
-          leftH: number;
-          rightW: number;
-          rightH: number;
-      }
-    | {
-          sameSize: true;
-          w: number;
-          h: number;
-          diffPx: number;
-          total: number;
-          percent: number;
-      };
+import { formatDiffStatsLabel, type DiffStats } from "./diffStatsLabel";
+
+/** Re-export so existing
+ *  `import { type DiffStats } from "../shared/pixelDiff"` paths keep
+ *  working — the canonical home is `./diffStatsLabel.ts` (no DOM
+ *  dependency, host-tsconfig-friendly). */
+export type { DiffStats };
 
 export function computeDiffStats(
     leftBase64: string,
@@ -118,4 +112,21 @@ export function computeDiffStats(
         left.src = "data:image/png;base64," + leftBase64;
         right.src = "data:image/png;base64," + rightBase64;
     });
+}
+
+/**
+ * Render the diff-stats label into [el]. Thin DOM wrapper around the
+ * pure `formatDiffStatsLabel` so the formatting logic stays unit-
+ * testable without a DOM. Sets `el.dataset.state` for CSS colouring
+ * (`identical` / `changed` / `size-mismatch`); removes the attribute
+ * when the formatter returns `state: null` (error / null input).
+ */
+export function applyDiffStats(el: HTMLElement, stats: DiffStats | null): void {
+    const { text, state } = formatDiffStatsLabel(stats);
+    el.textContent = text;
+    if (state) {
+        el.dataset.state = state;
+    } else {
+        el.removeAttribute("data-state");
+    }
 }

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -17,6 +17,7 @@
     "files": [
         "src/webview/preview/cardData.ts",
         "src/webview/history/historyData.ts",
+        "src/webview/shared/diffStatsLabel.ts",
         "src/webview/shared/types.ts"
     ]
 }


### PR DESCRIPTION
Continuing the dedup pattern from #823 (shared `pixelDiff.ts`). The `applyDiffStats` body was still duplicated between `preview/diffOverlay.ts` and `history/historyDiffView.ts` (slightly different shape — preview took `DiffStats`, history took `DiffStats | null`). Extracts the pure label-formatting logic into `webview/shared/diffStatsLabel.ts` and replaces both `applyDiffStats` copies with a thin DOM wrapper in `pixelDiff.ts`.

## Summary

- New `webview/shared/diffStatsLabel.ts` exports `formatDiffStatsLabel(stats: DiffStats | null) → { text: string; state: "size-mismatch" | "identical" | "changed" | null }` and the `DiffStats` discriminated union itself. No DOM dependencies — host tsconfig pulls it in via `files` (parallel to `cardData.ts` / `historyData.ts`).
- `pixelDiff.ts` becomes a thin DOM consumer: it re-exports `DiffStats` so existing `import { DiffStats } from "../shared/pixelDiff"` paths keep working, hosts the DOM-using `computeDiffStats`, and now exports `applyDiffStats(el, stats)` as a four-line wrapper around the pure formatter.
- Both `preview/diffOverlay.ts` and `history/historyDiffView.ts` drop their local `applyDiffStats` and import the shared one. The two consumers continue to re-export `DiffStats` from their own surface.

## Tests

7 new unit tests in `src/test/diffStatsLabel.test.ts` covering:
- `null` stats → empty label, no state.
- error variant → error message, no state.
- size-mismatch → `"sizes differ — WxH vs WxH"`, `state="size-mismatch"`.
- same size, zero diff → `"identical · WxH"`, `state="identical"`.
- ≥ 0.01% diffs use 2-decimal percent.
- < 0.01% diffs use 3-decimal percent (so a single-pixel diff on a megapixel render reads as `0.000%` rather than `0.00%`).
- `diffPx` uses locale-aware thousands separators.

## Drive-by

The previous preview-side `applyDiffStats` only handled `DiffStats` (no null branch) — the shared version handles `null` uniformly. Doesn't change observable behaviour because the live diff overlay only ever calls `applyDiffStats` with a non-null result, but removes a real shape difference between the two consumers.

`webview/shared/diffStatsLabel.ts`: +93 lines (new file).
`webview/shared/pixelDiff.ts`: 121 → 132 lines (+11 — type re-export + DOM wrapper).
`preview/diffOverlay.ts`: 244 → 217 lines (−27 LOC).
`history/historyDiffView.ts`: 266 → 229 lines (−37 LOC).

Net LOC is +40 (new file + test file outweigh the dedup), but **the source of truth for the label format goes from two copies to one** — the underlying goal.

377 → 384 tests passing.

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 384/384 passing (377 prior + 7 new)
- [x] `npm run format:check` clean
- [ ] Manual smoke:
  - Live preview diff: stats label renders identical / changed / sizes-differ states with the right `data-state`.
  - History per-row diff expansion: same.
  - History toolbar two-way diff (`showDiff` inline banner): not affected by this change but worth confirming nothing regressed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_