### PR TITLE
refactor(vscode): lift renderPreviews into cardBuilder.ts

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -22,6 +22,7 @@ import {
     applyRelativeSizing,
     buildPreviewCard,
     type CardBuilderConfig,
+    renderPreviews as renderPreviewsImpl,
     updateCardMetadata,
     updateImage,
 } from "./cardBuilder";
@@ -687,6 +688,7 @@ export function setupPreviewBehavior(
     // `CardBuilderConfig` shape for its collaborator surface.
     const cardBuilderConfig: CardBuilderConfig = {
         vscode,
+        grid,
         cardCaptures,
         cardA11yFindings,
         cardA11yNodes,
@@ -706,96 +708,12 @@ export function setupPreviewBehavior(
         enterFocus: focusOnCard,
         exitFocus,
         observeForViewport: observeCardForViewport,
+        forgetViewport: (id, card) => viewport.forget(id, card),
+        setMessage,
+        getMessageOwner: () => messageBanner.getOwner(),
     };
-    function createCard(p: PreviewInfo): HTMLElement {
-        return buildPreviewCard(p, cardBuilderConfig);
-    }
-
-    /**
-     * Incremental diff: update existing cards, add new ones, remove missing.
-     * Keeps rendered images in place during refresh — they're replaced as
-     * new images stream in from updateImage messages.
-     */
     function renderPreviews(previews: readonly PreviewInfo[]): void {
-        if (previews.length === 0) {
-            // Defensive fallback — the extension now always sends an
-            // explicit showMessage for empty states, so this branch
-            // shouldn't normally fire. Kept so the view never ends up
-            // with an empty grid + empty message if a bug slips through.
-            grid.innerHTML = "";
-            setMessage("No @Preview functions found", "fallback");
-            return;
-        }
-        const newIds = new Set(previews.map((p) => p.id));
-        const existingCards = new Map<string, HTMLElement>();
-        grid.querySelectorAll<HTMLElement>(".preview-card").forEach((card) => {
-            const id = card.dataset.previewId;
-            if (id) existingCards.set(id, card);
-        });
-
-        // Remove cards that no longer exist — drop their cached capture
-        // data so stale entries don't pile up if a preview is renamed.
-        for (const [id, card] of existingCards) {
-            if (!newIds.has(id)) {
-                cardCaptures.delete(id);
-                viewport.forget(id, card);
-                card.remove();
-            }
-        }
-
-        // Refresh per-preview findings cache so updateImage can attach
-        // them to each new image load. Drop stale entries (preview
-        // removed) so the map doesn't grow across sessions.
-        cardA11yFindings.clear();
-        for (const p of previews) {
-            if (p.a11yFindings && p.a11yFindings.length > 0) {
-                cardA11yFindings.set(p.id, p.a11yFindings);
-            }
-        }
-
-        // Add new cards / update existing ones, preserving order
-        let lastInsertedCard = null;
-        for (const p of previews) {
-            const existing = existingCards.get(p.id);
-            if (existing) {
-                updateCardMetadata(existing, p, cardBuilderConfig);
-                // Ensure correct position
-                if (lastInsertedCard) {
-                    if (lastInsertedCard.nextSibling !== existing) {
-                        grid.insertBefore(
-                            existing,
-                            lastInsertedCard.nextSibling,
-                        );
-                    }
-                } else if (grid.firstChild !== existing) {
-                    grid.insertBefore(existing, grid.firstChild);
-                }
-                lastInsertedCard = existing;
-            } else {
-                const card = createCard(p);
-                if (lastInsertedCard) {
-                    grid.insertBefore(card, lastInsertedCard.nextSibling);
-                } else {
-                    grid.insertBefore(card, grid.firstChild);
-                }
-                lastInsertedCard = card;
-            }
-        }
-
-        // Clear transient owner messages now that cards are in the DOM.
-        // The 'loading' Building… banner and the 'fallback' "Preparing
-        // previews…" placeholder both get cleared here. 'extension'-owned
-        // messages (build errors, empty-state notices) are left alone —
-        // those are terminal states the extension is asserting and the
-        // caller wouldn't be sending setPreviews alongside them anyway.
-        //
-        // Must run *after* cards are inserted: setMessage('', …) calls
-        // ensureNotBlank, which would re-set "Preparing previews…" if
-        // the grid still looked empty when the message was cleared.
-        const owner = messageBanner.getOwner();
-        if (owner && owner !== "extension") {
-            setMessage("", owner);
-        }
+        renderPreviewsImpl(previews, cardBuilderConfig);
     }
 
     // ----- Viewport tracking (daemon scroll-ahead, PREDICTIVE.md § 7) -----

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -38,6 +38,8 @@ import {
 } from "./interactiveInput";
 import type { LiveStateController } from "./liveState";
 import type { StaleBadgeController } from "./staleBadge";
+import type { PreviewGrid } from "./components/PreviewGrid";
+import type { MessageOwner } from "./components/MessageBanner";
 import type {
     AccessibilityFinding,
     AccessibilityNode,
@@ -47,6 +49,10 @@ import type { VsCodeApi } from "../shared/vscode";
 
 export interface CardBuilderConfig {
     vscode: VsCodeApi<unknown>;
+    /** The `<preview-grid>` host — `renderPreviews` walks its
+     *  `.preview-card` children to diff against the new manifest, and
+     *  uses `insertBefore` to keep the manifest's order stable. */
+    grid: PreviewGrid;
     /** Per-preview carousel runtime state — populated here on creation,
      *  read by `updateImage` / `setImageError` / `frameCarousel` later. */
     cardCaptures: Map<string, CapturePresentation[]>;
@@ -94,6 +100,17 @@ export interface CardBuilderConfig {
     /** Hook the freshly-built card into the viewport tracker so daemon
      *  scroll-ahead works. */
     observeForViewport(card: HTMLElement): void;
+    /** Drop a card from the viewport tracker — paired with
+     *  `observeForViewport`; called by `renderPreviews` when an existing
+     *  preview disappears from the new manifest. */
+    forgetViewport(previewId: string, card: HTMLElement): void;
+    /** Set the message banner text + owner, with `ensureNotBlank()`
+     *  backstop. Used by `renderPreviews`'s empty-state fallback. */
+    setMessage(text: string, owner: MessageOwner): void;
+    /** Read the current message-banner owner so `renderPreviews` knows
+     *  whether to clear a transient `loading` / `fallback` placeholder
+     *  after cards land in the DOM. */
+    getMessageOwner(): MessageOwner | null;
 }
 
 /**
@@ -634,5 +651,138 @@ export function applyA11yUpdate(
     }
     if (config.inFocus() && config.focusedCard() === card) {
         config.inspector.render(card);
+    }
+}
+
+/** Subset `renderPreviews` reaches for — initial-build + metadata-refresh
+ *  collaborator surface plus the grid + viewport + message-banner hooks. */
+export type RenderPreviewsConfig = Pick<
+    CardBuilderConfig,
+    | "vscode"
+    | "grid"
+    | "cardCaptures"
+    | "cardA11yFindings"
+    | "cardA11yNodes"
+    | "staleBadge"
+    | "frameCarousel"
+    | "liveState"
+    | "interactiveInputConfig"
+    | "diffOverlayConfig"
+    | "inspector"
+    | "getAllPreviews"
+    | "earlyFeatures"
+    | "inFocus"
+    | "focusedCard"
+    | "enterFocus"
+    | "exitFocus"
+    | "observeForViewport"
+    | "forgetViewport"
+    | "setMessage"
+    | "getMessageOwner"
+>;
+
+/**
+ * Incremental diff against the grid's current contents: update existing
+ * cards, add new ones, remove missing. Keeps rendered images in place
+ * during refresh — they're replaced as new images stream in from
+ * `updateImage` messages.
+ *
+ * Side effects:
+ *  - Removed cards drop their `cardCaptures` entry and detach from the
+ *    viewport tracker via `config.forgetViewport`.
+ *  - The `cardA11yFindings` cache is fully rebuilt from each preview's
+ *    `a11yFindings` so `updateImage`'s on-load handler can repaint
+ *    overlays consistently.
+ *  - Insert order matches the manifest; `insertBefore` keeps existing
+ *    cards in place when their position survives.
+ *  - After cards land, transient owner messages (`loading`, `fallback`)
+ *    are cleared via `config.setMessage("", owner)` — the
+ *    `extension`-owned messages (build errors, empty-state notices) are
+ *    left alone.
+ */
+export function renderPreviews(
+    previews: readonly PreviewInfo[],
+    config: RenderPreviewsConfig,
+): void {
+    if (previews.length === 0) {
+        // Defensive fallback — the extension now always sends an
+        // explicit showMessage for empty states, so this branch
+        // shouldn't normally fire. Kept so the view never ends up
+        // with an empty grid + empty message if a bug slips through.
+        config.grid.innerHTML = "";
+        config.setMessage("No @Preview functions found", "fallback");
+        return;
+    }
+    const newIds = new Set(previews.map((p) => p.id));
+    const existingCards = new Map<string, HTMLElement>();
+    config.grid
+        .querySelectorAll<HTMLElement>(".preview-card")
+        .forEach((card) => {
+            const id = card.dataset.previewId;
+            if (id) existingCards.set(id, card);
+        });
+
+    // Remove cards that no longer exist — drop their cached capture
+    // data so stale entries don't pile up if a preview is renamed.
+    for (const [id, card] of existingCards) {
+        if (!newIds.has(id)) {
+            config.cardCaptures.delete(id);
+            config.forgetViewport(id, card);
+            card.remove();
+        }
+    }
+
+    // Refresh per-preview findings cache so updateImage can attach
+    // them to each new image load. Drop stale entries (preview
+    // removed) so the map doesn't grow across sessions.
+    config.cardA11yFindings.clear();
+    for (const p of previews) {
+        if (p.a11yFindings && p.a11yFindings.length > 0) {
+            config.cardA11yFindings.set(p.id, p.a11yFindings);
+        }
+    }
+
+    // Add new cards / update existing ones, preserving order
+    let lastInsertedCard: HTMLElement | null = null;
+    for (const p of previews) {
+        const existing = existingCards.get(p.id);
+        if (existing) {
+            updateCardMetadata(existing, p, config);
+            // Ensure correct position
+            if (lastInsertedCard) {
+                if (lastInsertedCard.nextSibling !== existing) {
+                    config.grid.insertBefore(
+                        existing,
+                        lastInsertedCard.nextSibling,
+                    );
+                }
+            } else if (config.grid.firstChild !== existing) {
+                config.grid.insertBefore(existing, config.grid.firstChild);
+            }
+            lastInsertedCard = existing;
+        } else {
+            const card = buildPreviewCard(p, config);
+            if (lastInsertedCard) {
+                config.grid.insertBefore(card, lastInsertedCard.nextSibling);
+            } else {
+                config.grid.insertBefore(card, config.grid.firstChild);
+            }
+            lastInsertedCard = card;
+        }
+    }
+
+    // Clear transient owner messages now that cards are in the DOM.
+    // The 'loading' Building… banner and the 'fallback' "Preparing
+    // previews…" placeholder both get cleared here. 'extension'-owned
+    // messages (build errors, empty-state notices) are left alone —
+    // those are terminal states the extension is asserting and the
+    // caller wouldn't be sending setPreviews alongside them anyway.
+    //
+    // Must run *after* cards are inserted: setMessage('', …) calls
+    // ensureNotBlank, which would re-set "Preparing previews…" if
+    // the grid still looked empty when the message was cleared.
+    const owner = config.getMessageOwner();
+    if (owner && owner !== "extension") {
+        config.setMessage("", owner);
     }
 }


### PR DESCRIPTION
Final card-lifecycle lift. `renderPreviews` was the orchestrator over the four lifecycle functions already in `cardBuilder.ts` (`buildPreviewCard`, `updateCardMetadata`, `updateImage`, `applyA11yUpdate`) — moves it home so all card-lifecycle logic lives in one module.

## Summary

`CardBuilderConfig` grows by four fields to cover `renderPreviews`'s collaborator surface:
- `grid: PreviewGrid` — the host element to walk + `insertBefore` against.
- `forgetViewport(previewId, card): void` — paired with the existing `observeForViewport`; called when an existing preview disappears from the new manifest.
- `setMessage(text, owner): void` — the empty-state fallback path (`"No @Preview functions found"` when previews is empty) writes through this rather than reaching for the `<message-banner>` directly.
- `getMessageOwner(): MessageOwner | null` — read by the post-render cleanup that clears transient `loading` / `fallback` placeholders.

`RenderPreviewsConfig = Pick<CardBuilderConfig, ...>` is the narrow view the new export takes.

`behavior.ts` now exposes a thin one-line `renderPreviews(previews)` wrapper that calls `renderPreviewsImpl(previews, cardBuilderConfig)`. The local `createCard` shim is dropped (`renderPreviewsImpl` calls `buildPreviewCard` directly with the same config).

`behavior.ts`: 857 → 775 lines (**−82 LOC**).
`cardBuilder.ts`: 631 → 788 lines (+157 LOC for the lift + the four new config fields' jsdoc).

**`behavior.ts` is now down 76% from its 3208-line `@ts-nocheck` start.** All five card-lifecycle DOM operations PLUS their orchestrator now live in `cardBuilder.ts` ready to fold into the eventual `<preview-card>` Lit component as a single reactive `render()` driven by manifest props.

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 384/384 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke:
  - `setPreviews` for a fresh manifest: cards land in order; existing images survive; removed previews drop their `cardCaptures` entry.
  - `setPreviews` with empty `previews` array: fallback message "No @Preview functions found" appears.
  - `setPreviews` after a `loading` banner: banner clears once cards are in the DOM; an `extension`-owned banner (build error, empty-state) is left alone.
  - Card insertion order matches the manifest after a `setPreviews` that reorders existing previews.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_