### PR TITLE
feat(mcp): close the source-freshness gaps agents see as stale renders

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -435,20 +435,64 @@ class DaemonMcpServer(
     }
   }
 
+  /**
+   * Decides whether the user has edited [uri]'s source since the last time the daemon was told
+   * about it, and forwards a `fileChanged({kind: "source"})` notification when so. The daemon's
+   * [`UserClassLoaderHolder.swap`][ee.schimke.composeai.daemon.UserClassLoaderHolder.swap] only
+   * rotates the user classloader on `fileChanged`, so missing this signal is exactly what makes
+   * agents perceive "stale renders" after an edit.
+   *
+   * Two-stage detection:
+   * 1. **Fast path — mtime advanced.** Almost every editor advances the source's `lastModified` on
+   *    save, so the cheap `stat` is enough. Fire `fileChanged`, refresh the cached mtime + a fresh
+   *    content hash, return.
+   * 2. **Slow path — mtime did not advance.** Same-millisecond writes on fast SSDs / tmpfs,
+   *    mtime-preserving editors, and agent harnesses that touch files programmatically without
+   *    bumping mtime all leave the file's mtime exactly where discovery saw it. Hash the bytes and
+   *    compare against the cached hash; on mismatch, fire `fileChanged` and refresh the cache. The
+   *    hash cost (one SHA-256 over a Kotlin source — a few KB to ~tens of KB) is in the noise next
+   *    to the render itself (Robolectric: hundreds of ms).
+   *
+   * First-sighting (catalog entry has neither mtime nor hash) records both silently — the mtime is
+   * what was captured at discovery, and the hash is computed on demand. Matches the pre-fix
+   * behaviour of "first read after discovery is a no-op".
+   */
   private fun ensureSourceFreshBeforeRender(uri: PreviewUri, daemon: SupervisedDaemon) {
     val addr = DaemonAddr(uri.workspaceId, uri.modulePath)
     val entry = catalog[addr]?.get(uri.previewFqn) ?: return
     val sourceFile = resolvePreviewSourceFile(uri, entry.sourceFile) ?: return
     val currentModifiedMs = sourceFile.lastModified().takeIf { it > 0L } ?: return
-    val knownModifiedMs =
-      entry.sourceLastModifiedMs
+
+    val mtimeAdvanced =
+      entry.sourceLastModifiedMs?.let { currentModifiedMs > it }
         ?: run {
+          // First sighting via mtime — record what we know and bail without firing. The hash
+          // is filled in on the first slow-path probe so subsequent frozen-mtime edits get
+          // caught on iteration two.
           catalog[addr]?.computeIfPresent(uri.previewFqn) { _, current ->
             current.copy(sourceLastModifiedMs = currentModifiedMs)
           }
           return
         }
-    if (currentModifiedMs <= knownModifiedMs) return
+
+    val needsNotify =
+      if (mtimeAdvanced) {
+        true
+      } else {
+        // mtime didn't move — confirm with a content hash. If we have nothing to compare
+        // against (legacy entry / first probe after discovery without a hash), record the
+        // current hash so the next probe has a baseline.
+        val currentHash = runCatching { sha256Hex(sourceFile) }.getOrNull() ?: return
+        val knownHash = entry.sourceContentHash
+        if (knownHash == null) {
+          catalog[addr]?.computeIfPresent(uri.previewFqn) { _, current ->
+            current.copy(sourceContentHash = currentHash)
+          }
+          return
+        }
+        currentHash != knownHash
+      }
+    if (!needsNotify) return
 
     daemon.allClients().forEach { client ->
       runCatching {
@@ -459,8 +503,12 @@ class DaemonMcpServer(
         )
       }
     }
+    val refreshedHash = runCatching { sha256Hex(sourceFile) }.getOrNull()
     catalog[addr]?.computeIfPresent(uri.previewFqn) { _, current ->
-      current.copy(sourceLastModifiedMs = currentModifiedMs)
+      current.copy(
+        sourceLastModifiedMs = currentModifiedMs,
+        sourceContentHash = refreshedHash ?: current.sourceContentHash,
+      )
     }
   }
 
@@ -2824,18 +2872,21 @@ class DaemonMcpServer(
     for (entry in added + changed) {
       val id = entry["id"]?.jsonPrimitive?.contentOrNull ?: continue
       val sourceFile = entry["sourceFile"]?.jsonPrimitive?.contentOrNull
-      val sourceLastModifiedMs =
+      val resolved =
         resolvePreviewSourceFile(
-            PreviewUri(
-              workspaceId = daemon.workspaceId,
-              modulePath = daemon.modulePath,
-              previewFqn = id,
-              config = entry["config"]?.jsonPrimitive?.contentOrNull,
-            ),
-            sourceFile,
-          )
-          ?.lastModified()
-          ?.takeIf { it > 0L }
+          PreviewUri(
+            workspaceId = daemon.workspaceId,
+            modulePath = daemon.modulePath,
+            previewFqn = id,
+            config = entry["config"]?.jsonPrimitive?.contentOrNull,
+          ),
+          sourceFile,
+        )
+      val sourceLastModifiedMs = resolved?.lastModified()?.takeIf { it > 0L }
+      // Seed the content hash at discovery so the very first frozen-mtime edit is caught
+      // against this baseline. Failures (unreadable file, permissions) just leave the hash
+      // null — `ensureSourceFreshBeforeRender` falls back to the legacy mtime-only path.
+      val sourceContentHash = resolved?.let { runCatching { sha256Hex(it) }.getOrNull() }
       byId[id] =
         PreviewEntry(
           fqn = id,
@@ -2843,6 +2894,7 @@ class DaemonMcpServer(
           config = entry["config"]?.jsonPrimitive?.contentOrNull,
           sourceFile = sourceFile,
           sourceLastModifiedMs = sourceLastModifiedMs,
+          sourceContentHash = sourceContentHash,
         )
     }
     removed.forEach { byId.remove(it) }
@@ -3078,6 +3130,15 @@ class DaemonMcpServer(
     val config: String?,
     val sourceFile: String?,
     val sourceLastModifiedMs: Long? = null,
+    /**
+     * SHA-256 of the source file's bytes captured at discovery and refreshed on every
+     * [ensureSourceFreshBeforeRender] call that fires a `fileChanged`. Lets the freshness check
+     * detect content-only edits — same-millisecond writes on fast SSDs/tmpfs, mtime-preserving
+     * editors, agent harnesses that touch files programmatically without bumping mtime — that the
+     * mtime-only comparison misses. Null until the source is hashed for the first time (legacy
+     * entries; null sourceFile; unreadable file).
+     */
+    val sourceContentHash: String? = null,
   )
 
   /**

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -35,6 +35,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -68,12 +69,37 @@ class DaemonMcpServer(
   private val serverInfo: Implementation =
     Implementation(name = "compose-preview-mcp", version = "v0"),
   private val renderTimeoutMs: Long = 60_000,
+  /**
+   * Cadence (ms) of the background source-freshness poller. The poller walks the catalog and runs
+   * the same `ensureSourceFreshBeforeRender` probe as the on-demand path, so edits land on the
+   * daemon proactively even when no MCP `resources/read` arrives. `0` disables the poller — test
+   * fixtures use `0` to keep tests deterministic; production defaults to 30 s, slow enough to be
+   * cheap and fast enough that an interactive editor sees a refreshed render within the next
+   * `renderNow`.
+   */
+  private val sourcePollIntervalMs: Long = DEFAULT_SOURCE_POLL_INTERVAL_MS,
+  /**
+   * Cadence (ms) of the random-sampling deterministic-render probe. The sampler picks a preview at
+   * random whose render queue is empty, fires a `renderNow` past the freshness check (no
+   * `fileChanged` is sent, so the daemon's classloader stays put), and reads the resulting
+   * `renderFinished.unchanged` flag — a non-`true` reply indicates the preview's bytes drifted with
+   * no source change (clock-reading composables, daemon classloader bugs, build-output drift). `0`
+   * disables the sampler; production defaults to 10 minutes.
+   */
+  private val samplingIntervalMs: Long = DEFAULT_SAMPLING_INTERVAL_MS,
 ) {
 
   private val json = Json {
     ignoreUnknownKeys = true
     encodeDefaults = false
   }
+
+  /**
+   * Counters surfaced via the `status` MCP tool: probe outcomes, polling cycles, and random
+   * sampling determinism. Lets an operator answer "why does my agent see stale renders?" without
+   * digging through wire traces.
+   */
+  private val freshnessMetrics = FreshnessMetrics()
 
   /**
    * Per-(workspace, module) catalog: preview-id → minimal metadata. Updated from `discoveryUpdated`
@@ -167,6 +193,27 @@ class DaemonMcpServer(
     }
 
   /**
+   * Scheduled worker that owns the background source-freshness poller and the random-sampling
+   * deterministic-render probe. Pool size 2 so a slow probe can't push the next polling tick;
+   * daemon-flagged so neither delays JVM shutdown.
+   */
+  private val freshnessExecutor: java.util.concurrent.ScheduledExecutorService =
+    java.util.concurrent.Executors.newScheduledThreadPool(2) { r ->
+      Thread(r, "mcp-freshness").apply { isDaemon = true }
+    }
+
+  /**
+   * Per-(workspace, module, previewId) count of in-flight sampling probes. Bumped before the
+   * sampler issues `renderNow`; decremented (and removed when zero) by `onRenderFinished` so the
+   * matching `renderFinished` can be classified as a probe and its `unchanged` flag fed into the
+   * sampling counters. Race acceptable: a real user render arriving simultaneously with a probe may
+   * attribute the probe outcome incorrectly, but the sampler only fires when [previewQueues] is
+   * empty for the previewId, so the window is tiny.
+   */
+  private val pendingProbes =
+    ConcurrentHashMap<PreviewIdKey, java.util.concurrent.atomic.AtomicInteger>()
+
+  /**
    * Keep the MCP handshake off the full command-catalog path. Some clients enforce a tight startup
    * deadline; parsing every schema and loading extension command metadata before `initialize` risks
    * surfacing as "context deadline exceeded". Start with a compact core surface, build the full
@@ -214,6 +261,31 @@ class DaemonMcpServer(
       evictDataProductsForDaemon(daemon.workspaceId, daemon.modulePath)
       watchPropagator.forget(daemon)
     }
+    if (sourcePollIntervalMs > 0) {
+      freshnessExecutor.scheduleWithFixedDelay(
+        ::runSourceFreshnessPoll,
+        sourcePollIntervalMs,
+        sourcePollIntervalMs,
+        TimeUnit.MILLISECONDS,
+      )
+    }
+    if (samplingIntervalMs > 0) {
+      freshnessExecutor.scheduleWithFixedDelay(
+        ::runRandomSamplingProbe,
+        samplingIntervalMs,
+        samplingIntervalMs,
+        TimeUnit.MILLISECONDS,
+      )
+    }
+  }
+
+  /**
+   * Stops the freshness poller + sampler and shuts the executor down. Idempotent. Tests call this
+   * from `tearDown` so background tasks don't stretch into the next test; production never calls it
+   * because the executors are daemon-flagged and the JVM exits cleanly.
+   */
+  fun shutdown() {
+    runCatching { freshnessExecutor.shutdownNow() }
   }
 
   // -------------------------------------------------------------------------
@@ -457,11 +529,32 @@ class DaemonMcpServer(
    * what was captured at discovery, and the hash is computed on demand. Matches the pre-fix
    * behaviour of "first read after discovery is a no-op".
    */
-  private fun ensureSourceFreshBeforeRender(uri: PreviewUri, daemon: SupervisedDaemon) {
+  /**
+   * @return `true` when this probe forwarded a `fileChanged` to the daemon, `false` otherwise. The
+   *   polling path uses the return to bump `polling.changesDetected`; on-demand callers can ignore
+   *   it.
+   */
+  private fun ensureSourceFreshBeforeRender(uri: PreviewUri, daemon: SupervisedDaemon): Boolean {
+    freshnessMetrics.probesTotal.incrementAndGet()
     val addr = DaemonAddr(uri.workspaceId, uri.modulePath)
-    val entry = catalog[addr]?.get(uri.previewFqn) ?: return
-    val sourceFile = resolvePreviewSourceFile(uri, entry.sourceFile) ?: return
-    val currentModifiedMs = sourceFile.lastModified().takeIf { it > 0L } ?: return
+    val entry =
+      catalog[addr]?.get(uri.previewFqn)
+        ?: run {
+          freshnessMetrics.probesNoEntry.incrementAndGet()
+          return false
+        }
+    val sourceFile =
+      resolvePreviewSourceFile(uri, entry.sourceFile)
+        ?: run {
+          freshnessMetrics.probesNoSource.incrementAndGet()
+          return false
+        }
+    val currentModifiedMs =
+      sourceFile.lastModified().takeIf { it > 0L }
+        ?: run {
+          freshnessMetrics.probesNoSource.incrementAndGet()
+          return false
+        }
 
     val mtimeAdvanced =
       entry.sourceLastModifiedMs?.let { currentModifiedMs > it }
@@ -472,27 +565,41 @@ class DaemonMcpServer(
           catalog[addr]?.computeIfPresent(uri.previewFqn) { _, current ->
             current.copy(sourceLastModifiedMs = currentModifiedMs)
           }
-          return
+          freshnessMetrics.probesFirstSighting.incrementAndGet()
+          return false
         }
 
     val needsNotify =
       if (mtimeAdvanced) {
+        freshnessMetrics.probesChangedByMtime.incrementAndGet()
         true
       } else {
         // mtime didn't move — confirm with a content hash. If we have nothing to compare
         // against (legacy entry / first probe after discovery without a hash), record the
         // current hash so the next probe has a baseline.
-        val currentHash = runCatching { sha256Hex(sourceFile) }.getOrNull() ?: return
+        val currentHash =
+          runCatching { sha256Hex(sourceFile) }.getOrNull()
+            ?: run {
+              freshnessMetrics.probesNoSource.incrementAndGet()
+              return false
+            }
         val knownHash = entry.sourceContentHash
         if (knownHash == null) {
           catalog[addr]?.computeIfPresent(uri.previewFqn) { _, current ->
             current.copy(sourceContentHash = currentHash)
           }
-          return
+          freshnessMetrics.probesUnchangedNoBaseline.incrementAndGet()
+          return false
         }
-        currentHash != knownHash
+        if (currentHash == knownHash) {
+          freshnessMetrics.probesUnchangedByHash.incrementAndGet()
+          false
+        } else {
+          freshnessMetrics.probesChangedByHash.incrementAndGet()
+          true
+        }
       }
-    if (!needsNotify) return
+    if (!needsNotify) return false
 
     daemon.allClients().forEach { client ->
       runCatching {
@@ -510,6 +617,101 @@ class DaemonMcpServer(
         sourceContentHash = refreshedHash ?: current.sourceContentHash,
       )
     }
+    return true
+  }
+
+  /**
+   * Background poller — walks every spawned daemon's catalog and runs the same
+   * [ensureSourceFreshBeforeRender] probe as the on-demand path, so source edits land on the daemon
+   * proactively instead of waiting for the next `resources/read`. Cheap: one stat per preview on
+   * the fast path; one stat + one SHA-256 on the slow path. Wraps each per-preview probe in
+   * `runCatching` so a single broken entry doesn't cancel the whole cycle.
+   *
+   * Module-internal so tests can trigger a poll deterministically (with `sourcePollIntervalMs = 0`
+   * to disable the scheduled invocation) instead of racing the executor's cadence.
+   */
+  internal fun runSourceFreshnessPoll() {
+    runCatching {
+        freshnessMetrics.pollingCycles.incrementAndGet()
+        supervisor.listProjects().forEach { project ->
+          project.daemons.forEach { (modulePath, daemon) ->
+            val byId = catalog[DaemonAddr(project.workspaceId, modulePath)] ?: return@forEach
+            byId.values.forEach { entry ->
+              freshnessMetrics.pollingPreviewsScanned.incrementAndGet()
+              val uri =
+                PreviewUri(
+                  workspaceId = project.workspaceId,
+                  modulePath = modulePath,
+                  previewFqn = entry.fqn,
+                  config = entry.config,
+                )
+              val fired =
+                runCatching { ensureSourceFreshBeforeRender(uri, daemon) }.getOrDefault(false)
+              if (fired) freshnessMetrics.pollingChangesDetected.incrementAndGet()
+            }
+          }
+        }
+      }
+      .onFailure {
+        // Defensive — the executor swallows uncaught throws and cancels future runs; we'd lose
+        // the poller silently. Logging keeps the behaviour observable.
+        System.err.println("compose-preview-mcp: source-freshness poll failed: ${it.message}")
+      }
+  }
+
+  /**
+   * Random-sampling deterministic-render probe — picks a preview at random whose render queue is
+   * empty (so we don't compete with a real user request) and fires a `renderNow` past the freshness
+   * check. The daemon's frame-hash dedup (JsonRpcServer.kt:993) sets `unchanged: true` when the new
+   * bytes match the prior frame for this preview; a missing or `false` flag with no source change
+   * between probes means the preview drifted on its own — clock-reading composables, daemon
+   * classloader bugs, or build-output drift. Rare by design; the cadence is configurable via the
+   * constructor's `samplingIntervalMs`.
+   *
+   * Module-internal so tests can trigger a probe deterministically (with `samplingIntervalMs = 0`
+   * to disable the scheduled invocation) instead of racing the executor's cadence.
+   */
+  internal fun runRandomSamplingProbe() {
+    runCatching {
+        val candidates = mutableListOf<Triple<SupervisedDaemon, DaemonAddr, PreviewEntry>>()
+        supervisor.listProjects().forEach { project ->
+          project.daemons.forEach { (modulePath, daemon) ->
+            val addr = DaemonAddr(project.workspaceId, modulePath)
+            catalog[addr]?.values?.forEach { entry -> candidates.add(Triple(daemon, addr, entry)) }
+          }
+        }
+        if (candidates.isEmpty()) return@runCatching
+        val pick = candidates.random()
+        val (daemon, addr, entry) = pick
+        val key = PreviewIdKey(addr.workspaceId, addr.modulePath, entry.fqn)
+        if (previewQueues.containsKey(key)) {
+          freshnessMetrics.samplingSkippedBusy.incrementAndGet()
+          return@runCatching
+        }
+        pendingProbes
+          .computeIfAbsent(key) { java.util.concurrent.atomic.AtomicInteger() }
+          .incrementAndGet()
+        freshnessMetrics.samplingProbes.incrementAndGet()
+        runCatching {
+            daemon
+              .clientForRender(entry.fqn)
+              .renderNow(
+                previews = listOf(entry.fqn),
+                tier = RenderTier.FULL,
+                reason = "freshness:sampling",
+              )
+          }
+          .onFailure {
+            // Roll back the pending count on a wire failure so a future renderFinished isn't
+            // misattributed to a probe that never went out.
+            pendingProbes.computeIfPresent(key) { _, c ->
+              if (c.decrementAndGet() <= 0) null else c
+            }
+          }
+      }
+      .onFailure {
+        System.err.println("compose-preview-mcp: random-sampling probe failed: ${it.message}")
+      }
   }
 
   private fun resolvePreviewSourceFile(uri: PreviewUri, sourceFile: String?): File? {
@@ -1302,6 +1504,7 @@ class DaemonMcpServer(
           )
         }
       }
+      put("freshness", freshnessMetrics.toJson())
     }
     return textCallToolResult(payload.toString())
   }
@@ -2905,11 +3108,37 @@ class DaemonMcpServer(
   private fun onRenderFinished(daemon: SupervisedDaemon, params: JsonObject?) {
     val previewId = params?.get("id")?.jsonPrimitive?.contentOrNull ?: return
     val pngPath = params["pngPath"]?.jsonPrimitive?.contentOrNull ?: return
+    val key = PreviewIdKey(daemon.workspaceId, daemon.modulePath, previewId)
+    // 0. Sampling attribution. If a sampling probe was pending for this previewId, claim it and
+    //    classify the render's `unchanged` flag as deterministic / non-deterministic. Probes
+    //    never enqueue futures, so step 1's `popHeadAndPromoteNext` stays a no-op for them
+    //    (empty queue) and they don't disturb the user-driven serialization.
+    var probeClaimed = false
+    pendingProbes.computeIfPresent(key) { _, counter ->
+      probeClaimed = true
+      if (counter.decrementAndGet() <= 0) null else counter
+    }
+    if (probeClaimed) {
+      val unchanged = params["unchanged"]?.jsonPrimitive?.booleanOrNull == true
+      if (unchanged) {
+        freshnessMetrics.samplingDeterministic.incrementAndGet()
+      } else {
+        freshnessMetrics.samplingNondeterministic.incrementAndGet()
+        val entryForUri = catalog[DaemonAddr(daemon.workspaceId, daemon.modulePath)]?.get(previewId)
+        val probeUri =
+          PreviewUri(
+            workspaceId = daemon.workspaceId,
+            modulePath = daemon.modulePath,
+            previewFqn = previewId,
+            config = entryForUri?.config,
+          )
+        freshnessMetrics.recordNondeterministic(probeUri.toUri())
+      }
+    }
     // 1. Pop the head group of this URI's queue, wake its waiters with the rendered bytes, and
     //    promote-and-dispatch the next group's renderNow if one is queued. This is the
     //    serialization core that PR #432's by-previewId fanout (now removed) tried to paper
     //    over — see `popHeadAndPromoteNext` and `awaitNextRender`'s kdoc for the rationale.
-    val key = PreviewIdKey(daemon.workspaceId, daemon.modulePath, previewId)
     popHeadAndPromoteNext(daemon, key, RenderOutcome.Finished(pngPath))
     // 2. Refresh the data-product attachment cache for this `(uri)`. Any kind the daemon attached
     //    on this render is the new fresh payload; any kind it didn't attach is stale and gets
@@ -3283,6 +3512,22 @@ class DaemonMcpServer(
 
     /** Suggested delay before polling `watch(awaitDiscovery=false)` readiness again. */
     private const val WATCH_DISCOVERY_RETRY_AFTER_MS: Long = 500
+
+    /**
+     * Default cadence for the background source-freshness poller. 30 s is slow enough to be cheap
+     * (one stat + occasional SHA-256 per preview) and fast enough that an interactive editor sees a
+     * refreshed render within the next render request. Override per-instance via the constructor's
+     * `sourcePollIntervalMs`; pass `0` to disable.
+     */
+    const val DEFAULT_SOURCE_POLL_INTERVAL_MS: Long = 30_000
+
+    /**
+     * Default cadence for the random-sampling deterministic-render probe. 10 minutes keeps the
+     * sampler well below 1 % of total render work in a normal session while giving operators enough
+     * samples per hour to spot flaky previews. Override per-instance via the constructor's
+     * `samplingIntervalMs`; pass `0` to disable.
+     */
+    const val DEFAULT_SAMPLING_INTERVAL_MS: Long = 10 * 60_000
 
     /**
      * D2.1 — default `kind` for `render_preview_overlay` when the caller doesn't specify one.

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/FreshnessMetrics.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/FreshnessMetrics.kt
@@ -1,0 +1,109 @@
+package ee.schimke.composeai.mcp
+
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * Counters surfaced via the `status` MCP tool. Three buckets:
+ *
+ * 1. **Probe outcomes** — every call to `ensureSourceFreshBeforeRender` lands in exactly one of
+ *    these buckets, so an operator can see the rate of "actually changed" vs "unchanged" vs
+ *    "couldn't tell" decisions and compare against the rate of agent-perceived stale renders.
+ * 2. **Polling cycles** — the background source-freshness poller's run count + scan/fire totals. A
+ *    poller that scans many previews but never fires means agents are calling `resources/read` fast
+ *    enough to catch every edit; a poller that fires often means real edits are slipping through
+ *    the on-demand probe.
+ * 3. **Random sampling** — the deterministic-render probe's totals: how many probes ran, how many
+ *    came back with `unchanged: true` (deterministic), and how many came back with mismatched bytes
+ *    despite no source change (non-deterministic — points at clock-reading composables, daemon
+ *    classloader bugs, or build-output drift). Recent non-deterministic URIs are kept in a small
+ *    ring buffer so the operator can spot offending previews.
+ */
+class FreshnessMetrics {
+
+  // Probe outcomes — bumped from inside ensureSourceFreshBeforeRender. Mutually exclusive: every
+  // call increments `probesTotal` and exactly one of the outcome counters.
+  val probesTotal = AtomicLong()
+  val probesNoEntry = AtomicLong()
+  val probesNoSource = AtomicLong()
+  val probesFirstSighting = AtomicLong()
+  val probesUnchangedByHash = AtomicLong()
+  val probesUnchangedNoBaseline = AtomicLong()
+  val probesChangedByMtime = AtomicLong()
+  val probesChangedByHash = AtomicLong()
+
+  // Polling counters — the background poller bumps these as it walks the catalog.
+  val pollingCycles = AtomicLong()
+  val pollingPreviewsScanned = AtomicLong()
+  val pollingChangesDetected = AtomicLong()
+
+  // Random-sampling counters — the deterministic-render probe bumps these.
+  val samplingProbes = AtomicLong()
+  val samplingSkippedBusy = AtomicLong()
+  val samplingDeterministic = AtomicLong()
+  val samplingNondeterministic = AtomicLong()
+
+  /**
+   * Last-seen timestamp for previews observed to render non-deterministically. Insertion-ordered;
+   * the oldest entry is evicted past [MAX_RECENT_NONDETERMINISTIC]. Synchronised because the
+   * sampling thread and the status-tool thread both touch it.
+   */
+  private val recentNondeterministic = LinkedHashMap<String, Long>()
+
+  @Synchronized
+  fun recordNondeterministic(uri: String) {
+    recentNondeterministic.remove(uri)
+    recentNondeterministic[uri] = System.currentTimeMillis()
+    while (recentNondeterministic.size > MAX_RECENT_NONDETERMINISTIC) {
+      val oldest = recentNondeterministic.keys.iterator().next()
+      recentNondeterministic.remove(oldest)
+    }
+  }
+
+  @Synchronized
+  fun snapshotNondeterministic(): Map<String, Long> = LinkedHashMap(recentNondeterministic)
+
+  fun toJson(): JsonObject = buildJsonObject {
+    putJsonObject("probes") {
+      put("total", JsonPrimitive(probesTotal.get()))
+      put("noEntry", JsonPrimitive(probesNoEntry.get()))
+      put("noSource", JsonPrimitive(probesNoSource.get()))
+      put("firstSighting", JsonPrimitive(probesFirstSighting.get()))
+      put("unchangedByHash", JsonPrimitive(probesUnchangedByHash.get()))
+      put("unchangedNoBaseline", JsonPrimitive(probesUnchangedNoBaseline.get()))
+      put("changedByMtime", JsonPrimitive(probesChangedByMtime.get()))
+      put("changedByHash", JsonPrimitive(probesChangedByHash.get()))
+    }
+    putJsonObject("polling") {
+      put("cycles", JsonPrimitive(pollingCycles.get()))
+      put("previewsScanned", JsonPrimitive(pollingPreviewsScanned.get()))
+      put("changesDetected", JsonPrimitive(pollingChangesDetected.get()))
+    }
+    putJsonObject("sampling") {
+      put("probes", JsonPrimitive(samplingProbes.get()))
+      put("skippedBusy", JsonPrimitive(samplingSkippedBusy.get()))
+      put("deterministic", JsonPrimitive(samplingDeterministic.get()))
+      put("nondeterministic", JsonPrimitive(samplingNondeterministic.get()))
+      putJsonArray("recentNondeterministicUris") {
+        snapshotNondeterministic().forEach { (uri, ts) ->
+          add(
+            buildJsonObject {
+              put("uri", uri)
+              put("lastSeenMs", JsonPrimitive(ts))
+            }
+          )
+        }
+      }
+    }
+  }
+
+  companion object {
+    private const val MAX_RECENT_NONDETERMINISTIC = 32
+  }
+}

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -1666,6 +1666,284 @@ class DaemonMcpServerTest {
   }
 
   // -------------------------------------------------------------------------
+  // Freshness metrics, polling, and random-sampling determinism probe.
+  // Background workers run on a scheduled executor in production; tests use `= 0` cadence to
+  // disable scheduling and trigger the workers directly so timing isn't load-bearing.
+  // -------------------------------------------------------------------------
+
+  @Test
+  fun `freshness metrics buckets every probe outcome and surfaces them via status`() {
+    // Build a fresh server with the schedulers disabled so only on-demand probes count.
+    val freshFactory = FakeDaemonClientFactory()
+    val freshSupervisor =
+      DaemonSupervisor(descriptorProvider = FakeDescriptorProvider(), clientFactory = freshFactory)
+    val freshServer =
+      DaemonMcpServer(
+        supervisor = freshSupervisor,
+        sourcePollIntervalMs = 0,
+        samplingIntervalMs = 0,
+      )
+    val (clientToServer, serverFromClient) = pipedPair()
+    val (serverToClient, clientFromServer) = pipedPair()
+    val freshSession = freshServer.newSession(input = serverFromClient, output = serverToClient)
+    freshSession.start()
+    val freshClient = McpTestClient(input = clientFromServer, output = clientToServer)
+    try {
+      freshClient.initialize()
+      val projectDir = tmp.newFolder("metrics-workspace")
+      val moduleDir = tmp.newFolder("metrics-workspace", "module")
+      val sourceFile = moduleDir.resolve("src/main/kotlin/com/example/Preview.kt")
+      sourceFile.parentFile.mkdirs()
+      sourceFile.writeText("@Preview fun Red() { /* v0 */ }")
+      val baseMtime = System.currentTimeMillis() - 60_000
+      assertThat(sourceFile.setLastModified(baseMtime)).isTrue()
+
+      val ws =
+        json
+          .parseToJsonElement(
+            freshClient
+              .callTool(
+                "register_project",
+                buildJsonObject {
+                  put("path", projectDir.absolutePath)
+                  put("rootProjectName", "metrics-demo")
+                },
+              )
+              .firstTextContent()
+          )
+          .jsonObject["workspaceId"]!!
+          .jsonPrimitive
+          .content
+      freshClient.expectNotification("notifications/resources/list_changed", 2_000)
+      val workspaceId = WorkspaceId(ws)
+      freshSupervisor.daemonFor(workspaceId, ":module")
+      val daemon = freshFactory.daemons.getValue(workspaceId to ":module")
+      val previewId = "com.example.Red"
+      daemon.emitDiscovery(previewId, sourceFile = "src/main/kotlin/com/example/Preview.kt")
+      freshClient.expectNotification("notifications/resources/list_changed", 2_000)
+
+      val pngFile = tmp.newFile("metrics-render.png")
+      Files.write(pngFile.toPath(), byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47))
+      daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+
+      val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+
+      // First read — discovery seeded the hash + mtime, so the probe sees no change.
+      freshClient.request("resources/read", buildJsonObject { put("uri", uri) }, timeoutMs = 10_000)
+
+      // Mtime-advancing edit.
+      sourceFile.writeText("@Preview fun Red() { /* v1 */ }")
+      assertThat(sourceFile.setLastModified(baseMtime + 5_000)).isTrue()
+      freshClient.request("resources/read", buildJsonObject { put("uri", uri) }, timeoutMs = 10_000)
+
+      // Frozen-mtime edit (slow path).
+      sourceFile.writeText("@Preview fun Red() { /* v2 */ }")
+      assertThat(sourceFile.setLastModified(baseMtime + 5_000)).isTrue()
+      freshClient.request("resources/read", buildJsonObject { put("uri", uri) }, timeoutMs = 10_000)
+
+      // No-op read — mtime same, content same.
+      freshClient.request("resources/read", buildJsonObject { put("uri", uri) }, timeoutMs = 10_000)
+
+      val status =
+        json
+          .parseToJsonElement(freshClient.callTool("status").firstTextContent())
+          .jsonObject["freshness"]!!
+          .jsonObject
+      val probes = status["probes"]!!.jsonObject
+      assertThat(probes["total"]?.jsonPrimitive?.content?.toLong()).isEqualTo(4L)
+      assertThat(probes["changedByMtime"]?.jsonPrimitive?.content?.toLong()).isEqualTo(1L)
+      assertThat(probes["changedByHash"]?.jsonPrimitive?.content?.toLong()).isEqualTo(1L)
+      assertThat(probes["unchangedByHash"]?.jsonPrimitive?.content?.toLong()).isEqualTo(2L)
+      assertThat(probes["firstSighting"]?.jsonPrimitive?.content?.toLong()).isEqualTo(0L)
+    } finally {
+      runCatching { freshClient.close() }
+      runCatching { freshSession.close() }
+      runCatching { freshServer.shutdown() }
+      runCatching { freshSupervisor.shutdown() }
+    }
+  }
+
+  @Test
+  fun `background poller forwards fileChanged when a frozen-mtime edit lands between renders`() {
+    val freshFactory = FakeDaemonClientFactory()
+    val freshSupervisor =
+      DaemonSupervisor(descriptorProvider = FakeDescriptorProvider(), clientFactory = freshFactory)
+    val freshServer =
+      DaemonMcpServer(
+        supervisor = freshSupervisor,
+        sourcePollIntervalMs = 0,
+        samplingIntervalMs = 0,
+      )
+    val (clientToServer, serverFromClient) = pipedPair()
+    val (serverToClient, clientFromServer) = pipedPair()
+    val freshSession = freshServer.newSession(input = serverFromClient, output = serverToClient)
+    freshSession.start()
+    val freshClient = McpTestClient(input = clientFromServer, output = clientToServer)
+    try {
+      freshClient.initialize()
+      val projectDir = tmp.newFolder("poll-workspace")
+      val moduleDir = tmp.newFolder("poll-workspace", "module")
+      val sourceFile = moduleDir.resolve("src/main/kotlin/com/example/Preview.kt")
+      sourceFile.parentFile.mkdirs()
+      sourceFile.writeText("@Preview fun Red() { /* v0 */ }")
+      val baseMtime = System.currentTimeMillis() - 60_000
+      assertThat(sourceFile.setLastModified(baseMtime)).isTrue()
+
+      val ws =
+        json
+          .parseToJsonElement(
+            freshClient
+              .callTool(
+                "register_project",
+                buildJsonObject {
+                  put("path", projectDir.absolutePath)
+                  put("rootProjectName", "poll-demo")
+                },
+              )
+              .firstTextContent()
+          )
+          .jsonObject["workspaceId"]!!
+          .jsonPrimitive
+          .content
+      freshClient.expectNotification("notifications/resources/list_changed", 2_000)
+      val workspaceId = WorkspaceId(ws)
+      freshSupervisor.daemonFor(workspaceId, ":module")
+      val daemon = freshFactory.daemons.getValue(workspaceId to ":module")
+      val previewId = "com.example.Red"
+      daemon.emitDiscovery(previewId, sourceFile = "src/main/kotlin/com/example/Preview.kt")
+      freshClient.expectNotification("notifications/resources/list_changed", 2_000)
+
+      // Edit content but freeze mtime — exactly the case the on-demand path would miss without
+      // the hash fallback. The poller should nevertheless observe it.
+      sourceFile.writeText("@Preview fun Red() { /* v1 */ }")
+      assertThat(sourceFile.setLastModified(baseMtime)).isTrue()
+
+      // Drain anything left over from setup.
+      while (daemon.fileChanges.poll(0, TimeUnit.MILLISECONDS) != null) {}
+
+      freshServer.runSourceFreshnessPoll()
+
+      val fileChanged = daemon.fileChanges.poll(2_000, TimeUnit.MILLISECONDS)
+      assertWithMessage("polling cycle should detect the frozen-mtime content edit")
+        .that(fileChanged)
+        .isNotNull()
+      assertThat(fileChanged!!["kind"]?.jsonPrimitive?.contentOrNull).isEqualTo("source")
+
+      val status =
+        json
+          .parseToJsonElement(freshClient.callTool("status").firstTextContent())
+          .jsonObject["freshness"]!!
+          .jsonObject
+      val polling = status["polling"]!!.jsonObject
+      assertThat(polling["cycles"]?.jsonPrimitive?.content?.toLong()).isAtLeast(1L)
+      assertThat(polling["previewsScanned"]?.jsonPrimitive?.content?.toLong()).isAtLeast(1L)
+      assertThat(polling["changesDetected"]?.jsonPrimitive?.content?.toLong()).isEqualTo(1L)
+    } finally {
+      runCatching { freshClient.close() }
+      runCatching { freshSession.close() }
+      runCatching { freshServer.shutdown() }
+      runCatching { freshSupervisor.shutdown() }
+    }
+  }
+
+  @Test
+  fun `random-sampling probe classifies unchanged vs changed renders`() {
+    val freshFactory = FakeDaemonClientFactory()
+    val freshSupervisor =
+      DaemonSupervisor(descriptorProvider = FakeDescriptorProvider(), clientFactory = freshFactory)
+    val freshServer =
+      DaemonMcpServer(
+        supervisor = freshSupervisor,
+        sourcePollIntervalMs = 0,
+        samplingIntervalMs = 0,
+      )
+    val (clientToServer, serverFromClient) = pipedPair()
+    val (serverToClient, clientFromServer) = pipedPair()
+    val freshSession = freshServer.newSession(input = serverFromClient, output = serverToClient)
+    freshSession.start()
+    val freshClient = McpTestClient(input = clientFromServer, output = clientToServer)
+    try {
+      freshClient.initialize()
+      val projectDir = tmp.newFolder("sampling-workspace")
+      tmp.newFolder("sampling-workspace", "module")
+      val ws =
+        json
+          .parseToJsonElement(
+            freshClient
+              .callTool(
+                "register_project",
+                buildJsonObject {
+                  put("path", projectDir.absolutePath)
+                  put("rootProjectName", "sampling-demo")
+                },
+              )
+              .firstTextContent()
+          )
+          .jsonObject["workspaceId"]!!
+          .jsonPrimitive
+          .content
+      freshClient.expectNotification("notifications/resources/list_changed", 2_000)
+      val workspaceId = WorkspaceId(ws)
+      freshSupervisor.daemonFor(workspaceId, ":module")
+      val daemon = freshFactory.daemons.getValue(workspaceId to ":module")
+      val previewId = "com.example.Red"
+      daemon.emitDiscovery(previewId)
+      freshClient.expectNotification("notifications/resources/list_changed", 2_000)
+
+      val pngFile = tmp.newFile("sampling-render.png")
+      Files.write(pngFile.toPath(), byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47))
+      daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+
+      // Probe 1 — daemon reports `unchanged: true` (deterministic preview).
+      daemon.autoRenderUnchanged = { _ -> true }
+      freshServer.runRandomSamplingProbe()
+      assertThat(daemon.renderRequests.poll(2_000, TimeUnit.MILLISECONDS))
+        .isEqualTo(listOf(previewId))
+
+      // Probe 2 — daemon reports `unchanged: false` (preview drifted with no source change).
+      daemon.autoRenderUnchanged = { _ -> false }
+      freshServer.runRandomSamplingProbe()
+      assertThat(daemon.renderRequests.poll(2_000, TimeUnit.MILLISECONDS))
+        .isEqualTo(listOf(previewId))
+
+      // Give the renderFinished notifications time to round-trip on the daemon's reader thread.
+      val deadline = System.currentTimeMillis() + 2_000
+      while (System.currentTimeMillis() < deadline) {
+        val statusPayload =
+          json
+            .parseToJsonElement(freshClient.callTool("status").firstTextContent())
+            .jsonObject["freshness"]!!
+            .jsonObject["sampling"]!!
+            .jsonObject
+        val det = statusPayload["deterministic"]?.jsonPrimitive?.content?.toLong() ?: 0L
+        val nondet = statusPayload["nondeterministic"]?.jsonPrimitive?.content?.toLong() ?: 0L
+        if (det >= 1L && nondet >= 1L) break
+        Thread.sleep(50)
+      }
+
+      val sampling =
+        json
+          .parseToJsonElement(freshClient.callTool("status").firstTextContent())
+          .jsonObject["freshness"]!!
+          .jsonObject["sampling"]!!
+          .jsonObject
+      assertThat(sampling["probes"]?.jsonPrimitive?.content?.toLong()).isEqualTo(2L)
+      assertThat(sampling["deterministic"]?.jsonPrimitive?.content?.toLong()).isEqualTo(1L)
+      assertThat(sampling["nondeterministic"]?.jsonPrimitive?.content?.toLong()).isEqualTo(1L)
+      val recent =
+        sampling["recentNondeterministicUris"]!!.jsonArray.mapNotNull {
+          it.jsonObject["uri"]?.jsonPrimitive?.contentOrNull
+        }
+      assertThat(recent).contains(PreviewUri(workspaceId, ":module", previewId).toUri())
+    } finally {
+      runCatching { freshClient.close() }
+      runCatching { freshSession.close() }
+      runCatching { freshServer.shutdown() }
+      runCatching { freshSupervisor.shutdown() }
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // D1 — data product tools
   // -------------------------------------------------------------------------
 

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -31,7 +31,6 @@ import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -1568,23 +1567,12 @@ class DaemonMcpServerTest {
   }
 
   @Test
-  @Ignore(
-    "Documents the staleness mechanism agents observe: ensureSourceFreshBeforeRender " +
-      "(DaemonMcpServer.kt:451) returns early on `currentModifiedMs <= knownModifiedMs`, so " +
-      "edits that don't advance the source's mtime (same-millisecond writes, mtime-preserving " +
-      "editors, agent harnesses that touch files without bumping mtime) leak through stale. " +
-      "Test currently fails 0/5 fileChanged forwards. Remove @Ignore once the check augments " +
-      "mtime with a content-hash signal so content-only edits also fire fileChanged. " +
-      "Workaround for agents today: call notify_file_changed explicitly after each edit " +
-      "(covered by the next test)."
-  )
   fun `resources read forwards fileChanged when content changes but mtime is preserved`() {
-    // Reproduces the staleness agents observe: a tight edit loop where the source's
-    // mtime stays pinned (same-millisecond writes on fast SSDs / tmpfs, mtime-preserving
-    // editors, agent harnesses that touch files programmatically without bumping mtime).
-    // Today's ensureSourceFreshBeforeRender returns early on
-    // `currentModifiedMs <= knownModifiedMs` (DaemonMcpServer.kt:451) so the daemon
-    // never sees a fileChanged and the next render binds against stale bytecode.
+    // Tight edit loop where the source's mtime stays pinned across every iteration —
+    // simulates same-millisecond writes on fast SSDs / tmpfs, mtime-preserving editors, and
+    // agent harnesses that touch files programmatically without bumping mtime.
+    // ensureSourceFreshBeforeRender's slow path hashes the file when mtime didn't move, so
+    // content-only edits still fire `fileChanged` and the daemon's classloader rotates.
     client.initialize()
     val projectDir = tmp.newFolder("workspace")
     val moduleDir = tmp.newFolder("workspace", "module")

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.mcp
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import ee.schimke.composeai.mcp.protocol.ListToolsResult
 import ee.schimke.composeai.mcp.protocol.ReadResourceResult
 import ee.schimke.composeai.mcp.protocol.ResourceContents
@@ -30,6 +31,7 @@ import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -1507,6 +1509,172 @@ class DaemonMcpServerTest {
     assertThat(fileChanged["kind"]?.jsonPrimitive?.contentOrNull).isEqualTo("source")
     assertThat(daemon.renderRequests.poll(2_000, TimeUnit.MILLISECONDS))
       .isEqualTo(listOf(previewId))
+  }
+
+  // -------------------------------------------------------------------------
+  // Edit-loop staleness regression — agents that edit a preview source repeatedly
+  // and request a render after each edit observe stale renders when
+  // ensureSourceFreshBeforeRender (DaemonMcpServer.kt:438) doesn't forward a
+  // fileChanged. The daemon's UserClassLoaderHolder.swap fires only on
+  // fileChanged({kind: "source"}), so without it the next render binds against
+  // the previous bytecode.
+  // -------------------------------------------------------------------------
+
+  @Test
+  fun `resources read forwards fileChanged on every iteration of an edit render loop`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    val moduleDir = tmp.newFolder("workspace", "module")
+    val sourceFile = moduleDir.resolve("src/main/kotlin/com/example/Preview.kt")
+    sourceFile.parentFile.mkdirs()
+    sourceFile.writeText("@Preview fun Red() { /* v0 */ }")
+    val baseMtime = System.currentTimeMillis() - 60_000
+    assertThat(sourceFile.setLastModified(baseMtime)).isTrue()
+
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId, sourceFile = "src/main/kotlin/com/example/Preview.kt")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47)
+    val pngFile = tmp.newFile("loop-render.png")
+    Files.write(pngFile.toPath(), pngBytes)
+    daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+
+    val iterations = 5
+    repeat(iterations) { i ->
+      sourceFile.writeText("@Preview fun Red() { /* v${i + 1} */ }")
+      // Bump mtime forward each iteration. This is the happy path — File.lastModified()
+      // is monotonic so the daemon-side classloader swap fires.
+      assertThat(sourceFile.setLastModified(baseMtime + 1_000L * (i + 1))).isTrue()
+
+      client.request("resources/read", buildJsonObject { put("uri", uri) }, timeoutMs = 10_000)
+
+      val fileChanged = daemon.fileChanges.poll(2_000, TimeUnit.MILLISECONDS)
+      assertWithMessage(
+          "iteration #${i + 1}: expected fileChanged forwarded for advancing-mtime edit"
+        )
+        .that(fileChanged)
+        .isNotNull()
+      assertThat(fileChanged!!["path"]?.jsonPrimitive?.contentOrNull)
+        .isEqualTo(sourceFile.canonicalPath)
+      assertThat(fileChanged["kind"]?.jsonPrimitive?.contentOrNull).isEqualTo("source")
+      assertThat(daemon.renderRequests.poll(2_000, TimeUnit.MILLISECONDS))
+        .isEqualTo(listOf(previewId))
+    }
+  }
+
+  @Test
+  @Ignore(
+    "Documents the staleness mechanism agents observe: ensureSourceFreshBeforeRender " +
+      "(DaemonMcpServer.kt:451) returns early on `currentModifiedMs <= knownModifiedMs`, so " +
+      "edits that don't advance the source's mtime (same-millisecond writes, mtime-preserving " +
+      "editors, agent harnesses that touch files without bumping mtime) leak through stale. " +
+      "Test currently fails 0/5 fileChanged forwards. Remove @Ignore once the check augments " +
+      "mtime with a content-hash signal so content-only edits also fire fileChanged. " +
+      "Workaround for agents today: call notify_file_changed explicitly after each edit " +
+      "(covered by the next test)."
+  )
+  fun `resources read forwards fileChanged when content changes but mtime is preserved`() {
+    // Reproduces the staleness agents observe: a tight edit loop where the source's
+    // mtime stays pinned (same-millisecond writes on fast SSDs / tmpfs, mtime-preserving
+    // editors, agent harnesses that touch files programmatically without bumping mtime).
+    // Today's ensureSourceFreshBeforeRender returns early on
+    // `currentModifiedMs <= knownModifiedMs` (DaemonMcpServer.kt:451) so the daemon
+    // never sees a fileChanged and the next render binds against stale bytecode.
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    val moduleDir = tmp.newFolder("workspace", "module")
+    val sourceFile = moduleDir.resolve("src/main/kotlin/com/example/Preview.kt")
+    sourceFile.parentFile.mkdirs()
+    sourceFile.writeText("@Preview fun Red() { /* v0 */ }")
+    val frozenMtime = System.currentTimeMillis() - 60_000
+    assertThat(sourceFile.setLastModified(frozenMtime)).isTrue()
+
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId, sourceFile = "src/main/kotlin/com/example/Preview.kt")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47)
+    val pngFile = tmp.newFile("frozen-mtime-render.png")
+    Files.write(pngFile.toPath(), pngBytes)
+    daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+
+    val iterations = 5
+    val notifiedIterations = mutableListOf<Int>()
+    repeat(iterations) { i ->
+      sourceFile.writeText("@Preview fun Red() { /* v${i + 1} */ }")
+      // Pin mtime to the original value AFTER the write. Simulates a mtime-preserving
+      // editor or two writes within the same millisecond.
+      assertThat(sourceFile.setLastModified(frozenMtime)).isTrue()
+
+      client.request("resources/read", buildJsonObject { put("uri", uri) }, timeoutMs = 10_000)
+      // Drain the renderNow so the next iteration's poll doesn't see a stale entry.
+      daemon.renderRequests.poll(2_000, TimeUnit.MILLISECONDS)
+
+      val fileChanged = daemon.fileChanges.poll(500, TimeUnit.MILLISECONDS)
+      if (fileChanged != null) notifiedIterations.add(i + 1)
+    }
+
+    assertWithMessage(
+        "expected fileChanged to be forwarded for every edit (got ${notifiedIterations.size}/$iterations); " +
+          "ensureSourceFreshBeforeRender currently relies on mtime advancing, so content-only edits leak through stale"
+      )
+      .that(notifiedIterations)
+      .hasSize(iterations)
+  }
+
+  @Test
+  fun `notify_file_changed forwards fileChanged regardless of mtime so agents can bypass staleness`() {
+    // The documented workaround for the mtime-based staleness gap above: agents call
+    // the explicit `notify_file_changed` MCP tool after every edit. This test pins the
+    // workaround so a regression in the tool's forwarding path (DaemonMcpServer.kt:2766)
+    // is caught early.
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    val moduleDir = tmp.newFolder("workspace", "module")
+    val sourceFile = moduleDir.resolve("src/main/kotlin/com/example/Preview.kt")
+    sourceFile.parentFile.mkdirs()
+    sourceFile.writeText("@Preview fun Red() { /* v0 */ }")
+    val frozenMtime = System.currentTimeMillis() - 60_000
+    assertThat(sourceFile.setLastModified(frozenMtime)).isTrue()
+
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId, sourceFile = "src/main/kotlin/com/example/Preview.kt")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val iterations = 5
+    repeat(iterations) { i ->
+      sourceFile.writeText("@Preview fun Red() { /* v${i + 1} */ }")
+      assertThat(sourceFile.setLastModified(frozenMtime)).isTrue()
+
+      client.callTool(
+        "notify_file_changed",
+        buildJsonObject {
+          put("workspaceId", workspaceId.value)
+          put("path", sourceFile.absolutePath)
+          put("kind", "source")
+          put("changeType", "modified")
+        },
+      )
+
+      val fileChanged = daemon.fileChanges.poll(2_000, TimeUnit.MILLISECONDS)
+      assertWithMessage("iteration #${i + 1}: notify_file_changed must always forward")
+        .that(fileChanged)
+        .isNotNull()
+      assertThat(fileChanged!!["path"]?.jsonPrimitive?.contentOrNull)
+        .isEqualTo(sourceFile.absolutePath)
+      assertThat(fileChanged["kind"]?.jsonPrimitive?.contentOrNull).isEqualTo("source")
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -226,6 +226,14 @@ class FakeDaemon : DaemonSpawn {
    */
   @Volatile var autoRenderPngPath: ((previewId: String) -> String?)? = null
 
+  /**
+   * Optional companion to [autoRenderPngPath] — when set, the auto-emitted `renderFinished` carries
+   * an `unchanged: true|false` flag derived from this lambda. Returning `null` means "omit the
+   * field" (the wire's default), matching the daemon's "not deduplicated" path. Used by the
+   * freshness-sampling tests to drive deterministic vs non-deterministic outcomes.
+   */
+  @Volatile var autoRenderUnchanged: ((previewId: String) -> Boolean?)? = null
+
   private lateinit var _client: DaemonClient
 
   override val client: DaemonClient
@@ -297,11 +305,12 @@ class FakeDaemon : DaemonSpawn {
   }
 
   /** Pushes a `renderFinished` notification. Returns the synthetic pngPath emitted. */
-  fun emitRenderFinished(previewId: String, pngPath: String): String {
+  fun emitRenderFinished(previewId: String, pngPath: String, unchanged: Boolean? = null): String {
     val params = buildJsonObject {
       put("id", previewId)
       put("pngPath", pngPath)
       put("tookMs", 50L)
+      if (unchanged != null) put("unchanged", unchanged)
     }
     sendNotification("renderFinished", params)
     return pngPath
@@ -406,7 +415,7 @@ class FakeDaemon : DaemonSpawn {
         autoRenderPngPath?.let { provider ->
           previews.forEach { pid ->
             val path = provider(pid)
-            if (path != null) emitRenderFinished(pid, path)
+            if (path != null) emitRenderFinished(pid, path, autoRenderUnchanged?.invoke(pid))
           }
         }
       }


### PR DESCRIPTION
## Summary

Agents repeatedly perceive the MCP server as serving stale preview content after editing source files. This PR closes the gaps and adds the observability needed to keep them closed.

### 1. Fix: hash sources when mtime is unchanged

`ensureSourceFreshBeforeRender` decided whether to forward `fileChanged` to the daemon based on `File.lastModified()` alone. Any edit that did not advance mtime — same-millisecond writes on fast SSDs / tmpfs, mtime-preserving editors, agent harnesses that touch files programmatically without bumping mtime — was invisible. Without `fileChanged({kind:source})` the daemon's `UserClassLoaderHolder.swap` never fired and the next render bound against the previously loaded bytecode.

Now two-stage: if mtime advanced, fire and refresh the cache (no hash, same cost as before). If mtime did not advance, SHA-256 the file and compare against the cached hash. On mismatch, fire and refresh both fields. The hash cost on a Kotlin source is dwarfed by the render itself. Discovery seeds the content hash so the very first frozen-mtime edit is caught against the discovery snapshot.

### 2. Metrics on every probe outcome

A new `FreshnessMetrics` surfaced via the existing `status` MCP tool buckets every `ensureSourceFreshBeforeRender` call into one of: `noEntry`, `noSource`, `firstSighting`, `unchangedByHash`, `unchangedNoBaseline`, `changedByMtime`, `changedByHash`. Plus polling cycle counters and sampling determinism counters. Lets an operator see why agents are seeing stale renders without digging through wire traces.

### 3. Background source-freshness poller

Walks every spawned daemon's catalog at a configurable cadence (default 30 s) and runs the same probe as the on-demand path. Catches edits proactively before the next render request arrives. Cheap: one stat per preview on the fast path, one stat + one SHA-256 on the slow path. `sourcePollIntervalMs = 0` disables it.

### 4. Random-sampling deterministic-render probe

At a configurable cadence (default 10 min) picks a preview with an empty render queue, fires a `renderNow` past the freshness check (no `fileChanged` is sent, so the daemon's classloader stays put), and reads the resulting `renderFinished.unchanged` flag. A non-`true` reply with no source change between probes indicates the preview drifted on its own — clock-reading composables, daemon classloader bugs, or build-output drift. Recent non-deterministic preview URIs are kept in a small ring buffer surfaced via `status`. `samplingIntervalMs = 0` disables it.

## Test plan

Six new tests in `DaemonMcpServerTest`:

- [x] `resources read forwards fileChanged on every iteration of an edit render loop` — 5-iter advancing-mtime loop. Passes.
- [x] `resources read forwards fileChanged when content changes but mtime is preserved` — 5-iter frozen-mtime loop. Was 0/5 before the fix, now 5/5.
- [x] `notify_file_changed forwards fileChanged regardless of mtime so agents can bypass staleness` — pins the documented agent workaround. Passes.
- [x] `freshness metrics buckets every probe outcome and surfaces them via status` — drives 4 reads through 4 distinct outcome paths and asserts the counters via the `status` tool.
- [x] `background poller forwards fileChanged when a frozen-mtime edit lands between renders` — frozen-mtime content edit, manual poll trigger, asserts the daemon receives `fileChanged` and the polling counters bumped.
- [x] `random-sampling probe classifies unchanged vs changed renders` — drives the `unchanged: true` + `unchanged: false` paths via `FakeDaemon.autoRenderUnchanged` and asserts the deterministic / non-deterministic counters and the recent-URIs list.
- [x] Existing `resources read forwards fileChanged when preview source mtime moved since discovery` still passes.
- [x] Full `:mcp:test` suite green except for one pre-existing failure on `origin/main` (`record_preview rejects extension events advertised but not yet implemented`) that is unrelated to source freshness.

```
./gradlew :mcp:test --tests "ee.schimke.composeai.mcp.DaemonMcpServerTest.resources read forwards fileChanged*" \
                     --tests "ee.schimke.composeai.mcp.DaemonMcpServerTest.notify_file_changed*" \
                     --tests "ee.schimke.composeai.mcp.DaemonMcpServerTest.freshness*" \
                     --tests "ee.schimke.composeai.mcp.DaemonMcpServerTest.background poller*" \
                     --tests "ee.schimke.composeai.mcp.DaemonMcpServerTest.random-sampling*"
```
