### PR TITLE
feat(mcp): mcp doctor verdicts + skill guidance to stop spurious reinstalls

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -355,24 +356,14 @@ internal class McpCommand(args: List<String>) {
 
       val states = modules.map { module ->
         val descriptor = File(module.projectDir, "build/compose-previews/daemon-launch.json")
-        if (!descriptor.isFile) {
-          DoctorState(module.gradlePath, descriptor, status = "missing", enabled = false)
-        } else {
-          val obj = parseDescriptor(descriptor)
-          val enabled = obj?.get("enabled")?.jsonPrimitive?.boolean == true
-          DoctorState(
-            module.gradlePath,
-            descriptor,
-            status = if (enabled) "ok" else "disabled",
-            enabled = enabled,
-          )
-        }
+        inspectDescriptor(module.gradlePath, descriptor)
       }
 
       if (emitJson) {
         val payload = buildJsonObject {
           put("schema", JsonPrimitive("compose-preview-mcp-doctor/v1"))
           put("projectRoot", JsonPrimitive(projectDir.absolutePath))
+          put("verdict", JsonPrimitive(aggregateVerdict(states)))
           put(
             "modules",
             kotlinx.serialization.json.JsonArray(
@@ -382,6 +373,19 @@ internal class McpCommand(args: List<String>) {
                   put("descriptor", JsonPrimitive(it.descriptor.absolutePath))
                   put("status", JsonPrimitive(it.status))
                   put("enabled", JsonPrimitive(it.enabled))
+                  put("verdict", JsonPrimitive(it.verdict))
+                  put(
+                    "findings",
+                    kotlinx.serialization.json.JsonArray(
+                      it.findings.map { f ->
+                        buildJsonObject {
+                          put("id", JsonPrimitive(f.id))
+                          put("level", JsonPrimitive(f.level))
+                          put("message", JsonPrimitive(f.message))
+                        }
+                      }
+                    ),
+                  )
                 }
               }
             ),
@@ -390,21 +394,34 @@ internal class McpCommand(args: List<String>) {
         println(JSON.encodeToString(JsonObject.serializer(), payload))
       } else {
         states.forEach { s ->
-          val marker =
-            when (s.status) {
-              "ok" -> "ok"
-              "disabled" -> "disabled (run `compose-preview mcp install` to flip enabled=true)"
-              "missing" -> "missing (run `compose-preview mcp install`)"
-              else -> s.status
-            }
-          println(":${s.gradlePath}  $marker  (${s.descriptor})")
+          val tail = verdictHint(s.verdict)
+          println(":${s.gradlePath}  ${s.status}${if (tail.isNotEmpty()) " — $tail" else ""}")
+          s.findings
+            .filter { it.level != "ok" }
+            .forEach { println("    [${it.level}] ${it.id}: ${it.message}") }
+          println("    descriptor: ${s.descriptor}")
+        }
+        val verdict = aggregateVerdict(states)
+        if (verdict == "ok") {
+          println()
+          println(
+            "All checks passed. The supervisor handles classpath drift automatically " +
+              "(`classpathDirty` respawn) — do not re-run `mcp install` or kill daemons."
+          )
         }
       }
 
-      val anyMissing = states.any { it.status != "ok" }
-      if (anyMissing) exitProcess(1)
+      val anyProblem = states.any { it.verdict != "ok" }
+      if (anyProblem) exitProcess(1)
     }
   }
+
+  private fun verdictHint(verdict: String): String =
+    when (verdict) {
+      "ok" -> ""
+      "run-mcp-install" -> "run `compose-preview mcp install`"
+      else -> verdict
+    }
 
   // -- helpers -----------------------------------------------------------------------------------
 
@@ -527,13 +544,6 @@ internal class McpCommand(args: List<String>) {
     val enabled: Boolean,
   )
 
-  private data class DoctorState(
-    val gradlePath: String,
-    val descriptor: File,
-    val status: String,
-    val enabled: Boolean,
-  )
-
   private companion object {
     val JSON: Json = Json { prettyPrint = true }
 
@@ -565,3 +575,120 @@ internal class McpCommand(args: List<String>) {
     }
   }
 }
+
+// Pinned to DAEMON_DESCRIPTOR_SCHEMA_VERSION in
+// gradle-plugin/.../daemon/DaemonClasspathDescriptor.kt. Keep in sync — bump together.
+internal const val EXPECTED_DESCRIPTOR_SCHEMA_VERSION: Int = 1
+
+internal data class DoctorState(
+  val gradlePath: String,
+  val descriptor: File,
+  val status: String,
+  val enabled: Boolean,
+  val verdict: String = "ok",
+  val findings: List<DoctorFinding> = emptyList(),
+)
+
+internal data class DoctorFinding(val id: String, val level: String, val message: String)
+
+/**
+ * Validate the on-disk daemon descriptor and return findings + a verdict telling the agent what (if
+ * anything) to do. Lifted out of [McpCommand] so it's unit-testable without spinning up Gradle.
+ */
+internal fun inspectDescriptor(gradlePath: String, descriptor: File): DoctorState {
+  val findings = mutableListOf<DoctorFinding>()
+
+  if (!descriptor.isFile) {
+    findings += DoctorFinding("descriptor.present", "error", "descriptor file is missing")
+    return DoctorState(
+      gradlePath,
+      descriptor,
+      status = "missing",
+      enabled = false,
+      verdict = "run-mcp-install",
+      findings = findings,
+    )
+  }
+
+  val obj =
+    try {
+      Json.parseToJsonElement(descriptor.readText()).jsonObject
+    } catch (_: Exception) {
+      null
+    }
+  if (obj == null) {
+    findings += DoctorFinding("descriptor.parse", "error", "descriptor is not valid JSON")
+    return DoctorState(
+      gradlePath,
+      descriptor,
+      status = "corrupt",
+      enabled = false,
+      verdict = "run-mcp-install",
+      findings = findings,
+    )
+  }
+
+  val enabled = obj["enabled"]?.jsonPrimitive?.boolean == true
+  if (!enabled) {
+    findings +=
+      DoctorFinding("descriptor.enabled", "error", "enabled=false; install would flip to true")
+  }
+
+  val schemaVersion = obj["schemaVersion"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()
+  if (schemaVersion != null && schemaVersion != EXPECTED_DESCRIPTOR_SCHEMA_VERSION) {
+    findings +=
+      DoctorFinding(
+        "descriptor.schema",
+        "error",
+        "schemaVersion=$schemaVersion, expected $EXPECTED_DESCRIPTOR_SCHEMA_VERSION " +
+          "(plugin upgraded — re-run `mcp install`)",
+      )
+  }
+
+  val launcherPath = obj["javaLauncher"]?.jsonPrimitive?.contentOrNull
+  if (!launcherPath.isNullOrBlank()) {
+    val launcher = File(launcherPath)
+    if (!launcher.isFile || !launcher.canExecute()) {
+      findings +=
+        DoctorFinding(
+          "descriptor.launcher",
+          "error",
+          "javaLauncher missing or not executable: $launcherPath",
+        )
+    }
+  }
+
+  val manifestPath = obj["manifestPath"]?.jsonPrimitive?.contentOrNull
+  if (!manifestPath.isNullOrBlank() && !File(manifestPath).isFile) {
+    findings +=
+      DoctorFinding(
+        "descriptor.manifest",
+        "warning",
+        "previews.json missing at $manifestPath; will be regenerated on next render",
+      )
+  }
+
+  val errorCount = findings.count { it.level == "error" }
+  val verdict = if (errorCount > 0) "run-mcp-install" else "ok"
+  val status =
+    when {
+      !enabled -> "disabled"
+      errorCount > 0 -> "stale"
+      else -> "ok"
+    }
+  return DoctorState(
+    gradlePath,
+    descriptor,
+    status = status,
+    enabled = enabled,
+    verdict = verdict,
+    findings = findings,
+  )
+}
+
+internal fun aggregateVerdict(states: List<DoctorState>): String =
+  when {
+    states.all { it.verdict == "ok" } -> "ok"
+    states.any { it.verdict == "run-mcp-install" } -> "run-mcp-install"
+    else -> "warning"
+  }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/McpDoctorTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/McpDoctorTest.kt
@@ -1,0 +1,148 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class McpDoctorTest {
+  private val tempDirs = mutableListOf<File>()
+
+  @AfterTest
+  fun cleanup() {
+    tempDirs.forEach { it.deleteRecursively() }
+  }
+
+  private fun newTempDir(): File {
+    val dir = Files.createTempDirectory("mcp-doctor-test").toFile()
+    tempDirs += dir
+    return dir
+  }
+
+  private fun writeDescriptor(dir: File, body: String): File {
+    val f = File(dir, "daemon-launch.json")
+    f.writeText(body)
+    return f
+  }
+
+  @Test
+  fun `missing descriptor reports run-mcp-install`() {
+    val state = inspectDescriptor("app", File(newTempDir(), "daemon-launch.json"))
+    assertEquals("missing", state.status)
+    assertEquals("run-mcp-install", state.verdict)
+    assertEquals(listOf("descriptor.present"), state.findings.map { it.id })
+  }
+
+  @Test
+  fun `corrupt descriptor reports run-mcp-install`() {
+    val f = writeDescriptor(newTempDir(), "{ not valid json")
+    val state = inspectDescriptor("app", f)
+    assertEquals("corrupt", state.status)
+    assertEquals("run-mcp-install", state.verdict)
+    assertEquals("descriptor.parse", state.findings.single().id)
+  }
+
+  @Test
+  fun `disabled descriptor reports run-mcp-install`() {
+    val f =
+      writeDescriptor(
+        newTempDir(),
+        """{"enabled": false, "schemaVersion": $EXPECTED_DESCRIPTOR_SCHEMA_VERSION}""",
+      )
+    val state = inspectDescriptor("app", f)
+    assertEquals("disabled", state.status)
+    assertEquals("run-mcp-install", state.verdict)
+    assertTrue(state.findings.any { it.id == "descriptor.enabled" })
+  }
+
+  @Test
+  fun `schema mismatch reports run-mcp-install`() {
+    val bumped = EXPECTED_DESCRIPTOR_SCHEMA_VERSION + 1
+    val f = writeDescriptor(newTempDir(), """{"enabled": true, "schemaVersion": $bumped}""")
+    val state = inspectDescriptor("app", f)
+    assertEquals("stale", state.status)
+    assertEquals("run-mcp-install", state.verdict)
+    val finding = state.findings.single { it.id == "descriptor.schema" }
+    assertTrue(finding.message.contains("schemaVersion=$bumped"))
+  }
+
+  @Test
+  fun `missing launcher reports run-mcp-install`() {
+    val f =
+      writeDescriptor(
+        newTempDir(),
+        """
+        {"enabled": true, "schemaVersion": $EXPECTED_DESCRIPTOR_SCHEMA_VERSION,
+         "javaLauncher": "/no/such/path/to/java"}
+        """
+          .trimIndent(),
+      )
+    val state = inspectDescriptor("app", f)
+    assertEquals("run-mcp-install", state.verdict)
+    assertNotNull(state.findings.singleOrNull { it.id == "descriptor.launcher" })
+  }
+
+  @Test
+  fun `missing manifest is a non-blocking warning`() {
+    // Build a present, executable launcher so the only finding is the manifest one.
+    val dir = newTempDir()
+    val launcher = File(dir, "java").apply { writeText("#!/bin/sh\nexit 0\n") }
+    launcher.setExecutable(true)
+    val f =
+      writeDescriptor(
+        dir,
+        """
+        {"enabled": true, "schemaVersion": $EXPECTED_DESCRIPTOR_SCHEMA_VERSION,
+         "javaLauncher": "${launcher.absolutePath}",
+         "manifestPath": "/no/such/previews.json"}
+        """
+          .trimIndent(),
+      )
+    val state = inspectDescriptor("app", f)
+    assertEquals("ok", state.verdict)
+    assertEquals("ok", state.status)
+    val finding = state.findings.single { it.id == "descriptor.manifest" }
+    assertEquals("warning", finding.level)
+  }
+
+  @Test
+  fun `clean descriptor reports ok`() {
+    val dir = newTempDir()
+    val launcher = File(dir, "java").apply { writeText("") }
+    launcher.setExecutable(true)
+    val manifest = File(dir, "previews.json").apply { writeText("[]") }
+    val f =
+      writeDescriptor(
+        dir,
+        """
+        {"enabled": true, "schemaVersion": $EXPECTED_DESCRIPTOR_SCHEMA_VERSION,
+         "javaLauncher": "${launcher.absolutePath}",
+         "manifestPath": "${manifest.absolutePath}"}
+        """
+          .trimIndent(),
+      )
+    val state = inspectDescriptor("app", f)
+    assertEquals("ok", state.verdict)
+    assertEquals("ok", state.status)
+    assertTrue(state.findings.isEmpty())
+  }
+
+  @Test
+  fun `aggregate verdict picks worst per-module verdict`() {
+    val ok = DoctorState("a", File("/tmp/a"), status = "ok", enabled = true, verdict = "ok")
+    val install =
+      DoctorState(
+        "b",
+        File("/tmp/b"),
+        status = "missing",
+        enabled = false,
+        verdict = "run-mcp-install",
+      )
+    assertEquals("ok", aggregateVerdict(listOf(ok)))
+    assertEquals("run-mcp-install", aggregateVerdict(listOf(ok, install)))
+    assertEquals("run-mcp-install", aggregateVerdict(listOf(install)))
+  }
+}

--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -128,6 +128,12 @@ compose-preview mcp install                  # auto-detects Antigravity
 compose-preview mcp install --antigravity    # force the Antigravity config write
 ```
 
+`mcp install` is a one-time bootstrap. If a render misbehaves, do **not**
+re-run it and do **not** kill the daemon — run `compose-preview mcp doctor`
+first and follow the verdict it prints. The supervisor respawns daemons
+automatically on classpath changes. See
+[design/MCP.md § Troubleshooting](./design/MCP.md#troubleshooting-first--when-not-to-act).
+
 Apply the plugin in `<module>/build.gradle.kts`:
 
 <!-- x-release-please-start-version -->

--- a/skills/compose-preview/design/MCP.md
+++ b/skills/compose-preview/design/MCP.md
@@ -5,6 +5,39 @@ SDK, custom hosts) instead of from a shell. Companion to the
 [contributor README](https://github.com/yschimke/compose-ai-tools/blob/main/mcp/README.md);
 this file covers what the consumer of the published skill bundle needs.
 
+## Troubleshooting first — when NOT to act
+
+Before reaching for `mcp install`, killing a daemon, or restarting the host,
+run:
+
+```bash
+compose-preview mcp doctor
+```
+
+The doctor names the corrective action (or "no action needed") for every
+common stale state. Treat its output as authoritative; do not run
+`mcp install` to "refresh" without a doctor finding that asks for it.
+
+In particular:
+
+- **Do not re-run `mcp install`** to recover from a perceived hang, a stale
+  render, or a dependency bump. `install` is a one-time bootstrap; the only
+  conditions that warrant re-running it are the ones `mcp doctor` flags as
+  `run-mcp-install` (descriptor missing, schema mismatch, launcher path
+  broken, host config drifted).
+- **Do not kill or restart the daemon JVM.** When the classpath changes
+  (dependency bump, plugin upgrade, build script edit) the daemon detects it
+  via fingerprint, emits `classpathDirty`, and exits within
+  `daemon.classpathDirtyGraceMs` (default 2 s). The MCP supervisor respawns
+  it automatically and clients see `notifications/resources/list_changed`.
+  Manual restarts race the supervisor and produce duplicate spawns.
+- **Do not kill the MCP server.** On stdin EOF it tears down every
+  supervised daemon cleanly. If you killed it mid-session, the host will
+  reconnect on the next tool call; you do not need to re-`install`.
+- **Source edits don't need a restart either.** Call the `notify_file_changed`
+  MCP tool (or just trigger a render) — the daemon's classloader-swap fast
+  path picks up bytecode changes without rebooting.
+
 ## When to read this
 
 You want any of:


### PR DESCRIPTION
Agents have been reaching for `mcp install` and killing daemons whenever a
render looks off, even though the supervisor already handles classpath drift
automatically (`classpathDirty` respawn) and `install` is a one-time
bootstrap.

- Skill docs (SKILL.md, design/MCP.md) now lead with a "do not act" block:
  do not re-run `mcp install`, do not kill the daemon, run `mcp doctor`
  first.
- `mcp doctor` now inspects each descriptor for schema-version mismatches,
  missing/non-executable javaLauncher paths, and missing manifestPath, and
  emits a per-module + aggregate `verdict` (`ok` / `run-mcp-install`).
  Findings list spells out the underlying cause so the agent has evidence
  to act on (or to stand down). When everything is clean, the human-readable
  output explicitly tells the caller not to touch anything.