### PR TITLE
refactor(vscode): lift focus-mode orchestration into FocusController

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -16,7 +16,7 @@ import type {
     AccessibilityNode,
     PreviewInfo,
 } from "../shared/types";
-import { getVsCodeApi } from "../shared/vscode";
+import { getVsCodeApi, type VsCodeApi } from "../shared/vscode";
 import {
     applyA11yUpdate,
     applyRelativeSizing,
@@ -30,6 +30,10 @@ import { FilterToolbar } from "./components/FilterToolbar";
 import { MessageBanner, type MessageOwner } from "./components/MessageBanner";
 import { PreviewGrid } from "./components/PreviewGrid";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
+import {
+    FocusController,
+    type FocusControllerPersistedState,
+} from "./focusController";
 import { FocusInspectorController } from "./focusInspector";
 import {
     FocusToolbarController,
@@ -229,7 +233,16 @@ export function setupPreviewBehavior(
     const moduleDaemonReady = new Map<string, boolean>();
     const moduleInteractiveSupported = new Map<string, boolean>();
 
-    const inspector = new FocusInspectorController({
+    // Forward references — `inspector` / `liveState` / `focusController`
+    // close over each other via callback shapes, so we late-bind through
+    // these `let !` declarations. Each binding is dereferenced only at
+    // runtime (inside arrow callbacks fired by user events / message
+    // handlers), by which point all three are initialised.
+    let inspector!: FocusInspectorController;
+    let liveState!: LiveStateController;
+    let focusController!: FocusController;
+
+    inspector = new FocusInspectorController({
         el: focusInspector,
         earlyFeatures,
         getPreview: (id) => allPreviews.find((p) => p.id === id),
@@ -243,20 +256,18 @@ export function setupPreviewBehavior(
             [],
         getA11yOverlayId: a11yOverlay,
         isLive: (id) => liveState.isLive(id),
-        onToggleA11yOverlay: () => toggleA11yOverlay(),
+        onToggleA11yOverlay: () => focusController.toggleA11yOverlay(),
         onToggleInteractive: (shift) => liveState.toggleInteractive(shift),
         onToggleRecording: () => liveState.toggleRecording(),
-        onRequestFocusedDiff: (against) => requestFocusedDiff(against),
-        onRequestLaunchOnDevice: () => requestLaunchOnDevice(),
+        onRequestFocusedDiff: (against) =>
+            focusController.requestFocusedDiff(against),
+        onRequestLaunchOnDevice: () => focusController.requestLaunchOnDevice(),
     });
 
     // Config for the interactive-input pointer machine. The predicate
     // unifies live/recording state — both forward pointer/wheel input
     // to the daemon — so the module doesn't need direct access to
-    // either Set. `liveState` is initialised right below and only read
-    // when a real pointer event fires, so the closure access can never
-    // hit before the controller is bound.
-    let liveState!: LiveStateController;
+    // either Set.
     const interactiveInputConfig = {
         isLive: (id: string) =>
             liveState.isLive(id) || liveState.isRecording(id),
@@ -268,13 +279,12 @@ export function setupPreviewBehavior(
         recordingFormat,
         interactiveInputConfig,
         earlyFeatures,
-        inFocus: () => filterToolbar.getLayoutValue() === "focus",
-        focusedCard: () =>
-            filterToolbar.getLayoutValue() === "focus"
-                ? (getVisibleCards()[focusIndex] ?? null)
-                : null,
-        applyInteractiveButtonState: () => applyInteractiveButtonState(),
-        applyRecordingButtonState: () => applyRecordingButtonState(),
+        inFocus: () => focusController.inFocus(),
+        focusedCard: () => focusController.focusedCard(),
+        applyInteractiveButtonState: () =>
+            focusController.applyInteractiveButtonState(),
+        applyRecordingButtonState: () =>
+            focusController.applyRecordingButtonState(),
         renderInspector: (card) => inspector.render(card),
     });
 
@@ -292,6 +302,32 @@ export function setupPreviewBehavior(
             vscode.setState(state);
         },
     };
+
+    focusController = new FocusController({
+        vscode: vscode as VsCodeApi<FocusControllerPersistedState>,
+        grid,
+        filterToolbar,
+        focusControls,
+        focusPosition,
+        btnPrev,
+        btnNext,
+        focusToolbar,
+        inspector,
+        liveState,
+        diffOverlayConfig,
+        state,
+        moduleDaemonReady,
+        moduleInteractiveSupported,
+        earlyFeatures,
+        getA11yOverlayId: a11yOverlay,
+        setA11yOverlayId: setA11yOverlay,
+        getFocusIndex: () => focusIndex,
+        setFocusIndex,
+        getPreviousLayout: () => previousLayout,
+        setPreviousLayout,
+        getLastScopedPreviewId: () => lastScopedPreviewId,
+        setLastScopedPreviewId,
+    });
 
     const staleBadge = new StaleBadgeController(vscode);
     const loadingOverlay = new LoadingOverlay();
@@ -350,110 +386,40 @@ export function setupPreviewBehavior(
     btnRecording.addEventListener("click", () => liveState.toggleRecording());
     btnExitFocus.addEventListener("click", () => exitFocus());
 
-    function applyEarlyFeatureVisibility() {
-        focusToolbar.applyEarlyFeatureVisibility({
-            earlyFeatures: earlyFeatures(),
-            inFocus: filterToolbar.getLayoutValue() === "focus",
-        });
+    // Focus-mode orchestration (applyLayout, button-state hooks, focus
+    // navigation, the a11y-overlay toggle, focused-card actions) lives in
+    // `./focusController.ts` — see `FocusController`. The thin shims
+    // below keep the call shape stable for the message-context callbacks
+    // and for `applyFilters`, which is itself a closure over filterToolbar.
+    function applyLayout(): void {
+        focusController.applyLayout();
+    }
+    function applyInteractiveButtonState(): void {
+        focusController.applyInteractiveButtonState();
+    }
+    function applyRecordingButtonState(): void {
+        focusController.applyRecordingButtonState();
+    }
+    function navigateFocus(delta: number): void {
+        focusController.navigateFocus(delta);
+    }
+    function focusOnCard(card: HTMLElement): void {
+        focusController.focusOnCard(card);
+    }
+    function exitFocus(): void {
+        focusController.exitFocus();
+    }
+    function requestFocusedDiff(against: "head" | "main"): void {
+        focusController.requestFocusedDiff(against);
+    }
+    function requestLaunchOnDevice(): void {
+        focusController.requestLaunchOnDevice();
+    }
+    function toggleA11yOverlay(): void {
+        focusController.toggleA11yOverlay();
     }
 
-    function applyInteractiveButtonState() {
-        const inFocus = filterToolbar.getLayoutValue() === "focus";
-        const card = inFocus ? getVisibleCards()[focusIndex] : null;
-        const previewId = card?.dataset.previewId ?? null;
-        const isLive = !!previewId && liveState.isLive(previewId);
-        focusToolbar.applyInteractiveButtonState({
-            inFocus,
-            focusedPreviewId: previewId,
-            isLive,
-            otherLiveCount: liveState.liveCount - (isLive ? 1 : 0),
-            hasLive: liveState.liveCount > 0,
-            daemonReady: isFocusedModuleReady(moduleDaemonReady),
-            interactiveSupported: isFocusedInteractiveSupported(
-                moduleDaemonReady,
-                moduleInteractiveSupported,
-            ),
-        });
-    }
-
-    function applyRecordingButtonState() {
-        const inFocus = filterToolbar.getLayoutValue() === "focus";
-        const card = inFocus ? getVisibleCards()[focusIndex] : null;
-        const previewId = card?.dataset.previewId ?? null;
-        focusToolbar.applyRecordingButtonState({
-            inFocus,
-            earlyFeatures: earlyFeatures(),
-            focusedPreviewId: previewId,
-            daemonReady: isFocusedModuleReady(moduleDaemonReady),
-            isRecording: !!previewId && liveState.isRecording(previewId),
-        });
-    }
-
-    function applyA11yOverlayButtonState() {
-        const inFocus = filterToolbar.getLayoutValue() === "focus";
-        const card = inFocus ? getVisibleCards()[focusIndex] : null;
-        focusToolbar.applyA11yOverlayButtonState({
-            inFocus,
-            earlyFeatures: earlyFeatures(),
-            focusedPreviewId: card?.dataset.previewId ?? null,
-            a11yOverlayId: a11yOverlay(),
-        });
-    }
-
-    // D2 — clicking the a11y toggle subscribes/unsubscribes via the extension. When
-    // turning OFF, the extension also pushes an empty updateA11y so the cached overlay
-    // tears down immediately rather than waiting for a next render. When turning ON for a
-    // different preview, first turn the previous one off so the wire stays clean.
-    function toggleA11yOverlay() {
-        if (!earlyFeatures()) return;
-        if (filterToolbar.getLayoutValue() !== "focus") return;
-        const card = getVisibleCards()[focusIndex];
-        const previewId = card ? card.dataset.previewId : null;
-        if (!previewId) return;
-        const turningOn = previewId !== a11yOverlay();
-        if (a11yOverlay() && a11yOverlay() !== previewId) {
-            vscode.postMessage({
-                command: "setA11yOverlay",
-                previewId: a11yOverlay(),
-                enabled: false,
-            });
-        }
-        setA11yOverlay(turningOn ? previewId : null);
-        vscode.postMessage({
-            command: "setA11yOverlay",
-            previewId,
-            enabled: turningOn,
-        });
-        applyA11yOverlayButtonState();
-        inspector.render(card);
-    }
-
-    // Live + recording state (toolbar/per-card buttons, badge re-stamping,
-    // single-target follow-focus, viewport auto-stop) lives in
-    // `./liveState.ts` — see `LiveStateController`. The pointer + wheel
-    // state machine the live cards use lives in `./interactiveInput.ts`.
-
-    // Document-level Left/Right in focus mode steps between cards. The
-    // animated-carousel frame-controls handler stops propagation so
-    // its arrow keys still walk captures within a single card. Skip
-    // when an input-like element has focus (the layout dropdown,
-    // future text inputs) so native keyboard semantics aren't stolen.
-    document.addEventListener("keydown", (e) => {
-        if (filterToolbar.getLayoutValue() !== "focus") return;
-        if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
-        const tag = e.target instanceof Element ? e.target.tagName : null;
-        if (tag === "INPUT" || tag === "SELECT" || tag === "TEXTAREA") return;
-        navigateFocus(e.key === "ArrowLeft" ? -1 : 1);
-        e.preventDefault();
-    });
-
-    filterToolbar.addEventListener("filter-changed", () => {
-        saveFilterState();
-        if (filterDebounce) clearTimeout(filterDebounce);
-        filterDebounce = setTimeout(applyFilters, 100);
-    });
-
-    function saveFilterState() {
+    function saveFilterState(): void {
         state.filters = {
             fn: filterToolbar.getFunctionValue(),
             group: filterToolbar.getGroupValue(),
@@ -461,7 +427,7 @@ export function setupPreviewBehavior(
         vscode.setState(state);
     }
 
-    function restoreFilterState() {
+    function restoreFilterState(): void {
         const f = state.filters || {};
         if (f.fn && filterToolbar.hasFunctionOption(f.fn))
             filterToolbar.setFunctionValue(f.fn);
@@ -469,7 +435,7 @@ export function setupPreviewBehavior(
             filterToolbar.setGroupValue(f.group);
     }
 
-    function applyFilters() {
+    function applyFilters(): void {
         const visibleCount = grid.applyFilters({
             fn: filterToolbar.getFunctionValue(),
             group: filterToolbar.getGroupValue(),
@@ -504,174 +470,11 @@ export function setupPreviewBehavior(
     // shouldn't normally trigger — the extension sends an explicit
     // message for every empty state — but a silent blank view was the
     // original complaint, so this catches any future regressions.
-    function ensureNotBlank() {
+    function ensureNotBlank(): void {
         const hasCards = grid.querySelector(".preview-card") !== null;
         if (!hasCards && !messageBanner.isVisible()) {
             messageBanner.setMessage("Preparing previews…", "fallback");
         }
-    }
-
-    function getVisibleCards() {
-        return grid.getVisibleCards();
-    }
-
-    function applyLayout() {
-        const mode = filterToolbar.getLayoutValue();
-        grid.setLayoutMode(mode);
-        focusControls.hidden = mode !== "focus";
-
-        if (mode === "focus") {
-            const visible = getVisibleCards();
-            if (visible.length === 0) {
-                focusPosition.textContent = "0 / 0";
-                inspector.render(null);
-                publishScopedPreview();
-                return;
-            }
-            if (focusIndex >= visible.length) {
-                setFocusIndex(visible.length - 1);
-            }
-            if (focusIndex < 0) setFocusIndex(0);
-            grid.applyFocusVisibility(visible[focusIndex]);
-            focusPosition.textContent = focusIndex + 1 + " / " + visible.length;
-            btnPrev.disabled = focusIndex === 0;
-            btnNext.disabled = focusIndex === visible.length - 1;
-            inspector.render(visible[focusIndex]);
-        } else {
-            grid.applyFocusVisibility(null);
-            inspector.render(null);
-        }
-        document
-            .querySelectorAll(".image-container")
-            .forEach((c) => c.removeAttribute("title"));
-        publishScopedPreview();
-        // Single-target follow-focus teardown — see
-        // `LiveStateController.enforceSingleTargetFollowFocus`.
-        liveState.enforceSingleTargetFollowFocus(
-            mode === "focus" ? (getVisibleCards()[focusIndex] ?? null) : null,
-        );
-        // D2 — same teardown for the a11y overlay: navigating off the previewed card
-        // (or exiting focus mode) unsubscribes so the wire stays quiet for cards the
-        // user isn't looking at.
-        if (a11yOverlay()) {
-            const visible = getVisibleCards();
-            const card = mode === "focus" ? visible[focusIndex] : null;
-            if (!card || card.dataset.previewId !== a11yOverlay()) {
-                if (earlyFeatures()) {
-                    vscode.postMessage({
-                        command: "setA11yOverlay",
-                        previewId: a11yOverlay(),
-                        enabled: false,
-                    });
-                }
-                setA11yOverlay(null);
-            }
-        }
-        applyInteractiveButtonState();
-        applyRecordingButtonState();
-        applyA11yOverlayButtonState();
-        applyEarlyFeatureVisibility();
-    }
-
-    // Compute the focus-mode previewId. History is intentionally focus-only:
-    // list/grid/filter layouts publish null even if only one card is visible.
-    // Posts only when it changes so the extension does not rebuild history scope
-    // on ordinary filter/layout churn.
-    function publishScopedPreview() {
-        const visible = getVisibleCards();
-        let previewId = null;
-        if (filterToolbar.getLayoutValue() === "focus") {
-            if (
-                visible.length > 0 &&
-                focusIndex >= 0 &&
-                focusIndex < visible.length
-            ) {
-                previewId = visible[focusIndex].dataset.previewId || null;
-            }
-        }
-        if (previewId === lastScopedPreviewId) return;
-        setLastScopedPreviewId(previewId);
-        // Mirror to the store so subscribed components (the upcoming
-        // `<focus-controls>`, `<focus-inspector>`, etc.) react without
-        // re-walking the DOM. Same value goes upstream to the extension
-        // so the History panel can re-scope.
-        previewStore.setState({ focusedPreviewId: previewId });
-        vscode.postMessage({
-            command: "previewScopeChanged",
-            previewId,
-        });
-    }
-
-    function navigateFocus(delta: number): void {
-        const visible = getVisibleCards();
-        if (visible.length === 0) return;
-        setFocusIndex(
-            Math.max(0, Math.min(visible.length - 1, focusIndex + delta)),
-        );
-        applyLayout();
-    }
-
-    // Switch the layout to focus mode and target the supplied card.
-    // No-op when the card is filtered out (it wouldn't be in the visible
-    // set anyway, and forcing focus on an invisible card surfaces an
-    // empty pane).
-    function focusOnCard(card: HTMLElement): void {
-        const visible = getVisibleCards();
-        const idx = visible.indexOf(card);
-        if (idx === -1) return;
-        setFocusIndex(idx);
-        const current = filterToolbar.getLayoutValue();
-        if (current !== "focus") {
-            setPreviousLayout(current);
-            filterToolbar.setLayoutValue("focus");
-            state.layout = "focus";
-            vscode.setState(state);
-        }
-        applyLayout();
-    }
-
-    function exitFocus() {
-        if (filterToolbar.getLayoutValue() !== "focus") return;
-        filterToolbar.setLayoutValue(previousLayout);
-        state.layout = previousLayout;
-        vscode.setState(state);
-        applyLayout();
-    }
-
-    // Live-panel diff: only meaningful when one preview is focused. Pulls
-    // the currently focused card's previewId and asks the extension to
-    // resolve the comparison anchor (HEAD = latest archived render,
-    // main = latest archived render on the main branch).
-    function requestFocusedDiff(against: "head" | "main"): void {
-        if (!earlyFeatures()) return;
-        if (filterToolbar.getLayoutValue() !== "focus") return;
-        const visible = getVisibleCards();
-        const card = visible[focusIndex];
-        if (!card) return;
-        const previewId = card.dataset.previewId;
-        if (!previewId) return;
-        showDiffOverlay(card, against, null, null, diffOverlayConfig);
-        vscode.postMessage({
-            command: "requestPreviewDiff",
-            previewId,
-            against,
-        });
-    }
-
-    // Live-panel "Launch on Device": runs the consumer's
-    // installDebug task and uses adb to start the launcher activity on
-    // a connected device. Only meaningful when one preview is focused
-    // -- the extension uses the focused previewId to pick the owning
-    // module before falling back to a quick-pick.
-    function requestLaunchOnDevice() {
-        if (!earlyFeatures()) return;
-        if (filterToolbar.getLayoutValue() !== "focus") return;
-        const visible = getVisibleCards();
-        const card = visible[focusIndex];
-        if (!card) return;
-        const previewId = card.dataset.previewId;
-        if (!previewId) return;
-        vscode.postMessage({ command: "requestLaunchOnDevice", previewId });
     }
 
     // populateFilter / hasOption are gone — `<filter-toolbar>` owns the
@@ -700,11 +503,8 @@ export function setupPreviewBehavior(
         inspector,
         getAllPreviews: () => allPreviews,
         earlyFeatures,
-        inFocus: () => filterToolbar.getLayoutValue() === "focus",
-        focusedCard: () =>
-            filterToolbar.getLayoutValue() === "focus"
-                ? (getVisibleCards()[focusIndex] ?? null)
-                : null,
+        inFocus: () => focusController.inFocus(),
+        focusedCard: () => focusController.focusedCard(),
         enterFocus: focusOnCard,
         exitFocus,
         observeForViewport: observeCardForViewport,

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -1,0 +1,369 @@
+// Focus-mode orchestration for the live "Compose Preview" panel.
+//
+// Lifted verbatim from `behavior.ts`'s `applyLayout` / `publishScopedPreview`
+// / `navigateFocus` / `focusOnCard` / `exitFocus` / `requestFocusedDiff` /
+// `requestLaunchOnDevice` / `toggleA11yOverlay` cluster, plus the four
+// `applyXxxButtonState` hooks that drive the focus-mode toolbar. After
+// this lift `behavior.ts` is mostly setup + message-event wiring; the
+// focus-mode behaviour lives here.
+//
+// Owns no closure state of its own — the panel-level scalars (focusIndex,
+// previousLayout, lastScopedPreviewId, a11yOverlayPreviewId) live in
+// `previewStore` and are read/written via the getter/setter pairs the
+// caller threads through `FocusControllerConfig`. The persisted-state
+// scalar (`state.layout`) is shared by-reference so layout writes persist
+// through the same `vscode.setState(state)` round-trip the rest of the
+// panel uses.
+
+import { showDiffOverlay, type DiffOverlayConfig } from "./diffOverlay";
+import type { FocusInspectorController } from "./focusInspector";
+import {
+    type FocusToolbarController,
+    isFocusedInteractiveSupported,
+    isFocusedModuleReady,
+} from "./focusToolbar";
+import type { LiveStateController } from "./liveState";
+import type { FilterToolbar } from "./components/FilterToolbar";
+import { previewStore } from "./previewStore";
+import type { PreviewGrid } from "./components/PreviewGrid";
+import type { DiffMode } from "../shared/diffModeBar";
+import type { VsCodeApi } from "../shared/vscode";
+
+/** Mutable persisted-state scalar shared with `behavior.ts`. The
+ *  controller mutates `state.layout` and the caller persists via
+ *  `vscode.setState(state)`. */
+export interface FocusControllerPersistedState {
+    layout?: "grid" | "flow" | "column" | "focus";
+    diffMode?: DiffMode;
+    filters?: { fn?: string; group?: string };
+}
+
+export interface FocusControllerConfig {
+    vscode: VsCodeApi<FocusControllerPersistedState>;
+    grid: PreviewGrid;
+    filterToolbar: FilterToolbar;
+    /** `<div id="focus-controls">` — the focus-mode toolbar container.
+     *  Toggled `hidden` based on layout mode. */
+    focusControls: HTMLElement;
+    /** `<div id="focus-position">` — the "N / M" position indicator. */
+    focusPosition: HTMLElement;
+    btnPrev: HTMLButtonElement;
+    btnNext: HTMLButtonElement;
+    focusToolbar: FocusToolbarController;
+    inspector: FocusInspectorController;
+    liveState: LiveStateController;
+    diffOverlayConfig: DiffOverlayConfig;
+    /** Shared mutable persisted state. The controller writes
+     *  `state.layout` directly and calls `vscode.setState(state)` for
+     *  layout transitions. */
+    state: FocusControllerPersistedState;
+    moduleDaemonReady: Map<string, boolean>;
+    moduleInteractiveSupported: Map<string, boolean>;
+    earlyFeatures(): boolean;
+    getA11yOverlayId(): string | null;
+    setA11yOverlayId(id: string | null): void;
+    getFocusIndex(): number;
+    setFocusIndex(idx: number): void;
+    getPreviousLayout(): "grid" | "flow" | "column";
+    setPreviousLayout(layout: "grid" | "flow" | "column"): void;
+    getLastScopedPreviewId(): string | null;
+    setLastScopedPreviewId(id: string | null): void;
+}
+
+export class FocusController {
+    constructor(private readonly config: FocusControllerConfig) {}
+
+    getVisibleCards(): HTMLElement[] {
+        return this.config.grid.getVisibleCards();
+    }
+
+    /** Whether the panel is currently in focus layout. */
+    inFocus(): boolean {
+        return this.config.filterToolbar.getLayoutValue() === "focus";
+    }
+
+    /** Currently-focused preview card, or null when no card is focused. */
+    focusedCard(): HTMLElement | null {
+        if (!this.inFocus()) return null;
+        const visible = this.getVisibleCards();
+        return visible[this.config.getFocusIndex()] ?? null;
+    }
+
+    applyEarlyFeatureVisibility(): void {
+        this.config.focusToolbar.applyEarlyFeatureVisibility({
+            earlyFeatures: this.config.earlyFeatures(),
+            inFocus: this.inFocus(),
+        });
+    }
+
+    applyInteractiveButtonState(): void {
+        const inFocus = this.inFocus();
+        const card = inFocus
+            ? this.getVisibleCards()[this.config.getFocusIndex()]
+            : null;
+        const previewId = card?.dataset.previewId ?? null;
+        const isLive = !!previewId && this.config.liveState.isLive(previewId);
+        this.config.focusToolbar.applyInteractiveButtonState({
+            inFocus,
+            focusedPreviewId: previewId,
+            isLive,
+            otherLiveCount: this.config.liveState.liveCount - (isLive ? 1 : 0),
+            hasLive: this.config.liveState.liveCount > 0,
+            daemonReady: isFocusedModuleReady(this.config.moduleDaemonReady),
+            interactiveSupported: isFocusedInteractiveSupported(
+                this.config.moduleDaemonReady,
+                this.config.moduleInteractiveSupported,
+            ),
+        });
+    }
+
+    applyRecordingButtonState(): void {
+        const inFocus = this.inFocus();
+        const card = inFocus
+            ? this.getVisibleCards()[this.config.getFocusIndex()]
+            : null;
+        const previewId = card?.dataset.previewId ?? null;
+        this.config.focusToolbar.applyRecordingButtonState({
+            inFocus,
+            earlyFeatures: this.config.earlyFeatures(),
+            focusedPreviewId: previewId,
+            daemonReady: isFocusedModuleReady(this.config.moduleDaemonReady),
+            isRecording:
+                !!previewId && this.config.liveState.isRecording(previewId),
+        });
+    }
+
+    applyA11yOverlayButtonState(): void {
+        const inFocus = this.inFocus();
+        const card = inFocus
+            ? this.getVisibleCards()[this.config.getFocusIndex()]
+            : null;
+        this.config.focusToolbar.applyA11yOverlayButtonState({
+            inFocus,
+            earlyFeatures: this.config.earlyFeatures(),
+            focusedPreviewId: card?.dataset.previewId ?? null,
+            a11yOverlayId: this.config.getA11yOverlayId(),
+        });
+    }
+
+    /**
+     * D2 — clicking the a11y toggle subscribes/unsubscribes via the
+     * extension. When turning OFF, the extension also pushes an empty
+     * updateA11y so the cached overlay tears down immediately rather
+     * than waiting for a next render. When turning ON for a different
+     * preview, first turn the previous one off so the wire stays clean.
+     */
+    toggleA11yOverlay(): void {
+        if (!this.config.earlyFeatures()) return;
+        if (!this.inFocus()) return;
+        const card = this.getVisibleCards()[this.config.getFocusIndex()];
+        const previewId = card ? card.dataset.previewId : null;
+        if (!previewId) return;
+        const currentId = this.config.getA11yOverlayId();
+        const turningOn = previewId !== currentId;
+        if (currentId && currentId !== previewId) {
+            this.config.vscode.postMessage({
+                command: "setA11yOverlay",
+                previewId: currentId,
+                enabled: false,
+            });
+        }
+        this.config.setA11yOverlayId(turningOn ? previewId : null);
+        this.config.vscode.postMessage({
+            command: "setA11yOverlay",
+            previewId,
+            enabled: turningOn,
+        });
+        this.applyA11yOverlayButtonState();
+        this.config.inspector.render(card);
+    }
+
+    applyLayout(): void {
+        const mode = this.config.filterToolbar.getLayoutValue();
+        this.config.grid.setLayoutMode(mode);
+        this.config.focusControls.hidden = mode !== "focus";
+
+        if (mode === "focus") {
+            const visible = this.getVisibleCards();
+            if (visible.length === 0) {
+                this.config.focusPosition.textContent = "0 / 0";
+                this.config.inspector.render(null);
+                this.publishScopedPreview();
+                return;
+            }
+            let focusIndex = this.config.getFocusIndex();
+            if (focusIndex >= visible.length) {
+                focusIndex = visible.length - 1;
+                this.config.setFocusIndex(focusIndex);
+            }
+            if (focusIndex < 0) {
+                focusIndex = 0;
+                this.config.setFocusIndex(0);
+            }
+            this.config.grid.applyFocusVisibility(visible[focusIndex]);
+            this.config.focusPosition.textContent =
+                focusIndex + 1 + " / " + visible.length;
+            this.config.btnPrev.disabled = focusIndex === 0;
+            this.config.btnNext.disabled = focusIndex === visible.length - 1;
+            this.config.inspector.render(visible[focusIndex]);
+        } else {
+            this.config.grid.applyFocusVisibility(null);
+            this.config.inspector.render(null);
+        }
+        document
+            .querySelectorAll(".image-container")
+            .forEach((c) => c.removeAttribute("title"));
+        this.publishScopedPreview();
+        // Single-target follow-focus teardown — see
+        // `LiveStateController.enforceSingleTargetFollowFocus`.
+        this.config.liveState.enforceSingleTargetFollowFocus(
+            mode === "focus"
+                ? (this.getVisibleCards()[this.config.getFocusIndex()] ?? null)
+                : null,
+        );
+        // D2 — same teardown for the a11y overlay: navigating off the
+        // previewed card (or exiting focus mode) unsubscribes so the wire
+        // stays quiet for cards the user isn't looking at.
+        const a11yId = this.config.getA11yOverlayId();
+        if (a11yId) {
+            const visible = this.getVisibleCards();
+            const card =
+                mode === "focus" ? visible[this.config.getFocusIndex()] : null;
+            if (!card || card.dataset.previewId !== a11yId) {
+                if (this.config.earlyFeatures()) {
+                    this.config.vscode.postMessage({
+                        command: "setA11yOverlay",
+                        previewId: a11yId,
+                        enabled: false,
+                    });
+                }
+                this.config.setA11yOverlayId(null);
+            }
+        }
+        this.applyInteractiveButtonState();
+        this.applyRecordingButtonState();
+        this.applyA11yOverlayButtonState();
+        this.applyEarlyFeatureVisibility();
+    }
+
+    /**
+     * Compute the focus-mode previewId. History is intentionally focus-
+     * only: list/grid/filter layouts publish null even if only one card is
+     * visible. Posts only when it changes so the extension does not
+     * rebuild history scope on ordinary filter/layout churn.
+     */
+    publishScopedPreview(): void {
+        const visible = this.getVisibleCards();
+        let previewId: string | null = null;
+        if (this.inFocus()) {
+            const focusIndex = this.config.getFocusIndex();
+            if (
+                visible.length > 0 &&
+                focusIndex >= 0 &&
+                focusIndex < visible.length
+            ) {
+                previewId = visible[focusIndex].dataset.previewId || null;
+            }
+        }
+        if (previewId === this.config.getLastScopedPreviewId()) return;
+        this.config.setLastScopedPreviewId(previewId);
+        // Mirror to the store so subscribed components (the upcoming
+        // `<focus-controls>`, `<focus-inspector>`, etc.) react without
+        // re-walking the DOM. Same value goes upstream to the extension
+        // so the History panel can re-scope.
+        previewStore.setState({ focusedPreviewId: previewId });
+        this.config.vscode.postMessage({
+            command: "previewScopeChanged",
+            previewId,
+        });
+    }
+
+    navigateFocus(delta: number): void {
+        const visible = this.getVisibleCards();
+        if (visible.length === 0) return;
+        const cur = this.config.getFocusIndex();
+        this.config.setFocusIndex(
+            Math.max(0, Math.min(visible.length - 1, cur + delta)),
+        );
+        this.applyLayout();
+    }
+
+    /**
+     * Switch the layout to focus mode and target the supplied card. No-op
+     * when the card is filtered out (it wouldn't be in the visible set
+     * anyway, and forcing focus on an invisible card surfaces an empty
+     * pane).
+     */
+    focusOnCard(card: HTMLElement): void {
+        const visible = this.getVisibleCards();
+        const idx = visible.indexOf(card);
+        if (idx === -1) return;
+        this.config.setFocusIndex(idx);
+        const current = this.config.filterToolbar.getLayoutValue();
+        if (current !== "focus") {
+            this.config.setPreviousLayout(current);
+            this.config.filterToolbar.setLayoutValue("focus");
+            this.config.state.layout = "focus";
+            this.config.vscode.setState(this.config.state);
+        }
+        this.applyLayout();
+    }
+
+    exitFocus(): void {
+        if (!this.inFocus()) return;
+        const target = this.config.getPreviousLayout();
+        this.config.filterToolbar.setLayoutValue(target);
+        this.config.state.layout = target;
+        this.config.vscode.setState(this.config.state);
+        this.applyLayout();
+    }
+
+    /**
+     * Live-panel diff: only meaningful when one preview is focused. Pulls
+     * the currently focused card's previewId and asks the extension to
+     * resolve the comparison anchor (HEAD = latest archived render, main
+     * = latest archived render on the main branch).
+     */
+    requestFocusedDiff(against: "head" | "main"): void {
+        if (!this.config.earlyFeatures()) return;
+        if (!this.inFocus()) return;
+        const visible = this.getVisibleCards();
+        const card = visible[this.config.getFocusIndex()];
+        if (!card) return;
+        const previewId = card.dataset.previewId;
+        if (!previewId) return;
+        showDiffOverlay(
+            card,
+            against,
+            null,
+            null,
+            this.config.diffOverlayConfig,
+        );
+        this.config.vscode.postMessage({
+            command: "requestPreviewDiff",
+            previewId,
+            against,
+        });
+    }
+
+    /**
+     * Live-panel "Launch on Device": runs the consumer's installDebug
+     * task and uses adb to start the launcher activity on a connected
+     * device. Only meaningful when one preview is focused — the
+     * extension uses the focused previewId to pick the owning module
+     * before falling back to a quick-pick.
+     */
+    requestLaunchOnDevice(): void {
+        if (!this.config.earlyFeatures()) return;
+        if (!this.inFocus()) return;
+        const visible = this.getVisibleCards();
+        const card = visible[this.config.getFocusIndex()];
+        if (!card) return;
+        const previewId = card.dataset.previewId;
+        if (!previewId) return;
+        this.config.vscode.postMessage({
+            command: "requestLaunchOnDevice",
+            previewId,
+        });
+    }
+}


### PR DESCRIPTION
Lifts the last big imperative cluster out of `preview/behavior.ts`: the focus-mode orchestration (`applyLayout`, the four `applyXxxButtonState` hooks, `toggleA11yOverlay`, `publishScopedPreview`, `navigateFocus`, `focusOnCard`, `exitFocus`, `requestFocusedDiff`, `requestLaunchOnDevice`) into a typed `FocusController` class.

**After this, `behavior.ts` is mostly setup + message-event wiring; every substantial DOM operation is in a typed sibling module** (`cardBuilder.ts`, `focusController.ts`, `liveState.ts`, `focusInspector.ts`, `frameCarousel.ts`, `staleBadge.ts`, `viewportTracker.ts`, `a11yOverlay.ts`, `interactiveInput.ts`, `messageHandlers.ts`, `loadingOverlay.ts`, `diffOverlay.ts`).

## Summary

New `focusController.ts` exports:
- `FocusController` class with twelve public methods covering the cluster lifted from behavior.ts, plus internal `inFocus()`, `focusedCard()`, `getVisibleCards()` helpers.
- `FocusControllerConfig` — the collaborator surface: `vscode`, `grid`, `filterToolbar`, `focusControls`, `focusPosition`, `btnPrev`, `btnNext`, `focusToolbar`, `inspector`, `liveState`, `diffOverlayConfig`, plus state accessors over panel-level scalars (`focusIndex`, `previousLayout`, `lastScopedPreviewId`, `a11yOverlayPreviewId`) and module-readiness Maps.
- `FocusControllerPersistedState` — slim `vscode.setState`/`getState` shape (`layout`, `diffMode`, `filters`).

`behavior.ts` builds the controller after `liveState` (because `liveState`'s config closes over `focusController.inFocus` / `focusController.focusedCard`) and then keeps thin function shims for the names other parts of the panel still call by reference (event listeners, `messageContext` callbacks, `cardBuilderConfig.enterFocus` / `exitFocus`, `applyFilters`'s call to `applyLayout`).

The `inspector` / `liveState` / `focusController` triplet has a forward-reference cycle (each closes over the others' methods). Resolved with `let X!: T;` declarations and arrow-callback late-binding — same pattern that already covered `interactiveInputConfig` ↔ `liveState`.

## Drive-by

The `cardBuilderConfig`'s `inFocus` / `focusedCard` arrow-functions, which previously inlined the `filterToolbar.getLayoutValue() === "focus"` predicate and the `getVisibleCards()[focusIndex]` lookup, now delegate to the controller methods so the predicate has one source of truth.

`behavior.ts`: 775 → 575 lines (**−200 LOC**).
`focusController.ts`: +369 lines (new file).

**`behavior.ts` is now down 82% from its 3208-line `@ts-nocheck` starting point.**

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 384/384 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke (focus-mode behaviours):
  - Layout dropdown: enter focus → exit focus restores `previousLayout`.
  - Focus arrow keys / btnPrev / btnNext step through visible cards.
  - "N / M" position indicator updates on navigation.
  - btnDiffHead / btnDiffMain trigger `requestFocusedDiff` against the right anchor; diff overlay renders.
  - btnLaunchDevice posts `requestLaunchOnDevice` for the focused preview.
  - btnA11yOverlay subscribes/unsubscribes the focused preview's a11y overlay; switches preview cleanly when toggled on a different focused card.
  - Layout change tears down a non-focused a11y subscription via `setA11yOverlay`-off post.
  - `previewScopeChanged` posts only when the focused previewId changes (filter churn during focus shouldn't spam the History panel).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_