### PR TITLE
test(vscode): extract safeArrayIndex into shared/ + add prototype-pollution tests

### DIFF
--- a/vscode-extension/src/test/safeIndex.test.ts
+++ b/vscode-extension/src/test/safeIndex.test.ts
@@ -1,0 +1,43 @@
+import * as assert from "assert";
+import { safeArrayIndex } from "../webview/shared/safeIndex";
+
+describe("safeArrayIndex", () => {
+    it("returns valid non-negative integers unchanged", () => {
+        assert.strictEqual(safeArrayIndex(0), 0);
+        assert.strictEqual(safeArrayIndex(1), 1);
+        assert.strictEqual(safeArrayIndex(42), 42);
+        assert.strictEqual(safeArrayIndex(1_000_000), 1_000_000);
+    });
+
+    it("collapses negative numbers to 0", () => {
+        assert.strictEqual(safeArrayIndex(-1), 0);
+        assert.strictEqual(safeArrayIndex(-42), 0);
+        assert.strictEqual(safeArrayIndex(-Infinity), 0);
+    });
+
+    it("collapses non-integer numbers to 0", () => {
+        assert.strictEqual(safeArrayIndex(1.5), 0);
+        assert.strictEqual(safeArrayIndex(0.1), 0);
+        assert.strictEqual(safeArrayIndex(NaN), 0);
+        assert.strictEqual(safeArrayIndex(Infinity), 0);
+    });
+
+    it("collapses non-numeric inputs to 0", () => {
+        assert.strictEqual(safeArrayIndex(undefined), 0);
+        assert.strictEqual(safeArrayIndex(null), 0);
+        assert.strictEqual(safeArrayIndex(""), 0);
+        assert.strictEqual(safeArrayIndex("0"), 0);
+        assert.strictEqual(safeArrayIndex("42"), 0);
+        assert.strictEqual(safeArrayIndex(true), 0);
+        assert.strictEqual(safeArrayIndex({}), 0);
+        assert.strictEqual(safeArrayIndex([]), 0);
+    });
+
+    it("collapses the prototype-pollution attack string to 0", () => {
+        // The CodeQL-flagged threat: an attacker passes "__proto__" as
+        // captureIndex, expecting `caps["__proto__"] = ...` to mutate
+        // Array.prototype. After coercion it's 0 — a normal in-range write.
+        assert.strictEqual(safeArrayIndex("__proto__"), 0);
+        assert.strictEqual(safeArrayIndex("constructor"), 0);
+    });
+});

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -35,6 +35,7 @@ import type {
     PreviewInfo,
 } from "../shared/types";
 import type { VsCodeApi } from "../shared/vscode";
+import { safeArrayIndex } from "../shared/safeIndex";
 import { sanitizeId } from "./cardData";
 import { PreviewGrid } from "./components/PreviewGrid";
 import { buildErrorPanel } from "./errorPanel";
@@ -487,16 +488,4 @@ function assertNever(value: never): never {
     throw new Error(
         `Unhandled ExtensionToWebview variant: ${JSON.stringify(value)}`,
     );
-}
-
-/** Coerce a wire-supplied capture index into a safe non-negative integer.
- *  TypeScript types `captureIndex` as `number`, but the value crosses the
- *  webview boundary so a defensive runtime check is warranted: anything
- *  non-integer / negative / non-finite collapses to 0 (the representative
- *  capture). Eliminates the prototype-pollution flow CodeQL flags when an
- *  unconstrained index is used to write into an array. */
-function safeArrayIndex(value: unknown): number {
-    return typeof value === "number" && Number.isInteger(value) && value >= 0
-        ? value
-        : 0;
 }

--- a/vscode-extension/src/webview/shared/safeIndex.ts
+++ b/vscode-extension/src/webview/shared/safeIndex.ts
@@ -1,0 +1,25 @@
+// Defensive coercions for values that cross the webview boundary.
+//
+// TypeScript types these on the wire (e.g. `captureIndex: number` on
+// `setImageError` / `updateImage` `ExtensionToWebview` variants), but the
+// runtime value is whatever the extension actually sent — in principle a
+// non-number could slip through. CodeQL flags array writes whose index
+// flows from such a value, so we coerce defensively at the edge.
+//
+// `safeArrayIndex` lives in `webview/shared/` so both the preview-side
+// `messageHandlers.ts` and any future webview module can pick it up
+// without dragging the wider message-dispatch surface in. It has no DOM
+// dependencies, so the host tsconfig can compile it for unit tests.
+
+/**
+ * Coerce a wire-supplied capture / array index into a safe non-negative
+ * integer. Anything non-integer / negative / non-finite collapses to 0
+ * (the representative capture / first element). Eliminates the
+ * prototype-pollution flow CodeQL flags when an unconstrained index is
+ * used to write into an array.
+ */
+export function safeArrayIndex(value: unknown): number {
+    return typeof value === "number" && Number.isInteger(value) && value >= 0
+        ? value
+        : 0;
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -18,6 +18,7 @@
         "src/webview/preview/cardData.ts",
         "src/webview/history/historyData.ts",
         "src/webview/shared/diffStatsLabel.ts",
+        "src/webview/shared/safeIndex.ts",
         "src/webview/shared/types.ts"
     ]
 }


### PR DESCRIPTION
Closes a coverage gap on the defensive helper that prompted the prototype-pollution fix in #800. `safeArrayIndex` was a private function in `messageHandlers.ts` (which can't be tested under the host tsconfig — it imports DOM-dependent modules); moves it to `webview/shared/safeIndex.ts` so the host build can compile it for unit tests.

## Summary

5 new tests covering:
- Valid non-negative integers pass through unchanged.
- Negative numbers / non-finite numbers (`Infinity`, `NaN`) / non-integer numbers (`1.5`, `0.1`) collapse to 0.
- Non-numeric inputs (strings, booleans, objects, arrays) collapse to 0.
- The CodeQL-flagged attack string `"__proto__"` (and the related `"constructor"`) collapse to 0 — the prototype-pollution flow is blocked by the typeof check before the index ever reaches an array write.

`messageHandlers.ts` drops its local definition and imports from the shared module. `tsconfig.json` adds `safeIndex.ts` to its `files` list (parallel to the existing `cardData.ts`, `historyData.ts`, `diffStatsLabel.ts` entries).

384 → 389 tests passing. No behaviour change.

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 389/389 passing (384 prior + 5 new)
- [x] `npm run format:check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_