### PR TITLE
test(vscode): extract module-readiness predicates + add unit tests

### DIFF
--- a/vscode-extension/src/test/moduleReadiness.test.ts
+++ b/vscode-extension/src/test/moduleReadiness.test.ts
@@ -1,0 +1,78 @@
+import * as assert from "assert";
+import {
+    isFocusedInteractiveSupported,
+    isFocusedModuleReady,
+} from "../webview/preview/moduleReadiness";
+
+describe("isFocusedModuleReady", () => {
+    it("returns false for an empty Map", () => {
+        assert.strictEqual(isFocusedModuleReady(new Map()), false);
+    });
+
+    it("returns true when at least one module is ready", () => {
+        const m = new Map([
+            [":app", true],
+            [":lib", false],
+        ]);
+        assert.strictEqual(isFocusedModuleReady(m), true);
+    });
+
+    it("returns false when every module is not ready", () => {
+        const m = new Map([
+            [":app", false],
+            [":lib", false],
+        ]);
+        assert.strictEqual(isFocusedModuleReady(m), false);
+    });
+});
+
+describe("isFocusedInteractiveSupported", () => {
+    it("returns false when the readiness map is empty", () => {
+        assert.strictEqual(
+            isFocusedInteractiveSupported(new Map(), new Map()),
+            false,
+        );
+    });
+
+    it("returns true when at least one ready module is interactive-supported", () => {
+        const ready = new Map([
+            [":app", true],
+            [":lib", true],
+        ]);
+        const supported = new Map([
+            [":app", false],
+            [":lib", true],
+        ]);
+        assert.strictEqual(
+            isFocusedInteractiveSupported(ready, supported),
+            true,
+        );
+    });
+
+    it("returns false when ready modules are all v1-fallback (interactive unsupported)", () => {
+        const ready = new Map([[":app", true]]);
+        const supported = new Map([[":app", false]]);
+        assert.strictEqual(
+            isFocusedInteractiveSupported(ready, supported),
+            false,
+        );
+    });
+
+    it("returns false when supported modules aren't ready", () => {
+        const ready = new Map([[":app", false]]);
+        const supported = new Map([[":app", true]]);
+        assert.strictEqual(
+            isFocusedInteractiveSupported(ready, supported),
+            false,
+        );
+    });
+
+    it("returns false when a module is ready but missing from the supported map", () => {
+        const ready = new Map([[":app", true]]);
+        const supported = new Map<string, boolean>();
+        assert.strictEqual(
+            isFocusedInteractiveSupported(ready, supported),
+            false,
+        );
+    });
+});

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -196,37 +196,11 @@ export class FocusToolbarController {
     }
 }
 
-/**
- * Daemon-ready predicate for the focused module. The webview doesn't
- * know moduleId per preview today; we fall back to "any module ready"
- * because the extension-side panel is single-module-scoped (it only
- * ever holds one module's previews at a time) — so the readiness of
- * the sole module is also the readiness for whatever's focused. If
- * the panel ever shows multiple modules at once, swap this to lookup
- * by the focused card's `data-module-id`.
- */
-export function isFocusedModuleReady(
-    moduleDaemonReady: ReadonlyMap<string, boolean>,
-): boolean {
-    for (const ready of moduleDaemonReady.values()) {
-        if (ready) return true;
-    }
-    return false;
-}
-
-/**
- * Whether the focused module supports full v2 live mode (with
- * preserved Compose state) vs the v1 fallback where pointer events
- * round-trip through the daemon but renders refresh from scratch.
- * Same module-scoping caveat as [isFocusedModuleReady].
- */
-export function isFocusedInteractiveSupported(
-    moduleDaemonReady: ReadonlyMap<string, boolean>,
-    moduleInteractiveSupported: ReadonlyMap<string, boolean>,
-): boolean {
-    for (const [moduleId, ready] of moduleDaemonReady.entries()) {
-        if (ready && moduleInteractiveSupported.get(moduleId) === true)
-            return true;
-    }
-    return false;
-}
+// Pure predicates over `moduleDaemonReady` / `moduleInteractiveSupported`
+// live in `./moduleReadiness.ts` so they can be unit-tested under the host
+// tsconfig. Re-exported here for callers that already imported them from
+// `focusToolbar`.
+export {
+    isFocusedInteractiveSupported,
+    isFocusedModuleReady,
+} from "./moduleReadiness";

--- a/vscode-extension/src/webview/preview/moduleReadiness.ts
+++ b/vscode-extension/src/webview/preview/moduleReadiness.ts
@@ -1,0 +1,40 @@
+// Pure predicates over the per-module daemon readiness Maps. Lifted out
+// of `focusToolbar.ts` so they can be unit-tested under the host
+// tsconfig — `focusToolbar.ts` itself holds the DOM-bound
+// `FocusToolbarController` class and so can't be compiled there.
+
+/**
+ * Daemon-ready predicate for the focused module. The webview doesn't
+ * know moduleId per preview today; we fall back to "any module ready"
+ * because the extension-side panel is single-module-scoped (it only
+ * ever holds one module's previews at a time) — so the readiness of
+ * the sole module is also the readiness for whatever's focused. If the
+ * panel ever shows multiple modules at once, swap this to lookup by
+ * the focused card's `data-module-id`.
+ */
+export function isFocusedModuleReady(
+    moduleDaemonReady: ReadonlyMap<string, boolean>,
+): boolean {
+    for (const ready of moduleDaemonReady.values()) {
+        if (ready) return true;
+    }
+    return false;
+}
+
+/**
+ * Whether the focused module supports full v2 live mode (with preserved
+ * Compose state) vs the v1 fallback where pointer events round-trip
+ * through the daemon but renders refresh from scratch. Same module-
+ * scoping caveat as [isFocusedModuleReady]: returns true when *any*
+ * module is both ready and supports interactive mode.
+ */
+export function isFocusedInteractiveSupported(
+    moduleDaemonReady: ReadonlyMap<string, boolean>,
+    moduleInteractiveSupported: ReadonlyMap<string, boolean>,
+): boolean {
+    for (const [moduleId, ready] of moduleDaemonReady.entries()) {
+        if (ready && moduleInteractiveSupported.get(moduleId) === true)
+            return true;
+    }
+    return false;
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -16,6 +16,7 @@
     "exclude": ["node_modules", "src/webview/**"],
     "files": [
         "src/webview/preview/cardData.ts",
+        "src/webview/preview/moduleReadiness.ts",
         "src/webview/history/historyData.ts",
         "src/webview/shared/diffStatsLabel.ts",
         "src/webview/shared/safeIndex.ts",


### PR DESCRIPTION
`isFocusedModuleReady` and `isFocusedInteractiveSupported` were pure helpers buried in `focusToolbar.ts` (which can't be unit-tested under the host tsconfig — its `FocusToolbarController` class binds to DOM button elements). Moves them to a sibling `moduleReadiness.ts` and adds 8 tests covering:

- empty Map → false (both helpers).
- at least one ready module → `isFocusedModuleReady` true.
- every module unready → `isFocusedModuleReady` false.
- ready module + supported flag → interactive-supported true.
- ready but v1-fallback (`supported=false`) → false.
- supported but not ready → false.
- ready module missing from supported map → false (the `.get(moduleId) === true` strict-equality check rejects `undefined`).

`focusToolbar.ts` re-exports the predicates from the new module so existing imports (`import { isFocusedModuleReady } from "./focusToolbar"`) keep working without ripple-edits across `behavior.ts` / `focusController.ts`.

`tsconfig.json` adds `moduleReadiness.ts` to its `files` list (parallel to the existing `cardData.ts`, `historyData.ts`, `diffStatsLabel.ts`, `safeIndex.ts` entries).

389 → 397 tests passing. No behaviour change.

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 397/397 passing (389 prior + 8 new)
- [x] `npm run format:check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_