### PR TITLE
test(vscode): add unit tests for StoreController

### DIFF
--- a/vscode-extension/src/test/storeController.test.ts
+++ b/vscode-extension/src/test/storeController.test.ts
@@ -1,0 +1,178 @@
+import * as assert from "assert";
+import type { ReactiveControllerHost } from "lit";
+import { Store } from "../webview/shared/store";
+import { StoreController } from "../webview/shared/storeController";
+
+interface TestState {
+    counter: number;
+    label: string;
+    nested: { id: string };
+}
+
+const initial: TestState = {
+    counter: 0,
+    label: "init",
+    nested: { id: "a" },
+};
+
+/** Minimal ReactiveControllerHost stub. Captures the controller and
+ *  the requestUpdate calls so tests can assert subscription behaviour. */
+class HostStub implements ReactiveControllerHost {
+    requestUpdateCalls = 0;
+    addControllerCalls = 0;
+    addController(): void {
+        this.addControllerCalls++;
+    }
+    removeController(): void {
+        // unused
+    }
+    requestUpdate(): void {
+        this.requestUpdateCalls++;
+    }
+    updateComplete = Promise.resolve(true);
+}
+
+function makeStore(): Store<TestState> {
+    return new Store<TestState>({ ...initial, nested: { ...initial.nested } });
+}
+
+describe("StoreController", () => {
+    describe("construction", () => {
+        it("captures the initial selector value before subscribing", () => {
+            const host = new HostStub();
+            const store = makeStore();
+            const controller = new StoreController(
+                host,
+                store,
+                (s) => s.counter,
+            );
+            assert.strictEqual(controller.value, 0);
+        });
+
+        it("registers itself with the host via addController", () => {
+            const host = new HostStub();
+            const store = makeStore();
+            new StoreController(host, store, (s) => s.counter);
+            assert.strictEqual(host.addControllerCalls, 1);
+        });
+
+        it("does NOT subscribe to the store at construction time", () => {
+            // hostConnected drives the subscription. Constructing the
+            // controller without connecting it should leave the store
+            // listener-less.
+            const host = new HostStub();
+            const store = makeStore();
+            new StoreController(host, store, (s) => s.counter);
+            store.setState({ counter: 42 });
+            assert.strictEqual(host.requestUpdateCalls, 0);
+        });
+    });
+
+    describe("hostConnected → store change", () => {
+        it("requestUpdate fires when the selector value changes", () => {
+            const host = new HostStub();
+            const store = makeStore();
+            const controller = new StoreController(
+                host,
+                store,
+                (s) => s.counter,
+            );
+            controller.hostConnected();
+            store.setState({ counter: 1 });
+            assert.strictEqual(host.requestUpdateCalls, 1);
+            assert.strictEqual(controller.value, 1);
+        });
+
+        it("requestUpdate does NOT fire when the selector returns the same value", () => {
+            const host = new HostStub();
+            const store = makeStore();
+            const controller = new StoreController(
+                host,
+                store,
+                (s) => s.counter,
+            );
+            controller.hostConnected();
+            // Mutate an unrelated field; selector value is unchanged.
+            store.setState({ label: "next" });
+            assert.strictEqual(host.requestUpdateCalls, 0);
+            assert.strictEqual(controller.value, 0);
+        });
+
+        it("requestUpdate fires on each new selector value, not on every store change", () => {
+            const host = new HostStub();
+            const store = makeStore();
+            const controller = new StoreController(
+                host,
+                store,
+                (s) => s.counter,
+            );
+            controller.hostConnected();
+            store.setState({ counter: 1 }); // counter 0 → 1: fires
+            store.setState({ counter: 1, label: "x" }); // counter 1 → 1: skips
+            store.setState({ counter: 2 }); // counter 1 → 2: fires
+            assert.strictEqual(host.requestUpdateCalls, 2);
+            assert.strictEqual(controller.value, 2);
+        });
+
+        it("uses reference-equality on selector return values", () => {
+            // A nested object whose reference is replaced should trigger
+            // an update even if the inner contents are deep-equal.
+            const host = new HostStub();
+            const store = makeStore();
+            const controller = new StoreController(
+                host,
+                store,
+                (s) => s.nested,
+            );
+            controller.hostConnected();
+            // Same id, but a fresh object reference → update fires.
+            store.setState({ nested: { id: "a" } });
+            assert.strictEqual(host.requestUpdateCalls, 1);
+        });
+    });
+
+    describe("hostDisconnected", () => {
+        it("unsubscribes from the store so further changes don't fire requestUpdate", () => {
+            const host = new HostStub();
+            const store = makeStore();
+            const controller = new StoreController(
+                host,
+                store,
+                (s) => s.counter,
+            );
+            controller.hostConnected();
+            controller.hostDisconnected();
+            store.setState({ counter: 99 });
+            assert.strictEqual(host.requestUpdateCalls, 0);
+        });
+
+        it("hostDisconnected is idempotent (calling twice is safe)", () => {
+            const host = new HostStub();
+            const store = makeStore();
+            const controller = new StoreController(
+                host,
+                store,
+                (s) => s.counter,
+            );
+            controller.hostConnected();
+            controller.hostDisconnected();
+            // Second call should not throw.
+            assert.doesNotThrow(() => controller.hostDisconnected());
+        });
+
+        it("re-connecting after disconnect resubscribes cleanly", () => {
+            const host = new HostStub();
+            const store = makeStore();
+            const controller = new StoreController(
+                host,
+                store,
+                (s) => s.counter,
+            );
+            controller.hostConnected();
+            controller.hostDisconnected();
+            controller.hostConnected();
+            store.setState({ counter: 1 });
+            assert.strictEqual(host.requestUpdateCalls, 1);
+        });
+    });
+});

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -21,6 +21,7 @@
         "src/webview/shared/diffStatsLabel.ts",
         "src/webview/shared/safeIndex.ts",
         "src/webview/shared/store.ts",
+        "src/webview/shared/storeController.ts",
         "src/webview/shared/types.ts"
     ]
 }


### PR DESCRIPTION
Companion to #833. Covers `webview/shared/storeController.ts` — the Lit `ReactiveController` that subscribes a host component to a selector over a `Store<T>` and triggers `requestUpdate` on reference-equality changes to the selector return value.

## Summary

10 new tests covering:

**Construction:**
- Captures the initial selector value before subscribing.
- Registers itself with the host via `addController`.
- Does NOT subscribe at construction time — subscription happens in `hostConnected`. (Pinning this matters: if a host swaps a controller in mid-lifecycle but never connects it, the controller shouldn't silently leak a store subscription.)

**`hostConnected` → store change:**
- `requestUpdate` fires when the selector value changes.
- Does NOT fire when the selector returns the same value (so updating unrelated state fields doesn't cascade re-renders to every consumer).
- Counts updates correctly across mixed-change setStates (counter 0→1 fires, 1→1 skips, 1→2 fires).
- Reference-equality on the selector return: a fresh object with deep-equal contents triggers an update.

**`hostDisconnected`:**
- Unsubscribes from the store so further setStates don't fire `requestUpdate`.
- Idempotent — calling twice is safe.
- Re-connecting after disconnect resubscribes cleanly.

The `HostStub` mocks `ReactiveControllerHost` with three counters (`requestUpdateCalls`, `addControllerCalls`, plus `removeController` no-op + a resolved `updateComplete` Promise so the structural-typed interface check passes).

`tsconfig.json` adds `storeController.ts` to its `files` list. Lit's `ReactiveController` / `ReactiveControllerHost` types compile cleanly under the host config because the imports are type-only and Lit is already in `node_modules` for the webview build.

411 → 421 tests passing. No source changes.

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 421/421 passing (411 prior + 10 new)
- [x] `npm run format:check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_