### PR TITLE
refactor(vscode): lift filter + message-banner orchestration into FilterController

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -29,6 +29,7 @@ import {
 import { FilterToolbar } from "./components/FilterToolbar";
 import { MessageBanner, type MessageOwner } from "./components/MessageBanner";
 import { PreviewGrid } from "./components/PreviewGrid";
+import { FilterController } from "./filterController";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
 import {
     FocusController,
@@ -329,6 +330,20 @@ export function setupPreviewBehavior(
         setLastScopedPreviewId,
     });
 
+    // Filter + message-banner orchestration lives in `./filterController.ts`
+    // — see `FilterController`. Built after `focusController` because
+    // `apply()` calls `applyLayout()` to recompute focus bounds against the
+    // narrowed visible set.
+    const filterController = new FilterController({
+        vscode,
+        state,
+        filterToolbar,
+        grid,
+        messageBanner,
+        getAllPreviews: () => allPreviews,
+        applyLayout: () => focusController.applyLayout(),
+    });
+
     const staleBadge = new StaleBadgeController(vscode);
     const loadingOverlay = new LoadingOverlay();
 
@@ -419,63 +434,15 @@ export function setupPreviewBehavior(
         focusController.toggleA11yOverlay();
     }
 
-    function saveFilterState(): void {
-        state.filters = {
-            fn: filterToolbar.getFunctionValue(),
-            group: filterToolbar.getGroupValue(),
-        };
-        vscode.setState(state);
-    }
-
-    function restoreFilterState(): void {
-        const f = state.filters || {};
-        if (f.fn && filterToolbar.hasFunctionOption(f.fn))
-            filterToolbar.setFunctionValue(f.fn);
-        if (f.group && filterToolbar.hasGroupOption(f.group))
-            filterToolbar.setGroupValue(f.group);
-    }
-
-    function applyFilters(): void {
-        const visibleCount = grid.applyFilters({
-            fn: filterToolbar.getFunctionValue(),
-            group: filterToolbar.getGroupValue(),
-        });
-
-        // Only own the message when we have a filter-specific thing to
-        // say. When there are no previews at all, the extension owns the
-        // message (e.g. "No @Preview functions in this file") — clearing
-        // it here was how the view went blank after a refresh.
-        if (allPreviews.length > 0 && visibleCount === 0) {
-            setMessage("No previews match the current filters", "filter");
-        } else if (messageBanner.getOwner() === "filter") {
-            // We set this earlier; clear it now that it no longer applies.
-            setMessage("", "filter");
-        }
-
-        // Re-apply layout so focus mode updates correctly after filter change
-        applyLayout();
-    }
-
-    // Thin shim around `<message-banner>.setMessage` that keeps the
-    // ensureNotBlank() backstop wired in. The owner tag is used only to
-    // let applyFilters clear its own message without touching extension-
-    // set text (empty-file notice, build errors, etc.).
-    function setMessage(text: string, owner?: MessageOwner): void {
-        messageBanner.setMessage(text, owner ?? "extension");
-        ensureNotBlank();
-    }
-
-    // Safety net: if the grid ends up empty *and* no message is showing,
-    // surface a placeholder so the user doesn't stare at a void. This
-    // shouldn't normally trigger — the extension sends an explicit
-    // message for every empty state — but a silent blank view was the
-    // original complaint, so this catches any future regressions.
-    function ensureNotBlank(): void {
-        const hasCards = grid.querySelector(".preview-card") !== null;
-        if (!hasCards && !messageBanner.isVisible()) {
-            messageBanner.setMessage("Preparing previews…", "fallback");
-        }
-    }
+    // Filter + message-banner orchestration shims — implementations live
+    // in `./filterController.ts`. The shims keep the call shape stable
+    // for the message-context callbacks and the various event listeners.
+    const saveFilterState = (): void => filterController.save();
+    const restoreFilterState = (): void => filterController.restore();
+    const applyFilters = (): void => filterController.apply();
+    const setMessage = (text: string, owner?: MessageOwner): void =>
+        filterController.setMessage(text, owner);
+    const ensureNotBlank = (): void => filterController.ensureNotBlank();
 
     // populateFilter / hasOption are gone — `<filter-toolbar>` owns the
     // option lists via setFunctionOptions / setGroupOptions and exposes

--- a/vscode-extension/src/webview/preview/filterController.ts
+++ b/vscode-extension/src/webview/preview/filterController.ts
@@ -1,0 +1,126 @@
+// Filter + message-banner orchestration for the live "Compose Preview"
+// panel.
+//
+// Lifted verbatim from `behavior.ts`'s `applyFilters` / `saveFilterState`
+// / `restoreFilterState` / `setMessage` / `ensureNotBlank` cluster.
+// These five operations are tightly coupled — `applyFilters` may call
+// `setMessage` to surface "no previews match the current filters" and
+// `setMessage` always runs `ensureNotBlank()` as its tail, so they fold
+// into one controller.
+//
+// Owns no closure state of its own. The persisted filter state lives on
+// the shared `state` object passed via `FilterControllerConfig` (the same
+// reference `behavior.ts` and `FocusController` mutate). The
+// message-banner is a Lit element accessed via the typed handle in the
+// config.
+
+import type { FilterToolbar } from "./components/FilterToolbar";
+import type { MessageBanner, MessageOwner } from "./components/MessageBanner";
+import type { PreviewGrid } from "./components/PreviewGrid";
+import type { PreviewInfo } from "../shared/types";
+import type { VsCodeApi } from "../shared/vscode";
+
+/** Slim slice of the persisted state the filter controller writes. */
+export interface FilterControllerPersistedState {
+    filters?: { fn?: string; group?: string };
+}
+
+export interface FilterControllerConfig {
+    vscode: VsCodeApi<FilterControllerPersistedState>;
+    /** Shared mutable persisted-state reference. The controller mutates
+     *  `state.filters` and calls `vscode.setState(state)` to persist. */
+    state: FilterControllerPersistedState;
+    filterToolbar: FilterToolbar;
+    grid: PreviewGrid;
+    messageBanner: MessageBanner;
+    /** Read the current manifest — `apply` checks for the
+     *  "no previews at all" state to decide whether the extension owns
+     *  the empty-state message. */
+    getAllPreviews(): readonly PreviewInfo[];
+    /** Re-apply layout after filter change — focus mode needs to
+     *  recompute focusIndex bounds against the narrowed visible set. */
+    applyLayout(): void;
+}
+
+export class FilterController {
+    constructor(private readonly config: FilterControllerConfig) {}
+
+    /** Persist the current filter selections via `vscode.setState` so a
+     *  panel reload restores them. */
+    save(): void {
+        this.config.state.filters = {
+            fn: this.config.filterToolbar.getFunctionValue(),
+            group: this.config.filterToolbar.getGroupValue(),
+        };
+        this.config.vscode.setState(this.config.state);
+    }
+
+    /** Restore filter selections from `state.filters`, but only when
+     *  the saved value still exists as an option (the manifest may have
+     *  lost the function / group across panel reloads). */
+    restore(): void {
+        const f = this.config.state.filters || {};
+        if (f.fn && this.config.filterToolbar.hasFunctionOption(f.fn))
+            this.config.filterToolbar.setFunctionValue(f.fn);
+        if (f.group && this.config.filterToolbar.hasGroupOption(f.group))
+            this.config.filterToolbar.setGroupValue(f.group);
+    }
+
+    /** Apply the active filter to the grid, surface a "no previews
+     *  match" message when applicable, then re-apply layout (so focus
+     *  mode recomputes focusIndex bounds against the narrowed visible
+     *  set). */
+    apply(): void {
+        const visibleCount = this.config.grid.applyFilters({
+            fn: this.config.filterToolbar.getFunctionValue(),
+            group: this.config.filterToolbar.getGroupValue(),
+        });
+
+        // Only own the message when we have a filter-specific thing to
+        // say. When there are no previews at all, the extension owns
+        // the message (e.g. "No @Preview functions in this file") —
+        // clearing it here was how the view went blank after a refresh.
+        if (this.config.getAllPreviews().length > 0 && visibleCount === 0) {
+            this.setMessage("No previews match the current filters", "filter");
+        } else if (this.config.messageBanner.getOwner() === "filter") {
+            // We set this earlier; clear it now that it no longer applies.
+            this.setMessage("", "filter");
+        }
+
+        // Re-apply layout so focus mode updates correctly after filter change
+        this.config.applyLayout();
+    }
+
+    /**
+     * Thin shim around `<message-banner>.setMessage` that keeps the
+     * `ensureNotBlank()` backstop wired in. The owner tag is used only
+     * to let `apply` clear its own message without touching extension-
+     * set text (empty-file notice, build errors, etc.).
+     *
+     * `renderPreviews` (in `cardBuilder.ts`) and the `messageHandlers`
+     * dispatcher reach for this via the `setMessage` callback in their
+     * respective contexts.
+     */
+    setMessage(text: string, owner?: MessageOwner): void {
+        this.config.messageBanner.setMessage(text, owner ?? "extension");
+        this.ensureNotBlank();
+    }
+
+    /**
+     * Safety net: if the grid ends up empty *and* no message is showing,
+     * surface a placeholder so the user doesn't stare at a void. This
+     * shouldn't normally trigger — the extension sends an explicit
+     * message for every empty state — but a silent blank view was the
+     * original complaint, so this catches any future regressions.
+     */
+    ensureNotBlank(): void {
+        const hasCards =
+            this.config.grid.querySelector(".preview-card") !== null;
+        if (!hasCards && !this.config.messageBanner.isVisible()) {
+            this.config.messageBanner.setMessage(
+                "Preparing previews…",
+                "fallback",
+            );
+        }
+    }
+}


### PR DESCRIPTION
Lifts the `applyFilters` / `saveFilterState` / `restoreFilterState` / `setMessage` / `ensureNotBlank` cluster out of `behavior.ts` into a typed `FilterController`. These five operations are tightly coupled — `applyFilters` may call `setMessage` to surface "no previews match the current filters", `setMessage` always runs `ensureNotBlank()` as its tail — so they fold into one controller alongside the existing `FocusController` and `LiveStateController`.

## Summary

New `filterController.ts` exports `FilterController` class with five methods (`save`, `restore`, `apply`, `setMessage`, `ensureNotBlank`), plus `FilterControllerConfig` covering `vscode`, the shared mutable `state` reference, `filterToolbar`, `grid`, `messageBanner`, `getAllPreviews`, and an `applyLayout` callback (`apply` re-applies layout so focus mode recomputes focusIndex bounds against the narrowed visible set).

`behavior.ts` builds the controller after `focusController` (because `apply` calls `applyLayout`) and exposes thin arrow-function shims for the names other parts of the panel still reference by callable — event listeners (filter-changed handler), `messageContext` callbacks (`applyFilters`, `saveFilterState`, `restoreFilterState`, `ensureNotBlank` are passed to `messageHandlers`), and the `cardBuilderConfig.setMessage` / `getMessageOwner` pair already threaded through `renderPreviews`.

`behavior.ts`: 575 → 542 lines (**−33 LOC**).
`filterController.ts`: +126 lines (new file).

**`behavior.ts` is now down 83% from its 3208-line `@ts-nocheck` start.** The remaining content is mostly setup glue: DOM lookup helpers, button references, store accessors, controller construction, event listener wiring, viewport tracker setup, message-handler installation.

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 421/421 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke:
  - Filter dropdowns: pick a function / group; saved across panel reload.
  - Filter narrows visible set to 0 with previews present: "No previews match the current filters" message appears; clears when filter is relaxed.
  - Empty grid + no extension message: "Preparing previews…" fallback appears (timing-sensitive, exercise during boot).
  - Layout dropdown change after filter applied: focus mode recomputes bounds correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_