### PR TITLE
fix(mcp): notify on every bootstrap-to-full tool catalog transition

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -87,7 +87,11 @@ class DaemonMcpServer(
    * disables the sampler; production defaults to 10 minutes.
    */
   private val samplingIntervalMs: Long = DEFAULT_SAMPLING_INTERVAL_MS,
+  fullToolDefsLoader: (() -> List<ToolDef>)? = null,
 ) {
+
+  private val fullToolDefsLoader: () -> List<ToolDef> =
+    fullToolDefsLoader ?: { buildFullToolDefs() }
 
   private val json = Json {
     ignoreUnknownKeys = true
@@ -228,8 +232,21 @@ class DaemonMcpServer(
   private val fullToolCatalogWasDelayed = AtomicBoolean(false)
   @Volatile private var fullToolCatalogError: String? = null
 
+  /**
+   * Sessions that have been served [bootstrapToolDefs] from `tools/list` while [fullToolDefsFuture]
+   * was still loading. Each such session must receive `notifications/tools/list_changed` once the
+   * full catalog is ready, regardless of whether the load took more or less than
+   * [TOOL_CATALOG_NOTIFY_DELAY_MS] — clients that rely on `listChanged` would otherwise permanently
+   * miss the tools that only appear in the full catalog (see #670). Guarded by
+   * [bootstrapNotifyLock] so the future-completion handler and `tools/list` callers cannot lose a
+   * session through the isDone/add race.
+   */
+  private val bootstrapNotifyLock = Any()
+  private val bootstrapServedSessions = mutableSetOf<Session>()
+
   private val fullToolDefsFuture: CompletableFuture<List<ToolDef>> =
-    CompletableFuture.supplyAsync({ buildFullToolDefs() }, toolCatalogExecutor).also { future ->
+    CompletableFuture.supplyAsync({ this.fullToolDefsLoader() }, toolCatalogExecutor).also { future
+      ->
       progressBeatExecutor.schedule(
         {
           if (!future.isDone) {
@@ -243,8 +260,14 @@ class DaemonMcpServer(
         if (error != null) {
           fullToolCatalogError = error.message ?: error::class.java.simpleName
           System.err.println("compose-preview-mcp: full tool catalog failed: ${error.message}")
-        } else if (fullToolCatalogWasDelayed.get()) {
-          sessions.forEach { it.notifyToolListChanged() }
+        } else {
+          val toNotify =
+            synchronized(bootstrapNotifyLock) {
+              val snapshot = bootstrapServedSessions.toList()
+              bootstrapServedSessions.clear()
+              snapshot
+            }
+          toNotify.forEach { runCatching { it.notifyToolListChanged() } }
         }
       }
     }
@@ -304,7 +327,7 @@ class DaemonMcpServer(
           sdkServer.installComposePreviewHandlers(
             sdkSession = sdkSession,
             session = session,
-            listTools = { currentToolDefs() },
+            listTools = { currentToolDefs(session) },
             callTool = { name, arguments -> handleCallTool(session, name, arguments) },
             listResources = { catalogResources() },
             readResource = { uri, progressToken ->
@@ -329,6 +352,7 @@ class DaemonMcpServer(
     val released = subscriptions.forgetDataSubscriptions(session)
     released.forEach { key -> dispatchDataUnsubscribe(key) }
     subscriptions.forget(session)
+    synchronized(bootstrapNotifyLock) { bootstrapServedSessions.remove(session) }
     sessions.unregister(session)
   }
 
@@ -770,12 +794,29 @@ class DaemonMcpServer(
   // Tool surface
   // -------------------------------------------------------------------------
 
-  private fun currentToolDefs(): List<ToolDef> =
-    if (!fullToolDefsFuture.isDone) {
+  private fun currentToolDefs(session: Session): List<ToolDef> {
+    if (fullToolDefsFuture.isDone) {
+      return runCatching { fullToolDefsFuture.getNow(bootstrapToolDefs) }
+        .getOrDefault(bootstrapToolDefs)
+    }
+    // Bootstrap path: enroll the session under the lock so the future-completion handler cannot
+    // race past it. If the future completed between the outer isDone check and acquiring the lock,
+    // serve the full list directly and skip enrollment — the transition has already happened.
+    val servedBootstrap =
+      synchronized(bootstrapNotifyLock) {
+        if (fullToolDefsFuture.isDone) {
+          false
+        } else {
+          bootstrapServedSessions.add(session)
+          true
+        }
+      }
+    return if (servedBootstrap) {
       bootstrapToolDefs
     } else {
       runCatching { fullToolDefsFuture.getNow(bootstrapToolDefs) }.getOrDefault(bootstrapToolDefs)
     }
+  }
 
   private val bootstrapToolDefs: List<ToolDef> by lazy {
     listOf(

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -135,6 +135,64 @@ class DaemonMcpServerTest {
   }
 
   @Test
+  fun `bootstrap tools list_changed fires when full catalog completes inside grace period`() {
+    // Race covered by issue #670: a client receives bootstrapToolDefs from tools/list, the full
+    // catalog finishes loading well under TOOL_CATALOG_NOTIFY_DELAY_MS, and without this fix no
+    // notifications/tools/list_changed is sent — so listChanged-only clients permanently miss
+    // tools like `record_preview`.
+    runCatching { client.close() }
+    runCatching { session.close() }
+    runCatching { supervisor.shutdown() }
+
+    val gate = java.util.concurrent.CountDownLatch(1)
+    val loaderEntered = java.util.concurrent.CountDownLatch(1)
+    factory = FakeDaemonClientFactory()
+    supervisor =
+      DaemonSupervisor(descriptorProvider = FakeDescriptorProvider(), clientFactory = factory)
+    server =
+      DaemonMcpServer(
+        supervisor = supervisor,
+        fullToolDefsLoader = {
+          loaderEntered.countDown()
+          gate.await()
+          listOf(
+            ee.schimke.composeai.mcp.protocol.ToolDef(
+              name = "record_preview",
+              description = "stub for the test",
+              inputSchema =
+                Json.parseToJsonElement("""{"type":"object","properties":{}}""").jsonObject,
+            )
+          )
+        },
+      )
+
+    val (clientToServer, serverFromClient) = pipedPair()
+    val (serverToClient, clientFromServer) = pipedPair()
+    session =
+      server.newSession(input = serverFromClient, output = serverToClient).also { it.start() }
+    client = McpTestClient(input = clientFromServer, output = clientToServer)
+
+    client.initialize()
+
+    // Wait until the loader is actually blocked, otherwise we might race past the bootstrap window.
+    assertThat(loaderEntered.await(5, TimeUnit.SECONDS)).isTrue()
+
+    val bootstrap =
+      json.decodeFromJsonElement(ListToolsResult.serializer(), client.request("tools/list"))
+    assertThat(bootstrap.tools.map { it.name }).doesNotContain("record_preview")
+
+    // Release the loader; the full catalog now resolves quickly — long before the 3s grace window.
+    gate.countDown()
+
+    // The fix's contract: this notification arrives even though the load was not "delayed".
+    client.expectNotification("notifications/tools/list_changed", 5_000)
+
+    val full =
+      json.decodeFromJsonElement(ListToolsResult.serializer(), client.request("tools/list"))
+    assertThat(full.tools.map { it.name }).contains("record_preview")
+  }
+
+  @Test
   fun `register_project returns workspaceId and notifies list_changed`() {
     client.initialize()
     val projectDir = tmp.newFolder("workspace")


### PR DESCRIPTION
## Summary

- Track which sessions have been served `bootstrapToolDefs` from `tools/list` and fire `notifications/tools/list_changed` to each of them when `fullToolDefsFuture` completes — regardless of whether the load took more or less than the 3 s grace period.
- Previously the notification was gated on `fullToolCatalogWasDelayed`, so a client that read the bootstrap list and then saw the full catalog finish quickly (e.g. 500 ms) never received `list_changed` and could permanently miss tools like `record_preview`.
- The 3 s delayed marker still drives `status.toolCatalog.delayed`, but no longer gates correctness notifications.

Fixes #670.

## Test plan

- [x] `:mcp:test --tests "DaemonMcpServerTest.bootstrap*"` — new test `bootstrap tools list_changed fires when full catalog completes inside grace period` exercises the fast-completion race by injecting a `CountDownLatch`-gated `fullToolDefsLoader`: asserts the first `tools/list` returns bootstrap, releases the gate, and asserts `notifications/tools/list_changed` arrives well inside the 3 s window.
- [x] `:mcp:test --tests "DaemonMcpServerTest.initialize*" "DaemonMcpServerTest.status*"` still green.
- [x] `:mcp:ktfmtCheck` clean.
- [x] Full `:mcp:test` run shows only the pre-existing, unrelated failure (`record_preview rejects extension events advertised but not yet implemented`) that fails identically on `origin/main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3xMZ72vborBUwVJWtzQfg)_