### PR TITLE
refactor(daemon/android): migrate fonts/resources/i18n recorders to data extensions

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/FontsRecorderExtension.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/FontsRecorderExtension.kt
@@ -1,0 +1,69 @@
+package ee.schimke.composeai.daemon
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalFontFamilyResolver
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionComposeContext
+import java.io.File
+
+/**
+ * Always-on data extension that records every font resolution made during composition and writes
+ * the `fonts/used` artefact after capture.
+ *
+ * Implements both [AroundComposableHook] (to install the recording [LocalFontFamilyResolver]) and
+ * [PostCaptureProcessor] (to write the JSON artefact once the bitmap is captured) so the recorder
+ * lifecycle is owned end-to-end by this extension. The render engine no longer constructs
+ * `FontResolverRecorder` directly or threads its payload through `FontsUsedDataProducer
+ * .writeArtifacts`.
+ *
+ * Constructed per render via [factory] so the recorder can take the per-render Android [Context]
+ * for resource-name resolution.
+ */
+class FontsRecorderExtension(context: Context? = null) :
+  AroundComposableHook, PostCaptureProcessor {
+  private val recorder = FontResolverRecorder(context)
+
+  override val id: DataExtensionId = ID
+  override val hooks: Set<DataExtensionHookKind> =
+    setOf(DataExtensionHookKind.AroundComposable, DataExtensionHookKind.AfterCapture)
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(phase = DataExtensionPhase.Instrumentation)
+  override val targets: Set<DataExtensionTarget> = setOf(DataExtensionTarget.Android)
+
+  @Composable
+  override fun Around(context: ExtensionComposeContext, content: @Composable () -> Unit) {
+    val baseFontResolver = LocalFontFamilyResolver.current
+    CompositionLocalProvider(
+      LocalFontFamilyResolver provides recordingFontFamilyResolver(baseFontResolver, recorder),
+      content = content,
+    )
+  }
+
+  override fun process(context: ExtensionPostCaptureContext) {
+    val rootDir = context.require(RenderDataArtifactContextKeys.RootDir)
+    val outputBaseName = context.require(RenderDataArtifactContextKeys.OutputBaseName)
+    val previewId = context.get(RenderDataArtifactContextKeys.PreviewId) ?: outputBaseName
+    FontsUsedDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = previewId,
+      payload = recorder.payload(),
+    )
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId(FontsUsedDataProducer.KIND)
+
+    /** Factory wired into the render engine's data-artifact extension list. */
+    val factory: RenderDataArtifactExtensionFactory =
+      RenderDataArtifactExtensionFactory { context: Context -> FontsRecorderExtension(context) }
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/I18nTranslationsExtension.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/I18nTranslationsExtension.kt
@@ -1,0 +1,45 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+
+/**
+ * Always-on post-capture extension that walks the captured semantics tree and writes the
+ * `i18n/translations` artefact for the rendered preview.
+ *
+ * Pure post-capture: no Compose-side hook is needed because the producer reads the visible text
+ * out of the rendered semantics root rather than recording during composition.
+ */
+class I18nTranslationsExtension : PostCaptureProcessor {
+  override val id: DataExtensionId = ID
+  override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.AfterCapture)
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(phase = DataExtensionPhase.Capture)
+  override val targets: Set<DataExtensionTarget> = setOf(DataExtensionTarget.Android)
+
+  override fun process(context: ExtensionPostCaptureContext) {
+    val rootDir = context.require(RenderDataArtifactContextKeys.RootDir)
+    val outputBaseName = context.require(RenderDataArtifactContextKeys.OutputBaseName)
+    val semanticsRoot = context.require(RenderDataArtifactContextKeys.SemanticsRoot)
+    val renderedLocale =
+      context.get(RenderDataArtifactContextKeys.RenderedLocale)?.takeIf { it.isNotBlank() }
+    I18nTranslationsDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = outputBaseName,
+      root = semanticsRoot,
+      renderedLocale = renderedLocale,
+    )
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId(I18nTranslationsDataProducer.KIND)
+
+    val factory: RenderDataArtifactExtensionFactory =
+      RenderDataArtifactExtensionFactory { _ -> I18nTranslationsExtension() }
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderDataArtifactExtensions.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderDataArtifactExtensions.kt
@@ -1,0 +1,72 @@
+package ee.schimke.composeai.daemon
+
+import android.content.Context
+import androidx.compose.ui.semantics.SemanticsNode
+import ee.schimke.composeai.data.render.extensions.ExtensionContextKey
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import java.io.File
+
+/**
+ * Per-render builder for "always-on" data extensions (fonts, resources, i18n).
+ *
+ * Distinct from [PreviewOverrideExtensions] in two ways:
+ * - Extensions returned here always run, regardless of `renderNow.overrides`.
+ * - The factory is invoked per render with the render-time platform [Context], so the extension
+ *   instance can stand up its recorder + `CompositionLocal` install before composition starts.
+ *
+ * The render engine threads the resulting list through the Compose data-extension pipeline (for
+ * any [ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook] members) and then
+ * iterates the same list for [ee.schimke.composeai.data.render.extensions.PostCaptureProcessor]
+ * members during the post-capture pass — so one extension class can both install a recording
+ * `CompositionLocal` during composition and write its typed artifact after capture.
+ */
+fun interface RenderDataArtifactExtensionFactory {
+  fun create(context: Context): PlannedDataExtension
+}
+
+class RenderDataArtifactExtensions(val factories: List<RenderDataArtifactExtensionFactory>) {
+  fun build(context: Context): List<PlannedDataExtension> = factories.map { it.create(context) }
+
+  companion object {
+    val Empty: RenderDataArtifactExtensions = RenderDataArtifactExtensions(emptyList())
+  }
+}
+
+/**
+ * Typed keys the render engine populates on [ee.schimke.composeai.data.render.extensions
+ * .ExtensionPostCaptureContext.data] before invoking each always-on data extension. Lets the
+ * extensions reach the per-preview output directory, the file-system base name, the requested
+ * locale tag, and the captured semantics root through the same typed-key pattern other
+ * post-capture extensions already use.
+ */
+object RenderDataArtifactContextKeys {
+  /** Per-preview data-product output root (`<dataDir>/<previewId>/<file>`). */
+  val RootDir: ExtensionContextKey<File> =
+    ExtensionContextKey(name = "render-data-artifact.rootDir", type = File::class.java)
+
+  /**
+   * File-system base name (`spec.outputBaseName`) — used by extensions that key their per-preview
+   * directory off the renderer-generated output name rather than the protocol-level previewId.
+   */
+  val OutputBaseName: ExtensionContextKey<String> =
+    ExtensionContextKey(name = "render-data-artifact.outputBaseName", type = String::class.java)
+
+  /**
+   * Protocol-level preview identifier (`spec.previewId`), if the caller supplied one. Distinct
+   * from [OutputBaseName]; some extensions (fonts) historically prefer this when present and fall
+   * back to the base name otherwise.
+   */
+  val PreviewId: ExtensionContextKey<String> =
+    ExtensionContextKey(name = "render-data-artifact.previewId", type = String::class.java)
+
+  /** BCP-47 locale tag the render was performed with, when the request specified one. */
+  val RenderedLocale: ExtensionContextKey<String> =
+    ExtensionContextKey(name = "render-data-artifact.renderedLocale", type = String::class.java)
+
+  /** Captured root semantics node for the rendered preview. */
+  val SemanticsRoot: ExtensionContextKey<SemanticsNode> =
+    ExtensionContextKey(
+      name = "render-data-artifact.semanticsRoot",
+      type = SemanticsNode::class.java,
+    )
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -19,10 +19,9 @@ import androidx.compose.runtime.tooling.CompositionData
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalFontFamilyResolver
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.ViewRootForTest
+import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
@@ -37,7 +36,9 @@ import ee.schimke.composeai.data.theme.ThemePayload
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionContextValue
 import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
 import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
 import ee.schimke.composeai.data.render.extensions.provides
 import ee.schimke.composeai.renderer.AccessibilityDataProducts
@@ -128,6 +129,16 @@ class RenderEngine(
    */
   private val previewOverrideExtensions: PreviewOverrideExtensions =
     PreviewOverrideExtensions.Empty,
+  /**
+   * Always-on data extensions (fonts, resources, i18n) that own their recorder + post-capture
+   * artefact write. Distinct from [previewOverrideExtensions]: every factory here runs on every
+   * render rather than gating on a `renderNow.overrides` field. Each factory is invoked per
+   * render with the per-render Android [Context] so the extension can install recording
+   * `CompositionLocal`s before composition starts; the same instance is then asked to write its
+   * typed artefact during the post-capture pass.
+   */
+  private val dataArtifactExtensions: RenderDataArtifactExtensions =
+    RenderDataArtifactExtensions.Empty,
 ) {
 
   /**
@@ -252,8 +263,11 @@ class RenderEngine(
 
             val bgArgb = resolveBackgroundColor(spec).toArgb()
             rule.runOnUiThread { rule.activity.window.decorView.setBackgroundColor(bgArgb) }
-            val resourceRecorder = ResourcesUsedDataProducer.recorder(rule.activity)
-            val fontRecorder = FontResolverRecorder(rule.activity)
+            // Always-on data extensions (fonts, resources, i18n recorders + post-capture
+            // writers) — built per render so each extension owns its own recorder lifecycle.
+            // Threaded through the same Compose pipeline as `previewOverrideExtensions` and
+            // re-used during the post-capture pass below to write the artefacts.
+            val builtDataArtifactExtensions = dataArtifactExtensions.build(rule.activity)
 
             trace.section("compose:setContent") {
               rule.setContent {
@@ -263,20 +277,16 @@ class RenderEngine(
                 // through rather than parking under the paused clock — same trade
                 // `RobolectricRenderTest.renderWithA11y` already pays.
                 val inspectionMode = if (runAccessibility) false else spec.inspectionMode ?: true
-                val baseFontResolver = LocalFontFamilyResolver.current
-                CompositionLocalProvider(
-                  LocalInspectionMode provides inspectionMode,
-                  LocalContext provides ResourcesUsedDataProducer.context(rule.activity, resourceRecorder),
-                  LocalFontFamilyResolver provides
-                    recordingFontFamilyResolver(baseFontResolver, fontRecorder),
-                ) {
+                CompositionLocalProvider(LocalInspectionMode provides inspectionMode) {
                   CaptureMaterialTheme { _, typography, shapes, payload ->
                     themeFallbackCapture.capture(typography, shapes)
                     themeFallbackCapture.capture(payload)
                   }
                   val content: @Composable () -> Unit = {
                     ComposeDataExtensionPipeline.Apply(
-                      extensions = previewOverrideExtensions.plan(spec.overrides),
+                      extensions =
+                        previewOverrideExtensions.plan(spec.overrides) +
+                          builtDataArtifactExtensions,
                       previewId = spec.previewId,
                       renderMode = spec.renderMode,
                       sink = RecordingExtensionCompositionSink(),
@@ -313,47 +323,16 @@ class RenderEngine(
                 }
               }
 
-            if (dataDir != null) {
-              try {
-                trace.section("compose:fontsUsedDataProduct") {
-                  FontsUsedDataProducer.writeArtifacts(
-                    rootDir = dataDir,
-                    previewId = spec.previewId ?: spec.outputBaseName,
-                    payload = fontRecorder.payload(),
-                  )
-                }
-              } catch (t: Throwable) {
-                System.err.println(
-                  "RenderEngine: fonts/used data write failed for ${spec.outputBaseName}: " +
-                    "${t.javaClass.simpleName}: ${t.message}"
-                )
-              }
-            }
-
-            if (dataDir != null) {
-              try {
-                trace.section("android:resourcesUsedDataProduct") {
-                  ResourcesUsedDataProducer.writeArtifacts(
-                    rootDir = dataDir,
-                    previewId = spec.outputBaseName,
-                    recorder = resourceRecorder,
-                  )
-                }
-              } catch (t: Throwable) {
-                System.err.println(
-                  "RenderEngine: resources/used data write failed for ${spec.outputBaseName}: " +
-                    "${t.javaClass.simpleName}: ${t.message}"
-                )
-              }
-            }
-
-            // compose/semantics and i18n/translations data products. Both are default-mode data,
-            // independent of the accessibility checker: clients get inspector text bounds and
-            // locale coverage without paying ATF costs.
+            // compose/semantics + layoutinspector data products. Default-mode data, independent
+            // of the accessibility checker: clients get inspector text bounds without paying ATF
+            // costs. The captured semantics root is also fed into the always-on data-artifact
+            // post-capture pass below (i18n).
+            var capturedSemanticsRoot: SemanticsNode? = null
             if (dataDir != null) {
               try {
                 trace.section("compose:defaultDataProducts") {
                   val semanticsRoot = rule.onRoot(useUnmergedTree = true).fetchSemanticsNode()
+                  capturedSemanticsRoot = semanticsRoot
                   ComposeSemanticsDataProducer.writeArtifacts(
                     rootDir = dataDir,
                     previewId = spec.outputBaseName,
@@ -382,18 +361,59 @@ class RenderEngine(
                     previewId = spec.outputBaseName,
                     previewContext = layoutInspectionContext,
                   )
-                  I18nTranslationsDataProducer.writeArtifacts(
-                    rootDir = dataDir,
-                    previewId = spec.outputBaseName,
-                    root = semanticsRoot,
-                    renderedLocale = spec.localeTag,
-                  )
                 }
               } catch (t: Throwable) {
                 System.err.println(
                   "RenderEngine: default data write failed for ${spec.outputBaseName}: " +
                     "${t.javaClass.simpleName}: ${t.message}"
                 )
+              }
+            }
+
+            // Always-on data-artifact extensions (fonts, resources, i18n). Each extension owns
+            // its own recorder lifecycle (installed during composition via
+            // [AroundComposableHook]) and writes its typed artefact through
+            // [PostCaptureProcessor.process]. The render engine just hands them the typed
+            // post-capture context (rootDir, previewId, semantics root, locale) and lets each
+            // extension decide what to write.
+            if (dataDir != null && builtDataArtifactExtensions.isNotEmpty()) {
+              val resolvedSemanticsRoot =
+                capturedSemanticsRoot
+                  ?: runCatching { rule.onRoot(useUnmergedTree = true).fetchSemanticsNode() }
+                    .getOrNull()
+              val artifactContextData = buildList<ExtensionContextValue<*>> {
+                add(RenderDataArtifactContextKeys.RootDir provides dataDir)
+                add(RenderDataArtifactContextKeys.OutputBaseName provides spec.outputBaseName)
+                spec.previewId?.let { add(RenderDataArtifactContextKeys.PreviewId provides it) }
+                spec.localeTag?.takeIf { it.isNotBlank() }?.let {
+                  add(RenderDataArtifactContextKeys.RenderedLocale provides it)
+                }
+                resolvedSemanticsRoot?.let {
+                  add(RenderDataArtifactContextKeys.SemanticsRoot provides it)
+                }
+              }
+              val extensionContextData = ExtensionContextData.of(*artifactContextData.toTypedArray())
+              val productStore = RecordingDataProductStore()
+              for (ext in builtDataArtifactExtensions) {
+                if (ext !is PostCaptureProcessor) continue
+                try {
+                  trace.section("dataArtifact:${ext.id}") {
+                    ext.process(
+                      ExtensionPostCaptureContext(
+                        extensionId = ext.id,
+                        previewId = spec.previewId,
+                        renderMode = spec.renderMode,
+                        products = productStore.scopedFor(ext),
+                        data = extensionContextData,
+                      )
+                    )
+                  }
+                } catch (t: Throwable) {
+                  System.err.println(
+                    "RenderEngine: ${ext.id} data write failed for ${spec.outputBaseName}: " +
+                      "${t.javaClass.simpleName}: ${t.message}"
+                  )
+                }
               }
             }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ResourcesRecorderExtension.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ResourcesRecorderExtension.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.daemon
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalContext
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionComposeContext
+
+/**
+ * Always-on data extension that records every Android resource (`getString`, `getDrawable`, …)
+ * resolved during composition and writes the `resources/used` artefact after capture.
+ *
+ * Implements both [AroundComposableHook] (installs a recording [LocalContext] over the activity)
+ * and [PostCaptureProcessor] (writes the JSON artefact once the bitmap is captured). The recorder
+ * is constructed inside the extension; the render engine no longer touches
+ * `ResourcesUsedDataProducer.recorder(...)` or `.writeArtifacts(...)` directly.
+ */
+class ResourcesRecorderExtension(private val baseContext: Context) :
+  AroundComposableHook, PostCaptureProcessor {
+  private val recorder: RecordingResources = ResourcesUsedDataProducer.recorder(baseContext)
+  private val recordingContext: Context =
+    ResourcesUsedDataProducer.context(baseContext, recorder)
+
+  override val id: DataExtensionId = ID
+  override val hooks: Set<DataExtensionHookKind> =
+    setOf(DataExtensionHookKind.AroundComposable, DataExtensionHookKind.AfterCapture)
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(phase = DataExtensionPhase.Instrumentation)
+  override val targets: Set<DataExtensionTarget> = setOf(DataExtensionTarget.Android)
+
+  @Composable
+  override fun Around(context: ExtensionComposeContext, content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalContext provides recordingContext, content = content)
+  }
+
+  override fun process(context: ExtensionPostCaptureContext) {
+    val rootDir = context.require(RenderDataArtifactContextKeys.RootDir)
+    val outputBaseName = context.require(RenderDataArtifactContextKeys.OutputBaseName)
+    ResourcesUsedDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = outputBaseName,
+      recorder = recorder,
+    )
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId(ResourcesUsedDataProducer.KIND)
+
+    val factory: RenderDataArtifactExtensionFactory =
+      RenderDataArtifactExtensionFactory { context -> ResourcesRecorderExtension(context) }
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1152,7 +1152,15 @@ open class RobolectricHost(
         previewOverrideExtensions =
           PreviewOverrideExtensions(
             listOf(WallpaperPreviewOverrideExtension(), Material3ThemePreviewOverrideExtension())
-          )
+          ),
+        dataArtifactExtensions =
+          RenderDataArtifactExtensions(
+            listOf(
+              FontsRecorderExtension.factory,
+              ResourcesRecorderExtension.factory,
+              I18nTranslationsExtension.factory,
+            )
+          ),
       )
     }
 

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/FontsRecorderExtensionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/FontsRecorderExtensionTest.kt
@@ -1,0 +1,89 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.provides
+import java.nio.file.Files
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FontsRecorderExtensionTest {
+
+  @Test
+  fun `extension declares around-composable plus after-capture hooks`() {
+    val extension = FontsRecorderExtension()
+    assertEquals("fonts/used", extension.id.value)
+    assertEquals(
+      setOf(DataExtensionHookKind.AroundComposable, DataExtensionHookKind.AfterCapture),
+      extension.hooks,
+    )
+    assertEquals(setOf(DataExtensionTarget.Android), extension.targets)
+    assertEquals(FontsRecorderExtension.ID, extension.id)
+  }
+
+  @Test
+  fun `process writes empty fonts-used artefact when no fonts were recorded`() {
+    val extension = FontsRecorderExtension()
+    val rootDir = Files.createTempDirectory("fonts-extension-test").toFile()
+    try {
+      val store = RecordingDataProductStore()
+      val context =
+        ExtensionPostCaptureContext(
+          extensionId = extension.id,
+          previewId = null,
+          renderMode = null,
+          products = store.scopedFor(extension),
+          data =
+            ExtensionContextData.of(
+              RenderDataArtifactContextKeys.RootDir provides rootDir,
+              RenderDataArtifactContextKeys.OutputBaseName provides "preview-base",
+            ),
+        )
+      extension.process(context)
+
+      val artefact = rootDir.resolve("preview-base").resolve(FontsUsedDataProducer.FILE)
+      assertTrue("expected fonts-used.json at $artefact", artefact.exists())
+      val payload =
+        FontsUsedDataProducer.json.parseToJsonElement(artefact.readText()).jsonObject
+      assertTrue("empty recorder should produce empty fonts list", payload["fonts"]!!.jsonArray.isEmpty())
+    } finally {
+      rootDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `process prefers protocol previewId over outputBaseName when present`() {
+    val extension = FontsRecorderExtension()
+    val rootDir = Files.createTempDirectory("fonts-extension-protocol-id").toFile()
+    try {
+      val store = RecordingDataProductStore()
+      val context =
+        ExtensionPostCaptureContext(
+          extensionId = extension.id,
+          previewId = null,
+          renderMode = null,
+          products = store.scopedFor(extension),
+          data =
+            ExtensionContextData.of(
+              RenderDataArtifactContextKeys.RootDir provides rootDir,
+              RenderDataArtifactContextKeys.OutputBaseName provides "fallback-base",
+              RenderDataArtifactContextKeys.PreviewId provides "protocol-id",
+            ),
+        )
+      extension.process(context)
+
+      val byProtocolId = rootDir.resolve("protocol-id").resolve(FontsUsedDataProducer.FILE)
+      val byBaseName = rootDir.resolve("fallback-base").resolve(FontsUsedDataProducer.FILE)
+      assertTrue("expected fonts artefact under protocol previewId: $byProtocolId", byProtocolId.exists())
+      assertTrue("must not also write under outputBaseName: $byBaseName", !byBaseName.exists())
+    } finally {
+      rootDir.deleteRecursively()
+    }
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/I18nTranslationsExtensionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/I18nTranslationsExtensionTest.kt
@@ -1,0 +1,51 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.provides
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class I18nTranslationsExtensionTest {
+
+  @Test
+  fun `extension declares after-capture hook only`() {
+    val extension = I18nTranslationsExtension()
+    assertEquals("i18n/translations", extension.id.value)
+    assertEquals(setOf(DataExtensionHookKind.AfterCapture), extension.hooks)
+    assertEquals(DataExtensionPhase.Capture, extension.constraints.phase)
+    assertEquals(setOf(DataExtensionTarget.Android), extension.targets)
+  }
+
+  @Test
+  fun `process fails fast when the captured semantics root is missing`() {
+    val extension = I18nTranslationsExtension()
+    val rootDir = Files.createTempDirectory("i18n-extension-test").toFile()
+    try {
+      val store = RecordingDataProductStore()
+      val context =
+        ExtensionPostCaptureContext(
+          extensionId = extension.id,
+          previewId = null,
+          renderMode = null,
+          products = store.scopedFor(extension),
+          data =
+            ExtensionContextData.of(
+              RenderDataArtifactContextKeys.RootDir provides rootDir,
+              RenderDataArtifactContextKeys.OutputBaseName provides "preview-base",
+            ),
+        )
+      // No SemanticsRoot key present — the extension must surface a clear error rather than
+      // silently emit a half-populated artefact.
+      assertThrows(IllegalStateException::class.java) { extension.process(context) }
+    } finally {
+      rootDir.deleteRecursively()
+    }
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderDataArtifactExtensionsTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderDataArtifactExtensionsTest.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.daemon
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.SimplePlannedDataExtension
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class RenderDataArtifactExtensionsTest {
+
+  @Test
+  fun `empty registry produces empty list`() {
+    val built = RenderDataArtifactExtensions.Empty.build(applicationContext())
+    assertTrue(built.isEmpty())
+  }
+
+  @Test
+  fun `factories receive the per-render context`() {
+    val context = applicationContext()
+    val seen = mutableListOf<Context>()
+    val sentinel: PlannedDataExtension =
+      SimplePlannedDataExtension(id = DataExtensionId("test/sentinel"))
+    val registry =
+      RenderDataArtifactExtensions(
+        listOf(
+          RenderDataArtifactExtensionFactory { ctx ->
+            seen += ctx
+            sentinel
+          }
+        )
+      )
+
+    val built = registry.build(context)
+
+    assertEquals(listOf(context), seen)
+    assertEquals(listOf<PlannedDataExtension>(sentinel), built)
+  }
+
+  @Test
+  fun `built extensions instantiate fresh per render`() {
+    val factory = RenderDataArtifactExtensionFactory { _ ->
+      SimplePlannedDataExtension(
+        id = DataExtensionId("test/per-render"),
+        constraints = DataExtensionConstraints(),
+      )
+    }
+    val registry = RenderDataArtifactExtensions(listOf(factory))
+    val first = registry.build(applicationContext()).single()
+    val second = registry.build(applicationContext()).single()
+    assertEquals(first.id, second.id)
+    assertTrue(
+      "factory should hand back a fresh instance each render so per-render recorders cannot leak",
+      first !== second,
+    )
+  }
+
+  @Test
+  fun `bundled factories register fonts, resources, and i18n`() {
+    val context = applicationContext()
+    val factories =
+      listOf(
+        FontsRecorderExtension.factory,
+        ResourcesRecorderExtension.factory,
+        I18nTranslationsExtension.factory,
+      )
+    val registry = RenderDataArtifactExtensions(factories)
+    assertEquals(3, registry.factories.size)
+    val fonts = FontsRecorderExtension.factory.create(context)
+    val resources = ResourcesRecorderExtension.factory.create(context)
+    val i18n = I18nTranslationsExtension.factory.create(context)
+    assertEquals(FontsRecorderExtension.ID, fonts.id)
+    assertEquals(ResourcesRecorderExtension.ID, resources.id)
+    assertEquals(I18nTranslationsExtension.ID, i18n.id)
+    assertEquals(
+      "fonts factory must always return a FontsRecorderExtension",
+      FontsRecorderExtension::class.java,
+      fonts.javaClass,
+    )
+    assertTrue(DataExtensionHookKind.AroundComposable in fonts.hooks)
+    assertTrue(DataExtensionHookKind.AfterCapture in fonts.hooks)
+    assertTrue(DataExtensionHookKind.AroundComposable in resources.hooks)
+    assertTrue(DataExtensionHookKind.AfterCapture in resources.hooks)
+    assertTrue(DataExtensionHookKind.AfterCapture in i18n.hooks)
+  }
+
+  private fun applicationContext(): Context =
+    ApplicationProvider.getApplicationContext<Context>()
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/ResourcesRecorderExtensionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/ResourcesRecorderExtensionTest.kt
@@ -1,0 +1,38 @@
+package ee.schimke.composeai.daemon
+
+import androidx.test.core.app.ApplicationProvider
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class ResourcesRecorderExtensionTest {
+
+  @Test
+  fun `extension declares around-composable plus after-capture hooks`() {
+    val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+    val extension = ResourcesRecorderExtension(context)
+    assertEquals("resources/used", extension.id.value)
+    assertEquals(
+      setOf(DataExtensionHookKind.AroundComposable, DataExtensionHookKind.AfterCapture),
+      extension.hooks,
+    )
+    assertEquals(setOf(DataExtensionTarget.Android), extension.targets)
+    assertEquals(ResourcesRecorderExtension.ID, extension.id)
+  }
+
+  @Test
+  fun `factory builds a fresh recorder on every render`() {
+    val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+    val first = ResourcesRecorderExtension.factory.create(context)
+    val second = ResourcesRecorderExtension.factory.create(context)
+    assertEquals(first.id, second.id)
+    assertTrue("each render must own its own recorder lifecycle", first !== second)
+  }
+}


### PR DESCRIPTION
Closes #692.

## Summary

Move the fonts/resources/i18n recorders out of the Android `RenderEngine` and behind typed data extensions, so the renderer no longer constructs `FontResolverRecorder`, calls `ResourcesUsedDataProducer.recorder/context`, or invokes any of the three `writeArtifacts` paths directly.

- `FontsRecorderExtension` — `AroundComposableHook` installing the recording `LocalFontFamilyResolver`, plus `PostCaptureProcessor` that writes `fonts/used` after capture.
- `ResourcesRecorderExtension` — same shape, wraps `LocalContext` with the recording context and writes `resources/used`.
- `I18nTranslationsExtension` — pure post-capture processor that walks the captured semantics root and writes `i18n/translations`.
- `RenderDataArtifactExtensions` — small per-render registry + typed context keys (`rootDir`, `outputBaseName`, `previewId`, `renderedLocale`, `semanticsRoot`) so the engine can hand each extension what it needs without baking producer-specific knowledge into the render loop.

`RobolectricHost` registers the three factories alongside the existing wallpaper + Material3 planners; the engine threads the extension list through `ComposeDataExtensionPipeline.Apply` and runs the post-capture pass uniformly. Outputs and attachment behaviour are protocol-compatible.

## Test plan

- [x] `./gradlew :daemon:android:compileDebugKotlin :daemon:android:compileDebugUnitTestKotlin`
- [x] `./gradlew :daemon:android:testDebugUnitTest` — full suite green, including `RenderEngineTest.serifTextWritesFontsUsedDataProduct` and `resourceReadsWriteResourcesUsedDataProduct` exercising the new extension path end-to-end through `RobolectricHost`.
- [x] New unit tests cover hook installation + post-capture artefact publishing:
  - `RenderDataArtifactExtensionsTest`
  - `FontsRecorderExtensionTest`
  - `ResourcesRecorderExtensionTest`
  - `I18nTranslationsExtensionTest`
- [x] `./gradlew :daemon:desktop:compileKotlin :daemon:desktop:compileTestKotlin` (no cross-module breakage).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqqZhs1bxgtchHrwCMBRhQ)_