### PR TITLE
Add text truncation and overflow metrics to semantics and strings

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -64,6 +64,12 @@ object ComposeSemanticsDataProducer {
       layoutFontSize = layout?.fontSize,
       layoutForegroundColor = layout?.foregroundColor,
       layoutBackgroundColor = layout?.backgroundColor,
+      layoutLineCount = layout?.lineCount,
+      layoutMaxLines = layout?.maxLines,
+      layoutOverflow = layout?.overflow,
+      layoutTruncated = layout?.truncated,
+      layoutDidOverflowWidth = layout?.didOverflowWidth,
+      layoutDidOverflowHeight = layout?.didOverflowHeight,
       editableText = cfg.getOrNull(SemanticsProperties.EditableText)?.text,
       inputText = cfg.getOrNull(SemanticsProperties.InputText)?.text,
       role = cfg.getOrNull(SemanticsProperties.Role)?.toString(),
@@ -118,6 +124,20 @@ object ComposeSemanticsDataProducer {
         .distinct()
         .singleOrNull()
         ?.let { "${it}sp" }
+    val truncated = results.any { it.hasVisualOverflow }
+    val didOverflowWidth = results.any { it.didOverflowWidth }
+    val didOverflowHeight = results.any { it.didOverflowHeight }
+    val lineCount = results.sumOf { it.lineCount }.takeIf { it > 0 }
+    val maxLines =
+      results
+        .map { it.layoutInput.maxLines }
+        .filter { it != Int.MAX_VALUE && it > 0 }
+        .distinct()
+        .singleOrNull()
+    val overflow =
+      results.map { it.layoutInput.overflow.toString() }.distinct().singleOrNull()?.takeIf {
+        it.isNotBlank()
+      }
     return LayoutTextDetails(
       text = text,
       fontSize = fontSize,
@@ -125,6 +145,12 @@ object ComposeSemanticsDataProducer {
         unambiguousColor(results.flatMap { it.textColors() })?.let(::colorToWireString),
       backgroundColor =
         unambiguousColor(results.flatMap { it.backgroundColors() })?.let(::colorToWireString),
+      lineCount = lineCount,
+      maxLines = maxLines,
+      overflow = overflow,
+      truncated = truncated.takeIf { results.isNotEmpty() },
+      didOverflowWidth = didOverflowWidth.takeIf { results.isNotEmpty() },
+      didOverflowHeight = didOverflowHeight.takeIf { results.isNotEmpty() },
     )
   }
 
@@ -151,6 +177,12 @@ object ComposeSemanticsDataProducer {
     val fontSize: String?,
     val foregroundColor: String?,
     val backgroundColor: String?,
+    val lineCount: Int?,
+    val maxLines: Int?,
+    val overflow: String?,
+    val truncated: Boolean?,
+    val didOverflowWidth: Boolean?,
+    val didOverflowHeight: Boolean?,
   )
 
   private fun androidx.compose.ui.geometry.Rect.toWireBounds(): String =

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProductRegistryTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProductRegistryTest.kt
@@ -29,7 +29,7 @@ class ComposeSemanticsDataProductRegistryTest {
     val registry = ComposeSemanticsDataProductRegistry(rootDir)
     val cap = registry.capabilities.single()
     assertEquals("compose/semantics", cap.kind)
-    assertEquals(1, cap.schemaVersion)
+    assertEquals(2, cap.schemaVersion)
     assertTrue(cap.attachable)
     assertTrue(cap.fetchable)
     assertTrue(!cap.requiresRerender)

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 object ComposeSemanticsProduct {
   const val KIND: String = "compose/semantics"
-  const val SCHEMA_VERSION: Int = 1
+  const val SCHEMA_VERSION: Int = 2
   const val FILE: String = "compose-semantics.json"
 }
 
@@ -26,6 +26,12 @@ data class ComposeSemanticsNode(
   val layoutFontSize: String? = null,
   val layoutForegroundColor: String? = null,
   val layoutBackgroundColor: String? = null,
+  val layoutLineCount: Int? = null,
+  val layoutMaxLines: Int? = null,
+  val layoutOverflow: String? = null,
+  val layoutTruncated: Boolean? = null,
+  val layoutDidOverflowWidth: Boolean? = null,
+  val layoutDidOverflowHeight: Boolean? = null,
   val editableText: String? = null,
   val inputText: String? = null,
   val role: String? = null,

--- a/data/strings/connector/src/main/kotlin/ee/schimke/composeai/daemon/TextStringsDataProduct.kt
+++ b/data/strings/connector/src/main/kotlin/ee/schimke/composeai/daemon/TextStringsDataProduct.kt
@@ -140,6 +140,12 @@ class TextStringsDataProductRegistry(
           boundsInScreen = node.boundsInRoot,
           localeTag = localeTag,
           fontScale = fontScale,
+          truncated = node.layoutTruncated,
+          lineCount = node.layoutLineCount,
+          maxLines = node.layoutMaxLines,
+          overflow = node.layoutOverflow?.takeIf { it.isNotBlank() },
+          didOverflowWidth = node.layoutDidOverflowWidth,
+          didOverflowHeight = node.layoutDidOverflowHeight,
         )
       )
     }

--- a/data/strings/connector/src/test/kotlin/ee/schimke/composeai/daemon/TextStringsDataProductRegistryTest.kt
+++ b/data/strings/connector/src/test/kotlin/ee/schimke/composeai/daemon/TextStringsDataProductRegistryTest.kt
@@ -4,6 +4,8 @@ import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
 import java.io.File
 import java.nio.file.Files
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -109,6 +111,66 @@ class TextStringsDataProductRegistryTest {
     assertNull("semantic-only entries omit text", second["text"])
     assertNull("semantic-only entries omit text source", second["textSource"])
     assertEquals("Settings", second["semanticsLabel"]!!.jsonPrimitive.content)
+
+    assertNull("v1 payloads omit truncation flags", first["truncated"])
+    assertNull("v1 payloads omit overflow", first["overflow"])
+    assertNull("v1 payloads omit lineCount", first["lineCount"])
+  }
+
+  @Test
+  fun `fetch surfaces truncation overflow line count and maxLines from semantics`() {
+    val previewId = "com.example.TextPreview"
+    writeSemantics(
+      previewId,
+      """
+      {
+        "root": {
+          "nodeId": "1",
+          "boundsInRoot": "0,0,200,200",
+          "children": [
+            {
+              "nodeId": "2",
+              "boundsInRoot": "10,20,90,40",
+              "layoutText": "A very long French label",
+              "layoutTruncated": true,
+              "layoutDidOverflowWidth": true,
+              "layoutDidOverflowHeight": false,
+              "layoutLineCount": 1,
+              "layoutMaxLines": 1,
+              "layoutOverflow": "Ellipsis"
+            }
+          ]
+        }
+      }
+      """
+        .trimIndent(),
+    )
+    val registry =
+      TextStringsDataProductRegistry(rootDir = rootDir, previewIndex = PreviewIndex.empty())
+
+    val outcome =
+      registry.fetch(
+        previewId = previewId,
+        kind = TextStringsDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      )
+
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val entry =
+      (outcome as DataProductRegistry.Outcome.Ok)
+        .result
+        .payload!!
+        .jsonObject["texts"]!!
+        .jsonArray
+        .single()
+        .jsonObject
+    assertEquals(true, entry["truncated"]!!.jsonPrimitive.boolean)
+    assertEquals(true, entry["didOverflowWidth"]!!.jsonPrimitive.boolean)
+    assertEquals(false, entry["didOverflowHeight"]!!.jsonPrimitive.boolean)
+    assertEquals(1, entry["lineCount"]!!.jsonPrimitive.int)
+    assertEquals(1, entry["maxLines"]!!.jsonPrimitive.int)
+    assertEquals("Ellipsis", entry["overflow"]!!.jsonPrimitive.content)
   }
 
   @Test
@@ -177,7 +239,7 @@ class TextStringsDataProductRegistryTest {
       registry.attachmentsFor(previewId, setOf(TextStringsDataProductRegistry.KIND)).single()
 
     assertEquals(TextStringsDataProductRegistry.KIND, attachment.kind)
-    assertEquals(1, attachment.schemaVersion)
+    assertEquals(2, attachment.schemaVersion)
     assertNull(attachment.path)
     assertNotNull(attachment.payload)
     val entry = attachment.payload!!.jsonObject["texts"]!!.jsonArray.single().jsonObject

--- a/data/strings/core/src/main/kotlin/ee/schimke/composeai/data/strings/StringModels.kt
+++ b/data/strings/core/src/main/kotlin/ee/schimke/composeai/data/strings/StringModels.kt
@@ -8,7 +8,7 @@ import org.w3c.dom.Element
 
 object TextStringsProduct {
   const val KIND: String = "text/strings"
-  const val SCHEMA_VERSION: Int = 1
+  const val SCHEMA_VERSION: Int = 2
 }
 
 object I18nTranslationsProduct {
@@ -34,6 +34,12 @@ data class TextStringEntry(
   val boundsInScreen: String,
   val localeTag: String,
   val fontScale: Float,
+  val truncated: Boolean? = null,
+  val lineCount: Int? = null,
+  val maxLines: Int? = null,
+  val overflow: String? = null,
+  val didOverflowWidth: Boolean? = null,
+  val didOverflowHeight: Boolean? = null,
 )
 
 @Serializable

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -228,7 +228,7 @@ A `data/fetch` that needs a re-render:
 | `compose/recomposition` | instrumented | medium | `[{nodeId, count, sinceFrameStreamId?}]`. Heat map. Snapshot or click-delta. |
 | `compose/theme` | default | medium | Resolved `MaterialTheme.*` values + which nodes consumed them. |
 | `resources/used` | default | low | `R.*` references resolved during render. |
-| `text/strings` | default | low | Drawn text with locale, fontScale, fontSize, colors, bounds. |
+| `text/strings` | default | low | Drawn text with locale, fontScale, fontSize, colors, bounds, plus per-entry `truncated` / `overflow` / `lineCount` / `maxLines` / `didOverflowWidth/Height` from the Compose `TextLayoutResult`. |
 | `i18n/translations` | default | low | Per-string locale coverage from `values*/strings.xml`. Android only. |
 | `render/composeAiTrace` | default/live | low | Render pipeline trace as Perfetto-importable Chrome trace JSON. |
 | `render/trace` | default | low | Phase breakdown from render metrics. |

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -131,7 +131,12 @@ Issue-identifying output:
         "nodeId": "7",
         "boundsInScreen": "16,10,96,34",
         "localeTag": "de-DE",
-        "fontScale": 1.0
+        "fontScale": 1.0,
+        "truncated": true,
+        "didOverflowWidth": true,
+        "lineCount": 1,
+        "maxLines": 1,
+        "overflow": "Ellipsis"
       }
     ]
   }
@@ -158,11 +163,11 @@ Issue-identifying output:
 
 Action: cite both products: `resources/used` proves the German resource was
 selected, and `text/strings` proves the German text is what was laid out in
-the 96 dp button. Open the rendered PNG to confirm visible truncation; explicit
-`truncated` / `clipBounds` fields are not exposed yet (tracked in
-compose-ai-tools#705). Ask for flexible width, wrapping, shorter localized
-copy, or an alternate compact layout. Then rerender with the same `localeTag`
-override.
+the 96 dp button. The `truncated`, `overflow`, and `didOverflowWidth/Height`
+fields on each entry confirm visible truncation directly without needing to
+inspect the PNG; pair with the rendered image when the audit needs a visual.
+Ask for flexible width, wrapping, shorter localized copy, or an alternate
+compact layout. Then rerender with the same `localeTag` override.
 
 Check:
 
@@ -295,9 +300,10 @@ Issue-identifying output:
 
 Action: ask for wrapping, a vertical layout at larger font scales, constrained
 number formatting, or `TextOverflow.Ellipsis` only when truncation is accepted
-by product. `text/strings` does not yet report overlap or truncation directly
-(tracked in compose-ai-tools#705), so confirm with the same data product and
-the rendered PNG.
+by product. `text/strings` reports per-entry `truncated` / `overflow` /
+`didOverflowWidth/Height`; for adjacent-content overlap (which is not implied
+by truncation flags), check `boundsInScreen` overlap across entries or confirm
+visually in the rendered PNG.
 
 Check:
 


### PR DESCRIPTION
## Summary
Expose text truncation, overflow, and line count metrics from Compose layout measurements through the semantics and text strings data products. This enables audits to detect text truncation without requiring visual inspection of rendered previews.

## Key Changes

- **Schema version bumps**: Increment `compose/semantics` and `text/strings` schema versions from 1 to 2
- **Semantics data model**: Add 6 new optional fields to `ComposeSemanticsNode`:
  - `layoutLineCount`, `layoutMaxLines`, `layoutOverflow`
  - `layoutTruncated`, `layoutDidOverflowWidth`, `layoutDidOverflowHeight`
- **Text strings data model**: Add corresponding 6 fields to `TextStringEntry` for audit consumption
- **Data extraction**: Update `ComposeSemanticsDataProducer` to:
  - Extract truncation and overflow flags from `TextLayoutResult`
  - Aggregate line counts across multiple layout results
  - Resolve maxLines and overflow values with conflict detection
- **Data propagation**: Wire extracted metrics from semantics nodes into text string entries in `TextStringsDataProductRegistry`
- **Tests**: Add comprehensive test validating truncation/overflow/lineCount extraction and update schema version assertions
- **Documentation**: Update `AGENT_AUDITS.md` to reference the new fields for detecting truncation without visual inspection, and clarify the distinction between text truncation and adjacent-content overlap

## Implementation Details

The truncation metrics are extracted from Compose's `TextLayoutResult` objects during semantics collection. For multi-line text scenarios, the implementation:
- Uses `any()` for boolean flags (truncated, overflow flags)
- Sums line counts across results
- Selects single distinct values for maxLines and overflow, filtering out defaults (MAX_VALUE for maxLines, blank strings for overflow)
- Only includes boolean fields when results are non-empty to avoid false negatives

https://claude.ai/code/session_01Wb3APFBqgCWFeiWsnp3UTG