### PR TITLE
fix(vscode): exempt composePreviewDaemonStart from refresh cancel

### DIFF
--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -124,6 +124,12 @@ export class TaskCancelledError extends Error {
 
 const CANCELLED_RE = /\bCANCELLED\b/i;
 
+/** `cancellationKey` is `compose-preview-${counter}|${task}`; extract the task. */
+function taskFromKey(key: string): string {
+    const sep = key.indexOf("|");
+    return sep < 0 ? key : key.slice(sep + 1);
+}
+
 // Module identifiers are stored as forward-slash relative paths from the
 // workspace root (e.g. `samples/wear`) so the same string serves both as a
 // Gradle project segment and a filesystem path through `path.join`. Gradle
@@ -622,13 +628,34 @@ export class GradleService {
     }
 
     async cancel(): Promise<void> {
-        const keys = [...this.activeKeys];
-        this.activeKeys.clear();
-        for (const key of keys) {
+        // `composePreviewDaemonStart` is intentionally excluded from the cancel
+        // pool. It's a one-shot, cheap, idempotent task that writes the launch
+        // descriptor every subsequent refresh needs; cancelling it mid-flight
+        // when the next refresh fires creates a permanent cycle where bootstrap
+        // is killed by the refresh it was supposed to enable, leaving
+        // "no launch descriptor" / "Build cancelled" forever.
+        //
+        // Tradeoff: a refresh that arrives while the first-time bootstrap is
+        // still running now queues behind it on the Gradle daemon (the daemon
+        // serialises clients) instead of jumping the queue. That can add a few
+        // seconds on the very first refresh of a cold module, but only once
+        // per session — the descriptor is then UP-TO-DATE and bootstrap
+        // returns instantly. Steady-state is unaffected.
+        const toCancel: string[] = [];
+        const toKeep = new Set<string>();
+        for (const key of this.activeKeys) {
+            if (taskFromKey(key).endsWith(":composePreviewDaemonStart")) {
+                toKeep.add(key);
+            } else {
+                toCancel.push(key);
+            }
+        }
+        this.activeKeys = toKeep;
+        for (const key of toCancel) {
             try {
                 await this.gradleApi.cancelRunTask({
                     projectFolder: this.workspaceRoot,
-                    taskName: key.split("|")[1],
+                    taskName: taskFromKey(key),
                     cancellationKey: key,
                 });
             } catch {

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -861,5 +861,61 @@ describe("GradleService", () => {
                 assert.strictEqual(api.cancelCalls.length >= 0, true); // at least attempted
             }),
         );
+
+        it(
+            "skips composePreviewDaemonStart so a refresh-cancel can't kill the daemon bootstrap mid-flight",
+            withTempDir(async (dir, api) => {
+                // Stub that keeps runTask pending until we tell it to resolve,
+                // so the cancellation key is still in activeKeys when cancel()
+                // is called. Without this the default stub resolves before the
+                // test even gets to cancel(), and the assertion is vacuous.
+                const resolvers: Array<() => void> = [];
+                const heldApi: GradleApi = {
+                    async runTask(opts) {
+                        api.runCalls.push({
+                            taskName: opts.taskName,
+                            cancellationKey: opts.cancellationKey,
+                        });
+                        await new Promise<void>((r) => {
+                            resolvers.push(r);
+                        });
+                    },
+                    async cancelRunTask(opts) {
+                        api.cancelCalls.push({
+                            taskName: opts.taskName,
+                            cancellationKey: opts.cancellationKey,
+                        });
+                    },
+                };
+                const service = new GradleService(dir, heldApi);
+
+                const bootstrap = service
+                    .runDaemonBootstrap("mod")
+                    .catch(() => {});
+                const render = service.discoverPreviews("mod").catch(() => {});
+                // Yield enough turns for both runTask invocations to be
+                // recorded in activeKeys.
+                await new Promise((resolve) => setImmediate(resolve));
+                await new Promise((resolve) => setImmediate(resolve));
+
+                await service.cancel();
+
+                const cancelledTasks = api.cancelCalls.map((c) => c.taskName);
+                assert.ok(
+                    !cancelledTasks.some((t) =>
+                        t.endsWith(":composePreviewDaemonStart"),
+                    ),
+                    `bootstrap must not be cancelled, got: ${cancelledTasks.join(", ")}`,
+                );
+                assert.ok(
+                    cancelledTasks.some((t) => t.endsWith(":discoverPreviews")),
+                    `render-path task must still be cancelled, got: ${cancelledTasks.join(", ")}`,
+                );
+
+                // Release both held tasks so the test cleans up.
+                for (const r of resolvers) r();
+                await Promise.all([bootstrap, render]);
+            }),
+        );
     });
 });


### PR DESCRIPTION
## Summary

- Every refresh starts with `gradleService.cancel()`, which used to kill any in-flight `composePreviewDaemonStart`. The bootstrap writes the daemon launch descriptor that the next refresh needs, so cancelling it locked the daemon out: each retry got cancelled by the next refresh's cancel sweep, and the log filled with `[daemon] no launch descriptor for wear; run :wear:composePreviewDaemonStart first` followed by `Build cancelled` on every attempt.
- `cancel()` now skips cancellation keys whose task name ends in `:composePreviewDaemonStart`. Render-path tasks are still cancelled as before.
- Tradeoff: a refresh that arrives during the first-time cold bootstrap now queues behind it on the Gradle daemon rather than jumping the queue. The bootstrap is `@CacheableTask`, so this only costs latency once per cold module per session — afterwards it's UP-TO-DATE.

## Test plan

- [x] `npm test` (412 passing, including the new `cancel` case)
- New unit test holds `runTask` open across a bootstrap + render pair, calls `cancel()`, and asserts the bootstrap key is preserved while the render-path key is cancelled.