### PR TITLE
refactor(vscode): dedupe DOM-lookup helpers into webview/shared/domRefs

### DIFF
--- a/vscode-extension/src/webview/history/behavior.ts
+++ b/vscode-extension/src/webview/history/behavior.ts
@@ -11,6 +11,7 @@
 // rendered its skeleton into light DOM, so `document.getElementById(...)`
 // queries below resolve.
 
+import { requireElementById } from "../shared/domRefs";
 import type { HistoryEntry, HistoryToWebview } from "../shared/types";
 import { getVsCodeApi } from "../shared/vscode";
 import { cssEscape } from "./historyData";
@@ -25,15 +26,6 @@ import {
     populateThumb,
     renderTimeline as renderTimelineDom,
 } from "./historyTimeline";
-
-/** Look up a known-present DOM element. Used for the static ids that
- *  `<history-app>` has already rendered into the light DOM. Throws so a
- *  missing template surfaces early. */
-function requireElementById<T extends HTMLElement>(id: string): T {
-    const el = document.getElementById(id);
-    if (!el) throw new Error(`Required element #${id} not found`);
-    return el as T;
-}
 
 export function setupHistoryBehavior(): void {
     const vscode = getVsCodeApi();

--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -16,6 +16,7 @@ import type {
     AccessibilityNode,
     PreviewInfo,
 } from "../shared/types";
+import { requireElementById, requireSelector } from "../shared/domRefs";
 import { getVsCodeApi, type VsCodeApi } from "../shared/vscode";
 import {
     applyA11yUpdate,
@@ -62,22 +63,6 @@ interface PersistedState {
     filters?: { fn?: string; group?: string };
     layout?: "grid" | "flow" | "column" | "focus";
     diffMode?: DiffMode;
-}
-
-/** Look up a known-present DOM element. Used for the static ids that
- *  `<preview-app>` has already rendered into the light DOM by the time this
- *  module runs. Throws so a missing template (e.g. an HTML-template typo)
- *  surfaces early rather than landing as a runtime null-deref deeper in. */
-function requireElementById<T extends HTMLElement>(id: string): T {
-    const el = document.getElementById(id);
-    if (!el) throw new Error(`Required element #${id} not found`);
-    return el as T;
-}
-
-function requireSelector<T extends Element>(selector: string): T {
-    const el = document.querySelector<T>(selector);
-    if (!el) throw new Error(`Required element ${selector} not found`);
-    return el;
 }
 
 export function setupPreviewBehavior(

--- a/vscode-extension/src/webview/shared/domRefs.ts
+++ b/vscode-extension/src/webview/shared/domRefs.ts
@@ -1,0 +1,34 @@
+// Fail-fast DOM lookup helpers used at panel boot to grab the static
+// elements `<preview-app>` / `<history-app>` have already rendered into
+// the light DOM. Throw on miss so a missing template (e.g. an
+// HTML-template typo) surfaces early rather than landing as a runtime
+// null-deref deeper in the panel's setup code.
+//
+// Lifted out of duplicated copies in `preview/behavior.ts` and
+// `history/behavior.ts` so the two panels share one source of truth.
+// Both helpers are pure DOM operations — `document.getElementById` /
+// `document.querySelector` — and live in `webview/shared/` so any
+// future panel can pick them up without a re-implementation.
+
+/**
+ * Look up a known-present DOM element by id. Throws if `#id` is
+ * missing (typo in the static HTML template, or the element rendered
+ * conditionally and the lookup ran before it landed).
+ */
+export function requireElementById<T extends HTMLElement>(id: string): T {
+    const el = document.getElementById(id);
+    if (!el) throw new Error(`Required element #${id} not found`);
+    return el as T;
+}
+
+/**
+ * Look up a known-present DOM element by CSS selector. Throws if no
+ * match. Use for custom-element queries (e.g.
+ * `requireSelector<MessageBanner>("message-banner")`) where the host
+ * has registered the tag and rendered exactly one instance.
+ */
+export function requireSelector<T extends Element>(selector: string): T {
+    const el = document.querySelector<T>(selector);
+    if (!el) throw new Error(`Required element ${selector} not found`);
+    return el;
+}


### PR DESCRIPTION
`requireElementById` was duplicated between `preview/behavior.ts` and `history/behavior.ts` — same fail-fast `document.getElementById` body, same throw-on-miss semantics. Moves both helpers (+ `requireSelector` which only the preview side currently uses) to `webview/shared/domRefs.ts` so the two panels share one source of truth and any future panel can pick them up without re-implementing.

`preview/behavior.ts`: 542 → 527 lines (−15 LOC).
`history/behavior.ts`: 253 → 245 lines (−8 LOC).
`webview/shared/domRefs.ts`: +34 lines (new file).

Net +11 LOC because the new file's jsdoc balances the extraction, but **the helper now has a single source of truth** — the dedup goal — and the behaviour stays identical.

## Drive-by audit

While picking the next slice: `grep -rEn "@ts-nocheck|@ts-ignore|@ts-expect-error|as any|: any" src/` returns zero non-comment matches across the host + webview tree. **The `@ts-nocheck` removal arc that started after #767 is fully closed.**

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 421/421 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke: open both webviews, verify the static template ids are still found (`#preview-grid`, `#focus-controls`, `#timeline`, `#filter-source`, etc.).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_