### PR TITLE
fix(mcp): re-import previews.json when discoverPreviews rewrites it

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -659,6 +659,16 @@ class DaemonMcpServer(
         freshnessMetrics.pollingCycles.incrementAndGet()
         supervisor.listProjects().forEach { project ->
           project.daemons.forEach { (modulePath, daemon) ->
+            // Manifest stat first — a Gradle `discoverPreviews` re-run between renders rewrites
+            // `previews.json`. Picking that up here means new preview ids land in the catalog
+            // (and `render_preview` works) before the user's next request, without the
+            // restart-the-MCP-server escape hatch reported in issue #834.
+            runCatching { reloadManifestIfChanged(daemon) }
+              .onFailure {
+                System.err.println(
+                  "compose-preview-mcp: manifest reload failed for ${daemon.workspaceId}/${daemon.modulePath}: ${it.message}"
+                )
+              }
             val byId = catalog[DaemonAddr(project.workspaceId, modulePath)] ?: return@forEach
             byId.values.forEach { entry ->
               freshnessMetrics.pollingPreviewsScanned.incrementAndGet()
@@ -681,6 +691,73 @@ class DaemonMcpServer(
         // the poller silently. Logging keeps the behaviour observable.
         System.err.println("compose-preview-mcp: source-freshness poll failed: ${it.message}")
       }
+  }
+
+  /**
+   * Per-(workspace, module) last-seen mtime + content hash of the daemon's `previews.json`. The
+   * fast path (mtime unchanged) skips re-reading the file; on mtime advance we hash to confirm a
+   * real content change before incurring the parse + diff + dispatch cost, matching the
+   * source-freshness probe's two-stage shape.
+   */
+  private val manifestState = ConcurrentHashMap<DaemonAddr, ManifestState>()
+
+  private data class ManifestState(val mtimeMs: Long, val hash: String)
+
+  /**
+   * Stats the daemon's `previews.json`; if the file changed since the last cycle, parses it, diffs
+   * the preview ids against the current catalog, and routes a synthetic `discoveryUpdated` through
+   * [onDiscoveryUpdated] so the catalog + subscribers + watch-propagator all see the new ids
+   * exactly as if the daemon had pushed the notification itself. Idempotent: a no-op when the
+   * manifest hasn't changed since the last cycle.
+   *
+   * Internal so tests can drive it directly without racing the scheduled poll.
+   */
+  internal fun reloadManifestIfChanged(daemon: SupervisedDaemon) {
+    val manifestPath = daemon.manifestPath?.takeIf { it.isNotBlank() } ?: return
+    val file = File(manifestPath)
+    if (!file.isFile) return
+    freshnessMetrics.manifestStats.incrementAndGet()
+    val mtime = file.lastModified().takeIf { it > 0L } ?: return
+    val addr = DaemonAddr(daemon.workspaceId, daemon.modulePath)
+    val previous = manifestState[addr]
+    if (previous != null && mtime <= previous.mtimeMs) return
+
+    val hash = runCatching { sha256Hex(file) }.getOrNull() ?: return
+    if (previous != null && hash == previous.hash) {
+      // mtime moved (e.g. `touch` on previews.json) but bytes didn't — refresh mtime so the
+      // next cycle skips the hash, and bail out without redispatching.
+      manifestState[addr] = ManifestState(mtime, hash)
+      return
+    }
+
+    val text = runCatching { file.readText() }.getOrNull() ?: return
+    val previews =
+      runCatching {
+          val obj = json.parseToJsonElement(text) as? JsonObject ?: return@runCatching null
+          (obj["previews"] as? JsonArray)?.mapNotNull { it as? JsonObject }
+        }
+        .getOrNull() ?: return
+    manifestState[addr] = ManifestState(mtime, hash)
+
+    val incomingIds = previews.mapNotNull { it["id"]?.jsonPrimitive?.contentOrNull }.toSet()
+    val currentIds = catalog[addr]?.keys?.toSet() ?: emptySet()
+    val added = previews.filter { (it["id"]?.jsonPrimitive?.contentOrNull ?: "") !in currentIds }
+    val changed = previews.filter { (it["id"]?.jsonPrimitive?.contentOrNull ?: "") in currentIds }
+    val removed = currentIds.filter { it !in incomingIds }
+
+    if (added.isEmpty() && removed.isEmpty()) return
+
+    freshnessMetrics.manifestRereads.incrementAndGet()
+    freshnessMetrics.manifestPreviewsAdded.addAndGet(added.size.toLong())
+    freshnessMetrics.manifestPreviewsRemoved.addAndGet(removed.size.toLong())
+
+    val params = buildJsonObject {
+      put("added", JsonArray(added))
+      put("removed", JsonArray(removed.map { JsonPrimitive(it) }))
+      put("changed", JsonArray(changed))
+      put("totalPreviews", JsonPrimitive(previews.size))
+    }
+    onDiscoveryUpdated(daemon, params)
   }
 
   /**

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -225,6 +225,10 @@ class DaemonSupervisor(
         // RECORDING.md § "encoded formats" — same pattern. Empty list pre-feature; validation falls
         // open and `record_preview` calls round-trip without the diagnostic.
         supervised.recordingFormats = result.capabilities.recordingFormats.toSet()
+        // Cache the manifest path so the MCP server's background poller can detect a Gradle
+        // `discoverPreviews` re-run between renders and re-load the manifest into the catalog
+        // (issue #834). Blank for backends that don't ship a `previews.json`.
+        supervised.manifestPath = result.manifest.path.takeIf { it.isNotBlank() }
         // The daemon only emits `discoveryUpdated` for *deltas* — the initial preview set comes
         // via `initialize.manifest.path` (a `previews.json` written by the gradle plugin's
         // `discoverPreviews` task). Synthesise an initial `discoveryUpdated` notification by
@@ -378,6 +382,19 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
    */
   @Volatile
   var recordingFormats: Set<String> = emptySet()
+    internal set
+
+  /**
+   * Path to `previews.json` (the per-module manifest written by the gradle plugin's
+   * `discoverPreviews` task). Captured at `initialize` time from the daemon's
+   * `InitializeResult.manifest.path`. The `DaemonMcpServer`'s background poller stats this file
+   * each cycle so a `discoverPreviews` re-run between renders publishes new preview ids into the
+   * MCP catalog without an MCP server restart — closes the "manifest doesn't auto-refresh" gap
+   * reported in issue #834. Null/blank when the daemon doesn't advertise a manifest path (older
+   * daemons / non-Gradle backends).
+   */
+  @Volatile
+  var manifestPath: String? = null
     internal set
 
   /**

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/FreshnessMetrics.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/FreshnessMetrics.kt
@@ -43,6 +43,14 @@ class FreshnessMetrics {
   val pollingPreviewsScanned = AtomicLong()
   val pollingChangesDetected = AtomicLong()
 
+  // Manifest reload counters — bumped when the poller re-reads `previews.json` because its
+  // mtime+hash advanced. Lets an operator confirm the issue-#834 path actually fires when
+  // Gradle's `discoverPreviews` rewrites the manifest between renders.
+  val manifestStats = AtomicLong()
+  val manifestRereads = AtomicLong()
+  val manifestPreviewsAdded = AtomicLong()
+  val manifestPreviewsRemoved = AtomicLong()
+
   // Random-sampling counters — the deterministic-render probe bumps these.
   val samplingProbes = AtomicLong()
   val samplingSkippedBusy = AtomicLong()
@@ -84,6 +92,12 @@ class FreshnessMetrics {
       put("cycles", JsonPrimitive(pollingCycles.get()))
       put("previewsScanned", JsonPrimitive(pollingPreviewsScanned.get()))
       put("changesDetected", JsonPrimitive(pollingChangesDetected.get()))
+    }
+    putJsonObject("manifest") {
+      put("stats", JsonPrimitive(manifestStats.get()))
+      put("rereads", JsonPrimitive(manifestRereads.get()))
+      put("previewsAdded", JsonPrimitive(manifestPreviewsAdded.get()))
+      put("previewsRemoved", JsonPrimitive(manifestPreviewsRemoved.get()))
     }
     putJsonObject("sampling") {
       put("probes", JsonPrimitive(samplingProbes.get()))

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -2001,6 +2001,133 @@ class DaemonMcpServerTest {
     }
   }
 
+  @Test
+  fun `manifest poller imports new previews when discoverPreviews rewrites previews-json`() {
+    // Reproduces issue #834: a Gradle `discoverPreviews` re-run between renders rewrites the
+    // module's `previews.json` to include new `@Preview` ids. The MCP server must pick that up
+    // without a daemon restart so `render_preview` for the new id no longer fails with
+    // `PreviewManifestRouter: no manifest entry`.
+    val freshFactory = FakeDaemonClientFactory()
+    val freshSupervisor =
+      DaemonSupervisor(descriptorProvider = FakeDescriptorProvider(), clientFactory = freshFactory)
+    val freshServer =
+      DaemonMcpServer(
+        supervisor = freshSupervisor,
+        sourcePollIntervalMs = 0,
+        samplingIntervalMs = 0,
+      )
+    val (clientToServer, serverFromClient) = pipedPair()
+    val (serverToClient, clientFromServer) = pipedPair()
+    val freshSession = freshServer.newSession(input = serverFromClient, output = serverToClient)
+    freshSession.start()
+    val freshClient = McpTestClient(input = clientFromServer, output = clientToServer)
+    try {
+      freshClient.initialize()
+      val projectDir = tmp.newFolder("manifest-workspace")
+      tmp.newFolder("manifest-workspace", "module")
+      val manifestFile = tmp.newFile("manifest-workspace.previews.json")
+      // Boot manifest — one entry. The supervisor's `synthesiseInitialDiscovery` reads it on
+      // initialize, so the catalog already contains `Initial`.
+      manifestFile.writeText(
+        """{"previews":[{"id":"com.example.Initial","className":"com.example","methodName":"Initial","displayName":"Initial"}]}"""
+      )
+      val initialMtime = System.currentTimeMillis() - 60_000
+      assertThat(manifestFile.setLastModified(initialMtime)).isTrue()
+
+      freshFactory.daemonConfigurer = { fake ->
+        fake.advertisedManifestPath = manifestFile.absolutePath
+      }
+
+      val ws =
+        json
+          .parseToJsonElement(
+            freshClient
+              .callTool(
+                "register_project",
+                buildJsonObject {
+                  put("path", projectDir.absolutePath)
+                  put("rootProjectName", "manifest-demo")
+                },
+              )
+              .firstTextContent()
+          )
+          .jsonObject["workspaceId"]!!
+          .jsonPrimitive
+          .content
+      freshClient.expectNotification("notifications/resources/list_changed", 2_000)
+      val workspaceId = WorkspaceId(ws)
+      freshSupervisor.daemonFor(workspaceId, ":module")
+
+      // The synthesiseInitialDiscovery fan-out triggers a list_changed; drain it.
+      freshClient.expectNotification("notifications/resources/list_changed", 2_000)
+
+      // Sanity: the boot id is in the catalog via `resources/list`.
+      val listBefore =
+        json
+          .decodeFromJsonElement(
+            ee.schimke.composeai.mcp.protocol.ListResourcesResult.serializer(),
+            freshClient.request("resources/list"),
+          )
+          .resources
+          .map { it.uri }
+      assertThat(listBefore.any { it.contains("com.example.Initial") }).isTrue()
+
+      // Gradle's `discoverPreviews` re-runs and rewrites the manifest with a new id.
+      manifestFile.writeText(
+        """
+        {"previews":[
+          {"id":"com.example.Initial","className":"com.example","methodName":"Initial","displayName":"Initial"},
+          {"id":"com.example.WeatherForecast_Light","className":"com.example","methodName":"WeatherForecast_Light","displayName":"WeatherForecast_Light"}
+        ]}
+        """
+          .trimIndent()
+      )
+      assertThat(manifestFile.setLastModified(initialMtime + 5_000)).isTrue()
+
+      // Drive the poll explicitly (the scheduler is disabled).
+      freshServer.runSourceFreshnessPoll()
+
+      // The new id should now be visible to MCP clients without a restart.
+      freshClient.expectNotification("notifications/resources/list_changed", 2_000)
+      val listAfter =
+        json
+          .decodeFromJsonElement(
+            ee.schimke.composeai.mcp.protocol.ListResourcesResult.serializer(),
+            freshClient.request("resources/list"),
+          )
+          .resources
+          .map { it.uri }
+      assertThat(listAfter.any { it.contains("com.example.WeatherForecast_Light") }).isTrue()
+      assertThat(listAfter.any { it.contains("com.example.Initial") }).isTrue()
+
+      // And the manifest counters should reflect the reread + the diff.
+      val manifest =
+        json
+          .parseToJsonElement(freshClient.callTool("status").firstTextContent())
+          .jsonObject["freshness"]!!
+          .jsonObject["manifest"]!!
+          .jsonObject
+      assertThat(manifest["rereads"]?.jsonPrimitive?.content?.toLong()).isAtLeast(1L)
+      assertThat(manifest["previewsAdded"]?.jsonPrimitive?.content?.toLong()).isEqualTo(1L)
+      assertThat(manifest["previewsRemoved"]?.jsonPrimitive?.content?.toLong()).isEqualTo(0L)
+
+      // Idempotency: a second poll with no manifest change does not re-fire.
+      freshServer.runSourceFreshnessPoll()
+      val manifestAfter =
+        json
+          .parseToJsonElement(freshClient.callTool("status").firstTextContent())
+          .jsonObject["freshness"]!!
+          .jsonObject["manifest"]!!
+          .jsonObject
+      assertThat(manifestAfter["rereads"]?.jsonPrimitive?.content?.toLong()).isEqualTo(1L)
+    } finally {
+      runCatching { freshClient.close() }
+      runCatching { freshSession.close() }
+      runCatching { freshServer.shutdown() }
+      runCatching { freshSupervisor.shutdown() }
+    }
+  }
+
   // -------------------------------------------------------------------------
   // D1 — data product tools
   // -------------------------------------------------------------------------

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -234,6 +234,14 @@ class FakeDaemon : DaemonSpawn {
    */
   @Volatile var autoRenderUnchanged: ((previewId: String) -> Boolean?)? = null
 
+  /**
+   * Path returned in `InitializeResult.manifest.path`. The MCP server's `DaemonSupervisor` caches
+   * it on `SupervisedDaemon.manifestPath` so the background poller can stat the file and re-read on
+   * change (issue #834). Tests that drive the manifest poller assign this before the spawn calls
+   * `initialize`.
+   */
+  @Volatile var advertisedManifestPath: String = ""
+
   private lateinit var _client: DaemonClient
 
   override val client: DaemonClient
@@ -382,7 +390,7 @@ class FakeDaemon : DaemonSpawn {
                 recordingFormats = advertisedRecordingFormats,
               ),
             classpathFingerprint = "fake-fingerprint",
-            manifest = Manifest(path = "", previewCount = 0),
+            manifest = Manifest(path = advertisedManifestPath, previewCount = 0),
           )
         sendResponse(id, json.encodeToJsonElement(InitializeResult.serializer(), result))
       }


### PR DESCRIPTION
## Summary

Closes #834. A Gradle `discoverPreviews` re-run between renders rewrites the module's `previews.json` to include new `@Preview` ids, but the MCP server's catalog stayed pinned to the boot-time set — `render_preview` for the new id failed with `PreviewManifestRouter: no manifest entry`, and the only known workaround was restarting the MCP server.

The fix lives entirely in the MCP layer:

1. `SupervisedDaemon` gains a `manifestPath` field, populated from `InitializeResult.manifest.path` during spawn.
2. The existing freshness poll cycle (from #826) gains a manifest-stat step per spawned daemon. Two-stage: stat fast path, SHA-256 only when mtime advanced. On a real content change, parse the file, diff `added`/`changed`/`removed` against the current catalog, and route a synthetic `discoveryUpdated` through `onDiscoveryUpdated` so the catalog + subscribers + watch-propagator see the new ids exactly as if the daemon had pushed the notification itself.
3. New `freshness.manifest` counters (`stats`, `rereads`, `previewsAdded`, `previewsRemoved`) surfaced via the existing `status` tool so an operator can confirm the path actually fires.

No daemon code touched, no new wire fields. The fix composes with #826's poller cadence (default 30 s; `sourcePollIntervalMs = 0` disables) and is idempotent — a poll with no manifest change is a no-op.

## Test plan

- [x] New test `manifest poller imports new previews when discoverPreviews rewrites previews-json`: writes a boot manifest with one id, verifies it's in the catalog, rewrites `previews.json` with a new id, drives `runSourceFreshnessPoll()` directly, and asserts the new id appears in `resources/list` plus the `freshness.manifest.previewsAdded` counter is `1`. A second poll with no change does not re-fire.
- [x] Full `:mcp:test` suite green (51 of 51 in `DaemonMcpServerTest` plus all sibling test classes) except for the same pre-existing failure on `main` (`record_preview rejects extension events advertised but not yet implemented`) that is unrelated.

```
./gradlew :mcp:test --tests "ee.schimke.composeai.mcp.DaemonMcpServerTest.manifest poller imports new previews when discoverPreviews rewrites previews-json"
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01GwpyYFqw6fF7qBKehTHLtS)_