### PR TITLE
test(vscode): extract pointer-geometry helpers + tests

### DIFF
--- a/vscode-extension/src/test/pointerGeometry.test.ts
+++ b/vscode-extension/src/test/pointerGeometry.test.ts
@@ -1,0 +1,120 @@
+import * as assert from "assert";
+import {
+    computeImagePoint,
+    isEventInsideRect,
+} from "../webview/preview/pointerGeometry";
+
+describe("computeImagePoint", () => {
+    it("maps a 1:1-scaled image's center to the natural-pixel center", () => {
+        // 100×100 natural, 100×100 displayed at (0,0). Click in the middle.
+        const point = computeImagePoint(100, 100, 100, 100, 0, 0, 50, 50);
+        assert.deepStrictEqual(point, {
+            clientX: 50,
+            clientY: 50,
+            pixelX: 50,
+            pixelY: 50,
+        });
+    });
+
+    it("scales 2x-displayed CSS pixels back to natural pixels", () => {
+        // 100×100 natural, displayed at 200×200 → each CSS pixel is 0.5
+        // natural pixels.
+        const point = computeImagePoint(100, 100, 200, 200, 0, 0, 100, 100);
+        assert.strictEqual(point?.pixelX, 50);
+        assert.strictEqual(point?.pixelY, 50);
+        // clientX / clientY are still in displayed-CSS space.
+        assert.strictEqual(point?.clientX, 100);
+        assert.strictEqual(point?.clientY, 100);
+    });
+
+    it("subtracts rect.left / rect.top so the math is image-relative", () => {
+        const point = computeImagePoint(100, 100, 100, 100, 50, 30, 75, 80);
+        assert.strictEqual(point?.clientX, 25);
+        assert.strictEqual(point?.clientY, 50);
+        assert.strictEqual(point?.pixelX, 25);
+        assert.strictEqual(point?.pixelY, 50);
+    });
+
+    it("clamps a click on the right/bottom edge to naturalDimension - 1", () => {
+        // 100×100 natural at (0,0), exactly 100×100 displayed. Click at
+        // the bottom-right corner — without the clamp pixelX/pixelY would
+        // be 100 (out of bounds for a 100-pixel image).
+        const point = computeImagePoint(100, 100, 100, 100, 0, 0, 100, 100);
+        assert.strictEqual(point?.pixelX, 99);
+        assert.strictEqual(point?.pixelY, 99);
+    });
+
+    it("clamps a click outside the left/top edge to 0", () => {
+        const point = computeImagePoint(100, 100, 100, 100, 50, 50, 0, 0);
+        assert.strictEqual(point?.pixelX, 0);
+        assert.strictEqual(point?.pixelY, 0);
+    });
+
+    it("rounds rather than truncates the natural-pixel coords", () => {
+        // 3-pixel-wide natural image displayed at 10 CSS pixels:
+        // each CSS pixel = 0.3 natural. Click at clientX=2 (CSS) →
+        // pixelX = round(2 * 3/10) = round(0.6) = 1.
+        const point = computeImagePoint(3, 3, 10, 10, 0, 0, 2, 2);
+        assert.strictEqual(point?.pixelX, 1);
+        assert.strictEqual(point?.pixelY, 1);
+    });
+
+    it("returns null when the image's natural dimensions are zero", () => {
+        // <img> not yet loaded — naturalWidth/Height are 0.
+        assert.strictEqual(
+            computeImagePoint(0, 100, 100, 100, 0, 0, 50, 50),
+            null,
+        );
+        assert.strictEqual(
+            computeImagePoint(100, 0, 100, 100, 0, 0, 50, 50),
+            null,
+        );
+    });
+
+    it("returns null when the displayed rect has zero size", () => {
+        // Hidden / collapsed image — getBoundingClientRect width / height
+        // are zero.
+        assert.strictEqual(
+            computeImagePoint(100, 100, 0, 100, 0, 0, 50, 50),
+            null,
+        );
+        assert.strictEqual(
+            computeImagePoint(100, 100, 100, 0, 0, 0, 50, 50),
+            null,
+        );
+    });
+});
+
+describe("isEventInsideRect", () => {
+    const rect = { left: 10, top: 20, right: 110, bottom: 120 };
+
+    it("returns true for a point in the interior", () => {
+        assert.strictEqual(isEventInsideRect(rect, 50, 50), true);
+    });
+
+    it("returns true for a point exactly on each edge (inclusive)", () => {
+        assert.strictEqual(isEventInsideRect(rect, 10, 50), true); // left
+        assert.strictEqual(isEventInsideRect(rect, 110, 50), true); // right
+        assert.strictEqual(isEventInsideRect(rect, 50, 20), true); // top
+        assert.strictEqual(isEventInsideRect(rect, 50, 120), true); // bottom
+    });
+
+    it("returns true for the four corner points (inclusive)", () => {
+        assert.strictEqual(isEventInsideRect(rect, 10, 20), true);
+        assert.strictEqual(isEventInsideRect(rect, 110, 20), true);
+        assert.strictEqual(isEventInsideRect(rect, 10, 120), true);
+        assert.strictEqual(isEventInsideRect(rect, 110, 120), true);
+    });
+
+    it("returns false for points just outside any edge", () => {
+        assert.strictEqual(isEventInsideRect(rect, 9, 50), false); // left of left
+        assert.strictEqual(isEventInsideRect(rect, 111, 50), false); // right of right
+        assert.strictEqual(isEventInsideRect(rect, 50, 19), false); // above top
+        assert.strictEqual(isEventInsideRect(rect, 50, 121), false); // below bottom
+    });
+
+    it("returns false for points outside two edges (corner + offset)", () => {
+        assert.strictEqual(isEventInsideRect(rect, 9, 19), false);
+        assert.strictEqual(isEventInsideRect(rect, 200, 200), false);
+    });
+});

--- a/vscode-extension/src/webview/preview/interactiveInput.ts
+++ b/vscode-extension/src/webview/preview/interactiveInput.ts
@@ -23,13 +23,13 @@
 // See docs/daemon/INTERACTIVE.md §§ 3, 6, 7.
 
 import type { VsCodeApi } from "../shared/vscode";
+import {
+    computeImagePoint,
+    isEventInsideRect,
+    type ImagePoint,
+} from "./pointerGeometry";
 
-export interface ImagePoint {
-    clientX: number;
-    clientY: number;
-    pixelX: number;
-    pixelY: number;
-}
+export type { ImagePoint };
 
 export interface InteractiveInputConfig {
     /**
@@ -197,40 +197,34 @@ export function attachInteractiveInputHandlers(
     });
 }
 
+/** DOM-bound shim around `computeImagePoint` — extracts natural / rect
+ *  dimensions from the live `<img>` and the pure helper does the math. */
 function imagePoint(
     img: HTMLImageElement,
     evt: { clientX: number; clientY: number },
 ): ImagePoint | null {
-    // Image-natural pixel coords — same space the daemon's renderer
-    // works in. The webview's offsetX/Y is in CSS pixels of the
-    // displayed image; scale by the displayed/natural ratio to recover
-    // the pixel the user actually clicked.
-    const natW = img.naturalWidth || 0;
-    const natH = img.naturalHeight || 0;
     const rect = img.getBoundingClientRect();
-    if (!natW || !natH || rect.width === 0 || rect.height === 0) return null;
-    const clientX = evt.clientX - rect.left;
-    const clientY = evt.clientY - rect.top;
-    const pixelX = Math.round(clientX * (natW / rect.width));
-    const pixelY = Math.round(clientY * (natH / rect.height));
-    return {
-        clientX,
-        clientY,
-        pixelX: Math.max(0, Math.min(natW - 1, pixelX)),
-        pixelY: Math.max(0, Math.min(natH - 1, pixelY)),
-    };
+    return computeImagePoint(
+        img.naturalWidth || 0,
+        img.naturalHeight || 0,
+        rect.width,
+        rect.height,
+        rect.left,
+        rect.top,
+        evt.clientX,
+        evt.clientY,
+    );
 }
 
+/** DOM-bound shim around `isEventInsideRect`. */
 function eventInsideElement(
     el: Element,
     evt: { clientX: number; clientY: number },
 ): boolean {
-    const rect = el.getBoundingClientRect();
-    return (
-        evt.clientX >= rect.left &&
-        evt.clientX <= rect.right &&
-        evt.clientY >= rect.top &&
-        evt.clientY <= rect.bottom
+    return isEventInsideRect(
+        el.getBoundingClientRect(),
+        evt.clientX,
+        evt.clientY,
     );
 }
 

--- a/vscode-extension/src/webview/preview/pointerGeometry.ts
+++ b/vscode-extension/src/webview/preview/pointerGeometry.ts
@@ -1,0 +1,95 @@
+// Pure geometry helpers used by the live (interactive) pointer / wheel
+// state machine in `./interactiveInput.ts`. Lifted out so the
+// CSS-pixel-to-natural-pixel mapping (the heart of the daemon's input
+// coord-system requirement) is testable without DOM, and so the
+// "is this event inside this rect" predicate can be re-used in
+// other places without going through `Element.getBoundingClientRect`.
+//
+// `ImagePoint` is the result of mapping a pointer event to the image's
+// natural pixel space — the same space the renderer paints in. The
+// webview ships these coordinates to the daemon so live previews can
+// dispatch pointer input back into a held composition without the host
+// needing to know about CSS scaling. See `docs/daemon/INTERACTIVE.md`
+// §§ 3, 6, 7.
+
+export interface ImagePoint {
+    /** Pointer client-X relative to the image's `getBoundingClientRect().left`. */
+    clientX: number;
+    /** Pointer client-Y relative to the image's `getBoundingClientRect().top`. */
+    clientY: number;
+    /** Image-natural-pixel X, clamped to `[0, naturalWidth - 1]`. */
+    pixelX: number;
+    /** Image-natural-pixel Y, clamped to `[0, naturalHeight - 1]`. */
+    pixelY: number;
+}
+
+/**
+ * Map a pointer event into the image's natural-pixel space. Returns
+ * `null` when the image has no natural dimensions (`<img>` not yet
+ * loaded) or has zero displayed size (hidden, off-screen, etc.) — in
+ * either case there's no useful point to ship to the daemon.
+ *
+ * Inputs:
+ *  - `naturalWidth` / `naturalHeight`: the image's intrinsic pixel
+ *    dimensions (`HTMLImageElement.naturalWidth`).
+ *  - `rectWidth` / `rectHeight` / `rectLeft` / `rectTop`: the image's
+ *    `getBoundingClientRect()` displayed rectangle.
+ *  - `eventClientX` / `eventClientY`: the pointer event's client
+ *    coordinates (page-relative; the function subtracts `rect.left/top`
+ *    to convert to image-relative).
+ *
+ * The returned `pixelX` / `pixelY` are rounded and clamped so the
+ * daemon never receives an out-of-bounds index even if the user clicks
+ * exactly on the right / bottom border.
+ */
+export function computeImagePoint(
+    naturalWidth: number,
+    naturalHeight: number,
+    rectWidth: number,
+    rectHeight: number,
+    rectLeft: number,
+    rectTop: number,
+    eventClientX: number,
+    eventClientY: number,
+): ImagePoint | null {
+    if (!naturalWidth || !naturalHeight || rectWidth === 0 || rectHeight === 0)
+        return null;
+    const clientX = eventClientX - rectLeft;
+    const clientY = eventClientY - rectTop;
+    const pixelX = Math.round(clientX * (naturalWidth / rectWidth));
+    const pixelY = Math.round(clientY * (naturalHeight / rectHeight));
+    return {
+        clientX,
+        clientY,
+        pixelX: Math.max(0, Math.min(naturalWidth - 1, pixelX)),
+        pixelY: Math.max(0, Math.min(naturalHeight - 1, pixelY)),
+    };
+}
+
+/** Slim subset of `DOMRect` the geometry helpers actually need. Lets
+ *  callers pass a real rect, a stub, or a `{ left, top, right, bottom }`
+ *  literal. */
+export interface RectBounds {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+}
+
+/**
+ * Whether [event] (with client-coords) lies inside [rect]. Inclusive on
+ * all four edges so a click exactly on the bottom-right pixel still
+ * counts as inside.
+ */
+export function isEventInsideRect(
+    rect: RectBounds,
+    eventClientX: number,
+    eventClientY: number,
+): boolean {
+    return (
+        eventClientX >= rect.left &&
+        eventClientX <= rect.right &&
+        eventClientY >= rect.top &&
+        eventClientY <= rect.bottom
+    );
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -18,6 +18,7 @@
         "src/webview/preview/cardData.ts",
         "src/webview/preview/liveTransitions.ts",
         "src/webview/preview/moduleReadiness.ts",
+        "src/webview/preview/pointerGeometry.ts",
         "src/webview/history/historyData.ts",
         "src/webview/shared/diffStatsLabel.ts",
         "src/webview/shared/safeIndex.ts",


### PR DESCRIPTION
Lifts the CSS-pixel-to-natural-pixel mapping (the heart of the daemon's input coord-system requirement, see INTERACTIVE.md §§ 3, 6, 7) out of `interactiveInput.ts`'s DOM-bound `imagePoint` / `eventInsideElement` helpers into pure `computeImagePoint` / `isEventInsideRect` functions in a new `pointerGeometry.ts`.

The DOM-bound helpers in `interactiveInput.ts` become four-line shims that read `naturalWidth` / `naturalHeight` / `getBoundingClientRect()` off the live `<img>` and call into the pure module.

`ImagePoint` moves to `pointerGeometry.ts` and is re-exported from `interactiveInput.ts` so existing imports keep working.

## Tests

13 new unit tests covering:

**`computeImagePoint`:**
- 1:1-scaled image: center clicks → natural-pixel center.
- 2x-displayed image: CSS pixels scale back to natural pixels by the displayed/natural ratio. `clientX/Y` stays in CSS space; `pixelX/Y` is natural.
- Subtracts `rect.left/top` so the math is image-relative.
- Right/bottom edge clicks clamp to `naturalDimension - 1` (so the daemon never sees out-of-bounds indices).
- Negative client coords (events outside the image) clamp to 0.
- Sub-pixel values round rather than truncate (3px-natural displayed at 10 CSS px → ratio 0.3, click at CSS=2 → pixel=round(0.6)=1).
- Returns null when natural dimensions are zero (`<img>` not loaded).
- Returns null when displayed rect has zero size (hidden / collapsed).

**`isEventInsideRect`:**
- Interior point → true.
- Each edge / corner is inclusive (a click exactly on the bottom-right pixel is still inside).
- Just-outside-each-edge → false.
- Far-outside → false.

`tsconfig.json` adds `pointerGeometry.ts` to its `files` list.

435 → 448 tests passing. No behaviour change.

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 448/448 passing (435 prior + 13 new)
- [x] `npm run format:check` clean
- [ ] Manual smoke: focus a live preview, click and drag.
  - Pointer events still reach the daemon — verify by watching the daemon log for `recordInteractiveInput` messages with sensible `pixelX` / `pixelY` in image-natural space.
  - Wheel events on the live image map to `rotaryScroll`.
  - Wheel events on the card chrome (outside the image) still get consumed (don't scroll the grid).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_