### PR TITLE
test(vscode): set up happy-dom global registration for DOM-touching tests

### DIFF
--- a/vscode-extension/.mocharc.json
+++ b/vscode-extension/.mocharc.json
@@ -1,0 +1,3 @@
+{
+    "file": ["out/test/setup-dom.js"]
+}

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "devDependencies": {
+                "@happy-dom/global-registrator": "^20.9.0",
                 "@types/mocha": "^10.0.0",
                 "@types/node": "^24.0.0",
                 "@types/vscode": "^1.85.0",
@@ -17,6 +18,7 @@
                 "@vscode/vsce": "^3.0.0",
                 "esbuild": "^0.28.0",
                 "glob": "^13.0.0",
+                "happy-dom": "^20.9.0",
                 "lit": "^3.2.0",
                 "mocha": "^11.0.0",
                 "prettier": "^3.8.3",
@@ -688,6 +690,20 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@happy-dom/global-registrator": {
+            "version": "20.9.0",
+            "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-20.9.0.tgz",
+            "integrity": "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": ">=20.0.0",
+                "happy-dom": "^20.9.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@isaacs/cliui": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -1079,6 +1095,23 @@
             "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/whatwg-mimetype": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+            "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@typespec/ts-http-runtime": {
             "version": "0.3.5",
@@ -2714,6 +2747,47 @@
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/happy-dom": {
+            "version": "20.9.0",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+            "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": ">=20.0.0",
+                "@types/whatwg-mimetype": "^3.0.2",
+                "@types/ws": "^8.18.1",
+                "entities": "^7.0.1",
+                "whatwg-mimetype": "^3.0.0",
+                "ws": "^8.18.3"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/happy-dom/node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -5612,6 +5686,28 @@
             "dev": true,
             "license": "ISC",
             "optional": true
+        },
+        "node_modules/ws": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/wsl-utils": {
             "version": "0.1.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -167,6 +167,7 @@
         "package": "npm run compile && vsce package --no-dependencies"
     },
     "devDependencies": {
+        "@happy-dom/global-registrator": "^20.9.0",
         "@types/mocha": "^10.0.0",
         "@types/node": "^24.0.0",
         "@types/vscode": "^1.85.0",
@@ -175,6 +176,7 @@
         "@vscode/vsce": "^3.0.0",
         "esbuild": "^0.28.0",
         "glob": "^13.0.0",
+        "happy-dom": "^20.9.0",
         "lit": "^3.2.0",
         "mocha": "^11.0.0",
         "prettier": "^3.8.3",

--- a/vscode-extension/src/test/dom-smoke.test.ts
+++ b/vscode-extension/src/test/dom-smoke.test.ts
@@ -1,0 +1,69 @@
+// Smoke tests proving the happy-dom global registration set up by
+// `setup-dom.ts` actually exposes `document` / `window` / standard
+// element types to test code, so DOM-touching webview modules can be
+// unit-tested without each test having to spin up its own environment.
+//
+// Real-feature DOM tests live in their own files (e.g. `liveState.test.ts`,
+// `cardBuilder.test.ts`) once the corresponding source file is added to
+// the host tsconfig's `files` list. This file just smoke-checks the
+// infrastructure.
+
+import * as assert from "assert";
+
+describe("DOM smoke (happy-dom)", () => {
+    it("exposes document on globalThis after happy-dom registration", () => {
+        assert.ok(typeof document !== "undefined", "document should be global");
+        assert.ok(typeof window !== "undefined", "window should be global");
+    });
+
+    it("createElement returns a real HTMLElement", () => {
+        const div = document.createElement("div");
+        assert.ok(div instanceof HTMLElement);
+        assert.strictEqual(div.tagName, "DIV");
+    });
+
+    it("classList toggles work", () => {
+        const div = document.createElement("div");
+        div.classList.add("foo", "bar");
+        assert.strictEqual(div.className, "foo bar");
+        div.classList.remove("foo");
+        assert.strictEqual(div.className, "bar");
+        assert.strictEqual(div.classList.contains("bar"), true);
+        assert.strictEqual(div.classList.contains("foo"), false);
+    });
+
+    it("dataset round-trips through `data-*` attributes", () => {
+        const div = document.createElement("div");
+        div.dataset.previewId = "preview:A";
+        assert.strictEqual(div.getAttribute("data-preview-id"), "preview:A");
+        assert.strictEqual(div.dataset.previewId, "preview:A");
+    });
+
+    it("appendChild + querySelector navigate the DOM tree", () => {
+        const root = document.createElement("div");
+        const child = document.createElement("span");
+        child.className = "leaf";
+        root.appendChild(child);
+        assert.strictEqual(root.querySelector(".leaf"), child);
+        assert.strictEqual(root.children.length, 1);
+    });
+
+    it("getElementById finds elements attached to document.body", () => {
+        const div = document.createElement("div");
+        div.id = "test-target";
+        document.body.appendChild(div);
+        try {
+            assert.strictEqual(document.getElementById("test-target"), div);
+        } finally {
+            document.body.removeChild(div);
+        }
+    });
+
+    it("CSS custom properties round-trip via element.style", () => {
+        const div = document.createElement("div");
+        div.style.setProperty("--size-ratio", "0.5");
+        assert.strictEqual(div.style.getPropertyValue("--size-ratio"), "0.5");
+        div.style.removeProperty("--size-ratio");
+        assert.strictEqual(div.style.getPropertyValue("--size-ratio"), "");
+    });
+});

--- a/vscode-extension/src/test/setup-dom.ts
+++ b/vscode-extension/src/test/setup-dom.ts
@@ -1,0 +1,25 @@
+// Mocha setup file that registers a global `document` / `window` /
+// `HTMLElement` / etc. via happy-dom so tests can exercise webview
+// modules that touch the DOM without each test having to spin up its
+// own environment.
+//
+// Loaded via `.mocharc.json`'s `file` field — runs once before any
+// `describe(...)` block.
+//
+// happy-dom is the lightest of the three popular DOM impls (jsdom,
+// happy-dom, linkedom). The webview DOM ops we test against (`<div>`
+// creation, classList toggles, dataset access, querySelector,
+// getBoundingClientRect, getElementById, IntersectionObserver shape)
+// all work under happy-dom; if a test needs something happy-dom
+// doesn't ship — most commonly element-resize observers or the full
+// CSSOM — switch the test to a hand-rolled stub for that one case
+// rather than swapping the global setup.
+//
+// Tests that operate on pure data (Store, formatRelative,
+// formatDiffStatsLabel, etc.) ignore this file entirely — Node's
+// global namespace has document/window after registration but pure
+// helpers don't reach for them.
+
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "ES2022",
-        "lib": ["ES2022"],
+        "lib": ["ES2022", "DOM"],
         "types": ["node", "mocha"],
         "outDir": "out",
         "rootDir": "src",


### PR DESCRIPTION
Unblocks the next round of webview testing — `LiveStateController`'s state mutators, `FocusController.applyLayout`'s side effects, `messageHandlers`'s handler bodies, `cardBuilder`'s lifecycle operations — by adding a Mocha-side global DOM environment via `@happy-dom/global-registrator`. Tests that need `document`, `window`, `HTMLElement`, etc. now find them on `globalThis` without each test having to spin up its own environment.

happy-dom is the lightest of the popular DOM impls (jsdom / happy-dom / linkedom). The webview DOM ops we test against — element creation, classList toggles, dataset access, querySelector, getElementById, CSS custom properties, getBoundingClientRect — all work under it.

## What this PR adds

- `@happy-dom/global-registrator` (v20) as a devDependency. Registers DOM globals on `globalThis` from a single import.
- `src/test/setup-dom.ts` — top-level Mocha setup file that calls `GlobalRegistrator.register()` once before any `describe(...)` block.
- `.mocharc.json` — `{ "file": ["out/test/setup-dom.js"] }` so Mocha picks up the setup file via the existing `out/test/!(electron)/**/*.test.js` glob pattern.
- `tsconfig.json` adds `"DOM"` to the host `lib` array so test code that references `document` / `HTMLElement` / etc. compiles. The webview directory tree is the only place that should reach for these in non-test code; the host-side `extension.ts` / `daemon/` / `historyPanel.ts` etc. don't, but the type-checker now permits it. Acceptable trade-off for the test-coverage upside.
- `src/test/dom-smoke.test.ts` — 7 smoke tests verifying the happy-dom global registration actually exposes what we'll need: `document` / `window` / `HTMLElement` globals, `createElement`, `classList.add/remove/contains`, `dataset`-to-`data-*` round-trip, `appendChild` + `querySelector`, `getElementById` against `document.body`, CSS custom property `setProperty` / `getPropertyValue` / `removeProperty` round-trip.

The smoke tests act as a regression backstop — if happy-dom drops or changes one of these features in a future major, the smoke tests catch it before the corresponding feature tests start mysteriously failing.

## Future tests

Pure-helper coverage (cardData, historyData, diffStatsLabel, moduleReadiness, store, storeController, liveTransitions, pointerGeometry, safeIndex) is now joined by an unblocked path for DOM-feature tests. Follow-ups can:

- Test `LiveStateController.applyLiveBadge` re-stamping `.live` / the per-card stop button on Set membership changes.
- Test `cardBuilder.applyRelativeSizing` writing the right `--size-ratio` / `--aspect-ratio` per card.
- Test `messageHandlers` dispatch routing with a synthetic event fired against `window`.
- Test `historyTimeline.populateThumb` building the right `<img>` tree.

448 → 455 tests passing.

Built from `main`.

## Test plan

- [x] `npm install` clean (adds `@happy-dom/global-registrator` + `happy-dom`)
- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 455/455 passing
- [x] `npm run format:check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_