### PR TITLE
test(vscode): extract applyRelativeSizing + first DOM-touching unit tests

### DIFF
--- a/vscode-extension/src/test/relativeSizing.test.ts
+++ b/vscode-extension/src/test/relativeSizing.test.ts
@@ -1,0 +1,175 @@
+import * as assert from "assert";
+import { applyRelativeSizing } from "../webview/preview/relativeSizing";
+import { sanitizeId } from "../webview/preview/cardData";
+import type { Capture, PreviewInfo, PreviewParams } from "../types";
+
+const baseCapture: Capture = {
+    advanceTimeMillis: null,
+    scroll: null,
+    renderOutput: "x.png",
+};
+
+const baseParams: PreviewParams = {
+    name: null,
+    device: null,
+    widthDp: null,
+    heightDp: null,
+    fontScale: 1.0,
+    showSystemUi: false,
+    showBackground: false,
+    backgroundColor: 0,
+    uiMode: 0,
+    locale: null,
+    group: null,
+};
+
+function preview(
+    id: string,
+    overrides: Partial<PreviewParams> = {},
+): PreviewInfo {
+    return {
+        id,
+        functionName: "MyPreview",
+        className: "com.example.PreviewsKt",
+        sourceFile: null,
+        params: { ...baseParams, ...overrides },
+        captures: [baseCapture],
+    };
+}
+
+/** Build the matching `<div id="preview-...">` cards in document.body and
+ *  return them keyed by previewId so tests can assert on each. */
+function setupCards(
+    previews: readonly PreviewInfo[],
+): Map<string, HTMLElement> {
+    document.body.innerHTML = "";
+    const cards = new Map<string, HTMLElement>();
+    for (const p of previews) {
+        const card = document.createElement("div");
+        card.id = "preview-" + sanitizeId(p.id);
+        document.body.appendChild(card);
+        cards.set(p.id, card);
+    }
+    return cards;
+}
+
+afterEach(() => {
+    document.body.innerHTML = "";
+});
+
+describe("applyRelativeSizing", () => {
+    it("sets --size-ratio and --aspect-ratio per card from widthDp/heightDp", () => {
+        const previews = [
+            preview("com.example.A", { widthDp: 100, heightDp: 200 }),
+            preview("com.example.B", { widthDp: 200, heightDp: 400 }),
+        ];
+        const cards = setupCards(previews);
+        applyRelativeSizing(previews);
+
+        const a = cards.get("com.example.A")!;
+        // 100 / max(100,200) = 0.5
+        assert.strictEqual(a.style.getPropertyValue("--size-ratio"), "0.5000");
+        assert.strictEqual(
+            a.style.getPropertyValue("--aspect-ratio"),
+            "100 / 200",
+        );
+
+        const b = cards.get("com.example.B")!;
+        // 200 / 200 = 1
+        assert.strictEqual(b.style.getPropertyValue("--size-ratio"), "1.0000");
+        assert.strictEqual(
+            b.style.getPropertyValue("--aspect-ratio"),
+            "200 / 400",
+        );
+    });
+
+    it("fixes --size-ratio to 4 decimal places", () => {
+        const previews = [
+            preview("com.example.C", { widthDp: 1, heightDp: 1 }),
+            preview("com.example.D", { widthDp: 7, heightDp: 7 }),
+        ];
+        setupCards(previews);
+        applyRelativeSizing(previews);
+        const c = document.getElementById("preview-com_example_C")!;
+        // 1/7 = 0.142857... → rounded to 4 dp = 0.1429
+        assert.strictEqual(c.style.getPropertyValue("--size-ratio"), "0.1429");
+    });
+
+    it("removes both CSS vars when widthDp / heightDp are missing", () => {
+        const previews = [
+            preview("com.example.E"), // no width/height
+        ];
+        const cards = setupCards(previews);
+        // Pre-populate to verify removal actually happens.
+        cards.get("com.example.E")!.style.setProperty("--size-ratio", "0.5");
+        cards
+            .get("com.example.E")!
+            .style.setProperty("--aspect-ratio", "100 / 200");
+        applyRelativeSizing(previews);
+        const e = cards.get("com.example.E")!;
+        assert.strictEqual(e.style.getPropertyValue("--size-ratio"), "");
+        assert.strictEqual(e.style.getPropertyValue("--aspect-ratio"), "");
+    });
+
+    it("removes vars from a card whose width is set but height isn't (and vice versa)", () => {
+        // Defensive: if only one dimension survives a metadata swap, neither
+        // var should be set (the CSS expects both to compute correctly).
+        const previews = [
+            preview("com.example.F", { widthDp: 100, heightDp: null }),
+            preview("com.example.G", { widthDp: null, heightDp: 200 }),
+        ];
+        setupCards(previews);
+        applyRelativeSizing(previews);
+        const f = document.getElementById("preview-com_example_F")!;
+        const g = document.getElementById("preview-com_example_G")!;
+        assert.strictEqual(f.style.getPropertyValue("--size-ratio"), "");
+        assert.strictEqual(g.style.getPropertyValue("--size-ratio"), "");
+    });
+
+    it("leaves the maxW computation tolerant of zero / negative widths", () => {
+        // Filter is `(w) => w > 0` — zero / negative are dropped before max.
+        const previews = [
+            preview("com.example.H", { widthDp: 0, heightDp: 0 }),
+            preview("com.example.I", { widthDp: 100, heightDp: 200 }),
+        ];
+        setupCards(previews);
+        applyRelativeSizing(previews);
+        const i = document.getElementById("preview-com_example_I")!;
+        // I has widthDp=100, maxW=100, ratio = 1.0
+        assert.strictEqual(i.style.getPropertyValue("--size-ratio"), "1.0000");
+        const h = document.getElementById("preview-com_example_H")!;
+        // H widthDp=0 → fails `if (w && h && maxW > 0)` → no vars set
+        assert.strictEqual(h.style.getPropertyValue("--size-ratio"), "");
+    });
+
+    it("skips silently when a manifest entry has no matching DOM card", () => {
+        // Exercising the `if (!card) continue;` guard.
+        const previews = [
+            preview("com.example.J", { widthDp: 100, heightDp: 100 }),
+            preview("com.example.K", { widthDp: 200, heightDp: 200 }),
+        ];
+        // Only stub up J's card; K has no DOM presence.
+        const cards = setupCards([previews[0]]);
+        // Should not throw on the missing K.
+        assert.doesNotThrow(() => applyRelativeSizing(previews));
+        // J was processed — its --size-ratio is set against maxW = 200
+        // (maxW comes from the manifest, not the DOM).
+        const j = cards.get("com.example.J")!;
+        assert.strictEqual(j.style.getPropertyValue("--size-ratio"), "0.5000");
+    });
+
+    it("is idempotent — calling twice produces the same final state", () => {
+        const previews = [
+            preview("com.example.L", { widthDp: 100, heightDp: 200 }),
+        ];
+        setupCards(previews);
+        applyRelativeSizing(previews);
+        applyRelativeSizing(previews);
+        const l = document.getElementById("preview-com_example_L")!;
+        assert.strictEqual(l.style.getPropertyValue("--size-ratio"), "1.0000");
+        assert.strictEqual(
+            l.style.getPropertyValue("--aspect-ratio"),
+            "100 / 200",
+        );
+    });
+});

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -402,35 +402,11 @@ export function updateCardMetadata(
     }
 }
 
-/**
- * Scale image containers so preview variants at different device sizes
- * (e.g. wearos_large_round 227dp vs wearos_small_round 192dp) render at
- * relative sizes in fixed-layout modes. Only applied when we have real
- * widthDp/heightDp — variants without known dimensions fall back to the
- * default CSS (full card width, auto aspect).
- *
- * Walks all of [previews] once; idempotent — subsequent calls overwrite
- * the CSS custom properties cleanly.
- */
-export function applyRelativeSizing(previews: readonly PreviewInfo[]): void {
-    const widths = previews
-        .map((p) => p.params.widthDp ?? 0)
-        .filter((w) => w > 0);
-    const maxW = widths.length > 0 ? Math.max(...widths) : 0;
-    for (const p of previews) {
-        const card = document.getElementById("preview-" + sanitizeId(p.id));
-        if (!card) continue;
-        const w = p.params.widthDp;
-        const h = p.params.heightDp;
-        if (w && h && maxW > 0) {
-            card.style.setProperty("--size-ratio", (w / maxW).toFixed(4));
-            card.style.setProperty("--aspect-ratio", w + " / " + h);
-        } else {
-            card.style.removeProperty("--size-ratio");
-            card.style.removeProperty("--aspect-ratio");
-        }
-    }
-}
+// `applyRelativeSizing` lives in `./relativeSizing.ts` so the DOM
+// operation is testable under happy-dom without dragging cardBuilder's
+// wider transitive imports into the host tsconfig. Re-exported here for
+// the existing `behavior.ts` import paths.
+export { applyRelativeSizing } from "./relativeSizing";
 
 /** Subset `updateImage` reaches for — every per-frame paint dependency. */
 export type UpdateImageConfig = Pick<

--- a/vscode-extension/src/webview/preview/relativeSizing.ts
+++ b/vscode-extension/src/webview/preview/relativeSizing.ts
@@ -1,0 +1,44 @@
+// Card sizing helper used by `cardBuilder.ts`'s `setPreviews` post-render
+// pass. Lifted into its own file so the DOM operation is testable under
+// happy-dom without dragging cardBuilder's wider DOM-bound transitive
+// imports (Lit-decorator-using `<message-banner>` etc.) into the host
+// tsconfig.
+//
+// The previews carry `widthDp` / `heightDp` annotations from the Compose
+// `@Preview` parameters; we use them to set CSS custom properties on each
+// card so fixed-layout modes can render variants at their relative sizes
+// (e.g. `wearos_large_round` 227dp vs `wearos_small_round` 192dp side-by-
+// side). Variants without dimensions fall back to the default CSS (full
+// card width, auto aspect ratio).
+
+import { sanitizeId } from "./cardData";
+import type { PreviewInfo } from "../shared/types";
+
+/**
+ * Walk the manifest and stamp each card's `--size-ratio` /
+ * `--aspect-ratio` CSS custom properties from its `widthDp` / `heightDp`.
+ *
+ * Idempotent: subsequent calls overwrite the custom properties cleanly,
+ * and previews whose dimensions become unknown lose both vars (the CSS
+ * falls back to the default layout). Cards that disappeared from the
+ * manifest aren't touched — `renderPreviews` removes them separately.
+ */
+export function applyRelativeSizing(previews: readonly PreviewInfo[]): void {
+    const widths = previews
+        .map((p) => p.params.widthDp ?? 0)
+        .filter((w) => w > 0);
+    const maxW = widths.length > 0 ? Math.max(...widths) : 0;
+    for (const p of previews) {
+        const card = document.getElementById("preview-" + sanitizeId(p.id));
+        if (!card) continue;
+        const w = p.params.widthDp;
+        const h = p.params.heightDp;
+        if (w && h && maxW > 0) {
+            card.style.setProperty("--size-ratio", (w / maxW).toFixed(4));
+            card.style.setProperty("--aspect-ratio", w + " / " + h);
+        } else {
+            card.style.removeProperty("--size-ratio");
+            card.style.removeProperty("--aspect-ratio");
+        }
+    }
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -19,6 +19,7 @@
         "src/webview/preview/liveTransitions.ts",
         "src/webview/preview/moduleReadiness.ts",
         "src/webview/preview/pointerGeometry.ts",
+        "src/webview/preview/relativeSizing.ts",
         "src/webview/history/historyData.ts",
         "src/webview/shared/diffStatsLabel.ts",
         "src/webview/shared/safeIndex.ts",


### PR DESCRIPTION
First DOM-feature test landing on the happy-dom infra from #851. Extracts `applyRelativeSizing` from `cardBuilder.ts` into its own file `relativeSizing.ts` so the function can be type-checked under the host tsconfig without dragging cardBuilder's wider transitive imports — Lit-decorator-using `<message-banner>` in particular — into the host build.

`cardBuilder.ts` re-exports `applyRelativeSizing` from the new module so the existing `behavior.ts` import path keeps working.

## Tests

7 new unit tests pinning down:
- The base case (`--size-ratio` / `--aspect-ratio` set per card, ratio relative to the manifest's max widthDp).
- 4-decimal precision on `--size-ratio` (1/7 → 0.1429, not 0.14285714…).
- Both vars removed when widthDp / heightDp are missing.
- Both vars removed when only one dimension survives (defensive against partial-metadata swaps mid-session).
- `maxW` filter: zero / negative widths drop before `Math.max`.
- The `if (!card) continue;` guard — manifest entry without a matching DOM card silently skips.
- Idempotency: calling twice produces the same final state.

Test setup uses happy-dom's `document.body` directly — each test builds the cards it needs, calls `applyRelativeSizing`, and asserts on `style.getPropertyValue(...)`. An `afterEach` hook clears `document.body` so tests stay isolated.

## tsconfig

`tsconfig.json` adds `relativeSizing.ts` to its `files` list. The pattern going forward: extract a pure / narrow-deps file when a function needs DOM testing, rather than expanding the host include over decorator-using component files.

455 → 462 tests passing.

Built from `main`.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 462/462 passing (455 prior + 7 new)
- [x] `npm run format:check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_