### PR TITLE
feat(daemon): default daemon to no extensions, opt-in via extensions/enable

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -242,91 +242,168 @@ fun main(args: Array<String>) {
     )
   }
 
-  // D2 — wire data-product registries. `compose/semantics` is default-mode data emitted by the
-  // Android render loop whenever a render output dir exists. A11y is selected through the generic
-  // data-plugin property emitted by Gradle, not a daemon-specific feature flag.
+  // ExtensionRegistry — every extension is registered here in the inactive state. Clients call
+  // `extensions/enable` to opt in to specific contributions. A11y registries / descriptors are
+  // wired only when `composeai.a11y.previewExtension.enabled=true` because the host doesn't ship
+  // an ATF dispatch path otherwise; if the prop is unset the extension simply isn't registered.
   val renderOutputDir = System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
   val a11yPreviewExtensionEnabled =
     System.getProperty(RenderEngine.A11Y_PREVIEW_EXTENSION_ENABLED_PROP) == "true"
   val composeTraceEnabled = renderOutputDir != null && PerfettoTraceDataProducer.enabled()
-  val dataProducts: DataProductRegistry =
-    buildList {
-        System.err.println("compose-ai-tools daemon: DeviceClipDataProductRegistry active")
-        add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
-        System.err.println("compose-ai-tools daemon: DeviceBackgroundDataProductRegistry active")
-        add(DeviceBackgroundDataProductRegistry(previewIndex = previewIndex))
-        System.err.println("compose-ai-tools daemon: RenderTraceDataProductRegistry active")
-        add(RenderTraceDataProductRegistry())
-        System.err.println("compose-ai-tools daemon: TestFailureDataProductRegistry active")
-        add(TestFailureDataProductRegistry())
-        System.err.println("compose-ai-tools daemon: ThemeDataProductRegistry active")
-        add(ThemeDataProductRegistry())
-        System.err.println("compose-ai-tools daemon: WallpaperDataProductRegistry active")
-        add(WallpaperDataProductRegistry())
+  val dataRoot: File? =
+    renderOutputDir?.let { File(it).parentFile?.resolve("data") ?: File(it) }
+  val extensions =
+    ExtensionRegistry(
+      buildList {
+        add(
+          Extension(
+            id = "device/clip",
+            displayName = "Device clip",
+            dataProductRegistry = DeviceClipDataProductRegistry(previewIndex = previewIndex),
+            previewExtensionDescriptors = listOf(RenderPreviewExtension.deviceClipDescriptor),
+          )
+        )
+        add(
+          Extension(
+            id = "device/background",
+            displayName = "Device background",
+            dataProductRegistry = DeviceBackgroundDataProductRegistry(previewIndex = previewIndex),
+            previewExtensionDescriptors =
+              listOf(RenderPreviewExtension.deviceBackgroundDescriptor),
+          )
+        )
+        add(
+          Extension(
+            id = "render/trace",
+            displayName = "Render trace",
+            dataProductRegistry = RenderTraceDataProductRegistry(),
+            previewExtensionDescriptors = listOf(RenderPreviewExtension.renderTraceDescriptor),
+          )
+        )
+        add(
+          Extension(
+            id = "render/test-failure",
+            displayName = "Test failure",
+            dataProductRegistry = TestFailureDataProductRegistry(),
+          )
+        )
+        add(
+          Extension(
+            id = "render/overlay-legend",
+            displayName = "Render overlay legend",
+            previewExtensionDescriptors = listOf(RenderPreviewExtension.overlayLegendDescriptor),
+          )
+        )
+        add(
+          Extension(
+            id = "data/theme",
+            displayName = "Material 3 theme override",
+            dataProductRegistry = ThemeDataProductRegistry(),
+          )
+        )
+        add(
+          Extension(
+            id = "data/wallpaper",
+            displayName = "Wallpaper override",
+            dataProductRegistry = WallpaperDataProductRegistry(),
+          )
+        )
         if (historyManager != null) {
-          System.err.println(
-            "compose-ai-tools daemon: HistoryDiffRegionsDataProductRegistry active"
+          add(
+            Extension(
+              id = "history/diff-regions",
+              displayName = "History diff regions",
+              dataProductRegistry =
+                HistoryDiffRegionsDataProductRegistry(historyManager = historyManager),
+            )
           )
-          add(HistoryDiffRegionsDataProductRegistry(historyManager = historyManager))
         }
-        if (renderOutputDir != null) {
-          val dataRoot = File(renderOutputDir).parentFile?.resolve("data") ?: File(renderOutputDir)
-          System.err.println(
-            "compose-ai-tools daemon: ComposeSemanticsDataProductRegistry active (dataRoot=$dataRoot)"
+        if (dataRoot != null) {
+          add(
+            Extension(
+              id = "compose/semantics",
+              displayName = "Compose semantics snapshot",
+              dataProductRegistry = ComposeSemanticsDataProductRegistry(rootDir = dataRoot),
+            )
           )
-          add(ComposeSemanticsDataProductRegistry(rootDir = dataRoot))
-          System.err.println(
-            "compose-ai-tools daemon: LayoutInspectorDataProductRegistry active (dataRoot=$dataRoot)"
+          add(
+            Extension(
+              id = "layout/inspector",
+              displayName = "Layout inspector",
+              dataProductRegistry = LayoutInspectorDataProductRegistry(rootDir = dataRoot),
+            )
           )
-          add(LayoutInspectorDataProductRegistry(rootDir = dataRoot))
-          System.err.println(
-            "compose-ai-tools daemon: ResourcesUsedDataProductRegistry active (dataRoot=$dataRoot)"
+          add(
+            Extension(
+              id = "resources/used",
+              displayName = "Resources used",
+              dataProductRegistry = ResourcesUsedDataProductRegistry(rootDir = dataRoot),
+            )
           )
-          add(ResourcesUsedDataProductRegistry(rootDir = dataRoot))
-          System.err.println(
-            "compose-ai-tools daemon: I18nTranslationsDataProductRegistry active (dataRoot=$dataRoot)"
+          add(
+            Extension(
+              id = "i18n/translations",
+              displayName = "i18n translations",
+              dataProductRegistry = I18nTranslationsDataProductRegistry(rootDir = dataRoot),
+            )
           )
-          add(I18nTranslationsDataProductRegistry(rootDir = dataRoot))
-          System.err.println(
-            "compose-ai-tools daemon: FontsUsedDataProductRegistry active (dataRoot=$dataRoot)"
+          add(
+            Extension(
+              id = "fonts/used",
+              displayName = "Fonts used",
+              dataProductRegistry = FontsUsedDataProductRegistry(rootDir = dataRoot),
+            )
           )
-          add(FontsUsedDataProductRegistry(rootDir = dataRoot))
           if (composeTraceEnabled) {
-            System.err.println(
-              "compose-ai-tools daemon: PerfettoTraceDataProductRegistry active (dataRoot=$dataRoot)"
+            add(
+              Extension(
+                id = "compose/trace",
+                displayName = "Compose Perfetto trace",
+                dataProductRegistry = PerfettoTraceDataProductRegistry(rootDir = dataRoot),
+                previewExtensionDescriptors =
+                  listOf(RenderPreviewExtension.composeTraceDescriptor),
+              )
             )
-            add(PerfettoTraceDataProductRegistry(rootDir = dataRoot))
           }
-          System.err.println(
-            "compose-ai-tools daemon: TextStringsDataProductRegistry active (dataRoot=$dataRoot)"
-          )
-          add(TextStringsDataProductRegistry(rootDir = dataRoot, previewIndex = previewIndex))
-          if (a11yPreviewExtensionEnabled) {
-            System.err.println(
-              "compose-ai-tools daemon: AccessibilityDataProductRegistry active (dataRoot=$dataRoot)"
+          add(
+            Extension(
+              id = "text/strings",
+              displayName = "Text strings",
+              dataProductRegistry =
+                TextStringsDataProductRegistry(rootDir = dataRoot, previewIndex = previewIndex),
             )
-            add(AccessibilityDataProductRegistry(rootDir = dataRoot))
-          } else {
-            System.err.println("compose-ai-tools daemon: a11y data product plugin disabled")
+          )
+          if (a11yPreviewExtensionEnabled) {
+            add(
+              Extension(
+                id = "a11y",
+                displayName = "Accessibility",
+                dataProductRegistry = AccessibilityDataProductRegistry(rootDir = dataRoot),
+                dataExtensionDescriptors = AccessibilityRecordingScriptEvents.descriptors,
+                previewExtensionDescriptors =
+                  listOf(
+                    AccessibilitySemanticsPreviewExtension.descriptor,
+                    AtfChecksPreviewExtension.descriptor,
+                    AccessibilityOverlayPreviewExtension.descriptor,
+                    AccessibilityAnnotatedPreviewExtension.descriptor,
+                  ),
+              )
+            )
           }
         }
+        // host-wired recording-script extensions + renderer-agnostic roadmap descriptors. The
+        // host's contribution flips supported flags as new handlers land in its session registry.
+        add(
+          Extension(
+            id = "recording/script",
+            displayName = "Recording-script extensions",
+            dataExtensionDescriptors =
+              host.recordingScriptEventDescriptors() +
+                RecordingScriptDataExtensions.roadmapDescriptors,
+          )
+        )
       }
-      .let(::CompositeDataProductRegistry)
-  val previewExtensions = buildList {
-    add(RenderPreviewExtension.deviceClipDescriptor)
-    add(RenderPreviewExtension.deviceBackgroundDescriptor)
-    add(RenderPreviewExtension.renderTraceDescriptor)
-    if (composeTraceEnabled) {
-      add(RenderPreviewExtension.composeTraceDescriptor)
-    }
-    add(RenderPreviewExtension.overlayLegendDescriptor)
-    if (a11yPreviewExtensionEnabled) {
-      add(AccessibilitySemanticsPreviewExtension.descriptor)
-      add(AtfChecksPreviewExtension.descriptor)
-      add(AccessibilityOverlayPreviewExtension.descriptor)
-      add(AccessibilityAnnotatedPreviewExtension.descriptor)
-    }
-  }
+    )
 
   val server =
     JsonRpcServer(
@@ -338,24 +415,7 @@ fun main(args: Array<String>) {
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
-      dataProducts = dataProducts,
-      // dataExtensions composition:
-      //   - host.recordingScriptEventDescriptors()  → host-wired extensions
-      //     (recording.probe + lifecycle + preview.reload + state.{recreate,save,restore})
-      //   - AccessibilityRecordingScriptEvents.descriptor  → the `a11y` extension. Single
-      //     descriptor carrying all 19 actions; 12 are supported = true, 7 are supported = false.
-      //     Wired only when the a11y preview extension is enabled so a non-a11y daemon doesn't
-      //     advertise actions it can't dispatch.
-      //   - RecordingScriptDataExtensions.roadmapDescriptors  → renderer-agnostic roadmap
-      //     (currently empty; new entries land here when an event has a renderer-agnostic
-      //     dispatch story but no host has wired it yet).
-      // `record_preview`'s validateRecordingScriptKinds filters by per-event `supported` flag.
-      dataExtensions =
-        host.recordingScriptEventDescriptors() +
-          (if (a11yPreviewExtensionEnabled) AccessibilityRecordingScriptEvents.descriptors
-          else emptyList()) +
-          RecordingScriptDataExtensions.roadmapDescriptors,
-      previewExtensions = previewExtensions,
+      extensions = extensions,
     )
   server.run()
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/Extension.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/Extension.kt
@@ -1,0 +1,51 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
+
+/**
+ * A daemon extension. Bundles every contribution one feature makes to the daemon's wire surface so
+ * a single id can flip the whole thing on or off at runtime.
+ *
+ * Daemons start with an [ExtensionRegistry] holding every registered extension in the **inactive**
+ * state — registered only as metadata. Until a client (today, the MCP supervisor) calls
+ * `extensions/enable`, none of the contributions below appear in JSON-RPC responses or run during
+ * renders. This is how the daemon defaults to "almost no extensions" without losing the descriptive
+ * surface clients need to discover what's available.
+ *
+ * `dataProductRegistry` and `previewOverrideExtensions` are the **executing** halves: they snapshot
+ * render results, observe interactive sessions, and wrap previews. The descriptor lists are pure
+ * metadata: clients consult them via `initialize.capabilities` and `extensions/list` but the daemon
+ * doesn't act on them by itself.
+ *
+ * **Dependencies** name other extensions whose execution side this one relies on. When extension A
+ * is publicly enabled and declares `dependencies = listOf("data/theme")`, the registry brings the
+ * theme extension online so its `onRender` can run and feed A — but theme's data-product kinds and
+ * descriptors stay invisible to clients (they don't show up in `extensions/list`'s public set, and
+ * `data/fetch` against them returns `Unknown`). This matches the rule "dependencies don't
+ * contribute to responses directly, just via the extension that depends on them."
+ *
+ * IDs are free-form short strings — `data/theme`, `data/recomposition`, `override/wallpaper`. Match
+ * the `kind` namespace where a single registry advertises a single kind (so the id reads naturally
+ * in `extensions/enable` calls); use a feature-shaped id when one extension carries several kinds
+ * or pure metadata.
+ */
+data class Extension(
+  val id: String,
+  val displayName: String = id,
+  val dependencies: List<String> = emptyList(),
+  val dataProductRegistry: DataProductRegistry? = null,
+  val dataExtensionDescriptors: List<DataExtensionDescriptor> = emptyList(),
+  val previewExtensionDescriptors: List<PreviewExtensionDescriptor> = emptyList(),
+  val previewOverrideExtensions: List<PreviewOverrideExtension> = emptyList(),
+) {
+  init {
+    require(id.isNotBlank()) { "Extension id must not be blank" }
+    require(id !in dependencies) { "Extension '$id' must not depend on itself" }
+  }
+
+  /** Capabilities this extension advertises when active. Empty for descriptor-only extensions. */
+  val dataProductCapabilities: List<DataProductCapability>
+    get() = dataProductRegistry?.capabilities ?: emptyList()
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ExtensionRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ExtensionRegistry.kt
@@ -1,0 +1,338 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Holds every [Extension] the daemon knows about plus the live "publicly enabled" set. Every wire
+ * surface that needs to filter by activation goes through this object — JSON-RPC handlers consult
+ * it for capabilities and routing, render-time hooks consult it to decide which producers run, and
+ * the `extensions/{list,enable,disable}` methods mutate it.
+ *
+ * **Activation states.** Each extension is in one of three states at any moment:
+ *
+ * - **inactive** — neither publicly enabled nor pulled in by another active extension. Its
+ *   contributions are entirely dormant.
+ * - **active as dependency** — pulled in transitively because another publicly-enabled extension
+ *   declared it. Render-time hooks (`onRender`, override planning) run so the depending extension
+ *   sees its data; client-visible surfaces (capabilities lists, `data/fetch`, `data/subscribe`,
+ *   render attachments, `extensions/list`'s "enabled" set) stay empty for this id.
+ * - **publicly enabled** — turned on by an `extensions/enable` call. Contributes to every wire
+ *   surface as well as render-time hooks.
+ *
+ * The registry is thread-safe; `enable`/`disable` take a write lock, every read path takes a read
+ * lock and snapshots into an immutable view. This matches the JSON-RPC server's existing
+ * concurrency shape (read thread + worker thread + watcher thread).
+ */
+class ExtensionRegistry(extensions: List<Extension>) {
+  private val byId: Map<String, Extension>
+  private val lock = ReentrantReadWriteLock()
+  private val publicIds = HashSet<String>()
+  // Cached transitive closure of `publicIds` plus dependencies, recomputed on each mutation.
+  private var activeIdsCache: Set<String> = emptySet()
+
+  init {
+    val seen = HashMap<String, Extension>()
+    for (ext in extensions) {
+      val prior = seen.put(ext.id, ext)
+      require(prior == null) { "Duplicate extension id '${ext.id}'" }
+    }
+    byId = seen
+    for (ext in extensions) {
+      for (dep in ext.dependencies) {
+        require(dep in byId) { "Extension '${ext.id}' depends on unknown extension '$dep'" }
+      }
+    }
+    detectCycle()
+  }
+
+  private fun detectCycle() {
+    val visiting = HashSet<String>()
+    val done = HashSet<String>()
+    fun visit(id: String, path: List<String>) {
+      if (id in done) return
+      require(id !in visiting) { "Extension dependency cycle: ${(path + id).joinToString(" -> ")}" }
+      visiting += id
+      for (dep in byId.getValue(id).dependencies) visit(dep, path + id)
+      visiting -= id
+      done += id
+    }
+    for (id in byId.keys) visit(id, emptyList())
+  }
+
+  /** All registered extensions, in the order they were supplied. */
+  fun all(): List<Extension> = byId.values.toList()
+
+  /** True iff [id] was made public via [enable] (and not since [disable]d). */
+  fun isPubliclyEnabled(id: String): Boolean = lock.read { id in publicIds }
+
+  /** True iff [id] is publicly enabled or pulled in transitively. */
+  fun isActive(id: String): Boolean = lock.read { id in activeIdsCache }
+
+  /** Snapshot of publicly enabled ids. */
+  fun publicIds(): Set<String> = lock.read { publicIds.toSet() }
+
+  /** Snapshot of all ids that should run during a render (public + transitive deps). */
+  fun activeIds(): Set<String> = lock.read { activeIdsCache.toSet() }
+
+  /**
+   * Enable [requested] ids. Unknown ids land in [EnableOutcome.unknown] and the rest are processed.
+   * Already-enabled ids are reported separately. Transitive dependencies that come online land in
+   * [EnableOutcome.pulledIn].
+   */
+  fun enable(requested: Iterable<String>): EnableOutcome {
+    val asked = requested.toSet()
+    val unknown = asked.filter { it !in byId }.sorted()
+    val known = asked - unknown.toSet()
+    return lock.write {
+      val priorActive = activeIdsCache
+      val alreadyEnabled = known.filter { it in publicIds }.sorted()
+      val newlyEnabled = (known - publicIds).sorted()
+      publicIds += newlyEnabled
+      recomputeActive()
+      val pulledIn = (activeIdsCache - priorActive - newlyEnabled.toSet()).sorted()
+      EnableOutcome(
+        newlyEnabled = newlyEnabled,
+        pulledIn = pulledIn,
+        alreadyEnabled = alreadyEnabled,
+        unknown = unknown,
+      )
+    }
+  }
+
+  /**
+   * Disable [requested] ids from the public set. Ids that remain active because another publicly
+   * enabled extension still depends on them land in [DisableOutcome.stillActiveAsDependency] —
+   * disabling them publicly is fine, the client just sees the dep didn't fully deactivate.
+   */
+  fun disable(requested: Iterable<String>): DisableOutcome {
+    val asked = requested.toSet()
+    val unknown = asked.filter { it !in byId }.sorted()
+    val known = asked - unknown.toSet()
+    return lock.write {
+      val priorActive = activeIdsCache
+      val notEnabled = known.filter { it !in publicIds }.sorted()
+      val disabled = (known intersect publicIds).sorted()
+      publicIds -= disabled.toSet()
+      recomputeActive()
+      val deactivated = (priorActive - activeIdsCache).sorted()
+      val stillActive = disabled.filter { it in activeIdsCache }.sorted()
+      DisableOutcome(
+        disabled = disabled,
+        deactivated = deactivated,
+        stillActiveAsDependency = stillActive,
+        notEnabled = notEnabled,
+        unknown = unknown,
+      )
+    }
+  }
+
+  private fun recomputeActive() {
+    val out = HashSet<String>()
+    fun pull(id: String) {
+      if (!out.add(id)) return
+      for (dep in byId.getValue(id).dependencies) pull(dep)
+    }
+    for (id in publicIds) pull(id)
+    activeIdsCache = out
+  }
+
+  // -------------------------------------------------------------------------
+  // Wire-facing snapshots — only publicly enabled extensions contribute.
+  // -------------------------------------------------------------------------
+
+  fun publicDataProductCapabilities(): List<DataProductCapability> = lock.read {
+    publicIds.sorted().flatMap { byId.getValue(it).dataProductCapabilities }
+  }
+
+  fun publicDataExtensionDescriptors(): List<DataExtensionDescriptor> = lock.read {
+    publicIds.sorted().flatMap { byId.getValue(it).dataExtensionDescriptors }
+  }
+
+  fun publicPreviewExtensionDescriptors(): List<PreviewExtensionDescriptor> = lock.read {
+    publicIds.sorted().flatMap { byId.getValue(it).previewExtensionDescriptors }
+  }
+
+  fun infoList(): List<ExtensionInfo> = lock.read {
+    byId.values.map { ext ->
+      ExtensionInfo(
+        id = ext.id,
+        displayName = ext.displayName,
+        dependencies = ext.dependencies,
+        publiclyEnabled = ext.id in publicIds,
+        active = ext.id in activeIdsCache,
+        dataProductKinds = ext.dataProductCapabilities.map { it.kind },
+        dataExtensionIds = ext.dataExtensionDescriptors.map { it.id.value },
+        previewExtensionIds = ext.previewExtensionDescriptors.map { it.id },
+      )
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Render-time + JSON-RPC delegation surfaces consumed by JsonRpcServer.
+  //
+  // Two facades over the registered registries:
+  //  - [publicDataProducts] — the client-facing view. Capabilities, fetch, attachments, subscribe
+  //    only delegate to publicly enabled extensions. Dep-only extensions stay invisible.
+  //  - [activeDataProducts] — the render-time view. Run for any extension that's active, public or
+  //    dependency. This is what feeds dependencies their producer-side data so a public extension
+  //    that depends on them can read derived state.
+  //
+  // Both facades poll the live mutable state on every call so an `extensions/enable` mid-render
+  // takes effect on the next render cycle without rebuilding the renderer.
+  // -------------------------------------------------------------------------
+
+  /** Composite over publicly enabled extensions. */
+  fun publicDataProducts(): DataProductRegistry = ScopedDataProducts {
+    lock.read { publicIds.toList() }
+  }
+
+  /** Composite over publicly enabled or transitively active extensions. */
+  fun activeDataProducts(): DataProductRegistry = ScopedDataProducts {
+    lock.read { activeIdsCache.toList() }
+  }
+
+  private inner class ScopedDataProducts(private val ids: () -> List<String>) :
+    DataProductRegistry {
+    override val capabilities: List<DataProductCapability>
+      get() = ids().flatMap { byId.getValue(it).dataProductCapabilities }
+
+    override fun isKnown(kind: String): Boolean =
+      ids().any { byId.getValue(it).dataProductRegistry?.isKnown(kind) == true }
+
+    override fun fetch(
+      previewId: String,
+      kind: String,
+      params: JsonElement?,
+      inline: Boolean,
+    ): DataProductRegistry.Outcome {
+      val reg =
+        ids().firstNotNullOfOrNull { id ->
+          val r = byId.getValue(id).dataProductRegistry ?: return@firstNotNullOfOrNull null
+          if (r.isKnown(kind)) r else null
+        } ?: return DataProductRegistry.Outcome.Unknown
+      return reg.fetch(previewId, kind, params, inline)
+    }
+
+    override fun attachmentsFor(
+      previewId: String,
+      kinds: Set<String>,
+    ): List<DataProductAttachment> =
+      ids().flatMap { id ->
+        val reg = byId.getValue(id).dataProductRegistry ?: return@flatMap emptyList()
+        val supported = kinds.filterTo(mutableSetOf()) { reg.isKnown(it) }
+        if (supported.isEmpty()) emptyList() else reg.attachmentsFor(previewId, supported)
+      }
+
+    override fun onRender(previewId: String, result: RenderResult) {
+      onRender(previewId, result, overrides = null, previewContext = result.previewContext)
+    }
+
+    override fun onRender(previewId: String, result: RenderResult, overrides: PreviewOverrides?) {
+      onRender(previewId, result, overrides, previewContext = result.previewContext)
+    }
+
+    override fun onRender(
+      previewId: String,
+      result: RenderResult,
+      overrides: PreviewOverrides?,
+      previewContext: PreviewContext?,
+    ) {
+      for (id in ids()) {
+        byId
+          .getValue(id)
+          .dataProductRegistry
+          ?.onRender(previewId, result, overrides, previewContext)
+      }
+    }
+
+    override fun onRenderFailed(previewId: String, cause: Throwable) {
+      for (id in ids()) byId.getValue(id).dataProductRegistry?.onRenderFailed(previewId, cause)
+    }
+
+    override fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {
+      ids()
+        .firstOrNull { byId.getValue(it).dataProductRegistry?.isKnown(kind) == true }
+        ?.let { byId.getValue(it).dataProductRegistry?.onSubscribe(previewId, kind, params) }
+    }
+
+    override fun onUnsubscribe(previewId: String, kind: String) {
+      ids()
+        .firstOrNull { byId.getValue(it).dataProductRegistry?.isKnown(kind) == true }
+        ?.let { byId.getValue(it).dataProductRegistry?.onUnsubscribe(previewId, kind) }
+    }
+  }
+
+  /**
+   * Build a [PreviewOverrideExtensions] aggregator that planners are run from. The aggregator polls
+   * "is active" on each `plan(...)` so re-enabling/disabling at runtime takes effect on the next
+   * render without rebuilding the renderer. Active-as-dependency overrides plan too — the depending
+   * extension may need them to wrap the composable correctly.
+   */
+  fun activeOverrideExtensions(): PreviewOverrideExtensions {
+    val byOverrideId = HashMap<String, String>() // dataExtensionId -> owning extension id
+    for (ext in byId.values) {
+      for (over in ext.previewOverrideExtensions) {
+        byOverrideId[over.id.value] = ext.id
+      }
+    }
+    val all = byId.values.flatMap { it.previewOverrideExtensions }
+    return PreviewOverrideExtensions(
+      extensions = all,
+      isActive = { extension ->
+        val owningId = byOverrideId[extension.id.value] ?: return@PreviewOverrideExtensions false
+        isActive(owningId)
+      },
+    )
+  }
+
+  companion object {
+    val Empty: ExtensionRegistry = ExtensionRegistry(emptyList())
+  }
+}
+
+/**
+ * Outcome of an [ExtensionRegistry.enable] call. Disjoint partition of the requested ids: every id
+ * lands in exactly one of [newlyEnabled], [alreadyEnabled], or [unknown]. [pulledIn] is additive —
+ * dependencies that came online as a side effect.
+ */
+data class EnableOutcome(
+  val newlyEnabled: List<String>,
+  val pulledIn: List<String>,
+  val alreadyEnabled: List<String>,
+  val unknown: List<String>,
+)
+
+/**
+ * Outcome of an [ExtensionRegistry.disable] call. [disabled] are ids that were public and have been
+ * removed from the public set; [deactivated] are ids that are no longer active at all (no remaining
+ * public dependent); [stillActiveAsDependency] are ids that were disabled publicly but remain
+ * active because another public extension still depends on them.
+ */
+data class DisableOutcome(
+  val disabled: List<String>,
+  val deactivated: List<String>,
+  val stillActiveAsDependency: List<String>,
+  val notEnabled: List<String>,
+  val unknown: List<String>,
+)
+
+/** Per-extension snapshot returned by `extensions/list`. */
+data class ExtensionInfo(
+  val id: String,
+  val displayName: String,
+  val dependencies: List<String>,
+  val publiclyEnabled: Boolean,
+  val active: Boolean,
+  val dataProductKinds: List<String>,
+  val dataExtensionIds: List<String>,
+  val previewExtensionIds: List<String>,
+)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -14,6 +14,12 @@ import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataSubscribeParams
 import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
 import ee.schimke.composeai.daemon.protocol.DiscoveryUpdatedParams
+import ee.schimke.composeai.daemon.protocol.ExtensionInfoDto
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableParams
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableParams
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
 import ee.schimke.composeai.daemon.protocol.FileChangedParams
 import ee.schimke.composeai.daemon.protocol.FileKind
 import ee.schimke.composeai.daemon.protocol.HistoryAddedParams
@@ -50,8 +56,6 @@ import ee.schimke.composeai.daemon.protocol.ServerCapabilities
 import ee.schimke.composeai.daemon.protocol.SetFocusParams
 import ee.schimke.composeai.daemon.protocol.SetVisibleParams
 import ee.schimke.composeai.daemon.protocol.UiMode
-import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
-import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import java.io.ByteArrayOutputStream
 import java.io.EOFException
 import java.io.IOException
@@ -178,14 +182,16 @@ class JsonRpcServer(
    */
   private val autoPruneInitialDelayMs: Long = HistoryManager.DEFAULT_INITIAL_DELAY_MS,
   /**
-   * D1 — producer-side seam for the data-product surface. Defaults to [DataProductRegistry.Empty]
-   * so pre-D2 callers keep `capabilities.dataProducts = []` and every `data/fetch` /
-   * `data/subscribe` short-circuits to `DataProductUnknown`. The renderer-side a11y producer (D2,
-   * in `renderer-android`) is the first concrete implementation that gets wired in by `DaemonMain`.
+   * Daemon extension registry (see [Extension] and [ExtensionRegistry]). Replaces the per-feature
+   * lists this constructor used to take (`dataProducts`, `dataExtensions`, `previewExtensions`).
+   *
+   * Daemons start with every extension registered as inactive — `initialize.capabilities` reports
+   * empty kind/descriptor lists and every `data/fetch`/`data/subscribe` short-circuits to
+   * `DataProductUnknown`. Clients call `extensions/enable` to opt in to the contributions they
+   * actually need. Defaults to [ExtensionRegistry.Empty] for in-process tests and harness fake-mode
+   * scenarios that don't wire any.
    */
-  private val dataProducts: DataProductRegistry = DataProductRegistry.Empty,
-  private val dataExtensions: List<DataExtensionDescriptor> = emptyList(),
-  private val previewExtensions: List<PreviewExtensionDescriptor> = emptyList(),
+  internal val extensions: ExtensionRegistry = ExtensionRegistry.Empty,
   /**
    * D3 — per-request budget for `data/fetch` re-render-on-demand (DATA-PRODUCTS.md § "Re-render
    * semantics"). When the registry returns [DataProductRegistry.Outcome.RequiresRerender] the
@@ -569,6 +575,9 @@ class JsonRpcServer(
       "data/fetch" -> handleDataFetch(req)
       "data/subscribe" -> handleDataSubscribe(req, subscribe = true)
       "data/unsubscribe" -> handleDataSubscribe(req, subscribe = false)
+      "extensions/list" -> handleExtensionsList(req)
+      "extensions/enable" -> handleExtensionsEnable(req)
+      "extensions/disable" -> handleExtensionsDisable(req)
       "interactive/start" -> handleInteractiveStart(req)
       "recording/start" -> handleRecordingStart(req)
       "recording/stop" -> handleRecordingStop(req)
@@ -612,7 +621,8 @@ class JsonRpcServer(
     // silently dropped: pre-D2 daemons advertise nothing, so even an over-eager client falls
     // back to no global attachments rather than tripping `DataProductUnknown` on every
     // render.
-    val attachableKinds = dataProducts.capabilities.filter { it.attachable }.map { it.kind }.toSet()
+    val attachableKinds =
+      extensions.publicDataProductCapabilities().filter { it.attachable }.map { it.kind }.toSet()
     globalAttachKinds =
       (params.options?.attachDataProducts ?: emptyList()).toSet().intersect(attachableKinds)
     // PROTOCOL.md § 3 — per-render timeout override. Positive values win; null / ≤ 0 keeps the
@@ -640,9 +650,9 @@ class JsonRpcServer(
             // Leak detection (B2.4) not wired yet — empty list = unavailable.
             leakDetection = emptyList<LeakDetectionMode>(),
             // D1 — advertised kinds. Empty when no producer was wired (pre-D2 default).
-            dataProducts = dataProducts.capabilities,
-            dataExtensions = dataExtensions,
-            previewExtensions = previewExtensions,
+            dataProducts = extensions.publicDataProductCapabilities(),
+            dataExtensions = extensions.publicDataExtensionDescriptors(),
+            previewExtensions = extensions.publicPreviewExtensionDescriptors(),
             // INTERACTIVE.md § 9 — `true` when the host's `acquireInteractiveSession` returns a
             // real held-scene session (DesktopHost). `false` for hosts that inherit the throwing
             // default (FakeHost, RobolectricHost today) — clients fall back to v1 dispatch.
@@ -974,12 +984,9 @@ class JsonRpcServer(
     // and we emit `tookMs = 0`. Other RenderMetrics fields (heap / native / sandbox-age) stay
     // null until B2.3 wires the cost-model collection path.
     try {
-      dataProducts.onRender(
-        previewId,
-        result,
-        hostIdToOverrides.remove(result.id),
-        result.previewContext,
-      )
+      extensions
+        .activeDataProducts()
+        .onRender(previewId, result, hostIdToOverrides.remove(result.id), result.previewContext)
     } catch (t: Throwable) {
       System.err.println(
         "compose-ai-daemon: data product onRender failed for $previewId " +
@@ -1411,7 +1418,7 @@ class JsonRpcServer(
     inFlightRenders.remove(failure.hostId)
     previewIdsWithOverridesInFlight.remove(previewId)
     try {
-      dataProducts.onRenderFailed(previewId, failure.cause)
+      extensions.activeDataProducts().onRenderFailed(previewId, failure.cause)
     } catch (t: Throwable) {
       System.err.println(
         "compose-ai-daemon: data product onRenderFailed failed for $previewId " +
@@ -1520,7 +1527,7 @@ class JsonRpcServer(
       (subscriptions[previewId]?.toSet() ?: emptySet()) + globalAttachKinds
     val attachments: List<DataProductAttachment> =
       if (requestedKinds.isEmpty()) emptyList()
-      else dataProducts.attachmentsFor(previewId, requestedKinds)
+      else extensions.publicDataProducts().attachmentsFor(previewId, requestedKinds)
     return RenderFinishedParams(
       id = previewId,
       pngPath = pngPath,
@@ -1546,7 +1553,10 @@ class JsonRpcServer(
         )
         return
       }
-    val outcome = dataProducts.fetch(params.previewId, params.kind, params.params, params.inline)
+    val outcome =
+      extensions
+        .publicDataProducts()
+        .fetch(params.previewId, params.kind, params.params, params.inline)
     if (outcome is DataProductRegistry.Outcome.RequiresRerender) {
       // D3 — kick the re-render off the read loop so other notifications / requests aren't
       // blocked while we wait out the budget. The worker thread submits the render, parks on a
@@ -1630,7 +1640,9 @@ class JsonRpcServer(
               // producer bug — we don't recurse, we surface a fetch-failed so callers see it.
               val secondOutcome =
                 try {
-                  dataProducts.fetch(params.previewId, params.kind, params.params, params.inline)
+                  extensions
+                    .publicDataProducts()
+                    .fetch(params.previewId, params.kind, params.params, params.inline)
                 } catch (t: Throwable) {
                   DataProductRegistry.Outcome.FetchFailed(
                     "registry threw on post-rerender fetch: ${t.message ?: t.javaClass.simpleName}"
@@ -1765,7 +1777,8 @@ class JsonRpcServer(
         return
       }
     if (subscribe) {
-      val capability = dataProducts.capabilities.firstOrNull { it.kind == params.kind }
+      val capability =
+        extensions.publicDataProductCapabilities().firstOrNull { it.kind == params.kind }
       if (capability == null || !capability.attachable) {
         sendErrorResponse(
           id = req.id,
@@ -1783,7 +1796,7 @@ class JsonRpcServer(
       // leaves the dispatcher state consistent with the client's view (a subsequent unsubscribe
       // will clear it). Re-subscribes pass the latest `params` through verbatim — producers that
       // care about reset-on-re-subscribe handle that themselves.
-      dataProducts.onSubscribe(params.previewId, params.kind, params.params)
+      extensions.publicDataProducts().onSubscribe(params.previewId, params.kind, params.params)
     } else {
       val existed = subscriptions[params.previewId]?.remove(params.kind) == true
       // Drop the inner set when its last subscription cleared so the bookkeeping doesn't
@@ -1792,7 +1805,7 @@ class JsonRpcServer(
       // Notify the producer — but only if there was actually a live subscription. Calling
       // onUnsubscribe for a never-subscribed pair would invite producers to log spurious
       // "no such subscription" warnings.
-      if (existed) dataProducts.onUnsubscribe(params.previewId, params.kind)
+      if (existed) extensions.publicDataProducts().onUnsubscribe(params.previewId, params.kind)
     }
     sendResponse(req.id, encode(DataSubscribeResult.serializer(), DataSubscribeResult.OK))
   }
@@ -1811,8 +1824,110 @@ class JsonRpcServer(
     val toDrop = subscriptions.keys - visible
     for (id in toDrop) {
       val droppedKinds = subscriptions.remove(id) ?: continue
-      for (kind in droppedKinds) dataProducts.onUnsubscribe(id, kind)
+      for (kind in droppedKinds) extensions.publicDataProducts().onUnsubscribe(id, kind)
     }
+  }
+
+  // --------------------------------------------------------------------------
+  // extensions/{list,enable,disable} — see PROTOCOL.md § 3a.
+  //
+  // The daemon registers every Extension at startup but leaves them inactive. Clients call
+  // `extensions/enable` to opt in to specific contributions; the response contains the new public
+  // capability snapshot so the client doesn't need a follow-up `list`. Dependencies pulled in
+  // transitively are reported in `pulledIn` but their kinds/descriptors do not appear in any
+  // public surface — they only flow through their depending extension.
+  // --------------------------------------------------------------------------
+
+  private fun handleExtensionsList(req: JsonRpcRequest) {
+    val result =
+      ExtensionsListResult(
+        extensions =
+          extensions.infoList().map { info ->
+            ExtensionInfoDto(
+              id = info.id,
+              displayName = info.displayName,
+              dependencies = info.dependencies,
+              publiclyEnabled = info.publiclyEnabled,
+              active = info.active,
+              dataProductKinds = info.dataProductKinds,
+              dataExtensionIds = info.dataExtensionIds,
+              previewExtensionIds = info.previewExtensionIds,
+            )
+          }
+      )
+    sendResponse(req.id, encode(ExtensionsListResult.serializer(), result))
+  }
+
+  private fun handleExtensionsEnable(req: JsonRpcRequest) {
+    val params =
+      try {
+        decodeParams(req.params, ExtensionsEnableParams.serializer())
+      } catch (e: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INVALID_PARAMS,
+          message = "invalid extensions/enable params: ${e.message}",
+        )
+        return
+      }
+    val outcome = extensions.enable(params.ids)
+    val result =
+      ExtensionsEnableResult(
+        newlyEnabled = outcome.newlyEnabled,
+        pulledIn = outcome.pulledIn,
+        alreadyEnabled = outcome.alreadyEnabled,
+        unknown = outcome.unknown,
+        dataProducts = extensions.publicDataProductCapabilities(),
+        dataExtensions = extensions.publicDataExtensionDescriptors(),
+        previewExtensions = extensions.publicPreviewExtensionDescriptors(),
+      )
+    sendResponse(req.id, encode(ExtensionsEnableResult.serializer(), result))
+  }
+
+  private fun handleExtensionsDisable(req: JsonRpcRequest) {
+    val params =
+      try {
+        decodeParams(req.params, ExtensionsDisableParams.serializer())
+      } catch (e: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INVALID_PARAMS,
+          message = "invalid extensions/disable params: ${e.message}",
+        )
+        return
+      }
+    // Drop subscriptions for kinds whose owning extension is being disabled — the producer side
+    // would otherwise leak per-subscription state and a future re-enable would inherit it.
+    val priorPublic = extensions.publicDataProductCapabilities().map { it.kind }.toSet()
+    val outcome = extensions.disable(params.ids)
+    val nowPublic = extensions.publicDataProductCapabilities().map { it.kind }.toSet()
+    val droppedKinds = priorPublic - nowPublic
+    if (droppedKinds.isNotEmpty()) {
+      for ((previewId, kinds) in subscriptions) {
+        val toRemove = kinds.intersect(droppedKinds)
+        if (toRemove.isEmpty()) continue
+        kinds.removeAll(toRemove)
+        // We can't dispatch onUnsubscribe through `publicDataProducts()` here because the kind is
+        // no longer public. Reach through the active set instead so the producer still tears down
+        // its per-subscription state.
+        for (kind in toRemove) {
+          extensions.activeDataProducts().onUnsubscribe(previewId, kind)
+        }
+      }
+      subscriptions.values.removeIf { it.isEmpty() }
+    }
+    val result =
+      ExtensionsDisableResult(
+        disabled = outcome.disabled,
+        deactivated = outcome.deactivated,
+        stillActiveAsDependency = outcome.stillActiveAsDependency,
+        notEnabled = outcome.notEnabled,
+        unknown = outcome.unknown,
+        dataProducts = extensions.publicDataProductCapabilities(),
+        dataExtensions = extensions.publicDataExtensionDescriptors(),
+        previewExtensions = extensions.publicPreviewExtensionDescriptors(),
+      )
+    sendResponse(req.id, encode(ExtensionsDisableResult.serializer(), result))
   }
 
   // --------------------------------------------------------------------------
@@ -2897,8 +3012,14 @@ class JsonRpcServer(
   }
 
   companion object {
-    /** PROTOCOL.md § 7. */
-    const val PROTOCOL_VERSION: Int = 1
+    /**
+     * PROTOCOL.md § 7. Bumped to 2 when daemons stopped advertising every extension's contributions
+     * by default — `initialize.capabilities.{dataProducts,dataExtensions,previewExtensions}` are
+     * empty until the client opts in via `extensions/enable`. v1 clients calling against a v2
+     * daemon will see empty capability lists and assume nothing is supported; the daemon errors out
+     * on `protocolVersion` mismatch so they get a clean handshake failure instead.
+     */
+    const val PROTOCOL_VERSION: Int = 2
 
     const val IDLE_TIMEOUT_PROP: String = "composeai.daemon.idleTimeoutMs"
     const val DEFAULT_IDLE_TIMEOUT_MS: Long = 5_000L

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideExtensions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideExtensions.kt
@@ -31,11 +31,19 @@ typealias PreviewOverrideExtension = DataExtension<PreviewOverrides>
  * Used to keep render-engine call sites generic: instead of hardcoding `spec.wallpaper?.let(...)`
  * and friends, the engine calls [plan] and receives the list of [PlannedDataExtension] entries to
  * thread through `ComposeDataExtensionPipeline.Apply`.
+ *
+ * `isActive` is consulted on every `plan(...)` call so a runtime `extensions/enable` /
+ * `extensions/disable` from the [ExtensionRegistry] takes effect on the next render without
+ * rebuilding the renderer. The default predicate considers every extension active — used by tests
+ * and by callers that want the legacy "always on" behaviour.
  */
-class PreviewOverrideExtensions(val extensions: List<PreviewOverrideExtension>) {
+class PreviewOverrideExtensions(
+  val extensions: List<PreviewOverrideExtension>,
+  private val isActive: (PreviewOverrideExtension) -> Boolean = { true },
+) {
   fun plan(overrides: PreviewOverrides?): List<PlannedDataExtension> {
     if (overrides == null || extensions.isEmpty()) return emptyList()
-    return extensions.mapNotNull { it.plan(overrides) }
+    return extensions.mapNotNull { if (isActive(it)) it.plan(overrides) else null }
   }
 
   companion object {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -285,6 +285,57 @@ enum class LeakDetectionMode {
 @Serializable data class Manifest(val path: String, val previewCount: Int)
 
 // =====================================================================
+// 2b. extensions/{list,enable,disable} (PROTOCOL.md § 3a)
+//
+// Daemons register every extension as inactive. Clients call `extensions/enable` to opt in to the
+// ones they want — the corresponding kinds, descriptors, and override planners come online for
+// that daemon's lifetime (until a matching `extensions/disable`). Dependencies declared by an
+// extension are pulled in transitively but stay invisible to direct client RPC.
+// =====================================================================
+
+@Serializable
+data class ExtensionInfoDto(
+  val id: String,
+  val displayName: String,
+  val dependencies: List<String> = emptyList(),
+  val publiclyEnabled: Boolean = false,
+  val active: Boolean = false,
+  val dataProductKinds: List<String> = emptyList(),
+  val dataExtensionIds: List<String> = emptyList(),
+  val previewExtensionIds: List<String> = emptyList(),
+)
+
+@Serializable data class ExtensionsListResult(val extensions: List<ExtensionInfoDto>)
+
+@Serializable data class ExtensionsEnableParams(val ids: List<String>)
+
+@Serializable
+data class ExtensionsEnableResult(
+  val newlyEnabled: List<String> = emptyList(),
+  val pulledIn: List<String> = emptyList(),
+  val alreadyEnabled: List<String> = emptyList(),
+  val unknown: List<String> = emptyList(),
+  /** New public capability snapshots so a client doesn't need a follow-up `extensions/list`. */
+  val dataProducts: List<DataProductCapability> = emptyList(),
+  val dataExtensions: List<DataExtensionDescriptor> = emptyList(),
+  val previewExtensions: List<PreviewExtensionDescriptor> = emptyList(),
+)
+
+@Serializable data class ExtensionsDisableParams(val ids: List<String>)
+
+@Serializable
+data class ExtensionsDisableResult(
+  val disabled: List<String> = emptyList(),
+  val deactivated: List<String> = emptyList(),
+  val stillActiveAsDependency: List<String> = emptyList(),
+  val notEnabled: List<String> = emptyList(),
+  val unknown: List<String> = emptyList(),
+  val dataProducts: List<DataProductCapability> = emptyList(),
+  val dataExtensions: List<DataExtensionDescriptor> = emptyList(),
+  val previewExtensions: List<PreviewExtensionDescriptor> = emptyList(),
+)
+
+// =====================================================================
 // 3. Client → daemon notifications (PROTOCOL.md § 4)
 // =====================================================================
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
@@ -442,7 +442,9 @@ class DataFetchRerenderTest {
         host = host,
         daemonVersion = "test",
         idleTimeoutMs = 100L,
-        dataProducts = producer,
+        extensions =
+          ExtensionRegistry(listOf(Extension(id = "test/producer", dataProductRegistry = producer)))
+            .also { it.enable(listOf("test/producer")) },
         dataFetchRerenderBudgetMs = dataFetchRerenderBudgetMs,
         onExit = { code ->
           exitCode.set(code)
@@ -524,7 +526,7 @@ class DataFetchRerenderTest {
       send(
         """
         {"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-          "protocolVersion":1,
+          "protocolVersion":2,
           "clientVersion":"test",
           "workspaceRoot":"/tmp",
           "moduleId":":test",

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DeviceOverrideEncodingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DeviceOverrideEncodingTest.kt
@@ -162,7 +162,7 @@ class DeviceOverrideEncodingTest {
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":t","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":false}}}""",
       )

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/ExtensionRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/ExtensionRegistryTest.kt
@@ -1,0 +1,244 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.render.PreviewContext
+import kotlinx.serialization.json.JsonElement
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExtensionRegistryTest {
+
+  private fun cap(kind: String) =
+    DataProductCapability(
+      kind = kind,
+      schemaVersion = 1,
+      transport = DataProductTransport.PATH,
+      attachable = true,
+      fetchable = true,
+      requiresRerender = false,
+    )
+
+  private class RecordingRegistry(kind: String) : DataProductRegistry {
+    val onRenderCount = java.util.concurrent.atomic.AtomicInteger(0)
+    val onSubscribeCount = java.util.concurrent.atomic.AtomicInteger(0)
+    val fetchCount = java.util.concurrent.atomic.AtomicInteger(0)
+    override val capabilities =
+      listOf(
+        DataProductCapability(
+          kind = kind,
+          schemaVersion = 1,
+          transport = DataProductTransport.PATH,
+          attachable = true,
+          fetchable = true,
+          requiresRerender = false,
+        )
+      )
+
+    override fun fetch(
+      previewId: String,
+      kind: String,
+      params: JsonElement?,
+      inline: Boolean,
+    ): DataProductRegistry.Outcome {
+      fetchCount.incrementAndGet()
+      return DataProductRegistry.Outcome.Ok(DataFetchResult(kind = kind, schemaVersion = 1))
+    }
+
+    override fun attachmentsFor(
+      previewId: String,
+      kinds: Set<String>,
+    ): List<DataProductAttachment> = emptyList()
+
+    override fun onRender(
+      previewId: String,
+      result: RenderResult,
+      overrides: PreviewOverrides?,
+      previewContext: PreviewContext?,
+    ) {
+      onRenderCount.incrementAndGet()
+    }
+
+    override fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {
+      onSubscribeCount.incrementAndGet()
+    }
+  }
+
+  @Test
+  fun `default registry advertises nothing public until enabled`() {
+    val a = RecordingRegistry("a/kind")
+    val registry = ExtensionRegistry(listOf(Extension(id = "ext/a", dataProductRegistry = a)))
+
+    assertTrue(registry.publicDataProductCapabilities().isEmpty())
+    assertEquals(emptyList<String>(), registry.publicIds().toList())
+    assertFalse(registry.isPubliclyEnabled("ext/a"))
+    assertFalse(registry.isActive("ext/a"))
+
+    val list = registry.infoList()
+    assertEquals(1, list.size)
+    assertEquals("a/kind", list[0].dataProductKinds.single())
+    assertFalse(list[0].publiclyEnabled)
+    assertFalse(list[0].active)
+  }
+
+  @Test
+  fun `enable publishes capabilities and activates the extension`() {
+    val a = RecordingRegistry("a/kind")
+    val registry = ExtensionRegistry(listOf(Extension(id = "ext/a", dataProductRegistry = a)))
+
+    val out = registry.enable(listOf("ext/a"))
+    assertEquals(listOf("ext/a"), out.newlyEnabled)
+    assertEquals(emptyList<String>(), out.pulledIn)
+    assertEquals(emptyList<String>(), out.unknown)
+    assertTrue(registry.isPubliclyEnabled("ext/a"))
+    assertTrue(registry.isActive("ext/a"))
+    assertEquals(listOf("a/kind"), registry.publicDataProductCapabilities().map { it.kind })
+  }
+
+  @Test
+  fun `enable unknown id is reported and skipped`() {
+    val registry =
+      ExtensionRegistry(
+        listOf(Extension(id = "ext/a", dataProductRegistry = RecordingRegistry("a/kind")))
+      )
+    val out = registry.enable(listOf("ext/a", "nope"))
+    assertEquals(listOf("ext/a"), out.newlyEnabled)
+    assertEquals(listOf("nope"), out.unknown)
+    assertTrue(registry.isPubliclyEnabled("ext/a"))
+  }
+
+  @Test
+  fun `dependencies are pulled in but stay invisible to public surface`() {
+    val a = RecordingRegistry("a/kind")
+    val b = RecordingRegistry("b/kind")
+    val registry =
+      ExtensionRegistry(
+        listOf(
+          Extension(id = "ext/b", dataProductRegistry = b),
+          Extension(id = "ext/a", dataProductRegistry = a, dependencies = listOf("ext/b")),
+        )
+      )
+
+    val out = registry.enable(listOf("ext/a"))
+    assertEquals(listOf("ext/a"), out.newlyEnabled)
+    assertEquals(listOf("ext/b"), out.pulledIn)
+    assertTrue(registry.isPubliclyEnabled("ext/a"))
+    assertFalse(registry.isPubliclyEnabled("ext/b"))
+    assertTrue(registry.isActive("ext/b"))
+
+    // Public surface only reports `a/kind` — the dep's kind is invisible.
+    assertEquals(listOf("a/kind"), registry.publicDataProductCapabilities().map { it.kind })
+    assertFalse(registry.publicDataProducts().isKnown("b/kind"))
+    // Active surface includes the dep so onRender flows through.
+    assertTrue(registry.activeDataProducts().isKnown("b/kind"))
+  }
+
+  @Test
+  fun `disable deactivates the extension and clears public capabilities`() {
+    val a = RecordingRegistry("a/kind")
+    val registry = ExtensionRegistry(listOf(Extension(id = "ext/a", dataProductRegistry = a)))
+    registry.enable(listOf("ext/a"))
+
+    val out = registry.disable(listOf("ext/a"))
+    assertEquals(listOf("ext/a"), out.disabled)
+    assertEquals(listOf("ext/a"), out.deactivated)
+    assertTrue(out.stillActiveAsDependency.isEmpty())
+    assertFalse(registry.isPubliclyEnabled("ext/a"))
+    assertFalse(registry.isActive("ext/a"))
+    assertTrue(registry.publicDataProductCapabilities().isEmpty())
+  }
+
+  @Test
+  fun `disabling a public extension keeps it active when another dependent extension still wants it`() {
+    val a = RecordingRegistry("a/kind")
+    val b = RecordingRegistry("b/kind")
+    val registry =
+      ExtensionRegistry(
+        listOf(
+          Extension(id = "ext/b", dataProductRegistry = b),
+          Extension(id = "ext/a", dataProductRegistry = a, dependencies = listOf("ext/b")),
+        )
+      )
+    registry.enable(listOf("ext/a", "ext/b"))
+
+    val out = registry.disable(listOf("ext/b"))
+    assertEquals(listOf("ext/b"), out.disabled)
+    assertTrue(out.deactivated.isEmpty())
+    assertEquals(listOf("ext/b"), out.stillActiveAsDependency)
+    assertFalse(registry.isPubliclyEnabled("ext/b"))
+    assertTrue(registry.isActive("ext/b"))
+  }
+
+  @Test
+  fun `active dataProducts onRender fans out to public and dep extensions`() {
+    val a = RecordingRegistry("a/kind")
+    val b = RecordingRegistry("b/kind")
+    val registry =
+      ExtensionRegistry(
+        listOf(
+          Extension(id = "ext/b", dataProductRegistry = b),
+          Extension(id = "ext/a", dataProductRegistry = a, dependencies = listOf("ext/b")),
+        )
+      )
+    registry.enable(listOf("ext/a"))
+
+    val result =
+      RenderResult(id = 1L, classLoaderHashCode = 0, classLoaderName = "test", pngPath = null)
+    registry.activeDataProducts().onRender(previewId = "p1", result = result)
+    assertEquals(1, a.onRenderCount.get())
+    assertEquals(1, b.onRenderCount.get())
+  }
+
+  @Test
+  fun `public dataProducts fetch routes only to public extension and skips deps`() {
+    val a = RecordingRegistry("a/kind")
+    val b = RecordingRegistry("b/kind")
+    val registry =
+      ExtensionRegistry(
+        listOf(
+          Extension(id = "ext/b", dataProductRegistry = b),
+          Extension(id = "ext/a", dataProductRegistry = a, dependencies = listOf("ext/b")),
+        )
+      )
+    registry.enable(listOf("ext/a"))
+
+    val outcomeOk =
+      registry
+        .publicDataProducts()
+        .fetch(previewId = "p1", kind = "a/kind", params = null, inline = false)
+    assertTrue(outcomeOk is DataProductRegistry.Outcome.Ok)
+    assertEquals(1, a.fetchCount.get())
+
+    val outcomeUnknown =
+      registry
+        .publicDataProducts()
+        .fetch(previewId = "p1", kind = "b/kind", params = null, inline = false)
+    assertEquals(DataProductRegistry.Outcome.Unknown, outcomeUnknown)
+    assertEquals(0, b.fetchCount.get())
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `dependency cycle is rejected at construction`() {
+    ExtensionRegistry(
+      listOf(
+        Extension(id = "a", dependencies = listOf("b")),
+        Extension(id = "b", dependencies = listOf("a")),
+      )
+    )
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `unknown dependency is rejected at construction`() {
+    ExtensionRegistry(listOf(Extension(id = "a", dependencies = listOf("b"))))
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `duplicate ids are rejected at construction`() {
+    ExtensionRegistry(listOf(Extension(id = "a"), Extension(id = "a")))
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InputRecordingScriptEventsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InputRecordingScriptEventsTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveCoalescingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveCoalescingTest.kt
@@ -173,7 +173,7 @@ class InteractiveCoalescingTest {
     writeFrame(
       out,
       """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-        "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+        "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
         "moduleId":":test","moduleProjectDir":"/tmp",
         "capabilities":{"visibility":true,"metrics":false}}}""",
     )

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveRpcIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveRpcIntegrationTest.kt
@@ -365,7 +365,7 @@ class InteractiveRpcIntegrationTest {
     writeFrame(
       out,
       """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-        "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+        "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
         "moduleId":":test","moduleProjectDir":"/tmp",
         "capabilities":{"visibility":true,"metrics":false}}}""",
     )

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
@@ -371,7 +371,7 @@ class InteractiveSessionPlumbingTest {
     writeFrame(
       out,
       """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-        "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+        "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
         "moduleId":":test","moduleProjectDir":"/tmp",
         "capabilities":{"visibility":true,"metrics":false}}}""",
     )

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
@@ -108,7 +108,7 @@ class JsonRpcServerIntegrationTest {
         clientToServerOut,
         """
         {"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-                  "protocolVersion":1,
+                  "protocolVersion":2,
                   "clientVersion":"test",
                   "workspaceRoot":"/tmp",
                   "moduleId":":test",
@@ -218,13 +218,18 @@ class JsonRpcServerIntegrationTest {
 
     val registry = FailureRecordingDataProductRegistry()
     val host = FakeRenderHost(failureToThrow = IllegalStateException("deliberate test failure"))
+    val extensions =
+      ExtensionRegistry(
+        listOf(Extension(id = "test/failure-recording", dataProductRegistry = registry))
+      )
+    extensions.enable(listOf("test/failure-recording"))
     val server =
       JsonRpcServer(
         input = clientToServerIn,
         output = serverToClientOut,
         host = host,
         daemonVersion = "test",
-        dataProducts = registry,
+        extensions = extensions,
       )
     val serverThread =
       Thread({ server.run() }, "json-rpc-server-test-failure-data").apply { isDaemon = true }
@@ -251,7 +256,7 @@ class JsonRpcServerIntegrationTest {
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":test","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":false}}}""",
       )
@@ -358,7 +363,7 @@ class JsonRpcServerIntegrationTest {
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":test","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":false}}}""",
       )
@@ -436,7 +441,7 @@ class JsonRpcServerIntegrationTest {
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":test","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":false}}}""",
       )
@@ -523,7 +528,7 @@ class JsonRpcServerIntegrationTest {
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":test","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":false}}}""",
       )
@@ -645,7 +650,7 @@ class JsonRpcServerIntegrationTest {
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":test","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":false}}}""",
       )
@@ -760,7 +765,7 @@ class JsonRpcServerIntegrationTest {
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":test","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":false}}}""",
       )
@@ -883,7 +888,7 @@ class JsonRpcServerIntegrationTest {
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":test","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":false}}}""",
       )
@@ -1001,7 +1006,7 @@ class JsonRpcServerIntegrationTest {
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":test","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":false}}}""",
       )
@@ -1169,7 +1174,7 @@ class JsonRpcServerIntegrationTest {
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":test","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":true}}}""",
       )
@@ -1266,7 +1271,7 @@ class JsonRpcServerIntegrationTest {
         clientToServerOut,
         """
         {"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-                  "protocolVersion":1,
+                  "protocolVersion":2,
                   "clientVersion":"test",
                   "workspaceRoot":"/tmp",
                   "moduleId":":test",

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
@@ -266,7 +266,7 @@ class HistoryDiffTest {
       // initialize → initialized.
       send(
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":test","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":false}}}"""
       )

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
@@ -111,7 +111,7 @@ class JsonRpcServerHistoryIntegrationTest {
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":test","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":false}}}""",
       )
@@ -387,7 +387,7 @@ class JsonRpcServerHistoryIntegrationTest {
       writeFrame(
         clientToServerOut,
         """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
               "moduleId":":test","moduleProjectDir":"/tmp",
               "capabilities":{"visibility":true,"metrics":false},
               "options":{"historyPrune":{

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -93,68 +93,13 @@ fun main(args: Array<String>) {
       PreviewIndex.empty()
     }
 
-  // D5 — wire the `compose/recomposition` data-product producer. The producer is itself a
-  // [DesktopHost.InteractiveSessionListener]; we pass it to both the host (so it learns about
-  // session lifecycle) and the JsonRpcServer (so it surfaces capabilities + handles
-  // data/subscribe). Constructed unconditionally on desktop — it advertises one kind, and a
-  // panel that doesn't subscribe pays nothing.
+  // Producer-side registries. Constructed unconditionally so they can be referenced from
+  // capture/listener lambdas; their per-render side effects are gated by the [ExtensionRegistry]
+  // built below — when an extension is inactive, no callbacks fire.
   val recompositionRegistry = RecompositionDataProductRegistry()
   val themeRegistry = ThemeDataProductRegistry()
   val wallpaperRegistry = WallpaperDataProductRegistry()
-  val renderEngine =
-    RenderEngine(
-      previewContextCapture =
-        object : RenderEngine.PreviewContextCapture {
-          override fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
-            themeRegistry.shouldCapture(previewId, renderMode)
-        },
-      previewOverrideExtensions =
-        PreviewOverrideExtensions(
-          listOf(
-            // Both planners run for every render — each abstains (returns null) when its own
-            // override field on PreviewOverrides is not set. Order in the list controls
-            // around-composable wrapping order: wallpaper applies first so an explicit
-            // material3Theme override still wins for any role the caller pinned.
-            WallpaperPreviewOverrideExtension(),
-            Material3ThemePreviewOverrideExtension(),
-          )
-        ),
-    )
 
-  val manifestPath = System.getProperty("composeai.harness.previewsManifest")
-  val host: RenderHost =
-    if (manifestPath != null && manifestPath.isNotBlank()) {
-      val manifest = PreviewManifestRouter.loadManifest(File(manifestPath))
-      System.err.println(
-        "compose-ai-tools desktop daemon: PreviewManifestRouter active " +
-          "(manifest=$manifestPath, previews=${manifest.previews.map { it.id }})"
-      )
-      PreviewManifestRouter(
-        manifest = manifest,
-        engine = renderEngine,
-        userClassloaderHolder = userClassloaderHolder,
-      )
-    } else {
-      DesktopHost(
-        engine = renderEngine,
-        userClassloaderHolder = userClassloaderHolder,
-        // v2 — resolve `previewId` via PreviewIndex for the interactive session path. Issue #420
-        // wired the `params` block on `PreviewInfoDto`, so when the discovery JSON carries
-        // explicit `widthDp` / `heightDp` / `density` / `fontScale` / `locale` / `uiMode` /
-        // `device` / `showBackground` / `backgroundColor`, the resolver builds a `RenderSpec` that
-        // matches the user's `@Preview(...)` exactly. Per-field fallback to the `RenderSpec`
-        // defaults (320x320, density 2.0, white background, ...) when an individual field is null.
-        // See INTERACTIVE.md § 9 ("RenderHost surface").
-        previewSpecResolver =
-          previewIndexBackedSpecResolver(previewIndex)?.takeIf { previewIndex.size > 0 },
-        // D5 — see RecompositionDataProductRegistry KDoc. Producer learns about session
-        // lifecycle here so it can install/dispose its CompositionObserver.
-        interactiveSessionListener =
-          DesktopHost.InteractiveSessionListener { previewId, scene ->
-            recompositionRegistry.onSessionLifecycle(previewId, scene)
-          },
-      )
-    }
   // B2.1 — wire Tier-1 classpath fingerprinting (DESIGN § 8). Cheap-signal file set comes from
   // `composeai.daemon.cheapSignalFiles` (set by the gradle plugin's composePreviewDaemonStart).
   // Authoritative classpath comes from this JVM's own `java.class.path`. When the cheap-signal
@@ -231,34 +176,156 @@ fun main(args: Array<String>) {
 
   val composeTraceEnabled =
     PerfettoTraceDataProducer.enabled() && System.getProperty(RenderEngine.OUTPUT_DIR_PROP) != null
-  val dataProducts =
-    CompositeDataProductRegistry(
+
+  // ExtensionRegistry — every contribution the daemon can expose is registered here, all inactive
+  // by default. Clients call `extensions/enable` to opt in (typically the MCP supervisor enables a
+  // configured allowlist on connect). See docs/daemon/PROTOCOL.md § 3a.
+  val perfettoDataRoot =
+    if (composeTraceEnabled) {
+      System.getProperty(RenderEngine.OUTPUT_DIR_PROP)?.let { renderOutputDir ->
+        File(renderOutputDir).parentFile?.resolve("data") ?: File(renderOutputDir)
+      }
+    } else null
+  val extensions =
+    ExtensionRegistry(
       buildList {
-        add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
-        add(DeviceBackgroundDataProductRegistry(previewIndex = previewIndex))
-        add(RenderTraceDataProductRegistry())
-        add(TestFailureDataProductRegistry())
-        add(themeRegistry)
-        add(wallpaperRegistry)
-        add(recompositionRegistry)
-        if (composeTraceEnabled) {
-          System.getProperty(RenderEngine.OUTPUT_DIR_PROP)?.let { renderOutputDir ->
-            val dataRoot =
-              File(renderOutputDir).parentFile?.resolve("data") ?: File(renderOutputDir)
-            System.err.println(
-              "compose-ai-tools desktop daemon: PerfettoTraceDataProductRegistry active (dataRoot=$dataRoot)"
+        add(
+          Extension(
+            id = "device/clip",
+            displayName = "Device clip",
+            dataProductRegistry = DeviceClipDataProductRegistry(previewIndex = previewIndex),
+            previewExtensionDescriptors = listOf(RenderPreviewExtension.deviceClipDescriptor),
+          )
+        )
+        add(
+          Extension(
+            id = "device/background",
+            displayName = "Device background",
+            dataProductRegistry = DeviceBackgroundDataProductRegistry(previewIndex = previewIndex),
+            previewExtensionDescriptors = listOf(RenderPreviewExtension.deviceBackgroundDescriptor),
+          )
+        )
+        add(
+          Extension(
+            id = "render/trace",
+            displayName = "Render trace",
+            dataProductRegistry = RenderTraceDataProductRegistry(),
+            previewExtensionDescriptors = listOf(RenderPreviewExtension.renderTraceDescriptor),
+          )
+        )
+        add(
+          Extension(
+            id = "render/test-failure",
+            displayName = "Test failure",
+            dataProductRegistry = TestFailureDataProductRegistry(),
+          )
+        )
+        add(
+          Extension(
+            id = "render/overlay-legend",
+            displayName = "Render overlay legend",
+            previewExtensionDescriptors = listOf(RenderPreviewExtension.overlayLegendDescriptor),
+          )
+        )
+        add(
+          Extension(
+            id = "data/theme",
+            displayName = "Material 3 theme override",
+            dataProductRegistry = themeRegistry,
+            previewOverrideExtensions = listOf(Material3ThemePreviewOverrideExtension()),
+          )
+        )
+        add(
+          Extension(
+            id = "data/wallpaper",
+            displayName = "Wallpaper override",
+            dataProductRegistry = wallpaperRegistry,
+            previewOverrideExtensions = listOf(WallpaperPreviewOverrideExtension()),
+          )
+        )
+        add(
+          Extension(
+            id = "data/recomposition",
+            displayName = "Recomposition counters",
+            dataProductRegistry = recompositionRegistry,
+          )
+        )
+        if (composeTraceEnabled && perfettoDataRoot != null) {
+          add(
+            Extension(
+              id = "compose/trace",
+              displayName = "Compose Perfetto trace",
+              dataProductRegistry = PerfettoTraceDataProductRegistry(rootDir = perfettoDataRoot),
+              previewExtensionDescriptors = listOf(RenderPreviewExtension.composeTraceDescriptor),
             )
-            add(PerfettoTraceDataProductRegistry(rootDir = dataRoot))
-          }
+          )
         }
         if (historyManager != null) {
-          System.err.println(
-            "compose-ai-tools desktop daemon: HistoryDiffRegionsDataProductRegistry active"
+          add(
+            Extension(
+              id = "history/diff-regions",
+              displayName = "History diff regions",
+              dataProductRegistry =
+                HistoryDiffRegionsDataProductRegistry(historyManager = historyManager),
+            )
           )
-          add(HistoryDiffRegionsDataProductRegistry(historyManager = historyManager))
         }
+        // Recording-script extensions are descriptor-only on the daemon side — the host's session
+        // registry decides what's actually dispatchable. The roadmap descriptors are advertised so
+        // panels can grey out unimplemented actions.
+        add(
+          Extension(
+            id = "recording/script",
+            displayName = "Recording-script extensions",
+            dataExtensionDescriptors = RecordingScriptDataExtensions.roadmapDescriptors,
+          )
+        )
       }
     )
+
+  // Render engine consumes the registry's live override aggregator so `extensions/enable` mid-
+  // session takes effect on the next render. PreviewContextCapture gates on `data/theme`'s
+  // active state; while theme is inactive the renderer skips the per-render Compose-context
+  // capture.
+  val renderEngine =
+    RenderEngine(
+      previewContextCapture =
+        object : RenderEngine.PreviewContextCapture {
+          override fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
+            extensions.isActive("data/theme") && themeRegistry.shouldCapture(previewId, renderMode)
+        },
+      previewOverrideExtensions = extensions.activeOverrideExtensions(),
+    )
+
+  val manifestPath = System.getProperty("composeai.harness.previewsManifest")
+  val host: RenderHost =
+    if (manifestPath != null && manifestPath.isNotBlank()) {
+      val manifest = PreviewManifestRouter.loadManifest(File(manifestPath))
+      System.err.println(
+        "compose-ai-tools desktop daemon: PreviewManifestRouter active " +
+          "(manifest=$manifestPath, previews=${manifest.previews.map { it.id }})"
+      )
+      PreviewManifestRouter(
+        manifest = manifest,
+        engine = renderEngine,
+        userClassloaderHolder = userClassloaderHolder,
+      )
+    } else {
+      DesktopHost(
+        engine = renderEngine,
+        userClassloaderHolder = userClassloaderHolder,
+        previewSpecResolver =
+          previewIndexBackedSpecResolver(previewIndex)?.takeIf { previewIndex.size > 0 },
+        // Recomposition session listener gates on the extension's active state — when inactive,
+        // the producer doesn't install its CompositionObserver.
+        interactiveSessionListener =
+          DesktopHost.InteractiveSessionListener { previewId, scene ->
+            if (extensions.isActive("data/recomposition")) {
+              recompositionRegistry.onSessionLifecycle(previewId, scene)
+            }
+          },
+      )
+    }
 
   val server =
     JsonRpcServer(
@@ -270,29 +337,7 @@ fun main(args: Array<String>) {
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
-      // D5 — only the desktop daemon advertises `compose/recomposition` today. The
-      // PreviewManifestRouter
-      // path doesn't expose interactive sessions, so the producer's lookups will all return empty
-      // for that host; a delta subscribe degrades to "advertise but useless" via the same code
-      // path as a future Compose API rename. Wiring is intentionally global — kinds advertised
-      // in `initialize.capabilities.dataProducts` reflect the daemon's whole surface.
-      dataProducts = dataProducts,
-      // dataExtensions = host's supported recording-script extensions + renderer-agnostic roadmap
-      // descriptors. The host's contribution flips supported flags as new handlers land in its
-      // session registry; the roadmap list is the global "advertised but not yet implemented" set
-      // (state.save / state.restore / lifecycle.event / preview.reload).
-      dataExtensions =
-        host.recordingScriptEventDescriptors() + RecordingScriptDataExtensions.roadmapDescriptors,
-      previewExtensions =
-        buildList {
-          add(RenderPreviewExtension.deviceClipDescriptor)
-          add(RenderPreviewExtension.deviceBackgroundDescriptor)
-          add(RenderPreviewExtension.renderTraceDescriptor)
-          if (composeTraceEnabled) {
-            add(RenderPreviewExtension.composeTraceDescriptor)
-          }
-          add(RenderPreviewExtension.overlayLegendDescriptor)
-        },
+      extensions = extensions,
     )
 
   installSigtermShutdownHook(host, originalStdin = System.`in`)

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcDesktopIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcDesktopIntegrationTest.kt
@@ -121,7 +121,7 @@ class JsonRpcDesktopIntegrationTest {
         clientToServerOut,
         """
         {"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-                  "protocolVersion":1,
+                  "protocolVersion":2,
                   "clientVersion":"test",
                   "workspaceRoot":"/tmp",
                   "moduleId":":test",
@@ -370,7 +370,7 @@ class JsonRpcDesktopIntegrationTest {
       out,
       """
       {"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-                "protocolVersion":1,
+                "protocolVersion":2,
                 "clientVersion":"test",
                 "workspaceRoot":"/tmp",
                 "moduleId":":test",

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
@@ -86,7 +86,7 @@ private constructor(
     val id = nextId.getAndIncrement()
     val params =
       InitializeParams(
-        protocolVersion = 1,
+        protocolVersion = 2,
         clientVersion = "harness-v0",
         workspaceRoot = workspaceRoot,
         moduleId = moduleId,

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -1,6 +1,6 @@
 # Preview daemon — IPC protocol
 
-> **Status:** v1 contract. Locked as of this document; further changes require a PR that updates both the daemon (Kotlin) and the VS Code client (TypeScript) in lockstep, plus a `protocolVersion` bump.
+> **Status:** v2 contract. Pre-1.0 — wire shape may break across minor versions in a coordinated daemon + client release. v2 made `initialize.capabilities.{dataProducts,dataExtensions,previewExtensions}` opt-in via `extensions/enable` (see § 3a); v1 clients fail the `protocolVersion` check.
 
 This document is the authoritative wire-format spec for the JSON-RPC channel between the VS Code extension and the per-module preview daemon. It is referenced by [DESIGN.md § 5](DESIGN.md). Open protocol work is tracked in [ROADMAP.md](ROADMAP.md).
 
@@ -89,7 +89,7 @@ Params:
 
 ```ts
 {
-  protocolVersion: number;           // currently 1
+  protocolVersion: number;           // currently 2
   clientVersion: string;             // e.g. extension semver "0.8.6"
   workspaceRoot: string;             // absolute path
   moduleId: string;                  // Gradle path, e.g. ":samples:android"
@@ -174,6 +174,87 @@ No params. Result is `null`. Daemon stops accepting `renderNow`, drains the in-f
 ### `exit` (notification, client → daemon)
 
 No params. Daemon exits.
+
+## 3a. Extensions
+
+Daemons boot with every extension registered as inactive metadata only — `initialize.capabilities.{dataProducts,dataExtensions,previewExtensions}` start empty. Clients use the methods below to opt in to specific contributions for the daemon's lifetime. Registry semantics are documented in `Extension.kt` / `ExtensionRegistry.kt`; the wire shapes round-trip through `protocol/Messages.kt`.
+
+Three states for each extension:
+
+- **inactive** — neither publicly enabled nor pulled in as a dependency. Contributes nothing anywhere.
+- **active as dependency** — pulled in transitively by another publicly-enabled extension. `onRender` runs in-process so the depending extension can read derived state, but client-visible surfaces (capability lists, `data/fetch`, `data/subscribe`, render attachments, `extensions/list`'s `publiclyEnabled` flag) stay empty for this id.
+- **publicly enabled** — turned on by `extensions/enable`. Contributes everywhere.
+
+### `extensions/list` (request, client → daemon)
+
+No params. Result:
+
+```ts
+{
+  extensions: Array<{
+    id: string;
+    displayName: string;
+    dependencies: string[];
+    publiclyEnabled: boolean;
+    active: boolean;          // public OR pulled in as dependency
+    dataProductKinds: string[];
+    dataExtensionIds: string[];
+    previewExtensionIds: string[];
+  }>;
+}
+```
+
+### `extensions/enable` (request, client → daemon)
+
+```ts
+{ ids: string[] }
+```
+
+Enables every id in the list. Unknown ids are reported and skipped. Already-public ids are reported separately (idempotent on the wire). Dependencies declared by a freshly-enabled extension are pulled in transitively and reported in `pulledIn` — those ids' kinds and descriptors do **not** appear in the response's capability snapshots, only their owning public extension's contributions do.
+
+Result:
+
+```ts
+{
+  newlyEnabled: string[];
+  pulledIn: string[];
+  alreadyEnabled: string[];
+  unknown: string[];
+  // Updated public capability snapshots — same shape as the corresponding
+  // initialize.capabilities fields. Saves a follow-up extensions/list round-trip.
+  dataProducts: DataProductCapability[];
+  dataExtensions: DataExtensionDescriptor[];
+  previewExtensions: PreviewExtensionDescriptor[];
+}
+```
+
+### `extensions/disable` (request, client → daemon)
+
+```ts
+{ ids: string[] }
+```
+
+Removes the listed ids from the public set. An id that was disabled publicly but remains active as a dependency of some other publicly-enabled extension lands in `stillActiveAsDependency` — disabling it is fine, the client just sees that the dep didn't fully deactivate. Subscriptions for kinds whose owning extension just left the public set are torn down (the producer's `onUnsubscribe` fires through the active path).
+
+Result:
+
+```ts
+{
+  disabled: string[];
+  deactivated: string[];          // ids no longer active anywhere (no remaining dependent)
+  stillActiveAsDependency: string[];
+  notEnabled: string[];           // requested but weren't public to begin with
+  unknown: string[];
+  dataProducts: DataProductCapability[];
+  dataExtensions: DataExtensionDescriptor[];
+  previewExtensions: PreviewExtensionDescriptor[];
+}
+```
+
+### Caveats
+
+- `initialize.options.attachDataProducts` is filtered against the **public** capability set captured at initialize time. Enabling extensions afterwards does **not** retroactively widen the global attach set; the client sets up the ambient attach configuration during the handshake or not at all.
+- The MCP supervisor's `defaultExtensions: List<String>` is the production knob for "always enable these on every spawned daemon". `DaemonMcpMain` exposes a CLI flag for this; embedding consumers populate it directly.
 
 ## 4. Client → daemon notifications
 
@@ -580,7 +661,7 @@ Emitted after each NON-EMPTY prune pass. Empty (no-op) passes produce no notific
 
 ## 7. Versioning
 
-- `protocolVersion: 1` is this document.
+- `protocolVersion: 2` is this document. v2 introduced `extensions/{list,enable,disable}` (§ 3a) and emptied the default `initialize.capabilities.{dataProducts,dataExtensions,previewExtensions}` lists. v1 clients are rejected at handshake.
 - Non-breaking additions (new optional fields, new notification methods) **do not** bump the version. Daemon and client must ignore unknown fields and unknown notifications.
 - Breaking changes (renamed/removed fields, changed semantics, new required fields) bump `protocolVersion` and require a coordinated daemon + extension release.
 - `initialize` is the only handshake; mismatched versions fail closed with `InvalidRequest`.

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
@@ -6,6 +6,11 @@ import ee.schimke.composeai.daemon.protocol.DataFetchParams
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataSubscribeParams
 import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableParams
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableParams
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
 import ee.schimke.composeai.daemon.protocol.FileChangedParams
 import ee.schimke.composeai.daemon.protocol.FileKind
 import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
@@ -100,7 +105,7 @@ class DaemonClient(
     val id = nextId.getAndIncrement()
     val params =
       InitializeParams(
-        protocolVersion = 1,
+        protocolVersion = 2,
         clientVersion = "compose-preview-mcp/v0",
         workspaceRoot = workspaceRoot,
         moduleId = moduleId,
@@ -303,6 +308,54 @@ class DaemonClient(
     kind: String,
     timeout: Duration = 15.seconds,
   ): DataSubscribeResult = dataSubOrUnsub("data/unsubscribe", previewId, kind, timeout)
+
+  // ---------------------------------------------------------------------------
+  // extensions/{list,enable,disable} — see PROTOCOL.md § 3a.
+  //
+  // The MCP supervisor calls `extensionsEnable` right after `initialize` to opt the daemon into
+  // the contributions this MCP session needs (today: nothing by default; future: per-tool
+  // requirements). Disabling them on shutdown is unnecessary — the daemon dies with the spawn.
+  // ---------------------------------------------------------------------------
+
+  fun extensionsList(timeout: Duration = 15.seconds): ExtensionsListResult {
+    val id = nextId.getAndIncrement()
+    val request =
+      JsonRpcRequest(id = id, method = "extensions/list", params = JsonObject(emptyMap()))
+    val response = sendAndAwait(id, request, timeout)
+    val resultElem = response["result"] ?: error("extensions/list: no result — full=$response")
+    return json.decodeFromJsonElement(ExtensionsListResult.serializer(), resultElem)
+  }
+
+  fun extensionsEnable(ids: List<String>, timeout: Duration = 15.seconds): ExtensionsEnableResult {
+    val id = nextId.getAndIncrement()
+    val params = ExtensionsEnableParams(ids = ids)
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "extensions/enable",
+        params = json.encodeToJsonElement(ExtensionsEnableParams.serializer(), params),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val resultElem = response["result"] ?: error("extensions/enable: no result — full=$response")
+    return json.decodeFromJsonElement(ExtensionsEnableResult.serializer(), resultElem)
+  }
+
+  fun extensionsDisable(
+    ids: List<String>,
+    timeout: Duration = 15.seconds,
+  ): ExtensionsDisableResult {
+    val id = nextId.getAndIncrement()
+    val params = ExtensionsDisableParams(ids = ids)
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "extensions/disable",
+        params = json.encodeToJsonElement(ExtensionsDisableParams.serializer(), params),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val resultElem = response["result"] ?: error("extensions/disable: no result — full=$response")
+    return json.decodeFromJsonElement(ExtensionsDisableResult.serializer(), resultElem)
+  }
 
   private fun dataSubOrUnsub(
     method: String,

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -61,6 +61,17 @@ class DaemonSupervisor(
    * `initialize` path. Tests use it directly (see `DaemonMcpServerTest`).
    */
   private val globalAttachDataProducts: List<String> = emptyList(),
+  /**
+   * Extension ids the supervisor enables on every spawned daemon right after `initialize` succeeds.
+   * Maps onto the daemon's `extensions/enable` JSON-RPC method (PROTOCOL.md § 3a). Daemons start
+   * with everything inactive; the supervisor opts in to the contributions this MCP session needs.
+   *
+   * Defaults to empty so a baseline daemon is as lean as possible. Production entry points
+   * ([DaemonMcpMain]) and embedding consumers populate this with the kinds their tools require. The
+   * supervisor passes them through verbatim — unknown ids land in the daemon's `extensions/enable`
+   * response under `unknown` and are logged but not retried.
+   */
+  private val defaultExtensions: List<String> = emptyList(),
 ) {
 
   init {
@@ -206,12 +217,31 @@ class DaemonSupervisor(
             moduleProjectDir = descriptor.workingDirectory,
             attachDataProducts = globalAttachDataProducts.takeIf { it.isNotEmpty() },
           )
-        // D1 — surface the daemon's advertised data-product kinds so the MCP server's
-        // `list_data_products` tool can answer without a wire round-trip. Empty list on pre-D2
-        // daemons; the field is also `emptyList()` by default in [ServerCapabilities] so absent
-        // and `[]` collapse the same way client-side.
-        supervised.dataProductCapabilities = result.capabilities.dataProducts
-        supervised.dataExtensionDescriptors = result.capabilities.dataExtensions
+        // PROTOCOL.md § 3a — the daemon comes up with every extension inactive so
+        // `initialize.capabilities.dataProducts` / `dataExtensions` / `previewExtensions` are
+        // empty.
+        // Opt the daemon into the configured `defaultExtensions` set; the response carries the
+        // updated public capability lists which we cache below so the MCP catalogue surfaces them
+        // without a follow-up `extensions/list` round-trip.
+        val initialDataProducts: List<DataProductCapability>
+        val initialDataExtensions:
+          List<ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor>
+        if (defaultExtensions.isNotEmpty()) {
+          val enableResult = spawn.client.extensionsEnable(defaultExtensions)
+          if (enableResult.unknown.isNotEmpty()) {
+            System.err.println(
+              "daemon ${project.workspaceId}/${descriptor.modulePath}: extensions/enable " +
+                "skipped unknown ids ${enableResult.unknown}"
+            )
+          }
+          initialDataProducts = enableResult.dataProducts
+          initialDataExtensions = enableResult.dataExtensions
+        } else {
+          initialDataProducts = result.capabilities.dataProducts
+          initialDataExtensions = result.capabilities.dataExtensions
+        }
+        supervised.dataProductCapabilities = initialDataProducts
+        supervised.dataExtensionDescriptors = initialDataExtensions
         // PROTOCOL.md § 3 — cache the daemon's advertised supportedOverrides + knownDevice ids so
         // `DaemonMcpServer.toolRenderPreview` can validate inbound `overrides` against what this
         // backend will actually apply (instead of silently no-op'ing fields the backend ignores)

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -367,7 +367,7 @@ class FakeDaemon : DaemonSpawn {
         if (params != null) runCatching { onInitializeReceived(params) }
         val result =
           InitializeResult(
-            protocolVersion = 1,
+            protocolVersion = 2,
             daemonVersion = "fake",
             pid = 0,
             capabilities =


### PR DESCRIPTION
## Summary

- Daemons now boot with every contribution registered as inactive metadata only. `initialize.capabilities.{dataProducts,dataExtensions,previewExtensions}` start empty; clients call new `extensions/{list,enable,disable}` JSON-RPC methods to opt in to what they actually need. Bumps `PROTOCOL_VERSION` → 2 (no backwards-compat path; v1 clients are rejected at handshake).
- Introduces `Extension` + `ExtensionRegistry` in `:daemon:core`. Each registered extension can declare dependencies; deps are pulled in transitively when their dependent is enabled, but stay invisible to direct client RPC — `data/fetch` against a dep-only kind returns `Unknown`, render attachments skip them, and they don't surface in `extensions/list`'s public set. Active deps still execute `onRender`/override planners in-process so the depending extension gets the data it needs.
- Desktop and Android `DaemonMain` move every registry, override extension, and descriptor list into `Extension(...)` registrations. Render seams that referenced specific registries (`PreviewContextCapture` for theme, `interactiveSessionListener` for recomposition) now gate on `extensions.isActive(...)`.
- MCP `DaemonClient` exposes `extensionsList/Enable/Disable`; `DaemonSupervisor` takes `defaultExtensions: List<String>` and enables them right after `initialize` succeeds. Default empty — embedding consumers (production CLI flag, future agent-driven negotiation) populate it.
- `PROTOCOL.md` § 3a documents the activation states and wire shapes. The Android in-sandbox `PreviewOverrideExtensions` stays always-on for now — bridging the active set across the Robolectric sandbox is deferred (override planners already abstain when their override field is null, so it only matters for the "client passes the override but didn't enable the extension" edge).

## Test plan

- [x] `./gradlew :daemon:core:test` — 64/65 pass; the one failure is the pre-existing flaky `InteractiveCoalescingTest` (verified by checking out base files and re-running).
- [x] `./gradlew :daemon:desktop:test` — clean.
- [x] `./gradlew :mcp:test` — 62/63 pass; the one failure is the pre-existing `record_preview rejects extension events advertised but not yet implemented` (verified on base).
- [x] `./gradlew :daemon:android:compileReleaseKotlin` — clean.
- [x] `./gradlew :daemon:harness:compileKotlin` — clean.
- [x] `./gradlew ktfmtFormatAll` — applied across the tree.
- [x] New `ExtensionRegistryTest` covers enable/disable, transitive dep activation, public-vs-active filtering, cycle + duplicate + unknown-dependency rejection.
- [ ] Downstream consumers (VS Code TS protocol mirror, `DATA-PRODUCTS.md`) not yet updated — they will see empty `initialize.capabilities` until they call `extensions/enable`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDExhffhKM1zJM8db9Ghbc)_