### PR TITLE
refactor(daemon-android): migrate a11y to data-artifact extension

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityArtifactExtension.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityArtifactExtension.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.provides
+import ee.schimke.composeai.renderer.AccessibilityDataProducts
+import ee.schimke.composeai.renderer.AccessibilityHierarchyContextKeys
+import ee.schimke.composeai.renderer.AccessibilityHierarchyExtension
+
+/**
+ * Always-on post-capture extension that walks the captured `ViewRootForTest` and writes
+ * `a11y/atf` and `a11y/hierarchy` sidecars for the rendered preview.
+ *
+ * Bails out cleanly when the render didn't run in a11y mode: presence of
+ * [RenderDataArtifactContextKeys.AccessibilityViewRoot] is the gate, replacing the old
+ * `if (runAccessibility) { ... }` wrapper around an inline sidecar block in the engine. Lets
+ * the registration list stay flat (registered once; runs on every render) while the engine
+ * keeps deciding which renders carry accessibility data.
+ *
+ * Internally drives [AccessibilityHierarchyExtension] (a typed extension that owns the
+ * platform-specific ATF walk) before handing the merged hierarchy + findings to
+ * [AccessibilityDataProducer]. The legacy `imageProcessors` escape hatch is threaded through
+ * [RenderDataArtifactContextKeys.ImageProcessors]; absent entries default to an empty list.
+ */
+class AccessibilityArtifactExtension : PostCaptureProcessor {
+  override val id: DataExtensionId = ID
+  override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.AfterCapture)
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(phase = DataExtensionPhase.Capture)
+  override val targets: Set<DataExtensionTarget> = setOf(DataExtensionTarget.Android)
+
+  override fun process(context: ExtensionPostCaptureContext) {
+    val view =
+      context.get(RenderDataArtifactContextKeys.AccessibilityViewRoot)
+        ?: return // a11y data not collected for this render — nothing to write
+    val rootDir = context.require(RenderDataArtifactContextKeys.RootDir)
+    val outputBaseName = context.require(RenderDataArtifactContextKeys.OutputBaseName)
+    val density = context.require(RenderDataArtifactContextKeys.RenderDensity)
+    val pngFile = context.require(RenderDataArtifactContextKeys.OutputPngFile)
+    val isRound = context.get(RenderDataArtifactContextKeys.IsRoundScreen) ?: false
+    val imageProcessors =
+      context.get(RenderDataArtifactContextKeys.ImageProcessors) ?: emptyList()
+
+    val hierarchyExtension = AccessibilityHierarchyExtension()
+    val store = RecordingDataProductStore()
+    hierarchyExtension.process(
+      ExtensionPostCaptureContext(
+        extensionId = hierarchyExtension.id,
+        previewId = outputBaseName,
+        renderMode = context.renderMode,
+        products = store.scopedFor(hierarchyExtension),
+        data =
+          ExtensionContextData.of(AccessibilityHierarchyContextKeys.ViewRoot provides view),
+      )
+    )
+    val hierarchy = store.require(AccessibilityDataProducts.Hierarchy)
+    val findings = store.require(AccessibilityDataProducts.Atf)
+    AccessibilityDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = outputBaseName,
+      findings = findings.findings,
+      nodes = hierarchy.nodes,
+      density = density,
+      pngFile = pngFile,
+      isRound = isRound,
+      imageProcessors = imageProcessors,
+    )
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId("a11y/postCaptureArtifact")
+
+    val factory: RenderDataArtifactExtensionFactory =
+      RenderDataArtifactExtensionFactory { _ -> AccessibilityArtifactExtension() }
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderDataArtifactExtensions.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderDataArtifactExtensions.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.daemon
 
 import android.content.Context
+import android.view.View
 import androidx.compose.ui.semantics.SemanticsNode
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.ExtensionContextKey
@@ -81,5 +82,48 @@ object RenderDataArtifactContextKeys {
     ExtensionContextKey(
       name = "render-data-artifact.layoutInspectorPreviewContext",
       type = PreviewContext::class.java,
+    )
+
+  /**
+   * The Android `View` backing `ViewRootForTest` after capture. Populated only when the render
+   * ran in a11y mode; extensions that consume this key should treat its absence as "accessibility
+   * data not collected for this render" rather than fail. This key's presence doubles as the
+   * gate that replaces the old `if (runAccessibility) { ... }` wrapper around the inline
+   * accessibility sidecar block.
+   */
+  val AccessibilityViewRoot: ExtensionContextKey<View> =
+    ExtensionContextKey(
+      name = "render-data-artifact.accessibilityViewRoot",
+      type = View::class.java,
+    )
+
+  /** Render-time density in dp/px (`spec.density`). */
+  val RenderDensity: ExtensionContextKey<Float> =
+    ExtensionContextKey(
+      name = "render-data-artifact.renderDensity",
+      type = Float::class.javaObjectType,
+    )
+
+  /** Path to the just-captured PNG. Used by sidecars that overlay onto the preview image. */
+  val OutputPngFile: ExtensionContextKey<File> =
+    ExtensionContextKey(name = "render-data-artifact.outputPngFile", type = File::class.java)
+
+  /** True when the render qualifier set "round" was applied (Wear OS round screens). */
+  val IsRoundScreen: ExtensionContextKey<Boolean> =
+    ExtensionContextKey(
+      name = "render-data-artifact.isRoundScreen",
+      type = Boolean::class.javaObjectType,
+    )
+
+  /**
+   * Legacy [ImageProcessor] list configured on the render engine. Only consulted by extensions
+   * that interop with the pre-extension `ImageProcessor` surface; defaults to empty when not
+   * populated.
+   */
+  val ImageProcessors: ExtensionContextKey<List<ImageProcessor>> =
+    @Suppress("UNCHECKED_CAST")
+    ExtensionContextKey(
+      name = "render-data-artifact.imageProcessors",
+      type = List::class.java as Class<List<ImageProcessor>>,
     )
 }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -40,9 +40,6 @@ import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
 import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
 import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
 import ee.schimke.composeai.data.render.extensions.provides
-import ee.schimke.composeai.renderer.AccessibilityDataProducts
-import ee.schimke.composeai.renderer.AccessibilityHierarchyContextKeys
-import ee.schimke.composeai.renderer.AccessibilityHierarchyExtension
 import java.io.File
 import java.util.Base64
 import kotlinx.serialization.decodeFromString
@@ -356,6 +353,10 @@ class RenderEngine(
               val artifactContextData = buildList<ExtensionContextValue<*>> {
                 add(RenderDataArtifactContextKeys.RootDir provides dataDir)
                 add(RenderDataArtifactContextKeys.OutputBaseName provides spec.outputBaseName)
+                add(RenderDataArtifactContextKeys.RenderDensity provides spec.density)
+                add(RenderDataArtifactContextKeys.OutputPngFile provides outputFile)
+                add(RenderDataArtifactContextKeys.IsRoundScreen provides isRound)
+                add(RenderDataArtifactContextKeys.ImageProcessors provides imageProcessors)
                 spec.previewId?.let { add(RenderDataArtifactContextKeys.PreviewId provides it) }
                 spec.localeTag?.takeIf { it.isNotBlank() }?.let {
                   add(RenderDataArtifactContextKeys.RenderedLocale provides it)
@@ -365,6 +366,17 @@ class RenderEngine(
                 }
                 layoutInspectorPreviewContext?.let {
                   add(RenderDataArtifactContextKeys.LayoutInspectorPreviewContext provides it)
+                }
+                // a11y data is collected only when the render ran in a11y mode. Presence of this
+                // key is the gate the AccessibilityArtifactExtension uses to decide whether to
+                // run; absence means "this render didn't collect accessibility data, skip the
+                // sidecar."
+                if (runAccessibility) {
+                  runCatching {
+                    (rule.onRoot().fetchSemanticsNode().root as ViewRootForTest).view
+                  }
+                    .getOrNull()
+                    ?.let { add(RenderDataArtifactContextKeys.AccessibilityViewRoot provides it) }
                 }
               }
               val extensionContextData = ExtensionContextData.of(*artifactContextData.toTypedArray())
@@ -392,56 +404,6 @@ class RenderEngine(
               }
             }
 
-            // D2 — a11y data products. Walk the same `ViewRootForTest` ATF can populate, dump
-            // `a11y-atf.json` (findings) and `a11y-hierarchy.json` (nodes) next to the PNG. The
-            // dispatcher reads these on `data/fetch` / `data/subscribe` attachment via
-            // `AccessibilityDataProductRegistry`. Wrapped in try/catch so an a11y failure does
-            // not strand the PNG the user already cares about — the registry sees a missing
-            // file as "no attachment for this kind on this render".
-            if (runAccessibility && dataDir != null) {
-              try {
-                trace.section("a11y:dataProducts") {
-                  val view = (rule.onRoot().fetchSemanticsNode().root as ViewRootForTest).view
-                  // Hierarchy + ATF come from a typed extension instead of a direct
-                  // AccessibilityChecker.analyze call. The extension owns the platform-specific
-                  // ATF walk; downstream consumers (TouchTargets, Overlay) read declared inputs
-                  // without re-walking the View. A future :data-a11y-hierarchy-desktop (CMP
-                  // semantics walk) would target {Desktop} and emit the same product keys; the
-                  // planner's target filter selects exactly one provider per platform.
-                  val hierarchyExtension = AccessibilityHierarchyExtension()
-                  val store = RecordingDataProductStore()
-                  hierarchyExtension.process(
-                    ExtensionPostCaptureContext(
-                      extensionId = hierarchyExtension.id,
-                      previewId = spec.outputBaseName,
-                      renderMode = spec.renderMode,
-                      products = store.scopedFor(hierarchyExtension),
-                      data =
-                        ExtensionContextData.of(
-                          AccessibilityHierarchyContextKeys.ViewRoot provides view
-                        ),
-                    )
-                  )
-                  val hierarchy = store.require(AccessibilityDataProducts.Hierarchy)
-                  val findings = store.require(AccessibilityDataProducts.Atf)
-                  AccessibilityDataProducer.writeArtifacts(
-                    rootDir = dataDir,
-                    previewId = spec.outputBaseName,
-                    findings = findings.findings,
-                    nodes = hierarchy.nodes,
-                    density = spec.density,
-                    pngFile = outputFile,
-                    isRound = isRound,
-                    imageProcessors = imageProcessors,
-                  )
-                }
-              } catch (t: Throwable) {
-                System.err.println(
-                  "RenderEngine: a11y data write failed for ${spec.outputBaseName}: " +
-                    "${t.javaClass.simpleName}: ${t.message}"
-                )
-              }
-            }
           } finally {
             // DESIGN § 9 + § 10 cleanup epilogue. The Compose test rule does not allow a second
             // `setContent` on the same `ComponentActivity`, so we can't drive the

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1161,6 +1161,7 @@ open class RobolectricHost(
               ComposeSemanticsExtension.factory,
               LayoutInspectorExtension.factory,
               I18nTranslationsExtension.factory,
+              AccessibilityArtifactExtension.factory,
             )
           ),
       )

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityArtifactExtensionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityArtifactExtensionTest.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.provides
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class AccessibilityArtifactExtensionTest {
+
+  @Test
+  fun `extension declares after-capture hook only`() {
+    val extension = AccessibilityArtifactExtension()
+    assertEquals("a11y/postCaptureArtifact", extension.id.value)
+    assertEquals(setOf(DataExtensionHookKind.AfterCapture), extension.hooks)
+    assertEquals(DataExtensionPhase.Capture, extension.constraints.phase)
+    assertEquals(setOf(DataExtensionTarget.Android), extension.targets)
+  }
+
+  @Test
+  fun `process is a no-op when the accessibility view-root key is absent`() {
+    val extension = AccessibilityArtifactExtension()
+    val rootDir = Files.createTempDirectory("a11y-extension-test").toFile()
+    try {
+      val store = RecordingDataProductStore()
+      val context =
+        ExtensionPostCaptureContext(
+          extensionId = extension.id,
+          previewId = null,
+          renderMode = null,
+          products = store.scopedFor(extension),
+          // Required keys present except for AccessibilityViewRoot — the gate. Extension must
+          // bail without throwing or writing any sidecar.
+          data =
+            ExtensionContextData.of(
+              RenderDataArtifactContextKeys.RootDir provides rootDir,
+              RenderDataArtifactContextKeys.OutputBaseName provides "preview-base",
+              RenderDataArtifactContextKeys.RenderDensity provides 2.0f,
+              RenderDataArtifactContextKeys.OutputPngFile provides rootDir.resolve("preview.png"),
+              RenderDataArtifactContextKeys.IsRoundScreen provides false,
+            ),
+        )
+
+      extension.process(context)
+
+      assertFalse(
+        "no a11y artefact should be written without the view-root gate key",
+        rootDir.walkTopDown().any { it.isFile },
+      )
+    } finally {
+      rootDir.deleteRecursively()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Last `RenderEngine` sidecar block migrated. The `if (runAccessibility && dataDir != null) { ... a11y:dataProducts ... }` block at `RenderEngine.kt:401` was the only remaining hardcoded per-feature sidecar after #838 (fonts/resources/i18n) and #855 (semantics/layout-inspector). Replaces it with `AccessibilityArtifactExtension` — a `PostCaptureProcessor` that gates on **presence** of `RenderDataArtifactContextKeys.AccessibilityViewRoot` rather than an engine-level `if`.

### What changed

- **New `AccessibilityArtifactExtension`** — `PostCaptureProcessor` that drives `AccessibilityHierarchyExtension` internally (the typed ATF walk that used to live inline in RenderEngine), then hands hierarchy + findings to `AccessibilityDataProducer.writeArtifacts`.
- **Four new `RenderDataArtifactContextKeys`** entries:
  - `AccessibilityViewRoot` — the `View` from `ViewRootForTest`. Populated **only** when `runAccessibility=true`; absence is the gate.
  - `RenderDensity` — `spec.density` (Float).
  - `OutputPngFile` — the just-captured PNG.
  - `IsRoundScreen` — wear-OS round-screen indicator.
  - `ImageProcessors` — legacy escape hatch for the pre-extension `ImageProcessor` surface; defaults to empty when absent.
- **`RenderEngine.kt`** drops the inline a11y block and the `AccessibilityHierarchyExtension`/`AccessibilityHierarchyContextKeys`/`AccessibilityDataProducts` imports. Populates all the new keys unconditionally except `AccessibilityViewRoot`, which is gated on `runAccessibility` — same condition as before, just expressed as "include the key or not" rather than "wrap the call site in an `if`."
- **`RobolectricHost.kt`** adds `AccessibilityArtifactExtension.factory` to the always-on list.

### Stacking

This PR is **stacked on #855** (semantics + layout-inspector migration). Both add entries to `RenderDataArtifactContextKeys` so they conflict on rebase if landed in either order independently — the base of this PR is `agent/render-engine-android-migrate-remainder`. Merge #855 first, then this rebases cleanly onto `main`.

Together with #838 + #855, the engine is now extension-driven for all six post-capture data products. The original "RenderEngine has hardcoded extension wiring" smell from the audit is fully resolved.

## Test plan

- [x] `./gradlew :daemon:android:compileDebugKotlin :daemon:android:compileDebugUnitTestKotlin` — green
- [x] `./gradlew :daemon:android:testDebugUnitTest` — green (new `AccessibilityArtifactExtensionTest` plus full existing suite)
- [x] `./gradlew :daemon:android:ktfmtFormat` — clean
- [ ] CI `check`
- [ ] `./gradlew :samples:android:renderAllPreviews` — load-bearing smoke test for the Android render path; not run locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_018xiW9hpADkmVm3GyFMXrap)_