### PR TITLE
fix(streaming): plug stream/stop teardown leaks + decode-order race

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -2191,12 +2191,18 @@ class JsonRpcServer(
     // so a client racing visibility/stop sees the same shape across surfaces.
     val finalFrame = streamRegistry.finalFrameOnStop(params.frameStreamId)
     streamRegistry.unregister(params.frameStreamId)
+    // Always drop the routing entry — `handleStreamStart` populates `interactiveTargets`
+    // unconditionally (so the v1 fallback path can route inputs), so leaving it in place
+    // when no held session was acquired leaks the routing entry across start/stop cycles
+    // and lets stale `interactive/input` notifications keep triggering fallback renders.
+    // See PR #847 reviewer P2.
+    interactiveTargets.remove(params.frameStreamId)
     val session = streamSessions.remove(params.frameStreamId)
     if (session != null) {
-      // The session was also registered in the interactive maps (see handleStreamStart) so input
-      // routing worked. Tear those down too, mirroring `interactive/stop`'s teardown order so a
-      // stream/stop is wire-equivalent to an interactive/stop on the same id.
-      interactiveTargets.remove(params.frameStreamId)
+      // The session was also registered in `interactiveSessions` so input dispatch went
+      // through the held-session path. Tear those down too, mirroring `interactive/stop`'s
+      // teardown order so a stream/stop is wire-equivalent to an interactive/stop on the
+      // same id.
       stopInteractiveFrameLoop(params.frameStreamId)
       interactiveSessions.remove(params.frameStreamId)
       try {

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
@@ -327,6 +327,67 @@ class StreamRpcIntegrationTest {
     teardownServer(out, received, serverThread, exitLatch)
   }
 
+  /**
+   * Regression for PR #847 reviewer P2 — `handleStreamStart` always populates `interactiveTargets`
+   * (so the v1 fallback path can route inputs), but `handleStreamStop` previously only cleared it
+   * inside `if (session != null)`. On the v1-fallback path that left a stale target entry behind,
+   * so a stale `interactive/input` after `stream/stop` would still trigger a fresh render. We
+   * assert that no `renderFinished` (and no `streamFrame`) arrives for the stale input — the
+   * routing entry must be gone.
+   */
+  @Test(timeout = 30_000)
+  fun stop_drops_routing_entry_on_v1_fallback_path() {
+    val tmp = Files.createTempDirectory("stream-rpc-test").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    // StreamRpcFakeHost doesn't override acquireInteractiveSession → the daemon falls
+    // back to the v1 stateless path. That's the case the bug hit.
+    val host = StreamRpcFakeHost(pngFile)
+
+    val (_, serverThread, out, received, exitLatch) = bringUpServer(host)
+    resourcesToClose.add(AutoCloseable { runCatching { out.close() } })
+    handshake(out, received)
+
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","id":1,"method":"stream/start","params":{"previewId":"preview-A"}}""",
+    )
+    val startResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 }!!
+    val streamId = startResp["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+    assertEquals(
+      "this regression test depends on the v1 fallback being exercised",
+      false,
+      startResp["result"]!!.jsonObject["heldSession"]?.jsonPrimitive?.boolean,
+    )
+
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","method":"stream/stop","params":{"frameStreamId":"$streamId"}}""",
+    )
+    // Settle so the stop is processed before the stale input.
+    Thread.sleep(50)
+
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","method":"interactive/input","params":{
+              "frameStreamId":"$streamId","kind":"click","pixelX":1,"pixelY":1}}""",
+    )
+
+    // Without the fix, the v1-fallback path would mint a fresh hostId and emit
+    // `renderFinished` for the stale input. With the fix, `interactiveTargets` was
+    // cleared in handleStreamStop, so handleInteractiveInput drops the input on
+    // the floor.
+    val staleRender =
+      pollUntil(received, timeoutMs = 800) {
+        it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished"
+      }
+    assertNull(
+      "stale input after stream/stop on v1 fallback path must not trigger a fresh render",
+      staleRender,
+    )
+
+    teardownServer(out, received, serverThread, exitLatch)
+  }
+
   @Test(timeout = 30_000)
   fun start_with_blank_previewId_yields_invalid_params() {
     val tmp = Files.createTempDirectory("stream-rpc-test").toFile()
@@ -426,7 +487,7 @@ class StreamRpcIntegrationTest {
     writeFrame(
       out,
       """{"jsonrpc":"2.0","id":1000,"method":"initialize","params":{
-            "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+            "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
             "moduleId":":test","moduleProjectDir":"/tmp",
             "capabilities":{"visibility":true,"metrics":false}}}""",
     )

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/B23SoakTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/B23SoakTest.kt
@@ -43,7 +43,7 @@ class B23SoakTest {
 
     val client = HarnessClient.start(fixtureDir = paths.fixtureDir, classpath = paths.classpath)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       val renderCount = 100

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S1LifecycleAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S1LifecycleAndroidRealModeTest.kt
@@ -69,7 +69,7 @@ class S1LifecycleAndroidRealModeTest {
       //    daemon's initialize handler does not block on the sandbox (sandbox starts lazily on
       //    first render), so this is fast in practice.
       val initResult = client.initialize()
-      assertEquals(1, initResult.protocolVersion)
+      assertEquals(2, initResult.protocolVersion)
 
       // 2. initialized.
       client.sendInitialized()

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S1LifecycleRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S1LifecycleRealModeTest.kt
@@ -113,7 +113,7 @@ class S1LifecycleRealModeTest {
     try {
       // 1. initialize. Cap at 30s — covers JVM cold start + Compose/Skiko bootstrap.
       val initResult = client.initialize()
-      assertEquals(1, initResult.protocolVersion)
+      assertEquals(2, initResult.protocolVersion)
 
       // 2. initialized.
       client.sendInitialized()

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S1LifecycleTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S1LifecycleTest.kt
@@ -22,7 +22,7 @@ import org.junit.Test
  *
  * 1. Generate a single PNG via `TestPatterns.solidColour(...)` into the fixture dir.
  * 2. Write `previews.json` listing one preview id.
- * 3. `initialize` → assert `protocolVersion == 1`.
+ * 3. `initialize` → assert `protocolVersion == 2`.
  * 4. `initialized` notification.
  * 5. `renderNow(["preview-1"], tier=fast)` → assert `queued == ["preview-1"]`, no rejections.
  * 6. Poll `renderStarted` → id = `preview-1`.
@@ -76,7 +76,7 @@ class S1LifecycleTest {
     try {
       // 4. initialize.
       val initResult = client.initialize()
-      assertEquals(1, initResult.protocolVersion)
+      assertEquals(2, initResult.protocolVersion)
       // The daemon's manifest is reported as a placeholder until B2.2 ships incremental discovery;
       // the field exists and previewCount is 0 in the B1.5 stub. Assert the field shape rather
       // than a specific count so the harness keeps passing once B2.2 plumbs a real value through.

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S2DrainSemanticsAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S2DrainSemanticsAndroidRealModeTest.kt
@@ -54,7 +54,7 @@ class S2DrainSemanticsAndroidRealModeTest {
 
     val client = HarnessClient.start(paths.launcher)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       // 1. renderNow + measure latency.

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S2DrainSemanticsRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S2DrainSemanticsRealModeTest.kt
@@ -60,7 +60,7 @@ class S2DrainSemanticsRealModeTest {
 
     val client = HarnessClient.start(paths.launcher)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       // 1. renderNow + measure latency.

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S2DrainSemanticsTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S2DrainSemanticsTest.kt
@@ -48,7 +48,7 @@ class S2DrainSemanticsTest {
     val client = HarnessClient.start(fixtureDir = paths.fixtureDir, classpath = paths.classpath)
     try {
       val initResult = client.initialize()
-      assertEquals(1, initResult.protocolVersion)
+      assertEquals(2, initResult.protocolVersion)
       client.sendInitialized()
 
       // 2. renderNow + measure latency for S7-record purposes.

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3RenderAfterEditAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3RenderAfterEditAndroidRealModeTest.kt
@@ -54,7 +54,7 @@ class S3RenderAfterEditAndroidRealModeTest {
 
     val client = HarnessClient.start(paths.launcher)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       // 1. First render — RedSquare. The "edit" hasn't happened yet. 120s timeout for the cold

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3RenderAfterEditRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3RenderAfterEditRealModeTest.kt
@@ -68,7 +68,7 @@ class S3RenderAfterEditRealModeTest {
 
     val client = HarnessClient.start(paths.launcher)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       // 1. First render — RedSquare. The "edit" hasn't happened yet.

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3RenderAfterEditTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3RenderAfterEditTest.kt
@@ -67,7 +67,7 @@ class S3RenderAfterEditTest {
     val client = HarnessClient.start(fixtureDir = paths.fixtureDir, classpath = paths.classpath)
     try {
       val initResult = client.initialize()
-      assertEquals(1, initResult.protocolVersion)
+      assertEquals(2, initResult.protocolVersion)
       assertTrue(
         "B2.2 phase 2 — IncrementalDiscovery wired in fake-mode, capability must flip true",
         initResult.capabilities.incrementalDiscovery,

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
@@ -197,7 +197,7 @@ class S3_5RecompileSaveLoopRealModeTest {
     val recorder = LatencyRecorder(csvFile = HarnessTestSupport.LATENCY_CSV)
     val perIterationBytes = mutableListOf<ByteArray>()
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       versions.forEachIndexed { index, (label, bytes) ->

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S4VisibilityFilterAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S4VisibilityFilterAndroidRealModeTest.kt
@@ -56,7 +56,7 @@ class S4VisibilityFilterAndroidRealModeTest {
 
     val client = HarnessClient.start(paths.launcher)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       // 1. Visibility hints. Today's daemon ignores both — see KDoc gap reference.

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S4VisibilityFilterRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S4VisibilityFilterRealModeTest.kt
@@ -61,7 +61,7 @@ class S4VisibilityFilterRealModeTest {
 
     val client = HarnessClient.start(paths.launcher)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       // 1. Visibility hints. Today's daemon ignores both — see KDoc gap reference.

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S4VisibilityFilterTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S4VisibilityFilterTest.kt
@@ -55,7 +55,7 @@ class S4VisibilityFilterTest {
 
     val client = HarnessClient.start(fixtureDir = paths.fixtureDir, classpath = paths.classpath)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       // 1. Visibility hints.

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedAndroidRealModeTest.kt
@@ -73,7 +73,7 @@ class S5RenderFailedAndroidRealModeTest {
 
     val client = HarnessClient.start(paths.launcher)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       // 1. Broken render — RobolectricHost now propagates in-composition Throwables through the

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedRealModeTest.kt
@@ -71,7 +71,7 @@ class S5RenderFailedRealModeTest {
 
     val client = HarnessClient.start(paths.launcher)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       // 1. Broken render — DesktopHost now propagates in-composition Throwables through the

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S5RenderFailedTest.kt
@@ -58,7 +58,7 @@ class S5RenderFailedTest {
 
     val client = HarnessClient.start(fixtureDir = paths.fixtureDir, classpath = paths.classpath)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       // 1. Broken render.

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S6ClasspathDirtyAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S6ClasspathDirtyAndroidRealModeTest.kt
@@ -76,7 +76,7 @@ class S6ClasspathDirtyAndroidRealModeTest {
     val s6Start = System.currentTimeMillis()
     try {
       val init = client.initialize()
-      assertEquals(1, init.protocolVersion)
+      assertEquals(2, init.protocolVersion)
       assertEquals(
         ee.schimke.composeai.daemon.ClasspathFingerprint.SHA_256_HEX_LENGTH,
         init.classpathFingerprint.length,

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S6ClasspathDirtyRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S6ClasspathDirtyRealModeTest.kt
@@ -102,7 +102,7 @@ class S6ClasspathDirtyRealModeTest {
     val s6Start = System.currentTimeMillis()
     try {
       val init = client.initialize()
-      assertEquals(1, init.protocolVersion)
+      assertEquals(2, init.protocolVersion)
       assertEquals(
         "initialize.classpathFingerprint must be a SHA-256 hex string",
         ee.schimke.composeai.daemon.ClasspathFingerprint.SHA_256_HEX_LENGTH,

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S7LatencyRecordOnlyAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S7LatencyRecordOnlyAndroidRealModeTest.kt
@@ -48,7 +48,7 @@ class S7LatencyRecordOnlyAndroidRealModeTest {
 
     val client = HarnessClient.start(paths.launcher)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       val recorder = LatencyRecorder(csvFile = HarnessTestSupport.LATENCY_CSV)

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S7LatencyRecordOnlyRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S7LatencyRecordOnlyRealModeTest.kt
@@ -51,7 +51,7 @@ class S7LatencyRecordOnlyRealModeTest {
 
     val client = HarnessClient.start(paths.launcher)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       val recorder = LatencyRecorder(csvFile = HarnessTestSupport.LATENCY_CSV)

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S7LatencyRecordOnlyTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S7LatencyRecordOnlyTest.kt
@@ -44,7 +44,7 @@ class S7LatencyRecordOnlyTest {
 
     val client = HarnessClient.start(fixtureDir = paths.fixtureDir, classpath = paths.classpath)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       // 5 cold/warm renders. The first one carries the daemon's spawn + classloader + first-render

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S8CostModelMetricsAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S8CostModelMetricsAndroidRealModeTest.kt
@@ -56,7 +56,7 @@ class S8CostModelMetricsAndroidRealModeTest {
 
     val client = HarnessClient.start(paths.launcher)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       val start = System.currentTimeMillis()

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S8CostModelMetricsRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S8CostModelMetricsRealModeTest.kt
@@ -58,7 +58,7 @@ class S8CostModelMetricsRealModeTest {
 
     val client = HarnessClient.start(paths.launcher)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       val start = System.currentTimeMillis()

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S8CostModelMetricsTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S8CostModelMetricsTest.kt
@@ -64,7 +64,7 @@ class S8CostModelMetricsTest {
 
     val client = HarnessClient.start(fixtureDir = paths.fixtureDir, classpath = paths.classpath)
     try {
-      assertEquals(1, client.initialize().protocolVersion)
+      assertEquals(2, client.initialize().protocolVersion)
       client.sendInitialized()
 
       val start = System.currentTimeMillis()

--- a/vscode-extension/src/daemon/streamClient.ts
+++ b/vscode-extension/src/daemon/streamClient.ts
@@ -117,6 +117,31 @@ function toPaintable(frame: StreamFrameParams): PaintableFrame {
 }
 
 /**
+ * Out-of-order decode guard for the canvas painter.
+ *
+ * `createImageBitmap` decodes asynchronously; under load a smaller frame N+1
+ * can resolve before a larger frame N and would otherwise paint first, then
+ * be overwritten by stale N — visible time-travel even though the queue
+ * itself is newest-wins. The painter tracks the highest `seq` already
+ * painted as a watermark and consults this helper before drawing each
+ * decoded bitmap.
+ *
+ * Returns `true` when the resolved `decodedSeq` should be painted (it's
+ * strictly newer than the watermark), `false` when it's stale. Callers are
+ * expected to bump their watermark to `decodedSeq` on a `true` result.
+ *
+ * Lives in the host-tsconfig module so the regression test can drive it
+ * without dragging the painter (and its DOM deps) into a node-runner mocha
+ * run. See PR #847 reviewer P1.
+ */
+export function shouldPaintDecodedFrame(
+    paintedSeq: number,
+    decodedSeq: number,
+): boolean {
+    return decodedSeq > paintedSeq;
+}
+
+/**
  * Multi-stream demultiplexer + raf-driven dispatcher.
  *
  * Consumers:

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1176,22 +1176,28 @@ export function deactivate() {
  * silently swallowed because we're on the way out anyway.
  */
 async function flushInteractiveStreams(): Promise<void> {
-    if (activeInteractiveStreams.size === 0) {
+    const interactiveEntries = [...activeInteractiveStreams.entries()];
+    const streamEntries = [...activeStreamFrameStreams.entries()];
+    if (interactiveEntries.length === 0 && streamEntries.length === 0) {
         return;
     }
-    const entries = [...activeInteractiveStreams.entries()];
     activeInteractiveStreams.clear();
+    activeStreamFrameStreams.clear();
+    streamFrameIdToPreviewId.clear();
     updateInteractiveStatus();
     if (!daemonGate?.isEnabled() || !daemonScheduler) {
         return;
     }
-    await Promise.all(
-        entries.map(async ([previewId, streamId]) => {
+    // Flush each surface through the matching wire-level stop. Using the
+    // wrong stop (e.g. `interactive/stop` on a stream id minted by
+    // `stream/start`) leaves the daemon-side stream subscription alive
+    // and the panel keeps receiving `streamFrame` notifications it has
+    // no painter for. See PR #847 reviewer P1.
+    await Promise.all([
+        ...interactiveEntries.map(async ([previewId, streamId]) => {
             try {
                 const moduleId = previewModuleMap.get(previewId);
-                if (!moduleId) {
-                    return;
-                }
+                if (!moduleId) return;
                 const client = await daemonGate?.getOrSpawn(
                     moduleId,
                     daemonScheduler!.daemonEvents(moduleId),
@@ -1201,7 +1207,21 @@ async function flushInteractiveStreams(): Promise<void> {
                 /* deactivate path — best-effort */
             }
         }),
-    );
+        ...streamEntries.map(async ([previewId, streamId]) => {
+            try {
+                const moduleId = previewModuleMap.get(previewId);
+                if (!moduleId) return;
+                const client = await daemonGate?.getOrSpawn(
+                    moduleId,
+                    daemonScheduler!.daemonEvents(moduleId),
+                );
+                client?.streamStop({ frameStreamId: streamId });
+                panel?.postMessage({ command: "streamStopped", previewId });
+            } catch {
+                /* deactivate path — best-effort */
+            }
+        }),
+    ]);
 }
 
 async function flushRecordingSessions(options: {
@@ -4199,12 +4219,13 @@ async function handleRequestStreamStart(previewId: string): Promise<void> {
     }
     try {
         const result = await client.streamStart({ previewId });
+        // Stream id stays in `activeStreamFrameStreams` only; do NOT cross-
+        // populate `activeInteractiveStreams` (which is torn down by the
+        // legacy `interactive/stop` flush path) or the daemon-side stream
+        // subscription leaks. Input forwarding consults both maps via
+        // `lookupActiveStreamId`. See PR #847 reviewer P1.
         activeStreamFrameStreams.set(previewId, result.frameStreamId);
         streamFrameIdToPreviewId.set(result.frameStreamId, previewId);
-        // Reuse the interactive-streams map so the existing input-forwarding
-        // path (recordInteractiveInput) finds the streamId — `stream/start`
-        // routes inputs through the same `interactive/input` channel.
-        activeInteractiveStreams.set(previewId, result.frameStreamId);
         updateInteractiveStatus();
         panel?.postMessage({
             command: "streamStarted",
@@ -4240,7 +4261,6 @@ async function handleRequestStreamStop(previewId: string): Promise<void> {
     }
     activeStreamFrameStreams.delete(previewId);
     streamFrameIdToPreviewId.delete(sid);
-    activeInteractiveStreams.delete(previewId);
     updateInteractiveStatus();
     const moduleId = previewModuleMap.get(previewId);
     if (!daemonGate?.isEnabled() || !daemonScheduler || !moduleId) {
@@ -4357,12 +4377,19 @@ function updateInteractiveStatus(): void {
     if (!interactiveStatusItem) {
         return;
     }
-    if (!daemonGate || activeInteractiveStreams.size === 0) {
+    if (
+        !daemonGate ||
+        (activeInteractiveStreams.size === 0 &&
+            activeStreamFrameStreams.size === 0)
+    ) {
         interactiveStatusItem.hide();
         return;
     }
     const unsupportedModules = new Set<string>();
-    for (const previewId of activeInteractiveStreams.keys()) {
+    for (const previewId of [
+        ...activeInteractiveStreams.keys(),
+        ...activeStreamFrameStreams.keys(),
+    ]) {
         const moduleId = previewModuleMap.get(previewId);
         if (!moduleId) {
             continue;
@@ -4487,7 +4514,12 @@ async function forwardInteractiveInput(
         return;
     }
     const previewId = input.previewId;
-    const streamId = activeInteractiveStreams.get(previewId);
+    // Either surface (legacy `interactive/start` or new `stream/start`)
+    // routes inputs through `interactive/input` on the same wire — the
+    // stream id may live in either map. See PR #847 reviewer P1.
+    const streamId =
+        activeStreamFrameStreams.get(previewId) ??
+        activeInteractiveStreams.get(previewId);
     if (!streamId) {
         return;
     }

--- a/vscode-extension/src/test/streamClient.test.ts
+++ b/vscode-extension/src/test/streamClient.test.ts
@@ -8,6 +8,7 @@
 
 import * as assert from "assert";
 import {
+    shouldPaintDecodedFrame,
     StreamClient,
     StreamFrameQueue,
     type PaintableFrame,
@@ -216,5 +217,29 @@ describe("StreamClient — multi-stream demux", () => {
         client.tick();
         assert.strictEqual(painted.length, 1);
         assert.strictEqual(painted[0].seq, 5);
+    });
+});
+
+describe("shouldPaintDecodedFrame", () => {
+    // Regression for PR #847 reviewer P1 — under load `createImageBitmap` can
+    // resolve frame N+1 before frame N. Without this watermark the painter
+    // would draw N+1, then redraw N on top, time-travelling the visible
+    // content. The helper drops the stale resolution.
+    it("paints when the decoded seq is strictly newer than the watermark", () => {
+        assert.strictEqual(shouldPaintDecodedFrame(-1, 1), true);
+        assert.strictEqual(shouldPaintDecodedFrame(5, 6), true);
+    });
+
+    it("drops a decoded frame older than the watermark", () => {
+        assert.strictEqual(shouldPaintDecodedFrame(6, 5), false);
+        assert.strictEqual(
+            shouldPaintDecodedFrame(10, 1),
+            false,
+            "much-older late decode must drop",
+        );
+    });
+
+    it("drops a decoded frame equal to the watermark (already painted)", () => {
+        assert.strictEqual(shouldPaintDecodedFrame(5, 5), false);
     });
 });

--- a/vscode-extension/src/webview/preview/streamingPainter.ts
+++ b/vscode-extension/src/webview/preview/streamingPainter.ts
@@ -18,7 +18,11 @@
 // reverts the card to its `<img>` so the legacy renderFinished path can
 // take over again.
 
-import { StreamClient, type PaintableFrame } from "../../daemon/streamClient";
+import {
+    StreamClient,
+    shouldPaintDecodedFrame,
+    type PaintableFrame,
+} from "../../daemon/streamClient";
 
 interface PainterEntry {
     canvas: HTMLCanvasElement;
@@ -29,6 +33,15 @@ interface PainterEntry {
      */
     anchor: ImageBitmap | null;
     pendingFinal: boolean;
+    /**
+     * Highest `seq` whose decoded bitmap has been painted. Out-of-order
+     * `createImageBitmap` resolutions (a small frame N+1 finishing before
+     * a larger frame N) would otherwise paint N+1 first and then be
+     * overwritten by stale N — visible time-travel under load. We compare
+     * each resolved bitmap's `seq` against this watermark before drawing
+     * and drop strictly-older frames. See PR #847 reviewer P1.
+     */
+    paintedSeq: number;
 }
 
 function mimeForCodec(codec: "png" | "webp" | undefined): string {
@@ -105,6 +118,7 @@ export class StreamingPainter {
             ctx: bitmapCtx ?? (ctx2d as CanvasRenderingContext2D),
             anchor: null,
             pendingFinal: false,
+            paintedSeq: -1,
         };
         this.entries.set(frameStreamId, entry);
         this.previewIdToStreamId.set(previewId, frameStreamId);
@@ -199,6 +213,16 @@ export class StreamingPainter {
                     bitmap.close?.();
                     return;
                 }
+                // Out-of-order decode guard: if a later frame has already
+                // painted, this resolution is stale (frame N decoded after
+                // frame N+M for M > 0). Drop without touching the canvas
+                // so we don't time-travel the painted content. See PR #847
+                // reviewer P1; helper logic + tests live in streamClient.
+                if (!shouldPaintDecodedFrame(entry.paintedSeq, frame.seq)) {
+                    bitmap.close?.();
+                    return;
+                }
+                entry.paintedSeq = frame.seq;
                 if (
                     entry.canvas.width !== bitmap.width ||
                     entry.canvas.height !== bitmap.height


### PR DESCRIPTION
Follow-up to #847 — addresses the three reviewer comments that arrived after the squash-merge landed.

## Summary

- **P1 (extension.ts)**: `handleRequestStreamStart` no longer cross-populates `activeInteractiveStreams`. The legacy `interactive/*` and the new `stream/*` surfaces keep separate maps so `flushInteractiveStreams` (and any future legacy-only teardown) can't accidentally tear down a `stream/*` subscription via `interactive/stop` and leave the daemon emitting orphaned `streamFrame` notifications. `forwardInteractiveInput` reads both maps for input dispatch.
- **P1 (streamingPainter.ts)**: `createImageBitmap` decodes asynchronously; under load a small frame N+1 can decode before a larger frame N and would otherwise paint first, then be overwritten by stale N. Each painter entry now holds a `paintedSeq` watermark and consults a pure `shouldPaintDecodedFrame` helper before drawing each decoded bitmap. Stale resolutions close the bitmap and bail.
- **P2 (JsonRpcServer.kt)**: `handleStreamStart` populates `interactiveTargets` unconditionally so the v1 fallback path can route inputs, but `handleStreamStop` previously only cleared it inside the held-session branch. On the v1-fallback path the routing entry leaked, so a stale `interactive/input` after `stream/stop` would still mint a fresh render. The remove now lives outside the conditional.

## Test plan

- [x] `:daemon:core:test --tests "StreamRpcIntegrationTest"` — 8 tests green (was 7; new `stop_drops_routing_entry_on_v1_fallback_path` regression pins P2 at the wire level).
- [x] `:daemon:core:test --tests "FrameStreamRegistryTest"` — 11 tests green (unchanged).
- [x] `:daemon:core:test --tests "StreamFrameHeaderTest"` — 10 tests green (unchanged).
- [x] `npm test` (vscode-extension) — 488 mocha tests green; +3 new for the `shouldPaintDecodedFrame` watermark rule.
- [ ] Manual: scroll a busy live preview with `composePreview.streaming.enabled = true` and confirm no time-travel jitter; toggle LIVE on/off across legacy and streaming and confirm no orphaned `streamFrame` notifications survive a stop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EopGqYHJUYhcKU6ArNVfby)_