### PR TITLE
refactor(cli): generalize renderModules helper for show-resources

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -362,11 +362,59 @@ abstract class Command(protected val args: List<String>) {
   )
 
   /**
-   * Shared "discover modules → run `:renderAllPreviews` → load manifests → build results" pipeline
-   * used by `show` and `a11y` (and follow-up commands). Each subcommand contributes the per-feature
-   * gradle properties via [gradleArguments] (e.g. a11y enables checks via
-   * `-PcomposePreview.previewExtensions.a11y.enableAllChecks=true`); the shared body is what was
-   * previously duplicated in their `run()` methods.
+   * Lower-level outcome of [renderModules] — only the gradle build result and the (optionally
+   * filtered) module list, leaving manifest reads + result building to the caller. Used by commands
+   * whose manifests don't fit the `PreviewManifest` / `PreviewResult` shape (today:
+   * `show-resources`, which has its own resource-manifest type).
+   */
+  protected data class RawRenderOutcome(val buildOk: Boolean, val modules: List<PreviewModule>)
+
+  /**
+   * Shared gradle-drive pipeline — open the connector, resolve preview modules, optionally filter
+   * them, run a per-module task, report failures. Returns the build result + the modules the caller
+   * should read manifests from.
+   *
+   * [moduleFilter] runs after `resolveModules`; pass it when only a subset of plugin-applied
+   * modules participates in this pipeline (e.g. `show-resources` filters to Android-only modules
+   * because `:renderAndroidResources` doesn't exist on CMP modules).
+   *
+   * [taskFor] builds the gradle task path for one module. Standard preview commands use
+   * `:${path}:renderAllPreviews`; resource commands use `:${path}:renderAndroidResources`.
+   *
+   * Skips the actual `runGradle` call (and reports `buildOk = true`) when [moduleFilter] yields an
+   * empty list — there's nothing to render and `gradle.runTasks([])` has no defined meaning.
+   */
+  protected fun renderModules(
+    silenceStdout: Boolean,
+    moduleFilter: (PreviewModule) -> Boolean = { true },
+    taskFor: (PreviewModule) -> String = { ":${it.gradlePath}:renderAllPreviews" },
+    gradleArguments: List<String> = emptyList(),
+  ): RawRenderOutcome {
+    var outcome: RawRenderOutcome? = null
+    withGradle(silenceStdout = silenceStdout) { gradle ->
+      val modules = withGradleStdout(silenceStdout) { resolveModules(gradle).filter(moduleFilter) }
+      val buildOk =
+        if (modules.isEmpty()) true
+        else {
+          val tasks = modules.map(taskFor).toTypedArray()
+          val ok =
+            withGradleStdout(silenceStdout) {
+              runGradle(gradle, *tasks, arguments = gradleArguments)
+            }
+          if (!ok) reportRenderFailures(gradle)
+          ok
+        }
+      outcome = RawRenderOutcome(buildOk = buildOk, modules = modules)
+    }
+    return outcome ?: error("renderModules: gradle block did not produce an outcome")
+  }
+
+  /**
+   * Standard "discover modules → run `:renderAllPreviews` → load manifests → build results"
+   * pipeline used by `show` and `a11y`. Wraps [renderModules] with the preview-manifest read
+   * + [PreviewResult] build steps. Each subcommand contributes per-feature gradle properties via
+   *   [gradleArguments] (e.g. a11y enables checks via
+   *   `-PcomposePreview.previewExtensions.a11y.enableAllChecks=true`).
    *
    * [silenceStdout] mirrors each command's `--json` flag: when on, the shared helpers redirect
    * stdout to stderr so the gradle progress output doesn't poison the JSON envelope.
@@ -375,24 +423,15 @@ abstract class Command(protected val args: List<String>) {
     silenceStdout: Boolean,
     gradleArguments: List<String> = emptyList(),
   ): RenderModulesOutcome {
-    var outcome: RenderModulesOutcome? = null
-    withGradle(silenceStdout = silenceStdout) { gradle ->
-      val modules = withGradleStdout(silenceStdout) { resolveModules(gradle) }
-      val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
-      val buildOk =
-        withGradleStdout(silenceStdout) { runGradle(gradle, *tasks, arguments = gradleArguments) }
-      if (!buildOk) reportRenderFailures(gradle)
-      val manifests = readAllManifests(modules)
-      val results = if (manifests.isEmpty()) emptyList() else buildResults(manifests)
-      outcome =
-        RenderModulesOutcome(
-          buildOk = buildOk,
-          modules = modules,
-          manifests = manifests,
-          results = results,
-        )
-    }
-    return outcome ?: error("renderAllModules: gradle block did not produce an outcome")
+    val raw = renderModules(silenceStdout = silenceStdout, gradleArguments = gradleArguments)
+    val manifests = readAllManifests(raw.modules)
+    val results = if (manifests.isEmpty()) emptyList() else buildResults(manifests)
+    return RenderModulesOutcome(
+      buildOk = raw.buildOk,
+      modules = raw.modules,
+      manifests = manifests,
+      results = results,
+    )
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
@@ -160,79 +160,76 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
   private val jsonOutput = "--json" in args
 
   override fun run() {
-    withGradle(silenceStdout = jsonOutput) { gradle ->
-      // Auto-detect picks up every plugin-applied module — including CMP-only
-      // ones that never get `:<module>:renderAndroidResources` (the resource
-      // pipeline is gated on the Android-side `AndroidPreviewSupport` path,
-      // which CMP modules don't go through). Filter to modules that have
-      // an `AndroidManifest.xml` on disk: cheap, accurate, and the same
-      // signal the resource discovery task itself uses upstream.
-      //
-      // When the user passes an explicit `--module samples:cmp`, the filter
-      // still applies — we'd rather print a friendly "no Android modules"
-      // message than surface a gradle "task not found" stack trace.
-      val modules =
-        withGradleStdout(jsonOutput) { resolveModules(gradle).filter { isAndroidModule(it) } }
-      if (modules.isEmpty()) {
-        if (jsonOutput) println(encodeResourceResponse(emptyList(), emptyList()))
-        else println("No Android modules with the resource preview pipeline found.")
-        // Mirror ShowCommand: flush before exitProcess because System.exit
-        // doesn't drain PrintStream buffers, and the redirected stdout in
-        // `compose-preview show-resources --json > _resources.json` would
-        // otherwise see an empty file and trip the downstream JSON parser
-        // (issue #292).
-        System.out.flush()
-        exitProcess(0)
-      }
-
-      val tasks = modules.map { ":${it.gradlePath}:renderAndroidResources" }.toTypedArray()
-      val buildOk = withGradleStdout(jsonOutput) { runGradle(gradle, *tasks) }
-      if (!buildOk) {
-        reportRenderFailures(gradle)
-        System.err.println("Resource render failed")
-        System.out.flush()
-        exitProcess(2)
-      }
-
-      val manifests = readAllResourceManifests(modules)
-      if (manifests.isEmpty() || manifests.all { it.second.resources.isEmpty() }) {
-        if (jsonOutput) println(encodeResourceResponse(emptyList(), emptyList()))
-        else println("No Android resource previews found.")
-        // Resources are an opt-out feature — exit 0 (not 3) so consumers
-        // running `show-resources` against a workspace that legitimately
-        // has no XML drawables don't get a non-zero exit on every CI run.
-        System.out.flush()
-        exitProcess(0)
-      }
-
-      val all = buildResourceResults(manifests)
-      val filtered = applyResourceFilters(all)
-      val allReferences = manifests.flatMap { it.second.manifestReferences }
-
-      if (filtered.isEmpty()) {
-        if (jsonOutput) println(encodeResourceResponse(emptyList(), allReferences, all))
-        else println("No resource previews matched.")
-        System.out.flush()
-        exitProcess(3)
-      }
-
-      if (jsonOutput) {
-        println(encodeResourceResponse(filtered, allReferences, all))
-      } else {
-        printText(modules, filtered)
-      }
-
-      val missing = filtered.filter { r -> r.captures.any { it.pngPath == null } }
-      if (missing.isNotEmpty()) {
-        System.err.println(
-          "Resource render completed but produced no PNG for ${missing.size} of " +
-            "${filtered.size} resource preview(s)."
-        )
-        System.out.flush()
-        exitProcess(2)
-      }
+    // Auto-detect picks up every plugin-applied module — including CMP-only ones that never
+    // get `:<module>:renderAndroidResources` (the resource pipeline is gated on the Android-side
+    // `AndroidPreviewSupport` path, which CMP modules don't go through). Filter to modules
+    // that have an `AndroidManifest.xml` on disk: cheap, accurate, and the same signal the
+    // resource discovery task itself uses upstream.
+    //
+    // When the user passes an explicit `--module samples:cmp`, the filter still applies — we'd
+    // rather print a friendly "no Android modules" message than surface a gradle "task not
+    // found" stack trace.
+    val outcome =
+      renderModules(
+        silenceStdout = jsonOutput,
+        moduleFilter = { isAndroidModule(it) },
+        taskFor = { ":${it.gradlePath}:renderAndroidResources" },
+      )
+    if (outcome.modules.isEmpty()) {
+      if (jsonOutput) println(encodeResourceResponse(emptyList(), emptyList()))
+      else println("No Android modules with the resource preview pipeline found.")
+      // Mirror ShowCommand: flush before exitProcess because System.exit doesn't drain
+      // PrintStream buffers, and the redirected stdout in
+      // `compose-preview show-resources --json > _resources.json` would otherwise see an
+      // empty file and trip the downstream JSON parser (issue #292).
       System.out.flush()
+      exitProcess(0)
     }
+    if (!outcome.buildOk) {
+      System.err.println("Resource render failed")
+      System.out.flush()
+      exitProcess(2)
+    }
+
+    val modules = outcome.modules
+    val manifests = readAllResourceManifests(modules)
+    if (manifests.isEmpty() || manifests.all { it.second.resources.isEmpty() }) {
+      if (jsonOutput) println(encodeResourceResponse(emptyList(), emptyList()))
+      else println("No Android resource previews found.")
+      // Resources are an opt-out feature — exit 0 (not 3) so consumers running
+      // `show-resources` against a workspace that legitimately has no XML drawables don't get
+      // a non-zero exit on every CI run.
+      System.out.flush()
+      exitProcess(0)
+    }
+
+    val all = buildResourceResults(manifests)
+    val filtered = applyResourceFilters(all)
+    val allReferences = manifests.flatMap { it.second.manifestReferences }
+
+    if (filtered.isEmpty()) {
+      if (jsonOutput) println(encodeResourceResponse(emptyList(), allReferences, all))
+      else println("No resource previews matched.")
+      System.out.flush()
+      exitProcess(3)
+    }
+
+    if (jsonOutput) {
+      println(encodeResourceResponse(filtered, allReferences, all))
+    } else {
+      printText(modules, filtered)
+    }
+
+    val missing = filtered.filter { r -> r.captures.any { it.pngPath == null } }
+    if (missing.isNotEmpty()) {
+      System.err.println(
+        "Resource render completed but produced no PNG for ${missing.size} of " +
+          "${filtered.size} resource preview(s)."
+      )
+      System.out.flush()
+      exitProcess(2)
+    }
+    System.out.flush()
   }
 
   // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extends the shared gradle-drive pipeline added in #862 to fit `ShowResourcesCommand`'s shape — Android-only module filter and `:renderAndroidResources` task instead of `:renderAllPreviews`. The underlying contract (open connector → resolve → filter → run → report → return modules + buildOk) is identical; the differences are the filter predicate and the per-module task path, both now parameters.

### What changed

- **New `Command.renderModules`** lower-level helper: `renderModules(silenceStdout, moduleFilter, taskFor, gradleArguments) -> RawRenderOutcome`. Returns just build result + filtered module list, leaving manifest reads and result building to the caller. Useful when the caller's manifest type doesn't fit the `PreviewManifest` / `PreviewResult` shape (today: `show-resources`).
- **`renderAllModules`** now wraps `renderModules` with the preview-manifest read + `PreviewResult` build steps. Same external API, internal layering only.
- **`ShowResourcesCommand.run()`** drops its inline gradle plumbing (filter + run + report + buildOk-handling = ~30 lines) and calls `renderModules(moduleFilter = ::isAndroidModule, taskFor = { ":${it.gradlePath}:renderAndroidResources" })` directly. Manifest read + filter + format remain command-specific.

### Why a separate helper layer

Show-resources has a different manifest type (`ResourceManifest` not `PreviewManifest`) and a different result builder, so reusing `renderAllModules` directly would mean awkward conversions. Splitting at the natural seam (gradle drive vs. manifest pipeline) gives both commands what they need without templating the whole pipeline on four type parameters.

### Stacking

Base of this PR is `agent/cli-a11y-via-shared-action` (#862), not `main`. Merge #862 first, then this rebases cleanly.

### Behaviour preserved

- Empty Android-modules list still exits 0 with the friendly "No Android modules with the resource preview pipeline found." message.
- `!buildOk` still exits 2 with `Resource render failed`.
- Empty manifests still exit 0 (resources are opt-out).
- Empty filtered-results still exit 3.
- Missing-PNG check still exits 2.

`ShowResourcesCommand.run()` shrinks from ~75 to ~55 lines.

## Test plan

- [x] `./gradlew :cli:compileKotlin :cli:test` — green
- [x] `./gradlew :cli:ktfmtFormat` — clean
- [ ] CI `check`
- [ ] End-to-end smoke: `compose-preview show-resources` against `samples:android` — load-bearing, not run locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_018xiW9hpADkmVm3GyFMXrap)_