### PR TITLE
refactor(vscode): move per-preview Maps into previewStore

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -11,11 +11,7 @@
 // rendered its skeleton into light DOM, so `document.getElementById(...)`
 // queries below resolve.
 
-import type {
-    AccessibilityFinding,
-    AccessibilityNode,
-    PreviewInfo,
-} from "../shared/types";
+import type { PreviewInfo } from "../shared/types";
 import { requireElementById, requireSelector } from "../shared/domRefs";
 import { getVsCodeApi, type VsCodeApi } from "../shared/vscode";
 import {
@@ -42,10 +38,7 @@ import {
     isFocusedInteractiveSupported,
     isFocusedModuleReady,
 } from "./focusToolbar";
-import {
-    FrameCarouselController,
-    type CapturePresentation,
-} from "./frameCarousel";
+import { FrameCarouselController } from "./frameCarousel";
 import { LiveStateController } from "./liveState";
 import { LoadingOverlay } from "./loadingOverlay";
 import {
@@ -146,15 +139,14 @@ export function setupPreviewBehavior(
     const setA11yOverlay = (id: string | null): void => {
         previewStore.setState({ a11yOverlayPreviewId: id });
     };
-    // previewId -> findings. Populated from setPreviews so updateImage can
-    // re-read the list on every image (re)load without re-querying the
-    // DOM for data attributes.
-    const cardA11yFindings = new Map<string, readonly AccessibilityFinding[]>();
-    // D2 — previewId -> nodes for the daemon-attached a11y/hierarchy payload. Drives
-    // the local hierarchy overlay (translucent rectangles + label/role/states tooltip
-    // on hover) drawn on top of the existing finding overlay. Populated by
-    // applyA11yUpdate and re-read on each image (re)load via applyHierarchyOverlay.
-    const cardA11yNodes = new Map<string, readonly AccessibilityNode[]>();
+    // The per-preview a11y caches (`cardA11yFindings`, `cardA11yNodes`)
+    // and the per-preview capture cache (`cardCaptures`) live in
+    // `previewStore` — populated from `setPreviews` so `updateImage`
+    // can re-read findings + hierarchy nodes on every image (re)load
+    // without re-querying the DOM. The store owns them so the upcoming
+    // `<preview-card>` Lit component can subscribe per-card without
+    // going through this closure (see the versioned-counter notes in
+    // `previewStore.ts`).
     const focusPosition = requireElementById<HTMLElement>("focus-position");
     // Progress bar is owned by `<progress-bar>` — see
     // `components/ProgressBar.ts`. It listens for `setProgress` /
@@ -239,11 +231,11 @@ export function setupPreviewBehavior(
         earlyFeatures,
         getPreview: (id) => allPreviews.find((p) => p.id === id),
         getA11yFindings: (id) =>
-            cardA11yFindings.get(id) ||
+            previewStore.getState().cardA11yFindings.get(id) ||
             allPreviews.find((p) => p.id === id)?.a11yFindings ||
             [],
         getA11yNodes: (id) =>
-            cardA11yNodes.get(id) ||
+            previewStore.getState().cardA11yNodes.get(id) ||
             allPreviews.find((p) => p.id === id)?.a11yNodes ||
             [],
         getA11yOverlayId: a11yOverlay,
@@ -340,13 +332,12 @@ export function setupPreviewBehavior(
     const loadingOverlay = new LoadingOverlay();
 
     // Per-preview carousel runtime state — imageData / errorMessage per
-    // capture. Populated from updateImage / setImageError messages so
-    // prev/next navigation can swap the visible <img> without a fresh
-    // extension round-trip.
-    const cardCaptures = new Map<string, CapturePresentation[]>();
+    // capture — lives on `previewStore.cardCaptures`. Populated from
+    // updateImage / setImageError messages so prev/next navigation can
+    // swap the visible <img> without a fresh extension round-trip; the
+    // carousel reads it via `previewStore.getState().cardCaptures`.
     const frameCarousel = new FrameCarouselController({
         vscode,
-        cardCaptures,
         interactiveInputConfig,
     });
 
@@ -451,9 +442,6 @@ export function setupPreviewBehavior(
     const cardBuilderConfig: CardBuilderConfig = {
         vscode,
         grid,
-        cardCaptures,
-        cardA11yFindings,
-        cardA11yNodes,
         staleBadge,
         frameCarousel,
         liveState,
@@ -503,9 +491,6 @@ export function setupPreviewBehavior(
         loadingOverlay,
         diffOverlayConfig,
         streamingPainter,
-        cardCaptures,
-        cardA11yFindings,
-        cardA11yNodes,
         moduleDaemonReady,
         moduleInteractiveSupported,
         earlyFeatures,

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -40,6 +40,17 @@ import type { LiveStateController } from "./liveState";
 import type { StaleBadgeController } from "./staleBadge";
 import type { PreviewGrid } from "./components/PreviewGrid";
 import type { MessageOwner } from "./components/MessageBanner";
+import {
+    bumpPreviewMapsRevision,
+    clearCardA11yFindings,
+    deleteCardA11yFindings,
+    deleteCardA11yNodes,
+    deleteCardCaptures,
+    previewStore,
+    setCardA11yFindings,
+    setCardA11yNodes,
+    setCardCaptures,
+} from "./previewStore";
 import type {
     AccessibilityFinding,
     AccessibilityNode,
@@ -53,16 +64,6 @@ export interface CardBuilderConfig {
      *  `.preview-card` children to diff against the new manifest, and
      *  uses `insertBefore` to keep the manifest's order stable. */
     grid: PreviewGrid;
-    /** Per-preview carousel runtime state — populated here on creation,
-     *  read by `updateImage` / `setImageError` / `frameCarousel` later. */
-    cardCaptures: Map<string, CapturePresentation[]>;
-    /** Per-preview a11y findings cache — populated by
-     *  `applyA11yUpdate` from daemon `a11y/atf` payloads, re-read on
-     *  every image (re)load to repaint the finding overlay. */
-    cardA11yFindings: Map<string, readonly AccessibilityFinding[]>;
-    /** Per-preview a11y hierarchy nodes cache — same shape, populated
-     *  from `a11y/hierarchy` payloads. */
-    cardA11yNodes: Map<string, readonly AccessibilityNode[]>;
     staleBadge: StaleBadgeController;
     frameCarousel: FrameCarouselController;
     liveState: LiveStateController;
@@ -120,8 +121,8 @@ export interface CardBuilderConfig {
  * keyed on `previewId`).
  *
  * Side effects:
- *  - Seeds `config.cardCaptures.set(p.id, ...)` with one
- *    `CapturePresentation` per `p.captures` entry.
+ *  - Seeds `previewStore`'s `cardCaptures` with one `CapturePresentation`
+ *    per `p.captures` entry (via `setCardCaptures`).
  *  - Calls `config.staleBadge.apply(card, false)` once so the badge slot
  *    exists in DOM order before the rest of the header is appended.
  *  - Calls `config.observeForViewport(card)` so the viewport tracker
@@ -154,7 +155,7 @@ export function buildPreviewCard(
     if (p.referenced) {
         card.dataset.referenced = "1";
     }
-    config.cardCaptures.set(
+    setCardCaptures(
         p.id,
         captures.map(
             (c): CapturePresentation => ({
@@ -297,10 +298,12 @@ export function buildPreviewCard(
 
 /** Subset of `CardBuilderConfig` that `updateCardMetadata` actually
  *  reaches for. Kept narrow so callers — and the eventual reactive
- *  Lit component — only have to satisfy what's used. */
+ *  Lit component — only have to satisfy what's used. The capture
+ *  cache itself lives in `previewStore` (see `setCardCaptures`),
+ *  so it isn't part of this surface. */
 export type CardUpdateConfig = Pick<
     CardBuilderConfig,
-    "cardCaptures" | "frameCarousel" | "earlyFeatures"
+    "frameCarousel" | "earlyFeatures"
 >;
 
 /**
@@ -334,7 +337,7 @@ export function updateCardMetadata(
         renderOutput: c.renderOutput,
         label: c.label || "",
     }));
-    const prior = config.cardCaptures.get(p.id) ?? [];
+    const prior = previewStore.getState().cardCaptures.get(p.id) ?? [];
     // Match by index rather than renderOutput since filenames may
     // legitimately change (e.g. a preview gains a @RoboComposePreviewOptions
     // annotation). Mismatched positions just reset to null-image.
@@ -347,7 +350,7 @@ export function updateCardMetadata(
             renderError: prior[i]?.renderError ?? null,
         }),
     );
-    config.cardCaptures.set(p.id, mergedCaps);
+    setCardCaptures(p.id, mergedCaps);
     const curIdx = parseInt(card.dataset.currentIndex || "0", 10);
     if (curIdx >= mergedCaps.length) {
         card.dataset.currentIndex = String(Math.max(0, mergedCaps.length - 1));
@@ -408,13 +411,12 @@ export function updateCardMetadata(
 // the existing `behavior.ts` import paths.
 export { applyRelativeSizing } from "./relativeSizing";
 
-/** Subset `updateImage` reaches for — every per-frame paint dependency. */
+/** Subset `updateImage` reaches for — every per-frame paint dependency.
+ *  The per-preview caches (`cardCaptures`, `cardA11yFindings`,
+ *  `cardA11yNodes`) live in `previewStore` and are read directly there. */
 export type UpdateImageConfig = Pick<
     CardBuilderConfig,
     | "vscode"
-    | "cardCaptures"
-    | "cardA11yFindings"
-    | "cardA11yNodes"
     | "frameCarousel"
     | "liveState"
     | "interactiveInputConfig"
@@ -429,7 +431,9 @@ export type UpdateImageConfig = Pick<
  * touched (the bytes wait for prev/next).
  *
  * Side effects (when [captureIndex] matches the displayed capture):
- *  - Updates / mutates the per-capture cache entry on `cardCaptures`.
+ *  - Updates / mutates the per-capture cache entry on
+ *    `previewStore`'s `cardCaptures` and bumps `mapsRevision` so
+ *    subscribers selecting on the cache notice the new bytes.
  *  - Replaces the card's `<img>` `src` (or creates one if missing).
  *  - Re-attaches the live pointer/wheel handlers via
  *    `attachInteractiveInputHandlers`.
@@ -448,8 +452,11 @@ export function updateImage(
     if (!card) return;
 
     // Cache so carousel navigation can restore this capture without
-    // a fresh extension round-trip.
-    const caps = config.cardCaptures.get(previewId);
+    // a fresh extension round-trip. Mutates the capture object in
+    // place — the Map identity is unchanged but `mapsRevision` is
+    // bumped so subscribers selecting on it can react to fresh
+    // frames in live mode.
+    const caps = previewStore.getState().cardCaptures.get(previewId);
     const capture =
         caps && captureIndex >= 0 && captureIndex < caps.length
             ? caps[captureIndex]
@@ -458,6 +465,7 @@ export function updateImage(
         capture.imageData = imageData;
         capture.errorMessage = null;
         capture.renderError = null;
+        bumpPreviewMapsRevision();
     }
 
     // Only paint the <img> if the currently-displayed capture is the
@@ -532,8 +540,8 @@ export function updateImage(
     // renderPreviews pipeline. Gated on earlyFeatures so the
     // overlay only paints when the user has opted into the
     // accessibility-overlay feature surface.
-    const findings = config.cardA11yFindings.get(previewId);
-    const nodes = config.cardA11yNodes.get(previewId);
+    const findings = previewStore.getState().cardA11yFindings.get(previewId);
+    const nodes = previewStore.getState().cardA11yNodes.get(previewId);
     if (
         config.earlyFeatures() &&
         ((findings && findings.length > 0) || (nodes && nodes.length > 0))
@@ -553,16 +561,12 @@ export function updateImage(
     }
 }
 
-/** Subset `applyA11yUpdate` reaches for. */
+/** Subset `applyA11yUpdate` reaches for. The a11y caches themselves
+ *  live in `previewStore` and are written via the `setCardA11y…` /
+ *  `deleteCardA11y…` helpers. */
 export type A11yUpdateConfig = Pick<
     CardBuilderConfig,
-    | "cardA11yFindings"
-    | "cardA11yNodes"
-    | "getAllPreviews"
-    | "inspector"
-    | "earlyFeatures"
-    | "inFocus"
-    | "focusedCard"
+    "getAllPreviews" | "inspector" | "earlyFeatures" | "inFocus" | "focusedCard"
 >;
 
 /**
@@ -587,7 +591,7 @@ export function applyA11yUpdate(
     const img = container?.querySelector<HTMLImageElement>("img") ?? null;
     if (findings !== undefined) {
         if (findings && findings.length > 0) {
-            config.cardA11yFindings.set(previewId, findings);
+            setCardA11yFindings(previewId, findings);
             if (container && !container.querySelector(".a11y-overlay")) {
                 const overlay = document.createElement("div");
                 overlay.className = "a11y-overlay";
@@ -605,7 +609,7 @@ export function applyA11yUpdate(
                 buildA11yOverlay(card, findings, img);
             }
         } else {
-            config.cardA11yFindings.delete(previewId);
+            deleteCardA11yFindings(previewId);
             const overlay = card.querySelector(".a11y-overlay");
             if (overlay) overlay.remove();
             const legend = card.querySelector(".a11y-legend");
@@ -614,13 +618,13 @@ export function applyA11yUpdate(
     }
     if (nodes !== undefined) {
         if (nodes && nodes.length > 0) {
-            config.cardA11yNodes.set(previewId, nodes);
+            setCardA11yNodes(previewId, nodes);
             ensureHierarchyOverlay(container);
             if (img && img.complete && img.naturalWidth > 0) {
                 applyHierarchyOverlay(card, nodes, img);
             }
         } else {
-            config.cardA11yNodes.delete(previewId);
+            deleteCardA11yNodes(previewId);
             const layer = card.querySelector(".a11y-hierarchy-overlay");
             if (layer) layer.remove();
         }
@@ -631,14 +635,14 @@ export function applyA11yUpdate(
 }
 
 /** Subset `renderPreviews` reaches for — initial-build + metadata-refresh
- *  collaborator surface plus the grid + viewport + message-banner hooks. */
+ *  collaborator surface plus the grid + viewport + message-banner hooks.
+ *  The per-preview Maps live in `previewStore` and are mutated through
+ *  the `…CardCaptures` / `…CardA11y…` helpers, so they don't appear on
+ *  this surface. */
 export type RenderPreviewsConfig = Pick<
     CardBuilderConfig,
     | "vscode"
     | "grid"
-    | "cardCaptures"
-    | "cardA11yFindings"
-    | "cardA11yNodes"
     | "staleBadge"
     | "frameCarousel"
     | "liveState"
@@ -664,11 +668,12 @@ export type RenderPreviewsConfig = Pick<
  * `updateImage` messages.
  *
  * Side effects:
- *  - Removed cards drop their `cardCaptures` entry and detach from the
- *    viewport tracker via `config.forgetViewport`.
- *  - The `cardA11yFindings` cache is fully rebuilt from each preview's
- *    `a11yFindings` so `updateImage`'s on-load handler can repaint
- *    overlays consistently.
+ *  - Removed cards drop their `previewStore` `cardCaptures` entry (via
+ *    `deleteCardCaptures`) and detach from the viewport tracker via
+ *    `config.forgetViewport`.
+ *  - The `cardA11yFindings` cache on `previewStore` is fully rebuilt
+ *    from each preview's `a11yFindings` so `updateImage`'s on-load
+ *    handler can repaint overlays consistently.
  *  - Insert order matches the manifest; `insertBefore` keeps existing
  *    cards in place when their position survives.
  *  - After cards land, transient owner messages (`loading`, `fallback`)
@@ -702,7 +707,7 @@ export function renderPreviews(
     // data so stale entries don't pile up if a preview is renamed.
     for (const [id, card] of existingCards) {
         if (!newIds.has(id)) {
-            config.cardCaptures.delete(id);
+            deleteCardCaptures(id);
             config.forgetViewport(id, card);
             card.remove();
         }
@@ -710,11 +715,14 @@ export function renderPreviews(
 
     // Refresh per-preview findings cache so updateImage can attach
     // them to each new image load. Drop stale entries (preview
-    // removed) so the map doesn't grow across sessions.
-    config.cardA11yFindings.clear();
+    // removed) so the map doesn't grow across sessions. Mutates the
+    // store's Map in place; the per-id `setCardA11yFindings` helper
+    // bumps `mapsRevision` for each addition, plus `clearCardA11y…`
+    // covers the case where the manifest reseed brings zero findings.
+    clearCardA11yFindings();
     for (const p of previews) {
         if (p.a11yFindings && p.a11yFindings.length > 0) {
-            config.cardA11yFindings.set(p.id, p.a11yFindings);
+            setCardA11yFindings(p.id, p.a11yFindings);
         }
     }
 

--- a/vscode-extension/src/webview/preview/frameCarousel.ts
+++ b/vscode-extension/src/webview/preview/frameCarousel.ts
@@ -7,17 +7,17 @@
 // swap and error-panel attach.
 //
 // Carousel state lives outside this module: `cardCaptures` is the
-// shared `Map<previewId, CapturePresentation[]>` owned by `behavior.ts`
-// (populated from `setPreviews`, mutated by `updateImage` /
-// `setImageError`, drained by `renderPreviews`'s removal pass), and
-// `card.dataset.currentIndex` tracks the visible frame as a string.
-// Both are passed in via `FrameCarouselConfig` so this module never
-// needs to reach into closures in `behavior.ts`.
+// shared `Map<previewId, CapturePresentation[]>` owned by
+// `previewStore` (populated from `setPreviews`, mutated by
+// `updateImage` / `setImageError`, drained by `renderPreviews`'s
+// removal pass), and `card.dataset.currentIndex` tracks the visible
+// frame as a string. The carousel reads the captures Map directly
+// off `previewStore.getState()` so this module never needs to reach
+// into closures in `behavior.ts`.
 //
 // Held as a `FrameCarouselController` so the dependencies (vscode,
-// the captures Map, the interactive-input config used when swapping
-// to a fresh `<img>`) bind once at panel boot rather than threading
-// through every call site.
+// the interactive-input config used when swapping to a fresh `<img>`)
+// bind once at panel boot rather than threading through every call site.
 
 import { mimeFor } from "./cardData";
 import { buildErrorPanel } from "./errorPanel";
@@ -25,6 +25,7 @@ import {
     attachInteractiveInputHandlers,
     type InteractiveInputConfig,
 } from "./interactiveInput";
+import { previewStore } from "./previewStore";
 import type { PreviewRenderError } from "../shared/types";
 import type { VsCodeApi } from "../shared/vscode";
 
@@ -47,7 +48,6 @@ export interface CapturePresentation {
 
 export interface FrameCarouselConfig {
     vscode: VsCodeApi<unknown>;
-    cardCaptures: Map<string, CapturePresentation[]>;
     interactiveInputConfig: InteractiveInputConfig;
 }
 
@@ -122,7 +122,7 @@ export class FrameCarouselController {
         const nextBtn = card.querySelector<HTMLButtonElement>(".frame-next");
         if (!indicator) return;
         const previewId = card.dataset.previewId ?? "";
-        const caps = this.config.cardCaptures.get(previewId);
+        const caps = previewStore.getState().cardCaptures.get(previewId);
         if (!caps) return;
         const idx = parseInt(card.dataset.currentIndex || "0", 10);
         const capture = caps[idx];
@@ -134,7 +134,7 @@ export class FrameCarouselController {
 
     private step(card: HTMLElement, delta: number): void {
         const previewId = card.dataset.previewId ?? "";
-        const caps = this.config.cardCaptures.get(previewId);
+        const caps = previewStore.getState().cardCaptures.get(previewId);
         if (!caps) return;
         const cur = parseInt(card.dataset.currentIndex || "0", 10);
         const next = Math.max(0, Math.min(caps.length - 1, cur + delta));
@@ -145,7 +145,7 @@ export class FrameCarouselController {
 
     private show(card: HTMLElement, index: number): void {
         const previewId = card.dataset.previewId ?? "";
-        const caps = this.config.cardCaptures.get(previewId);
+        const caps = previewStore.getState().cardCaptures.get(previewId);
         if (!caps) return;
         const capture = caps[index];
         if (!capture) return;

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -13,13 +13,15 @@
 // are thin orchestration over a typed controller (live state, stale badge,
 // loading overlay, focus inspector, diff overlay, viewport tracker) call into
 // those controllers directly. The remaining fields on the context cover the
-// state still owned imperatively by `behavior.ts` — `cardCaptures`,
-// `cardA11yFindings`, `cardA11yNodes`, `moduleDaemonReady`,
-// `moduleInteractiveSupported`, `allPreviews`, `moduleDir`,
-// `lastScopedPreviewId`, `a11yOverlayPreviewId` — and the orchestration
-// callbacks (`renderPreviews`, `applyLayout`, `applyFilters`, `updateImage`,
-// `applyA11yUpdate`, `focusOnCard`, etc.) that should fold into a future
-// `<preview-card>` Lit component.
+// state still owned imperatively by `behavior.ts` —
+// `moduleDaemonReady`, `moduleInteractiveSupported`, `allPreviews`,
+// `moduleDir`, `lastScopedPreviewId`, `a11yOverlayPreviewId` — and the
+// orchestration callbacks (`renderPreviews`, `applyLayout`,
+// `applyFilters`, `updateImage`, `applyA11yUpdate`, `focusOnCard`, etc.)
+// that should fold into a future `<preview-card>` Lit component. The
+// per-preview Maps (`cardCaptures`, `cardA11yFindings`, `cardA11yNodes`)
+// now live on `previewStore` and are reached through the helpers in
+// `previewStore.ts`.
 //
 // Some `ExtensionToWebview` variants are handled directly by Lit components
 // without going through this dispatcher — `<message-banner>` listens for
@@ -41,10 +43,14 @@ import { PreviewGrid } from "./components/PreviewGrid";
 import { buildErrorPanel } from "./errorPanel";
 import { showDiffOverlay, type DiffOverlayConfig } from "./diffOverlay";
 import { FocusInspectorController } from "./focusInspector";
-import type { CapturePresentation } from "./frameCarousel";
 import { LiveStateController } from "./liveState";
 import { LoadingOverlay } from "./loadingOverlay";
-import { previewStore } from "./previewStore";
+import {
+    bumpPreviewMapsRevision,
+    clearCardA11yFindings,
+    clearCardA11yNodes,
+    previewStore,
+} from "./previewStore";
 import { StaleBadgeController } from "./staleBadge";
 import { StreamingPainter } from "./streamingPainter";
 
@@ -65,13 +71,6 @@ export interface PreviewMessageContext {
     /** Painter for `composestream/1` live frames — see streamingPainter.ts. */
     streamingPainter: StreamingPainter;
 
-    /** Per-preview carousel runtime state — imageData / errorMessage per
-     *  capture. Populated from `setPreviews` / `updateImage` / `setImageError`
-     *  so prev/next navigation can swap the visible `<img>` without a fresh
-     *  extension round-trip. */
-    cardCaptures: Map<string, CapturePresentation[]>;
-    cardA11yFindings: Map<string, readonly AccessibilityFinding[]>;
-    cardA11yNodes: Map<string, readonly AccessibilityNode[]>;
     moduleDaemonReady: Map<string, boolean>;
     moduleInteractiveSupported: Map<string, boolean>;
 
@@ -332,7 +331,7 @@ function handleErrorMessage(
     const captureIndex = safeArrayIndex(rawCaptureIndex);
     const renderError =
         msg.command === "setImageError" ? (msg.renderError ?? null) : null;
-    const caps = ctx.cardCaptures.get(msg.previewId);
+    const caps = previewStore.getState().cardCaptures.get(msg.previewId);
     const replaceExisting =
         msg.command !== "setImageError" || msg.replaceExisting !== false;
     const container = errCard.querySelector<HTMLElement>(".image-container");
@@ -352,6 +351,10 @@ function handleErrorMessage(
         if (!keepExistingImage) {
             capture.imageData = null;
         }
+        // Mutated the capture object in place — Map identity unchanged
+        // but `mapsRevision` needs to advance so subscribers selecting
+        // on it see the new error state.
+        bumpPreviewMapsRevision();
     }
     const cur = parseInt(errCard.dataset.currentIndex || "0", 10);
     if (caps && cur !== captureIndex) return;
@@ -502,8 +505,8 @@ function handleSetEarlyFeatures(
                 ".a11y-legend, .a11y-overlay, .a11y-hierarchy-overlay",
             )
             .forEach((el) => el.remove());
-        ctx.cardA11yFindings.clear();
-        ctx.cardA11yNodes.clear();
+        clearCardA11yFindings();
+        clearCardA11yNodes();
         ctx.inspector.clearProducts();
         const a11yId = ctx.getA11yOverlayId();
         if (a11yId) {

--- a/vscode-extension/src/webview/preview/previewStore.ts
+++ b/vscode-extension/src/webview/preview/previewStore.ts
@@ -1,15 +1,34 @@
 // Singleton state for the live "Compose Preview" panel.
 //
 // Migration scope: the panel-level scalars that components want to
-// subscribe to. The big per-preview maps (`cardCaptures`,
-// `cardA11yFindings`, `cardA11yNodes`) intentionally still live as
-// closure state in `behavior.ts` until the `<preview-card>` Lit
-// component lands — moving them in would force every `Map.set` to
-// allocate a fresh Map (the store's reference-equality rule for change
-// detection) which is too much churn while the imperative
-// `renderPreviews` / `updateImage` paths still own them.
+// subscribe to plus the per-preview Maps (`cardCaptures`,
+// `cardA11yFindings`, `cardA11yNodes`) that the upcoming
+// `<preview-card>` Lit component will subscribe to. Owning the Maps
+// here lets components react to per-card churn without `behavior.ts`
+// holding the only references — step 1 of issue #857.
+//
+// Versioned-counter pattern: the Maps are MUTABLE references. Mutating
+// the same Map in place would defeat the store's reference-equality
+// change detection (a `Map.set` does not change the Map's identity),
+// but `updateImage` fires per frame in live mode so allocating a fresh
+// Map for every mutation is too churny. Instead, callers mutate the
+// Maps in place via the helpers exported below — each helper bumps
+// `mapsRevision`, a single monotonic counter that subscribers can use
+// as a selector to detect "something in the per-preview caches
+// changed". Step 2 of issue #857 (the `<preview-card>` shell) wires
+// the actual subscriptions; this module only owns the state and the
+// mutation choreography.
+//
+// Outside this module, treat the Maps as read-only — every mutation
+// must go through one of the helpers below so the revision counter
+// stays in sync.
 
-import type { PreviewInfo } from "../shared/types";
+import type {
+    AccessibilityFinding,
+    AccessibilityNode,
+    PreviewInfo,
+} from "../shared/types";
+import type { CapturePresentation } from "./frameCarousel";
 import { Store } from "../shared/store";
 
 export interface PreviewState {
@@ -85,6 +104,42 @@ export interface PreviewState {
      * filter tweak).
      */
     lastScopedPreviewId: string | null;
+
+    /**
+     * Per-preview carousel runtime state — `imageData` / `errorMessage`
+     * / `renderError` per capture. Populated by `buildPreviewCard` /
+     * `updateCardMetadata`, mutated by `updateImage` / `setImageError`,
+     * pruned by `renderPreviews` when a preview disappears from the
+     * manifest. MUTABLE — bump `mapsRevision` after every change via
+     * the helpers below.
+     */
+    cardCaptures: Map<string, CapturePresentation[]>;
+
+    /**
+     * Per-preview a11y findings cache — populated by `applyA11yUpdate`
+     * from daemon `a11y/atf` payloads (and rebuilt from `setPreviews`
+     * by `renderPreviews`), re-read on every image (re)load to repaint
+     * the finding overlay. MUTABLE — bump `mapsRevision` after every
+     * change.
+     */
+    cardA11yFindings: Map<string, readonly AccessibilityFinding[]>;
+
+    /**
+     * Per-preview a11y hierarchy nodes cache — same shape, populated
+     * from `a11y/hierarchy` payloads. MUTABLE — bump `mapsRevision`
+     * after every change.
+     */
+    cardA11yNodes: Map<string, readonly AccessibilityNode[]>;
+
+    /**
+     * Monotonic counter bumped on every mutation of `cardCaptures` /
+     * `cardA11yFindings` / `cardA11yNodes`. Subscribers select on this
+     * field to detect "something in the per-preview caches changed"
+     * without us having to allocate a fresh Map per `Map.set`. The
+     * counter is the only reference-equality-friendly signal the
+     * store's change detection has against the in-place Map mutations.
+     */
+    mapsRevision: number;
 }
 
 const initialState: PreviewState = {
@@ -97,6 +152,92 @@ const initialState: PreviewState = {
     focusIndex: 0,
     previousLayout: "grid",
     lastScopedPreviewId: null,
+    cardCaptures: new Map(),
+    cardA11yFindings: new Map(),
+    cardA11yNodes: new Map(),
+    mapsRevision: 0,
 };
 
 export const previewStore = new Store<PreviewState>(initialState);
+
+/**
+ * Bump the maps-revision counter so subscribers selecting on
+ * `mapsRevision` see a change. Callers that mutate any of the
+ * per-preview Maps in place MUST call this afterwards. The dedicated
+ * `setCardCaptures` / `deleteCardCaptures` / etc. helpers below already
+ * call this — only reach for it directly when a single logical update
+ * spans several Map mutations and you want one notification at the
+ * end (e.g. `renderPreviews`'s manifest reseed).
+ */
+export function bumpPreviewMapsRevision(): void {
+    const cur = previewStore.getState().mapsRevision;
+    previewStore.setState({ mapsRevision: cur + 1 });
+}
+
+/** Replace the captures array for a previewId. */
+export function setCardCaptures(
+    previewId: string,
+    captures: CapturePresentation[],
+): void {
+    previewStore.getState().cardCaptures.set(previewId, captures);
+    bumpPreviewMapsRevision();
+}
+
+/** Drop the captures entry for a previewId (preview removed from
+ *  manifest). Bumps revision only if there was actually an entry. */
+export function deleteCardCaptures(previewId: string): void {
+    if (previewStore.getState().cardCaptures.delete(previewId)) {
+        bumpPreviewMapsRevision();
+    }
+}
+
+/** Replace the a11y findings list for a previewId. */
+export function setCardA11yFindings(
+    previewId: string,
+    findings: readonly AccessibilityFinding[],
+): void {
+    previewStore.getState().cardA11yFindings.set(previewId, findings);
+    bumpPreviewMapsRevision();
+}
+
+/** Drop the a11y findings entry for a previewId. Bumps revision only
+ *  if there was actually an entry. */
+export function deleteCardA11yFindings(previewId: string): void {
+    if (previewStore.getState().cardA11yFindings.delete(previewId)) {
+        bumpPreviewMapsRevision();
+    }
+}
+
+/** Replace the a11y hierarchy nodes for a previewId. */
+export function setCardA11yNodes(
+    previewId: string,
+    nodes: readonly AccessibilityNode[],
+): void {
+    previewStore.getState().cardA11yNodes.set(previewId, nodes);
+    bumpPreviewMapsRevision();
+}
+
+/** Drop the a11y hierarchy nodes entry for a previewId. Bumps revision
+ *  only if there was actually an entry. */
+export function deleteCardA11yNodes(previewId: string): void {
+    if (previewStore.getState().cardA11yNodes.delete(previewId)) {
+        bumpPreviewMapsRevision();
+    }
+}
+
+/** Wipe the a11y findings cache (e.g. on `setPreviews` reseed or
+ *  `setEarlyFeatures` off). No-op + no revision bump if already empty. */
+export function clearCardA11yFindings(): void {
+    const map = previewStore.getState().cardA11yFindings;
+    if (map.size === 0) return;
+    map.clear();
+    bumpPreviewMapsRevision();
+}
+
+/** Wipe the a11y hierarchy nodes cache. No-op if already empty. */
+export function clearCardA11yNodes(): void {
+    const map = previewStore.getState().cardA11yNodes;
+    if (map.size === 0) return;
+    map.clear();
+    bumpPreviewMapsRevision();
+}


### PR DESCRIPTION
## Summary

Move `cardCaptures`, `cardA11yFindings`, and `cardA11yNodes` from `behavior.ts` closure variables into `previewStore` fields so the upcoming `<preview-card>` Lit component (step 2 of #857) can subscribe per-card without going through that closure.

The store's reference-equality change detection requires a new object on every notification, but `updateImage` fires per frame in live mode — allocating a fresh `Map` per `Map.set` is too churny. Instead, the Maps are mutated in place and a new monotonic `mapsRevision` counter is bumped on every change. Subscribers select on `mapsRevision` to detect "something in the per-preview caches changed".

Mutations are routed through helpers exported from `previewStore.ts`:

- `setCardCaptures(id, caps)` / `deleteCardCaptures(id)`
- `setCardA11yFindings(id, findings)` / `deleteCardA11yFindings(id)` / `clearCardA11yFindings()`
- `setCardA11yNodes(id, nodes)` / `deleteCardA11yNodes(id)` / `clearCardA11yNodes()`
- `bumpPreviewMapsRevision()` for in-place capture mutations (e.g. `updateImage` updating `capture.imageData` per frame; `setImageError` stamping per-capture errors).

The file's header comment documents the versioned-counter pattern.

`behavior.ts`, `cardBuilder.ts`, `messageHandlers.ts`, and `frameCarousel.ts` no longer hold or pass these Maps as closure variables or config fields — they read directly off `previewStore.getState()` and write through the helpers. No subscribers are wired yet (step 2).

## Concrete diff

- `previewStore.ts` (+155 lines): three new Map fields + `mapsRevision: number`, eight helper functions, header rewritten to document the pattern.
- `behavior.ts` (-15 lines, 535 → 520): drops the closure `cardCaptures`, `cardA11yFindings`, `cardA11yNodes` Maps; drops the matching `CardBuilderConfig` / `PreviewMessageContext` fields; reads via `previewStore.getState()`.
- `cardBuilder.ts`: removes the three Map fields from `CardBuilderConfig` and the `Pick`s for `CardUpdateConfig` / `UpdateImageConfig` / `A11yUpdateConfig` / `RenderPreviewsConfig`; switches all `.set` / `.delete` / `.clear` to the helpers; `updateImage` calls `bumpPreviewMapsRevision()` after the in-place capture mutation so per-frame subscribers can react.
- `messageHandlers.ts`: drops the three Map fields from `PreviewMessageContext`; `handleErrorMessage` bumps the revision after mutating a capture object in place; `setEarlyFeatures` off goes through `clearCardA11y…` helpers.
- `frameCarousel.ts`: drops the `cardCaptures` field from `FrameCarouselConfig`; reads from `previewStore.getState().cardCaptures` directly.

## Test plan

- [x] `cd vscode-extension && npm run compile` — passes (host + webview).
- [x] `cd vscode-extension && npm test` — 485 passing.
- [x] `cd vscode-extension && npm run format:check` — clean.
- [ ] Manual smoke (deferred to step 2 wiring): live mode per-frame paints, focus inspector a11y rendering, frame carousel prev/next, focus mode entry/exit, `setEarlyFeatures` toggle. The data flow is unchanged — the maps just live in the store now and mutations go through helpers — so existing imperative paths should be unaffected.

Part of #857.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_