### PR TITLE
feat(vscode): mirror PROTOCOL v2 and enable all advertised extensions on connect

### DIFF
--- a/docs/daemon/protocol-fixtures/client-initialize.json
+++ b/docs/daemon/protocol-fixtures/client-initialize.json
@@ -1,5 +1,5 @@
 {
-  "protocolVersion": 1,
+  "protocolVersion": 2,
   "clientVersion": "0.8.6",
   "workspaceRoot": "/home/dev/projects/my-app",
   "moduleId": ":samples:android",

--- a/docs/daemon/protocol-fixtures/daemon-initializeResult.json
+++ b/docs/daemon/protocol-fixtures/daemon-initializeResult.json
@@ -1,5 +1,5 @@
 {
-  "protocolVersion": 1,
+  "protocolVersion": 2,
   "daemonVersion": "0.8.7-SNAPSHOT",
   "pid": 12345,
   "capabilities": {

--- a/vscode-extension/src/daemon/daemonClient.ts
+++ b/vscode-extension/src/daemon/daemonClient.ts
@@ -16,6 +16,11 @@ import {
     HistoryListResult,
     HistoryReadParams,
     HistoryReadResult,
+    ExtensionsDisableParams,
+    ExtensionsDisableResult,
+    ExtensionsEnableParams,
+    ExtensionsEnableResult,
+    ExtensionsListResult,
     InitializeParams,
     InitializeResult,
     InteractiveInputParams,
@@ -142,6 +147,38 @@ export class DaemonClient {
 
     initialized(): void {
         this.notify("initialized", undefined);
+    }
+
+    /**
+     * `extensions/list` (PROTOCOL.md § 3a). Snapshot of every registered extension and
+     * whether it's currently public or pulled in as a dependency. Cheap; the panel calls
+     * this once after `initialize` to learn what's available before deciding what to enable.
+     */
+    extensionsList(): Promise<ExtensionsListResult> {
+        return this.request<ExtensionsListResult>("extensions/list", undefined);
+    }
+
+    /**
+     * `extensions/enable {ids}`. Returns the new public capability snapshot in the
+     * response so callers don't need a follow-up `extensions/list`.
+     */
+    extensionsEnable(
+        params: ExtensionsEnableParams,
+    ): Promise<ExtensionsEnableResult> {
+        return this.request<ExtensionsEnableResult>(
+            "extensions/enable",
+            params,
+        );
+    }
+
+    /** `extensions/disable {ids}`. */
+    extensionsDisable(
+        params: ExtensionsDisableParams,
+    ): Promise<ExtensionsDisableResult> {
+        return this.request<ExtensionsDisableResult>(
+            "extensions/disable",
+            params,
+        );
     }
 
     setVisible(params: SetVisibleParams): void {

--- a/vscode-extension/src/daemon/daemonProcess.ts
+++ b/vscode-extension/src/daemon/daemonProcess.ts
@@ -184,6 +184,39 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
         throw err;
     }
 
+    // PROTOCOL.md § 3a — daemons advertise an empty capability surface until the client
+    // opts in via `extensions/enable`. The panel doesn't yet do per-card lifecycle
+    // (open card → enable extension → subscribe → close → unsubscribe), so as a
+    // transitional step we enable every extension the daemon registered, restoring the
+    // pre-v2 "everything advertised" behaviour. Lean opt-in is a follow-up.
+    try {
+        const list = await client.extensionsList();
+        const ids = list.extensions.map((info) => info.id);
+        if (ids.length > 0) {
+            const enabled = await client.extensionsEnable({ ids });
+            initializeResult = {
+                ...initializeResult,
+                capabilities: {
+                    ...initializeResult.capabilities,
+                    dataProducts: enabled.dataProducts,
+                    dataExtensions: enabled.dataExtensions,
+                    previewExtensions: enabled.previewExtensions,
+                },
+            };
+            if (enabled.unknown.length > 0) {
+                opts.logger?.appendLine(
+                    `[daemon] extensions/enable skipped unknown ids ${enabled.unknown.join(", ")}`,
+                );
+            }
+        }
+    } catch (err) {
+        // Non-fatal — daemons that don't speak v2 of this method still serve the
+        // initialize round-trip; the panel just sees empty capabilities and degrades.
+        opts.logger?.appendLine(
+            `[daemon] extensions/list+enable failed: ${(err as Error).message}`,
+        );
+    }
+
     client.initialized();
     return { client, process: child, initializeResult, exited };
 }

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -1,13 +1,16 @@
 /**
- * TypeScript mirrors of the locked v1 protocol from
+ * TypeScript mirrors of the locked v2 protocol from
  * `daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt`.
  * Kept hand-rolled (no generator) so the round-trip golden fixtures under
  * `docs/daemon/protocol-fixtures/` are the only authority both sides depend on.
  *
- * Spec: docs/daemon/PROTOCOL.md (v1).
+ * Spec: docs/daemon/PROTOCOL.md (v2). v2 introduced `extensions/{list,enable,disable}`
+ * and emptied the default `initialize.capabilities.{dataProducts,dataExtensions,
+ * previewExtensions}` lists — clients call `extensions/enable` after the handshake to
+ * opt in to the contributions they actually use.
  */
 
-export const PROTOCOL_VERSION = 1;
+export const PROTOCOL_VERSION = 2;
 
 // JSON-RPC envelopes (PROTOCOL.md § 2)
 
@@ -304,6 +307,62 @@ export interface InitializeResult {
     };
     classpathFingerprint: string;
     manifest: { path: string; previewCount: number };
+}
+
+// extensions/{list,enable,disable} (PROTOCOL.md § 3a)
+//
+// Daemons boot with every extension registered as inactive. Capability lists in
+// `InitializeResult.capabilities.{dataProducts,dataExtensions,previewExtensions}` start
+// empty; clients opt in via `extensions/enable`. Dependencies declared by an extension
+// are pulled in transitively but stay invisible to direct client RPC.
+
+export interface ExtensionInfo {
+    id: string;
+    displayName: string;
+    dependencies: string[];
+    publiclyEnabled: boolean;
+    /** True iff publicly enabled OR pulled in as a dependency of another public extension. */
+    active: boolean;
+    dataProductKinds: string[];
+    dataExtensionIds: string[];
+    previewExtensionIds: string[];
+}
+
+export interface ExtensionsListResult {
+    extensions: ExtensionInfo[];
+}
+
+export interface ExtensionsEnableParams {
+    ids: string[];
+}
+
+export interface ExtensionsEnableResult {
+    newlyEnabled: string[];
+    pulledIn: string[];
+    alreadyEnabled: string[];
+    unknown: string[];
+    /**
+     * Updated public capability snapshots — same shape as the `initialize.capabilities`
+     * fields. Saves a follow-up `extensions/list` round-trip after enabling.
+     */
+    dataProducts: DataProductCapability[];
+    dataExtensions: DataExtensionDescriptor[];
+    previewExtensions: PreviewExtensionDescriptor[];
+}
+
+export interface ExtensionsDisableParams {
+    ids: string[];
+}
+
+export interface ExtensionsDisableResult {
+    disabled: string[];
+    deactivated: string[];
+    stillActiveAsDependency: string[];
+    notEnabled: string[];
+    unknown: string[];
+    dataProducts: DataProductCapability[];
+    dataExtensions: DataExtensionDescriptor[];
+    previewExtensions: PreviewExtensionDescriptor[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Mirrors PROTOCOL v2 in `vscode-extension/src/daemon/daemonProtocol.ts`: adds `ExtensionInfo`, `ExtensionsListResult`, `ExtensionsEnable{Params,Result}`, `ExtensionsDisable{Params,Result}`, and bumps `PROTOCOL_VERSION` to 2 so the handshake check against a v2 daemon passes.
- `DaemonClient` exposes `extensionsList`, `extensionsEnable`, `extensionsDisable`.
- `spawnDaemon` now calls `extensions/list` + `extensions/enable(allIds)` after the initialize round-trip and merges the response's public capability snapshot back into `InitializeResult.capabilities`. This preserves the pre-v2 panel UX where every advertised kind is immediately usable, without requiring the per-card lifecycle (open card → enable extension → subscribe → close → unsubscribe). That lazy opt-in is a follow-up; the goal of this PR is just "panel keeps working after the v2 daemon merge."
- Bumps the round-trip golden fixtures under `docs/daemon/protocol-fixtures/` to `protocolVersion: 2`.

## Test plan

- [x] `npm run compile` — clean.
- [x] `npm test` — 485 passing.
- [x] `npm run format` — no diffs.
- [ ] Live VS Code panel smoke test against a v2 daemon (not run in this sandbox; the extension host requires Electron).

## Follow-ups (deferred)

- Lazy per-card extension lifecycle so closed cards don't pay for their producers.
- `extensions/disable` UX (or just relying on daemon shutdown).
- `DATA-PRODUCTS.md` update covering the activation gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDExhffhKM1zJM8db9Ghbc)_