### PR TITLE
test(vscode): extract stampLiveBadgesOnGrid + applyLiveBadge unit tests

### DIFF
--- a/vscode-extension/src/test/liveBadge.test.ts
+++ b/vscode-extension/src/test/liveBadge.test.ts
@@ -1,0 +1,190 @@
+import * as assert from "assert";
+import { stampLiveBadgesOnGrid } from "../webview/preview/liveBadge";
+import { sanitizeId } from "../webview/preview/cardData";
+
+/** Build a `<div class="preview-card" id="preview-...">` with an
+ *  `.image-container` child (the place the per-card stop button gets
+ *  appended to) and append it to `document.body`. Returns the card. */
+function buildCard(previewId: string): HTMLElement {
+    const card = document.createElement("div");
+    card.className = "preview-card";
+    card.id = "preview-" + sanitizeId(previewId);
+    card.dataset.previewId = previewId;
+    const container = document.createElement("div");
+    container.className = "image-container";
+    card.appendChild(container);
+    document.body.appendChild(card);
+    return card;
+}
+
+/** Stand-in for `LiveStateController.ensureLiveCardControls` — appends a
+ *  no-op `.card-live-stop-btn` if one isn't already there. The real
+ *  controller also wires a click handler and re-attaches pointer/wheel
+ *  input; this test stub keeps the contract narrow (idempotent button
+ *  injection into `.image-container`). */
+function ensureControlsStub(card: HTMLElement): void {
+    const container = card.querySelector(".image-container");
+    if (!container) return;
+    if (!container.querySelector(".card-live-stop-btn")) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "icon-button card-live-stop-btn";
+        container.appendChild(btn);
+    }
+}
+
+afterEach(() => {
+    document.body.innerHTML = "";
+});
+
+describe("stampLiveBadgesOnGrid", () => {
+    it("adds .live and a .card-live-stop-btn to every card in the live set", () => {
+        const a = buildCard("com.example.A");
+        const b = buildCard("com.example.B");
+        buildCard("com.example.C"); // not live
+
+        stampLiveBadgesOnGrid(
+            new Set(["com.example.A", "com.example.B"]),
+            ensureControlsStub,
+        );
+
+        assert.strictEqual(a.classList.contains("live"), true);
+        assert.strictEqual(b.classList.contains("live"), true);
+        assert.strictEqual(a.querySelectorAll(".card-live-stop-btn").length, 1);
+        assert.strictEqual(b.querySelectorAll(".card-live-stop-btn").length, 1);
+        const c = document.getElementById("preview-com_example_C")!;
+        assert.strictEqual(c.classList.contains("live"), false);
+        assert.strictEqual(c.querySelector(".card-live-stop-btn"), null);
+    });
+
+    it("removes .live and the stop button from cards no longer in the live set", () => {
+        const a = buildCard("com.example.A");
+        const b = buildCard("com.example.B");
+
+        // First pass: both live.
+        stampLiveBadgesOnGrid(
+            new Set(["com.example.A", "com.example.B"]),
+            ensureControlsStub,
+        );
+        assert.strictEqual(a.classList.contains("live"), true);
+        assert.strictEqual(b.classList.contains("live"), true);
+
+        // Second pass: only A live — B should be stripped.
+        stampLiveBadgesOnGrid(new Set(["com.example.A"]), ensureControlsStub);
+        assert.strictEqual(a.classList.contains("live"), true);
+        assert.strictEqual(b.classList.contains("live"), false);
+        assert.strictEqual(a.querySelectorAll(".card-live-stop-btn").length, 1);
+        assert.strictEqual(b.querySelector(".card-live-stop-btn"), null);
+    });
+
+    it("clears every .live decoration when called with an empty set", () => {
+        const a = buildCard("com.example.A");
+        const b = buildCard("com.example.B");
+
+        stampLiveBadgesOnGrid(
+            new Set(["com.example.A", "com.example.B"]),
+            ensureControlsStub,
+        );
+        stampLiveBadgesOnGrid(new Set(), ensureControlsStub);
+
+        assert.strictEqual(a.classList.contains("live"), false);
+        assert.strictEqual(b.classList.contains("live"), false);
+        assert.strictEqual(a.querySelector(".card-live-stop-btn"), null);
+        assert.strictEqual(b.querySelector(".card-live-stop-btn"), null);
+    });
+
+    it("is idempotent — calling twice produces the same final DOM", () => {
+        const a = buildCard("com.example.A");
+        const b = buildCard("com.example.B");
+
+        const liveSet = new Set(["com.example.A", "com.example.B"]);
+        stampLiveBadgesOnGrid(liveSet, ensureControlsStub);
+        const firstPassHtml = document.body.innerHTML;
+        stampLiveBadgesOnGrid(liveSet, ensureControlsStub);
+        const secondPassHtml = document.body.innerHTML;
+
+        assert.strictEqual(secondPassHtml, firstPassHtml);
+        // And the per-card stop button never duplicates on re-stamp.
+        assert.strictEqual(a.querySelectorAll(".card-live-stop-btn").length, 1);
+        assert.strictEqual(b.querySelectorAll(".card-live-stop-btn").length, 1);
+    });
+
+    it("skips silently when a previewId in the live set has no DOM card", () => {
+        const a = buildCard("com.example.A");
+        // No card for `com.example.GHOST` — exercises the
+        // `if (!(card instanceof HTMLElement)) return;` guard.
+        assert.doesNotThrow(() =>
+            stampLiveBadgesOnGrid(
+                new Set(["com.example.A", "com.example.GHOST"]),
+                ensureControlsStub,
+            ),
+        );
+        // The real card was still stamped.
+        assert.strictEqual(a.classList.contains("live"), true);
+        assert.strictEqual(a.querySelectorAll(".card-live-stop-btn").length, 1);
+        // No stray ghost card appeared.
+        assert.strictEqual(
+            document.getElementById("preview-com_example_GHOST"),
+            null,
+        );
+    });
+
+    it("calls ensureControls exactly once per live card, with that card", () => {
+        buildCard("com.example.A");
+        buildCard("com.example.B");
+        buildCard("com.example.C"); // not live — must not be visited
+
+        const visited: string[] = [];
+        stampLiveBadgesOnGrid(
+            new Set(["com.example.A", "com.example.B"]),
+            (card) => {
+                visited.push(card.dataset.previewId ?? "");
+            },
+        );
+
+        assert.deepStrictEqual(visited.slice().sort(), [
+            "com.example.A",
+            "com.example.B",
+        ]);
+    });
+
+    it("uses sanitizeId for DOM lookup so previewIds with special chars resolve", () => {
+        // sanitizeId rewrites non-`[a-zA-Z0-9_-]` chars to `_`. The function
+        // must look the card up under that sanitized id, not the raw id.
+        const rawId = "com.example.A$Inner.preview";
+        const card = buildCard(rawId);
+        // Sanity: sanitizeId of the raw id matches the DOM id we stamped.
+        assert.strictEqual(card.id, "preview-com_example_A_Inner_preview");
+        stampLiveBadgesOnGrid(new Set([rawId]), ensureControlsStub);
+        assert.strictEqual(card.classList.contains("live"), true);
+        assert.strictEqual(
+            card.querySelectorAll(".card-live-stop-btn").length,
+            1,
+        );
+    });
+
+    it("strips a stale stop button from a no-longer-live card even if .live was already removed", () => {
+        // Defensive: covers a transient state where some other code path
+        // dropped the `.live` class but left the overlay button behind.
+        // The query selector is `.preview-card.live` — that path won't
+        // catch the orphaned button. This test pins current behaviour:
+        // the orphan survives one pass and is only cleared once the card
+        // is re-added then re-removed from the live set.
+        const a = buildCard("com.example.A");
+        stampLiveBadgesOnGrid(new Set(["com.example.A"]), ensureControlsStub);
+        assert.strictEqual(a.querySelectorAll(".card-live-stop-btn").length, 1);
+        // Force the transient state.
+        a.classList.remove("live");
+        // A subsequent empty-set pass won't see `.preview-card.live`, so
+        // the orphan button persists. This is the documented contract:
+        // callers must keep the `.live` class in sync via this helper,
+        // not bypass it.
+        stampLiveBadgesOnGrid(new Set(), ensureControlsStub);
+        assert.strictEqual(a.querySelectorAll(".card-live-stop-btn").length, 1);
+        // Re-stamp and re-clear: the orphan is now gone because the
+        // class came back through the controlled path first.
+        stampLiveBadgesOnGrid(new Set(["com.example.A"]), ensureControlsStub);
+        stampLiveBadgesOnGrid(new Set(), ensureControlsStub);
+        assert.strictEqual(a.querySelectorAll(".card-live-stop-btn").length, 0);
+    });
+});

--- a/vscode-extension/src/webview/preview/liveBadge.ts
+++ b/vscode-extension/src/webview/preview/liveBadge.ts
@@ -1,0 +1,47 @@
+// Live-badge DOM stamping helper used by `LiveStateController.applyLiveBadge`.
+// Lifted into its own file so the DOM operation is testable under happy-dom
+// without dragging `LiveStateController`'s wider transitive imports
+// (`interactiveInput.ts`'s pointer-handler module, the vscode handle, etc.)
+// into the host tsconfig.
+//
+// The mutation is intentionally torn-down-then-stamped: we strip every
+// `.preview-card.live` decoration on entry so removals (Shift+click off,
+// daemon-not-ready, setPreviews dropping a previewId) cleanly wipe the
+// prior decoration before we re-stamp from the live set. The per-card
+// stop-button injection is delegated to [ensureControls] so callers can
+// keep their controller-bound handlers (`stopInteractiveForCard`, the
+// pointer-input attachment) without leaking that surface here.
+
+import { sanitizeId } from "./cardData";
+
+/**
+ * Re-stamp every `.preview-card.live` decoration in the document from
+ * [liveIds]. Cards present in [liveIds] gain `.live` and have
+ * [ensureControls] invoked on them; every other previously-live card has
+ * `.live` removed and its `.card-live-stop-btn` overlay torn down.
+ *
+ * Idempotent: calling repeatedly converges on the same final DOM.
+ *
+ * Silently skips previewIds in [liveIds] that have no matching DOM card —
+ * `pruneLive` ahead of a fresh `setPreviews` is the supported way to keep
+ * the set in lockstep, but a transient mismatch (e.g. between a daemon
+ * teardown and the next manifest) shouldn't blow up the badge pass.
+ */
+export function stampLiveBadgesOnGrid(
+    liveIds: ReadonlySet<string>,
+    ensureControls: (card: HTMLElement) => void,
+): void {
+    document.querySelectorAll(".preview-card.live").forEach((c) => {
+        c.classList.remove("live");
+        c.querySelector(".card-live-stop-btn")?.remove();
+    });
+    if (liveIds.size === 0) return;
+    liveIds.forEach((previewId) => {
+        const card = document.getElementById(
+            "preview-" + sanitizeId(previewId),
+        );
+        if (!(card instanceof HTMLElement)) return;
+        card.classList.add("live");
+        ensureControls(card);
+    });
+}

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -35,9 +35,9 @@ import {
 } from "../../daemon/liveCommand";
 import { attachInteractiveInputHandlers } from "./interactiveInput";
 import type { InteractiveInputConfig } from "./interactiveInput";
+import { stampLiveBadgesOnGrid } from "./liveBadge";
 import { planLiveToggle, planRecordingToggle } from "./liveTransitions";
 import type { VsCodeApi } from "../shared/vscode";
-import { sanitizeId } from "./cardData";
 
 export interface LiveStateConfig {
     vscode: VsCodeApi<unknown>;
@@ -115,21 +115,16 @@ export class LiveStateController {
 
     /** Re-stamp every `.preview-card.live` decoration from the current set.
      *  Tear-down first so removals (Shift+click off, daemon-not-ready,
-     *  setPreviews dropping a previewId) cleanly wipe the prior decoration. */
+     *  setPreviews dropping a previewId) cleanly wipe the prior decoration.
+     *
+     *  The DOM mutation lives in `./liveBadge.ts` so it's testable under
+     *  happy-dom without dragging this controller's wider transitive
+     *  imports into the host tsconfig; we delegate, passing
+     *  `ensureLiveCardControls` as the per-card overlay hook. */
     applyLiveBadge(): void {
-        document.querySelectorAll(".preview-card.live").forEach((c) => {
-            c.classList.remove("live");
-            c.querySelector(".card-live-stop-btn")?.remove();
-        });
-        if (this.interactivePreviewIds.size === 0) return;
-        this.interactivePreviewIds.forEach((previewId) => {
-            const card = document.getElementById(
-                "preview-" + sanitizeId(previewId),
-            );
-            if (!card) return;
-            card.classList.add("live");
-            this.ensureLiveCardControls(card);
-        });
+        stampLiveBadgesOnGrid(this.interactivePreviewIds, (card) =>
+            this.ensureLiveCardControls(card),
+        );
     }
 
     /** Toolbar `<i class="codicon codicon-debug-stop">` button — stop every

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -16,6 +16,7 @@
     "exclude": ["node_modules", "src/webview/**"],
     "files": [
         "src/webview/preview/cardData.ts",
+        "src/webview/preview/liveBadge.ts",
         "src/webview/preview/liveTransitions.ts",
         "src/webview/preview/moduleReadiness.ts",
         "src/webview/preview/pointerGeometry.ts",


### PR DESCRIPTION
## Summary

Lift the DOM-mutating body of `LiveStateController.applyLiveBadge` into a narrow-deps helper `stampLiveBadgesOnGrid(liveIds, ensureControls)` in a new `webview/preview/liveBadge.ts`, and have the controller delegate to it. Mirrors the PR #852 pattern for `applyRelativeSizing`: keeps the wider controller imports (interactiveInput, vscode handle, transition planners) out of the host tsconfig so the badge-stamp DOM op is testable under happy-dom without dragging the whole controller surface in.

The split is mechanical — the public `applyLiveBadge()` keeps the same signature and behaviour; only the body changed:

```ts
applyLiveBadge(): void {
    stampLiveBadgesOnGrid(this.interactivePreviewIds, (card) =>
        this.ensureLiveCardControls(card),
    );
}
```

`sanitizeId` no longer needs to be imported from `liveState.ts` (it's used inside `liveBadge.ts`); the `cardData` import was dropped.

`liveBadge.ts` is added to `tsconfig.json`'s `files` list so the host-side test compile picks it up the same way `relativeSizing.ts` is wired.

Eight unit tests in `src/test/liveBadge.test.ts` covering the documented contract:
- adds `.live` + injects a `.card-live-stop-btn` overlay for every card in the live set
- removes `.live` + tears down the stop button for cards no longer in the set
- clears every decoration when called with an empty set (handles tear-down-only path)
- idempotent — calling twice produces byte-identical DOM (`document.body.innerHTML` snapshot match) and the stop button never duplicates
- skips silently when a previewId in the live set has no matching DOM card (the `card instanceof HTMLElement` guard)
- calls `ensureControls` exactly once per live card and never visits non-live cards
- routes the DOM lookup through `sanitizeId` so previewIds with `.` / `$` resolve
- documents the orphan-class transient-state contract — if a caller bypasses the helper and strips `.live` directly, the next zero-set pass won't sweep the orphan button (the query selector is `.preview-card.live`); the orphan only clears once the card cycles back through the controlled path

## Test plan

- [x] `cd vscode-extension && npm run compile` — clean
- [x] `cd vscode-extension && npm test` — 485 → 493 passing (+8)
- [x] `cd vscode-extension && npm run format:check` — clean

Part of #859.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_