### PR TITLE
refactor(vscode): extract <history-row> Lit element with reactive thumb

### DIFF
--- a/vscode-extension/src/webview/history/behavior.ts
+++ b/vscode-extension/src/webview/history/behavior.ts
@@ -1,11 +1,13 @@
 // Imperative behaviour for the read-only Preview History panel.
 //
-// Verbatim port of the previously-inline IIFE script in
-// `src/historyPanel.ts` (the `<script nonce="...">` block in `getHtml()`).
-// Now type-checked end-to-end against `HistoryToWebview` (from
-// `shared/types`). Pieces still imperative — `renderTimeline` (~85 lines
-// of `document.createElement`), the diff stack builder, the per-row event
-// handlers — are slated to fold into Lit components in a follow-up.
+// Originally a verbatim port of the inline IIFE script in
+// `src/historyPanel.ts`'s `getHtml()`. Type-checked end-to-end against
+// `HistoryToWebview` (from `shared/types`). Step 1 of #858 lifted the
+// per-row markup into the `<history-row>` Lit component
+// (`./components/HistoryRow.ts`) and routed thumb bytes through
+// `historyStore`; selection / expansion / diff overlays still flow
+// through closure-state callbacks in this file pending the later
+// steps of the issue.
 //
 // Runs once per webview load. Assumes `<history-app>` has already
 // rendered its skeleton into light DOM, so `document.getElementById(...)`
@@ -20,10 +22,10 @@ import {
     type HistoryDiffViewConfig,
     showDiff as showDiffDom,
 } from "./historyDiffView";
+import { setThumb } from "./historyStore";
 import {
     fillExpansion as fillExpansionDom,
     type HistoryRowConfig,
-    populateThumb,
     renderTimeline as renderTimelineDom,
 } from "./historyTimeline";
 
@@ -43,10 +45,11 @@ export function setupHistoryBehavior(): void {
     let entries: HistoryEntry[] = [];
     const selectedIds = new Set<string>();
     let expandedId: string | null = null;
-    // Thumbnail cache + dedup so each entry's PNG is fetched at most once
-    // per panel session even if scrolling brings the same row back into
-    // view repeatedly.
-    const thumbCache = new Map<string, string>();
+    // Thumbnail bytes live in `historyStore` so `<history-row>` can
+    // subscribe and re-render reactively. `thumbRequested` here just
+    // dedupes the per-session fetch — the IntersectionObserver fires
+    // once per row scroll-into-view and we skip ids we've already
+    // asked the extension to load.
     const thumbRequested = new Set<string>();
     const thumbObserver: IntersectionObserver | null =
         "IntersectionObserver" in window
@@ -127,11 +130,12 @@ export function setupHistoryBehavior(): void {
         }
     }
 
-    // Timeline row construction lives in `./historyTimeline.ts` — see
-    // `renderTimeline`, `toggleSelected`, `expandRow`, `requestRowDiff`,
-    // `fillExpansion`, `populateThumb`. The config exposes the static DOM
-    // handles plus thin getter/setter pairs over `expandedId` so the lifted
-    // module doesn't need closure access to this scope.
+    // Timeline row markup lives in the `<history-row>` Lit component
+    // (`./components/HistoryRow.ts`); orchestration around it —
+    // selection set, expansion DOM, diff requests — stays in
+    // `./historyTimeline.ts`. The config exposes the static DOM
+    // handles plus thin getter/setter pairs over `expandedId` so the
+    // lifted module doesn't need closure access to this scope.
     const rowConfig: HistoryRowConfig = {
         vscode,
         timelineEl,
@@ -141,7 +145,6 @@ export function setupHistoryBehavior(): void {
         setExpandedId: (next) => {
             expandedId = next;
         },
-        thumbCache,
         thumbRequested,
         thumbObserver,
     };
@@ -196,14 +199,12 @@ export function setupHistoryBehavior(): void {
                         (msg.message || "(no detail)");
                 break;
             }
-            case "thumbReady": {
-                thumbCache.set(msg.id, msg.imageData);
-                const thumbEl = timelineEl.querySelector<HTMLElement>(
-                    '.thumb[data-id="' + cssEscape(msg.id) + '"]',
-                );
-                if (thumbEl) populateThumb(thumbEl, msg.imageData);
+            case "thumbReady":
+                // Writing into `historyStore` re-renders the matching
+                // `<history-row>` via its StoreController subscription;
+                // no manual DOM patch needed.
+                setThumb(msg.id, msg.imageData);
                 break;
-            }
             case "thumbError":
                 // Drop the dedup so a future re-render can retry. Leave
                 // the gray box in place; surfacing per-entry errors at

--- a/vscode-extension/src/webview/history/components/HistoryRow.ts
+++ b/vscode-extension/src/webview/history/components/HistoryRow.ts
@@ -1,0 +1,210 @@
+// `<history-row>` — Lit component for a single timeline row.
+//
+// Step 1 of #858: shell + reactive thumb. The row renders the markup
+// the imperative `renderTimeline` used to build with
+// `document.createElement` (thumb, meta, badge, action buttons), takes
+// its `entry` as a `@property`, and subscribes to `historyStore` for
+// the thumbnail bytes via [StoreController]. When the extension's
+// `thumbReady` message lands and `behavior.ts` writes it into the
+// store, only the rows whose entry id matches re-render.
+//
+// Selection (`.selected` class) and inline expansion (`.expanded`
+// sibling div) STAY OWNED by the host — the row exposes
+// `setSelected(bool)` for the host to toggle, and the click handlers
+// route back through the existing config callbacks. Step 2 of #858
+// migrates that state into `@state` and a reactive `expanded` slot.
+//
+// Light DOM: `media/history.css` rules target `.row`, `.thumb`,
+// `.meta`, etc. — keep them applying without touching CSS.
+
+import { LitElement, html, type TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { StoreController } from "../../shared/storeController";
+import type { HistoryEntry } from "../../shared/types";
+import { escapeHtml, formatAbsolute, formatRelative } from "../historyData";
+import { historyStore, type HistoryState } from "../historyStore";
+
+/** Per-row callbacks the host wires up so the row stays presentational
+ *  while step-1 keeps selection/expansion logic in `behavior.ts`. */
+export interface HistoryRowCallbacks {
+    /** Shift-click: toggle membership in the (max-2) selection set. */
+    onToggleSelected(id: string, row: HistoryRow): void;
+    /** Plain click: open / collapse the inline image expansion. */
+    onExpand(id: string, row: HistoryRow): void;
+    /** Up-arrow icon: diff against the previous entry for this preview. */
+    onDiffPrevious(id: string, row: HistoryRow): void;
+    /** Compare icon: diff against the live render of this preview. */
+    onDiffCurrent(id: string, row: HistoryRow): void;
+    /** Lazy-load hook fired once after the row mounts. The host
+     *  registers the `.thumb` element with its IntersectionObserver so
+     *  the thumb byte fetch is deferred until scroll-into-view. No-op
+     *  on environments without IntersectionObserver. */
+    onThumbConnected(thumbEl: HTMLElement, id: string): void;
+}
+
+@customElement("history-row")
+export class HistoryRow extends LitElement {
+    /** The history entry this row renders. Required — render() returns
+     *  empty until set. */
+    @property({ attribute: false }) entry: HistoryEntry | null = null;
+
+    /** When true the row paints with the `.selected` class — used by the
+     *  shift-click selection logic. Mirror state, not source of truth
+     *  yet (step 2 of #858 moves the source-of-truth into the row). */
+    @property({ type: Boolean }) selected = false;
+
+    /** Hash of the latest archived render on `main` for the currently
+     *  scoped preview. Drives the "vs main" indicator dot. `null` when
+     *  no main-branch entry has a `pngHash`. */
+    @property({ attribute: false }) mainHash: string | null = null;
+
+    /** Callbacks supplied by the host's `renderTimeline` so the row's
+     *  click / button handlers stay routed through the existing
+     *  selection / expansion / diff plumbing. Set imperatively after
+     *  construction. */
+    callbacks: HistoryRowCallbacks | null = null;
+
+    private readonly thumbBytes = new StoreController<
+        HistoryState,
+        string | undefined
+    >(this, historyStore, (s) =>
+        this.entry?.id ? s.thumbCache.get(this.entry.id) : undefined,
+    );
+
+    // Light DOM so the panel-specific `.row` / `.thumb` / `.meta`
+    // styles in `media/history.css` apply unchanged.
+    protected createRenderRoot(): HTMLElement {
+        return this;
+    }
+
+    /** Imperative setter so the host doesn't have to re-render the
+     *  whole timeline to flip selection state. Mirrors the legacy
+     *  `row.classList.add/remove("selected")` calls. */
+    setSelected(next: boolean): void {
+        if (this.selected === next) return;
+        this.selected = next;
+    }
+
+    protected updated(): void {
+        // Mirror dataset attributes the host's `applyFilters` /
+        // expansion-anchor / cssEscape selectors rely on. Lit doesn't
+        // bind `data-*` from `@property` automatically, and using
+        // `?attribute` on a non-string field is the wrong tool — we
+        // just stamp them after each render.
+        const entry = this.entry;
+        const id = entry?.id ?? "";
+        this.classList.add("row");
+        this.classList.toggle("selected", this.selected);
+        this.setAttribute("role", "listitem");
+        this.dataset.id = id;
+        this.dataset.sourceKind = (entry?.source && entry.source.kind) || "";
+        this.dataset.branch = (entry?.git && entry.git.branch) || "";
+    }
+
+    protected firstUpdated(): void {
+        // Hook the host's IntersectionObserver up to our `.thumb` once
+        // it's in the DOM. The store subscription handles cache hits;
+        // this path covers the cold lazy-load.
+        const id = this.entry?.id;
+        if (!id) return;
+        const thumbEl = this.querySelector<HTMLElement>(".thumb");
+        if (thumbEl) this.callbacks?.onThumbConnected(thumbEl, id);
+    }
+
+    protected render(): TemplateResult {
+        const entry = this.entry;
+        if (!entry) return html``;
+        const entryId = entry.id ?? "";
+        const cached = this.thumbBytes.value;
+        const dotChanged =
+            entry.deltaFromPrevious && entry.deltaFromPrevious.pngHashChanged
+                ? '<span class="changed-dot" title="bytes changed vs previous"></span>'
+                : "";
+        const dotMain =
+            this.mainHash && entry.pngHash && entry.pngHash !== this.mainHash
+                ? '<span class="main-dot" title="bytes differ from latest main render"></span>'
+                : "";
+        const absolute = formatAbsolute(entry.timestamp);
+        const trigger = entry.trigger ? entry.trigger : "—";
+        const branch = (entry.git && entry.git.branch) || "";
+        const subParts: string[] = [];
+        if (absolute) subParts.push(escapeHtml(absolute));
+        subParts.push(escapeHtml(trigger));
+        if (branch) subParts.push(escapeHtml(branch));
+        const subHtml = dotChanged + dotMain + subParts.join(" · ");
+        const sourceKind = (entry.source && entry.source.kind) || "fs";
+
+        return html`
+            <div class="thumb" data-id=${entryId}>
+                ${cached !== undefined
+                    ? html`<img
+                          src=${"data:image/png;base64," + cached}
+                          alt=""
+                      />`
+                    : ""}
+            </div>
+            <div class="meta">
+                <div class="ts" title=${entry.timestamp || ""}>
+                    ${formatRelative(entry.timestamp)}
+                </div>
+                <div class="sub">${unsafeHTML(subHtml)}</div>
+            </div>
+            <span class="badge">${sourceKind}</span>
+            <div class="row-actions">
+                <button
+                    class="icon-button row-action"
+                    title="Diff against the previous entry for this preview"
+                    aria-label="Diff vs previous"
+                    @click=${this.onDiffPrevClick}
+                >
+                    <i class="codicon codicon-arrow-up" aria-hidden="true"></i>
+                </button>
+                <button
+                    class="icon-button row-action"
+                    title="Diff against the live render of this preview"
+                    aria-label="Diff vs current"
+                    @click=${this.onDiffCurrentClick}
+                >
+                    <i
+                        class="codicon codicon-git-compare"
+                        aria-hidden="true"
+                    ></i>
+                </button>
+            </div>
+        `;
+    }
+
+    connectedCallback(): void {
+        super.connectedCallback();
+        this.addEventListener("click", this.onRowClick);
+    }
+
+    disconnectedCallback(): void {
+        this.removeEventListener("click", this.onRowClick);
+        super.disconnectedCallback();
+    }
+
+    private readonly onRowClick = (ev: MouseEvent): void => {
+        // The action buttons stop propagation themselves — anything
+        // reaching here is a click on the row body.
+        const id = this.entry?.id ?? "";
+        if (!id || !this.callbacks) return;
+        if (ev.shiftKey) this.callbacks.onToggleSelected(id, this);
+        else this.callbacks.onExpand(id, this);
+    };
+
+    private readonly onDiffPrevClick = (ev: MouseEvent): void => {
+        ev.stopPropagation();
+        const id = this.entry?.id ?? "";
+        if (!id || !this.callbacks) return;
+        this.callbacks.onDiffPrevious(id, this);
+    };
+
+    private readonly onDiffCurrentClick = (ev: MouseEvent): void => {
+        ev.stopPropagation();
+        const id = this.entry?.id ?? "";
+        if (!id || !this.callbacks) return;
+        this.callbacks.onDiffCurrent(id, this);
+    };
+}

--- a/vscode-extension/src/webview/history/historyStore.ts
+++ b/vscode-extension/src/webview/history/historyStore.ts
@@ -1,0 +1,42 @@
+// Singleton state for the read-only "Preview History" panel.
+//
+// Migration scope (step 1 of #858): only the thumbnail byte cache.
+// `<history-row>` subscribes to this store to pick up its thumb PNG
+// once the extension streams it back via `thumbReady`. The rest of the
+// panel state — selection, expansion, entries list, filters — still
+// lives in `behavior.ts` closure scope until later steps of the issue
+// migrate them.
+//
+// `thumbCache` is a `ReadonlyMap<string, string>`. The reference is
+// REPLACED (never mutated in place) on every insert so the store's
+// reference-equality change detection actually fires; per-row
+// selectors then key off `state.thumbCache.get(entryId)` and re-render
+// only when the matching entry's bytes change.
+
+import { Store } from "../shared/store";
+
+export interface HistoryState {
+    /**
+     * Thumbnail bytes by `HistoryEntry.id`. Populated by `thumbReady`
+     * messages from the extension. Treated as immutable — writers MUST
+     * allocate a new Map (`new Map(prev).set(id, bytes)`) so reference
+     * comparison detects the change.
+     */
+    thumbCache: ReadonlyMap<string, string>;
+}
+
+const initialState: HistoryState = {
+    thumbCache: new Map(),
+};
+
+export const historyStore = new Store<HistoryState>(initialState);
+
+/** Insert a thumb byte string for [id] without mutating the existing
+ *  Map reference. No-op when the bytes are already present unchanged. */
+export function setThumb(id: string, imageData: string): void {
+    const prev = historyStore.getState().thumbCache;
+    if (prev.get(id) === imageData) return;
+    const next = new Map(prev);
+    next.set(id, imageData);
+    historyStore.setState({ thumbCache: next });
+}

--- a/vscode-extension/src/webview/history/historyTimeline.ts
+++ b/vscode-extension/src/webview/history/historyTimeline.ts
@@ -1,29 +1,28 @@
 // Timeline + row construction for the History panel.
 //
-// Lifted verbatim from `behavior.ts`'s `renderTimeline` / `toggleSelected` /
-// `expandRow` / `requestRowDiff` / `fillExpansion` / `populateThumb` cluster
-// so the imperative DOM operations stop needing closure access to the
-// rest of the panel. The diff sub-views (`fillDiff`, `computeDiffStats`,
-// `applyDiffStats`, `renderHistoryDiffMode`, `buildHistoryDiffStack`,
-// `buildDiffPane`, `showDiff`) are a follow-up — they're a separate
-// concern with its own state and call into a different DOM tree.
+// Step 1 of #858: row markup now lives in the `<history-row>` Lit
+// component (`./components/HistoryRow.ts`). This module shrank to:
 //
-// Each function takes a `HistoryRowConfig` covering the collaborator
-// surface — `vscode` (postMessage), the static `timelineEl` /
-// `btnDiffEl` DOM handles, the `selectedIds` Set + `expandedId` mutable
-// scalar, and the thumb-loading infrastructure (cache + dedup +
-// IntersectionObserver). The state stays owned by `behavior.ts` until
-// the eventual `<history-row>` Lit component lands and can claim it.
+//  - `renderTimeline`: declarative iteration over `entries`, swapping
+//    out `<history-row>` children on the timeline container.
+//  - `toggleSelected`: still owns the (max-2) selection set since
+//    that state lives in the host's `behavior.ts` closure for now.
+//    Step 2 of #858 moves selection state into the row's `@state`.
+//  - `expandRow` / `requestRowDiff` / `fillExpansion`: still
+//    imperative because the inline `.expanded` sibling div is a
+//    separate concern from row rendering and gets its own component
+//    later in the issue.
+//
+// Thumb byte cache: deleted from the config in favour of
+// `historyStore` (`./historyStore.ts`). Rows subscribe directly via
+// [StoreController] and re-render when their entry's bytes land.
+
+import "./components/HistoryRow";
 
 import type { HistoryEntry } from "../shared/types";
 import type { VsCodeApi } from "../shared/vscode";
-import {
-    cssEscape,
-    escapeHtml,
-    findLatestMainHash,
-    formatAbsolute,
-    formatRelative,
-} from "./historyData";
+import { HistoryRow, type HistoryRowCallbacks } from "./components/HistoryRow";
+import { cssEscape, findLatestMainHash } from "./historyData";
 
 export interface HistoryRowConfig {
     vscode: VsCodeApi<unknown>;
@@ -38,10 +37,6 @@ export interface HistoryRowConfig {
      *  Mutated by `expandRow` (toggle) and `requestRowDiff` (replace). */
     getExpandedId(): string | null;
     setExpandedId(id: string | null): void;
-    /** Thumb image cache (id → base64 PNG). Populated by the
-     *  `thumbReady` message handler; read here on render to skip a fresh
-     *  request for already-loaded thumbs. */
-    thumbCache: Map<string, string>;
     /** Dedup set: ids we've already asked the extension to load.
      *  Cleared per `renderTimeline` so a fresh entry set retries. */
     thumbRequested: Set<string>;
@@ -59,120 +54,57 @@ export function renderTimeline(
     if (config.thumbObserver) config.thumbObserver.disconnect();
     config.thumbRequested.clear();
     config.timelineEl.innerHTML = "";
+
     // Latest archived render on main for the currently scoped preview.
     // O(N) over the visible page; no extra request. Used for the
-    // "vs main" indicator dot below.
+    // "vs main" indicator dot in each row.
     const mainHash = findLatestMainHash(entries);
+
+    const callbacks: HistoryRowCallbacks = {
+        onToggleSelected: (id, row) => toggleSelected(id, row, config),
+        onExpand: (id, row) => expandRow(id, row, config),
+        onDiffPrevious: (id, row) =>
+            requestRowDiff(id, row, "previous", config),
+        onDiffCurrent: (id, row) => requestRowDiff(id, row, "current", config),
+        onThumbConnected: (thumbEl) => {
+            // Defer the byte fetch to the host's IntersectionObserver
+            // so off-screen rows don't hammer the daemon. The store
+            // covers cache hits already.
+            if (config.thumbObserver) config.thumbObserver.observe(thumbEl);
+        },
+    };
+
     for (const entry of entries) {
-        const entryId = entry.id ?? "";
-        const row = document.createElement("div");
-        row.className = "row";
-        row.setAttribute("role", "listitem");
-        row.dataset.id = entryId;
-        row.dataset.sourceKind = (entry.source && entry.source.kind) || "";
-        row.dataset.branch = (entry.git && entry.git.branch) || "";
-
-        const thumb = document.createElement("div");
-        thumb.className = "thumb";
-        thumb.dataset.id = entryId;
-        const cached = config.thumbCache.get(entryId);
-        if (cached !== undefined) {
-            populateThumb(thumb, cached);
-        } else if (config.thumbObserver) {
-            config.thumbObserver.observe(thumb);
-        }
-        row.appendChild(thumb);
-
-        const meta = document.createElement("div");
-        meta.className = "meta";
-        const ts = document.createElement("div");
-        ts.className = "ts";
-        ts.textContent = formatRelative(entry.timestamp);
-        ts.title = entry.timestamp || "";
-        meta.appendChild(ts);
-
-        const sub = document.createElement("div");
-        sub.className = "sub";
-        const dot =
-            entry.deltaFromPrevious && entry.deltaFromPrevious.pngHashChanged
-                ? '<span class="changed-dot" title="bytes changed vs previous"></span>'
-                : "";
-        const mainDot =
-            mainHash && entry.pngHash && entry.pngHash !== mainHash
-                ? '<span class="main-dot" title="bytes differ from latest main render"></span>'
-                : "";
-        const absolute = formatAbsolute(entry.timestamp);
-        const trigger = entry.trigger ? entry.trigger : "—";
-        const branch = (entry.git && entry.git.branch) || "";
-        const subParts: string[] = [];
-        if (absolute) subParts.push(escapeHtml(absolute));
-        subParts.push(escapeHtml(trigger));
-        if (branch) subParts.push(escapeHtml(branch));
-        sub.innerHTML = dot + mainDot + subParts.join(" · ");
-        meta.appendChild(sub);
-        row.appendChild(meta);
-
-        const badge = document.createElement("span");
-        badge.className = "badge";
-        badge.textContent = (entry.source && entry.source.kind) || "fs";
-        row.appendChild(badge);
-
-        const actions = document.createElement("div");
-        actions.className = "row-actions";
-        const diffPrevBtn = document.createElement("button");
-        diffPrevBtn.className = "icon-button row-action";
-        diffPrevBtn.title = "Diff against the previous entry for this preview";
-        diffPrevBtn.setAttribute("aria-label", "Diff vs previous");
-        diffPrevBtn.innerHTML =
-            '<i class="codicon codicon-arrow-up" aria-hidden="true"></i>';
-        diffPrevBtn.addEventListener("click", (ev) => {
-            ev.stopPropagation();
-            requestRowDiff(entryId, row, "previous", config);
-        });
-        actions.appendChild(diffPrevBtn);
-        const diffCurrentBtn = document.createElement("button");
-        diffCurrentBtn.className = "icon-button row-action";
-        diffCurrentBtn.title = "Diff against the live render of this preview";
-        diffCurrentBtn.setAttribute("aria-label", "Diff vs current");
-        diffCurrentBtn.innerHTML =
-            '<i class="codicon codicon-git-compare" aria-hidden="true"></i>';
-        diffCurrentBtn.addEventListener("click", (ev) => {
-            ev.stopPropagation();
-            requestRowDiff(entryId, row, "current", config);
-        });
-        actions.appendChild(diffCurrentBtn);
-        row.appendChild(actions);
-
-        row.addEventListener("click", (ev) => {
-            if (ev.shiftKey) toggleSelected(entryId, row, config);
-            else expandRow(entryId, row, config);
-        });
+        const row = document.createElement("history-row") as HistoryRow;
+        row.entry = entry;
+        row.mainHash = mainHash;
+        row.callbacks = callbacks;
         config.timelineEl.appendChild(row);
     }
 }
 
 /** Toggle [id] in/out of the (max-2) selection set, mirroring the row's
- *  `.selected` class. Drops the oldest selection when adding a third. */
+ *  `.selected` state. Drops the oldest selection when adding a third. */
 export function toggleSelected(
     id: string,
-    row: HTMLElement,
+    row: HistoryRow,
     config: HistoryRowConfig,
 ): void {
     if (config.selectedIds.has(id)) {
         config.selectedIds.delete(id);
-        row.classList.remove("selected");
+        row.setSelected(false);
     } else {
         if (config.selectedIds.size >= 2) {
             // Drop oldest selection so we never have more than 2.
             const drop = [...config.selectedIds][0];
             config.selectedIds.delete(drop);
-            const prev = config.timelineEl.querySelector(
-                '.row[data-id="' + cssEscape(drop) + '"]',
+            const prev = config.timelineEl.querySelector<HistoryRow>(
+                'history-row[data-id="' + cssEscape(drop) + '"]',
             );
-            if (prev) prev.classList.remove("selected");
+            prev?.setSelected(false);
         }
         config.selectedIds.add(id);
-        row.classList.add("selected");
+        row.setSelected(true);
     }
     config.btnDiffEl.disabled = config.selectedIds.size !== 2;
 }
@@ -182,7 +114,7 @@ export function toggleSelected(
  *  extension streams the PNG bytes back asynchronously. */
 export function expandRow(
     id: string,
-    row: HTMLElement,
+    row: HistoryRow,
     config: HistoryRowConfig,
 ): void {
     const prev = config.timelineEl.querySelector(".expanded");
@@ -206,7 +138,7 @@ export function expandRow(
  *  to compute the comparison. */
 export function requestRowDiff(
     id: string,
-    row: HTMLElement,
+    row: HistoryRow,
     against: "previous" | "current",
     config: HistoryRowConfig,
 ): void {
@@ -255,14 +187,4 @@ export function fillExpansion(
         actions.appendChild(open);
     }
     expansion.appendChild(actions);
-}
-
-/** Stamp a thumbnail image into a `.thumb` div. Idempotent — drops any
- *  prior content first. */
-export function populateThumb(thumbEl: HTMLElement, imageData: string): void {
-    thumbEl.innerHTML = "";
-    const img = document.createElement("img");
-    img.src = "data:image/png;base64," + imageData;
-    img.alt = "";
-    thumbEl.appendChild(img);
 }


### PR DESCRIPTION
## Summary

Lift the per-row markup out of the imperative `renderTimeline` loop into a `<history-row>` Lit element (`vscode-extension/src/webview/history/components/HistoryRow.ts`). The element:

- Renders in light DOM so `media/history.css` keeps applying unchanged.
- Takes its `HistoryEntry` as a `@property` plus a `mainHash` property for the "vs main" indicator dot.
- Subscribes to a new `historyStore` (mirroring `previewStore`) via `StoreController` for the thumbnail bytes — when `thumbReady` arrives in `behavior.ts` and writes into the store, only the matching row re-renders.

`renderTimeline` becomes declarative iteration over `entries` producing `<history-row>` children. Selection / expansion / per-row diff handlers stay routed through the existing `HistoryRowConfig` callbacks for now — step 2 of #858 migrates that state into the row's `@state`.

`historyTimeline.ts` shrinks from 268 to 190 lines (-78 lines, ~30%).

## Concrete diff

- `webview/history/historyStore.ts` (new, 42 lines): typed `Store<HistoryState>` exposing `thumbCache: ReadonlyMap<string, string>` plus a `setThumb(id, bytes)` helper that allocates a fresh Map so reference-equality change detection actually fires.
- `webview/history/components/HistoryRow.ts` (new, 210 lines): `<history-row>` Lit element with `entry`, `selected`, `mainHash` properties, `setSelected()` imperative setter, and an `HistoryRowCallbacks` surface for the host's selection / expansion / diff / lazy-load hooks.
- `webview/history/historyTimeline.ts`: drops the `document.createElement` walk and the `populateThumb` helper; `renderTimeline` now wires up the callbacks and appends `<history-row>` elements.
- `webview/history/behavior.ts`: drops the closure-local `thumbCache` Map and the imperative thumb DOM patch — `thumbReady` calls `setThumb` and the row's StoreController takes care of re-rendering.

Part of #858 — only step 1 of the suggested PR breakdown (shell + reactive thumb). Steps 2 (selection / expansion via `@state`) and 3 are deferred.

## Test plan

- [x] `cd vscode-extension && npm run compile` (host + webview)
- [x] `cd vscode-extension && npm test` (485 passing)
- [x] `cd vscode-extension && npm run format:check`
- [ ] Manual: open the History panel, scroll to load thumbnails, click a row to expand, shift-click two rows + Diff, click per-row up-arrow / compare buttons.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_