### PR TITLE
refactor(vscode): introduce &lt;preview-card&gt; Lit shell

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -25,6 +25,7 @@ import {
 } from "./cardBuilder";
 import { FilterToolbar } from "./components/FilterToolbar";
 import { MessageBanner, type MessageOwner } from "./components/MessageBanner";
+import "./components/PreviewCard";
 import { PreviewGrid } from "./components/PreviewGrid";
 import { FilterController } from "./filterController";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -39,6 +39,7 @@ import {
 import type { LiveStateController } from "./liveState";
 import type { StaleBadgeController } from "./staleBadge";
 import type { PreviewGrid } from "./components/PreviewGrid";
+import type { PreviewCard } from "./components/PreviewCard";
 import type { MessageOwner } from "./components/MessageBanner";
 import {
     bumpPreviewMapsRevision,
@@ -115,12 +116,19 @@ export interface CardBuilderConfig {
 }
 
 /**
- * Build the initial DOM for a preview card. Returns a detached
- * `HTMLDivElement` — caller is responsible for inserting it into the grid in
+ * Build the initial DOM for a preview card. Returns a `<preview-card>`
+ * Lit element — caller is responsible for inserting it into the grid in
  * the right position (`renderPreviews` orchestrates a stable insertion order
  * keyed on `previewId`).
  *
- * Side effects:
+ * Step 2 of #857: this is now a thin shim that constructs the
+ * `<preview-card>` shell and hands it the `preview` + `config` props.
+ * The imperative population (id / dataset / className / header /
+ * imgContainer / a11y / variant / carousel / observe-for-viewport)
+ * lives in `populatePreviewCard` and runs from the element's
+ * `firstUpdated()`.
+ *
+ * Side effects (deferred until the element's `firstUpdated`):
  *  - Seeds `previewStore`'s `cardCaptures` with one `CapturePresentation`
  *    per `p.captures` entry (via `setCardCaptures`).
  *  - Calls `config.staleBadge.apply(card, false)` once so the badge slot
@@ -132,10 +140,31 @@ export function buildPreviewCard(
     p: PreviewInfo,
     config: CardBuilderConfig,
 ): HTMLElement {
+    const card = document.createElement("preview-card") as PreviewCard;
+    card.preview = p;
+    card.config = config;
+    return card;
+}
+
+/**
+ * Imperative population helper — runs from the `<preview-card>` shell's
+ * `firstUpdated()` against the host element itself. Extracted from the
+ * old `buildPreviewCard` body; logic is otherwise unchanged.
+ *
+ * `card` here is the `<preview-card>` host (not a child div). The id,
+ * `preview-card` class, dataset attributes, and all child DOM land on
+ * `card` directly so existing `document.getElementById("preview-…")`
+ * lookups, `.preview-card` selectors, and CSS rules keep targeting the
+ * same element.
+ */
+export function populatePreviewCard(
+    card: HTMLElement,
+    p: PreviewInfo,
+    config: CardBuilderConfig,
+): void {
     const animated = isAnimatedPreview(p);
     const captures = p.captures;
 
-    const card = document.createElement("div");
     // `referenced` previews live in another file but target the active one
     // (idiomatic `XxxPreviews.kt` / `screenshotTest` layout). The CSS hook lets
     // the panel render them under a "from elsewhere" treatment without changing
@@ -293,7 +322,6 @@ export function buildPreviewCard(
     }
 
     config.observeForViewport(card);
-    return card;
 }
 
 /** Subset of `CardBuilderConfig` that `updateCardMetadata` actually

--- a/vscode-extension/src/webview/preview/components/PreviewCard.ts
+++ b/vscode-extension/src/webview/preview/components/PreviewCard.ts
@@ -1,0 +1,64 @@
+// `<preview-card>` — Lit shell that owns the preview-card DOM the
+// imperative `buildPreviewCard` previously built directly on a
+// `<div class="preview-card">`.
+//
+// Step 2 of #857. The shell is intentionally minimal: it carries the
+// `preview` (PreviewInfo) and `config` (CardBuilderConfig) the host
+// hands in, and on `firstUpdated()` runs the imperative population
+// logic against `this`. Step 3 (#857) lifts the metadata refresh into
+// reactive `@state`; step 4 lifts the image / a11y overlay paths.
+//
+// We pass `preview` as a `@property` rather than just a `previewId`
+// because `populatePreviewCard` needs the full `PreviewInfo` (function
+// name, params, captures, a11yFindings, …). Resolving from
+// `previewStore.allPreviews` would work but adds an indirection that
+// step 3 will need to undo when it switches to a reactive selection
+// against the store.
+//
+// Light DOM only — `media/preview.css` selectors target
+// `.preview-card .card-header .card-title-row` etc. and would not
+// pierce a shadow root. The id (`preview-${sanitizeId(p.id)}`),
+// `preview-card` className, and dataset attributes (`previewId`,
+// `className`, `wearPreview`, `currentIndex`, `function`, `group`,
+// `referenced`) all land on the host element so the existing
+// `document.getElementById` paths in `messageHandlers.ts` /
+// `liveState.ts` and the `.preview-card` selector in `renderPreviews`
+// keep working unchanged.
+
+import { LitElement, html, type TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import type { CardBuilderConfig } from "../cardBuilder";
+import { populatePreviewCard } from "../cardBuilder";
+import type { PreviewInfo } from "../../shared/types";
+
+@customElement("preview-card")
+export class PreviewCard extends LitElement {
+    /** The preview manifest entry this card renders. Required —
+     *  `firstUpdated` no-ops until both `preview` and `config` are set. */
+    @property({ attribute: false }) preview: PreviewInfo | null = null;
+
+    /** Collaborator surface the host hands in. Carries `vscode`,
+     *  `staleBadge`, `frameCarousel`, `liveState`, focus / viewport /
+     *  message hooks — everything `populatePreviewCard` reaches for. */
+    @property({ attribute: false }) config: CardBuilderConfig | null = null;
+
+    // Light DOM keeps `media/preview.css` rules applying unchanged.
+    protected createRenderRoot(): HTMLElement {
+        return this;
+    }
+
+    // Lit calls `render()` even though we populate imperatively; return
+    // an empty template so it doesn't wipe children we add in
+    // `firstUpdated`. Step 3 / step 4 will start producing real
+    // template content here as the metadata / image paths go reactive.
+    protected render(): TemplateResult {
+        return html``;
+    }
+
+    protected firstUpdated(): void {
+        const preview = this.preview;
+        const config = this.config;
+        if (!preview || !config) return;
+        populatePreviewCard(this, preview, config);
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces `<preview-card>` Lit element with light DOM that owns the card DOM `buildPreviewCard` previously built imperatively.
- `buildPreviewCard` is now a thin shim that constructs `<preview-card>` and hands it `preview` + `config` props; the body lives in a helper `firstUpdated()` invokes.
- Keeps id / dataset / class names on the host element so existing `getElementById` paths and CSS selectors are unchanged.
- Step 2 of #857; step 3 (reactive metadata) and step 4 (reactive image/a11y) are separate PRs.

## Test plan
- [x] `npm run compile`
- [x] `npm test` (485+ passing)
- [x] `npm run format:check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_