### PR TITLE
refactor(vscode): make <preview-card> reactive to manifest reseed

### DIFF
--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -759,7 +759,13 @@ export function renderPreviews(
     for (const p of previews) {
         const existing = existingCards.get(p.id);
         if (existing) {
-            updateCardMetadata(existing, p, config);
+            // Reassigning `.preview` triggers `<preview-card>`'s reactive
+            // `updated()` hook, which calls `updateCardMetadata` against
+            // the host element. Cast is safe — `existingCards` is
+            // populated from the `.preview-card`-classed elements
+            // `buildPreviewCard` creates, all of which are
+            // `<preview-card>` instances.
+            (existing as PreviewCard).preview = p;
             // Ensure correct position
             if (lastInsertedCard) {
                 if (lastInsertedCard.nextSibling !== existing) {

--- a/vscode-extension/src/webview/preview/components/PreviewCard.ts
+++ b/vscode-extension/src/webview/preview/components/PreviewCard.ts
@@ -28,7 +28,7 @@
 import { LitElement, html, type TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import type { CardBuilderConfig } from "../cardBuilder";
-import { populatePreviewCard } from "../cardBuilder";
+import { populatePreviewCard, updateCardMetadata } from "../cardBuilder";
 import type { PreviewInfo } from "../../shared/types";
 
 @customElement("preview-card")
@@ -42,6 +42,11 @@ export class PreviewCard extends LitElement {
      *  message hooks — everything `populatePreviewCard` reaches for. */
     @property({ attribute: false }) config: CardBuilderConfig | null = null;
 
+    /** Set once `firstUpdated` has populated the card. Guards `updated`
+     *  from running the metadata patch on the initial render — that path
+     *  is already covered by `populatePreviewCard`. */
+    private _built = false;
+
     // Light DOM keeps `media/preview.css` rules applying unchanged.
     protected createRenderRoot(): HTMLElement {
         return this;
@@ -49,8 +54,8 @@ export class PreviewCard extends LitElement {
 
     // Lit calls `render()` even though we populate imperatively; return
     // an empty template so it doesn't wipe children we add in
-    // `firstUpdated`. Step 3 / step 4 will start producing real
-    // template content here as the metadata / image paths go reactive.
+    // `firstUpdated`. Step 4 will start producing real template content
+    // here as the image / a11y paths go reactive.
     protected render(): TemplateResult {
         return html``;
     }
@@ -60,5 +65,20 @@ export class PreviewCard extends LitElement {
         const config = this.config;
         if (!preview || !config) return;
         populatePreviewCard(this, preview, config);
+        this._built = true;
+    }
+
+    /** React to a `preview` reassignment from the host (`renderPreviews`
+     *  reseed). Patches the card's dataset, title, capture cache,
+     *  variant badge, and a11y legend / overlay in place — same body
+     *  the imperative call site used to drive directly. Skipped on the
+     *  first render: `firstUpdated` already built the card. */
+    protected updated(changedProperties: Map<string, unknown>): void {
+        if (!this._built) return;
+        if (!changedProperties.has("preview")) return;
+        const preview = this.preview;
+        const config = this.config;
+        if (!preview || !config) return;
+        updateCardMetadata(this, preview, config);
     }
 }


### PR DESCRIPTION
## Summary
- `<preview-card>` now patches its DOM in `updated()` when the `preview` @property is reassigned, replacing the imperative `updateCardMetadata` call site in `renderPreviews`.
- `renderPreviews`'s existing-card branch becomes a single `existing.preview = p` assignment; Lit's reactive update drives the patch.
- `updateCardMetadata` stays in `cardBuilder.ts` and is invoked from inside the component — no behavior change.
- Step 3 of #857; step 4 (reactive image / a11y via StoreController) is the next PR.

## Test plan
- [x] `npm run compile`
- [x] `npm test` (496 passing)
- [x] `npm run format:check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_