### PR TITLE
refactor(vscode): subscribe <preview-card> to per-preview store via StoreController

### DIFF
--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -619,7 +619,10 @@ export function applyA11yUpdate(
     const img = container?.querySelector<HTMLImageElement>("img") ?? null;
     if (findings !== undefined) {
         if (findings && findings.length > 0) {
-            setCardA11yFindings(previewId, findings);
+            // Ensure the empty `.a11y-overlay` container exists before
+            // bumping the store — `<preview-card>`'s mapsRevision
+            // subscription will paint into it once the per-id Map
+            // write below fires the rebroadcast.
             if (container && !container.querySelector(".a11y-overlay")) {
                 const overlay = document.createElement("div");
                 overlay.className = "a11y-overlay";
@@ -633,9 +636,12 @@ export function applyA11yUpdate(
                 p.a11yFindings = [...findings];
                 card.appendChild(buildA11yLegend(card, p));
             }
-            if (img && img.complete && img.naturalWidth > 0) {
-                buildA11yOverlay(card, findings, img);
-            }
+            // Store write last — the `mapsRevision` bump triggers the
+            // component's `_repaintA11yOverlaysFromCache()` which runs
+            // `buildA11yOverlay` against the fresh findings. The
+            // component gates on `img.complete && img.naturalWidth > 0`
+            // exactly as the previous imperative branch did.
+            setCardA11yFindings(previewId, findings);
         } else {
             deleteCardA11yFindings(previewId);
             const overlay = card.querySelector(".a11y-overlay");
@@ -646,11 +652,11 @@ export function applyA11yUpdate(
     }
     if (nodes !== undefined) {
         if (nodes && nodes.length > 0) {
-            setCardA11yNodes(previewId, nodes);
             ensureHierarchyOverlay(container);
-            if (img && img.complete && img.naturalWidth > 0) {
-                applyHierarchyOverlay(card, nodes, img);
-            }
+            // Same pattern as findings above: store write fires the
+            // mapsRevision bump, the component re-paints the layer
+            // via `applyHierarchyOverlay`.
+            setCardA11yNodes(previewId, nodes);
         } else {
             deleteCardA11yNodes(previewId);
             const layer = card.querySelector(".a11y-hierarchy-overlay");

--- a/vscode-extension/src/webview/preview/components/PreviewCard.ts
+++ b/vscode-extension/src/webview/preview/components/PreviewCard.ts
@@ -6,7 +6,16 @@
 // `preview` (PreviewInfo) and `config` (CardBuilderConfig) the host
 // hands in, and on `firstUpdated()` runs the imperative population
 // logic against `this`. Step 3 (#857) lifts the metadata refresh into
-// reactive `@state`; step 4 lifts the image / a11y overlay paths.
+// reactive `@state`; step 4 (this file) wires a `StoreController`
+// against `previewStore.mapsRevision` so the per-preview a11y caches
+// drive overlay repaints from the component itself instead of from
+// `applyA11yUpdate`.
+//
+// Step 4 still leaves the `<img>` paint and the on-image-load a11y
+// branch in `updateImage` — only the cache-change overlay refresh
+// path moves into the component. That gives us the StoreController
+// integration without disturbing the more delicate image-load
+// timing or the legend rebuild.
 //
 // We pass `preview` as a `@property` rather than just a `previewId`
 // because `populatePreviewCard` needs the full `PreviewInfo` (function
@@ -27,8 +36,11 @@
 
 import { LitElement, html, type TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { applyHierarchyOverlay, buildA11yOverlay } from "../a11yOverlay";
 import type { CardBuilderConfig } from "../cardBuilder";
 import { populatePreviewCard, updateCardMetadata } from "../cardBuilder";
+import { previewStore, type PreviewState } from "../previewStore";
+import { StoreController } from "../../shared/storeController";
 import type { PreviewInfo } from "../../shared/types";
 
 @customElement("preview-card")
@@ -46,6 +58,19 @@ export class PreviewCard extends LitElement {
      *  from running the metadata patch on the initial render — that path
      *  is already covered by `populatePreviewCard`. */
     private _built = false;
+
+    /** Subscription to `previewStore.mapsRevision`. Each per-preview
+     *  Map mutation (`setCardCaptures` / `setCardA11yFindings` /
+     *  `setCardA11yNodes`) bumps the counter, which fires
+     *  `requestUpdate()` on this component. The `updated()` hook then
+     *  re-paints the a11y overlays for this card from the latest
+     *  cache snapshot — `applyA11yUpdate` no longer needs to drive the
+     *  overlay repaint itself. */
+    private readonly _mapsRevision = new StoreController<PreviewState, number>(
+        this,
+        previewStore,
+        (s) => s.mapsRevision,
+    );
 
     // Light DOM keeps `media/preview.css` rules applying unchanged.
     protected createRenderRoot(): HTMLElement {
@@ -69,16 +94,60 @@ export class PreviewCard extends LitElement {
     }
 
     /** React to a `preview` reassignment from the host (`renderPreviews`
-     *  reseed). Patches the card's dataset, title, capture cache,
-     *  variant badge, and a11y legend / overlay in place — same body
-     *  the imperative call site used to drive directly. Skipped on the
-     *  first render: `firstUpdated` already built the card. */
+     *  reseed) AND to per-preview store map mutations.
+     *
+     *  - Preview reassignment: patches the card's dataset, title,
+     *    capture cache, variant badge, and a11y legend / overlay in
+     *    place — same body the imperative call site used to drive
+     *    directly. Skipped on the first render: `firstUpdated`
+     *    already built the card.
+     *  - `mapsRevision` change: re-paint the a11y findings / hierarchy
+     *    overlays from the cache snapshot for `this.preview.id`. This
+     *    runs on every `updated()` (Lit re-renders fire the hook
+     *    regardless of which property changed) so the cache-change
+     *    case is covered without an explicit changedProperties guard.
+     *    The image-load case stays in `updateImage` — that path
+     *    triggers when the `<img>` becomes paintable, not when the
+     *    cache changes. */
     protected updated(changedProperties: Map<string, unknown>): void {
         if (!this._built) return;
-        if (!changedProperties.has("preview")) return;
+        if (changedProperties.has("preview")) {
+            const preview = this.preview;
+            const config = this.config;
+            if (preview && config) {
+                updateCardMetadata(this, preview, config);
+            }
+        }
+        this._repaintA11yOverlaysFromCache();
+    }
+
+    /** Re-paint the a11y findings / hierarchy overlays from the latest
+     *  per-preview store snapshot, if the `<img>` is ready to drive
+     *  the percent-of-natural math. No-op if the cache is empty for
+     *  this preview, the image hasn't loaded, or `earlyFeatures` is
+     *  off — matches the gating in `applyA11yUpdate`. The overlay
+     *  paint helpers are idempotent (they `innerHTML = ""` the layer
+     *  before re-emitting boxes), so calling this on every store fire
+     *  is safe. The legend rebuild stays in `applyA11yUpdate` — that
+     *  side effect lives next to the per-id store write and isn't
+     *  driven by `mapsRevision`. */
+    private _repaintA11yOverlaysFromCache(): void {
         const preview = this.preview;
         const config = this.config;
         if (!preview || !config) return;
-        updateCardMetadata(this, preview, config);
+        if (!config.earlyFeatures()) return;
+        const img = this.querySelector<HTMLImageElement>(
+            ".image-container img",
+        );
+        if (!img || !img.complete || img.naturalWidth === 0) return;
+        const state = previewStore.getState();
+        const findings = state.cardA11yFindings.get(preview.id);
+        if (findings && findings.length > 0) {
+            buildA11yOverlay(this, findings, img);
+        }
+        const nodes = state.cardA11yNodes.get(preview.id);
+        if (nodes && nodes.length > 0) {
+            applyHierarchyOverlay(this, nodes, img);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `<preview-card>` now subscribes to `previewStore.mapsRevision` via `StoreController` and repaints its a11y findings / hierarchy overlays from the component's `updated()` hook when the per-preview caches change.
- `applyA11yUpdate` no longer drives those overlay repaints directly — it keeps writing to the store and rebuilding the legend; the component owns overlay refresh on cache change.
- `updateImage`'s on-image-load a11y branch stays for now (step 5 will move that too).
- Step 4 of #857.

## Test plan
- [x] `npm run compile`
- [x] `npm test` (496 passing)
- [x] `npm run format:check`


---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_