### PR TITLE
feat(daemon)!: gate history/diff behind experimental sysprop for 1.0

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -172,6 +172,19 @@ class JsonRpcServer(
    */
   private val historyManager: HistoryManager? = null,
   /**
+   * Experimental gate for `history/diff`. The metadata-mode handler exists (H3) but the broader
+   * history surface — pixel mode (H5), git-ref write modes, LFS/squash-GC handling — is incomplete
+   * (see `docs/daemon/ROADMAP.md` § History). For 1.0 the dispatcher returns method-not-found
+   * unless this flag is on, so consumers don't accidentally code against an interface that's still
+   * moving. Defaults to the [HISTORY_DIFF_EXPERIMENTAL_PROP] sysprop (off in production); tests
+   * that assert on the diff handler pass `historyDiffExperimental = true` explicitly.
+   *
+   * TODO(1.1): land H5 + the remaining roadmap items, flip the default to on, and remove this
+   *   parameter.
+   */
+  private val historyDiffExperimental: Boolean =
+    System.getProperty(HISTORY_DIFF_EXPERIMENTAL_PROP)?.toBoolean() ?: false,
+  /**
    * H4 — initial delay for the auto-prune scheduler. Defaults to
    * [HistoryManager.DEFAULT_INITIAL_DELAY_MS] (5s — runs after sandbox bootstrap). Tests pass a
    * very small value (e.g. 50ms) to drive the schedule deterministically.
@@ -564,7 +577,20 @@ class JsonRpcServer(
       "shutdown" -> handleShutdown(req)
       "history/list" -> handleHistoryList(req)
       "history/read" -> handleHistoryRead(req)
-      "history/diff" -> handleHistoryDiff(req)
+      "history/diff" ->
+        // TODO(1.1): drop the experimental gate once the History roadmap lands (pixel mode H5,
+        // git-ref write modes, LFS/squash-GC). Until then, production daemons report
+        // method-not-found so clients that pre-handle that case (`historyDiff` UI on vscode) keep
+        // working without coding against a half-finished surface.
+        if (historyDiffExperimental) handleHistoryDiff(req)
+        else
+          sendErrorResponse(
+            id = req.id,
+            code = ERR_METHOD_NOT_FOUND,
+            message =
+              "history/diff is experimental in 1.0 and disabled by default; " +
+                "set -D$HISTORY_DIFF_EXPERIMENTAL_PROP=true to enable",
+          )
       "history/prune" -> handleHistoryPrune(req)
       "data/fetch" -> handleDataFetch(req)
       "data/subscribe" -> handleDataSubscribe(req, subscribe = true)
@@ -1221,9 +1247,13 @@ class JsonRpcServer(
   }
 
   /**
-   * H3 — `history/diff` metadata mode. Resolves [from] and [to] entry ids via the [historyManager]
-   * (which iterates configured sources in priority order, so a cross-source diff "LocalFs vs GitRef
-   * preview/main" works the same as an intra-source diff). Emits:
+   * H3 — `history/diff` metadata mode. Gated experimental in 1.0 (see [historyDiffExperimental]);
+   * the dispatcher returns method-not-found unless the gate is on, so this body only runs in tests
+   * or with `-D$HISTORY_DIFF_EXPERIMENTAL_PROP=true`. TODO(1.1): drop the gate.
+   *
+   * Resolves [from] and [to] entry ids via the [historyManager] (which iterates configured sources
+   * in priority order, so a cross-source diff "LocalFs vs GitRef preview/main" works the same as an
+   * intra-source diff). Emits:
    *
    * - `HistoryEntryNotFound` (-32010) when either id is missing.
    * - `HistoryDiffMismatch` (-32011) when the two entries belong to different previews.
@@ -2926,6 +2956,13 @@ class JsonRpcServer(
      */
     const val DISCOVERY_WATCHDOG_PROP: String = "composeai.daemon.discoveryWatchdogMs"
     const val DEFAULT_DISCOVERY_WATCHDOG_MS: Long = 1_500L
+
+    /**
+     * Experimental gate for `history/diff`. See the constructor parameter on [JsonRpcServer] for
+     * rationale. TODO(1.1): remove once H5 + the rest of the History roadmap lands and the diff
+     * surface is no longer half-finished.
+     */
+    const val HISTORY_DIFF_EXPERIMENTAL_PROP: String = "composeai.experimental.historyDiff"
 
     /**
      * Ceiling on shutdown drain. Renders that take longer than this are still allowed to finish —

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
@@ -232,6 +232,7 @@ class HistoryDiffTest {
         host = StubHost(),
         daemonVersion = "test",
         historyManager = manager,
+        historyDiffExperimental = true,
         onExit = { _ -> exitLatch.countDown() },
       )
     val serverThread =

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
@@ -83,6 +83,7 @@ class JsonRpcServerHistoryIntegrationTest {
         host = host,
         daemonVersion = "test",
         historyManager = historyManager,
+        historyDiffExperimental = true,
         onExit = { _ -> exitLatch.countDown() },
       )
     val serverThread =

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -319,7 +319,14 @@ Errors:
 Errors:
 - `HistoryEntryNotFound` (-32010) — `id` does not match any entry in the configured sources.
 
-### `history/diff` (phase H3 — metadata mode)
+### `history/diff` (phase H3 — metadata mode, **experimental in 1.0**)
+
+> **Experimental — gated off by default.** Production daemons reply with
+> `MethodNotFound` (-32601) until launched with
+> `-Dcomposeai.experimental.historyDiff=true`. The metadata path works (and is
+> exercised by the daemon test suite) but pixel mode (H5), git-ref write
+> modes, and LFS / squash-GC handling are still on the roadmap, so the
+> contract may change. Stabilization is tracked for 1.1.
 
 ```ts
 // params

--- a/docs/daemon/ROADMAP.md
+++ b/docs/daemon/ROADMAP.md
@@ -10,7 +10,7 @@ not belong here; use GitHub PRs and commit history for that detail.
 | Sandbox lifecycle | Planned | Emit the reserved `sandboxRecycle`, `daemonWarming`, and `daemonReady` notifications from real recycle decisions. |
 | Leak detection | Planned | Add periodic active leak checks behind the existing `LeakDetectionMode` capability surface. |
 | Resource invalidation | Planned | Track per-preview resource reads so `fileChanged({ kind: "resource" })` can invalidate only affected previews. |
-| History | Partial | Add pixel-mode `history/diff`, git-ref write modes, and LFS/squash-GC handling. |
+| History | Partial — `history/diff` experimental in 1.0 | Add pixel-mode `history/diff`, git-ref write modes, and LFS/squash-GC handling, then flip the `composeai.experimental.historyDiff` gate on by default and remove it (1.1). |
 | Predictive prefetch | Planned | Prove scroll-ahead speculation with telemetry before adding more prediction signals. |
 | Startup time | Research | Revisit machine-resident daemon, AppCDS, and bytecode-cache options from `STARTUP.md` when startup latency becomes the bottleneck again. |
 

--- a/vscode-extension/src/daemon/daemonClient.ts
+++ b/vscode-extension/src/daemon/daemonClient.ts
@@ -167,7 +167,14 @@ export class DaemonClient {
 
     /** Phase H3 (metadata mode). `mode: 'pixel'` is reserved for H5 and
      *  rejects with `HistoryPixelNotImplemented` until then. See
-     *  PROTOCOL.md § 5 (history/diff). */
+     *  PROTOCOL.md § 5 (history/diff).
+     *
+     *  Experimental in 1.0: production daemons gate the handler behind
+     *  `composeai.experimental.historyDiff`, so this call rejects with
+     *  `MethodNotFound` (-32601) unless that sysprop is set. Callers should
+     *  treat `MethodNotFound` as "diff unavailable" and fall back to a
+     *  metadata-only side-by-side. TODO(1.1): once the daemon flips the
+     *  default, drop the fallback path on the call sites. */
     historyDiff(params: HistoryDiffParams): Promise<HistoryDiffResult> {
         return this.request<HistoryDiffResult>("history/diff", params);
     }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -669,6 +669,12 @@ export async function activate(
             if (!client) {
                 throw new Error("daemon unavailable");
             }
+            // TODO(1.1): history/diff is experimental in the 1.0 daemon and
+            // returns MethodNotFound unless the user opts in via
+            // `composeai.experimental.historyDiff`. Once the daemon flips the
+            // default, simplify this back to a direct call. Until then,
+            // surface the gate as a clear "diff unavailable" rather than a
+            // raw RPC error.
             return client.historyDiff({
                 from: fromId,
                 to: toId,


### PR DESCRIPTION
The H3 history/diff handler exists in metadata mode but the broader
History roadmap — pixel mode (H5), git-ref write modes, LFS/squash-GC
handling — is unfinished. Returning method-not-found by default keeps
clients from coding against a contract that's still moving while still
letting tests and opt-in users exercise the path.

- JsonRpcServer gains historyDiffExperimental (constructor param +
  composeai.experimental.historyDiff sysprop). Off by default; the two
  daemon tests that drive history/diff turn it on explicitly.
- vscode-extension: TODO(1.1) at the daemonDiff call sites; the existing
  promise rejection on MethodNotFound already surfaces as "diff
  unavailable" to the panel.
- PROTOCOL.md flags the method as experimental in 1.0.
- ROADMAP.md pins flipping the gate to 1.1 alongside the rest of the
  History work.