### PR TITLE
refactor(vscode): move history-row selection state into the component

### DIFF
--- a/vscode-extension/src/test/historyRow.test.ts
+++ b/vscode-extension/src/test/historyRow.test.ts
@@ -1,0 +1,185 @@
+// DOM-feature tests for `<history-row>`'s reactive selection state
+// (step 2 of #858). The row owns its `selected` boolean and
+// dispatches `history-row-selection-change` (bubbling) on shift-click;
+// the host's `behavior.ts` listener aggregates the (max-2) queue from
+// those events. These tests pin the row-side contract:
+//
+//   - shift-click flips `.selected` and dispatches the event with
+//     `selected: true` / `selected: false`,
+//   - the `.selected` class on the host element tracks `this.selected`,
+//   - non-shift clicks do NOT dispatch a selection-change event (they
+//     route through the `onExpand` callback instead),
+//   - external `.selected = ...` writes do NOT re-dispatch (so the
+//     host can clear an evicted oldest pick without re-entering its
+//     own listener).
+//
+// Mirrors the style of `liveBadge.test.ts` from PR #867: pure
+// happy-dom DOM, no Mocha-on-Mocha, narrow contract. The
+// host's max-2 enforcement is integration code in `behavior.ts` and
+// is intentionally out of scope here.
+
+import * as assert from "assert";
+// Side-effect import: `@customElement("history-row")` registers the
+// element with `customElements.define`. The named-only `HistoryRow`
+// import below is a type at the use sites (cast + `instanceof`), so
+// without this bare import TypeScript elides the module entirely
+// under glob runs and `document.createElement("history-row")` returns
+// an unupgraded `HTMLElement`.
+import "../webview/history/components/HistoryRow";
+import {
+    HistoryRow,
+    type HistoryRowSelectionChangeEvent,
+} from "../webview/history/components/HistoryRow";
+import type { HistoryEntry } from "../webview/shared/types";
+
+/** Build a minimal `HistoryEntry` with just enough fields for
+ *  `HistoryRow.render()` to succeed and `dataset.id` to populate. */
+function buildEntry(id: string): HistoryEntry {
+    return {
+        id,
+        previewId: "com.example.Preview",
+        timestamp: "2025-01-01T00:00:00Z",
+        trigger: "manual",
+        source: { kind: "fs" },
+    } as HistoryEntry;
+}
+
+/** Mount a fresh `<history-row>` with [entry] into `document.body`,
+ *  await its first render, return the element. */
+async function mountRow(entry: HistoryEntry): Promise<HistoryRow> {
+    const row = document.createElement("history-row") as HistoryRow;
+    row.entry = entry;
+    document.body.appendChild(row);
+    await row.updateComplete;
+    return row;
+}
+
+afterEach(() => {
+    document.body.innerHTML = "";
+});
+
+describe("<history-row> selection state", () => {
+    it("starts unselected with no `.selected` class", async () => {
+        const row = await mountRow(buildEntry("entry-1"));
+        assert.strictEqual(row.selected, false);
+        assert.strictEqual(row.classList.contains("selected"), false);
+    });
+
+    it("flips selected on shift-click and dispatches history-row-selection-change with selected: true", async () => {
+        const row = await mountRow(buildEntry("entry-1"));
+        const events: HistoryRowSelectionChangeEvent[] = [];
+        row.addEventListener("history-row-selection-change", (e) => {
+            events.push(e);
+        });
+
+        row.dispatchEvent(
+            new MouseEvent("click", { bubbles: true, shiftKey: true }),
+        );
+        await row.updateComplete;
+
+        assert.strictEqual(row.selected, true);
+        assert.strictEqual(row.classList.contains("selected"), true);
+        assert.strictEqual(events.length, 1);
+        assert.deepStrictEqual(events[0].detail, {
+            id: "entry-1",
+            selected: true,
+        });
+    });
+
+    it("toggles back to unselected on a second shift-click and dispatches selected: false", async () => {
+        const row = await mountRow(buildEntry("entry-1"));
+        const events: HistoryRowSelectionChangeEvent[] = [];
+        row.addEventListener("history-row-selection-change", (e) => {
+            events.push(e);
+        });
+
+        row.dispatchEvent(
+            new MouseEvent("click", { bubbles: true, shiftKey: true }),
+        );
+        await row.updateComplete;
+        row.dispatchEvent(
+            new MouseEvent("click", { bubbles: true, shiftKey: true }),
+        );
+        await row.updateComplete;
+
+        assert.strictEqual(row.selected, false);
+        assert.strictEqual(row.classList.contains("selected"), false);
+        assert.strictEqual(events.length, 2);
+        assert.deepStrictEqual(events[0].detail, {
+            id: "entry-1",
+            selected: true,
+        });
+        assert.deepStrictEqual(events[1].detail, {
+            id: "entry-1",
+            selected: false,
+        });
+    });
+
+    it("bubbles the selection-change event to ancestor listeners", async () => {
+        // The host listens on `timelineEl` (the row's parent), so the
+        // event must escape the row. `bubbles: true` + light DOM is
+        // what wires that up; this test pins that behaviour.
+        const row = await mountRow(buildEntry("entry-1"));
+        let receivedOnBody: HistoryRowSelectionChangeEvent | null = null;
+        document.body.addEventListener("history-row-selection-change", (e) => {
+            receivedOnBody = e;
+        });
+
+        row.dispatchEvent(
+            new MouseEvent("click", { bubbles: true, shiftKey: true }),
+        );
+        await row.updateComplete;
+
+        assert.notStrictEqual(receivedOnBody, null);
+        assert.deepStrictEqual(
+            (receivedOnBody as unknown as HistoryRowSelectionChangeEvent)
+                .detail,
+            { id: "entry-1", selected: true },
+        );
+    });
+
+    it("does not dispatch selection-change on a plain (non-shift) click", async () => {
+        // Plain click routes to `onExpand` via the row's callbacks.
+        // No selection mutation, no event. The expansion path is
+        // independently exercised by `historyTimeline.ts`'s integration.
+        const row = await mountRow(buildEntry("entry-1"));
+        row.callbacks = {
+            onExpand: () => {},
+            onDiffPrevious: () => {},
+            onDiffCurrent: () => {},
+            onThumbConnected: () => {},
+        };
+        const events: HistoryRowSelectionChangeEvent[] = [];
+        row.addEventListener("history-row-selection-change", (e) => {
+            events.push(e);
+        });
+
+        row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await row.updateComplete;
+
+        assert.strictEqual(events.length, 0);
+        assert.strictEqual(row.selected, false);
+    });
+
+    it("reflects external .selected writes in the `.selected` class without re-dispatching", async () => {
+        // The host clears the oldest pick by writing `row.selected = false`
+        // when a third row is shift-clicked. That must NOT re-enter the
+        // selection-change listener (otherwise the host would loop on
+        // its own eviction). Only user input (shift-click) dispatches.
+        const row = await mountRow(buildEntry("entry-1"));
+        const events: HistoryRowSelectionChangeEvent[] = [];
+        row.addEventListener("history-row-selection-change", (e) => {
+            events.push(e);
+        });
+
+        row.selected = true;
+        await row.updateComplete;
+        assert.strictEqual(row.classList.contains("selected"), true);
+
+        row.selected = false;
+        await row.updateComplete;
+        assert.strictEqual(row.classList.contains("selected"), false);
+
+        assert.strictEqual(events.length, 0);
+    });
+});

--- a/vscode-extension/src/webview/history/behavior.ts
+++ b/vscode-extension/src/webview/history/behavior.ts
@@ -5,9 +5,10 @@
 // `HistoryToWebview` (from `shared/types`). Step 1 of #858 lifted the
 // per-row markup into the `<history-row>` Lit component
 // (`./components/HistoryRow.ts`) and routed thumb bytes through
-// `historyStore`; selection / expansion / diff overlays still flow
-// through closure-state callbacks in this file pending the later
-// steps of the issue.
+// `historyStore`. Step 2 moved selection state into the row itself —
+// this module now just listens for `history-row-selection-change` to
+// keep a (max-2) queue for the diff button. Expansion / diff overlays
+// still flow through closure-state callbacks pending step 3 of #858.
 //
 // Runs once per webview load. Assumes `<history-app>` has already
 // rendered its skeleton into light DOM, so `document.getElementById(...)`
@@ -16,6 +17,7 @@
 import { requireElementById } from "../shared/domRefs";
 import type { HistoryEntry, HistoryToWebview } from "../shared/types";
 import { getVsCodeApi } from "../shared/vscode";
+import type { HistoryRow } from "./components/HistoryRow";
 import { cssEscape } from "./historyData";
 import {
     fillDiff as fillDiffDom,
@@ -43,7 +45,13 @@ export function setupHistoryBehavior(): void {
     // `components/ScopeChip.ts`. It listens for `setScopeLabel` directly.
 
     let entries: HistoryEntry[] = [];
-    const selectedIds = new Set<string>();
+    // (max-2) selection queue (oldest first). Each `<history-row>` owns
+    // its own `selected` state and dispatches
+    // `history-row-selection-change` on shift-click; this list is the
+    // host's aggregate view of which rows are currently picked, used to
+    // gate the diff button and to evict the oldest pick when a third
+    // row is shift-clicked.
+    const selectedOrder: string[] = [];
     let expandedId: string | null = null;
     // Thumbnail bytes live in `historyStore` so `<history-row>` can
     // subscribe and re-render reactively. `thumbRequested` here just
@@ -73,15 +81,40 @@ export function setupHistoryBehavior(): void {
         vscode.postMessage({ command: "refresh" });
     });
     btnDiffEl.addEventListener("click", () => {
-        const ids = [...selectedIds];
-        if (ids.length === 2) {
+        if (selectedOrder.length === 2) {
             vscode.postMessage({
                 command: "diff",
-                fromId: ids[0],
-                toId: ids[1],
+                fromId: selectedOrder[0],
+                toId: selectedOrder[1],
             });
         }
     });
+    timelineEl.addEventListener(
+        "history-row-selection-change",
+        (event: CustomEvent<{ id: string; selected: boolean }>) => {
+            const { id, selected } = event.detail;
+            if (selected) {
+                // Evict the oldest pick when a third row joins so we
+                // never exceed two selections. The row dispatched this
+                // event already, so its `.selected` is true; we only
+                // need to flip the evictee back.
+                if (selectedOrder.length >= 2) {
+                    const drop = selectedOrder.shift();
+                    if (drop !== undefined) {
+                        const prev = timelineEl.querySelector<HistoryRow>(
+                            'history-row[data-id="' + cssEscape(drop) + '"]',
+                        );
+                        if (prev) prev.selected = false;
+                    }
+                }
+                selectedOrder.push(id);
+            } else {
+                const idx = selectedOrder.indexOf(id);
+                if (idx !== -1) selectedOrder.splice(idx, 1);
+            }
+            btnDiffEl.disabled = selectedOrder.length !== 2;
+        },
+    );
     filterSourceEl.addEventListener("change", applyFilters);
     filterBranchEl.addEventListener("change", applyFilters);
 
@@ -131,8 +164,9 @@ export function setupHistoryBehavior(): void {
     }
 
     // Timeline row markup lives in the `<history-row>` Lit component
-    // (`./components/HistoryRow.ts`); orchestration around it —
-    // selection set, expansion DOM, diff requests — stays in
+    // (`./components/HistoryRow.ts`); selection state lives there too
+    // and bubbles up via the `history-row-selection-change` listener
+    // wired above. Expansion DOM and diff requests still flow through
     // `./historyTimeline.ts`. The config exposes the static DOM
     // handles plus thin getter/setter pairs over `expandedId` so the
     // lifted module doesn't need closure access to this scope.
@@ -140,7 +174,6 @@ export function setupHistoryBehavior(): void {
         vscode,
         timelineEl,
         btnDiffEl,
-        selectedIds,
         getExpandedId: () => expandedId,
         setExpandedId: (next) => {
             expandedId = next;

--- a/vscode-extension/src/webview/history/components/HistoryRow.ts
+++ b/vscode-extension/src/webview/history/components/HistoryRow.ts
@@ -8,11 +8,14 @@
 // `thumbReady` message lands and `behavior.ts` writes it into the
 // store, only the rows whose entry id matches re-render.
 //
-// Selection (`.selected` class) and inline expansion (`.expanded`
-// sibling div) STAY OWNED by the host — the row exposes
-// `setSelected(bool)` for the host to toggle, and the click handlers
-// route back through the existing config callbacks. Step 2 of #858
-// migrates that state into `@state` and a reactive `expanded` slot.
+// Step 2 of #858: the row now owns its `selected` state. Shift-click
+// flips `this.selected` and dispatches `history-row-selection-change`
+// (bubbling) so the host can aggregate the (max-2) selection queue
+// without holding a separate `Set<string>`. The host can still
+// imperatively set `.selected = false` to clear the oldest selection
+// when a third row gets picked. Inline expansion (`.expanded` sibling
+// div) STAYS OWNED by the host — step 3 of #858 folds that into the
+// component.
 //
 // Light DOM: `media/history.css` rules target `.row`, `.thumb`,
 // `.meta`, etc. — keep them applying without touching CSS.
@@ -26,10 +29,11 @@ import { escapeHtml, formatAbsolute, formatRelative } from "../historyData";
 import { historyStore, type HistoryState } from "../historyStore";
 
 /** Per-row callbacks the host wires up so the row stays presentational
- *  while step-1 keeps selection/expansion logic in `behavior.ts`. */
+ *  while the inline expansion / diff overlays still live in
+ *  `historyTimeline.ts`. Selection notifications travel via the
+ *  `history-row-selection-change` CustomEvent — see
+ *  [HistoryRowSelectionChangeEvent]. */
 export interface HistoryRowCallbacks {
-    /** Shift-click: toggle membership in the (max-2) selection set. */
-    onToggleSelected(id: string, row: HistoryRow): void;
     /** Plain click: open / collapse the inline image expansion. */
     onExpand(id: string, row: HistoryRow): void;
     /** Up-arrow icon: diff against the previous entry for this preview. */
@@ -43,15 +47,36 @@ export interface HistoryRowCallbacks {
     onThumbConnected(thumbEl: HTMLElement, id: string): void;
 }
 
+/** Detail for the `history-row-selection-change` CustomEvent the row
+ *  dispatches when its `selected` state flips because of user input
+ *  (shift-click). External `.selected = ...` writes do NOT dispatch —
+ *  only the row's own click handler does, so the host can imperatively
+ *  clear an oldest selection without re-entering its own listener. */
+export interface HistoryRowSelectionChangeDetail {
+    id: string;
+    selected: boolean;
+}
+
+export type HistoryRowSelectionChangeEvent =
+    CustomEvent<HistoryRowSelectionChangeDetail>;
+
+declare global {
+    interface HTMLElementEventMap {
+        "history-row-selection-change": HistoryRowSelectionChangeEvent;
+    }
+}
+
 @customElement("history-row")
 export class HistoryRow extends LitElement {
     /** The history entry this row renders. Required — render() returns
      *  empty until set. */
     @property({ attribute: false }) entry: HistoryEntry | null = null;
 
-    /** When true the row paints with the `.selected` class — used by the
-     *  shift-click selection logic. Mirror state, not source of truth
-     *  yet (step 2 of #858 moves the source-of-truth into the row). */
+    /** Source of truth for whether the row is in the (max-2) selection
+     *  set. The row flips this itself on shift-click and dispatches
+     *  `history-row-selection-change`; the host's listener may write it
+     *  back to `false` to evict the oldest selection when a third row
+     *  is picked. External writes do NOT re-dispatch. */
     @property({ type: Boolean }) selected = false;
 
     /** Hash of the latest archived render on `main` for the currently
@@ -61,8 +86,7 @@ export class HistoryRow extends LitElement {
 
     /** Callbacks supplied by the host's `renderTimeline` so the row's
      *  click / button handlers stay routed through the existing
-     *  selection / expansion / diff plumbing. Set imperatively after
-     *  construction. */
+     *  expansion / diff plumbing. Set imperatively after construction. */
     callbacks: HistoryRowCallbacks | null = null;
 
     private readonly thumbBytes = new StoreController<
@@ -76,14 +100,6 @@ export class HistoryRow extends LitElement {
     // styles in `media/history.css` apply unchanged.
     protected createRenderRoot(): HTMLElement {
         return this;
-    }
-
-    /** Imperative setter so the host doesn't have to re-render the
-     *  whole timeline to flip selection state. Mirrors the legacy
-     *  `row.classList.add/remove("selected")` calls. */
-    setSelected(next: boolean): void {
-        if (this.selected === next) return;
-        this.selected = next;
     }
 
     protected updated(): void {
@@ -189,9 +205,22 @@ export class HistoryRow extends LitElement {
         // The action buttons stop propagation themselves — anything
         // reaching here is a click on the row body.
         const id = this.entry?.id ?? "";
-        if (!id || !this.callbacks) return;
-        if (ev.shiftKey) this.callbacks.onToggleSelected(id, this);
-        else this.callbacks.onExpand(id, this);
+        if (!id) return;
+        if (ev.shiftKey) {
+            this.selected = !this.selected;
+            this.dispatchEvent(
+                new CustomEvent<HistoryRowSelectionChangeDetail>(
+                    "history-row-selection-change",
+                    {
+                        detail: { id, selected: this.selected },
+                        bubbles: true,
+                        composed: true,
+                    },
+                ),
+            );
+        } else {
+            this.callbacks?.onExpand(id, this);
+        }
     };
 
     private readonly onDiffPrevClick = (ev: MouseEvent): void => {

--- a/vscode-extension/src/webview/history/historyTimeline.ts
+++ b/vscode-extension/src/webview/history/historyTimeline.ts
@@ -1,13 +1,18 @@
 // Timeline + row construction for the History panel.
 //
 // Step 1 of #858: row markup now lives in the `<history-row>` Lit
-// component (`./components/HistoryRow.ts`). This module shrank to:
+// component (`./components/HistoryRow.ts`).
+//
+// Step 2 of #858: selection state moved into the row. The row owns
+// `selected` and dispatches `history-row-selection-change` on
+// shift-click; the host listens on `timelineEl` to maintain the
+// (max-2) queue and toggle the diff button. This module no longer
+// holds a `selectedIds` set or a `toggleSelected` helper.
+//
+// What's left here:
 //
 //  - `renderTimeline`: declarative iteration over `entries`, swapping
 //    out `<history-row>` children on the timeline container.
-//  - `toggleSelected`: still owns the (max-2) selection set since
-//    that state lives in the host's `behavior.ts` closure for now.
-//    Step 2 of #858 moves selection state into the row's `@state`.
 //  - `expandRow` / `requestRowDiff` / `fillExpansion`: still
 //    imperative because the inline `.expanded` sibling div is a
 //    separate concern from row rendering and gets its own component
@@ -28,11 +33,9 @@ export interface HistoryRowConfig {
     vscode: VsCodeApi<unknown>;
     /** `<div id="timeline">` — the parent container for all rows. */
     timelineEl: HTMLElement;
-    /** Toolbar diff button — disabled state tracks `selectedIds.size === 2`. */
+    /** Toolbar diff button — disabled state tracks the host-managed
+     *  selection queue length (must be exactly 2 to enable). */
     btnDiffEl: HTMLButtonElement;
-    /** Per-session selection set (max 2). Direct Set reference; mutated
-     *  by `toggleSelected`. */
-    selectedIds: Set<string>;
     /** Currently expanded row's id, or `null` when nothing is expanded.
      *  Mutated by `expandRow` (toggle) and `requestRowDiff` (replace). */
     getExpandedId(): string | null;
@@ -61,7 +64,6 @@ export function renderTimeline(
     const mainHash = findLatestMainHash(entries);
 
     const callbacks: HistoryRowCallbacks = {
-        onToggleSelected: (id, row) => toggleSelected(id, row, config),
         onExpand: (id, row) => expandRow(id, row, config),
         onDiffPrevious: (id, row) =>
             requestRowDiff(id, row, "previous", config),
@@ -81,32 +83,6 @@ export function renderTimeline(
         row.callbacks = callbacks;
         config.timelineEl.appendChild(row);
     }
-}
-
-/** Toggle [id] in/out of the (max-2) selection set, mirroring the row's
- *  `.selected` state. Drops the oldest selection when adding a third. */
-export function toggleSelected(
-    id: string,
-    row: HistoryRow,
-    config: HistoryRowConfig,
-): void {
-    if (config.selectedIds.has(id)) {
-        config.selectedIds.delete(id);
-        row.setSelected(false);
-    } else {
-        if (config.selectedIds.size >= 2) {
-            // Drop oldest selection so we never have more than 2.
-            const drop = [...config.selectedIds][0];
-            config.selectedIds.delete(drop);
-            const prev = config.timelineEl.querySelector<HistoryRow>(
-                'history-row[data-id="' + cssEscape(drop) + '"]',
-            );
-            prev?.setSelected(false);
-        }
-        config.selectedIds.add(id);
-        row.setSelected(true);
-    }
-    config.btnDiffEl.disabled = config.selectedIds.size !== 2;
 }
 
 /** Toggle the inline expansion (full-size image + actions) for [id].

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -10,7 +10,9 @@
         "esModuleInterop": true,
         "sourceMap": true,
         "skipLibCheck": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "experimentalDecorators": true,
+        "useDefineForClassFields": false
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules", "src/webview/**"],
@@ -21,7 +23,9 @@
         "src/webview/preview/moduleReadiness.ts",
         "src/webview/preview/pointerGeometry.ts",
         "src/webview/preview/relativeSizing.ts",
+        "src/webview/history/components/HistoryRow.ts",
         "src/webview/history/historyData.ts",
+        "src/webview/history/historyStore.ts",
         "src/webview/shared/diffStatsLabel.ts",
         "src/webview/shared/safeIndex.ts",
         "src/webview/shared/store.ts",


### PR DESCRIPTION
## Summary
- `<history-row>` now owns its `selected` state and dispatches `history-row-selection-change` on shift-click; the host listens and aggregates a max-2 queue for the diff button.
- `selectedIds: Set<string>` and `toggleSelected` are gone; `HistoryRowConfig` drops the selection field, `HistoryRowCallbacks` drops `onToggleSelected`.
- Step 2 of #858; expansion + diff sub-views are step 3.

## Test plan
- [x] `npm run compile`
- [x] `npm test` (502 passing, +6 new in `historyRow.test.ts`)
- [x] `npm run format:check`


---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_