### PR TITLE
refactor(vscode): move history-row expansion state into the component

### DIFF
--- a/vscode-extension/src/test/historyRow.test.ts
+++ b/vscode-extension/src/test/historyRow.test.ts
@@ -1,22 +1,30 @@
-// DOM-feature tests for `<history-row>`'s reactive selection state
-// (step 2 of #858). The row owns its `selected` boolean and
-// dispatches `history-row-selection-change` (bubbling) on shift-click;
-// the host's `behavior.ts` listener aggregates the (max-2) queue from
-// those events. These tests pin the row-side contract:
+// DOM-feature tests for `<history-row>`'s reactive selection +
+// expansion state (steps 2 and 3 of #858). The row owns its
+// `selected` / `_expandedKind` reactive state and dispatches
+// `history-row-selection-change` + `history-row-expand` (both
+// bubbling) on user input; the host's `behavior.ts` listeners
+// aggregate the (max-2) selection queue and route the matching
+// vscode messages from those events. These tests pin the row-side
+// contract:
 //
 //   - shift-click flips `.selected` and dispatches the event with
 //     `selected: true` / `selected: false`,
 //   - the `.selected` class on the host element tracks `this.selected`,
-//   - non-shift clicks do NOT dispatch a selection-change event (they
-//     route through the `onExpand` callback instead),
+//   - non-shift (plain) clicks toggle the inline image expansion and
+//     dispatch `history-row-expand` with `kind: "image"`,
+//   - the diff action buttons set the row to diff mode and dispatch
+//     `history-row-expand` with `kind: "diff"` + `against`,
+//   - `setImage` / `setImageError` paint the matching content into
+//     the `.expanded` block,
+//   - `collapse()` removes the `.expanded` block,
 //   - external `.selected = ...` writes do NOT re-dispatch (so the
 //     host can clear an evicted oldest pick without re-entering its
 //     own listener).
 //
 // Mirrors the style of `liveBadge.test.ts` from PR #867: pure
 // happy-dom DOM, no Mocha-on-Mocha, narrow contract. The
-// host's max-2 enforcement is integration code in `behavior.ts` and
-// is intentionally out of scope here.
+// host's max-2 enforcement and `fillDiff` integration are out of
+// scope here — both live in `behavior.ts` / `historyDiffView.ts`.
 
 import * as assert from "assert";
 // Side-effect import: `@customElement("history-row")` registers the
@@ -28,6 +36,7 @@ import * as assert from "assert";
 import "../webview/history/components/HistoryRow";
 import {
     HistoryRow,
+    type HistoryRowExpandEvent,
     type HistoryRowSelectionChangeEvent,
 } from "../webview/history/components/HistoryRow";
 import type { HistoryEntry } from "../webview/shared/types";
@@ -139,16 +148,10 @@ describe("<history-row> selection state", () => {
     });
 
     it("does not dispatch selection-change on a plain (non-shift) click", async () => {
-        // Plain click routes to `onExpand` via the row's callbacks.
-        // No selection mutation, no event. The expansion path is
-        // independently exercised by `historyTimeline.ts`'s integration.
+        // Plain click flips `_expandedKind` and dispatches
+        // `history-row-expand`, never `history-row-selection-change`.
         const row = await mountRow(buildEntry("entry-1"));
-        row.callbacks = {
-            onExpand: () => {},
-            onDiffPrevious: () => {},
-            onDiffCurrent: () => {},
-            onThumbConnected: () => {},
-        };
+        row.callbacks = { onThumbConnected: () => {} };
         const events: HistoryRowSelectionChangeEvent[] = [];
         row.addEventListener("history-row-selection-change", (e) => {
             events.push(e);
@@ -181,5 +184,147 @@ describe("<history-row> selection state", () => {
         assert.strictEqual(row.classList.contains("selected"), false);
 
         assert.strictEqual(events.length, 0);
+    });
+});
+
+describe("<history-row> inline expansion", () => {
+    it("plain-clicks open an image expansion and dispatch history-row-expand with kind: image", async () => {
+        const row = await mountRow(buildEntry("entry-1"));
+        const events: HistoryRowExpandEvent[] = [];
+        row.addEventListener("history-row-expand", (e) => {
+            events.push(e);
+        });
+
+        row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await row.updateComplete;
+
+        assert.strictEqual(events.length, 1);
+        assert.deepStrictEqual(events[0].detail, {
+            id: "entry-1",
+            kind: "image",
+        });
+        const expanded = row.querySelector(".expanded");
+        assert.notStrictEqual(expanded, null);
+        assert.strictEqual((expanded as HTMLElement).dataset.id, "entry-1");
+        assert.strictEqual(
+            expanded?.classList.contains("diff-expanded"),
+            false,
+        );
+    });
+
+    it("a second plain-click collapses the row and emits no further history-row-expand event", async () => {
+        const row = await mountRow(buildEntry("entry-1"));
+        const events: HistoryRowExpandEvent[] = [];
+        row.addEventListener("history-row-expand", (e) => {
+            events.push(e);
+        });
+
+        row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await row.updateComplete;
+        assert.notStrictEqual(row.querySelector(".expanded"), null);
+
+        row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await row.updateComplete;
+
+        assert.strictEqual(row.querySelector(".expanded"), null);
+        // Only the open emitted an event — the close is a pure local
+        // state flip with no associated vscode request.
+        assert.strictEqual(events.length, 1);
+    });
+
+    it("the diff-vs-previous button opens a diff-expanded block and dispatches history-row-expand with against: previous", async () => {
+        const row = await mountRow(buildEntry("entry-1"));
+        const events: HistoryRowExpandEvent[] = [];
+        row.addEventListener("history-row-expand", (e) => {
+            events.push(e);
+        });
+
+        const btn = row.querySelector<HTMLButtonElement>(
+            'button[aria-label="Diff vs previous"]',
+        );
+        assert.notStrictEqual(btn, null);
+        btn?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await row.updateComplete;
+
+        assert.strictEqual(events.length, 1);
+        assert.deepStrictEqual(events[0].detail, {
+            id: "entry-1",
+            kind: "diff",
+            against: "previous",
+        });
+        const shell = row.querySelector(".expanded.diff-expanded");
+        assert.notStrictEqual(shell, null);
+        assert.strictEqual((shell as HTMLElement).dataset.id, "entry-1");
+        assert.strictEqual((shell as HTMLElement).dataset.against, "previous");
+    });
+
+    it("the diff-vs-current button dispatches history-row-expand with against: current", async () => {
+        const row = await mountRow(buildEntry("entry-1"));
+        const events: HistoryRowExpandEvent[] = [];
+        row.addEventListener("history-row-expand", (e) => {
+            events.push(e);
+        });
+
+        const btn = row.querySelector<HTMLButtonElement>(
+            'button[aria-label="Diff vs current"]',
+        );
+        assert.notStrictEqual(btn, null);
+        btn?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await row.updateComplete;
+
+        assert.strictEqual(events.length, 1);
+        assert.deepStrictEqual(events[0].detail, {
+            id: "entry-1",
+            kind: "diff",
+            against: "current",
+        });
+    });
+
+    it("setImage paints the streamed bytes inside .expanded", async () => {
+        const row = await mountRow(buildEntry("entry-1"));
+        // Open the image expansion first so `.expanded` is in the DOM.
+        row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await row.updateComplete;
+
+        // Single-pixel transparent PNG, base64-encoded.
+        const bytes =
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+        row.setImage(bytes);
+        await row.updateComplete;
+
+        const img = row.querySelector<HTMLImageElement>(".expanded img");
+        assert.notStrictEqual(img, null);
+        assert.strictEqual(img?.src, "data:image/png;base64," + bytes);
+    });
+
+    it("setImageError surfaces the failure text in .expanded", async () => {
+        const row = await mountRow(buildEntry("entry-1"));
+        row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await row.updateComplete;
+
+        row.setImageError("daemon unreachable");
+        await row.updateComplete;
+
+        const expanded = row.querySelector(".expanded");
+        assert.notStrictEqual(expanded, null);
+        assert.match(
+            expanded?.textContent ?? "",
+            /Failed to load image: daemon unreachable/,
+        );
+        assert.strictEqual(row.querySelector(".expanded img"), null);
+    });
+
+    it("collapse() removes the .expanded block and clears reactive state", async () => {
+        const row = await mountRow(buildEntry("entry-1"));
+        row.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        await row.updateComplete;
+        row.setImage("AAAA");
+        await row.updateComplete;
+        assert.notStrictEqual(row.querySelector(".expanded"), null);
+
+        row.collapse();
+        await row.updateComplete;
+
+        assert.strictEqual(row.querySelector(".expanded"), null);
     });
 });

--- a/vscode-extension/src/webview/history/behavior.ts
+++ b/vscode-extension/src/webview/history/behavior.ts
@@ -6,9 +6,17 @@
 // per-row markup into the `<history-row>` Lit component
 // (`./components/HistoryRow.ts`) and routed thumb bytes through
 // `historyStore`. Step 2 moved selection state into the row itself —
-// this module now just listens for `history-row-selection-change` to
-// keep a (max-2) queue for the diff button. Expansion / diff overlays
-// still flow through closure-state callbacks pending step 3 of #858.
+// this module just listens for `history-row-selection-change` to
+// keep a (max-2) queue for the diff button.
+//
+// Step 3 of #858: inline expansion state is now also row-owned. The
+// row dispatches `history-row-expand` (bubbling) on plain-click /
+// diff-button-click; the listener below collapses any other open row
+// and posts the matching `loadImage` / `requestDiff`. Extension
+// responses (`imageReady` / `imageError` / `diffReady` /
+// `diffPairError`) route to the targeted row via `setImage` /
+// `setImageError` / `setDiff` / `setDiffError`. The host no longer
+// holds an `expandedId` scalar.
 //
 // Runs once per webview load. Assumes `<history-app>` has already
 // rendered its skeleton into light DOM, so `document.getElementById(...)`
@@ -20,13 +28,11 @@ import { getVsCodeApi } from "../shared/vscode";
 import type { HistoryRow } from "./components/HistoryRow";
 import { cssEscape } from "./historyData";
 import {
-    fillDiff as fillDiffDom,
     type HistoryDiffViewConfig,
     showDiff as showDiffDom,
 } from "./historyDiffView";
 import { setThumb } from "./historyStore";
 import {
-    fillExpansion as fillExpansionDom,
     type HistoryRowConfig,
     renderTimeline as renderTimelineDom,
 } from "./historyTimeline";
@@ -52,7 +58,6 @@ export function setupHistoryBehavior(): void {
     // gate the diff button and to evict the oldest pick when a third
     // row is shift-clicked.
     const selectedOrder: string[] = [];
-    let expandedId: string | null = null;
     // Thumbnail bytes live in `historyStore` so `<history-row>` can
     // subscribe and re-render reactively. `thumbRequested` here just
     // dedupes the per-session fetch — the IntersectionObserver fires
@@ -115,6 +120,30 @@ export function setupHistoryBehavior(): void {
             btnDiffEl.disabled = selectedOrder.length !== 2;
         },
     );
+    timelineEl.addEventListener(
+        "history-row-expand",
+        (
+            event: CustomEvent<{
+                id: string;
+                kind: "image" | "diff";
+                against?: "previous" | "current";
+            }>,
+        ) => {
+            const { id, kind, against } = event.detail;
+            // Only one expansion at a time. Walk all rows and collapse
+            // the others; the dispatching row has already flipped its
+            // own `_expandedKind` so we leave it alone.
+            const rows = timelineEl.querySelectorAll<HistoryRow>("history-row");
+            for (const row of rows) {
+                if (row.dataset.id !== id) row.collapse();
+            }
+            if (kind === "image") {
+                vscode.postMessage({ command: "loadImage", id });
+            } else if (kind === "diff" && against) {
+                vscode.postMessage({ command: "requestDiff", id, against });
+            }
+        },
+    );
     filterSourceEl.addEventListener("change", applyFilters);
     filterBranchEl.addEventListener("change", applyFilters);
 
@@ -163,31 +192,36 @@ export function setupHistoryBehavior(): void {
         }
     }
 
-    // Timeline row markup lives in the `<history-row>` Lit component
-    // (`./components/HistoryRow.ts`); selection state lives there too
-    // and bubbles up via the `history-row-selection-change` listener
-    // wired above. Expansion DOM and diff requests still flow through
-    // `./historyTimeline.ts`. The config exposes the static DOM
-    // handles plus thin getter/setter pairs over `expandedId` so the
-    // lifted module doesn't need closure access to this scope.
-    const rowConfig: HistoryRowConfig = {
-        vscode,
-        timelineEl,
-        btnDiffEl,
-        getExpandedId: () => expandedId,
-        setExpandedId: (next) => {
-            expandedId = next;
-        },
-        thumbRequested,
-        thumbObserver,
-    };
-    function renderTimeline(): void {
-        renderTimelineDom(entries, rowConfig);
+    /** Look up the `<history-row>` for [id] in the timeline. Returns
+     *  null when the row was removed (entry filtered out, panel
+     *  re-rendered between request and response). */
+    function findRow(id: string): HistoryRow | null {
+        return timelineEl.querySelector<HistoryRow>(
+            'history-row[data-id="' + cssEscape(id) + '"]',
+        );
     }
 
     // Diff sub-views (per-row diff expansion + inline two-way banner)
     // live in `./historyDiffView.ts`.
     const diffViewConfig: HistoryDiffViewConfig = { vscode, timelineEl };
+
+    // Timeline row markup lives in the `<history-row>` Lit component
+    // (`./components/HistoryRow.ts`); selection + expansion state live
+    // there too and bubble up via the `history-row-selection-change`
+    // and `history-row-expand` listeners wired above. The config now
+    // exposes only the static DOM handles plus the lazy-load observer
+    // and the diff-view config the row hands to `fillDiff`.
+    const rowConfig: HistoryRowConfig = {
+        vscode,
+        timelineEl,
+        btnDiffEl,
+        thumbRequested,
+        thumbObserver,
+        diffViewConfig,
+    };
+    function renderTimeline(): void {
+        renderTimelineDom(entries, rowConfig);
+    }
 
     window.addEventListener("message", (event: MessageEvent) => {
         const msg = event.data as HistoryToWebview;
@@ -219,17 +253,14 @@ export function setupHistoryBehavior(): void {
                 // for this command. Listed here so the discriminated-union
                 // exhaustiveness check holds.
                 break;
-            case "imageReady":
-                fillExpansionDom(msg.id, msg.imageData, msg.entry, rowConfig);
+            case "imageReady": {
+                const row = findRow(msg.id);
+                if (row) row.setImage(msg.imageData, msg.entry);
                 break;
+            }
             case "imageError": {
-                const expansion = timelineEl.querySelector<HTMLElement>(
-                    '.expanded[data-id="' + cssEscape(msg.id) + '"]',
-                );
-                if (expansion)
-                    expansion.textContent =
-                        "Failed to load image: " +
-                        (msg.message || "(no detail)");
+                const row = findRow(msg.id);
+                if (row) row.setImageError(msg.message || "(no detail)");
                 break;
             }
             case "thumbReady":
@@ -250,28 +281,22 @@ export function setupHistoryBehavior(): void {
             case "diffError":
                 showDiffDom(msg.fromId, msg.toId, null, diffViewConfig);
                 break;
-            case "diffReady":
-                fillDiffDom(
-                    msg.id,
-                    msg.against,
-                    msg.leftLabel,
-                    msg.leftImage,
-                    msg.rightLabel,
-                    msg.rightImage,
-                    diffViewConfig,
-                );
+            case "diffReady": {
+                const row = findRow(msg.id);
+                if (row)
+                    row.setDiff(
+                        msg.against,
+                        msg.leftLabel,
+                        msg.leftImage,
+                        msg.rightLabel,
+                        msg.rightImage,
+                    );
                 break;
+            }
             case "diffPairError": {
-                const expansion = timelineEl.querySelector(
-                    '.expanded[data-id="' +
-                        cssEscape(msg.id) +
-                        '"][data-against="' +
-                        cssEscape(msg.against) +
-                        '"]',
-                );
-                if (expansion)
-                    expansion.textContent =
-                        "Diff unavailable: " + (msg.message || "(no detail)");
+                const row = findRow(msg.id);
+                if (row)
+                    row.setDiffError(msg.against, msg.message || "(no detail)");
                 break;
             }
         }

--- a/vscode-extension/src/webview/history/components/HistoryRow.ts
+++ b/vscode-extension/src/webview/history/components/HistoryRow.ts
@@ -8,38 +8,49 @@
 // `thumbReady` message lands and `behavior.ts` writes it into the
 // store, only the rows whose entry id matches re-render.
 //
-// Step 2 of #858: the row now owns its `selected` state. Shift-click
+// Step 2 of #858: the row owns its `selected` state. Shift-click
 // flips `this.selected` and dispatches `history-row-selection-change`
 // (bubbling) so the host can aggregate the (max-2) selection queue
 // without holding a separate `Set<string>`. The host can still
 // imperatively set `.selected = false` to clear the oldest selection
-// when a third row gets picked. Inline expansion (`.expanded` sibling
-// div) STAYS OWNED by the host — step 3 of #858 folds that into the
-// component.
+// when a third row gets picked.
+//
+// Step 3 of #858: inline expansion (image / diff) state lives here
+// too. The row tracks `_expandedKind` / `_diffAgainst` plus the
+// pending payload via `@state` and renders the `.expanded` block as a
+// child of the row's light DOM. Plain-click toggles image expansion;
+// the action buttons request a diff. Either way the row dispatches
+// `history-row-expand` (bubbling, composed) so the host can post
+// `loadImage` / `requestDiff` and collapse any other open row. When
+// the extension's `imageReady` / `diffReady` messages land, the host
+// pushes the bytes into the row via `setImage` / `setDiff` (or the
+// matching error setters); the row re-renders and Lit paints the
+// new content. The `data-id` / `data-against` attributes on
+// `.expanded` are preserved — `historyDiffView.ts.fillDiff` still
+// targets them for the diff-body integration, and the inline CSS in
+// `historyPanel.ts` keys off `.expanded` / `.diff-expanded`.
 //
 // Light DOM: `media/history.css` rules target `.row`, `.thumb`,
 // `.meta`, etc. — keep them applying without touching CSS.
 
 import { LitElement, html, type TemplateResult } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { StoreController } from "../../shared/storeController";
 import type { HistoryEntry } from "../../shared/types";
+import type { VsCodeApi } from "../../shared/vscode";
 import { escapeHtml, formatAbsolute, formatRelative } from "../historyData";
+import {
+    fillDiff as fillDiffDom,
+    type HistoryDiffViewConfig,
+} from "../historyDiffView";
 import { historyStore, type HistoryState } from "../historyStore";
 
-/** Per-row callbacks the host wires up so the row stays presentational
- *  while the inline expansion / diff overlays still live in
- *  `historyTimeline.ts`. Selection notifications travel via the
- *  `history-row-selection-change` CustomEvent — see
- *  [HistoryRowSelectionChangeEvent]. */
+/** Per-row callbacks the host wires up. After step 3 of #858 the
+ *  only remaining concern is hooking the host's IntersectionObserver
+ *  up to the row's `.thumb` element for lazy-load — expansion / diff
+ *  flow through the `history-row-expand` CustomEvent now. */
 export interface HistoryRowCallbacks {
-    /** Plain click: open / collapse the inline image expansion. */
-    onExpand(id: string, row: HistoryRow): void;
-    /** Up-arrow icon: diff against the previous entry for this preview. */
-    onDiffPrevious(id: string, row: HistoryRow): void;
-    /** Compare icon: diff against the live render of this preview. */
-    onDiffCurrent(id: string, row: HistoryRow): void;
     /** Lazy-load hook fired once after the row mounts. The host
      *  registers the `.thumb` element with its IntersectionObserver so
      *  the thumb byte fetch is deferred until scroll-into-view. No-op
@@ -60,9 +71,24 @@ export interface HistoryRowSelectionChangeDetail {
 export type HistoryRowSelectionChangeEvent =
     CustomEvent<HistoryRowSelectionChangeDetail>;
 
+/** Detail for the `history-row-expand` CustomEvent the row
+ *  dispatches when the user opens / re-targets an inline expansion.
+ *  The host listens once on `timelineEl` and posts the appropriate
+ *  vscode message (`loadImage` for `kind: "image"`, `requestDiff`
+ *  for `kind: "diff"`) plus collapses any other currently-open row. */
+export interface HistoryRowExpandDetail {
+    id: string;
+    kind: "image" | "diff";
+    /** Only present when `kind === "diff"`. */
+    against?: "previous" | "current";
+}
+
+export type HistoryRowExpandEvent = CustomEvent<HistoryRowExpandDetail>;
+
 declare global {
     interface HTMLElementEventMap {
         "history-row-selection-change": HistoryRowSelectionChangeEvent;
+        "history-row-expand": HistoryRowExpandEvent;
     }
 }
 
@@ -84,10 +110,59 @@ export class HistoryRow extends LitElement {
      *  no main-branch entry has a `pngHash`. */
     @property({ attribute: false }) mainHash: string | null = null;
 
-    /** Callbacks supplied by the host's `renderTimeline` so the row's
-     *  click / button handlers stay routed through the existing
-     *  expansion / diff plumbing. Set imperatively after construction. */
+    /** Callbacks supplied by the host's `renderTimeline`. After step 3
+     *  of #858 this only carries the lazy-load thumb hook. Set
+     *  imperatively after construction. */
     callbacks: HistoryRowCallbacks | null = null;
+
+    /** Diff-view config used by the row's `updated()` hook to call
+     *  `historyDiffView.ts.fillDiff` once a `_diffPayload` lands. The
+     *  host wires this up the same way as `callbacks` so the row
+     *  doesn't need direct vscode access. */
+    diffViewConfig: HistoryDiffViewConfig | null = null;
+
+    /** Which inline expansion block (if any) is currently open below
+     *  the row body. `null` means collapsed; the row renders no
+     *  `.expanded` child in that case. */
+    @state() private _expandedKind: "image" | "diff" | null = null;
+
+    /** Direction for the diff expansion. Only meaningful when
+     *  `_expandedKind === "diff"`. Mirrored onto the rendered
+     *  `.expanded.diff-expanded` element via `data-against` so
+     *  `historyDiffView.ts.fillDiff` can target it. */
+    @state() private _diffAgainst: "previous" | "current" | null = null;
+
+    /** Base64 PNG bytes for the open image expansion, populated by the
+     *  host when the extension's `imageReady` message lands. `null`
+     *  while loading or after collapse. */
+    @state() private _imageBytes: string | null = null;
+
+    /** Error text for the open image expansion, populated by the host
+     *  when the extension's `imageError` message lands. */
+    @state() private _imageError: string | null = null;
+
+    /** Diff payload (left / right labels + base64 images) for the open
+     *  diff expansion, populated by the host when `diffReady` lands.
+     *  When non-null AND the `.expanded.diff-expanded` shell is in the
+     *  DOM, the row's `updated()` hook calls `fillDiff` once to render
+     *  the mode bar / panes / async pixel-diff stats — that machinery
+     *  stays in `historyDiffView.ts` for now. */
+    @state() private _diffPayload: {
+        leftLabel: string;
+        leftImage: string;
+        rightLabel: string;
+        rightImage: string;
+    } | null = null;
+
+    /** Error text for the open diff expansion, populated by the host
+     *  when the extension's `diffPairError` message lands. */
+    @state() private _diffError: string | null = null;
+
+    /** Identity of the diff payload the row last imperatively drew via
+     *  `fillDiff`. Lit's reactive lifecycle re-invokes `updated()`
+     *  every render; we only want to call `fillDiff` again when a new
+     *  payload arrives, not on every selection / thumb change. */
+    private _lastFilledDiff: object | null = null;
 
     private readonly thumbBytes = new StoreController<
         HistoryState,
@@ -116,6 +191,39 @@ export class HistoryRow extends LitElement {
         this.dataset.id = id;
         this.dataset.sourceKind = (entry?.source && entry.source.kind) || "";
         this.dataset.branch = (entry?.git && entry.git.branch) || "";
+
+        // Diff-body integration is still imperative — `fillDiff` wires
+        // up the persisted mode bar, the async pixel-diff stats, and
+        // the side / overlay / onion render swap. The row provides the
+        // empty `.expanded.diff-expanded` shell with `data-id` /
+        // `data-against` so the existing selector keeps resolving;
+        // when a fresh payload lands we hand off once. Identity-track
+        // via `_lastFilledDiff` so subsequent re-renders for unrelated
+        // reactive state (selection toggle, thumb bytes) don't re-call
+        // `fillDiff` and reset the persisted mode bar.
+        if (
+            this._expandedKind === "diff" &&
+            this._diffPayload &&
+            this._diffAgainst &&
+            this._lastFilledDiff !== this._diffPayload &&
+            this.diffViewConfig
+        ) {
+            const shell = this.querySelector<HTMLElement>(
+                ".expanded.diff-expanded",
+            );
+            if (shell) {
+                this._lastFilledDiff = this._diffPayload;
+                fillDiffDom(
+                    id,
+                    this._diffAgainst,
+                    this._diffPayload.leftLabel,
+                    this._diffPayload.leftImage,
+                    this._diffPayload.rightLabel,
+                    this._diffPayload.rightImage,
+                    this.diffViewConfig,
+                );
+            }
+        }
     }
 
     protected firstUpdated(): void {
@@ -188,7 +296,140 @@ export class HistoryRow extends LitElement {
                     ></i>
                 </button>
             </div>
+            ${this._expandedKind === "image"
+                ? html`<div class="expanded" data-id=${entryId}>
+                      ${this._renderImageExpansion(entry, entryId)}
+                  </div>`
+                : ""}
+            ${this._expandedKind === "diff" && this._diffAgainst
+                ? html`<div
+                      class="expanded diff-expanded"
+                      data-id=${entryId}
+                      data-against=${this._diffAgainst}
+                  >
+                      ${this._renderDiffExpansion()}
+                  </div>`
+                : ""}
         `;
+    }
+
+    private _renderImageExpansion(
+        entry: HistoryEntry,
+        entryId: string,
+    ): TemplateResult {
+        if (this._imageError !== null) {
+            return html`<div>
+                Failed to load image: ${this._imageError || "(no detail)"}
+            </div>`;
+        }
+        if (this._imageBytes !== null) {
+            const sourceFile =
+                entry &&
+                entry.previewMetadata &&
+                entry.previewMetadata.sourceFile;
+            const alt = (entry && entry.previewId) || entryId;
+            return html`
+                <img
+                    src=${"data:image/png;base64," + this._imageBytes}
+                    alt=${alt}
+                />
+                <div class="actions">
+                    ${sourceFile
+                        ? html`<button
+                              @click=${() => this._openSource(sourceFile)}
+                          >
+                              Open in Editor
+                          </button>`
+                        : ""}
+                </div>
+            `;
+        }
+        return html`<div>Loading…</div>`;
+    }
+
+    private _renderDiffExpansion(): TemplateResult {
+        if (this._diffError !== null) {
+            return html`<div>
+                Diff unavailable: ${this._diffError || "(no detail)"}
+            </div>`;
+        }
+        // When `_diffPayload` is non-null the imperative `fillDiff`
+        // call in `updated()` replaces this placeholder with the real
+        // body. Keeping a Lit-rendered loading line here makes the
+        // empty-state visible during the request gap and gives Lit a
+        // valid template to render before the imperative takeover.
+        if (this._diffPayload === null) {
+            return html`<div>Loading diff…</div>`;
+        }
+        return html``;
+    }
+
+    private _openSource(sourceFile: string): void {
+        const vscode = this.diffViewConfig?.vscode as
+            | VsCodeApi<unknown>
+            | undefined;
+        if (vscode) vscode.postMessage({ command: "openSource", sourceFile });
+    }
+
+    /** Host-side hook for the extension's `imageReady` message. The
+     *  host finds the matching row by id and forwards the bytes; the
+     *  row re-renders and Lit paints the `<img>` plus the actions
+     *  block (with the optional "Open in Editor" button). */
+    setImage(imageData: string, _entry?: HistoryEntry): void {
+        // Drop any stale diff state. `expandWithImage` already
+        // guarantees the row is in image mode by the time the host
+        // posts `loadImage`, but `setImage` is a public method and a
+        // direct caller may race a collapse — pin the kind defensively.
+        this._expandedKind = "image";
+        this._imageError = null;
+        this._imageBytes = imageData;
+    }
+
+    /** Host-side hook for `imageError`. Replaces any pending bytes
+     *  with the error message; the row re-renders into the failure
+     *  state. */
+    setImageError(message: string): void {
+        this._expandedKind = "image";
+        this._imageBytes = null;
+        this._imageError = message;
+    }
+
+    /** Host-side hook for `diffReady`. Stash the payload; the row's
+     *  `updated()` hook hands off to `historyDiffView.ts.fillDiff`
+     *  which paints the mode bar / panes into the `.expanded`
+     *  shell. */
+    setDiff(
+        against: "previous" | "current",
+        leftLabel: string,
+        leftImage: string,
+        rightLabel: string,
+        rightImage: string,
+    ): void {
+        this._expandedKind = "diff";
+        this._diffAgainst = against;
+        this._diffError = null;
+        this._diffPayload = { leftLabel, leftImage, rightLabel, rightImage };
+    }
+
+    /** Host-side hook for `diffPairError`. Renders the error inside
+     *  the diff shell. */
+    setDiffError(against: "previous" | "current", message: string): void {
+        this._expandedKind = "diff";
+        this._diffAgainst = against;
+        this._diffPayload = null;
+        this._diffError = message;
+    }
+
+    /** Collapse any open expansion. Used by the host when a new row
+     *  expands so only one expansion is open at a time. */
+    collapse(): void {
+        this._expandedKind = null;
+        this._diffAgainst = null;
+        this._imageBytes = null;
+        this._imageError = null;
+        this._diffPayload = null;
+        this._diffError = null;
+        this._lastFilledDiff = null;
     }
 
     connectedCallback(): void {
@@ -218,22 +459,60 @@ export class HistoryRow extends LitElement {
                     },
                 ),
             );
-        } else {
-            this.callbacks?.onExpand(id, this);
+            return;
         }
+        // Plain click → toggle the image expansion. Already-open image
+        // collapses; anything else (closed, or open in diff mode)
+        // (re)opens as image. Either way we dispatch
+        // `history-row-expand` so the host can collapse other rows
+        // and post the corresponding `loadImage`. Collapse-only
+        // transitions don't post a request — there's nothing to load.
+        if (this._expandedKind === "image") {
+            this.collapse();
+            return;
+        }
+        this._expandedKind = "image";
+        this._diffAgainst = null;
+        this._imageBytes = null;
+        this._imageError = null;
+        this._diffPayload = null;
+        this._diffError = null;
+        this._lastFilledDiff = null;
+        this.dispatchEvent(
+            new CustomEvent<HistoryRowExpandDetail>("history-row-expand", {
+                detail: { id, kind: "image" },
+                bubbles: true,
+                composed: true,
+            }),
+        );
     };
 
     private readonly onDiffPrevClick = (ev: MouseEvent): void => {
         ev.stopPropagation();
-        const id = this.entry?.id ?? "";
-        if (!id || !this.callbacks) return;
-        this.callbacks.onDiffPrevious(id, this);
+        this._requestDiff("previous");
     };
 
     private readonly onDiffCurrentClick = (ev: MouseEvent): void => {
         ev.stopPropagation();
-        const id = this.entry?.id ?? "";
-        if (!id || !this.callbacks) return;
-        this.callbacks.onDiffCurrent(id, this);
+        this._requestDiff("current");
     };
+
+    private _requestDiff(against: "previous" | "current"): void {
+        const id = this.entry?.id ?? "";
+        if (!id) return;
+        this._expandedKind = "diff";
+        this._diffAgainst = against;
+        this._imageBytes = null;
+        this._imageError = null;
+        this._diffPayload = null;
+        this._diffError = null;
+        this._lastFilledDiff = null;
+        this.dispatchEvent(
+            new CustomEvent<HistoryRowExpandDetail>("history-row-expand", {
+                detail: { id, kind: "diff", against },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
 }

--- a/vscode-extension/src/webview/history/historyTimeline.ts
+++ b/vscode-extension/src/webview/history/historyTimeline.ts
@@ -6,17 +6,23 @@
 // Step 2 of #858: selection state moved into the row. The row owns
 // `selected` and dispatches `history-row-selection-change` on
 // shift-click; the host listens on `timelineEl` to maintain the
-// (max-2) queue and toggle the diff button. This module no longer
-// holds a `selectedIds` set or a `toggleSelected` helper.
+// (max-2) queue and toggle the diff button.
+//
+// Step 3 of #858: the row also owns inline expansion state (image /
+// diff). Plain click + action-button click now dispatch
+// `history-row-expand` (bubbling) — the host listens once on
+// `timelineEl`, collapses any other open row, and posts the matching
+// `loadImage` / `requestDiff` vscode message. Extension responses
+// (`imageReady` / `imageError` / `diffReady` / `diffPairError`) flow
+// through `setImage` / `setImageError` / `setDiff` / `setDiffError`
+// on the targeted row. The imperative `expandRow` / `requestRowDiff`
+// / `fillExpansion` helpers and the `getExpandedId` / `setExpandedId`
+// scalars are gone.
 //
 // What's left here:
 //
 //  - `renderTimeline`: declarative iteration over `entries`, swapping
 //    out `<history-row>` children on the timeline container.
-//  - `expandRow` / `requestRowDiff` / `fillExpansion`: still
-//    imperative because the inline `.expanded` sibling div is a
-//    separate concern from row rendering and gets its own component
-//    later in the issue.
 //
 // Thumb byte cache: deleted from the config in favour of
 // `historyStore` (`./historyStore.ts`). Rows subscribe directly via
@@ -27,7 +33,8 @@ import "./components/HistoryRow";
 import type { HistoryEntry } from "../shared/types";
 import type { VsCodeApi } from "../shared/vscode";
 import { HistoryRow, type HistoryRowCallbacks } from "./components/HistoryRow";
-import { cssEscape, findLatestMainHash } from "./historyData";
+import { findLatestMainHash } from "./historyData";
+import type { HistoryDiffViewConfig } from "./historyDiffView";
 
 export interface HistoryRowConfig {
     vscode: VsCodeApi<unknown>;
@@ -36,16 +43,18 @@ export interface HistoryRowConfig {
     /** Toolbar diff button — disabled state tracks the host-managed
      *  selection queue length (must be exactly 2 to enable). */
     btnDiffEl: HTMLButtonElement;
-    /** Currently expanded row's id, or `null` when nothing is expanded.
-     *  Mutated by `expandRow` (toggle) and `requestRowDiff` (replace). */
-    getExpandedId(): string | null;
-    setExpandedId(id: string | null): void;
     /** Dedup set: ids we've already asked the extension to load.
      *  Cleared per `renderTimeline` so a fresh entry set retries. */
     thumbRequested: Set<string>;
     /** Lazy-load observer for the thumb column — `null` on environments
      *  without `IntersectionObserver`. Disconnected per render. */
     thumbObserver: IntersectionObserver | null;
+    /** Diff-view config the row hands to `historyDiffView.ts.fillDiff`
+     *  once a `diffReady` payload lands. The diff body still flows
+     *  through that module's persisted-mode-bar + async pixel-diff
+     *  machinery; the row provides the empty `.expanded.diff-expanded`
+     *  shell and calls `fillDiff` from its `updated()` hook. */
+    diffViewConfig: HistoryDiffViewConfig;
 }
 
 export function renderTimeline(
@@ -64,10 +73,6 @@ export function renderTimeline(
     const mainHash = findLatestMainHash(entries);
 
     const callbacks: HistoryRowCallbacks = {
-        onExpand: (id, row) => expandRow(id, row, config),
-        onDiffPrevious: (id, row) =>
-            requestRowDiff(id, row, "previous", config),
-        onDiffCurrent: (id, row) => requestRowDiff(id, row, "current", config),
         onThumbConnected: (thumbEl) => {
             // Defer the byte fetch to the host's IntersectionObserver
             // so off-screen rows don't hammer the daemon. The store
@@ -81,86 +86,7 @@ export function renderTimeline(
         row.entry = entry;
         row.mainHash = mainHash;
         row.callbacks = callbacks;
+        row.diffViewConfig = config.diffViewConfig;
         config.timelineEl.appendChild(row);
     }
-}
-
-/** Toggle the inline expansion (full-size image + actions) for [id].
- *  Collapses any other open expansion first. Posts `loadImage` so the
- *  extension streams the PNG bytes back asynchronously. */
-export function expandRow(
-    id: string,
-    row: HistoryRow,
-    config: HistoryRowConfig,
-): void {
-    const prev = config.timelineEl.querySelector(".expanded");
-    if (prev) prev.remove();
-    if (config.getExpandedId() === id) {
-        config.setExpandedId(null);
-        return;
-    }
-    config.setExpandedId(id);
-
-    const expansion = document.createElement("div");
-    expansion.className = "expanded";
-    expansion.dataset.id = id;
-    expansion.innerHTML = "<div>Loading…</div>";
-    row.parentNode?.insertBefore(expansion, row.nextSibling);
-    config.vscode.postMessage({ command: "loadImage", id });
-}
-
-/** Open an inline diff expansion against the previous / current entry.
- *  Replaces any open expansion (image OR diff) and asks the extension
- *  to compute the comparison. */
-export function requestRowDiff(
-    id: string,
-    row: HistoryRow,
-    against: "previous" | "current",
-    config: HistoryRowConfig,
-): void {
-    const prev = config.timelineEl.querySelector(".expanded");
-    if (prev) prev.remove();
-    config.setExpandedId(id);
-    const expansion = document.createElement("div");
-    expansion.className = "expanded diff-expanded";
-    expansion.dataset.id = id;
-    expansion.dataset.against = against;
-    expansion.innerHTML = "<div>Loading diff…</div>";
-    row.parentNode?.insertBefore(expansion, row.nextSibling);
-    config.vscode.postMessage({ command: "requestDiff", id, against });
-}
-
-/** Populate an open expansion with the streamed full-size image plus
- *  an "Open in Editor" action when the entry's previewMetadata
- *  surfaces a sourceFile. No-op when the matching `.expanded` is gone
- *  (user collapsed before the bytes arrived). */
-export function fillExpansion(
-    id: string,
-    imageData: string,
-    entry: HistoryEntry | undefined,
-    config: HistoryRowConfig,
-): void {
-    const expansion = config.timelineEl.querySelector(
-        '.expanded[data-id="' + cssEscape(id) + '"]',
-    );
-    if (!expansion) return;
-    expansion.innerHTML = "";
-    const img = document.createElement("img");
-    img.src = "data:image/png;base64," + imageData;
-    img.alt = (entry && entry.previewId) || id;
-    expansion.appendChild(img);
-
-    const actions = document.createElement("div");
-    actions.className = "actions";
-    const sourceFile =
-        entry && entry.previewMetadata && entry.previewMetadata.sourceFile;
-    if (sourceFile) {
-        const open = document.createElement("button");
-        open.textContent = "Open in Editor";
-        open.addEventListener("click", () =>
-            config.vscode.postMessage({ command: "openSource", sourceFile }),
-        );
-        actions.appendChild(open);
-    }
-    expansion.appendChild(actions);
 }


### PR DESCRIPTION
## Summary
- `<history-row>` now owns image / diff expansion state via `@state` and renders the inline expansion as part of its own template.
- `expandRow`, `requestRowDiff`, `fillExpansion` are gone from `historyTimeline.ts`; the row dispatches `history-row-expand` and the host posts `loadImage` / `requestDiff` in response.
- Extension messages (`imageReady`, `imageError`, `diffReady`, `diffPairError`) now route to the matching row via `setImage` / `setImageError` / `setDiff` / `setDiffError` methods.
- `historyDiffView.ts.fillDiff` stays as the diff-body entry point; the row calls it from `updated()` once the `.expanded.diff-expanded` shell is in the DOM.
- Step 3 of #858. Issue #858 is now ready to close after this lands.

## Test plan
- [x] `npm run compile`
- [x] `npm test` (509 passing)
- [x] `npm run format:check`


---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_