### PR TITLE
feat(vscode)!: remove composePreview.daemon.enabled setting

### DIFF
--- a/docs/daemon/CONFIG.md
+++ b/docs/daemon/CONFIG.md
@@ -26,7 +26,7 @@ The block used to live under `experimental`; new builds should use the top-level
 |-|-|
 | **Default** | `true` |
 | **Range** | `true` / `false` |
-| **Effect** | Master switch. When `false`, `composePreviewDaemonStart` still runs and writes a descriptor with `"enabled": false` so VS Code can warn and use the Gradle render path temporarily. When `true`, the descriptor's `"enabled": true` flag is set and the VS Code extension launches the daemon per its own `composePreview.daemon.enabled` setting. |
+| **Effect** | Master switch. When `false`, `composePreviewDaemonStart` still runs and writes a descriptor with `"enabled": false` so VS Code can warn and use the Gradle render path temporarily. When `true`, the descriptor's `"enabled": true` flag is set and the VS Code extension launches the daemon. |
 
 The flag does NOT control task registration: the task is always registered so the file-presence check on the VS Code side has a stable signal.
 
@@ -85,7 +85,7 @@ model.
 
 ## Gradle properties
 
-There is intentionally NO `-PcomposePreview.daemon.enabled=...` property override. Gradle property reads at config time key the configuration cache, and the daemon flag is one consumers may flip from VS Code — a property override would force a ~5–10s reconfigure on every toggle. Flip via build script and rely on Gradle's incremental task graph, or use VS Code's own setting (which gates the spawn without re-running `composePreviewDaemonStart`).
+There is intentionally NO `-PcomposePreview.daemon.enabled=...` property override. Gradle property reads at config time key the configuration cache, and a property override would force a ~5–10s reconfigure on every toggle. Flip via build script and rely on Gradle's incremental task graph.
 
 ## Schema
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
@@ -25,12 +25,12 @@ abstract class DaemonExtension @Inject constructor(objects: ObjectFactory) {
    * false` so the VS Code extension can sniff the file and learn the user explicitly opted out —
    * but the extension must NOT spawn the daemon JVM in that case.
    *
-   * When `true`, the descriptor's `enabled: true` flag is set and the VS Code extension may launch
-   * the daemon per its `composePreview.daemon.enabled` setting.
+   * When `true`, the descriptor's `enabled: true` flag is set and the VS Code extension launches
+   * the daemon.
    *
    * Flip via build script (`composePreview { daemon { enabled = false } }`). The Gradle property
-   * override is intentionally NOT wired here — it would key the config cache on a property that VS
-   * Code flips frequently. See `CONFIG.md`.
+   * override is intentionally NOT wired here — it would key the config cache on a property that may
+   * be toggled frequently. See `CONFIG.md`.
    */
   val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -124,11 +124,6 @@
                     "default": "debug",
                     "description": "Build variant to use for preview rendering"
                 },
-                "composePreview.daemon.enabled": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Use the persistent preview daemon for refresh on saves to files the user has open, plus scroll-ahead speculative renders. When on, daemon failures are shown as errors instead of silently falling back to the Gradle `renderPreviews` task. Turning this off temporarily uses the Gradle path, but the daemon will become required by the extension in a future release."
-                },
                 "composePreview.earlyFeatures.enabled": {
                     "type": "boolean",
                     "default": false,

--- a/vscode-extension/src/daemon/daemonGate.ts
+++ b/vscode-extension/src/daemon/daemonGate.ts
@@ -1,4 +1,3 @@
-import * as vscode from "vscode";
 import { GradleService } from "../gradleService";
 import { LogFilter } from "../logFilter";
 import {
@@ -13,15 +12,12 @@ import {
 } from "./daemonProcess";
 import { DaemonLaunchDescriptor } from "./daemonProtocol";
 
-const SETTING_ENABLED = "daemon.enabled";
-
 /**
  * Source-of-truth for "is the daemon path live for this user/workspace?"
  *
- * Controlled by the `composePreview.daemon.enabled` setting (true by default).
- * When enabled, daemon startup/render failures are surfaced to the user rather
- * than silently falling back to `renderPreviews`. Users can explicitly disable
- * the daemon setting to use the Gradle path temporarily.
+ * The daemon path is always on; the build can still opt out by emitting a
+ * descriptor with `enabled: false` (`composePreview { daemon { enabled = false } }`),
+ * in which case we fall back to the Gradle render path for that module.
  *
  * One daemon per Gradle module (per `:samples:android`, etc.). Modules are
  * spawned lazily on first use and shut down on extension dispose.
@@ -30,7 +26,6 @@ export class DaemonGate {
     private readonly daemons = new Map<string, ManagedDaemon>();
     private readonly spawns = new Map<string, Promise<DaemonClient>>();
     private disposed = false;
-    private warnedUserDisabled = false;
     private readonly warnedBuildDisabled = new Set<string>();
 
     constructor(
@@ -40,38 +35,17 @@ export class DaemonGate {
         private readonly logFilter: LogFilter = new LogFilter(),
     ) {}
 
-    /** Reads the user setting freshly each time so toggles don't need a reload. */
-    isEnabled(): boolean {
-        const config = vscode.workspace.getConfiguration("composePreview");
-        const current = config.inspect<boolean>(SETTING_ENABLED);
-        const value =
-            current?.workspaceFolderValue ??
-            current?.workspaceValue ??
-            current?.globalValue ??
-            true;
-        if (!value && !this.warnedUserDisabled) {
-            this.warnedUserDisabled = true;
-            this.logger.appendLine(
-                "[daemon] WARNING: composePreview.daemon.enabled is false; using the Gradle render path. " +
-                    "The daemon will become required by the VS Code extension in a future release.",
-            );
-        }
-        return value;
-    }
-
     /**
      * Returns a healthy daemon for [moduleId], spawning one if needed. Returns null when the daemon
-     * path has been explicitly disabled by user or build config. Throws when the daemon is enabled
-     * but unavailable, so callers can surface the failure instead of silently rendering via Gradle.
-     * Reasons null is returned:
-     *   - Setting disabled.
-     *   - Descriptor's `enabled: false` (user didn't opt in at the build level).
+     * has been explicitly disabled by build config. Throws when the daemon is enabled but
+     * unavailable, so callers can surface the failure instead of silently rendering via Gradle.
+     * Returns null when the descriptor's `enabled: false` (user didn't opt in at the build level).
      */
     async getOrSpawn(
         moduleId: string,
         events: DaemonClientEvents,
     ): Promise<DaemonClient | null> {
-        if (this.disposed || !this.isEnabled()) {
+        if (this.disposed) {
             return null;
         }
 
@@ -184,9 +158,6 @@ export class DaemonGate {
         gradleService: GradleService,
         moduleId: string,
     ): Promise<void> {
-        if (!this.isEnabled()) {
-            return;
-        }
         await gradleService.runDaemonBootstrap(moduleId);
     }
 

--- a/vscode-extension/src/daemon/daemonProcess.ts
+++ b/vscode-extension/src/daemon/daemonProcess.ts
@@ -94,7 +94,7 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
 
     if (!descriptor.enabled) {
         throw new Error(
-            "Daemon disabled in build config: set composePreview.daemon.enabled = true",
+            "Daemon disabled in build config: set `composePreview { daemon { enabled = true } }`",
         );
     }
 

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -175,18 +175,14 @@ export class DaemonScheduler {
      *
      * `progress` fires through `'spawning'` while the JVM comes up, `'bootstrapping'` only when the
      * cached descriptor could not be used, and `'ready'` once `initialize` is acknowledged.
-     * `'fallback'` fires only when the daemon is explicitly disabled.
-     * Enabled-but-broken daemon failures throw so the UI can surface the error. No-op when the gate
-     * is disabled.
+     * `'fallback'` fires only when the daemon is explicitly disabled by the build.
+     * Enabled-but-broken daemon failures throw so the UI can surface the error.
      */
     async warmModule(
         gradleService: GradleService,
         moduleId: string,
         progress?: WarmProgress,
     ): Promise<boolean> {
-        if (!this.gate.isEnabled()) {
-            return false;
-        }
         if (this.gate.isDaemonReady(moduleId)) {
             progress?.("ready");
             return true;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -429,10 +429,10 @@ export async function activate(
         logFilter,
     );
 
-    // Daemon path is controlled by composePreview.daemon.enabled (true by default). When disabled
-    // the gate's `isEnabled()` returns false and the scheduler is never asked to spawn anything —
-    // the Gradle path is the temporary escape hatch. When enabled, daemon failures surface as
-    // errors instead of silently falling back to Gradle.
+    // The daemon path is always on; the build can still opt out per-module via
+    // `composePreview { daemon { enabled = false } }`, in which case the gate falls back to the
+    // Gradle render path for that module. Daemon failures surface as errors instead of silently
+    // falling back to Gradle.
     daemonGate = new DaemonGate(
         workspaceRoot,
         "0.1.0",
@@ -1185,7 +1185,7 @@ async function flushInteractiveStreams(): Promise<void> {
     activeStreamFrameStreams.clear();
     streamFrameIdToPreviewId.clear();
     updateInteractiveStatus();
-    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+    if (!daemonGate || !daemonScheduler) {
         return;
     }
     // Flush each surface through the matching wire-level stop. Using the
@@ -1234,7 +1234,7 @@ async function flushRecordingSessions(options: {
     const formats = new Map(activeRecordingFormats);
     activeRecordingSessions.clear();
     activeRecordingFormats.clear();
-    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+    if (!daemonGate || !daemonScheduler) {
         return;
     }
     await Promise.all(
@@ -1452,14 +1452,15 @@ async function applyDiscoveryDiff(
 }
 
 /**
- * Side-channel save handler that pushes a `fileChanged` + focus-scoped `renderNow` to the daemon
- * when the daemon path is enabled. Explicit daemon opt-out returns `'disabled'` so the caller can
- * use the Gradle render path; daemon failures return `'failed'` and do not fall back.
+ * Side-channel save handler that pushes a `fileChanged` + focus-scoped `renderNow` to the daemon.
+ * A build-side opt-out (`composePreview { daemon { enabled = false } }`) returns `'disabled'` so
+ * the caller can use the Gradle render path; daemon failures return `'failed'` and do not fall
+ * back.
  */
 type DaemonSaveResult = "accepted" | "disabled" | "failed";
 
 async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) {
+    if (!daemonGate || !daemonScheduler || !gradleService) {
         return "disabled";
     }
     const module = gradleService.resolveModule(filePath);
@@ -1714,14 +1715,14 @@ async function runActivationRefresh(filePath: string): Promise<void> {
  * daemon-enabled module, kick off `composePreviewDaemonStart` + JVM spawn
  * in the background so the first save in the session collapses to
  * "kotlinc + render" instead of paying the cold-bootstrap latency on the
- * user's interactive path. No-op when the daemon flag is off, when the
- * file isn't in a preview module, or when the daemon is already up.
+ * user's interactive path. No-op when the file isn't in a preview module
+ * or when the daemon is already up.
  */
 async function warmDaemonForFile(
     filePath: string,
     opts: { refreshAfterReady?: boolean } = {},
 ): Promise<boolean> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) {
+    if (!daemonGate || !daemonScheduler || !gradleService) {
         return false;
     }
     const module = gradleService.resolveModule(filePath);
@@ -1760,7 +1761,7 @@ async function warmDaemonForFile(
             `daemon: warm failed for ${module}: ${String((err as Error).message ?? err)}`,
         );
         vscode.window.showErrorMessage(
-            "Compose Preview daemon is enabled but failed to start. Preview saves will not fall back to Gradle until the daemon is fixed or disabled.",
+            "Compose Preview daemon failed to start. Preview saves will not render until the daemon is fixed.",
         );
         return false;
     }
@@ -2131,7 +2132,7 @@ async function warmShownPreviewsForFile(
     filePath: string,
     reason: string,
 ): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) {
+    if (!daemonGate || !daemonScheduler || !gradleService) {
         return;
     }
     const module = gradleService.resolveModule(filePath);
@@ -2390,9 +2391,9 @@ function maybeFirePendingRefresh(): void {
  *  during the run, re-applying the debounce-elapsed check.
  *
  *  Picks daemon-vs-Gradle deliberately — never runs both for the same save.
- *  When the daemon is enabled for the file's module, the save uses the daemon path. If the daemon
- *  is unavailable while enabled, we surface an error instead of rendering via Gradle. Explicitly
- *  disabling the daemon keeps the Gradle render path available for now.
+ *  Saves use the daemon path; if the daemon is unavailable we surface an error instead of
+ *  rendering via Gradle. The build can still opt out per-module via
+ *  `composePreview { daemon { enabled = false } }`, in which case the Gradle render path runs.
  *
  *  **Recompile-before-notify invariant.** In the daemon path the compile
  *  step runs *first*, then the daemon is notified. The daemon's
@@ -2430,7 +2431,7 @@ async function runRefreshExclusive(filePath: string): Promise<void> {
                 return;
             }
             vscode.window.showErrorMessage(
-                "Compose Preview daemon is enabled but unavailable. Restart the preview daemon after fixing the daemon issue.",
+                "Compose Preview daemon is unavailable. Restart the preview daemon after fixing the daemon issue.",
             );
             return;
         }
@@ -2499,11 +2500,7 @@ function pickRefreshMode(filePath: string): RefreshMode {
     if (!daemonGate || !gradleService) {
         return "gradle";
     }
-    return pickRefreshModeFor(
-        filePath,
-        daemonGate.isEnabled(),
-        gradleService.resolveModule(filePath),
-    );
+    return pickRefreshModeFor(filePath, gradleService.resolveModule(filePath));
 }
 
 function sendModuleList() {
@@ -3234,7 +3231,7 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             const mod = previewModuleMap.get(msg.previewId);
             if (mod) {
                 optInHeavyRefresh(mod, msg.previewId);
-                if (daemonGate?.isEnabled() && daemonScheduler) {
+                if (daemonGate && daemonScheduler) {
                     void daemonScheduler.renderNow(
                         mod,
                         [msg.previewId],
@@ -4107,7 +4104,7 @@ async function handleSetInteractive(
     previewId: string,
     enabled: boolean,
 ): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+    if (!daemonGate || !daemonScheduler) {
         return;
     }
     const moduleId = previewModuleMap.get(previewId);
@@ -4194,7 +4191,7 @@ async function handleSetInteractive(
  * frameStreamId regardless of which handler minted it.
  */
 async function handleRequestStreamStart(previewId: string): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+    if (!daemonGate || !daemonScheduler) {
         return;
     }
     const moduleId = previewModuleMap.get(previewId);
@@ -4263,7 +4260,7 @@ async function handleRequestStreamStop(previewId: string): Promise<void> {
     streamFrameIdToPreviewId.delete(sid);
     updateInteractiveStatus();
     const moduleId = previewModuleMap.get(previewId);
-    if (!daemonGate?.isEnabled() || !daemonScheduler || !moduleId) {
+    if (!daemonGate || !daemonScheduler || !moduleId) {
         return;
     }
     const client = await daemonGate?.getOrSpawn(
@@ -4285,7 +4282,7 @@ async function handleRequestStreamVisibility(
         return;
     }
     const moduleId = previewModuleMap.get(previewId);
-    if (!daemonGate?.isEnabled() || !daemonScheduler || !moduleId) {
+    if (!daemonGate || !daemonScheduler || !moduleId) {
         return;
     }
     const client = await daemonGate?.getOrSpawn(
@@ -4421,7 +4418,7 @@ async function handleSetRecording(
     enabled: boolean,
     format: "apng" | "mp4",
 ): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+    if (!daemonGate || !daemonScheduler) {
         return;
     }
     const moduleId = previewModuleMap.get(previewId);
@@ -4510,7 +4507,7 @@ async function handleSetRecording(
 async function forwardInteractiveInput(
     input: Extract<WebviewToExtension, { command: "recordInteractiveInput" }>,
 ): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+    if (!daemonGate || !daemonScheduler) {
         return;
     }
     const previewId = input.previewId;
@@ -4546,7 +4543,7 @@ async function forwardInteractiveInput(
 async function forwardRecordingInput(
     input: Extract<WebviewToExtension, { command: "recordInteractiveInput" }>,
 ): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+    if (!daemonGate || !daemonScheduler) {
         return;
     }
     const previewId = input.previewId;
@@ -4598,7 +4595,7 @@ async function notifyDaemonViewport(
     visible: string[],
     predicted: string[],
 ): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+    if (!daemonGate || !daemonScheduler) {
         return;
     }
     // Group by owning module — viewports cross module boundaries only when

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -775,8 +775,7 @@ export class GradleService {
     /**
      * Runs `:<module>:composePreviewDaemonStart` so the daemon launch
      * descriptor (`build/compose-previews/daemon-launch.json`) is up to date.
-     * Cheap and cacheable — emits a small JSON. Called only when the daemon
-     * path is enabled (`composePreview.daemon.enabled`); the caller (DaemonGate) handles errors.
+     * Cheap and cacheable — emits a small JSON. The caller (DaemonGate) handles errors.
      */
     async runDaemonBootstrap(module: string): Promise<void> {
         await this.runTask(

--- a/vscode-extension/src/refreshMode.ts
+++ b/vscode-extension/src/refreshMode.ts
@@ -4,27 +4,20 @@
  * VS Code API (extension.ts imports `vscode`).
  *
  * The production wrapper inside extension.ts reads the live
- * `daemonGate` / `gradleService` state and forwards into here.
+ * `gradleService` state and forwards into here.
  */
 
 export type RefreshMode = "daemon" | "gradle";
 
 /**
- * - `'daemon'` — the daemon flag is on and the file resolves to a module. The save path skips
+ * - `'daemon'` — the file resolves to a module. The save path skips
  *   `renderPreviews` entirely; daemon failures are surfaced as errors instead of falling back.
- * - `'gradle'` — daemon disabled or file outside any module. Existing Gradle render path runs.
- *
- * The decision is made fresh on each save, so explicitly disabling the daemon still gives users a
- * temporary Gradle escape hatch while the daemon path is being stabilised.
+ * - `'gradle'` — file outside any module. Existing Gradle render path runs.
  */
 export function pickRefreshModeFor(
     _filePath: string,
-    daemonEnabled: boolean,
     moduleId: string | null,
 ): RefreshMode {
-    if (!daemonEnabled) {
-        return "gradle";
-    }
     if (!moduleId) {
         return "gradle";
     }

--- a/vscode-extension/src/test/daemonProcess.test.ts
+++ b/vscode-extension/src/test/daemonProcess.test.ts
@@ -117,9 +117,8 @@ describe("readLaunchDescriptor", () => {
     it(
         "preserves an explicit enabled=false flag without mutating it",
         withTempWorkspace((dir) => {
-            // The build can opt out via composePreview.daemon.enabled = false
-            // even with the VS Code setting on. Reader must return the descriptor
-            // honestly; the gate decides what to do with it.
+            // The build can opt out via composePreview { daemon { enabled = false } }.
+            // Reader must return the descriptor honestly; the gate decides what to do with it.
             const descriptor = { ...validDescriptor(), enabled: false };
             writeDescriptor(dir, "samples/android", descriptor);
             const result = readLaunchDescriptor(dir, "samples/android");

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -65,7 +65,6 @@ class FakeClient {
  * scheduler may register a different bag per module.
  */
 class FakeGate {
-    public enabled = true;
     public client: FakeClient | null = new FakeClient();
     public ready = false;
     public getOrSpawnCalls: string[] = [];
@@ -93,9 +92,6 @@ class FakeGate {
         }
     >();
 
-    isEnabled(): boolean {
-        return this.enabled;
-    }
     isDaemonReady(_moduleId: string): boolean {
         return this.ready;
     }
@@ -283,9 +279,8 @@ describe("DaemonScheduler", () => {
         assert.deepStrictEqual(params.previews, ["fresh1", "fresh2"]);
     });
 
-    it("skips daemon traffic entirely when the gate is disabled", async () => {
+    it("skips daemon traffic entirely when the gate has no client", async () => {
         const { gate, scheduler } = build();
-        gate.enabled = false;
         gate.client = null;
         await scheduler.fileChanged("mod", "/x.kt");
         await scheduler.setFocus("mod", ["a"]);
@@ -520,7 +515,6 @@ describe("DaemonScheduler", () => {
         const ok = await scheduler.renderNow("mod", ["p1"], "fast");
         assert.strictEqual(ok, true);
 
-        gate.enabled = false;
         gate.client = null;
         const fail = await scheduler.renderNow("mod2", ["p1"], "fast");
         assert.strictEqual(fail, false);
@@ -649,21 +643,6 @@ describe("DaemonScheduler", () => {
                 "spawning",
                 "fallback",
             ]);
-        });
-
-        it("returns false without progress events when the gate is disabled", async () => {
-            const { gate, scheduler } = build();
-            gate.enabled = false;
-            const gradle = new FakeGradleService();
-            const states: string[] = [];
-            const ok = await scheduler.warmModule(
-                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                "mod",
-                (s) => states.push(s),
-            );
-            assert.strictEqual(ok, false);
-            assert.deepStrictEqual(states, []);
-            assert.deepStrictEqual(gradle.bootstrapCalls, []);
         });
     });
 

--- a/vscode-extension/src/test/refreshMode.test.ts
+++ b/vscode-extension/src/test/refreshMode.test.ts
@@ -8,21 +8,11 @@ import { pickRefreshModeFor } from "../refreshMode";
  * every branch without stubbing the VS Code API.
  */
 describe("pickRefreshModeFor", () => {
-    it("returns gradle when the daemon flag is off", () => {
-        assert.strictEqual(
-            pickRefreshModeFor("/x.kt", /* enabled */ false, "mod"),
-            "gradle",
-        );
-    });
-
     it("returns gradle when the file resolves to no module", () => {
-        assert.strictEqual(
-            pickRefreshModeFor("/outside.kt", true, null),
-            "gradle",
-        );
+        assert.strictEqual(pickRefreshModeFor("/outside.kt", null), "gradle");
     });
 
-    it("returns daemon when enabled and the file resolves to a module", () => {
-        assert.strictEqual(pickRefreshModeFor("/x.kt", true, "mod"), "daemon");
+    it("returns daemon when the file resolves to a module", () => {
+        assert.strictEqual(pickRefreshModeFor("/x.kt", "mod"), "daemon");
     });
 });


### PR DESCRIPTION
## Summary

- Drops the `composePreview.daemon.enabled` VS Code setting. The daemon path is now always on; the build can still opt out per-module via `composePreview { daemon { enabled = false } }`, in which case the extension falls back to the Gradle render path for that module.
- Removes `DaemonGate.isEnabled()`, `SETTING_ENABLED`, the disabled-warning bookkeeping, and the matching short-circuits in `bootstrap()` and `DaemonScheduler.warmModule`.
- `pickRefreshModeFor` now takes only the module id; the `daemonEnabled` branch and its test are gone.
- Refreshes stale comments and two user-facing error strings ("daemon is enabled but…") in `extension.ts`, `gradleService.ts`, `daemonProcess.ts`, `DaemonExtension.kt`, and `docs/daemon/CONFIG.md`.

## Test plan

- [x] `npm test` in `vscode-extension/` (494 passing)
- [x] `./gradlew :gradle-plugin:ktfmtCheckMain`
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_019VsVA94R3drcpkTdfNP5T3)_