### PR TITLE
fix(vscode): forward live wheel events through the streaming canvas

### DIFF
--- a/vscode-extension/src/test/interactiveInput.test.ts
+++ b/vscode-extension/src/test/interactiveInput.test.ts
@@ -1,0 +1,245 @@
+// Streaming-mode coverage for the live-preview wheel handler. The
+// streaming painter (`streamingPainter.ts`) hides the legacy `<img>` and
+// paints frames into a `<canvas class="stream-canvas">`. The wheel
+// handler must follow that swap, otherwise rotary scroll never reaches
+// the daemon and `evt.preventDefault()` silently eats the user's input.
+
+import * as assert from "assert";
+import {
+    attachInteractiveInputHandlers,
+    liveRenderSurface,
+} from "../webview/preview/interactiveInput";
+
+interface PostedMessage {
+    [key: string]: unknown;
+}
+
+interface FakeRect {
+    width: number;
+    height: number;
+    left: number;
+    top: number;
+}
+
+/** happy-dom's layout engine returns 0×0 rects for everything, so each
+ *  test pins a synthetic rect on the surface element it's exercising. */
+function stubBoundingRect(el: Element, rect: FakeRect): void {
+    Object.defineProperty(el, "getBoundingClientRect", {
+        configurable: true,
+        value: () => ({
+            width: rect.width,
+            height: rect.height,
+            left: rect.left,
+            top: rect.top,
+            right: rect.left + rect.width,
+            bottom: rect.top + rect.height,
+            x: rect.left,
+            y: rect.top,
+            toJSON: () => ({}),
+        }),
+    });
+}
+
+/** happy-dom's `new WheelEvent("wheel", { clientX, clientY })` drops the
+ *  pointer coords from the init dict (only `deltaY` survives). Patch them
+ *  on after construction so the handler sees realistic values. */
+function makeWheelEvent(opts: {
+    clientX: number;
+    clientY: number;
+    deltaY: number;
+}): WheelEvent {
+    const evt = new WheelEvent("wheel", {
+        deltaY: opts.deltaY,
+        bubbles: true,
+        cancelable: true,
+    });
+    Object.defineProperty(evt, "clientX", {
+        configurable: true,
+        value: opts.clientX,
+    });
+    Object.defineProperty(evt, "clientY", {
+        configurable: true,
+        value: opts.clientY,
+    });
+    return evt;
+}
+
+function buildLiveCard(previewId: string): {
+    card: HTMLDivElement;
+    img: HTMLImageElement;
+} {
+    const card = document.createElement("div");
+    card.className = "preview-card";
+    card.dataset.previewId = previewId;
+    const container = document.createElement("div");
+    container.className = "image-container";
+    const img = document.createElement("img");
+    img.className = "preview-image";
+    container.appendChild(img);
+    card.appendChild(container);
+    document.body.appendChild(card);
+    return { card, img };
+}
+
+/** Match `streamingPainter.attach` — hides the `<img>` and appends a
+ *  sized `<canvas class="stream-canvas">` inside `.image-container`. */
+function attachStreamCanvas(
+    card: HTMLElement,
+    width: number,
+    height: number,
+): HTMLCanvasElement {
+    const container = card.querySelector(".image-container")!;
+    const img = container.querySelector<HTMLImageElement>("img");
+    if (img) img.style.display = "none";
+    const canvas = document.createElement("canvas");
+    canvas.className = "stream-canvas";
+    canvas.width = width;
+    canvas.height = height;
+    container.appendChild(canvas);
+    return canvas;
+}
+
+function createVscode(): {
+    posted: PostedMessage[];
+    api: {
+        postMessage(msg: unknown): void;
+        getState(): undefined;
+        setState(): void;
+    };
+} {
+    const posted: PostedMessage[] = [];
+    return {
+        posted,
+        api: {
+            postMessage(msg: unknown) {
+                posted.push(msg as PostedMessage);
+            },
+            getState() {
+                return undefined;
+            },
+            setState() {
+                /* noop */
+            },
+        },
+    };
+}
+
+afterEach(() => {
+    document.body.innerHTML = "";
+});
+
+describe("liveRenderSurface", () => {
+    it("returns the streaming <canvas> when present and sized", () => {
+        const { card } = buildLiveCard("p1");
+        const canvas = attachStreamCanvas(card, 480, 320);
+        const surface = liveRenderSurface(card);
+        assert.ok(surface);
+        assert.strictEqual(surface.el, canvas);
+        assert.strictEqual(surface.naturalWidth, 480);
+        assert.strictEqual(surface.naturalHeight, 320);
+    });
+
+    it("falls back to the legacy <img> when no streaming canvas is attached", () => {
+        const { card, img } = buildLiveCard("p1");
+        Object.defineProperty(img, "naturalWidth", {
+            configurable: true,
+            value: 200,
+        });
+        Object.defineProperty(img, "naturalHeight", {
+            configurable: true,
+            value: 100,
+        });
+        const surface = liveRenderSurface(card);
+        assert.ok(surface);
+        assert.strictEqual(surface.el, img);
+        assert.strictEqual(surface.naturalWidth, 200);
+        assert.strictEqual(surface.naturalHeight, 100);
+    });
+
+    it("returns the canvas even at the painter's initial 1×1 placeholder size", () => {
+        // streamingPainter sets canvas.width/height = 1 immediately on
+        // attach, so the canvas wins from the very first event — even
+        // before the first decoded frame swaps the real dimensions in.
+        const { card, img } = buildLiveCard("p1");
+        Object.defineProperty(img, "naturalWidth", {
+            configurable: true,
+            value: 200,
+        });
+        Object.defineProperty(img, "naturalHeight", {
+            configurable: true,
+            value: 100,
+        });
+        const canvas = attachStreamCanvas(card, 1, 1);
+        const surface = liveRenderSurface(card);
+        assert.ok(surface);
+        assert.strictEqual(surface.el, canvas);
+    });
+
+    it("returns null when neither surface has natural dimensions yet", () => {
+        const { card } = buildLiveCard("p1");
+        assert.strictEqual(liveRenderSurface(card), null);
+    });
+});
+
+describe("attachInteractiveInputHandlers wheel — streaming mode", () => {
+    it("forwards rotaryScroll using the streaming canvas's natural-pixel dims", () => {
+        const { card, img } = buildLiveCard("p1");
+        const canvas = attachStreamCanvas(card, 400, 300);
+        // Canvas displayed at 100×75 CSS pixels at the page origin.
+        stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
+        const { posted, api } = createVscode();
+        attachInteractiveInputHandlers(card, img, {
+            isLive: () => true,
+            vscode: api,
+        });
+        const evt = makeWheelEvent({ clientX: 50, clientY: 25, deltaY: 120 });
+        card.dispatchEvent(evt);
+        assert.strictEqual(posted.length, 1);
+        assert.deepStrictEqual(posted[0], {
+            command: "recordInteractiveInput",
+            previewId: "p1",
+            kind: "rotaryScroll",
+            // 50 CSS px * (400 nat / 100 css) = 200; 25 CSS px * (300 nat / 75 css) = 100.
+            pixelX: 200,
+            pixelY: 100,
+            imageWidth: 400,
+            imageHeight: 300,
+            scrollDeltaY: 120,
+        });
+        assert.strictEqual(evt.defaultPrevented, true);
+    });
+
+    it("still consumes the wheel when the cursor sits over card chrome (outside the surface)", () => {
+        const { card, img } = buildLiveCard("p1");
+        const canvas = attachStreamCanvas(card, 400, 300);
+        stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
+        const { posted, api } = createVscode();
+        attachInteractiveInputHandlers(card, img, {
+            isLive: () => true,
+            vscode: api,
+        });
+        const evt = makeWheelEvent({ clientX: 500, clientY: 500, deltaY: 120 });
+        card.dispatchEvent(evt);
+        // Outside the surface — no rotaryScroll posted, but wheel still consumed
+        // so enthusiastic scrolling can't push the live preview out of view.
+        assert.strictEqual(posted.length, 0);
+        assert.strictEqual(evt.defaultPrevented, true);
+    });
+
+    it("does nothing when the card is no longer live (predicate flips off)", () => {
+        const { card, img } = buildLiveCard("p1");
+        const canvas = attachStreamCanvas(card, 400, 300);
+        stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
+        const { posted, api } = createVscode();
+        let live = true;
+        attachInteractiveInputHandlers(card, img, {
+            isLive: () => live,
+            vscode: api,
+        });
+        live = false;
+        const evt = makeWheelEvent({ clientX: 50, clientY: 25, deltaY: 120 });
+        card.dispatchEvent(evt);
+        assert.strictEqual(posted.length, 0);
+        assert.strictEqual(evt.defaultPrevented, false);
+    });
+});

--- a/vscode-extension/src/webview/preview/interactiveInput.ts
+++ b/vscode-extension/src/webview/preview/interactiveInput.ts
@@ -21,6 +21,13 @@
 // same space the renderer paints in. The CSS-pixel offsets the browser
 // gives us are scaled by the displayed/natural ratio in `imagePoint`.
 // See docs/daemon/INTERACTIVE.md §§ 3, 6, 7.
+//
+// Streaming-mode wheel quirk: when the daemon is pushing live frames over
+// `composestream/1` the painter hides the `<img>` (display:none → 0×0
+// rect) and paints into a `<canvas class="stream-canvas">` overlay. The
+// wheel handler resolves the live render surface dynamically per event
+// via `liveRenderSurface(card)` — preferring the canvas — so rotary
+// scroll keeps reaching the daemon after the painter swap.
 
 import type { VsCodeApi } from "../shared/vscode";
 import {
@@ -30,6 +37,45 @@ import {
 } from "./pointerGeometry";
 
 export type { ImagePoint };
+
+/** Visible live render surface: an `<img>` in the legacy capture-and-show
+ *  path, or the streaming `<canvas class="stream-canvas">` once the
+ *  painter has taken over. The interactive wheel/pointer plumbing only
+ *  cares about its bounding rect and natural-pixel dimensions. */
+export interface LiveSurface {
+    el: Element;
+    naturalWidth: number;
+    naturalHeight: number;
+}
+
+/** Resolve the live render surface inside [card]. Streaming canvas wins
+ *  when present and sized — the painter hides the legacy `<img>` once
+ *  it attaches, so `<img>.getBoundingClientRect()` is 0×0 and pointer
+ *  geometry against it always returns null. Returns null when neither
+ *  surface has usable natural dimensions yet. */
+export function liveRenderSurface(card: Element): LiveSurface | null {
+    const canvas = card.querySelector<HTMLCanvasElement>(
+        "canvas.stream-canvas",
+    );
+    if (canvas && canvas.width > 0 && canvas.height > 0) {
+        return {
+            el: canvas,
+            naturalWidth: canvas.width,
+            naturalHeight: canvas.height,
+        };
+    }
+    const img = card.querySelector<HTMLImageElement>(
+        "img.preview-image, img.preview-gif, img",
+    );
+    if (img && img.naturalWidth > 0 && img.naturalHeight > 0) {
+        return {
+            el: img,
+            naturalWidth: img.naturalWidth,
+            naturalHeight: img.naturalHeight,
+        };
+    }
+    return null;
+}
 
 export interface InteractiveInputConfig {
     /**
@@ -65,18 +111,20 @@ export function attachInteractiveInputHandlers(
                 // wheel lands on preview pixels, forward it as rotary scroll; if it lands on
                 // the card chrome, still consume it so enthusiastic scrolling cannot bubble to
                 // the list and push the live preview out of view.
-                const currentImg = card.querySelector<HTMLImageElement>(
-                    "img.preview-image, img.preview-gif, img",
-                );
+                //
+                // Resolve the visible surface dynamically so the streaming `<canvas>` takes
+                // over from the (now hidden) `<img>` once `streamingPainter` attaches — see
+                // module header.
+                const surface = liveRenderSurface(card);
                 const point =
-                    currentImg && eventInsideElement(currentImg, evt)
-                        ? imagePoint(currentImg, evt)
+                    surface && eventInsideElement(surface.el, evt)
+                        ? surfacePoint(surface, evt)
                         : null;
-                if (currentImg && point) {
+                if (surface && point) {
                     postInteractiveInput(
                         config.vscode,
                         id,
-                        currentImg,
+                        surface,
                         "rotaryScroll",
                         point,
                         evt.deltaY,
@@ -197,16 +245,33 @@ export function attachInteractiveInputHandlers(
     });
 }
 
-/** DOM-bound shim around `computeImagePoint` — extracts natural / rect
- *  dimensions from the live `<img>` and the pure helper does the math. */
+/** DOM-bound shim around `computeImagePoint` — extracts the live `<img>`'s
+ *  natural and rect dimensions and lets the pure helper do the math. */
 function imagePoint(
     img: HTMLImageElement,
     evt: { clientX: number; clientY: number },
 ): ImagePoint | null {
-    const rect = img.getBoundingClientRect();
+    return surfacePoint(
+        {
+            el: img,
+            naturalWidth: img.naturalWidth || 0,
+            naturalHeight: img.naturalHeight || 0,
+        },
+        evt,
+    );
+}
+
+/** Same as `imagePoint`, but for an arbitrary `LiveSurface` — used by the
+ *  wheel handler so the streaming `<canvas>` is treated identically to a
+ *  legacy `<img>`. */
+function surfacePoint(
+    surface: LiveSurface,
+    evt: { clientX: number; clientY: number },
+): ImagePoint | null {
+    const rect = surface.el.getBoundingClientRect();
     return computeImagePoint(
-        img.naturalWidth || 0,
-        img.naturalHeight || 0,
+        surface.naturalWidth,
+        surface.naturalHeight,
         rect.width,
         rect.height,
         rect.left,
@@ -238,13 +303,19 @@ type InteractiveInputKind =
 function postInteractiveInput(
     vscode: VsCodeApi<unknown>,
     previewId: string,
-    img: HTMLImageElement,
+    target: LiveSurface | HTMLImageElement,
     kind: InteractiveInputKind,
     point: ImagePoint | null,
     scrollDeltaY?: number,
 ): void {
-    const natW = img.naturalWidth || 0;
-    const natH = img.naturalHeight || 0;
+    const natW =
+        target instanceof HTMLImageElement
+            ? target.naturalWidth || 0
+            : target.naturalWidth;
+    const natH =
+        target instanceof HTMLImageElement
+            ? target.naturalHeight || 0
+            : target.naturalHeight;
     if (!point || !natW || !natH) return;
     vscode.postMessage({
         command: "recordInteractiveInput",

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -18,6 +18,7 @@
     "exclude": ["node_modules", "src/webview/**"],
     "files": [
         "src/webview/preview/cardData.ts",
+        "src/webview/preview/interactiveInput.ts",
         "src/webview/preview/liveBadge.ts",
         "src/webview/preview/liveTransitions.ts",
         "src/webview/preview/moduleReadiness.ts",


### PR DESCRIPTION
## Summary

Scrolling stopped reaching live previews after the streaming-frame swap landed. `streamingPainter.attach()` hides the legacy `<img>` (display:none → 0×0 rect) and paints frames into a `<canvas class="stream-canvas">`, but the wheel handler in `interactiveInput.ts` still queried for the `<img>`. `eventInsideElement` then always returned false, no `rotaryScroll` reached the daemon, and `evt.preventDefault()` silently ate the user's input.

- Add `liveRenderSurface(card)` that resolves the visible surface per event, preferring the streaming canvas over the (hidden) img.
- Treat both surfaces as a uniform `LiveSurface` (natural-pixel dims + bounding rect) inside the wheel/post helpers.
- Pointer handlers are unchanged — they only fire when the img is visible. Click/drag forwarding through the streaming canvas is a separate gap; out of scope here.

## Test plan

- [x] `npm test` (509 passing)
- [x] New `interactiveInput.test.ts`: 7 cases covering surface resolution (canvas wins when present, img fallback, painter's 1×1 placeholder still wins, both-empty → null) and the streaming-mode wheel path (rotary scroll posted with canvas natural dims, wheel still consumed over card chrome, no-op when predicate flips off).
- [ ] Manual smoke: with `composePreview.streaming.enabled = true`, scroll a Wear watch face preview → daemon receives `rotaryScroll` events instead of swallowing them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Gxrw2TkQZzdwRhPtyBAp)_