### PR TITLE
fix(vscode): forward live pointer events through the streaming canvas

### DIFF
--- a/vscode-extension/src/test/interactiveInput.test.ts
+++ b/vscode-extension/src/test/interactiveInput.test.ts
@@ -1,8 +1,9 @@
-// Streaming-mode coverage for the live-preview wheel handler. The
-// streaming painter (`streamingPainter.ts`) hides the legacy `<img>` and
-// paints frames into a `<canvas class="stream-canvas">`. The wheel
-// handler must follow that swap, otherwise rotary scroll never reaches
-// the daemon and `evt.preventDefault()` silently eats the user's input.
+// Streaming-mode coverage for the live-preview wheel and pointer
+// handlers. The streaming painter (`streamingPainter.ts`) hides the
+// legacy `<img>` and paints frames into a `<canvas class="stream-canvas">`.
+// Both handler families must follow that swap, otherwise input never
+// reaches the daemon (rotary scroll, click, drag) and the user's gesture
+// is silently eaten by `evt.preventDefault()`.
 
 import * as assert from "assert";
 import {
@@ -183,12 +184,12 @@ describe("liveRenderSurface", () => {
 
 describe("attachInteractiveInputHandlers wheel — streaming mode", () => {
     it("forwards rotaryScroll using the streaming canvas's natural-pixel dims", () => {
-        const { card, img } = buildLiveCard("p1");
+        const { card } = buildLiveCard("p1");
         const canvas = attachStreamCanvas(card, 400, 300);
         // Canvas displayed at 100×75 CSS pixels at the page origin.
         stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
         const { posted, api } = createVscode();
-        attachInteractiveInputHandlers(card, img, {
+        attachInteractiveInputHandlers(card, {
             isLive: () => true,
             vscode: api,
         });
@@ -210,11 +211,11 @@ describe("attachInteractiveInputHandlers wheel — streaming mode", () => {
     });
 
     it("still consumes the wheel when the cursor sits over card chrome (outside the surface)", () => {
-        const { card, img } = buildLiveCard("p1");
+        const { card } = buildLiveCard("p1");
         const canvas = attachStreamCanvas(card, 400, 300);
         stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
         const { posted, api } = createVscode();
-        attachInteractiveInputHandlers(card, img, {
+        attachInteractiveInputHandlers(card, {
             isLive: () => true,
             vscode: api,
         });
@@ -227,18 +228,222 @@ describe("attachInteractiveInputHandlers wheel — streaming mode", () => {
     });
 
     it("does nothing when the card is no longer live (predicate flips off)", () => {
-        const { card, img } = buildLiveCard("p1");
+        const { card } = buildLiveCard("p1");
         const canvas = attachStreamCanvas(card, 400, 300);
         stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
         const { posted, api } = createVscode();
         let live = true;
-        attachInteractiveInputHandlers(card, img, {
+        attachInteractiveInputHandlers(card, {
             isLive: () => live,
             vscode: api,
         });
         live = false;
         const evt = makeWheelEvent({ clientX: 50, clientY: 25, deltaY: 120 });
         card.dispatchEvent(evt);
+        assert.strictEqual(posted.length, 0);
+        assert.strictEqual(evt.defaultPrevented, false);
+    });
+});
+
+function pointerEvent(
+    type: string,
+    opts: {
+        clientX: number;
+        clientY: number;
+        pointerId?: number;
+        button?: number;
+    },
+): PointerEvent {
+    return new PointerEvent(type, {
+        clientX: opts.clientX,
+        clientY: opts.clientY,
+        pointerId: opts.pointerId ?? 1,
+        button: opts.button ?? 0,
+        bubbles: true,
+        cancelable: true,
+    });
+}
+
+describe("attachInteractiveInputHandlers pointer — streaming mode", () => {
+    it("forwards a click on the streaming canvas to the daemon", () => {
+        const { card } = buildLiveCard("p1");
+        const canvas = attachStreamCanvas(card, 400, 300);
+        // Canvas displayed at 100×75 CSS pixels at the page origin.
+        stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
+        const { posted, api } = createVscode();
+        attachInteractiveInputHandlers(card, {
+            isLive: () => true,
+            vscode: api,
+        });
+
+        canvas.dispatchEvent(
+            pointerEvent("pointerdown", { clientX: 50, clientY: 25 }),
+        );
+        canvas.dispatchEvent(
+            pointerEvent("pointerup", { clientX: 50, clientY: 25 }),
+        );
+
+        assert.strictEqual(posted.length, 1);
+        assert.deepStrictEqual(posted[0], {
+            command: "recordInteractiveInput",
+            previewId: "p1",
+            kind: "click",
+            // 50 CSS px * (400 nat / 100 css) = 200; 25 * (300/75) = 100.
+            pixelX: 200,
+            pixelY: 100,
+            imageWidth: 400,
+            imageHeight: 300,
+            scrollDeltaY: undefined,
+        });
+    });
+
+    it("forwards a drag on the streaming canvas as pointerDown + pointerMove + pointerUp", () => {
+        const { card } = buildLiveCard("p1");
+        const canvas = attachStreamCanvas(card, 400, 300);
+        stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
+        const { posted, api } = createVscode();
+        attachInteractiveInputHandlers(card, {
+            isLive: () => true,
+            vscode: api,
+        });
+
+        canvas.dispatchEvent(
+            pointerEvent("pointerdown", { clientX: 10, clientY: 10 }),
+        );
+        // Move past the 4-CSS-px drag threshold (Math.hypot >= 4).
+        canvas.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 20, clientY: 20 }),
+        );
+        canvas.dispatchEvent(
+            pointerEvent("pointerup", { clientX: 20, clientY: 20 }),
+        );
+
+        const kinds = posted.map((m) => m["kind"]);
+        assert.deepStrictEqual(kinds, [
+            "pointerDown",
+            "pointerMove",
+            "pointerUp",
+        ]);
+        // Every event carries the canvas's natural-pixel dims.
+        for (const m of posted) {
+            assert.strictEqual(m["imageWidth"], 400);
+            assert.strictEqual(m["imageHeight"], 300);
+            assert.strictEqual(m["previewId"], "p1");
+        }
+    });
+
+    it("ignores pointerdowns on chrome (target ≠ surface) so the stop button keeps its click", () => {
+        const { card } = buildLiveCard("p1");
+        const canvas = attachStreamCanvas(card, 400, 300);
+        stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
+        const container = card.querySelector(".image-container")!;
+        const stopBtn = document.createElement("button");
+        stopBtn.className = "card-live-stop-btn";
+        container.appendChild(stopBtn);
+        const { posted, api } = createVscode();
+        attachInteractiveInputHandlers(card, {
+            isLive: () => true,
+            vscode: api,
+        });
+
+        const evt = pointerEvent("pointerdown", { clientX: 50, clientY: 25 });
+        stopBtn.dispatchEvent(evt);
+
+        // Chrome event — handler must not consume it (the button's own click
+        // handler depends on default behavior reaching it).
+        assert.strictEqual(posted.length, 0);
+        assert.strictEqual(evt.defaultPrevented, false);
+    });
+
+    it("still works against the legacy <img> when the streaming canvas isn't there yet", () => {
+        const { card, img } = buildLiveCard("p1");
+        Object.defineProperty(img, "naturalWidth", {
+            configurable: true,
+            value: 400,
+        });
+        Object.defineProperty(img, "naturalHeight", {
+            configurable: true,
+            value: 300,
+        });
+        stubBoundingRect(img, { width: 100, height: 75, left: 0, top: 0 });
+        const { posted, api } = createVscode();
+        attachInteractiveInputHandlers(card, {
+            isLive: () => true,
+            vscode: api,
+        });
+
+        img.dispatchEvent(
+            pointerEvent("pointerdown", { clientX: 50, clientY: 25 }),
+        );
+        img.dispatchEvent(
+            pointerEvent("pointerup", { clientX: 50, clientY: 25 }),
+        );
+
+        assert.strictEqual(posted.length, 1);
+        assert.strictEqual(posted[0]["kind"], "click");
+        assert.strictEqual(posted[0]["imageWidth"], 400);
+    });
+
+    it("holds the pointerdown surface across a streaming swap mid-drag", () => {
+        const { card, img } = buildLiveCard("p1");
+        // Start with the legacy img surface.
+        Object.defineProperty(img, "naturalWidth", {
+            configurable: true,
+            value: 200,
+        });
+        Object.defineProperty(img, "naturalHeight", {
+            configurable: true,
+            value: 100,
+        });
+        stubBoundingRect(img, { width: 100, height: 50, left: 0, top: 0 });
+        const { posted, api } = createVscode();
+        attachInteractiveInputHandlers(card, {
+            isLive: () => true,
+            vscode: api,
+        });
+
+        img.dispatchEvent(
+            pointerEvent("pointerdown", { clientX: 10, clientY: 10 }),
+        );
+        // Streaming painter attaches mid-gesture (different natural dims).
+        const canvas = attachStreamCanvas(card, 800, 400);
+        stubBoundingRect(canvas, { width: 100, height: 50, left: 0, top: 0 });
+
+        img.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 30, clientY: 30 }),
+        );
+        img.dispatchEvent(
+            pointerEvent("pointerup", { clientX: 30, clientY: 30 }),
+        );
+
+        // All forwarded events must carry the surface dims captured at
+        // pointerdown (the img's 200×100), not the canvas's 800×400 — otherwise
+        // the daemon would receive coords in two different spaces inside one
+        // gesture.
+        assert.ok(posted.length >= 2);
+        for (const m of posted) {
+            assert.strictEqual(m["imageWidth"], 200);
+            assert.strictEqual(m["imageHeight"], 100);
+        }
+        // Touch the canvas variable so the lint check sees the swap happened.
+        assert.strictEqual(canvas.width, 800);
+    });
+
+    it("does nothing on pointerdown when the predicate flips off", () => {
+        const { card } = buildLiveCard("p1");
+        const canvas = attachStreamCanvas(card, 400, 300);
+        stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
+        const { posted, api } = createVscode();
+        let live = true;
+        attachInteractiveInputHandlers(card, {
+            isLive: () => live,
+            vscode: api,
+        });
+        live = false;
+
+        const evt = pointerEvent("pointerdown", { clientX: 50, clientY: 25 });
+        canvas.dispatchEvent(evt);
+
         assert.strictEqual(posted.length, 0);
         assert.strictEqual(evt.defaultPrevented, false);
     });

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -531,7 +531,7 @@ export function updateImage(
     // than a sequence of independent renders. See INTERACTIVE.md § 3.
     const isLive = config.liveState.isLive(previewId);
     img.className = isLive ? "live-frame" : "fade-in";
-    attachInteractiveInputHandlers(card, img, config.interactiveInputConfig);
+    attachInteractiveInputHandlers(card, config.interactiveInputConfig);
 
     if (caps) config.frameCarousel.updateIndicator(card);
 

--- a/vscode-extension/src/webview/preview/frameCarousel.ts
+++ b/vscode-extension/src/webview/preview/frameCarousel.ts
@@ -171,7 +171,6 @@ export class FrameCarouselController {
             img.className = "fade-in";
             attachInteractiveInputHandlers(
                 card,
-                img,
                 this.config.interactiveInputConfig,
             );
             if (capture.errorMessage || capture.renderError) {

--- a/vscode-extension/src/webview/preview/interactiveInput.ts
+++ b/vscode-extension/src/webview/preview/interactiveInput.ts
@@ -1,33 +1,38 @@
 // Pointer + wheel state machine for live (interactive) previews.
 //
-// Lifted verbatim from `behavior.ts` (`ensureInteractiveInputHandlers`,
-// `imagePoint`, `eventInsideElement`, `postInteractiveInput`) so the
-// pointer logic stops needing `@ts-nocheck`. Behaviour is unchanged:
-// pointer down / move / up / cancel / context-menu on the live image,
-// plus a capture-phase wheel listener on the whole card that maps
-// vertical deltas to rotary scroll. Listeners are idempotent — flagged
-// via `dataset.interactiveBound` / `dataset.interactiveWheelBound` so
-// re-attaching on subsequent `updateImage` calls doesn't stack
-// duplicates.
+// Both handler families attach to the `.preview-card` element, gated
+// per event by an `isLive` predicate, and resolve the visible render
+// surface dynamically via `liveRenderSurface(card)`:
 //
-// The handlers stay attached after a card leaves live mode. They go
-// inert because every event re-checks the `isLive` predicate — so a
-// non-live card swallows nothing. We deliberately don't tear handlers
-// down because live can be re-entered without producing a fresh `<img>`
-// (e.g. the same image element survives a single-target → re-toggle
-// cycle), and re-binding would race with in-flight pointer captures.
+//  - **Wheel** — capture-phase listener on the card. Vertical deltas
+//    over the surface forward as rotary scroll; deltas over chrome are
+//    still consumed so enthusiastic scrolling can't push the live
+//    preview out of view.
+//  - **Pointer** — bubble-phase listeners on the card. Pointerdown is
+//    only hijacked when `evt.target === surface.el`, so the stop
+//    button / focus toolbar / badges keep native click semantics. The
+//    surface resolved at pointerdown is held in `state.surface` for
+//    the lifetime of the gesture, so coords stay in a single natural-
+//    pixel space even if the painter swaps the surface mid-drag (the
+//    `<img>` ↔ `<canvas>` flip is asynchronous).
+//
+// Listeners are idempotent — flagged via
+// `dataset.interactiveWheelBound` and `dataset.interactivePointerBound`
+// so re-attaching on subsequent `updateImage` / live-toggle calls
+// doesn't stack duplicates. The handlers stay attached after a card
+// leaves live mode; they go inert because every event re-checks the
+// `isLive` predicate.
 //
 // Coordinates the daemon expects are image-natural pixel space — the
 // same space the renderer paints in. The CSS-pixel offsets the browser
-// gives us are scaled by the displayed/natural ratio in `imagePoint`.
+// gives us are scaled by the displayed/natural ratio in `surfacePoint`.
 // See docs/daemon/INTERACTIVE.md §§ 3, 6, 7.
 //
-// Streaming-mode wheel quirk: when the daemon is pushing live frames over
-// `composestream/1` the painter hides the `<img>` (display:none → 0×0
-// rect) and paints into a `<canvas class="stream-canvas">` overlay. The
-// wheel handler resolves the live render surface dynamically per event
-// via `liveRenderSurface(card)` — preferring the canvas — so rotary
-// scroll keeps reaching the daemon after the painter swap.
+// Streaming-mode rationale: the painter hides the legacy `<img>`
+// (display:none → 0×0 rect, pointer events never fire on it) and paints
+// into a `<canvas class="stream-canvas">` overlay. Both handler families
+// hang off the card (not the img) so they keep working across that
+// swap. `liveRenderSurface` prefers the canvas when present.
 
 import type { VsCodeApi } from "../shared/vscode";
 import {
@@ -93,7 +98,6 @@ export interface InteractiveInputConfig {
 
 export function attachInteractiveInputHandlers(
     card: HTMLElement,
-    img: HTMLImageElement,
     config: InteractiveInputConfig,
 ): void {
     const previewId = card.dataset.previewId;
@@ -137,8 +141,8 @@ export function attachInteractiveInputHandlers(
         );
     }
 
-    if (img.dataset.interactiveBound === "1") return;
-    img.dataset.interactiveBound = "1";
+    if (card.dataset.interactivePointerBound === "1") return;
+    card.dataset.interactivePointerBound = "1";
 
     interface PointerState {
         pointerId: number | null;
@@ -146,6 +150,13 @@ export function attachInteractiveInputHandlers(
         last: ImagePoint | null;
         dragging: boolean;
         sentDown: boolean;
+        /**
+         * Surface captured at pointerdown. Held for the lifetime of a
+         * drag so coords stay in a single natural-pixel space even if
+         * the painter swaps surfaces mid-gesture (rare but the
+         * `<img>` ↔ `<canvas>` flip is asynchronous).
+         */
+        surface: LiveSurface | null;
     }
     const state: PointerState = {
         pointerId: null,
@@ -153,27 +164,41 @@ export function attachInteractiveInputHandlers(
         last: null,
         dragging: false,
         sentDown: false,
+        surface: null,
     };
 
-    img.addEventListener("pointerdown", (evt) => {
+    card.addEventListener("pointerdown", (evt) => {
         const id = card.dataset.previewId;
         if (!id || !config.isLive(id)) return;
         if (evt.button !== 0 && evt.button !== 2) return;
+        const surface = liveRenderSurface(card);
+        // Only hijack the gesture when it starts on the live surface.
+        // Anything else (stop button, focus toolbar, badges) is chrome and
+        // must keep its native click semantics — those overlay siblings
+        // sit on top of the surface so `evt.target` is the truth.
+        if (!surface || evt.target !== surface.el) return;
+        const point = surfacePoint(surface, evt);
+        if (!point) return;
         state.pointerId = evt.pointerId;
-        state.start = imagePoint(img, evt);
-        state.last = state.start;
+        state.start = point;
+        state.last = point;
         state.dragging = false;
         state.sentDown = false;
-        img.setPointerCapture?.(evt.pointerId);
+        state.surface = surface;
+        // Capture on the card so subsequent move/up route here even when
+        // the cursor leaves the surface (or the surface gets swapped out
+        // mid-drag by the streaming painter).
+        card.setPointerCapture?.(evt.pointerId);
         evt.preventDefault();
         evt.stopPropagation();
     });
 
-    img.addEventListener("pointermove", (evt) => {
+    card.addEventListener("pointermove", (evt) => {
         const id = card.dataset.previewId;
         if (!id || !config.isLive(id)) return;
-        if (state.pointerId !== evt.pointerId || !state.start) return;
-        const next = imagePoint(img, evt);
+        if (state.pointerId !== evt.pointerId || !state.start || !state.surface)
+            return;
+        const next = surfacePoint(state.surface, evt);
         if (!next) return;
         const dx = next.clientX - state.start.clientX;
         const dy = next.clientY - state.start.clientY;
@@ -185,85 +210,92 @@ export function attachInteractiveInputHandlers(
                 postInteractiveInput(
                     config.vscode,
                     id,
-                    img,
+                    state.surface,
                     "pointerDown",
                     state.start,
                 );
                 state.sentDown = true;
             }
-            postInteractiveInput(config.vscode, id, img, "pointerMove", next);
+            postInteractiveInput(
+                config.vscode,
+                id,
+                state.surface,
+                "pointerMove",
+                next,
+            );
             state.last = next;
             evt.preventDefault();
             evt.stopPropagation();
         }
     });
 
-    img.addEventListener("pointerup", (evt) => {
+    card.addEventListener("pointerup", (evt) => {
         const id = card.dataset.previewId;
         if (!id || !config.isLive(id)) return;
-        if (state.pointerId !== evt.pointerId || !state.start) return;
-        const point = imagePoint(img, evt) || state.last || state.start;
+        if (state.pointerId !== evt.pointerId || !state.start || !state.surface)
+            return;
+        const point =
+            surfacePoint(state.surface, evt) || state.last || state.start;
         if (state.dragging) {
             if (!state.sentDown) {
                 postInteractiveInput(
                     config.vscode,
                     id,
-                    img,
+                    state.surface,
                     "pointerDown",
                     state.start,
                 );
             }
-            postInteractiveInput(config.vscode, id, img, "pointerUp", point);
+            postInteractiveInput(
+                config.vscode,
+                id,
+                state.surface,
+                "pointerUp",
+                point,
+            );
         } else {
-            postInteractiveInput(config.vscode, id, img, "click", point);
+            postInteractiveInput(
+                config.vscode,
+                id,
+                state.surface,
+                "click",
+                point,
+            );
         }
-        img.releasePointerCapture?.(evt.pointerId);
+        card.releasePointerCapture?.(evt.pointerId);
         state.pointerId = null;
         state.start = null;
         state.last = null;
         state.dragging = false;
         state.sentDown = false;
+        state.surface = null;
         evt.preventDefault();
         evt.stopPropagation();
     });
 
-    img.addEventListener("pointercancel", (evt) => {
+    card.addEventListener("pointercancel", (evt) => {
         if (state.pointerId !== evt.pointerId) return;
-        img.releasePointerCapture?.(evt.pointerId);
+        card.releasePointerCapture?.(evt.pointerId);
         state.pointerId = null;
         state.start = null;
         state.last = null;
         state.dragging = false;
         state.sentDown = false;
+        state.surface = null;
     });
 
-    img.addEventListener("contextmenu", (evt) => {
+    card.addEventListener("contextmenu", (evt) => {
         const id = card.dataset.previewId;
         if (!id || !config.isLive(id)) return;
+        const surface = liveRenderSurface(card);
+        if (!surface || evt.target !== surface.el) return;
         evt.preventDefault();
         evt.stopPropagation();
     });
 }
 
-/** DOM-bound shim around `computeImagePoint` — extracts the live `<img>`'s
- *  natural and rect dimensions and lets the pure helper do the math. */
-function imagePoint(
-    img: HTMLImageElement,
-    evt: { clientX: number; clientY: number },
-): ImagePoint | null {
-    return surfacePoint(
-        {
-            el: img,
-            naturalWidth: img.naturalWidth || 0,
-            naturalHeight: img.naturalHeight || 0,
-        },
-        evt,
-    );
-}
-
-/** Same as `imagePoint`, but for an arbitrary `LiveSurface` — used by the
- *  wheel handler so the streaming `<canvas>` is treated identically to a
- *  legacy `<img>`. */
+/** DOM-bound shim around `computeImagePoint` — extracts the surface's
+ *  bounding rect and lets the pure helper do the natural-pixel math. */
 function surfacePoint(
     surface: LiveSurface,
     evt: { clientX: number; clientY: number },
@@ -303,28 +335,20 @@ type InteractiveInputKind =
 function postInteractiveInput(
     vscode: VsCodeApi<unknown>,
     previewId: string,
-    target: LiveSurface | HTMLImageElement,
+    surface: LiveSurface,
     kind: InteractiveInputKind,
     point: ImagePoint | null,
     scrollDeltaY?: number,
 ): void {
-    const natW =
-        target instanceof HTMLImageElement
-            ? target.naturalWidth || 0
-            : target.naturalWidth;
-    const natH =
-        target instanceof HTMLImageElement
-            ? target.naturalHeight || 0
-            : target.naturalHeight;
-    if (!point || !natW || !natH) return;
+    if (!point || !surface.naturalWidth || !surface.naturalHeight) return;
     vscode.postMessage({
         command: "recordInteractiveInput",
         previewId,
         kind,
         pixelX: point.pixelX,
         pixelY: point.pixelY,
-        imageWidth: natW,
-        imageHeight: natH,
+        imageWidth: surface.naturalWidth,
+        imageHeight: surface.naturalHeight,
         scrollDeltaY,
     });
 }

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -179,14 +179,10 @@ export class LiveStateController {
         }
         this.interactivePreviewIds = plan.next;
         if (plan.turnOnTarget) {
-            const img = card.querySelector(".image-container img");
-            if (img instanceof HTMLImageElement) {
-                attachInteractiveInputHandlers(
-                    card,
-                    img,
-                    this.cfg.interactiveInputConfig,
-                );
-            }
+            attachInteractiveInputHandlers(
+                card,
+                this.cfg.interactiveInputConfig,
+            );
         }
         this.postLiveCommand(previewId, plan.turnOnTarget);
         this.applyLiveBadge();
@@ -221,14 +217,10 @@ export class LiveStateController {
         }
         this.recordingPreviewIds = plan.next;
         if (plan.turnOnTarget) {
-            const img = card.querySelector(".image-container img");
-            if (img instanceof HTMLImageElement) {
-                attachInteractiveInputHandlers(
-                    card,
-                    img,
-                    this.cfg.interactiveInputConfig,
-                );
-            }
+            attachInteractiveInputHandlers(
+                card,
+                this.cfg.interactiveInputConfig,
+            );
         }
         this.cfg.vscode.postMessage({
             command: "setRecording",
@@ -364,13 +356,6 @@ export class LiveStateController {
             });
             container.appendChild(btn);
         }
-        const img = container.querySelector("img");
-        if (img instanceof HTMLImageElement) {
-            attachInteractiveInputHandlers(
-                card,
-                img,
-                this.cfg.interactiveInputConfig,
-            );
-        }
+        attachInteractiveInputHandlers(card, this.cfg.interactiveInputConfig);
     }
 }


### PR DESCRIPTION
## Summary

Sibling fix to #880. Pointer handlers were attached to the legacy `<img>`, which the streaming painter hides (`display:none`). Pointer events never fire on a `display:none` element, so clicks and drags on the live preview canvas were silently dropped — same shape as the wheel bug, different surface.

- Move `pointerdown`/`move`/`up`/`cancel`/`contextmenu` listeners off the img onto the card.
- Gate `pointerdown` (and `contextmenu`) on `evt.target === surface.el` so chrome overlays (stop button, focus toolbar, badges) keep their native click semantics.
- Capture the surface resolved at pointerdown into `state.surface` and reuse it for the rest of the gesture, so coords stay in a single natural-pixel space even if the painter swaps the surface mid-drag.
- Move the idempotency flag from `img.dataset.interactiveBound` to `card.dataset.interactivePointerBound`, matching the wheel flag.
- Drop the now-unused `img` parameter from `attachInteractiveInputHandlers` and the four call sites' `instanceof HTMLImageElement` guards.

## Test plan

- [x] `npm test` (520 passing — 6 new pointer cases)
- [x] New cases in `interactiveInput.test.ts`: click/drag forwarded with canvas natural dims, chrome pointerdown ignored, legacy `<img>` path still works, surface held across a mid-drag streaming swap, predicate-flip-off no-op.
- [ ] Manual smoke: with `composePreview.streaming.enabled = true`, click + drag a live preview → daemon sees `click` / `pointerDown`+`pointerMove`+`pointerUp` instead of nothing; stop button / focus toolbar still respond to clicks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Gxrw2TkQZzdwRhPtyBAp)_