### PR TITLE
refactor(vscode): move module-availability Maps into LiveStateController

### DIFF
--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -57,8 +57,6 @@ export interface FocusControllerConfig {
      *  `state.layout` directly and calls `vscode.setState(state)` for
      *  layout transitions. */
     state: FocusControllerPersistedState;
-    moduleDaemonReady: Map<string, boolean>;
-    moduleInteractiveSupported: Map<string, boolean>;
     earlyFeatures(): boolean;
     getA11yOverlayId(): string | null;
     setA11yOverlayId(id: string | null): void;
@@ -109,10 +107,12 @@ export class FocusController {
             isLive,
             otherLiveCount: this.config.liveState.liveCount - (isLive ? 1 : 0),
             hasLive: this.config.liveState.liveCount > 0,
-            daemonReady: isFocusedModuleReady(this.config.moduleDaemonReady),
+            daemonReady: isFocusedModuleReady(
+                this.config.liveState.getModuleDaemonReady(),
+            ),
             interactiveSupported: isFocusedInteractiveSupported(
-                this.config.moduleDaemonReady,
-                this.config.moduleInteractiveSupported,
+                this.config.liveState.getModuleDaemonReady(),
+                this.config.liveState.getModuleInteractiveSupported(),
             ),
         });
     }
@@ -127,7 +127,9 @@ export class FocusController {
             inFocus,
             earlyFeatures: this.config.earlyFeatures(),
             focusedPreviewId: previewId,
-            daemonReady: isFocusedModuleReady(this.config.moduleDaemonReady),
+            daemonReady: isFocusedModuleReady(
+                this.config.liveState.getModuleDaemonReady(),
+            ),
             isRecording:
                 !!previewId && this.config.liveState.isRecording(previewId),
         });

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -16,6 +16,16 @@
 // `isLive` / `isRecording`); `attachInteractiveInputHandlers` from
 // `./interactiveInput.ts` consults them through `interactiveInputConfig.isLive`.
 //
+// Also owns two per-module availability Maps populated from the
+// `setInteractiveAvailability` wire message:
+//  - `moduleDaemonReady` — whether the module's daemon is up and ready.
+//  - `moduleInteractiveSupported` — whether the daemon advertises full v2
+//    live mode (vs the Android/v1 fallback where renders refresh but pointer
+//    input doesn't mutate held composition state).
+// Writes flow through `setAvailability(moduleId, ready, interactiveSupported)`;
+// reads are exposed as ReadonlyMaps so callers (focus toolbar predicates) keep
+// their existing signatures.
+//
 // Plain click on the LIVE button is single-target — drop every prior stream
 // before adding (or re-removing) this one. Shift+click is multi-target — toggle
 // just this preview without disturbing the others. Recording is currently
@@ -82,7 +92,40 @@ export class LiveStateController {
     private interactivePreviewIds: Set<string> = new Set<string>();
     private recordingPreviewIds: Set<string> = new Set<string>();
 
+    // Per-module availability — written from `setInteractiveAvailability`
+    // via `setAvailability`, read by the focus toolbar predicates through
+    // the `getModuleDaemonReady` / `getModuleInteractiveSupported`
+    // ReadonlyMap accessors. See module-header doc.
+    private readonly moduleDaemonReady = new Map<string, boolean>();
+    private readonly moduleInteractiveSupported = new Map<string, boolean>();
+
     constructor(private readonly cfg: LiveStateConfig) {}
+
+    /** Record per-module daemon readiness + interactive-support flags. The
+     *  callers (`handleSetInteractiveAvailability`) coerce the wire payload
+     *  to booleans before calling. */
+    setAvailability(
+        moduleId: string,
+        ready: boolean,
+        interactiveSupported: boolean,
+    ): void {
+        this.moduleDaemonReady.set(moduleId, ready);
+        this.moduleInteractiveSupported.set(moduleId, interactiveSupported);
+    }
+
+    /** Read view of the per-module daemon-readiness map. Exposed as a
+     *  ReadonlyMap so the existing `isFocusedModuleReady` /
+     *  `isFocusedInteractiveSupported` predicates in `./moduleReadiness.ts`
+     *  consume it without signature changes. */
+    getModuleDaemonReady(): ReadonlyMap<string, boolean> {
+        return this.moduleDaemonReady;
+    }
+
+    /** Read view of the per-module interactive-supported map. See
+     *  `getModuleDaemonReady`. */
+    getModuleInteractiveSupported(): ReadonlyMap<string, boolean> {
+        return this.moduleInteractiveSupported;
+    }
 
     /**
      * Posts the live-mode wire command for [previewId] — routes through

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -353,22 +353,14 @@ export class PreviewApp extends LitElement {
         });
         let filterDebounce: ReturnType<typeof setTimeout> | null = null;
 
-        // Interactive (live-stream) mode state. Declared up here — *before*
-        // the first applyLayout() call below — because applyLayout reaches
-        // through `liveState` on the early-exit-on-focus-change path.
-        // moduleDaemonReady tracks per-module daemon readiness pushed by the
-        // extension via setInteractiveAvailability; the button enables only
-        // when the focused card's owning module is ready. moduleInteractiveSupported
-        // distinguishes full v2 live mode from the Android/v1 fallback where
-        // renders refresh but pointer input doesn't mutate held composition state.
+        // Interactive (live-stream) mode state — the live + recording sets,
+        // their state machine, and the per-module daemon-readiness +
+        // interactive-supported maps (populated from
+        // `setInteractiveAvailability`) all live on `LiveStateController` in
+        // `./liveState.ts`. Constructed below, after `interactiveInputConfig`
+        // so the controller can hand the config to
+        // `attachInteractiveInputHandlers`.
         //
-        // The live + recording sets and their state machine live in
-        // `./liveState.ts` — see `LiveStateController`. Constructed below,
-        // after `interactiveInputConfig` so the controller can hand the
-        // config to `attachInteractiveInputHandlers`.
-        const moduleDaemonReady = new Map<string, boolean>();
-        const moduleInteractiveSupported = new Map<string, boolean>();
-
         // Forward references — `inspector` / `liveState` / `focusController`
         // close over each other via callback shapes, so we late-bind through
         // these `let !` declarations. Each binding is dereferenced only at
@@ -463,8 +455,6 @@ export class PreviewApp extends LitElement {
             liveState,
             diffOverlayConfig,
             state,
-            moduleDaemonReady,
-            moduleInteractiveSupported,
             earlyFeatures,
             getA11yOverlayId: a11yOverlay,
             setA11yOverlayId: setA11yOverlay,
@@ -663,8 +653,6 @@ export class PreviewApp extends LitElement {
             loadingOverlay,
             diffOverlayConfig,
             streamingPainter,
-            moduleDaemonReady,
-            moduleInteractiveSupported,
             earlyFeatures,
             getA11yOverlayId: a11yOverlay,
             setA11yOverlayId: setA11yOverlay,

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -13,15 +13,16 @@
 // are thin orchestration over a typed controller (live state, stale badge,
 // loading overlay, focus inspector, diff overlay, viewport tracker) call into
 // those controllers directly. The remaining fields on the context cover the
-// state still owned imperatively by `behavior.ts` —
-// `moduleDaemonReady`, `moduleInteractiveSupported`, `allPreviews`,
+// state still owned imperatively by `behavior.ts` — `allPreviews`,
 // `moduleDir`, `lastScopedPreviewId`, `a11yOverlayPreviewId` — and the
 // orchestration callbacks (`renderPreviews`, `applyLayout`,
 // `applyFilters`, `updateImage`, `applyA11yUpdate`, `focusOnCard`, etc.)
 // that should fold into a future `<preview-card>` Lit component. The
 // per-preview Maps (`cardCaptures`, `cardA11yFindings`, `cardA11yNodes`)
 // now live on `previewStore` and are reached through the helpers in
-// `previewStore.ts`.
+// `previewStore.ts`. The per-module availability Maps (`moduleDaemonReady`,
+// `moduleInteractiveSupported`) live on `LiveStateController`; this
+// dispatcher writes them via `ctx.liveState.setAvailability(...)`.
 //
 // Some `ExtensionToWebview` variants are handled directly by Lit components
 // without going through this dispatcher — `<message-banner>` listens for
@@ -70,9 +71,6 @@ export interface PreviewMessageContext {
     diffOverlayConfig: DiffOverlayConfig;
     /** Painter for `composestream/1` live frames — see streamingPainter.ts. */
     streamingPainter: StreamingPainter;
-
-    moduleDaemonReady: Map<string, boolean>;
-    moduleInteractiveSupported: Map<string, boolean>;
 
     earlyFeatures(): boolean;
     getA11yOverlayId(): string | null;
@@ -446,9 +444,9 @@ function handleSetInteractiveAvailability(
     msg: Extract<ExtensionToWebview, { command: "setInteractiveAvailability" }>,
     ctx: PreviewMessageContext,
 ): void {
-    ctx.moduleDaemonReady.set(msg.moduleId, !!msg.ready);
-    ctx.moduleInteractiveSupported.set(
+    ctx.liveState.setAvailability(
         msg.moduleId,
+        !!msg.ready,
         !!msg.interactiveSupported,
     );
     // Daemon went away while a card was live — drop the live state so the


### PR DESCRIPTION
## Summary
- `moduleDaemonReady` and `moduleInteractiveSupported` Maps are now owned by `LiveStateController`; `setAvailability(moduleId, ready, interactiveSupported)` is the single write entry point.
- `<preview-app>` no longer holds the Maps; `FocusController` reads them via `liveState.getModuleDaemonReady()` / `liveState.getModuleInteractiveSupported()` ReadonlyMap accessors so the existing `isFocusedModuleReady` / `isFocusedInteractiveSupported` predicates keep their signatures; `messageHandlers.handleSetInteractiveAvailability` calls `ctx.liveState.setAvailability(...)`.
- `PreviewMessageContext` and `FocusControllerConfig` drop the two Map fields.
- Step 3 of #860 (continued).

## Test plan
- [x] `npm run compile`
- [x] `npm test` (520 passing)
- [x] `npm run format:check`


---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_