### PR TITLE
fix(vscode): coalesce live pointerMove sends to rAF cadence

### DIFF
--- a/vscode-extension/src/test/interactiveInput.test.ts
+++ b/vscode-extension/src/test/interactiveInput.test.ts
@@ -125,7 +125,34 @@ function createVscode(): {
     };
 }
 
+/** Deterministic stub for `requestAnimationFrame`: queues callbacks until
+ *  `flushRaf()` runs them. The pointermove coalescer dispatches via rAF,
+ *  so tests need to control when the flush fires to assert the
+ *  before/after states (otherwise happy-dom's real rAF would race the
+ *  assertions). Restored after each test. */
+let pendingRaf: FrameRequestCallback[] = [];
+let originalRaf: typeof globalThis.requestAnimationFrame | undefined;
+function installRafStub(): void {
+    originalRaf = globalThis.requestAnimationFrame;
+    pendingRaf = [];
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+        pendingRaf.push(cb);
+        return pendingRaf.length;
+    }) as typeof globalThis.requestAnimationFrame;
+}
+function flushRaf(): void {
+    const cbs = pendingRaf;
+    pendingRaf = [];
+    for (const cb of cbs) cb(performance.now());
+}
+function restoreRaf(): void {
+    if (originalRaf) globalThis.requestAnimationFrame = originalRaf;
+    originalRaf = undefined;
+    pendingRaf = [];
+}
+
 afterEach(() => {
+    restoreRaf();
     document.body.innerHTML = "";
 });
 
@@ -446,5 +473,161 @@ describe("attachInteractiveInputHandlers pointer — streaming mode", () => {
 
         assert.strictEqual(posted.length, 0);
         assert.strictEqual(evt.defaultPrevented, false);
+    });
+});
+
+describe("attachInteractiveInputHandlers pointermove — rAF coalescing", () => {
+    it("collapses a burst of pointermoves into one daemon post per rAF tick", () => {
+        installRafStub();
+        const { card } = buildLiveCard("p1");
+        const canvas = attachStreamCanvas(card, 400, 300);
+        stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
+        const { posted, api } = createVscode();
+        attachInteractiveInputHandlers(card, {
+            isLive: () => true,
+            vscode: api,
+        });
+
+        canvas.dispatchEvent(
+            pointerEvent("pointerdown", { clientX: 10, clientY: 10 }),
+        );
+        // First crossing the 4-CSS-px threshold flips `dragging` and posts
+        // pointerDown synchronously.
+        canvas.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 20, clientY: 10 }),
+        );
+        // Three more moves arrive before the rAF fires — the painter only
+        // consumes one frame per rAF, so one post per rAF is what the
+        // daemon should see too.
+        canvas.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 30, clientY: 10 }),
+        );
+        canvas.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 40, clientY: 10 }),
+        );
+        canvas.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 50, clientY: 10 }),
+        );
+
+        // pointerDown went through immediately, but no pointerMove yet.
+        assert.deepStrictEqual(
+            posted.map((m) => m["kind"]),
+            ["pointerDown"],
+        );
+
+        flushRaf();
+
+        // After the rAF flush, exactly one pointerMove is posted carrying
+        // the latest position (50,10 in CSS → 200,40 in natural pixels).
+        assert.deepStrictEqual(
+            posted.map((m) => m["kind"]),
+            ["pointerDown", "pointerMove"],
+        );
+        const move = posted[1];
+        assert.strictEqual(move["pixelX"], 200);
+        assert.strictEqual(move["pixelY"], 40);
+    });
+
+    it("schedules a fresh rAF for moves that arrive after the previous flush", () => {
+        installRafStub();
+        const { card } = buildLiveCard("p1");
+        const canvas = attachStreamCanvas(card, 400, 300);
+        stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
+        const { posted, api } = createVscode();
+        attachInteractiveInputHandlers(card, {
+            isLive: () => true,
+            vscode: api,
+        });
+
+        canvas.dispatchEvent(
+            pointerEvent("pointerdown", { clientX: 10, clientY: 10 }),
+        );
+        canvas.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 20, clientY: 10 }),
+        );
+        flushRaf();
+        // Second burst — must trigger a new rAF, not piggyback on a stale flag.
+        canvas.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 60, clientY: 10 }),
+        );
+        flushRaf();
+
+        const moves = posted.filter((m) => m["kind"] === "pointerMove");
+        assert.strictEqual(moves.length, 2);
+        assert.strictEqual(moves[0]["pixelX"], 80); // 20 css → 80 nat
+        assert.strictEqual(moves[1]["pixelX"], 240); // 60 css → 240 nat
+    });
+
+    it("flushes any pending coalesced move on pointerup so the gesture's tail isn't dropped", () => {
+        installRafStub();
+        const { card } = buildLiveCard("p1");
+        const canvas = attachStreamCanvas(card, 400, 300);
+        stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
+        const { posted, api } = createVscode();
+        attachInteractiveInputHandlers(card, {
+            isLive: () => true,
+            vscode: api,
+        });
+
+        canvas.dispatchEvent(
+            pointerEvent("pointerdown", { clientX: 10, clientY: 10 }),
+        );
+        canvas.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 20, clientY: 10 }),
+        );
+        canvas.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 30, clientY: 10 }),
+        );
+        // Pointerup before the rAF would have fired — without an explicit
+        // flush the daemon would never see the (30,10) position.
+        canvas.dispatchEvent(
+            pointerEvent("pointerup", { clientX: 35, clientY: 10 }),
+        );
+
+        const kinds = posted.map((m) => m["kind"]);
+        assert.deepStrictEqual(kinds, [
+            "pointerDown",
+            "pointerMove",
+            "pointerUp",
+        ]);
+        const move = posted[1];
+        assert.strictEqual(move["pixelX"], 120); // 30 css → 120 nat
+        const up = posted[2];
+        assert.strictEqual(up["pixelX"], 140); // 35 css → 140 nat
+
+        // The deferred rAF, if any, must not double-post once it fires.
+        flushRaf();
+        const movesAfter = posted.filter((m) => m["kind"] === "pointerMove");
+        assert.strictEqual(movesAfter.length, 1);
+    });
+
+    it("drops pending moves on pointercancel without posting them", () => {
+        installRafStub();
+        const { card } = buildLiveCard("p1");
+        const canvas = attachStreamCanvas(card, 400, 300);
+        stubBoundingRect(canvas, { width: 100, height: 75, left: 0, top: 0 });
+        const { posted, api } = createVscode();
+        attachInteractiveInputHandlers(card, {
+            isLive: () => true,
+            vscode: api,
+        });
+
+        canvas.dispatchEvent(
+            pointerEvent("pointerdown", { clientX: 10, clientY: 10 }),
+        );
+        canvas.dispatchEvent(
+            pointerEvent("pointermove", { clientX: 20, clientY: 10 }),
+        );
+        canvas.dispatchEvent(
+            pointerEvent("pointercancel", { clientX: 20, clientY: 10 }),
+        );
+        flushRaf();
+
+        // Only the pointerDown made it; the pending coalesced move was
+        // discarded along with the cancelled gesture.
+        assert.deepStrictEqual(
+            posted.map((m) => m["kind"]),
+            ["pointerDown"],
+        );
     });
 });

--- a/vscode-extension/src/webview/preview/interactiveInput.ts
+++ b/vscode-extension/src/webview/preview/interactiveInput.ts
@@ -157,6 +157,14 @@ export function attachInteractiveInputHandlers(
          * `<img>` ↔ `<canvas>` flip is asynchronous).
          */
         surface: LiveSurface | null;
+        /**
+         * Latest pointerMove position not yet posted to the daemon —
+         * coalesced and flushed once per animation frame. See
+         * `flushPendingMove`.
+         */
+        pendingMove: ImagePoint | null;
+        /** True between scheduling and firing the rAF flush. */
+        rafScheduled: boolean;
     }
     const state: PointerState = {
         pointerId: null,
@@ -165,6 +173,36 @@ export function attachInteractiveInputHandlers(
         dragging: false,
         sentDown: false,
         surface: null,
+        pendingMove: null,
+        rafScheduled: false,
+    };
+
+    // Coalesce pointerMove dispatch to rAF cadence. Native pointermove
+    // fires faster than the painter's frame rate (typical mice ~120 Hz,
+    // gaming mice up to 1 kHz; the painter consumes one frame per rAF,
+    // ~60 Hz). Posting every native move overwhelms the daemon's render
+    // pipeline — frames pile up faster than they can be produced, the
+    // painter's newest-wins drops most of them, and the user sees motion
+    // that lags and skips between cursor positions instead of cleanly
+    // tracking the gesture. Sending one move per frame keeps the daemon
+    // in step with what the painter can actually display.
+    //
+    // pointerDown / pointerUp still go through immediately so the
+    // gesture's begin / end aren't delayed by up to 16 ms.
+    const flushPendingMove = (): void => {
+        state.rafScheduled = false;
+        const move = state.pendingMove;
+        state.pendingMove = null;
+        if (!move || !state.surface) return;
+        const id = card.dataset.previewId;
+        if (!id || !config.isLive(id)) return;
+        postInteractiveInput(
+            config.vscode,
+            id,
+            state.surface,
+            "pointerMove",
+            move,
+        );
     };
 
     card.addEventListener("pointerdown", (evt) => {
@@ -216,14 +254,20 @@ export function attachInteractiveInputHandlers(
                 );
                 state.sentDown = true;
             }
-            postInteractiveInput(
-                config.vscode,
-                id,
-                state.surface,
-                "pointerMove",
-                next,
-            );
+            // Stash the latest position; the rAF tick will post it. See
+            // `flushPendingMove` for the rationale on coalescing.
+            state.pendingMove = next;
             state.last = next;
+            if (!state.rafScheduled) {
+                if (typeof requestAnimationFrame === "function") {
+                    state.rafScheduled = true;
+                    requestAnimationFrame(flushPendingMove);
+                } else {
+                    // No rAF (test runner / non-browser host) — dispatch
+                    // immediately so events aren't silently lost.
+                    flushPendingMove();
+                }
+            }
             evt.preventDefault();
             evt.stopPropagation();
         }
@@ -244,6 +288,18 @@ export function attachInteractiveInputHandlers(
                     state.surface,
                     "pointerDown",
                     state.start,
+                );
+            }
+            // Flush any coalesced move so the daemon sees the cursor's
+            // last in-flight position before the lift-off, otherwise the
+            // gesture's tail (up to a frame's worth of motion) is dropped.
+            if (state.pendingMove) {
+                postInteractiveInput(
+                    config.vscode,
+                    id,
+                    state.surface,
+                    "pointerMove",
+                    state.pendingMove,
                 );
             }
             postInteractiveInput(
@@ -269,6 +325,7 @@ export function attachInteractiveInputHandlers(
         state.dragging = false;
         state.sentDown = false;
         state.surface = null;
+        state.pendingMove = null;
         evt.preventDefault();
         evt.stopPropagation();
     });
@@ -282,6 +339,7 @@ export function attachInteractiveInputHandlers(
         state.dragging = false;
         state.sentDown = false;
         state.surface = null;
+        state.pendingMove = null;
     });
 
     card.addEventListener("contextmenu", (evt) => {


### PR DESCRIPTION
## Summary

Follow-up to #882. With pointer events now reaching the daemon over the streaming canvas, drag visibly stutters while wheel ("rsb") stays smooth. The asymmetry comes from input rate, not a paint bug:

- Wheel fires ~10–30 Hz — well under the painter's ~60 Hz rAF.
- pointermove fires ~120 Hz on typical mice and up to 1 kHz on gaming mice.

Posting every native pointermove overwhelms the daemon's render pipeline. Frames pile up faster than they can be produced, the painter's newest-wins drops most of them, and the user sees motion that lags and skips between cursor positions instead of cleanly tracking the gesture.

The fix stashes the latest pointermove position in `state.pendingMove` and flushes it once per `requestAnimationFrame`, so the daemon's render cadence stays in step with what the painter can display. pointerDown / pointerUp still go through immediately (no perceptible gesture begin/end latency); pointerUp explicitly flushes the pending move so the gesture's tail isn't dropped; pointercancel discards it.

## Test plan

- [x] `npm test` (524 passing — 4 new coalescing cases)
- [x] New cases in `interactiveInput.test.ts`: burst-of-moves collapses to one post per rAF; a fresh burst after the previous flush schedules a new rAF; pointerup flushes any pending move and the deferred rAF doesn't double-post; pointercancel drops the pending move silently.
- [ ] Manual smoke: with `composePreview.streaming.enabled = true`, drag a live preview slowly and quickly — the painted frames should track the cursor cleanly without the previously-visible mid-drag stutter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Gxrw2TkQZzdwRhPtyBAp)_