### PR TITLE
refactor(vscode): fold on-image-load a11y repaint into <preview-card>

### DIFF
--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -461,14 +461,20 @@ export type UpdateImageConfig = Pick<
  * Side effects (when [captureIndex] matches the displayed capture):
  *  - Updates / mutates the per-capture cache entry on
  *    `previewStore`'s `cardCaptures` and bumps `mapsRevision` so
- *    subscribers selecting on the cache notice the new bytes.
+ *    subscribers selecting on the cache notice the new bytes. The
+ *    bump is issued AFTER the `<img>` `src` swap so the
+ *    `<preview-card>` StoreController fires with the new image
+ *    state and its on-load a11y deferral attaches against the right
+ *    src.
  *  - Replaces the card's `<img>` `src` (or creates one if missing).
  *  - Re-attaches the live pointer/wheel handlers via
  *    `attachInteractiveInputHandlers`.
  *  - If a diff overlay is open against `head` / `main`, re-issues the
  *    diff request so the user sees the new bytes without clicking.
- *  - Repaints the a11y finding / hierarchy overlays once the image's
- *    natural dimensions are known.
+ *
+ * Note: the a11y overlay repaint that used to live at the tail of
+ * this function now runs inside `<preview-card>`'s `mapsRevision`
+ * subscription — see `PreviewCard._repaintA11yOverlaysFromCache`.
  */
 export function updateImage(
     previewId: string,
@@ -481,9 +487,10 @@ export function updateImage(
 
     // Cache so carousel navigation can restore this capture without
     // a fresh extension round-trip. Mutates the capture object in
-    // place — the Map identity is unchanged but `mapsRevision` is
-    // bumped so subscribers selecting on it can react to fresh
-    // frames in live mode.
+    // place — the Map identity is unchanged. The matching
+    // `bumpPreviewMapsRevision()` is deferred until after the
+    // `<img>` `src` swap below, so the `<preview-card>` StoreController
+    // fires with the new image element / src in place.
     const caps = previewStore.getState().cardCaptures.get(previewId);
     const capture =
         caps && captureIndex >= 0 && captureIndex < caps.length
@@ -493,7 +500,6 @@ export function updateImage(
         capture.imageData = imageData;
         capture.errorMessage = null;
         capture.renderError = null;
-        bumpPreviewMapsRevision();
     }
 
     // Only paint the <img> if the currently-displayed capture is the
@@ -533,6 +539,12 @@ export function updateImage(
     img.className = isLive ? "live-frame" : "fade-in";
     attachInteractiveInputHandlers(card, config.interactiveInputConfig);
 
+    // Bump AFTER `img.src` is set so `<preview-card>`'s StoreController
+    // sees the new image when it re-runs `_repaintA11yOverlaysFromCache`.
+    // The component handles both the immediately-decoded path and the
+    // on-load deferral itself — see PreviewCard.
+    if (capture) bumpPreviewMapsRevision();
+
     if (caps) config.frameCarousel.updateIndicator(card);
 
     // If a diff overlay is open on this card and uses the live render
@@ -561,32 +573,13 @@ export function updateImage(
         }
     }
 
-    // Re-build the a11y overlay once the image natural dimensions
-    // are known. Data-URL srcs may resolve synchronously; in that
-    // case img.complete is true and load will not fire, so we
-    // check both. Findings are stashed at setPreviews time via the
-    // renderPreviews pipeline. Gated on earlyFeatures so the
-    // overlay only paints when the user has opted into the
-    // accessibility-overlay feature surface.
-    const findings = previewStore.getState().cardA11yFindings.get(previewId);
-    const nodes = previewStore.getState().cardA11yNodes.get(previewId);
-    if (
-        config.earlyFeatures() &&
-        ((findings && findings.length > 0) || (nodes && nodes.length > 0))
-    ) {
-        const paintedImg = img;
-        const apply = (): void => {
-            if (findings && findings.length > 0)
-                buildA11yOverlay(card, findings, paintedImg);
-            if (nodes && nodes.length > 0)
-                applyHierarchyOverlay(card, nodes, paintedImg);
-        };
-        if (paintedImg.complete && paintedImg.naturalWidth > 0) {
-            apply();
-        } else {
-            paintedImg.addEventListener("load", apply, { once: true });
-        }
-    }
+    // The a11y overlay repaint that used to run here lives in
+    // `<preview-card>` — the `mapsRevision` bump above (via the
+    // `if (capture)` branch) drives `_repaintA11yOverlaysFromCache`
+    // inside the component, which both handles the synchronous
+    // (`img.complete && naturalWidth > 0`) case and attaches a
+    // one-time `load` listener when the new bytes haven't decoded
+    // yet.
 }
 
 /** Subset `applyA11yUpdate` reaches for. The a11y caches themselves

--- a/vscode-extension/src/webview/preview/components/PreviewCard.ts
+++ b/vscode-extension/src/webview/preview/components/PreviewCard.ts
@@ -11,11 +11,15 @@
 // drive overlay repaints from the component itself instead of from
 // `applyA11yUpdate`.
 //
-// Step 4 still leaves the `<img>` paint and the on-image-load a11y
-// branch in `updateImage` — only the cache-change overlay refresh
-// path moves into the component. That gives us the StoreController
-// integration without disturbing the more delicate image-load
-// timing or the legend rebuild.
+// The `<img>` paint itself stays in `updateImage` (it owns the
+// `img.src` swap, the live-frame class, and the interactive-input
+// rebind). The on-image-load a11y repaint, however, lives here:
+// when a `mapsRevision` bump arrives but the `<img>` has not yet
+// resolved its `naturalWidth`, this component attaches a one-time
+// `load` listener instead of bailing. Combined with `updateImage`
+// bumping `mapsRevision` AFTER assigning the new `src`, the
+// component's StoreController fires with the right image element
+// and the load listener attaches against the new src.
 //
 // We pass `preview` as a `@property` rather than just a `previewId`
 // because `populatePreviewCard` needs the full `PreviewInfo` (function
@@ -106,9 +110,10 @@ export class PreviewCard extends LitElement {
      *    runs on every `updated()` (Lit re-renders fire the hook
      *    regardless of which property changed) so the cache-change
      *    case is covered without an explicit changedProperties guard.
-     *    The image-load case stays in `updateImage` — that path
-     *    triggers when the `<img>` becomes paintable, not when the
-     *    cache changes. */
+     *    If the `<img>` has not yet resolved natural dimensions,
+     *    `_repaintA11yOverlaysFromCache` falls back to a one-time
+     *    `load` listener so a fresh `updateImage` swap is followed by
+     *    a deferred repaint once the new bytes are decoded. */
     protected updated(changedProperties: Map<string, unknown>): void {
         if (!this._built) return;
         if (changedProperties.has("preview")) {
@@ -122,15 +127,18 @@ export class PreviewCard extends LitElement {
     }
 
     /** Re-paint the a11y findings / hierarchy overlays from the latest
-     *  per-preview store snapshot, if the `<img>` is ready to drive
-     *  the percent-of-natural math. No-op if the cache is empty for
-     *  this preview, the image hasn't loaded, or `earlyFeatures` is
-     *  off — matches the gating in `applyA11yUpdate`. The overlay
-     *  paint helpers are idempotent (they `innerHTML = ""` the layer
-     *  before re-emitting boxes), so calling this on every store fire
-     *  is safe. The legend rebuild stays in `applyA11yUpdate` — that
-     *  side effect lives next to the per-id store write and isn't
-     *  driven by `mapsRevision`. */
+     *  per-preview store snapshot. No-op if the cache is empty for
+     *  this preview or `earlyFeatures` is off — matches the gating in
+     *  `applyA11yUpdate`. If the `<img>` has resolved its natural
+     *  dimensions the paint runs immediately; if not (e.g. a fresh
+     *  `updateImage` just assigned a new `src` and decoding hasn't
+     *  finished) we attach a one-time `load` listener instead and
+     *  paint when the bytes land. The overlay paint helpers are
+     *  idempotent (they `innerHTML = ""` the layer before re-emitting
+     *  boxes), so calling this on every store fire is safe. The
+     *  legend rebuild stays in `applyA11yUpdate` — that side effect
+     *  lives next to the per-id store write and isn't driven by
+     *  `mapsRevision`. */
     private _repaintA11yOverlaysFromCache(): void {
         const preview = this.preview;
         const config = this.config;
@@ -139,15 +147,41 @@ export class PreviewCard extends LitElement {
         const img = this.querySelector<HTMLImageElement>(
             ".image-container img",
         );
-        if (!img || !img.complete || img.naturalWidth === 0) return;
+        if (!img) return;
         const state = previewStore.getState();
         const findings = state.cardA11yFindings.get(preview.id);
-        if (findings && findings.length > 0) {
-            buildA11yOverlay(this, findings, img);
-        }
         const nodes = state.cardA11yNodes.get(preview.id);
-        if (nodes && nodes.length > 0) {
-            applyHierarchyOverlay(this, nodes, img);
+        const haveFindings = !!findings && findings.length > 0;
+        const haveNodes = !!nodes && nodes.length > 0;
+        if (!haveFindings && !haveNodes) return;
+        if (img.complete && img.naturalWidth > 0) {
+            if (haveFindings) buildA11yOverlay(this, findings, img);
+            if (haveNodes) applyHierarchyOverlay(this, nodes, img);
+            return;
         }
+        // Image not yet decoded — defer to the next `load` event.
+        // `mapsRevision` may bump again before the image lands (e.g.
+        // a follow-up live frame), and Lit re-runs `updated()` on
+        // every fire, so guard against stacking listeners on the
+        // same `<img>` via a dataset flag. The handler clears the
+        // flag before painting so a later swap (new `<img>` element
+        // or a future `src` change once this one is loaded) can
+        // re-arm.
+        if (img.dataset.a11yPaintScheduled === "1") return;
+        img.dataset.a11yPaintScheduled = "1";
+        img.addEventListener(
+            "load",
+            () => {
+                delete img.dataset.a11yPaintScheduled;
+                // Re-read the cache at fire time — it may have been
+                // updated again between schedule and load.
+                const s = previewStore.getState();
+                const f = s.cardA11yFindings.get(preview.id);
+                const n = s.cardA11yNodes.get(preview.id);
+                if (f && f.length > 0) buildA11yOverlay(this, f, img);
+                if (n && n.length > 0) applyHierarchyOverlay(this, n, img);
+            },
+            { once: true },
+        );
     }
 }


### PR DESCRIPTION
## Summary
- The on-image-load a11y overlay branch in `updateImage` moves into `<preview-card>` — when a `mapsRevision` bump arrives but the card's `<img>` hasn't loaded yet, the component attaches a one-time `load` listener for the repaint.
- `updateImage` now bumps `mapsRevision` AFTER setting the new `<img>` src so the component's StoreController fires with the right image state.
- Closes out the residual `updateImage` a11y work from #857 step 4.

## Test plan
- [x] `npm run compile`
- [x] `npm test` (520 passing)
- [x] `npm run format:check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpuFkeRzXH8kxksC4jtEH1)_