### PR TITLE
feat(vscode): restore composePreview.daemon.enabled as deprecated no-op

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -124,6 +124,12 @@
                     "default": "debug",
                     "description": "Build variant to use for preview rendering"
                 },
+                "composePreview.daemon.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Deprecated. The preview daemon is always on; this setting is ignored. Opt out at the build level via `composePreview { daemon { enabled = false } }`.",
+                    "markdownDeprecationMessage": "This setting has no effect. The preview daemon is always on; opt out at the build level via `composePreview { daemon { enabled = false } }`."
+                },
                 "composePreview.earlyFeatures.enabled": {
                     "type": "boolean",
                     "default": false,


### PR DESCRIPTION
## Summary

- Re-add the `composePreview.daemon.enabled` configuration contribution that was removed in #878 so users with the setting in their `settings.json` don't see an "unknown configuration" warning.
- Marked as deprecated via `markdownDeprecationMessage`; the value is ignored. The daemon path is always on; opt-out lives in the build script (`composePreview { daemon { enabled = false } }`).

## Test plan

- [ ] `npm run format:check` (runs in pre-commit) passes.
- [ ] In a workspace with `"composePreview.daemon.enabled": false` in `settings.json`, VS Code shows the strikethrough + deprecation hint instead of the unknown-setting warning, and the daemon still starts.

---
_Generated by [Claude Code](https://claude.ai/code/session_012LD3mcPWfkGkM1JQc8F1dC)_