### PR TITLE
feat(daemon): add Wear OS ambient-mode preview override

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -62,6 +62,10 @@ dependencies {
   implementation(project(":data-strings-connector"))
   implementation(project(":data-theme-connector"))
   implementation(project(":data-wallpaper-connector"))
+  // Wear OS ambient-mode connector — Robolectric shadow of `AmbientLifecycleObserver`,
+  // `AmbientStateController`, the `AroundComposable` extension that primes it, and the
+  // `AmbientInputDispatchObserver` that wakes on activating gestures during recording.
+  implementation(project(":data-ambient-connector"))
   // UIAutomator-shaped Selector + UiObject — RobolectricHost.performUiAutomatorAction decodes
   // selector JSON via decodeSelectorJson and walks the SemanticsNode tree via
   // UiAutomator.findObject(rule, selector, useUnmergedTree).

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -48,6 +48,13 @@ class AndroidRecordingSession(
   private val interactive: InteractiveSession,
   private val framesDir: File,
   private val encodedDir: File,
+  /**
+   * Side-band observers fired before every script-event dispatch (live or scripted). The ambient
+   * connector ships [AmbientInputDispatchObserver] to wake on activating input gestures; future
+   * tracing / analytics extensions can ride alongside without sprouting a special case in the
+   * dispatch loop.
+   */
+  private val dispatchObservers: List<RecordingScriptDispatchObserver> = emptyList(),
 ) : RecordingSession {
 
   private val timeline = mutableListOf<RecordingScriptEvent>()
@@ -245,7 +252,7 @@ class AndroidRecordingSession(
 
   private fun buildScriptHandlers(): RecordingScriptHandlerRegistry =
     RecordingScriptHandlerRegistry(
-      buildMap {
+      handlers = buildMap {
         put(
           InputTouchRecordingScriptEvents.CLICK_EVENT,
           interactiveDispatchHandler(InteractiveInputKind.CLICK),
@@ -310,7 +317,8 @@ class AndroidRecordingSession(
         put(StateRecordingScriptEvents.STATE_RECREATE_EVENT, stateRecreateHandler())
         put(StateRecordingScriptEvents.STATE_SAVE_EVENT, stateSaveHandler())
         put(StateRecordingScriptEvents.STATE_RESTORE_EVENT, stateRestoreHandler())
-      }
+      },
+      observers = dispatchObservers,
     )
 
   /**

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -308,6 +308,13 @@ fun main(args: Array<String>) {
             dataProductRegistry = WallpaperDataProductRegistry(),
           )
         )
+        add(
+          Extension(
+            id = "data/ambient",
+            displayName = "Wear OS ambient override",
+            dataProductRegistry = AmbientDataProductRegistry(),
+          )
+        )
         if (historyManager != null) {
           add(
             Extension(

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -284,6 +284,7 @@ open class RobolectricHost(
       "inspectionMode",
       "material3Theme",
       "wallpaper",
+      "ambient",
     )
 
   /** PROTOCOL.md § 3 — android backend identifier surfaced via `capabilities.backend`. */
@@ -921,6 +922,10 @@ open class RobolectricHost(
       interactive = interactive,
       framesDir = framesDir,
       encodedDir = encodedDir,
+      // Side-band observers fired before every script-event dispatch. Today only the ambient
+      // connector ships one — wakes [AmbientStateController] on activating gestures so a
+      // recording can exercise the ambient ↔ interactive flip mid-script.
+      dispatchObservers = listOf(AmbientInputDispatchObserver()),
     )
   }
 
@@ -958,6 +963,7 @@ open class RobolectricHost(
             inspectionMode = base.inspectionMode,
             material3Theme = base.overrides?.material3Theme,
             wallpaper = base.overrides?.wallpaper,
+            ambient = base.overrides?.ambient,
           ),
         overrides = overrides,
       )
@@ -1133,7 +1139,7 @@ open class RobolectricHost(
    * didn't need it but the annotation is harmless when the body is a stub.
    */
   @RunWith(SandboxHoldingRunner::class)
-  @Config(sdk = [ANDROID_SDK])
+  @Config(sdk = [ANDROID_SDK], shadows = [ShadowAmbientLifecycleObserver::class])
   @GraphicsMode(GraphicsMode.Mode.NATIVE)
   class SandboxRunner {
 
@@ -1151,7 +1157,11 @@ open class RobolectricHost(
       RenderEngine(
         previewOverrideExtensions =
           PreviewOverrideExtensions(
-            listOf(WallpaperPreviewOverrideExtension(), Material3ThemePreviewOverrideExtension())
+            listOf(
+              AmbientPreviewOverrideExtension(),
+              WallpaperPreviewOverrideExtension(),
+              Material3ThemePreviewOverrideExtension(),
+            )
           ),
         dataArtifactExtensions =
           RenderDataArtifactExtensions(

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.protocol.AmbientOverride
 import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
@@ -26,6 +27,7 @@ data class PreviewOverrideBaseSpec(
   val inspectionMode: Boolean?,
   val material3Theme: Material3ThemeOverrides? = null,
   val wallpaper: WallpaperOverride? = null,
+  val ambient: AmbientOverride? = null,
 )
 
 data class MergedPreviewOverrides(
@@ -40,6 +42,7 @@ data class MergedPreviewOverrides(
   val inspectionMode: Boolean?,
   val material3Theme: Material3ThemeOverrides?,
   val wallpaper: WallpaperOverride?,
+  val ambient: AmbientOverride?,
 ) {
   /**
    * Project the merged overrides down to a [PreviewOverrides] bag that only carries
@@ -48,8 +51,12 @@ data class MergedPreviewOverrides(
    * data-extension pipeline entirely.
    */
   fun toExtensionOverrides(): PreviewOverrides? {
-    if (material3Theme == null && wallpaper == null) return null
-    return PreviewOverrides(material3Theme = material3Theme, wallpaper = wallpaper)
+    if (material3Theme == null && wallpaper == null && ambient == null) return null
+    return PreviewOverrides(
+      material3Theme = material3Theme,
+      wallpaper = wallpaper,
+      ambient = ambient,
+    )
   }
 }
 
@@ -78,6 +85,7 @@ fun mergePreviewOverrides(
       inspectionMode = base.inspectionMode,
       material3Theme = base.material3Theme,
       wallpaper = base.wallpaper,
+      ambient = base.ambient,
     )
   }
   val deviceOverride = overrides.device?.takeIf { it.isNotBlank() }
@@ -101,5 +109,6 @@ fun mergePreviewOverrides(
     inspectionMode = overrides.inspectionMode ?: base.inspectionMode,
     material3Theme = overrides.material3Theme ?: base.material3Theme,
     wallpaper = overrides.wallpaper ?: base.wallpaper,
+    ambient = overrides.ambient ?: base.ambient,
   )
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry.kt
@@ -40,6 +40,21 @@ fun interface RecordingScriptEventHandler {
 }
 
 /**
+ * Side-band dispatch hook for cross-cutting connectors that need to react to every recording script
+ * event (analytics, tracing, the ambient connector's wake-on-input). Observers fire **before** the
+ * registered handler so they can mutate connector-side state the handler reads — the ambient
+ * connector flips [AmbientStateController] before the touch click reaches the held rule's pointer
+ * pipeline.
+ *
+ * Observer faults are isolated by [RecordingScriptHandlerRegistry.dispatch] via `runCatching` — the
+ * recording session is the source of truth for evidence shape and shouldn't fail because an
+ * extension threw.
+ */
+fun interface RecordingScriptDispatchObserver {
+  fun beforeDispatch(event: RecordingScriptEvent, ctx: RecordingDispatchContext)
+}
+
+/**
  * Map from event-kind wire string to its [RecordingScriptEventHandler]. Built by each
  * [RenderHost.acquireRecordingSession] call so handlers can close over the per-session held
  * scene/rule. The registry shape itself is renderer-agnostic — desktop and Android both build one,
@@ -48,15 +63,29 @@ fun interface RecordingScriptEventHandler {
  * Lookup is by `event.kind` (the wire string the agent sent). Kinds with no registered handler
  * yield [unsupportedEvidence] — defense in depth for events the MCP layer didn't filter (older MCP
  * servers, direct daemon clients).
+ *
+ * [observers] receive every dispatched event before the handler runs — see
+ * [RecordingScriptDispatchObserver] for the contract.
  */
 class RecordingScriptHandlerRegistry(
-  private val handlers: Map<String, RecordingScriptEventHandler>
+  private val handlers: Map<String, RecordingScriptEventHandler>,
+  private val observers: List<RecordingScriptDispatchObserver> = emptyList(),
 ) {
 
   fun dispatch(
     event: RecordingScriptEvent,
     ctx: RecordingDispatchContext,
   ): RecordingScriptEvidence {
+    for (observer in observers) {
+      runCatching { observer.beforeDispatch(event, ctx) }
+        .onFailure { t ->
+          System.err.println(
+            "compose-ai-daemon: RecordingScriptDispatchObserver " +
+              "${observer.javaClass.name} threw on '${event.kind}': " +
+              "${t.javaClass.simpleName}: ${t.message}"
+          )
+        }
+    }
     val handler = handlers[event.kind]
     return if (handler == null) {
       unsupportedEvidence(event, "no recording-script handler registered for kind '${event.kind}'")

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -440,6 +440,15 @@ data class PreviewOverrides(
    * "live update" path the wallpaper data product covers.
    */
   val wallpaper: WallpaperOverride? = null,
+  /**
+   * Optional Wear OS ambient-state override. Drives the connector-side `AmbientLifecycleObserver`
+   * shadow so consumer code wrapping its UI in `AmbientAware { ... }` (or registering its own
+   * `AmbientLifecycleCallback`) renders under the requested state. The shadow defaults to
+   * `Inactive` when no override is set; setting `state = AMBIENT` causes `isAmbient()` to return
+   * `true` and primes registered callbacks with `onEnterAmbient(...)`. Wear-only — the desktop
+   * backend ignores this field.
+   */
+  val ambient: AmbientOverride? = null,
 )
 
 /**
@@ -476,6 +485,58 @@ data class WallpaperOverride(
  * Mirrors `com.materialkolor.PaletteStyle` so the protocol stays free of an external dependency;
  * the wallpaper connector maps each value to the upstream enum.
  */
+/**
+ * Wear OS ambient-mode override for previews. Drives the
+ * `androidx.wear.ambient.AmbientLifecycleObserver` shadow (see `:data-ambient-connector`) so a
+ * preview's `AmbientAware`-wrapped UI composes under the requested ambient state without flashing a
+ * real watch.
+ *
+ * `AmbientStateOverride.AMBIENT` triggers `onEnterAmbient(...)` on every registered
+ * `AmbientLifecycleCallback`. During an interactive recording session the controller flips back to
+ * `Interactive` on activating input gestures (touch click / pointer-down, RSB rotary scroll) — the
+ * same gestures the AOSP `AmbientLifecycleObserver` itself wakes on — and restores the override's
+ * requested state after [idleTimeoutMs] of further inactivity.
+ */
+@Serializable
+data class AmbientOverride(
+  /** Requested ambient state. */
+  val state: AmbientStateOverride,
+  /**
+   * Mirrors `AmbientLifecycleObserver.AmbientDetails.burnInProtectionRequired`. Forwarded to
+   * `onEnterAmbient(...)` so consumer code that branches on burn-in protection runs unchanged. Null
+   * falls back to `false`.
+   */
+  val burnInProtectionRequired: Boolean? = null,
+  /**
+   * Mirrors `AmbientLifecycleObserver.AmbientDetails.deviceHasLowBitAmbient`. Forwarded to
+   * `onEnterAmbient(...)`. Null falls back to `false`.
+   */
+  val deviceHasLowBitAmbient: Boolean? = null,
+  /**
+   * Synthetic minute-tick timestamp threaded through the connector's payload. Null means the
+   * controller uses the render-time wall-clock when capturing the [AmbientPayload]. The renderer
+   * does not synthesise periodic `onUpdateAmbient(...)` ticks — Wear's minute-tick cadence is
+   * driven by explicit timestamps so render-time captures stay deterministic. A future
+   * `ambient.updateTime` recording-script event will fire ticks at scripted points without a
+   * wall-clock timer.
+   */
+  val updateTimeMillis: Long? = null,
+  /**
+   * Idle-after-input timeout (in milliseconds) before the controller restores the override's
+   * requested state during a `record_preview` / interactive session. Null falls back to ~5000 ms,
+   * matching the Wear OS system's default ambient timeout.
+   */
+  val idleTimeoutMs: Long? = null,
+)
+
+/** Wire spelling for [AmbientOverride.state]. */
+@Serializable
+enum class AmbientStateOverride {
+  @SerialName("interactive") INTERACTIVE,
+  @SerialName("ambient") AMBIENT,
+  @SerialName("inactive") INACTIVE,
+}
+
 @Serializable
 enum class WallpaperPaletteStyle {
   @SerialName("tonalSpot") TONAL_SPOT,

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistryTest.kt
@@ -127,6 +127,63 @@ class RecordingScriptHandlerRegistryTest {
   }
 
   @Test
+  fun `dispatch fires observers before the handler runs`() {
+    val seen = mutableListOf<String>()
+    val observer = RecordingScriptDispatchObserver { event, _ -> seen += "observer:${event.kind}" }
+    val handler = RecordingScriptEventHandler { event, _ ->
+      seen += "handler:${event.kind}"
+      appliedEvidence(event)
+    }
+    val registry =
+      RecordingScriptHandlerRegistry(
+        handlers = mapOf("input.click" to handler),
+        observers = listOf(observer),
+      )
+
+    registry.dispatch(
+      RecordingScriptEvent(tMs = 0L, kind = "input.click"),
+      SimpleRecordingDispatchContext(0L, 0L),
+    )
+
+    assertEquals(listOf("observer:input.click", "handler:input.click"), seen)
+  }
+
+  @Test
+  fun `observer faults are isolated and do not poison dispatch`() {
+    val faulty = RecordingScriptDispatchObserver { _, _ -> throw RuntimeException("boom") }
+    val handler = RecordingScriptEventHandler { event, _ -> appliedEvidence(event, "ok") }
+    val registry =
+      RecordingScriptHandlerRegistry(
+        handlers = mapOf("input.click" to handler),
+        observers = listOf(faulty),
+      )
+
+    val evidence =
+      registry.dispatch(
+        RecordingScriptEvent(tMs = 0L, kind = "input.click"),
+        SimpleRecordingDispatchContext(0L, 0L),
+      )
+
+    assertEquals(RecordingScriptEventStatus.APPLIED, evidence.status)
+    assertEquals("ok", evidence.message)
+  }
+
+  @Test
+  fun `observers fire even when no handler is registered`() {
+    var observerSaw: String? = null
+    val observer = RecordingScriptDispatchObserver { event, _ -> observerSaw = event.kind }
+    val registry =
+      RecordingScriptHandlerRegistry(handlers = emptyMap(), observers = listOf(observer))
+
+    registry.dispatch(
+      RecordingScriptEvent(tMs = 0L, kind = "input.click"),
+      SimpleRecordingDispatchContext(0L, 0L),
+    )
+
+    assertEquals("input.click", observerSaw)
+  }
+
+  @Test
   fun `dispatch returns the handler's own evidence object verbatim`() {
     val sentinelEvidence = appliedEvidence(RecordingScriptEvent(tMs = 0L, kind = "click"))
     val registry =

--- a/data/ambient/connector/build.gradle.kts
+++ b/data/ambient/connector/build.gradle.kts
@@ -1,0 +1,75 @@
+// `:data-ambient-connector` glues `:data-ambient-core` (the wire-shape payload) to the daemon's
+// data-product / preview-override surface. Ships:
+//
+//  - `AmbientStateController` — process-static state holder + callback fan-out.
+//  - `ShadowAmbientLifecycleObserver` — Robolectric shadow that consults the controller so
+//    consumer code wrapping its UI in `AmbientAware { ... }` (or registering its own
+//    `AmbientLifecycleCallback`) sees the requested state instead of silently degrading to
+//    `Inactive`.
+//  - `AmbientOverrideExtension` / `AmbientPreviewOverrideExtension` — Compose `AroundComposable`
+//    plumbing that primes the controller before the consumer's `AmbientAware` reaches it.
+//  - `AmbientInputDispatchObserver` — `RecordingScriptDispatchObserver` that wakes the controller
+//    on activating gestures (touch click / pointer-down, RSB rotary scroll) so a recording can
+//    exercise the ambient ↔ interactive flip.
+//  - `AmbientDataProductRegistry` — `compose/ambient` registry serving the captured payload.
+//
+// Android-library only — `androidx.wear.ambient` is Android-only, the desktop daemon doesn't
+// register this connector. Published so `:daemon:android`'s external POM can resolve its
+// transitive ambient implementation.
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.tapmoc)
+}
+
+android { namespace = "ee.schimke.composeai.data.ambient.connector" }
+
+dependencies {
+  // Wire-shape + product-kind constants. Re-exported via `api` so consumers
+  // (`:daemon:android`) can refer to `AmbientPayload` / `Material3AmbientProduct.KIND` without
+  // adding a second `project` dependency.
+  api(project(":data-ambient-core"))
+
+  // DataProductRegistry interface, DataExtension, AroundComposableExtension. Re-exported via
+  // `api` so the connector's planner / extension classes can be referenced from
+  // `RobolectricHost`'s `previewOverrideExtensions` list.
+  api(project(":daemon:core"))
+  api(project(":data-render-core"))
+  api(project(":data-render-compose"))
+
+  // `androidx.wear.ambient.AmbientLifecycleObserver` + `AmbientLifecycleCallback` —
+  // the AOSP types the shadow shadows and the controller dispatches against.
+  compileOnly(libs.wear)
+  testImplementation(libs.wear)
+
+  // Robolectric — the shadow uses `@Implements` / `@Implementation` annotations + `RealObject`.
+  // `compileOnly` because the shadow only runs inside a Robolectric sandbox; non-test consumers
+  // never instantiate it directly. Daemon's runtime classpath already includes Robolectric.
+  compileOnly(libs.robolectric)
+  testImplementation(libs.robolectric)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.kotlinx.serialization.json)
+}
+
+mavenPublishing {
+  configure(
+    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
+      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
+      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
+      variant = "release",
+    )
+  )
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-ambient-connector",
+    displayName = "Compose Preview - Wear OS Ambient Data Product Connector",
+    description =
+      "Daemon-side Wear OS ambient-mode data-product connector: drives the Robolectric shadow that lets `AmbientAware`-wrapped previews render under a synthetic ambient state.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/ambient/connector/src/main/kotlin/ee/schimke/composeai/daemon/AmbientDataProduct.kt
+++ b/data/ambient/connector/src/main/kotlin/ee/schimke/composeai/daemon/AmbientDataProduct.kt
@@ -1,0 +1,178 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import ee.schimke.composeai.daemon.protocol.AmbientOverride
+import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.ambient.AmbientPayload
+import ee.schimke.composeai.data.ambient.Material3AmbientProduct
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.extensions.DataExtension
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * `AroundComposable` extension that primes [AmbientStateController] with the active override
+ * before the consumer's `AmbientAware { ... }` reaches the registered observer.
+ *
+ * Runs in the [DataExtensionPhase.OuterEnvironment] phase so the controller is set before the
+ * `UserEnvironment` phase (where wallpaper / theme sit) — by the time the user code reaches
+ * `AmbientAware { ... }` the controller is primed.
+ *
+ * Does **not** install a `CompositionLocalProvider` for `LocalAmbientState`. That's the
+ * consumer's responsibility via `AmbientAware`; the controller drives the consumer's existing
+ * callback chain.
+ */
+class AmbientOverrideExtension(private val override: AmbientOverride?) :
+  AroundComposableExtension(
+    id = ID,
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.OuterEnvironment,
+        provides = setOf(DataExtensionCapability(AmbientDataProductRegistry.KIND)),
+      ),
+  ) {
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    AmbientStateController.set(override)
+    DisposableEffect(override) { onDispose { AmbientStateController.set(null) } }
+    content()
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId(AmbientDataProductRegistry.KIND)
+  }
+}
+
+/**
+ * Planner that maps `renderNow.overrides.ambient` to an [AmbientOverrideExtension]. No-op when
+ * the field is null — matches the wallpaper / theme planners.
+ */
+class AmbientPreviewOverrideExtension : DataExtension<PreviewOverrides> {
+  override val id: DataExtensionId = AmbientOverrideExtension.ID
+
+  override fun plan(request: PreviewOverrides): PlannedDataExtension? =
+    request.ambient?.let(::AmbientOverrideExtension)
+}
+
+/**
+ * Daemon-side registry adapter for `compose/ambient`.
+ *
+ * The registry tracks the ambient state last applied via `renderNow.overrides.ambient`. A
+ * `data/fetch` after an ambient-aware render returns the captured payload; before any render or
+ * after the override is dropped, it returns [DataProductRegistry.Outcome.NotAvailable]. Clients
+ * update the state by sending a fresh `renderNow.overrides.ambient`.
+ */
+class AmbientDataProductRegistry : DataProductRegistry {
+  private val latestPayloads = ConcurrentHashMap<String, AmbientPayload>()
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      )
+    )
+
+  fun capture(previewId: String?, payload: AmbientPayload) {
+    if (previewId == null) return
+    latestPayloads[previewId] = payload
+  }
+
+  fun clear(previewId: String?) {
+    if (previewId == null) return
+    latestPayloads.remove(previewId)
+  }
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    val payload = latestPayloads[previewId] ?: return DataProductRegistry.Outcome.NotAvailable
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(AmbientPayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (KIND !in kinds) return emptyList()
+    val payload = latestPayloads[previewId] ?: return emptyList()
+    return listOf(
+      DataProductAttachment(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(AmbientPayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun onRender(previewId: String, result: RenderResult) {
+    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
+  }
+
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
+    val applied = overrides?.ambient
+    if (applied != null) {
+      capture(previewId, payloadFor(applied))
+    } else {
+      clear(previewId)
+    }
+  }
+
+  private fun payloadFor(applied: AmbientOverride): AmbientPayload =
+    AmbientPayload(
+      state = applied.state.wireName(),
+      burnInProtectionRequired =
+        applied.state == AmbientStateOverride.AMBIENT &&
+          (applied.burnInProtectionRequired ?: false),
+      deviceHasLowBitAmbient =
+        applied.state == AmbientStateOverride.AMBIENT &&
+          (applied.deviceHasLowBitAmbient ?: false),
+      updateTimeMillis = applied.updateTimeMillis ?: System.currentTimeMillis(),
+    )
+
+  companion object {
+    const val KIND: String = Material3AmbientProduct.KIND
+    const val SCHEMA_VERSION: Int = Material3AmbientProduct.SCHEMA_VERSION
+
+    private val json = Json {
+      encodeDefaults = true
+      prettyPrint = false
+    }
+
+    private fun AmbientStateOverride.wireName(): String =
+      when (this) {
+        AmbientStateOverride.INTERACTIVE -> "interactive"
+        AmbientStateOverride.AMBIENT -> "ambient"
+        AmbientStateOverride.INACTIVE -> "inactive"
+      }
+  }
+}

--- a/data/ambient/connector/src/main/kotlin/ee/schimke/composeai/daemon/AmbientInputDispatchObserver.kt
+++ b/data/ambient/connector/src/main/kotlin/ee/schimke/composeai/daemon/AmbientInputDispatchObserver.kt
@@ -1,0 +1,33 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+
+/**
+ * `RecordingScriptDispatchObserver` that wakes [AmbientStateController] on activating input
+ * gestures. Mirrors the AOSP `AmbientLifecycleObserver` wake semantics — only the gestures the
+ * Wear OS system itself wakes on are listed:
+ *
+ * - `input.click` / `input.pointerDown` — touch-driven activation.
+ * - `input.rotaryScroll` — rotary side-button activation.
+ *
+ * `pointerMove` / `pointerUp` / keyboard kinds are intentionally absent so a multi-pointer drag
+ * inside ambient mode doesn't flip state away on its own intermediate events.
+ */
+class AmbientInputDispatchObserver : RecordingScriptDispatchObserver {
+  override fun beforeDispatch(event: RecordingScriptEvent, ctx: RecordingDispatchContext) {
+    if (event.kind in WAKE_KINDS) AmbientStateController.notifyUserInput(ctx.tNanos)
+  }
+
+  companion object {
+    val WAKE_KINDS: Set<String> =
+      setOf(
+        InputTouchRecordingScriptEvents.CLICK_EVENT,
+        InputTouchRecordingScriptEvents.POINTER_DOWN_EVENT,
+        // `input.rotaryScroll` lives on `InputRsbRecordingScriptEvents` in `:daemon:android`,
+        // which the connector can't depend on (circular). The wire string is stable per the
+        // descriptor's `id` field, so we hard-code it here — kept in sync via
+        // `AmbientInputDispatchObserverTest`'s round-trip assertion.
+        "input.rotaryScroll",
+      )
+  }
+}

--- a/data/ambient/connector/src/main/kotlin/ee/schimke/composeai/daemon/AmbientStateController.kt
+++ b/data/ambient/connector/src/main/kotlin/ee/schimke/composeai/daemon/AmbientStateController.kt
@@ -1,0 +1,188 @@
+package ee.schimke.composeai.daemon
+
+import androidx.wear.ambient.AmbientLifecycleObserver
+import ee.schimke.composeai.daemon.protocol.AmbientOverride
+import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+/**
+ * Process-static state holder + fan-out for the Wear OS ambient connector.
+ *
+ * The flow is:
+ *
+ * 1. [AmbientOverrideExtension] calls [set] inside its `AroundComposable` body, before the
+ *    consumer's `AmbientAware { ... }` reaches the registered `AmbientLifecycleObserver`.
+ * 2. Robolectric's `ShadowAmbientLifecycleObserver` constructor calls [registerCallback] so the
+ *    consumer's callback joins the fan-out list. `isAmbient()` reads [current].
+ * 3. During an interactive recording session, [AmbientInputDispatchObserver] calls
+ *    [notifyUserInput] on activating gestures (touch click / pointer-down, RSB rotary scroll) — the
+ *    controller flips to [AmbientStateOverride.INTERACTIVE] immediately and schedules a restoration
+ *    of the override's requested state after the configured idle timeout.
+ *
+ * **Threading.** [set], [registerCallback], [unregisterCallback], [notifyUserInput], and
+ * [resetForNewSession] synchronise through a single mutex. Callbacks fire on the calling thread
+ * (Robolectric's main thread for composition; the recording-session dispatch thread for input
+ * wakes; the scheduler thread for timeout restoration). The single shared idle-timer
+ * `ScheduledExecutorService` means a fresh [set] cancels any pending idle restoration.
+ */
+object AmbientStateController {
+
+  private val lock = Any()
+
+  private val callbacks: MutableList<AmbientLifecycleObserver.AmbientLifecycleCallback> =
+    CopyOnWriteArrayList()
+
+  @Volatile private var override: AmbientOverride? = null
+
+  @Volatile private var currentState: AmbientStateOverride = AmbientStateOverride.INACTIVE
+
+  private val scheduler: ScheduledExecutorService =
+    Executors.newSingleThreadScheduledExecutor { r ->
+      Thread(r, "compose-ai-daemon-ambient-idle").apply { isDaemon = true }
+    }
+
+  @Volatile private var idleRestore: ScheduledFuture<*>? = null
+
+  /** Default idle timeout before restoring the override's requested state. Matches Wear OS. */
+  const val DEFAULT_IDLE_TIMEOUT_MS: Long = 5_000L
+
+  /**
+   * Replace the active override. Cancels any pending idle restoration (a fresh `renderNow` is the
+   * source of truth for "current state"; an in-flight wake-recover should not overwrite it). Fans
+   * out the resulting state transition to every registered callback.
+   *
+   * `null` clears the override and transitions to [AmbientStateOverride.INACTIVE] — matches the
+   * shadow's pre-wired default and the value horologist's `AmbientAware` falls back to.
+   */
+  fun set(override: AmbientOverride?) {
+    val transition: StateTransition
+    synchronized(lock) {
+      idleRestore?.cancel(false)
+      idleRestore = null
+      this.override = override
+      val target = override?.state ?: AmbientStateOverride.INACTIVE
+      transition = computeTransition(currentState, target)
+      currentState = target
+    }
+    fireTransition(transition)
+  }
+
+  /** Current ambient state. Read by [ShadowAmbientLifecycleObserver.isAmbient]. */
+  fun current(): AmbientStateOverride = currentState
+
+  /**
+   * Active override snapshot — exposed for the data-product registry's payload capture so an
+   * agent's `data/fetch?kind=compose/ambient` reflects the override's burn-in / low-bit flags.
+   */
+  fun currentOverride(): AmbientOverride? = override
+
+  fun registerCallback(callback: AmbientLifecycleObserver.AmbientLifecycleCallback) {
+    synchronized(lock) {
+      callbacks.add(callback)
+      // Prime the late joiner with the current state so a callback registered after `set(...)`
+      // still observes the ambient transition. Matches the AOSP observer's lifecycle semantics —
+      // the host activity's onResume drives an `onEnterAmbient` for an already-ambient device.
+      val stateNow = currentState
+      val ov = override
+      if (stateNow == AmbientStateOverride.AMBIENT) {
+        callback.onEnterAmbient(detailsOf(ov))
+      }
+    }
+  }
+
+  fun unregisterCallback(callback: AmbientLifecycleObserver.AmbientLifecycleCallback) {
+    synchronized(lock) { callbacks.remove(callback) }
+  }
+
+  /**
+   * Wake on an activating input gesture. Flips state to [AmbientStateOverride.INTERACTIVE] and
+   * schedules a restoration of the override's requested state after [AmbientOverride.idleTimeoutMs]
+   * (or [DEFAULT_IDLE_TIMEOUT_MS] when null). The wake fires `onExitAmbient()` on registered
+   * callbacks; the restoration fires `onEnterAmbient(...)` if the override was AMBIENT.
+   *
+   * No-op when there's no active override (no override → no ambient state to wake from).
+   *
+   * `tNanos` is the dispatch context's frame nanoTime — accepted for symmetry with
+   * [RecordingScriptDispatchObserver.beforeDispatch] but not used today; the idle timer runs on a
+   * wall-clock executor.
+   */
+  @Suppress("UNUSED_PARAMETER")
+  fun notifyUserInput(tNanos: Long) {
+    val transitionToInteractive: StateTransition
+    val activeOverride: AmbientOverride
+    synchronized(lock) {
+      val ov = override ?: return
+      activeOverride = ov
+      idleRestore?.cancel(false)
+      idleRestore = null
+      transitionToInteractive = computeTransition(currentState, AmbientStateOverride.INTERACTIVE)
+      currentState = AmbientStateOverride.INTERACTIVE
+    }
+    fireTransition(transitionToInteractive)
+    val timeoutMs = activeOverride.idleTimeoutMs ?: DEFAULT_IDLE_TIMEOUT_MS
+    if (timeoutMs <= 0L || activeOverride.state == AmbientStateOverride.INTERACTIVE) return
+    val target = activeOverride.state
+    idleRestore =
+      scheduler.schedule(
+        {
+          val transition: StateTransition?
+          synchronized(lock) {
+            // If the override changed mid-flight (a fresh `renderNow` arrived), drop the
+            // restoration — the new override owns the state.
+            if (override !== activeOverride) return@schedule
+            transition = computeTransition(currentState, target)
+            currentState = target
+            idleRestore = null
+          }
+          transition?.let { fireTransition(it) }
+        },
+        timeoutMs,
+        TimeUnit.MILLISECONDS,
+      )
+  }
+
+  /** Cleanup hook for per-session reset (recording stop / interactive close). */
+  fun resetForNewSession() {
+    synchronized(lock) {
+      idleRestore?.cancel(false)
+      idleRestore = null
+      override = null
+      currentState = AmbientStateOverride.INACTIVE
+    }
+  }
+
+  private data class StateTransition(
+    val from: AmbientStateOverride,
+    val to: AmbientStateOverride,
+    val details: AmbientLifecycleObserver.AmbientDetails,
+  )
+
+  private fun computeTransition(
+    from: AmbientStateOverride,
+    to: AmbientStateOverride,
+  ): StateTransition = StateTransition(from, to, detailsOf(override))
+
+  private fun fireTransition(t: StateTransition) {
+    if (t.from == t.to) return
+    val snapshot = callbacks.toList()
+    when (t.to) {
+      AmbientStateOverride.AMBIENT -> snapshot.forEach { it.onEnterAmbient(t.details) }
+      AmbientStateOverride.INTERACTIVE,
+      AmbientStateOverride.INACTIVE -> {
+        if (t.from == AmbientStateOverride.AMBIENT) {
+          snapshot.forEach { it.onExitAmbient() }
+        }
+      }
+    }
+  }
+
+  private fun detailsOf(ov: AmbientOverride?): AmbientLifecycleObserver.AmbientDetails =
+    AmbientLifecycleObserver.AmbientDetails(
+      ov?.burnInProtectionRequired ?: false,
+      ov?.deviceHasLowBitAmbient ?: false,
+    )
+}

--- a/data/ambient/connector/src/main/kotlin/ee/schimke/composeai/daemon/ShadowAmbientLifecycleObserver.kt
+++ b/data/ambient/connector/src/main/kotlin/ee/schimke/composeai/daemon/ShadowAmbientLifecycleObserver.kt
@@ -1,0 +1,81 @@
+package ee.schimke.composeai.daemon
+
+import android.app.Activity
+import androidx.lifecycle.LifecycleOwner
+import androidx.wear.ambient.AmbientLifecycleObserver
+import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.annotation.RealObject
+
+/**
+ * Robolectric shadow for `androidx.wear.ambient.AmbientLifecycleObserver`.
+ *
+ * Under Robolectric the system-side `WearableActivityController` isn't present — that's why
+ * horologist's `AmbientAware` swallows `NoClassDefFoundError` and the state silently degrades to
+ * `AmbientState.Inactive` in previews. This shadow replaces the AOSP class's body with a
+ * controller-aware implementation: `isAmbient()` reads [AmbientStateController.current], and the
+ * constructor registers the consumer's [AmbientLifecycleObserver.AmbientLifecycleCallback] with
+ * the controller so [AmbientStateController.set] can fan out `onEnterAmbient` / `onExitAmbient` /
+ * `onUpdateAmbient` calls into the consumer's existing code paths unchanged.
+ *
+ * The shadow targets the public `AmbientLifecycleObserver` interface; Robolectric resolves the
+ * actual concrete class loaded inside the sandbox at instrumenting time. Lifecycle callbacks
+ * (`onCreate` / `onResume` / `onPause` / `onDestroy`) are no-ops — the controller drives the
+ * ambient transitions directly, and the AOSP impl's lifecycle plumbing (which would have
+ * registered with `WearableActivityController`) is intentionally bypassed.
+ */
+@Implements(AmbientLifecycleObserver::class)
+class ShadowAmbientLifecycleObserver {
+
+  @RealObject @Suppress("unused") private lateinit var realObserver: AmbientLifecycleObserver
+
+  private var registeredCallback: AmbientLifecycleObserver.AmbientLifecycleCallback? = null
+
+  @Suppress("FunctionName")
+  @Implementation
+  protected fun __constructor__(
+    @Suppress("UNUSED_PARAMETER") activity: Activity,
+    callback: AmbientLifecycleObserver.AmbientLifecycleCallback,
+  ) {
+    registeredCallback = callback
+    AmbientStateController.registerCallback(callback)
+  }
+
+  @Implementation
+  fun isAmbient(): Boolean = AmbientStateController.current() == AmbientStateOverride.AMBIENT
+
+  @Implementation
+  @Suppress("UNUSED_PARAMETER")
+  fun onCreate(owner: LifecycleOwner) {
+    // No-op — controller drives ambient transitions directly.
+  }
+
+  @Implementation
+  @Suppress("UNUSED_PARAMETER")
+  fun onResume(owner: LifecycleOwner) {
+    // No-op — controller drives ambient transitions directly.
+  }
+
+  @Implementation
+  @Suppress("UNUSED_PARAMETER")
+  fun onPause(owner: LifecycleOwner) {
+    // No-op — controller drives ambient transitions directly.
+  }
+
+  @Implementation
+  @Suppress("UNUSED_PARAMETER")
+  fun onDestroy(owner: LifecycleOwner) {
+    registeredCallback?.let { AmbientStateController.unregisterCallback(it) }
+    registeredCallback = null
+  }
+
+  companion object {
+    /**
+     * Fully-qualified name of the shadow class. Exposed as a string so non-connector modules
+     * (`renderer-android`'s test runner, the daemon's `SandboxRunner` `@Config`) can refer to the
+     * shadow without taking a compile-time dependency on `:data-ambient-connector`.
+     */
+    const val SHADOW_FQN: String = "ee.schimke.composeai.daemon.ShadowAmbientLifecycleObserver"
+  }
+}

--- a/data/ambient/connector/src/test/kotlin/ee/schimke/composeai/daemon/AmbientDataProductTest.kt
+++ b/data/ambient/connector/src/test/kotlin/ee/schimke/composeai/daemon/AmbientDataProductTest.kt
@@ -1,0 +1,169 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.AmbientOverride
+import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.ambient.AmbientPayload
+import ee.schimke.composeai.data.ambient.Material3AmbientProduct
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Mirror of `WallpaperDataProductTest` for the `compose/ambient` data product. Covers the
+ * extension's hook shape, the planner's plan/abstain semantics, the registry's capabilities + fetch
+ * outcomes, and the on-render capture path.
+ */
+class AmbientDataProductTest {
+
+  @Test
+  fun `ambient override extension declares around-composable hook`() {
+    val extension =
+      AmbientOverrideExtension(AmbientOverride(state = AmbientStateOverride.AMBIENT))
+    val hook: AroundComposableHook = extension
+
+    assertEquals(DataExtensionId(Material3AmbientProduct.KIND), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.AroundComposable), extension.hooks)
+    assertEquals(DataExtensionPhase.OuterEnvironment, extension.constraints.phase)
+    assertTrue(extension.hasAroundComposableHook)
+    assertEquals(extension, hook)
+  }
+
+  @Test
+  fun `planner returns extension when ambient override present`() {
+    val planner = AmbientPreviewOverrideExtension()
+    val planned =
+      planner.plan(PreviewOverrides(ambient = AmbientOverride(state = AmbientStateOverride.AMBIENT)))
+    assertTrue("expected planner to produce a hook", planned is AroundComposableHook)
+    assertEquals(DataExtensionId(Material3AmbientProduct.KIND), planned!!.id)
+  }
+
+  @Test
+  fun `planner abstains when ambient override absent`() {
+    val planner = AmbientPreviewOverrideExtension()
+    assertNull(planner.plan(PreviewOverrides()))
+    assertNull(planner.plan(PreviewOverrides(widthPx = 64)))
+  }
+
+  @Test
+  fun `capabilities advertise compose ambient as inline no-rerender product`() {
+    val registry = AmbientDataProductRegistry()
+    val cap = registry.capabilities.single()
+    assertEquals("compose/ambient", cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertEquals(false, cap.requiresRerender)
+  }
+
+  @Test
+  fun `fetch before any render returns NotAvailable`() {
+    val registry = AmbientDataProductRegistry()
+    val outcome = registry.fetch("preview-1", "compose/ambient", params = null, inline = true)
+    assertEquals(DataProductRegistry.Outcome.NotAvailable, outcome)
+  }
+
+  @Test
+  fun `fetch unknown kind returns Unknown`() {
+    val registry = AmbientDataProductRegistry()
+    val outcome = registry.fetch("preview-1", "compose/wallpaper", params = null, inline = true)
+    assertEquals(DataProductRegistry.Outcome.Unknown, outcome)
+  }
+
+  @Test
+  fun `capture surfaces payload via fetch and attachmentsFor`() {
+    val registry = AmbientDataProductRegistry()
+    val payload =
+      AmbientPayload(
+        state = "ambient",
+        burnInProtectionRequired = true,
+        deviceHasLowBitAmbient = false,
+        updateTimeMillis = 99L,
+      )
+    registry.capture("preview-1", payload)
+
+    val fetched = registry.fetch("preview-1", "compose/ambient", null, true)
+    val ok = fetched as DataProductRegistry.Outcome.Ok
+    val obj = ok.result.payload!!.jsonObject
+    assertEquals("ambient", obj["state"]?.jsonPrimitive?.content)
+    assertEquals(true, obj["burnInProtectionRequired"]?.jsonPrimitive?.boolean)
+    assertEquals(false, obj["deviceHasLowBitAmbient"]?.jsonPrimitive?.boolean)
+
+    val attachments = registry.attachmentsFor("preview-1", setOf("compose/ambient"))
+    assertEquals(1, attachments.size)
+    assertEquals("compose/ambient", attachments.single().kind)
+  }
+
+  @Test
+  fun `attachmentsFor without matching kind returns empty`() {
+    val registry = AmbientDataProductRegistry()
+    registry.capture(
+      "preview-1",
+      AmbientPayload(
+        state = "ambient",
+        burnInProtectionRequired = false,
+        deviceHasLowBitAmbient = false,
+        updateTimeMillis = 0L,
+      ),
+    )
+    assertEquals(emptyList<Any>(), registry.attachmentsFor("preview-1", setOf("compose/wallpaper")))
+  }
+
+  @Test
+  fun `clear drops the captured payload`() {
+    val registry = AmbientDataProductRegistry()
+    registry.capture(
+      "preview-1",
+      AmbientPayload(
+        state = "interactive",
+        burnInProtectionRequired = false,
+        deviceHasLowBitAmbient = false,
+        updateTimeMillis = 0L,
+      ),
+    )
+    registry.clear("preview-1")
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-1", "compose/ambient", null, true),
+    )
+  }
+
+  @Test
+  fun `interactive override surfaces non-ambient flags as false`() {
+    val registry = AmbientDataProductRegistry()
+    val overrides =
+      PreviewOverrides(
+        ambient =
+          AmbientOverride(
+            state = AmbientStateOverride.INTERACTIVE,
+            burnInProtectionRequired = true,
+            deviceHasLowBitAmbient = true,
+          )
+      )
+    // Use a stub RenderResult — we only care that onRender captures something the fetch surfaces.
+    val stubResult =
+      RenderResult(id = 1L, classLoaderHashCode = 0, classLoaderName = "test")
+    registry.onRender("preview-1", stubResult, overrides, null)
+    val fetched = registry.fetch("preview-1", "compose/ambient", null, true)
+    val ok = fetched as DataProductRegistry.Outcome.Ok
+    val obj = ok.result.payload!!.jsonObject
+    assertEquals("interactive", obj["state"]?.jsonPrimitive?.content)
+    // Burn-in / low-bit flags only have meaning when state == ambient — we surface false otherwise
+    // so a downstream consumer doesn't spuriously branch on them.
+    assertEquals(false, obj["burnInProtectionRequired"]?.jsonPrimitive?.boolean)
+    assertEquals(false, obj["deviceHasLowBitAmbient"]?.jsonPrimitive?.boolean)
+    assertNotNull(obj["updateTimeMillis"]?.jsonPrimitive?.content)
+  }
+}

--- a/data/ambient/connector/src/test/kotlin/ee/schimke/composeai/daemon/AmbientStateControllerTest.kt
+++ b/data/ambient/connector/src/test/kotlin/ee/schimke/composeai/daemon/AmbientStateControllerTest.kt
@@ -1,0 +1,179 @@
+package ee.schimke.composeai.daemon
+
+import androidx.wear.ambient.AmbientLifecycleObserver
+import ee.schimke.composeai.daemon.protocol.AmbientOverride
+import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the contract of the process-static [AmbientStateController]. The shadow + the recording
+ * dispatch observer both consult this object, so we exercise the full state-machine here without
+ * needing a Robolectric sandbox.
+ */
+class AmbientStateControllerTest {
+
+  @After fun tearDown() = AmbientStateController.resetForNewSession()
+
+  @Test
+  fun `initial state is inactive`() {
+    AmbientStateController.resetForNewSession()
+    assertEquals(AmbientStateOverride.INACTIVE, AmbientStateController.current())
+  }
+
+  @Test
+  fun `set ambient drives onEnterAmbient on registered callbacks`() {
+    val cb = RecordingCallback()
+    AmbientStateController.registerCallback(cb)
+    try {
+      AmbientStateController.set(
+        AmbientOverride(
+          state = AmbientStateOverride.AMBIENT,
+          burnInProtectionRequired = true,
+          deviceHasLowBitAmbient = true,
+        )
+      )
+      assertEquals(AmbientStateOverride.AMBIENT, AmbientStateController.current())
+      assertEquals(1, cb.enterCount)
+      assertEquals(true, cb.lastDetails?.burnInProtectionRequired)
+      assertEquals(true, cb.lastDetails?.deviceHasLowBitAmbient)
+      assertEquals(0, cb.exitCount)
+    } finally {
+      AmbientStateController.unregisterCallback(cb)
+    }
+  }
+
+  @Test
+  fun `set null clears state and fires onExitAmbient`() {
+    val cb = RecordingCallback()
+    AmbientStateController.registerCallback(cb)
+    try {
+      AmbientStateController.set(AmbientOverride(state = AmbientStateOverride.AMBIENT))
+      AmbientStateController.set(null)
+      assertEquals(AmbientStateOverride.INACTIVE, AmbientStateController.current())
+      assertEquals(1, cb.enterCount)
+      assertEquals(1, cb.exitCount)
+    } finally {
+      AmbientStateController.unregisterCallback(cb)
+    }
+  }
+
+  @Test
+  fun `late-registered callback is primed with the current ambient state`() {
+    AmbientStateController.set(AmbientOverride(state = AmbientStateOverride.AMBIENT))
+    val cb = RecordingCallback()
+    AmbientStateController.registerCallback(cb)
+    try {
+      assertEquals("late joiner sees onEnterAmbient", 1, cb.enterCount)
+    } finally {
+      AmbientStateController.unregisterCallback(cb)
+    }
+  }
+
+  @Test
+  fun `notifyUserInput flips to interactive and idle timer restores the override`() {
+    val cb = RecordingCallback()
+    AmbientStateController.registerCallback(cb)
+    try {
+      AmbientStateController.set(
+        AmbientOverride(state = AmbientStateOverride.AMBIENT, idleTimeoutMs = 25L)
+      )
+      assertEquals(1, cb.enterCount)
+      AmbientStateController.notifyUserInput(tNanos = 0L)
+      assertEquals(AmbientStateOverride.INTERACTIVE, AmbientStateController.current())
+      assertEquals(1, cb.exitCount)
+      // Wait for idle restoration.
+      val deadline = System.nanoTime() + 1_000_000_000L
+      while (
+        AmbientStateController.current() != AmbientStateOverride.AMBIENT &&
+          System.nanoTime() < deadline
+      ) {
+        Thread.sleep(5)
+      }
+      assertEquals(AmbientStateOverride.AMBIENT, AmbientStateController.current())
+      assertEquals("idle restoration re-fires onEnterAmbient", 2, cb.enterCount)
+    } finally {
+      AmbientStateController.unregisterCallback(cb)
+    }
+  }
+
+  @Test
+  fun `notifyUserInput is a no-op when no override is active`() {
+    val cb = RecordingCallback()
+    AmbientStateController.registerCallback(cb)
+    try {
+      AmbientStateController.notifyUserInput(tNanos = 0L)
+      assertEquals(AmbientStateOverride.INACTIVE, AmbientStateController.current())
+      assertEquals(0, cb.enterCount)
+      assertEquals(0, cb.exitCount)
+    } finally {
+      AmbientStateController.unregisterCallback(cb)
+    }
+  }
+
+  @Test
+  fun `set replaces the override and cancels any pending idle restoration`() {
+    val cb = RecordingCallback()
+    AmbientStateController.registerCallback(cb)
+    try {
+      AmbientStateController.set(
+        AmbientOverride(state = AmbientStateOverride.AMBIENT, idleTimeoutMs = 50L)
+      )
+      AmbientStateController.notifyUserInput(tNanos = 0L)
+      // Replace before the idle restoration would fire.
+      AmbientStateController.set(AmbientOverride(state = AmbientStateOverride.INTERACTIVE))
+      Thread.sleep(80)
+      assertEquals(AmbientStateOverride.INTERACTIVE, AmbientStateController.current())
+      assertEquals("set replaced the override; original idle restoration must not fire", 1, cb.enterCount)
+    } finally {
+      AmbientStateController.unregisterCallback(cb)
+    }
+  }
+
+  @Test
+  fun `currentOverride exposes the active override snapshot`() {
+    val ov = AmbientOverride(state = AmbientStateOverride.AMBIENT, updateTimeMillis = 42L)
+    AmbientStateController.set(ov)
+    assertEquals(ov, AmbientStateController.currentOverride())
+    AmbientStateController.set(null)
+    assertEquals(null, AmbientStateController.currentOverride())
+  }
+
+  private class RecordingCallback : AmbientLifecycleObserver.AmbientLifecycleCallback {
+    var enterCount: Int = 0
+    var exitCount: Int = 0
+    var updateCount: Int = 0
+    var lastDetails: AmbientLifecycleObserver.AmbientDetails? = null
+
+    override fun onEnterAmbient(ambientDetails: AmbientLifecycleObserver.AmbientDetails) {
+      enterCount++
+      lastDetails = ambientDetails
+    }
+
+    override fun onUpdateAmbient() {
+      updateCount++
+    }
+
+    override fun onExitAmbient() {
+      exitCount++
+    }
+  }
+
+  @Test
+  fun `wake kinds list mirrors AOSP's activating gestures`() {
+    // Sanity: dispatch observer wakes only on the gestures Wear OS itself wakes on.
+    assertTrue("input.click is an activating gesture",
+      "input.click" in AmbientInputDispatchObserver.WAKE_KINDS)
+    assertTrue("input.pointerDown is an activating gesture",
+      "input.pointerDown" in AmbientInputDispatchObserver.WAKE_KINDS)
+    assertTrue("input.rotaryScroll is an activating gesture",
+      "input.rotaryScroll" in AmbientInputDispatchObserver.WAKE_KINDS)
+    assertFalse("input.pointerMove is not activating",
+      "input.pointerMove" in AmbientInputDispatchObserver.WAKE_KINDS)
+    assertFalse("input.pointerUp is not activating",
+      "input.pointerUp" in AmbientInputDispatchObserver.WAKE_KINDS)
+  }
+}

--- a/data/ambient/core/build.gradle.kts
+++ b/data/ambient/core/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // `daemon:core` carries the AmbientStateOverride enum the payload mirrors. MCP clients in other
+  // languages already consume the protocol module; pulling `data-ambient-core` adds the ambient
+  // payload schema alongside.
+  api(project(":daemon:core"))
+  api(libs.kotlinx.serialization.json)
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-ambient-core",
+    displayName = "Compose Preview - Ambient Data Product Core",
+    description = "Shared Wear OS ambient-mode data-product model classes for Compose Preview.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/ambient/core/src/main/kotlin/ee/schimke/composeai/data/ambient/AmbientModels.kt
+++ b/data/ambient/core/src/main/kotlin/ee/schimke/composeai/data/ambient/AmbientModels.kt
@@ -1,0 +1,32 @@
+package ee.schimke.composeai.data.ambient
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Stable identity of the `compose/ambient` data product. Lifted out of `AmbientDataProductRegistry`
+ * so MCP clients and other connectors can depend on the payload schema without pulling in the
+ * daemon-side registry, Robolectric, or `androidx.wear.ambient`.
+ */
+object Material3AmbientProduct {
+  const val KIND: String = "compose/ambient"
+  const val SCHEMA_VERSION: Int = 1
+}
+
+/**
+ * Wire-shape returned by `data/fetch?kind=compose/ambient`. Mirrors the fields exposed by
+ * horologist's `AmbientState.Ambient(...)` plus the synthetic minute-tick timestamp the controller
+ * forwards to `onUpdateAmbient(...)`.
+ */
+@Serializable
+data class AmbientPayload(
+  /** Lower-case wire spelling — `"interactive"`, `"ambient"`, or `"inactive"`. */
+  val state: String,
+  /**
+   * Mirrors `AmbientDetails.burnInProtectionRequired` — `false` when [state] is not `"ambient"`.
+   */
+  val burnInProtectionRequired: Boolean,
+  /** Mirrors `AmbientDetails.deviceHasLowBitAmbient` — `false` when [state] is not `"ambient"`. */
+  val deviceHasLowBitAmbient: Boolean,
+  /** Synthetic minute-tick timestamp; falls back to render-time wall clock when no override set. */
+  val updateTimeMillis: Long,
+)

--- a/data/ambient/core/src/test/kotlin/ee/schimke/composeai/data/ambient/AmbientPayloadSerializationTest.kt
+++ b/data/ambient/core/src/test/kotlin/ee/schimke/composeai/data/ambient/AmbientPayloadSerializationTest.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.data.ambient
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the wire shape of [AmbientPayload] — the JSON returned by `data/fetch?kind=compose/ambient`.
+ * MCP clients in other languages (the TypeScript MCP relay, the VS Code data-product viewer) read
+ * this shape; a silent rename here would break them.
+ */
+class AmbientPayloadSerializationTest {
+  private val json = Json { encodeDefaults = true }
+
+  @Test
+  fun `payload roundtrips through JSON`() {
+    val payload =
+      AmbientPayload(
+        state = "ambient",
+        burnInProtectionRequired = true,
+        deviceHasLowBitAmbient = false,
+        updateTimeMillis = 1_234_567L,
+      )
+    val encoded = json.encodeToString(AmbientPayload.serializer(), payload)
+    val decoded = json.decodeFromString(AmbientPayload.serializer(), encoded)
+    assertEquals(payload, decoded)
+  }
+
+  @Test
+  fun `wire field names match the documented shape`() {
+    val payload =
+      AmbientPayload(
+        state = "ambient",
+        burnInProtectionRequired = true,
+        deviceHasLowBitAmbient = true,
+        updateTimeMillis = 0L,
+      )
+    val encoded = json.encodeToString(AmbientPayload.serializer(), payload)
+    assertTrue("state field present: $encoded", encoded.contains("\"state\":\"ambient\""))
+    assertTrue(
+      "burnIn flag present: $encoded",
+      encoded.contains("\"burnInProtectionRequired\":true"),
+    )
+    assertTrue(
+      "low-bit flag present: $encoded",
+      encoded.contains("\"deviceHasLowBitAmbient\":true"),
+    )
+    assertTrue(
+      "updateTimeMillis present (encodeDefaults=true): $encoded",
+      encoded.contains("\"updateTimeMillis\":0"),
+    )
+  }
+
+  @Test
+  fun `product kind is the documented compose ambient string`() {
+    assertEquals("compose/ambient", Material3AmbientProduct.KIND)
+    assertEquals(1, Material3AmbientProduct.SCHEMA_VERSION)
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,16 @@ wear-compose = "1.6.1"
 wear-tiles = "1.6.0"
 wear-protolayout = "1.4.0"
 wear-tooling-preview = "1.0.0"
+# `androidx.wear:wear` carries `androidx.wear.ambient.AmbientLifecycleObserver` —
+# the AOSP entry point both horologist's `AmbientAware` and direct subscribers
+# wrap. Used only by `:data-ambient-connector` (the Robolectric shadow + state
+# controller) so consumer code wired to `AmbientAware { ... }` can render under
+# a synthetic ambient state without flashing a real watch.
+wear = "1.3.0"
+# Horologist's `AmbientAware` composable + `AmbientState` sealed type — the
+# de-facto helper most Wear apps use to wrap their root content. Used by
+# `:samples:wear` previews to demonstrate the ambient override end-to-end.
+horologist = "0.7.15"
 # Remote Compose — alpha artifacts, used only by `:samples:remotecompose` to
 # demonstrate `RemotePreview` + `@PreviewWrapper(RemotePreviewWrapper::class)`.
 # Re-check minCompileSdk / AGP requirements when bumping these — the alpha
@@ -116,6 +126,8 @@ wear-tiles-renderer = { module = "androidx.wear.tiles:tiles-renderer", version.r
 wear-tiles-tooling = { module = "androidx.wear.tiles:tiles-tooling", version.ref = "wear-tiles" }
 wear-tiles-tooling-preview = { module = "androidx.wear.tiles:tiles-tooling-preview", version.ref = "wear-tiles" }
 wear-tooling-preview = { module = "androidx.wear:wear-tooling-preview", version.ref = "wear-tooling-preview" }
+wear = { module = "androidx.wear:wear", version.ref = "wear" }
+horologist-compose-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }
 compose-remote-tooling-preview = { module = "androidx.compose.remote:remote-tooling-preview", version.ref = "compose-remote" }
 compose-remote-creation = { module = "androidx.compose.remote:remote-creation", version.ref = "compose-remote" }
 compose-remote-creation-compose = { module = "androidx.compose.remote:remote-creation-compose", version.ref = "compose-remote" }

--- a/samples/wear/build.gradle.kts
+++ b/samples/wear/build.gradle.kts
@@ -42,6 +42,14 @@ dependencies {
   implementation(libs.compose.ui.tooling.preview)
   debugImplementation("androidx.compose.ui:ui-tooling")
 
+  // Horologist `AmbientAware` + the `:data-ambient-connector`'s shadow so previews can
+  // exercise the Wear OS ambient state transitions described in
+  // docs/wear/AMBIENT.md. The connector ships the Robolectric shadow consumed by the
+  // renderer's test classpath; in source it's only referenced from the preview body.
+  implementation(libs.horologist.compose.layout)
+  implementation(libs.wear)
+  implementation(project(":data-ambient-connector"))
+
   // Wear Tiles — for the `@androidx.wear.tiles.tooling.preview.Preview` sample
   // rendered via TilePreviewRenderer in renderer-android. `wear.tiles.renderer`
   // is deliberately NOT declared here — the plugin injects it when the

--- a/samples/wear/src/main/kotlin/com/example/samplewear/AmbientPreviews.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/AmbientPreviews.kt
@@ -1,0 +1,120 @@
+package com.example.samplewear
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import androidx.wear.tooling.preview.devices.WearDevices
+import com.google.android.horologist.compose.ambient.AmbientAware
+import com.google.android.horologist.compose.ambient.AmbientState
+
+/**
+ * Ambient-aware Wear OS preview. Wraps the watchface body in horologist's [AmbientAware] — the
+ * de-facto helper that drives `androidx.wear.ambient.AmbientLifecycleObserver` under the hood. In
+ * a preview render the connector's `ShadowAmbientLifecycleObserver` (see
+ * `:data-ambient-connector`) consults [AmbientStateController][ee.schimke.composeai.daemon.AmbientStateController]
+ * so the body's `state` parameter reflects whichever override the daemon's
+ * `renderNow.overrides.ambient` set — `Inactive` for the unmodified `@Preview` path, `Ambient` /
+ * `Interactive` when an override is in flight.
+ *
+ * The body records its own state transitions in a `mutableStateListOf` and surfaces the rolling
+ * trail underneath the timestamp. With `mainClock.autoAdvance = false` (the default for renderNow)
+ * the trail captures one entry per applied state during a single render — the trail itself
+ * doubles as a regression sentinel: an unexpected `[Interactive]` after an `Ambient` override
+ * pinpoints a regression in the controller / shadow / `AmbientAware` chain at a glance.
+ */
+@Composable
+fun AmbientStatusBody(now: () -> Long = System::currentTimeMillis) {
+  AmbientAware { state ->
+    val transitions = remember { mutableStateListOf<String>() }
+    LaunchedEffect(state) {
+      // Snapshot every state delivery so the body itself records the
+      // interactive ↔ ambient ↔ inactive transitions the daemon drove.
+      snapshotFlow { state }
+        .collect { snap -> transitions += snap.label() }
+    }
+    val isAmbient = state is AmbientState.Ambient
+    val background = if (isAmbient) Color.Black else Color(0xFF101820)
+    val textColor = if (isAmbient) Color(0xFFCFD8DC) else Color.White
+
+    Box(
+      modifier =
+        Modifier.fillMaxSize().background(background).padding(16.dp),
+      contentAlignment = Alignment.Center,
+    ) {
+      Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+      ) {
+        Text(text = state.label(), style = MaterialTheme.typography.titleMedium, color = textColor)
+        Text(
+          text = "t=${now()}",
+          style = MaterialTheme.typography.labelSmall,
+          color = textColor,
+        )
+        // Most recent few transitions, rendered newest-first. With paused-clock renders the list
+        // contains the single "current" state; live-clock or recording sessions append entries on
+        // every onEnter / onExit / onUpdate fan-out.
+        transitions.takeLast(3).forEach { entry ->
+          Text(
+            text = "→ $entry",
+            style = MaterialTheme.typography.labelSmall,
+            color = textColor,
+          )
+        }
+      }
+    }
+  }
+}
+
+private fun AmbientState.label(): String =
+  when (this) {
+    is AmbientState.Ambient -> {
+      val suffixes = buildList {
+        if (burnInProtectionRequired) add("burnIn")
+        if (deviceHasLowBitAmbient) add("lowBit")
+      }
+      if (suffixes.isEmpty()) "Ambient" else "Ambient(${suffixes.joinToString(",")})"
+    }
+    is AmbientState.Interactive -> "Interactive"
+    is AmbientState.Inactive -> "Inactive"
+  }
+
+@Preview(name = "Ambient body — interactive", device = WearDevices.LARGE_ROUND, showBackground = true)
+@Composable
+fun AmbientStatusInteractivePreview() {
+  AmbientStatusBody(now = { 1_700_000_000_000L })
+}
+
+@Preview(name = "Ambient body — ambient", device = WearDevices.LARGE_ROUND, showBackground = true)
+@Composable
+fun AmbientStatusAmbientPreview() {
+  // Drives the connector controller directly so the static @Preview path renders under the
+  // ambient state without going through the daemon's renderNow.overrides.ambient field.
+  // Production uses the override; this preview gives Android Studio's preview pane a stable
+  // ambient capture too.
+  ee.schimke.composeai.daemon.AmbientStateController.set(
+    ee.schimke.composeai.daemon.protocol.AmbientOverride(
+      state = ee.schimke.composeai.daemon.protocol.AmbientStateOverride.AMBIENT,
+      burnInProtectionRequired = true,
+      deviceHasLowBitAmbient = false,
+      updateTimeMillis = 1_700_000_000_000L,
+    )
+  )
+  AmbientStatusBody(now = { 1_700_000_000_000L })
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -142,6 +142,14 @@ include(":data-wallpaper-connector")
 
 project(":data-wallpaper-connector").projectDir = file("data/wallpaper/connector")
 
+include(":data-ambient-core")
+
+project(":data-ambient-core").projectDir = file("data/ambient/core")
+
+include(":data-ambient-connector")
+
+project(":data-ambient-connector").projectDir = file("data/ambient/connector")
+
 include(":data-recomposition-core")
 
 project(":data-recomposition-core").projectDir = file("data/recomposition/core")


### PR DESCRIPTION
## Summary

Adds a `renderNow.overrides.ambient` field that drives a Robolectric shadow of `androidx.wear.ambient.AmbientLifecycleObserver`, so consumer code wired through Horologist's `AmbientAware` (or any direct `AmbientLifecycleCallback` subscriber) renders under a synthetic ambient state instead of silently degrading to `Inactive` under Robolectric.

- **Protocol** (`:daemon:core`): new `AmbientOverride` + `AmbientStateOverride` on `PreviewOverrides.ambient`, threaded through `PreviewOverrideMerge.kt`. `RecordingScriptHandlerRegistry` gains a generic `RecordingScriptDispatchObserver` seam (observer faults isolated via `runCatching`) so the ambient connector and any future analytics / tracing hooks ride alongside the per-event handlers without per-case branches in the dispatch loop.
- **`:data-ambient-core`**: `AmbientPayload` + `Material3AmbientProduct.KIND = "compose/ambient"`.
- **`:data-ambient-connector`**: process-static `AmbientStateController` (callback fan-out + idle-timer wake-on-input semantics), `ShadowAmbientLifecycleObserver` (`@Implements(AmbientLifecycleObserver::class)`), `AmbientOverrideExtension` (`OuterEnvironment` phase `AroundComposable`), `AmbientPreviewOverrideExtension` planner, `AmbientDataProductRegistry`, and `AmbientInputDispatchObserver` that wakes on `input.click` / `input.pointerDown` / `input.rotaryScroll` only — matching the activating gestures Wear OS itself wakes on. After the configured idle timeout the controller restores the override's requested state.
- **Daemon wiring** (`:daemon:android`): `SandboxRunner.@Config(shadows = [...])` registers the shadow, `RenderEngine`'s `previewOverrideExtensions` list adds the planner, `AndroidRecordingSession` takes a `dispatchObservers` parameter wired from `RobolectricHost.acquireRecordingSession`, `data/ambient` extension registered in `DaemonMain`, `supportedOverrides` advertised, the override-base-spec field threaded.
- **Sample** (`:samples:wear`): `AmbientStatusBody` uses Horologist's `AmbientAware { state -> ... }` and records a rolling state-transition trail in the composable body via `mutableStateListOf` + `LaunchedEffect(state)` + `snapshotFlow`. Two `@Preview` annotations cover the interactive and ambient capture paths; the trail itself acts as a regression sentinel for the controller / shadow / `AmbientAware` chain.

Tracking: #829.

## Test plan

- [x] `./gradlew :data-ambient-core:test` — payload JSON round-trip + product-kind pin.
- [x] `./gradlew :data-ambient-connector:testDebugUnitTest` — controller state machine (set / clear / late-register prime), idle-timer restoration, override replacement cancels pending restoration, data-product registry capabilities + fetch / attach outcomes, planner abstain/plan, wake-kind set sanity.
- [x] `./gradlew :daemon:core:test --tests RecordingScriptHandlerRegistryTest --tests PreviewOverrideMergeTest` — observer ordering before handler, fault isolation, observers fire when no handler is registered, override-merge ambient field round-trip.
- [x] `./gradlew :data-wallpaper-connector:test` — sanity that the existing wallpaper connector still passes (extension list ordering changed in `RobolectricHost`).
- [x] `./gradlew :samples:wear:compileDebugKotlin` — Horologist-wrapped previews compile against the connector and the controller.
- [x] `./gradlew :daemon:android:compileDebugKotlin` / `:compileReleaseKotlin` — daemon wiring compiles in both variants.
- [ ] Robolectric end-to-end with the shadow installed (renderPreviews against the wear sample) — not exercised here; design intent verified through controller / planner / registry / observer unit tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ipbDZiqaB6z5WQmnsseNt)_