### PR TITLE
fix(daemon): break live-frame loop when interactive session auto-closes

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -165,7 +165,7 @@ internal constructor(
    * panel-side handler that wants to redraw the v1 fallback hint when the daemon force-closes a
    * stream out from under it.
    */
-  val isClosed: Boolean
+  override val isClosed: Boolean
     get() = closed
 
   /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
@@ -37,6 +37,20 @@ interface InteractiveSession : AutoCloseable {
   val previewId: String
 
   /**
+   * `true` once the session has been closed — either by explicit [close] or by a host-internal
+   * watchdog (e.g. [AndroidInteractiveSession]'s idle-lease watchdog). After this flips, [render]
+   * throws and [dispatch] is a no-op. [JsonRpcServer.submitInteractiveRenderAsync]'s catch path
+   * checks this on render failure to distinguish "session is gone, stop the live-frame loop" from
+   * "render itself blew up, leave the session in place for the next input".
+   *
+   * Default `false` keeps in-test sessions that don't model close semantics on the pre-existing
+   * behaviour (the worker still cleans up when their `render()` throws — see the catch in
+   * `submitInteractiveRenderAsync` — but the loop won't pre-emptively stop).
+   */
+  val isClosed: Boolean
+    get() = false
+
+  /**
    * Feed one wire-level [InteractiveInputParams] (click, pointer down/up, key down/up) into the
    * held composition. Implementations translate the protocol-level kind into the host's pointer-
    * input dispatch (e.g. `ImageComposeScene.sendPointerEvent` on desktop), splitting `CLICK` into

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -2294,7 +2294,8 @@ class JsonRpcServer(
             running.get() &&
               !shutdownRequested.get() &&
               interactiveTargets.containsKey(streamId) &&
-              interactiveSessions[streamId] === session
+              interactiveSessions[streamId] === session &&
+              !session.isClosed
           ) {
             requestInteractiveRender(streamId, previewId, session)
             try {
@@ -2409,22 +2410,40 @@ class JsonRpcServer(
             // inputs from the queue; without new arrivals the queue empties and the next claim
             // skips re-spawning.
             interactiveRenderInFlight.remove(streamId)
-            val pending = pendingInteractiveInputs[streamId]
-            if (
-              pending != null &&
-                pending.isNotEmpty() &&
-                interactiveRenderInFlight.putIfAbsent(streamId, true) == null
-            ) {
-              val curSession = interactiveSessions[streamId]
-              val curTarget = interactiveTargets[streamId]
-              if (curSession != null && curTarget != null) {
-                submitInteractiveRenderAsync(streamId, curTarget.previewId, curSession)
-              } else {
-                // Session was stopped while we were rendering; drop the queued inputs and clear
-                // the slot. Stale inputs against a stopped stream are dropped per the v1
-                // contract (handleInteractiveInput would also short-circuit on the next poll).
-                pendingInteractiveInputs.remove(streamId)
-                interactiveRenderInFlight.remove(streamId)
+            // Detect a session that closed itself out from under us — typically the
+            // [AndroidInteractiveSession] idle-lease watchdog firing while we were live, but also
+            // any host that decides to drop the session asynchronously. Without this branch the
+            // live-frame loop in [startInteractiveFrameLoop] keeps re-claiming the in-flight slot
+            // and dispatching renders against the dead session, each one throwing
+            // `IllegalStateException("…called after close()")`, producing the spin we hit at
+            // sample-wear (renders 573, 574, … all failing with the same message). Clearing the
+            // session reference makes the loop's `interactiveSessions[streamId] === session` /
+            // `!session.isClosed` exit checks fire on its next wake; dropping pending inputs
+            // matches the `interactive/stop` contract — stale inputs against a stopped stream
+            // are silently discarded.
+            if (session.isClosed) {
+              interactiveSessions.remove(streamId, session)
+              interactiveTargets.remove(streamId)
+              pendingInteractiveInputs.remove(streamId)
+              stopInteractiveFrameLoop(streamId)
+            } else {
+              val pending = pendingInteractiveInputs[streamId]
+              if (
+                pending != null &&
+                  pending.isNotEmpty() &&
+                  interactiveRenderInFlight.putIfAbsent(streamId, true) == null
+              ) {
+                val curSession = interactiveSessions[streamId]
+                val curTarget = interactiveTargets[streamId]
+                if (curSession != null && curTarget != null && !curSession.isClosed) {
+                  submitInteractiveRenderAsync(streamId, curTarget.previewId, curSession)
+                } else {
+                  // Session was stopped while we were rendering; drop the queued inputs and clear
+                  // the slot. Stale inputs against a stopped stream are dropped per the v1
+                  // contract (handleInteractiveInput would also short-circuit on the next poll).
+                  pendingInteractiveInputs.remove(streamId)
+                  interactiveRenderInFlight.remove(streamId)
+                }
               }
             }
           }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
@@ -283,6 +283,65 @@ class InteractiveSessionPlumbingTest {
   }
 
   @Test(timeout = 30_000)
+  fun session_marked_closed_terminates_live_frame_loop() {
+    // Regression: when an InteractiveSession closes itself out from under JsonRpcServer (e.g.
+    // AndroidInteractiveSession's idle-lease watchdog), the live-frame loop in
+    // startInteractiveFrameLoop must observe `session.isClosed` and stop dispatching renders
+    // against the dead session. Without the fix, every frame-interval tick claims the in-flight
+    // slot, calls session.render(), catches the IllegalStateException, releases the slot, sleeps,
+    // and repeats — producing the unbounded stderr spam we saw on samples/wear (renders 573,
+    // 574, … all failing with "called after close()").
+    val tmp = Files.createTempDirectory("interactive-session-closed-loop").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val host = SessionAwareFakeHost(pngFile)
+
+    val (_, serverThread, clientToServerOut, received, exitLatch) =
+      bringUpServer(host, interactiveFrameIntervalMs = 25)
+    resourcesToClose.add(AutoCloseable { runCatching { clientToServerOut.close() } })
+
+    handshake(clientToServerOut, received)
+
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","id":10,"method":"interactive/start","params":{"previewId":"preview-A"}}""",
+    )
+    val startResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 10 }
+    assertNotNull(startResp)
+    val session = host.lastSession()!!
+
+    // Let the live-frame loop fire a handful of renders so we know it's actually running before
+    // we mark the session closed. 25ms interval × ~150ms wall clock should clear several frames
+    // even on a loaded CI box.
+    val deadline = System.currentTimeMillis() + 1_000
+    while (session.renderCount.get() < 3 && System.currentTimeMillis() < deadline) {
+      Thread.sleep(10)
+    }
+    assertTrue(
+      "live-frame loop should have fired several renders before close (got ${session.renderCount.get()})",
+      session.renderCount.get() >= 3,
+    )
+
+    // Flip the session into the closed state — render() now throws, mirroring the
+    // AndroidInteractiveSession watchdog auto-close path.
+    session.markClosed()
+    val countAtClose = session.renderCount.get()
+
+    // Give the loop ample time to discover the closed state and terminate. A pre-fix run would
+    // continue incrementing renderCount indefinitely as it spins on the failing render.
+    Thread.sleep(500)
+
+    val countAfterClose = session.renderCount.get()
+    val tolerance = 2 // one in-flight render at the moment of mark + the loop's exit check
+    assertTrue(
+      "live-frame loop must stop firing after session.isClosed flips " +
+        "(countAtClose=$countAtClose countAfterClose=$countAfterClose)",
+      countAfterClose - countAtClose <= tolerance,
+    )
+
+    teardownServer(clientToServerOut, received, serverThread, exitLatch)
+  }
+
+  @Test(timeout = 30_000)
   fun cleanShutdown_closes_all_open_sessions() {
     val tmp = Files.createTempDirectory("interactive-session-shutdown").toFile()
     val aPng = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
@@ -482,16 +541,33 @@ private class RecordingSession(override val previewId: String, private val pngFi
 
   @Volatile private var lastClickX: Int? = null
   @Volatile private var lastClickY: Int? = null
+  @Volatile private var closedFlag: Boolean = false
 
   fun lastClick(): Pair<Int, Int>? = lastClickX?.let { x -> lastClickY?.let { y -> x to y } }
 
+  /**
+   * Flip the session into the closed state without going through [close] — models a host-internal
+   * watchdog (e.g. [AndroidInteractiveSession]'s idle-lease watchdog) that closes the session out
+   * from under the JsonRpcServer's tracking maps. Subsequent [render] calls throw the same
+   * `IllegalStateException` the production session emits, and [isClosed] flips so the live-frame
+   * loop's exit check fires.
+   */
+  fun markClosed() {
+    closedFlag = true
+  }
+
+  override val isClosed: Boolean
+    get() = closedFlag
+
   override fun dispatch(input: InteractiveInputParams) {
+    if (closedFlag) return
     dispatchCount.incrementAndGet()
     lastClickX = input.pixelX
     lastClickY = input.pixelY
   }
 
   override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {
+    check(!closedFlag) { "RecordingSession.render() called after close()" }
     renderCount.incrementAndGet()
     return RenderResult(
       id = requestId,
@@ -503,6 +579,7 @@ private class RecordingSession(override val previewId: String, private val pngFi
   }
 
   override fun close() {
+    closedFlag = true
     closeCount.incrementAndGet()
   }
 }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
@@ -42,6 +42,9 @@ class DesktopInteractiveSession(
 
   @Volatile private var closed: Boolean = false
 
+  override val isClosed: Boolean
+    get() = closed
+
   override fun dispatch(input: InteractiveInputParams) {
     if (closed) return
     val px = input.pixelX


### PR DESCRIPTION
When AndroidInteractiveSession's idle-lease watchdog force-closed a held
session out from under JsonRpcServer, the live-frame loop kept ticking
against the dead session — every interactiveFrameIntervalMs the worker
called session.render(), caught the IllegalStateException("...called
after close()"), released the in-flight slot, slept, and tried again.
On samples/wear that produced unbounded stderr spam (renders 573, 574,
... all failing identically) and prevented the panel from recovering.

Add isClosed to the InteractiveSession interface (default false; Android
+ Desktop both already tracked the flag privately and now expose it),
have the frame loop check it as part of its exit condition, and clean
up interactiveSessions/interactiveTargets/pendingInteractiveInputs +
stop the loop in the render worker's finally block when the session is
observed closed. Regression covered in InteractiveSessionPlumbingTest.