### PR TITLE
feat(vscode): drop static base capture when scroll image data product exists

### DIFF
--- a/vscode-extension/src/captureLabels.ts
+++ b/vscode-extension/src/captureLabels.ts
@@ -76,13 +76,25 @@ function dataProductToCapture(p: PreviewDataProduct): Capture {
 /** Returns a copy of [preview] with image-bearing data products folded into
  *  the captures list as additional carousel frames. The webview only renders
  *  `captures`; surfacing `@ScrollingPreview(LONG/GIF)` requires moving those
- *  entries across the boundary so the panel actually paints them. Order:
- *  base captures first, then data products in declaration order. */
+ *  entries across the boundary so the panel actually paints them.
+ *
+ *  When a scroll image data product is present, the base static capture
+ *  (no `advanceTimeMillis`, no `scroll`) is dropped: the LONG stitched image
+ *  starts at the top and the GIF includes the initial frame, so the static
+ *  frame is just a redundant duplicate of the scroll capture's starting
+ *  state. Animated (`advanceTimeMillis`-bearing) and scroll-mode
+ *  (`scroll != null`, e.g. `TOP`/`END`) captures are kept.
+ *
+ *  Order: surviving base captures first, then data products in declaration
+ *  order. */
 export function withDataProductCaptures(preview: PreviewInfo): PreviewInfo {
     const products = (preview.dataProducts ?? []).filter(isImageDataProduct);
     if (products.length === 0) return preview;
+    const baseCaptures = preview.captures.filter(
+        (c) => c.advanceTimeMillis != null || c.scroll != null,
+    );
     return {
         ...preview,
-        captures: [...preview.captures, ...products.map(dataProductToCapture)],
+        captures: [...baseCaptures, ...products.map(dataProductToCapture)],
     };
 }

--- a/vscode-extension/src/test/captureLabels.test.ts
+++ b/vscode-extension/src/test/captureLabels.test.ts
@@ -89,7 +89,7 @@ describe("withDataProductCaptures", () => {
         assert.strictEqual(withDataProductCaptures(preview), preview);
     });
 
-    it("appends LONG/GIF data products as carousel captures", () => {
+    it("replaces the static base capture with LONG/GIF data products", () => {
         const longScroll = {
             mode: "LONG",
             axis: "VERTICAL",
@@ -124,20 +124,70 @@ describe("withDataProductCaptures", () => {
             ],
         });
         const merged = withDataProductCaptures(preview);
-        assert.strictEqual(merged.captures.length, 3);
+        assert.strictEqual(merged.captures.length, 2);
         assert.strictEqual(
-            merged.captures[1].renderOutput,
+            merged.captures[0].renderOutput,
             "data/scroll/long/x.png",
         );
-        assert.strictEqual(merged.captures[1].label, "scrolled end");
-        assert.strictEqual(merged.captures[1].cost, 20);
+        assert.strictEqual(merged.captures[0].label, "scrolled end");
+        assert.strictEqual(merged.captures[0].cost, 20);
         assert.strictEqual(
-            merged.captures[2].renderOutput,
+            merged.captures[1].renderOutput,
             "data/scroll/gif/x.gif",
         );
-        assert.strictEqual(merged.captures[2].label, "scroll gif");
+        assert.strictEqual(merged.captures[1].label, "scroll gif");
         assert.notStrictEqual(merged, preview);
         assert.strictEqual(preview.captures.length, 1);
+    });
+
+    it("keeps TOP and animated captures alongside LONG/GIF data products", () => {
+        const topScroll = {
+            mode: "TOP",
+            axis: "VERTICAL",
+            maxScrollPx: 0,
+            reduceMotion: false,
+            atEnd: false,
+            reachedPx: null,
+        };
+        const longScroll = { ...topScroll, mode: "LONG", atEnd: true };
+        const preview = makePreview({
+            captures: [
+                {
+                    advanceTimeMillis: null,
+                    scroll: null,
+                    renderOutput: "renders/static.png",
+                },
+                {
+                    advanceTimeMillis: 500,
+                    scroll: null,
+                    renderOutput: "renders/animated.png",
+                },
+                {
+                    advanceTimeMillis: null,
+                    scroll: topScroll,
+                    renderOutput: "renders/top.png",
+                },
+            ],
+            dataProducts: [
+                {
+                    kind: "render/scroll/long",
+                    advanceTimeMillis: null,
+                    scroll: longScroll,
+                    output: "data/scroll/long/x.png",
+                },
+            ],
+        });
+        const merged = withDataProductCaptures(preview);
+        assert.strictEqual(merged.captures.length, 3);
+        assert.strictEqual(
+            merged.captures[0].renderOutput,
+            "renders/animated.png",
+        );
+        assert.strictEqual(merged.captures[1].renderOutput, "renders/top.png");
+        assert.strictEqual(
+            merged.captures[2].renderOutput,
+            "data/scroll/long/x.png",
+        );
     });
 
     it("makes a single-capture preview animated when a data product is added", () => {


### PR DESCRIPTION
## Summary

When a preview emits a `render/scroll/long` or `render/scroll/gif` data product, the base static `@Preview` capture is just the scroll output's top frame at native dimensions. Surfacing both forces the carousel onto page 1/2 with the redundant static and hides the scroll preview behind pagination.

`withDataProductCaptures` ([vscode-extension/src/captureLabels.ts](../blob/agent/enable-scrolling-previews-foGAd/vscode-extension/src/captureLabels.ts)) now drops base captures with no `advanceTimeMillis` and no `scroll` when image-bearing scroll data products are present, so the long/gif scroll capture becomes the default (and only) frame.

- Static base captures (`advanceTimeMillis == null && scroll == null`) are dropped only when a `render/scroll/long` or `render/scroll/gif` is present.
- `TOP` / `END` scroll captures (`scroll != null`) and animated captures (`advanceTimeMillis != null`) are preserved, so `@ScrollingPreview(modes = [TOP, LONG])` and `@AnimatedPreview` + `@ScrollingPreview(LONG)` still produce a multi-frame carousel.
- Previews without scroll image data products are unaffected (early return).

## Test plan

- [x] `npx mocha out/test/captureLabels.test.js` — all 7 cases pass, including a new "keeps TOP and animated captures alongside LONG/GIF data products" case.
- [x] `npm run format` clean.
- [ ] Manual: open the VS Code extension on a sample with `@Preview` + `@ScrollingPreview(modes = [LONG])` and confirm the long capture shows on page 1 with no `1/2` pagination.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJ5q1nMv8gToucvTGCnikc)_