### PR TITLE
Increase default sandbox pool size from 4 to 5 sandboxes

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -76,11 +76,11 @@ fun main(args: Array<String>) {
   // The plugin has exposed `composeai.daemon.warmSpare=true` by default since the daemon launch
   // descriptor was introduced, but the Android daemon previously ignored it and came up with a
   // single sandbox unless the experimental sandbox-count property was set manually. Held
-  // interactive sessions need slot 1 pinned while slot 0 continues normal renders, so default the
-  // pool to two sandboxes when warmSpare is on. Explicit `composeai.daemon.sandboxCount` still
-  // wins.
+  // interactive sessions need slot 1 pinned while slot 0 continues normal renders, and a typical
+  // preview grid wants extra slots for parallel renders, so default the pool to five sandboxes
+  // when warmSpare is on. Explicit `composeai.daemon.sandboxCount` still wins.
   val warmSpareEnabled = System.getProperty(WARM_SPARE_PROP)?.toBooleanStrictOrNull() ?: true
-  val defaultSandboxCount = if (warmSpareEnabled) 2 else 1
+  val defaultSandboxCount = if (warmSpareEnabled) 5 else 1
 
   // SANDBOX-POOL.md (Layer 3) — read the supervisor-supplied sandbox-count knob. When unset, use
   // the warm-spare-derived default above so production Android daemons have the second sandbox

--- a/docs/daemon/SANDBOX-POOL.md
+++ b/docs/daemon/SANDBOX-POOL.md
@@ -14,8 +14,8 @@ All three layers landed.
   `composeai.daemon.sandboxCount = 1 + replicasPerDaemon` on the launch
   descriptor instead of spawning N+1 JVM subprocesses. Public surface
   (`SupervisedDaemon.client`, `allClients`, `clientForRender`) is
-  unchanged. **Default `replicasPerDaemon = 3`** — every daemon comes up
-  with 4 in-JVM sandboxes. Set `0` to opt out.
+  unchanged. **Default `replicasPerDaemon = 4`** — every daemon comes up
+  with 5 in-JVM sandboxes. Set `0` to opt out.
 
 ## Memory math
 
@@ -132,8 +132,8 @@ Attribution against the subprocess model:
 |------------------:|----------------:|----------:|----:|
 | 0 (1 sandbox)     | ~1 GB           | ~1 GB     | 0   |
 | 2 (3 sandboxes)   | ~3 GB           | ~1.15 GB  | ~1.85 GB |
-| 3 (4 sandboxes, default) | ~4 GB    | ~1.23 GB  | ~2.77 GB |
-| 4 (5 sandboxes)   | ~5 GB           | ~1.30 GB  | ~3.70 GB |
+| 3 (4 sandboxes)   | ~4 GB           | ~1.23 GB  | ~2.77 GB |
+| 4 (5 sandboxes, default) | ~5 GB    | ~1.30 GB  | ~3.70 GB |
 
 Bench prints to JUnit's `<system-out>` so CI logs preserve the numbers;
 rerun and update the table on Robolectric / JDK / framework upgrades.

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.json.JsonObject
  * the in-JVM sandbox pool size: total sandboxes per (workspace, module) = `1 + N`. SANDBOX-POOL.md
  * Layer 3 collapsed what used to be N+1 separate JVM subprocesses into a single daemon JVM hosting
  * N+1 Robolectric sandboxes, so this knob no longer multiplies the JVM-baseline cost. Default
- * [DaemonSupervisor.DEFAULT_REPLICAS_PER_DAEMON] (= 3, i.e. 4 sandboxes per daemon). Set `0` to opt
+ * [DaemonSupervisor.DEFAULT_REPLICAS_PER_DAEMON] (= 4, i.e. 5 sandboxes per daemon). Set `0` to opt
  * out and run a single sandbox per daemon.
  *
  * On stdin EOF the server tears down every supervised daemon (sending `shutdown` + `exit` per

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -303,12 +303,12 @@ class DaemonSupervisor(
   companion object {
     /**
      * Out-of-the-box value for [replicasPerDaemon]. Picked so a typical preview grid renders
-     * concurrently without the user opting in: 4 sandboxes per daemon (1 primary + 3 replicas). The
+     * concurrently without the user opting in: 5 sandboxes per daemon (1 primary + 4 replicas). The
      * marginal cost is per-sandbox instrumented bytecode in one shared JVM, not a whole extra JVM
      * each — see SANDBOX-POOL.md Layer 3 for the memory math. Override via the MCP CLI's
      * `--replicas-per-daemon N` flag or the `composeai.mcp.replicasPerDaemon` system property.
      */
-    const val DEFAULT_REPLICAS_PER_DAEMON: Int = 3
+    const val DEFAULT_REPLICAS_PER_DAEMON: Int = 4
   }
 }
 


### PR DESCRIPTION
## Summary
Increases the default number of in-JVM sandboxes per daemon from 4 to 5 (1 primary + 4 replicas) to better support concurrent preview grid rendering without requiring manual configuration.

## Changes
- **DaemonMain.kt**: Updated `defaultSandboxCount` from 2 to 5 when warm spare is enabled, with clarified comment explaining the need for extra slots for parallel preview grid renders
- **DaemonSupervisor.kt**: Increased `DEFAULT_REPLICAS_PER_DAEMON` constant from 3 to 4
- **DaemonMcpMain.kt**: Updated documentation to reflect the new default of 4 replicas (5 total sandboxes)
- **SANDBOX-POOL.md**: Updated documentation to reflect the new defaults and memory characteristics, marking 5 sandboxes as the new default configuration

## Implementation Details
The change maintains backward compatibility—users can still override the default via:
- MCP CLI's `--replicas-per-daemon N` flag
- `composeai.mcp.replicasPerDaemon` system property
- `composeai.daemon.sandboxCount` property

The memory cost remains reasonable as documented in SANDBOX-POOL.md: ~5 GB total with ~1.30 GB per-sandbox overhead, since all sandboxes run in a single JVM rather than separate processes.

https://claude.ai/code/session_015d96QtLsJrAREzGG3wHXAL