### PR TITLE
feat(samples): add inset focus ring demo in :samples:android-alpha

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -11,6 +11,9 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.input.InputModeManager
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
@@ -650,6 +653,25 @@ abstract class RobolectricRenderTestBase(
                     }?.let { SlotTreeCapture() }
                 val providedValues = buildList {
                     add(LocalInspectionMode provides !a11yEnabled)
+                    // Robolectric never receives real key input, so the host
+                    // [InputModeManager] reports [InputMode.Touch]. Compose's
+                    // `Modifier.clickable` registers its focusable with
+                    // [Focusability.SystemDefined], which short-circuits in
+                    // touch mode — meaning Button-shaped components silently
+                    // refuse focus and a preview that calls
+                    // `FocusRequester.requestFocus()` produces an
+                    // unfocused-looking capture. Modules that exercise focus
+                    // visualisation set `composeai.focus.inputMode=keyboard`
+                    // on the `renderPreviews` task; the renderer then hands
+                    // Compose a Keyboard-mode manager, the same state that
+                    // holds on a real device after the user has Tabbed to
+                    // the component. Off by default to keep components that
+                    // change appearance based on input mode (e.g. Wear's
+                    // EdgeButton) byte-identical.
+                    if (System.getProperty("composeai.focus.inputMode")
+                            ?.equals("keyboard", ignoreCase = true) == true) {
+                        add(LocalInputModeManager provides KeyboardInputModeManager)
+                    }
                     if (scrollCaptureProvidable != null) {
                         add(scrollCaptureProvidable provides scrollCaptureInProgress)
                     }
@@ -1690,6 +1712,19 @@ private const val AUTO_DURATION_TAIL_MS = 200L
  */
 private const val HOLD_START_ANIM_MS = 500
 private const val HOLD_END_ANIM_MS = 1000
+
+/**
+ * [InputModeManager] that always reports [InputMode.Keyboard] — provided
+ * via [LocalInputModeManager] so previews that call
+ * `FocusRequester.requestFocus()` actually receive focus. See the call
+ * site in [renderDefault]'s `providedValues` block for the full
+ * rationale.
+ */
+private object KeyboardInputModeManager : InputModeManager {
+    override val inputMode: InputMode = InputMode.Keyboard
+
+    override fun requestInputMode(inputMode: InputMode): Boolean = false
+}
 
 /**
  * Adds Robolectric's `+round` qualifier so `Configuration.isScreenRound` becomes

--- a/samples/android-alpha/build.gradle.kts
+++ b/samples/android-alpha/build.gradle.kts
@@ -1,0 +1,57 @@
+plugins {
+  id("composeai.android-conventions")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
+  id("ee.schimke.composeai.preview")
+}
+
+// Pinned to the prerelease compose-material3 line. Isolated from
+// `:samples:android` (which sticks to `compose-bom-stable`) so the
+// alpha-channel APIs and the transitive Compose 1.12.x bump they pull in
+// don't leak into the stable sample's classpath. Mirrors the pattern of
+// `:samples:remotecompose` riding alpha compose for a feature the BOM
+// doesn't have yet — see [docs/RENDERER_COMPATIBILITY.md] for the version
+// alignment story.
+
+android {
+  namespace = "com.example.samplealpha"
+  // compose-ui 1.12.0-alpha02 (transitively pulled by material3 1.5.0-alphaNN)
+  // raises minCompileSdk to 37, so this module diverges from the rest of the
+  // repo (still on 36).
+  compileSdk = 37
+
+  buildFeatures { compose = true }
+
+  testOptions { unitTests.all { it.jvmArgs("-Xmx2048m") } }
+}
+
+// The focus-ring previews call `FocusRequester.requestFocus()` to drive
+// real focus into a Material Button. Compose's clickable focusable is
+// `Focusability.SystemDefined` and refuses focus while the host
+// [InputModeManager] reports [InputMode.Touch] — Robolectric's default
+// for the renderer environment. This system property tells the renderer
+// to provide an [InputModeManager] reporting [InputMode.Keyboard],
+// matching the state a real device is in after the user Tabs to a
+// component. Scoped to this module's `renderPreviews` only; other
+// samples (wear EdgeButton in particular) keep the touch-mode default.
+tasks
+  .matching { it.name == "renderPreviews" }
+  .configureEach { (this as? Test)?.systemProperty("composeai.focus.inputMode", "keyboard") }
+
+dependencies {
+  // Pinning material3 directly: the inset-focus-ring APIs
+  // (RippleThemeConfiguration, LocalRippleThemeConfiguration,
+  // RippleDefaults.{Inset,Opacity}Focus*RippleThemeConfiguration) graduated
+  // to stable in 1.5.0-alpha18; alpha19 is the latest at time of writing.
+  // material3 1.5.0-alphaNN's metadata pulls compose-foundation/runtime/ui
+  // 1.12.0-alphaNN transitively, so no separate compose-bom application is
+  // needed (and would only fight conflict resolution).
+  implementation("androidx.compose.material3:material3:1.5.0-alpha19")
+  implementation(libs.compose.ui)
+  implementation(libs.compose.ui.tooling.preview)
+  implementation(libs.compose.foundation)
+  // `@AnimatedPreview` lives here — source-retained metadata read by
+  // `DiscoverPreviewsTask` at FQN.
+  implementation(project(":preview-annotations"))
+  debugImplementation("androidx.compose.ui:ui-tooling")
+}

--- a/samples/android-alpha/src/main/AndroidManifest.xml
+++ b/samples/android-alpha/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/samples/android-alpha/src/main/kotlin/com/example/samplealpha/FocusRingPreviews.kt
+++ b/samples/android-alpha/src/main/kotlin/com/example/samplealpha/FocusRingPreviews.kt
@@ -1,0 +1,113 @@
+package com.example.samplealpha
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.LocalRippleThemeConfiguration
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RippleDefaults
+import androidx.compose.material3.RippleThemeConfiguration
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.preview.AnimatedPreview
+import kotlinx.coroutines.delay
+
+private val LABELS = listOf("Save", "Edit", "Share", "Delete")
+
+@Composable
+private fun ButtonRow(focusedIndex: Int) {
+    val frs = remember { List(LABELS.size) { FocusRequester() } }
+    LaunchedEffect(focusedIndex) { frs[focusedIndex].requestFocus() }
+    Row(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        LABELS.forEachIndexed { i, label ->
+            Button(
+                onClick = {},
+                modifier = Modifier.padding(end = 8.dp).focusRequester(frs[i]),
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Text(label)
+            }
+        }
+    }
+}
+
+class FocusIndexProvider : PreviewParameterProvider<Int> {
+    override val values: Sequence<Int> = (0 until LABELS.size).asSequence()
+}
+
+@Composable
+private fun WithRippleConfig(config: RippleThemeConfiguration, content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalRippleThemeConfiguration provides config, content = content)
+}
+
+@Preview(
+    name = "Inset Focus Ring — fan-out",
+    widthDp = 480,
+    heightDp = 96,
+    showBackground = true,
+)
+@Composable
+fun InsetFocusRingFanOutPreview(@PreviewParameter(FocusIndexProvider::class) focusedIndex: Int) {
+    MaterialTheme {
+        WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) {
+            ButtonRow(focusedIndex)
+        }
+    }
+}
+
+@Preview(
+    name = "Inset Focus Ring — moving",
+    widthDp = 480,
+    heightDp = 96,
+    showBackground = true,
+)
+@AnimatedPreview(durationMs = 3200, frameIntervalMs = 200, showCurves = false)
+@Composable
+fun InsetFocusRingAnimatedPreview() {
+    var idx by remember { mutableIntStateOf(0) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(800)
+            idx = (idx + 1) % LABELS.size
+        }
+    }
+    MaterialTheme {
+        WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) { ButtonRow(idx) }
+    }
+}
+
+@Preview(
+    name = "Opacity vs Inset Ring",
+    widthDp = 480,
+    heightDp = 192,
+    showBackground = true,
+)
+@Composable
+fun OpacityVsInsetRingPreview() {
+    MaterialTheme {
+        Column {
+            WithRippleConfig(RippleDefaults.OpacityFocusRippleThemeConfiguration) {
+                ButtonRow(focusedIndex = 1)
+            }
+            WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) {
+                ButtonRow(focusedIndex = 1)
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,8 @@ include(":preview-annotations")
 
 include(":samples:android")
 
+include(":samples:android-alpha")
+
 include(":samples:android-library")
 
 include(":samples:android-screenshot-test")


### PR DESCRIPTION
## Summary

- New `:samples:android-alpha` module pinning `compose-material3:1.5.0-alpha19` (and the Compose 1.12.0-alpha02 stack it pulls transitively) so the inset-focus-ring APIs graduated in alpha18 — `RippleThemeConfiguration`, `LocalRippleThemeConfiguration`, `RippleDefaults.{Inset,Opacity}Focus*RippleThemeConfiguration` — can be exercised without leaking the alpha versions onto `:samples:android`. Three previews: a fan-out (4 PNGs, ring on each button), an animated GIF cycling the ring, and an opacity-vs-inset side-by-side.
- The preview bodies are natural Compose: `FocusRequester` + `LaunchedEffect { fr.requestFocus() }`. To make `requestFocus()` actually deliver under Robolectric, `renderer-android` gains a `composeai.focus.inputMode=keyboard` system property. When set, the renderer provides a Keyboard-mode `LocalInputModeManager` — Compose's `Modifier.clickable` focusable is `Focusability.SystemDefined` (`ui/focus/Focusability.kt:67-68`) and refuses focus under `InputMode.Touch`, which is what Robolectric's renderer environment is permanently in (no real key input ever arrives). Defaulting off keeps existing samples (notably Wear's `EdgeButton`) byte-identical; only `:samples:android-alpha` opts in via its `renderPreviews` task.

## Follow-up worth discussing

Long term this should become a `@FocusedPreview` extension on the same shape as `@AnimatedPreview` / `@ScrollingPreview` — drive focus by index through `FocusManager.moveFocus(...)`, capture one frame per stop, optional overlay. Replaces both the system-property gate and the consumer-side `FocusRequester` boilerplate, and works for Wear UI without per-target branching. Out of scope for this PR; happy to sketch the discovery + render plumbing in a separate one.

## Test plan

- [ ] `./gradlew :samples:android-alpha:renderAllPreviews` produces four distinct fan-out PNGs (ring on Save / Edit / Share / Delete in turn), one animated GIF, and the opacity-vs-inset comparison
- [ ] Visually confirm the inset ring is drawn and the opacity row shows no ring (intentional: the opacity variant tints the surface but is invisible against the saturated primary colour, which is the point of the demo)
- [ ] `./gradlew :renderer-android:test` — only the pre-existing `LongScrollGhostOverlayTest.Wear anchor path…` failure (also fails on `origin/main`); no new regressions
- [ ] `./gradlew :samples:android:check` — only the pre-existing `ScrollPreviewPixelTest` failure (also fails on `origin/main`); no new regressions


---
_Generated by [Claude Code](https://claude.ai/code/session_0197pgjb3LE9hWV5tda1CvwB)_