### PR TITLE
fix(daemon): propagate session-closed hook for proactive interactive cleanup

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -742,6 +742,7 @@ open class RobolectricHost(
     previewId: String,
     classLoader: ClassLoader,
     inspectionMode: Boolean?,
+    onSessionClosed: (() -> Unit)?,
   ): InteractiveSession {
     if (sandboxCount < 2) {
       throw UnsupportedOperationException(
@@ -766,6 +767,7 @@ open class RobolectricHost(
       previewId = previewId,
       spec = spec,
       inspectionMode = inspectionMode,
+      onSessionClosed = onSessionClosed,
     )
   }
 
@@ -773,6 +775,7 @@ open class RobolectricHost(
     previewId: String,
     spec: RenderSpec,
     inspectionMode: Boolean? = spec.inspectionMode,
+    onSessionClosed: (() -> Unit)? = null,
   ): AndroidInteractiveSession {
     val streamId = "android-stream-${nextStreamCounter.getAndIncrement()}"
     if (!activeInteractiveStreamId.compareAndSet(null, streamId)) {
@@ -856,7 +859,23 @@ open class RobolectricHost(
         slot = slot,
         activeStreamRef = activeInteractiveStreamId,
         idleLeaseMs = interactiveIdleLeaseMs,
-        onCloseHook = { activeInteractiveSession.compareAndSet(sessionBox[0], null) },
+        onCloseHook = {
+          activeInteractiveSession.compareAndSet(sessionBox[0], null)
+          // JsonRpcServer-side cleanup wired through the public acquire API. Wrapped in
+          // try/catch because a misbehaving caller hook shouldn't strand the host's own state
+          // mutation above (e.g. leaving activeInteractiveSession pinned after the watchdog
+          // ran). The hook itself runs on whatever thread fired the close — see RenderHost.
+          if (onSessionClosed != null) {
+            try {
+              onSessionClosed()
+            } catch (t: Throwable) {
+              System.err.println(
+                "compose-ai-daemon: RobolectricHost: onSessionClosed threw " +
+                  "(${t.javaClass.simpleName}: ${t.message}); continuing"
+              )
+            }
+          }
+        },
       )
     sessionBox[0] = session
     activeInteractiveSession.set(session)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -2050,7 +2050,12 @@ class JsonRpcServer(
           host.userClassloaderHolder?.currentChildLoader()
             ?: this::class.java.classLoader
             ?: ClassLoader.getSystemClassLoader()
-        host.acquireInteractiveSession(params.previewId, classLoader, params.inspectionMode)
+        host.acquireInteractiveSession(
+          previewId = params.previewId,
+          classLoader = classLoader,
+          inspectionMode = params.inspectionMode,
+          onSessionClosed = { cleanupClosedInteractiveSession(streamId) },
+        )
       } catch (t: UnsupportedOperationException) {
         fallbackReason = "${t.javaClass.simpleName}: ${t.message}"
         null
@@ -2159,7 +2164,12 @@ class JsonRpcServer(
           host.userClassloaderHolder?.currentChildLoader()
             ?: this::class.java.classLoader
             ?: ClassLoader.getSystemClassLoader()
-        host.acquireInteractiveSession(params.previewId, classLoader, params.inspectionMode)
+        host.acquireInteractiveSession(
+          previewId = params.previewId,
+          classLoader = classLoader,
+          inspectionMode = params.inspectionMode,
+          onSessionClosed = { cleanupClosedInteractiveSession(streamId) },
+        )
       } catch (t: UnsupportedOperationException) {
         fallbackReason = "${t.javaClass.simpleName}: ${t.message}"
         null
@@ -2317,6 +2327,43 @@ class JsonRpcServer(
     interactiveFrameLoops.remove(streamId)?.interrupt()
   }
 
+  /**
+   * Tear down server-side state for the held session attached to [streamId] when it has closed,
+   * while leaving the wire-level [streamId] valid so subsequent `interactive/input` notifications
+   * from a client that hasn't noticed the close yet route through the v1 stateless dispatch path
+   * (and produce a render) rather than dispatching into a dead session and getting silently
+   * dropped. Called from the `onSessionClosed` hook the server passes into
+   * [RenderHost.acquireInteractiveSession] — fires from whatever thread the host's session ran its
+   * close on (typically the watchdog's scheduled-executor thread for an idle-lease auto-close, the
+   * JSON-RPC read thread for explicit `interactive/stop`, or the JVM shutdown thread for
+   * `cleanShutdown`).
+   *
+   * Critically does NOT touch [interactiveTargets]: that map is what [handleInteractiveInput]'s
+   * lookup keys against to decide between v2 (held session) and v1 (stateless) paths. Keeping the
+   * entry means a post-auto-close click still produces pixels. The matching wire entry is finally
+   * cleared by [handleInteractiveStop] (when the client eventually hits stop) or by
+   * [cleanShutdown].
+   *
+   * Idempotent against concurrent / repeat close paths: every map operation is a `remove` on a
+   * `ConcurrentHashMap`, every registry call is documented as no-op-when-absent, and
+   * [stopInteractiveFrameLoop] interrupts at most one running thread. Safe to call from the
+   * server-internal handlers (`handleInteractiveStop`, `handleStreamStop`) AFTER they've already
+   * removed their entries — the second pass is a no-op. Without this proactive sweep the watchdog
+   * auto-close path on Android (idleLeaseMs default 5 min) would leave
+   * `interactiveSessions[streamId]` pointing at a dead session until the next render or input tried
+   * to use it; the live-frame loop's reactive sweep in [submitInteractiveRenderAsync] eventually
+   * catches it but only after one final failed render-then-cleanup round-trip per stream — and
+   * during that window any user click is dispatched into the dead session and lost.
+   */
+  private fun cleanupClosedInteractiveSession(streamId: String) {
+    interactiveSessions.remove(streamId)
+    pendingInteractiveInputs.remove(streamId)
+    interactiveRenderInFlight.remove(streamId)
+    streamSessions.remove(streamId)
+    streamRegistry.unregister(streamId)
+    stopInteractiveFrameLoop(streamId)
+  }
+
   private fun requestInteractiveRender(
     streamId: String,
     previewId: String,
@@ -2422,10 +2469,12 @@ class JsonRpcServer(
             // matches the `interactive/stop` contract — stale inputs against a stopped stream
             // are silently discarded.
             if (session.isClosed) {
-              interactiveSessions.remove(streamId, session)
-              interactiveTargets.remove(streamId)
-              pendingInteractiveInputs.remove(streamId)
-              stopInteractiveFrameLoop(streamId)
+              // Defensive sweep — typically the host's `onSessionClosed` hook (wired in
+              // [handleInteractiveStart]) has already done this synchronously when the session
+              // closed, but call again so hosts that don't wire the hook (older test fakes, the
+              // default RenderHost interface body) still get cleaned up before the loop's next
+              // tick. Idempotent.
+              cleanupClosedInteractiveSession(streamId)
             } else {
               val pending = pendingInteractiveInputs[streamId]
               if (

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -156,11 +156,22 @@ interface RenderHost {
    *   resolves the preview's class against this loader so a recompile during the session's lifetime
    *   doesn't drag stale bytecode into the held scene — the next `interactive/start` after a save
    *   gets a fresh loader.
+   * @param onSessionClosed fired exactly once after the session transitions to closed, regardless
+   *   of trigger: explicit [InteractiveSession.close], host-internal watchdog auto-close (e.g.
+   *   [AndroidInteractiveSession]'s idle-lease watchdog), or daemon shutdown. [JsonRpcServer] wires
+   *   a cleanup lambda here so a watchdog auto-close synchronously yanks the session out of
+   *   `interactiveSessions` / `interactiveTargets` / `pendingInteractiveInputs` rather than waiting
+   *   for the next render to discover it via [InteractiveSession.isClosed]. Defaults to `null` for
+   *   callers (in-process tests, fake hosts) that don't need the notification. The hook runs on
+   *   whatever thread fired the close — typically the watchdog's scheduled-executor thread for
+   *   auto-close, the JSON-RPC read thread for explicit stop, the JVM shutdown thread for
+   *   `cleanShutdown` — so implementations should be cheap and thread-safe.
    */
   fun acquireInteractiveSession(
     previewId: String,
     classLoader: ClassLoader,
     inspectionMode: Boolean? = null,
+    onSessionClosed: (() -> Unit)? = null,
   ): InteractiveSession =
     throw UnsupportedOperationException(
       "interactive mode unsupported by ${this::class.simpleName ?: this::class.java.name}"

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveCoalescingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveCoalescingTest.kt
@@ -253,6 +253,7 @@ private class SlowFakeHost(private val pngFile: File, private val renderDelayMs:
     previewId: String,
     classLoader: ClassLoader,
     inspectionMode: Boolean?,
+    onSessionClosed: (() -> Unit)?,
   ): InteractiveSession {
     val session = SlowSession(previewId, pngFile, renderDelayMs)
     sessions[nextSessionKey.getAndIncrement()] = session

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
@@ -342,6 +342,72 @@ class InteractiveSessionPlumbingTest {
   }
 
   @Test(timeout = 30_000)
+  fun watchdog_autoclose_routes_next_input_through_v1_fallback() {
+    // Proactive cleanup: when the host's onSessionClosed hook fires (mirroring the Android
+    // watchdog auto-close path), the server must synchronously yank the session out of
+    // interactiveSessions so the very next interactive/input lands on the v1 stateless
+    // dispatch path instead of routing into the dead session and dropping the user's click.
+    val tmp = Files.createTempDirectory("interactive-session-autoclose-fallback").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val host = SessionAwareFakeHost(pngFile)
+
+    // No live-frame loop — we want to prove the cleanup happens at close-time, not at
+    // next-render-time. With the loop disabled, the only path that could discover the closed
+    // session reactively is interactive/input → submitInteractiveRenderAsync → render-throws,
+    // which would dispatch the click into the dead session first (no-op) and drop it.
+    val (_, serverThread, clientToServerOut, received, exitLatch) = bringUpServer(host)
+    resourcesToClose.add(AutoCloseable { runCatching { clientToServerOut.close() } })
+
+    handshake(clientToServerOut, received)
+
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","id":10,"method":"interactive/start","params":{"previewId":"preview-A"}}""",
+    )
+    val startResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 10 }
+    val streamId =
+      startResp!!["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+    val session = host.lastSession()!!
+    assertNotNull("server should have wired an onSessionClosed hook", host.lastOnSessionClosed)
+
+    // Fire the auto-close. RecordingSession.markClosed() flips isClosed and invokes the captured
+    // hook synchronously — same shape as AndroidInteractiveSession.checkIdleLease() →
+    // close() → onCloseHook() in production.
+    session.markClosed()
+    val dispatchAtAutoClose = session.dispatchCount.get()
+    val submitAtAutoClose = host.submitCalls.get()
+
+    // Now fire an input. With the proactive sweep done, interactiveSessions[streamId] is null,
+    // handleInteractiveInput falls through to the v1 stateless path (host.submit), and
+    // session.dispatch is NOT called.
+    writeFrame(
+      clientToServerOut,
+      """
+      {"jsonrpc":"2.0","method":"interactive/input","params":{
+        "frameStreamId":"$streamId","kind":"click","pixelX":7,"pixelY":7
+      }}
+      """
+        .trimIndent(),
+    )
+
+    val finished =
+      pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+    assertNotNull("post-autoclose input should still produce a v1 renderFinished", finished)
+    assertEquals(
+      "post-autoclose input must NOT dispatch into the closed session " +
+        "(would drop the click — the bug this hook prevents)",
+      dispatchAtAutoClose,
+      session.dispatchCount.get(),
+    )
+    assertTrue(
+      "post-autoclose input must take the v1 fallback path (host.submit fires)",
+      host.submitCalls.get() > submitAtAutoClose,
+    )
+
+    teardownServer(clientToServerOut, received, serverThread, exitLatch)
+  }
+
+  @Test(timeout = 30_000)
   fun cleanShutdown_closes_all_open_sessions() {
     val tmp = Files.createTempDirectory("interactive-session-shutdown").toFile()
     val aPng = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
@@ -492,6 +558,7 @@ private class SessionAwareFakeHost(
 ) : RenderHost {
 
   val acquireCalls = AtomicInteger(0)
+  val submitCalls = AtomicInteger(0)
   @Volatile var lastInspectionMode: Boolean? = null
   private val sessions = ConcurrentHashMap<Long, RecordingSession>()
   private val nextSessionKey = AtomicLong(1)
@@ -500,6 +567,7 @@ private class SessionAwareFakeHost(
 
   override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
     require(request is RenderRequest.Render)
+    submitCalls.incrementAndGet()
     return RenderResult(
       id = request.id,
       classLoaderHashCode = 0,
@@ -514,15 +582,25 @@ private class SessionAwareFakeHost(
   override val supportsInteractive: Boolean
     get() = true
 
+  /**
+   * Captured hook the server passed at acquire time. Tests use [simulateAutoClose] to fire it,
+   * mirroring [AndroidInteractiveSession]'s idle-lease watchdog path without needing a real
+   * watchdog timer.
+   */
+  @Volatile var lastOnSessionClosed: (() -> Unit)? = null
+
   override fun acquireInteractiveSession(
     previewId: String,
     classLoader: ClassLoader,
     inspectionMode: Boolean?,
+    onSessionClosed: (() -> Unit)?,
   ): InteractiveSession {
     acquireCalls.incrementAndGet()
     lastInspectionMode = inspectionMode
+    lastOnSessionClosed = onSessionClosed
     val pngFile = perPreview[previewId] ?: defaultPng
-    val session = RecordingSession(previewId = previewId, pngFile = pngFile)
+    val session =
+      RecordingSession(previewId = previewId, pngFile = pngFile, onSessionClosed = onSessionClosed)
     sessions[nextSessionKey.getAndIncrement()] = session
     return session
   }
@@ -532,8 +610,11 @@ private class SessionAwareFakeHost(
   fun allSessions(): List<RecordingSession> = sessions.entries.sortedBy { it.key }.map { it.value }
 }
 
-private class RecordingSession(override val previewId: String, private val pngFile: File) :
-  InteractiveSession {
+private class RecordingSession(
+  override val previewId: String,
+  private val pngFile: File,
+  private val onSessionClosed: (() -> Unit)? = null,
+) : InteractiveSession {
 
   val dispatchCount = AtomicInteger(0)
   val renderCount = AtomicInteger(0)
@@ -550,10 +631,14 @@ private class RecordingSession(override val previewId: String, private val pngFi
    * watchdog (e.g. [AndroidInteractiveSession]'s idle-lease watchdog) that closes the session out
    * from under the JsonRpcServer's tracking maps. Subsequent [render] calls throw the same
    * `IllegalStateException` the production session emits, and [isClosed] flips so the live-frame
-   * loop's exit check fires.
+   * loop's exit check fires. Also fires the [onSessionClosed] hook the host wired at acquire time,
+   * mirroring what `AndroidInteractiveSession.checkIdleLease() → close() → onCloseHook()` does in
+   * production.
    */
   fun markClosed() {
+    if (closedFlag) return
     closedFlag = true
+    onSessionClosed?.invoke()
   }
 
   override val isClosed: Boolean
@@ -579,8 +664,12 @@ private class RecordingSession(override val previewId: String, private val pngFi
   }
 
   override fun close() {
+    val firstClose = !closedFlag
     closedFlag = true
     closeCount.incrementAndGet()
+    if (firstClose) {
+      onSessionClosed?.invoke()
+    }
   }
 }
 
@@ -632,6 +721,7 @@ private class FailingSessionHost(private val defaultPng: File) : RenderHost {
     previewId: String,
     classLoader: ClassLoader,
     inspectionMode: Boolean?,
+    onSessionClosed: (() -> Unit)?,
   ): InteractiveSession {
     throw IllegalStateException("boom")
   }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
@@ -1505,6 +1505,7 @@ private class DisconnectFakeHost : RenderHost {
     previewId: String,
     classLoader: ClassLoader,
     inspectionMode: Boolean?,
+    onSessionClosed: (() -> Unit)?,
   ): InteractiveSession {
     acquireCount.incrementAndGet()
     val session = RecordingDisconnectSession(previewId)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -269,6 +269,7 @@ open class DesktopHost(
     previewId: String,
     classLoader: ClassLoader,
     inspectionMode: Boolean?,
+    onSessionClosed: (() -> Unit)?,
   ): InteractiveSession {
     val resolver =
       previewSpecResolver
@@ -289,6 +290,7 @@ open class DesktopHost(
         engine = engine,
         state = state,
         sandboxStats = sandboxStats,
+        onCloseHook = onSessionClosed,
       )
     val listener = interactiveSessionListener
     if (listener == null) {
@@ -322,6 +324,9 @@ open class DesktopHost(
   ) : InteractiveSession {
 
     @Volatile private var closed = false
+
+    override val isClosed: Boolean
+      get() = closed || delegate.isClosed
 
     override fun dispatch(input: ee.schimke.composeai.daemon.protocol.InteractiveInputParams) =
       delegate.dispatch(input)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
@@ -38,6 +38,16 @@ class DesktopInteractiveSession(
   private val engine: RenderEngine,
   private val state: RenderEngine.SceneState,
   private val sandboxStats: SandboxLifecycleStats,
+  /**
+   * Fired exactly once after [close] flips `closed = true` and tears down the held scene. Mirrors
+   * [AndroidInteractiveSession.onCloseHook] so the same JsonRpcServer-side cleanup wiring works
+   * across both backends. DesktopHost has no idle-lease watchdog today (only explicit close + the
+   * D5 listener wrapper drive close), so on desktop the hook is effectively the same as
+   * `interactiveSessionListener.onSessionLifecycle(_, scene = null)` — but routing it through the
+   * same shape as Android keeps the host-shared API uniform and gives the desktop daemon a free
+   * hook point for any future async-close path.
+   */
+  private val onCloseHook: (() -> Unit)? = null,
 ) : InteractiveSession {
 
   @Volatile private var closed: Boolean = false
@@ -130,6 +140,16 @@ class DesktopInteractiveSession(
     if (closed) return
     closed = true
     engine.tearDown(state)
+    if (onCloseHook != null) {
+      try {
+        onCloseHook.invoke()
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: DesktopInteractiveSession: onCloseHook threw " +
+            "(${t.javaClass.simpleName}: ${t.message}); continuing"
+        )
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #892. That PR broke the auto-close → live-frame-loop spin reactively (the loop checks `InteractiveSession.isClosed` and the catch in `submitInteractiveRenderAsync` cleans up after the next render fails). This PR adds the proactive path so the watchdog auto-close synchronously yanks the session out of `JsonRpcServer`'s tracking maps, instead of waiting for the next render to discover it.

- New `onSessionClosed: (() -> Unit)? = null` parameter on `RenderHost.acquireInteractiveSession`. `JsonRpcServer.handleInteractiveStart` / `handleStreamStart` pass a lambda that does the cleanup; hosts compose it with whatever close hook they already wire (`RobolectricHost`'s `activeInteractiveSession`-CAS hook, `DesktopInteractiveSession`'s new `onCloseHook` slot).
- New `cleanupClosedInteractiveSession(streamId)` in `JsonRpcServer` clears `interactiveSessions` / `pendingInteractiveInputs` / `interactiveRenderInFlight` / `streamSessions`, unregisters from `streamRegistry`, and stops the live-frame loop. Idempotent. Deliberately leaves `interactiveTargets[streamId]` in place so an `interactive/input` from a client that hasn't noticed the close yet still produces a v1-fallback render rather than getting silently dropped.
- The reactive cleanup in `submitInteractiveRenderAsync`'s `catch`/`finally` now delegates to the same helper.
- `ListenerNotifyingSession` (Desktop's D5 listener wrapper) now mirrors its delegate's `isClosed`.

The bug this prevents: with only the reactive sweep, a click arriving after the watchdog auto-closes the session is dispatched into the dead session (no-op), and the failing render that follows is what finally cleans up — the user's click is lost. With the hook, the auto-close has already cleared `interactiveSessions[streamId]` by the time the click arrives, so `handleInteractiveInput` takes the v1 stateless dispatch path and the click produces a render.

## Test plan

- [x] New `watchdog_autoclose_routes_next_input_through_v1_fallback` regression in `InteractiveSessionPlumbingTest`: simulates the auto-close (mirrors `AndroidInteractiveSession.checkIdleLease() → close() → onCloseHook()`), fires an `interactive/input`, asserts `host.submit` fires (v1 fallback) and `session.dispatch` does not.
- [x] `:daemon:core:test` — `InteractiveSessionPlumbingTest`, `InteractiveRpcIntegrationTest`, `StreamRpcIntegrationTest` pass.
- [x] All affected modules compile clean (`:daemon:core`, `:daemon:android`, `:daemon:desktop`).
- [ ] `:daemon:android:testDebugUnitTest` — Android Robolectric tests timed out on a cold-cache sandbox VM (`holdSandboxOpen never registered`); pre-existing environment limit, not a regression. Local `:daemon:desktop:test` and the rest of `:daemon:core:test` should be re-verified by CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZWvZirQqsb1zZG2FKc2Gm)_