### PR TITLE
feat(preview-annotations): add @FocusedPreview to drive focus in previews

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -95,6 +95,9 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     // Animation-window capture — sibling annotation to @ScrollingPreview, same
     // FQN-match policy. See `AnimatedPreview.kt`.
     private const val ANIMATED_PREVIEW_FQN = "ee.schimke.composeai.preview.AnimatedPreview"
+    // Focus-state capture — sibling annotation to @ScrollingPreview /
+    // @AnimatedPreview, same FQN-match policy. See `FocusedPreview.kt`.
+    private const val FOCUSED_PREVIEW_FQN = "ee.schimke.composeai.preview.FocusedPreview"
     // The stable FQN is shared by both Android's ui-tooling-preview and CMP's
     // `org.jetbrains.compose.components:components-ui-tooling-preview` — Kotlin
     // `expect`/`actual` collapses onto the same `androidx...` class name on
@@ -482,6 +485,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     val wrapperFqn = extractWrapperFqn(annotations)
     val scrollSpecs = extractScrollSpecs(annotations)
     val animationSpec = extractAnimationSpec(annotations)
+    val focusSpecs = extractFocusSpecs(annotations)
     // @RoboComposePreviewOptions, similarly, applies to the function as a
     // whole — each timing fans out into its own manifest entry, orthogonal
     // to any multi-preview expansion.
@@ -525,6 +529,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             wrapperFqn,
             scrollSpecs,
             animationSpec,
+            focusSpecs,
             timings,
             previewParameter,
             previewSourceFile,
@@ -546,6 +551,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             wrapperFqn,
             scrollSpecs,
             animationSpec,
+            focusSpecs,
             timings,
             previewParameter,
             previewSourceFile,
@@ -598,6 +604,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     previewId: String,
     scrolls: List<ScrollCapture>,
     animation: AnimationCapture?,
+    focuses: List<FocusCapture>,
     timings: List<Long>,
   ): PreviewOutputPlan {
     val isTile = ann.name == TILE_PREVIEW_FQN
@@ -606,6 +613,9 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     // Tile previews don't go through `mainClock` either — `TileRenderer`
     // inflates a static View and there's no animation surface to drive.
     val effectiveAnimation = if (isTile) null else animation
+    // `@FocusedPreview` only applies to Compose previews (the focus owner
+    // is a Compose construct); tile previews ignore it.
+    val effectiveFocuses = if (isTile) emptyList() else focuses
 
     // @AnimatedPreview produces its own dedicated capture, alongside any
     // scroll / time fan-out. The GIF gets a distinguishing `_anim` suffix
@@ -645,42 +655,61 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     val timeRows: List<Pair<Long?, String>> =
       if (effectiveTimings.isEmpty()) listOf(null to "")
       else effectiveTimings.map { ms -> ms to "_TIME_${ms}ms" }
+    // `@FocusedPreview(indices = [...])` fans out one capture per index
+    // with `_FOCUS_<index>` suffix. Single-index keeps the plain filename
+    // (matches the @ScrollingPreview single-mode pattern). Empty → one
+    // (null, "") row, same shape as scroll/time when their annotations
+    // are absent.
+    val focusRows: List<Pair<FocusCapture?, String>> =
+      when {
+        effectiveFocuses.isEmpty() -> listOf(null to "")
+        effectiveFocuses.size == 1 -> listOf(effectiveFocuses[0] to "")
+        else -> effectiveFocuses.map { it to "_FOCUS_${it.tabIndex}" }
+      }
 
-    // When ONLY @AnimatedPreview is on the function, the scroll/time
-    // cross-product would still emit one (null, null) row — i.e. a static
-    // PNG capture. Suppress that to keep `@AnimatedPreview` a clean
+    // When ONLY @AnimatedPreview is on the function, the scroll/time/focus
+    // cross-product would still emit one (null, null, null) row — i.e. a
+    // static PNG capture. Suppress that to keep `@AnimatedPreview` a clean
     // single-output annotation.
     val emitStaticCross =
-      captureScrolls.isNotEmpty() || effectiveTimings.isNotEmpty() || effectiveAnimation == null
+      captureScrolls.isNotEmpty() ||
+        effectiveTimings.isNotEmpty() ||
+        effectiveFocuses.isNotEmpty() ||
+        effectiveAnimation == null
 
     val scrollTimeCaptures: List<Capture> =
       if (!emitStaticCross) emptyList()
       else {
         scrollRows.flatMap { (scroll, scrollSuffix) ->
-          timeRows.map { (ms, timeSuffix) ->
-            val ext = "png"
-            // Cost is normalised to a static @Preview = 1.0. The mode
-            // ladder (TOP < END) reflects how much extra
-            // work each scroll variant adds on top of the baseline
-            // compose pass. `advanceTimeMillis` alone is still one
-            // pass at a specific virtual time, so it doesn't bump the
-            // per-capture cost — the wall-time of a multi-timing
-            // fan-out is in the *count*, which lives in the captures
-            // list itself.
-            val captureCost =
-              when (scroll?.mode) {
-                null -> STATIC_COST
-                ScrollMode.TOP -> SCROLL_TOP_COST
-                ScrollMode.END -> SCROLL_END_COST
-                ScrollMode.LONG -> SCROLL_LONG_COST
-                ScrollMode.GIF -> SCROLL_GIF_COST
-              }
-            Capture(
-              advanceTimeMillis = ms,
-              scroll = scroll,
-              renderOutput = "renders/${previewId}${scrollSuffix}${timeSuffix}.${ext}",
-              cost = captureCost,
-            )
+          timeRows.flatMap { (ms, timeSuffix) ->
+            focusRows.map { (focus, focusSuffix) ->
+              val ext = "png"
+              // Cost is normalised to a static @Preview = 1.0. The mode
+              // ladder (TOP < END) reflects how much extra
+              // work each scroll variant adds on top of the baseline
+              // compose pass. `advanceTimeMillis` alone is still one
+              // pass at a specific virtual time, so it doesn't bump the
+              // per-capture cost — the wall-time of a multi-timing
+              // fan-out is in the *count*, which lives in the captures
+              // list itself. Focus drive is similar: one moveFocus call
+              // per stop, fixed-time work, no extra cost bucket.
+              val captureCost =
+                when (scroll?.mode) {
+                  null -> STATIC_COST
+                  ScrollMode.TOP -> SCROLL_TOP_COST
+                  ScrollMode.END -> SCROLL_END_COST
+                  ScrollMode.LONG -> SCROLL_LONG_COST
+                  ScrollMode.GIF -> SCROLL_GIF_COST
+                }
+              Capture(
+                advanceTimeMillis = ms,
+                scroll = scroll,
+                focus = focus,
+                renderOutput =
+                  "renders/${previewId}${scrollSuffix}${timeSuffix}${focusSuffix}.${ext}",
+                cost = captureCost,
+              )
+            }
           }
         }
       }
@@ -812,6 +841,23 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     )
   }
 
+  /**
+   * Reads `@FocusedPreview(indices = [...])` off the function annotation list. Returns one
+   * [FocusCapture] per requested tab index, sorted ascending and de-duplicated. Negative or empty
+   * inputs collapse to no captures (the annotation falls back to the cross-product's null row).
+   */
+  private fun extractFocusSpecs(annotations: List<AnnotationInfo>): List<FocusCapture> {
+    val ann = annotations.firstOrNull { it.name == FOCUSED_PREVIEW_FQN } ?: return emptyList()
+    val raw = ann.parameterValues.getValue("indices")
+    val indices: IntArray =
+      when (raw) {
+        is IntArray -> raw
+        is Array<*> -> raw.filterIsInstance<Int>().toIntArray()
+        else -> intArrayOf()
+      }
+    return indices.filter { it >= 0 }.distinct().sorted().map { FocusCapture(tabIndex = it) }
+  }
+
   private fun extractScrollSpecs(annotations: List<AnnotationInfo>): List<ScrollCapture> {
     val ann = annotations.firstOrNull { it.name == SCROLLING_PREVIEW_FQN } ?: return emptyList()
     val pv = ann.parameterValues
@@ -929,6 +975,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     wrapperClassName: String?,
     scrolls: List<ScrollCapture>,
     animation: AnimationCapture?,
+    focuses: List<FocusCapture>,
     timings: List<Long>,
     previewParameter: Pair<String, Int>?,
     previewSourceFile: String?,
@@ -938,7 +985,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     val fqn = "${classInfo.name}.${method.name}"
     val suffix = buildVariantSuffix(params)
     val id = fqn + suffix
-    val outputPlan = buildOutputPlan(ann, id, scrolls, animation, timings)
+    val outputPlan = buildOutputPlan(ann, id, scrolls, animation, focuses, timings)
     // Tile previews don't go through @Composable invocations — they return a `TilePreviewData`
     // and the renderer reflects them directly. Skipping the lazy means the bytecode walk never
     // runs for tile-only methods.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -78,6 +78,22 @@ data class AnimationCapture(
 )
 
 /**
+ * Focus capture state sourced from `@FocusedPreview`. Carried as its own field on [Capture] —
+ * orthogonal to [Capture.scroll] / [Capture.animation] — so the renderer can switch on its presence
+ * to (a) provide an `InputMode.Keyboard` `LocalInputModeManager` (Compose's `Modifier.clickable`
+ * focusable refuses focus under touch mode, which Robolectric is permanently in) and (b) walk the
+ * focus owner to [tabIndex] before capture.
+ */
+@Serializable
+data class FocusCapture(
+  /**
+   * Zero-based focus index in tab order. Capture 0 issues `moveFocus(Enter)`; later captures issue
+   * `moveFocus(Next)` to walk forward to the requested index.
+   */
+  val tabIndex: Int
+)
+
+/**
  * Cost catalogue, normalised so a static `@Preview` (single compose pass + one screenshot) is
  * `1.0`. The discovery task stamps the right value onto each [Capture]; tooling reads them back to
  * throttle interactive renders.
@@ -182,6 +198,8 @@ data class Capture(
   val scroll: ScrollCapture? = null,
   /** `null` → not an animation capture. Mutually exclusive with [scroll] in practice. */
   val animation: AnimationCapture? = null,
+  /** `null` → no focus drive. Set when the preview carries a `@FocusedPreview` annotation. */
+  val focus: FocusCapture? = null,
   /** Module-relative PNG path, e.g. `renders/<preview id>_TIME_500ms.png`. */
   val renderOutput: String = "",
   /**

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/FocusedPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/FocusedPreview.kt
@@ -1,0 +1,47 @@
+package ee.schimke.composeai.preview
+
+/**
+ * Opts a `@Preview` composable into focus-state capture.
+ *
+ * The compose-preview Gradle plugin's discovery task picks this up by FQN, mirroring the
+ * [ScrollingPreview] / [AnimatedPreview] split: consumers that want to use the annotation in their
+ * own code depend on `ee.schimke.composeai:preview-annotations`.
+ *
+ * The renderer fans out one capture per entry in [indices], driving the Compose focus owner across
+ * the focusables in tab order via `FocusManager.moveFocus(...)` — no `FocusRequester` needed in the
+ * preview body. Each frame is captured at its assigned focus position with a `_FOCUS_<index>`
+ * filename suffix.
+ *
+ * Compose's `Modifier.clickable` registers its focusable with `Focusability.SystemDefined`, which
+ * refuses focus while the host `LocalInputModeManager.inputMode == InputMode.Touch`. Robolectric's
+ * renderer environment is permanently in touch mode (no real key input ever arrives), so this
+ * annotation also flips `LocalInputModeManager` to Keyboard mode for the duration of its captures —
+ * matching the state a real device is in after the user Tabs to a component.
+ *
+ * Example — a row of buttons, ring on each in turn:
+ * ```
+ * @Preview
+ * @FocusedPreview(indices = [0, 1, 2, 3])
+ * @Composable
+ * fun MyButtonRow() {
+ *     Row {
+ *         listOf("Save", "Edit", "Share", "Delete").forEach { label ->
+ *             Button(onClick = {}) { Text(label) }
+ *         }
+ *     }
+ * }
+ * ```
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+@MustBeDocumented
+annotation class FocusedPreview(
+  /**
+   * Tab-order indices to capture. The renderer issues `moveFocus(Enter)` once on the first capture,
+   * then `moveFocus(Next)` to walk forward to each subsequent index. Indices must be non-negative
+   * and strictly increasing — backward traversal isn't supported because Compose's focus search
+   * doesn't expose a "go to absolute index" entry point. Defaults to `[0]` (a single capture with
+   * focus on the first focusable).
+   */
+  val indices: IntArray = [0]
+)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -50,6 +50,12 @@ data class AnimationCapture(
     val showCurves: Boolean = false,
 )
 
+/** Renderer-side mirror of the plugin's `FocusCapture`. */
+@Serializable
+data class FocusCapture(
+    val tabIndex: Int,
+)
+
 /**
  * Heavy/fast threshold for [RenderPreviewCapture.cost]. Mirrors the plugin's
  * `HEAVY_COST_THRESHOLD` — anything strictly greater is considered "heavy"
@@ -110,6 +116,7 @@ data class RenderPreviewCapture(
     val advanceTimeMillis: Long? = null,
     val scroll: ScrollCapture? = null,
     val animation: AnimationCapture? = null,
+    val focus: FocusCapture? = null,
     val renderOutput: String = "",
     /**
      * Estimated render cost normalised so a static `@Preview` is `1.0`. See

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -11,8 +11,10 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.InputModeManager
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.ViewRootForTest
@@ -584,6 +586,16 @@ abstract class RobolectricRenderTestBase(
         // Read after `captureRoboImage` to crop the PNG down to the composable's
         // actual bounds.
         var measured: IntSize? = null
+        // `@FocusedPreview` driver: outer loop bumps this state between
+        // captures; an inner `LaunchedEffect` keyed off it walks
+        // [FocusManager] to the requested tab index. Driving focus from
+        // *inside* composition (rather than via a `runOnUiThread`-posted
+        // `moveFocus` from the outer loop) is what makes the post-state
+        // emit + indication redraw land before the next capture — the
+        // outer-loop path leaves a one-frame off-by-one that no amount
+        // of `mainClock.advanceTimeBy` flushed.
+        val focusIndexState =
+            androidx.compose.runtime.mutableStateOf<Int?>(null)
         val statement = object : org.junit.runners.model.Statement() {
             override fun evaluate() {
                 rule.mainClock.autoAdvance = false
@@ -651,25 +663,19 @@ abstract class RobolectricRenderTestBase(
                     preview.captures.firstNotNullOfOrNull {
                         it.animation?.takeIf { a -> a.showCurves }
                     }?.let { SlotTreeCapture() }
+                // `@FocusedPreview` requests focus drive on at least one
+                // capture: hand Compose a Keyboard-mode `InputModeManager`
+                // for the duration of this preview, since
+                // `Modifier.clickable`'s focusable is
+                // `Focusability.SystemDefined` and refuses focus under
+                // [InputMode.Touch] — Robolectric's permanent default.
+                // Captures without focus stay byte-identical to the prior
+                // touch-mode behaviour because nothing in those captures
+                // reads the input mode.
+                val anyFocusCapture = preview.captures.any { it.focus != null }
                 val providedValues = buildList {
                     add(LocalInspectionMode provides !a11yEnabled)
-                    // Robolectric never receives real key input, so the host
-                    // [InputModeManager] reports [InputMode.Touch]. Compose's
-                    // `Modifier.clickable` registers its focusable with
-                    // [Focusability.SystemDefined], which short-circuits in
-                    // touch mode — meaning Button-shaped components silently
-                    // refuse focus and a preview that calls
-                    // `FocusRequester.requestFocus()` produces an
-                    // unfocused-looking capture. Modules that exercise focus
-                    // visualisation set `composeai.focus.inputMode=keyboard`
-                    // on the `renderPreviews` task; the renderer then hands
-                    // Compose a Keyboard-mode manager, the same state that
-                    // holds on a real device after the user has Tabbed to
-                    // the component. Off by default to keep components that
-                    // change appearance based on input mode (e.g. Wear's
-                    // EdgeButton) byte-identical.
-                    if (System.getProperty("composeai.focus.inputMode")
-                            ?.equals("keyboard", ignoreCase = true) == true) {
+                    if (anyFocusCapture) {
                         add(LocalInputModeManager provides KeyboardInputModeManager)
                     }
                     if (scrollCaptureProvidable != null) {
@@ -694,6 +700,47 @@ abstract class RobolectricRenderTestBase(
                     !isRoundDevice(params.device)
                 rule.setContent {
                     CompositionLocalProvider(values = providedValues) {
+                        if (anyFocusCapture) {
+                            val focusManager = LocalFocusManager.current
+                            val target = focusIndexState.value
+                            // Walk forward by the *delta* from the
+                            // previously-driven index. `moveFocus(Enter)`
+                            // returns false on second and later calls
+                            // (focus already inside the owner) and
+                            // `clearFocus(force=true)` doesn't restore the
+                            // owner to a state where Enter works again,
+                            // so we Enter once and then issue per-capture
+                            // `moveFocus(Next)` deltas. Discovery sorts
+                            // indices ascending so the walk is monotonic.
+                            val lastTarget =
+                                androidx.compose.runtime.remember {
+                                    androidx.compose.runtime.mutableStateOf(-1)
+                                }
+                            androidx.compose.runtime.LaunchedEffect(target) {
+                                if (target != null) {
+                                    val from = lastTarget.value
+                                    if (from < 0) {
+                                        // `moveFocus(Enter)` lands the
+                                        // owner on an internal root that
+                                        // sits *before* the first
+                                        // focusable, so the first walk
+                                        // needs `target + 1` Next steps
+                                        // to land on button `target`.
+                                        // Subsequent walks delta from the
+                                        // tracked `lastTarget`.
+                                        focusManager.moveFocus(FocusDirection.Enter)
+                                        repeat(target + 1) {
+                                            focusManager.moveFocus(FocusDirection.Next)
+                                        }
+                                    } else if (target > from) {
+                                        repeat(target - from) {
+                                            focusManager.moveFocus(FocusDirection.Next)
+                                        }
+                                    }
+                                    lastTarget.value = target
+                                }
+                            }
+                        }
                         val previewBody: @Composable () -> Unit = {
                             val core: @Composable () -> Unit = {
                                 if (wrapWidth || wrapHeight) {
@@ -746,7 +793,16 @@ abstract class RobolectricRenderTestBase(
                         )
                 var captureIndex = 0
                 jobs.forEach { job ->
-                    val target = job.advanceTimeMillis ?: CAPTURE_ADVANCE_MS
+                    // When the job has no explicit `advanceTimeMillis`, default
+                    // to `CAPTURE_ADVANCE_MS` *or* the current virtual time —
+                    // whichever is later. Internal advances (e.g. the
+                    // `@FocusedPreview` settle window) bump `currentTime`
+                    // past `CAPTURE_ADVANCE_MS` after the first such capture;
+                    // taking the max keeps the require's monotonicity check
+                    // satisfied without forcing every consumer to thread an
+                    // explicit `advanceTimeMillis` through.
+                    val target =
+                        job.advanceTimeMillis ?: maxOf(CAPTURE_ADVANCE_MS, currentTime)
                     require(target >= currentTime) {
                         "Preview ${preview.id}: output advanceTimeMillis must be ascending " +
                             "(got $target after clock was at $currentTime)"
@@ -755,6 +811,31 @@ abstract class RobolectricRenderTestBase(
                     if (delta > 0) {
                         rule.mainClock.advanceTimeBy(delta)
                         currentTime = target
+                    }
+
+                    // `@FocusedPreview` per-capture focus walk. Discovery
+                    // sorts focus indices ascending and emits one capture
+                    // per index, so we only need to walk forward —
+                    // `moveFocus(Enter)` once, then `moveFocus(Next)` for
+                    // the per-step delta. `runOnUiThread` because focus
+                    // mutation is main-thread-only; the surrounding
+                    // composition is paused (`autoAdvance = false`) and
+                    // resumes on the next `advanceTimeBy`. After the
+                    // focus event reaches the interaction stream the
+                    // ripple's `IndicationNode` schedules an invalidation;
+                    // [FOCUS_SETTLE_MS] advances enough virtual time for
+                    // the next layout/draw pass to redraw the focus ring
+                    // before [captureRoboImage] reads back pixels.
+                    val capture = (job as? CaptureRenderJob)?.capture
+                    val focus = capture?.focus
+                    if (focus != null) {
+                        rule.runOnUiThread {
+                            focusIndexState.value = focus.tabIndex
+                            androidx.compose.runtime.snapshots.Snapshot
+                                .sendApplyNotifications()
+                        }
+                        rule.mainClock.advanceTimeBy(FOCUS_SETTLE_MS)
+                        currentTime += FOCUS_SETTLE_MS
                     }
 
                     // @ScrollingPreview(END): drive the first scrollable on the
@@ -1052,6 +1133,22 @@ abstract class RobolectricRenderTestBase(
          * `mainClock.advanceTimeBy(...)` with no translation.
          */
         private const val CAPTURE_ADVANCE_MS = 32L
+
+        /**
+         * Per-`@FocusedPreview`-capture settle window. After
+         * `FocusManager.moveFocus(...)` the FocusableNode emits
+         * `FocusInteraction.{Focus, Unfocus}` to the interaction sources
+         * on the next frame; the ripple's `IndicationNode` collects the
+         * events and runs a fade animation (Material's focus indicator
+         * uses an `Animatable<Float>` that crossfades over ~150ms). The
+         * paused-clock test environment doesn't auto-advance these
+         * animations, so we need enough virtual time to (a) emit the
+         * interactions, (b) crossfade out the previous capture's
+         * highlight, and (c) crossfade in the new one. 250ms = ~16
+         * frames at 16ms — a comfortable margin around Material's
+         * default highlight duration.
+         */
+        private const val FOCUS_SETTLE_MS = 250L
     }
 }
 

--- a/samples/android-alpha/build.gradle.kts
+++ b/samples/android-alpha/build.gradle.kts
@@ -25,19 +25,6 @@ android {
   testOptions { unitTests.all { it.jvmArgs("-Xmx2048m") } }
 }
 
-// The focus-ring previews call `FocusRequester.requestFocus()` to drive
-// real focus into a Material Button. Compose's clickable focusable is
-// `Focusability.SystemDefined` and refuses focus while the host
-// [InputModeManager] reports [InputMode.Touch] — Robolectric's default
-// for the renderer environment. This system property tells the renderer
-// to provide an [InputModeManager] reporting [InputMode.Keyboard],
-// matching the state a real device is in after the user Tabs to a
-// component. Scoped to this module's `renderPreviews` only; other
-// samples (wear EdgeButton in particular) keep the touch-mode default.
-tasks
-  .matching { it.name == "renderPreviews" }
-  .configureEach { (this as? Test)?.systemProperty("composeai.focus.inputMode", "keyboard") }
-
 dependencies {
   // Pinning material3 directly: the inset-focus-ring APIs
   // (RippleThemeConfiguration, LocalRippleThemeConfiguration,
@@ -50,8 +37,8 @@ dependencies {
   implementation(libs.compose.ui)
   implementation(libs.compose.ui.tooling.preview)
   implementation(libs.compose.foundation)
-  // `@AnimatedPreview` lives here — source-retained metadata read by
-  // `DiscoverPreviewsTask` at FQN.
+  // `@AnimatedPreview` and `@FocusedPreview` live here — source-retained
+  // metadata read by `DiscoverPreviewsTask` at FQN.
   implementation(project(":preview-annotations"))
   debugImplementation("androidx.compose.ui:ui-tooling")
 }

--- a/samples/android-alpha/src/main/kotlin/com/example/samplealpha/FocusRingPreviews.kt
+++ b/samples/android-alpha/src/main/kotlin/com/example/samplealpha/FocusRingPreviews.kt
@@ -1,6 +1,5 @@
 package com.example.samplealpha
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -19,36 +18,27 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import ee.schimke.composeai.preview.AnimatedPreview
+import ee.schimke.composeai.preview.FocusedPreview
 import kotlinx.coroutines.delay
 
 private val LABELS = listOf("Save", "Edit", "Share", "Delete")
 
 @Composable
-private fun ButtonRow(focusedIndex: Int) {
-    val frs = remember { List(LABELS.size) { FocusRequester() } }
-    LaunchedEffect(focusedIndex) { frs[focusedIndex].requestFocus() }
+private fun ButtonRow() {
     Row(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
-        LABELS.forEachIndexed { i, label ->
+        LABELS.forEach { label ->
             Button(
                 onClick = {},
-                modifier = Modifier.padding(end = 8.dp).focusRequester(frs[i]),
+                modifier = Modifier.padding(end = 8.dp),
                 shape = RoundedCornerShape(12.dp),
             ) {
                 Text(label)
             }
         }
     }
-}
-
-class FocusIndexProvider : PreviewParameterProvider<Int> {
-    override val values: Sequence<Int> = (0 until LABELS.size).asSequence()
 }
 
 @Composable
@@ -62,12 +52,11 @@ private fun WithRippleConfig(config: RippleThemeConfiguration, content: @Composa
     heightDp = 96,
     showBackground = true,
 )
+@FocusedPreview(indices = [0, 1, 2, 3])
 @Composable
-fun InsetFocusRingFanOutPreview(@PreviewParameter(FocusIndexProvider::class) focusedIndex: Int) {
+fun InsetFocusRingFanOutPreview() {
     MaterialTheme {
-        WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) {
-            ButtonRow(focusedIndex)
-        }
+        WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) { ButtonRow() }
     }
 }
 
@@ -88,26 +77,59 @@ fun InsetFocusRingAnimatedPreview() {
         }
     }
     MaterialTheme {
-        WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) { ButtonRow(idx) }
+        WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) {
+            // The animated preview drives focus via in-composition state
+            // rather than the @FocusedPreview annotation: the GIF needs
+            // one row composable that re-renders its focus state across
+            // 16 frames, not 16 separate preview captures.
+            FocusRingRowAnimated(idx)
+        }
     }
 }
 
-@Preview(
-    name = "Opacity vs Inset Ring",
-    widthDp = 480,
-    heightDp = 192,
-    showBackground = true,
-)
 @Composable
-fun OpacityVsInsetRingPreview() {
-    MaterialTheme {
-        Column {
-            WithRippleConfig(RippleDefaults.OpacityFocusRippleThemeConfiguration) {
-                ButtonRow(focusedIndex = 1)
-            }
-            WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) {
-                ButtonRow(focusedIndex = 1)
+private fun FocusRingRowAnimated(focusedIndex: Int) {
+    val sources =
+        remember {
+            List(LABELS.size) {
+                androidx.compose.foundation.interaction.MutableInteractionSource()
             }
         }
+    LaunchedEffect(focusedIndex) {
+        sources[focusedIndex].emit(
+            androidx.compose.foundation.interaction.FocusInteraction.Focus()
+        )
+    }
+    Row(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        LABELS.forEachIndexed { i, label ->
+            Button(
+                onClick = {},
+                modifier = Modifier.padding(end = 8.dp),
+                shape = RoundedCornerShape(12.dp),
+                interactionSource = sources[i],
+            ) {
+                Text(label)
+            }
+        }
+    }
+}
+
+/**
+ * Opacity-focus baseline: the same row drawn under
+ * `RippleDefaults.OpacityFocusRippleThemeConfiguration`. Pair-render with
+ * the inset-ring fan-out to see the visual delta between the two
+ * focus-indication strategies.
+ */
+@Preview(
+    name = "Opacity Focus",
+    widthDp = 480,
+    heightDp = 96,
+    showBackground = true,
+)
+@FocusedPreview(indices = [1])
+@Composable
+fun OpacityFocusPreview() {
+    MaterialTheme {
+        WithRippleConfig(RippleDefaults.OpacityFocusRippleThemeConfiguration) { ButtonRow() }
     }
 }


### PR DESCRIPTION
## Summary

- New `@FocusedPreview(indices = [0, 1, 2, 3])` annotation in `:preview-annotations`. Fans a `@Preview` out into one capture per requested tab index; filename suffix `_FOCUS_<index>` per capture, mirroring the `@ScrollingPreview` shape. Captures stay byte-identical for previews that don't carry the annotation.
- Renderer drives focus from *inside* composition: a state holder is mutated between captures, a `LaunchedEffect` keyed off it walks `FocusManager` (`moveFocus(Enter)` once, then `moveFocus(Next)` deltas). Driving from the outer loop produced a one-frame off-by-one — state changes weren't reaching the `IndicationNode` before the capture buffer flushed.
- The Keyboard-mode `LocalInputModeManager` override that `:samples:android-alpha` previously got via the `composeai.focus.inputMode` system property is now scoped to previews carrying `@FocusedPreview`, and the system-property escape hatch is removed. Compose's `Modifier.clickable` focusable is `Focusability.SystemDefined` (`foundation/Focusable.kt`) and refuses focus under `InputMode.Touch`, which is what Robolectric's renderer is permanently in.

## Demo (`:samples:android-alpha`) reads as natural Compose

```kotlin
@Preview(name = "Inset Focus Ring — fan-out", widthDp = 480, heightDp = 96, showBackground = true)
@FocusedPreview(indices = [0, 1, 2, 3])
@Composable
fun InsetFocusRingFanOutPreview() {
    MaterialTheme {
        WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) {
            Row { LABELS.forEach { Button(onClick = {}) { Text(it) } } }
        }
    }
}
```

No `FocusRequester`, no `LaunchedEffect`, no `PreviewParameter` wiring on this preview, no system-property hack in `build.gradle.kts`. The animated cycle GIF keeps its synthetic `FocusInteraction.Focus` emit because the GIF needs one composable that re-renders focus state across 16 frames, not 16 separate captures. The opacity-vs-inset side-by-side is split into a separate `OpacityFocusPreview` since only one button can be focused globally.

## Implementation notes worth flagging

- `moveFocus(Enter)` lands the focus owner on an internal root one position *before* the first focusable, so the very first walk needs `target + 1` Next steps to land on button `target`. Subsequent walks delta from a tracked `lastTarget`. The KDoc on `FocusedPreview.kt` and the comment block in `RobolectricRenderTest.kt` explain.
- `clearFocus(force = true)` doesn't restore the focus owner to a state where `Enter` works again, so each composition only Enters once and walks forward by deltas.
- Discovery sorts `indices` ascending and de-duplicates, since `moveFocus(Previous)` doesn't expose a "go to absolute index" entry point and the walk needs to be monotonic.
- Default settle window is 250 ms (`FOCUS_SETTLE_MS`), comfortably above Material's ~150 ms focus-indicator crossfade.

## Follow-up worth discussing later

- Wear coverage: same `LocalInputModeManager` flip applies (Wear's d-pad maps to `InputMode.Keyboard`), but I haven't exercised it yet — a Wear sample preview would be a natural next test.
- Optional overlay (focus-rect highlight + index label) — surfaced as a possibility in the previous PR's discussion; not implemented here.
- Multi-frame "tab traversal" form (`@FocusedPreview(traverse = ["next", "next", "previous"])`) — single-walk indices already cover the common cases; defer until there's a concrete need.

## Test plan

- [ ] `./gradlew :samples:android-alpha:renderAllPreviews` produces four distinct fan-out PNGs (ring on Save / Edit / Share / Delete in turn), an animated GIF cycling through them, and the standalone opacity-focus baseline
- [ ] `./gradlew :renderer-android:test` — only the pre-existing `LongScrollGhostOverlayTest.Wear anchor path…` failure (also fails on `origin/main`); no new regressions
- [ ] `./gradlew :gradle-plugin:test` and `:gradle-plugin:functionalTest` pass
- [ ] `./gradlew ktfmtCheckAll` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_0197pgjb3LE9hWV5tda1CvwB)_