### PR TITLE
feat(preview-annotations): add traverse + overlay to @FocusedPreview

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -741,6 +741,7 @@ internal object ComposePreviewTasks {
         if (rel in expectedRelPaths) return@forEach
         if (paramStems.any { it.matches(rel, f.name) }) return@forEach
         if (isA11ySiblingOfExpected(rel, expectedRelPaths)) return@forEach
+        if (isRawSiblingOfExpected(rel, expectedRelPaths)) return@forEach
         if (!f.delete()) {
           logger.warn("compose-preview: couldn't delete stale render $f")
         }
@@ -755,6 +756,19 @@ internal object ComposePreviewTasks {
   internal fun isA11ySiblingOfExpected(rel: String, expectedRelPaths: Set<String>): Boolean {
     if (!rel.endsWith(".a11y.png")) return false
     val cleanSibling = rel.removeSuffix(".a11y.png") + ".png"
+    return cleanSibling in expectedRelPaths
+  }
+
+  /**
+   * `<stem>.raw.png` lives next to a clean `<stem>.png` registered in the manifest. Produced by
+   * `@FocusedPreview(overlay = true)` — the renderer copies the unmarked capture aside before
+   * applying the focus-rect overlay to the main file. Same preservation shape as
+   * [isA11ySiblingOfExpected] — match by mechanical suffix-strip, not by re-checking the manifest's
+   * overlay flag, so a `.raw.png` whose clean sibling has been removed is still garbage.
+   */
+  internal fun isRawSiblingOfExpected(rel: String, expectedRelPaths: Set<String>): Boolean {
+    if (!rel.endsWith(".raw.png")) return false
+    val cleanSibling = rel.removeSuffix(".raw.png") + ".png"
     return cleanSibling in expectedRelPaths
   }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -655,16 +655,16 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     val timeRows: List<Pair<Long?, String>> =
       if (effectiveTimings.isEmpty()) listOf(null to "")
       else effectiveTimings.map { ms -> ms to "_TIME_${ms}ms" }
-    // `@FocusedPreview(indices = [...])` fans out one capture per index
-    // with `_FOCUS_<index>` suffix. Single-index keeps the plain filename
-    // (matches the @ScrollingPreview single-mode pattern). Empty → one
-    // (null, "") row, same shape as scroll/time when their annotations
-    // are absent.
+    // `@FocusedPreview` fans out one capture per index (indexed mode) or
+    // per direction step (traversal mode). Single-capture annotations
+    // keep the plain filename (matches the @ScrollingPreview single-mode
+    // pattern). Empty → one (null, "") row, same shape as scroll/time
+    // when their annotations are absent.
     val focusRows: List<Pair<FocusCapture?, String>> =
       when {
         effectiveFocuses.isEmpty() -> listOf(null to "")
         effectiveFocuses.size == 1 -> listOf(effectiveFocuses[0] to "")
-        else -> effectiveFocuses.map { it to "_FOCUS_${it.tabIndex}" }
+        else -> effectiveFocuses.map { it to "_FOCUS_${focusSuffixOf(it)}" }
       }
 
     // When ONLY @AnimatedPreview is on the function, the scroll/time/focus
@@ -842,20 +842,50 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
   }
 
   /**
-   * Reads `@FocusedPreview(indices = [...])` off the function annotation list. Returns one
-   * [FocusCapture] per requested tab index, sorted ascending and de-duplicated. Negative or empty
-   * inputs collapse to no captures (the annotation falls back to the cross-product's null row).
+   * Filename suffix for a single [FocusCapture]. Traversal mode emits `step<n>_<direction>` so
+   * repeated directions (e.g. `Next, Next, Previous`) get unique paths; indexed mode emits the tab
+   * index. Empty when neither field is set (defensive — the discovery extractor doesn't emit such
+   * captures).
+   */
+  private fun focusSuffixOf(focus: FocusCapture): String =
+    when {
+      focus.direction != null && focus.step != null -> "step${focus.step}_${focus.direction.name}"
+      focus.tabIndex != null -> focus.tabIndex.toString()
+      else -> ""
+    }
+
+  /**
+   * Reads `@FocusedPreview(indices, traverse, overlay)` off the function annotation list. Returns
+   * one [FocusCapture] per capture requested — traversal mode (one per direction step) when
+   * `traverse` is non-empty, otherwise indexed mode (one per non-negative tab index, sorted
+   * ascending and de-duplicated). The boolean `overlay` flag is stamped onto every returned
+   * capture. Empty inputs collapse to no captures (the annotation falls back to the cross-product's
+   * null row).
    */
   private fun extractFocusSpecs(annotations: List<AnnotationInfo>): List<FocusCapture> {
     val ann = annotations.firstOrNull { it.name == FOCUSED_PREVIEW_FQN } ?: return emptyList()
-    val raw = ann.parameterValues.getValue("indices")
+    val pv = ann.parameterValues
+    val overlay = (pv.getValue("overlay") as? Boolean) ?: false
+    val directions = readEnumArray(pv.getValue("traverse")) { FocusDirection.valueOf(it) }
+    if (directions.isNotEmpty()) {
+      // 1-based `step` lets the overlay label and the filename suffix
+      // disambiguate repeated directions (e.g. `Next, Next, Previous`).
+      return directions.mapIndexed { i, dir ->
+        FocusCapture(direction = dir, step = i + 1, overlay = overlay)
+      }
+    }
+    val raw = pv.getValue("indices")
     val indices: IntArray =
       when (raw) {
         is IntArray -> raw
         is Array<*> -> raw.filterIsInstance<Int>().toIntArray()
         else -> intArrayOf()
       }
-    return indices.filter { it >= 0 }.distinct().sorted().map { FocusCapture(tabIndex = it) }
+    return indices
+      .filter { it >= 0 }
+      .distinct()
+      .sorted()
+      .map { FocusCapture(tabIndex = it, overlay = overlay) }
   }
 
   private fun extractScrollSpecs(annotations: List<AnnotationInfo>): List<ScrollCapture> {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -78,19 +78,51 @@ data class AnimationCapture(
 )
 
 /**
+ * Mirrors `ee.schimke.composeai.preview.FocusDirection` from the `preview-annotations` artifact.
+ * Duplicated here so the Gradle plugin can serialize the value into `previews.json` without pulling
+ * the annotation artifact (and Compose) onto the plugin's compile classpath.
+ */
+enum class FocusDirection {
+  Next,
+  Previous,
+  Up,
+  Down,
+  Left,
+  Right,
+}
+
+/**
  * Focus capture state sourced from `@FocusedPreview`. Carried as its own field on [Capture] —
  * orthogonal to [Capture.scroll] / [Capture.animation] — so the renderer can switch on its presence
  * to (a) provide an `InputMode.Keyboard` `LocalInputModeManager` (Compose's `Modifier.clickable`
  * focusable refuses focus under touch mode, which Robolectric is permanently in) and (b) walk the
- * focus owner to [tabIndex] before capture.
+ * focus owner to the requested target before capture.
  */
 @Serializable
 data class FocusCapture(
   /**
-   * Zero-based focus index in tab order. Capture 0 issues `moveFocus(Enter)`; later captures issue
-   * `moveFocus(Next)` to walk forward to the requested index.
+   * Zero-based focus index in tab order, in indexed-mode captures. `null` in traversal-mode
+   * captures (use [direction] instead). Capture 0 issues `moveFocus(Enter)` + Next steps to land on
+   * `tabIndex`; later captures issue `moveFocus(Next)` deltas.
    */
-  val tabIndex: Int
+  val tabIndex: Int? = null,
+  /**
+   * Direction to apply before this capture, in traversal-mode captures. `null` in indexed-mode
+   * captures (use [tabIndex] instead). The renderer issues `moveFocus(Enter)` once on the first
+   * traversal step, then `moveFocus(direction)` per capture.
+   */
+  val direction: FocusDirection? = null,
+  /**
+   * 1-based step number within a `traverse = [...]` array. Carried separately from [direction] so
+   * the renderer's overlay can label captures (`step 2`) even when several steps share a direction.
+   * `null` in indexed-mode captures.
+   */
+  val step: Int? = null,
+  /**
+   * When `true`, the renderer post-applies a stroke + label overlay to the captured PNG. The
+   * pre-overlay capture is kept alongside as `<basename>.raw.png`.
+   */
+  val overlay: Boolean = false,
 )
 
 /**

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/FocusedPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/FocusedPreview.kt
@@ -7,10 +7,20 @@ package ee.schimke.composeai.preview
  * [ScrollingPreview] / [AnimatedPreview] split: consumers that want to use the annotation in their
  * own code depend on `ee.schimke.composeai:preview-annotations`.
  *
- * The renderer fans out one capture per entry in [indices], driving the Compose focus owner across
- * the focusables in tab order via `FocusManager.moveFocus(...)` — no `FocusRequester` needed in the
- * preview body. Each frame is captured at its assigned focus position with a `_FOCUS_<index>`
- * filename suffix.
+ * Two driving modes — pick one:
+ *
+ * * **Indexed** ([indices]): fan out one capture per requested tab-order index. The renderer issues
+ *   `moveFocus(Enter)` once on the first capture, then `moveFocus(Next)` to walk forward to each
+ *   subsequent index. Filename suffix `_FOCUS_<index>`. Default mode (`indices = [0]`).
+ *
+ * * **Traversal** ([traverse]): one capture per direction in the array. The renderer issues
+ *   `moveFocus(Enter)` once before the first step, then `moveFocus(direction)` per entry. Filename
+ *   suffix `_FOCUS_step<n>_<direction>`. Useful for asserting Tab / Shift-Tab / D-pad traversal
+ *   order in PR diffs — each step is a separate PNG so reviewers see exactly which focusable each
+ *   move lands on.
+ *
+ * `traverse` takes precedence when both are set; mixing them in a single annotation isn't
+ * meaningful.
  *
  * Compose's `Modifier.clickable` registers its focusable with `Focusability.SystemDefined`, which
  * refuses focus while the host `LocalInputModeManager.inputMode == InputMode.Touch`. Robolectric's
@@ -18,7 +28,7 @@ package ee.schimke.composeai.preview
  * annotation also flips `LocalInputModeManager` to Keyboard mode for the duration of its captures —
  * matching the state a real device is in after the user Tabs to a component.
  *
- * Example — a row of buttons, ring on each in turn:
+ * Example — indexed:
  * ```
  * @Preview
  * @FocusedPreview(indices = [0, 1, 2, 3])
@@ -31,6 +41,18 @@ package ee.schimke.composeai.preview
  *     }
  * }
  * ```
+ *
+ * Example — traversal:
+ * ```
+ * @Preview
+ * @FocusedPreview(traverse = [FocusDirection.Next, FocusDirection.Next, FocusDirection.Previous])
+ * @Composable
+ * fun MyButtonRow() { ... }
+ * ```
+ *
+ * When [overlay] is `true`, the renderer draws a stroke + index label over the captured PNG showing
+ * the bounds of the currently-focused element. Useful when the component's own focus indicator is
+ * subtle and you want an unambiguous review-time marker.
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION)
@@ -41,7 +63,35 @@ annotation class FocusedPreview(
    * then `moveFocus(Next)` to walk forward to each subsequent index. Indices must be non-negative
    * and strictly increasing — backward traversal isn't supported because Compose's focus search
    * doesn't expose a "go to absolute index" entry point. Defaults to `[0]` (a single capture with
-   * focus on the first focusable).
+   * focus on the first focusable). Ignored when [traverse] is non-empty.
    */
-  val indices: IntArray = [0]
+  val indices: IntArray = [0],
+  /**
+   * Directions to apply, one capture per entry. Each capture is taken *after* applying that step's
+   * direction; the renderer issues a single `moveFocus(Enter)` before step 1 so the first move
+   * lands on a real focusable rather than no-op'ing on an inactive root. Empty (the default) → use
+   * [indices].
+   */
+  val traverse: Array<FocusDirection> = [],
+  /**
+   * When `true`, the renderer overlays a stroke + step / index label on each captured PNG showing
+   * the currently-focused element's bounds. The overlay is post-applied to the output file, so the
+   * pre-overlay capture is preserved alongside (`<basename>.raw.png`). Off by default to keep
+   * captures byte-identical to a no-overlay run when reviewers don't want the marker.
+   */
+  val overlay: Boolean = false,
 )
+
+/**
+ * Mirrors the Compose `androidx.compose.ui.focus.FocusDirection` value class as a discoverable
+ * enum. The Gradle plugin can't load Compose at discovery time, so we duplicate the relevant set
+ * here and let the renderer translate at render time.
+ */
+enum class FocusDirection {
+  Next,
+  Previous,
+  Up,
+  Down,
+  Left,
+  Right,
+}

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -50,10 +50,24 @@ data class AnimationCapture(
     val showCurves: Boolean = false,
 )
 
+/** Renderer-side mirror of the plugin's `FocusDirection`. */
+@Serializable
+enum class FocusDirection {
+    Next,
+    Previous,
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
 /** Renderer-side mirror of the plugin's `FocusCapture`. */
 @Serializable
 data class FocusCapture(
-    val tabIndex: Int,
+    val tabIndex: Int? = null,
+    val direction: FocusDirection? = null,
+    val step: Int? = null,
+    val overlay: Boolean = false,
 )
 
 /**

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
-import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusDirection as ComposeFocusDirection
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.InputModeManager
 import androidx.compose.ui.platform.LocalFocusManager
@@ -588,14 +588,21 @@ abstract class RobolectricRenderTestBase(
         var measured: IntSize? = null
         // `@FocusedPreview` driver: outer loop bumps this state between
         // captures; an inner `LaunchedEffect` keyed off it walks
-        // [FocusManager] to the requested tab index. Driving focus from
+        // [FocusManager] to the requested target. Driving focus from
         // *inside* composition (rather than via a `runOnUiThread`-posted
         // `moveFocus` from the outer loop) is what makes the post-state
         // emit + indication redraw land before the next capture — the
         // outer-loop path leaves a one-frame off-by-one that no amount
-        // of `mainClock.advanceTimeBy` flushed.
-        val focusIndexState =
-            androidx.compose.runtime.mutableStateOf<Int?>(null)
+        // of `mainClock.advanceTimeBy` flushed. Carries the whole
+        // [FocusCapture] (rather than just an index) so traversal-mode
+        // captures can dispatch by direction.
+        val focusCaptureState =
+            androidx.compose.runtime.mutableStateOf<FocusCapture?>(null)
+        // [android.view.View] read from inside composition so the
+        // post-capture overlay can reflect into AndroidComposeView's
+        // `focusOwner.getFocusRect()` to find the focused element's
+        // bounds. `null` until the first composition.
+        var capturedView: android.view.View? = null
         val statement = object : org.junit.runners.model.Statement() {
             override fun evaluate() {
                 rule.mainClock.autoAdvance = false
@@ -702,42 +709,53 @@ abstract class RobolectricRenderTestBase(
                     CompositionLocalProvider(values = providedValues) {
                         if (anyFocusCapture) {
                             val focusManager = LocalFocusManager.current
-                            val target = focusIndexState.value
-                            // Walk forward by the *delta* from the
-                            // previously-driven index. `moveFocus(Enter)`
-                            // returns false on second and later calls
-                            // (focus already inside the owner) and
-                            // `clearFocus(force=true)` doesn't restore the
-                            // owner to a state where Enter works again,
-                            // so we Enter once and then issue per-capture
-                            // `moveFocus(Next)` deltas. Discovery sorts
-                            // indices ascending so the walk is monotonic.
-                            val lastTarget =
+                            capturedView = androidx.compose.ui.platform.LocalView.current
+                            val cap = focusCaptureState.value
+                            // Indexed mode: track the last walked tab
+                            // index so subsequent captures only issue the
+                            // delta `moveFocus(Next)` calls. Traversal
+                            // mode: track whether we've Entered the focus
+                            // owner so the first directional step lands
+                            // on a real focusable rather than no-op'ing
+                            // on an inactive root.
+                            val lastIndex =
                                 androidx.compose.runtime.remember {
                                     androidx.compose.runtime.mutableStateOf(-1)
                                 }
-                            androidx.compose.runtime.LaunchedEffect(target) {
-                                if (target != null) {
-                                    val from = lastTarget.value
-                                    if (from < 0) {
+                            val entered =
+                                androidx.compose.runtime.remember {
+                                    androidx.compose.runtime.mutableStateOf(false)
+                                }
+                            androidx.compose.runtime.LaunchedEffect(cap) {
+                                if (cap != null) {
+                                    val direction = cap.direction
+                                    val tabIndex = cap.tabIndex
+                                    if (direction != null) {
+                                        if (!entered.value) {
+                                            focusManager.moveFocus(ComposeFocusDirection.Enter)
+                                            entered.value = true
+                                        }
+                                        focusManager.moveFocus(direction.toCompose())
+                                    } else if (tabIndex != null) {
                                         // `moveFocus(Enter)` lands the
                                         // owner on an internal root that
                                         // sits *before* the first
                                         // focusable, so the first walk
-                                        // needs `target + 1` Next steps
-                                        // to land on button `target`.
-                                        // Subsequent walks delta from the
-                                        // tracked `lastTarget`.
-                                        focusManager.moveFocus(FocusDirection.Enter)
-                                        repeat(target + 1) {
-                                            focusManager.moveFocus(FocusDirection.Next)
+                                        // needs `tabIndex + 1` Next steps
+                                        // to land on button `tabIndex`.
+                                        val from = lastIndex.value
+                                        if (from < 0) {
+                                            focusManager.moveFocus(ComposeFocusDirection.Enter)
+                                            repeat(tabIndex + 1) {
+                                                focusManager.moveFocus(ComposeFocusDirection.Next)
+                                            }
+                                        } else if (tabIndex > from) {
+                                            repeat(tabIndex - from) {
+                                                focusManager.moveFocus(ComposeFocusDirection.Next)
+                                            }
                                         }
-                                    } else if (target > from) {
-                                        repeat(target - from) {
-                                            focusManager.moveFocus(FocusDirection.Next)
-                                        }
+                                        lastIndex.value = tabIndex
                                     }
-                                    lastTarget.value = target
                                 }
                             }
                         }
@@ -830,7 +848,7 @@ abstract class RobolectricRenderTestBase(
                     val focus = capture?.focus
                     if (focus != null) {
                         rule.runOnUiThread {
-                            focusIndexState.value = focus.tabIndex
+                            focusCaptureState.value = focus
                             androidx.compose.runtime.snapshots.Snapshot
                                 .sendApplyNotifications()
                         }
@@ -943,6 +961,14 @@ abstract class RobolectricRenderTestBase(
                             wrapHeight = wrapHeight,
                             measured = measured!!,
                         )
+                    }
+
+                    // `@FocusedPreview(overlay = true)`: post-process the
+                    // captured PNG with a stroke + label drawn over the
+                    // currently-focused element. Pre-overlay capture is
+                    // preserved alongside as `<basename>.raw.png`.
+                    if (focus?.overlay == true) {
+                        applyFocusOverlay(capturedView, outputFile, focus)
                     }
 
                     if (
@@ -1822,6 +1848,115 @@ private object KeyboardInputModeManager : InputModeManager {
 
     override fun requestInputMode(inputMode: InputMode): Boolean = false
 }
+
+/**
+ * Converts the renderer-side [FocusDirection] enum (mirror of the plugin's, serialised through
+ * `previews.json`) onto Compose's `FocusDirection` value class.
+ */
+private fun FocusDirection.toCompose(): ComposeFocusDirection =
+    when (this) {
+        FocusDirection.Next -> ComposeFocusDirection.Next
+        FocusDirection.Previous -> ComposeFocusDirection.Previous
+        FocusDirection.Up -> ComposeFocusDirection.Up
+        FocusDirection.Down -> ComposeFocusDirection.Down
+        FocusDirection.Left -> ComposeFocusDirection.Left
+        FocusDirection.Right -> ComposeFocusDirection.Right
+    }
+
+/**
+ * Post-applies a stroke + label overlay to [outputFile] showing the bounds of the currently-focused
+ * element, sourced from `AndroidComposeView.focusOwner.getFocusRect()` (reflectively — the focus
+ * owner isn't on the renderer's public Compose surface). Saves the pre-overlay capture as
+ * `<basename>.raw.png` alongside so reviewers can A/B against the unmarked image.
+ *
+ * Skipped silently when the view isn't an AndroidComposeView, the focus owner has no active focus,
+ * or the focus rect is empty — overlays are a review aid, not a contract.
+ */
+private fun applyFocusOverlay(view: android.view.View?, outputFile: java.io.File, focus: FocusCapture) {
+    if (view == null) return
+    val rect = readFocusRect(view) ?: return
+    if (rect.width <= 0 || rect.height <= 0) return
+
+    val rawFile =
+        java.io.File(
+            outputFile.parentFile,
+            outputFile.nameWithoutExtension + ".raw." + outputFile.extension,
+        )
+    runCatching {
+        java.nio.file.Files.copy(
+            outputFile.toPath(),
+            rawFile.toPath(),
+            java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+        )
+    }
+
+    val image = runCatching { javax.imageio.ImageIO.read(outputFile) }.getOrNull() ?: return
+    val g = image.createGraphics()
+    try {
+        g.setRenderingHint(
+            java.awt.RenderingHints.KEY_ANTIALIASING,
+            java.awt.RenderingHints.VALUE_ANTIALIAS_ON,
+        )
+        g.setRenderingHint(
+            java.awt.RenderingHints.KEY_TEXT_ANTIALIASING,
+            java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_ON,
+        )
+        g.color = java.awt.Color(0xFF, 0x40, 0x40, 0xFF.toByte().toInt() and 0xFF)
+        g.stroke = java.awt.BasicStroke(3f)
+        g.drawRect(rect.x, rect.y, rect.width, rect.height)
+
+        val label = focusOverlayLabel(focus)
+        val font = java.awt.Font("SansSerif", java.awt.Font.BOLD, 16)
+        g.font = font
+        val metrics = g.fontMetrics
+        val textWidth = metrics.stringWidth(label)
+        val textHeight = metrics.height
+        val pillX = rect.x
+        val pillY = (rect.y - textHeight - 4).coerceAtLeast(0)
+        g.color = java.awt.Color(0xFF, 0x40, 0x40, 0xE0)
+        g.fillRoundRect(pillX, pillY, textWidth + 12, textHeight + 4, 8, 8)
+        g.color = java.awt.Color.WHITE
+        g.drawString(label, pillX + 6, pillY + textHeight - 4)
+    } finally {
+        g.dispose()
+    }
+    runCatching { javax.imageio.ImageIO.write(image, "png", outputFile) }
+}
+
+/**
+ * Reflects into `AndroidComposeView.focusOwner.getFocusRect()` to retrieve the focused element's
+ * bounds. Returns `null` when the view isn't an AndroidComposeView, the focus owner has no active
+ * focus, or any reflective lookup fails. Used by [applyFocusOverlay] — failure here is silent
+ * because the overlay is a review aid, not a render contract.
+ */
+private fun readFocusRect(view: android.view.View): java.awt.Rectangle? {
+    return runCatching {
+        val getFocusOwner =
+            view::class.java.methods.firstOrNull { it.name == "getFocusOwner" } ?: return null
+        val owner = getFocusOwner.invoke(view) ?: return null
+        val getFocusRect =
+            owner::class.java.methods.firstOrNull { it.name == "getFocusRect" } ?: return null
+        val rect = getFocusRect.invoke(owner) ?: return null
+        val left = (rect::class.java.getMethod("getLeft").invoke(rect) as? Float) ?: return null
+        val top = (rect::class.java.getMethod("getTop").invoke(rect) as? Float) ?: return null
+        val right = (rect::class.java.getMethod("getRight").invoke(rect) as? Float) ?: return null
+        val bottom = (rect::class.java.getMethod("getBottom").invoke(rect) as? Float) ?: return null
+        // Compose's `Rect` reports `left = top = Float.POSITIVE_INFINITY` (`Rect.Zero`) when no
+        // focus is active; clamp to int silently here.
+        if (!left.isFinite() || !top.isFinite() || !right.isFinite() || !bottom.isFinite()) {
+            return null
+        }
+        java.awt.Rectangle(left.toInt(), top.toInt(), (right - left).toInt(), (bottom - top).toInt())
+    }.getOrNull()
+}
+
+private fun focusOverlayLabel(focus: FocusCapture): String =
+    when {
+        focus.direction != null && focus.step != null ->
+            "step ${focus.step} • ${focus.direction.name}"
+        focus.tabIndex != null -> "index ${focus.tabIndex}"
+        else -> "focus"
+    }
 
 /**
  * Adds Robolectric's `+round` qualifier so `Configuration.isScreenRound` becomes

--- a/samples/android-alpha/src/main/kotlin/com/example/samplealpha/FocusRingPreviews.kt
+++ b/samples/android-alpha/src/main/kotlin/com/example/samplealpha/FocusRingPreviews.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ee.schimke.composeai.preview.AnimatedPreview
+import ee.schimke.composeai.preview.FocusDirection
 import ee.schimke.composeai.preview.FocusedPreview
 import kotlinx.coroutines.delay
 
@@ -131,5 +132,48 @@ private fun FocusRingRowAnimated(focusedIndex: Int) {
 fun OpacityFocusPreview() {
     MaterialTheme {
         WithRippleConfig(RippleDefaults.OpacityFocusRippleThemeConfiguration) { ButtonRow() }
+    }
+}
+
+/**
+ * Traversal demo: each capture shows where focus lands after applying that step's direction. The
+ * sequence walks Tab → Tab → Shift-Tab → Tab, so Save → Edit → Share → Edit → Share. Useful for
+ * asserting keyboard-nav order in PR diffs — each step is a separate PNG so reviewers see exactly
+ * which focusable each move targets.
+ */
+@Preview(
+    name = "Focus Traversal",
+    widthDp = 480,
+    heightDp = 96,
+    showBackground = true,
+)
+@FocusedPreview(
+    traverse =
+        [FocusDirection.Next, FocusDirection.Next, FocusDirection.Previous, FocusDirection.Next],
+)
+@Composable
+fun FocusTraversalPreview() {
+    MaterialTheme {
+        WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) { ButtonRow() }
+    }
+}
+
+/**
+ * Overlay demo: same fan-out as [InsetFocusRingFanOutPreview] but with `overlay = true`. Each PNG
+ * carries a labelled stroke around the focused button so review tools can see which button is
+ * "supposed to" be focused regardless of whether the indication itself rendered correctly. The
+ * pre-overlay capture is preserved alongside as `<basename>.raw.png`.
+ */
+@Preview(
+    name = "Focus Overlay",
+    widthDp = 480,
+    heightDp = 96,
+    showBackground = true,
+)
+@FocusedPreview(indices = [0, 1, 2, 3], overlay = true)
+@Composable
+fun FocusOverlayPreview() {
+    MaterialTheme {
+        WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) { ButtonRow() }
     }
 }


### PR DESCRIPTION
## Summary

Two new modes on `@FocusedPreview`, both built on the same fan-out machinery as `indices`:

- **`traverse = [Next, Next, Previous]`** — one capture per direction step. The renderer issues `moveFocus(Enter)` once before step 1, then `moveFocus(direction)` per entry. Filename suffix `_FOCUS_step<n>_<direction>`. Useful for asserting Tab / Shift-Tab / D-pad traversal order in PR diffs: each step is a separate PNG so reviewers see exactly which focusable each move targets.
- **`overlay = true`** — post-capture stroke + label drawn over the focused element's bounds, sourced reflectively from `AndroidComposeView.focusOwner.getFocusRect()` (the focus owner isn't on Compose's public surface). Pre-overlay capture is preserved alongside as `<basename>.raw.png` so the unmarked baseline stays available for review. `cleanStaleRenders` gets a sibling-preservation rule matching the existing `.a11y.png` shape so the raw companion survives the per-run cleanup.

A renderer-side mirror of the new `FocusDirection` enum lives in `:renderer-android` (`RenderManifest.kt`) so the plugin doesn't need to pull Compose onto its compile classpath; conversion to Compose's `FocusDirection` value class happens at render time. The Compose import is aliased to `ComposeFocusDirection` to disambiguate from our enum.

## Demo additions in `:samples:android-alpha`

```kotlin
@FocusedPreview(
    traverse = [FocusDirection.Next, FocusDirection.Next, FocusDirection.Previous, FocusDirection.Next]
)
@Composable fun FocusTraversalPreview() { … }
//   step1_Next      → ring on Save
//   step2_Next      → ring on Edit
//   step3_Previous  → ring on Save
//   step4_Next      → ring on Edit

@FocusedPreview(indices = [0, 1, 2, 3], overlay = true)
@Composable fun FocusOverlayPreview() { … }
//   FOCUS_0.png  + FOCUS_0.raw.png
//   FOCUS_1.png  + FOCUS_1.raw.png  ← marked + baseline pair per index
//   FOCUS_2.png  + FOCUS_2.raw.png
//   FOCUS_3.png  + FOCUS_3.raw.png
```

The overlay's red rect + `index N` pill is drawn via Java2D (`BufferedImage` + `Graphics2D`) post-`captureRoboImage`. Skipped silently when the focus rect is `Rect.Zero` / non-finite, so previews without an active focus state never get a stray overlay.

## Implementation notes worth flagging

- **`indices` and `traverse` are mutually exclusive**; if both are set, `traverse` takes precedence. The annotation KDoc spells that out.
- **`moveFocus(Enter)` happens once per composition** — for both modes. Indexed mode walks `tabIndex + 1` Nexts on first call (the focus owner's internal root sits *before* the first focusable, so plain Enter doesn't land on a real element). Traversal mode does Enter then per-step direction.
- **Overlay's `.raw.png` companion** — same shape as `.a11y.png` siblings; `cleanStaleRenders` preserves both via mechanical suffix-strip rather than re-checking the manifest's overlay flag, so a `.raw.png` whose clean sibling is removed still gets cleaned up.
- **Reflection footprint** is small: only `view.getFocusOwner()` + `owner.getFocusRect()` + Compose `Rect`'s `getLeft / getTop / getRight / getBottom` getters. Failure is silent (overlay is a review aid, not a render contract).

## Test plan

- [ ] `./gradlew :samples:android-alpha:renderAllPreviews` produces:
  - 4 fan-out PNGs (existing)
  - 4 traversal PNGs `FocusTraversalPreview_*_step{1..4}_{Next|Previous}.png`
  - 4 overlay PNGs + 4 `.raw.png` baselines
  - Existing animated GIF + opacity baseline
- [ ] Eyeball: traversal lands on Save → Edit → Save → Edit (`Next, Next, Previous, Next`); overlay's red rect + `index N` label sits over the right button on each `_FOCUS_<n>.png`
- [ ] `./gradlew :renderer-android:test` — only the pre-existing `LongScrollGhostOverlayTest.Wear anchor path…` failure (also fails on `origin/main`); no new regressions
- [ ] `./gradlew :gradle-plugin:test` and `:gradle-plugin:functionalTest` pass
- [ ] `./gradlew ktfmtCheckAll` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_0197pgjb3LE9hWV5tda1CvwB)_