### PR TITLE
feat(daemon): add navigation script-event extension (deep link, back, predictive back)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -484,6 +484,50 @@ internal constructor(
     return replyApplied.get()
   }
 
+  /**
+   * Override of [InteractiveSession.dispatchNavigation]. Enqueues a
+   * [InteractiveCommand.DispatchNavigation] envelope; the sandbox-side loop in
+   * [RobolectricHost.SandboxRunner.runHeldInteractiveSession] resolves the wire-name string to
+   * either an `Activity.startActivity` call (for `deepLink`) or an `OnBackPressedDispatcher`
+   * method (for `back` / `predictiveBack*`).
+   *
+   * Returns `true` when the named action fired; `false` when the named [actionKind] isn't
+   * recognised (caller surfaces unsupported evidence). Throws when the action body itself failed.
+   */
+  override fun dispatchNavigation(
+    actionKind: String,
+    deepLinkUri: String?,
+    backProgress: Float?,
+    backEdge: String?,
+  ): Boolean {
+    if (closed) return false
+    lastUsedAtMs.set(System.currentTimeMillis())
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    val replyApplied = AtomicBoolean(false)
+    slot.interactiveCommands.put(
+      InteractiveCommand.DispatchNavigation(
+        streamId = streamId,
+        actionKind = actionKind,
+        deepLinkUri = deepLinkUri,
+        backProgress = backProgress,
+        backEdge = backEdge,
+        replyLatch = replyLatch,
+        replyError = replyError,
+        replyApplied = replyApplied,
+      )
+    )
+    if (!replyLatch.await(DISPATCH_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+      error(
+        "AndroidInteractiveSession.dispatchNavigation timed out after " +
+          "${DISPATCH_TIMEOUT_SEC}s for stream '$streamId' (actionKind=$actionKind). " +
+          "Held-rule loop may be stuck."
+      )
+    }
+    replyError.get()?.let { throw it }
+    return replyApplied.get()
+  }
+
   override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {
     check(!closed) { "AndroidInteractiveSession.render() called after close()" }
     val nowMs = System.currentTimeMillis()

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -308,6 +308,15 @@ class AndroidRecordingSession(
         put(LifecycleRecordingScriptEvents.LIFECYCLE_PAUSE_EVENT, lifecycleEventHandler("pause"))
         put(LifecycleRecordingScriptEvents.LIFECYCLE_RESUME_EVENT, lifecycleEventHandler("resume"))
         put(LifecycleRecordingScriptEvents.LIFECYCLE_STOP_EVENT, lifecycleEventHandler("stop"))
+        // Navigation dispatch — deep-link Intent + back / predictive-back gestures. Each
+        // `navigation.<actionKind>` id pre-binds the wire-name string at registration time and
+        // routes through `interactive.dispatchNavigation(...)` → `Activity.startActivity` /
+        // `OnBackPressedDispatcher.*`. See [NavigationRecordingScriptEvents] for the descriptor
+        // + payload mapping.
+        for (id in NavigationRecordingScriptEvents.WIRED_EVENTS) {
+          val actionKind = id.removePrefix("navigation.")
+          put(id, navigationEventHandler(actionKind))
+        }
         // Preview reload — `preview.reload` forces a fresh composition via the held rule's
         // `key(...)` reload counter. See [PreviewReloadRecordingScriptEvents].
         put(PreviewReloadRecordingScriptEvents.PREVIEW_RELOAD_EVENT, previewReloadHandler())
@@ -565,6 +574,44 @@ class AndroidRecordingSession(
           event,
           "host did not apply lifecycle transition '$target'; held composition may be missing " +
             "an ActivityScenario",
+        )
+      }
+    }
+
+  /**
+   * Shared factory for every `navigation.<actionKind>` script event. Pre-binds the wire-name
+   * string at registration time and forwards to `interactive.dispatchNavigation(actionKind, ...)`.
+   * The sandbox-side `when` in [RobolectricHost.SandboxRunner.performNavigationAction] picks the
+   * matching `Activity.startActivity` / `OnBackPressedDispatcher` method.
+   *
+   * Reports `unsupported` (with a specific reason) when `actionKind = "deepLink"` is missing the
+   * `deepLinkUri` field, when the host returned `false` (unknown kind / no held activity), or
+   * when the matched action couldn't fire. Throws (propagating into stop()) only when the action
+   * body itself fails — same shape as the lifecycle / a11y / uia paths.
+   */
+  private fun navigationEventHandler(actionKind: String): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      if (actionKind == "deepLink" && event.deepLinkUri.isNullOrBlank()) {
+        return@RecordingScriptEventHandler unsupportedEvidence(
+          event,
+          "${event.kind} requires a non-blank 'deepLinkUri' to fire as Intent(ACTION_VIEW, …)",
+        )
+      }
+      val applied =
+        interactive.dispatchNavigation(
+          actionKind = actionKind,
+          deepLinkUri = event.deepLinkUri,
+          backProgress = event.backProgress,
+          backEdge = event.backEdge,
+        )
+      if (applied) {
+        appliedEvidence(event, "navigation '$actionKind' fired on the held activity")
+      } else {
+        unsupportedEvidence(
+          event,
+          "host did not apply navigation action '$actionKind'; held composition may be missing " +
+            "an OnBackPressedDispatcher (back / predictive-back) or PackageManager-resolvable " +
+            "intent target (deepLink)",
         )
       }
     }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -407,6 +407,17 @@ fun main(args: Array<String>) {
               dataExtensionDescriptors = UiAutomatorRecordingScriptEvents.descriptors,
             )
           )
+          // Navigation script events (`navigation.deepLink`, `navigation.back`,
+          // `navigation.predictiveBack*`). Always wired on the Android backend — the dispatch
+          // path lives in RobolectricHost.performNavigationAction and exercises the held
+          // activity's `OnBackPressedDispatcher` / `startActivity`.
+          add(
+            Extension(
+              id = NavigationRecordingScriptEvents.EXTENSION_ID,
+              displayName = "Navigation script controls",
+              dataExtensionDescriptors = NavigationRecordingScriptEvents.descriptors,
+            )
+          )
         }
         // host-wired recording-script extensions + renderer-agnostic roadmap descriptors. The
         // host's contribution flips supported flags as new handlers land in its session registry.

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -361,6 +361,13 @@ fun main(args: Array<String>) {
               dataProductRegistry = FontsUsedDataProductRegistry(rootDir = dataRoot),
             )
           )
+          add(
+            Extension(
+              id = "data/navigation",
+              displayName = "Navigation snapshot",
+              dataProductRegistry = NavigationDataProductRegistry(rootDir = dataRoot),
+            )
+          )
           if (composeTraceEnabled) {
             add(
               Extension(

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/NavigationDataProduct.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/NavigationDataProduct.kt
@@ -1,0 +1,235 @@
+package ee.schimke.composeai.daemon
+
+import android.content.Intent
+import androidx.activity.ComponentActivity
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Wire payload for the `data/navigation` data product. Captures the held activity's launch
+ * `Intent` (action / data URI / categories / simple-typed extras) and the registered
+ * back-pressed-callback state — what an agent needs to verify deep-link routing landed and that
+ * the screen wired up an `OnBackPressedCallback` for the predictive-back gesture.
+ *
+ * **Robolectric caveat.** `ActivityScenarioRule<ComponentActivity>` launches the activity with the
+ * default `MAIN`/`LAUNCHER` intent under Robolectric, so production renders typically see
+ * `intent.action = "android.intent.action.MAIN"` and an empty extras bag — the producer ships the
+ * surface anyway, so non-Robolectric backends (or tests that override the launch intent) can
+ * populate it meaningfully without adding a new wire field later.
+ */
+@Serializable
+data class NavigationPayload(
+  val intent: NavigationIntent? = null,
+  val onBackPressed: NavigationBackPressedState,
+)
+
+@Serializable
+data class NavigationIntent(
+  /** Intent action — e.g. `"android.intent.action.VIEW"` for a deep-link Intent. */
+  val action: String? = null,
+  /** Intent data URI as a string — `null` when the intent has no data. */
+  val dataUri: String? = null,
+  /** Explicit MIME type set on the intent, when present. */
+  val type: String? = null,
+  /** ComponentName.flattenToShortString — `pkg/.Activity` form when set explicitly. */
+  val component: String? = null,
+  /** Restricted-package, when [Intent.setPackage] was called. */
+  val packageName: String? = null,
+  /** Bitmask of `Intent.FLAG_*` flags. */
+  val flags: Int = 0,
+  /** Categories added via [Intent.addCategory]. */
+  val categories: List<String> = emptyList(),
+  /**
+   * Extras keyed by string. Only simple types (String, Boolean, Int, Long, Float, Double) make it
+   * across the wire — Parcelables, byte arrays, and nested Bundles are dropped because the JSON
+   * payload would have to inline a Parcelable serialiser, and there's no path to round-trip them
+   * back into an Intent on the agent side. Agents that need to verify a Parcelable extra can use
+   * its `toString()` via a follow-up renderer-side custom check.
+   */
+  val extras: Map<String, JsonElement> = emptyMap(),
+)
+
+@Serializable
+data class NavigationBackPressedState(
+  /**
+   * Mirror of [`androidx.activity.OnBackPressedDispatcher.hasEnabledCallbacks`]. `true` means a
+   * `BackHandler { … }` (Compose) or `OnBackPressedCallback(enabled = true)` (View) has registered
+   * with the activity's dispatcher. When `false`, a back press would fall through to the
+   * activity's default behaviour (finish / pop the task).
+   */
+  val hasEnabledCallbacks: Boolean,
+)
+
+/**
+ * Producer for `data/navigation`. Reads the held activity's `getIntent()` and the
+ * `OnBackPressedDispatcher` state at post-capture time and writes a JSON snapshot next to the
+ * preview's other data products.
+ *
+ * Pure post-capture: the activity reference is threaded through
+ * [RenderDataArtifactContextKeys.HeldActivity] by [RenderEngine]. Mirrors
+ * [I18nTranslationsDataProducer]'s shape (in-module producer + registry; no separate connector
+ * module since navigation is Android-only and there are no shared cross-platform types).
+ */
+object NavigationDataProducer {
+  const val KIND: String = "data/navigation"
+  const val SCHEMA_VERSION: Int = 1
+  const val FILE: String = "navigation.json"
+
+  private val json = Json {
+    encodeDefaults = false
+    prettyPrint = false
+  }
+
+  fun writeArtifacts(rootDir: File, previewId: String, activity: ComponentActivity) {
+    val payload =
+      NavigationPayload(
+        intent = activity.intent?.toWireIntent(),
+        onBackPressed =
+          NavigationBackPressedState(
+            hasEnabledCallbacks = activity.onBackPressedDispatcher.hasEnabledCallbacks()
+          ),
+      )
+    val previewDir = rootDir.resolve(previewId).also { it.mkdirs() }
+    previewDir.resolve(FILE).writeText(json.encodeToString(payload))
+  }
+
+  internal fun Intent.toWireIntent(): NavigationIntent {
+    val keys = extras?.keySet().orEmpty()
+    val wireExtras: Map<String, JsonElement> =
+      if (keys.isEmpty()) emptyMap()
+      else
+        buildMap {
+          for (key in keys) {
+            wireExtraFor(this@toWireIntent, key)?.let { put(key, it) }
+          }
+        }
+    return NavigationIntent(
+      action = action,
+      dataUri = data?.toString(),
+      type = type,
+      component = component?.flattenToShortString(),
+      packageName = `package`,
+      flags = flags,
+      categories = categories?.toList().orEmpty(),
+      extras = wireExtras,
+    )
+  }
+
+  /**
+   * Read one extra from [intent] via its typed `get*Extra` accessor and emit a JSON-compatible
+   * primitive. Goes through the typed accessors instead of a single `Bundle.get(key)` call
+   * because under Robolectric the `Bundle` returned by `Intent.getExtras()` can be in a state
+   * where `keySet()` knows the keys but `Bundle.get(key)` returns null (parcel not fully
+   * materialised on the copy). The typed accessors take a different code path on the original
+   * intent and don't have that hazard.
+   *
+   * Type detection uses two probes per integer / boolean / float type — one with a low sentinel,
+   * one with a high one — so a real value that happens to equal a single sentinel can't be
+   * misclassified. Strings are checked first (`getStringExtra` returns null for any non-string).
+   * Returns `null` for unsupported types (Parcelables, byte arrays, nested Bundles); the data
+   * product deliberately doesn't ship a Parcel serialiser to round-trip them.
+   */
+  private fun wireExtraFor(intent: Intent, key: String): JsonElement? {
+    intent.getStringExtra(key)?.let { return JsonPrimitive(it) }
+    if (probeBoolean(intent, key)) return JsonPrimitive(intent.getBooleanExtra(key, false))
+    if (probeInt(intent, key)) return JsonPrimitive(intent.getIntExtra(key, 0))
+    if (probeLong(intent, key)) return JsonPrimitive(intent.getLongExtra(key, 0L))
+    if (probeFloat(intent, key)) return JsonPrimitive(intent.getFloatExtra(key, 0f))
+    if (probeDouble(intent, key)) return JsonPrimitive(intent.getDoubleExtra(key, 0.0))
+    return null
+  }
+
+  private fun probeBoolean(intent: Intent, key: String): Boolean =
+    intent.getBooleanExtra(key, false) == intent.getBooleanExtra(key, true)
+
+  private fun probeInt(intent: Intent, key: String): Boolean =
+    intent.getIntExtra(key, Int.MIN_VALUE) == intent.getIntExtra(key, Int.MAX_VALUE)
+
+  private fun probeLong(intent: Intent, key: String): Boolean =
+    intent.getLongExtra(key, Long.MIN_VALUE) == intent.getLongExtra(key, Long.MAX_VALUE)
+
+  private fun probeFloat(intent: Intent, key: String): Boolean =
+    intent.getFloatExtra(key, Float.NEGATIVE_INFINITY) ==
+      intent.getFloatExtra(key, Float.POSITIVE_INFINITY)
+
+  private fun probeDouble(intent: Intent, key: String): Boolean =
+    intent.getDoubleExtra(key, Double.NEGATIVE_INFINITY) ==
+      intent.getDoubleExtra(key, Double.POSITIVE_INFINITY)
+}
+
+/** Registry side for `data/navigation`; reads the latest JSON artefact from disk. */
+class NavigationDataProductRegistry(private val rootDir: File) : DataProductRegistry {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = NavigationDataProducer.KIND,
+        schemaVersion = NavigationDataProducer.SCHEMA_VERSION,
+        transport = DataProductTransport.PATH,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      )
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != NavigationDataProducer.KIND) return DataProductRegistry.Outcome.Unknown
+    val file = fileFor(previewId)
+    if (!file.exists()) return DataProductRegistry.Outcome.NotAvailable
+    if (!inline) {
+      return DataProductRegistry.Outcome.Ok(
+        DataFetchResult(
+          kind = kind,
+          schemaVersion = NavigationDataProducer.SCHEMA_VERSION,
+          path = file.absolutePath,
+        )
+      )
+    }
+    val payload: JsonObject =
+      try {
+        json.parseToJsonElement(file.readText()) as JsonObject
+      } catch (t: Throwable) {
+        return DataProductRegistry.Outcome.FetchFailed(
+          message = "could not parse $kind for $previewId: ${t.message}"
+        )
+      }
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(
+        kind = kind,
+        schemaVersion = NavigationDataProducer.SCHEMA_VERSION,
+        payload = payload,
+      )
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (NavigationDataProducer.KIND !in kinds) return emptyList()
+    val file = fileFor(previewId)
+    if (!file.exists()) return emptyList()
+    return listOf(
+      DataProductAttachment(
+        kind = NavigationDataProducer.KIND,
+        schemaVersion = NavigationDataProducer.SCHEMA_VERSION,
+        path = file.absolutePath,
+      )
+    )
+  }
+
+  private fun fileFor(previewId: String): File =
+    rootDir.resolve(previewId).resolve(NavigationDataProducer.FILE)
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/NavigationExtension.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/NavigationExtension.kt
@@ -1,0 +1,47 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+
+/**
+ * Always-on post-capture extension that walks the held [`androidx.activity.ComponentActivity`]
+ * and writes the `data/navigation` artefact for the rendered preview — see
+ * [NavigationDataProducer] for the payload shape and Robolectric caveats.
+ *
+ * Pure post-capture: no Compose-side hook is needed because the activity reference is threaded
+ * through [RenderDataArtifactContextKeys.HeldActivity]. Skips silently when the key isn't
+ * populated (host with no `ComposeTestRule.activity` available — defensive, the production path
+ * always populates it).
+ *
+ * Mirrors the [I18nTranslationsExtension] / [ComposeSemanticsExtension] shape.
+ */
+class NavigationExtension : PostCaptureProcessor {
+  override val id: DataExtensionId = ID
+  override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.AfterCapture)
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(phase = DataExtensionPhase.Capture)
+  override val targets: Set<DataExtensionTarget> = setOf(DataExtensionTarget.Android)
+
+  override fun process(context: ExtensionPostCaptureContext) {
+    val rootDir = context.require(RenderDataArtifactContextKeys.RootDir)
+    val outputBaseName = context.require(RenderDataArtifactContextKeys.OutputBaseName)
+    val activity = context.get(RenderDataArtifactContextKeys.HeldActivity) ?: return
+    NavigationDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = outputBaseName,
+      activity = activity,
+    )
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId(NavigationDataProducer.KIND)
+
+    val factory: RenderDataArtifactExtensionFactory =
+      RenderDataArtifactExtensionFactory { _ -> NavigationExtension() }
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/NavigationRecordingScriptEvents.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/NavigationRecordingScriptEvents.kt
@@ -1,0 +1,149 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescriptor
+
+/**
+ * Navigation-driven `record_preview` script events — deep-link routing and predictive-back gesture
+ * audits, dispatched against the held [`androidx.activity.ComponentActivity`]'s
+ * `onBackPressedDispatcher` (back / predictive-back) and `startActivity` (deep-link).
+ *
+ * Six event ids:
+ *
+ * - `navigation.deepLink` — fires `Intent(ACTION_VIEW, Uri.parse(deepLinkUri))` at the held
+ *   activity, exercising the consumer's intent-filter / `NavController` deep-link routing. The URI
+ *   travels on the wire as `RecordingScriptEvent.deepLinkUri`.
+ * - `navigation.back` — calls `OnBackPressedDispatcher.onBackPressed()` (no payload). Mirrors the
+ *   instant back press that pre-API-34 devices deliver.
+ * - `navigation.predictiveBackStarted` — drives `dispatchOnBackStarted(BackEventCompat)`. The wire
+ *   `backProgress` (0.0–1.0) and `backEdge` (`"left"` / `"right"`) populate the synthesised
+ *   `BackEventCompat`.
+ * - `navigation.predictiveBackProgressed` — drives `dispatchOnBackProgressed(BackEventCompat)`.
+ *   Same payload shape as `predictiveBackStarted`; emit one per animation frame to drive
+ *   progress-bound animations.
+ * - `navigation.predictiveBackCommitted` — calls `onBackPressed()` to commit the gesture (no
+ *   payload). Use after a `predictiveBackStarted` + N `predictiveBackProgressed` to land the back
+ *   stack pop.
+ * - `navigation.predictiveBackCancelled` — drives `dispatchOnBackCancelled()` (no payload). Use
+ *   to verify the screen restores cleanly when the gesture is abandoned.
+ *
+ * **Why per-id discrimination instead of one `navigation.event` with an `actionKind` payload.**
+ * Per-id ids let the MCP validator reject unknown actions at the kind level (no special payload
+ * check needed), make the surface self-documenting in `list_data_products`, and align with
+ * `lifecycle.*` / `state.*` / `preview.*` / `a11y.action.*` shapes — every other extension uses
+ * kind-level discrimination.
+ *
+ * Why this lives in `:daemon:android` (mirroring [LifecycleRecordingScriptEvents] /
+ * [PreviewReloadRecordingScriptEvents]) and not in a separate `:data-navigation-connector`
+ * module: navigation has no data products (no per-render JSON / overlay PNG), just dispatch arms
+ * in [RobolectricHost.SandboxRunner.performNavigationAction]. The connector pattern's value is
+ * shipping a separate matcher / overlay artefact across the daemon bridge — there's nothing of
+ * that shape here.
+ */
+object NavigationRecordingScriptEvents {
+
+  const val EXTENSION_ID: String = "navigation"
+
+  /** `navigation.deepLink` → `Intent(ACTION_VIEW, Uri.parse(event.deepLinkUri))`. */
+  const val NAV_DEEP_LINK_EVENT: String = "navigation.deepLink"
+
+  /** `navigation.back` → `OnBackPressedDispatcher.onBackPressed()`. */
+  const val NAV_BACK_EVENT: String = "navigation.back"
+
+  /**
+   * `navigation.predictiveBackStarted` → `dispatchOnBackStarted(BackEventCompat)` with the wire
+   * `backProgress` / `backEdge` payload.
+   */
+  const val NAV_PREDICTIVE_BACK_STARTED_EVENT: String = "navigation.predictiveBackStarted"
+
+  /**
+   * `navigation.predictiveBackProgressed` → `dispatchOnBackProgressed(BackEventCompat)`. Emit one
+   * per animation frame to drive progress-bound animations.
+   */
+  const val NAV_PREDICTIVE_BACK_PROGRESSED_EVENT: String = "navigation.predictiveBackProgressed"
+
+  /** `navigation.predictiveBackCommitted` → `OnBackPressedDispatcher.onBackPressed()`. */
+  const val NAV_PREDICTIVE_BACK_COMMITTED_EVENT: String = "navigation.predictiveBackCommitted"
+
+  /** `navigation.predictiveBackCancelled` → `dispatchOnBackCancelled()`. */
+  const val NAV_PREDICTIVE_BACK_CANCELLED_EVENT: String = "navigation.predictiveBackCancelled"
+
+  /** Wired event ids registered in `AndroidRecordingSession`'s handler block. */
+  val WIRED_EVENTS: List<String> =
+    listOf(
+      NAV_DEEP_LINK_EVENT,
+      NAV_BACK_EVENT,
+      NAV_PREDICTIVE_BACK_STARTED_EVENT,
+      NAV_PREDICTIVE_BACK_PROGRESSED_EVENT,
+      NAV_PREDICTIVE_BACK_COMMITTED_EVENT,
+      NAV_PREDICTIVE_BACK_CANCELLED_EVENT,
+    )
+
+  val descriptor: DataExtensionDescriptor =
+    DataExtensionDescriptor(
+      id = DataExtensionId(EXTENSION_ID),
+      displayName = "Navigation script controls",
+      recordingScriptEvents =
+        listOf(
+          RecordingScriptEventDescriptor(
+            id = NAV_DEEP_LINK_EVENT,
+            displayName = "Deep-link",
+            summary =
+              "Fires Intent(ACTION_VIEW, Uri.parse(event.deepLinkUri)) at the held activity. " +
+                "The intent is constrained to the activity's own package so unrelated resolvers " +
+                "don't intercept it. Use to audit the consumer's intent-filter / " +
+                "`NavController.navigate(deepLink)` routing without a real device.",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = NAV_BACK_EVENT,
+            displayName = "Back press",
+            summary =
+              "Calls OnBackPressedDispatcher.onBackPressed() on the held activity — the same " +
+                "path a pre-API-34 hardware back button takes. Use to verify a back-stack pop, " +
+                "an `OnBackPressedCallback` registration, or a `popBackStack()` from a Compose " +
+                "screen.",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = NAV_PREDICTIVE_BACK_STARTED_EVENT,
+            displayName = "Predictive back — start",
+            summary =
+              "Drives OnBackPressedDispatcher.dispatchOnBackStarted(BackEventCompat) with the " +
+                "wire `backProgress` (0.0–1.0) and `backEdge` (`left`/`right`) payload. Use as " +
+                "the first event in a predictive-back gesture sequence.",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = NAV_PREDICTIVE_BACK_PROGRESSED_EVENT,
+            displayName = "Predictive back — progress",
+            summary =
+              "Drives dispatchOnBackProgressed(BackEventCompat) — emit one per animation frame " +
+                "between `predictiveBackStarted` and a terminal `predictiveBackCommitted` / " +
+                "`predictiveBackCancelled` so progress-bound animations record their full curve.",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = NAV_PREDICTIVE_BACK_COMMITTED_EVENT,
+            displayName = "Predictive back — commit",
+            summary =
+              "Lands the predictive-back gesture by calling onBackPressed() — the same call the " +
+                "instant `navigation.back` event uses, but emitted after a started/progressed " +
+                "sequence so observers see the gesture commit rather than a cold back press.",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = NAV_PREDICTIVE_BACK_CANCELLED_EVENT,
+            displayName = "Predictive back — cancel",
+            summary =
+              "Drives dispatchOnBackCancelled() to abandon the in-flight gesture. Use to verify " +
+                "the screen restores cleanly when the user lets go before committing.",
+            supported = true,
+          ),
+        ),
+    )
+
+  /** Convenience for the host's `recordingScriptEventDescriptors()` override. */
+  val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderDataArtifactExtensions.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderDataArtifactExtensions.kt
@@ -72,6 +72,19 @@ object RenderDataArtifactContextKeys {
     )
 
   /**
+   * The held [`androidx.activity.ComponentActivity`] the rule launched for this render. Threaded
+   * to extensions that read activity-scoped state — `getIntent()` (deep-link routing audits),
+   * `onBackPressedDispatcher.hasEnabledCallbacks()` (registered back callbacks). Robolectric's
+   * `ActivityScenario` boots the activity with a default `MAIN`/`LAUNCHER` Intent and no extras,
+   * so production renders typically see an empty intent — extensions handle that gracefully.
+   */
+  val HeldActivity: ExtensionContextKey<androidx.activity.ComponentActivity> =
+    ExtensionContextKey(
+      name = "render-data-artifact.heldActivity",
+      type = androidx.activity.ComponentActivity::class.java,
+    )
+
+  /**
    * Pre-built [PreviewContext] for the layout-inspector data product. Carries the
    * captured slot tables, semantics root, device dimensions, and render-mode metadata that
    * `LayoutInspectorDataProducer.writeArtifacts` consumes — assembled once by the render engine

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -363,6 +363,7 @@ class RenderEngine(
                 resolvedSemanticsRoot?.let {
                   add(RenderDataArtifactContextKeys.SemanticsRoot provides it)
                 }
+                add(RenderDataArtifactContextKeys.HeldActivity provides rule.activity)
                 layoutInspectorPreviewContext?.let {
                   add(RenderDataArtifactContextKeys.LayoutInspectorPreviewContext provides it)
                 }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -204,6 +204,8 @@ open class RobolectricHost(
    * - `input.keyboard` (renderer-agnostic) — roadmap on every host; key dispatch isn't wired.
    * - `input.rsb` (Android-only) — rotary side-button scroll on Wear previews.
    * - `lifecycle.{pause,resume,stop}` (Android-only) — `ActivityScenario.moveToState(...)`.
+   * - `navigation.{deepLink,back,predictiveBack*}` (Android-only) — `Activity.startActivity` for
+   *   deep-link routing audits, `OnBackPressedDispatcher` for back / predictive-back gestures.
    * - `preview.reload` (Android-only today) — forces a fresh composition via the held rule's
    *   `key(...)` reload counter.
    * - `state.{recreate,save,restore}` (Android-only today) — Compose-level save/restore via the
@@ -223,6 +225,7 @@ open class RobolectricHost(
         InputKeyboardRecordingScriptEvents.descriptor,
         InputRsbRecordingScriptEvents.descriptor,
         LifecycleRecordingScriptEvents.descriptor,
+        NavigationRecordingScriptEvents.descriptor,
         PreviewReloadRecordingScriptEvents.descriptor,
         StateRecordingScriptEvents.descriptor,
       )
@@ -1849,6 +1852,24 @@ open class RobolectricHost(
                     cmd.replyLatch.countDown()
                   }
                 }
+                is InteractiveCommand.DispatchNavigation -> {
+                  try {
+                    val applied = performNavigationAction(rule, cmd)
+                    cmd.replyApplied.set(applied)
+                    if (applied) {
+                      // Same settle window the lifecycle / a11y / uia paths use — observers
+                      // hooked into the back-progress flow, recompositions triggered by a
+                      // popBackStack(), or an Activity launched by the deep-link Intent need a
+                      // clock tick to flush before subsequent renders observe the new state.
+                      rule.mainClock.advanceTimeBy(POINTER_MOVE_MS)
+                      rule.waitForIdle()
+                    }
+                  } catch (t: Throwable) {
+                    cmd.replyError.set(t)
+                  } finally {
+                    cmd.replyLatch.countDown()
+                  }
+                }
                 is InteractiveCommand.Close -> {
                   cmd.replyLatch.countDown()
                   return
@@ -2125,6 +2146,90 @@ open class RobolectricHost(
           as androidx.test.ext.junit.rules.ActivityScenarioRule<androidx.activity.ComponentActivity>
       activityRule.scenario.moveToState(target)
       return true
+    }
+
+    /**
+     * Sandbox-side dispatch for `navigation.*` script events. `deepLink` fires
+     * `Intent(ACTION_VIEW, Uri.parse(uri))` at the held activity (intent-filter / NavController
+     * deep-link routing); `back` calls the activity's `onBackPressedDispatcher.onBackPressed()`;
+     * the four predictive-back kinds drive the matching `OnBackPressedDispatcher` dispatcher
+     * methods with a synthesised `BackEventCompat` so animation observers see the same shape an
+     * on-device gesture emits. Unknown kinds yield `false` so the caller can surface a precise
+     * unsupported reason.
+     */
+    private fun performNavigationAction(
+      rule:
+        androidx.compose.ui.test.junit4.AndroidComposeTestRule<
+          *,
+          androidx.activity.ComponentActivity,
+        >,
+      cmd: InteractiveCommand.DispatchNavigation,
+    ): Boolean {
+      val activity = rule.activity
+      return when (cmd.actionKind) {
+        "deepLink" -> {
+          val uri = cmd.deepLinkUri ?: return false
+          if (uri.isBlank()) return false
+          val parsed = android.net.Uri.parse(uri)
+          val intent =
+            android.content.Intent(android.content.Intent.ACTION_VIEW, parsed).apply {
+              setPackage(activity.packageName)
+              addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+          rule.runOnUiThread { activity.startActivity(intent) }
+          true
+        }
+        "back" -> {
+          rule.runOnUiThread { activity.onBackPressedDispatcher.onBackPressed() }
+          true
+        }
+        "predictiveBackStarted" -> {
+          val event = synthesizeBackEvent(cmd)
+          rule.runOnUiThread { activity.onBackPressedDispatcher.dispatchOnBackStarted(event) }
+          true
+        }
+        "predictiveBackProgressed" -> {
+          val event = synthesizeBackEvent(cmd)
+          rule.runOnUiThread { activity.onBackPressedDispatcher.dispatchOnBackProgressed(event) }
+          true
+        }
+        "predictiveBackCommitted" -> {
+          // Commit phase mirrors a real predictive-back gesture's terminal step: the dispatcher
+          // doesn't expose a separate "complete" entry point — `onBackPressed()` is what callers
+          // run after the start/progress flow to commit.
+          rule.runOnUiThread { activity.onBackPressedDispatcher.onBackPressed() }
+          true
+        }
+        "predictiveBackCancelled" -> {
+          rule.runOnUiThread { activity.onBackPressedDispatcher.dispatchOnBackCancelled() }
+          true
+        }
+        else -> false
+      }
+    }
+
+    /**
+     * Build a [`androidx.activity.BackEventCompat`] for `predictiveBackStarted` /
+     * `predictiveBackProgressed`. `touchX` / `touchY` default to 0 because the on-device gesture's
+     * absolute pointer position is rarely what observers care about — `progress` and `swipeEdge`
+     * drive the animation bindings shipped via `LocalOnBackPressedDispatcherOwner`. Edge defaults
+     * to `EDGE_LEFT` (the dominant on-device shape) when the agent leaves it unset.
+     */
+    private fun synthesizeBackEvent(
+      cmd: InteractiveCommand.DispatchNavigation
+    ): androidx.activity.BackEventCompat {
+      val edge =
+        when (cmd.backEdge?.lowercase()) {
+          "right" -> androidx.activity.BackEventCompat.EDGE_RIGHT
+          else -> androidx.activity.BackEventCompat.EDGE_LEFT
+        }
+      val progress = cmd.backProgress?.coerceIn(0f, 1f) ?: 0f
+      return androidx.activity.BackEventCompat(
+        touchX = 0f,
+        touchY = 0f,
+        progress = progress,
+        swipeEdge = edge,
+      )
     }
 
     /**

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1174,6 +1174,7 @@ open class RobolectricHost(
               ComposeSemanticsExtension.factory,
               LayoutInspectorExtension.factory,
               I18nTranslationsExtension.factory,
+              NavigationExtension.factory,
             )
           ),
       )

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -600,4 +600,35 @@ sealed interface InteractiveCommand {
     val replyError: AtomicReference<Throwable?>,
     val replyApplied: AtomicBoolean,
   ) : InteractiveCommand
+
+  /**
+   * Navigation dispatch: fire a deep-link Intent at the held activity, an instant back press, or
+   * one phase of a predictive-back gesture. Used by `record_preview`'s `navigation.*` script
+   * events (deep-link routing audits, back-stack pop verification, predictive-back animation
+   * audits).
+   *
+   * [actionKind] is a short wire name — `"deepLink"`, `"back"`, `"predictiveBackStarted"`,
+   * `"predictiveBackProgressed"`, `"predictiveBackCommitted"`, `"predictiveBackCancelled"`. The
+   * sandbox-side handler maps each to the corresponding `Activity.startActivity` /
+   * `OnBackPressedDispatcher` method. Unknown names set [replyApplied] to `false` so the caller
+   * can emit a precise unsupported reason.
+   *
+   * Strings travel as `java.lang.String` (do-not-acquire). Floats are primitives. No
+   * `BackEventCompat` / `Intent` types cross the bridge — the sandbox owns the construction
+   * internally.
+   *
+   * [deepLinkUri] is populated only for `actionKind = "deepLink"` and ignored otherwise.
+   * [backProgress] / [backEdge] populate the `BackEventCompat` for the predictive-back start /
+   * progress phases; ignored for `back` / `predictiveBackCommitted` / `predictiveBackCancelled`.
+   */
+  data class DispatchNavigation(
+    override val streamId: String,
+    val actionKind: String,
+    val deepLinkUri: String?,
+    val backProgress: Float?,
+    val backEdge: String?,
+    val replyLatch: CountDownLatch,
+    val replyError: AtomicReference<Throwable?>,
+    val replyApplied: AtomicBoolean,
+  ) : InteractiveCommand
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -775,6 +775,197 @@ class AndroidRecordingSessionTest {
   }
 
   @Test
+  fun navigationEventsRouteThroughDispatchNavigation() {
+    // Pin every wired navigation id (`navigation.deepLink` / `navigation.back` /
+    // `navigation.predictiveBack{Started,Progressed,Committed,Cancelled}`): each registry entry
+    // pre-binds its action-kind at registration time, strips the `navigation.` prefix, and
+    // forwards through `interactive.dispatchNavigation(actionKind, ...)`. Payload fields ride
+    // through unchanged.
+    val framesDir = tempFolder.newFolder("navigation-frames")
+    val encodedDir = tempFolder.newFolder("navigation-encoded")
+    val sourcePng = File(tempFolder.newFolder("navigation-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng).apply { navigationResult = true }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-navigation",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      val events =
+        listOf(
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = NavigationRecordingScriptEvents.NAV_DEEP_LINK_EVENT,
+            deepLinkUri = "app://route/home",
+          ),
+          RecordingScriptEvent(tMs = 0L, kind = NavigationRecordingScriptEvents.NAV_BACK_EVENT),
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = NavigationRecordingScriptEvents.NAV_PREDICTIVE_BACK_STARTED_EVENT,
+            backProgress = 0.1f,
+            backEdge = "left",
+          ),
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = NavigationRecordingScriptEvents.NAV_PREDICTIVE_BACK_PROGRESSED_EVENT,
+            backProgress = 0.5f,
+            backEdge = "right",
+          ),
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = NavigationRecordingScriptEvents.NAV_PREDICTIVE_BACK_COMMITTED_EVENT,
+          ),
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = NavigationRecordingScriptEvents.NAV_PREDICTIVE_BACK_CANCELLED_EVENT,
+          ),
+        )
+      session.postScript(events)
+      val result = session.stop()
+
+      assertEquals(
+        "the registry must route navigation.* through dispatchNavigation, not pointer dispatch",
+        0,
+        interactive.dispatchCount,
+      )
+      assertEquals(
+        listOf(
+          RecordingDeltaSession.NavigationCall("deepLink", "app://route/home", null, null),
+          RecordingDeltaSession.NavigationCall("back", null, null, null),
+          RecordingDeltaSession.NavigationCall("predictiveBackStarted", null, 0.1f, "left"),
+          RecordingDeltaSession.NavigationCall("predictiveBackProgressed", null, 0.5f, "right"),
+          RecordingDeltaSession.NavigationCall("predictiveBackCommitted", null, null, null),
+          RecordingDeltaSession.NavigationCall("predictiveBackCancelled", null, null, null),
+        ),
+        interactive.navigationCalls,
+      )
+      assertEquals(events.size, result.scriptEvents.size)
+      result.scriptEvents.forEach { evidence ->
+        assertEquals(
+          "evidence for ${evidence.kind} must be applied",
+          ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
+          evidence.status,
+        )
+      }
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
+  fun navigationDeepLinkReportsUnsupportedWhenUriIsBlank() {
+    // navigation.deepLink without a deepLinkUri is rejected up front by the handler — the agent
+    // sees a precise unsupported reason instead of a silent no-op intent dispatch.
+    val framesDir = tempFolder.newFolder("navigation-blank-frames")
+    val encodedDir = tempFolder.newFolder("navigation-blank-encoded")
+    val sourcePng = File(tempFolder.newFolder("navigation-blank-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng).apply { navigationResult = true }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-navigation-blank",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = NavigationRecordingScriptEvents.NAV_DEEP_LINK_EVENT,
+            deepLinkUri = "",
+          )
+        )
+      )
+      val result = session.stop()
+
+      assertTrue(
+        "blank deepLinkUri must short-circuit before reaching dispatchNavigation",
+        interactive.navigationCalls.isEmpty(),
+      )
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
+        result.scriptEvents[0].status,
+      )
+      val message = result.scriptEvents[0].message ?: ""
+      assertTrue(
+        "miss diagnostic must mention the deepLinkUri requirement; got '$message'",
+        message.contains("deepLinkUri"),
+      )
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
+  fun navigationReportsUnsupportedWhenHostCannotDispatch() {
+    // When `dispatchNavigation` returns false (e.g. host has no held activity), the handler
+    // surfaces a specific unsupported reason naming the action kind.
+    val framesDir = tempFolder.newFolder("navigation-miss-frames")
+    val encodedDir = tempFolder.newFolder("navigation-miss-encoded")
+    val sourcePng = File(tempFolder.newFolder("navigation-miss-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng).apply { navigationResult = false }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-navigation-miss",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(
+          RecordingScriptEvent(tMs = 0L, kind = NavigationRecordingScriptEvents.NAV_BACK_EVENT)
+        )
+      )
+      val result = session.stop()
+
+      assertEquals(1, interactive.navigationCalls.size)
+      assertEquals("back", interactive.navigationCalls.single().actionKind)
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
+        result.scriptEvents[0].status,
+      )
+      val message = result.scriptEvents[0].message ?: ""
+      assertTrue(
+        "miss diagnostic must mention the action kind; got '$message'",
+        message.contains("'back'"),
+      )
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
   fun stateSaveRoutesThroughDispatchStateSave() {
     val framesDir = tempFolder.newFolder("state-save-frames")
     val encodedDir = tempFolder.newFolder("state-save-encoded")
@@ -1410,6 +1601,34 @@ class AndroidRecordingSessionTest {
       stateRestoreCalls += checkpointId
       val override = stateRestoreResult
       return override ?: super.dispatchStateRestore(checkpointId)
+    }
+
+    data class NavigationCall(
+      val actionKind: String,
+      val deepLinkUri: String?,
+      val backProgress: Float?,
+      val backEdge: String?,
+    )
+
+    val navigationCalls = mutableListOf<NavigationCall>()
+
+    /**
+     * When non-null, [dispatchNavigation] returns this value verbatim and records the call into
+     * [navigationCalls]. When null (the default), the inherited interface-level default
+     * (`return false`) is used so existing tests don't have to opt in.
+     */
+    var navigationResult: Boolean? = null
+
+    override fun dispatchNavigation(
+      actionKind: String,
+      deepLinkUri: String?,
+      backProgress: Float?,
+      backEdge: String?,
+    ): Boolean {
+      navigationCalls += NavigationCall(actionKind, deepLinkUri, backProgress, backEdge)
+      val override = navigationResult
+      return override
+        ?: super.dispatchNavigation(actionKind, deepLinkUri, backProgress, backEdge)
     }
 
     override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/NavigationDataProductRegistryTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/NavigationDataProductRegistryTest.kt
@@ -1,0 +1,131 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import java.nio.file.Files
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins [NavigationDataProductRegistry] — the registry side of the `data/navigation` data product.
+ * Plain JUnit (no Robolectric) because the registry only reads JSON off disk; the producer side
+ * is exercised in [NavigationDataProductTest] which boots a real `ComponentActivity`.
+ */
+class NavigationDataProductRegistryTest {
+  private lateinit var rootDir: File
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("navigation-product-test").toFile()
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+  }
+
+  @Test
+  fun `capability advertises data slash navigation as path transport`() {
+    val registry = NavigationDataProductRegistry(rootDir)
+    val cap = registry.capabilities.single()
+    assertEquals("data/navigation", cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertTrue(!cap.requiresRerender)
+  }
+
+  @Test
+  fun `fetch returns path by default and payload when inline requested`() {
+    val previewId = "com.example.NavPreview"
+    val file =
+      rootDir
+        .resolve(previewId)
+        .also { it.mkdirs() }
+        .resolve(NavigationDataProducer.FILE)
+    file.writeText(
+      """{"intent":{"action":"android.intent.action.VIEW","dataUri":"app://route/home"},"onBackPressed":{"hasEnabledCallbacks":true}}"""
+    )
+    val registry = NavigationDataProductRegistry(rootDir)
+
+    val pathOutcome =
+      registry.fetch(
+        previewId = previewId,
+        kind = "data/navigation",
+        params = null,
+        inline = false,
+      )
+    assertTrue(pathOutcome is DataProductRegistry.Outcome.Ok)
+    val pathResult = (pathOutcome as DataProductRegistry.Outcome.Ok).result
+    assertEquals(file.absolutePath, pathResult.path)
+    assertNull(pathResult.payload)
+
+    val inlineOutcome =
+      registry.fetch(
+        previewId = previewId,
+        kind = "data/navigation",
+        params = null,
+        inline = true,
+      )
+    assertTrue(inlineOutcome is DataProductRegistry.Outcome.Ok)
+    val inlineResult = (inlineOutcome as DataProductRegistry.Outcome.Ok).result
+    assertNull(inlineResult.path)
+    assertNotNull(inlineResult.payload)
+    assertEquals(
+      "app://route/home",
+      inlineResult.payload!!.jsonObject["intent"]!!.jsonObject["dataUri"]!!.jsonPrimitive.content,
+    )
+  }
+
+  @Test
+  fun `fetch returns NotAvailable when the artefact is missing`() {
+    val registry = NavigationDataProductRegistry(rootDir)
+    val outcome =
+      registry.fetch(
+        previewId = "missing-preview",
+        kind = "data/navigation",
+        params = null,
+        inline = false,
+      )
+    assertTrue(outcome is DataProductRegistry.Outcome.NotAvailable)
+  }
+
+  @Test
+  fun `fetch returns Unknown for foreign kinds`() {
+    val registry = NavigationDataProductRegistry(rootDir)
+    val outcome =
+      registry.fetch(
+        previewId = "irrelevant",
+        kind = "compose/semantics",
+        params = null,
+        inline = false,
+      )
+    assertTrue(outcome is DataProductRegistry.Outcome.Unknown)
+  }
+
+  @Test
+  fun `attachmentsFor returns the artefact path when the kind is requested`() {
+    val previewId = "preview-attached"
+    val file =
+      rootDir
+        .resolve(previewId)
+        .also { it.mkdirs() }
+        .resolve(NavigationDataProducer.FILE)
+    file.writeText("""{"onBackPressed":{"hasEnabledCallbacks":false}}""")
+    val registry = NavigationDataProductRegistry(rootDir)
+
+    val attachments = registry.attachmentsFor(previewId, setOf("data/navigation"))
+    assertEquals(1, attachments.size)
+    assertEquals(file.absolutePath, attachments.single().path)
+    assertEquals("data/navigation", attachments.single().kind)
+
+    val foreign = registry.attachmentsFor(previewId, setOf("compose/semantics"))
+    assertTrue(foreign.isEmpty())
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/NavigationDataProductTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/NavigationDataProductTest.kt
@@ -1,0 +1,164 @@
+package ee.schimke.composeai.daemon
+
+import android.content.ComponentName
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.OnBackPressedCallback
+import java.nio.file.Files
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Producer-side test for the `data/navigation` artefact. Builds a real `ComponentActivity` under
+ * Robolectric so we exercise the genuine `Intent` + `OnBackPressedDispatcher` machinery instead
+ * of a hand-rolled stub.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class NavigationDataProductTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun `producer captures default Robolectric intent and empty back-pressed state`() {
+    val rootDir = Files.createTempDirectory("nav-default").toFile()
+    val controller = Robolectric.buildActivity(ComponentActivity::class.java).setup()
+    try {
+      NavigationDataProducer.writeArtifacts(
+        rootDir = rootDir,
+        previewId = "preview-default",
+        activity = controller.get(),
+      )
+      val payload = readPayload(rootDir, "preview-default")
+      val intent = payload["intent"]!!.jsonObject
+      // Robolectric's ActivityScenario / buildActivity launches with a default Intent — `action`
+      // is null when no explicit action was set on the controller's intent. The artefact still
+      // ships the field so non-Robolectric backends can populate it.
+      assertNull(
+        "default Robolectric intent should expose no action",
+        intent["action"]?.jsonPrimitive?.contentOrNull,
+      )
+      val back = payload["onBackPressed"]!!.jsonObject
+      assertFalse(
+        "no callback registered → hasEnabledCallbacks must be false",
+        back["hasEnabledCallbacks"]!!.jsonPrimitive.boolean,
+      )
+    } finally {
+      controller.close()
+      rootDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `toWireIntent surfaces a deep-link Intent with simple-typed extras`() {
+    // Drive the Intent → wire-shape mapping directly so the test isn't entangled with
+    // ActivityScenario's intent-handling quirks (Robolectric's `buildActivity(cls, intent)` doesn't
+    // always preserve extras through `setup()` — we exercise the field-level mapping here and the
+    // end-to-end activity capture in [NavigationExtensionTest.process writes navigation json…]).
+    val intent =
+      Intent(Intent.ACTION_VIEW, Uri.parse("app://route/profile/42")).apply {
+        addCategory(Intent.CATEGORY_DEFAULT)
+        addCategory(Intent.CATEGORY_BROWSABLE)
+        setPackage("com.example.app")
+        component = ComponentName("com.example.app", "com.example.app.MainActivity")
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        putExtra("user_id", 42)
+        putExtra("show_fab", true)
+        putExtra("source", "notification")
+        putExtra("session_ms", 1_700_000_000_000L)
+        // Parcelable extras must be dropped — round-tripping them through the JSON wire shape
+        // would require a Parcel serialiser the data product deliberately doesn't ship.
+        putExtra("origin_uri", Uri.parse("app://from"))
+      }
+    val wire = with(NavigationDataProducer) { intent.toWireIntent() }
+
+    assertEquals(Intent.ACTION_VIEW, wire.action)
+    assertEquals("app://route/profile/42", wire.dataUri)
+    assertEquals("com.example.app", wire.packageName)
+    assertTrue("component must be present", wire.component!!.contains("MainActivity"))
+    assertTrue(
+      "Default + Browsable categories must travel through",
+      Intent.CATEGORY_DEFAULT in wire.categories && Intent.CATEGORY_BROWSABLE in wire.categories,
+    )
+
+    assertEquals(42, wire.extras["user_id"]!!.jsonPrimitive.intOrNull)
+    assertEquals(true, wire.extras["show_fab"]!!.jsonPrimitive.boolean)
+    assertEquals("notification", wire.extras["source"]!!.jsonPrimitive.contentOrNull)
+    assertEquals(1_700_000_000_000L, wire.extras["session_ms"]!!.jsonPrimitive.longOrNull)
+    assertFalse(
+      "Parcelable extras must be dropped — only simple types cross the wire",
+      "origin_uri" in wire.extras,
+    )
+  }
+
+  @Test
+  fun `producer reports hasEnabledCallbacks when a BackHandler-style callback is registered`() {
+    val rootDir = Files.createTempDirectory("nav-back").toFile()
+    val controller = Robolectric.buildActivity(ComponentActivity::class.java).setup()
+    try {
+      val callback =
+        object : OnBackPressedCallback(/* enabled = */ true) {
+          override fun handleOnBackPressed() {
+            // no-op — we only care that the dispatcher reports the callback.
+          }
+        }
+      controller.get().onBackPressedDispatcher.addCallback(callback)
+      NavigationDataProducer.writeArtifacts(
+        rootDir = rootDir,
+        previewId = "preview-back",
+        activity = controller.get(),
+      )
+      val payload = readPayload(rootDir, "preview-back")
+      val back = payload["onBackPressed"]!!.jsonObject
+      assertTrue(
+        "an enabled OnBackPressedCallback must surface as hasEnabledCallbacks=true",
+        back["hasEnabledCallbacks"]!!.jsonPrimitive.boolean,
+      )
+    } finally {
+      controller.close()
+      rootDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `toWireIntent drops bundle extras whose value type isn't a simple primitive or string`() {
+    // Cross-check the `else -> continue` arm in the producer: a custom-type extra (here an
+    // IntArray and a nested Bundle, but the same applies to byte arrays and Parcelables) must
+    // not appear in the payload, while sibling string / boolean extras stay.
+    val intent =
+      Intent().apply {
+        putExtra("flag", true)
+        putExtra("ints", intArrayOf(1, 2, 3))
+        putExtra("nested", Bundle().apply { putString("inner", "v") })
+        putExtra("name", "rendered")
+      }
+    val wire = with(NavigationDataProducer) { intent.toWireIntent() }
+    assertEquals(true, wire.extras["flag"]!!.jsonPrimitive.boolean)
+    assertEquals("rendered", wire.extras["name"]!!.jsonPrimitive.contentOrNull)
+    assertFalse("IntArray extras must be skipped", "ints" in wire.extras)
+    assertFalse("nested Bundle extras must be skipped", "nested" in wire.extras)
+  }
+
+  private fun readPayload(rootDir: java.io.File, previewId: String): JsonObject {
+    val file = rootDir.resolve(previewId).resolve(NavigationDataProducer.FILE)
+    assertTrue("navigation.json should exist for $previewId", file.exists())
+    return json.parseToJsonElement(file.readText()).jsonObject
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/NavigationExtensionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/NavigationExtensionTest.kt
@@ -1,0 +1,110 @@
+package ee.schimke.composeai.daemon
+
+import androidx.activity.ComponentActivity
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.provides
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Pins [NavigationExtension] — the Android-only post-capture extension that emits the
+ * `data/navigation` artefact for the rendered preview.
+ *
+ * Robolectric is required because `process()` writes a real `Intent` + `OnBackPressedDispatcher`
+ * snapshot; the activity is built with `Robolectric.buildActivity(ComponentActivity::class)` so we
+ * exercise the same code path the production held-rule loop hits.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class NavigationExtensionTest {
+
+  @Test
+  fun `extension declares after-capture hook only`() {
+    val extension = NavigationExtension()
+    assertEquals("data/navigation", extension.id.value)
+    assertEquals(setOf(DataExtensionHookKind.AfterCapture), extension.hooks)
+    assertEquals(DataExtensionPhase.Capture, extension.constraints.phase)
+    assertEquals(setOf(DataExtensionTarget.Android), extension.targets)
+  }
+
+  @Test
+  fun `process skips silently when the held activity is missing`() {
+    // Defensive: hosts that don't carry a held activity (a hypothetical desktop-on-Android target)
+    // shouldn't strand the post-capture pass with an IllegalStateException — the extension just
+    // emits no artefact and lets `attachmentsFor` see a missing file. Mirrors the I18n / Compose
+    // semantics extensions which DO require their key — the difference is intentional.
+    val extension = NavigationExtension()
+    val rootDir = Files.createTempDirectory("navigation-extension-test").toFile()
+    try {
+      val store = RecordingDataProductStore()
+      val context =
+        ExtensionPostCaptureContext(
+          extensionId = extension.id,
+          previewId = null,
+          renderMode = null,
+          products = store.scopedFor(extension),
+          data =
+            ExtensionContextData.of(
+              RenderDataArtifactContextKeys.RootDir provides rootDir,
+              RenderDataArtifactContextKeys.OutputBaseName provides "preview-base",
+            ),
+        )
+      extension.process(context)
+      assertFalse(
+        "no navigation.json must be written when the activity context key is absent",
+        rootDir.resolve("preview-base").resolve("navigation.json").exists(),
+      )
+    } finally {
+      rootDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `process writes navigation json when the held activity is present`() {
+    val extension = NavigationExtension()
+    val rootDir = Files.createTempDirectory("navigation-extension-write-test").toFile()
+    val activityController = Robolectric.buildActivity(ComponentActivity::class.java).setup()
+    try {
+      val store = RecordingDataProductStore()
+      val context =
+        ExtensionPostCaptureContext(
+          extensionId = extension.id,
+          previewId = null,
+          renderMode = null,
+          products = store.scopedFor(extension),
+          data =
+            ExtensionContextData.of(
+              RenderDataArtifactContextKeys.RootDir provides rootDir,
+              RenderDataArtifactContextKeys.OutputBaseName provides "preview-base",
+              RenderDataArtifactContextKeys.HeldActivity provides activityController.get(),
+            ),
+        )
+      extension.process(context)
+
+      val artefact = rootDir.resolve("preview-base").resolve("navigation.json")
+      assertTrue("navigation.json must be written next to the preview", artefact.exists())
+      val body = artefact.readText()
+      assertNotNull("payload must include onBackPressed state", body)
+      assertTrue(
+        "payload must include the hasEnabledCallbacks field",
+        body.contains("hasEnabledCallbacks"),
+      )
+    } finally {
+      activityController.close()
+      rootDir.deleteRecursively()
+    }
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/NavigationRecordingScriptEventsTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/NavigationRecordingScriptEventsTest.kt
@@ -1,0 +1,64 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [NavigationRecordingScriptEvents] — the Android-only navigation script-event descriptor
+ * that `RobolectricHost` advertises from `recordingScriptEventDescriptors()` and that
+ * `DaemonMain` registers as a discoverable extension.
+ *
+ * Each supported action has its own event id (`navigation.deepLink` / `navigation.back` /
+ * `navigation.predictiveBack{Started,Progressed,Committed,Cancelled}`) so the MCP validator can
+ * reject unknown actions at the kind level without a payload-shape branch. Dispatch routing is
+ * pinned in [AndroidRecordingSessionTest]; this test keeps the descriptor side honest.
+ */
+class NavigationRecordingScriptEventsTest {
+
+  @Test
+  fun `descriptor advertises one navigation event id per wired action`() {
+    val descriptor = NavigationRecordingScriptEvents.descriptor
+    assertEquals("navigation", descriptor.id.value)
+    val ids = descriptor.recordingScriptEvents.map { it.id }.toSet()
+    assertEquals(
+      setOf(
+        NavigationRecordingScriptEvents.NAV_DEEP_LINK_EVENT,
+        NavigationRecordingScriptEvents.NAV_BACK_EVENT,
+        NavigationRecordingScriptEvents.NAV_PREDICTIVE_BACK_STARTED_EVENT,
+        NavigationRecordingScriptEvents.NAV_PREDICTIVE_BACK_PROGRESSED_EVENT,
+        NavigationRecordingScriptEvents.NAV_PREDICTIVE_BACK_COMMITTED_EVENT,
+        NavigationRecordingScriptEvents.NAV_PREDICTIVE_BACK_CANCELLED_EVENT,
+      ),
+      ids,
+    )
+    val allSupported = descriptor.recordingScriptEvents.all { it.supported }
+    assertTrue(
+      "every wired navigation event id must advertise supported = true",
+      allSupported,
+    )
+  }
+
+  @Test
+  fun `wired event set covers deep-link back and the four predictive-back phases`() {
+    assertEquals(
+      listOf(
+        "navigation.deepLink",
+        "navigation.back",
+        "navigation.predictiveBackStarted",
+        "navigation.predictiveBackProgressed",
+        "navigation.predictiveBackCommitted",
+        "navigation.predictiveBackCancelled",
+      ),
+      NavigationRecordingScriptEvents.WIRED_EVENTS,
+    )
+  }
+
+  @Test
+  fun `descriptors convenience list wraps the single descriptor`() {
+    assertEquals(
+      listOf(NavigationRecordingScriptEvents.descriptor),
+      NavigationRecordingScriptEvents.descriptors,
+    )
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
@@ -290,6 +290,41 @@ class InteractiveCommandTest {
   }
 
   @Test
+  fun dispatchNavigationRoundTripsThroughTheBridge() {
+    // Pin the cross-classloader contract for the new variant: only `java.*` / primitive types in
+    // the payload, round-trips through `interactiveCommands` by reference (so the host's latch /
+    // atomic refs come back out unchanged for the await pattern).
+    DaemonHostBridge.reset()
+    val slot = DaemonHostBridge.slot(0)
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    val replyApplied = AtomicBoolean(false)
+    val cmd =
+      InteractiveCommand.DispatchNavigation(
+        streamId = "stream-A",
+        actionKind = "deepLink",
+        deepLinkUri = "app://route/home",
+        backProgress = null,
+        backEdge = null,
+        replyLatch = replyLatch,
+        replyError = replyError,
+        replyApplied = replyApplied,
+      )
+    slot.interactiveCommands.put(cmd)
+
+    val drained = slot.interactiveCommands.poll(1, TimeUnit.SECONDS)
+    assertSame("queue must round-trip the same instance, not a copy", cmd, drained)
+    val asNav = drained as InteractiveCommand.DispatchNavigation
+    assertSame(replyLatch, asNav.replyLatch)
+    assertSame(replyError, asNav.replyError)
+    assertSame(replyApplied, asNav.replyApplied)
+    assertEquals("deepLink", asNav.actionKind)
+    assertEquals("app://route/home", asNav.deepLinkUri)
+    assertNull("replyError defaults to null", asNav.replyError.get())
+    assertFalse("replyApplied defaults to false", asNav.replyApplied.get())
+  }
+
+  @Test
   fun dispatchSemanticsActionRoundTripsThroughTheBridge() {
     // Pin the cross-classloader contract for the new variant: only `java.*` types in the payload,
     // round-trips through `interactiveCommands` by reference (so the host's latch / atomic refs

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
@@ -196,6 +196,40 @@ interface InteractiveSession : AutoCloseable {
   fun dispatchStateRestore(checkpointId: String): Boolean = false
 
   /**
+   * Navigation-driven dispatch: fire a deep-link Intent at the held activity, an instant back
+   * press, or one phase of a predictive-back gesture. Used by `record_preview`'s `navigation.*`
+   * script events to exercise the consumer's intent-filter / `NavController` routing and the
+   * predictive-back flow without a real device.
+   *
+   * Returns `true` when the named action fired, `false` when the host doesn't support navigation
+   * dispatch (DesktopHost today) or the named [actionKind] isn't recognised. Throws when the action
+   * body itself failed — same propagation shape as [dispatch] / [dispatchLifecycle].
+   *
+   * Default returns `false` so hosts without an Android `OnBackPressedDispatcher` /
+   * `ActivityScenario` cleanly surface "no navigation dispatch available" instead of blowing up the
+   * session.
+   *
+   * @param actionKind short wire name — `"deepLink"`, `"back"`, `"predictiveBackStarted"`,
+   *   `"predictiveBackProgressed"`, `"predictiveBackCommitted"`, `"predictiveBackCancelled"`. Maps
+   *   to the matching `OnBackPressedDispatcher` method (or `Activity.startActivity` for
+   *   `deepLink`). Unknown kinds yield `false`.
+   * @param deepLinkUri payload for `actionKind = "deepLink"`; routed through
+   *   `Intent(Intent.ACTION_VIEW, Uri.parse(deepLinkUri))`. Ignored for other kinds.
+   * @param backProgress payload for `predictiveBackStarted` / `predictiveBackProgressed` — the
+   *   gesture progress value (0.0–1.0). Forwarded as
+   *   [`androidx.activity.BackEventCompat.progress`]. Ignored for other kinds.
+   * @param backEdge payload for `predictiveBackStarted` / `predictiveBackProgressed` — `"left"`
+   *   (default) or `"right"`. Mapped sandbox-side to
+   *   [`androidx.activity.BackEventCompat.EDGE_LEFT`] / `EDGE_RIGHT`.
+   */
+  fun dispatchNavigation(
+    actionKind: String,
+    deepLinkUri: String? = null,
+    backProgress: Float? = null,
+    backEdge: String? = null,
+  ): Boolean = false
+
+  /**
    * Render the current composition to a PNG and return the result. The implementation runs the
    * scene through enough frames to settle (typically two `scene.render()` calls — same heuristic as
    * the one-shot path) and encodes to disk at a stable path the daemon can publish via

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1233,6 +1233,26 @@ data class RecordingScriptEvent(
    * kinds.
    */
   val inputText: String? = null,
+  /**
+   * Payload for `kind = "navigation.deepLink"`: the URI to fire as `Intent(ACTION_VIEW, …)` at the
+   * held activity, exercising the consumer's intent-filter / NavController deep-link routing.
+   * Ignored for other event kinds.
+   */
+  val deepLinkUri: String? = null,
+  /**
+   * Predictive-back progress value (0.0–1.0) for `navigation.predictiveBackStarted` /
+   * `navigation.predictiveBackProgressed`. Threaded into the synthesised
+   * [`androidx.activity.BackEventCompat`] so animation observers driven by the back-progress flow
+   * see the same shape on-device gestures emit. Ignored for other event kinds.
+   */
+  val backProgress: Float? = null,
+  /**
+   * Predictive-back swipe edge for `navigation.predictiveBackStarted` /
+   * `navigation.predictiveBackProgressed` — `"left"` or `"right"`, mapped sandbox-side to
+   * [`androidx.activity.BackEventCompat.EDGE_LEFT`] / `EDGE_RIGHT`. Defaults to `"left"` when
+   * absent. Ignored for other event kinds.
+   */
+  val backEdge: String? = null,
 )
 
 @Serializable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,13 @@ compose-bom-stable = "2026.04.01"
 compose-bom-compat = "2025.11.01"
 compose-multiplatform = "1.10.3"
 activity-compose = "1.13.0"
+# `androidx.navigation:navigation-compose` — used only by the
+# `:samples:android` NavHost preview that exercises the daemon's
+# `data/navigation` data product (Intent + back-pressed snapshot) and the
+# `navigation.*` script-event surface end-to-end. Activity-compose 1.13's
+# transitive `androidx.navigationevent` floor (see CompatRules.kt) means
+# this stays compatible with the renderer's compileOnly stack.
+navigation-compose = "2.9.7"
 wear-compose = "1.6.1"
 wear-tiles = "1.6.0"
 wear-protolayout = "1.4.0"
@@ -118,6 +125,7 @@ jetbrains-compose-foundation = { module = "org.jetbrains.compose.foundation:foun
 jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
 jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multiplatform" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
+navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
 wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", version.ref = "wear-compose" }
 wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wear-compose" }
 wear-compose-ui-tooling = { module = "androidx.wear.compose:compose-ui-tooling", version.ref = "wear-compose" }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -2997,6 +2997,9 @@ class DaemonMcpServer(
         useUnmergedTree =
           obj["useUnmergedTree"]?.jsonPrimitive?.contentOrNull?.toBooleanStrictOrNull(),
         inputText = obj["inputText"]?.jsonPrimitive?.contentOrNull,
+        deepLinkUri = obj["deepLinkUri"]?.jsonPrimitive?.contentOrNull,
+        backProgress = obj["backProgress"]?.jsonPrimitive?.contentOrNull?.toFloatOrNull(),
+        backEdge = obj["backEdge"]?.jsonPrimitive?.contentOrNull,
       )
     }
   }

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -1129,6 +1129,225 @@ class DaemonMcpServerTest {
   }
 
   @Test
+  fun `MCP exposes data slash navigation snapshot and dispatches navigation deepLink + back`() {
+    // End-to-end exercise of the navigation surface from an MCP-tool perspective:
+    //
+    // 1. The MCP `get_preview_data` tool surfaces the daemon's `data/navigation` data product —
+    //    an agent can read the held activity's launch Intent (action / data URI / simple-typed
+    //    extras) and the registered `OnBackPressedCallback` state for the rendered preview.
+    // 2. The MCP `record_preview` tool forwards `navigation.deepLink` (with a `deepLinkUri`
+    //    payload) and `navigation.back` script events to the daemon's `recording/script` channel,
+    //    proving the wire shape carries the new fields end-to-end (including the
+    //    `decodeRecordingEvents` extension we added in `DaemonMcpServer.kt`).
+    //
+    // The fake daemon advertises the navigation descriptor + a `data/navigation` capability so
+    // the MCP-side validators (script-kind allow-list in `validateRecordingScriptKinds`,
+    // `data/fetch` advertised-kind check) accept the request. We don't render anything — the
+    // test verifies that the MCP server forwards the agent's intent verbatim, not that the
+    // daemon dispatches it. The dispatch end is pinned by `AndroidRecordingSessionTest`.
+    val recordingsDir = tmp.newFolder("nav-recordings-out")
+    val framesDir = tmp.newFolder("nav-recording-frames")
+    writeSolidPng(framesDir.resolve("frame-00000.png"), 0xFF000000.toInt())
+    val cannedApngBytes =
+      byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10, 0x01, 0x02, 0x03, 0x04, 0x05)
+
+    // Reconstruct the navigation descriptor inline rather than depending on
+    // `:daemon:android` from `:mcp` — `NavigationRecordingScriptEvents` lives there because the
+    // dispatch arms are Android-only, but the descriptor is plain metadata so we can construct
+    // the equivalent advertisement with `:data-render-core` types alone.
+    val navDescriptor =
+      ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor(
+        id = ee.schimke.composeai.data.render.extensions.DataExtensionId("navigation"),
+        displayName = "Navigation script controls",
+        recordingScriptEvents =
+          listOf(
+              "navigation.deepLink",
+              "navigation.back",
+              "navigation.predictiveBackStarted",
+              "navigation.predictiveBackProgressed",
+              "navigation.predictiveBackCommitted",
+              "navigation.predictiveBackCancelled",
+            )
+            .map { id ->
+              ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescriptor(
+                id = id,
+                displayName = id,
+                summary = "navigation script event $id",
+                supported = true,
+              )
+            },
+      )
+
+    factory.daemonConfigurer = { d ->
+      d.advertisedDataProducts =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "data/navigation",
+            schemaVersion = 1,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          )
+        )
+      d.advertisedDataExtensions =
+        ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions.descriptors +
+          ee.schimke.composeai.daemon.InputTouchRecordingScriptEvents.descriptor +
+          navDescriptor
+      d.dataFetchHandler = { _, kind, _, _ ->
+        // Mirror the wire shape that `NavigationDataProducer` writes on a real Android render —
+        // a deep-link Intent (post `navigation.deepLink` dispatch) with `hasEnabledCallbacks=true`
+        // because the held screen registered a `BackHandler` (matches the NavHostHomePreview
+        // sample's profile destination).
+        if (kind != "data/navigation") FakeDaemon.DataFetchOutcome.Unknown
+        else
+          FakeDaemon.DataFetchOutcome.Ok(
+            kind = kind,
+            schemaVersion = 1,
+            payload =
+              buildJsonObject {
+                putJsonObject("intent") {
+                  put("action", "android.intent.action.VIEW")
+                  put("dataUri", "app://route/profile/42")
+                  put("packageName", "com.example.sampleandroid")
+                  putJsonArray("categories") {
+                    add(JsonPrimitive("android.intent.category.DEFAULT"))
+                  }
+                  putJsonObject("extras") {
+                    put("user_id", 42)
+                    put("show_fab", true)
+                    put("source", "deeplink")
+                  }
+                }
+                putJsonObject("onBackPressed") { put("hasEnabledCallbacks", true) }
+              },
+          )
+      }
+      d.recordingEncodedBytes = cannedApngBytes
+      d.recordingEncodeDir = recordingsDir
+      d.recordingStopResult =
+        ee.schimke.composeai.daemon.protocol.RecordingStopResult(
+          frameCount = 1,
+          durationMs = 0L,
+          framesDir = framesDir.absolutePath,
+          frameWidthPx = 8,
+          frameHeightPx = 8,
+        )
+    }
+    client.initialize()
+    val projectDir = tmp.newFolder("nav-workspace")
+    tmp.newFolder("nav-workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo-nav")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.sampleandroid.NavHostPreviewKt.NavHostHomePreview"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+
+    // 1. `get_preview_data` round-trips the navigation snapshot.
+    val fetchResp =
+      client.callTool(
+        "get_preview_data",
+        buildJsonObject {
+          put("uri", uri)
+          put("kind", "data/navigation")
+          put("inline", true)
+        },
+        timeoutMs = 10_000,
+      )
+    assertWithMessage("get_preview_data should succeed for an advertised navigation kind")
+      .that(fetchResp.isError())
+      .isFalse()
+    val fetched = json.parseToJsonElement(fetchResp.firstTextContent()).jsonObject
+    val payload = fetched["payload"]!!.jsonObject
+    val intentJson = payload["intent"]!!.jsonObject
+    assertThat(intentJson["action"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("android.intent.action.VIEW")
+    assertThat(intentJson["dataUri"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("app://route/profile/42")
+    val extras = intentJson["extras"]!!.jsonObject
+    assertThat(extras["user_id"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()).isEqualTo(42)
+    assertThat(extras["show_fab"]?.jsonPrimitive?.contentOrNull).isEqualTo("true")
+    assertThat(extras["source"]?.jsonPrimitive?.contentOrNull).isEqualTo("deeplink")
+    assertThat(
+        payload["onBackPressed"]!!.jsonObject["hasEnabledCallbacks"]?.jsonPrimitive?.contentOrNull
+      )
+      .isEqualTo("true")
+
+    // 2. `record_preview` forwards a navigation.deepLink + predictive-back gesture sequence.
+    val recordResp =
+      client.callTool(
+        "record_preview",
+        buildJsonObject {
+          put("uri", uri)
+          put("fps", 30)
+          put("scale", 1.0)
+          putJsonArray("events") {
+            add(
+              buildJsonObject {
+                put("tMs", 0)
+                put("kind", "navigation.deepLink")
+                put("deepLinkUri", "app://route/profile/42")
+              }
+            )
+            add(
+              buildJsonObject {
+                put("tMs", 50)
+                put("kind", "navigation.predictiveBackStarted")
+                put("backProgress", 0.0)
+                put("backEdge", "left")
+              }
+            )
+            add(
+              buildJsonObject {
+                put("tMs", 100)
+                put("kind", "navigation.predictiveBackProgressed")
+                put("backProgress", 0.5)
+                put("backEdge", "left")
+              }
+            )
+            add(
+              buildJsonObject {
+                put("tMs", 150)
+                put("kind", "navigation.back")
+              }
+            )
+          }
+        },
+        timeoutMs = 10_000,
+      )
+    assertWithMessage("record_preview should accept navigation.* events advertised by the daemon")
+      .that(recordResp.isError())
+      .isFalse()
+
+    // The daemon's `recording/script` handler captures the events it received — assert the
+    // extension fields rode through the MCP encoder unchanged.
+    val scriptCall = daemon.recordingScripts.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(scriptCall).isNotNull()
+    assertThat(scriptCall!!.events).hasSize(4)
+
+    val deepLink = scriptCall.events[0]
+    assertThat(deepLink.kind).isEqualTo("navigation.deepLink")
+    assertThat(deepLink.deepLinkUri).isEqualTo("app://route/profile/42")
+
+    val started = scriptCall.events[1]
+    assertThat(started.kind).isEqualTo("navigation.predictiveBackStarted")
+    assertThat(started.backProgress).isEqualTo(0.0f)
+    assertThat(started.backEdge).isEqualTo("left")
+
+    val progressed = scriptCall.events[2]
+    assertThat(progressed.kind).isEqualTo("navigation.predictiveBackProgressed")
+    assertThat(progressed.backProgress).isEqualTo(0.5f)
+    assertThat(progressed.backEdge).isEqualTo("left")
+
+    val back = scriptCall.events[3]
+    assertThat(back.kind).isEqualTo("navigation.back")
+    assertThat(back.deepLinkUri).isNull()
+    assertThat(back.backProgress).isNull()
+  }
+
+  @Test
   fun `record_preview rejects unknown event kind without spawning a session`() {
     client.initialize()
     val projectDir = tmp.newFolder("workspace")

--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -66,6 +66,12 @@ dependencies {
   implementation(libs.compose.ui.tooling.preview)
   implementation(libs.compose.foundation)
   implementation(libs.activity.compose)
+  // NavHost-based sample (`NavHostPreview.kt`) exercises the daemon's
+  // `data/navigation` data product (Intent + back-pressed snapshot) and the
+  // `navigation.*` script-event surface end-to-end. The library's public
+  // composables (`NavHost`, `composable`, `rememberNavController`) have been
+  // stable since 2.7.x; we pin to the latest stable in libs.versions.toml.
+  implementation(libs.navigation.compose)
   // Exercises the `Font(GoogleFont(...), provider)` path under Robolectric —
   // the shadow in `renderer-android` swaps the GMS provider lookup for a
   // local cache under `.compose-preview-history/fonts/`.

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/NavHostPreview.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/NavHostPreview.kt
@@ -1,0 +1,104 @@
+package com.example.sampleandroid
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+
+/**
+ * NavHost-based preview that exercises the daemon's navigation surface end-to-end.
+ *
+ * **What this preview does (interactively):**
+ * - Boots a `NavHost` with two destinations — `home` and `profile/{userId}` — and a
+ *   [`BackHandler`] on the profile screen so an `OnBackPressedCallback` is registered with the
+ *   activity's `onBackPressedDispatcher`.
+ * - The home screen exposes a "Go to profile" button. The profile screen exposes a "Back" button
+ *   that calls `navController.popBackStack()`.
+ *
+ * **Why this fixture is useful for navigation audits:**
+ * - Agents can fetch `data/navigation` at any render and observe `intent` (action / data URI /
+ *   simple-typed extras) plus `onBackPressed.hasEnabledCallbacks` — the latter flips between
+ *   `false` (home) and `true` (profile) so the snapshot tracks where the back-stack pop will go.
+ * - Agents can drive `navigation.deepLink` (`Intent(ACTION_VIEW, "app://profile/42")`) to land
+ *   directly on the profile screen, then `navigation.predictiveBack*` events to verify the
+ *   gesture's animation curve renders correctly, and finally `navigation.back` (or the gesture
+ *   commit phase) to pop back to home.
+ *
+ * **Robolectric reality check.** Under `ActivityScenarioRule<ComponentActivity>`, the launch
+ * Intent has `action = MAIN` / `category = LAUNCHER` and an empty extras bag — so the
+ * `data/navigation` snapshot's `intent` block is sparse on the home preview. After a
+ * `navigation.deepLink` script event the snapshot's `intent.action` flips to `VIEW` and
+ * `intent.dataUri` carries the deep-link URI. See
+ * [`NavigationDataProducer`][ee.schimke.composeai.daemon.NavigationDataProducer] for the wire
+ * shape and the Robolectric-specific extras handling.
+ */
+@Preview(name = "NavHost — Home", showBackground = true, widthDp = 320, heightDp = 480)
+@Composable
+fun NavHostHomePreview() {
+  Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = "home") {
+      composable("home") {
+        HomeScreen(onProfile = { navController.navigate("profile/42") })
+      }
+      composable("profile/{userId}") { entry ->
+        // BackHandler installs an OnBackPressedCallback(enabled = true) — that's what
+        // `data/navigation`'s `onBackPressed.hasEnabledCallbacks` flips to true on this screen.
+        BackHandler { navController.popBackStack() }
+        ProfileScreen(
+          userId = entry.arguments?.getString("userId") ?: "?",
+          onBack = { navController.popBackStack() },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun HomeScreen(onProfile: () -> Unit) {
+  Column(
+    modifier = Modifier.fillMaxSize().padding(24.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+  ) {
+    Text("Home", style = MaterialTheme.typography.headlineSmall)
+    Text(
+      "Tap to navigate, or send `navigation.deepLink` with deepLinkUri=app://profile/42",
+      style = MaterialTheme.typography.bodyMedium,
+    )
+    Spacer(Modifier.height(8.dp))
+    Button(onClick = onProfile) { Text("Go to profile") }
+  }
+}
+
+@Composable
+private fun ProfileScreen(userId: String, onBack: () -> Unit) {
+  Column(
+    modifier = Modifier.fillMaxSize().padding(24.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+  ) {
+    Text("Profile #$userId", style = MaterialTheme.typography.headlineSmall)
+    Text(
+      "BackHandler is registered — `data/navigation.onBackPressed.hasEnabledCallbacks` reports true.",
+      style = MaterialTheme.typography.bodyMedium,
+    )
+    Spacer(Modifier.height(8.dp))
+    Button(onClick = onBack) { Text("Back") }
+  }
+}


### PR DESCRIPTION
Wires `navigation.*` recording-script events on the Android backend so agents
can drive the held composition's deep-link routing, instant back press, and
predictive-back gestures without a real device:

- `navigation.deepLink` (deepLinkUri) → Intent(ACTION_VIEW, …) scoped to the
  activity's own package
- `navigation.back` → OnBackPressedDispatcher.onBackPressed()
- `navigation.predictiveBack{Started,Progressed}` (backProgress, backEdge) →
  dispatchOnBackStarted / dispatchOnBackProgressed with a synthesised
  BackEventCompat
- `navigation.predictiveBackCommitted` → onBackPressed() (commit phase)
- `navigation.predictiveBackCancelled` → dispatchOnBackCancelled()

InteractiveSession.dispatchNavigation() (default false) carries the wire-name
plus optional payload; AndroidInteractiveSession enqueues a new
InteractiveCommand.DispatchNavigation envelope that the held-rule loop
resolves via RobolectricHost.performNavigationAction. AndroidRecordingSession
registers one handler per wired id and surfaces specific unsupported reasons
(missing deepLinkUri, host with no held activity).

Three wire fields added to RecordingScriptEvent (deepLinkUri, backProgress,
backEdge); the descriptor is registered alongside lifecycle / preview /
state / uiautomator in DaemonMain so list_data_products surfaces the surface
area. Dispatch-only — observable navigation state (current destination, back
stack) stays out of scope for now.