### PR TITLE
test(vscode): extract applyStaleBadge + DOM unit tests

### DIFF
--- a/vscode-extension/src/test/staleBadgeDom.test.ts
+++ b/vscode-extension/src/test/staleBadgeDom.test.ts
@@ -1,0 +1,160 @@
+import * as assert from "assert";
+import { applyStaleBadge } from "../webview/preview/staleBadgeDom";
+
+/** Build a `<div class="preview-card">` with a `.card-title-row` child
+ *  (the place the stale badge gets appended to) and append it to
+ *  `document.body`. Returns the card. */
+function buildCard(previewId = "com.example.A"): HTMLElement {
+    const card = document.createElement("div");
+    card.className = "preview-card";
+    card.dataset.previewId = previewId;
+    const titleRow = document.createElement("div");
+    titleRow.className = "card-title-row";
+    card.appendChild(titleRow);
+    document.body.appendChild(card);
+    return card;
+}
+
+afterEach(() => {
+    document.body.innerHTML = "";
+});
+
+describe("applyStaleBadge", () => {
+    it("stamps a .card-stale-btn into .card-title-row and adds .is-stale when isStale=true", () => {
+        const card = buildCard();
+        applyStaleBadge(card, true, () => {});
+
+        const titleRow = card.querySelector(".card-title-row")!;
+        const btn = titleRow.querySelector(".card-stale-btn") as HTMLElement;
+        assert.ok(btn, "badge button should be appended to title row");
+        assert.strictEqual(btn.tagName, "BUTTON");
+        assert.strictEqual(
+            btn.classList.contains("icon-button"),
+            true,
+            "should keep the shared .icon-button class",
+        );
+        assert.strictEqual(
+            btn.getAttribute("aria-label"),
+            "Keep stale capture fresh",
+        );
+        assert.ok(
+            btn.querySelector("i.codicon.codicon-warning"),
+            "should embed the warning codicon",
+        );
+        assert.strictEqual(card.classList.contains("is-stale"), true);
+    });
+
+    it("removes both the badge and .is-stale when isStale=false", () => {
+        const card = buildCard();
+        applyStaleBadge(card, true, () => {});
+        applyStaleBadge(card, false, () => {});
+
+        assert.strictEqual(card.querySelector(".card-stale-btn"), null);
+        assert.strictEqual(card.classList.contains("is-stale"), false);
+    });
+
+    it("is idempotent: repeat calls in the same direction are no-ops", () => {
+        const card = buildCard();
+        applyStaleBadge(card, true, () => {});
+        const afterFirstStamp = card.innerHTML;
+        applyStaleBadge(card, true, () => {});
+        applyStaleBadge(card, true, () => {});
+        assert.strictEqual(card.innerHTML, afterFirstStamp);
+        assert.strictEqual(
+            card.querySelectorAll(".card-stale-btn").length,
+            1,
+            "no duplicate buttons",
+        );
+
+        applyStaleBadge(card, false, () => {});
+        const afterFirstClear = card.innerHTML;
+        applyStaleBadge(card, false, () => {});
+        applyStaleBadge(card, false, () => {});
+        assert.strictEqual(card.innerHTML, afterFirstClear);
+        assert.strictEqual(card.querySelector(".card-stale-btn"), null);
+    });
+
+    it("survives stale → fresh → stale → fresh round trips", () => {
+        const card = buildCard();
+        for (let i = 0; i < 3; i++) {
+            applyStaleBadge(card, true, () => {});
+            assert.strictEqual(card.classList.contains("is-stale"), true);
+            assert.strictEqual(
+                card.querySelectorAll(".card-stale-btn").length,
+                1,
+            );
+            applyStaleBadge(card, false, () => {});
+            assert.strictEqual(card.classList.contains("is-stale"), false);
+            assert.strictEqual(card.querySelector(".card-stale-btn"), null);
+        }
+    });
+
+    it("invokes the onClick callback when the badge is clicked", () => {
+        const card = buildCard();
+        let clicks = 0;
+        applyStaleBadge(card, true, () => {
+            clicks++;
+        });
+
+        const btn = card.querySelector(".card-stale-btn") as HTMLElement;
+        btn.click();
+        btn.click();
+        assert.strictEqual(clicks, 2);
+    });
+
+    it("stops the click event from bubbling to ancestor handlers", () => {
+        const card = buildCard();
+        let cardClicks = 0;
+        card.addEventListener("click", () => {
+            cardClicks++;
+        });
+        applyStaleBadge(card, true, () => {});
+
+        const btn = card.querySelector(".card-stale-btn") as HTMLElement;
+        btn.click();
+        assert.strictEqual(
+            cardClicks,
+            0,
+            "stopPropagation should keep the card-level click handler from firing",
+        );
+    });
+
+    it("silently skips when the card has no .card-title-row", () => {
+        const card = document.createElement("div");
+        card.className = "preview-card";
+        document.body.appendChild(card);
+
+        assert.doesNotThrow(() => applyStaleBadge(card, true, () => {}));
+        assert.strictEqual(card.querySelector(".card-stale-btn"), null);
+        assert.strictEqual(
+            card.classList.contains("is-stale"),
+            false,
+            "must not stamp .is-stale without the title row to host the badge",
+        );
+        assert.doesNotThrow(() => applyStaleBadge(card, false, () => {}));
+    });
+
+    it("does not register a duplicate click handler on a re-stamp after class drift", () => {
+        // Defensive: if some other code path strips the badge button but
+        // leaves `.is-stale` on the card, the next true-pass should still
+        // succeed without double-binding the click handler.
+        const card = buildCard();
+        let clicks = 0;
+        applyStaleBadge(card, true, () => {
+            clicks++;
+        });
+        // Force the drift state.
+        card.querySelector(".card-stale-btn")!.remove();
+        applyStaleBadge(card, true, () => {
+            clicks++;
+        });
+
+        const btn = card.querySelector(".card-stale-btn") as HTMLElement;
+        btn.click();
+        assert.strictEqual(
+            clicks,
+            1,
+            "the previous (now-removed) button's handler should not fire",
+        );
+    });
+});

--- a/vscode-extension/src/webview/preview/staleBadge.ts
+++ b/vscode-extension/src/webview/preview/staleBadge.ts
@@ -19,6 +19,7 @@
 // reach into closure.
 
 import type { VsCodeApi } from "../shared/vscode";
+import { applyStaleBadge } from "./staleBadgeDom";
 
 export class StaleBadgeController {
     constructor(private readonly vscode: VsCodeApi<unknown>) {}
@@ -41,28 +42,7 @@ export class StaleBadgeController {
      * matches the DOM.
      */
     apply(card: HTMLElement, isStale: boolean): void {
-        const titleRow = card.querySelector(".card-title-row");
-        if (!titleRow) return;
-        const existing = card.querySelector(".card-stale-btn");
-        if (isStale && !existing) {
-            const btn = document.createElement("button");
-            btn.className = "icon-button card-stale-btn";
-            btn.title =
-                "Stale heavy capture — click to keep fresh while focused";
-            btn.setAttribute("aria-label", "Keep stale capture fresh");
-            btn.innerHTML =
-                '<i class="codicon codicon-warning" aria-hidden="true"></i>';
-            btn.addEventListener("click", (evt) => {
-                evt.preventDefault();
-                evt.stopPropagation();
-                this.requestHeavyRefresh(card);
-            });
-            titleRow.appendChild(btn);
-            card.classList.add("is-stale");
-        } else if (!isStale && existing) {
-            existing.remove();
-            card.classList.remove("is-stale");
-        }
+        applyStaleBadge(card, isStale, () => this.requestHeavyRefresh(card));
     }
 
     /**

--- a/vscode-extension/src/webview/preview/staleBadgeDom.ts
+++ b/vscode-extension/src/webview/preview/staleBadgeDom.ts
@@ -1,0 +1,50 @@
+// DOM mutator backing `StaleBadgeController.apply`. Lifted into its own
+// file so the badge add/remove operation is testable under happy-dom
+// without dragging the controller's wider transitive imports (the
+// `vscode` handle's `acquireVsCodeApi` global, etc.) into the host
+// tsconfig.
+//
+// The function is intentionally narrow: it owns the DOM mutation and
+// idempotency rules, and takes the click handler as a callback so the
+// controller can keep its `requestHeavyRefresh` wiring without leaking
+// the `vscode` handle into this file.
+
+/**
+ * Toggles the "stale heavy capture — click to refresh" affordance on a
+ * single card. Idempotent — when the desired state already matches the
+ * DOM (badge present iff [isStale]) the call is a no-op.
+ *
+ * Adds `.is-stale` to [card] and a `.card-stale-btn` button to its
+ * `.card-title-row` when [isStale] is true; removes both when false.
+ *
+ * Silently skips when [card] has no `.card-title-row` child — defensive
+ * against transient DOM states where the card hasn't finished mounting
+ * yet (the imperative copy in `behavior.ts` did the same).
+ */
+export function applyStaleBadge(
+    card: HTMLElement,
+    isStale: boolean,
+    onClick: () => void,
+): void {
+    const titleRow = card.querySelector(".card-title-row");
+    if (!titleRow) return;
+    const existing = card.querySelector(".card-stale-btn");
+    if (isStale && !existing) {
+        const btn = document.createElement("button");
+        btn.className = "icon-button card-stale-btn";
+        btn.title = "Stale heavy capture — click to keep fresh while focused";
+        btn.setAttribute("aria-label", "Keep stale capture fresh");
+        btn.innerHTML =
+            '<i class="codicon codicon-warning" aria-hidden="true"></i>';
+        btn.addEventListener("click", (evt) => {
+            evt.preventDefault();
+            evt.stopPropagation();
+            onClick();
+        });
+        titleRow.appendChild(btn);
+        card.classList.add("is-stale");
+    } else if (!isStale && existing) {
+        existing.remove();
+        card.classList.remove("is-stale");
+    }
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -25,6 +25,7 @@
         "src/webview/preview/moduleReadiness.ts",
         "src/webview/preview/pointerGeometry.ts",
         "src/webview/preview/relativeSizing.ts",
+        "src/webview/preview/staleBadgeDom.ts",
         "src/webview/history/components/HistoryRow.ts",
         "src/webview/history/historyData.ts",
         "src/webview/history/historyStore.ts",


### PR DESCRIPTION
Backfills `staleBadge.apply` on the happy-dom infra (#859). Lifts the
DOM mutator out of `StaleBadgeController` into `staleBadgeDom.ts` so the
add/remove + idempotency rules are testable under happy-dom without
dragging the controller's `vscode` handle into the host tsconfig.

`StaleBadgeController.apply` now delegates to `applyStaleBadge`, passing
`requestHeavyRefresh(card)` as the click callback — same DOM shape, same
button wiring, same idempotency.

8 new unit tests cover:
- Stamping `.card-stale-btn` into `.card-title-row` + `.is-stale` toggle
- Removing both on the false transition
- Idempotency in both directions (no duplicate buttons, no flicker)
- Stale ↔ fresh round trips
- Click callback firing on each press
- `stopPropagation` keeping the card-level click handler quiet
- Silent skip when `.card-title-row` is absent
- No double-bound handler after a manual `.card-stale-btn` removal +
  re-stamp (defensive against class-vs-button drift)

559 passing (551 prior + 8 new).