### PR TITLE
feat(plugin): move pixel-test wiring out of samples into composePreview { renderBeforeUnitTests }

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -616,7 +616,36 @@ internal object ComposePreviewTasks {
         marker.writeText("validated\n")
       }
     }
+
+    // Pixel-test wiring: chain the AGP unit-test tasks behind
+    // `renderAllPreviews` so a consumer test class that reads the PNGs under
+    // `build/compose-previews/renders/` (e.g. `:samples:android-alpha`'s
+    // `FocusedPreviewPixelTest`) sees the rendered output by the time its
+    // assertions run. Opt-in via `composePreview { renderBeforeUnitTests =
+    // true }` — default off so consumers without pixel tests don't pay the
+    // `renderAllPreviews` cost on every `:check`.
+    //
+    // Targets the AGP unit-test tasks by name rather than
+    // `tasks.withType<Test>()`: the plugin's own `renderPreviews` Test task
+    // is what `renderAllPreviews` already depends on, so matching it here
+    // would create a cycle. No-op on Compose Multiplatform / Desktop modules
+    // where those task names don't exist.
+    //
+    // `tasks.matching { ... }.configureEach { ... }` is the
+    // Isolated-Projects-safe lazy form: the matching predicate fires as
+    // each task is registered, and the configureEach body only fires for
+    // matches.
+    val renderBeforeUnitTests = extension.renderBeforeUnitTests
+    project.tasks
+      .matching { it.name in PIXEL_TEST_UNIT_TEST_TASKS }
+      .configureEach {
+        if (renderBeforeUnitTests.get()) {
+          dependsOn("renderAllPreviews")
+        }
+      }
   }
+
+  private val PIXEL_TEST_UNIT_TEST_TASKS = setOf("testDebugUnitTest", "testReleaseUnitTest")
 
   internal fun missingPreviewOutputIds(
     manifest: PreviewManifest,

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -79,6 +79,23 @@ abstract class PreviewExtension @Inject constructor(private val objects: ObjectF
    */
   val manageDependencies: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
+  /**
+   * When `true`, the plugin wires the AGP `testDebugUnitTest` / `testReleaseUnitTest` tasks to
+   * depend on `renderAllPreviews`, so a consumer's pixel-test class (e.g. one that reads the PNGs
+   * under `build/compose-previews/renders/`) sees a fully-rendered output directory by the time its
+   * assertions run. Mirror of the boilerplate `:samples:android` / `:samples:wear` /
+   * `:samples:android-alpha` previously each carried in their own `build.gradle.kts`. Default
+   * `false` so consumers without pixel tests don't pay the `renderAllPreviews` cost on every
+   * `:check`.
+   *
+   * Targets the AGP unit-test tasks by name rather than `tasks.withType<Test>()` because the
+   * plugin's own `renderPreviews` Test task is what `renderAllPreviews` already depends on —
+   * matching it here would create a cycle. No-op on Compose Multiplatform / Desktop modules where
+   * those task names don't exist.
+   */
+  val renderBeforeUnitTests: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(false)
+
   /** Generic selector for preview extensions that produce data alongside preview PNGs. */
   val previewExtensions: PreviewExtensionsExtension =
     objects.newInstance(PreviewExtensionsExtension::class.java)

--- a/samples/android-alpha/build.gradle.kts
+++ b/samples/android-alpha/build.gradle.kts
@@ -13,6 +13,14 @@ plugins {
 // doesn't have yet — see [docs/RENDERER_COMPATIBILITY.md] for the version
 // alignment story.
 
+composePreview {
+  // `FocusedPreviewPixelTest` reads PNGs under
+  // `build/compose-previews/renders/`; opt the unit-test tasks into a
+  // `dependsOn(renderAllPreviews)` chain so `:samples:android-alpha:check`
+  // renders before asserting.
+  renderBeforeUnitTests.set(true)
+}
+
 android {
   namespace = "com.example.samplealpha"
   // compose-ui 1.12.0-alpha02 (transitively pulled by material3 1.5.0-alphaNN)
@@ -24,19 +32,6 @@ android {
 
   testOptions { unitTests.all { it.jvmArgs("-Xmx2048m") } }
 }
-
-// Pixel-test wiring. `FocusedPreviewPixelTest` reads PNGs under
-// `build/compose-previews/renders/` produced by `renderAllPreviews`, so chain
-// the AGP unit-test tasks behind `renderAllPreviews` — same pattern as
-// `:samples:android`'s `ScrollPreviewPixelTest`. Targeting by name avoids
-// pulling the plugin's own `renderPreviews` Test task into a circular
-// `dependsOn` graph; `tasks.matching { ... }.configureEach { ... }` is the
-// Isolated-Projects-safe lazy form.
-val pixelTestUnitTestTasks = setOf("testDebugUnitTest", "testReleaseUnitTest")
-
-tasks
-  .matching { it.name in pixelTestUnitTestTasks }
-  .configureEach { dependsOn("renderAllPreviews") }
 
 dependencies {
   testImplementation(libs.junit)

--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -19,6 +19,12 @@ composePreview {
   // resourcePreviews { ... } is on by default — the sample exercises the
   // Android XML resource preview pipeline (vector / animated-vector /
   // adaptive-icon) without any extra config.
+
+  // `ScrollPreviewPixelTest` reads PNGs under
+  // `build/compose-previews/renders/`; opt the unit-test tasks into a
+  // `dependsOn(renderAllPreviews)` chain so `:samples:android:check`
+  // renders before asserting.
+  renderBeforeUnitTests.set(true)
 }
 
 android {
@@ -35,24 +41,6 @@ android {
 
   testOptions { unitTests.all { it.jvmArgs("-Xmx2048m") } }
 }
-
-// `ScrollPreviewPixelTest` reads PNGs under `build/compose-previews/renders/`
-// produced by `renderAllPreviews`. Wire the AGP unit-test tasks to depend on
-// it so `./gradlew :samples:android:check` renders the PNGs first then
-// pixel-asserts against them. Targeting the `test{Debug,Release}UnitTest`
-// tasks by name — `tasks.withType<Test>()` would also grab the plugin's own
-// `renderPreviews` Test task and create a circular dependency.
-//
-// `tasks.matching { ... }.configureEach { ... }` is the Isolated-Projects-
-// safe lazy pattern: the matching predicate is evaluated as each task is
-// registered, and the configureEach action only fires for matches. This
-// replaces the discouraged `afterEvaluate { tasks.findByName(...) }` block,
-// which forced eager configuration and isn't IP-friendly.
-val pixelTestUnitTestTasks = setOf("testDebugUnitTest", "testReleaseUnitTest")
-
-tasks
-  .matching { it.name in pixelTestUnitTestTasks }
-  .configureEach { dependsOn("renderAllPreviews") }
 
 dependencies {
   testImplementation(libs.junit)

--- a/samples/wear/build.gradle.kts
+++ b/samples/wear/build.gradle.kts
@@ -15,6 +15,12 @@ composePreview {
       // enableAllChecks()
     }
   }
+
+  // `LongScrollPreviewPixelTest` reads PNGs from
+  // `build/compose-previews/renders/`; opt the unit-test tasks into a
+  // `dependsOn(renderAllPreviews)` chain so `:samples:wear:check` renders
+  // before asserting.
+  renderBeforeUnitTests.set(true)
 }
 
 android {
@@ -67,18 +73,3 @@ dependencies {
   testImplementation(libs.junit)
   testImplementation(libs.truth)
 }
-
-// `LongScrollPreviewPixelTest` reads PNGs produced by `renderAllPreviews`.
-// Same dependency wiring as samples/android's pixel tests; targets the AGP
-// unit-test tasks by name so we don't include the plugin's own `renderPreviews`
-// Test task (which would create a circular dep).
-//
-// `tasks.matching { ... }.configureEach { ... }` is the Isolated-Projects-
-// safe lazy pattern — the predicate fires as each task is registered, so we
-// don't need the discouraged `afterEvaluate` block to wait for AGP to wire
-// the unit-test tasks.
-val pixelTestUnitTestTasks = setOf("testDebugUnitTest", "testReleaseUnitTest")
-
-tasks
-  .matching { it.name in pixelTestUnitTestTasks }
-  .configureEach { dependsOn("renderAllPreviews") }


### PR DESCRIPTION
## Summary

Three samples (`:samples:android`, `:samples:wear`, `:samples:android-alpha`) were each carrying the same eight-line block:

```kotlin
val pixelTestUnitTestTasks = setOf("testDebugUnitTest", "testReleaseUnitTest")
tasks.matching { it.name in pixelTestUnitTestTasks }
  .configureEach { dependsOn("renderAllPreviews") }
```

Enough boilerplate that a fourth consumer was likely to copy it again. Move it into the plugin under a new opt-in:

```kotlin
composePreview { renderBeforeUnitTests.set(true) }
```

The conditional wiring lives in `ComposePreviewTasks.registerRenderAllPreviews` and uses the same `tasks.matching { … }.configureEach { … }` predicate the samples used — Isolated-Projects-safe, and a no-op on Compose Multiplatform / Desktop modules where the AGP unit-test task names don't exist.

## Default

`false`, so consumers without a pixel test class don't pay the `renderAllPreviews` cost on every `:check`. The three samples each get a single-line opt-in inside their existing `composePreview { … }` block.

## Test plan

- [ ] `:samples:android-alpha:test` green from a fresh `build/compose-previews/renders/` dir — proves the dep is wired (verified)
- [ ] `:samples:wear:test` green (verified)
- [ ] `:gradle-plugin:test` + `:gradle-plugin:functionalTest` green (verified)
- [ ] `ktfmtCheckAll` clean (verified)
- [ ] Pre-existing `:samples:android` `ScrollPreviewPixelTest.GIF capture …` failures from `origin/main` are still present and unrelated to this change


---
_Generated by [Claude Code](https://claude.ai/code/session_0197pgjb3LE9hWV5tda1CvwB)_