### PR TITLE
Extract card metadata and image paint logic into testable helpers

### DIFF
--- a/vscode-extension/src/test/cardImage.test.ts
+++ b/vscode-extension/src/test/cardImage.test.ts
@@ -1,0 +1,265 @@
+// Unit tests for `paintCardCapture` — the per-frame paint that
+// `<preview-card>.paintCapture` delegates to (the message dispatcher
+// resolves the card by id and invokes the method).
+//
+// Pattern follows `relativeSizing.test.ts`: build a small
+// `<preview-card>`-shaped element with the DOM `populatePreviewCard`
+// produces (`.image-container`, `.skeleton`), seed
+// `previewStore.cardCaptures`, call `paintCardCapture`, assert on
+// the patched DOM and on cache + revision side effects.
+//
+// The diff-overlay auto-refresh path posts a vscode message; we
+// pass a fake `vscode.postMessage` and assert on the captured calls.
+
+import * as assert from "assert";
+import { paintCardCapture } from "../webview/preview/cardImage";
+import { sanitizeId } from "../webview/preview/cardData";
+import type { CapturePresentation } from "../webview/preview/frameCarousel";
+import type { DiffOverlayConfig } from "../webview/preview/diffOverlay";
+import type { InteractiveInputConfig } from "../webview/preview/interactiveInput";
+import { previewStore, setCardCaptures } from "../webview/preview/previewStore";
+import type { VsCodeApi } from "../webview/shared/vscode";
+import type { WebviewToExtension } from "../types";
+
+interface ConfigStub {
+    indicatorCalls: number;
+    isLiveValue: boolean;
+    earlyFeaturesValue: boolean;
+    postedMessages: WebviewToExtension[];
+}
+
+function buildCard(previewId: string): HTMLElement {
+    const card = document.createElement("div");
+    card.id = "preview-" + sanitizeId(previewId);
+    card.className = "preview-card";
+    card.dataset.previewId = previewId;
+    card.dataset.function = "MyPreview";
+    card.dataset.currentIndex = "0";
+
+    const imgContainer = document.createElement("div");
+    imgContainer.className = "image-container";
+    const skeleton = document.createElement("div");
+    skeleton.className = "skeleton";
+    imgContainer.appendChild(skeleton);
+    card.appendChild(imgContainer);
+
+    document.body.appendChild(card);
+    return card;
+}
+
+function buildConfig(
+    initial: { isLive?: boolean; earlyFeatures?: boolean } = {},
+) {
+    const stub: ConfigStub = {
+        indicatorCalls: 0,
+        isLiveValue: initial.isLive ?? false,
+        earlyFeaturesValue: initial.earlyFeatures ?? false,
+        postedMessages: [],
+    };
+    const vscode: VsCodeApi<unknown> = {
+        postMessage: (msg) => {
+            stub.postedMessages.push(msg as WebviewToExtension);
+        },
+        getState: () => null,
+        setState: () => {},
+    };
+    // attachInteractiveInputHandlers reaches `config.isLive(previewId)`
+    // immediately and bails when not live, so a test-only stub that
+    // matches the (cards are not live in this fixture) world is enough.
+    const interactiveInputConfig: InteractiveInputConfig = {
+        isLive: (_id: string) => stub.isLiveValue,
+        vscode,
+    };
+    const config = {
+        vscode,
+        frameCarousel: {
+            updateIndicator: (_card: HTMLElement) => {
+                stub.indicatorCalls += 1;
+            },
+        },
+        liveState: {
+            isLive: (_id: string) => stub.isLiveValue,
+        },
+        interactiveInputConfig,
+        diffOverlayConfig: {} as DiffOverlayConfig,
+        earlyFeatures: () => stub.earlyFeaturesValue,
+    };
+    return { stub, config };
+}
+
+function seedCapture(previewId: string, captures: CapturePresentation[]): void {
+    setCardCaptures(previewId, captures);
+}
+
+function freshCapture(renderOutput: string): CapturePresentation {
+    return {
+        renderOutput,
+        label: "",
+        imageData: null,
+        errorMessage: null,
+        renderError: null,
+    };
+}
+
+function resetStore(): void {
+    previewStore.setState({
+        cardCaptures: new Map<string, CapturePresentation[]>(),
+        cardA11yFindings: new Map(),
+        cardA11yNodes: new Map(),
+        mapsRevision: 0,
+    });
+}
+
+afterEach(() => {
+    document.body.innerHTML = "";
+    resetStore();
+});
+
+describe("paintCardCapture", () => {
+    it("swaps img.src, drops the skeleton, and bumps mapsRevision when captureIndex matches the displayed capture", () => {
+        const card = buildCard("preview:1");
+        seedCapture("preview:1", [freshCapture("a.png")]);
+        const startRevision = previewStore.getState().mapsRevision;
+        const { stub, config } = buildConfig();
+
+        paintCardCapture(card, "preview:1", 0, "BYTES-AAAA", config);
+
+        const img = card.querySelector<HTMLImageElement>(
+            ".image-container img",
+        );
+        assert.ok(img, "img element should be created when none exists");
+        assert.ok(
+            img!.src.startsWith("data:image/png;base64,BYTES-AAAA"),
+            "img.src should carry the new base64 bytes",
+        );
+        assert.strictEqual(
+            card.querySelector(".skeleton"),
+            null,
+            "skeleton should be removed once bytes land",
+        );
+        assert.strictEqual(img!.className, "fade-in");
+        assert.strictEqual(stub.indicatorCalls, 1);
+        const cap = previewStore.getState().cardCaptures.get("preview:1")![0]!;
+        assert.strictEqual(cap.imageData, "BYTES-AAAA");
+        assert.ok(
+            previewStore.getState().mapsRevision > startRevision,
+            "mapsRevision must advance so the component re-paints overlays",
+        );
+    });
+
+    it("uses 'live-frame' className instead of 'fade-in' when liveState.isLive(previewId)", () => {
+        const card = buildCard("preview:1");
+        seedCapture("preview:1", [freshCapture("a.png")]);
+        const { config } = buildConfig({ isLive: true });
+
+        paintCardCapture(card, "preview:1", 0, "BYTES", config);
+
+        const img = card.querySelector<HTMLImageElement>(
+            ".image-container img",
+        );
+        assert.ok(img);
+        assert.strictEqual(img!.className, "live-frame");
+    });
+
+    it("caches bytes but skips the img swap when captureIndex differs from dataset.currentIndex", () => {
+        const card = buildCard("preview:1");
+        card.dataset.currentIndex = "0";
+        seedCapture("preview:1", [
+            freshCapture("a.png"),
+            freshCapture("b.png"),
+        ]);
+        const { stub, config } = buildConfig();
+
+        paintCardCapture(card, "preview:1", 1, "BYTES-B", config);
+
+        // No <img> element created — skeleton still in place since the
+        // displayed capture (index 0) didn't get fresh bytes.
+        assert.strictEqual(
+            card.querySelector(".image-container img"),
+            null,
+            "img should not be created when paint is for a non-displayed capture",
+        );
+        assert.ok(
+            card.querySelector(".skeleton"),
+            "skeleton should remain since the displayed capture didn't paint",
+        );
+        // Carousel indicator still refreshed so the strip can highlight
+        // which captures have bytes.
+        assert.strictEqual(stub.indicatorCalls, 1);
+        // Cache for capture[1] populated.
+        const caps = previewStore.getState().cardCaptures.get("preview:1")!;
+        assert.strictEqual(caps[1]!.imageData, "BYTES-B");
+        // Cache for capture[0] untouched.
+        assert.strictEqual(caps[0]!.imageData, null);
+    });
+
+    it("clears stale .error-message and .has-error when fresh bytes land", () => {
+        const card = buildCard("preview:1");
+        card.classList.add("has-error");
+        const container = card.querySelector(".image-container")!;
+        const errorMsg = document.createElement("div");
+        errorMsg.className = "error-message";
+        errorMsg.textContent = "Render pending";
+        container.appendChild(errorMsg);
+        seedCapture("preview:1", [freshCapture("a.png")]);
+        const { config } = buildConfig();
+
+        paintCardCapture(card, "preview:1", 0, "BYTES", config);
+
+        assert.strictEqual(
+            card.querySelector(".error-message"),
+            null,
+            "error message should be torn down on fresh bytes",
+        );
+        assert.strictEqual(
+            card.classList.contains("has-error"),
+            false,
+            "has-error class should be cleared",
+        );
+    });
+
+    it("re-issues a requestPreviewDiff message when an open head/main diff overlay exists", () => {
+        const card = buildCard("preview:1");
+        const container = card.querySelector(".image-container")!;
+        const overlay = document.createElement("div");
+        overlay.className = "preview-diff-overlay";
+        overlay.dataset.against = "main";
+        container.appendChild(overlay);
+        seedCapture("preview:1", [freshCapture("a.png")]);
+
+        const { stub, config } = buildConfig({ earlyFeatures: true });
+
+        paintCardCapture(card, "preview:1", 0, "BYTES", config);
+
+        const requestDiffs = stub.postedMessages.filter(
+            (
+                m,
+            ): m is Extract<
+                WebviewToExtension,
+                { command: "requestPreviewDiff" }
+            > => m.command === "requestPreviewDiff",
+        );
+        assert.strictEqual(requestDiffs.length, 1);
+        assert.strictEqual(requestDiffs[0]!.previewId, "preview:1");
+        assert.strictEqual(requestDiffs[0]!.against, "main");
+    });
+
+    it("does NOT re-issue a diff request when earlyFeatures is off", () => {
+        const card = buildCard("preview:1");
+        const container = card.querySelector(".image-container")!;
+        const overlay = document.createElement("div");
+        overlay.className = "preview-diff-overlay";
+        overlay.dataset.against = "main";
+        container.appendChild(overlay);
+        seedCapture("preview:1", [freshCapture("a.png")]);
+
+        const { stub, config } = buildConfig({ earlyFeatures: false });
+
+        paintCardCapture(card, "preview:1", 0, "BYTES", config);
+
+        const requestDiffs = stub.postedMessages.filter(
+            (m) => m.command === "requestPreviewDiff",
+        );
+        assert.strictEqual(requestDiffs.length, 0);
+    });
+});

--- a/vscode-extension/src/test/cardMetadata.test.ts
+++ b/vscode-extension/src/test/cardMetadata.test.ts
@@ -1,0 +1,325 @@
+// Unit tests for `refreshCardMetadata` — the manifest-reseed path that
+// `<preview-card>`'s reactive `updated()` hook calls when the `preview`
+// property is reassigned by `renderPreviews`.
+//
+// Pattern mirrors `relativeSizing.test.ts` / `staleBadgeDom.test.ts`:
+// build a minimal `<preview-card>`-shaped element matching what
+// `populatePreviewCard` produces (id, dataset, `.card-title`,
+// `.image-container`, optional `.variant-badge`), seed
+// `previewStore.cardCaptures` with prior bytes, call
+// `refreshCardMetadata`, assert on the patched DOM and on the
+// merged-cache identity. happy-dom + the existing `setup-dom.ts`
+// global registration give us `document` / `HTMLElement` without an
+// extra harness.
+
+import * as assert from "assert";
+import { refreshCardMetadata } from "../webview/preview/cardMetadata";
+import { sanitizeId } from "../webview/preview/cardData";
+import type { CapturePresentation } from "../webview/preview/frameCarousel";
+import { previewStore, setCardCaptures } from "../webview/preview/previewStore";
+import type { Capture, PreviewInfo, PreviewParams } from "../types";
+
+const baseParams: PreviewParams = {
+    name: null,
+    device: null,
+    widthDp: null,
+    heightDp: null,
+    fontScale: 1.0,
+    showSystemUi: false,
+    showBackground: false,
+    backgroundColor: 0,
+    uiMode: 0,
+    locale: null,
+    group: null,
+};
+
+function capture(renderOutput: string, label = ""): Capture {
+    return {
+        advanceTimeMillis: null,
+        scroll: null,
+        renderOutput,
+        label,
+    };
+}
+
+function preview(
+    id: string,
+    overrides: {
+        functionName?: string;
+        className?: string;
+        params?: Partial<PreviewParams>;
+        captures?: Capture[];
+        a11yFindings?: PreviewInfo["a11yFindings"];
+    } = {},
+): PreviewInfo {
+    return {
+        id,
+        functionName: overrides.functionName ?? "MyPreview",
+        className: overrides.className ?? "com.example.PreviewsKt",
+        sourceFile: null,
+        params: { ...baseParams, ...(overrides.params ?? {}) },
+        captures: overrides.captures ?? [capture("a.png", "")],
+        a11yFindings: overrides.a11yFindings,
+    };
+}
+
+/** Build a minimum `<preview-card>`-shaped host element matching the
+ *  DOM that `populatePreviewCard` produces — the subset
+ *  `refreshCardMetadata` reaches for. */
+function buildCard(p: PreviewInfo): HTMLElement {
+    const card = document.createElement("div");
+    card.id = "preview-" + sanitizeId(p.id);
+    card.className = "preview-card";
+    card.dataset.previewId = p.id;
+    card.dataset.function = p.functionName;
+    card.dataset.className = p.className;
+    card.dataset.currentIndex = "0";
+
+    const header = document.createElement("div");
+    header.className = "card-header";
+    const titleRow = document.createElement("div");
+    titleRow.className = "card-title-row";
+    const title = document.createElement("button");
+    title.className = "card-title";
+    title.textContent = p.functionName;
+    titleRow.appendChild(title);
+    header.appendChild(titleRow);
+    card.appendChild(header);
+
+    const imgContainer = document.createElement("div");
+    imgContainer.className = "image-container";
+    card.appendChild(imgContainer);
+
+    document.body.appendChild(card);
+    return card;
+}
+
+interface ConfigStub {
+    earlyFeaturesValue: boolean;
+    indicatorCalls: number;
+}
+
+function buildConfig(initial: { earlyFeatures?: boolean } = {}) {
+    const stub: ConfigStub = {
+        earlyFeaturesValue: initial.earlyFeatures ?? false,
+        indicatorCalls: 0,
+    };
+    const config = {
+        frameCarousel: {
+            updateIndicator: (_card: HTMLElement) => {
+                stub.indicatorCalls += 1;
+            },
+        },
+        earlyFeatures: () => stub.earlyFeaturesValue,
+    };
+    return { stub, config };
+}
+
+function resetStore(): void {
+    previewStore.setState({
+        cardCaptures: new Map<string, CapturePresentation[]>(),
+        cardA11yFindings: new Map(),
+        cardA11yNodes: new Map(),
+        mapsRevision: 0,
+    });
+}
+
+afterEach(() => {
+    document.body.innerHTML = "";
+    resetStore();
+});
+
+describe("refreshCardMetadata", () => {
+    it("patches dataset, title text, and tooltip from the new PreviewInfo", () => {
+        const p0 = preview("preview:1");
+        const card = buildCard(p0);
+
+        const p1 = preview("preview:1", {
+            functionName: "Updated",
+            params: { name: "label", group: "g1", widthDp: 200, heightDp: 100 },
+        });
+        const { config } = buildConfig();
+        refreshCardMetadata(card, p1, config);
+
+        assert.strictEqual(card.dataset.function, "Updated");
+        assert.strictEqual(card.dataset.group, "g1");
+        const title = card.querySelector<HTMLButtonElement>(".card-title");
+        assert.ok(title);
+        assert.strictEqual(title!.textContent, "Updated — label");
+        // Tooltip is non-empty (buildTooltip stamps the function FQN +
+        // params); we don't pin its exact shape since that's covered by
+        // cardData.test.ts.
+        assert.ok((title!.title || "").length > 0);
+    });
+
+    it("merges existing capture imageData by index when capture count is unchanged", () => {
+        const p0 = preview("preview:1", {
+            captures: [
+                capture("a.png", "frame-0"),
+                capture("b.png", "frame-1"),
+            ],
+        });
+        const card = buildCard(p0);
+        // Seed the store as if `updateImage` had landed bytes for both
+        // captures already.
+        setCardCaptures("preview:1", [
+            {
+                renderOutput: "a.png",
+                label: "frame-0",
+                imageData: "BYTES-0",
+                errorMessage: null,
+                renderError: null,
+            },
+            {
+                renderOutput: "b.png",
+                label: "frame-1",
+                imageData: "BYTES-1",
+                errorMessage: null,
+                renderError: null,
+            },
+        ]);
+
+        const p1 = preview("preview:1", {
+            captures: [
+                capture("a.png", "frame-0-renamed"),
+                capture("b.png", "frame-1-renamed"),
+            ],
+        });
+        const { config } = buildConfig();
+        refreshCardMetadata(card, p1, config);
+
+        const merged = previewStore.getState().cardCaptures.get("preview:1");
+        assert.ok(merged);
+        assert.strictEqual(merged!.length, 2);
+        // Labels reseed from the new manifest.
+        assert.strictEqual(merged![0]!.label, "frame-0-renamed");
+        assert.strictEqual(merged![1]!.label, "frame-1-renamed");
+        // imageData survives the reseed by index.
+        assert.strictEqual(merged![0]!.imageData, "BYTES-0");
+        assert.strictEqual(merged![1]!.imageData, "BYTES-1");
+    });
+
+    it("clamps dataset.currentIndex when the new capture count is shorter", () => {
+        const p0 = preview("preview:1", {
+            captures: [capture("a.png"), capture("b.png"), capture("c.png")],
+        });
+        const card = buildCard(p0);
+        card.dataset.currentIndex = "2";
+        setCardCaptures("preview:1", [
+            {
+                renderOutput: "a.png",
+                label: "",
+                imageData: null,
+                errorMessage: null,
+                renderError: null,
+            },
+            {
+                renderOutput: "b.png",
+                label: "",
+                imageData: null,
+                errorMessage: null,
+                renderError: null,
+            },
+            {
+                renderOutput: "c.png",
+                label: "",
+                imageData: null,
+                errorMessage: null,
+                renderError: null,
+            },
+        ]);
+
+        const p1 = preview("preview:1", { captures: [capture("a.png")] });
+        const { config } = buildConfig();
+        refreshCardMetadata(card, p1, config);
+
+        assert.strictEqual(card.dataset.currentIndex, "0");
+    });
+
+    it("appends a .variant-badge when the new params produce a label", () => {
+        const p0 = preview("preview:1");
+        const card = buildCard(p0);
+        assert.strictEqual(card.querySelector(".variant-badge"), null);
+
+        const p1 = preview("preview:1", {
+            params: { fontScale: 1.5 },
+        });
+        const { config } = buildConfig();
+        refreshCardMetadata(card, p1, config);
+
+        const badge = card.querySelector(".variant-badge");
+        assert.ok(badge);
+        assert.ok((badge!.textContent || "").length > 0);
+    });
+
+    it("removes an existing .variant-badge when the new params produce no label", () => {
+        const p0 = preview("preview:1", { params: { fontScale: 1.5 } });
+        const card = buildCard(p0);
+        const stale = document.createElement("div");
+        stale.className = "variant-badge";
+        stale.textContent = "fontScale=1.5";
+        card.appendChild(stale);
+
+        const p1 = preview("preview:1");
+        const { config } = buildConfig();
+        refreshCardMetadata(card, p1, config);
+
+        assert.strictEqual(card.querySelector(".variant-badge"), null);
+    });
+
+    it("calls frameCarousel.updateIndicator for animated previews only", () => {
+        // Animated requires more than one capture.
+        const pStatic = preview("preview:S");
+        const pAnimated = preview("preview:A", {
+            captures: [capture("a.png"), capture("b.png")],
+        });
+        const cardS = buildCard(pStatic);
+        const cardA = buildCard(pAnimated);
+
+        const { stub, config } = buildConfig();
+
+        refreshCardMetadata(cardS, pStatic, config);
+        assert.strictEqual(stub.indicatorCalls, 0);
+
+        refreshCardMetadata(cardA, pAnimated, config);
+        assert.strictEqual(stub.indicatorCalls, 1);
+    });
+
+    it("rebuilds .a11y-legend / .a11y-overlay only when earlyFeatures is on and findings exist", () => {
+        const findings: PreviewInfo["a11yFindings"] = [
+            {
+                level: "WARNING",
+                type: "TextContrastCheck",
+                message: "Low contrast on label.",
+                boundsInScreen: "Rect(10, 20 - 110, 60)",
+            },
+        ];
+
+        const p0 = preview("preview:1");
+        const card = buildCard(p0);
+
+        const p1 = preview("preview:1", { a11yFindings: findings });
+
+        // earlyFeatures off — no legend / overlay even with findings.
+        const offConfig = buildConfig({ earlyFeatures: false }).config;
+        refreshCardMetadata(card, p1, offConfig);
+        assert.strictEqual(card.querySelector(".a11y-legend"), null);
+        assert.strictEqual(card.querySelector(".a11y-overlay"), null);
+
+        // earlyFeatures on — legend appended, empty overlay container
+        // appended inside .image-container.
+        const onConfig = buildConfig({ earlyFeatures: true }).config;
+        refreshCardMetadata(card, p1, onConfig);
+        assert.ok(card.querySelector(".a11y-legend"));
+        assert.ok(
+            card.querySelector(".image-container .a11y-overlay"),
+            "overlay container should be appended into .image-container",
+        );
+
+        // Subsequent reseed with empty findings drops both layers.
+        const p2 = preview("preview:1", { a11yFindings: [] });
+        refreshCardMetadata(card, p2, onConfig);
+        assert.strictEqual(card.querySelector(".a11y-legend"), null);
+        assert.strictEqual(card.querySelector(".a11y-overlay"), null);
+    });
+});

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -1,53 +1,48 @@
-// Lifecycle DOM operations for a single `<div class="preview-card">`:
-// initial build (`buildPreviewCard`), metadata refresh on a fresh
-// `setPreviews` (`updateCardMetadata`), grid-wide relative-sizing
-// (`applyRelativeSizing`), per-frame image swap (`updateImage`), and
-// daemon-attached a11y refresh (`applyA11yUpdate`).
+// Lifecycle DOM operations for a single `<preview-card>`:
+// initial build (`buildPreviewCard` + `populatePreviewCard`),
+// grid-wide relative-sizing (`applyRelativeSizing`, re-exported
+// from `./relativeSizing`), daemon-attached a11y refresh
+// (`applyA11yUpdate`), and the manifest-reseed orchestration
+// (`renderPreviews`).
+//
+// The metadata-refresh path (`updateCardMetadata`) lives in
+// `./cardMetadata.ts` and runs from `<preview-card>`'s reactive
+// `updated()` hook on a `preview` property reassignment. The
+// per-frame image paint (`updateImage`) lives in `./cardImage.ts`
+// and runs from the component's `paintCapture` method, invoked
+// by the message dispatcher after resolving the card by id.
 //
 // Lifted verbatim from `behavior.ts` so the imperative DOM operations
 // stop needing closure access to the rest of the panel. Each function
 // takes a narrow `Pick` of `CardBuilderConfig` covering only the fields
 // it touches — the shared interface is the single source of truth for
-// the card's collaborator surface, and the eventual `<preview-card>`
-// Lit component will reach for those collaborators through the same
-// shape.
+// the card's collaborator surface.
 
-import {
-    applyHierarchyOverlay,
-    buildA11yLegend,
-    buildA11yOverlay,
-    ensureHierarchyOverlay,
-} from "./a11yOverlay";
+import { buildA11yLegend, ensureHierarchyOverlay } from "./a11yOverlay";
 import {
     buildTooltip,
     buildVariantLabel,
     isAnimatedPreview,
     isWearPreview,
-    mimeFor,
     sanitizeId,
 } from "./cardData";
-import { showDiffOverlay, type DiffOverlayConfig } from "./diffOverlay";
+import type { DiffOverlayConfig } from "./diffOverlay";
 import type { FocusInspectorController } from "./focusInspector";
 import type {
     CapturePresentation,
     FrameCarouselController,
 } from "./frameCarousel";
-import {
-    attachInteractiveInputHandlers,
-    type InteractiveInputConfig,
-} from "./interactiveInput";
+import type { InteractiveInputConfig } from "./interactiveInput";
 import type { LiveStateController } from "./liveState";
 import type { StaleBadgeController } from "./staleBadge";
 import type { PreviewGrid } from "./components/PreviewGrid";
 import type { PreviewCard } from "./components/PreviewCard";
 import type { MessageOwner } from "./components/MessageBanner";
 import {
-    bumpPreviewMapsRevision,
     clearCardA11yFindings,
     deleteCardA11yFindings,
     deleteCardA11yNodes,
     deleteCardCaptures,
-    previewStore,
     setCardA11yFindings,
     setCardA11yNodes,
     setCardCaptures,
@@ -324,263 +319,11 @@ export function populatePreviewCard(
     config.observeForViewport(card);
 }
 
-/** Subset of `CardBuilderConfig` that `updateCardMetadata` actually
- *  reaches for. Kept narrow so callers — and the eventual reactive
- *  Lit component — only have to satisfy what's used. The capture
- *  cache itself lives in `previewStore` (see `setCardCaptures`),
- *  so it isn't part of this surface. */
-export type CardUpdateConfig = Pick<
-    CardBuilderConfig,
-    "frameCarousel" | "earlyFeatures"
->;
-
-/**
- * Refresh an existing card after a `setPreviews` for an id we already
- * have in the grid. Patches the card's dataset, title text, capture cache
- * (preserving already-received `imageData` for surviving renderOutputs),
- * variant badge, and a11y legend / overlay layer.
- *
- * Caller is responsible for finding the card — `renderPreviews` walks the
- * grid once and dispatches to `updateCardMetadata` vs `buildPreviewCard`
- * based on whether the previewId existed previously.
- */
-export function updateCardMetadata(
-    card: HTMLElement,
-    p: PreviewInfo,
-    config: CardUpdateConfig,
-): void {
-    card.dataset.function = p.functionName;
-    card.dataset.group = p.params.group || "";
-    card.dataset.wearPreview = isWearPreview(p) ? "1" : "0";
-    const title = card.querySelector<HTMLButtonElement>(".card-title");
-    if (title) {
-        title.textContent =
-            p.functionName + (p.params.name ? " — " + p.params.name : "");
-        title.title = buildTooltip(p);
-    }
-    // Refresh capture labels in place. If the capture count changed
-    // (e.g. user edited @RoboComposePreviewOptions) we preserve
-    // already-received imageData for renderOutputs that carry over.
-    const newCaps = p.captures.map((c) => ({
-        renderOutput: c.renderOutput,
-        label: c.label || "",
-    }));
-    const prior = previewStore.getState().cardCaptures.get(p.id) ?? [];
-    // Match by index rather than renderOutput since filenames may
-    // legitimately change (e.g. a preview gains a @RoboComposePreviewOptions
-    // annotation). Mismatched positions just reset to null-image.
-    const mergedCaps = newCaps.map(
-        (nc, i): CapturePresentation => ({
-            label: nc.label,
-            renderOutput: nc.renderOutput || "",
-            imageData: prior[i]?.imageData ?? null,
-            errorMessage: prior[i]?.errorMessage ?? null,
-            renderError: prior[i]?.renderError ?? null,
-        }),
-    );
-    setCardCaptures(p.id, mergedCaps);
-    const curIdx = parseInt(card.dataset.currentIndex || "0", 10);
-    if (curIdx >= mergedCaps.length) {
-        card.dataset.currentIndex = String(Math.max(0, mergedCaps.length - 1));
-    }
-    if (isAnimatedPreview(p)) config.frameCarousel.updateIndicator(card);
-    const variantLabel = buildVariantLabel(p);
-    let badge = card.querySelector(".variant-badge");
-    if (variantLabel) {
-        if (!badge) {
-            badge = document.createElement("div");
-            badge.className = "variant-badge";
-            card.appendChild(badge);
-        }
-        badge.textContent = variantLabel;
-    } else if (badge) {
-        badge.remove();
-    }
-
-    // Refresh the a11y legend + overlay in place when findings
-    // change (e.g. toggling a11y on turns findings from null → list,
-    // or a fresh render updates the set). Tear down the old nodes
-    // and rebuild: simpler than reconciling row-by-row for what is
-    // a rare event.
-    const existingLegend = card.querySelector(".a11y-legend");
-    const existingOverlay = card.querySelector(".a11y-overlay");
-    if (existingLegend) existingLegend.remove();
-    if (existingOverlay) existingOverlay.innerHTML = "";
-    if (config.earlyFeatures() && p.a11yFindings && p.a11yFindings.length > 0) {
-        const container = card.querySelector(".image-container");
-        if (container && !container.querySelector(".a11y-overlay")) {
-            const overlay = document.createElement("div");
-            overlay.className = "a11y-overlay";
-            overlay.setAttribute("aria-hidden", "true");
-            container.appendChild(overlay);
-        }
-        const legend = buildA11yLegend(card, p);
-        card.appendChild(legend);
-        // Repopulate box geometry if the image is already loaded —
-        // otherwise updateImage's load handler will pick it up on
-        // the next render cycle.
-        const img = card.querySelector<HTMLImageElement>(
-            ".image-container img",
-        );
-        if (img && img.complete && img.naturalWidth > 0) {
-            buildA11yOverlay(card, p.a11yFindings, img);
-        }
-    } else if (existingOverlay) {
-        // No findings or feature off — drop any leftover overlay
-        // div so cards stay clean when the user toggles
-        // earlyFeatures off mid-session.
-        existingOverlay.remove();
-    }
-}
-
 // `applyRelativeSizing` lives in `./relativeSizing.ts` so the DOM
 // operation is testable under happy-dom without dragging cardBuilder's
 // wider transitive imports into the host tsconfig. Re-exported here for
 // the existing `behavior.ts` import paths.
 export { applyRelativeSizing } from "./relativeSizing";
-
-/** Subset `updateImage` reaches for — every per-frame paint dependency.
- *  The per-preview caches (`cardCaptures`, `cardA11yFindings`,
- *  `cardA11yNodes`) live in `previewStore` and are read directly there. */
-export type UpdateImageConfig = Pick<
-    CardBuilderConfig,
-    | "vscode"
-    | "frameCarousel"
-    | "liveState"
-    | "interactiveInputConfig"
-    | "diffOverlayConfig"
-    | "earlyFeatures"
->;
-
-/**
- * Paint a fresh capture image into the matching card. Idempotent — if the
- * currently-displayed capture index doesn't match the arriving bytes, the
- * cache is updated and the carousel indicator refreshed but no `<img>` is
- * touched (the bytes wait for prev/next).
- *
- * Side effects (when [captureIndex] matches the displayed capture):
- *  - Updates / mutates the per-capture cache entry on
- *    `previewStore`'s `cardCaptures` and bumps `mapsRevision` so
- *    subscribers selecting on the cache notice the new bytes. The
- *    bump is issued AFTER the `<img>` `src` swap so the
- *    `<preview-card>` StoreController fires with the new image
- *    state and its on-load a11y deferral attaches against the right
- *    src.
- *  - Replaces the card's `<img>` `src` (or creates one if missing).
- *  - Re-attaches the live pointer/wheel handlers via
- *    `attachInteractiveInputHandlers`.
- *  - If a diff overlay is open against `head` / `main`, re-issues the
- *    diff request so the user sees the new bytes without clicking.
- *
- * Note: the a11y overlay repaint that used to live at the tail of
- * this function now runs inside `<preview-card>`'s `mapsRevision`
- * subscription — see `PreviewCard._repaintA11yOverlaysFromCache`.
- */
-export function updateImage(
-    previewId: string,
-    captureIndex: number,
-    imageData: string,
-    config: UpdateImageConfig,
-): void {
-    const card = document.getElementById("preview-" + sanitizeId(previewId));
-    if (!card) return;
-
-    // Cache so carousel navigation can restore this capture without
-    // a fresh extension round-trip. Mutates the capture object in
-    // place — the Map identity is unchanged. The matching
-    // `bumpPreviewMapsRevision()` is deferred until after the
-    // `<img>` `src` swap below, so the `<preview-card>` StoreController
-    // fires with the new image element / src in place.
-    const caps = previewStore.getState().cardCaptures.get(previewId);
-    const capture =
-        caps && captureIndex >= 0 && captureIndex < caps.length
-            ? caps[captureIndex]
-            : null;
-    if (capture) {
-        capture.imageData = imageData;
-        capture.errorMessage = null;
-        capture.renderError = null;
-    }
-
-    // Only paint the <img> if the currently-displayed capture is the
-    // one that just arrived. Otherwise the cached bytes wait for
-    // prev/next.
-    const cur = parseInt(card.dataset.currentIndex || "0", 10);
-    if (cur !== captureIndex) {
-        if (caps) config.frameCarousel.updateIndicator(card);
-        return;
-    }
-
-    const container = card.querySelector<HTMLElement>(".image-container");
-    if (!container) return;
-    // Tear down every prior state before showing the new image.
-    // Leftover .error-message divs here are what caused the
-    // "Render pending — save the file to trigger a render" banner
-    // to stay visible forever even after a successful render.
-    container.querySelector(".skeleton")?.remove();
-    container.querySelector(".loading-overlay")?.remove();
-    container.querySelector(".error-message")?.remove();
-    card.classList.remove("has-error");
-
-    const ro = capture ? capture.renderOutput : "";
-    const newSrc = "data:" + mimeFor(ro) + ";base64," + imageData;
-
-    let img = container.querySelector("img");
-    if (!img) {
-        img = document.createElement("img");
-        img.alt = (card.dataset.function ?? "") + " preview";
-        container.appendChild(img);
-    }
-    img.src = newSrc;
-    // In live mode the new bytes are a frame, not a card reload —
-    // skip the fade-in so successive frames read as a stream rather
-    // than a sequence of independent renders. See INTERACTIVE.md § 3.
-    const isLive = config.liveState.isLive(previewId);
-    img.className = isLive ? "live-frame" : "fade-in";
-    attachInteractiveInputHandlers(card, config.interactiveInputConfig);
-
-    // Bump AFTER `img.src` is set so `<preview-card>`'s StoreController
-    // sees the new image when it re-runs `_repaintA11yOverlaysFromCache`.
-    // The component handles both the immediately-decoded path and the
-    // on-load deferral itself — see PreviewCard.
-    if (capture) bumpPreviewMapsRevision();
-
-    if (caps) config.frameCarousel.updateIndicator(card);
-
-    // If a diff overlay is open on this card and uses the live render
-    // as its left anchor (head / main / current), the bytes the
-    // overlay is showing just went stale. Re-issue so the user sees
-    // the new render without clicking — symmetric with the
-    // compose-preview/main ref watcher's auto-refresh on the right anchor.
-    const openDiff = container.querySelector<HTMLElement>(
-        ".preview-diff-overlay",
-    );
-    if (config.earlyFeatures() && openDiff) {
-        const against = openDiff.dataset.against;
-        if (against === "head" || against === "main") {
-            showDiffOverlay(
-                card,
-                against,
-                null,
-                null,
-                config.diffOverlayConfig,
-            );
-            config.vscode.postMessage({
-                command: "requestPreviewDiff",
-                previewId,
-                against,
-            });
-        }
-    }
-
-    // The a11y overlay repaint that used to run here lives in
-    // `<preview-card>` — the `mapsRevision` bump above (via the
-    // `if (capture)` branch) drives `_repaintA11yOverlaysFromCache`
-    // inside the component, which both handles the synchronous
-    // (`img.complete && naturalWidth > 0`) case and attaches a
-    // one-time `load` listener when the new bytes haven't decoded
-    // yet.
-}
 
 /** Subset `applyA11yUpdate` reaches for. The a11y caches themselves
  *  live in `previewStore` and are written via the `setCardA11y…` /

--- a/vscode-extension/src/webview/preview/cardImage.ts
+++ b/vscode-extension/src/webview/preview/cardImage.ts
@@ -1,0 +1,167 @@
+// Per-frame image paint for `<preview-card>`.
+//
+// Lifted from `cardBuilder.ts`'s `updateImage` so the per-frame paint
+// is testable under happy-dom without dragging cardBuilder's wider
+// transitive imports into the host tsconfig. The component
+// (`<preview-card>`) calls `paintCardCapture` from its `paintCapture`
+// method, which the message dispatcher invokes after resolving the
+// card by id.
+//
+// Logic is unchanged from the old `updateImage`: cache mutation,
+// currently-displayed-vs-arriving capture comparison, container
+// teardown (skeleton / loading / error), `<img>` swap (or create) +
+// fade-in / live-frame class, interactive-input rebind, mapsRevision
+// bump for the `<preview-card>` overlay subscription, carousel
+// indicator refresh, diff-overlay auto-refresh.
+//
+// The `<preview-card>` reads the card by id from messageHandlers and
+// calls `paintCapture(captureIndex, imageData)` on the component;
+// the component delegates here with `this` as `card`.
+
+import { mimeFor } from "./cardData";
+import { showDiffOverlay, type DiffOverlayConfig } from "./diffOverlay";
+import type { FrameCarouselController } from "./frameCarousel";
+import {
+    attachInteractiveInputHandlers,
+    type InteractiveInputConfig,
+} from "./interactiveInput";
+import type { LiveStateController } from "./liveState";
+import { bumpPreviewMapsRevision, previewStore } from "./previewStore";
+import type { VsCodeApi } from "../shared/vscode";
+
+/** Subset of the card-builder collaborator surface that
+ *  `paintCardCapture` reaches for — every per-frame paint dependency.
+ *  The per-preview caches (`cardCaptures`, `cardA11yFindings`,
+ *  `cardA11yNodes`) live in `previewStore` and are read directly there. */
+export interface CardImageConfig {
+    vscode: VsCodeApi<unknown>;
+    frameCarousel: Pick<FrameCarouselController, "updateIndicator">;
+    liveState: Pick<LiveStateController, "isLive">;
+    interactiveInputConfig: InteractiveInputConfig;
+    diffOverlayConfig: DiffOverlayConfig;
+    /** Whether `composePreview.earlyFeatures` is on — gates the diff
+     *  overlay auto-refresh. */
+    earlyFeatures(): boolean;
+}
+
+/**
+ * Paint a fresh capture image into the matching card. Idempotent — if
+ * the currently-displayed capture index doesn't match the arriving
+ * bytes, the cache is updated and the carousel indicator refreshed but
+ * no `<img>` is touched (the bytes wait for prev/next).
+ *
+ * Side effects (when [captureIndex] matches the displayed capture):
+ *  - Mutates the per-capture cache entry on `previewStore`'s
+ *    `cardCaptures` and bumps `mapsRevision` so subscribers selecting
+ *    on it see the new bytes. The bump is issued AFTER the `<img>`
+ *    `src` swap so the `<preview-card>` StoreController fires with the
+ *    new image element / src in place and its on-load a11y deferral
+ *    attaches against the right src.
+ *  - Replaces the card's `<img>` `src` (or creates one if missing).
+ *  - Re-attaches the live pointer/wheel handlers via
+ *    `attachInteractiveInputHandlers`.
+ *  - If a diff overlay is open against `head` / `main`, re-issues the
+ *    diff request so the user sees the new bytes without clicking.
+ *
+ * The a11y overlay repaint that used to live at the tail of the old
+ * `updateImage` runs inside `<preview-card>`'s `mapsRevision`
+ * subscription — the `bumpPreviewMapsRevision()` call here drives it.
+ *
+ * `card` is the `<preview-card>` host element; the caller (the
+ * component's `paintCapture` method) resolves `this` from the dispatcher.
+ */
+export function paintCardCapture(
+    card: HTMLElement,
+    previewId: string,
+    captureIndex: number,
+    imageData: string,
+    config: CardImageConfig,
+): void {
+    // Cache so carousel navigation can restore this capture without
+    // a fresh extension round-trip. Mutates the capture object in
+    // place — the Map identity is unchanged. The matching
+    // `bumpPreviewMapsRevision()` is deferred until after the
+    // `<img>` `src` swap below, so the `<preview-card>` StoreController
+    // fires with the new image element / src in place.
+    const caps = previewStore.getState().cardCaptures.get(previewId);
+    const capture =
+        caps && captureIndex >= 0 && captureIndex < caps.length
+            ? caps[captureIndex]
+            : null;
+    if (capture) {
+        capture.imageData = imageData;
+        capture.errorMessage = null;
+        capture.renderError = null;
+    }
+
+    // Only paint the <img> if the currently-displayed capture is the
+    // one that just arrived. Otherwise the cached bytes wait for
+    // prev/next.
+    const cur = parseInt(card.dataset.currentIndex || "0", 10);
+    if (cur !== captureIndex) {
+        if (caps) config.frameCarousel.updateIndicator(card);
+        return;
+    }
+
+    const container = card.querySelector<HTMLElement>(".image-container");
+    if (!container) return;
+    // Tear down every prior state before showing the new image.
+    // Leftover .error-message divs here are what caused the
+    // "Render pending — save the file to trigger a render" banner
+    // to stay visible forever even after a successful render.
+    container.querySelector(".skeleton")?.remove();
+    container.querySelector(".loading-overlay")?.remove();
+    container.querySelector(".error-message")?.remove();
+    card.classList.remove("has-error");
+
+    const ro = capture ? capture.renderOutput : "";
+    const newSrc = "data:" + mimeFor(ro) + ";base64," + imageData;
+
+    let img = container.querySelector("img");
+    if (!img) {
+        img = document.createElement("img");
+        img.alt = (card.dataset.function ?? "") + " preview";
+        container.appendChild(img);
+    }
+    img.src = newSrc;
+    // In live mode the new bytes are a frame, not a card reload —
+    // skip the fade-in so successive frames read as a stream rather
+    // than a sequence of independent renders. See INTERACTIVE.md § 3.
+    const isLive = config.liveState.isLive(previewId);
+    img.className = isLive ? "live-frame" : "fade-in";
+    attachInteractiveInputHandlers(card, config.interactiveInputConfig);
+
+    // Bump AFTER `img.src` is set so `<preview-card>`'s StoreController
+    // sees the new image when it re-runs `_repaintA11yOverlaysFromCache`.
+    // The component handles both the immediately-decoded path and the
+    // on-load deferral itself — see PreviewCard.
+    if (capture) bumpPreviewMapsRevision();
+
+    if (caps) config.frameCarousel.updateIndicator(card);
+
+    // If a diff overlay is open on this card and uses the live render
+    // as its left anchor (head / main / current), the bytes the
+    // overlay is showing just went stale. Re-issue so the user sees
+    // the new render without clicking — symmetric with the
+    // compose-preview/main ref watcher's auto-refresh on the right anchor.
+    const openDiff = container.querySelector<HTMLElement>(
+        ".preview-diff-overlay",
+    );
+    if (config.earlyFeatures() && openDiff) {
+        const against = openDiff.dataset.against;
+        if (against === "head" || against === "main") {
+            showDiffOverlay(
+                card,
+                against,
+                null,
+                null,
+                config.diffOverlayConfig,
+            );
+            config.vscode.postMessage({
+                command: "requestPreviewDiff",
+                previewId,
+                against,
+            });
+        }
+    }
+}

--- a/vscode-extension/src/webview/preview/cardMetadata.ts
+++ b/vscode-extension/src/webview/preview/cardMetadata.ts
@@ -1,0 +1,147 @@
+// Per-card metadata refresh for `<preview-card>` reseeds.
+//
+// Lifted from `cardBuilder.ts` so the manifest-reseed path is testable
+// under happy-dom without dragging cardBuilder's wider transitive
+// imports (Lit-decorator-using `<message-banner>`, the focus inspector,
+// the diff overlay) into the host tsconfig. The component
+// (`<preview-card>`) calls `refreshCardMetadata` from its reactive
+// `updated()` hook when the `preview` property is reassigned by
+// `renderPreviews`'s manifest reseed.
+//
+// Logic is unchanged from the old `updateCardMetadata`: dataset patch,
+// title text, capture-cache merge (preserving `imageData` for surviving
+// renderOutputs), variant badge add/remove, a11y legend + overlay
+// rebuild. The capture-cache merge is the load-bearing bit — tested
+// directly here so the @RoboComposePreviewOptions count-change path
+// stays guarded.
+//
+// Companion to `cardImage.ts` (per-frame paint) and `populatePreviewCard`
+// in `cardBuilder.ts` (initial DOM build, which the `<preview-card>`
+// shell still reaches into during `firstUpdated`).
+
+import { buildA11yLegend, buildA11yOverlay } from "./a11yOverlay";
+import {
+    buildTooltip,
+    buildVariantLabel,
+    isAnimatedPreview,
+    isWearPreview,
+} from "./cardData";
+import type {
+    CapturePresentation,
+    FrameCarouselController,
+} from "./frameCarousel";
+import { previewStore, setCardCaptures } from "./previewStore";
+import type { PreviewInfo } from "../shared/types";
+
+/** Subset of the card-builder collaborator surface that
+ *  `refreshCardMetadata` reaches for. Kept narrow so this helper —
+ *  and its tests — only depend on what's actually used. The capture
+ *  cache lives in `previewStore` (see `setCardCaptures`), so it
+ *  isn't part of this surface. */
+export interface CardMetadataConfig {
+    frameCarousel: Pick<FrameCarouselController, "updateIndicator">;
+    /** Whether `composePreview.earlyFeatures` is on — gates the a11y
+     *  legend / overlay rebuild. */
+    earlyFeatures(): boolean;
+}
+
+/**
+ * Refresh an existing card after a `setPreviews` for an id we already
+ * have in the grid. Patches the card's dataset, title text, capture
+ * cache (preserving already-received `imageData` for surviving
+ * renderOutputs), variant badge, and a11y legend / overlay layer.
+ *
+ * `card` is the `<preview-card>` host element — its DOM was built up
+ * front by `populatePreviewCard` so the selectors below
+ * (`.card-title`, `.image-container`, `.variant-badge`,
+ * `.a11y-legend`, `.a11y-overlay`) all resolve. Idempotent: subsequent
+ * calls overwrite the patched fields cleanly.
+ */
+export function refreshCardMetadata(
+    card: HTMLElement,
+    p: PreviewInfo,
+    config: CardMetadataConfig,
+): void {
+    card.dataset.function = p.functionName;
+    card.dataset.group = p.params.group || "";
+    card.dataset.wearPreview = isWearPreview(p) ? "1" : "0";
+    const title = card.querySelector<HTMLButtonElement>(".card-title");
+    if (title) {
+        title.textContent =
+            p.functionName + (p.params.name ? " — " + p.params.name : "");
+        title.title = buildTooltip(p);
+    }
+    // Refresh capture labels in place. If the capture count changed
+    // (e.g. user edited @RoboComposePreviewOptions) we preserve
+    // already-received imageData for renderOutputs that carry over.
+    const newCaps = p.captures.map((c) => ({
+        renderOutput: c.renderOutput,
+        label: c.label || "",
+    }));
+    const prior = previewStore.getState().cardCaptures.get(p.id) ?? [];
+    // Match by index rather than renderOutput since filenames may
+    // legitimately change (e.g. a preview gains a @RoboComposePreviewOptions
+    // annotation). Mismatched positions just reset to null-image.
+    const mergedCaps = newCaps.map(
+        (nc, i): CapturePresentation => ({
+            label: nc.label,
+            renderOutput: nc.renderOutput || "",
+            imageData: prior[i]?.imageData ?? null,
+            errorMessage: prior[i]?.errorMessage ?? null,
+            renderError: prior[i]?.renderError ?? null,
+        }),
+    );
+    setCardCaptures(p.id, mergedCaps);
+    const curIdx = parseInt(card.dataset.currentIndex || "0", 10);
+    if (curIdx >= mergedCaps.length) {
+        card.dataset.currentIndex = String(Math.max(0, mergedCaps.length - 1));
+    }
+    if (isAnimatedPreview(p)) config.frameCarousel.updateIndicator(card);
+    const variantLabel = buildVariantLabel(p);
+    let badge = card.querySelector(".variant-badge");
+    if (variantLabel) {
+        if (!badge) {
+            badge = document.createElement("div");
+            badge.className = "variant-badge";
+            card.appendChild(badge);
+        }
+        badge.textContent = variantLabel;
+    } else if (badge) {
+        badge.remove();
+    }
+
+    // Refresh the a11y legend + overlay in place when findings
+    // change (e.g. toggling a11y on turns findings from null → list,
+    // or a fresh render updates the set). Tear down the old nodes
+    // and rebuild: simpler than reconciling row-by-row for what is
+    // a rare event.
+    const existingLegend = card.querySelector(".a11y-legend");
+    const existingOverlay = card.querySelector(".a11y-overlay");
+    if (existingLegend) existingLegend.remove();
+    if (existingOverlay) existingOverlay.innerHTML = "";
+    if (config.earlyFeatures() && p.a11yFindings && p.a11yFindings.length > 0) {
+        const container = card.querySelector(".image-container");
+        if (container && !container.querySelector(".a11y-overlay")) {
+            const overlay = document.createElement("div");
+            overlay.className = "a11y-overlay";
+            overlay.setAttribute("aria-hidden", "true");
+            container.appendChild(overlay);
+        }
+        const legend = buildA11yLegend(card, p);
+        card.appendChild(legend);
+        // Repopulate box geometry if the image is already loaded —
+        // otherwise `paintCardCapture`'s store-write triggers a
+        // re-paint via `<preview-card>`'s mapsRevision subscription.
+        const img = card.querySelector<HTMLImageElement>(
+            ".image-container img",
+        );
+        if (img && img.complete && img.naturalWidth > 0) {
+            buildA11yOverlay(card, p.a11yFindings, img);
+        }
+    } else if (existingOverlay) {
+        // No findings or feature off — drop any leftover overlay
+        // div so cards stay clean when the user toggles
+        // earlyFeatures off mid-session.
+        existingOverlay.remove();
+    }
+}

--- a/vscode-extension/src/webview/preview/components/PreviewCard.ts
+++ b/vscode-extension/src/webview/preview/components/PreviewCard.ts
@@ -2,31 +2,34 @@
 // imperative `buildPreviewCard` previously built directly on a
 // `<div class="preview-card">`.
 //
-// Step 2 of #857. The shell is intentionally minimal: it carries the
-// `preview` (PreviewInfo) and `config` (CardBuilderConfig) the host
-// hands in, and on `firstUpdated()` runs the imperative population
-// logic against `this`. Step 3 (#857) lifts the metadata refresh into
-// reactive `@state`; step 4 (this file) wires a `StoreController`
-// against `previewStore.mapsRevision` so the per-preview a11y caches
-// drive overlay repaints from the component itself instead of from
-// `applyA11yUpdate`.
+// Step 3 of #857: the metadata refresh and per-frame image paint now
+// live behind narrow-deps helpers (`refreshCardMetadata` in
+// `../cardMetadata`, `paintCardCapture` in `../cardImage`) and the
+// component owns the call sites. The host's old free-function
+// `updateImage` shim is gone — the message dispatcher resolves the
+// card by id and calls `card.paintCapture(captureIndex, imageData)`
+// here, which delegates to `paintCardCapture` against `this`.
 //
-// The `<img>` paint itself stays in `updateImage` (it owns the
-// `img.src` swap, the live-frame class, and the interactive-input
-// rebind). The on-image-load a11y repaint, however, lives here:
-// when a `mapsRevision` bump arrives but the `<img>` has not yet
-// resolved its `naturalWidth`, this component attaches a one-time
-// `load` listener instead of bailing. Combined with `updateImage`
-// bumping `mapsRevision` AFTER assigning the new `src`, the
-// component's StoreController fires with the right image element
-// and the load listener attaches against the new src.
+// `firstUpdated` still runs the imperative `populatePreviewCard`
+// logic to build initial DOM — that one stays in `cardBuilder.ts`
+// for now since it touches collaborator hooks (`enterFocus`,
+// `observeForViewport`) that aren't on the narrow-deps surface.
+// Folding that one in is a follow-up step.
+//
+// `_mapsRevision` (`StoreController`) drives a11y-overlay repaints
+// from the per-preview cache: `paintCardCapture` bumps
+// `previewStore.mapsRevision` AFTER assigning the new `<img>.src`, so
+// the component re-runs `_repaintA11yOverlaysFromCache` with the new
+// image in place. When the `<img>` hasn't yet resolved its natural
+// dimensions, the repaint attaches a one-time `load` listener and
+// paints when the bytes land.
 //
 // We pass `preview` as a `@property` rather than just a `previewId`
-// because `populatePreviewCard` needs the full `PreviewInfo` (function
-// name, params, captures, a11yFindings, …). Resolving from
-// `previewStore.allPreviews` would work but adds an indirection that
-// step 3 will need to undo when it switches to a reactive selection
-// against the store.
+// because `populatePreviewCard` and `refreshCardMetadata` need the
+// full `PreviewInfo` (function name, params, captures, a11yFindings,
+// …). Resolving from `previewStore.allPreviews` would work but adds
+// an indirection a later step can undo when it switches to a reactive
+// selection against the store.
 //
 // Light DOM only — `media/preview.css` selectors target
 // `.preview-card .card-header .card-title-row` etc. and would not
@@ -42,7 +45,9 @@ import { LitElement, html, type TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { applyHierarchyOverlay, buildA11yOverlay } from "../a11yOverlay";
 import type { CardBuilderConfig } from "../cardBuilder";
-import { populatePreviewCard, updateCardMetadata } from "../cardBuilder";
+import { populatePreviewCard } from "../cardBuilder";
+import { paintCardCapture } from "../cardImage";
+import { refreshCardMetadata } from "../cardMetadata";
 import { previewStore, type PreviewState } from "../previewStore";
 import { StoreController } from "../../shared/storeController";
 import type { PreviewInfo } from "../../shared/types";
@@ -120,10 +125,27 @@ export class PreviewCard extends LitElement {
             const preview = this.preview;
             const config = this.config;
             if (preview && config) {
-                updateCardMetadata(this, preview, config);
+                refreshCardMetadata(this, preview, config);
             }
         }
         this._repaintA11yOverlaysFromCache();
+    }
+
+    /** Per-frame image paint — invoked by the message dispatcher
+     *  after resolving the card by id. Delegates to
+     *  `paintCardCapture` against `this`; the helper handles cache
+     *  mutation, currently-displayed-vs-arriving capture comparison,
+     *  `<img>` swap, interactive-input rebind, and the
+     *  `mapsRevision` bump that drives the overlay repaint. No-op
+     *  when `config` hasn't been set (the card is mid-construction
+     *  and `firstUpdated` hasn't run yet — shouldn't happen in
+     *  practice since the dispatcher only finds cards already
+     *  attached to the grid). */
+    paintCapture(captureIndex: number, imageData: string): void {
+        const preview = this.preview;
+        const config = this.config;
+        if (!preview || !config) return;
+        paintCardCapture(this, preview.id, captureIndex, imageData, config);
     }
 
     /** Re-paint the a11y findings / hierarchy overlays from the latest

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -16,11 +16,8 @@ import { getVsCodeApi, type VsCodeApi } from "../shared/vscode";
 import {
     applyA11yUpdate,
     applyRelativeSizing,
-    buildPreviewCard,
     type CardBuilderConfig,
     renderPreviews as renderPreviewsImpl,
-    updateCardMetadata,
-    updateImage,
 } from "./cardBuilder";
 import { FilterToolbar } from "./components/FilterToolbar";
 import { MessageBanner, type MessageOwner } from "./components/MessageBanner";
@@ -591,11 +588,13 @@ export class PreviewApp extends LitElement {
         // `<filter-toolbar>`'s reactive state retains `fnValue` / `grpValue`
         // when only `fnOptions` / `grpOptions` change.
 
-        // Card lifecycle lives in `./cardBuilder.ts` — see `buildPreviewCard`,
-        // `updateCardMetadata`, `applyRelativeSizing`, `updateImage`,
-        // `applyA11yUpdate`. The eventual `<preview-card>` Lit component will
-        // fold all five into a single reactive `render()` and consume the same
-        // `CardBuilderConfig` shape for its collaborator surface.
+        // Card lifecycle: initial DOM build in `./cardBuilder.ts`
+        // (`buildPreviewCard` / `populatePreviewCard`); reactive metadata
+        // refresh + per-frame image paint live behind `<preview-card>`'s
+        // `updated()` hook + `paintCapture` method (delegating to
+        // `./cardMetadata.refreshCardMetadata` and `./cardImage.paintCardCapture`).
+        // `applyA11yUpdate` and `applyRelativeSizing` still flow through
+        // `cardBuilderConfig` for now.
         const cardBuilderConfig: CardBuilderConfig = {
             vscode,
             grid,
@@ -665,13 +664,6 @@ export class PreviewApp extends LitElement {
             saveFilterState,
             restoreFilterState,
             ensureNotBlank,
-            updateImage: (previewId, captureIndex, imageData) =>
-                updateImage(
-                    previewId,
-                    captureIndex,
-                    imageData,
-                    cardBuilderConfig,
-                ),
             applyA11yUpdate: (previewId, findings, nodes) =>
                 applyA11yUpdate(previewId, findings, nodes, cardBuilderConfig),
             focusOnCard,

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -16,8 +16,11 @@
 // state still owned imperatively by `behavior.ts` — `allPreviews`,
 // `moduleDir`, `lastScopedPreviewId`, `a11yOverlayPreviewId` — and the
 // orchestration callbacks (`renderPreviews`, `applyLayout`,
-// `applyFilters`, `updateImage`, `applyA11yUpdate`, `focusOnCard`, etc.)
-// that should fold into a future `<preview-card>` Lit component. The
+// `applyFilters`, `applyA11yUpdate`, `focusOnCard`, etc.) that should
+// fold into a future `<preview-card>` Lit component. (`updateImage`
+// already has — the dispatcher resolves the card by id and calls
+// `card.paintCapture(...)` directly; no `ctx.updateImage` callback.)
+// The
 // per-preview Maps (`cardCaptures`, `cardA11yFindings`, `cardA11yNodes`)
 // now live on `previewStore` and are reached through the helpers in
 // `previewStore.ts`. The per-module availability Maps (`moduleDaemonReady`,
@@ -40,6 +43,7 @@ import type {
 import type { VsCodeApi } from "../shared/vscode";
 import { safeArrayIndex } from "../shared/safeIndex";
 import { sanitizeId } from "./cardData";
+import { PreviewCard } from "./components/PreviewCard";
 import { PreviewGrid } from "./components/PreviewGrid";
 import { buildErrorPanel } from "./errorPanel";
 import { showDiffOverlay, type DiffOverlayConfig } from "./diffOverlay";
@@ -93,11 +97,6 @@ export interface PreviewMessageContext {
     saveFilterState(): void;
     restoreFilterState(): void;
     ensureNotBlank(): void;
-    updateImage(
-        previewId: string,
-        captureIndex: number,
-        imageData: string,
-    ): void;
     applyA11yUpdate(
         previewId: string,
         findings: readonly AccessibilityFinding[] | null | undefined,
@@ -127,13 +126,22 @@ export function handleExtensionMessage(
             return;
         case "clearAll":
             return handleClearAll(ctx);
-        case "updateImage":
-            ctx.updateImage(
-                msg.previewId,
-                safeArrayIndex(msg.captureIndex),
-                msg.imageData,
+        case "updateImage": {
+            // Resolve the card and delegate to its `paintCapture`
+            // method — `<preview-card>` owns the per-frame paint
+            // path, so the dispatcher hands off the captureIndex /
+            // imageData straight to the component.
+            const card = document.getElementById(
+                "preview-" + sanitizeId(msg.previewId),
             );
+            if (card instanceof PreviewCard) {
+                card.paintCapture(
+                    safeArrayIndex(msg.captureIndex),
+                    msg.imageData,
+                );
+            }
             return;
+        }
         case "updateA11y":
             ctx.applyA11yUpdate(msg.previewId, msg.findings, msg.nodes);
             return;

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -18,6 +18,8 @@
     "exclude": ["node_modules", "src/webview/**"],
     "files": [
         "src/webview/preview/cardData.ts",
+        "src/webview/preview/cardImage.ts",
+        "src/webview/preview/cardMetadata.ts",
         "src/webview/preview/errorPanel.ts",
         "src/webview/preview/focusToolbar.ts",
         "src/webview/preview/interactiveInput.ts",


### PR DESCRIPTION
## Summary

Refactor the card lifecycle operations in `cardBuilder.ts` by extracting the metadata refresh and per-frame image paint logic into separate, narrowly-scoped helper modules. This enables unit testing these critical paths under happy-dom without dragging in heavy transitive dependencies, and prepares the ground for moving these operations into the `<preview-card>` Lit component.

## Key Changes

- **New `cardMetadata.ts`**: Extract `updateCardMetadata` → `refreshCardMetadata` with a narrow `CardMetadataConfig` interface. Handles dataset patching, title text, capture-cache merging (preserving `imageData` for surviving renderOutputs), variant badge management, and a11y legend/overlay rebuild.

- **New `cardImage.ts`**: Extract `updateImage` → `paintCardCapture` with a narrow `CardImageConfig` interface. Handles per-frame image paint, skeleton/error teardown, `<img>` src swap, live-frame vs fade-in class selection, interactive-input rebinding, `mapsRevision` bump, carousel indicator refresh, and diff-overlay auto-refresh.

- **Updated `cardBuilder.ts`**: Remove the extracted functions and update imports/exports. Keep `populatePreviewCard` (initial DOM build) since it still touches collaborator hooks not on the narrow-deps surface.

- **Updated `PreviewCard.ts`**: Wire up the new helpers:
  - Call `refreshCardMetadata` from reactive `updated()` hook when `preview` property is reassigned
  - Add `paintCapture(captureIndex, imageData)` method that delegates to `paintCardCapture`
  - Keep `_mapsRevision` StoreController for a11y-overlay repaints

- **Updated `messageHandlers.ts`**: Message dispatcher now resolves the card by id and calls `card.paintCapture(...)` directly instead of invoking a `ctx.updateImage` callback.

- **New test files**:
  - `cardMetadata.test.ts`: 325 lines covering capture-cache merging, currentIndex clamping, variant badge lifecycle, a11y legend/overlay rebuild, and animated preview indicator updates
  - `cardImage.test.ts`: 265 lines covering img.src swap, skeleton teardown, live-frame vs fade-in classes, non-displayed capture caching, error-state cleanup, and diff-overlay auto-refresh

- **Updated `tsconfig.json`**: Add new modules to the test-only files list so they're available to the test harness.

## Implementation Details

- Both new helpers use `previewStore` directly for cache reads/writes, keeping the config interfaces minimal
- The capture-cache merge logic (matching by index, preserving `imageData`) is now directly testable, guarding the @RoboComposePreviewOptions count-change path
- `mapsRevision` bump is deferred until after `<img>` src assignment so the `<preview-card>` StoreController fires with the new image in place
- Tests use happy-dom + existing `setup-dom.ts` global registration, no extra harness needed
- All logic is unchanged from the original `cardBuilder.ts` implementations — this is a pure refactor for testability and component integration

https://claude.ai/code/session_01QBDtyy2pYx16zHqdJ4fQpU