### PR TITLE
Add UIAutomator hierarchy producer for Compose semantics trees

### DIFF
--- a/data/uiautomator/core/build.gradle.kts
+++ b/data/uiautomator/core/build.gradle.kts
@@ -29,10 +29,15 @@ plugins {
 android { namespace = "ee.schimke.composeai.data.uiautomator.core" }
 
 dependencies {
+  // `DataProductKey` for the typed `uia/hierarchy` product key (#874). Carried in this module
+  // so the producer in `:data-uiautomator-hierarchy-android` and the connector both reference
+  // the same key; mirrors `:data-a11y-core`'s exposure of `AccessibilityDataProducts.Hierarchy`.
+  api(project(":data-render-core"))
+
   // Selector JSON wire format — needed so the matcher can travel across the daemon bridge
   // (DispatchUiAutomator envelope, see docs/daemon/INTERACTIVE-ANDROID.md) and the MCP
   // record_preview surface without forcing host code onto consumer classpaths.
-  implementation(libs.kotlinx.serialization.json)
+  api(libs.kotlinx.serialization.json)
 
   // Compose-side traversal walks `SemanticsNode` and dispatches actions through
   // `SemanticsActions` lambdas. `compileOnly` for the same reason `:renderer-android` does it

--- a/data/uiautomator/core/src/main/kotlin/ee/schimke/composeai/renderer/uiautomator/UiAutomatorHierarchyModels.kt
+++ b/data/uiautomator/core/src/main/kotlin/ee/schimke/composeai/renderer/uiautomator/UiAutomatorHierarchyModels.kt
@@ -1,0 +1,95 @@
+package ee.schimke.composeai.renderer.uiautomator
+
+import ee.schimke.composeai.data.render.extensions.DataProductKey
+import kotlinx.serialization.Serializable
+
+/**
+ * One Compose semantics node surfaced by the `uia/hierarchy` data product (#874). Shape is
+ * deliberately small: agents need just enough metadata to formulate a [Selector] that uniquely
+ * targets the node — text, contentDescription, testTag, role, the supported `uia.*` actions —
+ * not the full SemanticsNode graph.
+ *
+ * Emitted by [`UiAutomatorHierarchyExtractor`][ee.schimke.composeai.renderer.uiautomator.UiAutomatorHierarchyExtractor]
+ * (lives in `:data-uiautomator-hierarchy-android`). The extractor's default filter keeps only
+ * nodes that expose at least one of [UiAutomatorDataProducts.SUPPORTED_ACTIONS]; that drops the
+ * ~80% of layout-wrapper / pure-text nodes a real Material screen produces while still emitting
+ * everything a `uia.click` / `uia.scrollForward` / `uia.inputText` could plausibly target.
+ */
+@Serializable
+data class UiAutomatorHierarchyNode(
+  /**
+   * `EditableText` first (input fields), falling back to joined `Text` — same shape
+   * `SemanticsBacking` exposes to selector matching, so an emitted node's `text` is exactly
+   * what a `By.text(...)` would match against.
+   */
+  val text: String? = null,
+  /** Joined `ContentDescription`. */
+  val contentDescription: String? = null,
+  /** `Modifier.testTag(...)` — the closest stable per-node id Compose offers. */
+  val testTag: String? = null,
+  /**
+   * TestTags of ancestors, root-most → nearest, omitting blanks. Preserved on the emitted node
+   * so `hasParent({testTag: ...})` / `hasAncestor` selector chains stay resolvable from the
+   * hierarchy snapshot alone, even though intermediate non-actionable parents are filtered out.
+   */
+  val testTagAncestors: List<String> = emptyList(),
+  /**
+   * `SemanticsProperties.Role` stringified (`Button`, `Checkbox`, `Switch`, `RadioButton`,
+   * `Tab`, `Image`, `DropdownList`). `null` when the node carries no role.
+   */
+  val role: String? = null,
+  /**
+   * Sorted subset of [UiAutomatorDataProducts.SUPPORTED_ACTIONS] this node exposes. Stable order
+   * keeps wire diffs deterministic across runs.
+   */
+  val actions: List<String> = emptyList(),
+  /** `left,top,right,bottom` in source-bitmap pixels — same shape `AccessibilityNode` uses. */
+  val boundsInScreen: String,
+  /**
+   * `true` when the snapshot was taken against the merged semantics tree (the on-device
+   * UIAutomator default; what `Button { Text("Submit") }` collapses into one node), `false`
+   * when the unmerged tree was requested. Recorded on the emitted node so a downstream client
+   * can disambiguate two payloads pointing at the same preview.
+   */
+  val merged: Boolean = true,
+)
+
+/** Per-preview `uia/hierarchy` payload — the node list emitted by the producer. */
+@Serializable data class UiAutomatorHierarchyPayload(val nodes: List<UiAutomatorHierarchyNode>)
+
+object UiAutomatorDataProducts {
+  const val SCHEMA_VERSION: Int = 1
+  const val KIND_HIERARCHY: String = "uia/hierarchy"
+
+  /** Action names emitted on [UiAutomatorHierarchyNode.actions]. */
+  const val ACTION_CLICK: String = "click"
+  const val ACTION_LONG_CLICK: String = "longClick"
+  const val ACTION_SCROLL: String = "scroll"
+  const val ACTION_SET_TEXT: String = "setText"
+  const val ACTION_REQUEST_FOCUS: String = "requestFocus"
+  const val ACTION_EXPAND: String = "expand"
+  const val ACTION_COLLAPSE: String = "collapse"
+  const val ACTION_DISMISS: String = "dismiss"
+  const val ACTION_SET_PROGRESS: String = "setProgress"
+
+  /**
+   * Action set that makes a node a viable `uia.*` dispatch target. Matches the `when` arms in
+   * `RobolectricHost.performUiAutomatorAction` so the default-filtered hierarchy never hides a
+   * node the dispatch path could actually drive.
+   */
+  val SUPPORTED_ACTIONS: Set<String> =
+    setOf(
+      ACTION_CLICK,
+      ACTION_LONG_CLICK,
+      ACTION_SCROLL,
+      ACTION_SET_TEXT,
+      ACTION_REQUEST_FOCUS,
+      ACTION_EXPAND,
+      ACTION_COLLAPSE,
+      ACTION_DISMISS,
+      ACTION_SET_PROGRESS,
+    )
+
+  val Hierarchy: DataProductKey<UiAutomatorHierarchyPayload> =
+    DataProductKey(KIND_HIERARCHY, SCHEMA_VERSION, UiAutomatorHierarchyPayload::class.java)
+}

--- a/data/uiautomator/hierarchy-android/build.gradle.kts
+++ b/data/uiautomator/hierarchy-android/build.gradle.kts
@@ -1,0 +1,73 @@
+@file:Suppress(
+  "DEPRECATION"
+) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
+
+// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
+
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
+// `:data-uiautomator-hierarchy-android` — the Android-platform-specific producer for
+// `uia/hierarchy` (#874). Walks a Compose `SemanticsOwner` tree and emits a typed
+// `UiAutomatorHierarchyPayload` carrying the actionable subset agents need to formulate
+// `uia.*` selectors. Mirrors `:data-a11y-hierarchy-android`'s producer + extension shape;
+// uses the same `PostCaptureProcessor` hook so the typed product graph stays
+// platform-agnostic downstream.
+//
+// Default filter (per the issue's review feedback) keeps only nodes exposing at least one
+// of `UiAutomatorDataProducts.SUPPORTED_ACTIONS` — drops ~80% of layout / pure-text wrappers
+// while preserving every viable dispatch target. `includeNonActionable` flag reverts to a
+// debug-friendly walk for selector tuning.
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.tapmoc)
+}
+
+android { namespace = "ee.schimke.composeai.data.uiautomator.hierarchy.android" }
+
+dependencies {
+  api(project(":data-uiautomator-core"))
+
+  // Compose SemanticsNode / SemanticsActions / SemanticsProperties — same `compileOnly`
+  // pattern `:data-uiautomator-core` uses so we don't pin a Compose version onto downstream
+  // consumers' classpaths. Test classpath gets the full runtime.
+  compileOnly(platform(libs.compose.bom.compat))
+  compileOnly(libs.compose.ui)
+  compileOnly(libs.compose.runtime)
+  compileOnly("androidx.compose.ui:ui-test-junit4")
+
+  testImplementation(libs.junit)
+  testImplementation(libs.robolectric)
+  testImplementation(platform(libs.compose.bom.compat))
+  testImplementation(libs.compose.ui)
+  testImplementation(libs.compose.foundation)
+  testImplementation(libs.compose.material3)
+  testImplementation(libs.compose.runtime)
+  testImplementation(libs.activity.compose)
+  testImplementation("androidx.compose.ui:ui-test-junit4")
+  testImplementation("androidx.compose.ui:ui-test-manifest")
+}
+
+mavenPublishing {
+  configure(
+    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
+      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
+      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
+      variant = "release",
+    )
+  )
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-uiautomator-hierarchy-android",
+    displayName = "Compose Preview — UIAutomator Hierarchy Producer (Android)",
+    description =
+      "Android-platform-specific producer for the `uia/hierarchy` data product: walks a Compose " +
+        "SemanticsOwner tree and emits the actionable subset agents need to formulate `uia.*` " +
+        "selectors. Pairs with `:data-uiautomator-core`'s typed payload + selector DSL.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/uiautomator/hierarchy-android/src/main/kotlin/ee/schimke/composeai/renderer/uiautomator/UiAutomatorHierarchyExtension.kt
+++ b/data/uiautomator/hierarchy-android/src/main/kotlin/ee/schimke/composeai/renderer/uiautomator/UiAutomatorHierarchyExtension.kt
@@ -1,0 +1,213 @@
+package ee.schimke.composeai.renderer.uiautomator
+
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.DataProductKey
+import ee.schimke.composeai.data.render.extensions.ExtensionContextKey
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+
+/**
+ * Pure extractor — walks a Compose [SemanticsNode] tree and returns the typed
+ * [UiAutomatorHierarchyPayload]. The default emit set is the **actionable subset**: nodes whose
+ * `SemanticsConfiguration` exposes at least one `uia.*` action (Click, LongClick, Scroll,
+ * SetText, RequestFocus, Expand, Collapse, Dismiss, SetProgress). Per the #874 review, this
+ * drops ~80% of the SemanticsOwner walk on real screens — Material containers, layout
+ * wrappers, decorative `Text` nodes — while preserving every node a `uia.click` / `uia.scrollForward` /
+ * `uia.inputText` could plausibly target.
+ *
+ * The walk descends through filtered-out parents. A clickable buried under three layout
+ * wrappers is still emitted (only the wrappers are dropped); the wrapper's `testTag`, when it
+ * has one, is preserved on the descendant via [UiAutomatorHierarchyNode.testTagAncestors] so
+ * `hasParent({testTag: ...})` selector chains stay resolvable from the snapshot alone.
+ *
+ * # Flags
+ *
+ *  - [includeNonActionable] — when `true`, also emits any node carrying a selector-targetable
+ *    property (`text` / `contentDescription` / `testTag` / `role`). Off by default; use it when
+ *    debugging a `uia.click` whose selector targets static text or a description rather than
+ *    the action-bearing node itself.
+ *  - [merged] — descriptive only. Records on the emitted node whether the snapshot came from
+ *    the merged or unmerged tree. Choosing which tree to walk is upstream of this extractor:
+ *    the host calls `rule.onRoot(useUnmergedTree=...)` and hands the resulting [SemanticsNode]
+ *    in. We don't emit both trees — the agent picks one per request, same shape `record_preview`
+ *    already exposes for `uia.*` dispatch.
+ *
+ * Pure data — no platform side-effects. Unit-testable with a `ComposeContentTestRule`.
+ */
+object UiAutomatorHierarchyExtractor {
+  fun extract(
+    root: SemanticsNode,
+    includeNonActionable: Boolean = false,
+    merged: Boolean = true,
+  ): UiAutomatorHierarchyPayload {
+    val out = mutableListOf<UiAutomatorHierarchyNode>()
+    walk(root, ancestorTags = emptyList(), out, includeNonActionable, merged)
+    return UiAutomatorHierarchyPayload(out)
+  }
+
+  private fun walk(
+    node: SemanticsNode,
+    ancestorTags: List<String>,
+    out: MutableList<UiAutomatorHierarchyNode>,
+    includeNonActionable: Boolean,
+    merged: Boolean,
+  ) {
+    val emitted = nodeFor(node, ancestorTags, merged)
+    if (shouldEmit(emitted, includeNonActionable)) {
+      out += emitted
+    }
+    val ownTag = node.config.getOrNull(SemanticsProperties.TestTag)
+    val nextAncestors =
+      if (ownTag.isNullOrBlank()) ancestorTags else (ancestorTags + ownTag)
+    for (child in node.children) {
+      walk(child, nextAncestors, out, includeNonActionable, merged)
+    }
+  }
+
+  private fun shouldEmit(node: UiAutomatorHierarchyNode, includeNonActionable: Boolean): Boolean {
+    if (node.actions.isNotEmpty()) return true
+    if (!includeNonActionable) return false
+    // Even in debug mode, drop nodes with no selector-targetable property at all — a pure
+    // layout Box with empty bounds carries no signal for an agent.
+    return node.text != null ||
+      node.contentDescription != null ||
+      node.testTag != null ||
+      node.role != null
+  }
+
+  private fun nodeFor(
+    node: SemanticsNode,
+    ancestorTags: List<String>,
+    merged: Boolean,
+  ): UiAutomatorHierarchyNode {
+    val config = node.config
+    val text =
+      config.getOrNull(SemanticsProperties.EditableText)?.text
+        ?: config.getOrNull(SemanticsProperties.Text)?.joinToString(separator = " ") { it.text }
+    val description = config.getOrNull(SemanticsProperties.ContentDescription)?.joinToString(" ")
+    val testTag = config.getOrNull(SemanticsProperties.TestTag)?.takeIf { it.isNotBlank() }
+    val role = config.getOrNull(SemanticsProperties.Role)?.toString()
+    val actions = actionsFor(node)
+    val bounds = node.boundsInRoot
+    val boundsString =
+      "${bounds.left.toInt()},${bounds.top.toInt()},${bounds.right.toInt()},${bounds.bottom.toInt()}"
+    return UiAutomatorHierarchyNode(
+      text = text,
+      contentDescription = description,
+      testTag = testTag,
+      testTagAncestors = ancestorTags,
+      role = role,
+      actions = actions,
+      boundsInScreen = boundsString,
+      merged = merged,
+    )
+  }
+
+  private fun actionsFor(node: SemanticsNode): List<String> {
+    val config = node.config
+    val out = mutableListOf<String>()
+    if (config.getOrNull(SemanticsActions.OnClick) != null) {
+      out += UiAutomatorDataProducts.ACTION_CLICK
+    }
+    if (config.getOrNull(SemanticsActions.OnLongClick) != null) {
+      out += UiAutomatorDataProducts.ACTION_LONG_CLICK
+    }
+    if (config.getOrNull(SemanticsActions.ScrollBy) != null) {
+      out += UiAutomatorDataProducts.ACTION_SCROLL
+    }
+    if (config.getOrNull(SemanticsActions.SetText) != null) {
+      out += UiAutomatorDataProducts.ACTION_SET_TEXT
+    }
+    if (config.getOrNull(SemanticsActions.RequestFocus) != null) {
+      out += UiAutomatorDataProducts.ACTION_REQUEST_FOCUS
+    }
+    if (config.getOrNull(SemanticsActions.Expand) != null) {
+      out += UiAutomatorDataProducts.ACTION_EXPAND
+    }
+    if (config.getOrNull(SemanticsActions.Collapse) != null) {
+      out += UiAutomatorDataProducts.ACTION_COLLAPSE
+    }
+    if (config.getOrNull(SemanticsActions.Dismiss) != null) {
+      out += UiAutomatorDataProducts.ACTION_DISMISS
+    }
+    if (config.getOrNull(SemanticsActions.SetProgress) != null) {
+      out += UiAutomatorDataProducts.ACTION_SET_PROGRESS
+    }
+    return out
+  }
+}
+
+/**
+ * Default binding for [UiAutomatorHierarchyExtractor]: invokes it after capture and emits a
+ * typed [UiAutomatorHierarchyPayload] into the product store. Reads the captured
+ * [SemanticsNode] root from [UiAutomatorHierarchyContextKeys.SemanticsRoot] (host populates it
+ * from `rule.onRoot(useUnmergedTree=...)` or its on-device equivalent) and an
+ * [UiAutomatorHierarchyOptions] block from [UiAutomatorHierarchyContextKeys.Options] (defaults
+ * to filtered + merged when absent).
+ *
+ * `targets = {Android}` — a future Compose Multiplatform Desktop hierarchy producer would
+ * target `{Desktop}` and emit the same product key; the planner's target filter selects
+ * exactly one provider per platform.
+ */
+class UiAutomatorHierarchyExtension : PostCaptureProcessor {
+  override val id: DataExtensionId = DataExtensionId(EXTENSION_ID)
+  override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.AfterCapture)
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(phase = DataExtensionPhase.Capture)
+  override val outputs: Set<DataProductKey<*>> = setOf(UiAutomatorDataProducts.Hierarchy)
+  override val targets: Set<DataExtensionTarget> = setOf(DataExtensionTarget.Android)
+
+  override fun process(context: ExtensionPostCaptureContext) {
+    val root = context.require(UiAutomatorHierarchyContextKeys.SemanticsRoot)
+    val options =
+      context.get(UiAutomatorHierarchyContextKeys.Options) ?: UiAutomatorHierarchyOptions()
+    val payload =
+      UiAutomatorHierarchyExtractor.extract(
+        root = root,
+        includeNonActionable = options.includeNonActionable,
+        merged = options.merged,
+      )
+    context.products.put(UiAutomatorDataProducts.Hierarchy, payload)
+  }
+
+  companion object {
+    const val EXTENSION_ID: String = "uia-hierarchy"
+  }
+}
+
+/**
+ * Producer-side options. The host decides which tree to fetch (merged vs unmerged) before
+ * handing us the [SemanticsNode] root, so [merged] here is descriptive — it ends up on every
+ * emitted [UiAutomatorHierarchyNode] so a downstream consumer can disambiguate. The
+ * [includeNonActionable] flag flips the extractor between the agent-targeting view (default)
+ * and the debug walk.
+ */
+data class UiAutomatorHierarchyOptions(
+  val includeNonActionable: Boolean = false,
+  val merged: Boolean = true,
+)
+
+/**
+ * Typed keys this extension reads from [ExtensionPostCaptureContext.data]. The Android-platform
+ * binding lives here (where Compose [SemanticsNode] is in scope); a future
+ * `:data-uiautomator-hierarchy-desktop` would declare its own `SemanticsRoot` key with the
+ * Desktop equivalent (`ImageComposeScene` already exposes the same tree).
+ */
+object UiAutomatorHierarchyContextKeys {
+  val SemanticsRoot: ExtensionContextKey<SemanticsNode> =
+    ExtensionContextKey(name = "uia-hierarchy.semanticsRoot", type = SemanticsNode::class.java)
+
+  val Options: ExtensionContextKey<UiAutomatorHierarchyOptions> =
+    ExtensionContextKey(
+      name = "uia-hierarchy.options",
+      type = UiAutomatorHierarchyOptions::class.java,
+    )
+}

--- a/data/uiautomator/hierarchy-android/src/test/kotlin/ee/schimke/composeai/renderer/uiautomator/UiAutomatorHierarchyExtensionTest.kt
+++ b/data/uiautomator/hierarchy-android/src/test/kotlin/ee/schimke/composeai/renderer/uiautomator/UiAutomatorHierarchyExtensionTest.kt
@@ -1,0 +1,272 @@
+package ee.schimke.composeai.renderer.uiautomator
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.provides
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Producer-level tests for the `uia/hierarchy` extension (#874). Drives the extractor against
+ * real Compose `SemanticsNode` trees through `ComposeContentTestRule` — same path the daemon
+ * will use post-capture, so anything that passes here matches what an agent's `uia.click`
+ * dispatch sees.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], qualifiers = "w400dp-h800dp")
+class UiAutomatorHierarchyExtensionTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun `default filter drops layout wrappers and decorative text but keeps actionables`() {
+    rule.setContent {
+      Column {
+        Box { Button(onClick = {}) { Text("Submit") } }
+        Text("Just a label")
+      }
+    }
+
+    val payload = extractMerged()
+
+    val texts = payload.nodes.map { it.text }
+    assertTrue(
+      "expected the Submit button among emitted nodes, got $texts",
+      texts.any { it == "Submit" },
+    )
+    assertFalse(
+      "decorative 'Just a label' Text must not be emitted in the default filter, got $texts",
+      texts.contains("Just a label"),
+    )
+    // Every emitted node must carry at least one supported uia.* action — that's the contract
+    // of the default filter and what makes the snapshot useful as a dispatch target list.
+    for (node in payload.nodes) {
+      assertTrue(
+        "default-filtered node carried no actions: $node",
+        node.actions.isNotEmpty(),
+      )
+      assertTrue(
+        "node action '${node.actions}' contains an unsupported value",
+        node.actions.all { it in UiAutomatorDataProducts.SUPPORTED_ACTIONS },
+      )
+    }
+  }
+
+  @Test
+  fun `deeply nested clickable stays reachable through filtered parents`() {
+    rule.setContent {
+      Box {
+        Box {
+          Box { Button(onClick = {}) { Text("Deep") } }
+        }
+      }
+    }
+
+    val payload = extractMerged()
+    val deep = payload.nodes.firstOrNull { it.text == "Deep" }
+    assertNotNull("Deep button must survive three layers of Box wrappers", deep)
+    assertTrue(
+      "Deep button must expose `click`, got ${deep!!.actions}",
+      UiAutomatorDataProducts.ACTION_CLICK in deep.actions,
+    )
+  }
+
+  @Test
+  fun `includeNonActionable surfaces decorative text and contentDescription nodes`() {
+    rule.setContent {
+      Column {
+        Button(onClick = {}) { Text("Primary") }
+        Text("Just a label")
+        Box(modifier = Modifier.semantics { contentDescription = "decoration" })
+      }
+    }
+
+    val rootNode = rule.onRoot(useUnmergedTree = false).fetchSemanticsNode()
+    val filtered = UiAutomatorHierarchyExtractor.extract(rootNode)
+    val full = UiAutomatorHierarchyExtractor.extract(rootNode, includeNonActionable = true)
+
+    val filteredTexts = filtered.nodes.map { it.text }
+    val fullTexts = full.nodes.mapNotNull { it.text }
+    val fullDescriptions = full.nodes.mapNotNull { it.contentDescription }
+
+    assertFalse(
+      "filtered view must not include decorative Text, got $filteredTexts",
+      filteredTexts.contains("Just a label"),
+    )
+    assertTrue(
+      "debug view must include decorative Text, got $fullTexts",
+      fullTexts.contains("Just a label"),
+    )
+    assertTrue(
+      "debug view must include contentDescription nodes, got $fullDescriptions",
+      fullDescriptions.contains("decoration"),
+    )
+    assertTrue(
+      "debug view must be at least as large as filtered view (${full.nodes.size} vs " +
+        "${filtered.nodes.size})",
+      full.nodes.size >= filtered.nodes.size,
+    )
+  }
+
+  @Test
+  fun `testTag ancestors propagate to actionable descendant`() {
+    rule.setContent {
+      Column(modifier = Modifier.testTag("list")) {
+        Box(modifier = Modifier.testTag("row")) {
+          Button(onClick = {}, modifier = Modifier.testTag("submit-button")) { Text("Submit") }
+        }
+      }
+    }
+
+    val payload = extractMerged()
+    val submit = payload.nodes.firstOrNull { it.testTag == "submit-button" }
+    assertNotNull(
+      "expected the Submit button (testTag='submit-button') in the emitted nodes",
+      submit,
+    )
+    // Compose's merged tree collapses Button { Text("Submit") } so the click-bearing node owns
+    // the testTag we put on the Button. Ancestors `list` and `row` must travel along, root-most
+    // first, so a `hasParent({testTag: 'row'})` selector chain stays resolvable from this
+    // snapshot alone.
+    assertTrue(
+      "expected ancestor 'list' before 'row' in ${submit!!.testTagAncestors}",
+      submit.testTagAncestors.indexOf("list") in 0..submit.testTagAncestors.indexOf("row"),
+    )
+    assertTrue(
+      "expected 'row' among ancestors, got ${submit.testTagAncestors}",
+      "row" in submit.testTagAncestors,
+    )
+    assertFalse(
+      "node must not include its own testTag in testTagAncestors",
+      "submit-button" in submit.testTagAncestors,
+    )
+  }
+
+  @Test
+  fun `extension declares hierarchy output and Android target and fails loudly without root`() {
+    val extension = UiAutomatorHierarchyExtension()
+
+    assertTrue(extension.inputs.isEmpty())
+    assertEquals(setOf(UiAutomatorDataProducts.Hierarchy), extension.outputs)
+    assertEquals(setOf(DataExtensionTarget.Android), extension.targets)
+
+    // Missing SemanticsRoot context key must fail loudly with the key name in the message —
+    // mirrors the `:data-a11y-hierarchy-android` contract so misconfigured hosts surface the
+    // problem instead of silently emitting an empty hierarchy.
+    val store = RecordingDataProductStore()
+    val ex =
+      assertThrows(IllegalStateException::class.java) {
+        extension.process(
+          ExtensionPostCaptureContext(
+            extensionId = extension.id,
+            previewId = "preview",
+            renderMode = null,
+            products = store.scopedFor(extension),
+          )
+        )
+      }
+    assertTrue(
+      "missing-key error must mention the SemanticsRoot key name; was: ${ex.message}",
+      ex.message!!.contains(UiAutomatorHierarchyContextKeys.SemanticsRoot.name),
+    )
+  }
+
+  @Test
+  fun `extension writes payload through context and respects options`() {
+    rule.setContent {
+      Column {
+        Button(onClick = {}) { Text("Primary") }
+        Text("Just a label")
+      }
+    }
+
+    val rootNode = rule.onRoot(useUnmergedTree = false).fetchSemanticsNode()
+    val extension = UiAutomatorHierarchyExtension()
+    val store = RecordingDataProductStore()
+
+    extension.process(
+      ExtensionPostCaptureContext(
+        extensionId = extension.id,
+        previewId = "preview",
+        renderMode = null,
+        products = store.scopedFor(extension),
+        data =
+          ExtensionContextData.of(
+            UiAutomatorHierarchyContextKeys.SemanticsRoot provides rootNode,
+            UiAutomatorHierarchyContextKeys.Options provides
+              UiAutomatorHierarchyOptions(includeNonActionable = false, merged = false),
+          ),
+      )
+    )
+
+    val payload = store.get(UiAutomatorDataProducts.Hierarchy)
+    assertNotNull("extension must emit the Hierarchy product", payload)
+    val texts = payload!!.nodes.map { it.text }
+    assertTrue("expected Primary, got $texts", texts.any { it == "Primary" })
+    assertFalse(
+      "default filter (includeNonActionable=false) must not emit 'Just a label'",
+      texts.contains("Just a label"),
+    )
+    // `merged=false` is descriptive — it must show up on every emitted node so a consumer
+    // looking at two payloads knows which tree variant produced each.
+    for (node in payload.nodes) {
+      assertFalse("merged flag must round-trip onto emitted nodes", node.merged)
+    }
+
+    // Default options (no Options key provided) — verifies the extension falls back cleanly.
+    val store2 = RecordingDataProductStore()
+    extension.process(
+      ExtensionPostCaptureContext(
+        extensionId = extension.id,
+        previewId = "preview",
+        renderMode = null,
+        products = store2.scopedFor(extension),
+        data =
+          ExtensionContextData.of(
+            UiAutomatorHierarchyContextKeys.SemanticsRoot provides rootNode
+          ),
+      )
+    )
+    val defaulted = store2.get(UiAutomatorDataProducts.Hierarchy)
+    assertNotNull(defaulted)
+    assertTrue(
+      "default options must produce at least one node",
+      defaulted!!.nodes.isNotEmpty(),
+    )
+    assertTrue(
+      "default options imply merged=true on emitted nodes",
+      defaulted.nodes.all { it.merged },
+    )
+    assertNull(
+      "default filter must not emit 'Just a label' Text node",
+      defaulted.nodes.firstOrNull { it.text == "Just a label" },
+    )
+  }
+
+  private fun extractMerged(): UiAutomatorHierarchyPayload {
+    val root = rule.onRoot(useUnmergedTree = false).fetchSemanticsNode()
+    return UiAutomatorHierarchyExtractor.extract(root)
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -171,6 +171,11 @@ include(":data-uiautomator-connector")
 
 project(":data-uiautomator-connector").projectDir = file("data/uiautomator/connector")
 
+include(":data-uiautomator-hierarchy-android")
+
+project(":data-uiautomator-hierarchy-android").projectDir =
+  file("data/uiautomator/hierarchy-android")
+
 include(":daemon:android")
 
 include(":daemon:desktop")


### PR DESCRIPTION
## Summary
Implements the Android-platform producer for the `uia/hierarchy` data product (#874), which walks a Compose `SemanticsNode` tree and emits a filtered payload of actionable nodes that agents can use to formulate `uia.*` selectors.

## Key Changes

- **New module `:data-uiautomator-hierarchy-android`**: Platform-specific producer that extracts hierarchy from Compose semantics trees
  - `UiAutomatorHierarchyExtractor`: Pure extractor that walks the semantics tree and returns typed `UiAutomatorHierarchyPayload`
  - `UiAutomatorHierarchyExtension`: `PostCaptureProcessor` binding that integrates with the data product framework
  - Default filter keeps only nodes exposing at least one supported `uia.*` action (click, longClick, scroll, setText, requestFocus, expand, collapse, dismiss, setProgress), dropping ~80% of layout wrappers and decorative text nodes
  - `includeNonActionable` flag enables debug mode to surface all selector-targetable nodes

- **Updated `:data-uiautomator-core`**: 
  - Added `UiAutomatorHierarchyNode` and `UiAutomatorHierarchyPayload` data models
  - Added `UiAutomatorDataProducts` object defining action constants and the typed `Hierarchy` product key
  - Exposed `DataProductKey` dependency so both producer and connector reference the same key

- **Comprehensive test suite** (`UiAutomatorHierarchyExtensionTest`):
  - Validates default filter behavior (keeps actionables, drops decorative text)
  - Tests deeply nested clickables remain reachable through filtered parents
  - Verifies `includeNonActionable` flag surfaces debug information
  - Confirms `testTag` ancestors propagate correctly for selector chains
  - Tests extension integration with context keys and options
  - Validates error handling for missing required context

## Implementation Details

- **Ancestor tracking**: Non-actionable parents are filtered out but their `testTag` values are preserved on descendants via `testTagAncestors`, enabling `hasParent({testTag: ...})` selector chains to remain resolvable from the snapshot alone
- **Action mapping**: Walks `SemanticsActions` and `SemanticsProperties` to extract text, contentDescription, testTag, role, and supported actions
- **Bounds serialization**: Converts `boundsInRoot` to `left,top,right,bottom` format matching `AccessibilityNode` conventions
- **Tree variant tracking**: `merged` flag on each node indicates whether snapshot came from merged or unmerged semantics tree
- **Platform-agnostic design**: Mirrors `:data-a11y-hierarchy-android` shape; future Desktop producer would target `{Desktop}` and emit the same product key

https://claude.ai/code/session_018NGwFKCU9K74Fh4JU9nujf