### PR TITLE
refactor(focus): extract @FocusedPreview into a data-extension wrapper

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -66,6 +66,12 @@ dependencies {
   // `AmbientStateController`, the `AroundComposable` extension that primes it, and the
   // `AmbientInputDispatchObserver` that wakes on activating gestures during recording.
   implementation(project(":data-ambient-connector"))
+  // Focus / keyboard-traversal connector — `FocusController`, the `AroundComposable` extension
+  // that installs `LocalInputModeManager provides KeyboardInputModeManager` and drives the focus
+  // walk from a `LaunchedEffect`, the `FocusPreviewOverrideExtension` planner consuming
+  // `renderNow.overrides.focus`, and the post-capture `FocusOverlay`. The renderer-android plugin
+  // path consumes the same connector — see `:renderer-android`'s `implementation` line.
+  implementation(project(":data-focus-connector"))
   // UIAutomator-shaped Selector + UiObject — RobolectricHost.performUiAutomatorAction decodes
   // selector JSON via decodeSelectorJson and walks the SemanticsNode tree via
   // UiAutomator.findObject(rule, selector, useUnmergedTree).

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1183,6 +1183,7 @@ open class RobolectricHost(
               AmbientPreviewOverrideExtension(),
               WallpaperPreviewOverrideExtension(),
               Material3ThemePreviewOverrideExtension(),
+              FocusPreviewOverrideExtension(),
             )
           ),
         dataArtifactExtensions =

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.protocol.AmbientOverride
+import ee.schimke.composeai.daemon.protocol.FocusOverride
 import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
@@ -28,6 +29,7 @@ data class PreviewOverrideBaseSpec(
   val material3Theme: Material3ThemeOverrides? = null,
   val wallpaper: WallpaperOverride? = null,
   val ambient: AmbientOverride? = null,
+  val focus: FocusOverride? = null,
 )
 
 data class MergedPreviewOverrides(
@@ -43,6 +45,7 @@ data class MergedPreviewOverrides(
   val material3Theme: Material3ThemeOverrides?,
   val wallpaper: WallpaperOverride?,
   val ambient: AmbientOverride?,
+  val focus: FocusOverride?,
 ) {
   /**
    * Project the merged overrides down to a [PreviewOverrides] bag that only carries
@@ -51,11 +54,12 @@ data class MergedPreviewOverrides(
    * data-extension pipeline entirely.
    */
   fun toExtensionOverrides(): PreviewOverrides? {
-    if (material3Theme == null && wallpaper == null && ambient == null) return null
+    if (material3Theme == null && wallpaper == null && ambient == null && focus == null) return null
     return PreviewOverrides(
       material3Theme = material3Theme,
       wallpaper = wallpaper,
       ambient = ambient,
+      focus = focus,
     )
   }
 }
@@ -86,6 +90,7 @@ fun mergePreviewOverrides(
       material3Theme = base.material3Theme,
       wallpaper = base.wallpaper,
       ambient = base.ambient,
+      focus = base.focus,
     )
   }
   val deviceOverride = overrides.device?.takeIf { it.isNotBlank() }
@@ -110,5 +115,6 @@ fun mergePreviewOverrides(
     material3Theme = overrides.material3Theme ?: base.material3Theme,
     wallpaper = overrides.wallpaper ?: base.wallpaper,
     ambient = overrides.ambient ?: base.ambient,
+    focus = overrides.focus ?: base.focus,
   )
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -449,7 +449,60 @@ data class PreviewOverrides(
    * backend ignores this field.
    */
   val ambient: AmbientOverride? = null,
+  /**
+   * Optional focus / keyboard-traversal override. Drives the connector-side
+   * `FocusOverrideExtension` (see `:data-focus-connector`) so a single-frame render under the
+   * daemon can land focus on a specific tab index or apply a directional move (Tab / Shift-Tab /
+   * D-pad). Static `@Preview` rendering through the gradle plugin doesn't populate this field —
+   * `@FocusedPreview` discovery emits per-capture state that the renderer pushes into
+   * `FocusController` directly. Backends without a Compose focus owner (e.g. desktop
+   * Compose-Multiplatform) ignore this field.
+   */
+  val focus: FocusOverride? = null,
 )
+
+/**
+ * Focus / keyboard-traversal override for previews. Drives the connector-side
+ * `FocusOverrideExtension` (see `:data-focus-connector`).
+ *
+ * Two driving modes — same shape `@FocusedPreview` already produces:
+ *
+ * * **Indexed** ([tabIndex]): focus the n-th focusable in tab order. The connector issues
+ *   `moveFocus(Enter)` once on the first activation, then `moveFocus(Next)` to walk forward.
+ * * **Traversal** ([direction]): apply a single directional step. The connector issues
+ *   `moveFocus(Enter)` once before the first step, then `moveFocus(direction)` per call. [step]
+ *   carries the 1-based step index for overlay labels.
+ *
+ * Set both null to leave the focus driver inactive — the around-composable still installs keyboard
+ * input mode so `Modifier.clickable`'s focusable accepts focus if user code requests it
+ * programmatically.
+ *
+ * [overlay] toggles the post-capture stroke + label overlay drawn over the focused element's
+ * bounds. The renderer's per-capture loop reads it and calls
+ * `ee.schimke.composeai.daemon.FocusOverlay.apply` when set.
+ */
+@Serializable
+data class FocusOverride(
+  val tabIndex: Int? = null,
+  val direction: FocusDirection? = null,
+  val step: Int? = null,
+  val overlay: Boolean = false,
+)
+
+/**
+ * Mirror of Compose's `androidx.compose.ui.focus.FocusDirection`. Duplicated here because the
+ * gradle plugin's discovery task and the protocol can't take a runtime dep on `compose-ui`; the
+ * focus connector's `toCompose` adapter maps each value to the upstream constant at render time.
+ */
+@Serializable
+enum class FocusDirection {
+  Next,
+  Previous,
+  Up,
+  Down,
+  Left,
+  Right,
+}
 
 /**
  * Single-color seed for the wallpaper data extension.

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
@@ -1,9 +1,12 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.protocol.FocusDirection
+import ee.schimke.composeai.daemon.protocol.FocusOverride
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.UiMode
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class PreviewOverrideMergeTest {
@@ -73,5 +76,37 @@ class PreviewOverrideMergeTest {
     assertEquals(UiMode.LIGHT, merged.uiMode)
     assertEquals(Orientation.LANDSCAPE, merged.orientation)
     assertEquals(true, merged.inspectionMode)
+  }
+
+  @Test
+  fun `focus override merges into the bag and clears via toExtensionOverrides`() {
+    val base =
+      PreviewOverrideBaseSpec(
+        widthPx = 320,
+        heightPx = 480,
+        density = 2.0f,
+        device = null,
+        localeTag = null,
+        fontScale = null,
+        uiMode = null,
+        orientation = null,
+        inspectionMode = null,
+      )
+
+    val merged =
+      mergePreviewOverrides(
+        base,
+        PreviewOverrides(focus = FocusOverride(direction = FocusDirection.Next, step = 1)),
+      )
+
+    assertEquals(FocusOverride(direction = FocusDirection.Next, step = 1), merged.focus)
+    val extensionOverrides = merged.toExtensionOverrides()
+    assertEquals(
+      FocusOverride(direction = FocusDirection.Next, step = 1),
+      extensionOverrides?.focus,
+    )
+
+    val empty = mergePreviewOverrides(base, PreviewOverrides()).toExtensionOverrides()
+    assertNull("merged extension bag should be null when no extension fields are set", empty)
   }
 }

--- a/data/focus/connector/build.gradle.kts
+++ b/data/focus/connector/build.gradle.kts
@@ -1,0 +1,67 @@
+// `:data-focus-connector` glues `:data-focus-core` (the wire-shape) to the daemon's data-product /
+// preview-override surface. Mirrors `:data-ambient-connector`'s split — model in the core module,
+// daemon-side machinery (controller, around-composable extension, planner, overlay) here. Ships:
+//
+//  - `FocusController` — process-static state holder for the active `FocusOverride`, plus the
+//    settle-window constant the renderer's per-capture clock advance reads.
+//  - `FocusOverrideExtension` / `FocusPreviewOverrideExtension` — `AroundComposable` plumbing that
+//    installs `LocalInputModeManager provides KeyboardInputModeManager` and drives
+//    `FocusManager.moveFocus(...)` from a `LaunchedEffect`. Planner maps
+//    `renderNow.overrides.focus` to the extension; the renderer-android plugin path additionally
+//    invokes the around-composable directly when `@FocusedPreview` discovery emits per-capture
+//    focus state.
+//  - `FocusOverlay` — post-capture stroke + label overlay drawn over the focused element's bounds,
+//    moved off `RobolectricRenderTest` so the renderer no longer carries hardcoded focus logic.
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.tapmoc)
+}
+
+android { namespace = "ee.schimke.composeai.data.focus.connector" }
+
+dependencies {
+  // Wire-shape — re-exported via `api` so consumers (`:daemon:android`, `:renderer-android`) can
+  // refer to `FocusOverride` / `FocusDirection` without adding a second `project` dependency.
+  api(project(":data-focus-core"))
+
+  // DataProductRegistry / DataExtension / AroundComposableExtension. Re-exported so the
+  // connector's planner / extension classes can be referenced from `RobolectricHost`'s
+  // `previewOverrideExtensions` list without a second project dep on the consumer.
+  api(project(":daemon:core"))
+  api(project(":data-render-core"))
+  api(project(":data-render-compose"))
+
+  // Compose runtime / UI types (`@Composable`, `DisposableEffect`, `LocalInputModeManager`,
+  // `LocalFocusManager`) flow in transitively through `:data-render-compose`'s
+  // `api(libs.jetbrains.compose.runtime)` / `api(libs.jetbrains.compose.ui)` — no explicit dep
+  // here, mirroring `:data-ambient-connector`. Inline `@Composable` callsites from
+  // `:data-render-compose`-shipped APIs work at this layer; richer foundation widgets that need
+  // `compose-foundation` (e.g. `Box`) belong in the renderer / consumer modules.
+
+  testImplementation(libs.junit)
+  testImplementation(libs.kotlinx.serialization.json)
+}
+
+mavenPublishing {
+  configure(
+    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
+      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
+      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
+      variant = "release",
+    )
+  )
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-focus-connector",
+    displayName = "Compose Preview - Focus Data Product Connector",
+    description =
+      "Daemon-side focus / keyboard-traversal data-product connector: drives the Compose around-composable that lets `@FocusedPreview` and `renderNow.overrides.focus` walks render under a synthetic keyboard input mode.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusController.kt
+++ b/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusController.kt
@@ -1,0 +1,88 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.focus.FocusDirection as ComposeFocusDirection
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.input.InputModeManager
+import ee.schimke.composeai.daemon.protocol.FocusDirection
+import ee.schimke.composeai.daemon.protocol.FocusOverride
+
+/**
+ * Process-static state holder for the active focus override.
+ *
+ * The flow is:
+ *
+ * 1. Plugin path (`@FocusedPreview` / `renderAllPreviews`): the renderer's per-capture loop calls
+ *    [set] before each capture so the around-composable observes the next requested target.
+ * 2. Daemon path (`renderNow.overrides.focus`): [FocusOverrideExtension.AroundComposable] seeds
+ *    the controller from its constructor argument, the around-composable observes the same state
+ *    via [activeFocus]'s snapshot read.
+ *
+ * Both paths share the [activeFocus] state and the [SETTLE_MS] settle window so the
+ * `LaunchedEffect`-driven walk + the renderer's per-capture clock advance stay aligned without
+ * either side needing to know about the other.
+ */
+object FocusController {
+
+  private val state: MutableState<FocusOverride?> = mutableStateOf(null)
+
+  /**
+   * Snapshot-state read by [FocusOverrideExtension.AroundComposable]'s `LaunchedEffect`. Driving
+   * focus from inside composition (rather than from the outer per-capture loop via a
+   * `runOnUiThread`-posted `moveFocus`) is what makes the post-state emit + indication redraw land
+   * before the next capture; the outer-loop path leaves a one-frame off-by-one that no amount of
+   * `mainClock.advanceTimeBy` flushes.
+   */
+  val activeFocus: State<FocusOverride?>
+    get() = state
+
+  /**
+   * Per-capture settle window, in ms. After [FocusManager.moveFocus(...)] the FocusableNode emits
+   * `FocusInteraction.{Focus, Unfocus}` to the interaction sources; the ripple's `IndicationNode`
+   * collects the events and runs a fade animation (Material's focus indicator uses an
+   * `Animatable<Float>` that crossfades over ~150ms). The paused-clock test environment doesn't
+   * auto-advance these animations, so we need enough virtual time to (a) emit the interactions,
+   * (b) crossfade out the previous capture's highlight, and (c) crossfade in the new one. 250ms ≈
+   * 16 frames at 16ms — a comfortable margin around Material's default highlight duration.
+   */
+  const val SETTLE_MS: Long = 250L
+
+  /** Replace the active override. `null` clears the state and disables focus driving. */
+  fun set(override: FocusOverride?) {
+    state.value = override
+  }
+
+  fun current(): FocusOverride? = state.value
+
+  /** Cleanup hook for per-session reset. */
+  fun resetForNewSession() {
+    state.value = null
+  }
+}
+
+/**
+ * [InputModeManager] that always reports [InputMode.Keyboard] — provided via
+ * [androidx.compose.ui.platform.LocalInputModeManager] so previews that call
+ * `FocusRequester.requestFocus()` actually receive focus. Compose's `Modifier.clickable` registers
+ * its focusable with `Focusability.SystemDefined`, which refuses focus while the host's input mode
+ * is `InputMode.Touch` — Robolectric's permanent default. Forcing keyboard mode for the duration
+ * of any focus-driven render unblocks the focus walk.
+ */
+object KeyboardInputModeManager : InputModeManager {
+  override val inputMode: InputMode = InputMode.Keyboard
+
+  override fun requestInputMode(inputMode: InputMode): Boolean = false
+}
+
+/** Maps the wire-shape [FocusDirection] enum onto Compose's `FocusDirection` value class. */
+fun FocusDirection.toCompose(): ComposeFocusDirection =
+  when (this) {
+    FocusDirection.Next -> ComposeFocusDirection.Next
+    FocusDirection.Previous -> ComposeFocusDirection.Previous
+    FocusDirection.Up -> ComposeFocusDirection.Up
+    FocusDirection.Down -> ComposeFocusDirection.Down
+    FocusDirection.Left -> ComposeFocusDirection.Left
+    FocusDirection.Right -> ComposeFocusDirection.Right
+  }

--- a/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
+++ b/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
@@ -1,0 +1,116 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.focus.FocusDirection as ComposeFocusDirection
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalInputModeManager
+import ee.schimke.composeai.daemon.protocol.FocusOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.focus.Material3FocusProduct
+import ee.schimke.composeai.data.render.extensions.DataExtension
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+
+/**
+ * `AroundComposable` extension that owns the focus / keyboard-traversal around-composable
+ * concerns: installs `LocalInputModeManager provides KeyboardInputModeManager` and a
+ * `LaunchedEffect`-driven focus walk that observes [FocusController.activeFocus] and dispatches
+ * `FocusManager.moveFocus(...)` on every transition.
+ *
+ * The extension is the seam both render paths share:
+ *
+ * - **Plugin path** (`renderAllPreviews` / `RobolectricRenderTest`): the renderer wraps content
+ *   with this extension whenever `@FocusedPreview` discovery emitted any per-capture focus state,
+ *   and updates [FocusController.set] from the outer per-capture loop. The `LaunchedEffect`
+ *   re-walks each time the controller's state flips.
+ * - **Daemon path** (`renderNow.overrides.focus`): [FocusPreviewOverrideExtension] plans the
+ *   extension and seeds the controller from the constructor argument so a single-frame render
+ *   driven by the daemon picks up the requested focus target without going through the plugin's
+ *   per-capture loop.
+ *
+ * Runs in the [DataExtensionPhase.OuterEnvironment] phase so the input-mode flip happens before
+ * the user-environment phase reaches preview content.
+ */
+class FocusOverrideExtension(private val seed: FocusOverride? = null) :
+  AroundComposableExtension(
+    id = ID,
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.OuterEnvironment,
+        provides = setOf(DataExtensionCapability(Material3FocusProduct.KIND)),
+      ),
+  ) {
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    if (seed != null) {
+      DisposableEffect(seed) {
+        FocusController.set(seed)
+        onDispose { FocusController.set(null) }
+      }
+    }
+    CompositionLocalProvider(LocalInputModeManager provides KeyboardInputModeManager) {
+      val focusManager = LocalFocusManager.current
+      val active by FocusController.activeFocus
+      val lastIndex = remember { mutableStateOf(-1) }
+      val entered = remember { mutableStateOf(false) }
+      LaunchedEffect(active) {
+        val cap = active ?: return@LaunchedEffect
+        val direction = cap.direction
+        val tabIndex = cap.tabIndex
+        if (direction != null) {
+          if (!entered.value) {
+            focusManager.moveFocus(ComposeFocusDirection.Enter)
+            entered.value = true
+          }
+          focusManager.moveFocus(direction.toCompose())
+        } else if (tabIndex != null) {
+          // `moveFocus(Enter)` lands the owner on an internal root that sits *before* the first
+          // focusable, so the first walk needs `tabIndex + 1` Next steps to land on button
+          // `tabIndex`. Subsequent calls walk only the delta.
+          val from = lastIndex.value
+          if (from < 0) {
+            focusManager.moveFocus(ComposeFocusDirection.Enter)
+            repeat(tabIndex + 1) { focusManager.moveFocus(ComposeFocusDirection.Next) }
+          } else if (tabIndex > from) {
+            repeat(tabIndex - from) { focusManager.moveFocus(ComposeFocusDirection.Next) }
+          }
+          lastIndex.value = tabIndex
+        }
+      }
+      content()
+    }
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId(Material3FocusProduct.KIND)
+  }
+}
+
+/**
+ * Planner that maps `renderNow.overrides.focus` to a [FocusOverrideExtension]. No-op when the
+ * field is null — matches the wallpaper / theme / ambient planners.
+ */
+class FocusPreviewOverrideExtension : DataExtension<PreviewOverrides> {
+  override val id: DataExtensionId = FocusOverrideExtension.ID
+
+  override fun plan(request: PreviewOverrides): PlannedDataExtension? =
+    request.focus?.let(::FocusOverrideExtension)
+}
+
+/** Helper for the renderer's per-capture loop: seed the controller without constructing FQNs. */
+fun FocusManager.applyFocusOverride(override: FocusOverride?) {
+  // Renderer-side helper kept here so it can evolve alongside the connector's walk semantics
+  // without the renderer reaching into controller internals.
+  FocusController.set(override)
+}

--- a/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusOverlay.kt
+++ b/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusOverlay.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.daemon
+
+import android.view.View
+import ee.schimke.composeai.daemon.protocol.FocusOverride
+import java.awt.BasicStroke
+import java.awt.Color
+import java.awt.Font
+import java.awt.Rectangle
+import java.awt.RenderingHints
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import javax.imageio.ImageIO
+
+/**
+ * Post-capture stroke + label overlay drawn over the focused element's bounds. Sourced from
+ * `AndroidComposeView.focusOwner.getFocusRect()` reflectively — the focus owner isn't on
+ * compose-ui's public surface. Saves the pre-overlay capture as `<basename>.raw.png` alongside so
+ * reviewers can A/B against the unmarked image.
+ *
+ * Skipped silently when the view isn't an AndroidComposeView, the focus owner has no active
+ * focus, or the focus rect is empty — overlays are a review aid, not a render contract.
+ */
+object FocusOverlay {
+
+  fun apply(view: View?, outputFile: File, focus: FocusOverride) {
+    if (view == null) return
+    val rect = readFocusRect(view) ?: return
+    if (rect.width <= 0 || rect.height <= 0) return
+
+    val rawFile = File(outputFile.parentFile, outputFile.nameWithoutExtension + ".raw." + outputFile.extension)
+    runCatching {
+      Files.copy(outputFile.toPath(), rawFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+    }
+
+    val image = runCatching { ImageIO.read(outputFile) }.getOrNull() ?: return
+    val g = image.createGraphics()
+    try {
+      g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+      g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
+      g.color = Color(0xFF, 0x40, 0x40, 0xFF)
+      g.stroke = BasicStroke(3f)
+      g.drawRect(rect.x, rect.y, rect.width, rect.height)
+
+      val label = labelOf(focus)
+      val font = Font("SansSerif", Font.BOLD, 16)
+      g.font = font
+      val metrics = g.fontMetrics
+      val textWidth = metrics.stringWidth(label)
+      val textHeight = metrics.height
+      val pillX = rect.x
+      val pillY = (rect.y - textHeight - 4).coerceAtLeast(0)
+      g.color = Color(0xFF, 0x40, 0x40, 0xE0)
+      g.fillRoundRect(pillX, pillY, textWidth + 12, textHeight + 4, 8, 8)
+      g.color = Color.WHITE
+      g.drawString(label, pillX + 6, pillY + textHeight - 4)
+    } finally {
+      g.dispose()
+    }
+    runCatching { ImageIO.write(image, "png", outputFile) }
+  }
+
+  private fun labelOf(focus: FocusOverride): String {
+    val direction = focus.direction
+    val step = focus.step
+    val tabIndex = focus.tabIndex
+    return when {
+      direction != null && step != null -> "step $step • ${direction.name}"
+      tabIndex != null -> "index $tabIndex"
+      else -> "focus"
+    }
+  }
+
+  /**
+   * Reflects into `AndroidComposeView.focusOwner.getFocusRect()` to retrieve the focused element's
+   * bounds. Returns `null` when the view isn't an AndroidComposeView, the focus owner has no
+   * active focus, or any reflective lookup fails. Failure here is silent because the overlay is a
+   * review aid, not a render contract.
+   */
+  private fun readFocusRect(view: View): Rectangle? {
+    return runCatching {
+      val getFocusOwner = view::class.java.methods.firstOrNull { it.name == "getFocusOwner" } ?: return null
+      val owner = getFocusOwner.invoke(view) ?: return null
+      val getFocusRect = owner::class.java.methods.firstOrNull { it.name == "getFocusRect" } ?: return null
+      val rect = getFocusRect.invoke(owner) ?: return null
+      val left = (rect::class.java.getMethod("getLeft").invoke(rect) as? Float) ?: return null
+      val top = (rect::class.java.getMethod("getTop").invoke(rect) as? Float) ?: return null
+      val right = (rect::class.java.getMethod("getRight").invoke(rect) as? Float) ?: return null
+      val bottom = (rect::class.java.getMethod("getBottom").invoke(rect) as? Float) ?: return null
+      // Compose's `Rect` reports `left = top = Float.POSITIVE_INFINITY` (`Rect.Zero`) when no
+      // focus is active; clamp to int silently here.
+      if (!left.isFinite() || !top.isFinite() || !right.isFinite() || !bottom.isFinite()) {
+        return null
+      }
+      Rectangle(left.toInt(), top.toInt(), (right - left).toInt(), (bottom - top).toInt())
+    }.getOrNull()
+  }
+}

--- a/data/focus/connector/src/test/kotlin/ee/schimke/composeai/daemon/FocusDataProductTest.kt
+++ b/data/focus/connector/src/test/kotlin/ee/schimke/composeai/daemon/FocusDataProductTest.kt
@@ -1,0 +1,82 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.focus.Material3FocusProduct
+import ee.schimke.composeai.daemon.protocol.AmbientOverride
+import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
+import ee.schimke.composeai.daemon.protocol.FocusDirection
+import ee.schimke.composeai.daemon.protocol.FocusOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the contract of `:data-focus-connector`'s extension surface. Mirrors the layout of the
+ * ambient and wallpaper data-product tests: extension hook shape, planner plan/abstain semantics,
+ * controller state machine.
+ */
+class FocusDataProductTest {
+
+  @After fun tearDown() = FocusController.resetForNewSession()
+
+  @Test
+  fun `focus override extension declares around-composable hook in OuterEnvironment phase`() {
+    val extension = FocusOverrideExtension(FocusOverride(tabIndex = 0))
+    val hook: AroundComposableHook = extension
+
+    assertEquals(DataExtensionId(Material3FocusProduct.KIND), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.AroundComposable), extension.hooks)
+    assertEquals(DataExtensionPhase.OuterEnvironment, extension.constraints.phase)
+    assertTrue(extension.hasAroundComposableHook)
+    assertEquals(extension, hook)
+  }
+
+  @Test
+  fun `planner returns extension when focus override present`() {
+    val planner = FocusPreviewOverrideExtension()
+    val planned = planner.plan(PreviewOverrides(focus = FocusOverride(direction = FocusDirection.Next)))
+    assertTrue("expected planner to produce a hook", planned is AroundComposableHook)
+    assertEquals(DataExtensionId(Material3FocusProduct.KIND), planned!!.id)
+  }
+
+  @Test
+  fun `planner abstains when focus override absent`() {
+    val planner = FocusPreviewOverrideExtension()
+    assertNull(planner.plan(PreviewOverrides()))
+    assertNull(planner.plan(PreviewOverrides(widthPx = 320)))
+    // Sibling overrides (e.g. ambient) shouldn't trigger the focus planner.
+    assertNull(
+      planner.plan(PreviewOverrides(ambient = AmbientOverride(state = AmbientStateOverride.AMBIENT)))
+    )
+  }
+
+  @Test
+  fun `controller starts inactive`() {
+    FocusController.resetForNewSession()
+    assertNull(FocusController.current())
+  }
+
+  @Test
+  fun `controller set propagates state and clear resets it`() {
+    FocusController.set(FocusOverride(tabIndex = 2, overlay = true))
+    assertEquals(FocusOverride(tabIndex = 2, overlay = true), FocusController.current())
+
+    FocusController.set(null)
+    assertNull(FocusController.current())
+  }
+
+  @Test
+  fun `controller settle window matches the renderer's per-capture clock advance`() {
+    // Sentinel: the renderer's per-capture loop advances the paused clock by this amount, and
+    // changing it here has user-visible consequences (focus rings crossfade animation length).
+    // If this assertion fires, audit `RobolectricRenderTest` and bump in lockstep.
+    assertEquals(250L, FocusController.SETTLE_MS)
+  }
+}

--- a/data/focus/core/build.gradle.kts
+++ b/data/focus/core/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // `daemon:core` carries `PreviewOverrides`, which `:data-focus-connector`'s planner reads via the
+  // protocol's optional `focus` field. Keeping the wire-shape module on `daemon:core` mirrors
+  // `:data-ambient-core` / `:data-wallpaper-core` so MCP clients in other languages can depend on
+  // the focus model without dragging in the connector or any Compose / Robolectric runtime.
+  api(project(":daemon:core"))
+  api(libs.kotlinx.serialization.json)
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-focus-core",
+    displayName = "Compose Preview - Focus Data Product Core",
+    description = "Shared focus / keyboard-traversal model classes for Compose Preview.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/focus/core/src/main/kotlin/ee/schimke/composeai/data/focus/FocusModels.kt
+++ b/data/focus/core/src/main/kotlin/ee/schimke/composeai/data/focus/FocusModels.kt
@@ -1,0 +1,18 @@
+package ee.schimke.composeai.data.focus
+
+/**
+ * Stable identity of the `compose/focus` data product. Mirrors `Material3AmbientProduct` /
+ * `Material3WallpaperProduct`: lifted out of the daemon-side registry so MCP clients and other
+ * connectors can depend on the kind constant without pulling in the connector, Compose, or
+ * Robolectric.
+ *
+ * Wire-shape `FocusOverride` and the matching `FocusDirection` enum live alongside the other
+ * preview-override types on `daemon:core` (see
+ * `ee.schimke.composeai.daemon.protocol.FocusOverride`); the override is what
+ * `renderNow.overrides.focus` carries, and keeping it on `daemon:core` mirrors how
+ * `AmbientOverride` / `WallpaperOverride` / `Material3ThemeOverrides` are layered.
+ */
+object Material3FocusProduct {
+  const val KIND: String = "compose/focus"
+  const val SCHEMA_VERSION: Int = 1
+}

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -35,6 +35,14 @@ dependencies {
   implementation(project(":data-a11y-hierarchy-android"))
   implementation(project(":data-render-core"))
   implementation(project(":data-scroll-core"))
+  // Focus / keyboard-traversal connector. Owns `KeyboardInputModeManager`, the
+  // `LaunchedEffect`-driven focus walk via `FocusOverrideExtension`, the per-capture state
+  // holder `FocusController`, and the post-capture `FocusOverlay`. The renderer's per-capture
+  // loop pushes `RenderManifest.FocusCapture` into `FocusController.set(...)` and wraps content
+  // with `FocusOverrideExtension(...)` so static `@Preview` rendering and daemon-driven
+  // `renderNow.overrides.focus` share the same composable seam. **No hardcoded focus / keyboard
+  // logic should live in this module any more — extend the connector instead.**
+  implementation(project(":data-focus-connector"))
 
   implementation(libs.robolectric)
   implementation(libs.junit)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -11,11 +11,6 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
-import androidx.compose.ui.focus.FocusDirection as ComposeFocusDirection
-import androidx.compose.ui.input.InputMode
-import androidx.compose.ui.input.InputModeManager
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
@@ -32,6 +27,11 @@ import com.github.takahirom.roborazzi.inspectionMode
 import com.github.takahirom.roborazzi.locale
 import com.github.takahirom.roborazzi.size
 import com.github.takahirom.roborazzi.uiMode
+import ee.schimke.composeai.daemon.FocusController
+import ee.schimke.composeai.daemon.FocusOverlay
+import ee.schimke.composeai.daemon.FocusOverrideExtension
+import ee.schimke.composeai.daemon.protocol.FocusOverride
+import ee.schimke.composeai.daemon.protocol.FocusDirection as ProtocolFocusDirection
 import ee.schimke.composeai.data.render.PreviewAnimationContext
 import ee.schimke.composeai.data.render.extensions.ExtensionContextData
 import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
@@ -586,23 +586,15 @@ abstract class RobolectricRenderTestBase(
         // Read after `captureRoboImage` to crop the PNG down to the composable's
         // actual bounds.
         var measured: IntSize? = null
-        // `@FocusedPreview` driver: outer loop bumps this state between
-        // captures; an inner `LaunchedEffect` keyed off it walks
-        // [FocusManager] to the requested target. Driving focus from
-        // *inside* composition (rather than via a `runOnUiThread`-posted
-        // `moveFocus` from the outer loop) is what makes the post-state
-        // emit + indication redraw land before the next capture — the
-        // outer-loop path leaves a one-frame off-by-one that no amount
-        // of `mainClock.advanceTimeBy` flushed. Carries the whole
-        // [FocusCapture] (rather than just an index) so traversal-mode
-        // captures can dispatch by direction.
-        val focusCaptureState =
-            androidx.compose.runtime.mutableStateOf<FocusCapture?>(null)
         // [android.view.View] read from inside composition so the
         // post-capture overlay can reflect into AndroidComposeView's
         // `focusOwner.getFocusRect()` to find the focused element's
         // bounds. `null` until the first composition.
         var capturedView: android.view.View? = null
+        // The focus-driver state lives on the connector's [FocusController]; the around-composable
+        // installed by [FocusOverrideExtension] reads from it via snapshot state. Reset before
+        // each render so the previous preview's tab walk doesn't leak into this one.
+        FocusController.resetForNewSession()
         val statement = object : org.junit.runners.model.Statement() {
             override fun evaluate() {
                 rule.mainClock.autoAdvance = false
@@ -670,21 +662,22 @@ abstract class RobolectricRenderTestBase(
                     preview.captures.firstNotNullOfOrNull {
                         it.animation?.takeIf { a -> a.showCurves }
                     }?.let { SlotTreeCapture() }
-                // `@FocusedPreview` requests focus drive on at least one
-                // capture: hand Compose a Keyboard-mode `InputModeManager`
-                // for the duration of this preview, since
-                // `Modifier.clickable`'s focusable is
-                // `Focusability.SystemDefined` and refuses focus under
-                // [InputMode.Touch] — Robolectric's permanent default.
-                // Captures without focus stay byte-identical to the prior
-                // touch-mode behaviour because nothing in those captures
-                // reads the input mode.
+                // `@FocusedPreview` requests focus drive on at least one capture: the
+                // connector-side `FocusOverrideExtension.AroundComposable` installs
+                // `LocalInputModeManager provides KeyboardInputModeManager` and the
+                // `LaunchedEffect`-driven walk; the renderer just decides whether to wrap.
+                //
+                // **No more hardcoded focus / keyboard logic should live in this file.** Add new
+                // override-driven features as data extensions in `:data-focus-connector` (or peer
+                // connector modules) and either register a `DataExtension<PreviewOverrides>`
+                // planner here or wrap content with the extension's `AroundComposable` directly,
+                // matching the existing ambient / wallpaper / theme pattern. Per-feature renderer
+                // branches are a smell — see `docs/AGENTS.md` § "Architecture rules".
                 val anyFocusCapture = preview.captures.any { it.focus != null }
+                val focusExtension =
+                    if (anyFocusCapture) FocusOverrideExtension() else null
                 val providedValues = buildList {
                     add(LocalInspectionMode provides !a11yEnabled)
-                    if (anyFocusCapture) {
-                        add(LocalInputModeManager provides KeyboardInputModeManager)
-                    }
                     if (scrollCaptureProvidable != null) {
                         add(scrollCaptureProvidable provides scrollCaptureInProgress)
                     }
@@ -707,57 +700,8 @@ abstract class RobolectricRenderTestBase(
                     !isRoundDevice(params.device)
                 rule.setContent {
                     CompositionLocalProvider(values = providedValues) {
-                        if (anyFocusCapture) {
-                            val focusManager = LocalFocusManager.current
+                        if (focusExtension != null) {
                             capturedView = androidx.compose.ui.platform.LocalView.current
-                            val cap = focusCaptureState.value
-                            // Indexed mode: track the last walked tab
-                            // index so subsequent captures only issue the
-                            // delta `moveFocus(Next)` calls. Traversal
-                            // mode: track whether we've Entered the focus
-                            // owner so the first directional step lands
-                            // on a real focusable rather than no-op'ing
-                            // on an inactive root.
-                            val lastIndex =
-                                androidx.compose.runtime.remember {
-                                    androidx.compose.runtime.mutableStateOf(-1)
-                                }
-                            val entered =
-                                androidx.compose.runtime.remember {
-                                    androidx.compose.runtime.mutableStateOf(false)
-                                }
-                            androidx.compose.runtime.LaunchedEffect(cap) {
-                                if (cap != null) {
-                                    val direction = cap.direction
-                                    val tabIndex = cap.tabIndex
-                                    if (direction != null) {
-                                        if (!entered.value) {
-                                            focusManager.moveFocus(ComposeFocusDirection.Enter)
-                                            entered.value = true
-                                        }
-                                        focusManager.moveFocus(direction.toCompose())
-                                    } else if (tabIndex != null) {
-                                        // `moveFocus(Enter)` lands the
-                                        // owner on an internal root that
-                                        // sits *before* the first
-                                        // focusable, so the first walk
-                                        // needs `tabIndex + 1` Next steps
-                                        // to land on button `tabIndex`.
-                                        val from = lastIndex.value
-                                        if (from < 0) {
-                                            focusManager.moveFocus(ComposeFocusDirection.Enter)
-                                            repeat(tabIndex + 1) {
-                                                focusManager.moveFocus(ComposeFocusDirection.Next)
-                                            }
-                                        } else if (tabIndex > from) {
-                                            repeat(tabIndex - from) {
-                                                focusManager.moveFocus(ComposeFocusDirection.Next)
-                                            }
-                                        }
-                                        lastIndex.value = tabIndex
-                                    }
-                                }
-                            }
                         }
                         val previewBody: @Composable () -> Unit = {
                             val core: @Composable () -> Unit = {
@@ -779,10 +723,17 @@ abstract class RobolectricRenderTestBase(
                                 core()
                             }
                         }
-                        if (animationCurveCapture != null) {
-                            InspectablePreviewContent(animationCurveCapture, previewBody)
+                        val curveOrPlain: @Composable () -> Unit = {
+                            if (animationCurveCapture != null) {
+                                InspectablePreviewContent(animationCurveCapture, previewBody)
+                            } else {
+                                previewBody()
+                            }
+                        }
+                        if (focusExtension != null) {
+                            focusExtension.AroundComposable { curveOrPlain() }
                         } else {
-                            previewBody()
+                            curveOrPlain()
                         }
                     }
                 }
@@ -831,29 +782,25 @@ abstract class RobolectricRenderTestBase(
                         currentTime = target
                     }
 
-                    // `@FocusedPreview` per-capture focus walk. Discovery
-                    // sorts focus indices ascending and emits one capture
-                    // per index, so we only need to walk forward —
-                    // `moveFocus(Enter)` once, then `moveFocus(Next)` for
-                    // the per-step delta. `runOnUiThread` because focus
-                    // mutation is main-thread-only; the surrounding
-                    // composition is paused (`autoAdvance = false`) and
-                    // resumes on the next `advanceTimeBy`. After the
-                    // focus event reaches the interaction stream the
-                    // ripple's `IndicationNode` schedules an invalidation;
-                    // [FOCUS_SETTLE_MS] advances enough virtual time for
-                    // the next layout/draw pass to redraw the focus ring
-                    // before [captureRoboImage] reads back pixels.
+                    // `@FocusedPreview` per-capture focus walk. Discovery sorts focus indices
+                    // ascending and emits one capture per index; the around-composable installed
+                    // by [FocusOverrideExtension] consumes the controller state from inside
+                    // composition and walks `FocusManager.moveFocus(...)` in a `LaunchedEffect`
+                    // (driving focus from outside the composition leaves a one-frame
+                    // off-by-one). After the controller flips, [FocusController.SETTLE_MS]
+                    // advances enough virtual time for the focus event to reach the interaction
+                    // stream and the ripple's `IndicationNode` to schedule an invalidation
+                    // before `captureRoboImage` reads back pixels.
                     val capture = (job as? CaptureRenderJob)?.capture
                     val focus = capture?.focus
                     if (focus != null) {
                         rule.runOnUiThread {
-                            focusCaptureState.value = focus
+                            FocusController.set(focus.toFocusOverride())
                             androidx.compose.runtime.snapshots.Snapshot
                                 .sendApplyNotifications()
                         }
-                        rule.mainClock.advanceTimeBy(FOCUS_SETTLE_MS)
-                        currentTime += FOCUS_SETTLE_MS
+                        rule.mainClock.advanceTimeBy(FocusController.SETTLE_MS)
+                        currentTime += FocusController.SETTLE_MS
                     }
 
                     // @ScrollingPreview(END): drive the first scrollable on the
@@ -963,12 +910,12 @@ abstract class RobolectricRenderTestBase(
                         )
                     }
 
-                    // `@FocusedPreview(overlay = true)`: post-process the
-                    // captured PNG with a stroke + label drawn over the
-                    // currently-focused element. Pre-overlay capture is
+                    // `@FocusedPreview(overlay = true)`: post-process the captured PNG with a
+                    // stroke + label drawn over the currently-focused element. Implementation
+                    // lives in `:data-focus-connector`'s [FocusOverlay]; pre-overlay capture is
                     // preserved alongside as `<basename>.raw.png`.
                     if (focus?.overlay == true) {
-                        applyFocusOverlay(capturedView, outputFile, focus)
+                        FocusOverlay.apply(capturedView, outputFile, focus.toFocusOverride())
                     }
 
                     if (
@@ -1160,21 +1107,10 @@ abstract class RobolectricRenderTestBase(
          */
         private const val CAPTURE_ADVANCE_MS = 32L
 
-        /**
-         * Per-`@FocusedPreview`-capture settle window. After
-         * `FocusManager.moveFocus(...)` the FocusableNode emits
-         * `FocusInteraction.{Focus, Unfocus}` to the interaction sources
-         * on the next frame; the ripple's `IndicationNode` collects the
-         * events and runs a fade animation (Material's focus indicator
-         * uses an `Animatable<Float>` that crossfades over ~150ms). The
-         * paused-clock test environment doesn't auto-advance these
-         * animations, so we need enough virtual time to (a) emit the
-         * interactions, (b) crossfade out the previous capture's
-         * highlight, and (c) crossfade in the new one. 250ms = ~16
-         * frames at 16ms — a comfortable margin around Material's
-         * default highlight duration.
-         */
-        private const val FOCUS_SETTLE_MS = 250L
+        // The per-`@FocusedPreview`-capture settle window used to live here as
+        // `FOCUS_SETTLE_MS = 250L`. It moved to `:data-focus-connector`'s
+        // `FocusController.SETTLE_MS` so the connector's around-composable + the renderer's
+        // per-capture clock advance share a single source of truth. Don't redeclare it here.
     }
 }
 
@@ -1836,126 +1772,31 @@ private const val AUTO_DURATION_TAIL_MS = 200L
 private const val HOLD_START_ANIM_MS = 500
 private const val HOLD_END_ANIM_MS = 1000
 
-/**
- * [InputModeManager] that always reports [InputMode.Keyboard] — provided
- * via [LocalInputModeManager] so previews that call
- * `FocusRequester.requestFocus()` actually receive focus. See the call
- * site in [renderDefault]'s `providedValues` block for the full
- * rationale.
- */
-private object KeyboardInputModeManager : InputModeManager {
-    override val inputMode: InputMode = InputMode.Keyboard
+// `KeyboardInputModeManager`, `FocusDirection.toCompose`, the focus-walk `LaunchedEffect`, and
+// the `applyFocusOverlay` / `readFocusRect` reflection helpers used to live here. They moved to
+// `:data-focus-connector` so the renderer no longer carries hardcoded focus / keyboard logic —
+// see the around-composable installed via [FocusOverrideExtension] and the post-capture
+// `FocusOverlay`. Add new focus-related features inside the connector module, never inline.
 
-    override fun requestInputMode(inputMode: InputMode): Boolean = false
-}
+/** Maps the renderer-side [FocusCapture] (read from `previews.json`) onto the connector's
+ *  `protocol.FocusOverride` wire shape. Both types describe the same fields — duplicated only
+ *  because the renderer's `previews.json` schema predates the protocol module's override type. */
+private fun FocusCapture.toFocusOverride(): FocusOverride =
+    FocusOverride(
+        tabIndex = tabIndex,
+        direction = direction?.toProtocol(),
+        step = step,
+        overlay = overlay,
+    )
 
-/**
- * Converts the renderer-side [FocusDirection] enum (mirror of the plugin's, serialised through
- * `previews.json`) onto Compose's `FocusDirection` value class.
- */
-private fun FocusDirection.toCompose(): ComposeFocusDirection =
+private fun FocusDirection.toProtocol(): ProtocolFocusDirection =
     when (this) {
-        FocusDirection.Next -> ComposeFocusDirection.Next
-        FocusDirection.Previous -> ComposeFocusDirection.Previous
-        FocusDirection.Up -> ComposeFocusDirection.Up
-        FocusDirection.Down -> ComposeFocusDirection.Down
-        FocusDirection.Left -> ComposeFocusDirection.Left
-        FocusDirection.Right -> ComposeFocusDirection.Right
-    }
-
-/**
- * Post-applies a stroke + label overlay to [outputFile] showing the bounds of the currently-focused
- * element, sourced from `AndroidComposeView.focusOwner.getFocusRect()` (reflectively — the focus
- * owner isn't on the renderer's public Compose surface). Saves the pre-overlay capture as
- * `<basename>.raw.png` alongside so reviewers can A/B against the unmarked image.
- *
- * Skipped silently when the view isn't an AndroidComposeView, the focus owner has no active focus,
- * or the focus rect is empty — overlays are a review aid, not a contract.
- */
-private fun applyFocusOverlay(view: android.view.View?, outputFile: java.io.File, focus: FocusCapture) {
-    if (view == null) return
-    val rect = readFocusRect(view) ?: return
-    if (rect.width <= 0 || rect.height <= 0) return
-
-    val rawFile =
-        java.io.File(
-            outputFile.parentFile,
-            outputFile.nameWithoutExtension + ".raw." + outputFile.extension,
-        )
-    runCatching {
-        java.nio.file.Files.copy(
-            outputFile.toPath(),
-            rawFile.toPath(),
-            java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-        )
-    }
-
-    val image = runCatching { javax.imageio.ImageIO.read(outputFile) }.getOrNull() ?: return
-    val g = image.createGraphics()
-    try {
-        g.setRenderingHint(
-            java.awt.RenderingHints.KEY_ANTIALIASING,
-            java.awt.RenderingHints.VALUE_ANTIALIAS_ON,
-        )
-        g.setRenderingHint(
-            java.awt.RenderingHints.KEY_TEXT_ANTIALIASING,
-            java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_ON,
-        )
-        g.color = java.awt.Color(0xFF, 0x40, 0x40, 0xFF.toByte().toInt() and 0xFF)
-        g.stroke = java.awt.BasicStroke(3f)
-        g.drawRect(rect.x, rect.y, rect.width, rect.height)
-
-        val label = focusOverlayLabel(focus)
-        val font = java.awt.Font("SansSerif", java.awt.Font.BOLD, 16)
-        g.font = font
-        val metrics = g.fontMetrics
-        val textWidth = metrics.stringWidth(label)
-        val textHeight = metrics.height
-        val pillX = rect.x
-        val pillY = (rect.y - textHeight - 4).coerceAtLeast(0)
-        g.color = java.awt.Color(0xFF, 0x40, 0x40, 0xE0)
-        g.fillRoundRect(pillX, pillY, textWidth + 12, textHeight + 4, 8, 8)
-        g.color = java.awt.Color.WHITE
-        g.drawString(label, pillX + 6, pillY + textHeight - 4)
-    } finally {
-        g.dispose()
-    }
-    runCatching { javax.imageio.ImageIO.write(image, "png", outputFile) }
-}
-
-/**
- * Reflects into `AndroidComposeView.focusOwner.getFocusRect()` to retrieve the focused element's
- * bounds. Returns `null` when the view isn't an AndroidComposeView, the focus owner has no active
- * focus, or any reflective lookup fails. Used by [applyFocusOverlay] — failure here is silent
- * because the overlay is a review aid, not a render contract.
- */
-private fun readFocusRect(view: android.view.View): java.awt.Rectangle? {
-    return runCatching {
-        val getFocusOwner =
-            view::class.java.methods.firstOrNull { it.name == "getFocusOwner" } ?: return null
-        val owner = getFocusOwner.invoke(view) ?: return null
-        val getFocusRect =
-            owner::class.java.methods.firstOrNull { it.name == "getFocusRect" } ?: return null
-        val rect = getFocusRect.invoke(owner) ?: return null
-        val left = (rect::class.java.getMethod("getLeft").invoke(rect) as? Float) ?: return null
-        val top = (rect::class.java.getMethod("getTop").invoke(rect) as? Float) ?: return null
-        val right = (rect::class.java.getMethod("getRight").invoke(rect) as? Float) ?: return null
-        val bottom = (rect::class.java.getMethod("getBottom").invoke(rect) as? Float) ?: return null
-        // Compose's `Rect` reports `left = top = Float.POSITIVE_INFINITY` (`Rect.Zero`) when no
-        // focus is active; clamp to int silently here.
-        if (!left.isFinite() || !top.isFinite() || !right.isFinite() || !bottom.isFinite()) {
-            return null
-        }
-        java.awt.Rectangle(left.toInt(), top.toInt(), (right - left).toInt(), (bottom - top).toInt())
-    }.getOrNull()
-}
-
-private fun focusOverlayLabel(focus: FocusCapture): String =
-    when {
-        focus.direction != null && focus.step != null ->
-            "step ${focus.step} • ${focus.direction.name}"
-        focus.tabIndex != null -> "index ${focus.tabIndex}"
-        else -> "focus"
+        FocusDirection.Next -> ProtocolFocusDirection.Next
+        FocusDirection.Previous -> ProtocolFocusDirection.Previous
+        FocusDirection.Up -> ProtocolFocusDirection.Up
+        FocusDirection.Down -> ProtocolFocusDirection.Down
+        FocusDirection.Left -> ProtocolFocusDirection.Left
+        FocusDirection.Right -> ProtocolFocusDirection.Right
     }
 
 /**

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -152,6 +152,14 @@ include(":data-ambient-connector")
 
 project(":data-ambient-connector").projectDir = file("data/ambient/connector")
 
+include(":data-focus-core")
+
+project(":data-focus-core").projectDir = file("data/focus/core")
+
+include(":data-focus-connector")
+
+project(":data-focus-connector").projectDir = file("data/focus/connector")
+
 include(":data-recomposition-core")
 
 project(":data-recomposition-core").projectDir = file("data/recomposition/core")


### PR DESCRIPTION
## Summary

Aligns the focus / keyboard-traversal feature with the data-extension architecture the ambient / wallpaper / theme connectors already use. Pre-refactor, `RobolectricRenderTest` carried hardcoded focus logic — `KeyboardInputModeManager`, the `LaunchedEffect`-driven `FocusManager.moveFocus(...)` walk, the reflective focus-rect overlay helpers, and the `FOCUS_SETTLE_MS` constant — which violated the rule in `docs/AGENTS.md` against per-feature renderer wiring.

- New `:data-focus-core` (kind constant) and `:data-focus-connector` modules.
- `:data-focus-connector` ships `FocusController` (process-static state + `SETTLE_MS`), `KeyboardInputModeManager`, `FocusOverrideExtension : AroundComposableExtension` (installs the input-mode flip and the `LaunchedEffect`-driven walk), `FocusPreviewOverrideExtension` planner, and `FocusOverlay` (post-capture stroke + label).
- `PreviewOverrides.focus: FocusOverride?` added to `daemon:core`, threaded through `mergePreviewOverrides` + `toExtensionOverrides`. `RobolectricHost` registers the planner alongside the existing three.
- `RobolectricRenderTest` now wraps content with `FocusOverrideExtension(...).AroundComposable { ... }` when any capture requests focus driving, pushes `FocusController.set(focus)` per-capture, advances the clock by `FocusController.SETTLE_MS`, and delegates overlay to `FocusOverlay.apply(...)`. Inline focus block is removed; a fence comment marks the seam — no more hardcoded focus / keyboard logic in the renderer.

## Test plan

- [x] `./gradlew :data-focus-connector:test` — new `FocusDataProductTest` covers extension hook shape, planner plan/abstain semantics, controller state machine, and the settle-window sentinel.
- [x] `./gradlew :daemon:core:test --tests "*PreviewOverrideMergeTest*"` — extended for the new focus field merge + `toExtensionOverrides` clearing.
- [x] `./gradlew :samples:android-alpha:testDebugUnitTest --tests "*FocusedPreviewPixelTest*"` — existing end-to-end test exercising `@FocusedPreview(traverse = ...)` and `@FocusedPreview(indices = ...)` walks; passes against the new connector-driven path with no source change.
- [x] `./gradlew :samples:wear:check :samples:android:check` — focus-touching samples build clean.
- [ ] Daemon-driven `renderNow.overrides.focus` round-trip in a real interactive session — verifies the planner-installed around-composable lands focus on a single-frame render.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9MedfGsUQp6Mn2GY17hu5)_