### PR TITLE
Add UIAutomator hierarchy data product (#874)

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -70,10 +70,16 @@ dependencies {
   // selector JSON via decodeSelectorJson and walks the SemanticsNode tree via
   // UiAutomator.findObject(rule, selector, useUnmergedTree).
   implementation(project(":data-uiautomator-core"))
-  // `uia.*` script-event descriptors — DaemonMain registers an Extension(id="uiautomator", ...)
-  // carrying these descriptors; AndroidRecordingSession registers a handler per id that routes
-  // to dispatchUiAutomator.
+  // `uia.*` script-event descriptors + `UiAutomatorDataProducer` / `UiAutomatorDataProductRegistry`
+  // (#874). DaemonMain registers an Extension(id="uiautomator", ...) carrying these descriptors
+  // and the registry; AndroidRecordingSession registers a handler per id that routes to
+  // dispatchUiAutomator; RenderEngine.kt calls the producer's `writeArtifacts(...)` post-capture.
   implementation(project(":data-uiautomator-connector"))
+
+  // Android-platform-specific UIAutomator hierarchy producer — `RenderEngine.kt` installs
+  // `UiAutomatorHierarchyExtension` and runs the typed extension contract to compute the
+  // `UiAutomatorHierarchyPayload` before handing it to `UiAutomatorDataProducer`.
+  implementation(project(":data-uiautomator-hierarchy-android"))
 
   // Inherit the renderer's Compose/Roborazzi helpers (GoogleFontInterceptor,
   // AnimationInspector, ScrollDriver, PixelSystemFontAliases, RenderManifest,

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -404,13 +404,15 @@ fun main(args: Array<String>) {
               )
             )
           }
-          // UIAutomator-shaped script events (`uia.click`, `uia.inputText`, etc.). Always
-          // wired on the Android backend — the dispatch path lives in RobolectricHost and
-          // doesn't depend on the a11y opt-in.
+          // UIAutomator-shaped script events (`uia.click`, `uia.inputText`, etc.) plus the
+          // `uia/hierarchy` data product (#874). Always wired on the Android backend — the
+          // dispatch path lives in RobolectricHost and the hierarchy producer ride along on
+          // the same render pass; neither depends on the a11y opt-in.
           add(
             Extension(
               id = UiAutomatorRecordingScriptEvents.EXTENSION_ID,
               displayName = "UIAutomator script actions",
+              dataProductRegistry = UiAutomatorDataProductRegistry(rootDir = dataRoot),
               dataExtensionDescriptors = UiAutomatorRecordingScriptEvents.descriptors,
             )
           )

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -43,6 +43,9 @@ import ee.schimke.composeai.data.render.extensions.provides
 import ee.schimke.composeai.renderer.AccessibilityDataProducts
 import ee.schimke.composeai.renderer.AccessibilityHierarchyContextKeys
 import ee.schimke.composeai.renderer.AccessibilityHierarchyExtension
+import ee.schimke.composeai.renderer.uiautomator.UiAutomatorDataProducts
+import ee.schimke.composeai.renderer.uiautomator.UiAutomatorHierarchyContextKeys
+import ee.schimke.composeai.renderer.uiautomator.UiAutomatorHierarchyExtension
 import java.io.File
 import java.util.Base64
 import kotlinx.serialization.decodeFromString
@@ -439,6 +442,46 @@ class RenderEngine(
               } catch (t: Throwable) {
                 System.err.println(
                   "RenderEngine: a11y data write failed for ${spec.outputBaseName}: " +
+                    "${t.javaClass.simpleName}: ${t.message}"
+                )
+              }
+            }
+
+            // #874 — `uia/hierarchy` data product. Walks the same `SemanticsOwner` `uia.*`
+            // dispatch resolves selectors against and dumps the actionable subset to
+            // `uia-hierarchy.json` so agents can inspect what's clickable / scrollable /
+            // has-text *before* dispatching. Default filter (set by the producer) keeps
+            // ~20% of nodes a real Material screen produces while preserving every viable
+            // dispatch target. Always runs on the Android backend — independent of the a11y
+            // opt-in. Wrapped in try/catch so a hierarchy failure does not strand the PNG.
+            if (dataDir != null) {
+              try {
+                trace.section("uia:hierarchy") {
+                  val rootNode = rule.onRoot(useUnmergedTree = false).fetchSemanticsNode()
+                  val uiaExtension = UiAutomatorHierarchyExtension()
+                  val uiaStore = RecordingDataProductStore()
+                  uiaExtension.process(
+                    ExtensionPostCaptureContext(
+                      extensionId = uiaExtension.id,
+                      previewId = spec.outputBaseName,
+                      renderMode = spec.renderMode,
+                      products = uiaStore.scopedFor(uiaExtension),
+                      data =
+                        ExtensionContextData.of(
+                          UiAutomatorHierarchyContextKeys.SemanticsRoot provides rootNode
+                        ),
+                    )
+                  )
+                  val payload = uiaStore.require(UiAutomatorDataProducts.Hierarchy)
+                  UiAutomatorDataProducer.writeArtifacts(
+                    rootDir = dataDir,
+                    previewId = spec.outputBaseName,
+                    payload = payload,
+                  )
+                }
+              } catch (t: Throwable) {
+                System.err.println(
+                  "RenderEngine: uia/hierarchy write failed for ${spec.outputBaseName}: " +
                     "${t.javaClass.simpleName}: ${t.message}"
                 )
               }

--- a/data/uiautomator/connector/build.gradle.kts
+++ b/data/uiautomator/connector/build.gradle.kts
@@ -25,16 +25,27 @@ import com.vanniktech.maven.publish.SourcesJar
 plugins {
   id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.tapmoc)
 }
 
 android { namespace = "ee.schimke.composeai.data.uiautomator.connector" }
 
 dependencies {
+  // Typed payload + `UiAutomatorDataProducts.Hierarchy` key — the producer/registry below
+  // serialise / advertise this kind. Re-exported via `api` so `:daemon:android` can refer to
+  // `UiAutomatorHierarchyPayload` without adding a second `project` dep.
+  api(project(":data-uiautomator-core"))
+
+  // `DataProductRegistry` interface, `DataProductCapability` / `DataProductAttachment` wire
+  // types — re-exported via `api` for the same reason `:data-a11y-connector` does.
+  api(project(":daemon:core"))
+
   // `RecordingScriptEventDescriptor` + `DataExtensionDescriptor` types.
   api(project(":data-render-core"))
 
   testImplementation(libs.junit)
+  testImplementation(libs.kotlinx.serialization.json)
 }
 
 mavenPublishing {

--- a/data/uiautomator/connector/src/main/kotlin/ee/schimke/composeai/daemon/UiAutomatorDataProducer.kt
+++ b/data/uiautomator/connector/src/main/kotlin/ee/schimke/composeai/daemon/UiAutomatorDataProducer.kt
@@ -1,0 +1,159 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductFacet
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
+import ee.schimke.composeai.renderer.uiautomator.UiAutomatorDataProducts
+import ee.schimke.composeai.renderer.uiautomator.UiAutomatorHierarchyPayload
+import java.io.File
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * D2 — writes the per-render UIAutomator hierarchy artefact the data-product registry surfaces
+ * (#874).
+ *
+ * Single file per render under `<rootDir>/<previewId>/`:
+ * - `uia-hierarchy.json` — `{ "nodes": UiAutomatorHierarchyNode[] }`. Path-transport kind
+ *   (`uia/hierarchy`) returns this file's absolute path; the JSON shape matches
+ *   `UiAutomatorHierarchyPayload` so a downstream client can deserialise it directly.
+ *
+ * Always written after a successful render so the registry can distinguish "no actionable
+ * nodes on this preview" (file present, `nodes: []`) from "preview never rendered" (file
+ * missing).
+ */
+object UiAutomatorDataProducer {
+
+  private val json = Json {
+    encodeDefaults = false
+    prettyPrint = false
+  }
+
+  /** Schema version pinned alongside the on-disk shape. Bumped when the shape changes. */
+  const val SCHEMA_VERSION: Int = UiAutomatorDataProducts.SCHEMA_VERSION
+
+  /** `uia/hierarchy` — actionable Compose semantics nodes filtered for `uia.*` selectors. */
+  const val KIND_HIERARCHY: String = UiAutomatorDataProducts.KIND_HIERARCHY
+
+  /** File name under `<rootDir>/<previewId>/`. */
+  const val FILE_HIERARCHY: String = "uia-hierarchy.json"
+
+  /**
+   * Writes the hierarchy payload to `<rootDir>/<previewId>/uia-hierarchy.json`. Idempotent —
+   * overwrites any prior file. Caller drives the `SemanticsNode` walk through
+   * [`UiAutomatorHierarchyExtractor`][ee.schimke.composeai.renderer.uiautomator.UiAutomatorHierarchyExtractor]
+   * so the actionable-filter / `includeNonActionable` / `merged` knobs stay in one place.
+   */
+  fun writeArtifacts(rootDir: File, previewId: String, payload: UiAutomatorHierarchyPayload) {
+    val previewDir = rootDir.resolve(previewId)
+    previewDir.mkdirs()
+    previewDir
+      .resolve(FILE_HIERARCHY)
+      .writeText(json.encodeToString(UiAutomatorHierarchyPayload.serializer(), payload))
+  }
+}
+
+/**
+ * D2 — [DataProductRegistry] implementation that surfaces `uia/hierarchy` (path-transport) by
+ * reading the JSON file [UiAutomatorDataProducer] writes during each render. Mirrors
+ * [`AccessibilityDataProductRegistry`][AccessibilityDataProductRegistry]'s shape — single kind,
+ * path-and-inline both fine, no overlay extras.
+ *
+ * `attachable: true` so the kind rides `renderFinished.dataProducts` when the client has
+ * subscribed; `fetchable: true` for pull-on-demand reads from the same file. Doesn't trigger a
+ * re-render: the producer always runs in interactive-android mode, so the JSON is on disk for
+ * any preview that has rendered at least once.
+ *
+ * `rootDir` mirrors `RenderEngine`'s `dataDir`. Wired by [DaemonMain].
+ */
+class UiAutomatorDataProductRegistry(private val rootDir: File) : DataProductRegistry {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = UiAutomatorDataProducer.KIND_HIERARCHY,
+        schemaVersion = UiAutomatorDataProducer.SCHEMA_VERSION,
+        transport = DataProductTransport.PATH,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+        displayName = "UIAutomator hierarchy",
+        facets = listOf(DataProductFacet.STRUCTURED),
+        mediaTypes = listOf("application/json"),
+        sampling = SamplingPolicy.End,
+      )
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    val file =
+      when (kind) {
+        UiAutomatorDataProducer.KIND_HIERARCHY ->
+          fileFor(previewId, UiAutomatorDataProducer.FILE_HIERARCHY)
+        else -> return DataProductRegistry.Outcome.Unknown
+      }
+    if (!file.exists()) return DataProductRegistry.Outcome.NotAvailable
+    if (inline) {
+      val payloadElement: JsonElement =
+        try {
+          json.parseToJsonElement(file.readText())
+        } catch (t: Throwable) {
+          return DataProductRegistry.Outcome.FetchFailed(
+            message = "could not parse $kind for $previewId: ${t.message}"
+          )
+        }
+      return DataProductRegistry.Outcome.Ok(
+        DataFetchResult(
+          kind = kind,
+          schemaVersion = UiAutomatorDataProducer.SCHEMA_VERSION,
+          payload = payloadElement,
+        )
+      )
+    }
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(
+        kind = kind,
+        schemaVersion = UiAutomatorDataProducer.SCHEMA_VERSION,
+        path = file.absolutePath,
+      )
+    )
+  }
+
+  override fun attachmentsFor(
+    previewId: String,
+    kinds: Set<String>,
+  ): List<DataProductAttachment> {
+    val out = mutableListOf<DataProductAttachment>()
+    for (kind in kinds) {
+      when (kind) {
+        UiAutomatorDataProducer.KIND_HIERARCHY -> {
+          val file = fileFor(previewId, UiAutomatorDataProducer.FILE_HIERARCHY)
+          if (!file.exists()) continue
+          out.add(
+            DataProductAttachment(
+              kind = kind,
+              schemaVersion = UiAutomatorDataProducer.SCHEMA_VERSION,
+              path = file.absolutePath,
+            )
+          )
+        }
+      // Unknown kinds drop out silently — the dispatcher already filtered against
+      // `capabilities` before calling this; an unrecognised kind here means the
+      // dispatcher's filtering drifted and we'd rather skip than emit garbage.
+      }
+    }
+    return out
+  }
+
+  private fun fileFor(previewId: String, fileName: String): File =
+    rootDir.resolve(previewId).resolve(fileName)
+}

--- a/data/uiautomator/connector/src/test/kotlin/ee/schimke/composeai/daemon/UiAutomatorDataProductRegistryTest.kt
+++ b/data/uiautomator/connector/src/test/kotlin/ee/schimke/composeai/daemon/UiAutomatorDataProductRegistryTest.kt
@@ -1,0 +1,183 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.renderer.uiautomator.UiAutomatorDataProducts
+import ee.schimke.composeai.renderer.uiautomator.UiAutomatorHierarchyNode
+import ee.schimke.composeai.renderer.uiautomator.UiAutomatorHierarchyPayload
+import java.io.File
+import java.nio.file.Files
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins the producer/registry contract for the daemon's `uia/hierarchy` data product (#874).
+ * Producer writes `<rootDir>/<previewId>/uia-hierarchy.json`; registry advertises one
+ * path-transport kind, hands back the absolute path on `inline=false` and a parsed payload on
+ * `inline=true`. Unknown kinds route to `Outcome.Unknown`; missing files route to
+ * `Outcome.NotAvailable`. Mirrors `AccessibilityDataProductRegistryTest` so contract drift
+ * between the two surfaces shows up as a diff against the same shape of test.
+ */
+class UiAutomatorDataProductRegistryTest {
+
+  private lateinit var rootDir: File
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("uia-data-product-test").toFile()
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+  }
+
+  @Test
+  fun `capabilities advertise uia hierarchy as a single path-transport kind`() {
+    val registry = UiAutomatorDataProductRegistry(rootDir)
+
+    val byKind = registry.capabilities.associateBy { it.kind }
+    assertEquals(setOf(UiAutomatorDataProducts.KIND_HIERARCHY), byKind.keys)
+    val cap = byKind.getValue(UiAutomatorDataProducts.KIND_HIERARCHY)
+    assertEquals(DataProductTransport.PATH, cap.transport)
+    assertEquals(UiAutomatorDataProducts.SCHEMA_VERSION, cap.schemaVersion)
+    assertTrue("uia/hierarchy should be attachable", cap.attachable)
+    assertTrue("uia/hierarchy should be fetchable", cap.fetchable)
+    assertEquals(false, cap.requiresRerender)
+    assertEquals(listOf("application/json"), cap.mediaTypes)
+    assertTrue(registry.isKnown(UiAutomatorDataProducts.KIND_HIERARCHY))
+  }
+
+  @Test
+  fun `fetch unknown kind returns Outcome Unknown`() {
+    val registry = UiAutomatorDataProductRegistry(rootDir)
+
+    val outcome = registry.fetch(previewId = "p", kind = "uia/nonsense", params = null, inline = false)
+    assertEquals(DataProductRegistry.Outcome.Unknown, outcome)
+  }
+
+  @Test
+  fun `fetch with no rendered preview returns Outcome NotAvailable`() {
+    val registry = UiAutomatorDataProductRegistry(rootDir)
+
+    val outcome =
+      registry.fetch(
+        previewId = "never-rendered",
+        kind = UiAutomatorDataProducts.KIND_HIERARCHY,
+        params = null,
+        inline = false,
+      )
+    assertEquals(DataProductRegistry.Outcome.NotAvailable, outcome)
+  }
+
+  @Test
+  fun `producer writes and registry returns path on default fetch and parsed payload when inline`() {
+    val payload =
+      UiAutomatorHierarchyPayload(
+        nodes =
+          listOf(
+            UiAutomatorHierarchyNode(
+              text = "Submit",
+              testTag = "submit-button",
+              actions = listOf(UiAutomatorDataProducts.ACTION_CLICK),
+              boundsInScreen = "10,20,110,80",
+            )
+          )
+      )
+    UiAutomatorDataProducer.writeArtifacts(rootDir, previewId = "p", payload = payload)
+    val registry = UiAutomatorDataProductRegistry(rootDir)
+
+    // Default `inline=false` returns the absolute on-disk path so a co-located client can
+    // read the file directly.
+    val pathOutcome =
+      registry.fetch(
+        previewId = "p",
+        kind = UiAutomatorDataProducts.KIND_HIERARCHY,
+        params = null,
+        inline = false,
+      ) as DataProductRegistry.Outcome.Ok
+    assertNotNull("path-transport fetch must carry an absolute path", pathOutcome.result.path)
+    assertNull("path-transport fetch must not pre-parse the payload", pathOutcome.result.payload)
+    assertTrue(File(pathOutcome.result.path!!).exists())
+
+    // `inline=true` parses the JSON and hands the payload back so a remote client doesn't
+    // have to make a second hop.
+    val inlineOutcome =
+      registry.fetch(
+        previewId = "p",
+        kind = UiAutomatorDataProducts.KIND_HIERARCHY,
+        params = null,
+        inline = true,
+      ) as DataProductRegistry.Outcome.Ok
+    assertNotNull("inline fetch must produce a parsed payload", inlineOutcome.result.payload)
+    val node =
+      (inlineOutcome.result.payload as JsonObject)["nodes"]!!.jsonArray.first().jsonObject
+    assertEquals("Submit", node["text"]!!.jsonPrimitive.content)
+    assertEquals("submit-button", node["testTag"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `attachmentsFor returns one path attachment per kind when the file exists and skips otherwise`() {
+    val payload = UiAutomatorHierarchyPayload(nodes = emptyList())
+    UiAutomatorDataProducer.writeArtifacts(rootDir, previewId = "p", payload = payload)
+    val registry = UiAutomatorDataProductRegistry(rootDir)
+
+    val attachments =
+      registry.attachmentsFor(previewId = "p", kinds = setOf(UiAutomatorDataProducts.KIND_HIERARCHY))
+    assertEquals(1, attachments.size)
+    val attachment = attachments.single()
+    assertEquals(UiAutomatorDataProducts.KIND_HIERARCHY, attachment.kind)
+    assertEquals(UiAutomatorDataProducts.SCHEMA_VERSION, attachment.schemaVersion)
+    assertNotNull("path-transport attachment must carry a path", attachment.path)
+    assertNull("path-transport attachment must not inline the payload", attachment.payload)
+
+    // No render for `q` → no file → no attachment, but the call must not throw.
+    val emptyAttachments =
+      registry.attachmentsFor(previewId = "q", kinds = setOf(UiAutomatorDataProducts.KIND_HIERARCHY))
+    assertTrue(emptyAttachments.isEmpty())
+  }
+
+  @Test
+  fun `producer overwrites prior file so the registry always sees the latest payload`() {
+    val first =
+      UiAutomatorHierarchyPayload(
+        nodes =
+          listOf(
+            UiAutomatorHierarchyNode(
+              text = "Initial",
+              actions = listOf(UiAutomatorDataProducts.ACTION_CLICK),
+              boundsInScreen = "0,0,100,100",
+            )
+          )
+      )
+    UiAutomatorDataProducer.writeArtifacts(rootDir, previewId = "p", payload = first)
+
+    val second =
+      UiAutomatorHierarchyPayload(
+        nodes =
+          listOf(
+            UiAutomatorHierarchyNode(
+              text = "Updated",
+              actions = listOf(UiAutomatorDataProducts.ACTION_CLICK),
+              boundsInScreen = "0,0,100,100",
+            )
+          )
+      )
+    UiAutomatorDataProducer.writeArtifacts(rootDir, previewId = "p", payload = second)
+
+    val file =
+      File(rootDir, "p").resolve(UiAutomatorDataProducer.FILE_HIERARCHY)
+    val parsed = Json.parseToJsonElement(file.readText()).jsonObject
+    val node = parsed["nodes"]!!.jsonArray.first().jsonObject
+    assertEquals("Updated", node["text"]!!.jsonPrimitive.content)
+  }
+}


### PR DESCRIPTION
## Summary
Implements the `uia/hierarchy` data product that surfaces actionable UIAutomator nodes from the Compose semantics tree. This allows agents to inspect what's clickable, scrollable, or has text before dispatching actions, without requiring a separate round-trip.

## Key Changes

- **New `UiAutomatorDataProducer`**: Writes the UIAutomator hierarchy payload to `<rootDir>/<previewId>/uia-hierarchy.json` after each render. The producer walks the semantics tree via `UiAutomatorHierarchyExtension` and filters for actionable nodes (~20% of typical Material screens).

- **New `UiAutomatorDataProductRegistry`**: Implements `DataProductRegistry` to advertise and serve the `uia/hierarchy` kind as a path-transport data product. Supports both path-based fetch (for co-located clients) and inline fetch (for remote clients that need the parsed JSON payload).

- **RenderEngine integration**: Added post-capture section that installs `UiAutomatorHierarchyExtension`, computes the hierarchy payload, and writes artifacts via the producer. Wrapped in try/catch to prevent hierarchy failures from blocking PNG generation.

- **DaemonMain wiring**: Registered `UiAutomatorDataProductRegistry` with the daemon's extension system so the hierarchy rides `renderFinished.dataProducts` when subscribed.

- **Comprehensive test coverage**: Added `UiAutomatorDataProductRegistryTest` that mirrors `AccessibilityDataProductRegistryTest`'s shape, pinning the producer/registry contract for capabilities, fetch outcomes, attachments, and file overwrites.

## Implementation Details

- The hierarchy file is always written after a successful render, allowing the registry to distinguish "no actionable nodes" (empty file) from "preview never rendered" (missing file).
- The producer is idempotent and overwrites prior files, ensuring the registry always sees the latest payload.
- Unknown kinds route to `Outcome.Unknown`; missing files route to `Outcome.NotAvailable`.
- The implementation runs independently of the a11y opt-in, as the dispatch path and hierarchy producer both operate on the same `SemanticsOwner` walk.

https://claude.ai/code/session_018NGwFKCU9K74Fh4JU9nujf