### PR TITLE
feat(preview-annotations): add @AmbientPreview to drive Wear ambient state in previews

### DIFF
--- a/data/ambient/connector/build.gradle.kts
+++ b/data/ambient/connector/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
   id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.compose.compiler)
   alias(libs.plugins.tapmoc)
 }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -98,6 +98,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     // Focus-state capture — sibling annotation to @ScrollingPreview /
     // @AnimatedPreview, same FQN-match policy. See `FocusedPreview.kt`.
     private const val FOCUSED_PREVIEW_FQN = "ee.schimke.composeai.preview.FocusedPreview"
+    private const val AMBIENT_PREVIEW_FQN = "ee.schimke.composeai.preview.AmbientPreview"
     // The stable FQN is shared by both Android's ui-tooling-preview and CMP's
     // `org.jetbrains.compose.components:components-ui-tooling-preview` — Kotlin
     // `expect`/`actual` collapses onto the same `androidx...` class name on
@@ -486,6 +487,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     val scrollSpecs = extractScrollSpecs(annotations)
     val animationSpec = extractAnimationSpec(annotations)
     val focusSpecs = extractFocusSpecs(annotations)
+    val ambientSpec = extractAmbientSpec(annotations)
     // @RoboComposePreviewOptions, similarly, applies to the function as a
     // whole — each timing fans out into its own manifest entry, orthogonal
     // to any multi-preview expansion.
@@ -530,6 +532,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             scrollSpecs,
             animationSpec,
             focusSpecs,
+            ambientSpec,
             timings,
             previewParameter,
             previewSourceFile,
@@ -552,6 +555,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             scrollSpecs,
             animationSpec,
             focusSpecs,
+            ambientSpec,
             timings,
             previewParameter,
             previewSourceFile,
@@ -605,6 +609,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     scrolls: List<ScrollCapture>,
     animation: AnimationCapture?,
     focuses: List<FocusCapture>,
+    ambient: AmbientCapture?,
     timings: List<Long>,
   ): PreviewOutputPlan {
     val isTile = ann.name == TILE_PREVIEW_FQN
@@ -616,6 +621,10 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     // `@FocusedPreview` only applies to Compose previews (the focus owner
     // is a Compose construct); tile previews ignore it.
     val effectiveFocuses = if (isTile) emptyList() else focuses
+    // `@AmbientPreview` is Wear-Compose-only — it drives `LocalAmbientModeManager`. Tile previews
+    // render through `TileRenderer` and never enter the Compose composition where the local lives,
+    // so the override is a no-op there.
+    val effectiveAmbient = if (isTile) null else ambient
 
     // @AnimatedPreview produces its own dedicated capture, alongside any
     // scroll / time fan-out. The GIF gets a distinguishing `_anim` suffix
@@ -705,6 +714,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
                 advanceTimeMillis = ms,
                 scroll = scroll,
                 focus = focus,
+                ambient = effectiveAmbient,
                 renderOutput =
                   "renders/${previewId}${scrollSuffix}${timeSuffix}${focusSuffix}.${ext}",
                 cost = captureCost,
@@ -862,6 +872,30 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
    * capture. Empty inputs collapse to no captures (the annotation falls back to the cross-product's
    * null row).
    */
+  /**
+   * Reads `@AmbientPreview(state, burnInProtectionRequired, deviceHasLowBitAmbient)` off the
+   * function annotation list. Returns a single [AmbientCapture] when present, `null` otherwise.
+   * Mirrors `extractFocusSpecs` but single-shot — the annotation maps to one preview variant per
+   * function (the consumer authors a separate `@AmbientPreview` `@Preview` function for each state
+   * they want to render).
+   */
+  private fun extractAmbientSpec(annotations: List<AnnotationInfo>): AmbientCapture? {
+    val ann = annotations.firstOrNull { it.name == AMBIENT_PREVIEW_FQN } ?: return null
+    val pv = ann.parameterValues
+    val stateName =
+      (pv.getValue("state") as? AnnotationEnumValue)?.valueName ?: AmbientCaptureState.Ambient.name
+    val state =
+      runCatching { AmbientCaptureState.valueOf(stateName) }
+        .getOrDefault(AmbientCaptureState.Ambient)
+    val burnIn = (pv.getValue("burnInProtectionRequired") as? Boolean) ?: false
+    val lowBit = (pv.getValue("deviceHasLowBitAmbient") as? Boolean) ?: false
+    return AmbientCapture(
+      state = state,
+      burnInProtectionRequired = burnIn,
+      deviceHasLowBitAmbient = lowBit,
+    )
+  }
+
   private fun extractFocusSpecs(annotations: List<AnnotationInfo>): List<FocusCapture> {
     val ann = annotations.firstOrNull { it.name == FOCUSED_PREVIEW_FQN } ?: return emptyList()
     val pv = ann.parameterValues
@@ -1006,6 +1040,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     scrolls: List<ScrollCapture>,
     animation: AnimationCapture?,
     focuses: List<FocusCapture>,
+    ambient: AmbientCapture?,
     timings: List<Long>,
     previewParameter: Pair<String, Int>?,
     previewSourceFile: String?,
@@ -1015,7 +1050,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     val fqn = "${classInfo.name}.${method.name}"
     val suffix = buildVariantSuffix(params)
     val id = fqn + suffix
-    val outputPlan = buildOutputPlan(ann, id, scrolls, animation, focuses, timings)
+    val outputPlan = buildOutputPlan(ann, id, scrolls, animation, focuses, ambient, timings)
     // Tile previews don't go through @Composable invocations — they return a `TilePreviewData`
     // and the renderer reflects them directly. Skipping the lazy means the bytecode walk never
     // runs for tile-only methods.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -126,6 +126,40 @@ data class FocusCapture(
 )
 
 /**
+ * Wear OS ambient-mode capture state sourced from `@AmbientPreview`. Carried as its own field on
+ * [Capture] — orthogonal to [Capture.scroll] / [Capture.animation] / [Capture.focus] — so the
+ * renderer can switch on its presence to wrap the preview composition with the
+ * `AmbientOverrideExtension` from `:data-ambient-connector`. The extension installs
+ * `LocalAmbientModeManager` so consumer code reading `currentAmbientMode` observes the requested
+ * state — same seam the daemon-driven `renderNow.overrides.ambient` planner uses.
+ */
+@Serializable
+data class AmbientCapture(
+  /**
+   * Active state. Mirrors `androidx.wear.compose.foundation.AmbientMode` — only `Interactive` /
+   * `Ambient` round-trip through `@AmbientPreview` (no `Inactive` value in the new API surface).
+   */
+  val state: AmbientCaptureState = AmbientCaptureState.Ambient,
+  /**
+   * Mirrors `AmbientMode.Ambient.isBurnInProtectionRequired`. Only meaningful when [state] is
+   * [AmbientCaptureState.Ambient].
+   */
+  val burnInProtectionRequired: Boolean = false,
+  /**
+   * Mirrors `AmbientMode.Ambient.isLowBitAmbientSupported`. Only meaningful when [state] is
+   * [AmbientCaptureState.Ambient].
+   */
+  val deviceHasLowBitAmbient: Boolean = false,
+)
+
+/** Mirror of `androidx.wear.compose.foundation.AmbientMode`'s active states. */
+@Serializable
+enum class AmbientCaptureState {
+  Interactive,
+  Ambient,
+}
+
+/**
  * Cost catalogue, normalised so a static `@Preview` (single compose pass + one screenshot) is
  * `1.0`. The discovery task stamps the right value onto each [Capture]; tooling reads them back to
  * throttle interactive renders.
@@ -232,6 +266,12 @@ data class Capture(
   val animation: AnimationCapture? = null,
   /** `null` → no focus drive. Set when the preview carries a `@FocusedPreview` annotation. */
   val focus: FocusCapture? = null,
+  /**
+   * `null` → no Wear OS ambient-mode override. Set when the preview carries an `@AmbientPreview`
+   * annotation. Renderer wraps the composition with `:data-ambient-connector`'s
+   * `AmbientOverrideExtension` when present.
+   */
+  val ambient: AmbientCapture? = null,
   /** Module-relative PNG path, e.g. `renders/<preview id>_TIME_500ms.png`. */
   val renderOutput: String = "",
   /**

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/AmbientPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/AmbientPreview.kt
@@ -1,0 +1,65 @@
+package ee.schimke.composeai.preview
+
+/**
+ * Opts a `@Preview` composable into Wear OS ambient-mode capture.
+ *
+ * The compose-preview Gradle plugin's discovery task picks this up by FQN, mirroring
+ * [FocusedPreview] / [ScrollingPreview]: consumers that want to use the annotation in their own
+ * code depend on `ee.schimke.composeai:preview-annotations`. The renderer translates the captured
+ * state into an `AmbientOverrideExtension` (see `:data-ambient-connector`) wrapping the preview's
+ * composition, so consumer code reading
+ * `androidx.wear.compose.foundation.LocalAmbientModeManager.current?.currentAmbientMode` observes
+ * the requested state — same seam `androidx.wear.compose.foundation.samples.AmbientModeBasicSample`
+ * uses for its production lookup via `rememberAmbientModeManager()`.
+ *
+ * Static `@Preview` rendering through the plugin's per-capture loop pushes the override into
+ * `AmbientStateController.set(...)` before each capture; daemon-driven
+ * `renderNow.overrides.ambient` already does the same through the connector's planner. Both paths
+ * end up at the same composable seam.
+ *
+ * Example:
+ * ```
+ * @Preview(device = WearDevices.LARGE_ROUND, showBackground = true)
+ * @AmbientPreview(state = AmbientPreviewState.Ambient, burnInProtectionRequired = true)
+ * @Composable
+ * fun MyWatchFaceAmbientPreview() {
+ *   MyWatchFace()
+ * }
+ * ```
+ *
+ * Wear-only — applying this to a non-Wear preview is a no-op (the renderer installs the local but
+ * nothing in non-Wear UI reads it).
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+@MustBeDocumented
+annotation class AmbientPreview(
+  /**
+   * Requested ambient state. [AmbientPreviewState.Ambient] flips the manager's `currentAmbientMode`
+   * to `AmbientMode.Ambient(...)` for the render; [AmbientPreviewState.Interactive] forces
+   * `AmbientMode.Interactive` (useful when stacked under a multi-preview annotation that defaults
+   * elsewhere).
+   */
+  val state: AmbientPreviewState = AmbientPreviewState.Ambient,
+  /**
+   * Mirrors `AmbientMode.Ambient.isBurnInProtectionRequired`. Forwarded to the preview's
+   * `LocalAmbientModeManager.current.currentAmbientMode` so consumer code branching on burn-in
+   * protection runs unchanged. Only meaningful when [state] is [AmbientPreviewState.Ambient].
+   */
+  val burnInProtectionRequired: Boolean = false,
+  /**
+   * Mirrors `AmbientMode.Ambient.isLowBitAmbientSupported`. Only meaningful when [state] is
+   * [AmbientPreviewState.Ambient].
+   */
+  val deviceHasLowBitAmbient: Boolean = false,
+)
+
+/**
+ * Discoverable mirror of the active states `androidx.wear.compose.foundation.AmbientMode` exposes.
+ * The Gradle plugin can't load Compose at discovery time, so we duplicate the relevant set here and
+ * let the renderer translate at render time.
+ */
+enum class AmbientPreviewState {
+  Interactive,
+  Ambient,
+}

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -43,6 +43,14 @@ dependencies {
   // `renderNow.overrides.focus` share the same composable seam. **No hardcoded focus / keyboard
   // logic should live in this module any more — extend the connector instead.**
   implementation(project(":data-focus-connector"))
+  // Wear OS ambient-mode connector. Owns `AmbientStateController` and `AmbientOverrideExtension`
+  // (the `AroundComposable` that installs `LocalAmbientModeManager`). The renderer wraps content
+  // with the extension whenever `RenderPreviewCapture.ambient` is set — `@AmbientPreview`
+  // discovery stamps it onto every capture of an annotated function, and daemon-driven
+  // `renderNow.overrides.ambient` plans the same extension through `RobolectricHost`. Same
+  // architectural rule as focus: **no hardcoded ambient / `LocalAmbientModeManager` logic in
+  // this module — extend the connector instead.**
+  implementation(project(":data-ambient-connector"))
 
   implementation(libs.robolectric)
   implementation(libs.junit)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -70,6 +70,21 @@ data class FocusCapture(
     val overlay: Boolean = false,
 )
 
+/** Renderer-side mirror of the plugin's `AmbientCaptureState`. */
+@Serializable
+enum class AmbientCaptureState {
+    Interactive,
+    Ambient,
+}
+
+/** Renderer-side mirror of the plugin's `AmbientCapture`. */
+@Serializable
+data class AmbientCapture(
+    val state: AmbientCaptureState = AmbientCaptureState.Ambient,
+    val burnInProtectionRequired: Boolean = false,
+    val deviceHasLowBitAmbient: Boolean = false,
+)
+
 /**
  * Heavy/fast threshold for [RenderPreviewCapture.cost]. Mirrors the plugin's
  * `HEAVY_COST_THRESHOLD` — anything strictly greater is considered "heavy"
@@ -131,6 +146,7 @@ data class RenderPreviewCapture(
     val scroll: ScrollCapture? = null,
     val animation: AnimationCapture? = null,
     val focus: FocusCapture? = null,
+    val ambient: AmbientCapture? = null,
     val renderOutput: String = "",
     /**
      * Estimated render cost normalised so a static `@Preview` is `1.0`. See

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -27,9 +27,12 @@ import com.github.takahirom.roborazzi.inspectionMode
 import com.github.takahirom.roborazzi.locale
 import com.github.takahirom.roborazzi.size
 import com.github.takahirom.roborazzi.uiMode
+import ee.schimke.composeai.daemon.AmbientOverrideExtension
 import ee.schimke.composeai.daemon.FocusController
 import ee.schimke.composeai.daemon.FocusOverlay
 import ee.schimke.composeai.daemon.FocusOverrideExtension
+import ee.schimke.composeai.daemon.protocol.AmbientOverride
+import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
 import ee.schimke.composeai.daemon.protocol.FocusOverride
 import ee.schimke.composeai.daemon.protocol.FocusDirection as ProtocolFocusDirection
 import ee.schimke.composeai.data.render.PreviewAnimationContext
@@ -676,6 +679,17 @@ abstract class RobolectricRenderTestBase(
                 val anyFocusCapture = preview.captures.any { it.focus != null }
                 val focusExtension =
                     if (anyFocusCapture) FocusOverrideExtension() else null
+                // `@AmbientPreview` discovery stamps the same `AmbientCapture` onto every capture
+                // of an annotated function (single-shot per function — one preview produces one
+                // ambient state). Wrap the composition with `AmbientOverrideExtension` from
+                // `:data-ambient-connector` when present so consumer code reading
+                // `LocalAmbientModeManager.current?.currentAmbientMode` observes the override.
+                // Daemon-driven `renderNow.overrides.ambient` lands at the same extension via the
+                // `AmbientPreviewOverrideExtension` planner registered in `RobolectricHost`.
+                val ambientExtension =
+                    preview.captures.firstNotNullOfOrNull { it.ambient }?.let {
+                        AmbientOverrideExtension(it.toAmbientOverride())
+                    }
                 val providedValues = buildList {
                     add(LocalInspectionMode provides !a11yEnabled)
                     if (scrollCaptureProvidable != null) {
@@ -730,10 +744,17 @@ abstract class RobolectricRenderTestBase(
                                 previewBody()
                             }
                         }
-                        if (focusExtension != null) {
-                            focusExtension.AroundComposable { curveOrPlain() }
+                        val focusOrPlain: @Composable () -> Unit = {
+                            if (focusExtension != null) {
+                                focusExtension.AroundComposable { curveOrPlain() }
+                            } else {
+                                curveOrPlain()
+                            }
+                        }
+                        if (ambientExtension != null) {
+                            ambientExtension.AroundComposable { focusOrPlain() }
                         } else {
-                            curveOrPlain()
+                            focusOrPlain()
                         }
                     }
                 }
@@ -1798,6 +1819,21 @@ private fun FocusDirection.toProtocol(): ProtocolFocusDirection =
         FocusDirection.Left -> ProtocolFocusDirection.Left
         FocusDirection.Right -> ProtocolFocusDirection.Right
     }
+
+/** Maps the renderer-side [AmbientCapture] (read from `previews.json`) onto the connector's
+ *  `protocol.AmbientOverride` wire shape. Discovery emits `Interactive` / `Ambient` only; the
+ *  daemon's `AmbientStateOverride.INACTIVE` value is reserved for the controller's "no override"
+ *  state and never round-trips through `@AmbientPreview`. */
+private fun AmbientCapture.toAmbientOverride(): AmbientOverride =
+    AmbientOverride(
+        state =
+            when (state) {
+                AmbientCaptureState.Interactive -> AmbientStateOverride.INTERACTIVE
+                AmbientCaptureState.Ambient -> AmbientStateOverride.AMBIENT
+            },
+        burnInProtectionRequired = burnInProtectionRequired,
+        deviceHasLowBitAmbient = deviceHasLowBitAmbient,
+    )
 
 /**
  * Adds Robolectric's `+round` qualifier so `Configuration.isScreenRound` becomes

--- a/samples/wear/src/main/kotlin/com/example/samplewear/AmbientPreviews.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/AmbientPreviews.kt
@@ -25,6 +25,8 @@ import androidx.wear.compose.foundation.LocalAmbientModeManager
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import androidx.wear.tooling.preview.devices.WearDevices
+import ee.schimke.composeai.preview.AmbientPreview
+import ee.schimke.composeai.preview.AmbientPreviewState
 
 /**
  * Body for the ambient-aware demo. Reads its state from
@@ -103,8 +105,24 @@ private fun Modifier.ambientGray(ambientMode: AmbientMode): Modifier =
     this
   }
 
-@Preview(name = "Ambient body", device = WearDevices.LARGE_ROUND, showBackground = true)
+@Preview(name = "Ambient body — interactive", device = WearDevices.LARGE_ROUND, showBackground = true)
 @Composable
-fun AmbientStatusPreview() {
+fun AmbientStatusInteractivePreview() {
+  AmbientStatusBody(now = { 1_700_000_000_000L })
+}
+
+/**
+ * Renders the body under `AmbientMode.Ambient(burnInProtectionRequired = true)`. The
+ * `@AmbientPreview` annotation drives the renderer to wrap the composition with
+ * `:data-ambient-connector`'s `AmbientOverrideExtension`, which installs `LocalAmbientModeManager`
+ * — the same composition-local seam `androidx.wear.compose.foundation.samples.AmbientModeBasicSample`
+ * reads from `rememberAmbientModeManager()`. Daemon-driven `renderNow.overrides.ambient` lands at
+ * the same extension via the `AmbientPreviewOverrideExtension` planner registered in
+ * `RobolectricHost`.
+ */
+@Preview(name = "Ambient body — ambient", device = WearDevices.LARGE_ROUND, showBackground = true)
+@AmbientPreview(state = AmbientPreviewState.Ambient, burnInProtectionRequired = true)
+@Composable
+fun AmbientStatusAmbientPreview() {
   AmbientStatusBody(now = { 1_700_000_000_000L })
 }

--- a/samples/wear/src/test/kotlin/com/example/samplewear/AmbientPreviewPixelTest.kt
+++ b/samples/wear/src/test/kotlin/com/example/samplewear/AmbientPreviewPixelTest.kt
@@ -1,0 +1,50 @@
+package com.example.samplewear
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Test
+
+/**
+ * End-to-end verification that `@AmbientPreview` actually drives `LocalAmbientModeManager` through
+ * the renderer's Compose pipeline. Reads the files produced by `:samples:wear:renderAllPreviews`
+ * (wired in via `composePreview { renderBeforeUnitTests = true }`) and pixel-asserts that the
+ * Interactive vs Ambient renders differ.
+ *
+ * What this guards against:
+ *
+ * * Renderer-side regressions where `RenderPreviewCapture.ambient` isn't honoured — the
+ *   `AmbientOverrideExtension` wouldn't wrap the composition and both PNGs would render the
+ *   `Interactive` fallback (the bug PR #907 fixed: previously horologist's `AmbientAware` fell
+ *   back to `Inactive` and produced identical "Inactive" captures).
+ * * Discovery-side regressions where the `@AmbientPreview` annotation is dropped from
+ *   `previews.json`, the `ambient` capture field arrives null at the renderer, and the override
+ *   never fires.
+ * * Sample-side regressions where the body stops reading from `LocalAmbientModeManager` (e.g. an
+ *   accidental hard-coded `AmbientMode.Interactive` fallback).
+ */
+class AmbientPreviewPixelTest {
+
+  private val rendersDir = File("build/compose-previews/renders")
+
+  private val interactivePng =
+    File(rendersDir, "AmbientPreviewsKt.AmbientStatusInteractivePreview_Ambient_body_interactive.png")
+
+  private val ambientPng =
+    File(rendersDir, "AmbientPreviewsKt.AmbientStatusAmbientPreview_Ambient_body_ambient.png")
+
+  /**
+   * Both PNGs must exist and differ — same composition body, the only difference is the
+   * `@AmbientPreview` annotation on one of them. If they hash-match, the renderer didn't apply
+   * the connector's `AmbientOverrideExtension` for the annotated variant and the body fell back
+   * to `AmbientMode.Interactive` for both.
+   */
+  @Test
+  fun `Interactive and Ambient renders differ`() {
+    assertThat(interactivePng.exists()).isTrue()
+    assertThat(ambientPng.exists()).isTrue()
+
+    val interactiveHash = interactivePng.readBytes().contentHashCode()
+    val ambientHash = ambientPng.readBytes().contentHashCode()
+    assertThat(interactiveHash).isNotEqualTo(ambientHash)
+  }
+}


### PR DESCRIPTION
## Summary

Restores the second wear ambient sample variant lost when #907 simplified `AmbientStatusBody` to read from `LocalAmbientModeManager.current`. Static `@Preview` rendering doesn't run the daemon-side extension chain, so the annotated body fell back to `AmbientMode.Interactive` for both previews and only the Interactive PNG was meaningful (visible on `compose-preview/main` — only one ambient PNG present under `samples/wear`).

Mirrors `@FocusedPreview`'s pattern: a discoverable annotation in `:preview-annotations` whose state flows through discovery → manifest → renderer → the existing `AmbientOverrideExtension`. Previews stay plain `@Preview` functions; the annotation says "render under this ambient state" and the renderer wires up the same connector extension the daemon planner uses for `renderNow.overrides.ambient`.

- `:preview-annotations` ships `@AmbientPreview(state, burnInProtectionRequired, deviceHasLowBitAmbient)` + `AmbientPreviewState` enum.
- `gradle-plugin/PreviewData.Capture` gains `ambient: AmbientCapture?`; `DiscoverPreviewsTask.extractAmbientSpec` reads the annotation by FQN.
- `renderer-android/RenderManifest.RenderPreviewCapture` mirrors the new field; `RobolectricRenderTest` constructs `AmbientOverrideExtension(ambient.toAmbientOverride())` and wraps content via `AroundComposable` — same seam the existing focus extension uses.
- `:data-ambient-connector` now applies `compose.compiler` (mirrors `:data-focus-connector`). Without it the override's `AroundComposable` compiles against the pre-Composer base signature and consumers calling it from compose-compiled code hit `AbstractMethodError` at runtime — caught by the new pixel test.
- `samples/wear/AmbientPreviews.kt`: split back into Interactive + Ambient variants. The Ambient variant carries `@AmbientPreview(state = Ambient, burnInProtectionRequired = true)`.

## Verifying focus didn't regress

Before opening this PR I downloaded the rendered focus PNGs from the `compose-preview/main` baseline branch and confirmed:

- `FocusTraversalPreview_FOCUS_step1_Next.png` and `_step2_Next.png` differ — focus walk lands on Save vs Edit.
- `FocusOverlayPreview_FOCUS_0.png` carries the red bounding box + "index 0" label.

So #912's renderer-side delegation to `:data-focus-connector` is intact. This PR doesn't touch focus.

## Test plan

- [x] `./gradlew :samples:wear:check` — new `AmbientPreviewPixelTest` hash-asserts the Interactive vs Ambient renders differ.
- [x] `./gradlew :samples:wear:renderAllPreviews` — both PNGs land:
  - `AmbientStatusInteractivePreview_Ambient_body_interactive.png` (dark blue, "Interactive")
  - `AmbientStatusAmbientPreview_Ambient_body_ambient.png` (black, "Ambient(burnIn)" with greyscale + 0.9× scale)
- [x] `./gradlew :data-ambient-connector:check` — connector tests still pass after adding `compose.compiler`.
- [x] `./gradlew :samples:android-alpha:testDebugUnitTest --tests "*FocusedPreviewPixelTest*"` — focus walk tests still pass.
- [ ] `compose-preview/main` baseline regenerates two distinct `samples:wear` ambient PNGs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9MedfGsUQp6Mn2GY17hu5)_