### PR TITLE
feat(uia): typed unsupported-reason evidence for uia.* dispatches (#874)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -326,6 +326,48 @@ internal constructor(
   }
 
   /**
+   * Override of [InteractiveSession.findUiAutomatorEvidence] (#874 item #2). Enqueues a
+   * [InteractiveCommand.FindUiAutomatorEvidence] envelope through the bridge; the sandbox-side
+   * `UiAutomatorEvidence.compute(...)` walks the held composition's `SemanticsOwner`, computes
+   * the matched-count + closest near-match node, and hands back a typed
+   * [`UiAutomatorUnsupportedReason`][ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason].
+   */
+  override fun findUiAutomatorEvidence(
+    actionKind: String,
+    selectorJson: String,
+    useUnmergedTree: Boolean,
+    inputText: String?,
+  ): ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason? {
+    if (closed) return null
+    lastUsedAtMs.set(System.currentTimeMillis())
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    val replyReason =
+      AtomicReference<ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason?>(null)
+    slot.interactiveCommands.put(
+      InteractiveCommand.FindUiAutomatorEvidence(
+        streamId = streamId,
+        actionKind = actionKind,
+        selectorJson = selectorJson,
+        useUnmergedTree = useUnmergedTree,
+        inputText = inputText,
+        replyLatch = replyLatch,
+        replyError = replyError,
+        replyReason = replyReason,
+      )
+    )
+    if (!replyLatch.await(DISPATCH_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+      error(
+        "AndroidInteractiveSession.findUiAutomatorEvidence timed out after " +
+          "${DISPATCH_TIMEOUT_SEC}s for stream '$streamId' (action=$actionKind, " +
+          "selectorJson='$selectorJson'). Held-rule loop may be stuck."
+      )
+    }
+    replyError.get()?.let { throw it }
+    return replyReason.get()
+  }
+
+  /**
    * Override of [InteractiveSession.dispatchLifecycle]. Enqueues a
    * [InteractiveCommand.DispatchLifecycle] envelope through the bridge; the sandbox-side loop in
    * [RobolectricHost.SandboxRunner.runHeldInteractiveSession] resolves the wire-name string to a

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -410,13 +410,32 @@ class AndroidRecordingSession(
       if (selector == null) {
         return@RecordingScriptEventHandler unsupportedEvidence(
           event,
-          "${event.kind} requires a non-null 'selector' object to resolve the target node",
+          message =
+            "${event.kind} requires a non-null 'selector' object to resolve the target node",
+          unsupportedReason =
+            ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason(
+              code =
+                ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReasonCode
+                  .MISSING_SELECTOR,
+              actionKind = actionKind,
+              selectorJson = null,
+              useUnmergedTree = event.useUnmergedTree ?: false,
+            ),
         )
       }
       if (actionKind == "inputText" && event.inputText == null) {
         return@RecordingScriptEventHandler unsupportedEvidence(
           event,
-          "${event.kind} requires a non-null 'inputText' string",
+          message = "${event.kind} requires a non-null 'inputText' string",
+          unsupportedReason =
+            ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason(
+              code =
+                ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReasonCode
+                  .MISSING_INPUT_TEXT,
+              actionKind = actionKind,
+              selectorJson = selector.toString(),
+              useUnmergedTree = event.useUnmergedTree ?: false,
+            ),
         )
       }
       val selectorJson = selector.toString()
@@ -431,9 +450,21 @@ class AndroidRecordingSession(
       if (matched) {
         appliedEvidence(event, "uia '$actionKind' fired against selector=$selectorJson")
       } else {
+        // #874 item #2 — typed evidence shape. The bridge runs the heuristic in the same
+        // sandbox the matcher walked, so the near-match it returns is grounded against the
+        // same SemanticsOwner snapshot the dispatch saw zero / multi matches against.
+        val reason =
+          interactive.findUiAutomatorEvidence(
+            actionKind = actionKind,
+            selectorJson = selectorJson,
+            useUnmergedTree = useUnmergedTree,
+            inputText = event.inputText,
+          )
         unsupportedEvidence(
           event,
-          "no node matched selector=$selectorJson for uia '$actionKind' (or matched node didn't expose the action)",
+          message =
+            "no node matched selector=$selectorJson for uia '$actionKind' (or matched node didn't expose the action)",
+          unsupportedReason = reason,
         )
       }
     }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1775,6 +1775,22 @@ open class RobolectricHost(
                     cmd.replyLatch.countDown()
                   }
                 }
+                is InteractiveCommand.FindUiAutomatorEvidence -> {
+                  try {
+                    val reason =
+                      UiAutomatorEvidence.compute(
+                        rule = rule,
+                        actionKind = cmd.actionKind,
+                        selectorJson = cmd.selectorJson,
+                        useUnmergedTree = cmd.useUnmergedTree,
+                      )
+                    cmd.replyReason.set(reason)
+                  } catch (t: Throwable) {
+                    cmd.replyError.set(t)
+                  } finally {
+                    cmd.replyLatch.countDown()
+                  }
+                }
                 is InteractiveCommand.DispatchLifecycle -> {
                   try {
                     val applied = performLifecycleTransition(rule, cmd)

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/UiAutomatorEvidence.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/UiAutomatorEvidence.kt
@@ -1,0 +1,220 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.onRoot
+import ee.schimke.composeai.daemon.protocol.UiAutomatorNearMatchNode
+import ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason
+import ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReasonCode
+import ee.schimke.composeai.renderer.uiautomator.SelectorJson
+import ee.schimke.composeai.renderer.uiautomator.UiAutomator
+import ee.schimke.composeai.renderer.uiautomator.UiAutomatorDataProducts
+import ee.schimke.composeai.renderer.uiautomator.decodeSelectorJson
+import kotlinx.serialization.json.Json
+
+/**
+ * Sandbox-side helper that turns a missed `uia.*` dispatch into a structured
+ * [UiAutomatorUnsupportedReason] (#874 item #2). Walks the same `SemanticsOwner` tree the
+ * matcher uses and emits a near-match candidate alongside the matched-count so agents can
+ * iterate on selectors without re-rendering and reading the screenshot.
+ *
+ * # Heuristic
+ *
+ * 1. Resolve the selector against the merged-or-unmerged tree (mirroring the dispatch path).
+ *    `0` matches → `NO_MATCH`; `1` match where the action wasn't exposed → `ACTION_NOT_EXPOSED`;
+ *    `>=2` matches → `MULTIPLE_MATCHES`.
+ * 2. For `NO_MATCH`, score every actionable node against the selector's text axes. The score
+ *    rewards case-insensitive equality (5pt), substring match (3pt), and selector-state
+ *    overlap (2pt per state predicate). The highest-scoring node becomes [nearMatch].
+ *    Falls back to "the first actionable node we found" when no string axis matches at all —
+ *    that's the answer to "you matched 0; here's an actionable node you might have meant".
+ * 3. For `ACTION_NOT_EXPOSED`, [nearMatch] is the matched node — agents see exactly which
+ *    actions it exposes vs the one they tried.
+ *
+ * The scoring is deliberately simple: a Levenshtein / longest-common-subsequence pass would
+ * give marginally better results on typoed selectors but doubles the per-walk cost on real
+ * Material screens (hundreds of nodes). Case-insensitive equality + substring covers the
+ * common "Submit vs SUBMIT" / "row-2 vs row 2" failure modes m13v's #874 review called out.
+ */
+internal object UiAutomatorEvidence {
+
+  private val WireJson = Json {
+    encodeDefaults = false
+    ignoreUnknownKeys = true
+    prettyPrint = false
+  }
+
+  fun compute(
+    rule: AndroidComposeTestRule<*, androidx.activity.ComponentActivity>,
+    actionKind: String,
+    selectorJson: String,
+    useUnmergedTree: Boolean,
+  ): UiAutomatorUnsupportedReason {
+    if (actionKind !in WiredActions) {
+      return UiAutomatorUnsupportedReason(
+        code = UiAutomatorUnsupportedReasonCode.UNKNOWN_ACTION_KIND,
+        actionKind = actionKind,
+        selectorJson = selectorJson,
+        useUnmergedTree = useUnmergedTree,
+      )
+    }
+    val selector = decodeSelectorJson(selectorJson)
+    val parsedSelector =
+      runCatching { WireJson.decodeFromString(SelectorJson.serializer(), selectorJson) }
+        .getOrNull()
+    val matches = UiAutomator.findObjects(rule, selector, useUnmergedTree = useUnmergedTree)
+    if (matches.size >= 2) {
+      val firstMatched = matches.first().node
+      return UiAutomatorUnsupportedReason(
+        code = UiAutomatorUnsupportedReasonCode.MULTIPLE_MATCHES,
+        actionKind = actionKind,
+        selectorJson = selectorJson,
+        useUnmergedTree = useUnmergedTree,
+        matchCount = matches.size,
+        nearMatch = nearMatchNode(firstMatched),
+      )
+    }
+    if (matches.size == 1) {
+      return UiAutomatorUnsupportedReason(
+        code = UiAutomatorUnsupportedReasonCode.ACTION_NOT_EXPOSED,
+        actionKind = actionKind,
+        selectorJson = selectorJson,
+        useUnmergedTree = useUnmergedTree,
+        matchCount = 1,
+        nearMatch = nearMatchNode(matches.first().node),
+      )
+    }
+    val rootNode = rule.onRoot(useUnmergedTree = useUnmergedTree).fetchSemanticsNode()
+    val candidates = collectActionable(rootNode)
+    val best = candidates.maxByOrNull { score(parsedSelector, it) }
+    return UiAutomatorUnsupportedReason(
+      code = UiAutomatorUnsupportedReasonCode.NO_MATCH,
+      actionKind = actionKind,
+      selectorJson = selectorJson,
+      useUnmergedTree = useUnmergedTree,
+      matchCount = 0,
+      nearMatch = best?.let { nearMatchNode(it) },
+    )
+  }
+
+  private fun collectActionable(root: SemanticsNode): List<SemanticsNode> {
+    val out = mutableListOf<SemanticsNode>()
+    fun walk(node: SemanticsNode) {
+      if (actionsFor(node).isNotEmpty()) out += node
+      for (child in node.children) walk(child)
+    }
+    walk(root)
+    return out
+  }
+
+  private fun score(selector: SelectorJson?, node: SemanticsNode): Int {
+    if (selector == null) return 0
+    var s = 0
+    val text = textOf(node)?.lowercase()
+    val desc = descOf(node)?.lowercase()
+    val testTag =
+      node.config.getOrNull(SemanticsProperties.TestTag)?.takeIf { it.isNotBlank() }?.lowercase()
+    s += stringAxisScore(selector.text, text) + stringAxisScore(selector.text, desc)
+    s += stringAxisScore(selector.desc, desc) + stringAxisScore(selector.desc, text)
+    s += stringAxisScore(selector.res, testTag)
+    if (selector.clickable == true && node.config.getOrNull(SemanticsActions.OnClick) != null) {
+      s += 2
+    }
+    if (
+      selector.longClickable == true &&
+        node.config.getOrNull(SemanticsActions.OnLongClick) != null
+    ) {
+      s += 2
+    }
+    if (selector.scrollable == true && node.config.getOrNull(SemanticsActions.ScrollBy) != null) {
+      s += 2
+    }
+    return s
+  }
+
+  private fun stringAxisScore(needle: String?, haystack: String?): Int {
+    if (needle == null || haystack == null) return 0
+    val n = needle.lowercase()
+    if (n == haystack) return 5
+    if (haystack.contains(n)) return 3
+    if (n.contains(haystack) && haystack.length >= 2) return 2
+    return 0
+  }
+
+  private fun textOf(node: SemanticsNode): String? {
+    node.config.getOrNull(SemanticsProperties.EditableText)?.let { return it.text }
+    return node.config
+      .getOrNull(SemanticsProperties.Text)
+      ?.joinToString(separator = " ") { it.text }
+  }
+
+  private fun descOf(node: SemanticsNode): String? =
+    node.config.getOrNull(SemanticsProperties.ContentDescription)?.joinToString(" ")
+
+  private fun nearMatchNode(node: SemanticsNode): UiAutomatorNearMatchNode {
+    val testTag =
+      node.config.getOrNull(SemanticsProperties.TestTag)?.takeIf { it.isNotBlank() }
+    val role = node.config.getOrNull(SemanticsProperties.Role)?.toString()
+    val bounds = node.boundsInRoot
+    val boundsString =
+      "${bounds.left.toInt()},${bounds.top.toInt()},${bounds.right.toInt()},${bounds.bottom.toInt()}"
+    return UiAutomatorNearMatchNode(
+      text = textOf(node),
+      contentDescription = descOf(node),
+      testTag = testTag,
+      role = role,
+      actions = actionsFor(node),
+      boundsInScreen = boundsString,
+    )
+  }
+
+  private fun actionsFor(node: SemanticsNode): List<String> {
+    val config = node.config
+    val out = mutableListOf<String>()
+    if (config.getOrNull(SemanticsActions.OnClick) != null) {
+      out += UiAutomatorDataProducts.ACTION_CLICK
+    }
+    if (config.getOrNull(SemanticsActions.OnLongClick) != null) {
+      out += UiAutomatorDataProducts.ACTION_LONG_CLICK
+    }
+    if (config.getOrNull(SemanticsActions.ScrollBy) != null) {
+      out += UiAutomatorDataProducts.ACTION_SCROLL
+    }
+    if (config.getOrNull(SemanticsActions.SetText) != null) {
+      out += UiAutomatorDataProducts.ACTION_SET_TEXT
+    }
+    if (config.getOrNull(SemanticsActions.RequestFocus) != null) {
+      out += UiAutomatorDataProducts.ACTION_REQUEST_FOCUS
+    }
+    if (config.getOrNull(SemanticsActions.Expand) != null) {
+      out += UiAutomatorDataProducts.ACTION_EXPAND
+    }
+    if (config.getOrNull(SemanticsActions.Collapse) != null) {
+      out += UiAutomatorDataProducts.ACTION_COLLAPSE
+    }
+    if (config.getOrNull(SemanticsActions.Dismiss) != null) {
+      out += UiAutomatorDataProducts.ACTION_DISMISS
+    }
+    if (config.getOrNull(SemanticsActions.SetProgress) != null) {
+      out += UiAutomatorDataProducts.ACTION_SET_PROGRESS
+    }
+    return out
+  }
+
+  /** Action kinds the wired `UiObject` methods cover — must stay in sync with `RobolectricHost.performUiAutomatorAction`. */
+  private val WiredActions: Set<String> =
+    setOf(
+      "click",
+      "longClick",
+      "scrollForward",
+      "scrollBackward",
+      "requestFocus",
+      "expand",
+      "collapse",
+      "dismiss",
+      "inputText",
+    )
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -509,6 +509,30 @@ sealed interface InteractiveCommand {
   ) : InteractiveCommand
 
   /**
+   * Companion to [DispatchUiAutomator] for the unsupported path (#874 item #2). Walks the same
+   * `SemanticsOwner` tree the matcher uses, computes the structured
+   * [`UiAutomatorUnsupportedReason`][ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason]
+   * (matched-count + closest near-match node + exposed-actions list), and hands it back through
+   * [replyReason]. Issued by the recording-session handler after `dispatchUiAutomator` returns
+   * `false` so a single bridge round-trip turns into a typed evidence shape on the wire.
+   *
+   * Read-only against the held composition — the sandbox-side arm walks but doesn't dispatch
+   * actions, so it doesn't compete with renders or other dispatch commands. Throwables from the
+   * walk ride [replyError]; the host's `findUiAutomatorEvidence` rethrows on the caller thread.
+   */
+  data class FindUiAutomatorEvidence(
+    override val streamId: String,
+    val actionKind: String,
+    val selectorJson: String,
+    val useUnmergedTree: Boolean,
+    val inputText: String?,
+    val replyLatch: CountDownLatch,
+    val replyError: AtomicReference<Throwable?>,
+    val replyReason:
+      AtomicReference<ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason?>,
+  ) : InteractiveCommand
+
+  /**
    * Lifecycle dispatch: move the held activity to the named lifecycle state via
    * `ActivityScenario.moveToState(...)`. Used by `record_preview`'s `lifecycle.event` script
    * events to drive `onPause` / `onResume` / `onStop` on the held composition.

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
@@ -281,6 +281,40 @@ class AndroidInteractiveSessionTest {
           false,
           matched,
         )
+
+        // #874 item #2 — after a miss, the recording-session handler asks the bridge to
+        // compute structured evidence so the response carries the matched-count + closest
+        // near-match node. Verify the round-trip end-to-end through the same held-rule loop
+        // the dispatch ran against.
+        val reason =
+          session.findUiAutomatorEvidence(
+            actionKind = "click",
+            selectorJson = """{"text":"NoSuchLabel"}""",
+            useUnmergedTree = false,
+            inputText = null,
+          )
+        assertNotNull(
+          "findUiAutomatorEvidence must return a structured reason after a miss",
+          reason,
+        )
+        assertEquals(
+          ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReasonCode.NO_MATCH,
+          reason!!.code,
+        )
+        assertEquals(0, reason.matchCount)
+        assertEquals("click", reason.actionKind)
+        // ClickableToggleSquare exposes Modifier.clickable, so the heuristic must surface it
+        // as the near-match — agents see "you matched 0 nodes; here's the actionable node
+        // you might have meant" without re-rendering.
+        assertNotNull(
+          "the held composition has an actionable node; the heuristic must surface it",
+          reason.nearMatch,
+        )
+        assertTrue(
+          "near-match must expose the click action so the agent sees that fixing the selector " +
+            "will let the dispatch fire — got actions=${reason.nearMatch!!.actions}",
+          "click" in reason.nearMatch!!.actions,
+        )
       } finally {
         session.close()
       }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/UiAutomatorEvidenceTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/UiAutomatorEvidenceTest.kt
@@ -1,0 +1,167 @@
+package ee.schimke.composeai.daemon
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReasonCode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Pins the typed-evidence heuristic for unsupported `uia.*` dispatches (#874 item #2). Drives
+ * `UiAutomatorEvidence.compute(...)` against real Compose semantics trees through Robolectric
+ * — same path the held-rule sandbox runs at dispatch time, so anything passing here matches
+ * what an agent's `record_preview` response would look like in production.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], qualifiers = "w400dp-h800dp")
+class UiAutomatorEvidenceTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun `NO_MATCH surfaces a case-insensitive-equal node as the near match`() {
+    rule.setContent {
+      Column {
+        // Material3 Button merges its Text label, so the merged node carries text="SUBMIT"
+        // (Button forces uppercase via TextStyle). A `By.text("Submit")` would miss; the
+        // near-match heuristic must surface "SUBMIT" with the click action so the agent
+        // sees the case mismatch directly.
+        Button(onClick = {}) { Text("SUBMIT") }
+        Text("decorative")
+      }
+    }
+
+    val reason =
+      UiAutomatorEvidence.compute(
+        rule = rule,
+        actionKind = "click",
+        selectorJson = """{"text":"Submit"}""",
+        useUnmergedTree = false,
+      )
+    assertEquals(UiAutomatorUnsupportedReasonCode.NO_MATCH, reason.code)
+    assertEquals(0, reason.matchCount)
+    assertEquals("click", reason.actionKind)
+    assertEquals(false, reason.useUnmergedTree)
+    assertEquals("""{"text":"Submit"}""", reason.selectorJson)
+    val nearMatch = reason.nearMatch
+    assertNotNull("expected a near-match node, got null", nearMatch)
+    assertEquals("SUBMIT", nearMatch!!.text)
+    assertTrue(
+      "near-match must expose `click` so the agent knows the dispatch would fire after fixing the selector",
+      "click" in nearMatch.actions,
+    )
+  }
+
+  @Test
+  fun `ACTION_NOT_EXPOSED surfaces the matched node and the actions it does expose`() {
+    rule.setContent {
+      Box(
+        modifier =
+          Modifier.size(80.dp)
+            .testTag("only-clickable")
+            .clickable(onClick = {})
+      )
+    }
+
+    // The selector matches the only clickable node, but we asked for `inputText` — the
+    // matched node has no SetText action so the dispatch returned false. The heuristic must
+    // surface the matched node + its real action set so the agent sees "you matched, but
+    // this node only exposes click".
+    val reason =
+      UiAutomatorEvidence.compute(
+        rule = rule,
+        actionKind = "inputText",
+        selectorJson = """{"res":"only-clickable"}""",
+        useUnmergedTree = false,
+      )
+    assertEquals(UiAutomatorUnsupportedReasonCode.ACTION_NOT_EXPOSED, reason.code)
+    assertEquals(1, reason.matchCount)
+    val nearMatch = reason.nearMatch
+    assertNotNull(nearMatch)
+    assertEquals("only-clickable", nearMatch!!.testTag)
+    assertTrue(
+      "matched node must expose the click action it carries — agents see the action it does have",
+      "click" in nearMatch.actions,
+    )
+    assertTrue(
+      "matched node must NOT expose `setText` — that's the gap the agent needs to see",
+      "setText" !in nearMatch.actions,
+    )
+  }
+
+  @Test
+  fun `MULTIPLE_MATCHES surfaces the first match and a count above one`() {
+    rule.setContent {
+      Column {
+        Button(onClick = {}) { Text("Primary") }
+        Button(onClick = {}) { Text("Secondary") }
+      }
+    }
+
+    val reason =
+      UiAutomatorEvidence.compute(
+        rule = rule,
+        actionKind = "click",
+        selectorJson = """{"clickable":true}""",
+        useUnmergedTree = false,
+      )
+    assertEquals(UiAutomatorUnsupportedReasonCode.MULTIPLE_MATCHES, reason.code)
+    assertTrue(
+      "expected matchCount >= 2, got ${reason.matchCount}",
+      reason.matchCount >= 2,
+    )
+    assertNotNull("first matched node should be surfaced as the near-match", reason.nearMatch)
+  }
+
+  @Test
+  fun `UNKNOWN_ACTION_KIND short-circuits without walking the tree`() {
+    rule.setContent { Button(onClick = {}) { Text("Submit") } }
+
+    val reason =
+      UiAutomatorEvidence.compute(
+        rule = rule,
+        actionKind = "doesNotExist",
+        selectorJson = """{"text":"Submit"}""",
+        useUnmergedTree = false,
+      )
+    assertEquals(UiAutomatorUnsupportedReasonCode.UNKNOWN_ACTION_KIND, reason.code)
+    assertEquals(0, reason.matchCount)
+    assertNull("UNKNOWN_ACTION_KIND must not surface a near-match", reason.nearMatch)
+  }
+
+  @Test
+  fun `NO_MATCH with no actionable nodes leaves nearMatch null`() {
+    // Non-actionable composition — only a static Text. The heuristic should report
+    // NO_MATCH with `null` nearMatch (no candidate exists), not invent a synthetic node.
+    rule.setContent { Text("decorative") }
+
+    val reason =
+      UiAutomatorEvidence.compute(
+        rule = rule,
+        actionKind = "click",
+        selectorJson = """{"text":"Submit"}""",
+        useUnmergedTree = false,
+      )
+    assertEquals(UiAutomatorUnsupportedReasonCode.NO_MATCH, reason.code)
+    assertNull(
+      "without any actionable node the heuristic must not invent a near-match",
+      reason.nearMatch,
+    )
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
@@ -121,6 +121,25 @@ interface InteractiveSession : AutoCloseable {
   ): Boolean = false
 
   /**
+   * Typed companion to [dispatchUiAutomator] for the unsupported path (#874 item #2). Called by the
+   * recording-session handler after [dispatchUiAutomator] returns `false` — walks the same
+   * `SemanticsOwner` tree the matcher used and returns a structured
+   * [`UiAutomatorUnsupportedReason`][ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason]
+   * carrying the matched-count, the closest near-match node (text, contentDescription, testTag,
+   * role, exposed actions, bounds), and the action the agent attempted.
+   *
+   * Default returns `null` so hosts that don't ship a UIAutomator dispatch path (desktop today)
+   * cleanly degrade to the existing free-form `message` — agents iterating on selectors only see
+   * the structured field on backends that wired it up.
+   */
+  fun findUiAutomatorEvidence(
+    actionKind: String,
+    selectorJson: String,
+    useUnmergedTree: Boolean = false,
+    inputText: String? = null,
+  ): ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason? = null
+
+  /**
    * Lifecycle dispatch: move the held activity (or per-host equivalent) to the named lifecycle
    * state, exercising `onPause` / `onResume` / `onStop` etc. on the way. Used by `record_preview`'s
    * `lifecycle.event` script events to verify that a preview survives a pause-resume cycle or a

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry.kt
@@ -118,8 +118,16 @@ fun appliedEvidence(event: RecordingScriptEvent, message: String? = null): Recor
  * Build an [RecordingScriptEvidence] for an unsupported event. The [message] is required so the
  * agent always has a concrete reason for the unsupported status (which kind, on which backend, why
  * — e.g. "key dispatch is not implemented for desktop recording").
+ *
+ * Optional [unsupportedReason] carries a structured cause for `uia.*` dispatches (#874 item #2) —
+ * agents that decode it get the matched-count + nearest-match shape and can iterate on selectors
+ * without re-rendering. Other event kinds leave it `null`.
  */
-fun unsupportedEvidence(event: RecordingScriptEvent, message: String): RecordingScriptEvidence =
+fun unsupportedEvidence(
+  event: RecordingScriptEvent,
+  message: String,
+  unsupportedReason: ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason? = null,
+): RecordingScriptEvidence =
   RecordingScriptEvidence(
     tMs = event.tMs,
     kind = event.kind,
@@ -129,4 +137,5 @@ fun unsupportedEvidence(event: RecordingScriptEvent, message: String): Recording
     lifecycleEvent = event.lifecycleEvent,
     tags = event.tags,
     message = message,
+    unsupportedReason = unsupportedReason,
   )

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1323,6 +1323,13 @@ data class RecordingScriptEvidence(
   val lifecycleEvent: String? = null,
   val tags: List<String> = emptyList(),
   val message: String? = null,
+  /**
+   * Typed companion to [message] for unsupported `uia.*` dispatches (#874 item #2). When present,
+   * carries the structured cause + closest near-match node so agents can iterate on selectors
+   * without re-rendering. `null` for non-uia events and for applied uia dispatches — agents that
+   * pre-date this field keep reading [message] and ignore [unsupportedReason].
+   */
+  val unsupportedReason: UiAutomatorUnsupportedReason? = null,
 )
 
 /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason.kt
@@ -1,0 +1,101 @@
+package ee.schimke.composeai.daemon.protocol
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Typed evidence for an unsupported `uia.*` script-event dispatch (#874 item #2). Replaces the
+ * free-form `RecordingScriptEvidence.message` for the UIAutomator path with a structured shape
+ * agents can iterate on without re-rendering and reading the screenshot.
+ *
+ * Always carried alongside [RecordingScriptEvidence.message]; the message stays human-readable for
+ * trace logs, while [code] / [matchCount] / [nearMatch] / [nearMatchActions] give coding agents
+ * enough signal to fix the next selector. Example: a `By.text("Submit")` against a Material
+ * `Button` whose merged label is `"SUBMIT"` arrives as `{code: NO_MATCH, matchCount: 0, nearMatch:
+ * {text: "SUBMIT", actions: ["click"], …}}`.
+ *
+ * Wire-stable — fields are additive only. Pre-1.0; agents that didn't migrate continue to read
+ * `message` and ignore `unsupportedReason`. The MCP `record_preview` schema surfaces this on the
+ * response side.
+ */
+@Serializable
+data class UiAutomatorUnsupportedReason(
+  /** Coarse cause — see [UiAutomatorUnsupportedReasonCode]. */
+  val code: UiAutomatorUnsupportedReasonCode,
+  /** Action kind the dispatch attempted (`"click"`, `"longClick"`, `"inputText"`, …). */
+  val actionKind: String,
+  /**
+   * The selector JSON the agent supplied (round-trippable through `decodeSelectorJson`). `null` for
+   * [UiAutomatorUnsupportedReasonCode.MISSING_SELECTOR] where there was no selector to echo.
+   */
+  val selectorJson: String? = null,
+  /** Mirror of `useUnmergedTree` so agents can see which tree the dispatch walked. */
+  val useUnmergedTree: Boolean = false,
+  /**
+   * How many nodes matched the selector. `0` for `NO_MATCH`, `1` for `ACTION_NOT_EXPOSED`, `>=2`
+   * for `MULTIPLE_MATCHES`. Agents differentiate "selector too narrow" vs "selector too broad"
+   * directly off this field.
+   */
+  val matchCount: Int = 0,
+  /**
+   * Best near-match heuristic: the actionable Compose semantics node closest to the selector shape,
+   * by case-insensitive equality / substring on the selector's text axes. `null` when no actionable
+   * node exists in the tree (a preview with no clickables / scrollables).
+   *
+   * For `ACTION_NOT_EXPOSED`, this is the matched node — agents see exactly which actions it
+   * exposes vs the one they tried.
+   */
+  val nearMatch: UiAutomatorNearMatchNode? = null,
+)
+
+/**
+ * Distinguishes the coarse causes a `uia.*` dispatch can fail for, so agents can branch on the
+ * right next step (refine selector vs widen selector vs supply missing payload). New codes land
+ * additively; clients that don't recognise a new code fall back to the human-readable
+ * [RecordingScriptEvidence.message].
+ */
+@Serializable
+enum class UiAutomatorUnsupportedReasonCode {
+  /** Agent omitted the `selector` object entirely. */
+  @SerialName("missingSelector") MISSING_SELECTOR,
+  /** Agent omitted the `inputText` payload required by `uia.inputText`. */
+  @SerialName("missingInputText") MISSING_INPUT_TEXT,
+  /**
+   * Selector resolved to zero nodes. [UiAutomatorUnsupportedReason.nearMatch] is the closest
+   * candidate.
+   */
+  @SerialName("noMatch") NO_MATCH,
+  /** Selector resolved to a single node, but that node didn't expose the requested action. */
+  @SerialName("actionNotExposed") ACTION_NOT_EXPOSED,
+  /** Selector resolved to two or more nodes — agents must narrow the predicate. */
+  @SerialName("multipleMatches") MULTIPLE_MATCHES,
+  /** Backend doesn't ship a UIAutomator dispatch path (e.g. desktop sessions today). */
+  @SerialName("noHostSupport") NO_HOST_SUPPORT,
+  /** Action kind isn't one of the wired `UiObject` methods. */
+  @SerialName("unknownActionKind") UNKNOWN_ACTION_KIND,
+}
+
+/**
+ * Slim projection of one Compose semantics node, included on a [UiAutomatorUnsupportedReason] to
+ * give the agent just enough shape to formulate the next selector. Mirrors the actionable subset of
+ * `UiAutomatorHierarchyNode` from `:data-uiautomator-core` (text, contentDescription, testTag,
+ * role, exposed actions, bounds) — the two surfaces deliberately overlap so a `uia/hierarchy`
+ * payload and an `unsupportedReason.nearMatch` field carry the same selector vocabulary.
+ *
+ * Lives in `:daemon:core` (not `:data-uiautomator-core`) because [RecordingScriptEvidence] lives
+ * here and `:daemon:core` doesn't depend on `:data-uiautomator-core`. The shape is plain
+ * JSON-serializable, no Compose dep.
+ */
+@Serializable
+data class UiAutomatorNearMatchNode(
+  val text: String? = null,
+  val contentDescription: String? = null,
+  val testTag: String? = null,
+  val role: String? = null,
+  /**
+   * Action names this node exposes; same vocabulary as `UiAutomatorDataProducts.SUPPORTED_ACTIONS`.
+   */
+  val actions: List<String> = emptyList(),
+  /** `left,top,right,bottom` in source-bitmap pixels — same shape `AccessibilityNode` uses. */
+  val boundsInScreen: String,
+)


### PR DESCRIPTION
Item #2 from #874. Replaces the free-form
RecordingScriptEvidence.message for missed uia.* events with a
structured shape carrying the matched-count, the closest near-match
node (text / contentDescription / testTag / role / exposed actions /
bounds), and the action the agent attempted — so a coding agent
iterating on a selector gets "you matched 0 nodes; the only clickable
node has text 'SUBMIT' not 'Submit'" without re-rendering and reading
the screenshot.

Wire types in :daemon:core:
- UiAutomatorUnsupportedReason data class with code / actionKind /
  selectorJson / useUnmergedTree / matchCount / nearMatch.
- UiAutomatorUnsupportedReasonCode enum: MISSING_SELECTOR /
  MISSING_INPUT_TEXT / NO_MATCH / ACTION_NOT_EXPOSED /
  MULTIPLE_MATCHES / NO_HOST_SUPPORT / UNKNOWN_ACTION_KIND.
- UiAutomatorNearMatchNode mirrors the actionable subset of
  UiAutomatorHierarchyNode so the two surfaces share selector
  vocabulary.
- RecordingScriptEvidence gains an additive unsupportedReason field;
  existing callers and pre-migration agents keep reading message.
- unsupportedEvidence helper takes an optional structured reason.
- InteractiveSession adds findUiAutomatorEvidence(...) with default
  null, so desktop / non-uiautomator hosts naturally degrade.

Sandbox-side heuristic in :daemon:android:
- UiAutomatorEvidence.compute walks the same SemanticsOwner the
  matcher used. 0 matches with at least one actionable node yields
  NO_MATCH plus a near-match scored by case-insensitive equality /
  substring on the selector's text axes plus selector-state overlap;
  1 match yields ACTION_NOT_EXPOSED with the matched node so the
  agent sees the actual exposed actions vs the one they tried;
  >=2 matches yields MULTIPLE_MATCHES; unknown action kinds short
  circuit without walking.
- New InteractiveCommand.FindUiAutomatorEvidence envelope and
  RobolectricHost arm ride the same held-rule loop the dispatch uses.
- AndroidInteractiveSession.findUiAutomatorEvidence enqueues across
  the bridge and rethrows on the caller thread.
- AndroidRecordingSession's uia handler asks the bridge for the typed
  reason after a miss and packs it into structured evidence; the
  no-selector / no-inputText paths get typed reasons too.

Tests:
- UiAutomatorEvidenceTest pins the heuristic against real Compose
  semantics trees through Robolectric: NO_MATCH with case-insensitive
  near-match, NO_MATCH with no actionable nodes (null near-match),
  ACTION_NOT_EXPOSED surfaces the matched node + its real action set,
  MULTIPLE_MATCHES, UNKNOWN_ACTION_KIND short-circuits.
- AndroidInteractiveSessionTest's existing miss test now also
  exercises findUiAutomatorEvidence end-to-end through the bridge so
  drift between the heuristic and the dispatch path shows up here.