### PR TITLE
Extract ViewportTracker and LoadingOverlay into testable modules

### DIFF
--- a/vscode-extension/src/test/loadingOverlay.test.ts
+++ b/vscode-extension/src/test/loadingOverlay.test.ts
@@ -1,0 +1,249 @@
+// DOM-feature tests for `LoadingOverlay` (the two-stage loading
+// escalation lifted out of `behavior.ts` into a narrow-deps file).
+//
+// Pins the contract:
+//
+//   - `markAll` stamps `.loading-overlay.minimal` onto every
+//     `.preview-card .image-container` that has existing pixels.
+//   - Cards still showing the bare skeleton (no `<img>`) are skipped
+//     so we don't double-cover loading states.
+//   - Cards that already have an overlay don't get a duplicate.
+//   - 500ms after `markAll` any still-`.minimal` overlay is promoted
+//     to `.subtle`; overlays cleared in the meantime stay gone.
+//   - `cancel` cuts the pending escalation timer so a subsequent
+//     external clear doesn't re-introduce the dim+blur stage.
+//
+// Timer determinism: we replace `setTimeout` / `clearTimeout` on the
+// happy-dom-installed globalThis with a hand-rolled queue. The class
+// captures whichever callable lives on `globalThis.setTimeout` at
+// `markAll` time, so the swap takes effect without poking module
+// internals.
+
+import * as assert from "assert";
+import { LoadingOverlay } from "../webview/preview/loadingOverlay";
+
+interface ScheduledTimer {
+    id: number;
+    delay: number;
+    fn: () => void;
+}
+
+const realSetTimeout = globalThis.setTimeout;
+const realClearTimeout = globalThis.clearTimeout;
+let pending: ScheduledTimer[] = [];
+let nextTimerId = 1;
+
+function installFakeTimers(): void {
+    pending = [];
+    nextTimerId = 1;
+    (globalThis as unknown as { setTimeout: unknown }).setTimeout = ((
+        fn: () => void,
+        delay: number,
+    ) => {
+        const id = nextTimerId++;
+        pending.push({ id, delay, fn });
+        return id as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    (globalThis as unknown as { clearTimeout: unknown }).clearTimeout = ((
+        id: number,
+    ) => {
+        pending = pending.filter((t) => t.id !== id);
+    }) as typeof clearTimeout;
+}
+
+function restoreTimers(): void {
+    (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout =
+        realSetTimeout;
+    (
+        globalThis as unknown as { clearTimeout: typeof clearTimeout }
+    ).clearTimeout = realClearTimeout;
+    pending = [];
+}
+
+/** Run every queued timer's callback (escalation timers don't re-arm,
+ *  so a single drain matches a "clock advanced past 500 ms" jump). */
+function flushTimers(): void {
+    const drained = pending;
+    pending = [];
+    for (const t of drained) t.fn();
+}
+
+/** Build a `<div class="preview-card">` whose `.image-container`
+ *  already has a rendered `<img>` — i.e. the card has pixels worth
+ *  covering with a loading overlay. */
+function buildCardWithImage(previewId = "com.example.A"): HTMLElement {
+    const card = document.createElement("div");
+    card.className = "preview-card";
+    card.dataset.previewId = previewId;
+    const container = document.createElement("div");
+    container.className = "image-container";
+    const img = document.createElement("img");
+    img.src = "data:image/png;base64,AAAA";
+    container.appendChild(img);
+    card.appendChild(container);
+    document.body.appendChild(card);
+    return card;
+}
+
+/** Same shape as above but the `.image-container` only holds a
+ *  skeleton — `markAll` should skip these. */
+function buildCardWithSkeletonOnly(previewId = "com.example.B"): HTMLElement {
+    const card = document.createElement("div");
+    card.className = "preview-card";
+    card.dataset.previewId = previewId;
+    const container = document.createElement("div");
+    container.className = "image-container";
+    const skel = document.createElement("div");
+    skel.className = "skeleton";
+    container.appendChild(skel);
+    card.appendChild(container);
+    document.body.appendChild(card);
+    return card;
+}
+
+describe("LoadingOverlay", () => {
+    beforeEach(() => {
+        installFakeTimers();
+    });
+
+    afterEach(() => {
+        restoreTimers();
+        document.body.innerHTML = "";
+    });
+
+    describe("markAll", () => {
+        it("stamps .loading-overlay.minimal onto every image-container with pixels", () => {
+            const a = buildCardWithImage("com.example.A");
+            const b = buildCardWithImage("com.example.B");
+
+            new LoadingOverlay().markAll();
+
+            for (const card of [a, b]) {
+                const overlay = card.querySelector(".loading-overlay");
+                assert.ok(overlay, "expected an overlay to be appended");
+                assert.strictEqual(
+                    overlay!.classList.contains("minimal"),
+                    true,
+                );
+                assert.strictEqual(
+                    overlay!.classList.contains("subtle"),
+                    false,
+                );
+                assert.ok(
+                    overlay!.querySelector(".spinner"),
+                    "overlay should contain a .spinner",
+                );
+            }
+        });
+
+        it("skips cards that only have a skeleton (no pixels yet)", () => {
+            const card = buildCardWithSkeletonOnly();
+
+            new LoadingOverlay().markAll();
+
+            assert.strictEqual(card.querySelector(".loading-overlay"), null);
+        });
+
+        it("does not duplicate the overlay when called twice on the same card", () => {
+            const card = buildCardWithImage();
+            const overlay = new LoadingOverlay();
+
+            overlay.markAll();
+            overlay.markAll();
+
+            assert.strictEqual(
+                card.querySelectorAll(".loading-overlay").length,
+                1,
+            );
+        });
+
+        it("skips cards without an .image-container", () => {
+            const card = document.createElement("div");
+            card.className = "preview-card";
+            card.dataset.previewId = "com.example.C";
+            document.body.appendChild(card);
+
+            assert.doesNotThrow(() => new LoadingOverlay().markAll());
+            assert.strictEqual(card.querySelector(".loading-overlay"), null);
+        });
+
+        it("escalates remaining minimal overlays to subtle after the timer fires", () => {
+            const card = buildCardWithImage();
+
+            new LoadingOverlay().markAll();
+            const overlay = card.querySelector(".loading-overlay")!;
+            assert.strictEqual(overlay.classList.contains("minimal"), true);
+
+            flushTimers();
+
+            assert.strictEqual(overlay.classList.contains("minimal"), false);
+            assert.strictEqual(overlay.classList.contains("subtle"), true);
+        });
+
+        it("does not promote overlays that were removed before the timer fires", () => {
+            // Mirrors the production flow: `updateImage` lands in the
+            // 0–500 ms window and tears down the overlay before the
+            // escalation timer runs.
+            const card = buildCardWithImage();
+
+            new LoadingOverlay().markAll();
+            card.querySelector(".loading-overlay")!.remove();
+            flushTimers();
+
+            assert.strictEqual(card.querySelector(".loading-overlay"), null);
+            assert.strictEqual(card.querySelector(".subtle"), null);
+        });
+
+        it("schedules exactly one escalation timer per markAll invocation", () => {
+            buildCardWithImage("com.example.A");
+            const overlay = new LoadingOverlay();
+
+            overlay.markAll();
+            assert.strictEqual(pending.length, 1);
+            // A second markAll re-arms the timer rather than stacking.
+            overlay.markAll();
+            assert.strictEqual(pending.length, 1);
+        });
+
+        it("schedules the escalation at 500 ms", () => {
+            buildCardWithImage();
+            new LoadingOverlay().markAll();
+
+            assert.strictEqual(pending.length, 1);
+            assert.strictEqual(pending[0]!.delay, 500);
+        });
+    });
+
+    describe("cancel", () => {
+        it("cuts the pending escalation timer so subtle is never applied", () => {
+            const card = buildCardWithImage();
+            const overlay = new LoadingOverlay();
+
+            overlay.markAll();
+            assert.strictEqual(pending.length, 1);
+            overlay.cancel();
+            assert.strictEqual(pending.length, 0);
+
+            flushTimers(); // would have promoted to subtle if still armed
+            const dom = card.querySelector(".loading-overlay")!;
+            assert.strictEqual(dom.classList.contains("minimal"), true);
+            assert.strictEqual(dom.classList.contains("subtle"), false);
+        });
+
+        it("is a no-op when nothing is scheduled", () => {
+            const overlay = new LoadingOverlay();
+            assert.doesNotThrow(() => overlay.cancel());
+            assert.doesNotThrow(() => overlay.cancel());
+        });
+
+        it("can be called repeatedly without re-introducing the timer", () => {
+            buildCardWithImage();
+            const overlay = new LoadingOverlay();
+
+            overlay.markAll();
+            overlay.cancel();
+            overlay.cancel();
+            assert.strictEqual(pending.length, 0);
+        });
+    });
+});

--- a/vscode-extension/src/test/viewportTracker.test.ts
+++ b/vscode-extension/src/test/viewportTracker.test.ts
@@ -1,0 +1,506 @@
+// DOM-feature tests for `ViewportTracker` (the IntersectionObserver +
+// scroll-velocity EMA cluster lifted out of `behavior.ts` into a
+// narrow-deps file).
+//
+// happy-dom ships an `IntersectionObserver` constructor but does not
+// drive entries from layout, so we stub the global before constructing
+// the tracker, capture the callback the tracker hands in, and call it
+// manually with synthetic entries. The 120 ms publish debounce uses
+// `setTimeout` — same fake-timer trick as `loadingOverlay.test.ts`.
+//
+// Pinned contract:
+//
+//   - `observe` forwards each card to the IO; entering the viewport
+//     adds the id to the published `visible` array, leaving removes
+//     it and fires `onCardLeftViewport(id)` exactly once.
+//   - Publishes are coalesced through a 120 ms `setTimeout` so a
+//     burst of intersection / scroll events fans out one
+//     `viewportUpdated` post, not one per event.
+//   - `predictNextIds` returns up to 4 cards ahead of (or behind) the
+//     last (first) visible card based on signed scroll velocity, and
+//     skips `.filtered-out` cards.
+//   - `forget` removes the id from the live set without firing
+//     `onCardLeftViewport` again, and unobserves the card.
+//   - `unobserveAll` clears the live set and unobserves every
+//     `.preview-card`.
+//
+// IntersectionObserver shape pin (regression guard for happy-dom): the
+// constructor is invoked with a `{ root, rootMargin, threshold }` init
+// matching the production call.
+
+import * as assert from "assert";
+import { ViewportTracker } from "../webview/preview/viewportTracker";
+import type { VsCodeApi } from "../webview/shared/vscode";
+
+interface ScheduledTimer {
+    id: number;
+    delay: number;
+    fn: () => void;
+}
+
+const realSetTimeout = globalThis.setTimeout;
+const realClearTimeout = globalThis.clearTimeout;
+let pending: ScheduledTimer[] = [];
+let nextTimerId = 1;
+
+function installFakeTimers(): void {
+    pending = [];
+    nextTimerId = 1;
+    (globalThis as unknown as { setTimeout: unknown }).setTimeout = ((
+        fn: () => void,
+        delay: number,
+    ) => {
+        const id = nextTimerId++;
+        pending.push({ id, delay, fn });
+        return id as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+    (globalThis as unknown as { clearTimeout: unknown }).clearTimeout = ((
+        id: number,
+    ) => {
+        pending = pending.filter((t) => t.id !== id);
+    }) as typeof clearTimeout;
+}
+
+function restoreTimers(): void {
+    (globalThis as unknown as { setTimeout: typeof setTimeout }).setTimeout =
+        realSetTimeout;
+    (
+        globalThis as unknown as { clearTimeout: typeof clearTimeout }
+    ).clearTimeout = realClearTimeout;
+    pending = [];
+}
+
+function flushTimers(): void {
+    const drained = pending;
+    pending = [];
+    for (const t of drained) t.fn();
+}
+
+interface IOInit {
+    root: Element | Document | null;
+    rootMargin: string;
+    threshold: number | number[];
+}
+
+interface FakeObserver {
+    init: IOInit;
+    observed: Set<Element>;
+    callback: IntersectionObserverCallback;
+    fire(entries: Partial<IntersectionObserverEntry>[]): void;
+}
+
+let lastObserver: FakeObserver | null = null;
+let realIntersectionObserver: typeof IntersectionObserver | undefined;
+
+function installFakeIO(): void {
+    realIntersectionObserver = (
+        globalThis as unknown as {
+            IntersectionObserver?: typeof IntersectionObserver;
+        }
+    ).IntersectionObserver;
+    class FakeIO implements Partial<IntersectionObserver> {
+        readonly observed = new Set<Element>();
+        readonly init: IOInit;
+        readonly callback: IntersectionObserverCallback;
+        constructor(cb: IntersectionObserverCallback, init: IOInit) {
+            this.callback = cb;
+            this.init = init;
+            lastObserver = {
+                init,
+                observed: this.observed,
+                callback: cb,
+                fire: (entries) => {
+                    this.callback(
+                        entries as IntersectionObserverEntry[],
+                        this as unknown as IntersectionObserver,
+                    );
+                },
+            };
+        }
+        observe(el: Element): void {
+            this.observed.add(el);
+        }
+        unobserve(el: Element): void {
+            this.observed.delete(el);
+        }
+        disconnect(): void {
+            this.observed.clear();
+        }
+        takeRecords(): IntersectionObserverEntry[] {
+            return [];
+        }
+    }
+    (
+        globalThis as unknown as { IntersectionObserver: unknown }
+    ).IntersectionObserver = FakeIO as unknown as typeof IntersectionObserver;
+}
+
+function restoreIO(): void {
+    (
+        globalThis as unknown as { IntersectionObserver: unknown }
+    ).IntersectionObserver = realIntersectionObserver;
+    lastObserver = null;
+}
+
+/** Build a `<div class="preview-card" data-preview-id="…">` and append
+ *  it to `document.body`. Cards are added in DOM order so
+ *  `predictNextIds` traversal matches their construction order. */
+function buildCard(
+    previewId: string,
+    opts: { filteredOut?: boolean } = {},
+): HTMLElement {
+    const card = document.createElement("div");
+    card.className = "preview-card";
+    if (opts.filteredOut) card.classList.add("filtered-out");
+    card.dataset.previewId = previewId;
+    document.body.appendChild(card);
+    return card;
+}
+
+function fakeEntry(
+    target: Element,
+    isIntersecting: boolean,
+): Partial<IntersectionObserverEntry> {
+    return { target, isIntersecting };
+}
+
+interface RecordedPost {
+    command: string;
+    visible: string[];
+    predicted: string[];
+}
+
+function makeVscode(): { api: VsCodeApi<unknown>; posts: RecordedPost[] } {
+    const posts: RecordedPost[] = [];
+    const api: VsCodeApi<unknown> = {
+        postMessage: (m: unknown) => {
+            posts.push(m as RecordedPost);
+        },
+        getState: () => undefined,
+        setState: () => {},
+    };
+    return { api, posts };
+}
+
+describe("ViewportTracker", () => {
+    beforeEach(() => {
+        installFakeTimers();
+        installFakeIO();
+    });
+
+    afterEach(() => {
+        restoreTimers();
+        restoreIO();
+        document.body.innerHTML = "";
+    });
+
+    it("constructs the IntersectionObserver with the production init bag", () => {
+        const { api } = makeVscode();
+        new ViewportTracker({ vscode: api, onCardLeftViewport: () => {} });
+
+        assert.ok(lastObserver, "IO should have been constructed");
+        assert.strictEqual(lastObserver!.init.root, null);
+        assert.strictEqual(lastObserver!.init.rootMargin, "0px");
+        assert.strictEqual(lastObserver!.init.threshold, 0.1);
+    });
+
+    it("forwards observe(card) to the underlying IntersectionObserver", () => {
+        const { api } = makeVscode();
+        const tracker = new ViewportTracker({
+            vscode: api,
+            onCardLeftViewport: () => {},
+        });
+        const a = buildCard("com.example.A");
+        const b = buildCard("com.example.B");
+
+        tracker.observe(a);
+        tracker.observe(b);
+
+        assert.strictEqual(lastObserver!.observed.size, 2);
+        assert.ok(lastObserver!.observed.has(a));
+        assert.ok(lastObserver!.observed.has(b));
+    });
+
+    it("publishes the intersecting set after the 120 ms debounce", () => {
+        const { api, posts } = makeVscode();
+        const tracker = new ViewportTracker({
+            vscode: api,
+            onCardLeftViewport: () => {},
+        });
+        const a = buildCard("com.example.A");
+        const b = buildCard("com.example.B");
+        tracker.observe(a);
+        tracker.observe(b);
+
+        lastObserver!.fire([fakeEntry(a, true), fakeEntry(b, true)]);
+
+        // Coalesced — nothing posts until the timer fires.
+        assert.strictEqual(posts.length, 0);
+        assert.strictEqual(pending.length, 1);
+        assert.strictEqual(pending[0]!.delay, 120);
+
+        flushTimers();
+
+        assert.strictEqual(posts.length, 1);
+        assert.strictEqual(posts[0]!.command, "viewportUpdated");
+        assert.deepStrictEqual(posts[0]!.visible.slice().sort(), [
+            "com.example.A",
+            "com.example.B",
+        ]);
+        assert.deepStrictEqual(posts[0]!.predicted, []);
+    });
+
+    it("coalesces a burst of intersection events into a single publish", () => {
+        const { api, posts } = makeVscode();
+        const tracker = new ViewportTracker({
+            vscode: api,
+            onCardLeftViewport: () => {},
+        });
+        const a = buildCard("com.example.A");
+        const b = buildCard("com.example.B");
+        tracker.observe(a);
+        tracker.observe(b);
+
+        lastObserver!.fire([fakeEntry(a, true)]);
+        lastObserver!.fire([fakeEntry(b, true)]);
+        lastObserver!.fire([fakeEntry(a, false)]);
+
+        assert.strictEqual(
+            pending.length,
+            1,
+            "all three bursts share one timer",
+        );
+        flushTimers();
+
+        assert.strictEqual(posts.length, 1);
+        assert.deepStrictEqual(posts[0]!.visible, ["com.example.B"]);
+    });
+
+    it("fires onCardLeftViewport on every isIntersecting=false entry", () => {
+        // Pin current behaviour: the callback fires per `false` entry,
+        // not per visible→hidden transition. The host (live-state
+        // controller) is what dedups by checking whether the id is in
+        // its live set — a redundant call is cheap and idempotent.
+        const left: string[] = [];
+        const { api } = makeVscode();
+        const tracker = new ViewportTracker({
+            vscode: api,
+            onCardLeftViewport: (id) => left.push(id),
+        });
+        const a = buildCard("com.example.A");
+        tracker.observe(a);
+
+        lastObserver!.fire([fakeEntry(a, true)]);
+        lastObserver!.fire([fakeEntry(a, false)]);
+        lastObserver!.fire([fakeEntry(a, false)]);
+
+        assert.deepStrictEqual(left, ["com.example.A", "com.example.A"]);
+    });
+
+    it("ignores entries whose target has no data-preview-id", () => {
+        const { api, posts } = makeVscode();
+        const tracker = new ViewportTracker({
+            vscode: api,
+            onCardLeftViewport: () => {},
+        });
+        const orphan = document.createElement("div");
+        orphan.className = "preview-card";
+        document.body.appendChild(orphan);
+        tracker.observe(orphan);
+
+        lastObserver!.fire([fakeEntry(orphan, true)]);
+        flushTimers();
+
+        // A publish still happens (timer was scheduled), but visible is empty.
+        assert.strictEqual(posts.length, 1);
+        assert.deepStrictEqual(posts[0]!.visible, []);
+    });
+
+    it("forget(previewId, card) drops the id from the live set without firing onCardLeftViewport", () => {
+        const left: string[] = [];
+        const { api, posts } = makeVscode();
+        const tracker = new ViewportTracker({
+            vscode: api,
+            onCardLeftViewport: (id) => left.push(id),
+        });
+        const a = buildCard("com.example.A");
+        tracker.observe(a);
+        lastObserver!.fire([fakeEntry(a, true)]);
+        flushTimers();
+        assert.deepStrictEqual(posts[posts.length - 1]!.visible, [
+            "com.example.A",
+        ]);
+
+        tracker.forget("com.example.A", a);
+        // forget bypasses the IO callback path, so the leave callback
+        // must not fire (the card was deliberately removed from the
+        // grid, not scrolled out of view).
+        assert.deepStrictEqual(left, []);
+        assert.strictEqual(lastObserver!.observed.has(a), false);
+
+        // Subsequent publishes should no longer list the forgotten id.
+        lastObserver!.fire([fakeEntry(buildCard("com.example.B"), true)]);
+        flushTimers();
+        const last = posts[posts.length - 1]!;
+        assert.deepStrictEqual(last.visible, ["com.example.B"]);
+    });
+
+    it("unobserveAll clears the intersecting set and unhooks every preview card", () => {
+        const { api, posts } = makeVscode();
+        const tracker = new ViewportTracker({
+            vscode: api,
+            onCardLeftViewport: () => {},
+        });
+        const a = buildCard("com.example.A");
+        const b = buildCard("com.example.B");
+        tracker.observe(a);
+        tracker.observe(b);
+        lastObserver!.fire([fakeEntry(a, true), fakeEntry(b, true)]);
+
+        tracker.unobserveAll();
+        assert.strictEqual(lastObserver!.observed.size, 0);
+
+        // Drain the publish that was already armed by the pre-clear
+        // intersection burst so the next assertion sees a clean slate.
+        flushTimers();
+        const beforeCount = posts.length;
+
+        // After unobserveAll the live set is empty, so any subsequent
+        // publish should carry no `visible` ids.
+        lastObserver!.fire([fakeEntry(a, false)]);
+        flushTimers();
+        assert.strictEqual(posts.length, beforeCount + 1);
+        assert.deepStrictEqual(posts[posts.length - 1]!.visible, []);
+    });
+
+    describe("predictNextIds", () => {
+        function buildGrid(
+            ids: string[],
+            opts: { filteredIndices?: number[] } = {},
+        ): HTMLElement[] {
+            const cards: HTMLElement[] = [];
+            for (let i = 0; i < ids.length; i++) {
+                cards.push(
+                    buildCard(ids[i]!, {
+                        filteredOut: opts.filteredIndices?.includes(i) ?? false,
+                    }),
+                );
+            }
+            return cards;
+        }
+
+        it("returns empty when scroll velocity is below the 0.05 px/ms threshold", () => {
+            const { api, posts } = makeVscode();
+            const tracker = new ViewportTracker({
+                vscode: api,
+                onCardLeftViewport: () => {},
+            });
+            const cards = buildGrid(["A", "B", "C", "D"]);
+            for (const c of cards) tracker.observe(c);
+            lastObserver!.fire([fakeEntry(cards[0]!, true)]);
+            // No scroll events → velocity stays at 0 → no prediction.
+            flushTimers();
+
+            assert.deepStrictEqual(posts[posts.length - 1]!.predicted, []);
+        });
+
+        it("predicts the next four DOM-order cards when scrolling down", () => {
+            const { api, posts } = makeVscode();
+            const tracker = new ViewportTracker({
+                vscode: api,
+                onCardLeftViewport: () => {},
+            });
+            const cards = buildGrid(["A", "B", "C", "D", "E", "F", "G"]);
+            for (const c of cards) tracker.observe(c);
+            // B and C are in the viewport.
+            lastObserver!.fire([
+                fakeEntry(cards[1]!, true),
+                fakeEntry(cards[2]!, true),
+            ]);
+            // Force positive velocity by stubbing the EMA sample.
+            // Two scroll events: y goes from 0 to 100 over ~10 ms.
+            Object.defineProperty(window, "scrollY", {
+                configurable: true,
+                value: 0,
+            });
+            document.dispatchEvent(new Event("scroll"));
+            Object.defineProperty(window, "scrollY", {
+                configurable: true,
+                value: 200,
+            });
+            document.dispatchEvent(new Event("scroll"));
+
+            flushTimers();
+            const last = posts[posts.length - 1]!;
+            assert.deepStrictEqual(last.visible.slice().sort(), ["B", "C"]);
+            // Predicts D, E, F, G (PREDICT_AHEAD = 4) — i.e. the four
+            // DOM-order cards immediately after the lowest visible (C).
+            assert.deepStrictEqual(last.predicted, ["D", "E", "F", "G"]);
+        });
+
+        it("predicts upward when scrolling up", () => {
+            const { api, posts } = makeVscode();
+            const tracker = new ViewportTracker({
+                vscode: api,
+                onCardLeftViewport: () => {},
+            });
+            const cards = buildGrid(["A", "B", "C", "D", "E", "F"]);
+            for (const c of cards) tracker.observe(c);
+            // E and F are in the viewport.
+            lastObserver!.fire([
+                fakeEntry(cards[4]!, true),
+                fakeEntry(cards[5]!, true),
+            ]);
+            // Negative velocity: scrollY goes from 500 to 100.
+            Object.defineProperty(window, "scrollY", {
+                configurable: true,
+                value: 500,
+            });
+            document.dispatchEvent(new Event("scroll"));
+            Object.defineProperty(window, "scrollY", {
+                configurable: true,
+                value: 100,
+            });
+            document.dispatchEvent(new Event("scroll"));
+
+            flushTimers();
+            const last = posts[posts.length - 1]!;
+            assert.deepStrictEqual(last.visible.slice().sort(), ["E", "F"]);
+            // Predicts D, C, B, A — four cards above the topmost visible (E),
+            // in reverse DOM order.
+            assert.deepStrictEqual(last.predicted, ["D", "C", "B", "A"]);
+        });
+
+        it("skips .filtered-out cards when predicting", () => {
+            const { api, posts } = makeVscode();
+            const tracker = new ViewportTracker({
+                vscode: api,
+                onCardLeftViewport: () => {},
+            });
+            // C is filtered out — it sits between B (visible) and D
+            // (predicted). The filter test in `predictNextIds` is on
+            // the *whole* card list (the filter strips C from
+            // consideration entirely), so D is the next predicted card.
+            const cards = buildGrid(["A", "B", "C", "D", "E"], {
+                filteredIndices: [2],
+            });
+            for (const c of cards) tracker.observe(c);
+            lastObserver!.fire([fakeEntry(cards[1]!, true)]);
+            Object.defineProperty(window, "scrollY", {
+                configurable: true,
+                value: 0,
+            });
+            document.dispatchEvent(new Event("scroll"));
+            Object.defineProperty(window, "scrollY", {
+                configurable: true,
+                value: 200,
+            });
+            document.dispatchEvent(new Event("scroll"));
+
+            flushTimers();
+            const last = posts[posts.length - 1]!;
+            assert.ok(!last.predicted.includes("C"));
+            assert.deepStrictEqual(last.predicted, ["D", "E"]);
+        });
+    });
+});

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -26,6 +26,7 @@
         "src/webview/preview/interactiveInput.ts",
         "src/webview/preview/liveBadge.ts",
         "src/webview/preview/liveTransitions.ts",
+        "src/webview/preview/loadingOverlay.ts",
         "src/webview/preview/moduleReadiness.ts",
         "src/webview/preview/pointerGeometry.ts",
         "src/webview/preview/relativeSizing.ts",

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -31,6 +31,7 @@
         "src/webview/preview/pointerGeometry.ts",
         "src/webview/preview/relativeSizing.ts",
         "src/webview/preview/staleBadgeDom.ts",
+        "src/webview/preview/viewportTracker.ts",
         "src/webview/history/components/HistoryRow.ts",
         "src/webview/history/historyData.ts",
         "src/webview/history/historyStore.ts",


### PR DESCRIPTION
## Summary
Refactors viewport tracking and loading overlay functionality out of `behavior.ts` into dedicated, narrow-dependency modules with comprehensive test coverage. This improves code organization, testability, and maintainability.

## Key Changes
- **New module: `viewportTracker.ts`** - Extracts IntersectionObserver-based viewport tracking with scroll velocity prediction into a standalone class
  - Tracks visible cards in the viewport and predicts upcoming cards based on scroll direction
  - Publishes viewport updates coalesced through a 120ms debounce
  - Supports forgetting cards and unobserving all cards
  
- **New module: `loadingOverlay.ts`** - Extracts two-stage loading state visualization into a standalone class
  - Marks cards with minimal loading overlays
  - Escalates overlays to subtle state after 500ms if still loading
  - Supports canceling pending escalations

- **Comprehensive test suites**:
  - `viewportTracker.test.ts` (506 lines) - Tests IntersectionObserver integration, viewport coalescing, scroll velocity prediction, and card lifecycle management
  - `loadingOverlay.test.ts` (249 lines) - Tests overlay creation, escalation timing, and cancellation logic
  - Both test suites use fake timer and fake IntersectionObserver implementations for deterministic DOM testing

- **Updated `tsconfig.json`** - Includes new modules in the build configuration

## Implementation Details
- Tests use a custom fake timer implementation to control `setTimeout`/`clearTimeout` behavior without external dependencies
- IntersectionObserver is stubbed in tests to allow manual entry firing and assertion of observer configuration
- Scroll velocity prediction uses exponential moving average (EMA) with a 0.05 px/ms threshold
- Prediction looks ahead/behind up to 4 cards while skipping filtered-out cards
- Loading overlay escalation is re-armed on each `markAll()` call to handle rapid successive calls

https://claude.ai/code/session_01DUFNzFRko621Zhx42nhNMm