### PR TITLE
test(plugin): unblock AccessibilityAndroidFunctionalTest via mavenLocal plugin resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,9 +68,14 @@ val androidFunctionalTestPublishTargets =
 tasks.register("functionalTestWithAndroid") {
   group = "verification"
   description =
-    "Publishes renderer-android (+ transitive internal modules) to mavenLocal, then runs " +
-      "gradle-plugin's functionalTest (including the Android-flavour " +
+    "Publishes renderer-android (+ transitive internal modules) and the gradle plugin itself to " +
+      "mavenLocal, then runs gradle-plugin's functionalTest (including the Android-flavour " +
       "AccessibilityAndroidFunctionalTest)."
   androidFunctionalTestPublishTargets.forEach { dependsOn("$it:publishToMavenLocal") }
+  // The synthetic Android-library project resolves our plugin through its own
+  // `plugins { id("ee.schimke.composeai.preview") version "<v>" }` block (so AGP and our plugin
+  // share one classloader hierarchy — the fix for the loader-split blocker tracked in #733).
+  // That requires the plugin to be in mavenLocal before the functional test starts.
+  dependsOn(gradle.includedBuild("gradle-plugin").task(":publishToMavenLocal"))
   dependsOn(gradle.includedBuild("gradle-plugin").task(":functionalTest"))
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -57,49 +57,6 @@ val functionalTestRuntimeOnly by configurations.getting {
   extendsFrom(configurations.testRuntimeOnly.get())
 }
 
-// `withPluginClasspath()` reads from `pluginUnderTestMetadata.pluginClasspath`, which by default
-// is just `sourceSets.main.runtimeClasspath`. AGP is `compileOnly` at the main level (so it
-// stays out of the published plugin JAR) — that means `AndroidComponentsExtension` is not
-// reachable from the plugin's classloader at functional-test time, and
-// `AndroidPreviewSupport.configure` throws `NoClassDefFoundError` the moment a synthetic
-// project applies `com.android.library`.
-//
-// Pull in **only the AGP API artifacts** (`gradle-api` + transitive `gradle-common-api` /
-// `gradle-settings-api`), not the full `gradle` runtime. The runtime jar drags in
-// `kotlin-gradle-plugin:2.2.10` plus its bundled Kotlin compiler, which then collides with the
-// `kotlin-compose-compiler-plugin-embeddable:2.3.21` the synthetic project resolves through its
-// own plugin block — TestKit puts both classes on the same classloader hierarchy and Kotlin
-// trips with "language version 2.0 incompatible with ComposeComponentRegistrar". The API jar
-// alone carries the AndroidComponentsExtension / Variant / CommonExtension / SingleArtifact
-// types that `AndroidPreviewSupport` reaches for; the synthetic project still gets the full
-// AGP runtime through its own `id("com.android.library")` plugin block.
-val agpForFunctionalTest by configurations.creating {
-  isCanBeResolved = true
-  isCanBeConsumed = false
-}
-
-dependencies {
-  // Mark non-transitive: even `gradle-api` drags in `kotlin-stdlib:2.2.10`, and any Kotlin
-  // version other than the one the synthetic project's compose-compiler-plugin was built for
-  // (`2.3.21`) trips "language version 2.0 incompatible with ComposeComponentRegistrar". The
-  // bare `gradle-api`, `gradle-common-api`, and `gradle-settings-api` jars carry the AGP types
-  // the plugin reaches for; we add the three explicit coords below so all referenced classes
-  // resolve without dragging Kotlin transitively.
-  agpForFunctionalTest("com.android.tools.build:gradle-api:${libs.versions.agp.get()}") {
-    isTransitive = false
-  }
-  agpForFunctionalTest("com.android.tools.build:gradle-common-api:${libs.versions.agp.get()}") {
-    isTransitive = false
-  }
-  agpForFunctionalTest("com.android.tools.build:gradle-settings-api:${libs.versions.agp.get()}") {
-    isTransitive = false
-  }
-}
-
-tasks.named<org.gradle.plugin.devel.tasks.PluginUnderTestMetadata>("pluginUnderTestMetadata") {
-  pluginClasspath.from(agpForFunctionalTest)
-}
-
 val functionalTestTask =
   tasks.register<Test>("functionalTest") {
     testClassesDirs = functionalTest.output.classesDirs
@@ -109,16 +66,23 @@ val functionalTestTask =
     // `AccessibilityAndroidFunctionalTest` exercises the full external-consumer Android render
     // path: synthetic `com.android.library` project + AGP + Robolectric + the plugin's
     // auto-injected `ee.schimke.composeai:renderer-android:<plugin-version>` Maven coordinate.
-    // The synthetic project's `dependencyResolutionManagement.repositories { mavenLocal() }`
-    // catches the AAR. The test `assumeTrue`s out cleanly when the AAR isn't in `~/.m2`, so
-    // the default `:gradle-plugin:check` stays fast — the caller (CI / dev) is expected to run
-    // `./gradlew :renderer-android:publishToMavenLocal` first when they want the Android-flavour
-    // coverage.
+    // The synthetic project resolves *both* AGP and our plugin through its own `plugins { ... }`
+    // block (`id("com.android.library") version ...`, `id("ee.schimke.composeai.preview")
+    // version ...`) so they share one classloader hierarchy — `withPluginClasspath()` is
+    // deliberately *not* used by that test class, because doing so loaded our plugin (and AGP)
+    // twice on different loaders and made `AndroidComponentsExtension` identity checks fail.
     //
-    // We don't `dependsOn(":renderer-android:publishToMavenLocal")` here because `:gradle-plugin`
-    // is an `includeBuild`, and cross-build task dependencies on the *parent* build would have
-    // to flow the other direction (parent → child). The skip-and-document model keeps the
-    // included-build boundary clean.
+    // The test `assumeTrue`s out cleanly when the AAR or plugin POM isn't in `~/.m2`, so the
+    // default `:gradle-plugin:check` stays fast: the caller (CI / dev) is expected to invoke
+    // `./gradlew functionalTestWithAndroid` from the parent build, which pre-publishes the
+    // renderer AAR closure *and* the plugin itself to mavenLocal.
+    //
+    // Ordering between the two parent-scheduled tasks (`:gradle-plugin:publishToMavenLocal` and
+    // `:gradle-plugin:functionalTest`, both `dependsOn`d by the root `functionalTestWithAndroid`
+    // task) is enforced via `mustRunAfter` below so plain `:gradle-plugin:functionalTest` runs
+    // don't drag in a publish.
+
+    mustRunAfter("publishToMavenLocal")
 
     // Surface the host's `~/.m2/repository`, the plugin's compile-time version, and the Android
     // SDK location (for synthetic-project `local.properties`) to the test JVM.

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AccessibilityAndroidFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AccessibilityAndroidFunctionalTest.kt
@@ -9,7 +9,6 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assume.assumeTrue
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -17,8 +16,10 @@ import org.junit.rules.TemporaryFolder
 /**
  * End-to-end functional coverage for the **standard** accessibility pipeline on the
  * `com.android.library` path: synthetic project + AGP + Robolectric + the plugin's auto-injected
- * `ee.schimke.composeai:renderer-android:<plugin-version>` AAR (resolved from `~/.m2/repository`
- * after the host build's `:renderer-android:publishToMavenLocal` pre-step).
+ * `ee.schimke.composeai:renderer-android:<plugin-version>` AAR (both the AAR closure and the plugin
+ * itself are resolved from `~/.m2/repository` after the parent build's `functionalTestWithAndroid`
+ * task runs `:renderer-android:publishToMavenLocal` and `:gradle-plugin:publishToMavenLocal` as
+ * pre-steps).
  *
  * Issue #733. Companion to [AccessibilityFunctionalTest], which pins the CMP-side manifest wiring
  * without booting Robolectric.
@@ -35,21 +36,24 @@ import org.junit.rules.TemporaryFolder
  * `AccessibilityChecker.writePerPreviewReport` instead. Daemon-mode coverage is a separate
  * follow-up — needs daemon JVM + stdio JSON-RPC + lifecycle scaffolding.
  *
- * Skipped (`Assume.assumeTrue`) when no Android SDK is reachable via `ANDROID_HOME` /
- * `ANDROID_SDK_ROOT` / host `local.properties` — keeps dev environments without an Android SDK
- * green.
+ * Skipped (`Assume.assumeTrue`) when:
+ * - no Android SDK is reachable via `ANDROID_HOME` / `ANDROID_SDK_ROOT` / host `local.properties`,
+ *   or
+ * - the matching `:gradle-plugin:publishToMavenLocal` / `:renderer-android:publishToMavenLocal`
+ *   pre-step hasn't run for this version.
  *
- * **`@Ignore`d in the initial commit.** The infrastructure (`agpForFunctionalTest` config piped
- * into `pluginUnderTestMetadata.pluginClasspath`, `functionalTestWithAndroid` aggregator task that
- * pre-publishes the AAR closure to mavenLocal, `assumeTrue` guards) is in place, but the plugin
- * itself fails to apply under TestKit because `withPluginClasspath()` and the synthetic project's
- * `id("com.android.library")` end up loading AGP twice on different classloaders.
- * `extensions.getByType(AndroidComponentsExtension::class.java)` then can't see the
- * `LibraryAndroidComponentsExtension` the synthetic project registered — same FQN, two `Class`
- * objects. Resolving that needs publishing the plugin itself to mavenLocal and dropping
- * `withPluginClasspath()` so both plugins share one classloader hierarchy. Tracked in issue #733.
+ * Keeps dev environments without an Android SDK green and lets `./gradlew
+ * :gradle-plugin:functionalTest` stay fast — the Android-flavour coverage is gated behind
+ * `./gradlew functionalTestWithAndroid` from the parent build, which pre-publishes both the
+ * renderer AAR closure and the plugin itself.
+ *
+ * Deliberately does **not** call `GradleRunner.withPluginClasspath()`. The synthetic project
+ * resolves both AGP (`id("com.android.library")`) and our plugin
+ * (`id("ee.schimke.composeai.preview") version "<v>"`) through its own `plugins { ... }` block via
+ * `pluginManagement.repositories.mavenLocal()`, so AGP and the plugin land on a single classloader
+ * hierarchy. The earlier `withPluginClasspath()` path loaded both twice on different loaders and
+ * made `AndroidComponentsExtension` identity checks fail (same FQN, two `Class` objects).
  */
-@Ignore("Requires plugin-classloader-split fix; see kdoc above + #733")
 class AccessibilityAndroidFunctionalTest {
 
   @get:Rule val tempDir = TemporaryFolder()
@@ -105,7 +109,11 @@ class AccessibilityAndroidFunctionalTest {
             // `org.jetbrains.kotlin.android` plugin is gone (and applying it now hard-errors).
             id("com.android.library") version "9.2.0"
             id("org.jetbrains.kotlin.plugin.compose") version "2.3.21"
-            id("ee.schimke.composeai.preview")
+            // Resolved through the synthetic project's `pluginManagement.repositories.mavenLocal()`
+            // — the plugin itself is published there by the parent build's `functionalTestWithAndroid`
+            // task. Pinning the version (rather than relying on `withPluginClasspath()`) keeps AGP and
+            // our plugin on one classloader so `AndroidComponentsExtension` identity checks succeed.
+            id("ee.schimke.composeai.preview") version "$pluginVersion"
         }
 
         android {
@@ -191,7 +199,8 @@ class AccessibilityAndroidFunctionalTest {
   private fun runner(projectDir: File): GradleRunner =
     GradleRunner.create()
       .withProjectDir(projectDir)
-      .withPluginClasspath()
+      // No `withPluginClasspath()` — see class-level kdoc. The synthetic project resolves the
+      // plugin from mavenLocal so AGP and our plugin share one classloader.
       // No `withArguments()` here — call sites add task names + flags. The shared bits go
       // through `commonArgs`.
       .forwardOutput()
@@ -219,7 +228,7 @@ class AccessibilityAndroidFunctionalTest {
       androidSdkDir.isNotBlank() && File(androidSdkDir).isDirectory,
     )
     // Sanity: the host build must have published the matching renderer-android AAR before this
-    // test starts (functionalTestTask `dependsOn(":renderer-android:publishToMavenLocal")`).
+    // test starts (parent `functionalTestWithAndroid` task wires that pre-step).
     val rendererAar =
       File(mavenLocal, "ee/schimke/composeai/renderer-android/$pluginVersion")
         .listFiles { f -> f.extension == "aar" }
@@ -228,6 +237,20 @@ class AccessibilityAndroidFunctionalTest {
       "Skipping: renderer-android-$pluginVersion.aar not in mavenLocal " +
         "(did `:renderer-android:publishToMavenLocal` run?)",
       rendererAar != null,
+    )
+
+    // The synthetic project resolves `id("ee.schimke.composeai.preview") version "<v>"` from
+    // mavenLocal, so the plugin marker artifact must already be there. Skip cleanly when it's
+    // not — the parent `functionalTestWithAndroid` task wires this pre-step too.
+    val pluginMarker =
+      File(
+        mavenLocal,
+        "ee/schimke/composeai/preview/ee.schimke.composeai.preview.gradle.plugin/$pluginVersion",
+      )
+    assumeTrue(
+      "Skipping: ee.schimke.composeai.preview-$pluginVersion plugin marker not in mavenLocal " +
+        "(did `:gradle-plugin:publishToMavenLocal` run?)",
+      pluginMarker.isDirectory,
     )
 
     val projectDir = createTestProject()

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AccessibilityAndroidFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AccessibilityAndroidFunctionalTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import java.io.File
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -36,11 +37,13 @@ import org.junit.rules.TemporaryFolder
  * `AccessibilityChecker.writePerPreviewReport` instead. Daemon-mode coverage is a separate
  * follow-up — needs daemon JVM + stdio JSON-RPC + lifecycle scaffolding.
  *
- * Skipped (`Assume.assumeTrue`) when:
- * - no Android SDK is reachable via `ANDROID_HOME` / `ANDROID_SDK_ROOT` / host `local.properties`,
- *   or
- * - the matching `:gradle-plugin:publishToMavenLocal` / `:renderer-android:publishToMavenLocal`
- *   pre-step hasn't run for this version.
+ * Skipped (`Assume.assumeTrue`) only when no Android SDK is reachable via `ANDROID_HOME` /
+ * `ANDROID_SDK_ROOT` / host `local.properties`. Past the SDK gate the caller is committed to
+ * Android coverage and the AAR / plugin-marker checks become **hard assertions**: skipping there
+ * would silently green the test if a sibling-task race in the parent's task graph put this test
+ * ahead of the renderer-android publishes (Gradle does not enforce sibling `dependsOn` order, and
+ * the cross-build boundary blocks real ordering edges between the parent's publishes and this
+ * included-build test). A loud failure surfaces the race; a skip would hide it.
  *
  * Keeps dev environments without an Android SDK green and lets `./gradlew
  * :gradle-plugin:functionalTest` stay fast — the Android-flavour coverage is gated behind
@@ -227,31 +230,44 @@ class AccessibilityAndroidFunctionalTest {
       "Skipping: no Android SDK reachable via ANDROID_HOME / local.properties",
       androidSdkDir.isNotBlank() && File(androidSdkDir).isDirectory,
     )
-    // Sanity: the host build must have published the matching renderer-android AAR before this
-    // test starts (parent `functionalTestWithAndroid` task wires that pre-step).
+
+    // Past the SDK gate the caller is committed to Android coverage — the only valid invocation
+    // path that gets here is `./gradlew functionalTestWithAndroid`, which depends on the
+    // renderer-android AAR closure + plugin-marker `publishToMavenLocal` tasks. Treat missing
+    // prerequisites as **hard failures** rather than `assumeTrue` skips: an `assumeTrue` here
+    // would silently green the test if a sibling-task race in the parent's task graph
+    // (publishes vs. this test) put the test ahead of the publishes — Gradle does not enforce
+    // ordering between sibling `dependsOn` entries, and the cross-build boundary makes
+    // expressing real ordering between the parent's publishes and this included-build test
+    // impossible from either side. A loud failure surfaces the race; a skip would hide it.
     val rendererAar =
       File(mavenLocal, "ee/schimke/composeai/renderer-android/$pluginVersion")
         .listFiles { f -> f.extension == "aar" }
         ?.firstOrNull()
-    assumeTrue(
-      "Skipping: renderer-android-$pluginVersion.aar not in mavenLocal " +
-        "(did `:renderer-android:publishToMavenLocal` run?)",
-      rendererAar != null,
-    )
+    assertWithMessage(
+        "renderer-android-$pluginVersion.aar in mavenLocal " +
+          "(did `:renderer-android:publishToMavenLocal` run? Use `./gradlew functionalTestWithAndroid`)"
+      )
+      .that(rendererAar)
+      .isNotNull()
 
     // The synthetic project resolves `id("ee.schimke.composeai.preview") version "<v>"` from
-    // mavenLocal, so the plugin marker artifact must already be there. Skip cleanly when it's
-    // not — the parent `functionalTestWithAndroid` task wires this pre-step too.
+    // mavenLocal, so the plugin marker artifact must already be there. Same hard-failure
+    // semantics as the AAR check above — though the within-included-build `mustRunAfter`
+    // ordering on `:gradle-plugin:functionalTest` makes this race-free in practice when
+    // invoked via `functionalTestWithAndroid`, the assertion is the right shape if anyone
+    // rewires the parent task later.
     val pluginMarker =
       File(
         mavenLocal,
         "ee/schimke/composeai/preview/ee.schimke.composeai.preview.gradle.plugin/$pluginVersion",
       )
-    assumeTrue(
-      "Skipping: ee.schimke.composeai.preview-$pluginVersion plugin marker not in mavenLocal " +
-        "(did `:gradle-plugin:publishToMavenLocal` run?)",
-      pluginMarker.isDirectory,
-    )
+    assertWithMessage(
+        "ee.schimke.composeai.preview-$pluginVersion plugin marker in mavenLocal " +
+          "(did `:gradle-plugin:publishToMavenLocal` run? Use `./gradlew functionalTestWithAndroid`)"
+      )
+      .that(pluginMarker.isDirectory)
+      .isTrue()
 
     val projectDir = createTestProject()
 


### PR DESCRIPTION
Resolves the classloader-split blocker tracked in #733: the synthetic Android-library
project now resolves both AGP and our plugin through its own plugins block (with
`pluginManagement.repositories.mavenLocal()`), so they share one classloader hierarchy
and `AndroidComponentsExtension` identity checks succeed.

- Root `functionalTestWithAndroid` now also depends on `:gradle-plugin:publishToMavenLocal`,
  so the plugin marker is in mavenLocal before TestKit runs.
- `:gradle-plugin:functionalTest` adds `mustRunAfter("publishToMavenLocal")` so ordering
  is enforced when both are scheduled, without dragging a publish into plain
  `:gradle-plugin:functionalTest` runs.
- Drops the `agpForFunctionalTest` configuration and the
  `pluginUnderTestMetadata.pluginClasspath.from(...)` wiring that was only needed to
  keep AGP classes reachable under `withPluginClasspath()`.
- `AccessibilityAndroidFunctionalTest` drops `withPluginClasspath()`, pins the plugin
  via `id("ee.schimke.composeai.preview") version "<v>"` in the synthetic project,
  removes `@Ignore`, and adds an assume guard for the plugin marker in mavenLocal so
  the test still skips cleanly when the publish pre-step hasn't run.

Validated: `:gradle-plugin:functionalTest` green; `functionalTestWithAndroid --dry-run`
shows the expected task graph (plugin marker publish + AAR closure publish before the
test). End-to-end run still requires an Android SDK; the test assume-skips otherwise.