### PR TITLE
test(vscode): backfill happy-dom tests for ensureLiveCardControls (#859)

### DIFF
--- a/vscode-extension/src/test/liveCardControls.test.ts
+++ b/vscode-extension/src/test/liveCardControls.test.ts
@@ -1,0 +1,187 @@
+// DOM-feature tests for `ensureLiveCardControls` (the per-card
+// stop-button injection lifted out of `LiveStateController` into a
+// narrow-deps file so happy-dom can exercise it without dragging the
+// controller's interactive-input / vscode-api transitive imports
+// into the host tsconfig).
+//
+// Pins the contract:
+//
+//   - Stamps a `<button class="icon-button card-live-stop-btn">`
+//     into the card's `.image-container`, with the `Stop live preview`
+//     title / aria-label and an embedded `codicon-debug-stop` glyph.
+//   - Idempotent: a second call doesn't duplicate the button and
+//     doesn't re-bind the click handler.
+//   - Click on the button suppresses default + propagation and invokes
+//     the supplied `onStop` exactly once with the card.
+//   - Missing `.image-container` is a silent no-op (no throw, no
+//     stray button stamped onto the card root).
+
+import * as assert from "assert";
+import { ensureLiveCardControls } from "../webview/preview/liveCardControls";
+
+/** Build a `<div class="preview-card">` with an `.image-container`
+ *  child (the place the per-card stop button gets appended to) and
+ *  append it to `document.body`. Returns the card. */
+function buildCard(previewId = "com.example.A"): HTMLElement {
+    const card = document.createElement("div");
+    card.className = "preview-card";
+    card.dataset.previewId = previewId;
+    const container = document.createElement("div");
+    container.className = "image-container";
+    card.appendChild(container);
+    document.body.appendChild(card);
+    return card;
+}
+
+/** Build a `<div class="preview-card">` with NO `.image-container`
+ *  child. Exercises the silent no-op guard. */
+function buildBareCard(previewId = "com.example.A"): HTMLElement {
+    const card = document.createElement("div");
+    card.className = "preview-card";
+    card.dataset.previewId = previewId;
+    document.body.appendChild(card);
+    return card;
+}
+
+describe("ensureLiveCardControls", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("stamps a .card-live-stop-btn into .image-container with the right shape", () => {
+        const card = buildCard();
+        ensureLiveCardControls(card, () => {});
+
+        const container = card.querySelector(".image-container")!;
+        const btn = container.querySelector(
+            ".card-live-stop-btn",
+        ) as HTMLButtonElement | null;
+        assert.ok(btn, "stop button should be appended to image container");
+        assert.strictEqual(btn!.tagName, "BUTTON");
+        assert.strictEqual(btn!.type, "button");
+        assert.strictEqual(
+            btn!.classList.contains("icon-button"),
+            true,
+            "should keep the shared .icon-button class",
+        );
+        assert.strictEqual(btn!.classList.contains("card-live-stop-btn"), true);
+        assert.strictEqual(btn!.title, "Stop live preview");
+        assert.strictEqual(
+            btn!.getAttribute("aria-label"),
+            "Stop live preview",
+        );
+        const icon = btn!.querySelector("i.codicon.codicon-debug-stop");
+        assert.ok(icon, "should embed the debug-stop codicon");
+        assert.strictEqual(icon!.getAttribute("aria-hidden"), "true");
+    });
+
+    it("is idempotent — repeat calls don't duplicate the button", () => {
+        const card = buildCard();
+        ensureLiveCardControls(card, () => {});
+        const firstHtml = card.innerHTML;
+        ensureLiveCardControls(card, () => {});
+        ensureLiveCardControls(card, () => {});
+        assert.strictEqual(
+            card.querySelectorAll(".card-live-stop-btn").length,
+            1,
+            "second/third call must not duplicate the button",
+        );
+        assert.strictEqual(
+            card.innerHTML,
+            firstHtml,
+            "second call must not mutate the DOM at all",
+        );
+    });
+
+    it("doesn't re-bind the click handler on a repeat call", () => {
+        // The first call's `onStop` is the one wired to the button.
+        // A second call with a different `onStop` must not replace
+        // (or stack onto) the existing handler — the bound callback
+        // stays the original one.
+        const card = buildCard();
+        let firstCalls = 0;
+        let secondCalls = 0;
+        ensureLiveCardControls(card, () => {
+            firstCalls += 1;
+        });
+        ensureLiveCardControls(card, () => {
+            secondCalls += 1;
+        });
+        const btn = card.querySelector(
+            ".card-live-stop-btn",
+        ) as HTMLButtonElement;
+        btn.click();
+        assert.strictEqual(
+            firstCalls,
+            1,
+            "the original handler should fire once",
+        );
+        assert.strictEqual(
+            secondCalls,
+            0,
+            "the second-call handler should NOT have been wired",
+        );
+    });
+
+    it("click invokes onStop exactly once with the card", () => {
+        const card = buildCard("com.example.X");
+        const visited: HTMLElement[] = [];
+        ensureLiveCardControls(card, (c) => {
+            visited.push(c);
+        });
+        const btn = card.querySelector(
+            ".card-live-stop-btn",
+        ) as HTMLButtonElement;
+        btn.click();
+        assert.strictEqual(visited.length, 1);
+        assert.strictEqual(visited[0], card);
+        assert.strictEqual(visited[0].dataset.previewId, "com.example.X");
+    });
+
+    it("click suppresses default and stops propagation", () => {
+        const card = buildCard();
+        let bubbled = 0;
+        // Card-level click listener that would normally fire if the
+        // button click bubbled out of the image-container.
+        card.addEventListener("click", () => {
+            bubbled += 1;
+        });
+        ensureLiveCardControls(card, () => {});
+        const btn = card.querySelector(
+            ".card-live-stop-btn",
+        ) as HTMLButtonElement;
+        // Dispatch a cancellable click so we can observe `defaultPrevented`.
+        const evt = new Event("click", { bubbles: true, cancelable: true });
+        btn.dispatchEvent(evt);
+        assert.strictEqual(
+            evt.defaultPrevented,
+            true,
+            "handler must call preventDefault",
+        );
+        assert.strictEqual(
+            bubbled,
+            0,
+            "handler must call stopPropagation so card-level click never sees it",
+        );
+    });
+
+    it("is a silent no-op when .image-container is missing", () => {
+        const card = buildBareCard();
+        let invoked = 0;
+        assert.doesNotThrow(() =>
+            ensureLiveCardControls(card, () => {
+                invoked += 1;
+            }),
+        );
+        // No stray button stamped onto the card root.
+        assert.strictEqual(card.querySelector(".card-live-stop-btn"), null);
+        // Card body is untouched.
+        assert.strictEqual(card.children.length, 0);
+        // The callback isn't invoked just by ensureing controls.
+        assert.strictEqual(invoked, 0);
+    });
+});

--- a/vscode-extension/src/webview/preview/liveCardControls.ts
+++ b/vscode-extension/src/webview/preview/liveCardControls.ts
@@ -1,0 +1,46 @@
+// Per-card live stop-button DOM helper used by
+// `LiveStateController.ensureLiveCardControls`.
+//
+// Lifted into its own file (mirroring `liveBadge.ts`) so the DOM
+// mutation is testable under happy-dom without dragging
+// `LiveStateController`'s wider transitive imports
+// (`interactiveInput.ts`'s pointer-handler module, the vscode handle,
+// the live preview ID set, etc.) into the host tsconfig.
+//
+// Scope is intentionally narrow: this helper owns the stop-button
+// element lifecycle (idempotent injection + click → onStop with
+// `preventDefault` / `stopPropagation`) and nothing else. The caller
+// is still responsible for re-attaching pointer/wheel input handlers
+// after the button is in place — that wiring lives in `liveState.ts`.
+
+/**
+ * Idempotently inject a `.card-live-stop-btn` overlay into [card]'s
+ * `.image-container`. Wires a click handler that calls [onStop] with
+ * the card after suppressing default + propagation (so the click
+ * doesn't bubble up into card-selection / focus handlers).
+ *
+ * No-op if [card] has no `.image-container` child or if the button is
+ * already present. Safe to call repeatedly — never duplicates the
+ * button, never re-binds the click handler.
+ */
+export function ensureLiveCardControls(
+    card: HTMLElement,
+    onStop: (card: HTMLElement) => void,
+): void {
+    const container = card.querySelector(".image-container");
+    if (!container) return;
+    if (container.querySelector(".card-live-stop-btn")) return;
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "icon-button card-live-stop-btn";
+    btn.title = "Stop live preview";
+    btn.setAttribute("aria-label", "Stop live preview");
+    btn.innerHTML =
+        '<i class="codicon codicon-debug-stop" aria-hidden="true"></i>';
+    btn.addEventListener("click", (evt) => {
+        evt.preventDefault();
+        evt.stopPropagation();
+        onStop(card);
+    });
+    container.appendChild(btn);
+}

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -47,6 +47,7 @@ import {
 import { attachInteractiveInputHandlers } from "./interactiveInput";
 import type { InteractiveInputConfig } from "./interactiveInput";
 import { stampLiveBadgesOnGrid } from "./liveBadge";
+import { ensureLiveCardControls } from "./liveCardControls";
 import { planLiveToggle, planRecordingToggle } from "./liveTransitions";
 import type { VsCodeApi } from "../shared/vscode";
 
@@ -361,23 +362,13 @@ export class LiveStateController {
     }
 
     private ensureLiveCardControls(card: HTMLElement): void {
-        const container = card.querySelector(".image-container");
-        if (!container) return;
-        if (!container.querySelector(".card-live-stop-btn")) {
-            const btn = document.createElement("button");
-            btn.type = "button";
-            btn.className = "icon-button card-live-stop-btn";
-            btn.title = "Stop live preview";
-            btn.setAttribute("aria-label", "Stop live preview");
-            btn.innerHTML =
-                '<i class="codicon codicon-debug-stop" aria-hidden="true"></i>';
-            btn.addEventListener("click", (evt) => {
-                evt.preventDefault();
-                evt.stopPropagation();
-                this.stopInteractiveForCard(card);
-            });
-            container.appendChild(btn);
-        }
+        // Button DOM lives in `./liveCardControls.ts` so the mutation
+        // is testable under happy-dom without dragging this controller's
+        // wider transitive imports into the host tsconfig. The pointer
+        // / wheel input wiring stays here — `attachInteractiveInputHandlers`
+        // pulls in the broader interactive-input surface that the narrow
+        // helper deliberately avoids.
+        ensureLiveCardControls(card, (c) => this.stopInteractiveForCard(c));
         attachInteractiveInputHandlers(card, this.cfg.interactiveInputConfig);
     }
 }

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -25,6 +25,7 @@
         "src/webview/preview/focusToolbar.ts",
         "src/webview/preview/interactiveInput.ts",
         "src/webview/preview/liveBadge.ts",
+        "src/webview/preview/liveCardControls.ts",
         "src/webview/preview/liveTransitions.ts",
         "src/webview/preview/loadingOverlay.ts",
         "src/webview/preview/moduleReadiness.ts",


### PR DESCRIPTION
## Summary

Sub-task of #859. Extracts the per-card stop-button injection out of `LiveStateController` into a narrow-deps helper so it's testable under happy-dom without dragging the controller's pointer-input wiring into the host tsconfig.

`liveCardControls.ts` — `ensureLiveCardControls(card, onStop)` does only the button DOM lifecycle (idempotent injection into `.image-container`, click handler that calls `onStop(card)` with `preventDefault` + `stopPropagation`). `liveState.ts` keeps the `attachInteractiveInputHandlers` call after delegating, so behaviour is unchanged.

+6 tests pinning the contract: full button shape (classes, type, title, aria-label, embedded `codicon-debug-stop`), idempotent re-injection, click invokes the callback exactly once with the card, click stops propagation, silent no-op when `.image-container` is missing.

## Test plan

- [x] `npm --prefix vscode-extension run test` — clean
- [x] `npm --prefix vscode-extension run format:check` — clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUFNzFRko621Zhx42nhNMm)_