### PR TITLE
test(vscode): backfill happy-dom tests for enforceSingleTargetFollowFocus (#859)

### DIFF
--- a/vscode-extension/src/test/followFocus.test.ts
+++ b/vscode-extension/src/test/followFocus.test.ts
@@ -1,0 +1,75 @@
+import * as assert from "assert";
+import { planFollowFocusTeardown } from "../webview/preview/followFocus";
+
+// Pins the branch logic that `LiveStateController.enforceSingleTargetFollowFocus`
+// used to inline. The planner is the single choke point for the
+// "follow focus when exactly one stream is live" rule — every
+// non-trivial guard (size === 0, size > 1, focus matches lone, focus
+// missing) is exercised here so the controller wrapper can stay a
+// thin "post + clear + repaint" sandwich.
+describe("planFollowFocusTeardown", () => {
+    let liveSet: Set<string>;
+
+    beforeEach(() => {
+        liveSet = new Set<string>();
+    });
+
+    afterEach(() => {
+        liveSet.clear();
+    });
+
+    it("returns null when the live set is empty", () => {
+        // No live streams → nothing to tear down regardless of focus.
+        assert.strictEqual(planFollowFocusTeardown(liveSet, null), null);
+        assert.strictEqual(
+            planFollowFocusTeardown(liveSet, "com.example.A"),
+            null,
+        );
+    });
+
+    it("returns null when there are 2+ live targets (multi-target opt-in)", () => {
+        // Multi-target (size > 1) is the explicit Shift+click opt-in
+        // upstream. Those streams must persist across focus navigation.
+        liveSet.add("com.example.A");
+        liveSet.add("com.example.B");
+        assert.strictEqual(planFollowFocusTeardown(liveSet, null), null);
+        assert.strictEqual(
+            planFollowFocusTeardown(liveSet, "com.example.A"),
+            null,
+        );
+        assert.strictEqual(
+            planFollowFocusTeardown(liveSet, "com.example.OTHER"),
+            null,
+        );
+    });
+
+    it("returns null when exactly one live target matches the focused card", () => {
+        // The lone live stream is already focused — no teardown
+        // needed; the LIVE chip is on the right card.
+        liveSet.add("com.example.A");
+        assert.strictEqual(
+            planFollowFocusTeardown(liveSet, "com.example.A"),
+            null,
+        );
+    });
+
+    it("returns the lone teardown id when exactly one live target mismatches the focused card", () => {
+        // User navigated focus off the lone live card. The LIVE chip
+        // should follow focus, so the planner names the prior id for
+        // teardown.
+        liveSet.add("com.example.A");
+        const plan = planFollowFocusTeardown(liveSet, "com.example.B");
+        assert.notStrictEqual(plan, null);
+        assert.strictEqual(plan?.teardownId, "com.example.A");
+    });
+
+    it("returns the lone teardown id when exactly one live target and no focus", () => {
+        // No focused card (e.g. transient layout) and a single
+        // orphaned live stream — tear it down so the chip doesn't
+        // dangle.
+        liveSet.add("com.example.A");
+        const plan = planFollowFocusTeardown(liveSet, null);
+        assert.notStrictEqual(plan, null);
+        assert.strictEqual(plan?.teardownId, "com.example.A");
+    });
+});

--- a/vscode-extension/src/webview/preview/followFocus.ts
+++ b/vscode-extension/src/webview/preview/followFocus.ts
@@ -1,0 +1,48 @@
+// Pure planner for the single-target follow-focus teardown that
+// `LiveStateController.enforceSingleTargetFollowFocus` performs when the
+// user navigates focus off a live card. Lifted into its own file so the
+// branch logic (size === 1, focus match short-circuit, lone-id pickoff)
+// can be unit-tested without DOM, vscode, or the controller's wider
+// transitive imports.
+//
+// Contract: this module owns no state and performs no side effects. The
+// controller wraps it — invokes the planner, posts the live "off" wire
+// command for [teardownId], clears its local set, and re-stamps badges.
+//
+// Multi-target (size > 1) is treated as an explicit Shift+click opt-in
+// upstream — those streams persist across focus navigation until the
+// user toggles them off, so this planner returns null for any size that
+// isn't exactly 1.
+
+/** Result of [planFollowFocusTeardown]. `null` means "no-op": either
+ *  there isn't exactly one live target, or the lone live target is the
+ *  focused card. A non-null result names the lone live id the caller
+ *  should tear down. */
+export interface FollowFocusTeardownPlan {
+    /** The lone live previewId that should be torn down. The caller
+     *  posts the live "off" command for this id, drops it from the
+     *  local set, and re-stamps the live badges. */
+    teardownId: string;
+}
+
+/**
+ * Decide whether the single-target follow-focus teardown should fire.
+ *
+ * Returns a plan only when:
+ *  - exactly one previewId is live (multi-target opt-in is preserved),
+ *  - and either no card is focused, or the focused card's previewId is
+ *    different from the lone live one.
+ *
+ * Returns null otherwise (empty live set, multi-target live set, or
+ * focused card already matches the lone live id).
+ */
+export function planFollowFocusTeardown(
+    liveSet: ReadonlySet<string>,
+    focusedPreviewId: string | null,
+): FollowFocusTeardownPlan | null {
+    if (liveSet.size !== 1) return null;
+    const lone = liveSet.values().next().value;
+    if (lone === undefined) return null;
+    if (focusedPreviewId !== null && focusedPreviewId === lone) return null;
+    return { teardownId: lone };
+}

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -41,6 +41,7 @@
 // and re-posting would race the flush.
 
 import { liveToggleCommand } from "../../daemon/liveCommand";
+import { planFollowFocusTeardown } from "./followFocus";
 import { attachInteractiveInputHandlers } from "./interactiveInput";
 import type { InteractiveInputConfig } from "./interactiveInput";
 import { stampLiveBadgesOnGrid } from "./liveBadge";
@@ -272,11 +273,13 @@ export class LiveStateController {
      * navigation until the user explicitly toggles them off.
      */
     enforceSingleTargetFollowFocus(focusedCard: HTMLElement | null): void {
-        if (this.interactivePreviewIds.size !== 1) return;
-        const lone = this.interactivePreviewIds.values().next().value;
-        if (lone === undefined) return;
-        if (focusedCard && focusedCard.dataset.previewId === lone) return;
-        this.postLiveCommand(lone, false);
+        const focusedPreviewId = focusedCard?.dataset.previewId ?? null;
+        const plan = planFollowFocusTeardown(
+            this.interactivePreviewIds,
+            focusedPreviewId,
+        );
+        if (!plan) return;
+        this.postLiveCommand(plan.teardownId, false);
         this.interactivePreviewIds.clear();
         this.applyLiveBadge();
     }

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -24,6 +24,7 @@
         "src/webview/preview/cardMetadata.ts",
         "src/webview/preview/errorPanel.ts",
         "src/webview/preview/focusToolbar.ts",
+        "src/webview/preview/followFocus.ts",
         "src/webview/preview/frameCarouselDom.ts",
         "src/webview/preview/interactiveInput.ts",
         "src/webview/preview/liveBadge.ts",


### PR DESCRIPTION
## Summary

Sub-task of #859. Extracts the lone-stream follow-focus teardown logic out of `LiveStateController.enforceSingleTargetFollowFocus` into a pure planner so the invariants are pinnable without a DOM.

`followFocus.ts` — `planFollowFocusTeardown(liveSet, focusedPreviewId): { teardownId } | null`. Returns the id to tear down only when the live set has exactly one entry that doesn't match the focused preview; multi-target streams (Shift+click opt-in) are left alone. The controller method is now a thin wrapper that invokes the planner, posts the live command, clears the set, and re-stamps badges.

+5 tests covering: empty live set → no-op, 2+ live targets → no-op (multi-target opt-in survives focus nav), exactly one live + matching focus → no-op, exactly one live + mismatched focus → returns the teardown id, exactly one live + no focus → returns the teardown id.

## Test plan

- [x] `npm --prefix vscode-extension run test` — clean
- [x] `npm --prefix vscode-extension run format:check` — clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUFNzFRko621Zhx42nhNMm)_