### PR TITLE
test(vscode): backfill tests for onCardLeftViewport throttling (#859)

### DIFF
--- a/vscode-extension/src/test/liveViewportThrottle.test.ts
+++ b/vscode-extension/src/test/liveViewportThrottle.test.ts
@@ -1,0 +1,60 @@
+import * as assert from "assert";
+import { throttleLiveOnViewportLeave } from "../webview/preview/liveViewportThrottle";
+
+describe("throttleLiveOnViewportLeave", () => {
+    let posted: unknown[];
+    let post: (msg: unknown) => void;
+
+    beforeEach(() => {
+        posted = [];
+        post = (msg) => {
+            posted.push(msg);
+        };
+    });
+
+    afterEach(() => {
+        posted = [];
+    });
+
+    it("no-ops when previewId is not in the live set", () => {
+        const liveSet = new Set<string>(["com.example.A"]);
+        throttleLiveOnViewportLeave("com.example.B", liveSet, post);
+        assert.strictEqual(posted.length, 0);
+    });
+
+    it("no-ops when the live set is empty", () => {
+        const liveSet = new Set<string>();
+        throttleLiveOnViewportLeave("com.example.A", liveSet, post);
+        assert.strictEqual(posted.length, 0);
+    });
+
+    it("posts a requestStreamVisibility(visible=false) when previewId is in the live set", () => {
+        const liveSet = new Set<string>(["com.example.A"]);
+        throttleLiveOnViewportLeave("com.example.A", liveSet, post);
+        assert.strictEqual(posted.length, 1);
+        assert.deepStrictEqual(posted[0], {
+            command: "requestStreamVisibility",
+            previewId: "com.example.A",
+            visible: false,
+            fps: undefined,
+        });
+    });
+
+    it("leaves the live set unchanged after returning (LIVE chip survives the throttle)", () => {
+        const liveSet = new Set<string>(["com.example.A", "com.example.B"]);
+        throttleLiveOnViewportLeave("com.example.A", liveSet, post);
+        // The set is intentionally not mutated — the daemon throttles to
+        // keyframes-only but the local bookkeeping still says "this card
+        // is live" so the LIVE badge survives the throttle.
+        assert.strictEqual(liveSet.size, 2);
+        assert.strictEqual(liveSet.has("com.example.A"), true);
+        assert.strictEqual(liveSet.has("com.example.B"), true);
+    });
+
+    it("leaves the live set unchanged on the no-op path too", () => {
+        const liveSet = new Set<string>(["com.example.A"]);
+        throttleLiveOnViewportLeave("com.example.GHOST", liveSet, post);
+        assert.strictEqual(liveSet.size, 1);
+        assert.strictEqual(liveSet.has("com.example.A"), true);
+    });
+});

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -40,14 +40,12 @@
 // triggered after the extension or daemon has already torn the streams down,
 // and re-posting would race the flush.
 
-import {
-    liveToggleCommand,
-    liveViewportCommand,
-} from "../../daemon/liveCommand";
+import { liveToggleCommand } from "../../daemon/liveCommand";
 import { attachInteractiveInputHandlers } from "./interactiveInput";
 import type { InteractiveInputConfig } from "./interactiveInput";
 import { stampLiveBadgesOnGrid } from "./liveBadge";
 import { planLiveToggle, planRecordingToggle } from "./liveTransitions";
+import { throttleLiveOnViewportLeave } from "./liveViewportThrottle";
 import type { VsCodeApi } from "../shared/vscode";
 
 export interface LiveStateConfig {
@@ -293,8 +291,11 @@ export class LiveStateController {
      * LIVE badge survives the throttle.
      */
     onCardLeftViewport(previewId: string): void {
-        if (!this.interactivePreviewIds.has(previewId)) return;
-        this.cfg.vscode.postMessage(liveViewportCommand(previewId, false));
+        throttleLiveOnViewportLeave(
+            previewId,
+            this.interactivePreviewIds,
+            (msg) => this.cfg.vscode.postMessage(msg),
+        );
     }
 
     /** Drop live previewIds that are gone from a fresh setPreviews manifest.

--- a/vscode-extension/src/webview/preview/liveViewportThrottle.ts
+++ b/vscode-extension/src/webview/preview/liveViewportThrottle.ts
@@ -1,0 +1,30 @@
+// Viewport-leave throttle helper used by `LiveStateController.onCardLeftViewport`.
+// Lifted into its own file so the routing decision is testable in plain
+// mocha without dragging `LiveStateController`'s wider transitive imports
+// (`interactiveInput.ts`'s pointer-handler module, the vscode handle, etc.)
+// into the host tsconfig.
+//
+// The contract intentionally leaves [liveSet] untouched: the daemon's
+// `stream/visibility` "throttle to keyframes-only" mode keeps the held
+// session warm so scroll-back-into-view repaints from the cached anchor
+// instead of cold-blanking. The local set still says "this card is live"
+// so the LIVE badge survives the throttle (see the comment on
+// `LiveStateController.onCardLeftViewport`).
+
+import { liveViewportCommand } from "../../daemon/liveCommand";
+
+/**
+ * Soft-throttle a live stream once its card has scrolled fully out of
+ * view. If [previewId] isn't in [liveSet], no-op — the card wasn't live
+ * anyway, so there's nothing to throttle. Otherwise post a
+ * `requestStreamVisibility` (`visible=false`) via [post]; the local set
+ * is intentionally left unchanged so the LIVE badge survives the throttle.
+ */
+export function throttleLiveOnViewportLeave(
+    previewId: string,
+    liveSet: ReadonlySet<string>,
+    post: (msg: unknown) => void,
+): void {
+    if (!liveSet.has(previewId)) return;
+    post(liveViewportCommand(previewId, false));
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -26,6 +26,7 @@
         "src/webview/preview/interactiveInput.ts",
         "src/webview/preview/liveBadge.ts",
         "src/webview/preview/liveTransitions.ts",
+        "src/webview/preview/liveViewportThrottle.ts",
         "src/webview/preview/loadingOverlay.ts",
         "src/webview/preview/moduleReadiness.ts",
         "src/webview/preview/pointerGeometry.ts",


### PR DESCRIPTION
## Summary

Sub-task of #859. Extracts the viewport-leave throttle out of `LiveStateController.onCardLeftViewport` into a narrow helper so the contract is testable in isolation.

`liveViewportThrottle.ts` — `throttleLiveOnViewportLeave(previewId, liveSet, post)`. If the id isn't in the live set, no-op; otherwise post `liveViewportCommand(previewId, false)` (the daemon's "throttle to keyframes-only" message). The live set is intentionally _not_ cleared — the LIVE chip survives the throttle so scroll-back-into-view repaints from the cached anchor instead of cold-blanking. Pure (no DOM).

+5 tests covering: id not in live set → no `post` invocation, empty set → no-op, in-set post (asserts the exact `requestStreamVisibility` wire shape with `visible: false`), set unchanged after the success path, set unchanged on the no-op path.

## Test plan

- [x] `npm --prefix vscode-extension run test` — clean
- [x] `npm --prefix vscode-extension run format:check` — clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUFNzFRko621Zhx42nhNMm)_