### PR TITLE
test(vscode): extract + backfill happy-dom tests for applyA11yUpdate (#859)

### DIFF
--- a/vscode-extension/src/test/applyA11yUpdate.test.ts
+++ b/vscode-extension/src/test/applyA11yUpdate.test.ts
@@ -1,0 +1,381 @@
+import * as assert from "assert";
+import {
+    applyA11yUpdate,
+    type A11yUpdateConfig,
+} from "../webview/preview/applyA11yUpdate";
+import { sanitizeId } from "../webview/preview/cardData";
+import type {
+    AccessibilityFinding,
+    AccessibilityNode,
+    PreviewInfo,
+} from "../webview/shared/types";
+
+/** Build a `<div class="preview-card" id="preview-...">` with an
+ *  `.image-container` child (where the a11y overlays land) and append
+ *  it to `document.body`. Returns the card. */
+function buildCard(previewId: string): HTMLElement {
+    const card = document.createElement("div");
+    card.className = "preview-card";
+    card.id = "preview-" + sanitizeId(previewId);
+    card.dataset.previewId = previewId;
+    const container = document.createElement("div");
+    container.className = "image-container";
+    card.appendChild(container);
+    document.body.appendChild(card);
+    return card;
+}
+
+/** Minimal `PreviewInfo` shaped just enough for `buildA11yLegend` to
+ *  consume it. The legend reads `id` for the row dataset and
+ *  `a11yFindings` for the row content; nothing else is touched. */
+function buildPreviewInfo(id: string): PreviewInfo {
+    return {
+        id,
+        functionName: "Preview",
+        className: "com.example.PreviewKt",
+        sourceFile: null,
+        params: { name: "Preview" },
+        captures: [],
+    } as unknown as PreviewInfo;
+}
+
+function buildFinding(
+    level: "ERROR" | "WARNING" | "INFO",
+    message: string,
+): AccessibilityFinding {
+    return {
+        level,
+        type: "ContrastCheck",
+        message,
+        viewDescription: null,
+        boundsInScreen: "0,0,100,100",
+    };
+}
+
+function buildNode(label: string): AccessibilityNode {
+    return {
+        label,
+        role: "Button",
+        states: ["focusable"],
+        merged: true,
+        boundsInScreen: "0,0,100,100",
+    };
+}
+
+/** Stand-in for the per-preview a11y caches in `previewStore`. The real
+ *  store bumps a `mapsRevision` counter on every write — these helpers
+ *  just record into plain Maps so tests can assert what was written. */
+interface CacheState {
+    findings: Map<string, readonly AccessibilityFinding[]>;
+    nodes: Map<string, readonly AccessibilityNode[]>;
+}
+
+interface ConfigOverrides {
+    earlyFeatures?: boolean;
+    inFocus?: boolean;
+    focusedCard?: HTMLElement | null;
+    previews?: PreviewInfo[];
+    inspectorRender?: (card: HTMLElement) => void;
+    cache?: CacheState;
+}
+
+function buildConfig(overrides: ConfigOverrides = {}): {
+    config: A11yUpdateConfig;
+    cache: CacheState;
+    inspectorCalls: HTMLElement[];
+} {
+    const cache: CacheState = overrides.cache ?? {
+        findings: new Map(),
+        nodes: new Map(),
+    };
+    const inspectorCalls: HTMLElement[] = [];
+    const config: A11yUpdateConfig = {
+        getAllPreviews: () => overrides.previews ?? [],
+        inspector: {
+            render: (card) => {
+                inspectorCalls.push(card);
+                overrides.inspectorRender?.(card);
+            },
+        },
+        earlyFeatures: () => overrides.earlyFeatures ?? true,
+        inFocus: () => overrides.inFocus ?? false,
+        focusedCard: () => overrides.focusedCard ?? null,
+        setCardA11yFindings: (id, findings) => {
+            cache.findings.set(id, findings);
+        },
+        deleteCardA11yFindings: (id) => {
+            cache.findings.delete(id);
+        },
+        setCardA11yNodes: (id, nodes) => {
+            cache.nodes.set(id, nodes);
+        },
+        deleteCardA11yNodes: (id) => {
+            cache.nodes.delete(id);
+        },
+    };
+    return { config, cache, inspectorCalls };
+}
+
+describe("applyA11yUpdate", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("is a silent no-op when earlyFeatures() is false (no DOM mutation, no cache write)", () => {
+        const card = buildCard("com.example.A");
+        const { config, cache } = buildConfig({
+            earlyFeatures: false,
+            previews: [buildPreviewInfo("com.example.A")],
+        });
+
+        applyA11yUpdate(
+            "com.example.A",
+            [buildFinding("ERROR", "low contrast")],
+            [buildNode("Button")],
+            config,
+        );
+
+        assert.strictEqual(card.querySelector(".a11y-overlay"), null);
+        assert.strictEqual(card.querySelector(".a11y-legend"), null);
+        assert.strictEqual(card.querySelector(".a11y-hierarchy-overlay"), null);
+        assert.strictEqual(cache.findings.size, 0);
+        assert.strictEqual(cache.nodes.size, 0);
+    });
+
+    it("is a silent no-op when the previewId has no card in the DOM", () => {
+        // Stamp a different card so we can assert it was untouched.
+        const other = buildCard("com.example.OTHER");
+        const { config, cache } = buildConfig({
+            previews: [buildPreviewInfo("com.example.GHOST")],
+        });
+
+        assert.doesNotThrow(() =>
+            applyA11yUpdate(
+                "com.example.GHOST",
+                [buildFinding("ERROR", "missing card")],
+                [buildNode("Ghost")],
+                config,
+            ),
+        );
+
+        assert.strictEqual(other.querySelector(".a11y-overlay"), null);
+        assert.strictEqual(other.querySelector(".a11y-legend"), null);
+        assert.strictEqual(cache.findings.size, 0);
+        assert.strictEqual(cache.nodes.size, 0);
+    });
+
+    it("appends .a11y-overlay placeholder, stamps .a11y-legend, writes cache, and mutates the matching PreviewInfo when findings are present", () => {
+        const card = buildCard("com.example.A");
+        const preview = buildPreviewInfo("com.example.A");
+        const findings = [
+            buildFinding("ERROR", "contrast"),
+            buildFinding("WARNING", "label"),
+        ];
+        const { config, cache } = buildConfig({
+            previews: [preview],
+        });
+
+        applyA11yUpdate("com.example.A", findings, undefined, config);
+
+        const overlay = card.querySelector(".a11y-overlay");
+        assert.ok(overlay, ".a11y-overlay placeholder appended");
+        assert.strictEqual(overlay!.getAttribute("aria-hidden"), "true");
+        // The placeholder is empty — actual paint runs from the
+        // PreviewCard's mapsRevision subscription, not from this helper.
+        assert.strictEqual(overlay!.children.length, 0);
+
+        const legend = card.querySelector(".a11y-legend");
+        assert.ok(legend, ".a11y-legend stamped onto the card");
+        // Two findings → one header + two rows.
+        assert.strictEqual(
+            legend!.querySelectorAll(".a11y-row").length,
+            findings.length,
+        );
+
+        assert.deepStrictEqual(cache.findings.get("com.example.A"), findings);
+
+        // The matching PreviewInfo has its a11yFindings field replaced
+        // (with a fresh array, not the readonly arg directly).
+        assert.deepStrictEqual(preview.a11yFindings, [...findings]);
+        assert.notStrictEqual(preview.a11yFindings, findings);
+    });
+
+    it("re-stamps the legend on a second call rather than duplicating it", () => {
+        const card = buildCard("com.example.A");
+        const preview = buildPreviewInfo("com.example.A");
+        const { config } = buildConfig({ previews: [preview] });
+
+        applyA11yUpdate(
+            "com.example.A",
+            [buildFinding("ERROR", "first")],
+            undefined,
+            config,
+        );
+        applyA11yUpdate(
+            "com.example.A",
+            [
+                buildFinding("ERROR", "second-a"),
+                buildFinding("INFO", "second-b"),
+            ],
+            undefined,
+            config,
+        );
+
+        const legends = card.querySelectorAll(".a11y-legend");
+        assert.strictEqual(legends.length, 1);
+        assert.strictEqual(legends[0].querySelectorAll(".a11y-row").length, 2);
+        // The .a11y-overlay placeholder also stays unique (the helper
+        // only appends one when none exists).
+        assert.strictEqual(card.querySelectorAll(".a11y-overlay").length, 1);
+    });
+
+    it("removes overlay + legend and clears cache when findings is an empty array", () => {
+        const card = buildCard("com.example.A");
+        const preview = buildPreviewInfo("com.example.A");
+        const { config, cache } = buildConfig({ previews: [preview] });
+
+        // Stamp some findings first so there's something to remove.
+        applyA11yUpdate(
+            "com.example.A",
+            [buildFinding("ERROR", "x")],
+            undefined,
+            config,
+        );
+        assert.ok(card.querySelector(".a11y-overlay"));
+        assert.ok(card.querySelector(".a11y-legend"));
+        assert.strictEqual(cache.findings.size, 1);
+
+        applyA11yUpdate("com.example.A", [], undefined, config);
+
+        assert.strictEqual(card.querySelector(".a11y-overlay"), null);
+        assert.strictEqual(card.querySelector(".a11y-legend"), null);
+        assert.strictEqual(cache.findings.has("com.example.A"), false);
+    });
+
+    it("leaves the findings side untouched when findings is undefined", () => {
+        const card = buildCard("com.example.A");
+        const preview = buildPreviewInfo("com.example.A");
+        const { config, cache } = buildConfig({ previews: [preview] });
+
+        // Seed findings.
+        applyA11yUpdate(
+            "com.example.A",
+            [buildFinding("ERROR", "seed")],
+            undefined,
+            config,
+        );
+        assert.ok(card.querySelector(".a11y-legend"));
+        const cachedBefore = cache.findings.get("com.example.A");
+
+        // Nodes-only update — findings side must not be touched.
+        applyA11yUpdate("com.example.A", undefined, [buildNode("X")], config);
+
+        assert.ok(
+            card.querySelector(".a11y-legend"),
+            "legend not removed by a nodes-only update",
+        );
+        assert.ok(
+            card.querySelector(".a11y-overlay"),
+            "overlay not removed by a nodes-only update",
+        );
+        assert.strictEqual(cache.findings.get("com.example.A"), cachedBefore);
+    });
+
+    it("ensures .a11y-hierarchy-overlay and writes the nodes cache when nodes are present", () => {
+        const card = buildCard("com.example.A");
+        const nodes = [buildNode("Button"), buildNode("Text")];
+        const { config, cache } = buildConfig({
+            previews: [buildPreviewInfo("com.example.A")],
+        });
+
+        applyA11yUpdate("com.example.A", undefined, nodes, config);
+
+        const layer = card.querySelector(".a11y-hierarchy-overlay");
+        assert.ok(layer, ".a11y-hierarchy-overlay attached");
+        assert.strictEqual(layer!.getAttribute("aria-hidden"), "true");
+
+        assert.deepStrictEqual(cache.nodes.get("com.example.A"), nodes);
+    });
+
+    it("removes .a11y-hierarchy-overlay and clears the nodes cache when nodes is an empty array", () => {
+        const card = buildCard("com.example.A");
+        const { config, cache } = buildConfig({
+            previews: [buildPreviewInfo("com.example.A")],
+        });
+
+        applyA11yUpdate(
+            "com.example.A",
+            undefined,
+            [buildNode("Button")],
+            config,
+        );
+        assert.ok(card.querySelector(".a11y-hierarchy-overlay"));
+        assert.strictEqual(cache.nodes.size, 1);
+
+        applyA11yUpdate("com.example.A", undefined, [], config);
+
+        assert.strictEqual(card.querySelector(".a11y-hierarchy-overlay"), null);
+        assert.strictEqual(cache.nodes.has("com.example.A"), false);
+    });
+
+    it("calls inspector.render(card) when in focus mode and the focused card matches", () => {
+        const card = buildCard("com.example.A");
+        const { config, inspectorCalls } = buildConfig({
+            previews: [buildPreviewInfo("com.example.A")],
+            inFocus: true,
+            focusedCard: card,
+        });
+
+        applyA11yUpdate(
+            "com.example.A",
+            [buildFinding("ERROR", "x")],
+            undefined,
+            config,
+        );
+
+        assert.strictEqual(inspectorCalls.length, 1);
+        assert.strictEqual(inspectorCalls[0], card);
+    });
+
+    it("does NOT call inspector.render when in focus mode but a different card is focused", () => {
+        const cardA = buildCard("com.example.A");
+        const cardB = buildCard("com.example.B");
+        const { config, inspectorCalls } = buildConfig({
+            previews: [buildPreviewInfo("com.example.A")],
+            inFocus: true,
+            focusedCard: cardB,
+        });
+
+        applyA11yUpdate(
+            "com.example.A",
+            [buildFinding("ERROR", "x")],
+            undefined,
+            config,
+        );
+
+        assert.strictEqual(inspectorCalls.length, 0);
+        // Sanity: the matching card got its legend regardless.
+        assert.ok(cardA.querySelector(".a11y-legend"));
+    });
+
+    it("does NOT call inspector.render when not in focus mode even if focusedCard returns the matching card", () => {
+        const card = buildCard("com.example.A");
+        const { config, inspectorCalls } = buildConfig({
+            previews: [buildPreviewInfo("com.example.A")],
+            inFocus: false,
+            focusedCard: card,
+        });
+
+        applyA11yUpdate(
+            "com.example.A",
+            [buildFinding("ERROR", "x")],
+            undefined,
+            config,
+        );
+
+        assert.strictEqual(inspectorCalls.length, 0);
+    });
+});

--- a/vscode-extension/src/webview/preview/applyA11yUpdate.ts
+++ b/vscode-extension/src/webview/preview/applyA11yUpdate.ts
@@ -1,0 +1,138 @@
+// Daemon-attached a11y refresh DOM operations — handles `updateA11y`
+// from the extension. Lifted out of `cardBuilder.ts` so the imperative
+// DOM operation is testable under happy-dom without dragging
+// cardBuilder's wider transitive imports (PreviewCard, FocusInspector,
+// FrameCarousel, …) into the host tsconfig.
+//
+// The cache mutators (`setCardA11yFindings`, `deleteCardA11yFindings`,
+// `setCardA11yNodes`, `deleteCardA11yNodes`) are passed in as
+// callbacks rather than imported from `previewStore` directly: that
+// keeps this module narrow (only `a11yOverlay.ts` + `cardData.ts` from
+// the webview tree, plus `shared/types`) and lets tests stub the
+// per-preview Maps without standing up the full store. `cardBuilder.ts`
+// re-exports the helper bound to the real `previewStore` mutators so
+// existing call sites are unchanged.
+
+import { buildA11yLegend, ensureHierarchyOverlay } from "./a11yOverlay";
+import { sanitizeId } from "./cardData";
+import type {
+    AccessibilityFinding,
+    AccessibilityNode,
+    PreviewInfo,
+} from "../shared/types";
+
+/** Narrow inspector surface — `applyA11yUpdate` only ever calls
+ *  `render(card)` to repaint the focus inspector when fresh a11y data
+ *  lands for the focused card. Structural typing keeps
+ *  `FocusInspectorController` out of this module. */
+export interface InspectorRenderer {
+    render(card: HTMLElement): void;
+}
+
+/** Subset of `CardBuilderConfig` plus injected cache mutators that
+ *  `applyA11yUpdate` reaches for. The mutators are injected (rather
+ *  than imported from `previewStore`) so this module's import surface
+ *  stays narrow enough to fit the host tsconfig — see file header. */
+export interface A11yUpdateConfig {
+    /** Latest `setPreviews` manifest snapshot. `applyA11yUpdate`
+     *  mutates the matching entry's `a11yFindings` so legend rebuilds
+     *  via `buildA11yLegend(card, p)` see the fresh findings without a
+     *  separate parameter. */
+    getAllPreviews(): readonly PreviewInfo[];
+    /** Focus-inspector handle so we can re-render when a11y data lands
+     *  for the focused card. */
+    inspector: InspectorRenderer;
+    /** Gates the whole operation — daemon-attached a11y data is
+     *  dropped silently when the user has not opted into the
+     *  accessibility-overlay feature surface. */
+    earlyFeatures(): boolean;
+    /** Whether the panel is currently in focus mode. */
+    inFocus(): boolean;
+    /** The currently focused card element, or null outside focus mode
+     *  / when no card is selected. */
+    focusedCard(): HTMLElement | null;
+    /** Replace the a11y findings list for a previewId in the cache. */
+    setCardA11yFindings(
+        previewId: string,
+        findings: readonly AccessibilityFinding[],
+    ): void;
+    /** Drop the a11y findings entry for a previewId. */
+    deleteCardA11yFindings(previewId: string): void;
+    /** Replace the a11y hierarchy nodes for a previewId. */
+    setCardA11yNodes(
+        previewId: string,
+        nodes: readonly AccessibilityNode[],
+    ): void;
+    /** Drop the a11y hierarchy nodes entry for a previewId. */
+    deleteCardA11yNodes(previewId: string): void;
+}
+
+/**
+ * D2 — handles `updateA11y` from the extension (daemon-attached a11y data
+ * products). Updates the per-preview caches and re-applies whichever
+ * overlays are now relevant without rebuilding the whole card. Findings
+ * → legend + finding overlay; nodes → hierarchy overlay. Either argument
+ * may be omitted to leave that side untouched. Gated on `earlyFeatures()`
+ * so daemon-attached a11y data is dropped silently when the user has not
+ * opted into the accessibility-overlay feature surface.
+ */
+export function applyA11yUpdate(
+    previewId: string,
+    findings: readonly AccessibilityFinding[] | null | undefined,
+    nodes: readonly AccessibilityNode[] | null | undefined,
+    config: A11yUpdateConfig,
+): void {
+    if (!config.earlyFeatures()) return;
+    const card = document.getElementById("preview-" + sanitizeId(previewId));
+    if (!card) return;
+    const container = card.querySelector(".image-container");
+    if (findings !== undefined) {
+        if (findings && findings.length > 0) {
+            // Ensure the empty `.a11y-overlay` container exists before
+            // bumping the store — `<preview-card>`'s mapsRevision
+            // subscription will paint into it once the per-id Map
+            // write below fires the rebroadcast.
+            if (container && !container.querySelector(".a11y-overlay")) {
+                const overlay = document.createElement("div");
+                overlay.className = "a11y-overlay";
+                overlay.setAttribute("aria-hidden", "true");
+                container.appendChild(overlay);
+            }
+            const existingLegend = card.querySelector(".a11y-legend");
+            if (existingLegend) existingLegend.remove();
+            const p = config.getAllPreviews().find((pp) => pp.id === previewId);
+            if (p) {
+                p.a11yFindings = [...findings];
+                card.appendChild(buildA11yLegend(card, p));
+            }
+            // Store write last — the `mapsRevision` bump triggers the
+            // component's `_repaintA11yOverlaysFromCache()` which runs
+            // `buildA11yOverlay` against the fresh findings. The
+            // component gates on `img.complete && img.naturalWidth > 0`
+            // exactly as the previous imperative branch did.
+            config.setCardA11yFindings(previewId, findings);
+        } else {
+            config.deleteCardA11yFindings(previewId);
+            const overlay = card.querySelector(".a11y-overlay");
+            if (overlay) overlay.remove();
+            const legend = card.querySelector(".a11y-legend");
+            if (legend) legend.remove();
+        }
+    }
+    if (nodes !== undefined) {
+        if (nodes && nodes.length > 0) {
+            ensureHierarchyOverlay(container);
+            // Same pattern as findings above: store write fires the
+            // mapsRevision bump, the component re-paints the layer
+            // via `applyHierarchyOverlay`.
+            config.setCardA11yNodes(previewId, nodes);
+        } else {
+            config.deleteCardA11yNodes(previewId);
+            const layer = card.querySelector(".a11y-hierarchy-overlay");
+            if (layer) layer.remove();
+        }
+    }
+    if (config.inFocus() && config.focusedCard() === card) {
+        config.inspector.render(card);
+    }
+}

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -18,7 +18,11 @@
 // it touches — the shared interface is the single source of truth for
 // the card's collaborator surface.
 
-import { buildA11yLegend, ensureHierarchyOverlay } from "./a11yOverlay";
+import { buildA11yLegend } from "./a11yOverlay";
+import {
+    applyA11yUpdate as applyA11yUpdateImpl,
+    type A11yUpdateConfig as A11yUpdateConfigBase,
+} from "./applyA11yUpdate";
 import {
     buildTooltip,
     buildVariantLabel,
@@ -327,11 +331,20 @@ export { applyRelativeSizing } from "./relativeSizing";
 
 /** Subset `applyA11yUpdate` reaches for. The a11y caches themselves
  *  live in `previewStore` and are written via the `setCardA11y…` /
- *  `deleteCardA11y…` helpers. */
+ *  `deleteCardA11y…` helpers — the cardBuilder-level facade binds those
+ *  mutators automatically so callers only need this slimmer surface. */
 export type A11yUpdateConfig = Pick<
     CardBuilderConfig,
     "getAllPreviews" | "inspector" | "earlyFeatures" | "inFocus" | "focusedCard"
 >;
+
+// Re-export the underlying narrow helper (and its bag-with-mutators
+// config type) so test code that wants to stub the cache writes can
+// drive it directly without going through the cardBuilder facade.
+export {
+    applyA11yUpdate as applyA11yUpdateNarrow,
+    type A11yUpdateConfig as A11yUpdateNarrowConfig,
+} from "./applyA11yUpdate";
 
 /**
  * D2 — handles `updateA11y` from the extension (daemon-attached a11y data
@@ -341,6 +354,12 @@ export type A11yUpdateConfig = Pick<
  * may be omitted to leave that side untouched. Gated on `earlyFeatures()`
  * so daemon-attached a11y data is dropped silently when the user has not
  * opted into the accessibility-overlay feature surface.
+ *
+ * Thin facade over the narrow helper in `./applyA11yUpdate.ts` — this
+ * file binds the per-preview cache mutators (`setCardA11yFindings`,
+ * etc.) from `previewStore` so callers don't have to thread them through
+ * `CardBuilderConfig`. The helper itself is testable in isolation under
+ * happy-dom; see `vscode-extension/src/test/applyA11yUpdate.test.ts`.
  */
 export function applyA11yUpdate(
     previewId: string,
@@ -348,60 +367,18 @@ export function applyA11yUpdate(
     nodes: readonly AccessibilityNode[] | null | undefined,
     config: A11yUpdateConfig,
 ): void {
-    if (!config.earlyFeatures()) return;
-    const card = document.getElementById("preview-" + sanitizeId(previewId));
-    if (!card) return;
-    const container = card.querySelector(".image-container");
-    const img = container?.querySelector<HTMLImageElement>("img") ?? null;
-    if (findings !== undefined) {
-        if (findings && findings.length > 0) {
-            // Ensure the empty `.a11y-overlay` container exists before
-            // bumping the store — `<preview-card>`'s mapsRevision
-            // subscription will paint into it once the per-id Map
-            // write below fires the rebroadcast.
-            if (container && !container.querySelector(".a11y-overlay")) {
-                const overlay = document.createElement("div");
-                overlay.className = "a11y-overlay";
-                overlay.setAttribute("aria-hidden", "true");
-                container.appendChild(overlay);
-            }
-            const existingLegend = card.querySelector(".a11y-legend");
-            if (existingLegend) existingLegend.remove();
-            const p = config.getAllPreviews().find((pp) => pp.id === previewId);
-            if (p) {
-                p.a11yFindings = [...findings];
-                card.appendChild(buildA11yLegend(card, p));
-            }
-            // Store write last — the `mapsRevision` bump triggers the
-            // component's `_repaintA11yOverlaysFromCache()` which runs
-            // `buildA11yOverlay` against the fresh findings. The
-            // component gates on `img.complete && img.naturalWidth > 0`
-            // exactly as the previous imperative branch did.
-            setCardA11yFindings(previewId, findings);
-        } else {
-            deleteCardA11yFindings(previewId);
-            const overlay = card.querySelector(".a11y-overlay");
-            if (overlay) overlay.remove();
-            const legend = card.querySelector(".a11y-legend");
-            if (legend) legend.remove();
-        }
-    }
-    if (nodes !== undefined) {
-        if (nodes && nodes.length > 0) {
-            ensureHierarchyOverlay(container);
-            // Same pattern as findings above: store write fires the
-            // mapsRevision bump, the component re-paints the layer
-            // via `applyHierarchyOverlay`.
-            setCardA11yNodes(previewId, nodes);
-        } else {
-            deleteCardA11yNodes(previewId);
-            const layer = card.querySelector(".a11y-hierarchy-overlay");
-            if (layer) layer.remove();
-        }
-    }
-    if (config.inFocus() && config.focusedCard() === card) {
-        config.inspector.render(card);
-    }
+    const narrow: A11yUpdateConfigBase = {
+        getAllPreviews: config.getAllPreviews,
+        inspector: config.inspector,
+        earlyFeatures: config.earlyFeatures,
+        inFocus: config.inFocus,
+        focusedCard: config.focusedCard,
+        setCardA11yFindings,
+        deleteCardA11yFindings,
+        setCardA11yNodes,
+        deleteCardA11yNodes,
+    };
+    applyA11yUpdateImpl(previewId, findings, nodes, narrow);
 }
 
 /** Subset `renderPreviews` reaches for — initial-build + metadata-refresh

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -18,6 +18,7 @@
     "exclude": ["node_modules", "src/webview/**"],
     "files": [
         "src/webview/preview/a11yOverlay.ts",
+        "src/webview/preview/applyA11yUpdate.ts",
         "src/webview/preview/cardData.ts",
         "src/webview/preview/cardImage.ts",
         "src/webview/preview/cardMetadata.ts",


### PR DESCRIPTION
## Summary

Sub-task of #859. Extracts `applyA11yUpdate` from `cardBuilder.ts` into a narrow-deps file so the legend / overlay / hierarchy add-and-remove paths are testable without the controller's wide imports.

`applyA11yUpdate.ts` — takes the cache mutators (`setCardA11yFindings` / `deleteCardA11yFindings` / `setCardA11yNodes` / `deleteCardA11yNodes`) as injected callbacks plus a structural `InspectorRenderer` interface. That keeps `previewStore.ts` out of the host tsconfig — the helper has zero dependence on the wide preview-card / frame-carousel surface. `cardBuilder.ts` keeps a thin facade that binds the real mutators and forwards.

+11 tests covering: `earlyFeatures()` false → silent no-op, missing card → silent no-op, findings present → overlay placeholder + legend stamped + cache updated + `PreviewInfo.a11yFindings` mutated, findings empty → overlay/legend removed + cache cleared, findings undefined → side untouched, nodes present/empty paths, in-focus + matching focused card → `inspector.render(card)` invoked, in-focus + different focused card → not invoked, plus an idempotency check.

## Test plan

- [x] `npm --prefix vscode-extension run test` — clean
- [x] `npm --prefix vscode-extension run format:check` — clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUFNzFRko621Zhx42nhNMm)_