### PR TITLE
test(vscode): extract + backfill happy-dom tests for frame carousel DOM (#859)

### DIFF
--- a/vscode-extension/src/test/frameCarouselDom.test.ts
+++ b/vscode-extension/src/test/frameCarouselDom.test.ts
@@ -1,0 +1,286 @@
+import * as assert from "assert";
+import {
+    buildFrameControls,
+    updateFrameIndicator,
+} from "../webview/preview/frameCarouselDom";
+
+/** Build a bare `<div class="preview-card">` and append to body. The
+ *  carousel doesn't care about the rest of the card chrome — just that
+ *  the element it's handed accepts `dataset.currentIndex`. */
+function buildCard(): HTMLElement {
+    const card = document.createElement("div");
+    card.className = "preview-card";
+    document.body.appendChild(card);
+    return card;
+}
+
+/** Build the controls and append them to the card so query selectors
+ *  rooted on the card resolve them — mirrors how the controller wires
+ *  this up at create-card time. */
+function buildAndAttach(
+    card: HTMLElement,
+    onStep: (card: HTMLElement, delta: number) => void = () => {},
+    onSeed: (card: HTMLElement) => void = () => {},
+): HTMLElement {
+    const bar = buildFrameControls(card, onStep, onSeed);
+    card.appendChild(bar);
+    return bar;
+}
+
+describe("buildFrameControls", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("produces a .frame-controls bar with prev / indicator / next children in order", () => {
+        const card = buildCard();
+        const bar = buildAndAttach(card);
+
+        assert.strictEqual(bar.className, "frame-controls");
+        assert.strictEqual(bar.children.length, 3);
+
+        const prev = bar.children[0] as HTMLButtonElement;
+        const indicator = bar.children[1] as HTMLElement;
+        const next = bar.children[2] as HTMLButtonElement;
+
+        assert.strictEqual(prev.tagName, "BUTTON");
+        assert.strictEqual(prev.className, "icon-button frame-prev");
+        assert.strictEqual(prev.getAttribute("aria-label"), "Previous capture");
+        assert.strictEqual(prev.title, "Previous capture");
+        assert.ok(
+            prev.querySelector("i.codicon.codicon-chevron-left"),
+            "prev should contain the chevron-left codicon",
+        );
+
+        assert.strictEqual(indicator.tagName, "SPAN");
+        assert.strictEqual(indicator.className, "frame-indicator");
+        assert.strictEqual(indicator.getAttribute("aria-live"), "polite");
+
+        assert.strictEqual(next.tagName, "BUTTON");
+        assert.strictEqual(next.className, "icon-button frame-next");
+        assert.strictEqual(next.getAttribute("aria-label"), "Next capture");
+        assert.strictEqual(next.title, "Next capture");
+        assert.ok(
+            next.querySelector("i.codicon.codicon-chevron-right"),
+            "next should contain the chevron-right codicon",
+        );
+    });
+
+    it("makes the bar focusable so arrow keys can fire on it", () => {
+        const card = buildCard();
+        const bar = buildAndAttach(card);
+        assert.strictEqual(bar.tabIndex, 0);
+    });
+
+    it("calls onIndicatorSeed exactly once after build, with the card", () => {
+        const card = buildCard();
+        const seeded: HTMLElement[] = [];
+        buildFrameControls(
+            card,
+            () => {},
+            (c) => seeded.push(c),
+        );
+        assert.strictEqual(seeded.length, 1);
+        assert.strictEqual(seeded[0], card);
+    });
+
+    it("prev click invokes onStep(card, -1) exactly once", () => {
+        const card = buildCard();
+        const calls: Array<[HTMLElement, number]> = [];
+        const bar = buildAndAttach(card, (c, d) => calls.push([c, d]));
+        const prev = bar.querySelector<HTMLButtonElement>(".frame-prev")!;
+        prev.click();
+        assert.deepStrictEqual(calls, [[card, -1]]);
+    });
+
+    it("next click invokes onStep(card, +1) exactly once", () => {
+        const card = buildCard();
+        const calls: Array<[HTMLElement, number]> = [];
+        const bar = buildAndAttach(card, (c, d) => calls.push([c, d]));
+        const next = bar.querySelector<HTMLButtonElement>(".frame-next")!;
+        next.click();
+        assert.deepStrictEqual(calls, [[card, 1]]);
+    });
+
+    it("ArrowLeft on the bar fires onStep(card, -1), preventDefault, and stops propagation", () => {
+        const card = buildCard();
+        const calls: Array<[HTMLElement, number]> = [];
+        const bar = buildAndAttach(card, (c, d) => calls.push([c, d]));
+
+        let parentSawIt = false;
+        card.addEventListener("keydown", () => {
+            parentSawIt = true;
+        });
+
+        const ev = new KeyboardEvent("keydown", {
+            key: "ArrowLeft",
+            bubbles: true,
+            cancelable: true,
+        });
+        const dispatched = bar.dispatchEvent(ev);
+
+        assert.deepStrictEqual(calls, [[card, -1]]);
+        assert.strictEqual(ev.defaultPrevented, true);
+        assert.strictEqual(
+            dispatched,
+            false,
+            "preventDefault should make dispatchEvent return false",
+        );
+        assert.strictEqual(
+            parentSawIt,
+            false,
+            "stopPropagation should keep the parent listener from seeing it",
+        );
+    });
+
+    it("ArrowRight on the bar fires onStep(card, +1), preventDefault, and stops propagation", () => {
+        const card = buildCard();
+        const calls: Array<[HTMLElement, number]> = [];
+        const bar = buildAndAttach(card, (c, d) => calls.push([c, d]));
+
+        let parentSawIt = false;
+        card.addEventListener("keydown", () => {
+            parentSawIt = true;
+        });
+
+        const ev = new KeyboardEvent("keydown", {
+            key: "ArrowRight",
+            bubbles: true,
+            cancelable: true,
+        });
+        const dispatched = bar.dispatchEvent(ev);
+
+        assert.deepStrictEqual(calls, [[card, 1]]);
+        assert.strictEqual(ev.defaultPrevented, true);
+        assert.strictEqual(dispatched, false);
+        assert.strictEqual(parentSawIt, false);
+    });
+
+    it("ignores non-arrow keys — no onStep, no preventDefault", () => {
+        const card = buildCard();
+        const calls: Array<[HTMLElement, number]> = [];
+        const bar = buildAndAttach(card, (c, d) => calls.push([c, d]));
+
+        for (const key of ["Enter", " ", "a", "Tab", "ArrowUp", "ArrowDown"]) {
+            const ev = new KeyboardEvent("keydown", {
+                key,
+                bubbles: true,
+                cancelable: true,
+            });
+            bar.dispatchEvent(ev);
+            assert.strictEqual(
+                ev.defaultPrevented,
+                false,
+                `key ${key} should not be preventDefaulted`,
+            );
+        }
+        assert.deepStrictEqual(calls, []);
+    });
+});
+
+describe("updateFrameIndicator", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("writes 'idx / total · label' for currentIndex=0, captures of length 3", () => {
+        const card = buildCard();
+        buildAndAttach(card);
+        card.dataset.currentIndex = "0";
+        updateFrameIndicator(card, [
+            { label: "500ms" },
+            { label: "1000ms" },
+            { label: "1500ms" },
+        ]);
+        const indicator = card.querySelector<HTMLElement>(".frame-indicator")!;
+        assert.strictEqual(indicator.textContent, "1 / 3 · 500ms");
+    });
+
+    it("disables prev at idx=0 and leaves next enabled", () => {
+        const card = buildCard();
+        buildAndAttach(card);
+        card.dataset.currentIndex = "0";
+        updateFrameIndicator(card, [
+            { label: "a" },
+            { label: "b" },
+            { label: "c" },
+        ]);
+        const prev = card.querySelector<HTMLButtonElement>(".frame-prev")!;
+        const next = card.querySelector<HTMLButtonElement>(".frame-next")!;
+        assert.strictEqual(prev.disabled, true);
+        assert.strictEqual(next.disabled, false);
+    });
+
+    it("disables next at the last index and leaves prev enabled", () => {
+        const card = buildCard();
+        buildAndAttach(card);
+        card.dataset.currentIndex = "2";
+        updateFrameIndicator(card, [
+            { label: "a" },
+            { label: "b" },
+            { label: "c" },
+        ]);
+        const prev = card.querySelector<HTMLButtonElement>(".frame-prev")!;
+        const next = card.querySelector<HTMLButtonElement>(".frame-next")!;
+        assert.strictEqual(prev.disabled, false);
+        assert.strictEqual(next.disabled, true);
+    });
+
+    it("leaves both buttons enabled when idx is in the middle", () => {
+        const card = buildCard();
+        buildAndAttach(card);
+        card.dataset.currentIndex = "1";
+        updateFrameIndicator(card, [
+            { label: "a" },
+            { label: "b" },
+            { label: "c" },
+        ]);
+        const prev = card.querySelector<HTMLButtonElement>(".frame-prev")!;
+        const next = card.querySelector<HTMLButtonElement>(".frame-next")!;
+        assert.strictEqual(prev.disabled, false);
+        assert.strictEqual(next.disabled, false);
+    });
+
+    it("renders '… · —' when the capture at idx has an empty label", () => {
+        const card = buildCard();
+        buildAndAttach(card);
+        card.dataset.currentIndex = "0";
+        updateFrameIndicator(card, [{ label: "" }, { label: "b" }]);
+        const indicator = card.querySelector<HTMLElement>(".frame-indicator")!;
+        assert.strictEqual(indicator.textContent, "1 / 2 · —");
+    });
+
+    it("is a silent no-op when there is no .frame-indicator on the card", () => {
+        const card = buildCard();
+        // No controls attached at all.
+        card.dataset.currentIndex = "0";
+        assert.doesNotThrow(() =>
+            updateFrameIndicator(card, [{ label: "500ms" }]),
+        );
+        assert.strictEqual(
+            card.querySelector(".frame-indicator"),
+            null,
+            "no indicator should appear",
+        );
+    });
+
+    it("is a silent no-op for undefined captures", () => {
+        const card = buildCard();
+        buildAndAttach(card);
+        card.dataset.currentIndex = "0";
+        const indicator = card.querySelector<HTMLElement>(".frame-indicator")!;
+        const before = indicator.textContent;
+        assert.doesNotThrow(() => updateFrameIndicator(card, undefined));
+        assert.strictEqual(indicator.textContent, before);
+    });
+
+    it("is a silent no-op for an empty captures array", () => {
+        const card = buildCard();
+        buildAndAttach(card);
+        card.dataset.currentIndex = "0";
+        const indicator = card.querySelector<HTMLElement>(".frame-indicator")!;
+        const before = indicator.textContent;
+        assert.doesNotThrow(() => updateFrameIndicator(card, []));
+        assert.strictEqual(indicator.textContent, before);
+    });
+});

--- a/vscode-extension/src/webview/preview/frameCarousel.ts
+++ b/vscode-extension/src/webview/preview/frameCarousel.ts
@@ -21,6 +21,7 @@
 
 import { mimeFor } from "./cardData";
 import { buildErrorPanel } from "./errorPanel";
+import { buildFrameControls, updateFrameIndicator } from "./frameCarouselDom";
 import {
     attachInteractiveInputHandlers,
     type InteractiveInputConfig,
@@ -62,51 +63,11 @@ export class FrameCarouselController {
      * post-mount state.
      */
     buildControls(card: HTMLElement): HTMLElement {
-        const bar = document.createElement("div");
-        bar.className = "frame-controls";
-
-        const prev = document.createElement("button");
-        prev.className = "icon-button frame-prev";
-        prev.setAttribute("aria-label", "Previous capture");
-        prev.title = "Previous capture";
-        prev.innerHTML =
-            '<i class="codicon codicon-chevron-left" aria-hidden="true"></i>';
-        prev.addEventListener("click", () => this.step(card, -1));
-
-        const indicator = document.createElement("span");
-        indicator.className = "frame-indicator";
-        indicator.setAttribute("aria-live", "polite");
-
-        const next = document.createElement("button");
-        next.className = "icon-button frame-next";
-        next.setAttribute("aria-label", "Next capture");
-        next.title = "Next capture";
-        next.innerHTML =
-            '<i class="codicon codicon-chevron-right" aria-hidden="true"></i>';
-        next.addEventListener("click", () => this.step(card, 1));
-
-        bar.appendChild(prev);
-        bar.appendChild(indicator);
-        bar.appendChild(next);
-
-        // Arrow keys when the carousel has focus. Stop propagation so
-        // the document-level focus-mode nav doesn't also advance the card.
-        bar.tabIndex = 0;
-        bar.addEventListener("keydown", (e) => {
-            if (e.key === "ArrowLeft") {
-                this.step(card, -1);
-                e.preventDefault();
-                e.stopPropagation();
-            } else if (e.key === "ArrowRight") {
-                this.step(card, 1);
-                e.preventDefault();
-                e.stopPropagation();
-            }
-        });
-
-        // Seed indicator text so it's not blank before any image arrives.
-        requestAnimationFrame(() => this.updateIndicator(card));
-        return bar;
+        return buildFrameControls(
+            card,
+            (c, d) => this.step(c, d),
+            (c) => requestAnimationFrame(() => this.updateIndicator(c)),
+        );
     }
 
     /**
@@ -117,19 +78,9 @@ export class FrameCarouselController {
      * module updates the indicator itself after `step` / `show`.
      */
     updateIndicator(card: HTMLElement): void {
-        const indicator = card.querySelector<HTMLElement>(".frame-indicator");
-        const prevBtn = card.querySelector<HTMLButtonElement>(".frame-prev");
-        const nextBtn = card.querySelector<HTMLButtonElement>(".frame-next");
-        if (!indicator) return;
         const previewId = card.dataset.previewId ?? "";
         const caps = previewStore.getState().cardCaptures.get(previewId);
-        if (!caps) return;
-        const idx = parseInt(card.dataset.currentIndex || "0", 10);
-        const capture = caps[idx];
-        const label = capture && capture.label ? capture.label : "—";
-        indicator.textContent = idx + 1 + " / " + caps.length + " · " + label;
-        if (prevBtn) prevBtn.disabled = idx === 0;
-        if (nextBtn) nextBtn.disabled = idx === caps.length - 1;
+        updateFrameIndicator(card, caps);
     }
 
     private step(card: HTMLElement, delta: number): void {

--- a/vscode-extension/src/webview/preview/frameCarouselDom.ts
+++ b/vscode-extension/src/webview/preview/frameCarouselDom.ts
@@ -1,0 +1,100 @@
+// Pure-DOM helpers for the per-card frame carousel — extracted from
+// `FrameCarouselController` so the prev / indicator / next strip and the
+// `idx / total · label` indicator update can be exercised under happy-dom
+// without dragging in `previewStore`, `buildErrorPanel`, or the
+// pointer-input handlers (which the controller's `step` / `show` paint
+// pass needs but these two pieces don't).
+//
+// The controller wires its own dependencies into the callbacks: click /
+// arrow-key navigation calls `onStep(card, ±1)` so this module never
+// reaches into the captures map; the indicator-seed-after-mount call
+// becomes `onIndicatorSeed(card)` so the `requestAnimationFrame` →
+// `previewStore` lookup stays on the controller side. Tests can pass
+// jest-style spies for both.
+
+/**
+ * Build the prev / indicator / next strip placed under the image on
+ * multi-capture cards. Caller appends the result to the card.
+ *
+ * Click handlers and the keydown handler call [onStep] with `±1`. The
+ * post-mount indicator seed (originally
+ * `requestAnimationFrame(() => updateIndicator(card))` on the controller)
+ * becomes [onIndicatorSeed] so this module never reaches into the
+ * captures store.
+ */
+export function buildFrameControls(
+    card: HTMLElement,
+    onStep: (card: HTMLElement, delta: number) => void,
+    onIndicatorSeed: (card: HTMLElement) => void,
+): HTMLElement {
+    const bar = document.createElement("div");
+    bar.className = "frame-controls";
+
+    const prev = document.createElement("button");
+    prev.className = "icon-button frame-prev";
+    prev.setAttribute("aria-label", "Previous capture");
+    prev.title = "Previous capture";
+    prev.innerHTML =
+        '<i class="codicon codicon-chevron-left" aria-hidden="true"></i>';
+    prev.addEventListener("click", () => onStep(card, -1));
+
+    const indicator = document.createElement("span");
+    indicator.className = "frame-indicator";
+    indicator.setAttribute("aria-live", "polite");
+
+    const next = document.createElement("button");
+    next.className = "icon-button frame-next";
+    next.setAttribute("aria-label", "Next capture");
+    next.title = "Next capture";
+    next.innerHTML =
+        '<i class="codicon codicon-chevron-right" aria-hidden="true"></i>';
+    next.addEventListener("click", () => onStep(card, 1));
+
+    bar.appendChild(prev);
+    bar.appendChild(indicator);
+    bar.appendChild(next);
+
+    // Arrow keys when the carousel has focus. Stop propagation so
+    // the document-level focus-mode nav doesn't also advance the card.
+    bar.tabIndex = 0;
+    bar.addEventListener("keydown", (e) => {
+        if (e.key === "ArrowLeft") {
+            onStep(card, -1);
+            e.preventDefault();
+            e.stopPropagation();
+        } else if (e.key === "ArrowRight") {
+            onStep(card, 1);
+            e.preventDefault();
+            e.stopPropagation();
+        }
+    });
+
+    // Seed indicator text so it's not blank before any image arrives.
+    onIndicatorSeed(card);
+    return bar;
+}
+
+/**
+ * Update the `idx / total · label` indicator and disable the boundary
+ * buttons. Reads `card.dataset.currentIndex` (falling back to `"0"`) and
+ * the supplied [captures] array.
+ *
+ * No-ops if [captures] is undefined / empty or the card has no
+ * `.frame-indicator` child. Missing per-capture labels render as `"—"`.
+ */
+export function updateFrameIndicator(
+    card: HTMLElement,
+    captures: ReadonlyArray<{ label: string }> | undefined,
+): void {
+    const indicator = card.querySelector<HTMLElement>(".frame-indicator");
+    const prevBtn = card.querySelector<HTMLButtonElement>(".frame-prev");
+    const nextBtn = card.querySelector<HTMLButtonElement>(".frame-next");
+    if (!indicator) return;
+    if (!captures || captures.length === 0) return;
+    const idx = parseInt(card.dataset.currentIndex || "0", 10);
+    const capture = captures[idx];
+    const label = capture && capture.label ? capture.label : "—";
+    indicator.textContent = idx + 1 + " / " + captures.length + " · " + label;
+    if (prevBtn) prevBtn.disabled = idx === 0;
+    if (nextBtn) nextBtn.disabled = idx === captures.length - 1;
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -23,6 +23,7 @@
         "src/webview/preview/cardMetadata.ts",
         "src/webview/preview/errorPanel.ts",
         "src/webview/preview/focusToolbar.ts",
+        "src/webview/preview/frameCarouselDom.ts",
         "src/webview/preview/interactiveInput.ts",
         "src/webview/preview/liveBadge.ts",
         "src/webview/preview/liveTransitions.ts",


### PR DESCRIPTION
## Summary

Sub-task of #859. Extracts the pure-DOM half of `FrameCarouselController` (`buildControls` + `updateIndicator`) into a narrow-deps file so the prev / indicator / next strip is testable without `previewStore`, `errorPanel`, or the interactive-input handler attachment.

`frameCarouselDom.ts`:
- `buildFrameControls(card, onStep, onIndicatorSeed)` — same prev / indicator / next markup, focusable bar, ArrowLeft/Right keydown with `preventDefault` + `stopPropagation`. Click and keydown call `onStep(card, ±1)`; the post-mount `requestAnimationFrame` indicator seed becomes `onIndicatorSeed(card)` so this module never reaches into the captures store.
- `updateFrameIndicator(card, captures)` — reads `dataset.currentIndex`, writes `"idx / total · label"`, disables boundary buttons. No-op when captures or `.frame-indicator` is missing; missing label renders as `"—"`.

`FrameCarouselController` delegates to both helpers. The wide deps (`previewStore`, `errorPanel`, `interactiveInput`) stay on the controller — they're still needed by the private `step` / `show` paint paths.

+16 tests covering markup shape with codicons/aria/title, child order, `bar.tabIndex === 0`, click handlers, ArrowLeft/Right behavior with `defaultPrevented` and a parent-listener-not-fired check, non-arrow keys ignored, `onIndicatorSeed` invoked once, `"1 / 3 · 500ms"` format, boundary disable at idx=0/last/middle, missing-indicator no-op, undefined/empty captures no-op, empty-label `"… · —"`.

## Test plan

- [x] `npm --prefix vscode-extension run test` — clean
- [x] `npm --prefix vscode-extension run format:check` — clean
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUFNzFRko621Zhx42nhNMm)_