### PR TITLE
docs: add GitHub Pages site with data-product reference

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,55 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: site
+      - id: pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: site/_site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,13 @@ vscode-extension/media/webview/
 __pycache__/
 *.pyc
 
+# Jekyll site (built artefacts under site/)
+site/_site/
+site/.jekyll-cache/
+site/.jekyll-metadata
+site/Gemfile.lock
+site/vendor/
+
 # Daemon preview-history archive — written by the daemon's `HistoryManager` when running
 # (sysprop `composeai.daemon.historyDir`). Each module gets its own archive at
 # `<moduleDir>/.compose-preview-history/`. Ignore at any depth.

--- a/site/Gemfile
+++ b/site/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "jekyll-remote-theme"
+gem "jekyll-seo-tag"
+gem "just-the-docs", "~> 0.10"

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,0 +1,42 @@
+title: compose-ai-tools
+description: >-
+  Render @Preview composables to PNG outside Android Studio, plus per-render
+  structured data products (a11y, layout, theme, recomposition…) so AI coding
+  agents can see and reason about the UI they're changing.
+url: https://yschimke.github.io
+baseurl: /compose-ai-tools
+
+remote_theme: just-the-docs/just-the-docs
+plugins:
+  - jekyll-remote-theme
+  - jekyll-seo-tag
+
+color_scheme: light
+search_enabled: true
+heading_anchors: true
+
+aux_links:
+  GitHub: https://github.com/yschimke/compose-ai-tools
+  Maven Central: https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin
+  VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=yuri-schimke.compose-preview
+
+footer_content: >-
+  Apache 2.0 licensed. Source on
+  <a href="https://github.com/yschimke/compose-ai-tools">GitHub</a>.
+
+callouts:
+  warning:
+    title: Note
+    color: yellow
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default
+
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - vendor
+  - README.md

--- a/site/index.md
+++ b/site/index.md
@@ -1,0 +1,96 @@
+---
+title: Home
+layout: default
+nav_order: 1
+description: "Render @Preview composables to PNG so AI coding agents can see what they're changing."
+permalink: /
+---
+
+# compose-ai-tools
+
+Render `@Preview` composables to PNG outside Android Studio, so AI coding
+agents can see what they're changing. Works with Jetpack Compose
+(Android, via Robolectric) and Compose Multiplatform Desktop (via
+`ImageComposeScene`).
+
+Alongside each PNG the renderer can emit **structured data products** —
+ATF accessibility findings, layout-inspector trees, recomposition heat
+maps, resolved theme tokens, drawn text, and more — so an agent can
+reason about the UI, not just look at it.
+
+[Get started](#installation){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[Reference](./reference/){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[GitHub](https://github.com/yschimke/compose-ai-tools){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+## Installation
+
+### Gradle plugin
+
+The plugin is published to
+[Maven Central](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin)
+— no auth, no PAT.
+
+<!-- x-release-please-start-version -->
+```kotlin
+// <module>/build.gradle.kts
+plugins {
+    id("ee.schimke.composeai.preview") version "0.10.1"
+}
+```
+<!-- x-release-please-end -->
+
+Then:
+
+```sh
+./gradlew :app:discoverPreviews    # scan @Preview annotations
+./gradlew :app:renderAllPreviews   # render every @Preview to PNG
+```
+
+Requires Java 17+, Gradle 9.4.1+, AGP 9.1+ (Android), Kotlin 2.2.21,
+Compose Multiplatform 1.10.3 (Desktop).
+
+### VS Code extension
+
+Published to the
+[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=yuri-schimke.compose-preview)
+and [Open VSX](https://open-vsx.org/extension/yuri-schimke/compose-preview)
+(for VSCodium / Cursor / Windsurf).
+
+Install from inside the IDE: open the Extensions view (⇧⌘X /
+Ctrl+Shift+X), search **Compose Preview**, click *Install*.
+
+### CLI
+
+Install on `$PATH` for shell or agent use via the bootstrap script:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/scripts/install.sh | sh
+```
+
+### Agent skill
+
+Point any agent that can fetch a URL at
+[`skills/compose-preview/SKILL.md`](https://github.com/yschimke/compose-ai-tools/blob/main/skills/compose-preview/SKILL.md)
+— the skill is a complete install-and-iterate playbook.
+
+### CI / GitHub Actions
+
+Composite actions for CI pipelines:
+
+- [`install`](https://github.com/yschimke/compose-ai-tools/tree/main/.github/actions/install) — pin the CLI on `$PATH`.
+- [`preview-baselines`](https://github.com/yschimke/compose-ai-tools/tree/main/.github/actions/preview-baselines) — push baselines to a branch.
+- [`preview-comment`](https://github.com/yschimke/compose-ai-tools/tree/main/.github/actions/preview-comment) — before / after PR comments.
+- [`a11y-report`](https://github.com/yschimke/compose-ai-tools/tree/main/.github/actions/a11y-report) — accessibility findings on PRs.
+
+---
+
+## Where next?
+
+- **[Reference](./reference/)** — one page per data product (a11y,
+  layout, theme, recomposition, scroll captures, …): what it is, what
+  it answers, and how to enable it.
+- **[How it works](https://github.com/yschimke/compose-ai-tools/blob/main/docs/HOW_IT_WORKS.md)** — discovery, renderer pipeline, caching.
+- **[Samples](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main)** — rendered baselines for `samples:android`, `samples:wear`, `samples:cmp`, `samples:remotecompose`, regenerated on every push to `main`.
+- **[Releases](https://github.com/yschimke/compose-ai-tools/releases)** · **[Changelog](https://github.com/yschimke/compose-ai-tools/blob/main/CHANGELOG.md)** · **[License](https://github.com/yschimke/compose-ai-tools/blob/main/LICENSE)** (Apache 2.0).

--- a/site/reference/a11y.md
+++ b/site/reference/a11y.md
@@ -1,0 +1,94 @@
+---
+title: Accessibility
+parent: Reference
+nav_order: 1
+permalink: /reference/a11y/
+---
+
+# Accessibility
+
+Run the Accessibility Test Framework (ATF) over each rendered preview
+and surface the findings, the semantic hierarchy, the annotated overlay
+PNG, and a 48 dp touch-target audit as four related kinds.
+
+## At a glance
+
+| | |
+|---|---|
+| Kinds | `a11y/atf`, `a11y/hierarchy`, `a11y/overlay`, `a11y/touchTargets` |
+| Schema version | 1 |
+| Modules | `:data-a11y-core` (published) · `:data-a11y-connector` · `:data-a11y-hierarchy-android` |
+| Render mode | a11y (`composeai.a11y.enabled=true`) |
+| Cost | low |
+| Transport | inline (JSON) · path (overlay PNG) |
+| Platforms | Android |
+
+## What it answers
+
+- **`a11y/atf`** — does this preview violate WCAG / Android a11y best practices? Each `AccessibilityFinding` carries a check id, severity, source, and the node it implicates. Trade-off: a11y mode flips `LocalInspectionMode = false` so Compose populates real semantics, which means infinite animations tick through rather than parking on the paused frame clock.
+- **`a11y/hierarchy`** — what does an assistive technology see? Per-node `label`, `role`, `states`, `merged`, `boundsInScreen`. Read it the same way TalkBack would.
+- **`a11y/overlay`** — the rendered PNG with finding bounding boxes baked in. Pure-image; `transport=path`.
+- **`a11y/touchTargets`** — every interactive node with its measured bounds vs. the 48 dp Material minimum, with overlap detection between adjacent targets.
+
+## What it does NOT answer
+
+- It is not a substitute for testing with real assistive technology — TalkBack on a real device may surface gestures or focus order issues that a single static frame can't.
+- It does not opine on copy quality (placeholder text, jargon). Use [`text/strings`](../strings) for that.
+- Findings are advisory, not pass/fail; severity is the agent's signal.
+
+## Use cases
+
+- PR review: gate UI PRs on no new `ERROR`-severity findings; reviewers can paste the overlay PNG inline.
+- Refactor confidence: diff `a11y/hierarchy` before/after a state-hoisting change to confirm semantics didn't regress.
+- Density audit: sweep all previews for `a11y/touchTargets` violations on a Wear watch face where small targets matter most.
+
+## Payload shape
+
+`AccessibilityFindingsPayload`, `AccessibilityHierarchyPayload`,
+`AccessibilityTouchTargetsPayload`, `AccessibilityOverlayArtifact`
+(path-only) — defined in
+[`:data-a11y-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/a11y/core).
+
+```jsonc
+// a11y/atf
+{
+  "findings": [
+    { "checkId": "TouchTargetSize", "severity": "ERROR",
+      "label": "Submit", "boundsInScreen": "48,200,144,232" }
+  ]
+}
+
+// a11y/hierarchy
+{
+  "nodes": [
+    { "label": "Submit", "role": "Button", "states": ["Enabled"],
+      "merged": true, "boundsInScreen": "48,200,144,232" }
+  ]
+}
+```
+
+## Enabling
+
+```kotlin
+composePreview {
+    previewExtensions {
+        a11y { enableAllChecks() }   // or enableCheck("TouchTargetSize")
+    }
+}
+```
+
+When enabled, the renderer also writes
+`build/compose-previews/data/<id>/a11y-atf.json`,
+`a11y-hierarchy.json`, `a11y-overlay.png`, and `a11y-touchTargets.json`
+on every render of `<id>`.
+
+The legacy `build/compose-previews/accessibility-per-preview/<id>.json`
+location is kept as a back-compat alias for one release, then retires.
+
+## Companion products
+
+- [Layout inspector](../layout-inspector) — `compose/semantics` for testTag / role / mergeMode without the ATF audit.
+- [Strings](../strings) — `text/strings` for drawn-text quality next to assistive labels.
+
+See also the agent-facing review guidance in
+[`skills/compose-preview/design/A11Y.md`](https://github.com/yschimke/compose-ai-tools/blob/main/skills/compose-preview/design/A11Y.md).

--- a/site/reference/ambient.md
+++ b/site/reference/ambient.md
@@ -1,0 +1,80 @@
+---
+title: Ambient (Wear)
+parent: Reference
+nav_order: 2
+permalink: /reference/ambient/
+---
+
+# Ambient
+
+Drive Wear OS `AmbientMode` overrides through the preview pipeline so a
+single `@Preview` can be rendered in *Interactive* and *Ambient* modes
+without touching the on-device Wear Services SDK.
+
+## At a glance
+
+| | |
+|---|---|
+| Kind | `compose/ambient` |
+| Schema version | 1 |
+| Modules | `:data-ambient-core` (published) · `:data-ambient-connector` |
+| Render mode | default |
+| Cost | low |
+| Transport | inline |
+| Platforms | Wear OS (Android) |
+
+## What it answers
+
+- What does this composable look like in *Ambient* mode (low-power, monochrome) vs. *Interactive*?
+- Does the consumer's `LocalAmbientModeManager.current?.currentAmbientMode` read site behave correctly under each state?
+- Did wake-on-input transitions (touch, RSB rotary scroll) flip the state back to `Interactive` as expected?
+
+The connector primes an `AmbientStateController` and installs a
+`LocalAmbientModeManager` composition local backed by it, so consumer
+code that wraps its UI in horologist's `AmbientAware { ... }` — or
+reads the manager directly — sees the requested state without any
+real Wear Services dependency. The legacy
+`androidx.wear.ambient.AmbientLifecycleObserver` callback fan-out is
+preserved through `ShadowAmbientLifecycleObserver` under Robolectric.
+
+## What it does NOT answer
+
+- It does not measure battery impact or screen-burn-in risk of a given Ambient design — those need on-device measurement.
+- It does not enforce always-on display constraints (≤15% pixels lit, no animation); use a linter or design-review checklist for that.
+
+## Use cases
+
+- Render an Ambient mode baseline of every Wear watch-face preview alongside the Interactive baseline.
+- Verify a watch-face redesign keeps the time legible after the state flip.
+- Test wake-on-input handling for a custom complication tap target.
+
+## Payload shape
+
+`AmbientPayload` and the matching `AmbientOverride` /
+`AmbientStateOverride` types in
+[`:data-ambient-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/ambient/core).
+
+```jsonc
+// renderNow.overrides.ambient
+{
+  "state": { "value": "Ambient" },          // or "Interactive"
+  "lowBitAmbient": false,
+  "burnInProtection": false
+}
+```
+
+## Enabling
+
+The producer's `onRender` runs whenever its owning extension is
+publicly enabled. From the daemon side, that is the
+`extensions/enable` handshake; from Gradle, the extension is wired
+when the Wear sample (or a consumer with the Wear toolkit on the
+classpath) applies the plugin.
+
+## Companion products
+
+- [Wallpaper](../wallpaper) — `compose/wallpaper` for Material You seed colours that drive the Ambient palette.
+- [Theme](../theme) — `compose/theme` for the resolved Material 3 tokens at the active Ambient state.
+
+See also
+[`skills/compose-preview/design/WEAR_UI.md`](https://github.com/yschimke/compose-ai-tools/blob/main/skills/compose-preview/design/WEAR_UI.md).

--- a/site/reference/focus.md
+++ b/site/reference/focus.md
@@ -1,0 +1,78 @@
+---
+title: Focus
+parent: Reference
+nav_order: 3
+permalink: /reference/focus/
+---
+
+# Focus
+
+Snapshot the Compose focus state of a preview and drive directional
+focus traversal (`Up`, `Down`, `Left`, `Right`, `Next`, `Previous`) so
+agents can verify keyboard / D-pad navigation without an emulator.
+
+## At a glance
+
+| | |
+|---|---|
+| Kind | `compose/focus` |
+| Schema version | 1 |
+| Modules | `:data-focus-core` (published) · `:data-focus-connector` |
+| Render mode | default |
+| Cost | low |
+| Transport | inline |
+| Platforms | Android · Desktop · Wear · shared |
+
+## What it answers
+
+- Which node holds focus right now? What `testTag`, role, label?
+- After a directional `moveFocus(FocusDirection.Down)`, where does focus land?
+- Is there a focus trap, dead end, or unexpected wrap?
+- Does the focus ring overlay match the focusable bounds the developer expects?
+
+The connector ships a `FocusController` that drives Compose's
+`FocusManager` and a `FocusOverlay` that renders the focused-node
+bounding box on top of the captured PNG.
+
+## What it does NOT answer
+
+- It does not test physical input devices (rotary, gamepad, IME hardware) — it operates on the abstract `FocusDirection` enum.
+- It does not score focus order against a designer-defined intent — it reports what the framework chose; reading whether that's right is on the reviewer.
+
+## Use cases
+
+- TV / Wear traversal: render every `Up`/`Down`/`Left`/`Right` step from a known starting node and confirm the path lands on the intended target.
+- Dialog focus restoration: verify focus comes back to the trigger button after a dialog dismisses.
+- Form regression: catch a refactor that accidentally makes a `TextField` non-focusable.
+
+## Payload shape
+
+`Material3FocusProduct.KIND` /  `FocusOverride` and `FocusDirection`
+in [`:data-focus-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/focus/core)
+and `daemon:core`.
+
+```jsonc
+// compose/focus
+{
+  "focused": {
+    "testTag": "submit-button",
+    "role": "Button",
+    "label": "Submit",
+    "boundsInScreen": "48,200,144,232"
+  },
+  "history": [
+    { "direction": "Down", "from": "name-field", "to": "submit-button" }
+  ]
+}
+```
+
+## Enabling
+
+Pass an override on `renderNow.overrides.focus` (MCP) to drive
+traversal, or enable the extension and read focused-node snapshots on
+every render.
+
+## Companion products
+
+- [UIAutomator hierarchy](../uiautomator) — `uia/hierarchy` for the broader set of selector-shaped nodes a click / scroll / type could target.
+- [Layout inspector](../layout-inspector) — `compose/semantics` for testTag / role / mergeMode of the focused node.

--- a/site/reference/fonts.md
+++ b/site/reference/fonts.md
@@ -1,0 +1,69 @@
+---
+title: Fonts
+parent: Reference
+nav_order: 4
+permalink: /reference/fonts/
+---
+
+# Fonts
+
+Report every font family used during render, with weight, style, and
+the resolved fallback chain Compose actually picked.
+
+## At a glance
+
+| | |
+|---|---|
+| Kind | `fonts/used` |
+| Schema version | 1 |
+| Modules | `:data-fonts-core` (published) · `:data-fonts-connector` |
+| Render mode | default |
+| Cost | low |
+| Transport | inline |
+| Platforms | Android · Desktop · shared |
+
+## What it answers
+
+- Which font families ended up on screen?
+- For each `Text(...)` call site, what weight / style was requested vs. what the resolver returned?
+- Did Compose fall back to a system font because a custom font failed to load?
+- Are any glyphs being served by a font you didn't expect to ship in the APK / app bundle?
+
+## What it does NOT answer
+
+- It does not measure font file size, CFF subsetting, or runtime download cost — that is a build-tools / Play asset delivery question.
+- It does not validate whether a glyph is *visually* correct (Han ideograph variants, complex script shaping) — that requires designer review against the rendered PNG.
+
+## Use cases
+
+- Catch accidental fallback to `sans-serif` after a `FontFamily.Resolver` refactor.
+- Verify a paid brand font is the one actually drawing your headings, not a system stand-in.
+- Audit a Wear app's text for legibility-critical weights (Medium / SemiBold) the design system requires.
+
+## Payload shape
+
+`FontsUsedPayload`, `FontUsedEntry` in
+[`:data-fonts-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/fonts/core).
+
+```jsonc
+// fonts/used
+{
+  "fonts": [
+    { "family": "Roboto", "weight": 500, "style": "Normal",
+      "source": "system", "fallbackFrom": null },
+    { "family": "Inter", "weight": 700, "style": "Italic",
+      "source": "asset", "fallbackFrom": "InterVariable" }
+  ]
+}
+```
+
+## Enabling
+
+Producer runs by default once the Fonts extension is publicly enabled
+(`extensions/enable`). On the CLI / Gradle path the JSON lands at
+`build/compose-previews/data/<id>/fonts-used.json`.
+
+## Companion products
+
+- [Strings](../strings) — `text/strings` for the actual drawn text the fonts rendered.
+- [Theme](../theme) — `compose/theme` for the resolved typography tokens that picked these fonts.

--- a/site/reference/history.md
+++ b/site/reference/history.md
@@ -1,0 +1,73 @@
+---
+title: History diff
+parent: Reference
+nav_order: 5
+permalink: /reference/history/
+---
+
+# History diff
+
+Per-pixel bounding boxes of regions that changed between two history
+entries (e.g. base render vs. PR head, or before / after a code edit).
+
+## At a glance
+
+| | |
+|---|---|
+| Kind | `history/diff/regions` |
+| Schema version | 1 |
+| Modules | `:data-history-core` (published) · `:data-history-connector` |
+| Render mode | default |
+| Cost | low |
+| Transport | inline |
+| Platforms | Android · Desktop · shared |
+
+## What it answers
+
+- Where in the frame did the pixels change between two renders of the same `previewId`?
+- How many distinct change regions are there, and how big is each (in pixels and percentage)?
+- Is a "tiny visual change" PR actually tiny, or did the author break a screen further down the layout?
+
+## What it does NOT answer
+
+- It does not tell you *why* a region changed (theme tweak vs. layout regression vs. anti-aliasing) — pair it with [`compose/theme`](../theme) or [`layout/inspector`](../layout-inspector) for that.
+- It does not produce a perceptual / SSIM diff — it operates on raw pixel inequality, so font hinting differences and platform GPU drift can show up as regions.
+
+## Use cases
+
+- PR comments: post a single image with the changed regions outlined, plus a one-line "12 regions, ~3.4% of pixels".
+- Refactor verification: prove a state-hoisting refactor produced an empty diff against `compose-preview/main`.
+- Bisect: walk backwards through baselines to find the commit that changed pixels in a particular bounding box.
+
+## Payload shape
+
+`HistoryDiffPayload`, `HistoryDiffRegion` in
+[`:data-history-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/history/core).
+
+```jsonc
+// history/diff/regions
+{
+  "leftEntryId": "compose-preview/main@7a1c…",
+  "rightEntryId": "<head>",
+  "regions": [
+    { "boundsInScreen": "48,200,144,232",
+      "changedPixels": 412, "totalPixels": 3072,
+      "deltaSummary": "color-shift" }
+  ],
+  "totalChangedPixels": 9184,
+  "totalPixels": 1080000
+}
+```
+
+## Enabling
+
+The producer attaches when the History extension is publicly enabled
+and `data/fetch?kind=history/diff/regions` is called with a left and
+right entry id. The companion CI workflow is
+[`preview-comment`](https://github.com/yschimke/compose-ai-tools/tree/main/.github/actions/preview-comment),
+which posts before / after PR comments using the same machinery.
+
+## Companion products
+
+- [Layout inspector](../layout-inspector) — `layout/inspector` to attribute a changed region to a specific composable.
+- [Theme](../theme) — `compose/theme` to confirm a colour-shift region is from a token change rather than a regression.

--- a/site/reference/index.md
+++ b/site/reference/index.md
@@ -1,0 +1,70 @@
+---
+title: Reference
+layout: default
+nav_order: 2
+has_children: true
+permalink: /reference/
+---
+
+# Reference
+
+The renderer can produce structured data alongside each PNG —
+accessibility findings, semantic hierarchies, layout trees, theme
+tokens, recomposition heat maps, and more. Each is a **data product**
+identified by a namespaced *kind* string with its own JSON schema.
+
+This section has one page per product. Each page follows the same
+shape: at-a-glance metadata, what the product answers (and what it
+deliberately does not), use cases, payload shape, and how to enable it.
+
+## How to read these pages
+
+A data product is `(kind, schemaVersion, payload)`:
+
+- **kind** — namespaced string (`a11y/atf`, `compose/recomposition`, …). Reserved namespaces: `a11y/*`, `layout/*`, `compose/*`, `resources/*`, `text/*`, `render/*`, `fonts/*`, `test/*`, `i18n/*`, `history/*`, `uia/*`.
+- **schemaVersion** — positive integer, owned by the kind. Bumped only on incompatible payload changes; additive fields don't bump.
+- **payload** — JSON. Inline for small payloads (~64 KB), or a path to a sibling file the renderer wrote (lifecycle matches the PNG).
+
+Each kind has exactly one `@Serializable` definition in a
+`:data-<product>-core` module published to Maven Central. MCP clients
+in any language can generate parsers from those without depending on
+the Compose runtime, daemon, or AndroidX. The matching
+`:data-<product>-connector` module is daemon glue and is internal.
+
+## Catalogue
+
+| Product | Kind(s) | Mode | Notes |
+|---|---|---|---|
+| [Accessibility](./a11y) | `a11y/atf`, `a11y/hierarchy`, `a11y/overlay`, `a11y/touchTargets` | a11y | ATF findings, semantic tree, annotated overlay, 48 dp targets. |
+| [Ambient (Wear)](./ambient) | `compose/ambient` | default | Drive `AmbientMode` overrides for Wear ambient previews. |
+| [Focus](./focus) | `compose/focus` | default | Focused-node snapshot + directional traversal overrides. |
+| [Fonts](./fonts) | `fonts/used` | default | Font families with weight/style fallback chain. |
+| [History diff](./history) | `history/diff/regions` | default | Per-pixel bounding boxes of changed regions vs. another history entry. |
+| [Layout inspector](./layout-inspector) | `layout/inspector`, `compose/semantics` | default | Compose layout/component hierarchy with bounds, modifiers, source refs. |
+| [Recomposition](./recomposition) | `compose/recomposition` | instrumented | Per-node recomposition counts; heat-map source. |
+| [Render trace](./render) | `render/composeAiTrace`, `render/trace`, `render/deviceBackground`, `render/deviceClip` | default | Pipeline timing, device clip / background derivation. |
+| [Resources](./resources) | `resources/used` | default | `R.*` references resolved during render. |
+| [Scroll captures](./scroll) | `render/scroll/gif`, `render/scroll/long` | default | Long-form scrolling captures and animated GIFs (renderer-side, image-only). |
+| [Strings & i18n](./strings) | `text/strings`, `i18n/translations` | default | Drawn text + locale coverage. |
+| [Theme](./theme) | `compose/theme` | default | Resolved Material 3 tokens + which nodes consumed them. |
+| [UIAutomator hierarchy](./uiautomator) | `uia/hierarchy` | default | Selector-shaped Compose nodes for UIAutomator-style targeting. |
+| [Wallpaper](./wallpaper) | `compose/wallpaper` | default | Material You seed colour → derived scheme. |
+| [Test failure](./test-failure) | `test/failure` | failed render | Postmortem bundle after a `renderFailed`. |
+
+## Surfaces
+
+Two ways to consume a product:
+
+1. **MCP** — `list_data_products`, `subscribe_preview_data`,
+   `get_preview_data` on the
+   [`compose-preview-mcp`](https://github.com/yschimke/compose-ai-tools/tree/main/mcp)
+   server. The right path for any agent that's already driving previews
+   through MCP.
+2. **CLI / Gradle** — when a kind is enabled in the consumer's
+   `composePreview { ... }` config, the renderer writes the same payload
+   to `build/compose-previews/data/<previewId>/<kind-with-slashes-as-dashes>.json`
+   on every render. CLI / CI consumers read those files directly.
+
+For the full wire-protocol contract — error codes, transports,
+re-render semantics, extension activation — see
+[`docs/daemon/DATA-PRODUCTS.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/DATA-PRODUCTS.md).

--- a/site/reference/layout-inspector.md
+++ b/site/reference/layout-inspector.md
@@ -1,0 +1,87 @@
+---
+title: Layout inspector
+parent: Reference
+nav_order: 6
+permalink: /reference/layout-inspector/
+---
+
+# Layout inspector
+
+The Compose layout / component hierarchy with bounds, constraints,
+modifiers, and source refs — plus a sibling `compose/semantics`
+projection for testTag / role / mergeMode questions.
+
+## At a glance
+
+| | |
+|---|---|
+| Kinds | `layout/inspector`, `compose/semantics` |
+| Schema version | 1 |
+| Modules | `:data-layoutinspector-core` (published) · `:data-layoutinspector-connector` |
+| Render mode | default |
+| Cost | low |
+| Transport | inline |
+| Platforms | Android · Desktop · shared |
+
+## What it answers
+
+- **`layout/inspector`** — what's the parent / child shape of this composable? Measured size? Constraints? Z-order? Which inspectable modifiers are attached, with what values? Which source file / line declared the node?
+- **`compose/semantics`** — for each `SemanticsNode`, what is its `testTag`, `role`, `mergeMode`, `bounds`?
+
+It is intentionally separate from [`a11y/hierarchy`](../a11y) — the
+question there is "what does an assistive technology see"; the
+question here is layout structure or stable test selectors.
+
+## What it does NOT answer
+
+- It does not run accessibility checks — that is `a11y/atf`.
+- It does not measure recomposition — that is [`compose/recomposition`](../recomposition).
+- The Desktop / shared backend reaches the layout tree through `RootForTest`; non-Compose Android views (interop) are not modelled.
+
+## Use cases
+
+- Pinpoint which composable owns a misaligned region from [`history/diff/regions`](../history).
+- Confirm a refactor preserved testTags so existing UI tests keep finding their targets.
+- Inspect resolved `Modifier.padding(...)` values when a screenshot says one thing and the source says another.
+- Drive the VS Code extension's tree view of a preview.
+
+## Payload shape
+
+`LayoutInspectorPayload`, `LayoutInspectorNode`,
+`ComposeSemanticsPayload`, `ComposeSemanticsNode` in
+[`:data-layoutinspector-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/layoutinspector/core).
+
+```jsonc
+// layout/inspector
+{
+  "nodes": [
+    { "id": 1, "name": "Column", "boundsInScreen": "0,0,1080,1920",
+      "measuredSize": "1080x1920",
+      "constraints": "minW=0, maxW=1080, minH=0, maxH=1920",
+      "modifiers": [{ "name": "padding", "args": "16dp" }],
+      "sourceRef": "HomeScreen.kt:42" }
+  ]
+}
+
+// compose/semantics
+{
+  "nodes": [
+    { "testTag": "submit-button", "role": "Button",
+      "mergeMode": "Merged", "boundsInScreen": "48,200,144,232" }
+  ]
+}
+```
+
+## Enabling
+
+Producer runs whenever its owning extension is publicly enabled.
+Backed on Android by the daemon's `RootForTest` carried on
+`PreviewContext.inspection`. CLI / Gradle output:
+`build/compose-previews/data/<id>/layout-inspector.json` and
+`compose-semantics.json`.
+
+## Companion products
+
+- [Accessibility](../a11y) — `a11y/hierarchy` for the assistive-technology view of the same nodes.
+- [Recomposition](../recomposition) — `compose/recomposition` for per-node recomposition counts keyed off the same node ids.
+- [Theme](../theme) — `compose/theme` for the tokens consumed at each node.

--- a/site/reference/recomposition.md
+++ b/site/reference/recomposition.md
@@ -1,0 +1,86 @@
+---
+title: Recomposition
+parent: Reference
+nav_order: 7
+permalink: /reference/recomposition/
+---
+
+# Recomposition
+
+Per-node recomposition counts — the agent-facing performance signal
+for unnecessary recomposition. Source for heat maps and "this node
+recomposed N times for one click" reviews.
+
+## At a glance
+
+| | |
+|---|---|
+| Kind | `compose/recomposition` |
+| Schema version | 1 |
+| Modules | `:data-recomposition-core` (published) · `:data-recomposition-connector` |
+| Render mode | instrumented |
+| Cost | medium |
+| Transport | inline |
+| Platforms | Android · Desktop · shared |
+
+## What it answers
+
+- How many times did each composable recompose during this render?
+- Which subtree is the hot spot — a leaf re-running, or a parent re-running and dragging its children with it?
+- After a click / scroll / value change, what is the **delta** in recomposition counts compared to the steady-state snapshot?
+
+Two modes:
+
+- **Snapshot** — a single instrumented render reports cumulative counts.
+- **Click delta** — drive the input, then diff before / after counts to attribute work to the interaction.
+
+## What it does NOT answer
+
+- It does not measure wall-clock time spent in composition — pair with [`render/trace`](../render).
+- It does not detect the *cause* (unstable lambda, missing `remember`, key churn) — it points at the location; reading the source is on the reviewer.
+- It runs the renderer in instrumented mode, so absolute counts are not directly comparable to a non-instrumented production build.
+
+## Use cases
+
+- Catch a `Modifier` factory that captures a new lambda each composition and forces the whole row to recompose.
+- Verify a `derivedStateOf` / `remember` change actually trimmed the recomposition count it was supposed to.
+- Build a heat-map overlay for a "performance review" PR.
+
+## Payload shape
+
+`RecompositionPayload`, `RecompositionNode` in
+[`:data-recomposition-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/recomposition/core).
+
+```jsonc
+// compose/recomposition
+{
+  "mode": "snapshot",         // or "clickDelta"
+  "frameStreamId": "f-7a1c",  // when click-delta
+  "nodes": [
+    { "nodeId": 12, "name": "Row", "count": 3,
+      "boundsInScreen": "0,80,1080,160" },
+    { "nodeId": 14, "name": "Text", "count": 12,
+      "boundsInScreen": "16,96,1064,144" }
+  ]
+}
+```
+
+## Enabling
+
+Producer requires *instrumented* render mode and runs when its
+extension is publicly enabled. From an MCP client:
+
+```jsonc
+{ "method": "tools/call", "params": { "name": "subscribe_preview_data",
+  "arguments": { "uri": "compose-preview://<id>/_module/com.example.Foo",
+                 "kind": "compose/recomposition" } } }
+```
+
+For PR-review style "did this PR add unnecessary recomposition?"
+guidance, see
+[`compose-preview-review/design/AGENT_AUDITS.md`](https://github.com/yschimke/compose-ai-tools/blob/main/skills/compose-preview-review/design/AGENT_AUDITS.md).
+
+## Companion products
+
+- [Layout inspector](../layout-inspector) — `layout/inspector` to map `nodeId` to source.
+- [Render trace](../render) — `render/trace`, `render/composeAiTrace` for the wall-clock side of the same render.

--- a/site/reference/render.md
+++ b/site/reference/render.md
@@ -1,0 +1,79 @@
+---
+title: Render trace
+parent: Reference
+nav_order: 8
+permalink: /reference/render/
+---
+
+# Render trace
+
+Pipeline-level kinds emitted by the renderer itself: a Perfetto-importable
+Chrome trace, a phase breakdown, the device clip mask, and the device
+background.
+
+## At a glance
+
+| | |
+|---|---|
+| Kinds | `render/composeAiTrace`, `render/trace`, `render/deviceClip`, `render/deviceBackground` |
+| Schema version | 1 |
+| Modules | `:data-render-core` (published) · `:data-render-connector` · `:data-render-compose` |
+| Render mode | default · live |
+| Cost | low |
+| Transport | inline (JSON) · path (PNG for clip / background) |
+| Platforms | Android · Desktop · shared |
+
+## What it answers
+
+- **`render/composeAiTrace`** — a full Perfetto / Chrome-trace JSON of the render pipeline (discovery → setup → compose → capture → encode). Drop it into [`ui.perfetto.dev`](https://ui.perfetto.dev) to see exactly where time went.
+- **`render/trace`** — a flatter, summary-shaped phase breakdown (`totalMs`, ordered phases, free-form metrics map). Cheap to read in a CI log.
+- **`render/deviceClip`** — the device-shape clip mask used for round Wear watches and other non-rectangular previews. Pure-image.
+- **`render/deviceBackground`** — the device chrome / wallpaper layer composited under the preview. Pure-image.
+
+## What it does NOT answer
+
+- `render/trace` is a renderer pipeline trace, not a Compose composition trace — for that, use [`compose/recomposition`](../recomposition).
+- It does not contain on-device frame timing (Choreographer, jank stats) — the renderer runs under Robolectric / `ImageComposeScene`, not on a real Choreographer.
+- The Perfetto trace is sampled at function boundaries, not at the JVM-method granularity of an async-profiler dump.
+
+## Use cases
+
+- Diagnose a slow render that nudges past `daemon.dataFetchRerenderBudgetMs` — open the Perfetto trace and find the phase that ran long.
+- Build a CI dashboard of `totalMs` per preview to catch gradual regression.
+- Verify a Wear round-device clip mask matches the watch face's intended bezel.
+- Composite a custom device background under a preview for marketing screenshots.
+
+## Payload shape
+
+`PerfettoTraceDataProducer`, `RenderTraceDataProduct` in
+[`:data-render-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/render/core).
+
+```jsonc
+// render/trace
+{
+  "totalMs": 412,
+  "phases": [
+    { "name": "render", "startMs": 0, "durationMs": 412 }
+  ],
+  "metrics": { "tookMs": 412, "previewWidthPx": 1080, "previewHeightPx": 1920 }
+}
+
+// render/composeAiTrace — Chrome trace JSON, importable into ui.perfetto.dev
+{ "traceEvents": [ { "ph": "X", "name": "compose", "ts": 1234, "dur": 89, … } ] }
+```
+
+## Enabling
+
+`render/composeAiTrace` is gated by the JVM property
+`composeai.daemon.perfettoTrace=true`. The other three kinds run
+whenever their extension is publicly enabled. CLI / Gradle output:
+
+- `build/compose-previews/data/<id>/render-perfetto-trace.json`
+- `build/compose-previews/data/<id>/render-trace.json`
+- `build/compose-previews/data/<id>/render-deviceClip.png`
+- `build/compose-previews/data/<id>/render-deviceBackground.png`
+
+## Companion products
+
+- [Test failure](../test-failure) — `test/failure` for postmortems when a render fails before producing a trace.
+- [Recomposition](../recomposition) — `compose/recomposition` for the per-node side of the wall-clock story.

--- a/site/reference/resources.md
+++ b/site/reference/resources.md
@@ -1,0 +1,79 @@
+---
+title: Resources
+parent: Reference
+nav_order: 9
+permalink: /reference/resources/
+---
+
+# Resources
+
+Every `R.*` reference resolved during render — drawables, strings,
+colours, dimens, plurals, attrs, and theme attributes — with the
+resolved value and the source qualifier (default vs. `night`,
+`w600dp`, locale-specific, …).
+
+## At a glance
+
+| | |
+|---|---|
+| Kind | `resources/used` |
+| Schema version | 1 |
+| Modules | `:data-resources-core` (published) · `:data-resources-connector` |
+| Render mode | default |
+| Cost | low |
+| Transport | inline |
+| Platforms | Android |
+
+## What it answers
+
+- Which `R.drawable.*` / `R.string.*` / `R.color.*` references actually got read while rendering this preview?
+- Which qualifier folder did each value come from (e.g. `values-night/colors.xml` vs. `values/colors.xml`)?
+- Are any references dead — declared but never read on this preview?
+- Did a refactor accidentally introduce a reference to a removed resource id?
+
+## What it does NOT answer
+
+- It does not enumerate resources the preview *could* reference under a different configuration (different locale, dark mode) — only what was read on this render.
+- It does not validate XML schema correctness — that is `aapt2`'s job.
+- Compose Multiplatform resources flow through a different path; this kind is Android-only.
+
+## Use cases
+
+- Jump-to-source from VS Code: click a colour in the rendered PNG, get the `R.color.foo` it came from and the `values*/colors.xml` it was defined in.
+- Dead-code audits: render every preview and diff `resources/used` against the union of declared `R.*` ids.
+- Verify a string id rename was thorough — every preview that previously cited `R.string.old_name` now cites `R.string.new_name`.
+
+## Payload shape
+
+`ResourcesUsedPayload`, `ResourceUsedReference` in
+[`:data-resources-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/resources/core).
+
+```jsonc
+// resources/used
+{
+  "references": [
+    { "type": "string", "name": "submit", "id": "0x7f110042",
+      "value": "Submit",
+      "sourceFile": "values/strings.xml" },
+    { "type": "color", "name": "primary", "id": "0x7f060010",
+      "value": "#FF6750A4",
+      "sourceFile": "values-night/colors.xml" }
+  ]
+}
+```
+
+## Enabling
+
+Producer runs once the Resources extension is publicly enabled. CLI /
+Gradle output: `build/compose-previews/data/<id>/resources-used.json`.
+
+The plugin also separately renders Android XML resources directly
+(vector drawables, adaptive icons, animated-vector drawables) — that
+is a different feature; see
+[`skills/compose-preview/design/RESOURCE_PREVIEWS.md`](https://github.com/yschimke/compose-ai-tools/blob/main/skills/compose-preview/design/RESOURCE_PREVIEWS.md).
+
+## Companion products
+
+- [Strings](../strings) — `text/strings` for the actual drawn copy resolved from `R.string.*` references.
+- [Theme](../theme) — `compose/theme` for the Material 3 tokens that consumed `R.color.*` values.
+- [Fonts](../fonts) — `fonts/used` for the typeface side of the same render.

--- a/site/reference/scroll.md
+++ b/site/reference/scroll.md
@@ -1,0 +1,66 @@
+---
+title: Scroll captures
+parent: Reference
+nav_order: 10
+permalink: /reference/scroll/
+---
+
+# Scroll captures
+
+Long-form scrolling captures (one tall PNG that stitches the whole
+scrollable region) and animated GIFs of the scroll itself, driven
+through the renderer extension pipeline.
+
+## At a glance
+
+| | |
+|---|---|
+| Kinds | `render/scroll/long`, `render/scroll/gif` |
+| Schema version | n/a (image-only) |
+| Modules | `:data-scroll-core` |
+| Render mode | default |
+| Cost | medium (extra renders per scroll step) |
+| Transport | path (PNG / GIF) |
+| Platforms | Android · Desktop · shared |
+
+## What it answers
+
+- What does the entire scrollable region look like, end to end, not just the viewport at rest?
+- What does the scroll motion *look like* over time (entry animations, sticky headers settling, `LazyColumn` item placement)?
+- Does a `nestedScroll` collapse / expand land in the right state at the end of a fling?
+
+`data/scroll/core` ships scroll-scenario drivers (`ScrollDriver`,
+`ScrollGifEncoder`, `ScrollPreviewExtension`) that the renderer
+composes through the regular extension pipeline.
+
+## What it does NOT answer
+
+- Scroll is **renderer-side only** — it produces image artifacts, not a JSON payload, so it has no `kind` on the daemon's `initialize.capabilities.dataProducts` list. There is no `data-scroll-connector`. It never round-trips through `data/fetch` or `data/subscribe`; instead the renderer drives it directly via `PreviewPipelineStep` / scenario-driver hooks.
+- It does not measure scroll performance — for that, instrument [`compose/recomposition`](../recomposition) over the same scrolled frames.
+
+## Use cases
+
+- Render a tall settings screen as one PNG for design review.
+- GIF a `LazyColumn` to verify item-key stability across data changes.
+- Capture the full scroll of a Wear `ScalingLazyColumn` to confirm the curvature target.
+
+## Payload shape
+
+Image-only artifacts. Produced via
+[`:data-scroll-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/scroll/core)
+extensions. Output paths under
+`build/compose-previews/renders/<id>-long.png` and
+`build/compose-previews/renders/<id>.gif`.
+
+## Enabling
+
+Annotate the preview with the matching multi-preview annotation (e.g.
+`@ScrollingPreview`) — see
+[`skills/compose-preview/design/CAPTURE_MODES.md`](https://github.com/yschimke/compose-ai-tools/blob/main/skills/compose-preview/design/CAPTURE_MODES.md)
+for the multi-preview / scenario annotations the scroll extension
+recognises.
+
+## Companion products
+
+- [Recomposition](../recomposition) — `compose/recomposition` to attribute scroll cost to specific composables.
+- [History diff](../history) — `history/diff/regions` against a long-PNG baseline to catch list-item layout regressions.

--- a/site/reference/strings.md
+++ b/site/reference/strings.md
@@ -1,0 +1,81 @@
+---
+title: Strings & i18n
+parent: Reference
+nav_order: 11
+permalink: /reference/strings/
+---
+
+# Strings & i18n
+
+Drawn text on the rendered frame (`text/strings`) and per-string
+locale coverage from `values*/strings.xml` (`i18n/translations`).
+
+## At a glance
+
+| | |
+|---|---|
+| Kinds | `text/strings`, `i18n/translations` |
+| Schema version | 1 |
+| Modules | `:data-strings-core` (published) · `:data-strings-connector` |
+| Render mode | default |
+| Cost | low |
+| Transport | inline |
+| Platforms | Android (i18n is Android-only) · Desktop · shared (`text/strings`) |
+
+## What it answers
+
+- **`text/strings`** — every text run that ended up on screen, with locale, fontScale, fontSize, color, bounds, and per-entry `truncated` / `overflow` / `lineCount` / `maxLines` / `didOverflowWidth` / `didOverflowHeight` taken straight from Compose's `TextLayoutResult`.
+- **`i18n/translations`** — for each visible string id, which locales have a translation and which fall through to the default. Highlights missing translations *that actually matter on this screen* — not the entire `strings.xml`.
+
+## What it does NOT answer
+
+- It does not score copy quality (clarity, brand voice, jargon) — that is a manual review.
+- It does not measure RTL correctness — pair with a render at `locale=ar` and compare bounds.
+- `i18n/translations` does not include Compose Multiplatform string resources (different resolution path, Android-specific for now).
+
+## Use cases
+
+- Catch text overflow before it ships: filter `text/strings` for `didOverflowWidth=true` across every preview.
+- Audit a feature's locale coverage by listing visible strings whose missing-locale set is non-empty.
+- Verify a `fontScale=2.0` accessibility test does not push critical CTAs off-screen.
+- Drive jump-to-source on a drawn label in the VS Code extension.
+
+## Payload shape
+
+`TextStringsPayload`, `TextStringEntry`, `I18nTranslationsPayload`,
+`I18nVisibleString` in
+[`:data-strings-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/strings/core).
+
+```jsonc
+// text/strings
+{
+  "entries": [
+    { "text": "Submit", "locale": "en-US", "fontScale": 1.0,
+      "fontSize": 14, "color": "#FFFFFFFF",
+      "boundsInScreen": "48,200,144,232",
+      "truncated": false, "didOverflowWidth": false, "didOverflowHeight": false,
+      "lineCount": 1, "maxLines": 1 }
+  ]
+}
+
+// i18n/translations
+{
+  "strings": [
+    { "id": "submit", "default": "Submit",
+      "locales": { "en-US": "Submit", "fr": "Envoyer" },
+      "missing": ["de", "es"] }
+  ]
+}
+```
+
+## Enabling
+
+Producer runs once the Strings extension is publicly enabled. CLI /
+Gradle output: `build/compose-previews/data/<id>/text-strings.json`
+and `i18n-translations.json`.
+
+## Companion products
+
+- [Fonts](../fonts) — `fonts/used` for the typeface side of the same drawn text.
+- [Resources](../resources) — `resources/used` for which `R.string.*` references resolved here.
+- [Accessibility](../a11y) — `a11y/hierarchy` for assistive-technology labels alongside drawn copy.

--- a/site/reference/test-failure.md
+++ b/site/reference/test-failure.md
@@ -1,0 +1,95 @@
+---
+title: Test failure
+parent: Reference
+nav_order: 15
+permalink: /reference/test-failure/
+---
+
+# Test failure
+
+Postmortem bundle delivered after a `renderFailed` notification:
+phase, error type / message / top stack frame, a bounded stack trace,
+and explicit fallback fields for partial screenshot, pending effects,
+animation state, and a redacted snapshot summary.
+
+## At a glance
+
+| | |
+|---|---|
+| Kind | `test/failure` |
+| Schema version | 1 |
+| Modules | `:data-render-core` (published) · `:data-render-connector` |
+| Render mode | failed render |
+| Cost | low |
+| Transport | inline |
+| Availability | fetch-only after `renderFailed` |
+| Platforms | Android · Desktop · shared |
+
+## What it answers
+
+- Why did the most recent render of this preview fail?
+- What phase failed (`compose`, `capture`, `encode`, `setup`)?
+- What error type / message / top stack frame, and a bounded stack trace?
+- What was the renderer's last visible state — pending effects, running animations, frame-clock state — at the moment of failure?
+
+## What it does NOT answer
+
+- It does not include a partial screenshot in schema v1 (`partialScreenshotAvailable: false`); the fallback fields are placeholders for a future schema bump.
+- It does not capture state object values — `lastSnapshotSummary.redaction` is "state values are not captured in schema v1".
+- It is not a live debugger — read the stack and the phase, then iterate; you will not get a step-debugger session out of this.
+
+## Use cases
+
+- Triage a CI failure: fetch `test/failure` for every red preview to cluster failures by error type / phase.
+- Distinguish a renderer bug from a consumer bug — a NPE in the consumer's `LaunchedEffect` is theirs; a Robolectric sandbox boot failure is the renderer's.
+- Drive a "show me the failure" panel in the VS Code extension when a preview can't render.
+
+## Payload shape
+
+`TestFailureDataProduct` in
+[`:data-render-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/render/core).
+
+```jsonc
+// test/failure
+{
+  "status": "failed",
+  "phase": "compose",
+  "error": {
+    "type": "NullPointerException",
+    "message": "Cannot invoke \"...\" because \"...\" is null",
+    "topFrame": "HomeScreen.kt:42",
+    "stackTrace": [
+      "com.example.HomeScreenKt.HomeScreen(HomeScreen.kt:42)",
+      "..."
+    ]
+  },
+  "partialScreenshot": null,
+  "partialScreenshotAvailable": false,
+  "pendingEffects": [],
+  "runningAnimations": [],
+  "frameClockState": { "status": "unknown" },
+  "lastSnapshotSummary": {
+    "stateObjects": null,
+    "valuesCaptured": false,
+    "redaction": "state values are not captured in schema v1"
+  }
+}
+```
+
+## Enabling
+
+Always available for the Render-pipeline extension. After a
+`renderFailed` notification, call:
+
+```jsonc
+{ "method": "tools/call", "params": { "name": "get_preview_data",
+  "arguments": { "uri": "compose-preview://<id>/_module/com.example.Foo",
+                 "kind": "test/failure" } } }
+```
+
+The kind is fetch-only — it does not ride attachments.
+
+## Companion products
+
+- [Render trace](../render) — `render/trace`, `render/composeAiTrace` for successful-render timing context.
+- [Layout inspector](../layout-inspector) — `layout/inspector` from a previous *successful* render to compare against the failure point.

--- a/site/reference/theme.md
+++ b/site/reference/theme.md
@@ -1,0 +1,81 @@
+---
+title: Theme
+parent: Reference
+nav_order: 12
+permalink: /reference/theme/
+---
+
+# Theme
+
+Resolved Material 3 design tokens (colour scheme, typography, shapes)
+plus a back-pointer to which nodes consumed each token.
+
+## At a glance
+
+| | |
+|---|---|
+| Kind | `compose/theme` |
+| Schema version | 1 |
+| Modules | `:data-theme-core` (published) · `:data-theme-connector` |
+| Render mode | default |
+| Cost | medium |
+| Transport | inline |
+| Platforms | Android · Desktop · shared |
+
+## What it answers
+
+- What Material 3 colour scheme was active during this render? Light or dark? Seed colour? Contrast level?
+- What typography scale resolved for `headlineLarge`, `bodyMedium`, etc.?
+- Which composables actually *consumed* `MaterialTheme.colorScheme.primary` — i.e. read the token, not just inherited a `LocalContentColor`?
+- Did a theme refactor accidentally break a node's intended token (e.g. a `Surface` that now reads `surfaceVariant` instead of `surface`)?
+
+## What it does NOT answer
+
+- It does not opine on Material 3 best practice (don't use `tertiary` on a primary-action button) — it tells you *what* was used; the design intent is on the reviewer.
+- It does not enumerate tokens declared but unused in the theme — only what was read.
+
+## Use cases
+
+- Verify a Material You seed-colour change propagated correctly: render under two seeds and diff the resolved schemes.
+- Catch a stray hard-coded hex that a refactor was supposed to replace with a token reference.
+- Drive a theme-token inspector panel in the VS Code extension.
+
+## Payload shape
+
+`ThemePayload`, `ResolvedThemeTokens`, `TypographyToken` in
+[`:data-theme-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/theme/core).
+
+```jsonc
+// compose/theme
+{
+  "isDark": false,
+  "seedColor": "#FF6750A4",
+  "contrastLevel": 0.0,
+  "colorScheme": {
+    "primary": "#FF6750A4",
+    "onPrimary": "#FFFFFFFF",
+    "surface": "#FFFFFBFE"
+    // …
+  },
+  "typography": [
+    { "name": "headlineLarge", "fontFamily": "Roboto",
+      "fontWeight": 400, "fontSize": 32, "lineHeight": 40 }
+  ],
+  "consumers": [
+    { "token": "primary", "nodeIds": [12, 14] }
+  ]
+}
+```
+
+## Enabling
+
+Producer runs once the Theme extension is publicly enabled. May
+require a small re-render to attribute consumers to nodes — the
+default `daemon.dataFetchRerenderBudgetMs = 30000` covers it. CLI /
+Gradle output: `build/compose-previews/data/<id>/compose-theme.json`.
+
+## Companion products
+
+- [Wallpaper](../wallpaper) — `compose/wallpaper` for the Material You seed → derived scheme upstream of `compose/theme`.
+- [Layout inspector](../layout-inspector) — `layout/inspector` to map a `nodeId` consumer back to source.
+- [Resources](../resources) — `resources/used` for `R.color.*` references that fed the scheme.

--- a/site/reference/uiautomator.md
+++ b/site/reference/uiautomator.md
@@ -1,0 +1,82 @@
+---
+title: UIAutomator hierarchy
+parent: Reference
+nav_order: 13
+permalink: /reference/uiautomator/
+---
+
+# UIAutomator hierarchy
+
+A selector-shaped projection of Compose semantics: just enough metadata
+per node to formulate a UIAutomator-style `By.text(...)` /
+`By.contentDescription(...)` selector that uniquely targets it.
+
+## At a glance
+
+| | |
+|---|---|
+| Kind | `uia/hierarchy` |
+| Schema version | 1 |
+| Modules | `:data-uiautomator-core` (published) · `:data-uiautomator-hierarchy-android` (published) · `:data-uiautomator-connector` |
+| Render mode | default |
+| Cost | low |
+| Transport | inline |
+| Platforms | Android |
+
+## What it answers
+
+- For each actionable node, what selector inputs are available — `text`, `contentDescription`, `testTag`, `role`?
+- Which `uia.*` actions does it support — `uia.click`, `uia.scrollForward`, `uia.inputText`, …?
+- What is the node's bounds in source-bitmap pixels (same shape as `AccessibilityNode`'s `boundsInScreen`)?
+- Does the node have testTag ancestors that a `hasParent({testTag: …})` / `hasAncestor` selector chain could resolve?
+
+The default filter keeps only nodes that expose at least one of the
+supported actions, dropping ~80% of layout-wrapper / pure-text nodes
+while still emitting everything an agent's click / scroll / type
+could plausibly target. Snapshots can be taken against the merged
+semantics tree (the on-device UIAutomator default — `Button { Text("Submit") }`
+collapses into one node) or the unmerged tree.
+
+## What it does NOT answer
+
+- It is not a full SemanticsNode dump — for that, use [`compose/semantics`](../layout-inspector).
+- It does not execute a selector — it gives you what is *targetable*; running a `uia.click` is the daemon's `renderNow` path, not a data product fetch.
+- It does not include modifier or constraint detail; pair with [`layout/inspector`](../layout-inspector) when you need positioning context.
+
+## Use cases
+
+- Generate a UIAutomator-like end-to-end test plan for a screen without touching an emulator.
+- Confirm every actionable node has *at least one* stable selector input — fail review if a button has neither `text`, `contentDescription`, nor `testTag`.
+- Train an agent's "which selector should I use" heuristic on the same shape it will see at runtime.
+
+## Payload shape
+
+`UiAutomatorHierarchyNode`, `Selector` in
+[`:data-uiautomator-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/uiautomator/core).
+
+```jsonc
+// uia/hierarchy
+{
+  "merged": true,
+  "nodes": [
+    { "text": "Submit", "contentDescription": null,
+      "testTag": "submit-button",
+      "testTagAncestors": ["checkout-screen"],
+      "role": "Button",
+      "actions": ["uia.click"],
+      "boundsInScreen": "48,200,144,232" }
+  ]
+}
+```
+
+## Enabling
+
+Producer runs once the UIAutomator extension is publicly enabled.
+Hierarchy snapshot is emitted by `UiAutomatorHierarchyExtractor` in
+`:data-uiautomator-hierarchy-android` (Android-only).
+
+## Companion products
+
+- [Layout inspector](../layout-inspector) — `compose/semantics` for the full SemanticsNode shape and `layout/inspector` for positioning.
+- [Focus](../focus) — `compose/focus` for the focused-node subset that a directional traversal would target.
+- [Accessibility](../a11y) — `a11y/hierarchy` for the assistive-technology view of the same tree.

--- a/site/reference/wallpaper.md
+++ b/site/reference/wallpaper.md
@@ -1,0 +1,77 @@
+---
+title: Wallpaper
+parent: Reference
+nav_order: 14
+permalink: /reference/wallpaper/
+---
+
+# Wallpaper
+
+Material You seed colour → derived `ColorScheme`, computed by the same
+algorithm Android uses for system wallpaper-driven theming
+(`material-kolor` / `dynamic-color-utilities`).
+
+## At a glance
+
+| | |
+|---|---|
+| Kind | `compose/wallpaper` |
+| Schema version | 1 |
+| Modules | `:data-wallpaper-core` (published) · `:data-wallpaper-connector` |
+| Render mode | default |
+| Cost | low |
+| Transport | inline |
+| Platforms | Android · Wear |
+
+## What it answers
+
+- Given a seed colour and palette style, what Material 3 `ColorScheme` does the system derive?
+- How does the scheme change across `TonalSpot`, `Vibrant`, `Expressive`, `Monochrome`, etc.?
+- What does the same composable look like for three different wallpaper seeds without booting an emulator?
+
+The connector primes a `WallpaperOverride` so consumer code that
+reads the dynamic colour scheme sees the requested seed and palette
+style.
+
+## What it does NOT answer
+
+- It does not extract a seed from a real wallpaper bitmap — you supply the seed; that is upstream of this product.
+- It does not opine on contrast accessibility — pair with [`a11y/atf`](../a11y) under the chosen scheme.
+- The schema of `derivedColorScheme` matches `compose/theme`'s `colorScheme`; for *which composables consumed which token*, fetch `compose/theme` instead.
+
+## Use cases
+
+- Render Material You previews of a "what does this app look like for users with different wallpapers" PR review.
+- Catch seeds that produce inaccessible contrast pairings on a critical CTA before they ship.
+- Build a marketing screenshot set across the standard Material You palette styles.
+
+## Payload shape
+
+`Material3WallpaperProduct.KIND` /  `WallpaperPayload` in
+[`:data-wallpaper-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/wallpaper/core).
+
+```jsonc
+// compose/wallpaper
+{
+  "seedColor": "#FF6750A4",
+  "isDark": false,
+  "paletteStyle": "TONAL_SPOT",
+  "contrastLevel": 0.0,
+  "derivedColorScheme": {
+    "primary": "#FF6750A4",
+    "onPrimary": "#FFFFFFFF",
+    "surface": "#FFFFFBFE"
+    // …
+  }
+}
+```
+
+## Enabling
+
+Pass a `WallpaperOverride` on `renderNow.overrides.wallpaper` (MCP)
+to drive the seed / style / contrast / dark mode.
+
+## Companion products
+
+- [Theme](../theme) — `compose/theme` for the full Material 3 token set after the wallpaper-derived scheme is plugged in.
+- [Ambient](../ambient) — `compose/ambient` for the Wear ambient-state side of the same render.


### PR DESCRIPTION
Adds a Jekyll site under `site/` that publishes to GitHub Pages via a
new workflow. Home page is intentionally minimal — install snippet and
jump-offs to the VS Code Marketplace, Maven Central, the agent skill,
and the GitHub Actions composite actions.

The reference section has one page per data extension (a11y, ambient,
focus, fonts, history-diff, layout-inspector, recomposition,
render-trace, resources, scroll, strings/i18n, theme, uiautomator,
wallpaper, test-failure) following a standard structure: at-a-glance
metadata, what it answers, what it deliberately does not, use cases,
payload shape, how to enable, and companion products.

The site uses just-the-docs as a remote theme, so no Gemfile.lock is
required at build time. Built artefacts are gitignored under
`site/_site/`.