### PR TITLE
docs: link the GitHub Pages site from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # compose-ai-tools
 
+**[Documentation](https://yschimke.github.io/compose-ai-tools/)** —
+install, VS Code Marketplace, and one-page-per-product reference for
+each data extension.
+
 Render `@Preview` composables to PNG outside Android Studio, so AI coding
 agents can see what they're changing. Works with Jetpack Compose (Android,
 via Robolectric) and Compose Multiplatform Desktop (via `ImageComposeScene`).
@@ -91,6 +95,7 @@ Have one to add? Open a PR or [an issue](https://github.com/yschimke/compose-ai-
 
 ## More
 
+- [Documentation site](https://yschimke.github.io/compose-ai-tools/) — installation, VS Code Marketplace, and the per-product data-extension reference.
 - [How it works](docs/HOW_IT_WORKS.md) — discovery, renderer, caching, project structure, plugin configuration.
 - [CI install action](.github/actions/install/README.md) — pin the CLI on `$PATH` in any GitHub Actions job, with version-catalog + Renovate recipes.
 - [Cloud sandbox setup](skills/compose-preview/design/CLAUDE_CLOUD.md) — Claude Code on the web, network allowlist.


### PR DESCRIPTION
## Summary

- Adds a prominent **Documentation** link near the top of the README pointing at the GitHub Pages site published in #925.
- Adds a matching entry in the existing "More" section so the same link is reachable from the bottom navigation.

## Test plan

- [ ] README renders correctly on the repo home page.
- [ ] Both links resolve to `https://yschimke.github.io/compose-ai-tools/` once Pages has its first successful deploy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vu8828VC96oFKRA9yVhoKo)_