### PR TITLE
feat: add `force` escape hatch to render_preview + CLI to replace `rm -rf build/classes/`

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -4,6 +4,7 @@ import java.awt.image.BufferedImage
 import java.io.File
 import java.nio.ByteBuffer
 import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.imageio.ImageIO
 import kotlin.system.exitProcess
 import kotlinx.serialization.EncodeDefault
@@ -264,6 +265,36 @@ abstract class Command(protected val args: List<String>) {
    * cached on first call.
    */
   protected val brief: Boolean = "--brief" in args
+
+  /**
+   * Sanctioned escape hatch when an agent thinks `:renderAllPreviews` is serving a stale render.
+   * Set via `--force=<reason>`; threaded into Gradle as `--rerun-tasks` so every input task
+   * re-executes regardless of UP-TO-DATE. **Never** runs `:clean` and **never** touches
+   * `build/classes/` — agents that delete class files directly are exactly the failure mode we're
+   * giving an alternative to. Each use is logged to stderr with a pointer to issue #924, where
+   * agents are asked to report the freshness gap that made them reach for it.
+   */
+  protected val forceReason: String? = args.flagValue("--force")?.takeIf { it.isNotBlank() }
+
+  private val forceNoticePrinted = AtomicBoolean(false)
+
+  /**
+   * Build the gradle-side argument list for a render-pipeline task, prepending `--rerun-tasks` when
+   * [forceReason] is set so the build re-executes even if Gradle's UP-TO-DATE check would skip it.
+   * Emits a one-line stderr notice the first time it's called per process so the agent (and the
+   * human reading their transcript) can see the reason and the tracking-issue link.
+   */
+  protected fun gradleArgsWithForce(extra: List<String> = emptyList()): List<String> {
+    val reason = forceReason ?: return extra
+    if (forceNoticePrinted.compareAndSet(false, true)) {
+      System.err.println(
+        "compose-preview --force: reason='$reason' — passing --rerun-tasks. " +
+          "Please report on https://github.com/yschimke/compose-ai-tools/issues/924 " +
+          "(do not delete build/classes/ — that's what this flag exists to replace)."
+      )
+    }
+    return listOf("--rerun-tasks") + extra
+  }
 
   abstract fun run()
 
@@ -787,7 +818,8 @@ class ShowCommand(args: List<String>) : Command(args) {
   private val jsonOutput = "--json" in args
 
   override fun run() {
-    val outcome = renderAllModules(silenceStdout = jsonOutput)
+    val outcome =
+      renderAllModules(silenceStdout = jsonOutput, gradleArguments = gradleArgsWithForce())
     if (!outcome.buildOk) {
       System.err.println("Render failed")
       System.out.flush()
@@ -926,7 +958,7 @@ class RenderCommand(args: List<String>) : Command(args) {
       val modules = resolveModules(gradle)
       val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
 
-      if (!runGradle(gradle, *tasks)) {
+      if (!runGradle(gradle, *tasks, arguments = gradleArgsWithForce())) {
         reportRenderFailures(gradle)
         exitProcess(2)
       }
@@ -989,7 +1021,7 @@ class A11yCommand(args: List<String>, private val forceEnable: Boolean = false) 
   private val failOn: String? = args.flagValue("--fail-on")
 
   override fun run() {
-    val gradleArguments =
+    val a11yArgs =
       if (forceEnable) {
         listOf(
           "-PcomposePreview.previewExtensions.a11y.enableAllChecks=true",
@@ -998,7 +1030,8 @@ class A11yCommand(args: List<String>, private val forceEnable: Boolean = false) 
       } else {
         emptyList()
       }
-    val outcome = renderAllModules(silenceStdout = jsonOutput, gradleArguments = gradleArguments)
+    val outcome =
+      renderAllModules(silenceStdout = jsonOutput, gradleArguments = gradleArgsWithForce(a11yArgs))
 
     val enabledModules = outcome.manifests.filter { it.second.accessibilityReport != null }
     if (enabledModules.isEmpty()) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -126,6 +126,10 @@ private fun printUsage() {
       --verbose, -v        Show full Gradle build output (implies --progress)
       --timeout <seconds>  Gradle build timeout (default: 300)
       --fail-on <level>    a11y: exit non-zero on 'errors' or 'warnings' (default: mirror Gradle)
+      --force=<reason>     Sanctioned escape hatch when a render looks stale: passes
+                           --rerun-tasks to Gradle so every input task re-executes. Does NOT
+                           run :clean and does NOT touch build/classes/. Each use is logged
+                           with a pointer to issue #924 — please report the freshness gap.
 
     OSC 9;4 terminal progress (native taskbar/tab progress bar) is on by
     default in a TTY and auto-disables when stdout is piped or redirected.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ForceFlagTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ForceFlagTest.kt
@@ -1,0 +1,68 @@
+package ee.schimke.composeai.cli
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for the `--force=<reason>` flag wired into [Command]. The flag is the sanctioned
+ * alternative to agents reaching for `rm -rf build/classes/...`; this test pins:
+ * - `--force=<reason>` produces `--rerun-tasks` as the leading Gradle argument.
+ * - No `--force` produces no extra Gradle argument (preserves the cache-respecting default).
+ * - The first call emits a one-line stderr notice mentioning the reason and issue #924, so the
+ *   transcript carries the report-this-please breadcrumb.
+ *
+ * See https://github.com/yschimke/compose-ai-tools/issues/924.
+ */
+class ForceFlagTest {
+
+  /** Trivial [Command] subclass that exposes [gradleArgsWithForce] for direct assertion. */
+  private class Probe(args: List<String>) : Command(args) {
+    override fun run() = error("not used")
+
+    fun args(extra: List<String> = emptyList()): List<String> = gradleArgsWithForce(extra)
+  }
+
+  @Test
+  fun `force=reason prepends rerun-tasks and warns once with issue link`() {
+    val probe = Probe(listOf("--force=mtime not advancing"))
+    val captured = captureStderr { probe.args() }
+    assertEquals(listOf("--rerun-tasks", "-Pextra=1"), probe.args(listOf("-Pextra=1")))
+    assertTrue("mtime not advancing" in captured, "captured=$captured")
+    assertTrue("924" in captured, "captured=$captured")
+  }
+
+  @Test
+  fun `force flag with space-separated value also works`() {
+    val probe = Probe(listOf("--force", "edit didn't reflect"))
+    assertEquals(listOf("--rerun-tasks"), probe.args())
+  }
+
+  @Test
+  fun `no force produces no extra args`() {
+    val probe = Probe(emptyList())
+    assertEquals(listOf("-Pkeep=true"), probe.args(listOf("-Pkeep=true")))
+  }
+
+  @Test
+  fun `blank force reason is ignored to prevent silent --rerun-tasks`() {
+    // `--force=` with no value or only whitespace doesn't qualify as a reason — the field exists
+    // so the operator can find the report on issue #924, so an empty string defeats the purpose.
+    val probe = Probe(listOf("--force="))
+    assertEquals(emptyList(), probe.args())
+  }
+
+  private fun captureStderr(block: () -> Unit): String {
+    val originalErr = System.err
+    val buf = ByteArrayOutputStream()
+    System.setErr(PrintStream(buf))
+    try {
+      block()
+    } finally {
+      System.setErr(originalErr)
+    }
+    return buf.toString()
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -936,7 +936,11 @@ class DaemonMcpServer(
       ),
       ToolDef(
         name = "render_preview",
-        description = "Force-render a preview by URI, bypassing any cache. Returns the PNG inline.",
+        description =
+          "Render a preview by URI, bypassing the in-memory render cache. Returns the PNG inline. " +
+            "Pass `force={reason}` only when the freshness probe missed a real edit (this should be rare); " +
+            "report each use on https://github.com/yschimke/compose-ai-tools/issues/924. " +
+            "Do NOT delete `build/classes/...` or run `./gradlew clean` to chase a stale render.",
         inputSchema =
           parseSchema(
             """
@@ -944,7 +948,8 @@ class DaemonMcpServer(
               "type":"object",
               "properties":{
                 "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"},
-                "overrides":{"type":"object","description":"Optional per-call display overrides."}
+                "overrides":{"type":"object","description":"Optional per-call display overrides."},
+                "force":{"type":"object","description":"Sanctioned escape hatch when the freshness probe missed an edit. Forwards fileChanged({kind:\"classpath\"}) before rendering, dropping the daemon's user classloader. Each use is logged + counted; please report on issue #924.","properties":{"reason":{"type":"string","description":"Human-readable reason for needing force (required)."}},"required":["reason"]}
               },
               "required":["uri"]
             }
@@ -1059,10 +1064,17 @@ class DaemonMcpServer(
       ToolDef(
         name = "render_preview",
         description =
-          "Force-render a preview by URI, bypassing any cache. Returns the rendered PNG inline. " +
-            "Optional `overrides` apply per-call display-property overrides (size, density, " +
+          "Render a preview by URI, bypassing the in-memory render cache. Returns the rendered PNG " +
+            "inline. Optional `overrides` apply per-call display-property overrides (size, density, " +
             "locale, fontScale, uiMode, orientation, device, inspectionMode) — see PROTOCOL.md " +
-            "§ 5 (`renderNow.overrides`).",
+            "§ 5 (`renderNow.overrides`). " +
+            "Optional `force={reason}` is the sanctioned escape hatch for when the freshness " +
+            "probe missed a real edit — it forwards a `fileChanged({kind:\"classpath\"})` to every " +
+            "replica before rendering, dropping the daemon's user classloader. Use of `force` is a " +
+            "freshness-logic gap; please post a comment on " +
+            "https://github.com/yschimke/compose-ai-tools/issues/924 with the URI, reason, and the " +
+            "edit that didn't land. Do NOT delete `build/classes/...` or run `./gradlew clean` to " +
+            "chase a stale render.",
         inputSchema =
           parseSchema(
             """
@@ -1094,6 +1106,14 @@ class DaemonMcpServer(
                       }
                     }
                   }
+                },
+                "force":{
+                  "type":"object",
+                  "description":"Sanctioned escape hatch for stale renders. Forwards a fileChanged({kind:\"classpath\"}) to every replica of this URI's daemon before issuing renderNow, dropping the daemon's user classloader. Each use bumps a `forces.used` counter and is logged in `recent` (see `status`). Please report on https://github.com/yschimke/compose-ai-tools/issues/924.",
+                  "properties":{
+                    "reason":{"type":"string","description":"Human-readable reason for needing force (required). Stored in the recent-forces ring buffer for debugging."}
+                  },
+                  "required":["reason"]
                 }
               },
               "required":["uri"]
@@ -1727,6 +1747,17 @@ class DaemonMcpServer(
             return errorCallToolResult("render_preview: invalid overrides: ${e.message}")
           }
       }
+    val forceReason =
+      args["force"]?.let { force ->
+        val reason =
+          (force as? JsonObject)?.get("reason")?.jsonPrimitive?.contentOrNull?.takeIf {
+            it.isNotBlank()
+          }
+            ?: return errorCallToolResult(
+              "render_preview: 'force' requires a non-empty 'reason' string"
+            )
+        reason
+      }
     if (overrides != null) {
       val daemon = supervisor.daemonFor(uri.workspaceId, uri.modulePath)
       val violations = validateOverrides(overrides, daemon)
@@ -1734,11 +1765,41 @@ class DaemonMcpServer(
         return errorCallToolResult("render_preview: ${violations.joinToString("; ")}")
       }
     }
+    if (forceReason != null) invalidateClasspathForForce(uri, forceReason)
     return runCatching {
         val bytes = renderAndReadBytes(uri, overrides = overrides)
         pngCallToolResult(Base64.getEncoder().encodeToString(bytes))
       }
       .getOrElse { errorCallToolResult("render_preview failed: ${it.message}") }
+  }
+
+  /**
+   * Sanctioned classpath invalidation for `render_preview.force`. Forwards a
+   * `fileChanged({kind:"classpath"})` to every replica of the URI's daemon so the daemon's
+   * `UserClassLoaderHolder` rotates before the next `renderNow` binds. Bumps `forces.used` and
+   * keeps the reason in the recent-forces ring buffer so the operator can find it via `status`.
+   *
+   * Each call is a freshness-logic gap; report on
+   * https://github.com/yschimke/compose-ai-tools/issues/924.
+   */
+  private fun invalidateClasspathForForce(uri: PreviewUri, reason: String) {
+    val daemon = supervisor.daemonFor(uri.workspaceId, uri.modulePath)
+    // Use the catalogued source file when we have one (gives the daemon a real path to log) and
+    // fall back to a synthetic marker otherwise. The daemon doesn't gate the swap on path
+    // existence — it only cares about `kind`.
+    val path =
+      catalog[DaemonAddr(uri.workspaceId, uri.modulePath)]?.get(uri.previewFqn)?.sourceFile
+        ?: "force-render://${uri.previewFqn}"
+    daemon.allClients().forEach { client ->
+      runCatching {
+        client.fileChanged(path = path, kind = FileKind.CLASSPATH, changeType = ChangeType.MODIFIED)
+      }
+    }
+    freshnessMetrics.recordForce(uri.toUri(), reason)
+    System.err.println(
+      "render_preview.force: ${uri.toUri()} reason='$reason' — please report on " +
+        "https://github.com/yschimke/compose-ai-tools/issues/924"
+    )
   }
 
   /**

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/FreshnessMetrics.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/FreshnessMetrics.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 
 /**
- * Counters surfaced via the `status` MCP tool. Three buckets:
+ * Counters surfaced via the `status` MCP tool. Four buckets:
  *
  * 1. **Probe outcomes** — every call to `ensureSourceFreshBeforeRender` lands in exactly one of
  *    these buckets, so an operator can see the rate of "actually changed" vs "unchanged" vs
@@ -24,6 +24,10 @@ import kotlinx.serialization.json.putJsonObject
  *    despite no source change (non-deterministic — points at clock-reading composables, daemon
  *    classloader bugs, or build-output drift). Recent non-deterministic URIs are kept in a small
  *    ring buffer so the operator can spot offending previews.
+ * 4. **Forces** — every `render_preview.force` call. Bumped from
+ *    `DaemonMcpServer.invalidateClasspathForForce`; the recent-reasons ring buffer is what an
+ *    operator pastes into a comment on issue #924 when reporting the gap that made the agent reach
+ *    for the escape hatch.
  */
 class FreshnessMetrics {
 
@@ -57,12 +61,24 @@ class FreshnessMetrics {
   val samplingDeterministic = AtomicLong()
   val samplingNondeterministic = AtomicLong()
 
+  // Force counters — bumped by `render_preview` when an agent passed `force.reason`. Each call here
+  // is an agent telling us our freshness logic missed an edit; the goal is for this to stay near
+  // zero. See https://github.com/yschimke/compose-ai-tools/issues/924.
+  val forcesUsed = AtomicLong()
+
   /**
    * Last-seen timestamp for previews observed to render non-deterministically. Insertion-ordered;
    * the oldest entry is evicted past [MAX_RECENT_NONDETERMINISTIC]. Synchronised because the
    * sampling thread and the status-tool thread both touch it.
    */
   private val recentNondeterministic = LinkedHashMap<String, Long>()
+
+  /**
+   * Recent `render_preview.force.reason` strings, paired with the URI they fired against.
+   * Insertion-ordered; oldest evicted past [MAX_RECENT_FORCES]. Surfaced via `status` so an
+   * operator can see why agents reached for the escape hatch and link the report on issue #924.
+   */
+  private val recentForces = ArrayDeque<ForceRecord>()
 
   @Synchronized
   fun recordNondeterministic(uri: String) {
@@ -76,6 +92,17 @@ class FreshnessMetrics {
 
   @Synchronized
   fun snapshotNondeterministic(): Map<String, Long> = LinkedHashMap(recentNondeterministic)
+
+  @Synchronized
+  fun recordForce(uri: String, reason: String) {
+    forcesUsed.incrementAndGet()
+    recentForces.addLast(ForceRecord(uri = uri, reason = reason, atMs = System.currentTimeMillis()))
+    while (recentForces.size > MAX_RECENT_FORCES) recentForces.removeFirst()
+  }
+
+  @Synchronized fun snapshotForces(): List<ForceRecord> = recentForces.toList()
+
+  data class ForceRecord(val uri: String, val reason: String, val atMs: Long)
 
   fun toJson(): JsonObject = buildJsonObject {
     putJsonObject("probes") {
@@ -115,9 +142,24 @@ class FreshnessMetrics {
         }
       }
     }
+    putJsonObject("forces") {
+      put("used", JsonPrimitive(forcesUsed.get()))
+      putJsonArray("recent") {
+        snapshotForces().forEach { record ->
+          add(
+            buildJsonObject {
+              put("uri", record.uri)
+              put("reason", record.reason)
+              put("atMs", JsonPrimitive(record.atMs))
+            }
+          )
+        }
+      }
+    }
   }
 
   companion object {
     private const val MAX_RECENT_NONDETERMINISTIC = 32
+    private const val MAX_RECENT_FORCES = 16
   }
 }

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -3026,6 +3026,123 @@ class DaemonMcpServerTest {
   }
 
   // -------------------------------------------------------------------------
+  // `render_preview.force` — sanctioned escape hatch for stale renders.
+  // Issue #924 tracks reports; the field exists to take `rm -rf build/classes/`
+  // off the table for agents who'd otherwise reach for it.
+  // -------------------------------------------------------------------------
+
+  @Test
+  fun `render_preview with force forwards fileChanged classpath before renderNow`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    val moduleDir = tmp.newFolder("workspace", "module")
+    val sourceFile = moduleDir.resolve("src/main/kotlin/com/example/Preview.kt")
+    sourceFile.parentFile.mkdirs()
+    sourceFile.writeText("@Preview fun Red() {}")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId, sourceFile = "src/main/kotlin/com/example/Preview.kt")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47)
+    val pngFile = tmp.newFile("force-render.png")
+    Files.write(pngFile.toPath(), pngBytes)
+    daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    client.callTool(
+      "render_preview",
+      buildJsonObject {
+        put("uri", uri)
+        putJsonObject("force") { put("reason", "edit to Preview.kt didn't reflect") }
+      },
+      timeoutMs = 10_000,
+    )
+
+    val fileChanged = daemon.fileChanges.poll(2_000, TimeUnit.MILLISECONDS)
+    assertWithMessage("force must forward fileChanged before renderNow")
+      .that(fileChanged)
+      .isNotNull()
+    assertThat(fileChanged!!["kind"]?.jsonPrimitive?.contentOrNull).isEqualTo("classpath")
+    assertThat(fileChanged["changeType"]?.jsonPrimitive?.contentOrNull).isEqualTo("modified")
+    // Path defaults to the catalogued source file when present.
+    assertThat(fileChanged["path"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("src/main/kotlin/com/example/Preview.kt")
+
+    assertThat(daemon.renderRequests.poll(2_000, TimeUnit.MILLISECONDS))
+      .isEqualTo(listOf(previewId))
+  }
+
+  @Test
+  fun `render_preview rejects force without a non-empty reason`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    warmDaemonFor(workspaceId, ":module")
+
+    val uri = PreviewUri(workspaceId, ":module", "com.example.Red").toUri()
+    val missingReason =
+      client.callTool(
+        "render_preview",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonObject("force") {}
+        },
+      )
+    assertThat(missingReason.firstTextContent()).contains("'force' requires a non-empty 'reason'")
+
+    val blankReason =
+      client.callTool(
+        "render_preview",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonObject("force") { put("reason", "   ") }
+        },
+      )
+    assertThat(blankReason.firstTextContent()).contains("'force' requires a non-empty 'reason'")
+  }
+
+  @Test
+  fun `force usage bumps forces metric and surfaces the reason via status`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47)
+    val pngFile = tmp.newFile("force-metric.png")
+    Files.write(pngFile.toPath(), pngBytes)
+    daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    client.callTool(
+      "render_preview",
+      buildJsonObject {
+        put("uri", uri)
+        putJsonObject("force") { put("reason", "agent reached for rm -rf — caught by linter") }
+      },
+      timeoutMs = 10_000,
+    )
+
+    val statusResp = client.callTool("status", buildJsonObject {})
+    val payload = json.parseToJsonElement(statusResp.firstTextContent()).jsonObject
+    val forces = payload["freshness"]?.jsonObject?.get("forces")?.jsonObject!!
+    assertThat(forces["used"]?.jsonPrimitive?.content).isEqualTo("1")
+    val recent = forces["recent"]!!.jsonArray
+    assertThat(recent).hasSize(1)
+    val first = recent[0].jsonObject
+    assertThat(first["uri"]?.jsonPrimitive?.contentOrNull).isEqualTo(uri)
+    assertThat(first["reason"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("agent reached for rm -rf — caught by linter")
+  }
+
+  // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
 

--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -68,6 +68,10 @@ Options:
   --progress           Print per-task milestone/heartbeat lines to stderr
   --verbose, -v        Full Gradle build output (implies --progress)
   --timeout <seconds>  Gradle build timeout (default: 300)
+  --force=<reason>     Sanctioned escape hatch for stale renders: passes
+                       --rerun-tasks to Gradle. Does NOT run :clean and
+                       does NOT touch build/classes/. Logs the reason and
+                       points at issue #924 — please report.
 ```
 
 OSC 9;4 terminal progress (native taskbar/tab progress bar) is on by default

--- a/skills/compose-preview/design/MCP.md
+++ b/skills/compose-preview/design/MCP.md
@@ -20,6 +20,20 @@ common stale state. Treat its output as authoritative; do not run
 
 In particular:
 
+- **Do not delete `build/classes/...` or `build/intermediates/...`.** Some
+  agent loops have been observed reaching for `rm -rf` (or `./gradlew clean`)
+  when a render looks stale. Don't. The sanctioned escape hatch is the
+  `force` field on `render_preview`:
+  ```json
+  { "uri": "compose-preview://...", "force": { "reason": "edit to Foo.kt didn't reflect" } }
+  ```
+  It forwards `fileChanged({kind:"classpath"})` to every replica before
+  rendering, dropping the daemon's user classloader — same effect as
+  invalidating the bytecode, without touching `build/`. Every use bumps a
+  `forces.used` counter and is logged. **Report each use** on
+  [issue #924](https://github.com/yschimke/compose-ai-tools/issues/924)
+  with the URI, reason, and the edit that didn't land — those reports are
+  how the freshness logic gets fixed.
 - **Do not re-run `mcp install`** to recover from a perceived hang, a stale
   render, or a dependency bump. `install` is a one-time bootstrap; the only
   conditions that warrant re-running it are the ones `mcp doctor` flags as
@@ -132,9 +146,11 @@ for the full table) cover the rest:
   view (e.g. the agent invoked the Edit tool from a different process). The
   daemon's classloader-swap fast path picks up bytecode changes without a
   full reboot.
-- `render_preview(uri, overrides?)` — force-render bypassing cache. Use
-  `overrides` to flip device, locale, fontScale, uiMode, orientation, or
-  density per call without editing the `@Preview` annotation.
+- `render_preview(uri, overrides?, force?)` — render bypassing the in-memory
+  render cache. Use `overrides` to flip device, locale, fontScale, uiMode,
+  orientation, or density per call without editing the `@Preview` annotation.
+  `force = { reason }` is the sanctioned escape hatch for stale renders —
+  see the "do not delete `build/classes/`" note above.
 - `history_list` / `history_diff` — proxy the daemon's history feature for
   comparing rendered output across runs.
 - `list_data_products` / `get_preview_data` / `subscribe_preview_data` —

--- a/skills/compose-preview/design/PERMISSIONS.md
+++ b/skills/compose-preview/design/PERMISSIONS.md
@@ -22,6 +22,20 @@ keep anything that publishes or mutates shared state on the prompt path.
   on `gh api repos/<owner>/<repo>/{comments,actions,contents,…}`. The
   `gh run` calls come up constantly when a render fails on the runner.
 
+**Never** (even with consent — these are the wrong tool for the job):
+
+- **`rm -rf` against `build/classes/**`, `build/intermediates/**`, or
+  `build/tmp/**`.** Agents that delete compiled output to "force" a fresh
+  render are masking a bug in the freshness probe and risk leaving the
+  module in a broken state. Use `compose-preview render --force=<reason>`
+  (CLI) or `render_preview` with `force = { reason }` (MCP) instead — both
+  go through the daemon's classloader-swap path without touching `build/`.
+  Report each use on
+  [issue #924](https://github.com/yschimke/compose-ai-tools/issues/924).
+- **`./gradlew clean`** for the same reason. `--rerun-tasks` (which the
+  CLI's `--force` flag sets for you) re-executes the render pipeline
+  without throwing away the rest of `build/`.
+
 **Require explicit consent** (publish or mutate shared state — keep on the
 prompt path):
 


### PR DESCRIPTION
Some agent loops have been observed deleting `build/classes/...` (or running
`./gradlew clean`) when they think a preview render is stale — destructive,
masks the real bug, and risks breaking the build.

Two sanctioned alternatives:

- MCP: `render_preview` accepts `force = { reason: string }`. The server
  forwards `fileChanged({kind:"classpath"})` to every replica before
  `renderNow`, dropping the daemon's user classloader. Each call bumps a
  `forces.used` counter and is recorded in a small ring buffer surfaced via
  `status` (with the URI + reason), so an operator can find what made the
  agent reach for the escape hatch.
- CLI: `compose-preview show|render|a11y --force=<reason>` passes
  `--rerun-tasks` to Gradle. Neither path runs `:clean` or touches
  `build/classes/`.

Both surfaces log a one-line stderr notice with the reason and a pointer to
issue #924, where each use is meant to be reported with the freshness-probe
output and the edit that didn't land. The skill docs (MCP.md, PERMISSIONS.md,
SKILL.md) gain explicit "do not delete `build/classes/`" guidance.