### PR TITLE
Remove GitHub Packages publishing, add standalone MCP server build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,4 +55,3 @@ jobs:
     secrets: inherit
     permissions:
       contents: write   # needed by the called workflow's `release` job
-      packages: write   # needed by the called workflow's GH Packages publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release
 
-# Builds and publishes the CLI, VS Code extension, and Gradle plugin +
-# renderer-android for a given tag. Uploads the CLI/VSIX assets onto the
-# GitHub Release (creating it if it doesn't exist yet).
+# Builds and publishes the CLI, MCP server, VS Code extension, skills, and
+# Gradle plugin + renderer-android for a given tag. Uploads the CLI / MCP /
+# VSIX / skill assets onto the GitHub Release (creating it if it doesn't
+# exist yet). Maven coordinates ship to Maven Central only — we do not
+# mirror to GitHub Packages, since Central is the supported consumer path.
 #
 # Entry points:
 #   - workflow_call: called from release-please.yml after release-please
@@ -31,7 +33,6 @@ on:
       - 'v*'
 
 # Workflow-level default is read-only. Each job widens only what it needs:
-# - publish-gradle-plugin: packages: write (for GH Packages)
 # - release: contents: write (creates/updates the GitHub Release, uploads assets)
 permissions:
   contents: read
@@ -51,10 +52,11 @@ env:
 
 jobs:
   # Run gradle publish AFTER the other builds succeed so we don't orphan a
-  # published Maven artifact if the VSIX or CLI build fails (GitHub Packages
-  # refuses to overwrite an already-published release version — see #409).
+  # published Maven Central artifact if the VSIX, CLI, or MCP build fails —
+  # Central refuses to overwrite an already-published release version, so a
+  # half-released version can't be quietly rebuilt.
   # `renderer-android` is published alongside the plugin so external consumers
-  # that apply the plugin via GitHub Packages also get the Robolectric-based
+  # that apply the plugin via Maven Central also get the Robolectric-based
   # Android renderer AAR — the plugin resolves it via matching version.
   # `preview-annotations` ships the `@ScrollingPreview` marker that Compose
   # apps add to their compileOnly classpath, so it must publish in lockstep.
@@ -64,16 +66,11 @@ jobs:
   # docs/daemon/DESIGN.md § 17 for the publishing decision and § 19 for the
   # captureToImage fallback if Roborazzi's API ever does break binary compat.
   publish-gradle-plugin:
-    needs: [build-cli, build-vscode-extension]
+    needs: [build-applications, build-vscode-extension]
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write   # push to GitHub Packages
     env:
-      # Signing creds are shared by both publish steps. vanniktech's
-      # `signAllPublications()` wires the `sign*` tasks as dependencies of
-      # every publish task — including the GH Packages publication — so
-      # "no configured signatory" errors out either publish without them.
       ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
       ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
       ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
@@ -89,18 +86,6 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - name: Publish plugin, renderer-android, data-*, preview-annotations, daemon-* to GitHub Packages
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          # See the comment in snapshot.yml's publish step: root-level abbreviation fans out
-          # to every subproject applying `composeai.maven-publishing`; `:gradle-plugin` is an
-          # includeBuild and needs an explicit address.
-          ./gradlew \
-            :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository \
-            publishAllPublicationsToGitHubPackagesRepository
       - name: Publish plugin, renderer-android, data-*, preview-annotations, daemon-* to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
@@ -113,7 +98,12 @@ jobs:
             :gradle-plugin:publishAndReleaseToMavenCentral \
             publishAndReleaseToMavenCentral
 
-  build-cli:
+  # Build the runnable applications shipped on each GitHub Release: the CLI
+  # (`compose-preview-*`) and the standalone MCP server (`compose-preview-mcp-*`).
+  # The CLI tarball already implementation-bundles `:mcp`, so the standalone
+  # MCP archive is for consumers who only want `compose-preview-mcp` on its
+  # own (e.g. wiring it into an MCP client without dragging the CLI in).
+  build-applications:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -125,14 +115,16 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - name: Build CLI distribution
-        run: ./gradlew :cli:distZip :cli:distTar
+      - name: Build CLI and MCP distributions
+        run: ./gradlew :cli:distZip :cli:distTar :mcp:distZip :mcp:distTar
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: cli-dist
+          name: app-dist
           path: |
             cli/build/distributions/compose-preview-*.zip
             cli/build/distributions/compose-preview-*.tar.gz
+            mcp/build/distributions/compose-preview-mcp-*.zip
+            mcp/build/distributions/compose-preview-mcp-*.tar.gz
           retention-days: 1
 
   # Pack each `skills/<name>/` directory into its own `<name>-skill-<ver>.tar.gz`

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
@@ -7,7 +7,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.api.publish.PublishingExtension
 import org.gradle.kotlin.dsl.configure
 
 abstract class ComposeAiMavenPublishingExtension
@@ -43,23 +42,6 @@ class ComposeAiMavenPublishingPlugin : Plugin<Project> {
     project.version =
       project.providers.environmentVariable("PLUGIN_VERSION").orNull
         ?: project.nextPatchSnapshotVersion()
-
-    project.extensions.configure<PublishingExtension> {
-      repositories.maven {
-        name = "GitHubPackages"
-        url =
-          project.uri(
-            project.providers
-              .environmentVariable("GITHUB_REPOSITORY")
-              .map { "https://maven.pkg.github.com/$it" }
-              .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-          )
-        credentials {
-          username = project.providers.environmentVariable("GITHUB_ACTOR").orNull
-          password = project.providers.environmentVariable("GITHUB_TOKEN").orNull
-        }
-      }
-    }
 
     project.afterEvaluate {
       val artifactId =

--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -297,8 +297,6 @@ val daemonHarnessClasspathFile by configurations.creating {
   }
 }
 
-// GitHub Packages mirror — same shape as `:renderer-android`.
-
 // Use the new (non-deprecated) AndroidSingleVariantLibrary constructor — takes typed JavadocJar /
 // SourcesJar instead of booleans. `JavadocJar.Empty()` ships an empty javadoc jar (Maven Central
 // requires the file to exist) without invoking javadoc/Dokka. javadoc 17 fails on AndroidX

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -55,8 +55,6 @@ val generateDaemonVersionResource by tasks.registering {
 
 sourceSets.main.get().resources.srcDir(generateDaemonVersionResource)
 
-// GitHub Packages mirror — same shape as `:renderer-android` and `:preview-annotations`.
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "daemon-core",

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -143,8 +143,6 @@ afterEvaluate {
     }
 }
 
-// GitHub Packages mirror — same shape as `:renderer-android` and `:preview-annotations`.
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "daemon-desktop",

--- a/data/a11y/core/build.gradle.kts
+++ b/data/a11y/core/build.gradle.kts
@@ -50,7 +50,6 @@ dependencies {
   testImplementation(libs.robolectric)
 }
 
-// GitHub Packages repo kept alongside Maven Central for internal/CI convenience.
 // Vanniktech's `AndroidSingleVariantLibrary` creates the release publication
 // (with sources + javadoc jar) — do not create one manually; it clashes.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -37,7 +37,7 @@ Both fallbacks share the same concurrency group as the primary path, so they can
 
 ### What the `release.yml` workflow does
 
-1. Publishes to **Maven Central** via the Central Portal (and mirrors to GitHub Packages):
+1. Publishes to **Maven Central** via the Central Portal:
    - **Gradle plugin** — `ee.schimke.composeai:compose-preview-plugin`
    - **Android renderer AAR** — `ee.schimke.composeai:renderer-android`
    - **Preview annotations** — `ee.schimke.composeai:preview-annotations`
@@ -45,9 +45,12 @@ Both fallbacks share the same concurrency group as the primary path, so they can
    - **Daemon desktop** (pre-1.0) — `ee.schimke.composeai:daemon-desktop` — Compose Multiplatform desktop backend (DesktopHost + DaemonMain)
    - **Daemon android** (pre-1.0) — `ee.schimke.composeai:daemon-android` — Robolectric backend; Compose / Roborazzi / UI-test stay `compileOnly`, consumer supplies runtime versions
    - **Data product connectors** — `ee.schimke.composeai:data-*-connector` artifacts used by daemon modules, including recomposition
-2. Builds the **CLI** as `.zip` and `.tar.gz` distributions.
-3. Packages the **VS Code extension** as a `.vsix` file and publishes it to the **VS Code Marketplace** and **Open VSX** (runs alongside the Release upload, so a marketplace outage can't block the GitHub Release).
-4. Uploads the CLI + VS Code extension artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).
+
+   Maven Central is the only Maven coordinate source — we no longer mirror jars onto GitHub Packages. Consumers point Gradle at `mavenCentral()` and resolve every module from there.
+2. Builds the **CLI** and the standalone **MCP server** as `.zip` and `.tar.gz` distributions (`compose-preview-<ver>.{zip,tar.gz}` and `compose-preview-mcp-<ver>.{zip,tar.gz}`). The CLI tarball already implementation-bundles `:mcp`, so the MCP archive is for consumers who want to wire the server into an MCP client without dragging the CLI in.
+3. Packs each `skills/<name>/` directory into `<name>-skill-<ver>.tar.gz`.
+4. Packages the **VS Code extension** as a `.vsix` file and publishes it to the **VS Code Marketplace** and **Open VSX** (runs alongside the Release upload, so a marketplace outage can't block the GitHub Release).
+5. Uploads the CLI, MCP, skill, and VS Code extension artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).
 
 The `daemon-*` artifacts are **pre-1.0**; their public API is not yet stable. Expect breakage across minor versions until the surface settles. See [docs/daemon/DESIGN.md § 17](daemon/DESIGN.md) for the architectural decisions and § 19 for the captureToImage fallback path.
 
@@ -62,7 +65,7 @@ Required secrets on the repository:
 | `VSCE_PAT` | Azure DevOps PAT for the `yuri-schimke` VS Code Marketplace publisher (scope: Marketplace → Manage, all accessible orgs) |
 | `OVSX_PAT` | Open VSX PAT for the `yuri-schimke` namespace (https://open-vsx.org/user-settings/tokens) |
 
-`GITHUB_TOKEN` is provided automatically and is used for the GH Packages mirror.
+`GITHUB_TOKEN` is provided automatically and is used by the `release` job to upload assets onto the GitHub Release.
 
 Marketplace publishes are idempotent on re-runs: if the version is already published (e.g. on a `workflow_dispatch` retry for an existing tag), the step logs the "already published" message and exits 0 rather than failing.
 
@@ -161,13 +164,6 @@ plugins {
 }
 ```
 
-### Gradle plugin (GitHub Packages — fallback)
-
-The release workflow also publishes to GitHub Packages for users who
-prefer it. This path requires a PAT with `read:packages` scope; see git
-history for the repository+credentials setup if you need it. Maven
-Central is the supported default.
-
 ### CLI
 
 Download from the [Releases page](https://github.com/yschimke/compose-ai-tools/releases):
@@ -178,6 +174,21 @@ curl -L -o compose-preview.tar.gz \
     https://github.com/yschimke/compose-ai-tools/releases/latest/download/compose-preview-0.10.1.tar.gz
 tar xzf compose-preview.tar.gz
 ./compose-preview-0.10.1/bin/compose-preview list
+```
+<!-- x-release-please-end -->
+
+### MCP server (standalone)
+
+The CLI tarball already bundles the MCP server (`compose-preview mcp serve`).
+A standalone tarball is also attached to each Release for consumers who only
+want the server binary:
+
+<!-- x-release-please-start-version -->
+```bash
+curl -L -o compose-preview-mcp.tar.gz \
+    https://github.com/yschimke/compose-ai-tools/releases/latest/download/compose-preview-mcp-0.10.1.tar.gz
+tar xzf compose-preview-mcp.tar.gz
+./compose-preview-mcp-0.10.1/bin/compose-preview-mcp
 ```
 <!-- x-release-please-end -->
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -26,9 +26,9 @@ gradlePlugin {
   }
 }
 
-// Publish to both GitHub Packages (legacy / CI convenience) and Maven Central
-// via the new Central Portal. Snapshots (version ending in `-SNAPSHOT`) route
-// automatically to `https://central.sonatype.com/repository/maven-snapshots/`.
+// Publish to Maven Central via the Central Portal. Snapshots (version
+// ending in `-SNAPSHOT`) route automatically to
+// `https://central.sonatype.com/repository/maven-snapshots/`.
 
 dependencies {
   implementation(libs.classgraph)
@@ -167,7 +167,7 @@ fun resolveAndroidSdk(rootDir: java.io.File): String {
 
 // Bake the plugin's own version into a resource so it can resolve a matching
 // `renderer-android` AAR at runtime for external consumers (who apply the
-// plugin via GitHub Packages rather than includeBuild).
+// plugin via Maven Central rather than includeBuild).
 val generatePluginVersionResource by tasks.registering {
   val outputDir = layout.buildDirectory.dir("generated/plugin-version-resource")
   val pluginVersion = project.version.toString()


### PR DESCRIPTION
## Summary
This PR removes GitHub Packages as a Maven artifact distribution channel and adds a standalone MCP server distribution to the release workflow. Maven Central is now the sole Maven coordinate source for all published artifacts.

## Key Changes

- **Removed GitHub Packages publishing**: Eliminated the `publishAllPublicationsToGitHubPackagesRepository` gradle task and all related GitHub Packages repository configuration from the Maven publishing plugin
- **Simplified release workflow**: Removed the `packages: write` permission requirement and GitHub Packages-specific environment variables from the `publish-gradle-plugin` job
- **Added standalone MCP server distribution**: 
  - Renamed `build-cli` job to `build-applications` to reflect its expanded scope
  - Extended the build step to compile both CLI and MCP server distributions (`.zip` and `.tar.gz`)
  - Updated artifact upload to include MCP distributions alongside CLI artifacts
- **Updated documentation**: 
  - Clarified that Maven Central is the only supported Maven coordinate source
  - Added installation instructions for the standalone MCP server tarball
  - Removed references to GitHub Packages as a fallback publishing option
- **Cleaned up build scripts**: Removed obsolete comments about GitHub Packages mirroring from `build.gradle.kts` files in daemon and data modules
- **Updated workflow permissions**: Removed `packages: write` from `release-please.yml` since it's no longer needed

## Implementation Details

The MCP server is built alongside the CLI but distributed separately to allow consumers to use the standalone server without pulling in the full CLI. The CLI tarball already bundles the MCP server implementation, so the separate MCP archive is purely for convenience when only the server binary is needed.

All Maven artifacts (Gradle plugin, renderer-android, preview-annotations, daemon modules, and data connectors) now publish exclusively to Maven Central via the Central Portal, with snapshots automatically routing to the Maven Central snapshots repository.

https://claude.ai/code/session_01KM6LQzKPoAo5bZyAyYBKde