### PR TITLE
docs(site): add Token usage row to reference at-a-glance tables

### DIFF
--- a/site/reference/a11y.md
+++ b/site/reference/a11y.md
@@ -20,6 +20,7 @@ PNG, and a 48 dp touch-target audit as four related kinds.
 | Modules | `:data-a11y-core` (published) · `:data-a11y-connector` · `:data-a11y-hierarchy-android` |
 | Render mode | a11y (`composeai.a11y.enabled=true`) |
 | Cost | low |
+| Token usage | ~100 tok inline (e.g. `a11y/atf` ~370 chars); +~1.5 k per `a11y/overlay` PNG read. See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline (JSON) · path (overlay PNG) |
 | Platforms | Android |
 

--- a/site/reference/ambient.md
+++ b/site/reference/ambient.md
@@ -20,6 +20,7 @@ without touching the on-device Wear Services SDK.
 | Modules | `:data-ambient-core` (published) · `:data-ambient-connector` |
 | Render mode | default |
 | Cost | low |
+| Token usage | Inline JSON, not yet benchmarked. See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline |
 | Platforms | Wear OS (Android) |
 

--- a/site/reference/focus.md
+++ b/site/reference/focus.md
@@ -20,6 +20,7 @@ agents can verify keyboard / D-pad navigation without an emulator.
 | Modules | `:data-focus-core` (published) · `:data-focus-connector` |
 | Render mode | default |
 | Cost | low |
+| Token usage | Inline JSON, not yet benchmarked. See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline |
 | Platforms | Android · Desktop · Wear · shared |
 

--- a/site/reference/fonts.md
+++ b/site/reference/fonts.md
@@ -19,6 +19,7 @@ the resolved fallback chain Compose actually picked.
 | Modules | `:data-fonts-core` (published) · `:data-fonts-connector` |
 | Render mode | default |
 | Cost | low |
+| Token usage | Inline JSON, not yet benchmarked. See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline |
 | Platforms | Android · Desktop · shared |
 

--- a/site/reference/history.md
+++ b/site/reference/history.md
@@ -19,6 +19,7 @@ entries (e.g. base render vs. PR head, or before / after a code edit).
 | Modules | `:data-history-core` (published) · `:data-history-connector` |
 | Render mode | default |
 | Cost | low |
+| Token usage | Inline JSON, not yet benchmarked. See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline |
 | Platforms | Android · Desktop · shared |
 

--- a/site/reference/layout-inspector.md
+++ b/site/reference/layout-inspector.md
@@ -20,6 +20,7 @@ projection for testTag / role / mergeMode questions.
 | Modules | `:data-layoutinspector-core` (published) · `:data-layoutinspector-connector` |
 | Render mode | default |
 | Cost | low |
+| Token usage | Inline JSON, not yet benchmarked (scales with hierarchy depth). See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline |
 | Platforms | Android · Desktop · shared |
 

--- a/site/reference/recomposition.md
+++ b/site/reference/recomposition.md
@@ -20,6 +20,7 @@ recomposed N times for one click" reviews.
 | Modules | `:data-recomposition-core` (published) · `:data-recomposition-connector` |
 | Render mode | instrumented |
 | Cost | medium |
+| Token usage | ~1 000–1 500 tok per query (`compose/recomposition` ~3–5 KB). See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline |
 | Platforms | Android · Desktop · shared |
 

--- a/site/reference/render.md
+++ b/site/reference/render.md
@@ -20,6 +20,7 @@ background.
 | Modules | `:data-render-core` (published) · `:data-render-connector` · `:data-render-compose` |
 | Render mode | default · live |
 | Cost | low |
+| Token usage | ~50 tok inline per kind; +~1.5 k per `render/deviceClip` / `render/deviceBackground` PNG read. See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline (JSON) · path (PNG for clip / background) |
 | Platforms | Android · Desktop · shared |
 

--- a/site/reference/resources.md
+++ b/site/reference/resources.md
@@ -21,6 +21,7 @@ resolved value and the source qualifier (default vs. `night`,
 | Modules | `:data-resources-core` (published) · `:data-resources-connector` |
 | Render mode | default |
 | Cost | low |
+| Token usage | ~175 tok per query (`resources/used` ~610 chars). See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline |
 | Platforms | Android |
 

--- a/site/reference/scroll.md
+++ b/site/reference/scroll.md
@@ -20,6 +20,7 @@ through the renderer extension pipeline.
 | Modules | `:data-scroll-core` |
 | Render mode | default |
 | Cost | medium (extra renders per scroll step) |
+| Token usage | Image-only — ~1.5 k tok per `render/scroll/*` PNG read; payload itself is a `path`. See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | path (PNG / GIF) |
 | Platforms | Android · Desktop · shared |
 

--- a/site/reference/strings.md
+++ b/site/reference/strings.md
@@ -19,6 +19,7 @@ locale coverage from `values*/strings.xml` (`i18n/translations`).
 | Modules | `:data-strings-core` (published) · `:data-strings-connector` |
 | Render mode | default |
 | Cost | low |
+| Token usage | ~135 tok inline (`text/strings` ~470 chars); +~1.5 k per rendered PNG read. See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline |
 | Platforms | Android (i18n is Android-only) · Desktop · shared (`text/strings`) |
 

--- a/site/reference/test-failure.md
+++ b/site/reference/test-failure.md
@@ -21,6 +21,7 @@ animation state, and a redacted snapshot summary.
 | Modules | `:data-render-core` (published) · `:data-render-connector` |
 | Render mode | failed render |
 | Cost | low |
+| Token usage | ~195 tok per query (`test/failure` ~680 chars). See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline |
 | Availability | fetch-only after `renderFailed` |
 | Platforms | Android · Desktop · shared |

--- a/site/reference/theme.md
+++ b/site/reference/theme.md
@@ -19,6 +19,7 @@ plus a back-pointer to which nodes consumed each token.
 | Modules | `:data-theme-core` (published) · `:data-theme-connector` |
 | Render mode | default |
 | Cost | medium |
+| Token usage | Inline JSON, not yet benchmarked (scales with consuming nodes). See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline |
 | Platforms | Android · Desktop · shared |
 

--- a/site/reference/uiautomator.md
+++ b/site/reference/uiautomator.md
@@ -20,6 +20,7 @@ per node to formulate a UIAutomator-style `By.text(...)` /
 | Modules | `:data-uiautomator-core` (published) · `:data-uiautomator-hierarchy-android` (published) · `:data-uiautomator-connector` |
 | Render mode | default |
 | Cost | low |
+| Token usage | Inline JSON, not yet benchmarked (scales with selector node count). See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline |
 | Platforms | Android |
 

--- a/site/reference/wallpaper.md
+++ b/site/reference/wallpaper.md
@@ -20,6 +20,7 @@ algorithm Android uses for system wallpaper-driven theming
 | Modules | `:data-wallpaper-core` (published) · `:data-wallpaper-connector` |
 | Render mode | default |
 | Cost | low |
+| Token usage | Inline JSON, not yet benchmarked. See [token usage](https://github.com/yschimke/compose-ai-tools/blob/main/docs/TOKEN_USAGE.md). |
 | Transport | inline |
 | Platforms | Android · Wear |
 


### PR DESCRIPTION
## Summary

- Adds a `Token usage` row to every `site/reference/*.md` at-a-glance table, positioned right after the existing render `Cost` field so the two cost lenses (render time vs. LLM context) sit together.
- For kinds benchmarked in `docs/TOKEN_USAGE.md` — `a11y/atf` + `a11y/overlay`, `compose/recomposition`, `render/deviceClip` / `render/deviceBackground`, `resources/used`, `text/strings`, `test/failure`, and `render/scroll/*` PNG reads — quotes the marginal in-token figure from that doc.
- For the remaining pages (ambient, focus, fonts, history, layout-inspector, theme, uiautomator, wallpaper) flags the row as "not yet benchmarked" with a link to the full token-usage doc, so the table shape stays uniform across the reference section.

## Test plan

- [ ] Skim the rendered Jekyll site (`/reference/*`) and confirm the new `Token usage` row appears in each at-a-glance table without breaking the 2-column layout.
- [ ] Click the `token usage` link on a couple of pages and confirm it lands on `docs/TOKEN_USAGE.md`.
- [ ] Spot-check that the quoted figures match the per-audit table in `docs/TOKEN_USAGE.md` (e.g. recomposition ~1 000–1 500 tok, resources ~175 tok, test-failure ~195 tok).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSYdf6m6w4Teut8nQ5qsrj)_