### PR TITLE
Gate ambient connector registration on wear AAR availability

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -946,8 +946,16 @@ open class RobolectricHost(
       encodedDir = encodedDir,
       // Side-band observers fired before every script-event dispatch. Today only the ambient
       // connector ships one — wakes [AmbientStateController] on activating gestures so a
-      // recording can exercise the ambient ↔ interactive flip mid-script.
-      dispatchObservers = listOf(AmbientInputDispatchObserver()),
+      // recording can exercise the ambient ↔ interactive flip mid-script. Gated on wear-ambient
+      // availability for the same reason as the override extension above (loading
+      // `AmbientInputDispatchObserver` triggers `AmbientStateController` static init, which pulls
+      // in `AmbientLifecycleObserver` types not present on plain-Android consumers).
+      dispatchObservers =
+        if (isWearAmbientAvailable(javaClass.classLoader)) {
+          listOf(AmbientInputDispatchObserver())
+        } else {
+          emptyList()
+        },
     )
   }
 
@@ -1160,8 +1168,13 @@ open class RobolectricHost(
    * is only available under NATIVE graphics mode. The B1.3-era stub render
    * didn't need it but the annotation is harmless when the body is a stub.
    */
+  // The Wear ambient shadow ([ShadowAmbientLifecycleObserver]) is registered conditionally
+  // through [SandboxHoldingRunner.getExtraShadows] — putting it directly on `@Config(shadows=…)`
+  // forces Robolectric to resolve `androidx.wear.ambient.AmbientLifecycleObserver` via the
+  // shadow's `@Implements` annotation during sandbox bootstrap, which fails on non-Wear consumers
+  // whose classpath doesn't ship the Wear AAR. See [SandboxHoldingRunner.getExtraShadows].
   @RunWith(SandboxHoldingRunner::class)
-  @Config(sdk = [ANDROID_SDK], shadows = [ShadowAmbientLifecycleObserver::class])
+  @Config(sdk = [ANDROID_SDK])
   @GraphicsMode(GraphicsMode.Mode.NATIVE)
   class SandboxRunner {
 
@@ -1176,15 +1189,27 @@ open class RobolectricHost(
      * cross-classloader contract clean.
      */
     private val engine: RenderEngine by lazy {
+      // [AmbientPreviewOverrideExtension] (and its companion [AmbientInputDispatchObserver]
+      // registered alongside [acquireRecordingSession]) reach `LocalAmbientModeManager` /
+      // `AmbientMode` from `androidx.wear.compose.foundation` and `AmbientLifecycleObserver` from
+      // `androidx.wear:wear`. Instantiating them on a non-Wear consumer classpath raises
+      // `NoClassDefFoundError` at the lazy init line. Skip registration when the wear AAR isn't
+      // loadable so plain-Android consumers can still drive renders.
+      val ambientOverrides =
+        if (isWearAmbientAvailable(javaClass.classLoader)) {
+          listOf(AmbientPreviewOverrideExtension())
+        } else {
+          emptyList()
+        }
       RenderEngine(
         previewOverrideExtensions =
           PreviewOverrideExtensions(
-            listOf(
-              AmbientPreviewOverrideExtension(),
-              WallpaperPreviewOverrideExtension(),
-              Material3ThemePreviewOverrideExtension(),
-              FocusPreviewOverrideExtension(),
-            )
+            ambientOverrides +
+              listOf(
+                WallpaperPreviewOverrideExtension(),
+                Material3ThemePreviewOverrideExtension(),
+                FocusPreviewOverrideExtension(),
+              )
           ),
         dataArtifactExtensions =
           RenderDataArtifactExtensions(

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import org.junit.runners.model.FrameworkMethod
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.internal.bytecode.InstrumentationConfiguration
 
@@ -83,6 +84,46 @@ class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(testClas
         .forEach { builder.doNotAcquirePackage(it) }
     }
     return builder.build()
+  }
+
+  /**
+   * Conditionally registers [ShadowAmbientLifecycleObserver]. The shadow's
+   * `@Implements(AmbientLifecycleObserver::class)` value forces Robolectric's
+   * [org.robolectric.internal.bytecode.ShadowMap.obtainShadowInfo] to resolve
+   * `androidx.wear.ambient.AmbientLifecycleObserver` via reflection during sandbox bootstrap; on
+   * non-Wear consumers (e.g. `:samples:android`, plain Android apps) that class isn't on the
+   * runtime classpath and the resolution throws `TypeNotPresentException`, killing the daemon
+   * before any render runs (issue: PR #891 regression hit by run-agent-audit-samples.py).
+   *
+   * Returning the shadow only when wear-ambient is loadable keeps the existing wear path intact
+   * while leaving non-wear consumers untouched. The same gate is mirrored on the engine side in
+   * [ee.schimke.composeai.daemon.RobolectricHost] for `AmbientPreviewOverrideExtension` /
+   * `AmbientInputDispatchObserver` instantiation.
+   */
+  override fun getExtraShadows(method: FrameworkMethod): Array<Class<*>> =
+    if (isWearAmbientAvailable(javaClass.classLoader)) {
+      arrayOf(ShadowAmbientLifecycleObserver::class.java)
+    } else {
+      emptyArray()
+    }
+}
+
+/**
+ * Returns `true` when `androidx.wear.ambient.AmbientLifecycleObserver` is on the supplied
+ * classloader. Used by [SandboxHoldingRunner] (host loader) and the daemon's `SandboxRunner`
+ * (sandbox loader) to gate ambient connector registration on the consumer's classpath shape, so a
+ * plain Android consumer doesn't pull `:data-ambient-connector` classes through reflection paths
+ * that need the wear AAR.
+ */
+internal fun isWearAmbientAvailable(loader: ClassLoader?): Boolean {
+  val effective = loader ?: ClassLoader.getSystemClassLoader() ?: return false
+  return try {
+    Class.forName("androidx.wear.ambient.AmbientLifecycleObserver", false, effective)
+    true
+  } catch (_: ClassNotFoundException) {
+    false
+  } catch (_: NoClassDefFoundError) {
+    false
   }
 }
 

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AmbientClasspathDetectionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AmbientClasspathDetectionTest.kt
@@ -1,0 +1,44 @@
+package ee.schimke.composeai.daemon
+
+import java.net.URLClassLoader
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Guards [isWearAmbientAvailable] against the regression that hit
+ * `run-agent-audit-samples.py` after PR #891: Robolectric's
+ * `ShadowMap.obtainShadowInfo` reflectively resolves
+ * `androidx.wear.ambient.AmbientLifecycleObserver` from
+ * [ShadowAmbientLifecycleObserver]'s `@Implements` value at sandbox bootstrap, which throws
+ * `TypeNotPresentException` on plain-Android consumers (`:samples:android`) whose runtime
+ * classpath doesn't ship the Wear AAR. Detection has to return `false` against a classloader
+ * without the class so the daemon can suppress shadow / extension registration on those
+ * consumers. The wear-positive direction is covered end-to-end on `:samples:wear` integration —
+ * exercising it from a unit test would need either the AAR on the test classpath (it isn't, the
+ * connector keeps wear `compileOnly`) or a hand-rolled bytecode stub, neither of which adds
+ * meaningful coverage over the integration path.
+ */
+class AmbientClasspathDetectionTest {
+
+  @Test
+  fun returnsFalseWhenWearAmbientMissingFromLoader() {
+    val emptyLoader = URLClassLoader(emptyArray(), ClassLoader.getSystemClassLoader().parent)
+    assertFalse(
+      "AmbientLifecycleObserver must be reported absent on a classloader that does not ship it",
+      isWearAmbientAvailable(emptyLoader),
+    )
+  }
+
+  @Test
+  fun returnsFalseWhenLoaderIsNullAndSystemClasspathLacksWear() {
+    // The daemon/android module declares :data-ambient-connector as `implementation` and the
+    // connector keeps `androidx.wear:wear` as `compileOnly`, so the unit-test classpath here
+    // doesn't include `AmbientLifecycleObserver`. If that ever changes (a transitive bumps it
+    // onto the test runtime), this test starts failing — at which point the wear AAR has crept
+    // into the daemon's main runtime classpath and the gating logic needs revisiting.
+    assertFalse(
+      "Daemon test classpath unexpectedly ships androidx.wear.ambient",
+      isWearAmbientAvailable(null),
+    )
+  }
+}


### PR DESCRIPTION
## Summary
Fixes a regression where the daemon crashes on plain-Android consumers when Robolectric attempts to resolve wear-specific classes during sandbox bootstrap. The ambient connector is now conditionally registered only when the wear AAR is available on the classpath.

## Changes
- **Added `isWearAmbientAvailable()` function** in `SandboxHoldingRunner.kt` to safely detect whether `androidx.wear.ambient.AmbientLifecycleObserver` is loadable, handling both `ClassNotFoundException` and `NoClassDefFoundError`

- **Conditional shadow registration** in `SandboxHoldingRunner.getExtraShadows()`: Only registers `ShadowAmbientLifecycleObserver` when wear-ambient is available, preventing Robolectric from attempting to resolve the wear class during bootstrap on non-wear consumers

- **Conditional extension registration** in `RobolectricHost.SandboxRunner`: Gates `AmbientPreviewOverrideExtension` instantiation on wear availability to avoid `NoClassDefFoundError` when the wear AAR isn't on the classpath

- **Conditional observer registration** in `RobolectricHost.acquireRecordingSession()`: Gates `AmbientInputDispatchObserver` on wear availability for the same reason

- **Removed static shadow declaration** from `@Config(shadows=...)` annotation on `SandboxRunner` class, moving it to dynamic registration via `getExtraShadows()`

- **Added comprehensive test coverage** in `AmbientClasspathDetectionTest` to guard against regression, verifying that detection correctly returns `false` when wear-ambient is missing from the classloader

## Implementation Details
The fix uses a two-pronged approach:
1. **Host-side gating** (SandboxHoldingRunner): Prevents Robolectric from resolving wear classes during sandbox bootstrap
2. **Sandbox-side gating** (RobolectricHost): Prevents instantiation of wear-dependent components when the AAR isn't available

This allows plain-Android consumers (e.g., `:samples:android`) to render without pulling in wear connector classes, while preserving the full ambient functionality for wear consumers.

https://claude.ai/code/session_01MQyqUBnbiUTjBHBhgFw51z