### PR TITLE
fix(daemon): gate Wear ambient connector on consumer classpath presence

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -946,8 +946,16 @@ open class RobolectricHost(
       encodedDir = encodedDir,
       // Side-band observers fired before every script-event dispatch. Today only the ambient
       // connector ships one — wakes [AmbientStateController] on activating gestures so a
-      // recording can exercise the ambient ↔ interactive flip mid-script.
-      dispatchObservers = listOf(AmbientInputDispatchObserver()),
+      // recording can exercise the ambient ↔ interactive flip mid-script. Gated on wear-ambient
+      // availability for the same reason as the override extension above (loading
+      // `AmbientInputDispatchObserver` triggers `AmbientStateController` static init, which pulls
+      // in `AmbientLifecycleObserver` types not present on plain-Android consumers).
+      dispatchObservers =
+        if (isWearAmbientAvailable(javaClass.classLoader)) {
+          listOf(AmbientInputDispatchObserver())
+        } else {
+          emptyList()
+        },
     )
   }
 
@@ -1160,8 +1168,13 @@ open class RobolectricHost(
    * is only available under NATIVE graphics mode. The B1.3-era stub render
    * didn't need it but the annotation is harmless when the body is a stub.
    */
+  // The Wear ambient shadow ([ShadowAmbientLifecycleObserver]) is registered conditionally
+  // through [SandboxHoldingRunner.getExtraShadows] — putting it directly on `@Config(shadows=…)`
+  // forces Robolectric to resolve `androidx.wear.ambient.AmbientLifecycleObserver` via the
+  // shadow's `@Implements` annotation during sandbox bootstrap, which fails on non-Wear consumers
+  // whose classpath doesn't ship the Wear AAR. See [SandboxHoldingRunner.getExtraShadows].
   @RunWith(SandboxHoldingRunner::class)
-  @Config(sdk = [ANDROID_SDK], shadows = [ShadowAmbientLifecycleObserver::class])
+  @Config(sdk = [ANDROID_SDK])
   @GraphicsMode(GraphicsMode.Mode.NATIVE)
   class SandboxRunner {
 
@@ -1176,15 +1189,27 @@ open class RobolectricHost(
      * cross-classloader contract clean.
      */
     private val engine: RenderEngine by lazy {
+      // [AmbientPreviewOverrideExtension] (and its companion [AmbientInputDispatchObserver]
+      // registered alongside [acquireRecordingSession]) reach `LocalAmbientModeManager` /
+      // `AmbientMode` from `androidx.wear.compose.foundation` and `AmbientLifecycleObserver` from
+      // `androidx.wear:wear`. Instantiating them on a non-Wear consumer classpath raises
+      // `NoClassDefFoundError` at the lazy init line. Skip registration when the wear AAR isn't
+      // loadable so plain-Android consumers can still drive renders.
+      val ambientOverrides =
+        if (isWearAmbientAvailable(javaClass.classLoader)) {
+          listOf(AmbientPreviewOverrideExtension())
+        } else {
+          emptyList()
+        }
       RenderEngine(
         previewOverrideExtensions =
           PreviewOverrideExtensions(
-            listOf(
-              AmbientPreviewOverrideExtension(),
-              WallpaperPreviewOverrideExtension(),
-              Material3ThemePreviewOverrideExtension(),
-              FocusPreviewOverrideExtension(),
-            )
+            ambientOverrides +
+              listOf(
+                WallpaperPreviewOverrideExtension(),
+                Material3ThemePreviewOverrideExtension(),
+                FocusPreviewOverrideExtension(),
+              )
           ),
         dataArtifactExtensions =
           RenderDataArtifactExtensions(

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import org.junit.runners.model.FrameworkMethod
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.internal.bytecode.InstrumentationConfiguration
 
@@ -83,6 +84,46 @@ class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(testClas
         .forEach { builder.doNotAcquirePackage(it) }
     }
     return builder.build()
+  }
+
+  /**
+   * Conditionally registers [ShadowAmbientLifecycleObserver]. The shadow's
+   * `@Implements(AmbientLifecycleObserver::class)` value forces Robolectric's
+   * [org.robolectric.internal.bytecode.ShadowMap.obtainShadowInfo] to resolve
+   * `androidx.wear.ambient.AmbientLifecycleObserver` via reflection during sandbox bootstrap; on
+   * non-Wear consumers (e.g. `:samples:android`, plain Android apps) that class isn't on the
+   * runtime classpath and the resolution throws `TypeNotPresentException`, killing the daemon
+   * before any render runs (issue: PR #891 regression hit by run-agent-audit-samples.py).
+   *
+   * Returning the shadow only when wear-ambient is loadable keeps the existing wear path intact
+   * while leaving non-wear consumers untouched. The same gate is mirrored on the engine side in
+   * [ee.schimke.composeai.daemon.RobolectricHost] for `AmbientPreviewOverrideExtension` /
+   * `AmbientInputDispatchObserver` instantiation.
+   */
+  override fun getExtraShadows(method: FrameworkMethod): Array<Class<*>> =
+    if (isWearAmbientAvailable(javaClass.classLoader)) {
+      arrayOf(ShadowAmbientLifecycleObserver::class.java)
+    } else {
+      emptyArray()
+    }
+}
+
+/**
+ * Returns `true` when `androidx.wear.ambient.AmbientLifecycleObserver` is on the supplied
+ * classloader. Used by [SandboxHoldingRunner] (host loader) and the daemon's `SandboxRunner`
+ * (sandbox loader) to gate ambient connector registration on the consumer's classpath shape, so a
+ * plain Android consumer doesn't pull `:data-ambient-connector` classes through reflection paths
+ * that need the wear AAR.
+ */
+internal fun isWearAmbientAvailable(loader: ClassLoader?): Boolean {
+  val effective = loader ?: ClassLoader.getSystemClassLoader() ?: return false
+  return try {
+    Class.forName("androidx.wear.ambient.AmbientLifecycleObserver", false, effective)
+    true
+  } catch (_: ClassNotFoundException) {
+    false
+  } catch (_: NoClassDefFoundError) {
+    false
   }
 }
 

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AmbientClasspathDetectionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AmbientClasspathDetectionTest.kt
@@ -1,0 +1,44 @@
+package ee.schimke.composeai.daemon
+
+import java.net.URLClassLoader
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Guards [isWearAmbientAvailable] against the regression that hit
+ * `run-agent-audit-samples.py` after PR #891: Robolectric's
+ * `ShadowMap.obtainShadowInfo` reflectively resolves
+ * `androidx.wear.ambient.AmbientLifecycleObserver` from
+ * [ShadowAmbientLifecycleObserver]'s `@Implements` value at sandbox bootstrap, which throws
+ * `TypeNotPresentException` on plain-Android consumers (`:samples:android`) whose runtime
+ * classpath doesn't ship the Wear AAR. Detection has to return `false` against a classloader
+ * without the class so the daemon can suppress shadow / extension registration on those
+ * consumers. The wear-positive direction is covered end-to-end on `:samples:wear` integration —
+ * exercising it from a unit test would need either the AAR on the test classpath (it isn't, the
+ * connector keeps wear `compileOnly`) or a hand-rolled bytecode stub, neither of which adds
+ * meaningful coverage over the integration path.
+ */
+class AmbientClasspathDetectionTest {
+
+  @Test
+  fun returnsFalseWhenWearAmbientMissingFromLoader() {
+    val emptyLoader = URLClassLoader(emptyArray(), ClassLoader.getSystemClassLoader().parent)
+    assertFalse(
+      "AmbientLifecycleObserver must be reported absent on a classloader that does not ship it",
+      isWearAmbientAvailable(emptyLoader),
+    )
+  }
+
+  @Test
+  fun returnsFalseWhenLoaderIsNullAndSystemClasspathLacksWear() {
+    // The daemon/android module declares :data-ambient-connector as `implementation` and the
+    // connector keeps `androidx.wear:wear` as `compileOnly`, so the unit-test classpath here
+    // doesn't include `AmbientLifecycleObserver`. If that ever changes (a transitive bumps it
+    // onto the test runtime), this test starts failing — at which point the wear AAR has crept
+    // into the daemon's main runtime classpath and the gating logic needs revisiting.
+    assertFalse(
+      "Daemon test classpath unexpectedly ships androidx.wear.ambient",
+      isWearAmbientAvailable(null),
+    )
+  }
+}


### PR DESCRIPTION
## Summary

PR #891 wired `ShadowAmbientLifecycleObserver::class` directly into `RobolectricHost.SandboxRunner`'s `@Config(shadows=…)` and registered `AmbientPreviewOverrideExtension` / `AmbientInputDispatchObserver` unconditionally in the engine. On non-Wear consumers like `:samples:android` the wear AAR isn't on the daemon's runtime classpath, so:

- Robolectric's `ShadowMap.obtainShadowInfo` hits `TypeNotPresentException: androidx.wear.ambient.AmbientLifecycleObserver` while reflecting on the shadow's `@Implements` value at sandbox bootstrap — the daemon dies before serving any render. This is the failure `run-agent-audit-samples.py` hits in CI.
- The override extension and dispatch observer would `NoClassDefFoundError` on `LocalAmbientModeManager` / `AmbientLifecycleObserver` references the moment the lazy engine init runs.

This PR moves the shadow registration to `SandboxHoldingRunner.getExtraShadows`, gated on `Class.forName("androidx.wear.ambient.AmbientLifecycleObserver", …)` succeeding on the runner's classloader. The same gate is mirrored inside the `SandboxRunner.engine` initializer so the override extension and dispatch observer are only instantiated when wear-ambient is loadable. Wear consumers keep the full ambient surface; plain Android consumers get an empty ambient slot and a daemon that boots.

## Test plan

- [x] Reproduced end-to-end against `:samples:android` via `python3 skills/compose-preview-review/scripts/run-agent-audit-samples.py`. Pre-fix: daemon dies at sandbox bootstrap with `TypeNotPresentException`. Post-fix: daemon boots, all 5 sandboxes spin up, first render completes, script progresses past the original failure into `test_mcp_data_products` (which fails on a separate, pre-existing `text/strings` issue not touched by this change).
- [x] `AmbientClasspathDetectionTest` covers the negative branch with a URL-classloader fixture and guards against future transitive bumps that would silently re-introduce wear-ambient onto the daemon's main test classpath.
- [ ] Wear path (`:samples:wear`) — unchanged by inspection: when `AmbientLifecycleObserver` is loadable, `getExtraShadows` returns `[ShadowAmbientLifecycleObserver::class.java]` and the engine adds the override + dispatch observer exactly as before. CI's wear job will be the authoritative check.
- [ ] CI on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQyqUBnbiUTjBHBhgFw51z)_