### PR TITLE
fix(ci): collect nested release artifacts via find instead of shallow glob

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,25 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
+      - name: Collect release assets
+        # `actions/upload-artifact` preserves the lowest-common-ancestor of the
+        # paths it was given. `build-applications` ships files from both
+        # `cli/build/distributions/` and `mcp/build/distributions/`, so its LCA
+        # is the workspace root — meaning the CLI/MCP zips and tarballs land at
+        # `artifacts/cli/build/distributions/…` and `artifacts/mcp/build/…`,
+        # not directly under `artifacts/`. A shallow `artifacts/*.zip` glob
+        # therefore matched nothing on 0.10.4 and `gh release upload` exited 1
+        # with the literal pattern. Recurse with `find` so we pick up assets at
+        # any depth, then feed an explicit file list to `gh`.
+        run: |
+          mapfile -t assets < <(find artifacts -type f \
+            \( -name '*.zip' -o -name '*.tar.gz' -o -name '*.vsix' \) | sort)
+          if [[ ${#assets[@]} -eq 0 ]]; then
+            echo "No release assets found under artifacts/" >&2
+            exit 1
+          fi
+          printf 'asset: %s\n' "${assets[@]}"
+          printf '%s\n' "${assets[@]}" > "$RUNNER_TEMP/release-assets.txt"
       - name: Upload or create GitHub Release
         # $TAG_NAME is read from env (not templated into the script), so the
         # tag name — attacker-influenceable through git or the dispatch input
@@ -268,19 +287,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
+          mapfile -t assets < "$RUNNER_TEMP/release-assets.txt"
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
             echo "Release $TAG_NAME exists — uploading assets."
-            gh release upload "$TAG_NAME" \
-              --clobber \
-              artifacts/*.zip \
-              artifacts/*.tar.gz \
-              artifacts/*.vsix
+            gh release upload "$TAG_NAME" --clobber "${assets[@]}"
           else
             echo "Release $TAG_NAME does not exist — creating."
             gh release create "$TAG_NAME" \
               --title "compose-ai-tools ${TAG_NAME#v}" \
               --generate-notes \
-              artifacts/*.zip \
-              artifacts/*.tar.gz \
-              artifacts/*.vsix
+              "${assets[@]}"
           fi


### PR DESCRIPTION
## Summary

The `release` job in `.github/workflows/release.yml` failed in 9s on v0.10.4 (run 25574040622, job 75077719393) — *not* the `build-skills` ordering that #937 fixed. After #937, every build job and `publish-gradle-plugin` succeeded; only the asset-upload step blew up, leaving the GitHub Release without any assets.

`actions/upload-artifact@v4` preserves the lowest-common-ancestor of its `path:` patterns. `build-applications` uploads from both `cli/build/distributions/` and `mcp/build/distributions/`, so the artifact preserves `cli/build/distributions/…` and `mcp/build/distributions/…`. After `download-artifact` with `merge-multiple: true` into `artifacts/`, the CLI/MCP zips and tarballs end up nested under `artifacts/cli/build/distributions/…`, not at the top level. (Skill `.tar.gz` and `.vsix` happen to flatten because each of their builders has a single common parent.) Shallow `artifacts/*.zip` matches nothing → bash passes the literal pattern → `gh release upload` exits 1.

The fix recurses with `find` to collect `*.zip` / `*.tar.gz` / `*.vsix` at any depth and feeds an explicit file list to `gh`, so it doesn't matter what directory layout `upload-artifact`'s LCA logic produces for each builder. A separate "Collect release assets" step also fails fast with a clear message if zero matches are found, instead of silently letting `gh` complain about a literal glob.

The conventional-commit `fix:` prefix means release-please should pick this up and cut 0.10.5 once it lands.

## Test plan

- [ ] Merge → release-please opens a 0.10.5 release PR
- [ ] Merging that release PR cuts v0.10.5 with CLI / MCP zips and tarballs, skill bundles, and the VSIX attached as assets
- [ ] (Optional, to recover 0.10.4) `workflow_dispatch` `release.yml` with `tag: v0.10.4` after this lands

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXo4gAczjrNr4kw22kjFT8)_