### PR TITLE
Add androidx.customview:customview-poolingcontainer dependency injection

### DIFF
--- a/.github/ci/daemon-roundtrip.py
+++ b/.github/ci/daemon-roundtrip.py
@@ -399,7 +399,7 @@ def main() -> int:
         init_result = driver.request(
             "initialize",
             {
-                "protocolVersion": 1,
+                "protocolVersion": 2,
                 "clientVersion": "ci-roundtrip-0.1",
                 "workspaceRoot": str(workspace),
                 "moduleId": args.module_id,
@@ -409,8 +409,8 @@ def main() -> int:
             timeout_s=120.0,
         )
         proto = init_result.get("protocolVersion")
-        if proto != 1:
-            raise RuntimeError(f"daemon protocolVersion={proto}, expected 1")
+        if proto != 2:
+            raise RuntimeError(f"daemon protocolVersion={proto}, expected 2")
         print(f"[daemon-roundtrip] initialize OK (daemonVersion={init_result.get('daemonVersion')})")
         driver.notify("initialized")
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -494,6 +494,29 @@ internal object AndroidPreviewSupport {
       // >= 1.16 via their own deps (compose-bom 2026.x, etc.), so it's
       // non-destructive for the common case.
       project.dependencies.add("${variantName}Implementation", "androidx.core:core:1.16.0")
+      // Pin `androidx.customview:customview-poolingcontainer` for the same
+      // reason as `androidx.core:core` above. compose-ui's
+      // `ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool`
+      // reads `androidx.customview.poolingcontainer.R.id.*` from
+      // `PoolingContainer.<clinit>`, so the merged unit-test resource APK
+      // needs that R class. Tile-only consumers without compose-ui in main
+      // (e.g. WearTilesKotlin) carry no transitive customview-poolingcontainer
+      // on the main variant, so the field lookup crashes Robolectric the
+      // moment `AbstractComposeView.<init>` installs the strategy:
+      //
+      //   `NoClassDefFoundError: Could not initialize class
+      //   androidx.customview.poolingcontainer.PoolingContainer`
+      //   caused by `NoClassDefFoundError:
+      //   androidx/customview/poolingcontainer/R$id`
+      //
+      // 1.0.0 is the only published version (compose-ui 1.9.x → 1.11.x all
+      // depend on it unchanged); the floor here is a no-op for Compose-app
+      // consumers that already get it transitively, and a fix for tile-only
+      // consumers that don't.
+      project.dependencies.add(
+        "${variantName}Implementation",
+        "androidx.customview:customview-poolingcontainer:1.0.0",
+      )
       recordInjectedDependency(
         project,
         injectedDependencies,
@@ -521,6 +544,15 @@ internal object AndroidPreviewSupport {
         reason =
           "compose-ui 1.10+ on the renderer test classpath reads R.id.tag_compat_insets_dispatch (added in core 1.16); merged test APK needs the field",
       )
+      recordInjectedDependency(
+        project,
+        injectedDependencies,
+        coordinate = "androidx.customview:customview-poolingcontainer:1.0.0",
+        configuration = "${variantName}Implementation",
+        outcome = "APPLIED",
+        reason =
+          "compose-ui's ViewCompositionStrategy reads androidx.customview.poolingcontainer.R.id.* from PoolingContainer.<clinit>; merged test APK needs the R class",
+      )
     } else {
       recordInjectedDependency(
         project,
@@ -546,6 +578,15 @@ internal object AndroidPreviewSupport {
         outcome = "SKIPPED_BY_CONFIG",
         reason =
           "manageDependencies=false; consumer must ensure androidx.core:core >= 1.16.0 on the main variant so the merged test APK includes R.id.tag_compat_insets_dispatch",
+      )
+      recordInjectedDependency(
+        project,
+        injectedDependencies,
+        coordinate = "androidx.customview:customview-poolingcontainer:1.0.0",
+        configuration = "${variantName}Implementation",
+        outcome = "SKIPPED_BY_CONFIG",
+        reason =
+          "manageDependencies=false; consumer must ensure androidx.customview:customview-poolingcontainer is on the main variant so the merged test APK includes its R class (referenced by compose-ui's PoolingContainer)",
       )
     }
 
@@ -1769,6 +1810,16 @@ internal object AndroidPreviewSupport {
     }
     if (!hasCoord("${variantName}Implementation", "androidx.core", "core")) {
       missing += "${variantName}Implementation(\"androidx.core:core:1.16.0\")"
+    }
+    if (
+      !hasCoord(
+        "${variantName}Implementation",
+        "androidx.customview",
+        "customview-poolingcontainer",
+      )
+    ) {
+      missing +=
+        "${variantName}Implementation(\"androidx.customview:customview-poolingcontainer:1.0.0\")"
     }
     if (
       tilesRendererRequired &&


### PR DESCRIPTION
## Summary
This PR adds automatic dependency injection of `androidx.customview:customview-poolingcontainer:1.0.0` to Android preview test variants, alongside the existing `androidx.core:core` injection. It also updates the daemon protocol version from 1 to 2.

## Key Changes

- **AndroidPreviewSupport.kt**: 
  - Added injection of `androidx.customview:customview-poolingcontainer:1.0.0` to test variant implementations when `manageDependencies=true`
  - Added corresponding dependency tracking records for both managed and unmanaged dependency scenarios
  - Added validation check to ensure the customview-poolingcontainer dependency is present when `manageDependencies=false`
  - Included detailed comments explaining why this dependency is needed: compose-ui's `ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool` reads R class fields from `PoolingContainer.<clinit>`, which causes `NoClassDefFoundError` in Robolectric for tile-only consumers that don't have this dependency transitively

- **daemon-roundtrip.py**:
  - Updated protocol version from 1 to 2 in the daemon initialization request and validation

## Implementation Details

The customview-poolingcontainer dependency is pinned to version 1.0.0 (the only published version) and is injected for the same reason as androidx.core:core - to ensure the merged unit-test resource APK includes necessary R class definitions. This is particularly important for tile-only consumers (e.g., WearTilesKotlin) that don't carry transitive customview-poolingcontainer on the main variant.

https://claude.ai/code/session_017HBoLcafjDSQsVekrYzxYf