### PR TITLE
fix(vscode): detect plugin in Groovy build.gradle, not just .kts

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -35,7 +35,8 @@
     ],
     "activationEvents": [
         "onLanguage:kotlin",
-        "workspaceContains:**/build.gradle.kts"
+        "workspaceContains:**/build.gradle.kts",
+        "workspaceContains:**/build.gradle"
     ],
     "extensionDependencies": [
         "vscjava.vscode-gradle"

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5,7 +5,10 @@ import * as crypto from "crypto";
 import { GradleService, GradleApi, TaskCancelledError } from "./gradleService";
 import { JdkImageError } from "./jdkImageErrorDetector";
 import { KotlinCompileError } from "./kotlinCompileErrorDetector";
-import { findPluginAppliedAncestor } from "./pluginDetection";
+import {
+    BUILD_SCRIPT_NAMES,
+    findPluginAppliedAncestor,
+} from "./pluginDetection";
 import { PreviewPanel } from "./previewPanel";
 import { PreviewRegistry } from "./previewRegistry";
 import { PreviewGutterDecorations } from "./previewGutterDecorations";
@@ -4705,7 +4708,7 @@ function emptyStateMessage(activeFile: string | undefined): string {
     if (previewModules.length === 0) {
         return (
             "The Compose Preview Gradle plugin isn't applied in this workspace. " +
-            'Add id("ee.schimke.composeai.preview") to a module\'s build.gradle.kts to enable previews.'
+            'Add id("ee.schimke.composeai.preview") to a module\'s build script (build.gradle.kts or build.gradle) to enable previews.'
         );
     }
     if (fileHasPreviewAnnotation(activeFile)) {
@@ -4764,7 +4767,7 @@ function maybeShowSetupPrompt(activeFile: string): void {
     const message = missingAnywhere
         ? "Compose Preview: the Gradle plugin isn't applied in this workspace yet."
         : "Compose Preview: this module doesn't apply the Gradle plugin, but the file uses @Preview.";
-    const OPEN = "Open build.gradle.kts";
+    const OPEN = "Open build script";
     const DOCS = "View setup docs";
     const NEVER = "Don't show again";
     void vscode.window
@@ -4784,11 +4787,12 @@ function maybeShowSetupPrompt(activeFile: string): void {
 }
 
 /**
- * Opens the nearest ancestor `build.gradle.kts` of the given file — the
- * likely target for adding `id("ee.schimke.composeai.preview")`. Walks up
- * from the file's directory; if nothing is found before the workspace root,
- * falls back to the root's own build script. This handles both top-level
- * modules (the only kind findPreviewModules scans for) and nested layouts.
+ * Opens the nearest ancestor module build script (`build.gradle.kts` or
+ * `build.gradle`) of the given file — the likely target for adding
+ * `id("ee.schimke.composeai.preview")`. Walks up from the file's directory;
+ * if nothing is found before the workspace root, falls back to the root's
+ * own build script. This handles both top-level modules (the only kind
+ * findPreviewModules scans for) and nested layouts, and both DSLs.
  */
 async function openModuleBuildFile(
     workspaceRoot: string,
@@ -4803,11 +4807,13 @@ async function openModuleBuildFile(
     let dir = target === workspaceRoot ? workspaceRoot : path.dirname(target);
     const root = path.resolve(workspaceRoot);
     while (path.resolve(dir).startsWith(root)) {
-        const candidate = path.join(dir, "build.gradle.kts");
-        if (fs.existsSync(candidate)) {
-            const doc = await vscode.workspace.openTextDocument(candidate);
-            await vscode.window.showTextDocument(doc);
-            return;
+        for (const name of BUILD_SCRIPT_NAMES) {
+            const candidate = path.join(dir, name);
+            if (fs.existsSync(candidate)) {
+                const doc = await vscode.workspace.openTextDocument(candidate);
+                await vscode.window.showTextDocument(doc);
+                return;
+            }
         }
         const parent = path.dirname(dir);
         if (parent === dir) {
@@ -4816,7 +4822,7 @@ async function openModuleBuildFile(
         dir = parent;
     }
     vscode.window.showWarningMessage(
-        "No build.gradle.kts found for this file.",
+        "No build.gradle.kts or build.gradle found for this file.",
     );
 }
 

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -9,7 +9,7 @@ import {
     PreviewRenderError,
     ResourceManifest,
 } from "./types";
-import { appliesPlugin } from "./pluginDetection";
+import { appliesPlugin, BUILD_SCRIPT_NAMES } from "./pluginDetection";
 import { JdkImageError, JdkImageErrorDetector } from "./jdkImageErrorDetector";
 import {
     KotlinCompileError,
@@ -677,9 +677,11 @@ export class GradleService {
      *      marker written by the `composePreviewApplied` Gradle task. Covers
      *      every apply mechanism (literal `id`, version-catalog alias,
      *      convention plugin, buildSrc) because Gradle itself wrote it.
-     *   2. `<module>/build.gradle.kts` matching literal
-     *      `id("ee.schimke.composeai.preview")`. Pre-Gradle-run fallback so
-     *      trivially-configured workspaces aren't empty on first open.
+     *   2. `<module>/build.gradle.kts` or `<module>/build.gradle` matching
+     *      literal `id("ee.schimke.composeai.preview")` (Kotlin DSL) or
+     *      `id 'ee.schimke.composeai.preview'` (Groovy DSL). Pre-Gradle-run
+     *      fallback so trivially-configured workspaces aren't empty on
+     *      first open.
      *
      * Returning the union means running Gradle on one module doesn't cause
      * others (applied but not yet built) to disappear from the list.
@@ -728,18 +730,21 @@ export class GradleService {
                 if (fs.existsSync(marker)) {
                     found.add(childRel);
                 } else {
-                    const buildFile = path.join(
-                        this.workspaceRoot,
-                        childRel,
-                        "build.gradle.kts",
-                    );
-                    try {
-                        const content = fs.readFileSync(buildFile, "utf-8");
-                        if (appliesPlugin(content)) {
-                            found.add(childRel);
+                    for (const name of BUILD_SCRIPT_NAMES) {
+                        const buildFile = path.join(
+                            this.workspaceRoot,
+                            childRel,
+                            name,
+                        );
+                        try {
+                            const content = fs.readFileSync(buildFile, "utf-8");
+                            if (appliesPlugin(content)) {
+                                found.add(childRel);
+                                break;
+                            }
+                        } catch {
+                            /* try the next build-script name */
                         }
-                    } catch {
-                        /* skip */
                     }
                 }
                 walk(childRel, depth + 1);

--- a/vscode-extension/src/pluginDetection.ts
+++ b/vscode-extension/src/pluginDetection.ts
@@ -20,6 +20,15 @@ import * as path from "path";
 
 export const PLUGIN_ID = "ee.schimke.composeai.preview";
 
+/**
+ * Module build-script filenames we scan, in preference order. Kotlin DSL
+ * (`build.gradle.kts`) is checked first because that's what every sample in
+ * this repo uses, but Groovy DSL (`build.gradle`) is still common in
+ * AGP-bootstrapped consumer projects and must not produce a false-negative
+ * "plugin not applied" signal.
+ */
+export const BUILD_SCRIPT_NAMES = ["build.gradle.kts", "build.gradle"] as const;
+
 // Matches the plugin being *applied* literally (`id("ee.schimke.composeai.preview")`
 // or `id "ee.schimke.composeai.preview"`), not the plugin's own declaration in
 // gradle-plugin/build.gradle.kts (`id = "ee.schimke.composeai.preview"`). The
@@ -60,9 +69,9 @@ export function appliesPlugin(content: string): boolean {
 
 /**
  * Walks up from `filePath`'s directory looking for an ancestor containing a
- * `build.gradle.kts` that literally applies the plugin. Returns that
- * directory, or null if no such ancestor exists before hitting the
- * filesystem root.
+ * module build script (`build.gradle.kts` or `build.gradle`) that literally
+ * applies the plugin. Returns that directory, or null if no such ancestor
+ * exists before hitting the filesystem root.
  *
  * This is intentionally workspace-agnostic — unlike `GradleService.resolveModule`,
  * it doesn't care whether the match is a direct child of the VS Code workspace
@@ -72,22 +81,25 @@ export function appliesPlugin(content: string): boolean {
  * setup-prompt logic to avoid nagging users whose file is clearly already
  * plugin-enabled somewhere in its own project tree.
  *
- * Only matches the literal `id("…")` application form. Projects that apply
- * via a version catalog are picked up via the `applied.json` marker path in
- * [GradleService.findPreviewModules] once Gradle has run — this helper is a
- * purely static file-walk fallback, used where we don't have a marker.
+ * Only matches the literal `id("…")` / `id "…"` application form. Projects
+ * that apply via a version catalog are picked up via the `applied.json`
+ * marker path in [GradleService.findPreviewModules] once Gradle has run —
+ * this helper is a purely static file-walk fallback, used where we don't
+ * have a marker.
  */
 export function findPluginAppliedAncestor(filePath: string): string | null {
     let dir = path.dirname(filePath);
     while (true) {
-        const candidate = path.join(dir, "build.gradle.kts");
-        try {
-            const content = fs.readFileSync(candidate, "utf-8");
-            if (appliesPlugin(content)) {
-                return dir;
+        for (const name of BUILD_SCRIPT_NAMES) {
+            const candidate = path.join(dir, name);
+            try {
+                const content = fs.readFileSync(candidate, "utf-8");
+                if (appliesPlugin(content)) {
+                    return dir;
+                }
+            } catch {
+                /* no build file here, try the next name */
             }
-        } catch {
-            /* no build file here, keep walking */
         }
         const parent = path.dirname(dir);
         if (parent === dir) {

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -342,6 +342,26 @@ describe("GradleService", () => {
         );
 
         it(
+            "finds modules with the plugin applied via Groovy build.gradle",
+            withTempDir((dir, api) => {
+                fs.mkdirSync(path.join(dir, "app"));
+                fs.writeFileSync(
+                    path.join(dir, "app", "build.gradle"),
+                    "plugins { id 'ee.schimke.composeai.preview' }",
+                );
+
+                fs.mkdirSync(path.join(dir, "lib"));
+                fs.writeFileSync(
+                    path.join(dir, "lib", "build.gradle"),
+                    "plugins { id 'org.jetbrains.kotlin.jvm' }",
+                );
+
+                const service = new GradleService(dir, api);
+                assert.deepStrictEqual(service.findPreviewModules(), ["app"]);
+            }),
+        );
+
+        it(
             "returns empty for workspace with no modules",
             withTempDir((dir, api) => {
                 const service = new GradleService(dir, api);

--- a/vscode-extension/src/test/pluginDetection.test.ts
+++ b/vscode-extension/src/test/pluginDetection.test.ts
@@ -106,6 +106,46 @@ describe("findPluginAppliedAncestor", () => {
     );
 
     it(
+        "finds an ancestor that applies the plugin via Groovy build.gradle",
+        withTempDir((dir) => {
+            fs.mkdirSync(path.join(dir, "app", "src"), { recursive: true });
+            fs.writeFileSync(
+                path.join(dir, "app", "build.gradle"),
+                "plugins { id 'ee.schimke.composeai.preview' }",
+            );
+            assert.strictEqual(
+                findPluginAppliedAncestor(
+                    path.join(dir, "app", "src", "Foo.kt"),
+                ),
+                path.join(dir, "app"),
+            );
+        }),
+    );
+
+    it(
+        "prefers build.gradle.kts when both exist in the same directory",
+        withTempDir((dir) => {
+            fs.mkdirSync(path.join(dir, "app", "src"), { recursive: true });
+            fs.writeFileSync(
+                path.join(dir, "app", "build.gradle.kts"),
+                'id("ee.schimke.composeai.preview")',
+            );
+            // Groovy script in the same directory does NOT apply — but the
+            // .kts one does, so the ancestor should still be reported.
+            fs.writeFileSync(
+                path.join(dir, "app", "build.gradle"),
+                "plugins { id 'org.jetbrains.kotlin.jvm' }",
+            );
+            assert.strictEqual(
+                findPluginAppliedAncestor(
+                    path.join(dir, "app", "src", "Foo.kt"),
+                ),
+                path.join(dir, "app"),
+            );
+        }),
+    );
+
+    it(
         "skips literal applications trailing `apply false`",
         withTempDir((dir) => {
             fs.mkdirSync(path.join(dir, "wearApp", "src"), { recursive: true });


### PR DESCRIPTION
The "plugin isn't applied" warning fired for projects using the Groovy
DSL because every file-walk only looked at build.gradle.kts. Scan both
build.gradle.kts and build.gradle in findPreviewModules,
findPluginAppliedAncestor, and openModuleBuildFile, and add a Groovy
glob to activationEvents so the extension activates in Groovy-only
workspaces. Soften the empty-state and "Open" labels to mention the
build script generically.