### PR TITLE
fix(vscode): support modules whose projectDir != Gradle modulePath

### DIFF
--- a/vscode-extension/src/androidManifestCodeLensProvider.ts
+++ b/vscode-extension/src/androidManifestCodeLensProvider.ts
@@ -59,7 +59,7 @@ export class AndroidManifestCodeLensProvider
             }
             const pngPath = path.join(
                 this.gradleService.workspaceRoot,
-                module,
+                module.projectDir,
                 "build",
                 "compose-previews",
                 firstCapture.renderOutput,

--- a/vscode-extension/src/daemon/daemonGate.ts
+++ b/vscode-extension/src/daemon/daemonGate.ts
@@ -1,4 +1,4 @@
-import { GradleService } from "../gradleService";
+import { GradleService, ModuleInfo } from "../gradleService";
 import { LogFilter } from "../logFilter";
 import {
     DaemonClient,
@@ -42,42 +42,43 @@ export class DaemonGate {
      * Returns null when the descriptor's `enabled: false` (user didn't opt in at the build level).
      */
     async getOrSpawn(
-        moduleId: string,
+        module: ModuleInfo,
         events: DaemonClientEvents,
     ): Promise<DaemonClient | null> {
         if (this.disposed) {
             return null;
         }
 
-        const existing = this.daemons.get(moduleId);
+        const key = module.modulePath;
+        const existing = this.daemons.get(key);
         if (existing && !existing.client.isClosed()) {
             return existing.client;
         }
         if (existing && existing.client.isClosed()) {
-            this.daemons.delete(moduleId);
+            this.daemons.delete(key);
         }
-        const inFlight = this.spawns.get(moduleId);
+        const inFlight = this.spawns.get(key);
         if (inFlight) {
             return inFlight;
         }
 
         const descriptor = readLaunchDescriptor(
             this.workspaceRoot,
-            moduleId,
+            module,
             this.logger,
         );
         if (!descriptor) {
             const message =
-                `[daemon] no launch descriptor for ${moduleId}; ` +
-                `run :${moduleId.replace(/\//g, ":")}:composePreviewDaemonStart first`;
+                `[daemon] no launch descriptor for ${module.modulePath}; ` +
+                `run ${module.modulePath}:composePreviewDaemonStart first`;
             this.logger.appendLine(message);
             throw new Error(message);
         }
         if (!descriptor.enabled) {
-            if (!this.warnedBuildDisabled.has(moduleId)) {
-                this.warnedBuildDisabled.add(moduleId);
+            if (!this.warnedBuildDisabled.has(key)) {
+                this.warnedBuildDisabled.add(key);
                 this.logger.appendLine(
-                    `[daemon] WARNING: descriptor for ${moduleId} has enabled=false; ` +
+                    `[daemon] WARNING: descriptor for ${module.modulePath} has enabled=false; ` +
                         "using the Gradle render path for now. The daemon will become required by " +
                         "the VS Code extension in a future release. Configure composePreview { daemon { enabled = true } }.",
                 );
@@ -86,29 +87,30 @@ export class DaemonGate {
         }
 
         try {
-            const spawn = this.spawn(moduleId, descriptor, events).finally(() =>
-                this.spawns.delete(moduleId),
+            const spawn = this.spawn(module, descriptor, events).finally(() =>
+                this.spawns.delete(key),
             );
-            this.spawns.set(moduleId, spawn);
+            this.spawns.set(key, spawn);
             return await spawn;
         } catch (err) {
-            const message = `[daemon] spawn failed for ${moduleId}: ${(err as Error).message}`;
+            const message = `[daemon] spawn failed for ${module.modulePath}: ${(err as Error).message}`;
             this.logger.appendLine(message);
             throw new Error(message);
         }
     }
 
-    isBuildDisabled(moduleId: string): boolean {
+    isBuildDisabled(module: ModuleInfo): boolean {
         const descriptor = readLaunchDescriptor(
             this.workspaceRoot,
-            moduleId,
+            module,
             this.logger,
         );
+        const key = module.modulePath;
         if (descriptor?.enabled === false) {
-            if (!this.warnedBuildDisabled.has(moduleId)) {
-                this.warnedBuildDisabled.add(moduleId);
+            if (!this.warnedBuildDisabled.has(key)) {
+                this.warnedBuildDisabled.add(key);
                 this.logger.appendLine(
-                    `[daemon] WARNING: descriptor for ${moduleId} has enabled=false; ` +
+                    `[daemon] WARNING: descriptor for ${module.modulePath} has enabled=false; ` +
                         "using the Gradle render path for now. The daemon will become required by " +
                         "the VS Code extension in a future release. Configure composePreview { daemon { enabled = true } }.",
                 );
@@ -119,15 +121,16 @@ export class DaemonGate {
     }
 
     private async spawn(
-        moduleId: string,
+        module: ModuleInfo,
         descriptor: DaemonLaunchDescriptor,
         events: DaemonClientEvents,
     ): Promise<DaemonClient> {
+        const key = module.modulePath;
         const composed = composeEvents(events, () => {
             // On channel close drop the entry so the next caller spawns a
             // fresh JVM. Avoid awaiting `exited` here — events fires as
             // soon as the stream ends, exit code may lag by a tick.
-            this.daemons.delete(moduleId);
+            this.daemons.delete(key);
         });
         const spawned = await spawnDaemon({
             workspaceRoot: this.workspaceRoot,
@@ -137,9 +140,9 @@ export class DaemonGate {
             logger: this.logger,
             logFilter: this.logFilter,
         });
-        this.daemons.set(moduleId, { spawned, client: spawned.client });
+        this.daemons.set(key, { spawned, client: spawned.client });
         const readyLine =
-            `[daemon] ready for ${moduleId} ` +
+            `[daemon] ready for ${module.modulePath} ` +
             `(daemonVersion=${spawned.initializeResult.daemonVersion}, ` +
             `pid=${spawned.initializeResult.pid}, ` +
             `previews=${spawned.initializeResult.manifest.previewCount})`;
@@ -156,15 +159,15 @@ export class DaemonGate {
      */
     async bootstrap(
         gradleService: GradleService,
-        moduleId: string,
+        module: ModuleInfo,
     ): Promise<void> {
-        await gradleService.runDaemonBootstrap(moduleId);
+        await gradleService.runDaemonBootstrap(module);
     }
 
     /** True iff a healthy daemon is already up for this module — warm path
-     *  short-circuit. */
-    isDaemonReady(moduleId: string): boolean {
-        const existing = this.daemons.get(moduleId);
+     *  short-circuit. Lookups only need the canonical modulePath. */
+    isDaemonReady(modulePath: string): boolean {
+        const existing = this.daemons.get(modulePath);
         return existing != null && !existing.client.isClosed();
     }
 
@@ -183,8 +186,8 @@ export class DaemonGate {
      * hint instead of silently leaving the user wondering why clicks don't
      * mutate state.
      */
-    isInteractiveSupported(moduleId: string): boolean {
-        const existing = this.daemons.get(moduleId);
+    isInteractiveSupported(modulePath: string): boolean {
+        const existing = this.daemons.get(modulePath);
         if (existing == null || existing.client.isClosed()) {
             return false;
         }

--- a/vscode-extension/src/daemon/daemonProcess.ts
+++ b/vscode-extension/src/daemon/daemonProcess.ts
@@ -12,6 +12,7 @@ import {
     InitializeResult,
 } from "./daemonProtocol";
 import { LogFilter } from "../logFilter";
+import { ModuleInfo } from "../gradleService";
 
 /**
  * Reads `<module>/build/compose-previews/daemon-launch.json` and returns the
@@ -21,12 +22,12 @@ import { LogFilter } from "../logFilter";
  */
 export function readLaunchDescriptor(
     workspaceRoot: string,
-    moduleId: string,
+    module: ModuleInfo,
     logger?: DaemonClientLogger,
 ): DaemonLaunchDescriptor | null {
     const file = path.join(
         workspaceRoot,
-        moduleId,
+        module.projectDir,
         "build",
         "compose-previews",
         "daemon-launch.json",

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as fs from "fs";
-import { GradleService } from "../gradleService";
+import { GradleService, ModuleInfo } from "../gradleService";
 import { DaemonGate } from "./daemonGate";
 import {
     DataProductAttachment,
@@ -157,10 +157,10 @@ export class DaemonScheduler {
      * available (caller can use the daemon path); false means the daemon was explicitly disabled.
      * Enabled-but-broken daemon failures throw so callers do not silently fall back to Gradle.
      */
-    async ensureModule(moduleId: string): Promise<boolean> {
+    async ensureModule(module: ModuleInfo): Promise<boolean> {
         const client = await this.gate.getOrSpawn(
-            moduleId,
-            this.daemonEvents(moduleId),
+            module,
+            this.daemonEvents(module.modulePath),
         );
         return client !== null;
     }
@@ -180,42 +180,42 @@ export class DaemonScheduler {
      */
     async warmModule(
         gradleService: GradleService,
-        moduleId: string,
+        module: ModuleInfo,
         progress?: WarmProgress,
     ): Promise<boolean> {
-        if (this.gate.isDaemonReady(moduleId)) {
+        if (this.gate.isDaemonReady(module.modulePath)) {
             progress?.("ready");
             return true;
         }
         progress?.("spawning");
         try {
-            const ok = await this.ensureModule(moduleId);
+            const ok = await this.ensureModule(module);
             if (ok) {
                 progress?.("ready");
                 return true;
             }
         } catch (err) {
             this.logger.appendLine(
-                `[daemon] cached launch failed for ${moduleId}: ${(err as Error).message}; ` +
+                `[daemon] cached launch failed for ${module.modulePath}: ${(err as Error).message}; ` +
                     "running composePreviewDaemonStart",
             );
         }
         try {
             progress?.("bootstrapping");
-            await gradleService.runDaemonBootstrap(moduleId);
+            await gradleService.runDaemonBootstrap(module);
         } catch (err) {
             this.logger.appendLine(
-                `[daemon] bootstrap task failed for ${moduleId}: ${(err as Error).message}`,
+                `[daemon] bootstrap task failed for ${module.modulePath}: ${(err as Error).message}`,
             );
             throw err;
         }
         progress?.("spawning");
         let ok = false;
         try {
-            ok = await this.ensureModule(moduleId);
+            ok = await this.ensureModule(module);
         } catch (err) {
             this.logger.appendLine(
-                `[daemon] warm failed for ${moduleId}: ${(err as Error).message}`,
+                `[daemon] warm failed for ${module.modulePath}: ${(err as Error).message}`,
             );
             throw err;
         }
@@ -228,13 +228,13 @@ export class DaemonScheduler {
      * file internally per PROTOCOL.md § 4; we send a hint based on the path.
      */
     async fileChanged(
-        moduleId: string,
+        module: ModuleInfo,
         absPath: string,
         changeType: FileChangeType = "modified",
     ): Promise<void> {
         const client = await this.gate.getOrSpawn(
-            moduleId,
-            this.daemonEvents(moduleId),
+            module,
+            this.daemonEvents(module.modulePath),
         );
         if (!client) {
             return;
@@ -250,14 +250,15 @@ export class DaemonScheduler {
      * The user moved focus to (or saved a file scoped to) a set of preview
      * IDs. These are rendered first when the queue drains.
      */
-    async setFocus(moduleId: string, previewIds: string[]): Promise<void> {
-        if (sameSet(this.lastFocus.get(moduleId), previewIds)) {
+    async setFocus(module: ModuleInfo, previewIds: string[]): Promise<void> {
+        const key = module.modulePath;
+        if (sameSet(this.lastFocus.get(key), previewIds)) {
             return;
         }
-        this.lastFocus.set(moduleId, [...previewIds]);
+        this.lastFocus.set(key, [...previewIds]);
         const client = await this.gate.getOrSpawn(
-            moduleId,
-            this.daemonEvents(moduleId),
+            module,
+            this.daemonEvents(key),
         );
         if (!client) {
             return;
@@ -273,20 +274,21 @@ export class DaemonScheduler {
      * off for them up to [SPECULATIVE_BUDGET].
      */
     async setVisible(
-        moduleId: string,
+        module: ModuleInfo,
         visible: string[],
         predicted: string[] = [],
     ): Promise<void> {
+        const moduleKey = module.modulePath;
         if (
-            sameSet(this.lastVisible.get(moduleId), visible) &&
+            sameSet(this.lastVisible.get(moduleKey), visible) &&
             predicted.length === 0
         ) {
             return;
         }
-        this.lastVisible.set(moduleId, [...visible]);
+        this.lastVisible.set(moduleKey, [...visible]);
         const client = await this.gate.getOrSpawn(
-            moduleId,
-            this.daemonEvents(moduleId),
+            module,
+            this.daemonEvents(moduleKey),
         );
         if (!client) {
             return;
@@ -299,7 +301,7 @@ export class DaemonScheduler {
         // [setDataProductSubscription]; the panel calls in when the user toggles the
         // a11y overlay in focus mode.
         const visibleSetForSub = new Set(visible);
-        const modulePrefix = `${moduleId}::`;
+        const modulePrefix = `${moduleKey}::`;
         for (const key of [...this.subscribedPairs]) {
             if (!key.startsWith(modulePrefix)) {
                 continue;
@@ -321,13 +323,13 @@ export class DaemonScheduler {
         const visibleSet = new Set(visible);
         const fresh = predicted
             .filter((id) => !visibleSet.has(id))
-            .filter((id) => !this.speculated.has(specKey(moduleId, id)))
+            .filter((id) => !this.speculated.has(specKey(moduleKey, id)))
             .slice(0, SPECULATIVE_BUDGET);
         if (fresh.length === 0) {
             return;
         }
         for (const id of fresh) {
-            this.speculated.add(specKey(moduleId, id));
+            this.speculated.add(specKey(moduleKey, id));
         }
         try {
             await client.renderNow({
@@ -337,7 +339,7 @@ export class DaemonScheduler {
             });
         } catch (err) {
             this.logger.appendLine(
-                `[daemon] scroll-ahead renderNow failed for ${moduleId}: ${(err as Error).message}`,
+                `[daemon] scroll-ahead renderNow failed for ${moduleKey}: ${(err as Error).message}`,
             );
         }
     }
@@ -353,20 +355,20 @@ export class DaemonScheduler {
      * opt-in.
      */
     async setDataProductSubscription(
-        moduleId: string,
+        module: ModuleInfo,
         previewId: string,
         kinds: readonly string[],
         enabled: boolean,
     ): Promise<void> {
         const client = await this.gate.getOrSpawn(
-            moduleId,
-            this.daemonEvents(moduleId),
+            module,
+            this.daemonEvents(module.modulePath),
         );
         if (!client) {
             return;
         }
         for (const kind of kinds) {
-            const subKey = `${moduleId}::${previewId}::${kind}`;
+            const subKey = `${module.modulePath}::${previewId}::${kind}`;
             const already = this.subscribedPairs.has(subKey);
             if (enabled === already) {
                 continue;
@@ -403,14 +405,14 @@ export class DaemonScheduler {
      * via `onPreviewImageReady`.
      */
     async renderNow(
-        moduleId: string,
+        module: ModuleInfo,
         previewIds: string[],
         tier: RenderTier = "fast",
         reason?: string,
     ): Promise<boolean> {
         const client = await this.gate.getOrSpawn(
-            moduleId,
-            this.daemonEvents(moduleId),
+            module,
+            this.daemonEvents(module.modulePath),
         );
         if (!client) {
             return false;
@@ -429,7 +431,7 @@ export class DaemonScheduler {
             return true;
         } catch (err) {
             this.logger.appendLine(
-                `[daemon] renderNow failed for ${moduleId}: ${(err as Error).message}`,
+                `[daemon] renderNow failed for ${module.modulePath}: ${(err as Error).message}`,
             );
             return false;
         }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2,7 +2,12 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 import * as crypto from "crypto";
-import { GradleService, GradleApi, TaskCancelledError } from "./gradleService";
+import {
+    GradleService,
+    GradleApi,
+    ModuleInfo,
+    TaskCancelledError,
+} from "./gradleService";
 import { JdkImageError } from "./jdkImageErrorDetector";
 import { KotlinCompileError } from "./kotlinCompileErrorDetector";
 import {
@@ -114,7 +119,7 @@ const historyScopeRef: { current: HistoryScope | null } = { current: null };
 async function isSourceNewerThanRenders(
     activeFile: string,
     previews: PreviewInfo[],
-    modules: string[],
+    modules: ModuleInfo[],
 ): Promise<boolean> {
     if (!gradleService) {
         return false;
@@ -150,7 +155,7 @@ let lastLoadedModules: string[] = [];
  * webview has focus (undefined) or resolve to an unrelated editor.
  */
 let currentScopeFile: string | null = null;
-let currentScopeModule: string | null = null;
+let currentScopeModule: ModuleInfo | null = null;
 /**
  * True when the panel currently shows a compile-error banner the
  * extension posted (either from the LSP gate or from a kotlinc parse
@@ -163,7 +168,7 @@ let compileGateActive = false;
 const registry = new PreviewRegistry();
 /** previewId → module, updated on every refresh. Used to look up the
  *  owning module when the webview posts a per-preview action. */
-const previewModuleMap = new Map<string, string>();
+const previewModuleMap = new Map<string, ModuleInfo>();
 /** Tracks files saved at least once since activation. First save on a file
  *  renders immediately; subsequent saves go through the debounce path. */
 const firstSaveSeen = new Set<string>();
@@ -599,7 +604,9 @@ export async function activate(
                 // respawn so the lookup uses today's mapping.
                 const stale: string[] = [];
                 for (const previewId of activeInteractiveStreams.keys()) {
-                    if (previewModuleMap.get(previewId) === moduleId) {
+                    if (
+                        previewModuleMap.get(previewId)?.modulePath === moduleId
+                    ) {
                         stale.push(previewId);
                     }
                 }
@@ -610,7 +617,9 @@ export async function activate(
                 // a daemon respawn either, so a `requestStreamStop` against a stale id would
                 // be a wasted notification at best, mis-routed at worst.
                 for (const previewId of [...activeStreamFrameStreams.keys()]) {
-                    if (previewModuleMap.get(previewId) !== moduleId) {
+                    if (
+                        previewModuleMap.get(previewId)?.modulePath !== moduleId
+                    ) {
                         continue;
                     }
                     const sid = activeStreamFrameStreams.get(previewId);
@@ -619,7 +628,9 @@ export async function activate(
                     panel?.postMessage({ command: "streamStopped", previewId });
                 }
                 for (const previewId of [...activeRecordingSessions.keys()]) {
-                    if (previewModuleMap.get(previewId) === moduleId) {
+                    if (
+                        previewModuleMap.get(previewId)?.modulePath === moduleId
+                    ) {
                         activeRecordingSessions.delete(previewId);
                         activeRecordingFormats.delete(previewId);
                         panel?.postMessage({
@@ -704,12 +715,18 @@ export async function activate(
     // Phase H7 — preview history source. The standalone History view is not
     // contributed; history is surfaced from the focus view alongside data products.
     historyScopeRef.current = null;
+    const moduleInfoFromScope = (modulePath: string): ModuleInfo | null =>
+        gradleService?.findModuleByPath(modulePath) ?? null;
     historySource = buildHistorySource({
         isDaemonReady: (moduleId) =>
             daemonGate?.isDaemonReady(moduleId) ?? false,
         daemonList: async (scope) => {
+            const module = moduleInfoFromScope(scope.moduleId);
+            if (!module) {
+                throw new Error("daemon unavailable");
+            }
             const client = await daemonGate?.getOrSpawn(
-                scope.moduleId,
+                module,
                 daemonScheduler!.daemonEvents(scope.moduleId),
             );
             if (!client) {
@@ -722,8 +739,12 @@ export async function activate(
             if (!moduleId) {
                 throw new Error("no scope");
             }
+            const module = moduleInfoFromScope(moduleId);
+            if (!module) {
+                throw new Error("daemon unavailable");
+            }
             const client = await daemonGate?.getOrSpawn(
-                moduleId,
+                module,
                 daemonScheduler!.daemonEvents(moduleId),
             );
             if (!client) {
@@ -736,8 +757,12 @@ export async function activate(
             if (!moduleId) {
                 throw new Error("no scope");
             }
+            const module = moduleInfoFromScope(moduleId);
+            if (!module) {
+                throw new Error("daemon unavailable");
+            }
             const client = await daemonGate?.getOrSpawn(
-                moduleId,
+                module,
                 daemonScheduler!.daemonEvents(moduleId),
             );
             if (!client) {
@@ -1065,7 +1090,7 @@ export async function activate(
             // daemon's first `onPreviewImageReady` for this module.
             const journeyModule = gradleService?.resolveModule(doc.uri.fsPath);
             if (journeyModule) {
-                startEditJourney(journeyModule);
+                startEditJourney(journeyModule.modulePath);
             }
             // The daemon-vs-Gradle decision is made inside runRefreshExclusive
             // — either path runs, never both. See `pickRefreshMode` for the
@@ -1226,11 +1251,11 @@ async function flushInteractiveStreams(): Promise<void> {
     await Promise.all([
         ...interactiveEntries.map(async ([previewId, streamId]) => {
             try {
-                const moduleId = previewModuleMap.get(previewId);
-                if (!moduleId) return;
+                const module = previewModuleMap.get(previewId);
+                if (!module) return;
                 const client = await daemonGate?.getOrSpawn(
-                    moduleId,
-                    daemonScheduler!.daemonEvents(moduleId),
+                    module,
+                    daemonScheduler!.daemonEvents(module.modulePath),
                 );
                 client?.interactiveStop({ frameStreamId: streamId });
             } catch {
@@ -1239,11 +1264,11 @@ async function flushInteractiveStreams(): Promise<void> {
         }),
         ...streamEntries.map(async ([previewId, streamId]) => {
             try {
-                const moduleId = previewModuleMap.get(previewId);
-                if (!moduleId) return;
+                const module = previewModuleMap.get(previewId);
+                if (!module) return;
                 const client = await daemonGate?.getOrSpawn(
-                    moduleId,
-                    daemonScheduler!.daemonEvents(moduleId),
+                    module,
+                    daemonScheduler!.daemonEvents(module.modulePath),
                 );
                 client?.streamStop({ frameStreamId: streamId });
                 panel?.postMessage({ command: "streamStopped", previewId });
@@ -1270,13 +1295,13 @@ async function flushRecordingSessions(options: {
     await Promise.all(
         entries.map(async ([previewId, recordingId]) => {
             try {
-                const moduleId = previewModuleMap.get(previewId);
-                if (!moduleId) {
+                const module = previewModuleMap.get(previewId);
+                if (!module) {
                     return;
                 }
                 const client = await daemonGate?.getOrSpawn(
-                    moduleId,
-                    daemonScheduler!.daemonEvents(moduleId),
+                    module,
+                    daemonScheduler!.daemonEvents(module.modulePath),
                 );
                 if (!client) {
                     return;
@@ -1427,6 +1452,7 @@ function invalidateModuleCache(filePath: string): void {
     const module = gradleService.resolveModule(filePath);
     if (module) {
         gradleService.invalidateCache(module);
+        moduleManifestCache.delete(module.modulePath);
     }
 }
 
@@ -1470,15 +1496,20 @@ async function applyDiscoveryDiff(
         return;
     }
 
+    const module = gradleService.findModuleByPath(moduleId);
+    if (!module) {
+        logLine(`[daemon] discoveryUpdated for unknown module ${moduleId}`);
+        return;
+    }
     // Always reconcile caches, even when no preview editor is visible. Only
     // repaint the panel when its current scope still belongs to this module;
     // daemon save/discovery events can also arrive for background files.
     const repaintFile =
         currentScopeFile &&
-        gradleService.resolveModule(currentScopeFile) === moduleId
+        gradleService.resolveModule(currentScopeFile)?.modulePath === moduleId
             ? currentScopeFile
             : undefined;
-    await reconcilePreviewManifest(moduleId, repaintFile);
+    await reconcilePreviewManifest(module, repaintFile);
 }
 
 /**
@@ -1497,13 +1528,14 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
     if (!module) {
         return "failed";
     }
+    const moduleKey = module.modulePath;
 
     // Bootstrap (Gradle task + JVM spawn) happens once per module per
     // session. Normally it has already fired from the active-editor warm
     // path; on the rare case where the user saves before scope-in (e.g.
     // external file save, another editor split) we cover ourselves here.
-    if (!daemonBootstrappedModules.has(module)) {
-        daemonBootstrappedModules.add(module);
+    if (!daemonBootstrappedModules.has(moduleKey)) {
+        daemonBootstrappedModules.add(moduleKey);
         try {
             const warmed = await daemonScheduler.warmModule(
                 gradleService,
@@ -1511,13 +1543,13 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
                 (state) => updateDaemonStatus(module, state),
             );
             if (!warmed) {
-                daemonBootstrappedModules.delete(module);
+                daemonBootstrappedModules.delete(moduleKey);
                 return daemonGate.isBuildDisabled(module)
                     ? "disabled"
                     : "failed";
             }
         } catch (err) {
-            daemonBootstrappedModules.delete(module);
+            daemonBootstrappedModules.delete(moduleKey);
             logLine(`daemon: ${String((err as Error).message ?? err)}`);
             return daemonGate.isBuildDisabled(module) ? "disabled" : "failed";
         }
@@ -1544,7 +1576,7 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
     // own; the caller just shouldn't escalate to a Gradle render in that
     // case (the panel will repopulate via discover + the daemon's
     // discoveryUpdated push).
-    const manifest = moduleManifestCache.get(module) ?? [];
+    const manifest = moduleManifestCache.get(moduleKey) ?? [];
     let filePreviews = previewsForFile(manifest, module, filePath);
     if (await sourceMayHaveDroppedCachedPreviews(filePath, filePreviews)) {
         logLine(
@@ -1552,7 +1584,8 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
         );
         const repaintFile =
             currentScopeFile &&
-            gradleService.resolveModule(currentScopeFile) === module
+            gradleService.resolveModule(currentScopeFile)?.modulePath ===
+                moduleKey
                 ? currentScopeFile
                 : undefined;
         const fresh = await reconcilePreviewManifest(module, repaintFile);
@@ -1566,7 +1599,7 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
     }
     try {
         await daemonScheduler.setFocus(module, ids);
-        const fullIds = heavyOptInsFor(module, ids);
+        const fullIds = heavyOptInsFor(module.modulePath, ids);
         const fastIds =
             fullIds.length === 0
                 ? ids
@@ -1653,7 +1686,7 @@ async function preloadCachedPreviews(filePath: string): Promise<boolean> {
     panel.postMessage({
         command: "setPreviews",
         previews: displayPreviews,
-        moduleDir: module,
+        moduleDir: module.projectDir,
         heavyStaleIds: [],
     });
 
@@ -1693,8 +1726,8 @@ async function preloadCachedPreviews(filePath: string): Promise<boolean> {
     // takes the stealth-refresh path (no clearAll) rather
     // than tearing down what we just painted.
     hasPreviewsLoaded = true;
-    lastLoadedModules = [module];
-    moduleManifestCache.set(module, visiblePreviews);
+    lastLoadedModules = [module.modulePath];
+    moduleManifestCache.set(module.modulePath, visiblePreviews);
     setCurrentScopeFile(filePath);
     return true;
 }
@@ -1730,7 +1763,7 @@ async function runActivationRefresh(filePath: string): Promise<void> {
         return;
     }
     const module = gradleService.resolveModule(filePath);
-    if (!module || !daemonGate.isDaemonReady(module)) {
+    if (!module || !daemonGate.isDaemonReady(module.modulePath)) {
         return;
     }
     // Phase 3 — kick off a fresh render through the daemon. Reuses the same
@@ -1759,13 +1792,14 @@ async function warmDaemonForFile(
     if (!module) {
         return false;
     }
-    if (daemonBootstrappedModules.has(module)) {
-        if (daemonGate.isDaemonReady(module) && opts.refreshAfterReady) {
+    const moduleKey = module.modulePath;
+    if (daemonBootstrappedModules.has(moduleKey)) {
+        if (daemonGate.isDaemonReady(moduleKey) && opts.refreshAfterReady) {
             await refreshAfterDaemonReady(filePath, "view-open");
         }
-        return daemonGate.isDaemonReady(module);
+        return daemonGate.isDaemonReady(moduleKey);
     }
-    daemonBootstrappedModules.add(module);
+    daemonBootstrappedModules.add(moduleKey);
     try {
         const warmed = await daemonScheduler.warmModule(
             gradleService,
@@ -1776,7 +1810,7 @@ async function warmDaemonForFile(
             },
         );
         if (!warmed) {
-            daemonBootstrappedModules.delete(module);
+            daemonBootstrappedModules.delete(moduleKey);
         }
         finishDaemonStartupProgress(module, filePath, warmed);
         if (warmed && opts.refreshAfterReady) {
@@ -1784,11 +1818,11 @@ async function warmDaemonForFile(
         }
         return warmed;
     } catch (err) {
-        daemonBootstrappedModules.delete(module);
+        daemonBootstrappedModules.delete(moduleKey);
         stopDaemonStartupProgress(module);
         panel?.postMessage({ command: "clearProgress" });
         logLine(
-            `daemon: warm failed for ${module}: ${String((err as Error).message ?? err)}`,
+            `daemon: warm failed for ${moduleKey}: ${String((err as Error).message ?? err)}`,
         );
         vscode.window.showErrorMessage(
             "Compose Preview daemon failed to start. Preview saves will not render until the daemon is fixed.",
@@ -1804,7 +1838,10 @@ async function warmDaemonForFile(
  * bootstrapping the daemon. Surface the daemon phase in the panel itself so
  * the user can tell the extension is still doing useful work.
  */
-function publishDaemonStartupProgress(module: string, state: WarmState): void {
+function publishDaemonStartupProgress(
+    module: ModuleInfo,
+    state: WarmState,
+): void {
     if (!panel) {
         return;
     }
@@ -1812,12 +1849,13 @@ function publishDaemonStartupProgress(module: string, state: WarmState): void {
         stopDaemonStartupProgress(module);
         return;
     }
+    const moduleLabel = module.modulePath;
     switch (state) {
         case "bootstrapping":
             if (!hasPreviewsLoaded) {
                 panel.postMessage({
                     command: "showMessage",
-                    text: `Preparing Compose Preview daemon for ${module}…`,
+                    text: `Preparing Compose Preview daemon for ${moduleLabel}…`,
                 });
             }
             startDaemonStartupProgress(
@@ -1832,7 +1870,7 @@ function publishDaemonStartupProgress(module: string, state: WarmState): void {
             if (!hasPreviewsLoaded) {
                 panel.postMessage({
                     command: "showMessage",
-                    text: `Starting Compose Preview daemon for ${module}…`,
+                    text: `Starting Compose Preview daemon for ${moduleLabel}…`,
                 });
             }
             startDaemonStartupProgress(
@@ -1870,7 +1908,7 @@ function publishDaemonStartupProgress(module: string, state: WarmState): void {
             if (!hasPreviewsLoaded) {
                 panel.postMessage({
                     command: "showMessage",
-                    text: `Compose Preview daemon is disabled for ${module}; using Gradle previews.`,
+                    text: `Compose Preview daemon is disabled for ${moduleLabel}; using Gradle previews.`,
                 });
             }
             panel.postMessage({ command: "clearProgress" });
@@ -1879,7 +1917,7 @@ function publishDaemonStartupProgress(module: string, state: WarmState): void {
 }
 
 function startDaemonStartupProgress(
-    module: string,
+    module: ModuleInfo,
     label: string,
     start: number,
     end: number,
@@ -1906,16 +1944,16 @@ function startDaemonStartupProgress(
         });
     };
     tick();
-    daemonStartupProgressTimers.set(module, setInterval(tick, 250));
+    daemonStartupProgressTimers.set(module.modulePath, setInterval(tick, 250));
 }
 
-function isDaemonStartupScopeActive(module: string): boolean {
-    return currentScopeModule === module;
+function isDaemonStartupScopeActive(module: ModuleInfo): boolean {
+    return currentScopeModule?.modulePath === module.modulePath;
 }
 
 function setCurrentScopeFile(
     filePath: string | null,
-    module?: string | null,
+    module?: ModuleInfo | null,
 ): void {
     currentScopeFile = filePath;
     currentScopeModule =
@@ -1925,23 +1963,24 @@ function setCurrentScopeFile(
             : null);
 }
 
-function stopDaemonStartupProgress(module: string): void {
-    const timer = daemonStartupProgressTimers.get(module);
+function stopDaemonStartupProgress(module: ModuleInfo): void {
+    const timer = daemonStartupProgressTimers.get(module.modulePath);
     if (!timer) {
         return;
     }
     clearInterval(timer);
-    daemonStartupProgressTimers.delete(module);
+    daemonStartupProgressTimers.delete(module.modulePath);
 }
 
 function stopAllDaemonStartupProgress(): void {
-    for (const module of daemonStartupProgressTimers.keys()) {
-        stopDaemonStartupProgress(module);
+    for (const timer of daemonStartupProgressTimers.values()) {
+        clearInterval(timer);
     }
+    daemonStartupProgressTimers.clear();
 }
 
 function finishDaemonStartupProgress(
-    module: string,
+    module: ModuleInfo,
     filePath: string,
     warmed: boolean,
 ): void {
@@ -1953,7 +1992,7 @@ function finishDaemonStartupProgress(
         return;
     }
     panel.postMessage({ command: "clearProgress" });
-    const allPreviews = moduleManifestCache.get(module)?.length ?? 0;
+    const allPreviews = moduleManifestCache.get(module.modulePath)?.length ?? 0;
     panel.postMessage({
         command: "showMessage",
         text:
@@ -1963,14 +2002,14 @@ function finishDaemonStartupProgress(
     });
 }
 
-function visiblePreviewCount(module: string, filePath: string): number {
-    const previews = moduleManifestCache.get(module) ?? [];
+function visiblePreviewCount(module: ModuleInfo, filePath: string): number {
+    const previews = moduleManifestCache.get(module.modulePath) ?? [];
     return previewsForFile(previews, module, filePath).length;
 }
 
 function previewsForFile(
     previews: PreviewInfo[],
-    module: string,
+    module: ModuleInfo,
     filePath: string,
 ): PreviewInfo[] {
     if (!gradleService) {
@@ -1990,19 +2029,20 @@ function previewsForFile(
 }
 
 async function reconcilePreviewManifest(
-    module: string,
+    module: ModuleInfo,
     repaintFilePath?: string,
 ): Promise<PreviewInfo[] | null> {
     if (!gradleService) {
         return null;
     }
     gradleService.invalidateCache(module);
+    moduleManifestCache.delete(module.modulePath);
     let manifest;
     try {
         manifest = await gradleService.discoverPreviews(module);
     } catch (err) {
         logLine(
-            `[daemon] silent discover failed for ${module}: ${(err as Error).message}`,
+            `[daemon] silent discover failed for ${module.modulePath}: ${(err as Error).message}`,
         );
         return null;
     }
@@ -2011,8 +2051,9 @@ async function reconcilePreviewManifest(
     }
 
     const fresh = manifest.previews;
+    const moduleKey = module.modulePath;
     for (const [id, owner] of [...previewModuleMap.entries()]) {
-        if (owner === module) {
+        if (owner.modulePath === moduleKey) {
             previewModuleMap.delete(id);
         }
     }
@@ -2022,21 +2063,21 @@ async function reconcilePreviewManifest(
         }
         previewModuleMap.set(p.id, module);
     }
-    moduleManifestCache.set(module, fresh);
-    registry.replaceModule(module, fresh);
+    moduleManifestCache.set(moduleKey, fresh);
+    registry.replaceModule(moduleKey, fresh);
 
     if (!panel || !repaintFilePath) {
         return fresh;
     }
 
     const visiblePreviews = previewsForFile(fresh, module, repaintFilePath);
-    const heavyStaleIds = fastTierModules.has(module)
+    const heavyStaleIds = fastTierModules.has(moduleKey)
         ? visiblePreviews.filter(hasHeavyCapture).map((p) => p.id)
         : [];
     panel.postMessage({
         command: "setPreviews",
         previews: visiblePreviews.map(withDataProductCaptures),
-        moduleDir: module,
+        moduleDir: module.projectDir,
         heavyStaleIds,
     });
     return fresh;
@@ -2050,7 +2091,7 @@ async function refreshAfterDaemonReady(
         return;
     }
     const module = gradleService.resolveModule(filePath);
-    if (!module || !daemonGate.isDaemonReady(module)) {
+    if (!module || !daemonGate.isDaemonReady(module.modulePath)) {
         return;
     }
     if (currentScopeFile && currentScopeFile !== filePath) {
@@ -2058,7 +2099,7 @@ async function refreshAfterDaemonReady(
     }
     if (pendingRefresh || refreshInFlight) {
         logLine(
-            `daemon: skip post-warm refresh for ${module}; refresh already active`,
+            `daemon: skip post-warm refresh for ${module.modulePath}; refresh already active`,
         );
         return;
     }
@@ -2080,12 +2121,13 @@ async function refreshAfterDaemonReady(
 }
 
 async function reconcilePreviewManifestAfterDaemonReady(
-    module: string,
+    module: ModuleInfo,
     filePath: string,
 ): Promise<boolean> {
     if (!gradleService || !panel) {
         return false;
     }
+    const moduleKey = module.modulePath;
     try {
         panel.postMessage({
             command: "setProgress",
@@ -2095,6 +2137,7 @@ async function reconcilePreviewManifestAfterDaemonReady(
             slow: false,
         });
         gradleService.invalidateCache(module);
+        moduleManifestCache.delete(moduleKey);
         const manifest = await gradleService.discoverPreviews(module);
         if (!manifest) {
             panel.postMessage({ command: "clearProgress" });
@@ -2108,7 +2151,7 @@ async function reconcilePreviewManifestAfterDaemonReady(
         const fresh = manifest.previews;
         const freshIds = new Set(fresh.map((p) => p.id));
         for (const [id, owner] of [...previewModuleMap.entries()]) {
-            if (owner === module && !freshIds.has(id)) {
+            if (owner.modulePath === moduleKey && !freshIds.has(id)) {
                 previewModuleMap.delete(id);
             }
         }
@@ -2118,8 +2161,8 @@ async function reconcilePreviewManifestAfterDaemonReady(
             }
             previewModuleMap.set(p.id, module);
         }
-        moduleManifestCache.set(module, fresh);
-        registry.replaceModule(module, fresh);
+        moduleManifestCache.set(moduleKey, fresh);
+        registry.replaceModule(moduleKey, fresh);
 
         const visiblePreviews = previewsForFile(fresh, module, filePath);
         if (visiblePreviews.length === 0) {
@@ -2136,13 +2179,13 @@ async function reconcilePreviewManifestAfterDaemonReady(
             return false;
         }
 
-        const heavyStaleIds = fastTierModules.has(module)
+        const heavyStaleIds = fastTierModules.has(moduleKey)
             ? visiblePreviews.filter(hasHeavyCapture).map((p) => p.id)
             : [];
         panel.postMessage({
             command: "setPreviews",
             previews: visiblePreviews.map(withDataProductCaptures),
-            moduleDir: module,
+            moduleDir: module.projectDir,
             heavyStaleIds,
         });
         panel.postMessage({ command: "clearCompileErrors" });
@@ -2151,7 +2194,7 @@ async function reconcilePreviewManifestAfterDaemonReady(
         return true;
     } catch (err) {
         logLine(
-            `daemon: post-warm discover failed for ${module}: ${(err as Error).message}`,
+            `daemon: post-warm discover failed for ${moduleKey}: ${(err as Error).message}`,
         );
         panel.postMessage({ command: "clearProgress" });
         return false;
@@ -2166,7 +2209,7 @@ async function warmShownPreviewsForFile(
         return;
     }
     const module = gradleService.resolveModule(filePath);
-    if (!module || !daemonGate.isDaemonReady(module)) {
+    if (!module || !daemonGate.isDaemonReady(module.modulePath)) {
         return;
     }
 
@@ -2175,12 +2218,12 @@ async function warmShownPreviewsForFile(
         gradleService.workspaceRoot,
         module,
     );
-    const scopeKey = `${module}::${filterFile}`;
+    const scopeKey = `${module.modulePath}::${filterFile}`;
     if (daemonShownPreviewWarmScopes.has(scopeKey)) {
         return;
     }
 
-    const ids = (moduleManifestCache.get(module) ?? [])
+    const ids = (moduleManifestCache.get(module.modulePath) ?? [])
         .filter((p) =>
             previewSourceMatches(
                 p.sourceFile,
@@ -2202,7 +2245,7 @@ async function warmShownPreviewsForFile(
     } catch (err) {
         daemonShownPreviewWarmScopes.delete(scopeKey);
         logLine(
-            `daemon: view-open warmup failed for ${module}: ${String((err as Error).message ?? err)}`,
+            `daemon: view-open warmup failed for ${module.modulePath}: ${String((err as Error).message ?? err)}`,
         );
     }
 }
@@ -2223,13 +2266,13 @@ function clearDaemonShownPreviewWarmScopes(moduleId: string): void {
  * the user can see why their file was rendered via Gradle. Hidden any
  * time no module is in flight.
  */
-function updateDaemonStatus(module: string, state: WarmState): void {
+function updateDaemonStatus(module: ModuleInfo, state: WarmState): void {
     // Push availability for the interactive (live-stream) toggle on every
     // state transition. Done outside the !daemonStatusItem early-return so
     // tests that drive activate() without a status bar still see the
     // panel-side state propagate. Cheap: a no-op when panel isn't open.
     if (state === "ready" || state === "fallback") {
-        publishInteractiveAvailability(module);
+        publishInteractiveAvailability(module.modulePath);
     }
     if (!daemonStatusItem) {
         return;
@@ -2238,9 +2281,10 @@ function updateDaemonStatus(module: string, state: WarmState): void {
         clearTimeout(daemonStatusClearTimer);
         daemonStatusClearTimer = null;
     }
+    const moduleLabel = module.modulePath;
     switch (state) {
         case "bootstrapping":
-            daemonStatusItem.text = `$(loading~spin) Daemon: bootstrapping ${module}…`;
+            daemonStatusItem.text = `$(loading~spin) Daemon: bootstrapping ${moduleLabel}…`;
             // Cold-build context: composePreviewDaemonStart itself is a
             // small JSON-emit task, but it depends on the consumer's
             // compileKotlin / variant resolution. On a fresh checkout
@@ -2257,13 +2301,13 @@ function updateDaemonStatus(module: string, state: WarmState): void {
             daemonStatusItem.show();
             break;
         case "spawning":
-            daemonStatusItem.text = `$(loading~spin) Daemon: spawning ${module}…`;
+            daemonStatusItem.text = `$(loading~spin) Daemon: spawning ${moduleLabel}…`;
             daemonStatusItem.tooltip =
                 "Launching the preview daemon JVM and running initialize";
             daemonStatusItem.show();
             break;
         case "ready":
-            daemonStatusItem.text = `$(check) Daemon: ${module}`;
+            daemonStatusItem.text = `$(check) Daemon: ${moduleLabel}`;
             daemonStatusItem.tooltip =
                 "Preview daemon is up and serving renders";
             daemonStatusItem.show();
@@ -2273,7 +2317,7 @@ function updateDaemonStatus(module: string, state: WarmState): void {
             );
             break;
         case "fallback":
-            daemonStatusItem.text = `$(warning) Daemon: ${module} (using Gradle)`;
+            daemonStatusItem.text = `$(warning) Daemon: ${moduleLabel} (using Gradle)`;
             daemonStatusItem.tooltip =
                 "Daemon spawn failed — using the Gradle render path. See Output → Compose Preview.";
             daemonStatusItem.show();
@@ -2351,26 +2395,29 @@ function onDiagnosticsChanged(e: vscode.DiagnosticChangeEvent): void {
 
 /** Read calibrated phase durations for `module` from workspace state. Empty
  *  on first run; the tracker falls back to its built-in phase defaults. */
-function readCalibration(module: string): PhaseDurations {
+function readCalibration(module: ModuleInfo): PhaseDurations {
     if (!extensionContext) {
         return {};
     }
     const all = extensionContext.workspaceState.get<
         Record<string, PhaseDurations>
     >(PROGRESS_CALIBRATION_KEY, {});
-    return all[module] ?? {};
+    return all[module.modulePath] ?? {};
 }
 
 /** Persist updated calibration for `module`, blending into prior samples via
  *  EMA so a single anomalous run doesn't dominate. */
-function writeCalibration(module: string, latest: PhaseDurations): void {
+function writeCalibration(module: ModuleInfo, latest: PhaseDurations): void {
     if (!extensionContext) {
         return;
     }
     const all = extensionContext.workspaceState.get<
         Record<string, PhaseDurations>
     >(PROGRESS_CALIBRATION_KEY, {});
-    all[module] = mergeCalibration(all[module] ?? {}, latest);
+    all[module.modulePath] = mergeCalibration(
+        all[module.modulePath] ?? {},
+        latest,
+    );
     void extensionContext.workspaceState.update(PROGRESS_CALIBRATION_KEY, all);
 }
 
@@ -2446,14 +2493,15 @@ async function runRefreshExclusive(filePath: string): Promise<void> {
     // (not here) so it captures the debounce wait too. Manual refreshes
     // that bypass save have no timer running, in which case
     // `endEditJourney` no-ops below.
-    const journeyModule = gradleService?.resolveModule(filePath);
+    const journeyModuleKey =
+        gradleService?.resolveModule(filePath)?.modulePath ?? null;
     try {
         const mode = pickRefreshMode(filePath);
         if (mode === "daemon") {
             const compileOk = await runDaemonCompileOnly(filePath);
             if (!compileOk) {
-                if (journeyModule) {
-                    editJourneyByModule.delete(journeyModule);
+                if (journeyModuleKey) {
+                    editJourneyByModule.delete(journeyModuleKey);
                 }
                 vscode.window.showErrorMessage(
                     "Compose Preview daemon refresh failed because compile failed. Fix the compile error and save again.",
@@ -2469,13 +2517,13 @@ async function runRefreshExclusive(filePath: string): Promise<void> {
             }
             if (result === "disabled") {
                 await refresh(true, filePath, "fast");
-                if (journeyModule) {
-                    endEditJourney(journeyModule);
+                if (journeyModuleKey) {
+                    endEditJourney(journeyModuleKey);
                 }
                 return;
             }
-            if (journeyModule) {
-                editJourneyByModule.delete(journeyModule);
+            if (journeyModuleKey) {
+                editJourneyByModule.delete(journeyModuleKey);
             }
             vscode.window.showErrorMessage(
                 "Compose Preview daemon is unavailable. Restart the preview daemon after fixing the daemon issue.",
@@ -2483,8 +2531,8 @@ async function runRefreshExclusive(filePath: string): Promise<void> {
             return;
         }
         await refresh(true, filePath, "fast");
-        if (journeyModule) {
-            endEditJourney(journeyModule);
+        if (journeyModuleKey) {
+            endEditJourney(journeyModuleKey);
         }
     } finally {
         refreshInFlight = false;
@@ -2530,10 +2578,10 @@ async function runDaemonCompileOnly(filePath: string): Promise<boolean> {
         await gradleService.compileOnly(module);
     } catch (err) {
         if (err instanceof TaskCancelledError) {
-            logLine(`daemon: compileOnly cancelled for ${module}`);
+            logLine(`daemon: compileOnly cancelled for ${module.modulePath}`);
         } else {
             logLine(
-                `daemon: compileOnly failed for ${module}: ${(err as Error).message}`,
+                `daemon: compileOnly failed for ${module.modulePath}: ${(err as Error).message}`,
             );
         }
         return false;
@@ -2557,7 +2605,7 @@ function sendModuleList() {
     if (!gradleService || !panel) {
         return;
     }
-    const modules = gradleService.findPreviewModules();
+    const modules = gradleService.findPreviewModules().map((m) => m.modulePath);
     panel.postMessage({
         command: "setModules",
         modules,
@@ -2744,7 +2792,7 @@ async function refresh(
         clearHeavyRefreshOptIns();
     }
     logLine(
-        `start forceRender=${forceRender} file=${path.basename(activeFile)} (${scopeSource}) module=${module}`,
+        `start forceRender=${forceRender} file=${path.basename(activeFile)} (${scopeSource}) module=${module.modulePath}`,
     );
 
     // LSP gate. Saves a 5–30 s round-trip through compileKotlin when the
@@ -2800,9 +2848,13 @@ async function refresh(
     setCurrentScopeFile(activeFile, module);
     // Phase H7 — re-scope the History panel alongside the live panel.
     // `projectDir` is the consumer module's absolute path; we synthesize
-    // it from workspaceRoot + module here because GradleService keeps
-    // modules as relative slash-paths.
-    const projectDir = path.join(gradleService.workspaceRoot, module);
+    // it from workspaceRoot + module.projectDir here because GradleService
+    // keeps modules as relative slash-paths and reassigned-projectDir
+    // layouts (androidx-mini) make `module.projectDir` ≠ module.modulePath.
+    const projectDir = path.join(
+        gradleService.workspaceRoot,
+        module.projectDir,
+    );
     // Preserve the previewId narrow across same-module refreshes so a
     // save-driven refresh doesn't briefly widen the History panel to the
     // module before the webview re-publishes the narrow on next layout.
@@ -2810,24 +2862,26 @@ async function refresh(
     // owned by the previous module's preview set.
     const prior = historyScopeRef.current;
     const sameModule =
-        prior?.moduleId === module && prior.projectDir === projectDir;
+        prior?.moduleId === module.modulePath &&
+        prior.projectDir === projectDir;
     const newScope: HistoryScope = sameModule
         ? {
-              moduleId: module,
+              moduleId: module.modulePath,
               projectDir,
               previewId: prior!.previewId,
               previewLabel: prior!.previewLabel,
           }
-        : { moduleId: module, projectDir };
+        : { moduleId: module.modulePath, projectDir };
     historyScopeRef.current = newScope;
-    const modules = [module];
+    const modules: ModuleInfo[] = [module];
+    const modulePathList = modules.map((m) => m.modulePath);
 
     // When the module scope changes (user switched files to a different
     // module, or went from "all modules" to a single one) the old cards are
     // from a different context and should be discarded up front rather than
     // left visible until the diff in setPreviews prunes them — which won't
     // happen if the new refresh cancels before setPreviews.
-    const scopeChanged = !sameScope(modules, lastLoadedModules);
+    const scopeChanged = !sameScope(modulePathList, lastLoadedModules);
     if (scopeChanged) {
         panel.postMessage({ command: "clearAll" });
         hasPreviewsLoaded = false;
@@ -2844,7 +2898,7 @@ async function refresh(
             panel.postMessage({ command: "setLoading" });
         }
     }
-    lastLoadedModules = modules;
+    lastLoadedModules = modulePathList;
     gradleService.cancel();
 
     // Forward progress-bar updates to the webview. Single tracker per refresh
@@ -2885,6 +2939,7 @@ async function refresh(
             if (abort.signal.aborted) {
                 return "cancelled";
             }
+            const modKey = mod.modulePath;
 
             let manifest = !forceRender
                 ? gradleService.readManifest(mod)
@@ -2922,9 +2977,9 @@ async function refresh(
             // module (heavy captures are now fresh on disk).
             if (forceRender && manifest) {
                 if (tier === "fast") {
-                    fastTierModules.add(mod);
+                    fastTierModules.add(modKey);
                 } else {
-                    fastTierModules.delete(mod);
+                    fastTierModules.delete(modKey);
                 }
             }
 
@@ -2941,16 +2996,16 @@ async function refresh(
                     perModule.push(p);
                 }
             }
-            registry.replaceModule(mod, perModule);
+            registry.replaceModule(modKey, perModule);
             // Mirror per-module previews for the daemon scheduler — the
             // save side-channel uses this snapshot to translate "active
             // file" into a list of preview IDs without an extension-side
             // discovery round-trip. Cleared when the module's render
             // returns no manifest (preview-set went empty).
             if (manifest) {
-                moduleManifestCache.set(mod, perModule);
+                moduleManifestCache.set(modKey, perModule);
             } else {
-                moduleManifestCache.delete(mod);
+                moduleManifestCache.delete(modKey);
             }
         }
 
@@ -3004,7 +3059,7 @@ async function refresh(
         // webview decorates these cards with a stale badge so the user knows
         // the GIF/long-scroll image is from a previous full render.
         const moduleIsFastTier = modules.some((mod) =>
-            fastTierModules.has(mod),
+            fastTierModules.has(mod.modulePath),
         );
         const heavyStaleIds = moduleIsFastTier
             ? visiblePreviews.filter(hasHeavyCapture).map((p) => p.id)
@@ -3015,7 +3070,7 @@ async function refresh(
         panel.postMessage({
             command: "setPreviews",
             previews: displayPreviews,
-            moduleDir: modules.join(","),
+            moduleDir: modules.map((m) => m.projectDir).join(","),
             heavyStaleIds,
         });
         hasPreviewsLoaded = true;
@@ -3069,13 +3124,20 @@ async function refresh(
             ));
         if (!sourceIsStale) {
             const imageJobs: Promise<void>[] = [];
+            const modulesByPath = new Map<string, ModuleInfo>();
+            for (const m of modules) {
+                modulesByPath.set(m.modulePath, m);
+            }
             for (const preview of displayPreviews) {
                 const captures = preview.captures;
                 if (captures.length === 0) {
                     continue;
                 }
 
-                const mod = previewModuleMap.get(preview.id);
+                const ownerModule = previewModuleMap.get(preview.id);
+                const mod = ownerModule
+                    ? (modulesByPath.get(ownerModule.modulePath) ?? ownerModule)
+                    : undefined;
                 if (!mod) {
                     continue;
                 }
@@ -3280,7 +3342,7 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             // changing focus clears the opt-in set.
             const mod = previewModuleMap.get(msg.previewId);
             if (mod) {
-                optInHeavyRefresh(mod, msg.previewId);
+                optInHeavyRefresh(mod.modulePath, msg.previewId);
                 if (daemonGate && daemonScheduler) {
                     void daemonScheduler.renderNow(
                         mod,
@@ -3558,10 +3620,12 @@ async function runLivePreviewDiff(
     if (!panel || !historySource) {
         return;
     }
-    const moduleId = previewModuleMap.get(previewId);
-    const manifest = moduleId ? moduleManifestCache.get(moduleId) : undefined;
+    const module = previewModuleMap.get(previewId);
+    const manifest = module
+        ? moduleManifestCache.get(module.modulePath)
+        : undefined;
     const info = manifest?.find((p) => p.id === previewId);
-    if (!moduleId || !info || !gradleService) {
+    if (!module || !info || !gradleService) {
         panel.postMessage({
             command: "previewDiffError",
             previewId,
@@ -3580,7 +3644,7 @@ async function runLivePreviewDiff(
         });
         return;
     }
-    const moduleDir = path.join(gradleService.workspaceRoot, moduleId);
+    const moduleDir = path.join(gradleService.workspaceRoot, module.projectDir);
     const livePath = path.join(moduleDir, capture.renderOutput);
     const liveBytes = await fs.promises.readFile(livePath).catch(() => null);
     if (!liveBytes) {
@@ -3593,8 +3657,15 @@ async function runLivePreviewDiff(
         return;
     }
 
-    const projectDir = path.join(gradleService.workspaceRoot, moduleId);
-    const scope: HistoryScope = { moduleId, projectDir, previewId };
+    const projectDir = path.join(
+        gradleService.workspaceRoot,
+        module.projectDir,
+    );
+    const scope: HistoryScope = {
+        moduleId: module.modulePath,
+        projectDir,
+        previewId,
+    };
     let entries: unknown[];
     try {
         const result = await historySource.list(scope);
@@ -3655,7 +3726,7 @@ async function runLivePreviewDiff(
     if (against === "main") {
         const baseline = await readPreviewMainPng(
             gradleService.workspaceRoot,
-            moduleId,
+            module.modulePath,
             previewId,
         );
         if (baseline) {
@@ -3741,7 +3812,9 @@ async function launchOnDevice(focusedPreviewId?: string): Promise<void> {
     }
     const { module, applicationId, info } = preview;
     const composableFqn = `${info.className}.${info.functionName}`;
-    logLine(`launchOnDevice: ${module} (${applicationId}) → ${composableFqn}`);
+    logLine(
+        `launchOnDevice: ${module.modulePath} (${applicationId}) → ${composableFqn}`,
+    );
 
     await vscode.window.withProgress(
         {
@@ -3812,7 +3885,7 @@ async function launchOnDevice(focusedPreviewId?: string): Promise<void> {
 }
 
 interface ResolvedLaunchPreview {
-    module: string;
+    module: ModuleInfo;
     applicationId: string;
     info: PreviewInfo;
 }
@@ -3831,14 +3904,20 @@ interface ResolvedLaunchPreview {
  */
 async function resolveLaunchPreview(
     focusedPreviewId: string | undefined,
-    candidates: Array<{ module: string; applicationId: string }>,
+    candidates: Array<{ module: ModuleInfo; applicationId: string }>,
 ): Promise<ResolvedLaunchPreview | null> {
-    const candidateByModule = new Map(candidates.map((c) => [c.module, c]));
+    const candidateByModule = new Map(
+        candidates.map((c) => [c.module.modulePath, c]),
+    );
 
     if (focusedPreviewId) {
         const owner = previewModuleMap.get(focusedPreviewId);
-        const candidate = owner ? candidateByModule.get(owner) : undefined;
-        const previews = owner ? moduleManifestCache.get(owner) : undefined;
+        const candidate = owner
+            ? candidateByModule.get(owner.modulePath)
+            : undefined;
+        const previews = owner
+            ? moduleManifestCache.get(owner.modulePath)
+            : undefined;
         const info = previews?.find((p) => p.id === focusedPreviewId);
         if (candidate && info) {
             return {
@@ -3849,7 +3928,7 @@ async function resolveLaunchPreview(
         }
         if (owner && !candidate) {
             vscode.window.showInformationMessage(
-                `Compose Preview: ${owner} is not an Android application module — ` +
+                `Compose Preview: ${owner.modulePath} is not an Android application module — ` +
                     'add id("com.android.application") to deploy a preview from it.',
             );
             return null;
@@ -3857,17 +3936,18 @@ async function resolveLaunchPreview(
     }
 
     interface PreviewPickItem extends vscode.QuickPickItem {
-        candidate: { module: string; applicationId: string };
+        candidate: { module: ModuleInfo; applicationId: string };
         info: PreviewInfo;
     }
     const items: PreviewPickItem[] = [];
     for (const candidate of candidates) {
-        const previews = moduleManifestCache.get(candidate.module) ?? [];
+        const previews =
+            moduleManifestCache.get(candidate.module.modulePath) ?? [];
         for (const info of previews) {
             items.push({
                 label: info.functionName,
                 description: candidate.applicationId,
-                detail: `${candidate.module} · ${info.className}`,
+                detail: `${candidate.module.modulePath} · ${info.className}`,
                 candidate,
                 info,
             });
@@ -3922,13 +4002,14 @@ async function diffAllVsMain(): Promise<void> {
         );
         return;
     }
-    const moduleId = gradleService.resolveModule(currentScopeFile);
-    if (!moduleId) {
+    const module = gradleService.resolveModule(currentScopeFile);
+    if (!module) {
         vscode.window.showInformationMessage(
             "Active file is not part of a Compose Preview module.",
         );
         return;
     }
+    const moduleId = module.modulePath;
     const manifest = moduleManifestCache.get(moduleId);
     if (!manifest || manifest.length === 0) {
         vscode.window.showInformationMessage(
@@ -3936,7 +4017,10 @@ async function diffAllVsMain(): Promise<void> {
         );
         return;
     }
-    const projectDir = path.join(gradleService.workspaceRoot, moduleId);
+    const projectDir = path.join(
+        gradleService.workspaceRoot,
+        module.projectDir,
+    );
 
     interface DriftItem extends vscode.QuickPickItem {
         previewId: string;
@@ -4125,7 +4209,7 @@ function lookupPreviewLabel(previewId: string): string | undefined {
     if (!mod) {
         return undefined;
     }
-    const manifest = moduleManifestCache.get(mod);
+    const manifest = moduleManifestCache.get(mod.modulePath);
     const info = manifest?.find((p) => p.id === previewId);
     if (!info) {
         return undefined;
@@ -4154,8 +4238,8 @@ async function handleSetInteractive(
     if (!daemonGate || !daemonScheduler) {
         return;
     }
-    const moduleId = previewModuleMap.get(previewId);
-    if (!moduleId) {
+    const module = previewModuleMap.get(previewId);
+    if (!module) {
         logLine(
             `[interactive] no module for ${previewId}; ignoring setInteractive`,
         );
@@ -4167,8 +4251,8 @@ async function handleSetInteractive(
             activeInteractiveStreams.delete(previewId);
             updateInteractiveStatus();
             const client = await daemonGate?.getOrSpawn(
-                moduleId,
-                daemonScheduler.daemonEvents(moduleId),
+                module,
+                daemonScheduler.daemonEvents(module.modulePath),
             );
             client?.interactiveStop({ frameStreamId: stream });
         }
@@ -4176,8 +4260,8 @@ async function handleSetInteractive(
         return;
     }
     const client = await daemonGate?.getOrSpawn(
-        moduleId,
-        daemonScheduler.daemonEvents(moduleId),
+        module,
+        daemonScheduler.daemonEvents(module.modulePath),
     );
     if (!client) {
         // The webview already saw the toggle disabled — but the user could
@@ -4185,7 +4269,7 @@ async function handleSetInteractive(
         // fresh availability ping so the chip reverts cleanly.
         panel?.postMessage({
             command: "setInteractiveAvailability",
-            moduleId,
+            moduleId: module.modulePath,
             ready: false,
             interactiveSupported: false,
         });
@@ -4209,11 +4293,11 @@ async function handleSetInteractive(
         activeInteractiveStreams.set(previewId, result.frameStreamId);
         updateInteractiveStatus();
         logLine(
-            `[interactive] live mode on for ${previewId} (module=${moduleId}, ` +
+            `[interactive] live mode on for ${previewId} (module=${module.modulePath}, ` +
                 `streamId=${result.frameStreamId}, ` +
                 `heldSession=${result.heldSession})`,
         );
-        await daemonScheduler.setFocus(moduleId, [previewId]);
+        await daemonScheduler.setFocus(module, [previewId]);
         return;
     } catch (err) {
         logLine(
@@ -4240,21 +4324,21 @@ async function handleRequestStreamStart(previewId: string): Promise<void> {
     if (!daemonGate || !daemonScheduler) {
         return;
     }
-    const moduleId = previewModuleMap.get(previewId);
-    if (!moduleId) {
+    const module = previewModuleMap.get(previewId);
+    if (!module) {
         logLine(
             `[stream] no module for ${previewId}; ignoring requestStreamStart`,
         );
         return;
     }
     const client = await daemonGate?.getOrSpawn(
-        moduleId,
-        daemonScheduler.daemonEvents(moduleId),
+        module,
+        daemonScheduler.daemonEvents(module.modulePath),
     );
     if (!client) {
         panel?.postMessage({
             command: "setInteractiveAvailability",
-            moduleId,
+            moduleId: module.modulePath,
             ready: false,
             interactiveSupported: false,
         });
@@ -4278,11 +4362,11 @@ async function handleRequestStreamStart(previewId: string): Promise<void> {
             heldSession: result.heldSession,
         });
         logLine(
-            `[stream] started for ${previewId} (module=${moduleId}, ` +
+            `[stream] started for ${previewId} (module=${module.modulePath}, ` +
                 `streamId=${result.frameStreamId}, codec=${result.codec}, ` +
                 `heldSession=${result.heldSession})`,
         );
-        await daemonScheduler.setFocus(moduleId, [previewId]);
+        await daemonScheduler.setFocus(module, [previewId]);
     } catch (err) {
         // MethodNotFound on older daemons → silent fallback. The webview
         // already toggled the card into LIVE optimistically; revert it.
@@ -4305,13 +4389,13 @@ async function handleRequestStreamStop(previewId: string): Promise<void> {
     activeStreamFrameStreams.delete(previewId);
     streamFrameIdToPreviewId.delete(sid);
     updateInteractiveStatus();
-    const moduleId = previewModuleMap.get(previewId);
-    if (!daemonGate || !daemonScheduler || !moduleId) {
+    const module = previewModuleMap.get(previewId);
+    if (!daemonGate || !daemonScheduler || !module) {
         return;
     }
     const client = await daemonGate?.getOrSpawn(
-        moduleId,
-        daemonScheduler.daemonEvents(moduleId),
+        module,
+        daemonScheduler.daemonEvents(module.modulePath),
     );
     client?.streamStop({ frameStreamId: sid });
     panel?.postMessage({ command: "streamStopped", previewId });
@@ -4327,13 +4411,13 @@ async function handleRequestStreamVisibility(
     if (!sid) {
         return;
     }
-    const moduleId = previewModuleMap.get(previewId);
-    if (!daemonGate || !daemonScheduler || !moduleId) {
+    const module = previewModuleMap.get(previewId);
+    if (!daemonGate || !daemonScheduler || !module) {
         return;
     }
     const client = await daemonGate?.getOrSpawn(
-        moduleId,
-        daemonScheduler.daemonEvents(moduleId),
+        module,
+        daemonScheduler.daemonEvents(module.modulePath),
     );
     client?.streamVisibility({ frameStreamId: sid, visible, fps });
 }
@@ -4433,12 +4517,12 @@ function updateInteractiveStatus(): void {
         ...activeInteractiveStreams.keys(),
         ...activeStreamFrameStreams.keys(),
     ]) {
-        const moduleId = previewModuleMap.get(previewId);
-        if (!moduleId) {
+        const module = previewModuleMap.get(previewId);
+        if (!module) {
             continue;
         }
-        if (!daemonGate.isInteractiveSupported(moduleId)) {
-            unsupportedModules.add(moduleId);
+        if (!daemonGate.isInteractiveSupported(module.modulePath)) {
+            unsupportedModules.add(module.modulePath);
         }
     }
     if (unsupportedModules.size === 0) {
@@ -4467,16 +4551,16 @@ async function handleSetRecording(
     if (!daemonGate || !daemonScheduler) {
         return;
     }
-    const moduleId = previewModuleMap.get(previewId);
-    if (!moduleId) {
+    const module = previewModuleMap.get(previewId);
+    if (!module) {
         logLine(
             `[recording] no module for ${previewId}; ignoring setRecording`,
         );
         return;
     }
     const client = await daemonGate?.getOrSpawn(
-        moduleId,
-        daemonScheduler.daemonEvents(moduleId),
+        module,
+        daemonScheduler.daemonEvents(module.modulePath),
     );
     if (!client) {
         panel?.postMessage({ command: "clearRecording", previewId });
@@ -4529,10 +4613,10 @@ async function handleSetRecording(
         });
         activeRecordingSessions.set(previewId, result.recordingId);
         activeRecordingFormats.set(previewId, format);
-        await daemonScheduler.setFocus(moduleId, [previewId]);
+        await daemonScheduler.setFocus(module, [previewId]);
         logLine(
             `[recording] live recording on for ${previewId} ` +
-                `(module=${moduleId}, recordingId=${result.recordingId})`,
+                `(module=${module.modulePath}, recordingId=${result.recordingId})`,
         );
     } catch (err) {
         logLine(
@@ -4566,13 +4650,13 @@ async function forwardInteractiveInput(
     if (!streamId) {
         return;
     }
-    const moduleId = previewModuleMap.get(previewId);
-    if (!moduleId) {
+    const module = previewModuleMap.get(previewId);
+    if (!module) {
         return;
     }
     const client = await daemonGate?.getOrSpawn(
-        moduleId,
-        daemonScheduler.daemonEvents(moduleId),
+        module,
+        daemonScheduler.daemonEvents(module.modulePath),
     );
     if (!client) {
         return;
@@ -4597,13 +4681,13 @@ async function forwardRecordingInput(
     if (!recordingId) {
         return;
     }
-    const moduleId = previewModuleMap.get(previewId);
-    if (!moduleId) {
+    const module = previewModuleMap.get(previewId);
+    if (!module) {
         return;
     }
     const client = await daemonGate?.getOrSpawn(
-        moduleId,
-        daemonScheduler.daemonEvents(moduleId),
+        module,
+        daemonScheduler.daemonEvents(module.modulePath),
     );
     if (!client) {
         return;
@@ -4649,35 +4733,42 @@ async function notifyDaemonViewport(
     // panel is module-scoped). Each module's daemon gets its own slice.
     const visibleByModule = new Map<string, string[]>();
     const predictedByModule = new Map<string, string[]>();
+    const moduleByPath = new Map<string, ModuleInfo>();
     for (const id of visible) {
         const mod = previewModuleMap.get(id);
         if (!mod) {
             continue;
         }
-        if (!visibleByModule.has(mod)) {
-            visibleByModule.set(mod, []);
+        moduleByPath.set(mod.modulePath, mod);
+        if (!visibleByModule.has(mod.modulePath)) {
+            visibleByModule.set(mod.modulePath, []);
         }
-        visibleByModule.get(mod)!.push(id);
+        visibleByModule.get(mod.modulePath)!.push(id);
     }
     for (const id of predicted) {
         const mod = previewModuleMap.get(id);
         if (!mod) {
             continue;
         }
-        if (!predictedByModule.has(mod)) {
-            predictedByModule.set(mod, []);
+        moduleByPath.set(mod.modulePath, mod);
+        if (!predictedByModule.has(mod.modulePath)) {
+            predictedByModule.set(mod.modulePath, []);
         }
-        predictedByModule.get(mod)!.push(id);
+        predictedByModule.get(mod.modulePath)!.push(id);
     }
-    const modules = new Set([
+    const modulePaths = new Set([
         ...visibleByModule.keys(),
         ...predictedByModule.keys(),
     ]);
-    for (const mod of modules) {
+    for (const modulePath of modulePaths) {
+        const mod = moduleByPath.get(modulePath);
+        if (!mod) {
+            continue;
+        }
         await daemonScheduler.setVisible(
             mod,
-            visibleByModule.get(mod) ?? [],
-            predictedByModule.get(mod) ?? [],
+            visibleByModule.get(modulePath) ?? [],
+            predictedByModule.get(modulePath) ?? [],
         );
     }
 }

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -130,13 +130,66 @@ function taskFromKey(key: string): string {
     return sep < 0 ? key : key.slice(sep + 1);
 }
 
-// Module identifiers are stored as forward-slash relative paths from the
-// workspace root (e.g. `samples/wear`) so the same string serves both as a
-// Gradle project segment and a filesystem path through `path.join`. Gradle
-// task names take the colon-separated form (`:samples:wear:foo`) — convert
-// at task-name construction sites only.
-function gradleProjectPath(module: string): string {
-    return ":" + module.split("/").join(":");
+/**
+ * Identifies a Gradle module the extension knows about.
+ *
+ * `projectDir` and `modulePath` are usually trivially related (`a/b` ↔
+ * `:a:b`), but they can diverge when `settings.gradle.kts` reassigns a
+ * project's `projectDir` (the Android-X mini-checkout layout, for example).
+ * Keeping both lets us locate the build outputs on disk via `projectDir`
+ * while still naming the right Gradle task via `modulePath`.
+ */
+export interface ModuleInfo {
+    /** Workspace-relative filesystem path, forward-slash separated, no
+     *  leading slash (e.g. `samples/wear`). Used to build
+     *  `path.join(workspaceRoot, projectDir, "build", ...)`. */
+    readonly projectDir: string;
+    /** Canonical Gradle project path, beginning with ':' (e.g.
+     *  `:samples:wear`). Used as the prefix for every gradle task name and
+     *  as the cache / lookup key. */
+    readonly modulePath: string;
+}
+
+/** Synthesises a Gradle project path from a workspace-relative directory.
+ *  Used as a fallback when no `applied.json` has been written yet — the
+ *  marker, once present, supplies the authoritative `modulePath`. */
+function modulePathFromProjectDir(projectDir: string): string {
+    return ":" + projectDir.split("/").join(":");
+}
+
+const APPLIED_MARKER_SCHEMA = "compose-preview-applied/v1";
+
+interface AppliedMarker {
+    readonly schema: string;
+    readonly modulePath: string;
+}
+
+/**
+ * Reads a `build/compose-previews/applied.json` marker and returns the
+ * canonical `modulePath` recorded there, or `null` if the file is missing,
+ * malformed, or has an unrecognised schema. Callers fall back to the
+ * projectDir-derived path on `null`.
+ */
+function readAppliedMarker(file: string): AppliedMarker | null {
+    let raw: string;
+    try {
+        raw = fs.readFileSync(file, "utf-8");
+    } catch {
+        return null;
+    }
+    try {
+        const parsed = JSON.parse(raw) as Partial<AppliedMarker>;
+        if (
+            parsed.schema === APPLIED_MARKER_SCHEMA &&
+            typeof parsed.modulePath === "string" &&
+            parsed.modulePath.startsWith(":")
+        ) {
+            return { schema: parsed.schema, modulePath: parsed.modulePath };
+        }
+    } catch {
+        /* fall through */
+    }
+    return null;
 }
 
 const SCAN_SKIP_DIRS = new Set([
@@ -148,7 +201,13 @@ const SCAN_SKIP_DIRS = new Set([
     "dist",
     ".compose-preview-history",
 ]);
-const SCAN_MAX_DEPTH = 4;
+/**
+ * Defensive cap on directory-walk depth. The walk is already pruned by
+ * [SCAN_SKIP_DIRS] (skips `build`, `src`, etc.), so legitimate Gradle
+ * layouts can't push past this — the cap exists only to bound the worst
+ * case if a workspace has runaway symlink loops.
+ */
+const SCAN_MAX_DEPTH = 12;
 
 export interface Logger {
     appendLine(value: string): void;
@@ -209,6 +268,7 @@ export class GradleService {
     private gradleApi: GradleApi;
     private argsProvider: () => string[];
     private logFilter: LogFilter;
+    /** Keyed by `ModuleInfo.modulePath` — the canonical, stable identifier. */
     private manifestCache = new Map<
         string,
         { manifest: PreviewManifest; timestamp: number }
@@ -231,21 +291,20 @@ export class GradleService {
     }
 
     async discoverPreviews(
-        module: string,
+        module: ModuleInfo,
         opts?: TaskOptions,
     ): Promise<PreviewManifest | null> {
-        const cached = this.manifestCache.get(module);
+        const cached = this.manifestCache.get(module.modulePath);
         if (cached && Date.now() - cached.timestamp < MANIFEST_CACHE_TTL_MS) {
             return cached.manifest;
         }
-        await this.runTask(
-            `${gradleProjectPath(module)}:discoverPreviews`,
-            [],
-            opts,
-        );
+        await this.runTask(`${module.modulePath}:discoverPreviews`, [], opts);
         const manifest = this.readManifest(module);
         if (manifest) {
-            this.manifestCache.set(module, { manifest, timestamp: Date.now() });
+            this.manifestCache.set(module.modulePath, {
+                manifest,
+                timestamp: Date.now(),
+            });
         }
         return manifest;
     }
@@ -263,10 +322,10 @@ export class GradleService {
      * the on-disk `previews.json`. A subsequent gradle-mode save (daemon disabled or unhealthy)
      * will repopulate the cache through `discoverPreviews`.
      */
-    async compileOnly(module: string, opts?: TaskOptions): Promise<void> {
-        this.manifestCache.delete(module);
+    async compileOnly(module: ModuleInfo, opts?: TaskOptions): Promise<void> {
+        this.manifestCache.delete(module.modulePath);
         await this.runTask(
-            `${gradleProjectPath(module)}:composePreviewCompile`,
+            `${module.modulePath}:composePreviewCompile`,
             [],
             opts,
         );
@@ -290,19 +349,22 @@ export class GradleService {
      * burning a config-cache reconfigure (see `TierSystemPropProvider`).
      */
     async renderPreviews(
-        module: string,
+        module: ModuleInfo,
         tier: "fast" | "full" = "full",
         opts?: TaskOptions,
     ): Promise<PreviewManifest | null> {
-        this.manifestCache.delete(module);
+        this.manifestCache.delete(module.modulePath);
         await this.runTask(
-            `${gradleProjectPath(module)}:renderAllPreviews`,
+            `${module.modulePath}:renderAllPreviews`,
             [`-PcomposePreview.tier=${tier}`],
             opts,
         );
         const manifest = this.readManifest(module);
         if (manifest) {
-            this.manifestCache.set(module, { manifest, timestamp: Date.now() });
+            this.manifestCache.set(module.modulePath, {
+                manifest,
+                timestamp: Date.now(),
+            });
         }
         return manifest;
     }
@@ -314,12 +376,8 @@ export class GradleService {
      * separately. Throws on failure (e.g. no device, build error) so the
      * caller can surface the message to the user.
      */
-    async installDebug(module: string, opts?: TaskOptions): Promise<void> {
-        await this.runTask(
-            `${gradleProjectPath(module)}:installDebug`,
-            [],
-            opts,
-        );
+    async installDebug(module: ModuleInfo, opts?: TaskOptions): Promise<void> {
+        await this.runTask(`${module.modulePath}:installDebug`, [], opts);
     }
 
     /**
@@ -332,8 +390,8 @@ export class GradleService {
      * wasn't produced. Callers should treat null as "skip doctor
      * diagnostics for this module", not as an empty finding set.
      */
-    async runDoctor(module: string): Promise<DoctorModuleReport | null> {
-        const task = `${gradleProjectPath(module)}:composePreviewDoctor`;
+    async runDoctor(module: ModuleInfo): Promise<DoctorModuleReport | null> {
+        const task = `${module.modulePath}:composePreviewDoctor`;
         try {
             await this.runTask(task);
         } catch (e) {
@@ -344,7 +402,7 @@ export class GradleService {
         }
         const reportPath = path.join(
             this.workspaceRoot,
-            module,
+            module.projectDir,
             "build",
             "compose-previews",
             "doctor.json",
@@ -372,9 +430,9 @@ export class GradleService {
         }
     }
 
-    invalidateCache(module?: string): void {
+    invalidateCache(module?: ModuleInfo): void {
         if (module) {
-            this.manifestCache.delete(module);
+            this.manifestCache.delete(module.modulePath);
         } else {
             this.manifestCache.clear();
         }
@@ -391,10 +449,10 @@ export class GradleService {
      * sidecar to merge in. Downstream consumers (CodeLens, the upcoming resource webview tab)
      * use the raw shape directly.
      */
-    readResourceManifest(module: string): ResourceManifest | null {
+    readResourceManifest(module: ModuleInfo): ResourceManifest | null {
         const manifestPath = path.join(
             this.workspaceRoot,
-            module,
+            module.projectDir,
             "build",
             "compose-previews",
             "resources.json",
@@ -425,10 +483,10 @@ export class GradleService {
         }
     }
 
-    readManifest(module: string): PreviewManifest | null {
+    readManifest(module: ModuleInfo): PreviewManifest | null {
         const manifestPath = path.join(
             this.workspaceRoot,
-            module,
+            module.projectDir,
             "build",
             "compose-previews",
             "previews.json",
@@ -453,7 +511,7 @@ export class GradleService {
             // read the template path (which never exists).
             const rendersDir = path.join(
                 this.workspaceRoot,
-                module,
+                module.projectDir,
                 "build",
                 "compose-previews",
                 "renders",
@@ -515,7 +573,7 @@ export class GradleService {
      * the overlay wasn't generated — e.g. the preview had no findings).
      */
     private readA11yById(
-        module: string,
+        module: ModuleInfo,
         relativePath: string,
     ): Record<
         string,
@@ -523,7 +581,7 @@ export class GradleService {
     > {
         const reportPath = path.join(
             this.workspaceRoot,
-            module,
+            module.projectDir,
             "build",
             "compose-previews",
             relativePath,
@@ -562,12 +620,12 @@ export class GradleService {
     }
 
     async readPreviewImage(
-        module: string,
+        module: ModuleInfo,
         renderOutput: string,
     ): Promise<string | null> {
         const pngPath = path.join(
             this.workspaceRoot,
-            module,
+            module.projectDir,
             "build",
             "compose-previews",
             renderOutput,
@@ -593,12 +651,12 @@ export class GradleService {
      * manifest's existing `renderOutput` path.
      */
     async readPreviewRenderError(
-        module: string,
+        module: ModuleInfo,
         renderOutput: string,
     ): Promise<PreviewRenderError | null> {
         const sidecarPath = path.join(
             this.workspaceRoot,
-            module,
+            module.projectDir,
             "build",
             "compose-previews",
             `${renderOutput}.error.json`,
@@ -691,9 +749,14 @@ export class GradleService {
      * Recursion continues past a matched directory because Gradle allows
      * modules to nest (`:foo:bar` inside `:foo`). [SCAN_SKIP_DIRS] prunes
      * source / output trees that can't contain a module root.
+     *
+     * The returned [ModuleInfo.modulePath] comes from `applied.json` when
+     * present (so layouts that reassign `projectDir` in `settings.gradle.kts`
+     * end up with the correct gradle task prefix), and is synthesised from
+     * `projectDir` otherwise.
      */
-    findPreviewModules(): string[] {
-        const found = new Set<string>();
+    findPreviewModules(): ModuleInfo[] {
+        const found = new Map<string, ModuleInfo>();
         const walk = (relDir: string, depth: number): void => {
             if (depth > SCAN_MAX_DEPTH) {
                 return;
@@ -727,9 +790,18 @@ export class GradleService {
                     "compose-previews",
                     "applied.json",
                 );
+                let recorded = false;
                 if (fs.existsSync(marker)) {
-                    found.add(childRel);
-                } else {
+                    const parsed = readAppliedMarker(marker);
+                    found.set(childRel, {
+                        projectDir: childRel,
+                        modulePath:
+                            parsed?.modulePath ??
+                            modulePathFromProjectDir(childRel),
+                    });
+                    recorded = true;
+                }
+                if (!recorded) {
                     for (const name of BUILD_SCRIPT_NAMES) {
                         const buildFile = path.join(
                             this.workspaceRoot,
@@ -739,7 +811,11 @@ export class GradleService {
                         try {
                             const content = fs.readFileSync(buildFile, "utf-8");
                             if (appliesPlugin(content)) {
-                                found.add(childRel);
+                                found.set(childRel, {
+                                    projectDir: childRel,
+                                    modulePath:
+                                        modulePathFromProjectDir(childRel),
+                                });
                                 break;
                             }
                         } catch {
@@ -751,7 +827,9 @@ export class GradleService {
             }
         };
         walk("", 0);
-        return [...found].sort();
+        return [...found.values()].sort((a, b) =>
+            a.projectDir.localeCompare(b.projectDir),
+        );
     }
 
     /**
@@ -782,13 +860,26 @@ export class GradleService {
      * descriptor (`build/compose-previews/daemon-launch.json`) is up to date.
      * Cheap and cacheable — emits a small JSON. The caller (DaemonGate) handles errors.
      */
-    async runDaemonBootstrap(module: string): Promise<void> {
-        await this.runTask(
-            `${gradleProjectPath(module)}:composePreviewDaemonStart`,
-        );
+    async runDaemonBootstrap(module: ModuleInfo): Promise<void> {
+        await this.runTask(`${module.modulePath}:composePreviewDaemonStart`);
     }
 
-    resolveModule(filePath: string): string | null {
+    /**
+     * Looks up the discovered module whose canonical Gradle path is
+     * [modulePath]. Returns null when the module isn't on the discovered
+     * list — e.g. the workspace was reloaded and the marker hasn't been
+     * re-read yet, or the modulePath is stale.
+     */
+    findModuleByPath(modulePath: string): ModuleInfo | null {
+        for (const m of this.findPreviewModules()) {
+            if (m.modulePath === modulePath) {
+                return m;
+            }
+        }
+        return null;
+    }
+
+    resolveModule(filePath: string): ModuleInfo | null {
         const relative = path.relative(this.workspaceRoot, filePath);
         if (
             !relative ||
@@ -804,14 +895,18 @@ export class GradleService {
         if (segments.length < 2) {
             return null;
         }
-        const modules = new Set(this.findPreviewModules());
+        const byProjectDir = new Map<string, ModuleInfo>();
+        for (const m of this.findPreviewModules()) {
+            byProjectDir.set(m.projectDir, m);
+        }
         // Longest-prefix match: walk from deepest possible module path to
         // shallowest. With nested modules (e.g. `:foo:bar` inside `:foo`)
         // we prefer the more specific match.
         for (let n = segments.length - 1; n >= 1; n--) {
             const candidate = segments.slice(0, n).join("/");
-            if (modules.has(candidate)) {
-                return candidate;
+            const hit = byProjectDir.get(candidate);
+            if (hit) {
+                return hit;
             }
         }
         return null;

--- a/vscode-extension/src/launchOnDevice.ts
+++ b/vscode-extension/src/launchOnDevice.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { spawn } from "child_process";
+import { ModuleInfo } from "./gradleService";
 
 /**
  * Helpers for the "Launch on Device" panel button. This module is
@@ -211,11 +212,15 @@ export function buildPreviewActivityAmStartArgs(opts: {
  */
 export function collectAndroidApplicationModules(
     workspaceRoot: string,
-    modules: Iterable<string>,
-): Array<{ module: string; applicationId: string }> {
-    const out: Array<{ module: string; applicationId: string }> = [];
+    modules: Iterable<ModuleInfo>,
+): Array<{ module: ModuleInfo; applicationId: string }> {
+    const out: Array<{ module: ModuleInfo; applicationId: string }> = [];
     for (const module of modules) {
-        const buildFile = path.join(workspaceRoot, module, "build.gradle.kts");
+        const buildFile = path.join(
+            workspaceRoot,
+            module.projectDir,
+            "build.gradle.kts",
+        );
         let content: string;
         try {
             content = fs.readFileSync(buildFile, "utf-8");
@@ -227,6 +232,6 @@ export function collectAndroidApplicationModules(
             out.push({ module, applicationId: info.applicationId });
         }
     }
-    out.sort((a, b) => a.module.localeCompare(b.module));
+    out.sort((a, b) => a.module.modulePath.localeCompare(b.module.modulePath));
     return out;
 }

--- a/vscode-extension/src/previewDoctorDiagnostics.ts
+++ b/vscode-extension/src/previewDoctorDiagnostics.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
 import * as fs from "node:fs";
-import { GradleService } from "./gradleService";
+import { GradleService, ModuleInfo } from "./gradleService";
 import { DoctorFinding } from "./types";
 
 /**
@@ -37,7 +37,7 @@ export class PreviewDoctorDiagnostics implements vscode.Disposable {
      * Atomically swaps the DiagnosticCollection so stale findings from a
      * module that got its issue fixed disappear on the next refresh.
      */
-    async refresh(modules: ReadonlyArray<string>): Promise<void> {
+    async refresh(modules: ReadonlyArray<ModuleInfo>): Promise<void> {
         const next = new Map<string, vscode.Diagnostic[]>();
         for (const module of modules) {
             const report = await this.gradleService.runDoctor(module);
@@ -68,7 +68,7 @@ export class PreviewDoctorDiagnostics implements vscode.Disposable {
     }
 
     private toDiagnostic(
-        module: string,
+        module: ModuleInfo,
         finding: DoctorFinding,
     ): vscode.Diagnostic {
         const severity =
@@ -96,14 +96,18 @@ export class PreviewDoctorDiagnostics implements vscode.Disposable {
         const range = new vscode.Range(0, 0, 0, 0);
         const diag = new vscode.Diagnostic(range, parts.join("\n"), severity);
         diag.source = "compose-preview-doctor";
-        diag.code = `${module}:${finding.id}`;
+        diag.code = `${module.modulePath}:${finding.id}`;
         return diag;
     }
 
     /** Locate the module's build.gradle[.kts] relative to the workspace root. */
-    private resolveBuildFile(module: string): string | undefined {
+    private resolveBuildFile(module: ModuleInfo): string | undefined {
         for (const name of ["build.gradle.kts", "build.gradle"]) {
-            const candidate = path.join(this.workspaceRoot, module, name);
+            const candidate = path.join(
+                this.workspaceRoot,
+                module.projectDir,
+                name,
+            );
             if (fs.existsSync(candidate)) {
                 return candidate;
             }

--- a/vscode-extension/src/previewScope.ts
+++ b/vscode-extension/src/previewScope.ts
@@ -1,5 +1,6 @@
 import { PreviewInfo } from "./types";
 import { previewSourceMatches } from "./sourcePath";
+import { ModuleInfo } from "./gradleService";
 
 /**
  * Splits a module's previews into two buckets relative to [filePath]:
@@ -20,7 +21,7 @@ import { previewSourceMatches } from "./sourcePath";
 export function partitionPreviewsForFile(
     previews: PreviewInfo[],
     workspaceRoot: string,
-    module: string,
+    module: ModuleInfo,
     filePath: string,
 ): { primary: PreviewInfo[]; referenced: PreviewInfo[] } {
     const primary: PreviewInfo[] = [];
@@ -64,7 +65,7 @@ export function partitionPreviewsForFile(
 export function visiblePreviewsForFile(
     previews: PreviewInfo[],
     workspaceRoot: string,
-    module: string,
+    module: ModuleInfo,
     filePath: string,
 ): PreviewInfo[] {
     const { primary, referenced } = partitionPreviewsForFile(

--- a/vscode-extension/src/refreshMode.ts
+++ b/vscode-extension/src/refreshMode.ts
@@ -13,12 +13,16 @@ export type RefreshMode = "daemon" | "gradle";
  * - `'daemon'` — the file resolves to a module. The save path skips
  *   `renderPreviews` entirely; daemon failures are surfaced as errors instead of falling back.
  * - `'gradle'` — file outside any module. Existing Gradle render path runs.
+ *
+ * Accepts the resolved module as an opaque value — only truthiness matters
+ * here. Callers pass either `ModuleInfo | null` or the raw modulePath
+ * string; both work.
  */
 export function pickRefreshModeFor(
     _filePath: string,
-    moduleId: string | null,
+    module: { readonly modulePath: string } | string | null,
 ): RefreshMode {
-    if (!moduleId) {
+    if (!module) {
         return "gradle";
     }
     return "daemon";

--- a/vscode-extension/src/renderFreshness.ts
+++ b/vscode-extension/src/renderFreshness.ts
@@ -25,15 +25,26 @@ export async function sourceFileMtime(
     }
 }
 
+/**
+ * Workspace-relative description of a Gradle module — `projectDir` locates
+ * the build directory on disk, `modulePath` is the canonical id stamped
+ * into the freshness JSON. Decoupled here so this module doesn't have to
+ * import `gradleService`.
+ */
+export interface ModuleRef {
+    readonly projectDir: string;
+    readonly modulePath: string;
+}
+
 export function renderFreshnessStampPath(
     workspaceRoot: string,
-    module: string,
+    module: ModuleRef,
     sourceFile: string,
 ): string {
     const encoded = Buffer.from(sourceFile).toString("base64url");
     return path.join(
         workspaceRoot,
-        module,
+        module.projectDir,
         "build",
         "compose-previews",
         "render-freshness",
@@ -43,7 +54,7 @@ export function renderFreshnessStampPath(
 
 export async function writeRenderFreshnessStamp(
     workspaceRoot: string,
-    module: string,
+    module: ModuleRef,
     sourceFile: string,
     previews: PreviewInfo[],
 ): Promise<void> {
@@ -54,7 +65,7 @@ export async function writeRenderFreshnessStamp(
 
     const stamp: RenderFreshnessStamp = {
         schemaVersion: STAMP_SCHEMA_VERSION,
-        module,
+        module: module.modulePath,
         sourceFile,
         sourceMtimeMs: sourceMtime,
         renderedAtMs: Date.now(),
@@ -71,7 +82,7 @@ export async function writeRenderFreshnessStamp(
 
 export async function hasFreshRenderStamp(
     workspaceRoot: string,
-    module: string,
+    module: ModuleRef,
     sourceFile: string,
     previews: PreviewInfo[],
 ): Promise<boolean> {
@@ -88,7 +99,7 @@ export async function hasFreshRenderStamp(
         const stamp = JSON.parse(raw) as Partial<RenderFreshnessStamp>;
         if (
             stamp.schemaVersion !== STAMP_SCHEMA_VERSION ||
-            stamp.module !== module ||
+            stamp.module !== module.modulePath ||
             stamp.sourceFile !== sourceFile ||
             typeof stamp.sourceMtimeMs !== "number" ||
             !Array.isArray(stamp.previewIds)

--- a/vscode-extension/src/sourcePath.ts
+++ b/vscode-extension/src/sourcePath.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import { ModuleInfo } from "./gradleService";
 
 // Matches a top-level Kotlin package declaration. Tolerates optional trailing
 // semicolon and leading whitespace (annotations/comments above `package` are
@@ -31,10 +32,10 @@ export function packageQualifiedSourcePath(filePath: string): string {
 export function moduleRelativeSourcePath(
     filePath: string,
     workspaceRoot: string,
-    module: string,
+    module: ModuleInfo,
 ): string {
     return normalizeSourcePath(
-        path.relative(path.join(workspaceRoot, module), filePath),
+        path.relative(path.join(workspaceRoot, module.projectDir), filePath),
     );
 }
 
@@ -45,7 +46,7 @@ function normalizeSourcePath(value: string): string {
 function sourcePathCandidates(
     filePath: string,
     workspaceRoot: string,
-    module: string,
+    module: ModuleInfo,
 ): Set<string> {
     const candidates = new Set<string>();
     candidates.add(normalizeSourcePath(packageQualifiedSourcePath(filePath)));
@@ -69,7 +70,7 @@ export function previewSourceMatches(
     previewSourceFile: string | null | undefined,
     filePath: string,
     workspaceRoot: string,
-    module: string,
+    module: ModuleInfo,
 ): boolean {
     if (!previewSourceFile) {
         return false;

--- a/vscode-extension/src/test/daemonProcess.test.ts
+++ b/vscode-extension/src/test/daemonProcess.test.ts
@@ -53,7 +53,10 @@ describe("readLaunchDescriptor", () => {
     it(
         "returns null when the descriptor file does not exist",
         withTempWorkspace((dir) => {
-            const result = readLaunchDescriptor(dir, "samples/android");
+            const result = readLaunchDescriptor(dir, {
+                projectDir: "samples/android",
+                modulePath: ":samples:android",
+            });
             assert.strictEqual(result, null);
         }),
     );
@@ -63,7 +66,10 @@ describe("readLaunchDescriptor", () => {
         withTempWorkspace((dir) => {
             const descriptor = validDescriptor();
             writeDescriptor(dir, "samples/android", descriptor);
-            const result = readLaunchDescriptor(dir, "samples/android");
+            const result = readLaunchDescriptor(dir, {
+                projectDir: "samples/android",
+                modulePath: ":samples:android",
+            });
             assert.notStrictEqual(result, null);
             assert.strictEqual(result!.modulePath, ":samples:android");
             assert.strictEqual(result!.enabled, true);
@@ -77,9 +83,14 @@ describe("readLaunchDescriptor", () => {
             const logs: string[] = [];
             const descriptor = { ...validDescriptor(), schemaVersion: 999 };
             writeDescriptor(dir, "samples/android", descriptor);
-            const result = readLaunchDescriptor(dir, "samples/android", {
-                appendLine: (s) => logs.push(s),
-            });
+            const result = readLaunchDescriptor(
+                dir,
+                {
+                    projectDir: "samples/android",
+                    modulePath: ":samples:android",
+                },
+                { appendLine: (s) => logs.push(s) },
+            );
             assert.strictEqual(result, null);
             assert.ok(
                 logs.some((l) => l.includes("schema mismatch")),
@@ -103,9 +114,14 @@ describe("readLaunchDescriptor", () => {
                 path.join(descriptorDir, "daemon-launch.json"),
                 "{ not json",
             );
-            const result = readLaunchDescriptor(dir, "samples/android", {
-                appendLine: (s) => logs.push(s),
-            });
+            const result = readLaunchDescriptor(
+                dir,
+                {
+                    projectDir: "samples/android",
+                    modulePath: ":samples:android",
+                },
+                { appendLine: (s) => logs.push(s) },
+            );
             assert.strictEqual(result, null);
             assert.ok(
                 logs.some((l) => l.includes("failed to read")),
@@ -121,7 +137,10 @@ describe("readLaunchDescriptor", () => {
             // Reader must return the descriptor honestly; the gate decides what to do with it.
             const descriptor = { ...validDescriptor(), enabled: false };
             writeDescriptor(dir, "samples/android", descriptor);
-            const result = readLaunchDescriptor(dir, "samples/android");
+            const result = readLaunchDescriptor(dir, {
+                projectDir: "samples/android",
+                modulePath: ":samples:android",
+            });
             assert.strictEqual(result?.enabled, false);
         }),
     );
@@ -131,7 +150,10 @@ describe("readLaunchDescriptor", () => {
         withTempWorkspace((dir) => {
             const descriptor = { ...validDescriptor(), javaLauncher: null };
             writeDescriptor(dir, "samples/android", descriptor);
-            const result = readLaunchDescriptor(dir, "samples/android");
+            const result = readLaunchDescriptor(dir, {
+                projectDir: "samples/android",
+                modulePath: ":samples:android",
+            });
             assert.strictEqual(result?.javaLauncher, null);
         }),
     );

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -64,6 +64,18 @@ class FakeClient {
  * the daemon without spinning up streams. Keyed by moduleId because the
  * scheduler may register a different bag per module.
  */
+interface ModuleLike {
+    readonly projectDir: string;
+    readonly modulePath: string;
+}
+
+/** Builds a {@link ModuleLike} from a single string used as both projectDir
+ *  (filesystem) and the colon-form modulePath. Lets every existing test keep
+ *  passing a bare `"mod"` while the production API requires both fields. */
+function mod(name: string): ModuleLike {
+    return { projectDir: name, modulePath: `:${name}` };
+}
+
 class FakeGate {
     public client: FakeClient | null = new FakeClient();
     public ready = false;
@@ -92,16 +104,19 @@ class FakeGate {
         }
     >();
 
-    isDaemonReady(_moduleId: string): boolean {
+    isDaemonReady(_modulePath: string): boolean {
         return this.ready;
     }
-    getOrSpawn(moduleId: string, events: unknown): Promise<FakeClient | null> {
-        this.getOrSpawnCalls.push(moduleId);
+    getOrSpawn(
+        module: ModuleLike,
+        events: unknown,
+    ): Promise<FakeClient | null> {
+        this.getOrSpawnCalls.push(module.modulePath);
         const err = this.getOrSpawnErrors.shift();
         if (err) {
             return Promise.reject(err);
         }
-        this.capturedEvents.set(moduleId, events as never);
+        this.capturedEvents.set(module.modulePath, events as never);
         return Promise.resolve(this.client);
     }
 }
@@ -109,8 +124,8 @@ class FakeGate {
 class FakeGradleService {
     public bootstrapCalls: string[] = [];
     public bootstrapShouldThrow: Error | null = null;
-    async runDaemonBootstrap(moduleId: string): Promise<void> {
-        this.bootstrapCalls.push(moduleId);
+    async runDaemonBootstrap(module: ModuleLike): Promise<void> {
+        this.bootstrapCalls.push(module.modulePath);
         if (this.bootstrapShouldThrow) {
             throw this.bootstrapShouldThrow;
         }
@@ -208,9 +223,9 @@ function build() {
 describe("DaemonScheduler", () => {
     it("dedupes setVisible when the visible set is unchanged", async () => {
         const { gate, scheduler } = build();
-        await scheduler.setVisible("mod", ["a", "b"], []);
-        await scheduler.setVisible("mod", ["a", "b"], []); // no-op
-        await scheduler.setVisible("mod", ["b", "a"], []); // same set, different order — still no-op
+        await scheduler.setVisible(mod("mod"), ["a", "b"], []);
+        await scheduler.setVisible(mod("mod"), ["a", "b"], []); // no-op
+        await scheduler.setVisible(mod("mod"), ["b", "a"], []); // same set, different order — still no-op
         const visibleCalls = gate.client!.calls.filter(
             (c) => c.method === "setVisible",
         );
@@ -220,7 +235,7 @@ describe("DaemonScheduler", () => {
     it("caps speculative renderNow at the budget", async () => {
         const { gate, scheduler } = build();
         const predicted = ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"];
-        await scheduler.setVisible("mod", ["v1"], predicted);
+        await scheduler.setVisible(mod("mod"), ["v1"], predicted);
         const renderCalls = gate.client!.calls.filter(
             (c) => c.method === "renderNow",
         );
@@ -238,7 +253,7 @@ describe("DaemonScheduler", () => {
 
     it("does not re-speculate IDs already in the visible set", async () => {
         const { gate, scheduler } = build();
-        await scheduler.setVisible("mod", ["a", "b"], ["b", "c", "d"]);
+        await scheduler.setVisible(mod("mod"), ["a", "b"], ["b", "c", "d"]);
         const renderCalls = gate.client!.calls.filter(
             (c) => c.method === "renderNow",
         );
@@ -254,8 +269,8 @@ describe("DaemonScheduler", () => {
         // identical work; the daemon's reactive queue still handles them on
         // actual focus.
         const { gate, scheduler } = build();
-        await scheduler.setVisible("mod", ["v1"], ["p1", "p2"]);
-        await scheduler.setVisible("mod", ["v2"], ["p1", "p2"]); // same predictions
+        await scheduler.setVisible(mod("mod"), ["v1"], ["p1", "p2"]);
+        await scheduler.setVisible(mod("mod"), ["v2"], ["p1", "p2"]); // same predictions
         const renderCalls = gate.client!.calls.filter(
             (c) => c.method === "renderNow",
         );
@@ -269,8 +284,8 @@ describe("DaemonScheduler", () => {
         // them and may issue speculative renders even if visibility is the
         // same set as last time.
         const { gate, scheduler } = build();
-        await scheduler.setVisible("mod", ["v1"], []);
-        await scheduler.setVisible("mod", ["v1"], ["fresh1", "fresh2"]);
+        await scheduler.setVisible(mod("mod"), ["v1"], []);
+        await scheduler.setVisible(mod("mod"), ["v1"], ["fresh1", "fresh2"]);
         const renderCalls = gate.client!.calls.filter(
             (c) => c.method === "renderNow",
         );
@@ -282,23 +297,26 @@ describe("DaemonScheduler", () => {
     it("skips daemon traffic entirely when the gate has no client", async () => {
         const { gate, scheduler } = build();
         gate.client = null;
-        await scheduler.fileChanged("mod", "/x.kt");
-        await scheduler.setFocus("mod", ["a"]);
-        await scheduler.setVisible("mod", ["a"], ["b"]);
-        const ok = await scheduler.ensureModule("mod");
+        await scheduler.fileChanged(mod("mod"), "/x.kt");
+        await scheduler.setFocus(mod("mod"), ["a"]);
+        await scheduler.setVisible(mod("mod"), ["a"], ["b"]);
+        const ok = await scheduler.ensureModule(mod("mod"));
         assert.strictEqual(ok, false);
     });
 
     it("classifies file kinds for fileChanged", async () => {
         const { gate, scheduler } = build();
-        await scheduler.fileChanged("mod", "/proj/src/main/kotlin/Foo.kt");
+        await scheduler.fileChanged(mod("mod"), "/proj/src/main/kotlin/Foo.kt");
         await scheduler.fileChanged(
-            "mod",
+            mod("mod"),
             "/proj/src/main/res/values/strings.xml",
         );
-        await scheduler.fileChanged("mod", "/proj/gradle/libs.versions.toml");
-        await scheduler.fileChanged("mod", "/proj/build.gradle.kts");
-        await scheduler.fileChanged("mod", "/proj/gradle.properties");
+        await scheduler.fileChanged(
+            mod("mod"),
+            "/proj/gradle/libs.versions.toml",
+        );
+        await scheduler.fileChanged(mod("mod"), "/proj/build.gradle.kts");
+        await scheduler.fileChanged(mod("mod"), "/proj/gradle.properties");
         const kinds = gate
             .client!.calls.filter((c) => c.method === "fileChanged")
             .map((c) => (c.args as { kind: string }).kind);
@@ -313,8 +331,8 @@ describe("DaemonScheduler", () => {
 
     it("dedupes setFocus when ids are unchanged regardless of order", async () => {
         const { gate, scheduler } = build();
-        await scheduler.setFocus("mod", ["a", "b"]);
-        await scheduler.setFocus("mod", ["b", "a"]);
+        await scheduler.setFocus(mod("mod"), ["a", "b"]);
+        await scheduler.setFocus(mod("mod"), ["b", "a"]);
         const focusCalls = gate.client!.calls.filter(
             (c) => c.method === "setFocus",
         );
@@ -331,8 +349,8 @@ describe("DaemonScheduler", () => {
             ]); // PNG magic
             fs.writeFileSync(pngPath, bytes);
 
-            await scheduler.ensureModule("mod");
-            const evts = gate.capturedEvents.get("mod")!;
+            await scheduler.ensureModule(mod("mod"));
+            const evts = gate.capturedEvents.get(":mod")!;
             evts.onRenderFinished!({ id: "p1", pngPath, tookMs: 200 });
 
             assert.strictEqual(images.length, 1);
@@ -349,8 +367,8 @@ describe("DaemonScheduler", () => {
         // to the last frame for this preview id. The scheduler must skip the disk read +
         // base64 + onPreviewImageReady hop so the panel doesn't repaint identical bytes.
         const { gate, scheduler, images, failures } = build();
-        await scheduler.ensureModule("mod");
-        const evts = gate.capturedEvents.get("mod")!;
+        await scheduler.ensureModule(mod("mod"));
+        const evts = gate.capturedEvents.get(":mod")!;
         // Use a path that doesn't exist on disk — if the scheduler even tries to read it,
         // it would emit onRenderFailed. The dedup short-circuit means it does neither:
         // no image, no failure.
@@ -374,8 +392,8 @@ describe("DaemonScheduler", () => {
 
     it("reports onRenderFailed when the renderFinished PNG path is unreadable", async () => {
         const { gate, scheduler, failures } = build();
-        await scheduler.ensureModule("mod");
-        const evts = gate.capturedEvents.get("mod")!;
+        await scheduler.ensureModule(mod("mod"));
+        const evts = gate.capturedEvents.get(":mod")!;
         evts.onRenderFinished!({
             id: "pZ",
             pngPath: "/no/such/file.png",
@@ -393,8 +411,8 @@ describe("DaemonScheduler", () => {
         // the panel is already populated by the Gradle fallback. We
         // detect the documented stub-filename shape and skip.
         const { gate, scheduler, log, failures, images } = build();
-        await scheduler.ensureModule("mod");
-        const evts = gate.capturedEvents.get("mod")!;
+        await scheduler.ensureModule(mod("mod"));
+        const evts = gate.capturedEvents.get(":mod")!;
         for (let i = 1; i <= 5; i++) {
             evts.onRenderFinished!({
                 id: `p${i}`,
@@ -412,8 +430,8 @@ describe("DaemonScheduler", () => {
 
     it("detects gif stub paths the same way as png stubs", async () => {
         const { gate, scheduler, failures, images } = build();
-        await scheduler.ensureModule("mod");
-        const evts = gate.capturedEvents.get("mod")!;
+        await scheduler.ensureModule(mod("mod"));
+        const evts = gate.capturedEvents.get(":mod")!;
         evts.onRenderFinished!({
             id: "p1",
             pngPath: ".compose-preview-history/daemon-stub-1.gif",
@@ -428,8 +446,8 @@ describe("DaemonScheduler", () => {
         // happen to be missing must still surface as a failure so the
         // daemon's render bug is visible rather than silently swallowed.
         const { gate, scheduler, failures } = build();
-        await scheduler.ensureModule("mod");
-        const evts = gate.capturedEvents.get("mod")!;
+        await scheduler.ensureModule(mod("mod"));
+        const evts = gate.capturedEvents.get(":mod")!;
         evts.onRenderFinished!({
             id: "pY",
             pngPath: "/abs/build/compose-previews/renders/com.example.X.png",
@@ -441,19 +459,19 @@ describe("DaemonScheduler", () => {
 
     it("forwards onRenderFailed from the daemon directly to the caller", async () => {
         const { gate, scheduler, failures } = build();
-        await scheduler.ensureModule("mod");
-        const evts = gate.capturedEvents.get("mod")!;
+        await scheduler.ensureModule(mod("mod"));
+        const evts = gate.capturedEvents.get(":mod")!;
         evts.onRenderFailed!({ id: "pX", error: { message: "compile error" } });
         assert.deepStrictEqual(failures, [
-            { moduleId: "mod", previewId: "pX", message: "compile error" },
+            { moduleId: ":mod", previewId: "pX", message: "compile error" },
         ]);
     });
 
     it("clears the speculation cache and visibility memo when the channel closes", async () => {
         const { gate, scheduler } = build();
         // Speculate first so the cache is populated.
-        await scheduler.setVisible("mod", ["v1"], ["p1", "p2"]);
-        const evts = gate.capturedEvents.get("mod")!;
+        await scheduler.setVisible(mod("mod"), ["v1"], ["p1", "p2"]);
+        const evts = gate.capturedEvents.get(":mod")!;
 
         // Channel close → the gate registry will replace the client. Pretend
         // a fresh daemon spawned with a new client object.
@@ -462,7 +480,7 @@ describe("DaemonScheduler", () => {
         evts.onChannelClosed!();
 
         // Same predictions on a fresh daemon should re-issue, not dedup.
-        await scheduler.setVisible("mod", ["v1"], ["p1", "p2"]);
+        await scheduler.setVisible(mod("mod"), ["v1"], ["p1", "p2"]);
         const renderCalls = fresh.calls.filter((c) => c.method === "renderNow");
         assert.strictEqual(
             renderCalls.length,
@@ -476,29 +494,29 @@ describe("DaemonScheduler", () => {
         // daemon — frameStreamIds don't survive a JVM restart, so a stale entry would route
         // future clicks to a stream id the new daemon never minted.
         const { gate, scheduler, channelClosed } = build();
-        await scheduler.ensureModule("alpha");
-        await scheduler.ensureModule("beta");
-        gate.capturedEvents.get("alpha")!.onChannelClosed!();
-        assert.deepStrictEqual(channelClosed, ["alpha"]);
-        gate.capturedEvents.get("beta")!.onChannelClosed!();
-        assert.deepStrictEqual(channelClosed, ["alpha", "beta"]);
+        await scheduler.ensureModule(mod("alpha"));
+        await scheduler.ensureModule(mod("beta"));
+        gate.capturedEvents.get(":alpha")!.onChannelClosed!();
+        assert.deepStrictEqual(channelClosed, [":alpha"]);
+        gate.capturedEvents.get(":beta")!.onChannelClosed!();
+        assert.deepStrictEqual(channelClosed, [":alpha", ":beta"]);
     });
 
     it("routes classpathDirty to the caller and drops the module speculation cache", async () => {
         const { gate, scheduler, dirty } = build();
-        await scheduler.setVisible("mod", ["v1"], ["p1", "p2"]);
-        const evts = gate.capturedEvents.get("mod")!;
+        await scheduler.setVisible(mod("mod"), ["v1"], ["p1", "p2"]);
+        const evts = gate.capturedEvents.get(":mod")!;
         evts.onClasspathDirty!({ detail: "libs.versions.toml SHA changed" });
         assert.strictEqual(dirty.length, 1);
-        assert.strictEqual(dirty[0].moduleId, "mod");
+        assert.strictEqual(dirty[0].moduleId, ":mod");
     });
 
     it("forwards discoveryUpdated to the caller with the moduleId attached", async () => {
         const { gate, scheduler, discovery } = build();
         // First call any scheduler method that goes through getOrSpawn so the
         // events bag for `mod` is registered; setFocus is the cheapest.
-        await scheduler.setFocus("mod", ["p1"]);
-        const evts = gate.capturedEvents.get("mod")!;
+        await scheduler.setFocus(mod("mod"), ["p1"]);
+        const evts = gate.capturedEvents.get(":mod")!;
         evts.onDiscoveryUpdated!({
             added: [],
             removed: ["p1"],
@@ -506,17 +524,17 @@ describe("DaemonScheduler", () => {
             totalPreviews: 0,
         });
         assert.strictEqual(discovery.length, 1);
-        assert.strictEqual(discovery[0].moduleId, "mod");
+        assert.strictEqual(discovery[0].moduleId, ":mod");
         assert.deepStrictEqual(discovery[0].params.removed, ["p1"]);
     });
 
     it("renderNow returns true on accept and false when no daemon is available", async () => {
         const { gate, scheduler } = build();
-        const ok = await scheduler.renderNow("mod", ["p1"], "fast");
+        const ok = await scheduler.renderNow(mod("mod"), ["p1"], "fast");
         assert.strictEqual(ok, true);
 
         gate.client = null;
-        const fail = await scheduler.renderNow("mod2", ["p1"], "fast");
+        const fail = await scheduler.renderNow(mod("mod2"), ["p1"], "fast");
         assert.strictEqual(fail, false);
     });
 
@@ -526,7 +544,11 @@ describe("DaemonScheduler", () => {
             queued: ["p1"],
             rejected: [{ id: "pBad", reason: "unknown preview ID" }],
         };
-        const ok = await scheduler.renderNow("mod", ["p1", "pBad"], "fast");
+        const ok = await scheduler.renderNow(
+            mod("mod"),
+            ["p1", "pBad"],
+            "fast",
+        );
         assert.strictEqual(ok, true);
         assert.ok(
             log.some((l) => l.includes("rejected pBad")),
@@ -541,12 +563,12 @@ describe("DaemonScheduler", () => {
             const states: string[] = [];
             const ok = await scheduler.warmModule(
                 gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                "mod",
+                mod("mod"),
                 (s) => states.push(s),
             );
             assert.strictEqual(ok, true);
             assert.deepStrictEqual(states, ["spawning", "ready"]);
-            assert.deepStrictEqual(gate.getOrSpawnCalls, ["mod"]);
+            assert.deepStrictEqual(gate.getOrSpawnCalls, [":mod"]);
             assert.deepStrictEqual(
                 gradle.bootstrapCalls,
                 [],
@@ -563,7 +585,7 @@ describe("DaemonScheduler", () => {
             const states: string[] = [];
             const ok = await scheduler.warmModule(
                 gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                "mod",
+                mod("mod"),
                 (s) => states.push(s),
             );
             assert.strictEqual(ok, true);
@@ -573,8 +595,8 @@ describe("DaemonScheduler", () => {
                 "spawning",
                 "ready",
             ]);
-            assert.deepStrictEqual(gate.getOrSpawnCalls, ["mod", "mod"]);
-            assert.deepStrictEqual(gradle.bootstrapCalls, ["mod"]);
+            assert.deepStrictEqual(gate.getOrSpawnCalls, [":mod", ":mod"]);
+            assert.deepStrictEqual(gradle.bootstrapCalls, [":mod"]);
             assert.ok(
                 log.some((l) => l.includes("cached launch failed")),
                 `expected cached failure log, got: ${log.join(" / ")}`,
@@ -588,7 +610,7 @@ describe("DaemonScheduler", () => {
             const states: string[] = [];
             const ok = await scheduler.warmModule(
                 gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                "mod",
+                mod("mod"),
                 (s) => states.push(s),
             );
             assert.strictEqual(ok, true);
@@ -615,7 +637,7 @@ describe("DaemonScheduler", () => {
                     gradle as unknown as Parameters<
                         typeof scheduler.warmModule
                     >[0],
-                    "mod",
+                    mod("mod"),
                     (s) => states.push(s),
                 ),
                 /Gradle config-cache rejected/,
@@ -633,7 +655,7 @@ describe("DaemonScheduler", () => {
             gate.client = null;
             const ok = await scheduler.warmModule(
                 gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                "mod",
+                mod("mod"),
                 (s) => states.push(s),
             );
             assert.strictEqual(ok, false);
@@ -664,13 +686,13 @@ describe("DaemonScheduler", () => {
                 },
                 { appendLine: (s) => log.push(s) },
             );
-            await scheduler.ensureModule("mod");
-            const evts = gate.capturedEvents.get("mod")! as unknown as {
+            await scheduler.ensureModule(mod("mod"));
+            const evts = gate.capturedEvents.get(":mod")! as unknown as {
                 onHistoryAdded?: (params: { entry: unknown }) => void;
             };
             evts.onHistoryAdded!({ entry: { id: "abc", previewId: "X" } });
             assert.strictEqual(seen.length, 1);
-            assert.strictEqual(seen[0].moduleId, "mod");
+            assert.strictEqual(seen[0].moduleId, ":mod");
             assert.deepStrictEqual(seen[0].entry, {
                 id: "abc",
                 previewId: "X",
@@ -693,8 +715,8 @@ describe("DaemonScheduler", () => {
                     // no onHistoryAdded
                 },
             );
-            await scheduler.ensureModule("mod");
-            const evts = gate.capturedEvents.get("mod")! as unknown as {
+            await scheduler.ensureModule(mod("mod"));
+            const evts = gate.capturedEvents.get(":mod")! as unknown as {
                 onHistoryAdded?: (params: { entry: unknown }) => void;
             };
             // Doesn't throw.
@@ -710,7 +732,7 @@ describe("DaemonScheduler", () => {
     describe("data products", () => {
         it("does not auto-subscribe on setVisible by default — subscriptions are explicit", async () => {
             const { gate, scheduler } = build();
-            await scheduler.setVisible("mod", ["a", "b"], []);
+            await scheduler.setVisible(mod("mod"), ["a", "b"], []);
             const subs = gate.client!.calls.filter(
                 (c) => c.method === "dataSubscribe",
             );
@@ -720,7 +742,7 @@ describe("DaemonScheduler", () => {
         it("setDataProductSubscription(true) issues data/subscribe per kind", async () => {
             const { gate, scheduler } = build();
             await scheduler.setDataProductSubscription(
-                "mod",
+                mod("mod"),
                 "a",
                 ["a11y/atf", "a11y/hierarchy"],
                 true,
@@ -738,13 +760,13 @@ describe("DaemonScheduler", () => {
         it("setDataProductSubscription(true) twice is idempotent", async () => {
             const { gate, scheduler } = build();
             await scheduler.setDataProductSubscription(
-                "mod",
+                mod("mod"),
                 "a",
                 ["a11y/atf"],
                 true,
             );
             await scheduler.setDataProductSubscription(
-                "mod",
+                mod("mod"),
                 "a",
                 ["a11y/atf"],
                 true,
@@ -758,13 +780,13 @@ describe("DaemonScheduler", () => {
         it("setDataProductSubscription(false) issues data/unsubscribe and forgets the pair", async () => {
             const { gate, scheduler } = build();
             await scheduler.setDataProductSubscription(
-                "mod",
+                mod("mod"),
                 "a",
                 ["a11y/atf"],
                 true,
             );
             await scheduler.setDataProductSubscription(
-                "mod",
+                mod("mod"),
                 "a",
                 ["a11y/atf"],
                 false,
@@ -775,7 +797,7 @@ describe("DaemonScheduler", () => {
             assert.strictEqual(unsubs.length, 1);
             // Re-enabling re-issues subscribe (bookkeeping was cleared).
             await scheduler.setDataProductSubscription(
-                "mod",
+                mod("mod"),
                 "a",
                 ["a11y/atf"],
                 true,
@@ -789,7 +811,7 @@ describe("DaemonScheduler", () => {
         it("setDataProductSubscription(false) on an unknown pair is a no-op", async () => {
             const { gate, scheduler } = build();
             await scheduler.setDataProductSubscription(
-                "mod",
+                mod("mod"),
                 "a",
                 ["a11y/atf"],
                 false,
@@ -804,19 +826,19 @@ describe("DaemonScheduler", () => {
 
         it("setVisible drops bookkeeping for previews that left view", async () => {
             const { gate, scheduler } = build();
-            await scheduler.setVisible("mod", ["a", "b"], []);
+            await scheduler.setVisible(mod("mod"), ["a", "b"], []);
             await scheduler.setDataProductSubscription(
-                "mod",
+                mod("mod"),
                 "a",
                 ["a11y/atf"],
                 true,
             );
-            await scheduler.setVisible("mod", ["b"], []); // 'a' fell out
+            await scheduler.setVisible(mod("mod"), ["b"], []); // 'a' fell out
             // Re-subscribing 'a' should issue another subscribe (bookkeeping was cleared by
             // the visibility prune even though the daemon never received our explicit call).
-            await scheduler.setVisible("mod", ["a", "b"], []);
+            await scheduler.setVisible(mod("mod"), ["a", "b"], []);
             await scheduler.setDataProductSubscription(
-                "mod",
+                mod("mod"),
                 "a",
                 ["a11y/atf"],
                 true,
@@ -829,8 +851,8 @@ describe("DaemonScheduler", () => {
 
         it("forwards renderFinished.dataProducts via onDataProductsAttached", async () => {
             const { gate, scheduler, dataProducts } = build();
-            await scheduler.ensureModule("mod");
-            const evts = gate.capturedEvents.get("mod")! as unknown as {
+            await scheduler.ensureModule(mod("mod"));
+            const evts = gate.capturedEvents.get(":mod")! as unknown as {
                 onRenderFinished: (p: {
                     id: string;
                     pngPath: string;
@@ -868,8 +890,8 @@ describe("DaemonScheduler", () => {
 
         it("does not fire onDataProductsAttached when renderFinished carries no products", async () => {
             const { gate, scheduler, dataProducts } = build();
-            await scheduler.ensureModule("mod");
-            const evts = gate.capturedEvents.get("mod")! as unknown as {
+            await scheduler.ensureModule(mod("mod"));
+            const evts = gate.capturedEvents.get(":mod")! as unknown as {
                 onRenderFinished: (p: {
                     id: string;
                     pngPath: string;
@@ -890,7 +912,7 @@ describe("DaemonScheduler", () => {
             const { gate, scheduler, log } = build();
             gate.client!.dataSubscribeRejects = true;
             await scheduler.setDataProductSubscription(
-                "mod",
+                mod("mod"),
                 "a",
                 ["a11y/atf"],
                 true,
@@ -912,7 +934,7 @@ describe("DaemonScheduler", () => {
             // Retry succeeds (the rollback dropped the bookkeeping).
             gate.client!.dataSubscribeRejects = false;
             await scheduler.setDataProductSubscription(
-                "mod",
+                mod("mod"),
                 "a",
                 ["a11y/atf"],
                 true,

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -92,7 +92,10 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                const manifest = service.readManifest("testmodule");
+                const manifest = service.readManifest({
+                    projectDir: "testmodule",
+                    modulePath: ":testmodule",
+                });
 
                 assert.notStrictEqual(manifest, null);
                 assert.strictEqual(manifest!.module, "sample-android");
@@ -104,7 +107,13 @@ describe("GradleService", () => {
             "returns null for missing manifest",
             withTempDir((dir, api) => {
                 const service = new GradleService(dir, api);
-                assert.strictEqual(service.readManifest("nonexistent"), null);
+                assert.strictEqual(
+                    service.readManifest({
+                        projectDir: "nonexistent",
+                        modulePath: ":nonexistent",
+                    }),
+                    null,
+                );
             }),
         );
 
@@ -124,7 +133,13 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                assert.strictEqual(service.readManifest("bad"), null);
+                assert.strictEqual(
+                    service.readManifest({
+                        projectDir: "bad",
+                        modulePath: ":bad",
+                    }),
+                    null,
+                );
             }),
         );
 
@@ -144,7 +159,13 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                assert.strictEqual(service.readManifest("empty"), null);
+                assert.strictEqual(
+                    service.readManifest({
+                        projectDir: "empty",
+                        modulePath: ":empty",
+                    }),
+                    null,
+                );
             }),
         );
     });
@@ -174,7 +195,10 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                const manifest = service.readResourceManifest("testmodule");
+                const manifest = service.readResourceManifest({
+                    projectDir: "testmodule",
+                    modulePath: ":testmodule",
+                });
 
                 assert.notStrictEqual(manifest, null);
                 assert.strictEqual(manifest!.module, "sample-android");
@@ -233,7 +257,10 @@ describe("GradleService", () => {
             withTempDir((dir, api) => {
                 const service = new GradleService(dir, api);
                 assert.strictEqual(
-                    service.readResourceManifest("nonexistent"),
+                    service.readResourceManifest({
+                        projectDir: "nonexistent",
+                        modulePath: ":nonexistent",
+                    }),
                     null,
                 );
             }),
@@ -255,7 +282,13 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                assert.strictEqual(service.readResourceManifest("bad"), null);
+                assert.strictEqual(
+                    service.readResourceManifest({
+                        projectDir: "bad",
+                        modulePath: ":bad",
+                    }),
+                    null,
+                );
             }),
         );
 
@@ -275,7 +308,13 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                assert.strictEqual(service.readResourceManifest("empty"), null);
+                assert.strictEqual(
+                    service.readResourceManifest({
+                        projectDir: "empty",
+                        modulePath: ":empty",
+                    }),
+                    null,
+                );
             }),
         );
     });
@@ -299,7 +338,7 @@ describe("GradleService", () => {
 
                 const service = new GradleService(dir, api);
                 const base64 = await service.readPreviewImage(
-                    "mod",
+                    { projectDir: "mod", modulePath: ":mod" },
                     "renders/test.png",
                 );
 
@@ -313,7 +352,10 @@ describe("GradleService", () => {
             withTempDir(async (dir, api) => {
                 const service = new GradleService(dir, api);
                 assert.strictEqual(
-                    await service.readPreviewImage("mod", "missing.png"),
+                    await service.readPreviewImage(
+                        { projectDir: "mod", modulePath: ":mod" },
+                        "missing.png",
+                    ),
                     null,
                 );
             }),
@@ -337,7 +379,9 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                assert.deepStrictEqual(service.findPreviewModules(), ["app"]);
+                assert.deepStrictEqual(service.findPreviewModules(), [
+                    { projectDir: "app", modulePath: ":app" },
+                ]);
             }),
         );
 
@@ -357,7 +401,9 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                assert.deepStrictEqual(service.findPreviewModules(), ["app"]);
+                assert.deepStrictEqual(service.findPreviewModules(), [
+                    { projectDir: "app", modulePath: ":app" },
+                ]);
             }),
         );
 
@@ -392,7 +438,9 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                assert.deepStrictEqual(service.findPreviewModules(), ["app"]);
+                assert.deepStrictEqual(service.findPreviewModules(), [
+                    { projectDir: "app", modulePath: ":app" },
+                ]);
             }),
         );
 
@@ -434,7 +482,9 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                assert.deepStrictEqual(service.findPreviewModules(), ["mod"]);
+                assert.deepStrictEqual(service.findPreviewModules(), [
+                    { projectDir: "mod", modulePath: ":mod" },
+                ]);
             }),
         );
 
@@ -469,8 +519,8 @@ describe("GradleService", () => {
 
                 const service = new GradleService(dir, api);
                 assert.deepStrictEqual(service.findPreviewModules(), [
-                    "app",
-                    "lib",
+                    { projectDir: "app", modulePath: ":app" },
+                    { projectDir: "lib", modulePath: ":lib" },
                 ]);
             }),
         );
@@ -504,8 +554,8 @@ describe("GradleService", () => {
 
                 const service = new GradleService(dir, api);
                 assert.deepStrictEqual(service.findPreviewModules(), [
-                    "samples/cmp",
-                    "samples/wear",
+                    { projectDir: "samples/cmp", modulePath: ":samples:cmp" },
+                    { projectDir: "samples/wear", modulePath: ":samples:wear" },
                 ]);
             }),
         );
@@ -522,11 +572,14 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                assert.strictEqual(
+                assert.deepStrictEqual(
                     service.resolveModule(
                         path.join(dir, "sample-android", "src", "Foo.kt"),
                     ),
-                    "sample-android",
+                    {
+                        projectDir: "sample-android",
+                        modulePath: ":sample-android",
+                    },
                 );
             }),
         );
@@ -554,7 +607,7 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                assert.strictEqual(
+                assert.deepStrictEqual(
                     service.resolveModule(
                         path.join(
                             dir,
@@ -568,7 +621,10 @@ describe("GradleService", () => {
                             "Foo.kt",
                         ),
                     ),
-                    "samples/wear",
+                    {
+                        projectDir: "samples/wear",
+                        modulePath: ":samples:wear",
+                    },
                 );
             }),
         );
@@ -589,18 +645,96 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                assert.strictEqual(
+                assert.deepStrictEqual(
                     service.resolveModule(
                         path.join(dir, "foo", "bar", "src", "Foo.kt"),
                     ),
-                    "foo/bar",
+                    { projectDir: "foo/bar", modulePath: ":foo:bar" },
                 );
-                assert.strictEqual(
+                assert.deepStrictEqual(
                     service.resolveModule(
                         path.join(dir, "foo", "src", "Foo.kt"),
                     ),
-                    "foo",
+                    { projectDir: "foo", modulePath: ":foo" },
                 );
+            }),
+        );
+
+        it(
+            "returns the marker's canonical modulePath when projectDir is reassigned (androidx-mini layout)",
+            withTempDir((dir, api) => {
+                // Mirrors the AndroidX-style settings.gradle.kts that maps
+                // a deep filesystem path to a flatter Gradle project path —
+                // e.g. `androidx/wear/compose/remote/remote-material3/samples`
+                // hosting `:wear:compose:remote:remote-material3-samples`.
+                const projectDir = path.join(
+                    dir,
+                    "androidx",
+                    "wear",
+                    "compose",
+                    "remote",
+                    "remote-material3",
+                    "samples",
+                );
+                const markerDir = path.join(
+                    projectDir,
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(markerDir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(markerDir, "applied.json"),
+                    JSON.stringify({
+                        schema: "compose-preview-applied/v1",
+                        modulePath:
+                            ":wear:compose:remote:remote-material3-samples",
+                        moduleName: "remote-material3-samples",
+                        pluginVersion: "0.10.5",
+                    }),
+                );
+
+                const service = new GradleService(dir, api);
+                const expected = {
+                    projectDir:
+                        "androidx/wear/compose/remote/remote-material3/samples",
+                    modulePath: ":wear:compose:remote:remote-material3-samples",
+                };
+                assert.deepStrictEqual(service.findPreviewModules(), [
+                    expected,
+                ]);
+                assert.deepStrictEqual(
+                    service.resolveModule(
+                        path.join(projectDir, "src", "main", "Foo.kt"),
+                    ),
+                    expected,
+                );
+            }),
+        );
+
+        it(
+            "falls back to projectDir-derived modulePath when applied.json is malformed",
+            withTempDir((dir, api) => {
+                fs.mkdirSync(path.join(dir, "lib"));
+                fs.writeFileSync(
+                    path.join(dir, "lib", "build.gradle.kts"),
+                    'plugins { id("ee.schimke.composeai.preview") }',
+                );
+                const markerDir = path.join(
+                    dir,
+                    "lib",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(markerDir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(markerDir, "applied.json"),
+                    "{ not json",
+                );
+
+                const service = new GradleService(dir, api);
+                assert.deepStrictEqual(service.findPreviewModules(), [
+                    { projectDir: "lib", modulePath: ":lib" },
+                ]);
             }),
         );
     });
@@ -636,7 +770,10 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                await service.discoverPreviews("mod");
+                await service.discoverPreviews({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
 
                 assert.strictEqual(api.runCalls.length, 1);
                 assert.strictEqual(
@@ -678,7 +815,10 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                await service.discoverPreviews("samples/wear");
+                await service.discoverPreviews({
+                    projectDir: "samples/wear",
+                    modulePath: ":samples:wear",
+                });
 
                 assert.strictEqual(api.runCalls.length, 1);
                 assert.strictEqual(
@@ -713,8 +853,14 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                await service.discoverPreviews("mod");
-                await service.discoverPreviews("mod");
+                await service.discoverPreviews({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
+                await service.discoverPreviews({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
 
                 // Second call hit cache — only one Gradle invocation
                 assert.strictEqual(api.runCalls.length, 1);
@@ -747,7 +893,10 @@ describe("GradleService", () => {
 
                 const service = new GradleService(dir, api);
                 // Prime the cache via a discoverPreviews invocation.
-                await service.discoverPreviews("mod");
+                await service.discoverPreviews({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
                 assert.strictEqual(api.runCalls.length, 1);
                 assert.strictEqual(
                     api.runCalls[0].taskName,
@@ -755,7 +904,10 @@ describe("GradleService", () => {
                 );
 
                 // compileOnly runs a different task and invalidates the cache.
-                await service.compileOnly("mod");
+                await service.compileOnly({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
                 assert.strictEqual(api.runCalls.length, 2);
                 assert.strictEqual(
                     api.runCalls[1].taskName,
@@ -763,7 +915,10 @@ describe("GradleService", () => {
                 );
 
                 // Cache was dropped, so the next discoverPreviews calls Gradle again.
-                await service.discoverPreviews("mod");
+                await service.discoverPreviews({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
                 assert.strictEqual(api.runCalls.length, 3);
                 assert.strictEqual(
                     api.runCalls[2].taskName,
@@ -797,9 +952,18 @@ describe("GradleService", () => {
                 );
 
                 const service = new GradleService(dir, api);
-                await service.discoverPreviews("mod");
-                service.invalidateCache("mod");
-                await service.discoverPreviews("mod");
+                await service.discoverPreviews({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
+                service.invalidateCache({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
+                await service.discoverPreviews({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
 
                 assert.strictEqual(api.runCalls.length, 2);
             }),
@@ -812,7 +976,10 @@ describe("GradleService", () => {
 
                 const service = new GradleService(dir, api);
                 await assert.rejects(
-                    service.discoverPreviews("mod"),
+                    service.discoverPreviews({
+                        projectDir: "mod",
+                        modulePath: ":mod",
+                    }),
                     /Gradle task .* failed/,
                 );
             }),
@@ -829,7 +996,10 @@ describe("GradleService", () => {
 
                 const service = new GradleService(dir, api);
                 await assert.rejects(
-                    service.discoverPreviews("mod"),
+                    service.discoverPreviews({
+                        projectDir: "mod",
+                        modulePath: ":mod",
+                    }),
                     (err: unknown) => {
                         assert.ok(
                             err instanceof TaskCancelledError,
@@ -851,7 +1021,10 @@ describe("GradleService", () => {
 
                 const service = new GradleService(dir, api);
                 await assert.rejects(
-                    service.discoverPreviews("mod"),
+                    service.discoverPreviews({
+                        projectDir: "mod",
+                        modulePath: ":mod",
+                    }),
                     (err: unknown) => {
                         assert.ok(
                             err instanceof JdkImageError,
@@ -874,7 +1047,9 @@ describe("GradleService", () => {
             withTempDir(async (dir, api) => {
                 const service = new GradleService(dir, api);
                 // Start a task but don't await — simulate running
-                service.discoverPreviews("mod").catch(() => {}); // swallow error
+                service
+                    .discoverPreviews({ projectDir: "mod", modulePath: ":mod" })
+                    .catch(() => {}); // swallow error
                 await new Promise((resolve) => setTimeout(resolve, 10));
 
                 await service.cancel();
@@ -910,9 +1085,14 @@ describe("GradleService", () => {
                 const service = new GradleService(dir, heldApi);
 
                 const bootstrap = service
-                    .runDaemonBootstrap("mod")
+                    .runDaemonBootstrap({
+                        projectDir: "mod",
+                        modulePath: ":mod",
+                    })
                     .catch(() => {});
-                const render = service.discoverPreviews("mod").catch(() => {});
+                const render = service
+                    .discoverPreviews({ projectDir: "mod", modulePath: ":mod" })
+                    .catch(() => {});
                 // Yield enough turns for both runTask invocations to be
                 // recorded in activeKeys.
                 await new Promise((resolve) => setImmediate(resolve));

--- a/vscode-extension/src/test/launchOnDevice.test.ts
+++ b/vscode-extension/src/test/launchOnDevice.test.ts
@@ -253,12 +253,18 @@ describe("collectAndroidApplicationModules", () => {
             );
 
             const got = collectAndroidApplicationModules(dir, [
-                "samples/app",
-                "samples/lib",
-                "samples/cmp",
+                { projectDir: "samples/app", modulePath: ":samples:app" },
+                { projectDir: "samples/lib", modulePath: ":samples:lib" },
+                { projectDir: "samples/cmp", modulePath: ":samples:cmp" },
             ]);
             assert.deepStrictEqual(got, [
-                { module: "samples/app", applicationId: "com.example.app" },
+                {
+                    module: {
+                        projectDir: "samples/app",
+                        modulePath: ":samples:app",
+                    },
+                    applicationId: "com.example.app",
+                },
             ]);
         }),
     );
@@ -278,11 +284,11 @@ describe("collectAndroidApplicationModules", () => {
                 );
             }
             const got = collectAndroidApplicationModules(dir, [
-                "z-app",
-                "a-app",
+                { projectDir: "z-app", modulePath: ":z-app" },
+                { projectDir: "a-app", modulePath: ":a-app" },
             ]);
             assert.deepStrictEqual(
-                got.map((x) => x.module),
+                got.map((x) => x.module.projectDir),
                 ["a-app", "z-app"],
             );
         }),

--- a/vscode-extension/src/test/previewScope.test.ts
+++ b/vscode-extension/src/test/previewScope.test.ts
@@ -31,16 +31,20 @@ function makePreview(
 }
 
 function withTempProject(
-    fn: (workspaceRoot: string, module: string, homeScreenFile: string) => void,
+    fn: (
+        workspaceRoot: string,
+        module: { projectDir: string; modulePath: string },
+        homeScreenFile: string,
+    ) => void,
 ): void {
     const workspaceRoot = fs.mkdtempSync(
         path.join(os.tmpdir(), "compose-preview-scope-"),
     );
     try {
-        const module = "app";
+        const module = { projectDir: "app", modulePath: ":app" };
         const homeScreenFile = path.join(
             workspaceRoot,
-            module,
+            module.projectDir,
             "src",
             "main",
             "kotlin",

--- a/vscode-extension/src/test/renderFreshness.test.ts
+++ b/vscode-extension/src/test/renderFreshness.test.ts
@@ -52,15 +52,15 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
 describe("renderFreshness", () => {
     it("treats a stamped render as fresh even when PNG mtimes are older than the source", async () => {
         await withTempDir(async (dir) => {
-            const module = "app";
+            const module = { projectDir: "app", modulePath: ":app" };
             const source = path.join(
                 dir,
-                module,
+                module.projectDir,
                 "src/main/kotlin/com/example/Previews.kt",
             );
             const png = path.join(
                 dir,
-                module,
+                module.projectDir,
                 "build/compose-previews/renders/p1.png",
             );
             fs.mkdirSync(path.dirname(source), { recursive: true });
@@ -83,10 +83,10 @@ describe("renderFreshness", () => {
 
     it("marks the render stale when the source changes after the stamp", async () => {
         await withTempDir(async (dir) => {
-            const module = "app";
+            const module = { projectDir: "app", modulePath: ":app" };
             const source = path.join(
                 dir,
-                module,
+                module.projectDir,
                 "src/main/kotlin/com/example/Previews.kt",
             );
             fs.mkdirSync(path.dirname(source), { recursive: true });
@@ -107,10 +107,10 @@ describe("renderFreshness", () => {
 
     it("marks the render stale when the visible preview set is not covered by the stamp", async () => {
         await withTempDir(async (dir) => {
-            const module = "app";
+            const module = { projectDir: "app", modulePath: ":app" };
             const source = path.join(
                 dir,
-                module,
+                module.projectDir,
                 "src/main/kotlin/com/example/Previews.kt",
             );
             fs.mkdirSync(path.dirname(source), { recursive: true });
@@ -133,7 +133,7 @@ describe("renderFreshness", () => {
         await withTempDir(async (dir) => {
             const stampPath = renderFreshnessStampPath(
                 dir,
-                "app",
+                { projectDir: "app", modulePath: ":app" },
                 path.join(dir, "app/src/Previews.kt"),
             );
             assert.ok(

--- a/vscode-extension/src/test/sourcePath.test.ts
+++ b/vscode-extension/src/test/sourcePath.test.ts
@@ -5,16 +5,20 @@ import * as path from "path";
 import { moduleRelativeSourcePath, previewSourceMatches } from "../sourcePath";
 
 function withTempSource(
-    fn: (workspaceRoot: string, module: string, filePath: string) => void,
+    fn: (
+        workspaceRoot: string,
+        module: { projectDir: string; modulePath: string },
+        filePath: string,
+    ) => void,
 ): void {
     const workspaceRoot = fs.mkdtempSync(
         path.join(os.tmpdir(), "compose-preview-source-path-"),
     );
     try {
-        const module = "wear";
+        const module = { projectDir: "wear", modulePath: ":wear" };
         const filePath = path.join(
             workspaceRoot,
-            module,
+            module.projectDir,
             "src",
             "main",
             "kotlin",


### PR DESCRIPTION
## Summary

- Track each Gradle module as `{ projectDir, modulePath }` instead of a single string. `projectDir` is the workspace-relative filesystem path; `modulePath` is the canonical `:foo:bar` Gradle task prefix.
- Parse `build/compose-previews/applied.json` (schema `compose-preview-applied/v1`) to read the authoritative `modulePath` instead of synthesising it from the filesystem path. Falls back to the projectDir-derived path when the marker is absent or malformed.
- Raise `SCAN_MAX_DEPTH` from 4 to 12 so deeply nested layouts are reachable. Recursion is still pruned by `SCAN_SKIP_DIRS` (skips `build`, `src`, `node_modules`, …); the cap is just a defensive bound for symlink-loop pathologies.

### Why

Workspaces that reassign `projectDir` in `settings.gradle.kts` — the AndroidX-mini checkout layout, where `:wear:compose:remote:remote-material3-samples` lives at `androidx/wear/compose/remote/remote-material3/samples` on disk — used to log `[refresh] no module — activeFile=…` and render nothing. Two compounding bugs: the depth cap hid the marker, and the projectDir-derived module id (`androidx/wear/.../samples`) didn't match the real Gradle task name.

### Notable shape changes

- `GradleService.findPreviewModules(): ModuleInfo[]` (was `string[]`).
- `GradleService.resolveModule(filePath): ModuleInfo | null` (was `string | null`).
- Every per-module `GradleService` method (`discoverPreviews`, `compileOnly`, `renderPreviews`, `installDebug`, `runDoctor`, `readManifest`, `readResourceManifest`, `readPreviewImage`, `readPreviewRenderError`, `runDaemonBootstrap`, `invalidateCache`) takes `ModuleInfo` and uses `module.projectDir` for filesystem joins, `module.modulePath` for task names. Cache keys switched to `modulePath`.
- Daemon layer: `DaemonGate.{getOrSpawn,bootstrap,isBuildDisabled}` and `readLaunchDescriptor` take `ModuleInfo`; pure lookups (`isDaemonReady`, `isInteractiveSupported`) stay keyed by `modulePath: string`. `DaemonScheduler.{ensureModule,warmModule,fileChanged,setFocus,setVisible,renderNow,setDataProductSubscription}` take `ModuleInfo`.
- Wire-protocol/webview surface: `HistoryScope.moduleId` and `setInteractiveAvailability.moduleId` now carry the canonical gradle modulePath. `previewModuleMap` stores `ModuleInfo` so callers don't have to re-resolve.

## Test plan

- [x] `npx tsc -p .` clean
- [x] `npx tsc -p tsconfig.webview.json` clean
- [x] `npm test` — 681 passing
- [x] `npm run format:check` clean
- [x] New `gradleService.test.ts` cases:
  - marker with reassigned `modulePath` is preferred over the projectDir-derived path (androidx-mini layout)
  - malformed `applied.json` falls back to the projectDir-derived path
- [ ] Smoke test in a real androidx-mini workspace — open `androidx/wear/compose/remote/remote-material3/samples/...` and confirm the refresh log says `module=:wear:compose:remote:remote-material3-samples` instead of `no module — activeFile=…`
- [ ] `npm run test:electron` (e2e suite) — not run locally