### PR TITLE
Add display filter data product for post-capture color transforms

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -66,6 +66,12 @@ dependencies {
   // `AmbientStateController`, the `AroundComposable` extension that primes it, and the
   // `AmbientInputDispatchObserver` that wakes on activating gestures during recording.
   implementation(project(":data-ambient-connector"))
+  // Display-filter connector — DisplayFilterDataProductRegistry + DisplayFilterDataProducer.
+  // DaemonMain reads `composeai.displayfilter.filters` via `DisplayFilterConfig` to decide
+  // whether to register the extension; the host's render pipeline reads the same prop and
+  // calls `DisplayFilterDataProducer.writeArtifacts(...)` post-capture (RenderEngine wiring
+  // lands in a follow-up).
+  implementation(project(":data-displayfilter-connector"))
   // Focus / keyboard-traversal connector — `FocusController`, the `AroundComposable` extension
   // that installs `LocalInputModeManager provides KeyboardInputModeManager` and drives the focus
   // walk from a `LaunchedEffect`, the `FocusPreviewOverrideExtension` planner consuming

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -427,6 +427,20 @@ fun main(args: Array<String>) {
               dataExtensionDescriptors = NavigationRecordingScriptEvents.descriptors,
             )
           )
+          // Display filters — post-capture color-matrix variants (grayscale/bedtime, invert,
+          // daltonizer simulations). Gated on `composeai.displayfilter.filters` being non-empty
+          // so an `extensions/list` doesn't surface a phantom kind that has nothing on disk yet.
+          // The same prop drives the host's writeArtifacts call site (when wired up); keeping
+          // both reads in DisplayFilterConfig avoids drift between "registered" and "produced".
+          if (DisplayFilterConfig.fromSystemProperties().isNotEmpty()) {
+            add(
+              Extension(
+                id = "displayfilter",
+                displayName = "Display filter variants",
+                dataProductRegistry = DisplayFilterDataProductRegistry(rootDir = dataRoot),
+              )
+            )
+          }
         }
         // host-wired recording-script extensions + renderer-agnostic roadmap descriptors. The
         // host's contribution flips supported flags as new handlers land in its session registry.

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -486,6 +486,32 @@ class RenderEngine(
                 )
               }
             }
+
+            // Display filters — post-capture colour-matrix variants (grayscale/bedtime, invert,
+            // daltonizer simulations). Gated on `composeai.displayfilter.filters` being non-empty
+            // so the default render path stays free; the same prop drives the DaemonMain
+            // registration gate so "extension registered" and "filters produced" stay in sync.
+            // Wrapped in try/catch so a filter failure does not strand the PNG.
+            if (dataDir != null) {
+              val filters = DisplayFilterConfig.fromSystemProperties()
+              if (filters.isNotEmpty()) {
+                try {
+                  trace.section("displayfilter:variants") {
+                    DisplayFilterDataProducer.writeArtifacts(
+                      rootDir = dataDir,
+                      previewId = spec.outputBaseName,
+                      pngFile = outputFile,
+                      filters = filters,
+                    )
+                  }
+                } catch (t: Throwable) {
+                  System.err.println(
+                    "RenderEngine: displayfilter write failed for ${spec.outputBaseName}: " +
+                      "${t.javaClass.simpleName}: ${t.message}"
+                  )
+                }
+              }
+            }
           } finally {
             // DESIGN § 9 + § 10 cleanup epilogue. The Compose test rule does not allow a second
             // `setContent` on the same `ComponentActivity`, so we can't drive the

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -52,6 +52,10 @@ dependencies {
   implementation(project(":data-theme-connector"))
   implementation(project(":data-wallpaper-connector"))
   implementation(project(":data-recomposition-connector"))
+  // Display-filter connector — `DisplayFilterDataProducer.writeArtifacts` runs the post-capture
+  // pipeline and writes per-variant PNGs + the `displayfilter-variants.json` manifest after each
+  // PNG capture. Same dep on the Android side; the producer is renderer-agnostic (BufferedImage).
+  implementation(project(":data-displayfilter-connector"))
 
   // Compose runtime / foundation / ui — the B-desktop.1.4 RenderEngine body
   // imports `ImageComposeScene`, `@Composable`, `currentComposer`,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -336,6 +336,29 @@ class RenderEngine(
     state.outputFile.parentFile?.mkdirs()
     trace.section("render:writePng") { state.outputFile.writeBytes(pngData.bytes) }
 
+    // Display filters — post-capture colour-matrix variants (grayscale/bedtime, invert,
+    // daltonizer simulations). Gated on `composeai.displayfilter.filters` being non-empty so the
+    // default render path stays free. Wrapped in try/catch so a filter failure does not strand
+    // the PNG.
+    val displayFilters = DisplayFilterConfig.fromSystemProperties()
+    if (displayFilters.isNotEmpty()) {
+      try {
+        trace.section("displayfilter:variants") {
+          DisplayFilterDataProducer.writeArtifacts(
+            rootDir = dataDir,
+            previewId = state.spec.outputBaseName,
+            pngFile = state.outputFile,
+            filters = displayFilters,
+          )
+        }
+      } catch (t: Throwable) {
+        System.err.println(
+          "RenderEngine: displayfilter write failed for ${state.spec.outputBaseName}: " +
+            "${t.javaClass.simpleName}: ${t.message}"
+        )
+      }
+    }
+
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L
     val metrics = SandboxMeasurement.collect(sandboxStats, tookMs = tookMs)
     trace.write(dataDir)

--- a/data/displayfilter/connector/build.gradle.kts
+++ b/data/displayfilter/connector/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // Filter matrices, ColorMatrix4x5, PostCaptureProcessor implementation, shared constants.
+  api(project(":data-displayfilter-core"))
+  // DataProductRegistry, DataFetchResult / DataProductCapability wire types, the Extension class
+  // DaemonMain wires this into. Re-exported so daemon:android can depend on data-displayfilter-
+  // connector alone and still pick up DataProductRegistry transitively, mirroring data-a11y-
+  // connector's `api(project(":daemon:core"))`.
+  api(project(":daemon:core"))
+  api(libs.kotlinx.serialization.json)
+
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-displayfilter-connector",
+    displayName = "Compose Preview - Display Filter Data Product Connector",
+    description =
+      "Daemon-side display-filter data-product connector: writes per-render variant PNGs and a manifest JSON, and serves the displayfilter/variants kind via the compose-preview daemon's data/* JSON-RPC surface.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/displayfilter/connector/src/main/kotlin/ee/schimke/composeai/daemon/DisplayFilterConfig.kt
+++ b/data/displayfilter/connector/src/main/kotlin/ee/schimke/composeai/daemon/DisplayFilterConfig.kt
@@ -1,0 +1,39 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.displayfilter.DisplayFilter
+
+/**
+ * Sysprop-driven configuration for the display-filter extension. DaemonMain reads it to decide
+ * whether to register the extension; the host's render pipeline reads the same prop to decide which
+ * filters to actually apply per render. Keeping the parsing in one place avoids drift between
+ * "extension is registered" and "filters get produced".
+ */
+object DisplayFilterConfig {
+
+  /**
+   * Comma-separated list of [DisplayFilter.id] values. Empty / unset disables the feature entirely.
+   * Unknown ids are dropped with a warning so a typo in one filter doesn't strand the rest.
+   * Example: `-Dcomposeai.displayfilter.filters=grayscale,deuteranopia`.
+   */
+  const val FILTERS_PROP: String = "composeai.displayfilter.filters"
+
+  fun parseFilters(raw: String?): List<DisplayFilter> {
+    if (raw.isNullOrBlank()) return emptyList()
+    val out = mutableListOf<DisplayFilter>()
+    for (token in raw.split(',').map { it.trim() }.filter { it.isNotEmpty() }) {
+      val filter = DisplayFilter.fromId(token)
+      if (filter == null) {
+        System.err.println(
+          "DisplayFilterConfig: ignoring unknown filter id '$token' (known: ${
+            DisplayFilter.entries.joinToString { it.id }
+          })"
+        )
+        continue
+      }
+      if (filter !in out) out += filter
+    }
+    return out
+  }
+
+  fun fromSystemProperties(): List<DisplayFilter> = parseFilters(System.getProperty(FILTERS_PROP))
+}

--- a/data/displayfilter/connector/src/main/kotlin/ee/schimke/composeai/daemon/DisplayFilterDataProducer.kt
+++ b/data/displayfilter/connector/src/main/kotlin/ee/schimke/composeai/daemon/DisplayFilterDataProducer.kt
@@ -1,0 +1,86 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.displayfilter.DisplayFilter
+import ee.schimke.composeai.data.displayfilter.DisplayFilterDataProducts
+import ee.schimke.composeai.data.render.extensions.RenderImageArtifact
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Writes per-render display-filter artifacts the data-product registry serves.
+ *
+ * Layout under `<rootDir>/<previewId>/`:
+ * - `displayfilter_<filterId>.png` — one filtered PNG per enabled filter.
+ * - `displayfilter-variants.json` — manifest listing each variant `{ filter, path, mediaType }`.
+ *   The `displayfilter/variants` JSON-RPC kind serves this file (INLINE transport).
+ *
+ * Idempotent — overwrites prior files on repeat runs.
+ */
+object DisplayFilterDataProducer {
+
+  private val json = Json {
+    encodeDefaults = false
+    prettyPrint = false
+  }
+
+  const val SCHEMA_VERSION: Int = DisplayFilterDataProducts.SCHEMA_VERSION
+  const val KIND_VARIANTS: String = DisplayFilterDataProducts.KIND_VARIANTS
+  const val FILE_VARIANTS: String = "displayfilter-variants.json"
+
+  @Serializable internal data class VariantsManifest(val variants: List<VariantEntry>)
+
+  @Serializable
+  internal data class VariantEntry(val filter: String, val path: String, val mediaType: String)
+
+  /**
+   * Runs [runDisplayFilterPostCapturePipeline] against [pngFile] for the requested [filters],
+   * places the variant PNGs under `<rootDir>/<previewId>/`, and writes the manifest JSON.
+   *
+   * No-op when [filters] is empty — neither the variants directory nor the manifest is created.
+   * Returns the resolved variant entries so callers (e.g. RenderEngine integrations) can attach
+   * them to renderFinished payloads without re-reading the manifest.
+   */
+  fun writeArtifacts(
+    rootDir: File,
+    previewId: String,
+    pngFile: File,
+    filters: List<DisplayFilter>,
+  ): List<DisplayFilterArtifactRecord> {
+    if (filters.isEmpty()) return emptyList()
+    val previewDir = rootDir.resolve(previewId)
+    previewDir.mkdirs()
+    val store =
+      runDisplayFilterPostCapturePipeline(
+        previewId = previewId,
+        imageArtifact = RenderImageArtifact(path = pngFile.absolutePath),
+        outputDirectory = previewDir,
+        filters = filters,
+      )
+    val artifacts = store.displayFilterArtifacts()?.artifacts.orEmpty()
+    val records = artifacts.map { a ->
+      DisplayFilterArtifactRecord(filter = a.filter, path = a.path, mediaType = a.mediaType)
+    }
+    val manifest =
+      VariantsManifest(
+        variants =
+          records.map {
+            VariantEntry(filter = it.filter.id, path = it.path, mediaType = it.mediaType)
+          }
+      )
+    previewDir
+      .resolve(FILE_VARIANTS)
+      .writeText(json.encodeToString(VariantsManifest.serializer(), manifest))
+    return records
+  }
+}
+
+/**
+ * Connector-side projection of `DisplayFilterArtifact` for callers that don't want to depend on the
+ * typed data-product graph types.
+ */
+data class DisplayFilterArtifactRecord(
+  val filter: DisplayFilter,
+  val path: String,
+  val mediaType: String,
+)

--- a/data/displayfilter/connector/src/main/kotlin/ee/schimke/composeai/daemon/DisplayFilterDataProductRegistry.kt
+++ b/data/displayfilter/connector/src/main/kotlin/ee/schimke/composeai/daemon/DisplayFilterDataProductRegistry.kt
@@ -1,0 +1,128 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductExtra
+import ee.schimke.composeai.daemon.protocol.DataProductFacet
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
+import java.io.File
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Surfaces the `displayfilter/variants` kind by reading the manifest JSON
+ * [DisplayFilterDataProducer.writeArtifacts] writes during each render. The manifest enumerates the
+ * variant PNGs (`displayfilter_<filterId>.png`) the post-capture pipeline produced; clients use the
+ * listed paths to fetch each filtered image.
+ *
+ * `attachable: true` so the manifest rides `renderFinished.dataProducts`; `fetchable: true` for
+ * pull-on-demand. Variant PNGs ride along as `extras` so a panel that subscribed to the manifest
+ * still has every PNG path handy without a follow-up `data/fetch`.
+ *
+ * `rootDir` mirrors `RenderEngine`'s `dataDir` (defaults to `<outputDir.parent>/data`). Wired by
+ * [DaemonMain].
+ */
+class DisplayFilterDataProductRegistry(private val rootDir: File) : DataProductRegistry {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = DisplayFilterDataProducer.KIND_VARIANTS,
+        schemaVersion = DisplayFilterDataProducer.SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+        displayName = "Display filter variants",
+        facets = listOf(DataProductFacet.STRUCTURED, DataProductFacet.IMAGE),
+        mediaTypes = listOf("application/json"),
+        sampling = SamplingPolicy.End,
+      )
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != DisplayFilterDataProducer.KIND_VARIANTS) return DataProductRegistry.Outcome.Unknown
+    val file = manifestFile(previewId)
+    if (!file.exists()) return DataProductRegistry.Outcome.NotAvailable
+    val payload =
+      try {
+        json.parseToJsonElement(file.readText())
+      } catch (t: Throwable) {
+        return DataProductRegistry.Outcome.FetchFailed(
+          message = "could not parse $kind for $previewId: ${t.message}"
+        )
+      }
+    val extras = variantExtras(payload).takeIf { it.isNotEmpty() }
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(
+        kind = kind,
+        schemaVersion = DisplayFilterDataProducer.SCHEMA_VERSION,
+        payload = payload,
+        extras = extras,
+      )
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (DisplayFilterDataProducer.KIND_VARIANTS !in kinds) return emptyList()
+    val file = manifestFile(previewId)
+    if (!file.exists()) return emptyList()
+    val payload =
+      try {
+        json.parseToJsonElement(file.readText())
+      } catch (t: Throwable) {
+        System.err.println(
+          "DisplayFilterDataProductRegistry: parse manifest failed for $previewId: ${t.message}"
+        )
+        return emptyList()
+      }
+    val extras = variantExtras(payload).takeIf { it.isNotEmpty() }
+    return listOf(
+      DataProductAttachment(
+        kind = DisplayFilterDataProducer.KIND_VARIANTS,
+        schemaVersion = DisplayFilterDataProducer.SCHEMA_VERSION,
+        payload = payload,
+        extras = extras,
+      )
+    )
+  }
+
+  /**
+   * Maps each `variants[]` entry in the parsed manifest to a [DataProductExtra]. Reading the
+   * manifest as the source of truth (rather than globbing the filesystem) keeps the registry
+   * decoupled from `DisplayFilterExtension`'s on-disk filename scheme — if the renamer changes the
+   * only thing that has to follow is the producer.
+   */
+  private fun variantExtras(payload: JsonElement): List<DataProductExtra> {
+    val obj = payload as? JsonObject ?: return emptyList()
+    val variants = obj["variants"] as? JsonArray ?: return emptyList()
+    return variants.mapNotNull { element ->
+      val variant = element as? JsonObject ?: return@mapNotNull null
+      val filterId = variant["filter"]?.jsonPrimitive?.content ?: return@mapNotNull null
+      val path = variant["path"]?.jsonPrimitive?.content ?: return@mapNotNull null
+      val mediaType = variant["mediaType"]?.jsonPrimitive?.content ?: "image/png"
+      val file = File(path)
+      DataProductExtra(
+        name = filterId,
+        path = path,
+        mediaType = mediaType,
+        sizeBytes = file.length().takeIf { file.isFile && it > 0 },
+      )
+    }
+  }
+
+  private fun manifestFile(previewId: String): File =
+    rootDir.resolve(previewId).resolve(DisplayFilterDataProducer.FILE_VARIANTS)
+}

--- a/data/displayfilter/connector/src/main/kotlin/ee/schimke/composeai/daemon/DisplayFilterPostCapturePipeline.kt
+++ b/data/displayfilter/connector/src/main/kotlin/ee/schimke/composeai/daemon/DisplayFilterPostCapturePipeline.kt
@@ -1,0 +1,94 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.displayfilter.DisplayFilter
+import ee.schimke.composeai.data.displayfilter.DisplayFilterArtifacts
+import ee.schimke.composeai.data.displayfilter.DisplayFilterContextKeys
+import ee.schimke.composeai.data.displayfilter.DisplayFilterDataProducts
+import ee.schimke.composeai.data.displayfilter.DisplayFilterExtension
+import ee.schimke.composeai.data.render.extensions.CommonDataProducts
+import ee.schimke.composeai.data.render.extensions.DataExtensionPlanner
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.DataProductKey
+import ee.schimke.composeai.data.render.extensions.DataProductStore
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.RenderImageArtifact
+import ee.schimke.composeai.data.render.extensions.provides
+import java.io.File
+
+/**
+ * Seeds a [DataProductStore] with the captured PNG, plans the registered post-capture extensions,
+ * runs each [PostCaptureProcessor] in planner-determined order, and returns the populated store.
+ *
+ * Mirrors `runAccessibilityPostCapturePipeline` in shape so the two pipelines share a mental model.
+ * Per-extension `scopedFor(it)` views fail loudly on undeclared `put`/`get`. Failures from
+ * individual extensions are logged + skipped — one bad filter shouldn't strand the others.
+ */
+fun runDisplayFilterPostCapturePipeline(
+  previewId: String,
+  imageArtifact: RenderImageArtifact,
+  outputDirectory: File,
+  filters: List<DisplayFilter>,
+  extensions: List<PlannedDataExtension> = DisplayFilterPostCaptureExtensions.defaults,
+  target: DataExtensionTarget? = null,
+): DataProductStore {
+  val store = RecordingDataProductStore()
+  store.put(CommonDataProducts.ImageArtifact, imageArtifact)
+
+  val contextData =
+    ExtensionContextData.of(
+      DisplayFilterContextKeys.OutputDirectory provides outputDirectory,
+      DisplayFilterContextKeys.Filters provides filters,
+    )
+
+  val initialProducts: Set<DataProductKey<*>> = setOf(CommonDataProducts.ImageArtifact)
+  val requestedOutputs = extensions.flatMap { it.outputs }.toSet()
+  if (requestedOutputs.isEmpty()) return store
+
+  val plan =
+    DataExtensionPlanner.planOutputs(
+      extensions = extensions,
+      requestedOutputs = requestedOutputs,
+      initialProducts = initialProducts,
+      target = target,
+    )
+  if (!plan.isValid) {
+    System.err.println(
+      "DisplayFilterPostCapturePipeline: planning failed for $previewId — ${plan.errors}"
+    )
+    return store
+  }
+
+  for (ext in plan.orderedExtensions) {
+    if (ext !is PostCaptureProcessor) continue
+    try {
+      ext.process(
+        ExtensionPostCaptureContext(
+          extensionId = ext.id,
+          previewId = previewId,
+          renderMode = null,
+          products = store.scopedFor(ext),
+          data = contextData,
+        )
+      )
+    } catch (t: Throwable) {
+      System.err.println(
+        "DisplayFilterPostCapturePipeline: extension '${ext.id}' failed for " +
+          "$previewId: ${t.javaClass.simpleName}: ${t.message}"
+      )
+    }
+  }
+  return store
+}
+
+/** Default consumer set — just the one extension today; left as a list so additions are trivial. */
+object DisplayFilterPostCaptureExtensions {
+  val defaults: List<PlannedDataExtension> = listOf(DisplayFilterExtension())
+}
+
+/** Convenience helper for callers that just want the artifact bag, not the full store. */
+fun DataProductStore.displayFilterArtifacts(): DisplayFilterArtifacts? =
+  get(DisplayFilterDataProducts.Variants)

--- a/data/displayfilter/connector/src/test/kotlin/ee/schimke/composeai/daemon/DisplayFilterConfigTest.kt
+++ b/data/displayfilter/connector/src/test/kotlin/ee/schimke/composeai/daemon/DisplayFilterConfigTest.kt
@@ -1,0 +1,47 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.displayfilter.DisplayFilter
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DisplayFilterConfigTest {
+
+  @Test
+  fun parsesCommaSeparatedIdsInSourceOrder() {
+    assertEquals(
+      listOf(DisplayFilter.Grayscale, DisplayFilter.Invert, DisplayFilter.DeuteranopiaSimulation),
+      DisplayFilterConfig.parseFilters("grayscale,invert,deuteranopia"),
+    )
+  }
+
+  @Test
+  fun trimsWhitespaceAndTolerantOfEmptyTokens() {
+    assertEquals(
+      listOf(DisplayFilter.Grayscale, DisplayFilter.Invert),
+      DisplayFilterConfig.parseFilters("  grayscale , , invert "),
+    )
+  }
+
+  @Test
+  fun emptyOrNullProducesEmptyList() {
+    assertEquals(emptyList<DisplayFilter>(), DisplayFilterConfig.parseFilters(null))
+    assertEquals(emptyList<DisplayFilter>(), DisplayFilterConfig.parseFilters(""))
+    assertEquals(emptyList<DisplayFilter>(), DisplayFilterConfig.parseFilters("   "))
+  }
+
+  @Test
+  fun unknownFilterIdsAreDroppedSilently() {
+    assertEquals(
+      listOf(DisplayFilter.Grayscale),
+      DisplayFilterConfig.parseFilters("grayscale,bogusfilter,monochrome"),
+    )
+  }
+
+  @Test
+  fun duplicatesAreCollapsed() {
+    assertEquals(
+      listOf(DisplayFilter.Grayscale, DisplayFilter.Invert),
+      DisplayFilterConfig.parseFilters("grayscale,invert,grayscale"),
+    )
+  }
+}

--- a/data/displayfilter/connector/src/test/kotlin/ee/schimke/composeai/daemon/DisplayFilterDataProducerTest.kt
+++ b/data/displayfilter/connector/src/test/kotlin/ee/schimke/composeai/daemon/DisplayFilterDataProducerTest.kt
@@ -1,0 +1,90 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.displayfilter.DisplayFilter
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DisplayFilterDataProducerTest {
+
+  @get:Rule val temp = TemporaryFolder()
+
+  @Test
+  fun writesOnePngPerFilterAndManifestEnumeratingThem() {
+    val rootDir = temp.newFolder("data")
+    val pngFile = writeSolidPng(width = 4, height = 4, argb = 0xFFFF0000.toInt())
+
+    val records =
+      DisplayFilterDataProducer.writeArtifacts(
+        rootDir = rootDir,
+        previewId = "demo.SomePreview",
+        pngFile = pngFile,
+        filters = listOf(DisplayFilter.Grayscale, DisplayFilter.Invert),
+      )
+
+    val previewDir = rootDir.resolve("demo.SomePreview")
+    assertEquals(2, records.size)
+    val grayscaleRecord = records.first { it.filter == DisplayFilter.Grayscale }
+    assertTrue(File(grayscaleRecord.path).isFile)
+    assertEquals(previewDir, File(grayscaleRecord.path).parentFile)
+
+    val manifest = previewDir.resolve(DisplayFilterDataProducer.FILE_VARIANTS)
+    assertTrue("manifest at ${manifest.absolutePath}", manifest.isFile)
+    val text = manifest.readText()
+    assertTrue("manifest mentions grayscale: $text", text.contains("\"grayscale\""))
+    assertTrue("manifest mentions invert: $text", text.contains("\"invert\""))
+  }
+
+  @Test
+  fun emptyFilterListSkipsManifestAndPngsEntirely() {
+    val rootDir = temp.newFolder("data")
+    val pngFile = writeSolidPng(width = 2, height = 2, argb = 0xFF000000.toInt())
+
+    val records =
+      DisplayFilterDataProducer.writeArtifacts(
+        rootDir = rootDir,
+        previewId = "demo.Empty",
+        pngFile = pngFile,
+        filters = emptyList(),
+      )
+
+    assertEquals(emptyList<DisplayFilterArtifactRecord>(), records)
+    assertTrue(rootDir.listFiles()?.toList().orEmpty().none { it.name == "demo.Empty" })
+  }
+
+  @Test
+  fun filterFailureFallsBackToAnEmptyManifestWithoutThrowing() {
+    val rootDir = temp.newFolder("data")
+    val nonExistent = temp.newFile("missing.png").also { it.delete() }
+    // Pipeline logs + skips; producer still writes an empty manifest.
+    val records =
+      DisplayFilterDataProducer.writeArtifacts(
+        rootDir = rootDir,
+        previewId = "demo.Broken",
+        pngFile = nonExistent,
+        filters = listOf(DisplayFilter.Grayscale),
+      )
+    assertEquals(emptyList<DisplayFilterArtifactRecord>(), records)
+    val manifest = rootDir.resolve("demo.Broken").resolve(DisplayFilterDataProducer.FILE_VARIANTS)
+    assertTrue(manifest.isFile)
+    assertNotNull(manifest.readText())
+  }
+
+  private fun writeSolidPng(width: Int, height: Int, argb: Int): File {
+    val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    for (y in 0 until height) {
+      for (x in 0 until width) {
+        image.setRGB(x, y, argb)
+      }
+    }
+    val file = temp.newFile("base-${System.nanoTime()}.png")
+    ImageIO.write(image, "png", file)
+    return file
+  }
+}

--- a/data/displayfilter/connector/src/test/kotlin/ee/schimke/composeai/daemon/DisplayFilterDataProductRegistryTest.kt
+++ b/data/displayfilter/connector/src/test/kotlin/ee/schimke/composeai/daemon/DisplayFilterDataProductRegistryTest.kt
@@ -1,0 +1,120 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.displayfilter.DisplayFilter
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DisplayFilterDataProductRegistryTest {
+
+  @get:Rule val temp = TemporaryFolder()
+
+  @Test
+  fun advertisesDisplayFilterVariantsKindAsInlineAttachableFetchable() {
+    val registry = DisplayFilterDataProductRegistry(rootDir = temp.newFolder("data"))
+    val capability = registry.capabilities.single()
+    assertEquals("displayfilter/variants", capability.kind)
+    assertEquals(true, capability.attachable)
+    assertEquals(true, capability.fetchable)
+    assertEquals(false, capability.requiresRerender)
+  }
+
+  @Test
+  fun fetchReturnsNotAvailableWhenManifestNotWrittenYet() {
+    val registry = DisplayFilterDataProductRegistry(rootDir = temp.newFolder("data"))
+    val outcome =
+      registry.fetch(
+        previewId = "missing.Preview",
+        kind = "displayfilter/variants",
+        params = null,
+        inline = true,
+      )
+    assertEquals(DataProductRegistry.Outcome.NotAvailable, outcome)
+  }
+
+  @Test
+  fun fetchReturnsUnknownForOtherKinds() {
+    val registry = DisplayFilterDataProductRegistry(rootDir = temp.newFolder("data"))
+    val outcome =
+      registry.fetch(previewId = "any", kind = "a11y/atf", params = null, inline = false)
+    assertEquals(DataProductRegistry.Outcome.Unknown, outcome)
+  }
+
+  @Test
+  fun fetchAfterProducerReturnsManifestPayloadAndVariantPngsAsExtras() {
+    val rootDir = temp.newFolder("data")
+    val pngFile = writeSolidPng(width = 2, height = 2, argb = 0xFFFF0000.toInt())
+    DisplayFilterDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = "demo.Preview",
+      pngFile = pngFile,
+      filters = listOf(DisplayFilter.Grayscale, DisplayFilter.Invert),
+    )
+
+    val registry = DisplayFilterDataProductRegistry(rootDir = rootDir)
+    val outcome =
+      registry.fetch(
+        previewId = "demo.Preview",
+        kind = "displayfilter/variants",
+        params = null,
+        inline = true,
+      )
+    val ok = outcome as DataProductRegistry.Outcome.Ok
+    assertEquals("displayfilter/variants", ok.result.kind)
+    assertNotNull(ok.result.payload)
+    assertNull(ok.result.path) // INLINE transport — no path set
+    val variantsArray = (ok.result.payload as JsonObject)["variants"] as JsonArray
+    assertEquals(
+      setOf("grayscale", "invert"),
+      variantsArray.map { it.jsonObject["filter"]!!.jsonPrimitive.content }.toSet(),
+    )
+
+    val extras = ok.result.extras.orEmpty()
+    assertEquals(setOf("grayscale", "invert"), extras.map { it.name }.toSet())
+    extras.forEach { assertTrue("extra exists: ${it.path}", File(it.path).isFile) }
+  }
+
+  @Test
+  fun attachmentsForReturnsAttachmentOnlyForVariantsKind() {
+    val rootDir = temp.newFolder("data")
+    val pngFile = writeSolidPng(width = 2, height = 2, argb = 0xFFFFFFFF.toInt())
+    DisplayFilterDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = "demo.Attach",
+      pngFile = pngFile,
+      filters = listOf(DisplayFilter.Grayscale),
+    )
+
+    val registry = DisplayFilterDataProductRegistry(rootDir = rootDir)
+    val attachments =
+      registry.attachmentsFor(
+        previewId = "demo.Attach",
+        kinds = setOf("displayfilter/variants", "a11y/atf"),
+      )
+    assertEquals(1, attachments.size)
+    assertEquals("displayfilter/variants", attachments.single().kind)
+  }
+
+  private fun writeSolidPng(width: Int, height: Int, argb: Int): File {
+    val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    for (y in 0 until height) {
+      for (x in 0 until width) {
+        image.setRGB(x, y, argb)
+      }
+    }
+    val file = temp.newFile("base-${System.nanoTime()}.png")
+    ImageIO.write(image, "png", file)
+    return file
+  }
+}

--- a/data/displayfilter/core/build.gradle.kts
+++ b/data/displayfilter/core/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+}
+
+dependencies {
+  // The post-capture processor reads CommonDataProducts.ImageArtifact and emits its own
+  // DataProductKey artifacts; both live in :data-render-core. No Compose, no Android — color
+  // matrices apply to the captured PNG via java.awt.image.BufferedImage so the same module
+  // works for the Android (Robolectric, host JVM) and Desktop renderers.
+  api(project(":data-render-core"))
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-displayfilter-core",
+    displayName = "Compose Preview - Display Filter Data Product Core",
+    description =
+      "Post-capture color-matrix filters (grayscale/bedtime, color inversion, daltonizer simulation) for Compose Preview. Operates on rendered PNGs; renderer-agnostic.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/displayfilter/core/src/main/kotlin/ee/schimke/composeai/data/displayfilter/ColorMatrix4x5.kt
+++ b/data/displayfilter/core/src/main/kotlin/ee/schimke/composeai/data/displayfilter/ColorMatrix4x5.kt
@@ -1,0 +1,74 @@
+package ee.schimke.composeai.data.displayfilter
+
+/**
+ * 4x5 RGBA color matrix in the same layout Android's `android.graphics.ColorMatrix` and Skia's
+ * `SkColorMatrix` use. Stored row-major as 20 floats:
+ * ```
+ *   [ a  b  c  d  e ]   row 0 -> R'
+ *   [ f  g  h  i  j ]   row 1 -> G'
+ *   [ k  l  m  n  o ]   row 2 -> B'
+ *   [ p  q  r  s  t ]   row 3 -> A'
+ * ```
+ *
+ * Channels are 8-bit `[0, 255]`. Translation column (`e`, `j`, `o`, `t`) is in the same units, not
+ * normalized — matches how Android matrices are expressed in published references for grayscale,
+ * invert, and daltonizer.
+ */
+@JvmInline
+value class ColorMatrix4x5(val values: FloatArray) {
+  init {
+    require(values.size == LENGTH) { "ColorMatrix4x5 requires $LENGTH floats; got ${values.size}." }
+  }
+
+  /** Apply this matrix to a single ARGB pixel and clamp each output channel to `[0, 255]`. */
+  fun applyToArgb(argb: Int): Int {
+    val a = (argb ushr 24) and 0xFF
+    val r = (argb ushr 16) and 0xFF
+    val g = (argb ushr 8) and 0xFF
+    val b = argb and 0xFF
+    val v = values
+    val rr = clamp8(v[0] * r + v[1] * g + v[2] * b + v[3] * a + v[4])
+    val gg = clamp8(v[5] * r + v[6] * g + v[7] * b + v[8] * a + v[9])
+    val bb = clamp8(v[10] * r + v[11] * g + v[12] * b + v[13] * a + v[14])
+    val aa = clamp8(v[15] * r + v[16] * g + v[17] * b + v[18] * a + v[19])
+    return (aa shl 24) or (rr shl 16) or (gg shl 8) or bb
+  }
+
+  companion object {
+    const val LENGTH: Int = 20
+
+    /**
+     * Build a 4x5 RGBA matrix from four 5-element row arrays. Keeps each row literal on its own
+     * line — ktfmt would otherwise flatten a single 20-float `floatArrayOf(...)` call to one float
+     * per line, which makes the matrix structure unreadable at the call site.
+     */
+    fun ofRows(
+      red: FloatArray,
+      green: FloatArray,
+      blue: FloatArray,
+      alpha: FloatArray,
+    ): ColorMatrix4x5 {
+      require(red.size == 5 && green.size == 5 && blue.size == 5 && alpha.size == 5) {
+        "Each row must have 5 floats; got ${red.size},${green.size},${blue.size},${alpha.size}."
+      }
+      return ColorMatrix4x5(red + green + blue + alpha)
+    }
+
+    val Identity: ColorMatrix4x5 =
+      ofRows(
+        red = floatArrayOf(1f, 0f, 0f, 0f, 0f),
+        green = floatArrayOf(0f, 1f, 0f, 0f, 0f),
+        blue = floatArrayOf(0f, 0f, 1f, 0f, 0f),
+        alpha = floatArrayOf(0f, 0f, 0f, 1f, 0f),
+      )
+
+    private fun clamp8(value: Float): Int {
+      val rounded = value.toInt()
+      return when {
+        rounded < 0 -> 0
+        rounded > 255 -> 255
+        else -> rounded
+      }
+    }
+  }
+}

--- a/data/displayfilter/core/src/main/kotlin/ee/schimke/composeai/data/displayfilter/DisplayFilterArtifact.kt
+++ b/data/displayfilter/core/src/main/kotlin/ee/schimke/composeai/data/displayfilter/DisplayFilterArtifact.kt
@@ -13,6 +13,12 @@ data class DisplayFilterArtifact(
 data class DisplayFilterArtifacts(val artifacts: List<DisplayFilterArtifact>)
 
 object DisplayFilterDataProducts {
+  /** Protocol/on-disk kind shared between the typed product graph and the JSON-RPC surface. */
+  const val KIND_VARIANTS: String = "displayfilter/variants"
+
+  /** Bumped when the on-disk manifest layout changes. */
+  const val SCHEMA_VERSION: Int = 1
+
   /**
    * Single output product carrying every enabled filter's artifact for one preview. One product
    * (rather than one-key-per-filter) keeps the planner contract simple — the configured set of
@@ -20,8 +26,8 @@ object DisplayFilterDataProducts {
    */
   val Variants: DataProductKey<DisplayFilterArtifacts> =
     DataProductKey(
-      kind = "displayfilter/variants",
-      schemaVersion = 1,
+      kind = KIND_VARIANTS,
+      schemaVersion = SCHEMA_VERSION,
       type = DisplayFilterArtifacts::class.java,
     )
 }

--- a/data/displayfilter/core/src/main/kotlin/ee/schimke/composeai/data/displayfilter/DisplayFilterArtifact.kt
+++ b/data/displayfilter/core/src/main/kotlin/ee/schimke/composeai/data/displayfilter/DisplayFilterArtifact.kt
@@ -1,0 +1,27 @@
+package ee.schimke.composeai.data.displayfilter
+
+import ee.schimke.composeai.data.render.extensions.DataProductKey
+
+/** One filtered PNG produced from the base capture. */
+data class DisplayFilterArtifact(
+  val filter: DisplayFilter,
+  val path: String,
+  val mediaType: String = "image/png",
+)
+
+/** Bag of all enabled filters' outputs for a single preview. */
+data class DisplayFilterArtifacts(val artifacts: List<DisplayFilterArtifact>)
+
+object DisplayFilterDataProducts {
+  /**
+   * Single output product carrying every enabled filter's artifact for one preview. One product
+   * (rather than one-key-per-filter) keeps the planner contract simple — the configured set of
+   * filters is host-controlled context, not a graph dependency.
+   */
+  val Variants: DataProductKey<DisplayFilterArtifacts> =
+    DataProductKey(
+      kind = "displayfilter/variants",
+      schemaVersion = 1,
+      type = DisplayFilterArtifacts::class.java,
+    )
+}

--- a/data/displayfilter/core/src/main/kotlin/ee/schimke/composeai/data/displayfilter/DisplayFilterExtension.kt
+++ b/data/displayfilter/core/src/main/kotlin/ee/schimke/composeai/data/displayfilter/DisplayFilterExtension.kt
@@ -1,0 +1,70 @@
+package ee.schimke.composeai.data.displayfilter
+
+import ee.schimke.composeai.data.render.extensions.CommonDataProducts
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.DataProductKey
+import ee.schimke.composeai.data.render.extensions.ExtensionContextKey
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+import java.io.File
+
+/**
+ * Reads the captured PNG, applies every filter listed in [DisplayFilterContextKeys.Filters] (or an
+ * empty result if none are enabled), and writes one PNG per filter into
+ * [DisplayFilterContextKeys.OutputDirectory] using the filename pattern
+ * `<basename>_displayfilter_<filterId>.png`.
+ *
+ * Mirrors `OverlayExtension` in shape — host-controlled values (output directory, filter set) flow
+ * through context keys; the typed product graph carries inputs/outputs only.
+ */
+class DisplayFilterExtension : PostCaptureProcessor {
+  override val id: DataExtensionId = DataExtensionId(EXTENSION_ID)
+  override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.AfterRender)
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(phase = DataExtensionPhase.PostProcess)
+  override val inputs: Set<DataProductKey<*>> = setOf(CommonDataProducts.ImageArtifact)
+  override val outputs: Set<DataProductKey<*>> = setOf(DisplayFilterDataProducts.Variants)
+  override val targets: Set<DataExtensionTarget> =
+    setOf(DataExtensionTarget.Android, DataExtensionTarget.Desktop)
+
+  override fun process(context: ExtensionPostCaptureContext) {
+    val filters = context.get(DisplayFilterContextKeys.Filters).orEmpty()
+    if (filters.isEmpty()) {
+      context.products.put(DisplayFilterDataProducts.Variants, DisplayFilterArtifacts(emptyList()))
+      return
+    }
+    val image = context.products.require(CommonDataProducts.ImageArtifact)
+    val outputDir = context.require(DisplayFilterContextKeys.OutputDirectory)
+    val sourcePng = File(image.path)
+    val basename = sourcePng.nameWithoutExtension
+    val artifacts = filters.map { filter ->
+      val dest = outputDir.resolve("${basename}_displayfilter_${filter.id}.png")
+      PngColorMatrix.apply(sourcePng, dest, filter.matrix)
+      DisplayFilterArtifact(filter = filter, path = dest.absolutePath)
+    }
+    context.products.put(DisplayFilterDataProducts.Variants, DisplayFilterArtifacts(artifacts))
+  }
+
+  companion object {
+    const val EXTENSION_ID: String = "displayfilter"
+  }
+}
+
+/**
+ * Host-controlled inputs to [DisplayFilterExtension]. Output directory is per-preview and the
+ * filter set is per-render-config, neither of which fits as a typed product upstream.
+ */
+object DisplayFilterContextKeys {
+  val OutputDirectory: ExtensionContextKey<File> =
+    ExtensionContextKey(name = "displayfilter.outputDirectory", type = File::class.java)
+  val Filters: ExtensionContextKey<List<DisplayFilter>> =
+    @Suppress("UNCHECKED_CAST")
+    ExtensionContextKey(
+      name = "displayfilter.filters",
+      type = List::class.java as Class<List<DisplayFilter>>,
+    )
+}

--- a/data/displayfilter/core/src/main/kotlin/ee/schimke/composeai/data/displayfilter/DisplayFilters.kt
+++ b/data/displayfilter/core/src/main/kotlin/ee/schimke/composeai/data/displayfilter/DisplayFilters.kt
@@ -1,0 +1,92 @@
+package ee.schimke.composeai.data.displayfilter
+
+/**
+ * Catalogue of post-process color matrices applied to already-captured PNGs. These approximate the
+ * same transforms Android's `DisplayTransformManager` uses for accessibility / digital-wellbeing
+ * display effects, but applied per-PNG instead of system-wide.
+ *
+ * Each entry has a stable [id] used as the on-disk filename suffix and as the protocol kind
+ * (`displayfilter/<id>`).
+ */
+enum class DisplayFilter(val id: String, val matrix: ColorMatrix4x5) {
+
+  /**
+   * Grayscale / "bedtime mode" — Android's Digital Wellbeing schedule applies a saturation = 0
+   * color matrix at the display layer using Rec.709 luminance weights (R * 0.2126 + G * 0.7152 +
+   * B * 0.0722). Same weights `android.graphics.ColorMatrix` uses for `setSaturation(0f)`.
+   */
+  Grayscale(
+    id = "grayscale",
+    matrix =
+      ColorMatrix4x5.ofRows(
+        red = floatArrayOf(0.2126f, 0.7152f, 0.0722f, 0f, 0f),
+        green = floatArrayOf(0.2126f, 0.7152f, 0.0722f, 0f, 0f),
+        blue = floatArrayOf(0.2126f, 0.7152f, 0.0722f, 0f, 0f),
+        alpha = floatArrayOf(0f, 0f, 0f, 1f, 0f),
+      ),
+  ),
+
+  /**
+   * Classic color inversion (negate RGB, preserve alpha). Matches Android's "Color inversion"
+   * accessibility setting prior to the Smart Invert refinements.
+   */
+  Invert(
+    id = "invert",
+    matrix =
+      ColorMatrix4x5.ofRows(
+        red = floatArrayOf(-1f, 0f, 0f, 0f, 255f),
+        green = floatArrayOf(0f, -1f, 0f, 0f, 255f),
+        blue = floatArrayOf(0f, 0f, -1f, 0f, 255f),
+        alpha = floatArrayOf(0f, 0f, 0f, 1f, 0f),
+      ),
+  ),
+
+  /**
+   * Deuteranopia *simulation* — what a viewer with no functioning M (green) cones would see.
+   * Coefficients from Machado, Oliveira & Fernandes (2009), "A Physiologically-based Model for
+   * Simulation of Color Vision Deficiency", at severity 1.0. Most common form (~6% of males); a
+   * useful default for designers checking that hue isn't carrying signal alone.
+   *
+   * Note: this is *simulation*, not *correction*. The Android color-correction setting applies a
+   * different (error-shifted) matrix that compensates for the deficiency; that one belongs in the
+   * a11y bag, not here.
+   */
+  DeuteranopiaSimulation(
+    id = "deuteranopia",
+    matrix =
+      ColorMatrix4x5.ofRows(
+        red = floatArrayOf(0.367322f, 0.860646f, -0.227968f, 0f, 0f),
+        green = floatArrayOf(0.280085f, 0.672501f, 0.047413f, 0f, 0f),
+        blue = floatArrayOf(-0.011820f, 0.042940f, 0.968881f, 0f, 0f),
+        alpha = floatArrayOf(0f, 0f, 0f, 1f, 0f),
+      ),
+  ),
+
+  /** Protanopia simulation (no L / red cones). Machado 2009, severity 1.0. */
+  ProtanopiaSimulation(
+    id = "protanopia",
+    matrix =
+      ColorMatrix4x5.ofRows(
+        red = floatArrayOf(0.152286f, 1.052583f, -0.204868f, 0f, 0f),
+        green = floatArrayOf(0.114503f, 0.786281f, 0.099216f, 0f, 0f),
+        blue = floatArrayOf(-0.003882f, -0.048116f, 1.051998f, 0f, 0f),
+        alpha = floatArrayOf(0f, 0f, 0f, 1f, 0f),
+      ),
+  ),
+
+  /** Tritanopia simulation (no S / blue cones). Machado 2009, severity 1.0. */
+  TritanopiaSimulation(
+    id = "tritanopia",
+    matrix =
+      ColorMatrix4x5.ofRows(
+        red = floatArrayOf(1.255528f, -0.076749f, -0.178779f, 0f, 0f),
+        green = floatArrayOf(-0.078411f, 0.930809f, 0.147602f, 0f, 0f),
+        blue = floatArrayOf(0.004733f, 0.691367f, 0.303900f, 0f, 0f),
+        alpha = floatArrayOf(0f, 0f, 0f, 1f, 0f),
+      ),
+  );
+
+  companion object {
+    fun fromId(id: String): DisplayFilter? = entries.firstOrNull { it.id == id }
+  }
+}

--- a/data/displayfilter/core/src/main/kotlin/ee/schimke/composeai/data/displayfilter/PngColorMatrix.kt
+++ b/data/displayfilter/core/src/main/kotlin/ee/schimke/composeai/data/displayfilter/PngColorMatrix.kt
@@ -1,0 +1,32 @@
+package ee.schimke.composeai.data.displayfilter
+
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+
+/**
+ * Applies a [ColorMatrix4x5] to every pixel of a source PNG and writes the result as a new PNG.
+ * Pure JVM (BufferedImage / ImageIO) so it works under the Robolectric host JVM and the Desktop
+ * renderer without backend-specific glue.
+ */
+object PngColorMatrix {
+
+  fun apply(source: File, destination: File, matrix: ColorMatrix4x5): File {
+    require(source.isFile) { "Source PNG '${source.absolutePath}' does not exist." }
+    val image = ImageIO.read(source) ?: error("Could not decode PNG '${source.absolutePath}'.")
+    val output = BufferedImage(image.width, image.height, BufferedImage.TYPE_INT_ARGB)
+    val width = image.width
+    val height = image.height
+    val row = IntArray(width)
+    for (y in 0 until height) {
+      image.getRGB(0, y, width, 1, row, 0, width)
+      for (x in 0 until width) {
+        row[x] = matrix.applyToArgb(row[x])
+      }
+      output.setRGB(0, y, width, 1, row, 0, width)
+    }
+    destination.parentFile?.mkdirs()
+    ImageIO.write(output, "png", destination)
+    return destination
+  }
+}

--- a/data/displayfilter/core/src/test/kotlin/ee/schimke/composeai/data/displayfilter/ColorMatrix4x5Test.kt
+++ b/data/displayfilter/core/src/test/kotlin/ee/schimke/composeai/data/displayfilter/ColorMatrix4x5Test.kt
@@ -1,0 +1,114 @@
+package ee.schimke.composeai.data.displayfilter
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ColorMatrix4x5Test {
+
+  @Test
+  fun identityLeavesAllChannelsUnchanged() {
+    for (argb in samplePixels()) {
+      assertEquals(argb, ColorMatrix4x5.Identity.applyToArgb(argb))
+    }
+  }
+
+  @Test
+  fun grayscaleCollapsesPureRedGreenBlueToTheirRec709Luma() {
+    val matrix = DisplayFilter.Grayscale.matrix
+    // Red (255,0,0) -> luma = 255 * 0.2126 = ~54
+    val red = matrix.applyToArgb(0xFFFF0000.toInt())
+    assertChannelsEqual(red, alpha = 0xFF, r = 54, g = 54, b = 54)
+    // Green (0,255,0) -> luma = 255 * 0.7152 = ~182
+    val green = matrix.applyToArgb(0xFF00FF00.toInt())
+    assertChannelsEqual(green, alpha = 0xFF, r = 182, g = 182, b = 182)
+    // Blue (0,0,255) -> luma = 255 * 0.0722 = ~18
+    val blue = matrix.applyToArgb(0xFF0000FF.toInt())
+    assertChannelsEqual(blue, alpha = 0xFF, r = 18, g = 18, b = 18)
+  }
+
+  @Test
+  fun grayscalePreservesAlphaAndPureWhiteAndBlack() {
+    val matrix = DisplayFilter.Grayscale.matrix
+    assertChannelsEqual(
+      matrix.applyToArgb(0xFFFFFFFF.toInt()),
+      alpha = 0xFF,
+      r = 255,
+      g = 255,
+      b = 255,
+    )
+    assertChannelsEqual(matrix.applyToArgb(0xFF000000.toInt()), alpha = 0xFF, r = 0, g = 0, b = 0)
+    // Half-alpha grey stays half-alpha grey.
+    val translucent = matrix.applyToArgb(0x80808080.toInt())
+    assertChannelsEqual(translucent, alpha = 0x80, r = 128, g = 128, b = 128)
+  }
+
+  @Test
+  fun invertNegatesRgbAndKeepsAlpha() {
+    val matrix = DisplayFilter.Invert.matrix
+    assertChannelsEqual(matrix.applyToArgb(0xFF000000.toInt()), 0xFF, 255, 255, 255)
+    assertChannelsEqual(matrix.applyToArgb(0xFFFFFFFF.toInt()), 0xFF, 0, 0, 0)
+    assertChannelsEqual(
+      matrix.applyToArgb(0x80123456.toInt()),
+      0x80,
+      0xFF - 0x12,
+      0xFF - 0x34,
+      0xFF - 0x56,
+    )
+  }
+
+  @Test
+  fun outputClampsToZeroAnd255() {
+    // Matrix that doubles every channel; pure white should stay 255, not roll over.
+    val doubler =
+      ColorMatrix4x5.ofRows(
+        red = floatArrayOf(2f, 0f, 0f, 0f, 0f),
+        green = floatArrayOf(0f, 2f, 0f, 0f, 0f),
+        blue = floatArrayOf(0f, 0f, 2f, 0f, 0f),
+        alpha = floatArrayOf(0f, 0f, 0f, 1f, 0f),
+      )
+    assertChannelsEqual(doubler.applyToArgb(0xFFFFFFFF.toInt()), 0xFF, 255, 255, 255)
+    // Negative-everything matrix; midgrey (127,127,127) stays 0 even with -10 scaling, not wrapped.
+    val negator =
+      ColorMatrix4x5.ofRows(
+        red = floatArrayOf(-10f, 0f, 0f, 0f, 0f),
+        green = floatArrayOf(0f, -10f, 0f, 0f, 0f),
+        blue = floatArrayOf(0f, 0f, -10f, 0f, 0f),
+        alpha = floatArrayOf(0f, 0f, 0f, 1f, 0f),
+      )
+    assertChannelsEqual(negator.applyToArgb(0xFF7F7F7F.toInt()), 0xFF, 0, 0, 0)
+  }
+
+  @Test
+  fun deuteranopiaCollapsesGreenIntoRedYellowAxis() {
+    // Sanity check: pure green under deuteranopia should desaturate (M cone missing) but NOT
+    // become identical to pure red. Just assert it shifts away from pure green.
+    val green = DisplayFilter.DeuteranopiaSimulation.matrix.applyToArgb(0xFF00FF00.toInt())
+    val r = (green ushr 16) and 0xFF
+    val g = (green ushr 8) and 0xFF
+    val b = green and 0xFF
+    // Red channel should be substantial (Machado coefficient ~0.86 * 255 = ~219)
+    assert(r in 200..235) { "Expected R ~219 under deuteranopia, got $r" }
+    // Green channel reduced, not zero
+    assert(g in 150..200) { "Expected G ~172 under deuteranopia, got $g" }
+    // Blue lifts slightly above zero
+    assert(b in 0..30) { "Expected small B under deuteranopia, got $b" }
+  }
+
+  private fun samplePixels(): IntArray =
+    intArrayOf(
+      0xFF000000.toInt(),
+      0xFFFFFFFF.toInt(),
+      0xFFFF0000.toInt(),
+      0xFF00FF00.toInt(),
+      0xFF0000FF.toInt(),
+      0x80123456.toInt(),
+      0x00FFFFFF,
+    )
+
+  private fun assertChannelsEqual(argb: Int, alpha: Int, r: Int, g: Int, b: Int) {
+    assertEquals("alpha", alpha, (argb ushr 24) and 0xFF)
+    assertEquals("red", r, (argb ushr 16) and 0xFF)
+    assertEquals("green", g, (argb ushr 8) and 0xFF)
+    assertEquals("blue", b, argb and 0xFF)
+  }
+}

--- a/data/displayfilter/core/src/test/kotlin/ee/schimke/composeai/data/displayfilter/DisplayFilterExtensionTest.kt
+++ b/data/displayfilter/core/src/test/kotlin/ee/schimke/composeai/data/displayfilter/DisplayFilterExtensionTest.kt
@@ -1,0 +1,97 @@
+package ee.schimke.composeai.data.displayfilter
+
+import ee.schimke.composeai.data.render.extensions.CommonDataProducts
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.RenderImageArtifact
+import ee.schimke.composeai.data.render.extensions.provides
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class DisplayFilterExtensionTest {
+
+  @get:Rule val temp = TemporaryFolder()
+
+  @Test
+  fun emitsOnePngPerEnabledFilterUnderTheConfiguredOutputDirectory() {
+    val source = writeSolidPng(width = 4, height = 4, argb = 0xFFFF0000.toInt())
+    val outputDir = temp.newFolder("renders")
+    val store = RecordingDataProductStore()
+    store.put(CommonDataProducts.ImageArtifact, RenderImageArtifact(path = source.absolutePath))
+
+    val context =
+      ExtensionPostCaptureContext(
+        extensionId = DisplayFilterExtension().id,
+        previewId = "demo.SomePreview",
+        renderMode = "default",
+        products = store.scopedFor(DisplayFilterExtension()),
+        data =
+          ExtensionContextData.of(
+            DisplayFilterContextKeys.OutputDirectory provides outputDir,
+            DisplayFilterContextKeys.Filters provides
+              listOf(DisplayFilter.Grayscale, DisplayFilter.Invert),
+          ),
+      )
+
+    DisplayFilterExtension().process(context)
+
+    val emitted = store.require(DisplayFilterDataProducts.Variants).artifacts
+    assertEquals(2, emitted.size)
+    assertEquals(
+      setOf(DisplayFilter.Grayscale, DisplayFilter.Invert),
+      emitted.map { it.filter }.toSet(),
+    )
+    for (artifact in emitted) {
+      val file = File(artifact.path)
+      assertTrue("missing ${file.absolutePath}", file.isFile)
+      assertEquals(outputDir, file.parentFile)
+    }
+
+    // Pure red (255,0,0) under grayscale -> 54,54,54; under invert -> 0,255,255.
+    val grayPixel = readFirstPixel(emitted.first { it.filter == DisplayFilter.Grayscale }.path)
+    assertEquals(0xFF363636.toInt(), grayPixel)
+    val invertPixel = readFirstPixel(emitted.first { it.filter == DisplayFilter.Invert }.path)
+    assertEquals(0xFF00FFFF.toInt(), invertPixel)
+  }
+
+  @Test
+  fun emptyFilterListEmitsEmptyArtifactsAndDoesNotRequireOutputDirectory() {
+    val source = writeSolidPng(width = 2, height = 2, argb = 0xFF112233.toInt())
+    val store = RecordingDataProductStore()
+    store.put(CommonDataProducts.ImageArtifact, RenderImageArtifact(path = source.absolutePath))
+
+    val context =
+      ExtensionPostCaptureContext(
+        extensionId = DisplayFilterExtension().id,
+        previewId = null,
+        renderMode = null,
+        products = store.scopedFor(DisplayFilterExtension()),
+        data = ExtensionContextData.Empty,
+      )
+
+    DisplayFilterExtension().process(context)
+    val variants = store.require(DisplayFilterDataProducts.Variants)
+    assertTrue(variants.artifacts.isEmpty())
+  }
+
+  private fun writeSolidPng(width: Int, height: Int, argb: Int): File {
+    val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    for (y in 0 until height) {
+      for (x in 0 until width) {
+        image.setRGB(x, y, argb)
+      }
+    }
+    val file = temp.newFile("base-${System.nanoTime()}.png")
+    ImageIO.write(image, "png", file)
+    return file
+  }
+
+  private fun readFirstPixel(path: String): Int = ImageIO.read(File(path)).getRGB(0, 0)
+}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -16,6 +16,7 @@ Two audiences, two doc trees. Don't conflate them:
   - [`STATE_HOISTING.md`](../skills/compose-preview/design/STATE_HOISTING.md) — making composables previewable
   - [`CAPTURE_MODES.md`](../skills/compose-preview/design/CAPTURE_MODES.md) — multi-preview annotations, paused-clock animations, `@ScrollingPreview`
   - [`A11Y.md`](../skills/compose-preview/design/A11Y.md) — ATF accessibility checks
+  - [`DISPLAY_FILTERS.md`](../skills/compose-preview/design/DISPLAY_FILTERS.md) — post-process colour-matrix variants (bedtime grayscale, invert, daltonizer simulations)
   - [`CLAUDE_CLOUD.md`](../skills/compose-preview/design/CLAUDE_CLOUD.md) — running in Claude Code on the web (network allowlist, Setup script with `install.sh --android-sdk`, JVM-proxy gotcha)
   - [`CMP_SHARED.md`](../skills/compose-preview/design/CMP_SHARED.md) — applying the plugin to a CMP `:shared` (`com.android.kotlin.multiplatform.library`) module: previews go in `commonMain`, JVM target gives the Desktop renderer something to attach to (issue #248)
   - [`WEAR_UI.md`](../skills/compose-preview/design/WEAR_UI.md) — Material 3 Expressive design language for Wear OS

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -172,6 +172,10 @@ include(":data-displayfilter-core")
 
 project(":data-displayfilter-core").projectDir = file("data/displayfilter/core")
 
+include(":data-displayfilter-connector")
+
+project(":data-displayfilter-connector").projectDir = file("data/displayfilter/connector")
+
 // UIAutomator-shaped query/action API for the Compose preview renderer. Carries the matcher,
 // the Selector DSL, and the JSON wire format — consumed by `:daemon:android` for
 // `record_preview`'s `uia.*` script events.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -168,6 +168,10 @@ include(":data-recomposition-connector")
 
 project(":data-recomposition-connector").projectDir = file("data/recomposition/connector")
 
+include(":data-displayfilter-core")
+
+project(":data-displayfilter-core").projectDir = file("data/displayfilter/core")
+
 // UIAutomator-shaped query/action API for the Compose preview renderer. Carries the matcher,
 // the Selector DSL, and the JSON wire format — consumed by `:daemon:android` for
 // `record_preview`'s `uia.*` script events.

--- a/site/reference/displayfilter.md
+++ b/site/reference/displayfilter.md
@@ -27,7 +27,7 @@ deficiencies.
 | Token usage | ~10 tok inline (manifest is tiny — `{filter, path}` per variant); +~1.5 k per filtered PNG read. |
 | Transport | inline (JSON manifest) · variant PNGs ride as `extras` |
 | Platforms | Android, Desktop |
-| Status | **Experimental.** The data product, registry, and producer are wired; per-render invocation from `RenderEngine` lands in a follow-up. The producer is callable from any host today. |
+| Status | Daemon-mode renders (Android Robolectric + Desktop) write variants and the manifest after each capture. The Gradle-plugin direct path (`:samples:cmp:renderAllPreviews`) goes through a separate renderer subprocess and does **not** yet emit display-filter variants — wire it through `RobolectricRenderTest` / `DesktopRendererMain` if you need it there. |
 
 ## What it answers
 

--- a/site/reference/displayfilter.md
+++ b/site/reference/displayfilter.md
@@ -1,0 +1,107 @@
+---
+title: Display filters
+parent: Reference
+nav_order: 16
+permalink: /reference/displayfilter/
+---
+
+# Display filters
+
+Apply post-process colour-matrix transforms to each captured PNG —
+grayscale (Android's "bedtime mode"), classic colour inversion, and
+colour-blindness simulations (deuteranopia, protanopia, tritanopia).
+Each enabled filter produces an additional PNG sibling alongside the
+base capture, so an agent can verify a UI still communicates without
+hue, holds up under inversion, or remains readable for colour-vision
+deficiencies.
+
+## At a glance
+
+| | |
+|---|---|
+| Kinds | `displayfilter/variants` |
+| Schema version | 1 |
+| Modules | `:data-displayfilter-core` (published) · `:data-displayfilter-connector` |
+| Render mode | default — purely post-capture, no Compose changes |
+| Cost | very low — one matrix multiply per pixel per enabled filter on the captured `BufferedImage` |
+| Token usage | ~10 tok inline (manifest is tiny — `{filter, path}` per variant); +~1.5 k per filtered PNG read. |
+| Transport | inline (JSON manifest) · variant PNGs ride as `extras` |
+| Platforms | Android, Desktop |
+| Status | **Experimental.** The data product, registry, and producer are wired; per-render invocation from `RenderEngine` lands in a follow-up. The producer is callable from any host today. |
+
+## What it answers
+
+- **Hue-only signalling** — does this UI still distinguish error/success/warning when the display is grayscale? Run with `grayscale` and look at the variant PNG: if a red error pill collapses to the same grey as a green success pill, hue is carrying signal that contrast/iconography should.
+- **Inversion robustness** — does the UI hold up when the user has Android's "Color inversion" accessibility setting on? `invert` reveals hard-coded white/black assumptions and assets that don't react to dark theme.
+- **Colour-vision deficiency** — what does this design look like to a viewer with the most common forms of colour blindness? `deuteranopia` (~6% of males), `protanopia`, and `tritanopia` simulate cone-loss using the Machado / Oliveira / Fernandes 2009 LMS-cone-loss matrices at severity 1.0.
+
+## What it does NOT answer
+
+- It is **simulation**, not **correction**. Android's accessibility "Color correction" setting applies an error-shifted matrix that *compensates* for the deficiency; that's a separate transform that belongs in the a11y bag.
+- It does not perform contrast checks — for WCAG-style audits use [`a11y/atf`](./a11y).
+- It does not understand image *content* (e.g. embedded photos), so smart-invert-style preservation of media is not modelled.
+
+## Use cases
+
+- PR review: render any UI PR with `grayscale` enabled and skim the variant column — hue-only state is the most common reviewer-blind regression.
+- Accessibility audit: sweep the design system once with `deuteranopia` to find palette pairs that collapse for the most common colour-vision deficiency.
+- Bedtime / digital-wellbeing parity: confirm the app still looks deliberate when Android's bedtime grayscale schedule kicks in, not just "all icons gone grey".
+
+## Payload shape
+
+`DisplayFilterArtifact`, `DisplayFilterArtifacts` — defined in
+[`:data-displayfilter-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/displayfilter/core).
+The manifest written to disk:
+
+```jsonc
+// build/compose-previews/data/<previewId>/displayfilter-variants.json
+{
+  "variants": [
+    {
+      "filter": "grayscale",
+      "path": "<absolute>/build/compose-previews/data/<previewId>/render_displayfilter_grayscale.png",
+      "mediaType": "image/png"
+    },
+    {
+      "filter": "invert",
+      "path": "<absolute>/.../render_displayfilter_invert.png",
+      "mediaType": "image/png"
+    }
+  ]
+}
+```
+
+`data/fetch` against `displayfilter/variants` returns the same JSON
+inline plus one `DataProductExtra` per variant pointing at the variant
+PNG, so a panel that subscribed to the manifest gets every PNG path
+without a follow-up fetch.
+
+## Filter catalogue
+
+| id | Matrix source | What it simulates |
+|---|---|---|
+| `grayscale` | `setSaturation(0)` with Rec.709 luma weights (R · 0.2126 + G · 0.7152 + B · 0.0722) — same weights `android.graphics.ColorMatrix` uses | Android Digital Wellbeing's bedtime-mode grayscale |
+| `invert` | RGB channel negation, alpha preserved | Android "Color inversion" accessibility setting (classic, not Smart Invert) |
+| `deuteranopia` | Machado / Oliveira / Fernandes 2009, severity 1.0 — M-cone (green) loss | Most common colour-vision deficiency (~6% of males) |
+| `protanopia` | Machado 2009, severity 1.0 — L-cone (red) loss | Red-blind |
+| `tritanopia` | Machado 2009, severity 1.0 — S-cone (blue) loss | Rare blue/yellow deficiency |
+
+## Enabling
+
+`-Dcomposeai.displayfilter.filters=` controls which filters apply. Empty
+or unset disables the feature entirely; the daemon doesn't even register
+the extension.
+
+```sh
+./gradlew :samples:cmp:renderAllPreviews \
+    -Dcomposeai.displayfilter.filters=grayscale,deuteranopia
+```
+
+Unknown filter ids are dropped with a warning so a typo doesn't strand
+the rest. Duplicates collapse — `grayscale,invert,grayscale` runs each
+filter once.
+
+## Companion products
+
+- [Accessibility](./a11y) — `a11y/atf` for ATF audit, `a11y/overlay` for annotated PNG. Pair `grayscale` with `a11y/atf` contrast findings to triage the same palette from two angles.
+- [Theme](./theme) — `compose/theme` to see *which* tokens drove the render before applying a filter to the result.

--- a/site/reference/index.md
+++ b/site/reference/index.md
@@ -21,7 +21,7 @@ deliberately does not), use cases, payload shape, and how to enable it.
 
 A data product is `(kind, schemaVersion, payload)`:
 
-- **kind** — namespaced string (`a11y/atf`, `compose/recomposition`, …). Reserved namespaces: `a11y/*`, `layout/*`, `compose/*`, `resources/*`, `text/*`, `render/*`, `fonts/*`, `test/*`, `i18n/*`, `history/*`, `uia/*`.
+- **kind** — namespaced string (`a11y/atf`, `compose/recomposition`, …). Reserved namespaces: `a11y/*`, `layout/*`, `compose/*`, `resources/*`, `text/*`, `render/*`, `fonts/*`, `test/*`, `i18n/*`, `history/*`, `uia/*`, `displayfilter/*`.
 - **schemaVersion** — positive integer, owned by the kind. Bumped only on incompatible payload changes; additive fields don't bump.
 - **payload** — JSON. Inline for small payloads (~64 KB), or a path to a sibling file the renderer wrote (lifecycle matches the PNG).
 
@@ -37,6 +37,7 @@ the Compose runtime, daemon, or AndroidX. The matching
 |---|---|---|---|
 | [Accessibility](./a11y) | `a11y/atf`, `a11y/hierarchy`, `a11y/overlay`, `a11y/touchTargets` | a11y | ATF findings, semantic tree, annotated overlay, 48 dp targets. |
 | [Ambient (Wear)](./ambient) | `compose/ambient` | default | Drive `AmbientMode` overrides for Wear ambient previews. |
+| [Display filters](./displayfilter) | `displayfilter/variants` | default | Post-process colour-matrix variants — bedtime grayscale, invert, daltonizer simulations. |
 | [Focus](./focus) | `compose/focus` | default | Focused-node snapshot + directional traversal overrides. |
 | [Fonts](./fonts) | `fonts/used` | default | Font families with weight/style fallback chain. |
 | [History diff](./history) | `history/diff/regions` | default | Per-pixel bounding boxes of changed regions vs. another history entry. |

--- a/skills/compose-preview/design/DISPLAY_FILTERS.md
+++ b/skills/compose-preview/design/DISPLAY_FILTERS.md
@@ -1,0 +1,74 @@
+# Display filters
+
+Apply post-process colour-matrix transforms to each captured PNG. One
+extra PNG per enabled filter lands alongside the base capture, so a
+single render covers grayscale (bedtime mode), inversion, and the
+common daltonizer simulations without re-rendering.
+
+## When to enable
+
+- **Grayscale** (`grayscale`) — verifying state isn't carried by hue
+  alone. Red error / green success colour pairs are the most common
+  thing this catches; if both collapse to the same grey the UI relies
+  on hue more than it should.
+- **Inversion** (`invert`) — Android's "Color inversion" setting flips
+  the whole display. Useful for finding hard-coded white/black
+  assumptions (logos, illustrations, custom badges) and assets that
+  the dark-theme path doesn't cover.
+- **Colour-vision simulation** (`deuteranopia`, `protanopia`,
+  `tritanopia`) — what a viewer with that cone-loss sees. Default
+  pairing for most projects: `grayscale,deuteranopia` — bedtime mode
+  + the most common deficiency catches the bulk of hue-only signalling
+  bugs in one extra-cheap pass.
+
+These are **simulations**, not corrections. The Android
+"Color correction" accessibility setting applies a different
+(error-shifted) matrix that compensates for a deficiency; that is a
+separate transform that belongs alongside other a11y settings, not
+here.
+
+## Enabling
+
+System property, comma-separated filter ids:
+
+```sh
+./gradlew :samples:cmp:renderAllPreviews \
+    -Dcomposeai.displayfilter.filters=grayscale,deuteranopia
+```
+
+Empty / unset disables the feature entirely — the daemon doesn't
+register the extension, so `extensions/list` won't show it. Unknown
+ids are dropped with a warning. Duplicates collapse.
+
+## Output
+
+Per render under `build/compose-previews/data/<previewId>/`:
+
+- `displayfilter-variants.json` — manifest enumerating every variant.
+- `<base>_displayfilter_<filterId>.png` — one PNG per enabled filter.
+
+The data product surfaces over JSON-RPC as `displayfilter/variants`
+(inline transport, manifest as JSON, variant PNGs ride along as
+`extras`).
+
+## Reading the variants
+
+Quick agent loop: render once, look at the base PNG, then look at each
+variant. Two failure shapes worth flagging:
+
+1. **Identical greys** — different states collapse to the same luma
+   under `grayscale`. Fix: add an icon, weight, or text label so state
+   isn't hue-only.
+2. **Unreadable text under inversion** — text on photos / brand colours
+   that goes from black-on-white to white-on-black-on-bright-photo.
+   Fix: contrast scrim, or test if the assistive `Smart Invert` exempt
+   path is genuinely needed.
+
+## Caveats
+
+- Purely **post-process** — no Compose state changes, so things like
+  high-contrast text outlines or bold text aren't covered here. Those
+  belong on the a11y side (re-render with the OS flag set).
+- Daltonizer matrices are at severity 1.0 (full cone loss). Most users
+  with a deficiency have partial loss; severity-controlled matrices
+  could be added if needed.

--- a/skills/compose-preview/design/DISPLAY_FILTERS.md
+++ b/skills/compose-preview/design/DISPLAY_FILTERS.md
@@ -66,6 +66,12 @@ variant. Two failure shapes worth flagging:
 
 ## Caveats
 
+- Wired in the **daemon** render path today (Android + Desktop). The
+  Gradle-plugin direct path (`./gradlew :samples:cmp:renderAllPreviews`)
+  uses a separate renderer subprocess and does not yet emit variants —
+  agents driving the daemon (VS Code, MCP, the CLI's daemon mode) get
+  the variants automatically; CLI users on the direct-renderer path
+  don't yet.
 - Purely **post-process** — no Compose state changes, so things like
   high-contrast text outlines or bold text aren't covered here. Those
   belong on the a11y side (re-render with the OS flag set).


### PR DESCRIPTION
## Summary

Introduces a new display filter data product that applies post-capture color-matrix transforms to rendered PNGs. This enables accessibility testing for grayscale (bedtime mode), color inversion, and color-blindness simulations (deuteranopia, protanopia, tritanopia) without re-rendering.

## Key Changes

- **Core color matrix implementation** (`data/displayfilter/core`)
  - `ColorMatrix4x5`: 4x5 RGBA color matrix matching Android's `ColorMatrix` layout
  - `DisplayFilter` enum: Grayscale, Invert, and three daltonizer simulations using Machado 2009 coefficients
  - `PngColorMatrix`: Applies matrices to BufferedImage pixels and writes filtered PNGs
  - `DisplayFilterExtension`: PostCaptureProcessor that reads the captured PNG and emits filtered variants
  - `DisplayFilterArtifact` and related data classes for the product graph

- **Daemon integration** (`data/displayfilter/connector`)
  - `DisplayFilterDataProducer`: Writes per-render artifacts (filtered PNGs + manifest JSON) to disk
  - `DisplayFilterDataProductRegistry`: Surfaces the `displayfilter/variants` kind over JSON-RPC with INLINE transport
  - `DisplayFilterPostCapturePipeline`: Orchestrates the extension pipeline for filter application
  - `DisplayFilterConfig`: Parses comma-separated filter IDs from system property `composeai.displayfilter.filters`

- **Render engine wiring**
  - Android daemon: Calls `DisplayFilterDataProducer.writeArtifacts()` after PNG write in `RenderEngine`
  - Desktop daemon: Same integration point
  - `DaemonMain`: Registers `DisplayFilterDataProductRegistry` when filters are enabled

- **Documentation and tests**
  - Reference guide (`site/reference/displayfilter.md`) explaining use cases and payload shape
  - Design doc (`skills/compose-preview/design/DISPLAY_FILTERS.md`) for agent enablement
  - Comprehensive unit tests for color matrices, extension processing, data producer, and registry

## Implementation Details

- **Gated by system property**: Feature is disabled by default; only registers extension and produces variants when `composeai.displayfilter.filters` is non-empty
- **Idempotent**: Overwrites prior artifacts on repeat runs
- **Resilient**: Filter failures are caught and logged; one bad filter doesn't strand others
- **Efficient**: One matrix multiply per pixel per filter; manifest is tiny JSON with `{filter, path}` entries
- **Cross-platform**: Uses pure JVM (BufferedImage/ImageIO) so works on both Robolectric (Android) and Desktop renderers
- **Manifest-driven**: Registry reads manifest as source of truth rather than globbing filesystem, keeping it decoupled from disk layout

The feature answers three accessibility questions: hue-only signalling (grayscale), inversion robustness (color inversion), and color-vision deficiency simulation (daltonizers).

https://claude.ai/code/session_01VCmY14nGGMF4SFnyFUcGcj