### PR TITLE
fix(vscode): follow symlinked subdirectories when walking for preview modules

### DIFF
--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -771,14 +771,33 @@ export class GradleService {
                 return;
             }
             for (const entry of entries) {
-                if (!entry.isDirectory()) {
-                    continue;
-                }
                 if (entry.name.startsWith(".")) {
                     continue;
                 }
                 if (SCAN_SKIP_DIRS.has(entry.name)) {
                     continue;
+                }
+                if (!entry.isDirectory()) {
+                    // `withFileTypes` reports the entry's own type, so a
+                    // symlink-to-directory comes through as
+                    // `isSymbolicLink: true, isDirectory: false`. Follow it
+                    // via stat() — workspaces like the AndroidX-mini
+                    // checkout symlink the upstream source tree under their
+                    // workspace root.
+                    if (!entry.isSymbolicLink()) {
+                        continue;
+                    }
+                    try {
+                        if (
+                            !fs
+                                .statSync(path.join(absDir, entry.name))
+                                .isDirectory()
+                        ) {
+                            continue;
+                        }
+                    } catch {
+                        continue;
+                    }
                 }
                 const childRel = relDir
                     ? `${relDir}/${entry.name}`

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -559,6 +559,45 @@ describe("GradleService", () => {
                 ]);
             }),
         );
+
+        it(
+            "follows symlinked subdirectories during the walk (androidx-mini layout)",
+            withTempDir((dir, api) => {
+                // The AndroidX-mini workspace layout symlinks the upstream
+                // androidx checkout under the workspace root and reassigns
+                // each project's projectDir into that tree. `withFileTypes`
+                // reports the symlink itself, not its target, so without
+                // explicit symlink handling the walk stops at the symlink
+                // entry and never sees the markers underneath.
+                const target = fs.mkdtempSync(
+                    path.join(os.tmpdir(), "compose-preview-symlink-target-"),
+                );
+                try {
+                    const moduleProjectDir = path.join(target, "wear", "app");
+                    const markerDir = path.join(
+                        moduleProjectDir,
+                        "build",
+                        "compose-previews",
+                    );
+                    fs.mkdirSync(markerDir, { recursive: true });
+                    fs.writeFileSync(
+                        path.join(markerDir, "applied.json"),
+                        '{"schema":"compose-preview-applied/v1","modulePath":":wear:app","moduleName":"app","pluginVersion":"0.10.6"}',
+                    );
+                    fs.symlinkSync(target, path.join(dir, "androidx"), "dir");
+
+                    const service = new GradleService(dir, api);
+                    assert.deepStrictEqual(service.findPreviewModules(), [
+                        {
+                            projectDir: "androidx/wear/app",
+                            modulePath: ":wear:app",
+                        },
+                    ]);
+                } finally {
+                    fs.rmSync(target, { recursive: true, force: true });
+                }
+            }),
+        );
     });
 
     describe("resolveModule", () => {


### PR DESCRIPTION
## Summary

`fs.readdirSync(..., { withFileTypes: true })` reports the symlink itself, not its target — so `androidx -> /some/path` shows up as `isSymbolicLink: true, isDirectory: false` and `findPreviewModules` skips it entirely. That stops the walk reaching any preview modules whose project directories live under a symlinked source tree.

Concretely, AndroidX-mini-style workspaces symlink the upstream `androidx/` checkout into the workspace root and assign every project's `projectDir` somewhere under that symlink. Without this fix, `[refresh] no module — activeFile=…` shows for every file in those modules even after #948.

Stat the entry when it's a symlink and recurse if the target is a directory.

## Test plan

- [x] New unit test creates a real symlink in a tmp workspace pointing at a fixture tree with an `applied.json` and asserts `findPreviewModules` returns the discovered module.
- [x] `npm test` — 682 passing
- [x] `npm run format:check` clean
- [x] `npx tsc -p .` clean