### PR TITLE
fix(pseudolocale): snap paragraph-span boundaries when reattaching

### DIFF
--- a/data/pseudolocale/connector/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleResources.kt
+++ b/data/pseudolocale/connector/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleResources.kt
@@ -55,13 +55,43 @@ internal class PseudolocaleResources(
     val sb = SpannableStringBuilder(transformed.text)
     val map = transformed.indexMap
     val length = raw.length
+    val outText = transformed.text
     for (span in raw.getSpans(0, length, Any::class.java)) {
       val srcStart = raw.getSpanStart(span).coerceIn(0, length)
       val srcEnd = raw.getSpanEnd(span).coerceIn(srcStart, length)
       val flags = raw.getSpanFlags(span)
-      sb.setSpan(span, map[srcStart], map[srcEnd], flags)
+      var dstStart = map[srcStart]
+      var dstEnd = map[srcEnd]
+      // SPAN_PARAGRAPH spans (BulletSpan, LeadingMarginSpan, …) must start at 0 or right after a
+      // `\n`, and end at length or right after a `\n`. The transform prepends marker characters
+      // (`[` in accent mode, RLO in bidi) which would shift a span starting at input 0 to output
+      // position 1 and trip SpannableStringBuilder.setSpan's paragraph-boundary check at runtime.
+      // Snap each end to the nearest valid paragraph boundary before re-attaching; drop the span
+      // entirely if snapping produces a degenerate range.
+      if ((flags and Spanned.SPAN_PARAGRAPH) == Spanned.SPAN_PARAGRAPH) {
+        dstStart = snapToParagraphStart(outText, dstStart)
+        dstEnd = snapToParagraphEnd(outText, dstEnd)
+        if (dstStart >= dstEnd) continue
+      }
+      sb.setSpan(span, dstStart, dstEnd, flags)
     }
     return sb
+  }
+
+  private fun snapToParagraphStart(text: String, pos: Int): Int {
+    if (pos <= 0) return 0
+    for (i in pos - 1 downTo 0) {
+      if (text[i] == '\n') return i + 1
+    }
+    return 0
+  }
+
+  private fun snapToParagraphEnd(text: String, pos: Int): Int {
+    if (pos >= text.length) return text.length
+    for (i in pos until text.length) {
+      if (text[i] == '\n') return i + 1
+    }
+    return text.length
   }
 }
 

--- a/data/pseudolocale/connector/src/test/kotlin/ee/schimke/composeai/daemon/PseudolocaleResourcesSpanPreservationTest.kt
+++ b/data/pseudolocale/connector/src/test/kotlin/ee/schimke/composeai/daemon/PseudolocaleResourcesSpanPreservationTest.kt
@@ -51,6 +51,28 @@ class PseudolocaleResourcesSpanPreservationTest {
   }
 
   @Test
+  fun `paragraph spans are snapped to valid boundaries instead of throwing`() {
+    val styled = SpannableString("Battery low")
+    val bullet = android.text.style.BulletSpan()
+    // Whole-string paragraph span. Without the snap, the remap would put `start = 1` (right after
+    // the accent `[` prefix), which `SpannableStringBuilder.setSpan` rejects with
+    // `RuntimeException: PARAGRAPH span must start at paragraph boundary`.
+    styled.setSpan(bullet, 0, styled.length, Spanned.SPAN_PARAGRAPH)
+
+    val result = withSpannedGetText(styled).pseudolocaliseForTest(Pseudolocale.ACCENT)
+
+    val out = result as Spanned
+    val spans = out.getSpans(0, out.length, android.text.style.BulletSpan::class.java)
+    assertEquals(1, spans.size)
+    assertEquals("paragraph span must start at 0", 0, out.getSpanStart(spans[0]))
+    assertEquals(
+      "paragraph span must end at length",
+      out.length,
+      out.getSpanEnd(spans[0]),
+    )
+  }
+
+  @Test
   fun `plain CharSequence input takes the fast path and is not Spanned`() {
     val plain = "Battery low: charge soon."
     val result = withSpannedGetText(plain).pseudolocaliseForTest(Pseudolocale.ACCENT)


### PR DESCRIPTION
## Summary

Follow-up to #953. `SpannableStringBuilder.setSpan` enforces paragraph-boundary rules for `SPAN_PARAGRAPH` spans (`BulletSpan`, `LeadingMarginSpan`, `QuoteSpan`, …): the start must be `0` or right after a `\n`, and end must equal length or right after a `\n`. Pseudolocale output prepends marker characters — `[` in accent mode, RLO in bidi mode — so a span whose source range was `[0, len)` got remapped to `[1, …)`, which trips the runtime check and crashes the render with `RuntimeException: PARAGRAPH span must start at paragraph boundary`.

Fix: when reattaching a span carrying the `SPAN_PARAGRAPH` flag, snap both ends to the nearest valid paragraph boundary in the output (closest preceding `\n` + 1 or `0` for start; closest following `\n` + 1 or end-of-text for end) before calling `setSpan`. Drop the span if snapping produces a degenerate range.

## Test plan

- [x] `./gradlew :data-pseudolocale-connector:test` — Robolectric test attaches a `BulletSpan` over the whole input and asserts the reattached span starts at 0 and ends at output.length (the case that previously threw).
- [x] `./gradlew ktfmtCheckAll` clean.
- [ ] CI runs full check suite.

## Notes

Most resource-compiled `<string>` markup (`<b>`, `<i>`, `<annotation>`) produces non-paragraph spans, so the practical risk surfaced through programmatic `Spanned` content (`Html.fromHtml`, app-supplied styled text) more than through `<string>` resources. The fix is small and the cost of getting it wrong is a hard render crash, so worth shipping immediately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJiQULPqyi48etUL5ojbgg)_