### PR TITLE
Redesign focus inspector with bucketed product picker and suggestions

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -637,6 +637,152 @@ body {
     font-size: calc(var(--vscode-font-size) - 2px);
 }
 
+/* -- Suggestion chip row + bucketed picker ---------------------------- */
+
+.focus-suggestions {
+    border-top: 1px solid var(--card-border);
+    background: color-mix(in srgb, var(--card-bg) 70%, transparent);
+}
+
+.focus-suggestions-summary {
+    padding: 6px 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    list-style: none;
+}
+
+.focus-suggestions-summary::-webkit-details-marker {
+    display: none;
+}
+
+.focus-suggestions[open] .focus-summary-chevron {
+    transform: rotate(180deg);
+}
+
+.focus-suggestion-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 0 8px 8px;
+}
+
+.focus-suggestion-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--card-border);
+    background: var(--vscode-editor-background);
+    color: var(--text-primary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    cursor: pointer;
+}
+
+.focus-suggestion-chip:hover {
+    background: var(--toolbar-hover);
+}
+
+.focus-suggestion-chip:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 1px;
+}
+
+.focus-suggestion-chip[data-state="on"] {
+    background: color-mix(
+        in srgb,
+        var(--vscode-focusBorder) 25%,
+        var(--vscode-editor-background)
+    );
+    border-color: var(--vscode-focusBorder);
+}
+
+.focus-suggestion-chip[data-cost="expensive"]::after {
+    content: "$";
+    font-size: calc(var(--vscode-font-size) - 4px);
+    color: var(--text-secondary);
+    margin-left: 2px;
+}
+
+.focus-suggestion-chip-hint {
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+}
+
+.focus-suggestion-empty {
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    padding: 0 0 4px;
+}
+
+.focus-buckets {
+    border-top: 1px solid var(--card-border);
+}
+
+.focus-bucket {
+    border-top: 1px solid
+        color-mix(in srgb, var(--card-border) 70%, transparent);
+}
+
+.focus-bucket:first-child {
+    border-top: none;
+}
+
+.focus-bucket-summary {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    cursor: pointer;
+    color: var(--text-primary);
+    list-style: none;
+}
+
+.focus-bucket-summary::-webkit-details-marker {
+    display: none;
+}
+
+.focus-bucket-summary:hover {
+    background: var(--toolbar-hover);
+}
+
+.focus-bucket-label {
+    flex: 1;
+}
+
+.focus-bucket-count {
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    font-variant-numeric: tabular-nums;
+}
+
+.focus-bucket[open] .focus-summary-chevron {
+    transform: rotate(180deg);
+}
+
+.focus-bucket-body {
+    padding: 0 0 4px;
+}
+
+.focus-bucket-empty {
+    padding: 4px 8px 8px 30px;
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+}
+
+.focus-product-option[data-cost="expensive"] > .focus-product-text::after {
+    content: "$";
+    color: var(--text-secondary);
+    margin-left: auto;
+    padding-left: 6px;
+}
+
 /* -- Preview card ----------------------------------------------------- */
 
 .preview-card {

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -783,6 +783,260 @@ body {
     padding-left: 6px;
 }
 
+/* -- Presenter surfaces (errors / legends / reports / overlay) -------- */
+
+.focus-error-panel {
+    border-color: var(--vscode-inputValidation-errorBorder, #be1100);
+    background: color-mix(
+        in srgb,
+        var(--vscode-inputValidation-errorBackground, #5a1d1d) 50%,
+        var(--vscode-editor-background)
+    );
+}
+
+.focus-error-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 6px 8px;
+}
+
+.focus-error-row + .focus-error-row {
+    border-top: 1px solid
+        color-mix(in srgb, var(--card-border) 70%, transparent);
+}
+
+.focus-error-row > .codicon {
+    color: var(
+        --vscode-inputValidation-errorForeground,
+        var(--vscode-errorForeground)
+    );
+    margin-top: 2px;
+}
+
+.focus-error-body {
+    flex: 1;
+    min-width: 0;
+}
+
+.focus-error-title {
+    color: var(--text-primary);
+    font-size: calc(var(--vscode-font-size) - 1px);
+    font-weight: 600;
+}
+
+.focus-error-message,
+.focus-error-detail {
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    margin-top: 2px;
+    word-break: break-word;
+}
+
+.focus-legends-panel {
+    padding: 0 0 4px;
+}
+
+.focus-legend-block + .focus-legend-block {
+    border-top: 1px solid
+        color-mix(in srgb, var(--card-border) 70%, transparent);
+}
+
+.focus-legend-head {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 6px 8px 2px;
+}
+
+.focus-legend-title {
+    color: var(--text-primary);
+    font-size: calc(var(--vscode-font-size) - 1px);
+    font-weight: 600;
+}
+
+.focus-legend-summary {
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+}
+
+.focus-legend-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.focus-legend-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 4px 8px 4px 22px;
+    cursor: pointer;
+    color: var(--text-primary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+}
+
+.focus-legend-row:hover,
+.focus-legend-row:focus-visible {
+    background: var(--toolbar-hover);
+    outline: none;
+}
+
+.focus-legend-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--text-secondary);
+    margin-top: 5px;
+    flex: 0 0 8px;
+}
+
+.focus-legend-row[data-level="error"] .focus-legend-dot {
+    background: var(--vscode-errorForeground, #f48771);
+}
+
+.focus-legend-row[data-level="warning"] .focus-legend-dot {
+    background: var(--vscode-editorWarning-foreground, #cca700);
+}
+
+.focus-legend-row[data-level="info"] .focus-legend-dot {
+    background: var(--vscode-editorInfo-foreground, #4f9cd9);
+}
+
+.focus-legend-text {
+    flex: 1;
+    min-width: 0;
+}
+
+.focus-legend-label {
+    color: var(--text-primary);
+}
+
+.focus-legend-detail {
+    color: var(--text-secondary);
+    margin-top: 1px;
+    overflow-wrap: anywhere;
+}
+
+.focus-reports-panel {
+    padding: 0 0 4px;
+}
+
+.focus-report {
+    border-top: 1px solid
+        color-mix(in srgb, var(--card-border) 70%, transparent);
+}
+
+.focus-report:first-child {
+    border-top: none;
+}
+
+.focus-report-summary {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    cursor: pointer;
+    color: var(--text-primary);
+    list-style: none;
+}
+
+.focus-report-summary::-webkit-details-marker {
+    display: none;
+}
+
+.focus-report[open] .focus-summary-chevron {
+    transform: rotate(180deg);
+}
+
+.focus-report-title {
+    flex: 1;
+}
+
+.focus-report-summary-hint {
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    font-variant-numeric: tabular-nums;
+}
+
+.focus-report-body {
+    padding: 0 8px 8px 22px;
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+}
+
+.focus-report-empty {
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+.focus-report-list {
+    margin: 0;
+    padding-left: 20px;
+}
+
+.focus-report-list > li[data-legend-id] {
+    cursor: pointer;
+}
+
+.focus-report-list > li[data-legend-id]:hover {
+    color: var(--text-primary);
+}
+
+/* Card overlay stack — sized to the image's intrinsic pixel space so
+   bound coordinates from the renderer (left,top,right,bottom in
+   source-bitmap pixels) line up. The image-container is
+   position:relative; we layer on top with pointer-events: none so the
+   normal click-to-focus flow keeps working underneath. */
+
+.focus-overlay-stack {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 5;
+}
+
+.focus-presentation-overlay {
+    position: absolute;
+    inset: 0;
+}
+
+.focus-overlay-box {
+    position: absolute;
+    border: 1px solid
+        color-mix(in srgb, var(--vscode-focusBorder) 80%, transparent);
+    background: color-mix(in srgb, var(--vscode-focusBorder) 8%, transparent);
+    transition:
+        background 80ms ease-out,
+        border-color 80ms ease-out;
+}
+
+.focus-overlay-box[data-level="warning"] {
+    border-color: color-mix(
+        in srgb,
+        var(--vscode-editorWarning-foreground, #cca700) 80%,
+        transparent
+    );
+}
+
+.focus-overlay-box[data-level="info"] {
+    border-color: color-mix(
+        in srgb,
+        var(--vscode-editorInfo-foreground, #4f9cd9) 80%,
+        transparent
+    );
+}
+
+.focus-overlay-box.legend-active {
+    background: color-mix(in srgb, var(--vscode-focusBorder) 30%, transparent);
+    border-color: var(--vscode-focusBorder);
+    box-shadow: 0 0 0 2px var(--vscode-focusBorder);
+}
+
+#focus-legend-arrow {
+    color: var(--vscode-focusBorder);
+}
+
 /* -- Preview card ----------------------------------------------------- */
 
 .preview-card {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -136,6 +136,11 @@
                     "default": false,
                     "description": "Enable early, unstable preview features in the VS Code panel, including focus-mode diffs, focus inspector extension layers, a11y overlay controls, recording, and diff-all commands. Focus mode and live interactive previews remain available when this is off."
                 },
+                "composePreview.autoEnableCheap.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When the focus-mode inspector suggests a data extension that's cheap to compute (theme tokens, fonts, strings, layout tree), auto-enable it on first sight per module. Expensive layers (recomposition heatmap, render trace, accessibility re-render) are never auto-enabled and stay click-to-toggle. Suggestions themselves don't depend on this setting; only whether the suggestion auto-applies."
+                },
                 "composePreview.logging.level": {
                     "type": "string",
                     "enum": [

--- a/vscode-extension/src/daemon/daemonGate.ts
+++ b/vscode-extension/src/daemon/daemonGate.ts
@@ -193,6 +193,49 @@ export class DaemonGate {
         );
     }
 
+    /**
+     * Snapshot of the daemon's advertised data-product / data-extension
+     * capabilities for [moduleId]. Used by the live panel to populate
+     * the focus-mode inspector with the kinds the daemon can actually
+     * produce, instead of the panel's built-in placeholder set. Returns
+     * `null` when no daemon is up — caller can fall back to placeholders.
+     *
+     * The returned slice is intentionally narrow: only the fields the
+     * webview actually renders (kind, displayName, transport,
+     * requiresRerender; extension id + displayName). The full
+     * `DataProductCapability` carries schema bookkeeping the inspector
+     * doesn't need to see.
+     */
+    getCapabilitiesSnapshot(moduleId: string): {
+        dataProducts: {
+            kind: string;
+            schemaVersion: number;
+            transport: "inline" | "path" | "both";
+            requiresRerender: boolean;
+            displayName?: string;
+        }[];
+        dataExtensions: { id: string; displayName?: string }[];
+    } | null {
+        const existing = this.daemons.get(moduleId);
+        if (existing == null || existing.client.isClosed()) {
+            return null;
+        }
+        const caps = existing.spawned.initializeResult.capabilities;
+        return {
+            dataProducts: (caps.dataProducts ?? []).map((p) => ({
+                kind: p.kind,
+                schemaVersion: p.schemaVersion,
+                transport: p.transport,
+                requiresRerender: p.requiresRerender,
+                displayName: p.displayName,
+            })),
+            dataExtensions: (caps.dataExtensions ?? []).map((e) => ({
+                id: e.id,
+                displayName: e.displayName,
+            })),
+        };
+    }
+
     async dispose(): Promise<void> {
         this.disposed = true;
         const entries = [...this.daemons.values()];

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -235,6 +235,12 @@ function earlyFeaturesEnabled(): boolean {
         .get<boolean>("earlyFeatures.enabled", false);
 }
 
+function autoEnableCheapEnabled(): boolean {
+    return vscode.workspace
+        .getConfiguration("composePreview")
+        .get<boolean>("autoEnableCheap.enabled", false);
+}
+
 /**
  * Show the remediation notification for a detected JdkImageError. The offered
  * "Open JDK setting" action reveals `java.import.gradle.java.home` — the
@@ -674,8 +680,12 @@ export async function activate(
               handleWebviewMessage(msg);
           }
         : handleWebviewMessage;
-    panel = new PreviewPanel(context.extensionUri, onMessage, () =>
-        earlyFeaturesEnabled(),
+    panel = new PreviewPanel(
+        context.extensionUri,
+        onMessage,
+        () => earlyFeaturesEnabled(),
+        undefined,
+        () => autoEnableCheapEnabled(),
     );
     if (isTestMode) {
         // Tap into every outgoing webview message so the test API can assert
@@ -965,6 +975,16 @@ export async function activate(
                 panel?.postMessage({
                     command: "setEarlyFeatures",
                     enabled: earlyFeaturesEnabled(),
+                });
+            }
+            if (
+                event.affectsConfiguration(
+                    "composePreview.autoEnableCheap.enabled",
+                )
+            ) {
+                panel?.postMessage({
+                    command: "setAutoEnableCheap",
+                    enabled: autoEnableCheapEnabled(),
                 });
             }
         }),
@@ -4634,6 +4654,29 @@ function publishInteractiveAvailability(moduleId: string): void {
         ready,
         interactiveSupported:
             ready && (daemonGate?.isInteractiveSupported(moduleId) ?? false),
+    });
+    publishDaemonCapabilities(moduleId);
+}
+
+/**
+ * Push the daemon's advertised data-product / data-extension catalogue
+ * for [moduleId] to the live panel. The focus-mode inspector groups
+ * these into stable buckets (`focusProductTaxonomy.bucketOf`) and
+ * surfaces them as user-toggleable layers. When the daemon is down /
+ * not yet up, an empty payload is sent so the inspector falls back to
+ * its built-in placeholder set rather than holding stale capabilities
+ * from a previous daemon lifetime.
+ */
+function publishDaemonCapabilities(moduleId: string): void {
+    if (!panel) {
+        return;
+    }
+    const snap = daemonGate?.getCapabilitiesSnapshot(moduleId) ?? null;
+    panel.postMessage({
+        command: "setDaemonCapabilities",
+        moduleId,
+        dataProducts: snap?.dataProducts ?? [],
+        dataExtensions: snap?.dataExtensions ?? [],
     });
 }
 

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -8,6 +8,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     private extensionUri: vscode.Uri;
     private onMessage: (msg: WebviewToExtension) => void;
     private earlyFeaturesEnabled: () => boolean;
+    private autoEnableCheapEnabled: () => boolean;
     private shouldRestoreVisibility: () => boolean;
 
     constructor(
@@ -15,10 +16,12 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         onMessage: (msg: WebviewToExtension) => void,
         earlyFeaturesEnabled: () => boolean = () => false,
         shouldRestoreVisibility: () => boolean = () => false,
+        autoEnableCheapEnabled: () => boolean = () => false,
     ) {
         this.extensionUri = extensionUri;
         this.onMessage = onMessage;
         this.earlyFeaturesEnabled = earlyFeaturesEnabled;
+        this.autoEnableCheapEnabled = autoEnableCheapEnabled;
         this.shouldRestoreVisibility = shouldRestoreVisibility;
     }
 
@@ -51,6 +54,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     private getHtml(webview: vscode.Webview): string {
         const nonce = getNonce();
         const earlyFeaturesEnabled = this.earlyFeaturesEnabled();
+        const autoEnableCheapEnabled = this.autoEnableCheapEnabled();
         const styleUri = webview.asWebviewUri(
             vscode.Uri.joinPath(this.extensionUri, "media", "preview.css"),
         );
@@ -77,7 +81,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     <link href="${styleUri}" rel="stylesheet">
 </head>
 <body>
-    <preview-app data-early-features="${earlyFeaturesEnabled ? "true" : "false"}"></preview-app>
+    <preview-app
+        data-early-features="${earlyFeaturesEnabled ? "true" : "false"}"
+        data-auto-enable-cheap="${autoEnableCheapEnabled ? "true" : "false"}"
+    ></preview-app>
     <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>
 </html>`;

--- a/vscode-extension/src/test/focusInspectorPersistence.test.ts
+++ b/vscode-extension/src/test/focusInspectorPersistence.test.ts
@@ -1,0 +1,165 @@
+// Integration tests for the focus inspector's MRU persistence
+// hand-off — `loadMru` is read on first render per scope, `saveMru`
+// fires after every toggle. Uses happy-dom (registered globally via
+// `setup-dom.ts`) so we can drive the controller through real DOM
+// events instead of poking at private state.
+
+import * as assert from "assert";
+import { FocusInspectorController } from "../webview/preview/focusInspector";
+import type { PreviewInfo } from "../types";
+
+const baseParams: PreviewInfo["params"] = {
+    name: null,
+    device: null,
+    widthDp: 0,
+    heightDp: 0,
+    fontScale: 1.0,
+    showSystemUi: false,
+    showBackground: false,
+    backgroundColor: 0,
+    uiMode: 0,
+    locale: null,
+    group: null,
+};
+
+const samplePreview: PreviewInfo = {
+    id: "com.example.PreviewsKt.Sample",
+    functionName: "Sample",
+    className: "com.example.PreviewsKt",
+    sourceFile: "Previews.kt",
+    params: baseParams,
+    captures: [
+        {
+            advanceTimeMillis: null,
+            scroll: null,
+            renderOutput: "renders/sample.png",
+        },
+    ],
+};
+
+interface Harness {
+    inspector: FocusInspectorController;
+    container: HTMLElement;
+    card: HTMLElement;
+    saved: { scope: string; mru: string[] }[];
+    loaded: string[];
+    loadMru: (scope: string) => readonly string[];
+    setScope: (next: string) => void;
+}
+
+function makeHarness(opts?: {
+    initialMru?: Record<string, readonly string[]>;
+    scope?: string;
+}): Harness {
+    const initialMru = opts?.initialMru ?? {};
+    let scope = opts?.scope ?? "/workspace/sample";
+    const saved: { scope: string; mru: string[] }[] = [];
+    const loaded: string[] = [];
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const card = document.createElement("div");
+    card.dataset.previewId = samplePreview.id;
+    document.body.appendChild(card);
+
+    const inspector = new FocusInspectorController({
+        el: container,
+        earlyFeatures: () => true,
+        autoEnableCheap: () => false,
+        getPreview: (id) =>
+            id === samplePreview.id ? samplePreview : undefined,
+        getA11yFindings: () => [],
+        getA11yNodes: () => [],
+        getA11yOverlayId: () => null,
+        isLive: () => false,
+        onToggleA11yOverlay: () => {},
+        onToggleInteractive: () => {},
+        onToggleRecording: () => {},
+        onRequestFocusedDiff: () => {},
+        onRequestLaunchOnDevice: () => {},
+        getScope: () => scope,
+        loadMru: (s) => {
+            loaded.push(s);
+            return initialMru[s] ?? [];
+        },
+        saveMru: (s, mru) => {
+            saved.push({ scope: s, mru: [...mru] });
+        },
+    });
+
+    return {
+        inspector,
+        container,
+        card,
+        saved,
+        loaded,
+        loadMru: (s) => initialMru[s] ?? [],
+        setScope: (next) => {
+            scope = next;
+        },
+    };
+}
+
+describe("focus inspector MRU persistence", () => {
+    afterEach(() => {
+        // happy-dom is per-process; clean up DOM between tests to keep
+        // assertions independent.
+        document.body.innerHTML = "";
+    });
+
+    it("hydrates MRU from loadMru on first render of a scope", () => {
+        const h = makeHarness({
+            initialMru: {
+                "/workspace/sample": ["compose/theme", "fonts/used"],
+            },
+        });
+        h.inspector.render(h.card);
+        assert.deepStrictEqual(h.loaded, ["/workspace/sample"]);
+    });
+
+    it("does not call loadMru a second time for the same scope", () => {
+        const h = makeHarness({
+            initialMru: {
+                "/workspace/sample": ["compose/theme"],
+            },
+        });
+        h.inspector.render(h.card);
+        h.inspector.render(h.card);
+        h.inspector.render(h.card);
+        assert.deepStrictEqual(h.loaded, ["/workspace/sample"]);
+    });
+
+    it("calls saveMru with the kind moved to the front after a toggle", () => {
+        const h = makeHarness({
+            initialMru: {
+                "/workspace/sample": ["fonts/used", "compose/theme"],
+            },
+        });
+        h.inspector.render(h.card);
+        // The accessibility row routes through `onToggleA11yOverlay`
+        // (special case) and never touches MRU. Pick a theme-bucket
+        // checkbox so we exercise the `toggleProduct` path.
+        const themeCheckbox = h.container.querySelector<HTMLInputElement>(
+            '.focus-product-option[data-bucket="theming"] > input',
+        );
+        assert.ok(themeCheckbox, "expected a theming-bucket checkbox");
+        themeCheckbox.click();
+        assert.strictEqual(h.saved.length, 1);
+        assert.strictEqual(h.saved[0].scope, "/workspace/sample");
+        assert.strictEqual(h.saved[0].mru[0], "compose/theme");
+    });
+
+    it("partitions MRU by scope (switching scope re-hydrates)", () => {
+        const h = makeHarness({
+            initialMru: {
+                "/workspace/a": ["fonts/used"],
+                "/workspace/b": ["compose/theme"],
+            },
+            scope: "/workspace/a",
+        });
+        h.inspector.render(h.card);
+        h.setScope("/workspace/b");
+        h.inspector.render(h.card);
+        assert.deepStrictEqual(h.loaded, ["/workspace/a", "/workspace/b"]);
+    });
+});

--- a/vscode-extension/src/test/focusPresentation.test.ts
+++ b/vscode-extension/src/test/focusPresentation.test.ts
@@ -1,0 +1,234 @@
+// Unit tests for the presentation framework — registry behaviour
+// (built-in presenters dispatched correctly), and the arrow
+// correlator (attach/detach is idempotent and matches legend rows
+// against overlay elements by id).
+
+import * as assert from "assert";
+import {
+    _resetPresentersForTest,
+    getPresenter,
+    registerPresenter,
+} from "../webview/preview/focusPresentation";
+import { LegendArrowController } from "../webview/preview/legendArrow";
+import type {
+    AccessibilityFinding,
+    AccessibilityNode,
+    PreviewInfo,
+} from "../types";
+
+const baseParams: PreviewInfo["params"] = {
+    name: null,
+    device: null,
+    widthDp: 0,
+    heightDp: 0,
+    fontScale: 1.0,
+    showSystemUi: false,
+    showBackground: false,
+    backgroundColor: 0,
+    uiMode: 0,
+    locale: null,
+    group: null,
+};
+
+const samplePreview: PreviewInfo = {
+    id: "com.example.PreviewsKt.Sample",
+    functionName: "Sample",
+    className: "com.example.PreviewsKt",
+    sourceFile: "Previews.kt",
+    params: baseParams,
+    captures: [
+        {
+            advanceTimeMillis: null,
+            scroll: null,
+            renderOutput: "renders/sample.png",
+        },
+    ],
+};
+
+function ctx(overrides?: {
+    nodes?: readonly AccessibilityNode[];
+    findings?: readonly AccessibilityFinding[];
+    cardDataset?: Record<string, string>;
+}) {
+    const card = document.createElement("div");
+    if (overrides?.cardDataset) {
+        Object.assign(card.dataset, overrides.cardDataset);
+    }
+    return {
+        card,
+        preview: samplePreview,
+        findings: overrides?.findings ?? [],
+        nodes: overrides?.nodes ?? [],
+    };
+}
+
+describe("focusPresentation registry", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("dispatches the registered presenter for a kind", () => {
+        // The built-in presenters register at module import.
+        const a11y = getPresenter("a11y/hierarchy");
+        assert.ok(a11y, "a11y/hierarchy presenter should be registered");
+    });
+
+    it("returns a placeholder report for a11y/hierarchy with no nodes", () => {
+        const a11y = getPresenter("a11y/hierarchy")!;
+        const result = a11y(ctx());
+        assert.ok(result);
+        assert.ok(result!.report);
+        assert.strictEqual(result!.overlay, undefined);
+        assert.strictEqual(result!.legend, undefined);
+    });
+
+    it("paints overlay boxes and a legend when nodes are present", () => {
+        const a11y = getPresenter("a11y/hierarchy")!;
+        const nodes: AccessibilityNode[] = [
+            {
+                label: "Submit",
+                role: "Button",
+                states: ["enabled"],
+                merged: false,
+                boundsInScreen: "10,20,110,80",
+            },
+            {
+                label: "Description",
+                role: "Text",
+                states: [],
+                merged: true,
+                boundsInScreen: "0,90,200,140",
+            },
+        ];
+        const result = a11y(ctx({ nodes }));
+        assert.ok(result);
+        assert.ok(result!.overlay instanceof HTMLElement);
+        const boxes = result!.overlay!.querySelectorAll("[data-overlay-id]");
+        assert.strictEqual(boxes.length, 2);
+        assert.strictEqual(boxes[0].getAttribute("data-overlay-id"), "node-0");
+        assert.ok(result!.legend);
+        assert.strictEqual(result!.legend!.entries.length, 2);
+        assert.strictEqual(result!.legend!.entries[0].id, "node-0");
+        assert.strictEqual(result!.legend!.entries[1].level, "warning");
+    });
+
+    it("emits an error contribution when every bound is malformed", () => {
+        const a11y = getPresenter("a11y/hierarchy")!;
+        const nodes: AccessibilityNode[] = [
+            {
+                label: "Bad",
+                role: "Button",
+                states: [],
+                merged: false,
+                boundsInScreen: "garbage",
+            },
+        ];
+        const result = a11y(ctx({ nodes }));
+        assert.ok(result);
+        assert.ok(result!.error);
+        assert.strictEqual(result!.overlay, null);
+    });
+
+    it("renderErrorPresenter activates only when the card carries a render error", () => {
+        const renderErr = getPresenter("local/render/error")!;
+        assert.strictEqual(renderErr(ctx()), null);
+        const result = renderErr(
+            ctx({
+                cardDataset: { renderError: "NPE", renderErrorDetail: "boom" },
+            }),
+        );
+        assert.ok(result);
+        assert.ok(result!.error);
+        assert.strictEqual(result!.error!.message, "NPE");
+        assert.strictEqual(result!.error!.detail, "boom");
+    });
+
+    it("registerPresenter is last-write-wins (visible to tests)", () => {
+        // Snapshot the existing presenter so we can restore module
+        // behaviour for sibling tests.
+        const original = getPresenter("a11y/hierarchy")!;
+        registerPresenter("a11y/hierarchy", () => null);
+        assert.strictEqual(getPresenter("a11y/hierarchy")!(ctx()), null);
+        // Restore by re-registering the original directly. (Using
+        // `_resetPresentersForTest` would also drop the other built-ins.)
+        registerPresenter("a11y/hierarchy", original);
+        assert.notStrictEqual(getPresenter("a11y/hierarchy")!(ctx()), null);
+    });
+
+    it("_resetPresentersForTest empties the registry", () => {
+        _resetPresentersForTest();
+        assert.strictEqual(getPresenter("a11y/hierarchy"), undefined);
+        // Re-import to reseed for sibling tests in this file. Mocha
+        // doesn't reload modules across `describe` blocks, so mirror
+        // the side-effect register calls inline.
+        require("../webview/preview/focusPresentation");
+    });
+});
+
+describe("LegendArrowController", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    function setup(): {
+        legends: HTMLElement;
+        overlay: HTMLElement;
+        controller: LegendArrowController;
+    } {
+        const legends = document.createElement("div");
+        const overlay = document.createElement("div");
+        const row = document.createElement("li");
+        row.dataset.legendId = "node-0";
+        legends.appendChild(row);
+        const box = document.createElement("div");
+        box.dataset.overlayId = "node-0";
+        overlay.appendChild(box);
+        document.body.appendChild(legends);
+        document.body.appendChild(overlay);
+        const controller = new LegendArrowController();
+        return { legends, overlay, controller };
+    }
+
+    it("adds legend-active to the matching overlay on hover", () => {
+        const { legends, overlay, controller } = setup();
+        controller.attach(legends, overlay);
+        const row = legends.querySelector<HTMLElement>("[data-legend-id]")!;
+        row.dispatchEvent(new Event("mouseenter"));
+        const box = overlay.querySelector<HTMLElement>("[data-overlay-id]")!;
+        assert.ok(box.classList.contains("legend-active"));
+        row.dispatchEvent(new Event("mouseleave"));
+        assert.ok(!box.classList.contains("legend-active"));
+    });
+
+    it("detach removes listeners (idempotent)", () => {
+        const { legends, overlay, controller } = setup();
+        controller.attach(legends, overlay);
+        controller.detach();
+        controller.detach(); // no throw
+        const row = legends.querySelector<HTMLElement>("[data-legend-id]")!;
+        row.dispatchEvent(new Event("mouseenter"));
+        const box = overlay.querySelector<HTMLElement>("[data-overlay-id]")!;
+        assert.ok(!box.classList.contains("legend-active"));
+    });
+
+    it("re-attach replaces previous listeners", () => {
+        const { legends, overlay, controller } = setup();
+        controller.attach(legends, overlay);
+        controller.attach(legends, overlay);
+        const row = legends.querySelector<HTMLElement>("[data-legend-id]")!;
+        // Without dedupe, two listeners would fire and a removeEvent
+        // pair would still leave one dangling. We assert the toggle
+        // behaviour instead — enter then leave should clear the class.
+        row.dispatchEvent(new Event("mouseenter"));
+        row.dispatchEvent(new Event("mouseleave"));
+        const box = overlay.querySelector<HTMLElement>("[data-overlay-id]")!;
+        assert.ok(!box.classList.contains("legend-active"));
+    });
+
+    it("creates a singleton SVG arrow on document.body", () => {
+        const { legends, overlay, controller } = setup();
+        controller.attach(legends, overlay);
+        const svgs = document.querySelectorAll("#focus-legend-arrow");
+        assert.strictEqual(svgs.length, 1);
+    });
+});

--- a/vscode-extension/src/test/focusProductTaxonomy.test.ts
+++ b/vscode-extension/src/test/focusProductTaxonomy.test.ts
@@ -1,0 +1,322 @@
+import * as assert from "assert";
+import {
+    MAX_SUGGESTIONS,
+    bucketOf,
+    bumpMru,
+    costOf,
+    groupByBucket,
+    isWearDevice,
+    suggestFor,
+    type ProductDescriptor,
+} from "../webview/preview/focusProductTaxonomy";
+import type { PreviewInfo } from "../types";
+
+const baseParams: PreviewInfo["params"] = {
+    name: null,
+    device: null,
+    widthDp: 0,
+    heightDp: 0,
+    fontScale: 1.0,
+    showSystemUi: false,
+    showBackground: false,
+    backgroundColor: 0,
+    uiMode: 0,
+    locale: null,
+    group: null,
+};
+
+function makePreview(overrides: Partial<PreviewInfo> = {}): PreviewInfo {
+    return {
+        id: "com.example.PreviewsKt.Sample",
+        functionName: "Sample",
+        className: "com.example.PreviewsKt",
+        sourceFile: "Previews.kt",
+        params: baseParams,
+        captures: [
+            {
+                advanceTimeMillis: null,
+                scroll: null,
+                renderOutput: "renders/com.example.Sample.png",
+            },
+        ],
+        ...overrides,
+    };
+}
+
+function descriptor(kind: string): ProductDescriptor {
+    return {
+        kind,
+        label: kind,
+        icon: "circle",
+        cost: costOf(kind),
+        daemonBacked: true,
+    };
+}
+
+describe("focusProductTaxonomy.bucketOf", () => {
+    it("routes a11y/* to accessibility", () => {
+        assert.strictEqual(bucketOf("a11y/atf"), "accessibility");
+        assert.strictEqual(bucketOf("a11y/hierarchy"), "accessibility");
+    });
+
+    it("routes layout/* to layout", () => {
+        assert.strictEqual(bucketOf("layout/tree"), "layout");
+    });
+
+    it("special-cases compose/recomposition as performance", () => {
+        assert.strictEqual(bucketOf("compose/recomposition"), "performance");
+    });
+
+    it("special-cases compose/theme as theming", () => {
+        assert.strictEqual(bucketOf("compose/theme"), "theming");
+    });
+
+    it("routes render/* to performance", () => {
+        assert.strictEqual(bucketOf("render/trace"), "performance");
+        assert.strictEqual(bucketOf("render/composeAiTrace"), "performance");
+    });
+
+    it("routes resources/, fonts/, text/ to resources", () => {
+        assert.strictEqual(bucketOf("resources/used"), "resources");
+        assert.strictEqual(bucketOf("fonts/used"), "resources");
+        assert.strictEqual(bucketOf("text/strings"), "resources");
+    });
+
+    it("strips local/ prefix and recurses", () => {
+        assert.strictEqual(bucketOf("local/a11y/overlay"), "accessibility");
+        assert.strictEqual(bucketOf("local/layout/tree"), "layout");
+    });
+
+    it("falls through to 'more' for unknown namespaces", () => {
+        assert.strictEqual(bucketOf("future/widget"), "more");
+        assert.strictEqual(bucketOf("vendor.foo/bar"), "more");
+    });
+});
+
+describe("focusProductTaxonomy.costOf", () => {
+    it("classifies inspection-only kinds as cheap", () => {
+        assert.strictEqual(costOf("compose/theme"), "cheap");
+        assert.strictEqual(costOf("text/strings"), "cheap");
+        assert.strictEqual(costOf("fonts/used"), "cheap");
+        assert.strictEqual(costOf("resources/used"), "cheap");
+        assert.strictEqual(costOf("layout/tree"), "cheap");
+    });
+
+    it("classifies instrumented and re-render kinds as expensive", () => {
+        assert.strictEqual(costOf("compose/recomposition"), "expensive");
+        assert.strictEqual(costOf("render/trace"), "expensive");
+        assert.strictEqual(costOf("a11y/atf"), "expensive");
+    });
+
+    it("treats unknown kinds as expensive (safe default)", () => {
+        assert.strictEqual(costOf("future/widget"), "expensive");
+    });
+});
+
+describe("focusProductTaxonomy.isWearDevice", () => {
+    it("matches obvious Wear strings", () => {
+        assert.strictEqual(isWearDevice("id:wearos_small_round"), true);
+        assert.strictEqual(isWearDevice("id:wearos_square"), true);
+    });
+
+    it("matches watch substring", () => {
+        assert.strictEqual(isWearDevice("id:watch_round"), true);
+    });
+
+    it("matches spec strings with round=true", () => {
+        assert.strictEqual(
+            isWearDevice("spec:width=200dp,height=200dp,round=true"),
+            true,
+        );
+    });
+
+    it("rejects phone / null / undefined", () => {
+        assert.strictEqual(isWearDevice("id:pixel_5"), false);
+        assert.strictEqual(isWearDevice(null), false);
+        assert.strictEqual(isWearDevice(undefined), false);
+        assert.strictEqual(
+            isWearDevice("spec:width=200dp,height=200dp"),
+            false,
+        );
+    });
+});
+
+describe("focusProductTaxonomy.suggestFor", () => {
+    const allKinds = new Set([
+        "compose/recomposition",
+        "compose/theme",
+        "local/a11y/overlay",
+        "layout/tree",
+        "fonts/used",
+    ]);
+
+    it("suggests recomposition for Wear devices", () => {
+        const out = suggestFor({
+            preview: makePreview({
+                params: { ...baseParams, device: "id:wearos_small_round" },
+            }),
+            findingsCount: 0,
+            mru: [],
+            available: allKinds,
+        });
+        assert.ok(out.includes("compose/recomposition"));
+    });
+
+    it("suggests recomposition when a scroll capture is present", () => {
+        const out = suggestFor({
+            preview: makePreview({
+                captures: [
+                    {
+                        advanceTimeMillis: null,
+                        scroll: {
+                            mode: "LONG",
+                            axis: "VERTICAL",
+                            maxScrollPx: 1000,
+                            reduceMotion: false,
+                            atEnd: false,
+                            reachedPx: null,
+                        },
+                        renderOutput: "renders/scroll.png",
+                    },
+                ],
+            }),
+            findingsCount: 0,
+            mru: [],
+            available: allKinds,
+        });
+        assert.ok(out.includes("compose/recomposition"));
+    });
+
+    it("suggests a11y overlay when findings exist", () => {
+        const out = suggestFor({
+            preview: makePreview(),
+            findingsCount: 3,
+            mru: [],
+            available: allKinds,
+        });
+        assert.strictEqual(out[0], "local/a11y/overlay");
+    });
+
+    it("suggests theme tokens for non-default UI mode", () => {
+        const out = suggestFor({
+            preview: makePreview({
+                params: { ...baseParams, uiMode: 0x21 },
+            }),
+            findingsCount: 0,
+            mru: [],
+            available: allKinds,
+        });
+        assert.ok(out.includes("compose/theme"));
+    });
+
+    it("falls back to MRU when annotations don't trigger", () => {
+        const out = suggestFor({
+            preview: makePreview(),
+            findingsCount: 0,
+            mru: ["fonts/used", "compose/theme"],
+            available: allKinds,
+        });
+        assert.ok(
+            out.indexOf("fonts/used") < out.indexOf("local/a11y/overlay"),
+        );
+    });
+
+    it("drops suggestions that aren't in the available set", () => {
+        const out = suggestFor({
+            preview: makePreview({
+                params: { ...baseParams, device: "id:wearos_small_round" },
+            }),
+            findingsCount: 0,
+            mru: [],
+            available: new Set(["compose/theme"]),
+        });
+        assert.ok(!out.includes("compose/recomposition"));
+    });
+
+    it("caps suggestions at MAX_SUGGESTIONS", () => {
+        const out = suggestFor({
+            preview: makePreview(),
+            findingsCount: 1,
+            mru: [
+                "compose/recomposition",
+                "compose/theme",
+                "fonts/used",
+                "layout/tree",
+            ],
+            available: allKinds,
+        });
+        assert.ok(out.length <= MAX_SUGGESTIONS);
+    });
+
+    it("dedups when MRU and annotation hint overlap", () => {
+        const out = suggestFor({
+            preview: makePreview({
+                params: { ...baseParams, uiMode: 0x21 },
+            }),
+            findingsCount: 0,
+            mru: ["compose/theme"],
+            available: allKinds,
+        });
+        const themeOccurrences = out.filter(
+            (k) => k === "compose/theme",
+        ).length;
+        assert.strictEqual(themeOccurrences, 1);
+    });
+});
+
+describe("focusProductTaxonomy.groupByBucket", () => {
+    it("returns all five buckets plus more, in stable order", () => {
+        const result = groupByBucket([]);
+        assert.deepStrictEqual(
+            [...result.keys()],
+            [
+                "accessibility",
+                "layout",
+                "performance",
+                "theming",
+                "resources",
+                "more",
+            ],
+        );
+    });
+
+    it("places products into the right bucket and preserves input order", () => {
+        const products = [
+            descriptor("compose/theme"),
+            descriptor("a11y/atf"),
+            descriptor("a11y/hierarchy"),
+            descriptor("future/widget"),
+        ];
+        const grouped = groupByBucket(products);
+        assert.deepStrictEqual(
+            grouped.get("accessibility")?.map((p) => p.kind),
+            ["a11y/atf", "a11y/hierarchy"],
+        );
+        assert.deepStrictEqual(
+            grouped.get("theming")?.map((p) => p.kind),
+            ["compose/theme"],
+        );
+        assert.deepStrictEqual(
+            grouped.get("more")?.map((p) => p.kind),
+            ["future/widget"],
+        );
+    });
+});
+
+describe("focusProductTaxonomy.bumpMru", () => {
+    it("moves the kind to the front", () => {
+        assert.deepStrictEqual(bumpMru(["a", "b", "c"], "c"), ["c", "a", "b"]);
+    });
+
+    it("inserts when the kind is new", () => {
+        assert.deepStrictEqual(bumpMru(["a", "b"], "c"), ["c", "a", "b"]);
+    });
+
+    it("dedups instead of duplicating", () => {
+        assert.deepStrictEqual(bumpMru(["a", "b", "a"], "a"), ["a", "b"]);
+    });
+
+    it("trims to maxLen", () => {
+        assert.deepStrictEqual(bumpMru(["a", "b", "c"], "d", 2), ["d", "a"]);
+    });
+});

--- a/vscode-extension/src/test/focusProductTaxonomy.test.ts
+++ b/vscode-extension/src/test/focusProductTaxonomy.test.ts
@@ -111,6 +111,32 @@ describe("focusProductTaxonomy.costOf", () => {
     it("treats unknown kinds as expensive (safe default)", () => {
         assert.strictEqual(costOf("future/widget"), "expensive");
     });
+
+    it("trusts the daemon hint for unknown kinds", () => {
+        assert.strictEqual(
+            costOf("future/widget", { requiresRerender: false }),
+            "cheap",
+        );
+        assert.strictEqual(
+            costOf("future/widget", { requiresRerender: true }),
+            "expensive",
+        );
+    });
+
+    it("ignores the daemon hint when the kind is in the cheap allowlist", () => {
+        assert.strictEqual(
+            costOf("compose/theme", { requiresRerender: true }),
+            "cheap",
+        );
+    });
+
+    it("treats absent or undefined hint as no signal", () => {
+        assert.strictEqual(
+            costOf("future/widget", { requiresRerender: undefined }),
+            "expensive",
+        );
+        assert.strictEqual(costOf("future/widget", {}), "expensive");
+    });
 });
 
 describe("focusProductTaxonomy.isWearDevice", () => {

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -562,7 +562,58 @@ export type ExtensionToWebview =
           heldSession: boolean;
       }
     | { command: "streamStopped"; previewId: string }
-    | { command: "setEarlyFeatures"; enabled: boolean };
+    | { command: "setEarlyFeatures"; enabled: boolean }
+    /**
+     * Reflects `composePreview.autoEnableCheap.enabled` from settings.
+     * When `true` the focus inspector auto-flips on cheap, suggestion-
+     * matched data products (theme tokens, fonts, strings, layout tree)
+     * the first time it sees a preview in a given scope; expensive
+     * kinds (recomposition, render trace, a11y) stay click-to-enable.
+     * Sent at panel boot from `composePreview.autoEnableCheap.enabled`
+     * and again on settings change.
+     */
+    | { command: "setAutoEnableCheap"; enabled: boolean }
+    /**
+     * Daemon capabilities for the active module — the kinds the daemon
+     * can produce (`dataProducts`) and the data extensions registered
+     * (`dataExtensions`). The focus inspector groups these into its
+     * five stable buckets and uses them as the source of truth for
+     * "what's actually available on this backend." Empty / absent
+     * lists mean the daemon hasn't reported (yet); the inspector
+     * falls back to its built-in placeholder set.
+     *
+     * `dataProducts` are wire-shape `DataProductCapability` records;
+     * `dataExtensions` are descriptors. Both are forwarded as JSON-
+     * serialisable objects rather than re-importing the daemon
+     * protocol types webview-side — keeps the webview build free of
+     * the host-only `daemon/` tree.
+     */
+    | {
+          command: "setDaemonCapabilities";
+          moduleId: string;
+          dataProducts: DaemonDataProductCapability[];
+          dataExtensions: DaemonDataExtensionDescriptor[];
+      };
+
+/**
+ * Webview-facing slice of the daemon's `DataProductCapability`. Only
+ * the fields the inspector actually renders; we deliberately keep this
+ * decoupled from the daemon protocol module so the webview build
+ * doesn't pull in `daemon/`.
+ */
+export interface DaemonDataProductCapability {
+    kind: string;
+    schemaVersion?: number;
+    transport?: "inline" | "path" | "both";
+    requiresRerender?: boolean;
+    displayName?: string;
+}
+
+/** Webview-facing slice of `DataExtensionDescriptor`. */
+export interface DaemonDataExtensionDescriptor {
+    id: string;
+    displayName?: string;
+}
 
 /** Messages from webview to extension */
 export type WebviewToExtension =

--- a/vscode-extension/src/webview/preview/focusInspector.ts
+++ b/vscode-extension/src/webview/preview/focusInspector.ts
@@ -1,34 +1,45 @@
 // Focus-mode inspector — the side panel that appears when a single
-// preview is focused. Three sections: an Inspect product picker (a11y
-// / Layout / Strings / Resources / Fonts / Render / Theme /
-// Recomposition), a History accordion (diff vs HEAD, diff vs main),
-// and a Tools strip (a11y, device, live, record action buttons).
+// preview is focused. Three sections, top to bottom:
 //
-// Lifted verbatim from `behavior.ts`'s `renderFocusInspector` cluster
-// (`sectionHeader` / `actionButton` / `historyPanel` / `productSpec` /
-// `productPicker` / `productOption` / `toggleFocusProduct` /
-// `buildFocusPlaceholders`). Same DOM structure, same CSS classes,
-// same accordion-open persistence (`focusProductPickerOpen` /
-// `focusHistoryOpen`) — those flags and the `enabledFocusProducts`
-// Set live as private state on the controller now rather than free
-// variables in `setupPreviewBehavior`.
+//   1. **Suggested for this preview** — a short chip row driven by
+//      annotation hints (Wear device, scroll capture, existing a11y
+//      findings, non-default UI mode) plus the per-scope MRU. Capped
+//      at MAX_SUGGESTIONS so the eye lands on it. Cheap kinds may
+//      auto-enable when `composePreview.autoEnableCheap.enabled` is on.
 //
-// Action callbacks (toggleA11yOverlay / toggleInteractive /
-// toggleRecording / requestFocusedDiff / requestLaunchOnDevice) and
-// the per-preview state queries (a11y findings / nodes, live set,
-// store-backed `a11yOverlayId`) are passed in via `FocusInspectorConfig`
-// so the module doesn't need closure access to the rest of
-// `behavior.ts`. `clearAll` resets the `enabledFocusProducts` Set.
+//   2. **Five stable buckets** (Accessibility / Layout / Performance
+//      / Theming / Resources, plus a fallback "More" for unknown
+//      namespaces) — each `<details>` collapses by default; expanding
+//      reveals the kinds the daemon actually advertises (or, today,
+//      the built-in placeholder set). The chrome stays at five rows
+//      regardless of how many extensions register on the daemon
+//      side; only the contents change.
 //
-// `renderSummary` and `themeSummary` from the imperative copy were
-// dead code (defined but never called) and are dropped; behaviour
-// unchanged.
+//   3. **History** + **Tools** — diff buttons (HEAD / main) and
+//      action buttons (a11y, device, live, record). Unchanged from
+//      the previous flat-picker layout.
+//
+// All taxonomy / cheapness / suggestion logic lives in
+// `focusProductTaxonomy.ts` so it's testable without a DOM. This
+// module is the imperative DOM glue plus the per-scope MRU map.
 
 import type {
     AccessibilityFinding,
     AccessibilityNode,
     PreviewInfo,
 } from "../shared/types";
+import {
+    BUCKET_META,
+    MAX_SUGGESTIONS,
+    PRODUCT_BUCKETS,
+    type ProductBucket,
+    type ProductDescriptor,
+    bucketOf,
+    bumpMru,
+    costOf,
+    groupByBucket,
+    suggestFor,
+} from "./focusProductTaxonomy";
 
 export interface FocusInspectorConfig {
     /** The `<div id="focus-inspector">` element rendered by `<preview-app>`. */
@@ -36,42 +47,53 @@ export interface FocusInspectorConfig {
     /** Whether `composePreview.earlyFeatures` is on — when off the
      *  inspector hides and the caller's `clear` path clears it. */
     earlyFeatures(): boolean;
+    /** Whether `composePreview.autoEnableCheap.enabled` is on. When
+     *  true, suggested cheap kinds auto-enable on first sight per
+     *  scope. Always-false fallback is safe. */
+    autoEnableCheap(): boolean;
     /** Look up the manifest entry for a preview, or `undefined` when
-     *  the preview is unknown to this panel (e.g. transient state
-     *  during a `setPreviews` swap). */
+     *  the preview is unknown to this panel. */
     getPreview(previewId: string): PreviewInfo | undefined;
-    /** Latest a11y findings for a preview. Reads the runtime cache
-     *  populated from `setPreviews` / `updateA11y`. */
+    /** Latest a11y findings for a preview. */
     getA11yFindings(previewId: string): readonly AccessibilityFinding[];
     /** Latest a11y hierarchy nodes for a preview. */
     getA11yNodes(previewId: string): readonly AccessibilityNode[];
-    /** `previewId` whose a11y overlay subscription is currently on, or
-     *  `null` when no card is subscribed. */
+    /** `previewId` whose a11y overlay subscription is currently on. */
     getA11yOverlayId(): string | null;
     /** Whether [previewId] is currently in the live (interactive) set. */
     isLive(previewId: string): boolean;
-    /** Click handlers shared with the focus toolbar — pressed from
-     *  the inspector's product-picker rows / tools strip. */
+    /** Click handlers shared with the focus toolbar. */
     onToggleA11yOverlay(): void;
     /** `shift = false` matches the toolbar Live button — single-target. */
     onToggleInteractive(shift: boolean): void;
     onToggleRecording(): void;
     onRequestFocusedDiff(against: "head" | "main"): void;
     onRequestLaunchOnDevice(): void;
-}
-
-interface ProductOptionSpec {
-    icon: string;
-    label: string;
-    value: string;
-    enabled: boolean;
-    state: "ok" | "warn" | "idle";
-    onToggle(): void;
+    /**
+     * Scope key for MRU. Two previews in the same module share an MRU
+     * list; switching modules resets effective ranking. Empty string
+     * is a valid sentinel (treated as a single shared scope).
+     */
+    getScope(): string;
 }
 
 export class FocusInspectorController {
+    /** Toggles the user has explicitly enabled, by `kind`. Includes
+     *  daemon-side products (subscribed) and local placeholders. */
     private readonly enabled = new Set<string>();
-    private productPickerOpen = false;
+    /** Per-scope MRU: scope -> kinds, most-recent first. In-memory
+     *  for now; persistence via `vscode.setState` is a follow-up. */
+    private readonly mruByScope = new Map<string, string[]>();
+    /** Per-scope set of kinds we've already auto-enabled this session,
+     *  so `autoEnableCheap` doesn't keep flipping a kind back on after
+     *  the user explicitly turned it off. */
+    private readonly autoEnabledByScope = new Map<string, Set<string>>();
+    /** Daemon-advertised products. Replaces the built-in placeholders
+     *  when set. `null` means "use built-in fallback". Pushed in via
+     *  `setProducts`. */
+    private daemonProducts: ProductDescriptor[] | null = null;
+    private suggestionsOpen = true;
+    private bucketOpen: Partial<Record<ProductBucket, boolean>> = {};
     private historyOpen = false;
     /** Last card we rendered. Held so `toggleProduct` can re-render
      *  the panel on the same card after flipping a checkbox. */
@@ -79,9 +101,18 @@ export class FocusInspectorController {
 
     constructor(private readonly config: FocusInspectorConfig) {}
 
+    /**
+     * Replace the descriptor list with daemon-advertised products.
+     * Pass `null` to fall back to the built-in placeholder set.
+     * Re-renders if a card is currently focused.
+     */
+    setProducts(products: ProductDescriptor[] | null): void {
+        this.daemonProducts = products;
+        if (this.lastCard) this.render(this.lastCard);
+    }
+
     /** Repaint the inspector for [card], or clear it when [card] is
-     *  `null` / earlyFeatures is off. Called by `applyLayout`,
-     *  `setInteractiveForCard`, `toggleRecording`, etc. */
+     *  `null` / earlyFeatures is off. */
     render(card: HTMLElement | null): void {
         const el = this.config.el;
         el.innerHTML = "";
@@ -92,65 +123,59 @@ export class FocusInspectorController {
             return;
         }
         const previewId = card.dataset.previewId ?? "";
-        const p = previewId ? this.config.getPreview(previewId) : undefined;
-        if (!previewId || !p) {
+        const preview = previewId
+            ? this.config.getPreview(previewId)
+            : undefined;
+        if (!previewId || !preview) {
             this.lastCard = null;
             return;
         }
         this.lastCard = card;
 
+        const products = this.resolveProducts();
+        const productByKind = new Map(products.map((p) => [p.kind, p]));
+        const findings = this.config.getA11yFindings(previewId);
+        const scope = this.config.getScope();
+        const suggestions = suggestFor({
+            preview,
+            findingsCount: findings.length,
+            mru: this.mruByScope.get(scope) ?? [],
+            available: new Set(productByKind.keys()),
+        });
+
+        // Auto-enable cheap suggested kinds, once per scope per kind.
+        // Keeps the suggestion chip "active" without requiring a click,
+        // but never re-enables a kind the user has manually turned off
+        // since the autoEnabled map is sticky for the session.
+        if (this.config.autoEnableCheap()) {
+            const auto = this.ensureAutoEnabledSet(scope);
+            for (const kind of suggestions) {
+                if (auto.has(kind)) continue;
+                const p = productByKind.get(kind);
+                if (!p || p.cost !== "cheap") continue;
+                if (!this.enabled.has(kind)) {
+                    this.enabled.add(kind);
+                }
+                auto.add(kind);
+            }
+        }
+
         const inspect = document.createElement("section");
         inspect.className = "focus-panel focus-inspect-panel";
         inspect.appendChild(sectionHeader("search", "Inspect"));
-        const findings = this.config.getA11yFindings(previewId);
-        const nodes = this.config.getA11yNodes(previewId);
         inspect.appendChild(
-            this.productPicker([
-                {
-                    icon: "eye",
-                    label: "Accessibility",
-                    value:
-                        findings.length > 0
-                            ? findings.length +
-                              " finding" +
-                              (findings.length === 1 ? "" : "s")
-                            : "Overlay",
-                    enabled: previewId === this.config.getA11yOverlayId(),
-                    state: findings.length > 0 ? "warn" : "idle",
-                    onToggle: () => this.config.onToggleA11yOverlay(),
-                },
-                {
-                    icon: "list-tree",
-                    label: "Layout",
-                    value:
-                        nodes.length > 0
-                            ? nodes.length +
-                              " node" +
-                              (nodes.length === 1 ? "" : "s")
-                            : "Placeholder",
-                    enabled: this.enabled.has("layout"),
-                    state: nodes.length > 0 ? "ok" : "idle",
-                    onToggle: () => this.toggleProduct("layout"),
-                },
-                this.productSpec("symbol-string", "Strings", "strings"),
-                this.productSpec("file-code", "Resources", "resources"),
-                this.productSpec("text-size", "Fonts", "fonts"),
-                this.productSpec("pulse", "Render", "render"),
-                this.productSpec("symbol-color", "Theme", "theme"),
-                {
-                    icon: "sync",
-                    label: "Recomposition",
-                    value: this.config.isLive(previewId)
-                        ? "Live"
-                        : "Placeholder",
-                    enabled:
-                        this.enabled.has("recomposition") ||
-                        this.config.isLive(previewId),
-                    state: this.config.isLive(previewId) ? "ok" : "idle",
-                    onToggle: () => this.toggleProduct("recomposition"),
-                },
-            ]),
+            this.renderSuggestionRow(
+                suggestions,
+                productByKind,
+                preview,
+                previewId,
+                findings,
+            ),
         );
+        inspect.appendChild(
+            this.renderBuckets(products, preview, previewId, findings),
+        );
+
         const controls = document.createElement("section");
         controls.className = "focus-panel focus-controls-panel";
         controls.appendChild(sectionHeader("settings-gear", "Tools"));
@@ -189,76 +214,278 @@ export class FocusInspectorController {
         el.appendChild(inspect);
         el.appendChild(this.historyPanel());
         el.appendChild(controls);
-        const placeholders = this.buildPlaceholders();
-        if (placeholders) inspect.appendChild(placeholders);
     }
 
     /**
-     * Reset the per-preview product-enable Set. Called by `behavior.ts`
-     * on the `clearAll` message path (panel scope changed) so the
-     * inspector doesn't carry stale "Layout enabled" / "Render enabled"
-     * checkboxes into the new module's previews.
+     * Reset the per-preview product-enable Set. Called by the message
+     * dispatcher on the `clearAll` / `setEarlyFeatures off` path so the
+     * inspector doesn't carry stale toggles into a new module's
+     * previews.
      */
     clearProducts(): void {
         this.enabled.clear();
+        this.autoEnabledByScope.clear();
     }
 
-    private toggleProduct(id: string): void {
-        if (this.enabled.has(id)) {
-            this.enabled.delete(id);
-        } else {
-            this.enabled.add(id);
+    private resolveProducts(): ProductDescriptor[] {
+        if (this.daemonProducts && this.daemonProducts.length > 0) {
+            return this.daemonProducts;
         }
+        return BUILT_IN_PRODUCTS;
+    }
+
+    private ensureAutoEnabledSet(scope: string): Set<string> {
+        let s = this.autoEnabledByScope.get(scope);
+        if (!s) {
+            s = new Set();
+            this.autoEnabledByScope.set(scope, s);
+        }
+        return s;
+    }
+
+    private toggleProduct(kind: string): void {
+        if (this.enabled.has(kind)) {
+            this.enabled.delete(kind);
+        } else {
+            this.enabled.add(kind);
+        }
+        const scope = this.config.getScope();
+        const cur = this.mruByScope.get(scope) ?? [];
+        this.mruByScope.set(scope, bumpMru(cur, kind));
         if (this.lastCard) this.render(this.lastCard);
     }
 
-    private productSpec(
-        icon: string,
-        label: string,
-        id: string,
-    ): ProductOptionSpec {
-        return {
-            icon,
-            label,
-            value: "Placeholder",
-            enabled: this.enabled.has(id),
-            state: "idle",
-            onToggle: () => this.toggleProduct(id),
-        };
-    }
-
-    private productPicker(products: ProductOptionSpec[]): HTMLElement {
-        const picker = document.createElement("details");
-        picker.className = "focus-product-picker";
-        picker.open = this.productPickerOpen;
-        picker.addEventListener("toggle", () => {
-            this.productPickerOpen = picker.open;
+    private renderSuggestionRow(
+        suggestions: readonly string[],
+        productByKind: ReadonlyMap<string, ProductDescriptor>,
+        preview: PreviewInfo,
+        previewId: string,
+        findings: readonly AccessibilityFinding[],
+    ): HTMLElement {
+        const row = document.createElement("details");
+        row.className = "focus-suggestions";
+        row.open = this.suggestionsOpen;
+        row.addEventListener("toggle", () => {
+            this.suggestionsOpen = row.open;
         });
         const summary = document.createElement("summary");
-        summary.className = "focus-product-summary";
-        const selected = products.filter((product) => product.enabled);
+        summary.className = "focus-suggestions-summary";
         const summaryText = document.createElement("span");
-        summaryText.textContent =
-            selected.length === 0
-                ? "Choose inspection layers"
-                : selected.length === 1
-                  ? selected[0].label
-                  : selected.length + " layers selected";
+        const visibleSuggestions = suggestions.slice(0, MAX_SUGGESTIONS);
+        if (visibleSuggestions.length === 0) {
+            summaryText.textContent = "No suggestions for this preview";
+        } else {
+            summaryText.textContent =
+                "Suggested for this preview · " + visibleSuggestions.length;
+        }
         summary.appendChild(summaryText);
         const chevron = document.createElement("i");
         chevron.className =
             "codicon codicon-chevron-down focus-summary-chevron";
         chevron.setAttribute("aria-hidden", "true");
         summary.appendChild(chevron);
-        picker.appendChild(summary);
+        row.appendChild(summary);
 
-        const menu = document.createElement("div");
-        menu.className = "focus-product-menu";
-        for (const product of products) {
-            menu.appendChild(productOption(product));
+        const chipBox = document.createElement("div");
+        chipBox.className = "focus-suggestion-chips";
+        for (const kind of visibleSuggestions) {
+            const p = productByKind.get(kind);
+            if (!p) continue;
+            chipBox.appendChild(
+                this.renderChip(p, preview, previewId, findings),
+            );
         }
-        picker.appendChild(menu);
-        return picker;
+        if (visibleSuggestions.length === 0) {
+            const empty = document.createElement("span");
+            empty.className = "focus-suggestion-empty";
+            empty.textContent =
+                "Nothing matches this preview's annotations yet — pick layers below.";
+            chipBox.appendChild(empty);
+        }
+        row.appendChild(chipBox);
+        return row;
+    }
+
+    private renderChip(
+        p: ProductDescriptor,
+        preview: PreviewInfo,
+        previewId: string,
+        findings: readonly AccessibilityFinding[],
+    ): HTMLElement {
+        const chip = document.createElement("button");
+        chip.type = "button";
+        chip.className = "focus-suggestion-chip";
+        const isOn = this.isProductOn(p.kind, previewId);
+        chip.dataset.state = isOn ? "on" : "off";
+        chip.dataset.cost = p.cost;
+        const titleParts = [
+            p.label,
+            p.cost === "cheap"
+                ? "Cheap to enable."
+                : "May increase render cost.",
+        ];
+        chip.title = titleParts.join(" — ");
+        const icon = document.createElement("i");
+        icon.className = "codicon codicon-" + p.icon;
+        icon.setAttribute("aria-hidden", "true");
+        chip.appendChild(icon);
+        const label = document.createElement("span");
+        label.textContent = p.label;
+        chip.appendChild(label);
+        const hint = this.dynamicHint(p, previewId, findings);
+        if (hint) {
+            const hintEl = document.createElement("span");
+            hintEl.className = "focus-suggestion-chip-hint";
+            hintEl.textContent = hint;
+            chip.appendChild(hintEl);
+        }
+        chip.addEventListener("click", () => this.handleChipClick(p));
+        // Mark unused params consumed for lint — kept in the signature
+        // because future suggestion variants will read them.
+        void preview;
+        return chip;
+    }
+
+    private handleChipClick(p: ProductDescriptor): void {
+        if (p.kind === "local/a11y/overlay") {
+            this.config.onToggleA11yOverlay();
+            return;
+        }
+        this.toggleProduct(p.kind);
+    }
+
+    private renderBuckets(
+        products: readonly ProductDescriptor[],
+        preview: PreviewInfo,
+        previewId: string,
+        findings: readonly AccessibilityFinding[],
+    ): HTMLElement {
+        const wrapper = document.createElement("div");
+        wrapper.className = "focus-buckets";
+        const grouped = groupByBucket(products);
+        const order: ProductBucket[] = [...PRODUCT_BUCKETS];
+        // "More" bucket only renders when non-empty — unknown
+        // namespaces would otherwise add visual noise on every preview.
+        if ((grouped.get("more") ?? []).length > 0) order.push("more");
+        for (const bucket of order) {
+            const items = grouped.get(bucket) ?? [];
+            wrapper.appendChild(
+                this.renderBucket(bucket, items, preview, previewId, findings),
+            );
+        }
+        return wrapper;
+    }
+
+    private renderBucket(
+        bucket: ProductBucket,
+        items: readonly ProductDescriptor[],
+        preview: PreviewInfo,
+        previewId: string,
+        findings: readonly AccessibilityFinding[],
+    ): HTMLElement {
+        const meta = BUCKET_META[bucket];
+        const enabledCount = items.filter((p) =>
+            this.isProductOn(p.kind, previewId),
+        ).length;
+
+        const details = document.createElement("details");
+        details.className = "focus-bucket";
+        details.dataset.bucket = bucket;
+        details.open = !!this.bucketOpen[bucket];
+        details.addEventListener("toggle", () => {
+            this.bucketOpen[bucket] = details.open;
+        });
+
+        const summary = document.createElement("summary");
+        summary.className = "focus-bucket-summary";
+        const icon = document.createElement("i");
+        icon.className = "codicon codicon-" + meta.icon;
+        icon.setAttribute("aria-hidden", "true");
+        summary.appendChild(icon);
+        const label = document.createElement("span");
+        label.className = "focus-bucket-label";
+        label.textContent = meta.label;
+        summary.appendChild(label);
+        const count = document.createElement("span");
+        count.className = "focus-bucket-count";
+        if (items.length === 0) {
+            count.textContent = "—";
+        } else if (enabledCount > 0) {
+            count.textContent = enabledCount + " / " + items.length;
+        } else {
+            count.textContent = String(items.length);
+        }
+        summary.appendChild(count);
+        const chevron = document.createElement("i");
+        chevron.className =
+            "codicon codicon-chevron-down focus-summary-chevron";
+        chevron.setAttribute("aria-hidden", "true");
+        summary.appendChild(chevron);
+        details.appendChild(summary);
+
+        const body = document.createElement("div");
+        body.className = "focus-bucket-body";
+        if (items.length === 0) {
+            const empty = document.createElement("div");
+            empty.className = "focus-bucket-empty";
+            empty.textContent = "No layers from current extensions.";
+            body.appendChild(empty);
+        }
+        // Sort within bucket by MRU rank then label, so familiar
+        // layers float to the top without changing the bucket itself.
+        const mru = this.mruByScope.get(this.config.getScope()) ?? [];
+        const mruRank = (kind: string): number => {
+            const idx = mru.indexOf(kind);
+            return idx === -1 ? Number.MAX_SAFE_INTEGER : idx;
+        };
+        const sorted = [...items].sort((a, b) => {
+            const ra = mruRank(a.kind);
+            const rb = mruRank(b.kind);
+            if (ra !== rb) return ra - rb;
+            return a.label.localeCompare(b.label);
+        });
+        for (const p of sorted) {
+            body.appendChild(
+                this.renderProductRow(p, preview, previewId, findings),
+            );
+        }
+        details.appendChild(body);
+        return details;
+    }
+
+    private renderProductRow(
+        p: ProductDescriptor,
+        preview: PreviewInfo,
+        previewId: string,
+        findings: readonly AccessibilityFinding[],
+    ): HTMLElement {
+        const option = document.createElement("label");
+        option.className = "focus-product-option";
+        option.dataset.cost = p.cost;
+        option.dataset.bucket = bucketOf(p.kind);
+        const input = document.createElement("input");
+        input.type = "checkbox";
+        input.checked = this.isProductOn(p.kind, previewId);
+        input.addEventListener("change", () => this.handleChipClick(p));
+        option.appendChild(input);
+        const icon = document.createElement("i");
+        icon.className = "codicon codicon-" + p.icon;
+        icon.setAttribute("aria-hidden", "true");
+        option.appendChild(icon);
+        const text = document.createElement("div");
+        text.className = "focus-product-text";
+        const name = document.createElement("span");
+        name.className = "focus-product-name";
+        name.textContent = p.label;
+        const val = document.createElement("span");
+        val.className = "focus-product-value";
+        val.textContent =
+            this.dynamicHint(p, previewId, findings) ?? p.hint ?? "";
+        text.appendChild(name);
+        text.appendChild(val);
+        option.appendChild(text);
+        void preview;
+        return option;
     }
 
     private historyPanel(): HTMLElement {
@@ -303,34 +530,38 @@ export class FocusInspectorController {
         return history;
     }
 
-    private buildPlaceholders(): HTMLElement | null {
-        const defs: ReadonlyArray<readonly [string, string, string]> = [
-            ["layout", "Layout", "layout tree and bounds"],
-            ["strings", "Strings", "text/strings and i18n/translations"],
-            ["resources", "Resources", "resources/used"],
-            ["fonts", "Fonts", "fonts/used"],
-            ["render", "Render", "render/trace and render/composeAiTrace"],
-            ["theme", "Theme", "compose/theme"],
-            ["recomposition", "Recomposition", "compose/recomposition"],
-        ];
-        const active = defs.filter(([id]) => this.enabled.has(id));
-        if (active.length === 0) return null;
-        const wrapper = document.createElement("div");
-        wrapper.className = "focus-placeholder-list";
-        for (const [id, label, kind] of active) {
-            const details = document.createElement("details");
-            details.className = "focus-placeholder";
-            details.dataset.product = id;
-            const summary = document.createElement("summary");
-            summary.textContent = label;
-            details.appendChild(summary);
-            const body = document.createElement("div");
-            body.className = "focus-placeholder-body";
-            body.textContent = kind;
-            details.appendChild(body);
-            wrapper.appendChild(details);
+    private isProductOn(kind: string, previewId: string): boolean {
+        if (kind === "local/a11y/overlay") {
+            return previewId === this.config.getA11yOverlayId();
         }
-        return wrapper;
+        if (kind === "compose/recomposition") {
+            return this.config.isLive(previewId) || this.enabled.has(kind);
+        }
+        return this.enabled.has(kind);
+    }
+
+    private dynamicHint(
+        p: ProductDescriptor,
+        previewId: string,
+        findings: readonly AccessibilityFinding[],
+    ): string | null {
+        if (p.kind === "local/a11y/overlay" && findings.length > 0) {
+            return (
+                findings.length +
+                " finding" +
+                (findings.length === 1 ? "" : "s")
+            );
+        }
+        if (p.kind === "layout/tree") {
+            const nodes = this.config.getA11yNodes(previewId);
+            if (nodes.length > 0) {
+                return nodes.length + " node" + (nodes.length === 1 ? "" : "s");
+            }
+        }
+        if (p.kind === "compose/recomposition") {
+            return this.config.isLive(previewId) ? "Live" : null;
+        }
+        return null;
     }
 }
 
@@ -364,29 +595,77 @@ function actionButton(
     return btn;
 }
 
-function productOption(product: ProductOptionSpec): HTMLElement {
-    const option = document.createElement("label");
-    option.className = "focus-product-option";
-    option.dataset.state = product.state;
-    const input = document.createElement("input");
-    input.type = "checkbox";
-    input.checked = product.enabled;
-    input.addEventListener("change", product.onToggle);
-    option.appendChild(input);
-    const icon = document.createElement("i");
-    icon.className = "codicon codicon-" + product.icon;
-    icon.setAttribute("aria-hidden", "true");
-    option.appendChild(icon);
-    const text = document.createElement("div");
-    text.className = "focus-product-text";
-    const name = document.createElement("span");
-    name.className = "focus-product-name";
-    name.textContent = product.label;
-    const val = document.createElement("span");
-    val.className = "focus-product-value";
-    val.textContent = product.value;
-    text.appendChild(name);
-    text.appendChild(val);
-    option.appendChild(text);
-    return option;
-}
+/**
+ * Built-in placeholder set used until the daemon's advertised
+ * capabilities are pushed in via `setProducts`. Mirrors the layers the
+ * previous flat-picker shipped, classified into buckets by their
+ * pseudo-kinds (`local/<bucket-prefix>/...`). Kept here rather than in
+ * the taxonomy module because it's UI-shaped (icons, labels) — the
+ * taxonomy module is pure data classification.
+ */
+const BUILT_IN_PRODUCTS: ProductDescriptor[] = [
+    {
+        kind: "local/a11y/overlay",
+        label: "Accessibility",
+        icon: "eye",
+        hint: "Overlay",
+        cost: "expensive",
+        daemonBacked: true,
+    },
+    {
+        kind: "layout/tree",
+        label: "Layout",
+        icon: "list-tree",
+        hint: "Tree and bounds",
+        cost: "cheap",
+        daemonBacked: true,
+    },
+    {
+        kind: "text/strings",
+        label: "Strings",
+        icon: "symbol-string",
+        hint: "Text and translations",
+        cost: "cheap",
+        daemonBacked: true,
+    },
+    {
+        kind: "resources/used",
+        label: "Resources",
+        icon: "file-code",
+        hint: "Resources used",
+        cost: "cheap",
+        daemonBacked: true,
+    },
+    {
+        kind: "fonts/used",
+        label: "Fonts",
+        icon: "text-size",
+        hint: "Fonts used",
+        cost: "cheap",
+        daemonBacked: true,
+    },
+    {
+        kind: "render/trace",
+        label: "Render",
+        icon: "pulse",
+        hint: "Trace and AI trace",
+        cost: "expensive",
+        daemonBacked: true,
+    },
+    {
+        kind: "compose/theme",
+        label: "Theme",
+        icon: "symbol-color",
+        hint: "Theme tokens",
+        cost: "cheap",
+        daemonBacked: true,
+    },
+    {
+        kind: "compose/recomposition",
+        label: "Recomposition",
+        icon: "sync",
+        hint: "Heatmap",
+        cost: "expensive",
+        daemonBacked: true,
+    },
+];

--- a/vscode-extension/src/webview/preview/focusInspector.ts
+++ b/vscode-extension/src/webview/preview/focusInspector.ts
@@ -40,6 +40,15 @@ import {
     groupByBucket,
     suggestFor,
 } from "./focusProductTaxonomy";
+import {
+    type PresenterContext,
+    type PresentationError,
+    type PresentationLegend,
+    type PresentationReport,
+    type ProductPresentation,
+    getPresenter,
+} from "./focusPresentation";
+import { LegendArrowController } from "./legendArrow";
 
 export interface FocusInspectorConfig {
     /** The `<div id="focus-inspector">` element rendered by `<preview-app>`. */
@@ -112,6 +121,9 @@ export class FocusInspectorController {
     /** Last card we rendered. Held so `toggleProduct` can re-render
      *  the panel on the same card after flipping a checkbox. */
     private lastCard: HTMLElement | null = null;
+    /** Hover-arrow correlator. Re-attached on every render so it
+     *  rebinds against fresh legend rows. */
+    private readonly arrows = new LegendArrowController();
 
     constructor(private readonly config: FocusInspectorConfig) {}
 
@@ -225,9 +237,36 @@ export class FocusInspectorController {
             ),
         );
         controls.appendChild(toolActions);
+
+        // Presenter pipeline. Iterate every enabled kind, call its
+        // registered presenter (if any), and slot the contributions
+        // into the four surfaces: errors banner, card overlay layer,
+        // legends section, reports section. Always re-iterate from
+        // scratch — presenters are pure factories.
+        const presentations = this.collectPresentations(
+            card,
+            preview,
+            previewId,
+            findings,
+        );
+        const errorBanner = this.renderErrors(presentations);
+        const legendsSection = this.renderLegends(presentations);
+        const reportsSection = this.renderReports(presentations);
+        const overlayLayer = this.applyOverlays(card, presentations);
+
+        if (errorBanner) el.appendChild(errorBanner);
         el.appendChild(inspect);
+        if (legendsSection) el.appendChild(legendsSection);
+        if (reportsSection) el.appendChild(reportsSection);
         el.appendChild(this.historyPanel());
         el.appendChild(controls);
+
+        // Wire legend ↔ overlay correlation last so DOM is settled.
+        if (legendsSection) {
+            this.arrows.attach(legendsSection, overlayLayer);
+        } else {
+            this.arrows.detach();
+        }
     }
 
     /**
@@ -516,6 +555,245 @@ export class FocusInspectorController {
         option.appendChild(text);
         void preview;
         return option;
+    }
+
+    /**
+     * Walk the enabled set, call each kind's registered presenter,
+     * and return a flat list of `{kind, presentation}`. Presenters
+     * that aren't registered or return `null` are skipped.
+     *
+     * Special-cased a11y/recomposition toggles: the existing
+     * `local/a11y/overlay` and `compose/recomposition` rows route
+     * through dedicated controllers (focus toolbar / live state) and
+     * don't have presenters of their own. The presenter layer
+     * complements them rather than replacing them.
+     */
+    private collectPresentations(
+        card: HTMLElement,
+        preview: PreviewInfo,
+        previewId: string,
+        findings: readonly AccessibilityFinding[],
+    ): { kind: string; presentation: ProductPresentation }[] {
+        const nodes = this.config.getA11yNodes(previewId);
+        const ctx: PresenterContext = { card, preview, findings, nodes };
+        const out: { kind: string; presentation: ProductPresentation }[] = [];
+        // The error presenter is implicit: we always invoke it so a
+        // render error surfaces even when the user hasn't enabled
+        // anything. Other kinds only run when explicitly enabled.
+        const errorPresenter = getPresenter("local/render/error");
+        if (errorPresenter) {
+            const presentation = errorPresenter(ctx);
+            if (presentation) {
+                out.push({ kind: "local/render/error", presentation });
+            }
+        }
+        for (const kind of this.enabled) {
+            const presenter = getPresenter(kind);
+            if (!presenter) continue;
+            const presentation = presenter(ctx);
+            if (!presentation) continue;
+            out.push({ kind, presentation });
+        }
+        return out;
+    }
+
+    private renderErrors(
+        presentations: readonly {
+            kind: string;
+            presentation: ProductPresentation;
+        }[],
+    ): HTMLElement | null {
+        const errors: { kind: string; error: PresentationError }[] = [];
+        for (const { kind, presentation } of presentations) {
+            if (presentation.error) {
+                errors.push({ kind, error: presentation.error });
+            }
+        }
+        if (errors.length === 0) return null;
+        const banner = document.createElement("section");
+        banner.className = "focus-panel focus-error-panel";
+        banner.setAttribute("role", "alert");
+        for (const { kind, error } of errors) {
+            const row = document.createElement("div");
+            row.className = "focus-error-row";
+            row.dataset.kind = kind;
+            const icon = document.createElement("i");
+            icon.className = "codicon codicon-error";
+            icon.setAttribute("aria-hidden", "true");
+            row.appendChild(icon);
+            const body = document.createElement("div");
+            body.className = "focus-error-body";
+            const title = document.createElement("div");
+            title.className = "focus-error-title";
+            title.textContent = error.title;
+            const message = document.createElement("div");
+            message.className = "focus-error-message";
+            message.textContent = error.message;
+            body.appendChild(title);
+            body.appendChild(message);
+            if (error.detail) {
+                const detail = document.createElement("div");
+                detail.className = "focus-error-detail";
+                detail.textContent = error.detail;
+                body.appendChild(detail);
+            }
+            row.appendChild(body);
+            banner.appendChild(row);
+        }
+        return banner;
+    }
+
+    private renderLegends(
+        presentations: readonly {
+            kind: string;
+            presentation: ProductPresentation;
+        }[],
+    ): HTMLElement | null {
+        const legends: { kind: string; legend: PresentationLegend }[] = [];
+        for (const { kind, presentation } of presentations) {
+            if (presentation.legend && presentation.legend.entries.length > 0) {
+                legends.push({ kind, legend: presentation.legend });
+            }
+        }
+        if (legends.length === 0) return null;
+        const section = document.createElement("section");
+        section.className = "focus-panel focus-legends-panel";
+        section.appendChild(sectionHeader("symbol-key", "Legends"));
+        for (const { kind, legend } of legends) {
+            const block = document.createElement("div");
+            block.className = "focus-legend-block";
+            block.dataset.kind = kind;
+            const head = document.createElement("div");
+            head.className = "focus-legend-head";
+            const heading = document.createElement("span");
+            heading.className = "focus-legend-title";
+            heading.textContent = legend.title;
+            head.appendChild(heading);
+            if (legend.summary) {
+                const sum = document.createElement("span");
+                sum.className = "focus-legend-summary";
+                sum.textContent = legend.summary;
+                head.appendChild(sum);
+            }
+            block.appendChild(head);
+            const list = document.createElement("ul");
+            list.className = "focus-legend-list";
+            for (const entry of legend.entries) {
+                const li = document.createElement("li");
+                li.className = "focus-legend-row";
+                li.dataset.legendId = entry.id;
+                if (entry.level) li.dataset.level = entry.level;
+                // tabIndex so keyboard users can step through entries
+                // and trigger the same focus → arrow path as hover.
+                li.tabIndex = 0;
+                const dot = document.createElement("span");
+                dot.className = "focus-legend-dot";
+                li.appendChild(dot);
+                const text = document.createElement("div");
+                text.className = "focus-legend-text";
+                const lab = document.createElement("div");
+                lab.className = "focus-legend-label";
+                lab.textContent = entry.label;
+                text.appendChild(lab);
+                if (entry.detail) {
+                    const det = document.createElement("div");
+                    det.className = "focus-legend-detail";
+                    det.textContent = entry.detail;
+                    text.appendChild(det);
+                }
+                li.appendChild(text);
+                list.appendChild(li);
+            }
+            block.appendChild(list);
+            section.appendChild(block);
+        }
+        return section;
+    }
+
+    private renderReports(
+        presentations: readonly {
+            kind: string;
+            presentation: ProductPresentation;
+        }[],
+    ): HTMLElement | null {
+        const reports: { kind: string; report: PresentationReport }[] = [];
+        for (const { kind, presentation } of presentations) {
+            if (presentation.report) {
+                reports.push({ kind, report: presentation.report });
+            }
+        }
+        if (reports.length === 0) return null;
+        const section = document.createElement("section");
+        section.className = "focus-panel focus-reports-panel";
+        section.appendChild(sectionHeader("output", "Data"));
+        for (const { kind, report } of reports) {
+            const details = document.createElement("details");
+            details.className = "focus-report";
+            details.dataset.kind = kind;
+            const summary = document.createElement("summary");
+            summary.className = "focus-report-summary";
+            const title = document.createElement("span");
+            title.className = "focus-report-title";
+            title.textContent = report.title;
+            summary.appendChild(title);
+            if (report.summary) {
+                const sum = document.createElement("span");
+                sum.className = "focus-report-summary-hint";
+                sum.textContent = report.summary;
+                summary.appendChild(sum);
+            }
+            const chevron = document.createElement("i");
+            chevron.className =
+                "codicon codicon-chevron-down focus-summary-chevron";
+            chevron.setAttribute("aria-hidden", "true");
+            summary.appendChild(chevron);
+            details.appendChild(summary);
+            const body = document.createElement("div");
+            body.className = "focus-report-body";
+            body.appendChild(report.body);
+            details.appendChild(body);
+            section.appendChild(details);
+        }
+        return section;
+    }
+
+    /**
+     * Stamp every presentation's `overlay` into a stack on the focused
+     * card. Existing per-card overlays (`.a11y-overlay`,
+     * `.a11y-hierarchy-overlay`) keep painting through their own paths
+     * — this layer sits above them so presentation overlays can
+     * coexist without z-fighting.
+     */
+    private applyOverlays(
+        card: HTMLElement,
+        presentations: readonly {
+            kind: string;
+            presentation: ProductPresentation;
+        }[],
+    ): HTMLElement | null {
+        const container = card.querySelector<HTMLElement>(".image-container");
+        if (!container) return null;
+        let stack = container.querySelector<HTMLElement>(
+            ".focus-overlay-stack",
+        );
+        if (!stack) {
+            stack = document.createElement("div");
+            stack.className = "focus-overlay-stack";
+            container.appendChild(stack);
+        }
+        stack.innerHTML = "";
+        let painted = 0;
+        for (const { kind, presentation } of presentations) {
+            if (!presentation.overlay) continue;
+            presentation.overlay.dataset.kind = kind;
+            stack.appendChild(presentation.overlay);
+            painted += 1;
+        }
+        if (painted === 0) {
+            stack.remove();
+            return null;
+        }
+        return stack;
     }
 
     private historyPanel(): HTMLElement {

--- a/vscode-extension/src/webview/preview/focusInspector.ts
+++ b/vscode-extension/src/webview/preview/focusInspector.ts
@@ -75,6 +75,20 @@ export interface FocusInspectorConfig {
      * is a valid sentinel (treated as a single shared scope).
      */
     getScope(): string;
+    /**
+     * Read previously-persisted MRU for [scope]. Called once per scope
+     * the first time the inspector renders for it; the controller
+     * caches the result in memory and only writes back on changes.
+     * Implementations should return an empty array for unknown scopes.
+     */
+    loadMru(scope: string): readonly string[];
+    /**
+     * Persist the in-memory MRU for [scope]. Called from `toggleProduct`
+     * after `bumpMru`. Implementations are expected to debounce / batch
+     * if the underlying store is expensive — the inspector calls this
+     * synchronously on every toggle.
+     */
+    saveMru(scope: string, mru: readonly string[]): void;
 }
 
 export class FocusInspectorController {
@@ -139,7 +153,7 @@ export class FocusInspectorController {
         const suggestions = suggestFor({
             preview,
             findingsCount: findings.length,
-            mru: this.mruByScope.get(scope) ?? [],
+            mru: this.getMru(scope),
             available: new Set(productByKind.keys()),
         });
 
@@ -250,9 +264,25 @@ export class FocusInspectorController {
             this.enabled.add(kind);
         }
         const scope = this.config.getScope();
-        const cur = this.mruByScope.get(scope) ?? [];
-        this.mruByScope.set(scope, bumpMru(cur, kind));
+        const cur = this.getMru(scope);
+        const next = bumpMru(cur, kind);
+        this.mruByScope.set(scope, next);
+        this.config.saveMru(scope, next);
         if (this.lastCard) this.render(this.lastCard);
+    }
+
+    /**
+     * Lazy hydrate-and-cache: first read for a scope pulls from the
+     * persisted store via `config.loadMru`, subsequent reads stay in
+     * memory. Returns the live array reference so callers can pass it
+     * into `bumpMru` without copying.
+     */
+    private getMru(scope: string): readonly string[] {
+        const cached = this.mruByScope.get(scope);
+        if (cached) return cached;
+        const persisted = [...this.config.loadMru(scope)];
+        this.mruByScope.set(scope, persisted);
+        return persisted;
     }
 
     private renderSuggestionRow(
@@ -433,7 +463,7 @@ export class FocusInspectorController {
         }
         // Sort within bucket by MRU rank then label, so familiar
         // layers float to the top without changing the bucket itself.
-        const mru = this.mruByScope.get(this.config.getScope()) ?? [];
+        const mru = this.getMru(this.config.getScope());
         const mruRank = (kind: string): number => {
             const idx = mru.indexOf(kind);
             return idx === -1 ? Number.MAX_SAFE_INTEGER : idx;

--- a/vscode-extension/src/webview/preview/focusPresentation.ts
+++ b/vscode-extension/src/webview/preview/focusPresentation.ts
@@ -1,0 +1,319 @@
+// Presentation framework for focus-mode data products.
+//
+// The four surfaces a data product can contribute to:
+//
+//   1. **Overlay** — DOM painted on top of the focused card's preview
+//      image. Boxed regions, heatmaps, annotated points. Lives in a
+//      stacking context that scales with the image's natural pixel
+//      dimensions, so percentage-based positioning works without a
+//      resize handler. (Same coordinate model as the existing a11y
+//      overlay — see `a11yOverlay.ts`.)
+//
+//   2. **Legend** — sidecar list inside the inspector. One entry per
+//      logical item the overlay highlights (a finding, a node, a
+//      tracepoint). Hovering a legend entry lights up the matching
+//      overlay region via shared `data-legend-id` attributes plus an
+//      SVG arrow drawn from the entry to the region (see
+//      `legendArrow.ts`).
+//
+//   3. **Report** — collapsible block below the buckets list. Use for
+//      structured data that doesn't fit on the image: theme tokens,
+//      string tables, font metadata, render traces.
+//
+//   4. **Error** — banner at the top of the inspector. Surfaces when
+//      the data the presenter expected is missing, malformed, or the
+//      underlying daemon call failed. Distinct from a render error
+//      (those are per-capture and live on the card itself).
+//
+// Each `kind` registers a `ProductPresenter` with the registry. The
+// inspector iterates the enabled set, calls each presenter with the
+// current card / preview / cached data, and slots the returned DOM
+// into the right surface. Presenters are pure factories — no state
+// of their own — so re-rendering the inspector simply re-builds the
+// DOM. The arrow correlator is wired up after the legends are in the
+// DOM (see `attachLegendArrows` below).
+
+import type {
+    AccessibilityFinding,
+    AccessibilityNode,
+    PreviewInfo,
+} from "../shared/types";
+
+export interface PresenterContext {
+    /** The focused card element. Presenters that produce overlays
+     *  must paint into the card's `.focus-overlay-stack` layer. */
+    card: HTMLElement;
+    /** The currently-focused preview manifest entry. */
+    preview: PreviewInfo;
+    /** Latest cached a11y findings, or empty. */
+    findings: readonly AccessibilityFinding[];
+    /** Latest cached a11y hierarchy nodes, or empty. */
+    nodes: readonly AccessibilityNode[];
+}
+
+/** Bag of contributions a presenter can make to one or more surfaces.
+ *  Returning `null` skips the surface for this kind on this preview. */
+export interface ProductPresentation {
+    overlay?: HTMLElement | null;
+    legend?: PresentationLegend | null;
+    report?: PresentationReport | null;
+    error?: PresentationError | null;
+}
+
+export interface PresentationLegend {
+    /** Title shown in the legend block header. */
+    title: string;
+    /** Optional rollup like "(3 findings)". */
+    summary?: string;
+    /** Rows. Each row's `id` becomes `data-legend-id` and is matched
+     *  against `data-overlay-id` on overlay descendants for hover
+     *  correlation. */
+    entries: readonly LegendEntry[];
+}
+
+export interface LegendEntry {
+    id: string;
+    label: string;
+    detail?: string;
+    /** Influences the row's accent colour. `error`/`warning`/`info`
+     *  match the existing a11y level palette. */
+    level?: "error" | "warning" | "info";
+}
+
+export interface PresentationReport {
+    title: string;
+    summary?: string;
+    /** Pre-built body. The inspector wraps it in a `<details>` so the
+     *  presenter doesn't have to. */
+    body: HTMLElement;
+}
+
+export interface PresentationError {
+    title: string;
+    message: string;
+    detail?: string;
+}
+
+export type ProductPresenter = (
+    ctx: PresenterContext,
+) => ProductPresentation | null;
+
+const registry = new Map<string, ProductPresenter>();
+
+/**
+ * Register a presenter for [kind]. Last-write-wins so tests / future
+ * extensions can replace built-ins. Built-ins register at module load
+ * via the `register*` calls below — keeps the registration colocated
+ * with the implementation rather than centralising in `main.ts`.
+ */
+export function registerPresenter(
+    kind: string,
+    presenter: ProductPresenter,
+): void {
+    registry.set(kind, presenter);
+}
+
+export function getPresenter(kind: string): ProductPresenter | undefined {
+    return registry.get(kind);
+}
+
+/**
+ * Visible for tests only — clear the registry between cases. Using a
+ * registry that persists across tests would otherwise leak state from
+ * one test's `registerPresenter` into another's assertion.
+ */
+export function _resetPresentersForTest(): void {
+    registry.clear();
+}
+
+// ---- Built-in presenters --------------------------------------------------
+//
+// Concrete presenters live alongside the framework so the registry is
+// populated by the side-effect of importing this module. The a11y
+// hierarchy presenter is the worked example: it contributes to all
+// four surfaces. Other built-ins are deliberately narrow — the goal
+// here is to prove each surface's mount works end-to-end, not to fake
+// data the daemon doesn't actually produce.
+
+registerPresenter("a11y/hierarchy", a11yHierarchyPresenter);
+registerPresenter("a11y/atf", a11yFindingsPresenter);
+registerPresenter("compose/theme", composeThemePresenter);
+registerPresenter("local/render/error", renderErrorPresenter);
+
+function a11yHierarchyPresenter(
+    ctx: PresenterContext,
+): ProductPresentation | null {
+    const nodes = ctx.nodes;
+    if (nodes.length === 0) {
+        return {
+            report: {
+                title: "Layout hierarchy",
+                summary: "No nodes",
+                body: emptyBody("Daemon hasn't attached a11y/hierarchy yet."),
+            },
+        };
+    }
+
+    const overlay = document.createElement("div");
+    overlay.className = "focus-presentation-overlay focus-overlay-hierarchy";
+    overlay.dataset.kind = "a11y/hierarchy";
+    let parsed = 0;
+    let dropped = 0;
+    nodes.forEach((node, idx) => {
+        const bounds = parseBoundsString(node.boundsInScreen);
+        if (!bounds) {
+            dropped += 1;
+            return;
+        }
+        parsed += 1;
+        const box = document.createElement("div");
+        box.className = "focus-overlay-box";
+        box.dataset.overlayId = "node-" + idx;
+        box.dataset.level = node.merged ? "warning" : "info";
+        // Bounds are in source-bitmap pixels; the overlay layer sizes
+        // to the image's intrinsic size so % positioning lines up
+        // without a resize handler.
+        box.style.left = bounds.left + "px";
+        box.style.top = bounds.top + "px";
+        box.style.width = bounds.right - bounds.left + "px";
+        box.style.height = bounds.bottom - bounds.top + "px";
+        overlay.appendChild(box);
+    });
+
+    const entries: LegendEntry[] = nodes.map((node, idx) => ({
+        id: "node-" + idx,
+        label: node.label || "(unlabelled)",
+        detail:
+            (node.role ? node.role : "") +
+            (node.states.length > 0 ? " · " + node.states.join(", ") : ""),
+        level: node.merged ? "warning" : "info",
+    }));
+
+    const reportBody = document.createElement("ol");
+    reportBody.className = "focus-report-list";
+    nodes.forEach((node, idx) => {
+        const li = document.createElement("li");
+        li.dataset.legendId = "node-" + idx;
+        li.textContent = (node.label || "(unlabelled)") + " · " + node.role;
+        reportBody.appendChild(li);
+    });
+
+    return {
+        overlay: parsed > 0 ? overlay : null,
+        legend: {
+            title: "Hierarchy",
+            summary: parsed + " node" + (parsed === 1 ? "" : "s"),
+            entries,
+        },
+        report: {
+            title: "Layout hierarchy",
+            summary: parsed + " parsed · " + dropped + " dropped",
+            body: reportBody,
+        },
+        error:
+            dropped > 0 && parsed === 0
+                ? {
+                      title: "Hierarchy bounds malformed",
+                      message:
+                          "All " +
+                          dropped +
+                          " hierarchy node bounds failed to parse.",
+                  }
+                : null,
+    };
+}
+
+function a11yFindingsPresenter(
+    ctx: PresenterContext,
+): ProductPresentation | null {
+    const findings = ctx.findings;
+    if (findings.length === 0) {
+        return null;
+    }
+    const entries: LegendEntry[] = findings.map((f, idx) => ({
+        id: "finding-" + idx,
+        label: f.level + " · " + f.type,
+        detail: f.message,
+        level: levelOf(f.level),
+    }));
+    return {
+        legend: {
+            title: "A11y findings",
+            summary:
+                findings.length +
+                " finding" +
+                (findings.length === 1 ? "" : "s"),
+            entries,
+        },
+    };
+}
+
+function composeThemePresenter(
+    _ctx: PresenterContext,
+): ProductPresentation | null {
+    // Theme tokens are a placeholder until `compose/theme` lands as a
+    // real data product; the report mount is what we're proving here.
+    const body = document.createElement("div");
+    body.className = "focus-report-empty";
+    body.textContent =
+        "Theme tokens will appear here when the daemon attaches `compose/theme`.";
+    return {
+        report: {
+            title: "Theme tokens",
+            summary: "Awaiting data",
+            body,
+        },
+    };
+}
+
+function renderErrorPresenter(
+    ctx: PresenterContext,
+): ProductPresentation | null {
+    // Pulls a render-error sidecar off the card via dataset (set by
+    // `messageHandlers.handleErrorMessage` when present). When no
+    // error is recorded, the presenter contributes nothing.
+    const message = ctx.card.dataset.renderError;
+    if (!message) return null;
+    return {
+        error: {
+            title: "Render failed",
+            message,
+            detail: ctx.card.dataset.renderErrorDetail,
+        },
+    };
+}
+
+// ---- Local helpers --------------------------------------------------------
+
+function emptyBody(message: string): HTMLElement {
+    const div = document.createElement("div");
+    div.className = "focus-report-empty";
+    div.textContent = message;
+    return div;
+}
+
+function levelOf(s: string): "error" | "warning" | "info" {
+    const lower = s.toLowerCase();
+    if (lower === "error") return "error";
+    if (lower === "warning") return "warning";
+    return "info";
+}
+
+interface ParsedBounds {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+}
+
+function parseBoundsString(s: string | null | undefined): ParsedBounds | null {
+    if (!s) return null;
+    const parts = s.split(",").map((x) => parseInt(x.trim(), 10));
+    if (parts.length !== 4 || parts.some(isNaN)) return null;
+    return {
+        left: parts[0],
+        top: parts[1],
+        right: parts[2],
+        bottom: parts[3],
+    };
+}

--- a/vscode-extension/src/webview/preview/focusProductTaxonomy.ts
+++ b/vscode-extension/src/webview/preview/focusProductTaxonomy.ts
@@ -120,18 +120,32 @@ export function bucketOf(kind: string): ProductBucket {
 }
 
 /**
- * Cheapness classifier. Conservative: a kind is `cheap` only if it's
- * an inspection of already-captured render output (theme tokens,
- * strings, fonts, resource references) or static layout tree. Anything
- * that requires re-rendering, instruments the composition, or captures
- * a trace is `expensive`.
+ * Cheapness classifier. Two-tier:
  *
- * This deliberately doesn't read `DataProductCapability.requiresRerender`
- * — we want the cheap set to be a small, audited allowlist, not "every
- * kind the daemon claims is fast." Adding to the allowlist is a
- * deliberate change.
+ *   1. **Allowlist** (highest authority) — a small set of kinds we
+ *      know first-hand are inspections of already-captured render
+ *      output (theme tokens, strings, fonts, resources, static layout
+ *      tree). Always returns `cheap` for these regardless of any
+ *      daemon hint. A daemon misadvertising one of these as expensive
+ *      doesn't make us refuse to auto-enable; a daemon misadvertising
+ *      something else as cheap can't slip into this list.
+ *
+ *   2. **Daemon hint fallback** — for kinds outside the allowlist,
+ *      trust the daemon's `requiresRerender` flag from
+ *      `DataProductCapability`. `requiresRerender === false` means
+ *      "fetching this won't pay a render cost," which lines up with
+ *      the auto-enable contract (no surprise spikes). When the hint is
+ *      missing or `true`, default to `expensive`.
+ *
+ * Built-in placeholder products stamp their `cost` directly on the
+ * descriptor and never call this function; only the daemon-product
+ * translation in `productsFromDaemonCapabilities` exercises the hint
+ * path.
  */
-export function costOf(kind: string): "cheap" | "expensive" {
+export function costOf(
+    kind: string,
+    hint?: { requiresRerender?: boolean },
+): "cheap" | "expensive" {
     if (
         kind === "compose/theme" ||
         kind.startsWith("text/") ||
@@ -139,6 +153,9 @@ export function costOf(kind: string): "cheap" | "expensive" {
         kind.startsWith("resources/") ||
         kind === "layout/tree"
     ) {
+        return "cheap";
+    }
+    if (hint && hint.requiresRerender === false) {
         return "cheap";
     }
     return "expensive";

--- a/vscode-extension/src/webview/preview/focusProductTaxonomy.ts
+++ b/vscode-extension/src/webview/preview/focusProductTaxonomy.ts
@@ -1,0 +1,282 @@
+// Pure logic that turns the changing list of daemon-advertised data
+// products into a stable, ranked, partly-suggested UI for the focus
+// inspector.
+//
+// Three concerns live here, all as pure functions so they're easy to
+// unit-test against synthetic capability lists / `PreviewInfo` shapes:
+//
+//   1. Taxonomy — which of five fixed buckets a `kind` belongs to,
+//      derived from its namespace prefix. New unknown namespaces fall
+//      through to "More" so the chrome never loses items.
+//   2. Cheapness — whether a kind can be auto-enabled without
+//      meaningful render-cost impact. Kept conservative: anything that
+//      forces a re-render (`requiresRerender`) or instruments the
+//      composition (`compose/recomposition`, `render/trace`) is
+//      treated as expensive regardless of facet.
+//   3. Suggestions — the small chip row above the bucket list. Driven
+//      by the focused preview's annotations / device / cached a11y
+//      findings, joined with a per-scope MRU map maintained by the
+//      controller. The chip set is intentionally short (capped at
+//      MAX_SUGGESTIONS) so the eye can land on it.
+//
+// `focusInspector.ts` is the only consumer; tests live in
+// `focusProductTaxonomy.test.ts`.
+
+import type { PreviewInfo } from "../shared/types";
+
+/** Five stable user-facing buckets. Order matches inspector render order. */
+export const PRODUCT_BUCKETS = [
+    "accessibility",
+    "layout",
+    "performance",
+    "theming",
+    "resources",
+] as const;
+
+export type ProductBucket = (typeof PRODUCT_BUCKETS)[number] | "more";
+
+/**
+ * One product the inspector can show the user. Mirrors the bits of a
+ * daemon-advertised `DataProductCapability` we actually render, plus
+ * the few "always-shown" entries the panel ships built-in (a11y
+ * overlay, layout tree placeholder, recomposition).
+ *
+ * `kind` is the wire-level kind string when the product comes from the
+ * daemon, or a stable `local/<id>` string for built-ins. The controller
+ * uses `kind` as the toggle / MRU key.
+ */
+export interface ProductDescriptor {
+    kind: string;
+    label: string;
+    icon: string;
+    /**
+     * Short tagline shown under the label in the picker. May be the
+     * dynamic count ("3 findings") supplied by the controller, or a
+     * hint ("Overlay", "Placeholder").
+     */
+    hint?: string;
+    /**
+     * Cost class. `cheap` products may auto-enable when the
+     * `autoEnableCheap` setting is on AND the product is suggested.
+     * `expensive` products are never auto-enabled.
+     */
+    cost: "cheap" | "expensive";
+    /**
+     * `true` when toggling has a daemon-side side effect (subscribe,
+     * extra data fetch). `false` for purely cosmetic placeholders that
+     * the panel renders client-side. Used by tooltips and by the auto-
+     * enable gate (we still suggest cosmetic placeholders, but never
+     * auto-flip them since "auto-enable" carries an implicit cost
+     * assertion the user shouldn't have to second-guess).
+     */
+    daemonBacked: boolean;
+}
+
+/** Bucket label and codicon. Stable; never recomputed from the daemon. */
+export const BUCKET_META: Record<
+    ProductBucket,
+    { label: string; icon: string }
+> = {
+    accessibility: { label: "Accessibility", icon: "eye" },
+    layout: { label: "Layout", icon: "list-tree" },
+    performance: { label: "Performance", icon: "pulse" },
+    theming: { label: "Theming", icon: "symbol-color" },
+    resources: { label: "Resources", icon: "file-code" },
+    more: { label: "More", icon: "ellipsis" },
+};
+
+/**
+ * Map a wire `kind` to its bucket. Unknown namespaces fall through to
+ * `"more"` — the chrome never grows a sixth bucket as new namespaces
+ * land; the contents shift instead.
+ *
+ * Special-cased exactly twice:
+ *   - `compose/recomposition` is performance, not theming
+ *   - `compose/theme` is theming
+ *
+ * Everything else routes by namespace prefix: `a11y/*` → accessibility,
+ * `layout/*` → layout, `render/*` → performance, `resources/*` /
+ * `fonts/*` / `text/*` → resources.
+ */
+export function bucketOf(kind: string): ProductBucket {
+    if (kind === "compose/recomposition") return "performance";
+    if (kind === "compose/theme") return "theming";
+    if (kind.startsWith("a11y/")) return "accessibility";
+    if (kind.startsWith("layout/")) return "layout";
+    if (kind.startsWith("render/")) return "performance";
+    if (
+        kind.startsWith("resources/") ||
+        kind.startsWith("fonts/") ||
+        kind.startsWith("text/")
+    ) {
+        return "resources";
+    }
+    if (kind.startsWith("local/")) {
+        // Built-ins encode their bucket in the suffix: `local/a11y/...`,
+        // `local/layout/...` etc. Strip and recurse.
+        return bucketOf(kind.slice("local/".length));
+    }
+    return "more";
+}
+
+/**
+ * Cheapness classifier. Conservative: a kind is `cheap` only if it's
+ * an inspection of already-captured render output (theme tokens,
+ * strings, fonts, resource references) or static layout tree. Anything
+ * that requires re-rendering, instruments the composition, or captures
+ * a trace is `expensive`.
+ *
+ * This deliberately doesn't read `DataProductCapability.requiresRerender`
+ * — we want the cheap set to be a small, audited allowlist, not "every
+ * kind the daemon claims is fast." Adding to the allowlist is a
+ * deliberate change.
+ */
+export function costOf(kind: string): "cheap" | "expensive" {
+    if (
+        kind === "compose/theme" ||
+        kind.startsWith("text/") ||
+        kind.startsWith("fonts/") ||
+        kind.startsWith("resources/") ||
+        kind === "layout/tree"
+    ) {
+        return "cheap";
+    }
+    return "expensive";
+}
+
+/**
+ * Suggestion heuristic. Returns at most [MAX_SUGGESTIONS] kinds judged
+ * relevant to the focused preview, deduped, in display order.
+ *
+ * Inputs intentionally narrow:
+ *   - `preview` — the focused `PreviewInfo`. Annotations + device
+ *     hints + carousel `dataProducts` come off here.
+ *   - `findingsCount` — current cached a11y finding count for the
+ *     preview, since the inspector already has it and recomputing
+ *     from `preview.a11yFindings` would miss daemon-pushed updates.
+ *   - `mru` — kinds the user has toggled in this scope before, sorted
+ *     most-recent first. Acts as a tiebreaker / topup once the
+ *     annotation-driven suggestions are exhausted.
+ *   - `available` — the union of kinds the inspector currently knows
+ *     about (built-ins + daemon-advertised). Suggestions outside this
+ *     set are dropped — we don't want to suggest something the daemon
+ *     can't produce.
+ *
+ * Order matters: annotation-driven first (strongest signal), then MRU
+ * (familiarity), then a fixed "always-helpful" fallback (a11y).
+ */
+export const MAX_SUGGESTIONS = 4;
+
+export interface SuggestInput {
+    preview: PreviewInfo;
+    findingsCount: number;
+    mru: readonly string[];
+    available: ReadonlySet<string>;
+}
+
+export function suggestFor(input: SuggestInput): string[] {
+    const { preview, findingsCount, mru, available } = input;
+    const out: string[] = [];
+    const push = (kind: string): void => {
+        if (out.length >= MAX_SUGGESTIONS) return;
+        if (!available.has(kind)) return;
+        if (out.includes(kind)) return;
+        out.push(kind);
+    };
+
+    // 1. Annotation-driven. Wear devices + scroll captures imply
+    //    scroll trace / scroll-aware data products. We don't currently
+    //    ship a `compose/scroll` kind, so we surface
+    //    `compose/recomposition` as the closest available proxy when
+    //    a scroll capture is present. (When a dedicated scroll kind
+    //    lands the heuristic moves to that.)
+    const isWear = isWearDevice(preview.params.device);
+    const hasScrollCapture =
+        (preview.dataProducts ?? []).some((p) => p.scroll != null) ||
+        preview.captures.some((c) => c.scroll != null);
+    if (hasScrollCapture || isWear) {
+        push("compose/recomposition");
+    }
+
+    // 2. A11y findings already exist for this preview — strongest
+    //    signal that the user came here to look at a11y issues.
+    if (findingsCount > 0) {
+        push("local/a11y/overlay");
+    }
+
+    // 3. Theme tokens are cheap and useful when the preview's UI mode
+    //    is non-default (dark mode, car, TV) — the user is probably
+    //    auditing the theme.
+    if (preview.params.uiMode && preview.params.uiMode !== 0) {
+        push("compose/theme");
+    }
+
+    // 4. MRU topup. Don't repeat what we already pushed.
+    for (const kind of mru) {
+        push(kind);
+    }
+
+    // 5. Always-helpful fallback. A11y overlay is the single most
+    //    likely "I'd want to see this" toggle and costs nothing when
+    //    the daemon doesn't actually have findings (the overlay just
+    //    shows nothing).
+    push("local/a11y/overlay");
+
+    return out;
+}
+
+/**
+ * Returns true if the device id looks like a Wear / watch device.
+ * Wear is the "particularly think about" example in the design — but
+ * heuristics are forgiving: `id:wearos_*`, `wear` substring, `watch`
+ * substring, and `spec:` overrides with `round=true` all count.
+ *
+ * Exported so tests can pin the boundary.
+ */
+export function isWearDevice(device: string | null | undefined): boolean {
+    if (!device) return false;
+    const lower = device.toLowerCase();
+    if (lower.includes("wear")) return true;
+    if (lower.includes("watch")) return true;
+    if (lower.startsWith("spec:") && lower.includes("round=true")) return true;
+    return false;
+}
+
+/**
+ * Group descriptors into buckets, preserving input order within each
+ * bucket. The inspector calls this once per render and walks the
+ * result; the controller doesn't otherwise need to think about
+ * bucketing.
+ *
+ * Buckets are returned in `PRODUCT_BUCKETS` order followed by `more`.
+ * Empty buckets are still returned (with an empty array) so the
+ * inspector can render a stable five-row chrome and let buckets
+ * collapse-by-default when empty — easier to skim than a UI that
+ * grows and shrinks rows.
+ */
+export function groupByBucket(
+    products: readonly ProductDescriptor[],
+): Map<ProductBucket, ProductDescriptor[]> {
+    const out = new Map<ProductBucket, ProductDescriptor[]>();
+    for (const bucket of PRODUCT_BUCKETS) out.set(bucket, []);
+    out.set("more", []);
+    for (const p of products) {
+        const bucket = bucketOf(p.kind);
+        out.get(bucket)!.push(p);
+    }
+    return out;
+}
+
+/**
+ * Per-scope MRU helper. The controller maintains an in-memory list of
+ * recently-toggled kinds keyed by scope (module dir today). Calling
+ * this on a toggle moves [kind] to the front and trims to [maxLen].
+ */
+export function bumpMru(
+    current: readonly string[],
+    kind: string,
+    maxLen = 8,
+): string[] {
+    const next = [kind, ...current.filter((k) => k !== kind)];
+    return next.slice(0, maxLen);
+}

--- a/vscode-extension/src/webview/preview/legendArrow.ts
+++ b/vscode-extension/src/webview/preview/legendArrow.ts
@@ -1,0 +1,168 @@
+// Hover-arrow correlator linking legend entries to overlay regions.
+//
+// Each legend row carries `data-legend-id="<id>"`; each overlay
+// element carries `data-overlay-id="<id>"`. On `mouseenter` of a
+// legend row the controller:
+//
+//   1. Adds a `legend-active` class to the matching overlay element
+//      (so the box / shape can highlight with the regular CSS palette).
+//   2. Draws an SVG arrow from the legend row to the overlay element.
+//      The SVG is fixed-position on `document.body` and sized to the
+//      viewport so the arrow can cross from the inspector (right /
+//      bottom of layout) to the preview image (top / centre).
+//
+// `mouseleave` reverses both steps. A single SVG is re-used across
+// hovers so we don't churn DOM during quick legend traversals.
+//
+// Coordinates use `getBoundingClientRect` and the rects are recomputed
+// on every hover — cheap, and avoids stale geometry after layout
+// shifts (focus toggle, viewport resize, picker accordions opening).
+
+const ARROW_SVG_ID = "focus-legend-arrow";
+const ARROW_HEAD_ID = "focus-legend-arrow-head";
+
+export class LegendArrowController {
+    private readonly listeners = new Map<
+        HTMLElement,
+        { enter: (e: Event) => void; leave: (e: Event) => void }
+    >();
+    private readonly arrowEl: SVGSVGElement;
+    private readonly lineEl: SVGLineElement;
+
+    constructor() {
+        this.arrowEl = ensureArrowSvg();
+        this.lineEl = this.arrowEl.querySelector("line") as SVGLineElement;
+    }
+
+    /**
+     * Hook every `[data-legend-id]` row inside [legendsRoot] to its
+     * matching `[data-overlay-id]` element inside [overlayRoot]. Call
+     * once per inspector render — the controller forgets previous
+     * hooks first so re-rendering doesn't double-fire.
+     */
+    attach(legendsRoot: HTMLElement, overlayRoot: HTMLElement | null): void {
+        this.detach();
+        const rows =
+            legendsRoot.querySelectorAll<HTMLElement>("[data-legend-id]");
+        rows.forEach((row) => {
+            const id = row.dataset.legendId;
+            if (!id) return;
+            const enter = (): void => this.show(row, id, overlayRoot);
+            const leave = (): void => this.hide(id, overlayRoot);
+            row.addEventListener("mouseenter", enter);
+            row.addEventListener("mouseleave", leave);
+            // Keyboard parity: focusing a legend row also surfaces the
+            // arrow. Lets keyboard-only users see the correlation
+            // without needing a hover device.
+            row.addEventListener("focus", enter);
+            row.addEventListener("blur", leave);
+            this.listeners.set(row, { enter, leave });
+        });
+    }
+
+    /** Drop every hover handler the controller installed. Idempotent. */
+    detach(): void {
+        for (const [row, { enter, leave }] of this.listeners) {
+            row.removeEventListener("mouseenter", enter);
+            row.removeEventListener("mouseleave", leave);
+            row.removeEventListener("focus", enter);
+            row.removeEventListener("blur", leave);
+        }
+        this.listeners.clear();
+        this.arrowEl.style.opacity = "0";
+    }
+
+    private show(
+        row: HTMLElement,
+        id: string,
+        overlayRoot: HTMLElement | null,
+    ): void {
+        const target = overlayRoot?.querySelector<HTMLElement>(
+            '[data-overlay-id="' + cssEscape(id) + '"]',
+        );
+        if (target) {
+            target.classList.add("legend-active");
+        }
+        const fromRect = row.getBoundingClientRect();
+        const toRect = target?.getBoundingClientRect();
+        if (!toRect) {
+            // No overlay match — still allow the row to highlight,
+            // just skip the arrow.
+            this.arrowEl.style.opacity = "0";
+            return;
+        }
+        const fromX = fromRect.left;
+        const fromY = fromRect.top + fromRect.height / 2;
+        const toX = toRect.left + toRect.width / 2;
+        const toY = toRect.top + toRect.height / 2;
+        this.lineEl.setAttribute("x1", String(fromX));
+        this.lineEl.setAttribute("y1", String(fromY));
+        this.lineEl.setAttribute("x2", String(toX));
+        this.lineEl.setAttribute("y2", String(toY));
+        this.arrowEl.style.opacity = "1";
+    }
+
+    private hide(id: string, overlayRoot: HTMLElement | null): void {
+        const target = overlayRoot?.querySelector<HTMLElement>(
+            '[data-overlay-id="' + cssEscape(id) + '"]',
+        );
+        if (target) {
+            target.classList.remove("legend-active");
+        }
+        this.arrowEl.style.opacity = "0";
+    }
+}
+
+function ensureArrowSvg(): SVGSVGElement {
+    const existing = document.getElementById(ARROW_SVG_ID);
+    if (existing instanceof SVGSVGElement) return existing;
+    const svg = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "svg",
+    ) as SVGSVGElement;
+    svg.id = ARROW_SVG_ID;
+    svg.setAttribute("aria-hidden", "true");
+    svg.style.position = "fixed";
+    svg.style.inset = "0";
+    svg.style.width = "100vw";
+    svg.style.height = "100vh";
+    svg.style.pointerEvents = "none";
+    svg.style.zIndex = "9999";
+    svg.style.opacity = "0";
+    svg.style.transition = "opacity 80ms ease-out";
+
+    const defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
+    const marker = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "marker",
+    );
+    marker.id = ARROW_HEAD_ID;
+    marker.setAttribute("viewBox", "0 0 10 10");
+    marker.setAttribute("refX", "8");
+    marker.setAttribute("refY", "5");
+    marker.setAttribute("markerWidth", "6");
+    marker.setAttribute("markerHeight", "6");
+    marker.setAttribute("orient", "auto-start-reverse");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", "M 0 0 L 10 5 L 0 10 z");
+    path.setAttribute("fill", "currentColor");
+    marker.appendChild(path);
+    defs.appendChild(marker);
+    svg.appendChild(defs);
+
+    const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+    line.setAttribute("stroke", "currentColor");
+    line.setAttribute("stroke-width", "1.5");
+    line.setAttribute("marker-end", "url(#" + ARROW_HEAD_ID + ")");
+    svg.appendChild(line);
+
+    document.body.appendChild(svg);
+    return svg;
+}
+
+function cssEscape(s: string): string {
+    // Minimal escaping for `[attr="value"]` selectors — the only
+    // characters that break the predicate are `"` and `\`. CSS.escape
+    // is overkill and not in every webview environment.
+    return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -243,6 +243,7 @@ export class PreviewApp extends LitElement {
     protected firstUpdated(): void {
         const initialEarlyFeaturesEnabled =
             this.dataset.earlyFeatures === "true";
+        const initialAutoEnableCheap = this.dataset.autoEnableCheap === "true";
         const vscode = getVsCodeApi<PersistedState>();
         const state: PersistedState = vscode.getState() ?? { filters: {} };
         // `earlyFeaturesEnabled` lives in `previewStore` so future
@@ -251,6 +252,7 @@ export class PreviewApp extends LitElement {
         // terseness; writes go straight to `previewStore.setState`.
         previewStore.setState({
             earlyFeaturesEnabled: initialEarlyFeaturesEnabled,
+            autoEnableCheapEnabled: initialAutoEnableCheap,
         });
         const earlyFeatures = (): boolean =>
             previewStore.getState().earlyFeaturesEnabled;
@@ -366,6 +368,8 @@ export class PreviewApp extends LitElement {
         inspector = new FocusInspectorController({
             el: focusInspector,
             earlyFeatures,
+            autoEnableCheap: () =>
+                previewStore.getState().autoEnableCheapEnabled,
             getPreview: (id) =>
                 previewStore.getState().allPreviews.find((p) => p.id === id),
             getA11yFindings: (id) => {
@@ -393,6 +397,7 @@ export class PreviewApp extends LitElement {
                 focusController.requestFocusedDiff(against),
             onRequestLaunchOnDevice: () =>
                 focusController.requestLaunchOnDevice(),
+            getScope: () => previewStore.getState().moduleDir,
         });
 
         // Config for the interactive-input pointer machine. The predicate

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -59,6 +59,16 @@ interface PersistedState {
     filters?: { fn?: string; group?: string };
     layout?: "grid" | "flow" | "column" | "focus";
     diffMode?: DiffMode;
+    /**
+     * Per-scope MRU of focus-inspector data-product `kind` strings —
+     * scope is the active module dir today (see `getScope` in
+     * `FocusInspectorConfig`). Most-recent-first within each list,
+     * trimmed to taxonomy `bumpMru`'s default cap. Used as a
+     * tiebreaker for in-bucket sorting and as a topup signal in
+     * `suggestFor`. Persists across webview reload (panel hide/show)
+     * but not extension reload — same lifecycle as `filters` / `layout`.
+     */
+    focusMruByScope?: Record<string, string[]>;
 }
 
 @customElement("preview-app")
@@ -398,6 +408,19 @@ export class PreviewApp extends LitElement {
             onRequestLaunchOnDevice: () =>
                 focusController.requestLaunchOnDevice(),
             getScope: () => previewStore.getState().moduleDir,
+            loadMru: (scope) => state.focusMruByScope?.[scope] ?? [],
+            saveMru: (scope, mru) => {
+                // Persist to vscode workspace state. Same shape as the
+                // existing filter/layout fields — survives webview
+                // hide/show but not extension reload, which matches
+                // the lifetime users intuit for "ranked layers."
+                const existing = state.focusMruByScope ?? {};
+                state.focusMruByScope = {
+                    ...existing,
+                    [scope]: [...mru],
+                };
+                vscode.setState(state);
+            },
         });
 
         // Config for the interactive-input pointer machine. The predicate

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -576,7 +576,7 @@ export function productsFromDaemonCapabilities(
             label: p.displayName || prettifyKind(p.kind),
             icon: iconForBucket(bucketOf(p.kind)),
             hint: p.transport === "path" ? "On-disk artifact" : undefined,
-            cost: costOf(p.kind),
+            cost: costOf(p.kind, { requiresRerender: p.requiresRerender }),
             daemonBacked: true,
         });
     }

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -37,9 +37,16 @@
 import type {
     AccessibilityFinding,
     AccessibilityNode,
+    DaemonDataExtensionDescriptor,
+    DaemonDataProductCapability,
     ExtensionToWebview,
     PreviewInfo,
 } from "../shared/types";
+import {
+    type ProductDescriptor,
+    bucketOf,
+    costOf,
+} from "./focusProductTaxonomy";
 import type { VsCodeApi } from "../shared/vscode";
 import { safeArrayIndex } from "../shared/safeIndex";
 import { sanitizeId } from "./cardData";
@@ -183,6 +190,17 @@ export function handleExtensionMessage(
             return handlePreviewMainRefChanged(ctx);
         case "setEarlyFeatures":
             return handleSetEarlyFeatures(msg, ctx);
+        case "setAutoEnableCheap":
+            previewStore.setState({ autoEnableCheapEnabled: !!msg.enabled });
+            return;
+        case "setDaemonCapabilities":
+            ctx.inspector.setProducts(
+                productsFromDaemonCapabilities(
+                    msg.dataProducts,
+                    msg.dataExtensions,
+                ),
+            );
+            return;
         case "streamStarted": {
             const card = document.getElementById(
                 "preview-" + sanitizeId(msg.previewId),
@@ -529,4 +547,74 @@ function assertNever(value: never): never {
     throw new Error(
         `Unhandled ExtensionToWebview variant: ${JSON.stringify(value)}`,
     );
+}
+
+/**
+ * Translate the daemon's advertised capabilities into the inspector's
+ * `ProductDescriptor` shape — the icon/label/cost the inspector
+ * actually renders. The daemon side only knows wire kinds; the icon
+ * mapping lives client-side because it's a UI choice that varies per
+ * client (the MCP server may pick different glyphs).
+ *
+ * `dataExtensions` are surfaced as a one-row entry per extension that
+ * isn't already represented by a `dataProducts` entry — the inspector
+ * doesn't otherwise differentiate between "advertised by an extension"
+ * and "advertised as a product." Display names fall back to the wire
+ * `id` when the daemon didn't supply one.
+ */
+export function productsFromDaemonCapabilities(
+    products: readonly DaemonDataProductCapability[],
+    extensions: readonly DaemonDataExtensionDescriptor[],
+): ProductDescriptor[] {
+    const seen = new Set<string>();
+    const out: ProductDescriptor[] = [];
+    for (const p of products) {
+        if (seen.has(p.kind)) continue;
+        seen.add(p.kind);
+        out.push({
+            kind: p.kind,
+            label: p.displayName || prettifyKind(p.kind),
+            icon: iconForBucket(bucketOf(p.kind)),
+            hint: p.transport === "path" ? "On-disk artifact" : undefined,
+            cost: costOf(p.kind),
+            daemonBacked: true,
+        });
+    }
+    for (const ext of extensions) {
+        const key = "ext/" + ext.id;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push({
+            kind: key,
+            label: ext.displayName || ext.id,
+            icon: "extensions",
+            hint: "Extension",
+            cost: "expensive",
+            daemonBacked: true,
+        });
+    }
+    return out;
+}
+
+function prettifyKind(kind: string): string {
+    const slash = kind.lastIndexOf("/");
+    const tail = slash >= 0 ? kind.slice(slash + 1) : kind;
+    return tail.charAt(0).toUpperCase() + tail.slice(1).replace(/[-_]/g, " ");
+}
+
+function iconForBucket(bucket: ReturnType<typeof bucketOf>): string {
+    switch (bucket) {
+        case "accessibility":
+            return "eye";
+        case "layout":
+            return "list-tree";
+        case "performance":
+            return "pulse";
+        case "theming":
+            return "symbol-color";
+        case "resources":
+            return "file-code";
+        default:
+            return "circle-outline";
+    }
 }

--- a/vscode-extension/src/webview/preview/previewStore.ts
+++ b/vscode-extension/src/webview/preview/previewStore.ts
@@ -41,6 +41,16 @@ export interface PreviewState {
     earlyFeaturesEnabled: boolean;
 
     /**
+     * Reflects `composePreview.autoEnableCheap.enabled`. When `true`,
+     * the focus inspector auto-enables cheap, suggestion-matched
+     * data products on first sight per scope. Default `false` — the
+     * feature is opt-in so users don't see toggles flip without their
+     * input. Updated at runtime by the `setAutoEnableCheap` extension
+     * message.
+     */
+    autoEnableCheapEnabled: boolean;
+
+    /**
      * `previewId` of the card whose accessibility overlay subscription
      * is currently active, or `null` when no card is subscribed. Set by
      * `toggleA11yOverlay` and cleared on focus navigation, daemon
@@ -135,6 +145,7 @@ export interface PreviewState {
 
 const initialState: PreviewState = {
     earlyFeaturesEnabled: false,
+    autoEnableCheapEnabled: false,
     a11yOverlayPreviewId: null,
     focusedPreviewId: null,
     allPreviews: [],

--- a/vscode-extension/src/webview/shared/types.ts
+++ b/vscode-extension/src/webview/shared/types.ts
@@ -8,6 +8,8 @@ export type {
     AccessibilityFinding,
     AccessibilityNode,
     Capture,
+    DaemonDataExtensionDescriptor,
+    DaemonDataProductCapability,
     ExtensionToWebview,
     HistoryDiffSummary,
     HistoryEntry,


### PR DESCRIPTION
## Summary

Restructures the focus-mode inspector from a flat product picker into a three-tier layout: a suggestion chip row (driven by preview annotations and MRU), five stable product buckets (Accessibility/Layout/Performance/Theming/Resources), and a Tools strip. Introduces a presentation framework for data products to contribute overlays, legends, reports, and errors to the inspector UI.

## Key Changes

- **New taxonomy module** (`focusProductTaxonomy.ts`): Pure functions for bucketing products by namespace, classifying cost (cheap/expensive), and ranking suggestions based on preview hints, device type, a11y findings, and per-scope MRU.

- **Presentation framework** (`focusPresentation.ts`): Registry-based system allowing data products to contribute to four surfaces:
  - Overlay: DOM painted on the preview image
  - Legend: Sidecar list with hover-to-highlight correlation
  - Report: Collapsible structured data blocks
  - Error: Top banner for failures/missing data

- **Legend arrow correlator** (`legendArrow.ts`): SVG arrow drawn from legend entries to matching overlay regions on hover, with keyboard parity for focus events.

- **Inspector redesign** (`focusInspector.ts`):
  - Replaces flat picker with suggestion row + five collapsible bucket `<details>` elements
  - Adds per-scope MRU tracking via `loadMru`/`saveMru` callbacks
  - Implements auto-enable logic for cheap suggested products when `autoEnableCheap` setting is on
  - Integrates presenter pipeline to render data product contributions
  - Maintains backward compatibility with existing a11y overlay, device, live, and record buttons

- **Daemon integration** (`daemonGate.ts`, `messageHandlers.ts`): Wires daemon-advertised product capabilities into the inspector via `setDaemonCapabilities` message, replacing built-in placeholders.

- **Settings & persistence**:
  - New `composePreview.autoEnableCheap.enabled` setting
  - MRU persisted per scope in `vscode.setState`
  - Auto-enable state tracked per scope to prevent re-flipping user-disabled kinds

- **Styling** (`preview.css`): New classes for suggestion chips, bucket headers, legend rows, error banners, and presenter surfaces.

- **Comprehensive tests**:
  - `focusProductTaxonomy.test.ts`: Taxonomy routing, cost classification, suggestion ranking
  - `focusPresentation.test.ts`: Registry dispatch, presenter output validation
  - `focusInspectorPersistence.test.ts`: MRU load/save integration

## Implementation Details

- Taxonomy is intentionally conservative: unknown namespaces fall through to "More" bucket so the chrome never grows beyond five rows as new daemon products land.
- Cheapness defaults to expensive (safe) unless the kind is in an allowlist or the daemon provides a `requiresRerender` hint.
- Suggestions are capped at `MAX_SUGGESTIONS` to keep the chip row scannable; MRU ranking ensures frequently-toggled products surface first.
- Presenters are pure factories with no state, enabling re-render-on-demand without stale data.
- Arrow correlator is re-attached on every inspector render to rebind against fresh legend DOM.

https://claude.ai/code/session_01VMAKpmZ8j4XPZr1HBzsQkP