### PR TITLE
feat: emit display-filter variants from the gradle-plugin direct render path

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1194,6 +1194,13 @@ internal object AndroidPreviewSupport {
             debug = project.providers.gradleProperty("composeai.a11y.debug").orElse("false"),
           )
         )
+        // Display filters — same lazy-input pattern as a11y so `-PcomposePreview.displayFilter
+        // .filters=grayscale,invert` toggles don't invalidate the configuration cache.
+        // RobolectricRenderTest reads `composeai.displayfilter.filters` after each capture and
+        // calls DisplayFilterDataProducer.writeArtifacts when non-empty.
+        jvmArgumentProviders.add(
+          DisplayFilterSystemPropsProvider(filters = resolveDisplayFilterFilters(project))
+        )
         // Render-tier filter — fed via the same lazy `@Input` provider
         // pattern so VS Code can flip `-PcomposePreview.tier=fast` on
         // every save without paying a config-cache reconfigure. Renderer
@@ -1558,6 +1565,32 @@ internal object AndroidPreviewSupport {
         "-Dcomposeai.a11y.debug=${debug.get()}",
       )
   }
+
+  /**
+   * Forwards the `composePreview.displayFilter.filters` Gradle property as the
+   * `composeai.displayfilter.filters` system property on the spawned renderer JVM. Same
+   * `CommandLineArgumentProvider` shape as [AccessibilitySystemPropsProvider] so toggling filters
+   * on the command line (`-PcomposePreview.displayFilter.filters=grayscale,invert`) doesn't
+   * invalidate the configuration cache. Empty / unset is forwarded as an empty string;
+   * `DisplayFilterConfig.fromSystemProperties()` treats blank input as "feature disabled".
+   */
+  internal class DisplayFilterSystemPropsProvider(
+    @get:org.gradle.api.tasks.Input val filters: org.gradle.api.provider.Provider<String>
+  ) : org.gradle.process.CommandLineArgumentProvider {
+    override fun asArguments(): Iterable<String> =
+      listOf("-Dcomposeai.displayfilter.filters=${filters.get()}")
+  }
+
+  /**
+   * Lazy `Provider<String>` for the comma-separated display-filter list. Reads
+   * `-PcomposePreview.displayFilter.filters=...`; defaults to empty (feature off) so existing
+   * builds don't change behaviour. Same Provider-not-String discipline as [resolveA11yEnabled] for
+   * configuration-cache friendliness.
+   */
+  internal fun resolveDisplayFilterFilters(
+    project: org.gradle.api.Project
+  ): org.gradle.api.provider.Provider<String> =
+    project.providers.gradleProperty("composePreview.displayFilter.filters").orElse("")
 
   /**
    * Returns a lazy `Provider<Boolean>` for the effective a11y data-product selection. The

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -127,6 +127,7 @@ internal object ComposePreviewTasks {
           renderBackend.set("desktop")
           useComposeRenderer.set(true)
           tier.set(tierProperty(project))
+          displayFilterFilters.set(AndroidPreviewSupport.resolveDisplayFilterFilters(project))
           renderClasspath.from(sourceClassDirs)
           project.configurations.findByName(resolveDependencyConfigName())?.let {
             renderClasspath.from(it)
@@ -503,6 +504,9 @@ internal object ComposePreviewTasks {
         renderBackend.set("stub")
         useComposeRenderer.set(false)
         tier.set(tierProperty(project))
+        // Stub backend doesn't run any renderer, so display filters are a no-op here — but the
+        // input is required by the task type, so wire the same resolver for consistency.
+        displayFilterFilters.set(AndroidPreviewSupport.resolveDisplayFilterFilters(project))
         renderClasspath.from(sourceClassDirs)
         project.configurations.findByName(dependencyConfigName())?.let { renderClasspath.from(it) }
         group = "compose preview"

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -36,6 +36,14 @@ abstract class RenderPreviewsTask : DefaultTask() {
    */
   @get:Input abstract val tier: Property<String>
 
+  /**
+   * Comma-separated `composeai.displayfilter.filters` value forwarded as a system property to the
+   * desktop renderer subprocess. Empty / unset disables display filters. See
+   * [AndroidPreviewSupport.resolveDisplayFilterFilters] for the canonical resolver shared with the
+   * Android Test task. Marked `@Input` so a filter-list change drives re-render.
+   */
+  @get:Input abstract val displayFilterFilters: Property<String>
+
   @get:Classpath abstract val renderClasspath: ConfigurableFileCollection
 
   @get:OutputDirectory abstract val outputDir: DirectoryProperty
@@ -138,6 +146,10 @@ abstract class RenderPreviewsTask : DefaultTask() {
       execOperations.javaexec {
         classpath = renderClasspath
         this.mainClass.set(mainClass)
+        // Forward the display-filter selection so DesktopRendererMain can call
+        // DisplayFilterDataProducer.writeArtifacts after each render. Empty string is fine —
+        // DisplayFilterConfig.parseFilters treats blank input as "feature disabled".
+        systemProperty("composeai.displayfilter.filters", displayFilterFilters.get())
         args =
           listOf(
             preview.className,

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -56,6 +56,11 @@ dependencies {
   // focus / ambient: no hardcoded pseudolocale logic in this module — extend the connector
   // instead.
   implementation(project(":data-pseudolocale-connector"))
+  // Display-filter connector — RobolectricRenderTest reads `composeai.displayfilter.filters` after
+  // each successful PNG capture and calls `DisplayFilterDataProducer.writeArtifacts(...)` to emit
+  // per-filter variants alongside the base capture. Same dep on the daemon side; the producer is
+  // renderer-agnostic (BufferedImage / ImageIO).
+  implementation(project(":data-displayfilter-connector"))
 
   implementation(libs.robolectric)
   implementation(libs.junit)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -33,6 +33,8 @@ import ee.schimke.composeai.daemon.FocusOverlay
 import ee.schimke.composeai.daemon.FocusOverrideExtension
 import ee.schimke.composeai.daemon.protocol.AmbientOverride
 import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
+import ee.schimke.composeai.daemon.DisplayFilterConfig
+import ee.schimke.composeai.daemon.DisplayFilterDataProducer
 import ee.schimke.composeai.daemon.protocol.FocusOverride
 import ee.schimke.composeai.daemon.protocol.FocusDirection as ProtocolFocusDirection
 import ee.schimke.composeai.data.render.PreviewAnimationContext
@@ -1004,6 +1006,33 @@ abstract class RobolectricRenderTestBase(
                                 (preview.params.showSystemUi ||
                                     preview.params.kind == PreviewKind.TILE),
                         )
+                    }
+
+                    // Display filters — post-capture colour-matrix variants. Gated on
+                    // `composeai.displayfilter.filters` being non-empty; the gradle plugin
+                    // forwards it from the `composePreview.displayFilter.filters` Gradle
+                    // property. Wrapped in try/catch so a filter failure never invalidates the
+                    // just-captured PNG. Data dir mirrors the daemon convention
+                    // (`<renders>/../data/<previewId>/`) so consumers see the same on-disk
+                    // layout whether a render came through the daemon or the gradle plugin.
+                    if (job is CaptureRenderJob) {
+                        val displayFilters = DisplayFilterConfig.fromSystemProperties()
+                        if (displayFilters.isNotEmpty()) {
+                            try {
+                                val dfDataDir = (outputDir.parentFile ?: outputDir).resolve("data")
+                                DisplayFilterDataProducer.writeArtifacts(
+                                    rootDir = dfDataDir,
+                                    previewId = preview.id,
+                                    pngFile = outputFile,
+                                    filters = displayFilters,
+                                )
+                            } catch (t: Throwable) {
+                                System.err.println(
+                                    "RobolectricRenderTest: displayfilter write failed for " +
+                                        "${preview.id}: ${t.javaClass.simpleName}: ${t.message}",
+                                )
+                            }
+                        }
                     }
                     if (job is CaptureRenderJob) captureIndex++
                 }

--- a/renderer-desktop/build.gradle.kts
+++ b/renderer-desktop/build.gradle.kts
@@ -18,6 +18,11 @@ dependencies {
   // tags. Renderer applies the around-composable inline (LocalLayoutDirection.Rtl for ar-XB) and
   // rewrites the locale tag before it reaches `LocaleList`.
   implementation(project(":data-pseudolocale-core"))
+  // Display-filter connector — DesktopRendererMain reads `composeai.displayfilter.filters` after
+  // each successful PNG render and calls `DisplayFilterDataProducer.writeArtifacts(...)` to emit
+  // per-filter variants alongside the base capture. Same dep on the daemon side; the producer is
+  // renderer-agnostic (BufferedImage / ImageIO).
+  implementation(project(":data-displayfilter-connector"))
 
   testImplementation(libs.junit)
 }

--- a/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
+import ee.schimke.composeai.daemon.DisplayFilterConfig
+import ee.schimke.composeai.daemon.DisplayFilterDataProducer
 import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
@@ -159,6 +161,28 @@ fun main(args: Array<String>) {
         previewArgs,
         localeTag,
       )
+      // Display filters — post-capture colour-matrix variants (grayscale / invert / daltonizer
+      // simulations). Gated on `composeai.displayfilter.filters` being non-empty; the gradle plugin
+      // forwards it from the `composePreview.displayFilter.filters` Gradle property. Wrapped in
+      // try/catch so a filter failure does not invalidate the just-rendered PNG. Data dir mirrors
+      // the daemon's convention: `<renders-dir>/../data/<previewId>/`.
+      val displayFilters = DisplayFilterConfig.fromSystemProperties()
+      if (displayFilters.isNotEmpty()) {
+        try {
+          val dataDir = (targetFile.parentFile?.parentFile ?: targetFile.parentFile).resolve("data")
+          DisplayFilterDataProducer.writeArtifacts(
+            rootDir = dataDir,
+            previewId = targetFile.nameWithoutExtension,
+            pngFile = targetFile,
+            filters = displayFilters,
+          )
+        } catch (t: Throwable) {
+          System.err.println(
+            "DesktopRendererMain: displayfilter write failed for ${targetFile.name}: " +
+              "${t.javaClass.simpleName}: ${t.message}"
+          )
+        }
+      }
     } catch (e: Throwable) {
       // Catch Throwable, not Exception — preview functions can throw
       // Errors (e.g. AssertionError from a misused require) and the user

--- a/site/reference/displayfilter.md
+++ b/site/reference/displayfilter.md
@@ -27,7 +27,7 @@ deficiencies.
 | Token usage | ~10 tok inline (manifest is tiny — `{filter, path}` per variant); +~1.5 k per filtered PNG read. |
 | Transport | inline (JSON manifest) · variant PNGs ride as `extras` |
 | Platforms | Android, Desktop |
-| Status | Daemon-mode renders (Android Robolectric + Desktop) write variants and the manifest after each capture. The Gradle-plugin direct path (`:samples:cmp:renderAllPreviews`) goes through a separate renderer subprocess and does **not** yet emit display-filter variants — wire it through `RobolectricRenderTest` / `DesktopRendererMain` if you need it there. |
+| Status | Wired across both render paths — the daemon (VS Code, MCP, CLI daemon mode) and the Gradle-plugin direct path (`:samples:cmp:renderAllPreviews`) both emit variants and the manifest after each capture. |
 
 ## What it answers
 
@@ -88,14 +88,25 @@ without a follow-up fetch.
 
 ## Enabling
 
-`-Dcomposeai.displayfilter.filters=` controls which filters apply. Empty
-or unset disables the feature entirely; the daemon doesn't even register
-the extension.
+A comma-separated list of filter ids enables the feature. Empty / unset
+disables it entirely (no manifest, no variant PNGs, no extension
+registration).
+
+**Gradle plugin / direct render path.** Pass the Gradle property
+(matches the rest of the `composePreview.*` flag namespace):
 
 ```sh
 ./gradlew :samples:cmp:renderAllPreviews \
-    -Dcomposeai.displayfilter.filters=grayscale,deuteranopia
+    -PcomposePreview.displayFilter.filters=grayscale,deuteranopia
 ```
+
+The plugin forwards the value to the spawned renderer JVMs as
+`-Dcomposeai.displayfilter.filters=...`, where `RobolectricRenderTest`
+(Android) and `DesktopRendererMain` (CMP Desktop) read it after each
+PNG capture and run `DisplayFilterDataProducer.writeArtifacts(...)`.
+
+**Daemon path.** Same sysprop, set on the daemon JVM directly:
+`-Dcomposeai.displayfilter.filters=...`.
 
 Unknown filter ids are dropped with a warning so a typo doesn't strand
 the rest. Duplicates collapse — `grayscale,invert,grayscale` runs each

--- a/skills/compose-preview/design/DISPLAY_FILTERS.md
+++ b/skills/compose-preview/design/DISPLAY_FILTERS.md
@@ -29,16 +29,20 @@ here.
 
 ## Enabling
 
-System property, comma-separated filter ids:
+Gradle property on the direct render path (the plugin forwards it to
+the renderer subprocess as the `composeai.displayfilter.filters`
+sysprop):
 
 ```sh
 ./gradlew :samples:cmp:renderAllPreviews \
-    -Dcomposeai.displayfilter.filters=grayscale,deuteranopia
+    -PcomposePreview.displayFilter.filters=grayscale,deuteranopia
 ```
 
-Empty / unset disables the feature entirely — the daemon doesn't
-register the extension, so `extensions/list` won't show it. Unknown
-ids are dropped with a warning. Duplicates collapse.
+For daemon-mode use the matching JVM flag directly:
+`-Dcomposeai.displayfilter.filters=grayscale,deuteranopia`. Empty /
+unset disables the feature entirely — the daemon doesn't register the
+extension, so `extensions/list` won't show it. Unknown ids are dropped
+with a warning. Duplicates collapse.
 
 ## Output
 
@@ -66,12 +70,6 @@ variant. Two failure shapes worth flagging:
 
 ## Caveats
 
-- Wired in the **daemon** render path today (Android + Desktop). The
-  Gradle-plugin direct path (`./gradlew :samples:cmp:renderAllPreviews`)
-  uses a separate renderer subprocess and does not yet emit variants —
-  agents driving the daemon (VS Code, MCP, the CLI's daemon mode) get
-  the variants automatically; CLI users on the direct-renderer path
-  don't yet.
 - Purely **post-process** — no Compose state changes, so things like
   high-contrast text outlines or bold text aren't covered here. Those
   belong on the a11y side (re-render with the OS flag set).


### PR DESCRIPTION
## Summary

Closes the second consumption surface for `displayfilter/variants`. #950 wired the daemon path; this PR wires the Gradle-plugin direct path, so `:samples:cmp:renderAllPreviews` and the equivalent Robolectric Test task land `displayfilter-variants.json` plus per-filter PNGs under `<previewOutputDir>/data/<previewId>/` — the same on-disk shape the daemon writes.

- `RobolectricRenderTest` (Android) and `DesktopRendererMain` (CMP Desktop) call `DisplayFilterDataProducer.writeArtifacts` after each PNG capture, gated on `composeai.displayfilter.filters` being non-empty. Wrapped in try/catch so a filter failure never invalidates the just-captured PNG.
- `:renderer-android` and `:renderer-desktop` pick up `:data-displayfilter-connector`.
- Gradle plugin forwards the value as a JVM sysprop on both spawn paths: a `DisplayFilterSystemPropsProvider` (`CommandLineArgumentProvider`) on the Android `renderPreviews` Test task — same lazy-input shape as `AccessibilitySystemPropsProvider` so toggles don't invalidate the configuration cache — and a `systemProperty` call on the desktop `javaexec` block driven by a new `displayFilterFilters` `@Input` on `RenderPreviewsTask`.
- Public knob is the `composePreview.displayFilter.filters` Gradle property:

  ```sh
  ./gradlew :samples:cmp:renderAllPreviews \
      -PcomposePreview.displayFilter.filters=grayscale,deuteranopia
  ```

Docs: `site/reference/displayfilter.md` and the design doc drop the "Gradle-plugin direct path doesn't emit variants yet" caveat and document the `-P` flag alongside the `-D` daemon equivalent.

## Test plan

- [x] `./gradlew :samples:cmp:renderAllPreviews -PcomposePreview.displayFilter.filters=grayscale,deuteranopia` produces the expected `displayfilter-variants.json` plus `_displayfilter_grayscale.png` / `_displayfilter_deuteranopia.png` siblings under `samples/cmp/build/compose-previews/data/<previewId>/` for every rendered preview.
- [x] `:gradle-plugin:check` is green.
- [x] `:renderer-android` and `:renderer-desktop` compile with the new dep.
- [ ] Android side (`:samples:android:renderAllPreviews -PcomposePreview.displayFilter.filters=grayscale`) producing the same shape — not run locally; covered by the same wiring as the Desktop sample.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCmY14nGGMF4SFnyFUcGcj)_