### PR TITLE
Add API stability and versioning design docs for 1.0 release

### DIFF
--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -1,0 +1,160 @@
+# API stability — design
+
+Cross-cutting design doc for what counts as a public contract in this repo, how each contract evolves, and how the two sides of each contract negotiate compatibility. Companion to [VERSIONING.md](VERSIONING.md) (the policy) and [ROADMAP_1_0.md](ROADMAP_1_0.md) (the pre-1.0 punch list).
+
+## 1. The contracts
+
+Nine externally-observable surfaces, each with its own evolution story. Anything **not** in this list is internal and may move without notice.
+
+| # | Surface | Lives in | Consumed by | Stability tier |
+|---|---|---|---|---|
+| 1 | Daemon JSON-RPC over stdio | `daemon/core/.../protocol/Messages.kt`, [docs/daemon/PROTOCOL.md](daemon/PROTOCOL.md) | VS Code extension, MCP supervisor, any future client | Stable |
+| 2 | `previews.json` on disk | `gradle-plugin/.../DiscoverPreviewsTask.kt` | Daemon, CLI, CI workflows | Stable |
+| 3 | Per-data-product payload schemas | `data/<feature>/connector/`, [docs/daemon/DATA-PRODUCTS.md](daemon/DATA-PRODUCTS.md) | Daemon clients (versioned per-kind) | Stable per-kind |
+| 4 | Gradle plugin DSL (`composePreview { … }`) | `gradle-plugin/.../PreviewExtension.kt` | Consumer `build.gradle.kts` | Stable |
+| 5 | AGP × Kotlin × Compose × Robolectric matrix | [docs/RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md), [docs/AGENTS.md](AGENTS.md) | Consumers' transitive resolution | Documented, gated |
+| 6 | Preview annotations (`@ScrollingPreview`, `@AnimatedPreview`) | `preview-annotations/` | Consumer source code | Stable |
+| 7 | CLI argv (`compose-preview …`) | `cli/.../Args.kt`, `cli/.../Main.kt` | CI scripts, agents, GH actions | Stable |
+| 8 | MCP tool names + input schemas | `mcp/.../DaemonMcpServer.kt` | External AI agents | Stable |
+| 9 | GH composite actions + `compose-preview/main` branch convention | `.github/actions/*/action.yml` | Consumer workflows | Stable |
+
+The annotation library and per-data-product schemas are intentionally narrow. The other six surfaces are wide and the discipline below is what keeps them tractable.
+
+## 2. Evolution mechanism per surface
+
+### 2.1 Daemon JSON-RPC (surface 1)
+
+**Negotiation:** `initialize` request carries `protocolVersion: {min, max}` (post-1.0; today a single `int`). The daemon answers with its own `{min, max}` plus a `ServerCapabilities` bag. Both sides operate at `min(client.max, server.max)`. Mismatched ranges → `InvalidRequest`, daemon exits.
+
+**Feature detection:** capability bag, never daemon `semver`. The bag already covers `supportedOverrides`, `dataProducts`, `dataExtensions`, `previewExtensions`, `knownDevices`, `backend`, `androidSdk`, `recordingFormats`, `interactive`, `recording`. New features add a capability entry, not a behavior change under an existing field.
+
+**Additive change is free:**
+- New optional fields on existing message types.
+- New notification methods.
+- New request methods (clients gate on a capability flag before calling).
+- New error codes in the reserved `-32000..-32099` range.
+
+**Breaking change requires `protocolVersion` bump:**
+- Renamed or removed fields.
+- Field-meaning changes.
+- New required fields.
+- Changed default values that flip behavior.
+
+**Enums.** Every `@Serializable enum` on the wire is decoded tolerantly: unknown values map to an `UNKNOWN` sentinel rather than throwing. Without this, every new enum value is a silent break for old clients. See [VERSIONING.md § 4.1](VERSIONING.md#41-enum-discipline).
+
+**Test:** the JSON fixture corpus under [docs/daemon/protocol-fixtures/](daemon/protocol-fixtures/) round-trips on both Kotlin and TypeScript sides. Adding a message ⇒ add the fixture in the same PR. Renaming a field ⇒ either bump `protocolVersion` or revert.
+
+### 2.2 `previews.json` (surface 2)
+
+**Versioning:** top-level `schemaVersion: int`. Tolerant readers everywhere — unknown fields ignored, missing optional fields treated as default.
+
+**Negotiation:** none in-band. The plugin and daemon ship in lockstep; the CLI / VS Code extension treat `previews.json` as opaque except for fields they explicitly model. Any reader that crosses the process boundary keys off `schemaVersion` and ignores fields it doesn't understand.
+
+**Additive change is free:** new optional fields, new optional metadata blocks.
+
+**Breaking change:** bump `schemaVersion` and bump the daemon `protocolVersion` in the same release — clients should never see the new shape against an old daemon.
+
+### 2.3 Data products (surface 3)
+
+Each kind owns its own `schemaVersion: Int`. Producers evolve independently of the envelope. A client subscribing to `compose/recomposition` schemaVersion 2 against a daemon that only produces schemaVersion 1 receives the schemaVersion-1 payload — the client either degrades gracefully or refuses based on its own logic.
+
+`DataProductCapability` advertises the schema version the daemon supports. Clients gate against it; they don't fail closed on a mismatch unless their feature genuinely requires the newer version.
+
+### 2.4 Gradle plugin DSL (surface 4)
+
+**Stability tiers** (post-1.0):
+- `@Stable` — public, semver-governed. Property type changes, removals, and renames are breaking changes that bump the plugin major.
+- `@Incubating` — public but explicitly opt-in via `composePreview { incubating = true }`. May change in any release; warning at apply time.
+- Internal — `internal` Kotlin visibility. No contract.
+
+**Negotiation:** none. Gradle resolves the plugin coordinate; `apply()` validates the AGP/Kotlin/Compose versions present and either accepts or fails closed with a specific error. See § 2.5.
+
+**Additive change is free:** new `Property<T>` with a `convention(...)`, new nested extension blocks, new enum values on properties (because Gradle doesn't strict-decode user input).
+
+**Breaking change:** retype, rename, or remove. Goes through the deprecation cycle in [VERSIONING.md § 5](VERSIONING.md#5-deprecation-policy).
+
+**Enforced by:** `binary-compatibility-validator` (Kotlin BCV) on the plugin's Kotlin API.
+
+### 2.5 Toolchain matrix (surface 5)
+
+**Negotiation:** plugin `apply()` reads the resolved AGP version (and, where it can, Kotlin and Compose runtime versions) and compares against a baked-in compatibility table. Out-of-range → fail with the exact message "compose-preview X.Y supports AGP A.B–C.D; found E.F".
+
+**Documented:** [docs/RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md) is the authoritative table. `apply()` consults a generated subset of it.
+
+**Tested:** an `integration` workflow runs the sample renders against the matrix corners (current, current-1, next-RC) on every plugin release.
+
+**Evolution rule:** the matrix is allowed to slide. A plugin minor may drop support for an AGP version older than 18 months. A plugin major may drop two AGP majors at once. Any drop is documented in CHANGELOG with the exact "from X.Y you must be on AGP ≥ A.B".
+
+### 2.6 Preview annotations (surface 6)
+
+`@Retention(BINARY)`, FQN-stable, additive-only. Optional parameters with defaults are free. **Reordering** an annotation array literal default (e.g. `modes: Array<ScrollMode>`) is binary-breaking — array values are positional in Kotlin annotation defaults. Don't reorder.
+
+Renaming a parameter is breaking. Adding a new annotation class is free.
+
+The annotation library has no negotiation surface — the plugin's discovery task scans by FQN and accepts whatever annotation values are present.
+
+### 2.7 CLI argv (surface 7)
+
+**Stability:** flag names, subcommand names, and their argument shapes are public.
+
+**Output contracts:** any subcommand documented as machine-readable (`--json` outputs, exit codes) is part of the contract.
+
+**Deprecation:** flags follow the cycle in [VERSIONING.md § 5](VERSIONING.md#5-deprecation-policy) — warn for two minors, then remove.
+
+**Negotiation:** `compose-preview --version` and `compose-preview <cmd> --json-schema` (post-1.0) let CI and agents detect capability without parsing `--help`.
+
+### 2.8 MCP tool names (surface 8)
+
+**Stability:** tool names, input schemas, and output content shapes are public.
+
+**Negotiation:** MCP-spec `initialize` + `tools/list`. Agents are expected to re-list on `tools/list_changed`, but in practice agent configs hardcode names — so we treat names as immortal post-1.0.
+
+**Evolution rule:** add new tools rather than mutating old ones. When a tool is genuinely deprecated, keep it functional for the deprecation window and emit a warning in its description; remove only at a major.
+
+### 2.9 GH actions + branch conventions (surface 9)
+
+**Stability:** action `inputs:`, their default values, and the default branch names (`compose-preview/main`, `compose-preview/pr`, `compose-preview/resources/main`, `compose-preview/resources/pr`, `compose-preview/a11y/main`, `compose-preview/a11y/pr`).
+
+**Negotiation:** none. Consumers pin actions by SHA digest and pin the CLI via `version=catalog`.
+
+**Evolution rule:** input defaults are frozen post-1.0. New inputs default to "preserve existing behavior". Branch-name defaults are frozen forever — past PR comments embed permanent commit URLs on these branches.
+
+## 3. Multi-version support window
+
+| Pair | Window | Rationale |
+|---|---|---|
+| VS Code extension ↔ daemon | Extension supports daemon `protocolVersion` N..N-1 | Marketplace and project cadences diverge |
+| CLI ↔ plugin | Lockstep within a project | Mitigated by `version=catalog` |
+| Daemon ↔ in-repo plugin | Lockstep | Same build |
+| MCP server ↔ agent | Server keeps tool names stable indefinitely | Agents pin names in config |
+| GH action consumers | All published actions remain functional indefinitely | SHA-pinned references in workflows |
+| Plugin DSL consumers | Major-N plugin supports DSL written for major-N source | Standard Gradle plugin semver |
+
+The VS Code N..N-1 window is the only place we actively decode two protocol versions in the same binary. Everywhere else we either ship in lockstep or freeze the contract.
+
+## 4. What this design explicitly does not do
+
+- **No daemon `semver` checks at the protocol layer.** Capability bag only. `daemonVersion` is for logs and bug reports.
+- **No multiplexing.** One daemon, one client, one stdio pair.
+- **No on-the-wire schema migration.** Old client + new daemon → daemon serves the old protocol if it's in range; otherwise fail closed.
+- **No silent flag renames in CLI or DSL.** Every rename is a deprecation cycle.
+- **No automatic enum-value conversion.** Tolerant decode maps unknown to `UNKNOWN`; clients decide what to do.
+
+## 5. Stability tags in code
+
+Post-1.0 each public type carries one of:
+
+- `// API: stable` — semver-governed.
+- `// API: incubating` — opt-in, may change.
+- No tag — internal; do not depend on.
+
+Kotlin BCV runs on the plugin module and the annotations module. The daemon protocol is governed by the fixture corpus, not BCV (because internal types may move freely as long as the wire shape is stable).
+
+## 6. References
+
+- [VERSIONING.md](VERSIONING.md) — the policy that operationalises this design.
+- [ROADMAP_1_0.md](ROADMAP_1_0.md) — what has to land before 1.0 to make the contracts above real.
+- [docs/daemon/PROTOCOL.md](daemon/PROTOCOL.md) — wire format.
+- [docs/daemon/DATA-PRODUCTS.md](daemon/DATA-PRODUCTS.md) — per-kind schemas.
+- [docs/RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md) — toolchain matrix.
+- [docs/RELEASING.md](RELEASING.md) — release-please mechanics.

--- a/docs/ROADMAP_1_0.md
+++ b/docs/ROADMAP_1_0.md
@@ -1,0 +1,185 @@
+# 1.0 readiness — pre-release punch list
+
+What has to land before we can credibly cut `1.0.0` and honour the contracts in [API_STABILITY.md](API_STABILITY.md) under the policy in [VERSIONING.md](VERSIONING.md). Roughly ordered by leverage.
+
+Items marked **P0** are blockers. **P1** is "should land before 1.0 but a known-issues note is acceptable". **P2** is "nice to have at 1.0; can ship in 1.1".
+
+## P0 — wire-format hardening
+
+### 1. Tolerant enum decoding everywhere on the wire
+
+**Problem.** Every `@Serializable enum` in `daemon/core/.../protocol/Messages.kt` strict-decodes by default. Adding `BackendKind.IOS`, `RecordingFormat.HEVC`, `UiMode.HIGH_CONTRAST`, etc. throws on every old client. This silently invalidates the "additive enum values are non-breaking" promise in `PROTOCOL.md § 7`.
+
+**Affected enums.** `RenderTier`, `UiMode`, `Orientation`, `BackendKind`, `RecordingFormat`, `DataProductFacet`, `DataProductTransport`, `LogLevel`, `RenderErrorKind`, `ChangeType`, `FileKind`, `LeakDetectionMode`, `SandboxRecycleReason`, `WallpaperPaletteStyle`, `HistoryDiffMode`, `PruneReasonWire`, `InteractiveInputKind`, `RecordingScriptEventStatus`, `DetectLeaks`, `ClasspathDirtyReason`.
+
+**Plan.**
+- Add an `UNKNOWN` variant to each enum (or a sealed-interface alternative with `Known(kind)` / `Unknown(raw: String)`).
+- Write a tolerant `KSerializer` factory and apply via a single `@Serializable(with = …)` annotation pattern.
+- Same on the TypeScript side (`vscode-extension/src/daemon/daemonProtocol.ts`): decode unknown strings to `"unknown"` and document the contract.
+- Add fixture corpus entries with synthetic future values for every enum to prove tolerance round-trips.
+- Audit every `when (enum)` to add an explicit `else`.
+
+### 2. Add `schemaVersion` to `previews.json`
+
+**Problem.** No top-level version. The shape crosses three process boundaries (plugin → daemon → CLI/CI/VS Code). A silent rename has no detection mechanism.
+
+**Plan.**
+- `DiscoverPreviewsTask` writes `"schemaVersion": 1` at the top level.
+- All readers (`PreviewIndex`, CLI `previews.json` parser, VS Code `previewRegistry.ts`) read the field and gate on it.
+- Tolerant readers ignore unknown fields.
+- Document the schema in `docs/PREVIEWS_JSON.md` (new) with the same additive-vs-breaking rules as the daemon protocol.
+
+### 3. Add `schemaVersion` to `HistoryEntry` sidecar JSON
+
+**Problem.** Same as previews.json. Read by daemon, MCP, and any third-party tool that consumes `compose-preview/main` baselines.
+
+**Plan.** Mirror item 2 for `daemon/core/.../history/HistoryEntry.kt`. Document in `docs/daemon/HISTORY.md`.
+
+### 4. Switch `initialize.protocolVersion` to a `{min, max}` range
+
+**Problem.** Today's int handshake is fail-closed — when we ship `protocolVersion: 2` and a VS Code extension still on protocol 1 attaches, the daemon exits. We need the daemon to serve both for a window.
+
+**Plan.**
+- Wire shape becomes `{ "protocolVersion": { "min": 1, "max": 2 } }` on both sides; legacy int still accepted on the way in for one release.
+- Both sides operate at `min(client.max, server.max)`, fail closed only if the ranges don't overlap.
+- Document in `PROTOCOL.md § 3` and add fixtures.
+- Daemon serves N-1 for one minor cycle after a bump.
+
+## P0 — toolchain compatibility
+
+### 5. Plugin `apply()` validates AGP/Kotlin/Compose versions
+
+**Problem.** `RENDERER_COMPATIBILITY.md` documents the load-bearing tightrope; nothing enforces it. Consumers discover skew at render time with cryptic Robolectric errors.
+
+**Plan.**
+- Bake a compatibility table into the plugin (generated from RENDERER_COMPATIBILITY.md or hand-curated, but checked into source).
+- `ComposePreviewPlugin.apply()` reads the resolved AGP version (and Kotlin/Compose where it can) and fails configuration with the specific message: "compose-preview X.Y supports AGP A.B–C.D; found E.F. See [link]".
+- Out-of-range Kotlin / Compose versions print a warning, not a hard fail (we can't always detect them reliably).
+
+### 6. Toolchain matrix in CI
+
+**Problem.** We test against one toolchain. AGP/Compose/Kotlin minor bumps land every six weeks and can break the renderer in ways that don't surface until a consumer hits them.
+
+**Plan.**
+- New `.github/workflows/integration-matrix.yml` that runs `:samples:android:renderAllPreviews` and `:samples:cmp:renderAllPreviews` against the matrix corners: current, current-1, next-RC.
+- Required for plugin releases; advisory on PRs.
+- Document the matrix corners in [RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md).
+
+## P0 — public API surface lock
+
+### 7. Kotlin BCV on `:gradle-plugin` and `:preview-annotations`
+
+**Problem.** No mechanism stops a refactor from silently retyping a `Property<Int>` to `Property<Long>` or removing a public function.
+
+**Plan.**
+- Apply `org.jetbrains.kotlinx.binary-compatibility-validator` to both modules.
+- Generate the initial `api/` golden files from the current state.
+- Required-green CI check on PR.
+- Document opt-in `@Incubating` annotation usage so churning DSL stays out of the golden file.
+
+### 8. Audit and tag the plugin DSL
+
+**Problem.** Every public symbol on `PreviewExtension`, `PreviewExtensionsExtension`, `ResourcePreviewsExtension`, `DaemonExtension` is implicitly part of the contract. We haven't decided which.
+
+**Plan.**
+- Walk every public symbol and tag with `// API: stable` or `@Incubating`.
+- Anything still under design at 1.0 is `@Incubating` (e.g. data products are stable; recording knobs may still be incubating).
+- Write down the decision in [API_STABILITY.md § 5](API_STABILITY.md#5-stability-tags-in-code).
+
+## P0 — CLI surface
+
+### 9. Switch CLI to clikt (or equivalent)
+
+**Problem.** `cli/src/main/kotlin/ee/schimke/composeai/cli/Args.kt` is a hand-rolled `flagValue` / `flagValuesAll` helper. No `--help` schema, no deprecation cycle, no machine-readable command catalog. A flag rename is a silent break for every CI script and agent.
+
+**Plan.**
+- Migrate `Main.kt` and every command to clikt.
+- Stable `--help` output with parameter docs sourced from code.
+- `compose-preview <cmd> --json-schema` (or `compose-preview commands --json`) for machine introspection.
+- Deprecation infrastructure: warn-on-use for flags marked deprecated.
+- Lock the public flag set in 1.0 RC.
+
+### 10. Document CLI exit codes and `--json` output shapes
+
+**Problem.** Several commands emit JSON to stdout (e.g. `compose-preview ls`, `compose-preview doctor`). Their shapes are de-facto contracts but undocumented.
+
+**Plan.**
+- New `docs/CLI.md` listing every subcommand, every flag, exit codes, and `--json` output schema.
+- Treat the schemas as wire formats with their own `schemaVersion` if they're nontrivial.
+
+## P0 — release process
+
+### 11. Branch convention freeze
+
+**Problem.** GH action defaults (`compose-preview/main` etc.) are part of the contract; PR comments embed permanent commit URLs on them. They must be frozen forever post-1.0.
+
+**Plan.**
+- Add a `[VERSIONING.md § 7](VERSIONING.md#7-branch-conventions-gh-actions)` reference to each `action.yml` that declares one of these defaults.
+- CI guard that fails any PR that changes a branch-name default in `.github/actions/*/action.yml`.
+
+### 12. CHANGELOG audit
+
+**Problem.** Pre-1.0 minor bumps have carried breaking changes silently. Before cutting 1.0 we need a clean catalog of what's actually breaking from "today" to make sure nothing slips into the 1.0 RC.
+
+**Plan.**
+- Walk the CHANGELOG from the current minor backward; flag every breaking change since the last release that consumers might still be on.
+- Fold the list into the 1.0 announcement under "migrating from pre-1.0".
+
+## P1 — should-land
+
+### 13. MCP tool name freeze + deprecation infrastructure
+
+**Plan.**
+- List every MCP tool name in `docs/daemon/MCP.md` and tag stable vs. experimental.
+- Add deprecation infrastructure to `DaemonMcpServer` (description prefix, optional `_deprecated: true` in tool metadata even though it's not standard MCP).
+- Test that `tools/list_changed` fires when a tool is added/removed.
+
+### 14. VS Code extension supports daemon `protocolVersion` N..N-1
+
+**Plan.**
+- Once item 4 lands, the extension can negotiate the lower of its supported max and the daemon's max.
+- Add a `daemonProtocolSupported.ts` table with per-version capability detection.
+- Test against a fixture daemon that pretends to be N-1 and N.
+
+### 15. Fixture corpus completeness
+
+**Problem.** `docs/daemon/protocol-fixtures/` has decent coverage but isn't enforced as a gate. Some new messages (recording, history) may have landed without fixtures.
+
+**Plan.**
+- Audit every message type in `Messages.kt`; verify each has at least one fixture.
+- CI guard that fails if a `@Serializable` data class is added in `protocol/` without a fixture.
+
+### 16. `composePreview doctor` covers compatibility checks
+
+**Plan.**
+- Extend `DoctorCommand` to print the resolved AGP/Kotlin/Compose/Robolectric versions and gate them against the matrix.
+- Surface in VS Code as a diagnostic.
+
+### 17. Per-data-product schema documentation
+
+**Plan.**
+- Each `data/<feature>/connector/` documents its `schemaVersion`, payload shape, and additive-vs-breaking rules in a sibling `README.md` or in `docs/daemon/DATA-PRODUCTS.md`.
+- Producers carry a constant `SCHEMA_VERSION` that the connector publishes via `DataProductCapability`.
+
+## P1 — annotation library
+
+### 18. Annotation library binary-compatibility check
+
+**Plan.**
+- Same BCV setup as item 7 but explicitly tested for annotation-array-default reordering (which BCV doesn't catch — write a custom check).
+
+### 19. Document the migration from pre-0.7 single-mode `ScrollingPreview`
+
+**Plan.**
+- Already partially documented in code; promote to `docs/migration/SCROLLING_PREVIEW.md` if any 0.x consumers will see 1.0.
+
+## P2 — defer to 1.1
+
+- **Daemon `semver` range capabilities.** Today the daemon advertises one daemonVersion. Could become a richer compatibility surface, but capability bag covers the immediate need.
+- **Stable plugin SPI.** `PreviewOverrideExtensions` etc. are open under the additive rules but aren't a documented public API for third-party plugin authors. Deferred.
+- **Daemon multi-client support.** Architecture explicitly out of scope for v1.
+- **`previews.json` schema migration.** Once `schemaVersion` exists, write a migration helper for v1→v2 — but only when a v2 actually lands.
+
+## Tracking
+
+Each item above should become a GH issue with a `1.0-blocker` (P0) or `1.0-target` (P1) label. The 1.0 release-please milestone gates on every P0 closing.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,144 @@
+# Versioning policy
+
+Operational policy for evolving the contracts described in [API_STABILITY.md](API_STABILITY.md). This document is normative for everyone landing changes that touch a public surface.
+
+## 1. Versioning schemes
+
+Different surfaces use different schemes — pick the right one for the contract:
+
+| Surface | Scheme | Carrier |
+|---|---|---|
+| Gradle plugin (`ee.schimke.composeai.preview`) | Semver | Maven Central coordinate version |
+| CLI (`compose-preview`) | Semver | GitHub release tag, `compose-preview --version` |
+| VS Code extension | Semver | VSIX manifest |
+| MCP server | Semver | Tied to CLI release |
+| Annotation library (`preview-annotations`) | Semver | Maven Central coordinate |
+| Daemon JSON-RPC protocol | Integer | `protocolVersion` in `initialize` |
+| `previews.json` | Integer | `schemaVersion` field |
+| Per-data-product payload | Integer | `schemaVersion` per `DataProductCapability` |
+| `HistoryEntry` sidecar JSON | Integer | `schemaVersion` field |
+| GH composite actions | Semver via tag/SHA | Consumer `uses:` ref |
+
+Plugin / CLI / extension share one release-please-driven semver chain (see [RELEASING.md](RELEASING.md)). Protocol and schema integers are independent.
+
+## 2. Semver rules for the published artifacts
+
+For plugin, CLI, extension, MCP, annotations:
+
+- **Major** — breaking change to any public contract on the artifact. See § 3.
+- **Minor** — additive change: new feature, new flag, new DSL property, new annotation, new CLI subcommand, new MCP tool. New optional fields on existing types.
+- **Patch** — bug fix with no contract change. No new public surface.
+
+Pre-1.0 (today): minor bumps may carry breaking changes with a clear note in CHANGELOG. Post-1.0 they may not.
+
+## 3. What counts as breaking
+
+By surface:
+
+- **Plugin DSL** — removing or renaming a `Property<T>`, retyping it, removing a nested extension, removing an enum value, changing a `convention(...)` default in a way that flips semantics for an existing user, raising the supported AGP/Kotlin/Compose floor outside the matrix-slide rule (§ 6).
+- **CLI** — removing or renaming a flag or subcommand, changing exit codes, changing `--json` output shape (other than additive fields), changing default behavior of an existing flag.
+- **MCP** — removing a tool, renaming a tool, narrowing an input schema, changing the meaning of an existing input or output field.
+- **Annotation library** — removing a parameter, renaming a parameter, retyping a parameter, reordering an annotation array literal default.
+- **Daemon protocol** — anything outside the additive list in [API_STABILITY.md § 2.1](API_STABILITY.md#21-daemon-json-rpc-surface-1).
+- **`previews.json` / `HistoryEntry` schemas** — same as the protocol: removed/renamed fields, semantic changes.
+- **GH actions** — removing an input, changing a default that would change observed behavior for a workflow that didn't override it, renaming a default branch convention.
+
+Anything else is additive.
+
+## 4. The wire-format rules
+
+These apply to surfaces 1, 2, 3, and the history sidecar.
+
+### 4.1 Enum discipline
+
+Every enum that crosses a process boundary is decoded **tolerantly**:
+
+- An unknown string maps to a per-enum `UNKNOWN` value (Kotlin) or a falsy sentinel (TypeScript).
+- Code branching on the enum has an explicit `else` / default arm.
+- The fixture corpus has at least one fixture per enum that exercises a synthetic future value to prove tolerance.
+
+Adding a new enum value is **additive** under this rule. Without tolerant decode, every new enum value is a silent break — the rule is what makes the additive promise real. See [ROADMAP_1_0.md § Enum tolerance](ROADMAP_1_0.md) for the migration.
+
+### 4.2 Unknown fields
+
+Both sides ignore unknown JSON fields. Kotlin uses `Json { ignoreUnknownKeys = true }` (already configured); TypeScript decoders use a structural cast and only key off documented fields.
+
+### 4.3 Optional vs required
+
+New fields are **always** optional, with a documented default. The default must preserve old-behavior semantics. Promoting an optional field to required is a breaking change.
+
+### 4.4 Capabilities, not version checks
+
+Clients gate features on `ServerCapabilities` entries, not on `daemonVersion` semver. New features always add a capability flag, even when they look "obviously additive".
+
+### 4.5 protocolVersion bumps
+
+Bumping `protocolVersion` requires:
+
+- A coordinated daemon + every-client release.
+- A migration note in [docs/daemon/PROTOCOL.md](daemon/PROTOCOL.md).
+- Daemon support for the previous version for one minor cycle (clients may take longer to ship).
+- Updated fixture corpus.
+
+Post-1.0 the daemon advertises a `{min, max}` range and serves both. The VS Code extension supports `current..current-1` daemons.
+
+## 5. Deprecation policy
+
+Applies to plugin DSL, CLI flags, MCP tools, and any other named public surface.
+
+1. **Mark deprecated** in the same release that introduces the replacement.
+   - Kotlin: `@Deprecated(level = WARNING, replaceWith = ...)`.
+   - CLI: warning to stderr on use; mention in `--help` with strikethrough text.
+   - MCP: prefix tool description with `[DEPRECATED]` and document the replacement.
+   - GH action input: warning step that prints to the job log.
+2. **Keep functional** for at least two minor releases (≥ 6 months elapsed, whichever is longer).
+3. **Escalate to ERROR** in a subsequent minor (Kotlin: `level = ERROR`; CLI: warning becomes louder).
+4. **Remove** only at a major.
+
+Exceptions are permitted only for security fixes, documented in CHANGELOG.
+
+## 6. Toolchain compatibility (AGP × Kotlin × Compose × Robolectric)
+
+The plugin declares a **supported matrix** in [RENDERER_COMPATIBILITY.md](RENDERER_COMPATIBILITY.md). The matrix slides on its own cadence:
+
+- Adding a newer corner is **additive** (any minor).
+- Dropping a corner older than 18 months is permitted at any **minor** with one release of warning (`apply()` prints "AGP X.Y is deprecated; will be unsupported in compose-preview Z.0").
+- Dropping multiple majors at once requires a plugin **major**.
+
+`apply()` enforces the matrix at configuration time. Out-of-range versions fail with a specific error message naming both the consumer's version and the supported range.
+
+The CI integration suite covers at least three matrix points: current, current-1, and next-RC.
+
+## 7. Branch conventions (GH actions)
+
+The default branches are part of the public contract:
+
+- `compose-preview/main`, `compose-preview/pr`
+- `compose-preview/resources/main`, `compose-preview/resources/pr`
+- `compose-preview/a11y/main`, `compose-preview/a11y/pr`
+
+These names are **frozen forever**. PR comments published by the comment action embed permanent commit URLs on these branches; renaming them retroactively breaks every linked image in every closed PR.
+
+Adding new branch conventions for new pipelines is fine. Renaming an existing one is not.
+
+## 8. Release coordination
+
+Single release train governed by release-please. The plugin, CLI, MCP, extension, and annotations all bump together at minor and major; patches are independent per artifact.
+
+Daemon protocol versions and per-data-product schema versions are decoupled — a release may bump `protocolVersion` from 1 to 2 without bumping the artifact major (the artifact major bumps for *consumer-visible* breakage; the protocol bump is invisible to plugin/CLI consumers as long as the daemon supports the previous version).
+
+## 9. Compatibility testing
+
+Three layers, all required to remain green on `main`:
+
+1. **Fixture corpus** — `docs/daemon/protocol-fixtures/` round-trips on Kotlin and TypeScript.
+2. **Kotlin BCV** — `binary-compatibility-validator` on `:gradle-plugin` and `:preview-annotations`.
+3. **Toolchain integration matrix** — `.github/workflows/integration.yml` runs sample renders against the AGP matrix corners.
+
+Adding a public type or annotation without updating the BCV golden file is a CI failure. Adding a wire message without a fixture is a CI failure. Bumping the AGP corner without a green integration run is a CI failure.
+
+## 10. Pre-1.0 disclaimer
+
+Until `1.0.0`, the rules in §§ 2–5 are aspirational; the project may break any contract in any release with a CHANGELOG note. The contracts in [API_STABILITY.md](API_STABILITY.md) become enforceable at 1.0.
+
+The work needed to make 1.0 honourable is in [ROADMAP_1_0.md](ROADMAP_1_0.md).


### PR DESCRIPTION
## Summary

This PR introduces three comprehensive design documents that establish the contracts, evolution rules, and pre-1.0 readiness checklist for the compose-preview project:

- **API_STABILITY.md** — Defines the nine public contract surfaces (daemon protocol, CLI, plugin DSL, annotations, etc.), how each evolves, and the negotiation mechanisms between clients and servers.
- **VERSIONING.md** — Operationalizes the stability design with concrete rules for semver bumps, breaking changes, deprecation cycles, and toolchain compatibility.
- **ROADMAP_1_0.md** — A prioritized punch list of 19 items (P0/P1/P2) that must land before 1.0 can be cut, covering wire-format hardening, toolchain validation, API surface locks, CLI stability, and release process freezes.

## Key Changes

### API_STABILITY.md
- Documents nine externally-observable surfaces with their stability tiers and evolution stories
- Establishes negotiation mechanisms: `protocolVersion` ranges for daemon JSON-RPC, `schemaVersion` integers for `previews.json` and data products, capability bags for feature detection
- Defines tolerant enum decoding as a requirement to make "additive enum values are non-breaking" real
- Specifies multi-version support windows (e.g., VS Code extension supports daemon N..N-1)
- Clarifies what the design explicitly does not do (no daemon semver checks, no multiplexing, no silent renames)

### VERSIONING.md
- Prescribes semver for plugin/CLI/extension/MCP/annotations; integer versioning for protocols and schemas
- Details breaking-change definitions per surface (DSL, CLI, MCP, annotations, protocol, schemas, GH actions)
- Establishes wire-format rules: tolerant enum decode, unknown-field ignoring, optional-only new fields, capability-based feature detection
- Defines a three-step deprecation cycle: mark deprecated → keep functional for 2+ minors → escalate to error → remove at major
- Specifies toolchain matrix sliding rules (drop corners older than 18 months at any minor; multiple majors only at major)
- Freezes GH action branch conventions forever (post-1.0)
- Requires three compatibility-testing layers: fixture corpus, Kotlin BCV, and integration matrix

### ROADMAP_1_0.md
- **P0 blockers** (19 items total):
  - Wire-format hardening: tolerant enum decoding on 20+ enums, `schemaVersion` on `previews.json` and `HistoryEntry`, `protocolVersion` range negotiation
  - Toolchain compatibility: plugin `apply()` validates AGP/Kotlin/Compose versions, CI matrix testing
  - Public API surface lock: Kotlin BCV on plugin and annotations, audit and tag the plugin DSL
  - CLI surface: migrate to clikt, document exit codes and `--json` schemas
  - Release process: branch convention freeze, CHANGELOG audit
- **P1 should-land** (5 items): MCP tool deprecation infrastructure, extension protocol negotiation, fixture corpus completeness, `doctor` command enhancements, per-data-product schema docs
- **P2 defer to 1.1** (4 items): daemon semver ranges, stable plugin SPI, multi-client support, schema migration helpers

## Notable Implementation Details

- The design treats the daemon protocol as a negotiated contract where both client and server advertise `{min, max}` version ranges and operate at the intersection, failing closed only if ranges don't overlap.
- Tolerant enum decoding is positioned as a load-bearing requirement: without it, every new enum value silently breaks old clients, invalidating the additive-enum promise.
- The plugin DSL is split into `@Stable` (semver-governed) and `@Incubating` (opt-in, may change) tiers to allow DSL churn without breaking the contract.
- GH action branch names are frozen forever because PR comments embed permanent commit URLs on them; renaming retroactively breaks every linked image in closed PRs.
- The deprecation cycle is asymmetric: mark and keep functional for 2+ minors, then escalate

https://claude.ai/code/session_01Byh5ZLMBCsdQN1pkQStTcQ