### PR TITLE
fix(vscode): suppress duplicate refresh logs and collapse blank-line gaps

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -146,6 +146,12 @@ let panel: PreviewPanel | null = null;
 let debounceTimer: NodeJS.Timeout | null = null;
 let selectedModule: string | null = null;
 let pendingRefresh: AbortController | null = null;
+// Args of the most recent `[refresh] start` line we emitted. Used to suppress
+// the start log when a superseding refresh is invoked with identical args
+// (typical at startup, when activation, panel restore, and editor-focus paths
+// can each schedule the same refresh in quick succession). The Gradle task
+// itself still gets aborted + restarted; we only quiet the duplicate log.
+let pendingRefreshKey: string | null = null;
 let hasPreviewsLoaded = false;
 let lastLoadedModules: string[] = [];
 /**
@@ -2773,9 +2779,15 @@ async function refresh(
     }
 
     // Cancel any in-flight refresh
+    const wasInFlight = pendingRefresh !== null;
+    const previousRefreshKey = pendingRefreshKey;
     pendingRefresh?.abort();
     const abort = new AbortController();
     pendingRefresh = abort;
+    // Cleared until we resolve the scope and reach the start-log gate;
+    // early-return paths (no-module, gated) leave it null so a later
+    // refresh with the same args still gets a start log.
+    pendingRefreshKey = null;
 
     // The panel is always scoped to exactly one Kotlin source file. If no
     // suitable file is available (webview has focus → activeTextEditor is
@@ -2811,9 +2823,14 @@ async function refresh(
     if (currentScopeFile && currentScopeFile !== activeFile) {
         clearHeavyRefreshOptIns();
     }
-    logLine(
-        `start forceRender=${forceRender} file=${path.basename(activeFile)} (${scopeSource}) module=${module.modulePath}`,
-    );
+    const refreshKey = `${forceRender}|${tier}|${activeFile}|${module.modulePath}`;
+    const sameAsInFlight = wasInFlight && previousRefreshKey === refreshKey;
+    pendingRefreshKey = refreshKey;
+    if (!sameAsInFlight) {
+        logLine(
+            `start forceRender=${forceRender} file=${path.basename(activeFile)} (${scopeSource}) module=${module.modulePath}`,
+        );
+    }
 
     // LSP gate. Saves a 5–30 s round-trip through compileKotlin when the
     // user is mid-typo-fix — the active file's diagnostics already tell us
@@ -3319,6 +3336,7 @@ async function refresh(
         tracker.abort();
         if (pendingRefresh === abort) {
             pendingRefresh = null;
+            pendingRefreshKey = null;
         }
     }
 }

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -1019,17 +1019,21 @@ export class GradleService {
                         this.logger.appendLine(`> ${task} cancelled`);
                         throw new TaskCancelledError(task);
                     }
-                    this.logger.appendLine(`> ${task} FAILED: ${message}`);
                     detector.end();
                     kotlinDetector.end();
                     const finding = detector.getFinding();
                     if (finding) {
+                        // Caller logs a JDK-specific failure line; the generic
+                        // gRPC "Could not execute build" message would just be
+                        // noise next to it.
                         throw new JdkImageError(finding, task);
                     }
                     const kotlinErrors = kotlinDetector.getErrors();
                     if (kotlinErrors.length > 0) {
+                        // Same here: caller logs a typed Kotlin error summary.
                         throw new KotlinCompileError(kotlinErrors, task);
                     }
+                    this.logger.appendLine(`> ${task} FAILED: ${message}`);
                     throw new Error(
                         `Gradle task ${task} failed. See Output > Compose Preview.`,
                     );

--- a/vscode-extension/src/logFilter.ts
+++ b/vscode-extension/src/logFilter.ts
@@ -116,6 +116,12 @@ export class LogFilter {
     private warnedOnce = new Set<string>();
     private inConfigureBlock = false;
     private inRoborazziBlock = false;
+    // Tracks whether the last line we emitted from filterGradleChunk was blank,
+    // so that dropping interstitial content between blanks doesn't accumulate
+    // multiple consecutive blank lines in the output channel. Persists across
+    // chunks since Gradle's tooling-API splits a single FAILURE block over
+    // several stdout chunks.
+    private prevEmittedBlank = false;
 
     constructor(
         private readonly levelProvider: () => LogLevel = () => "normal",
@@ -143,7 +149,17 @@ export class LogFilter {
             const isLast = i === lines.length - 1;
             const decision = this.classifyGradleLine(line);
             if (decision === "keep") {
+                const isBlank = line.trimEnd().length === 0;
+                if (isBlank && this.prevEmittedBlank) {
+                    if (isLast) {
+                        out.push("");
+                    }
+                    continue;
+                }
                 out.push(line);
+                if (!isLast) {
+                    this.prevEmittedBlank = isBlank;
+                }
                 continue;
             }
             if (decision === "drop") {
@@ -328,5 +344,6 @@ export class LogFilter {
         this.warnedOnce.clear();
         this.inConfigureBlock = false;
         this.inRoborazziBlock = false;
+        this.prevEmittedBlank = false;
     }
 }

--- a/vscode-extension/src/test/logFilter.test.ts
+++ b/vscode-extension/src/test/logFilter.test.ts
@@ -173,6 +173,39 @@ describe("LogFilter", () => {
                 "e: Incremental compilation failed: foo.bin (No such file)\nw: Some warning\n",
             );
         });
+
+        it("collapses consecutive blank lines left behind by dropped sections", () => {
+            const f = withLevel("quiet");
+            const out = f.filterGradleChunk(
+                "FAILURE: Build failed with an exception.\n" +
+                    "\n" +
+                    "* What went wrong:\n" +
+                    "A problem occurred configuring project ':gradle-plugin'.\n" +
+                    "> Build cancelled.\n" +
+                    "\n" +
+                    "* Try:\n" +
+                    "> Run with --stacktrace option to get the stack trace.\n" +
+                    "> Run with --info or --debug option to get more log output.\n" +
+                    "\n" +
+                    "BUILD FAILED in 19s\n",
+            );
+            assert.strictEqual(
+                out,
+                "FAILURE: Build failed with an exception.\n" +
+                    "\n" +
+                    "* What went wrong:\n" +
+                    "\n" +
+                    "BUILD FAILED in 19s\n",
+            );
+        });
+
+        it("collapses blank lines across chunk boundaries", () => {
+            const f = withLevel("quiet");
+            // Two adjacent blank lines split across separate Gradle stdout
+            // chunks should still collapse to a single blank in the output.
+            assert.strictEqual(f.filterGradleChunk("\n"), "\n");
+            assert.strictEqual(f.filterGradleChunk("\n"), "");
+        });
     });
 
     describe("filterGradleChunk at verbose", () => {


### PR DESCRIPTION
## Summary

Three small wins for the "Compose Preview" output channel:

- **Dedupe the `[refresh] start ...` line** when an in-flight refresh with identical args is being superseded. Activation, panel restore, and editor-focus events can each schedule the same refresh in quick succession; logging the start three times back-to-back was noise.
- **Collapse consecutive blank lines** in `filterGradleChunk` so dropping the body of a `FAILURE` block at quiet level doesn't leave a gap of six empty newlines between `* What went wrong:` and `BUILD FAILED`.
- **Stop logging the generic `> :module:task FAILED: 13 INTERNAL: ...`** line in `GradleService` when a typed `JdkImageError` / `KotlinCompileError` is about to be thrown — the caller already prints a more useful `[refresh] FAILED — N Kotlin compile error(s) in :samples:wear:...` summary right after.

The Gradle task itself still gets aborted + restarted on a duplicate refresh; this PR only quiets the log. A follow-up will look at why activation/focus/panel-restore stack three refresh calls in the first place (which is also what's been wedging the build into "Build cancelled." at startup).

## Test plan

- [x] `npm run compile`
- [x] `npm test` — 731 tests pass, including two new `filterGradleChunk` cases that cover the blank-line collapse (single-chunk FAILURE block and across-chunk boundaries)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfLgEZUCQAutvbZXGZF7rg)_