### PR TITLE
fix(vscode): coalesce identical concurrent refresh calls instead of aborting Gradle

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2778,29 +2778,44 @@ async function refresh(
         return "no-module";
     }
 
-    // Cancel any in-flight refresh
-    const wasInFlight = pendingRefresh !== null;
-    const previousRefreshKey = pendingRefreshKey;
-    pendingRefresh?.abort();
-    const abort = new AbortController();
-    pendingRefresh = abort;
-    // Cleared until we resolve the scope and reach the start-log gate;
-    // early-return paths (no-module, gated) leave it null so a later
-    // refresh with the same args still gets a start log.
-    pendingRefreshKey = null;
-
     // The panel is always scoped to exactly one Kotlin source file. If no
     // suitable file is available (webview has focus → activeTextEditor is
     // undefined, build script, Log/Output pane has focus) the panel shows the
     // empty state rather than falling through to an ambiguous multi-file view.
     // Picks, in priority: caller > active editor > any visible Kotlin editor >
     // last-scoped file. See resolveScopeFile for the full chain.
+    //
+    // Resolved up-front (before the abort below) so we can detect a redundant
+    // call against an in-flight refresh with the same args and bail without
+    // disrupting Gradle.
     const { file: activeFile, source: scopeSource } =
         resolveScopeFile(forFilePath);
     const module =
         activeFile && isPreviewSourceFile(activeFile)
             ? gradleService.resolveModule(activeFile)
             : null;
+
+    // Coalesce identical concurrent refreshes. Activation, panel restore, and
+    // editor-focus events can each schedule the same refresh within ~100ms;
+    // aborting + restarting Gradle for each one wedges the build into a
+    // "Build cancelled." loop where no render ever finishes. The in-flight
+    // refresh will produce the same result this caller wants, so let it run.
+    if (activeFile && module && pendingRefresh !== null) {
+        const incomingKey = `${forceRender}|${tier}|${activeFile}|${module.modulePath}`;
+        if (pendingRefreshKey === incomingKey) {
+            return "cancelled";
+        }
+    }
+
+    // Cancel any in-flight refresh (different args — superseded)
+    pendingRefresh?.abort();
+    const abort = new AbortController();
+    pendingRefresh = abort;
+    // Cleared until we reach the start-log gate; early-return paths
+    // (no-module, gated) leave it null so a later refresh with the same args
+    // still runs.
+    pendingRefreshKey = null;
+
     if (!activeFile || !module) {
         logLine(
             `no module — activeFile=${activeFile ?? "<none>"} (${scopeSource})`,
@@ -2823,14 +2838,10 @@ async function refresh(
     if (currentScopeFile && currentScopeFile !== activeFile) {
         clearHeavyRefreshOptIns();
     }
-    const refreshKey = `${forceRender}|${tier}|${activeFile}|${module.modulePath}`;
-    const sameAsInFlight = wasInFlight && previousRefreshKey === refreshKey;
-    pendingRefreshKey = refreshKey;
-    if (!sameAsInFlight) {
-        logLine(
-            `start forceRender=${forceRender} file=${path.basename(activeFile)} (${scopeSource}) module=${module.modulePath}`,
-        );
-    }
+    pendingRefreshKey = `${forceRender}|${tier}|${activeFile}|${module.modulePath}`;
+    logLine(
+        `start forceRender=${forceRender} file=${path.basename(activeFile)} (${scopeSource}) module=${module.modulePath}`,
+    );
 
     // LSP gate. Saves a 5–30 s round-trip through compileKotlin when the
     // user is mid-typo-fix — the active file's diagnostics already tell us


### PR DESCRIPTION
**Stacked on #961** — please review/merge that one first. The diff in this PR includes the four files from #961 plus one additional change in `extension.ts` (the coalescing logic).

## Summary

Activation, panel restoration, and editor-focus events can each schedule the same `refresh(false, Previews.kt, "full")` within ~100 ms of each other. With the existing logic, the second and third calls just `pendingRefresh.abort()` the in-flight Gradle task and start an identical one. The Tooling API surfaces that abort as a `Build cancelled.` exception inside `:gradle-plugin` configuration; sometimes that wedges the configuration cache so subsequent refreshes keep cancelling themselves. End state: panel shows a compile-error banner over stale cards and never produces a fresh render — the symptom in the screenshot the user shared.

The fix builds on the dedupe-key infrastructure from #961:

1. Move scope resolution **above** `pendingRefresh.abort()` so we can compute the incoming refresh key before deciding whether to abort.
2. If an in-flight refresh has the same key, return `"cancelled"` and let it run. Every duplicate caller waits for the same panel update side-effects, so they all get what they wanted.
3. Different-args refreshes still supersede the in-flight one — module switch, force-render upgrade, focus to a new file all behave as before.

#961 added `pendingRefreshKey` so we could *quiet* the duplicate `[refresh] start` log; this PR uses the same key to *prevent* the duplicate work in the first place.

## Test plan

- [x] `npm run compile`
- [x] `npm test` — 731 tests pass
- [ ] Manual: open VS Code with `samples/wear/Previews.kt` already focused; confirm only one `[refresh] start … (caller) module=:samples:wear` line and one `> :samples:wear:discoverPreviews` invocation at activation, and that the panel actually paints cards instead of stalling on `Build cancelled.`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfLgEZUCQAutvbZXGZF7rg)_