### PR TITLE
Replace base64 encoding with SHA256 hash for freshness stamp paths

### DIFF
--- a/vscode-extension/src/renderFreshness.ts
+++ b/vscode-extension/src/renderFreshness.ts
@@ -1,3 +1,4 @@
+import * as crypto from "crypto";
 import * as fs from "fs";
 import * as path from "path";
 import { PreviewInfo } from "./types";
@@ -41,14 +42,19 @@ export function renderFreshnessStampPath(
     module: ModuleRef,
     sourceFile: string,
 ): string {
-    const encoded = Buffer.from(sourceFile).toString("base64url");
+    const hash = crypto
+        .createHash("sha256")
+        .update(sourceFile)
+        .digest("hex")
+        .slice(0, 16);
+    const base = path.basename(sourceFile);
     return path.join(
         workspaceRoot,
         module.projectDir,
         "build",
         "compose-previews",
         "render-freshness",
-        `${encoded}.json`,
+        `${base}-${hash}.json`,
     );
 }
 


### PR DESCRIPTION
## Summary
Updated the `renderFreshnessStampPath` function to use SHA256 hashing instead of base64 encoding for generating freshness stamp file names.

## Key Changes
- Added `crypto` module import for SHA256 hashing
- Replaced base64url encoding of the full source file path with a 16-character SHA256 hash
- Changed stamp file naming from `{base64-encoded-path}.json` to `{filename}-{hash}.json` format
- The new format includes the original base filename alongside the hash for improved readability and debuggability

## Implementation Details
- Uses `crypto.createHash("sha256")` to generate a hash of the source file path
- Truncates the hash to 16 characters (8 bytes in hex) to keep file names reasonably short
- Maintains the same directory structure and file location for freshness stamps
- The combination of base filename and hash provides both human readability and collision resistance

https://claude.ai/code/session_013BjWxR6c1FLCpEUnEhC3Tr