### PR TITLE
Fix card title overflow by preventing flex shrinking below content width

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1713,6 +1713,11 @@ body {
 
 .card-title-row .card-title {
     flex: 1;
+    /* min-width:0 lets the flex item shrink below its intrinsic content width;
+       without it, an unbreakable function name (e.g. RemoteIconButtonEnabledPreview)
+       expands the button to the full word width and pushes the focus icon out of
+       the row. The full name stays available via the hover tooltip. */
+    min-width: 0;
     text-align: left;
     background: transparent;
     border: none;
@@ -1720,6 +1725,17 @@ body {
     padding: 0;
     font: inherit;
     font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Trailing affordances in the title row keep their intrinsic width so a
+   long, unbreakable title can't push them off-row. */
+.card-title-row .card-focus-btn,
+.card-title-row .card-stale-btn,
+.card-title-row .animation-icon {
+    flex: none;
 }
 
 /* Focus icon next to the title — clicking enters focus mode for that card.


### PR DESCRIPTION
## Summary
This change fixes a layout issue where long, unbreakable card titles (like function names) would expand their container and push focus/stale icons off the row. The fix ensures titles can shrink and truncate while keeping trailing affordances visible.

## Key Changes
- Added `min-width: 0` to `.card-title-row .card-title` to allow flex items to shrink below intrinsic content width
- Added text truncation styles (`overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`) to card titles
- Added `flex: none` to trailing affordance elements (`.card-focus-btn`, `.card-stale-btn`, `.animation-icon`) to prevent them from being pushed off-row
- Added explanatory comments documenting the layout behavior and tooltip fallback

## Implementation Details
The solution leverages CSS flexbox behavior where `min-width: 0` overrides the default `auto` value, allowing flex items to shrink below their content size. Long titles are now truncated with an ellipsis while remaining accessible via hover tooltips. Trailing icons maintain their intrinsic width and won't be displaced by title overflow.

https://claude.ai/code/session_0169Tv4QdDjs6zwF5TyypKBQ