### PR TITLE
Only refresh inspector panel when in focus mode

### DIFF
--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -220,7 +220,13 @@ export class LiveStateController {
         this.postLiveCommand(previewId, plan.turnOnTarget);
         this.applyLiveBadge();
         this.cfg.applyInteractiveButtonState();
-        this.cfg.renderInspector(card);
+        // The focus inspector is a focus-mode-only panel — refreshing it from a
+        // grid-layout click would un-hide the Inspect surface (data extensions,
+        // legends, reports) on top of the grid. Only repaint when the inspector
+        // is actually showing.
+        if (this.cfg.inFocus()) {
+            this.cfg.renderInspector(card);
+        }
     }
 
     /** Single-click-to-LIVE entry point from the in-card image click handler.


### PR DESCRIPTION
## Summary
Fixed an issue where clicking on a card in grid layout would unnecessarily refresh the inspector panel, causing the Inspect surface (data extensions, legends, reports) to appear on top of the grid even when not in focus mode.

## Changes
- Added a conditional check before calling `renderInspector()` to only refresh the inspector panel when focus mode is active
- The inspector panel is now only repainted when `this.cfg.inFocus()` returns true, preventing unwanted UI overlays in grid layout mode

## Implementation Details
The fix wraps the `renderInspector(card)` call with a focus mode check. Since the focus inspector is a focus-mode-only panel, refreshing it from a grid-layout click would incorrectly display the Inspect surface on top of the grid. This change ensures the inspector is only updated when the user is actually in focus mode.

https://claude.ai/code/session_01TrHdx88De4PXLDEwQPuAEN