### PR TITLE
fix(plugin): drop private @Preview methods at discovery with a warning

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -167,12 +167,14 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
       ClassGraph()
         .enableMethodInfo()
         .enableAnnotationInfo()
-        // Kotlin `private fun` compiles to a JVM `private` method and
-        // ClassGraph's default visibility filter drops it; `internal
-        // fun` compiles to JVM `public` (with the `name$module` mangle)
-        // so it slips through. Without this flag, projects that follow
-        // the "private @Preview to keep them out of the namespace"
-        // convention silently surface zero previews.
+        // Surface JVM-private methods so the loop below can actively warn
+        // when a `private fun` is annotated with @Preview (the renderer's
+        // `getDeclaredComposableMethod` fails on private composables, so
+        // we drop them — see the `method.isPrivate` branch). Without this
+        // flag ClassGraph's default visibility filter would drop them
+        // silently and the user would never learn why their preview
+        // disappeared. `internal fun` compiles to JVM `public` (with the
+        // `name$module` mangle) and passes the default filter regardless.
         .ignoreMethodVisibility()
         .overrideClasspath(classpath.map { it.absolutePath })
         .ignoreParentClassLoaders()
@@ -200,6 +202,34 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
               if (annotations.isNotEmpty()) scanMethodsWithAnnotations++
               for (ann in annotations) {
                 annotationFqnCounts.merge(ann.name, 1, Int::plus)
+              }
+              // Kotlin `private fun` compiles to a JVM `private` method.
+              // `ComposableMethod` resolution at render time fails on those
+              // (NoSuchMethodException from `getDeclaredComposableMethod`, see
+              // RenderEngine), so the renderer cannot invoke private @Preview
+              // composables. Discover into a probe list first, and if anything
+              // came out, drop it with a clear warning instead of letting it
+              // surface and fail downstream. `internal fun` compiles to JVM
+              // `public` (with the `name$module` mangle) and is unaffected.
+              if (method.isPrivate) {
+                val probe = mutableListOf<PreviewInfo>()
+                discoverFromMethod(
+                  classInfo,
+                  method,
+                  annotations.toList(),
+                  scanResult,
+                  projectClassFqns,
+                  probe,
+                )
+                if (probe.isNotEmpty()) {
+                  logger.warn(
+                    "composePreview: skipping private @Preview " +
+                      "'${classInfo.name}.${method.name}' — private composables cannot be " +
+                      "reflectively invoked by the renderer; make it `internal` or `public` " +
+                      "to surface this preview."
+                  )
+                }
+                continue
               }
               discoverFromMethod(
                 classInfo,


### PR DESCRIPTION
The renderer's `getDeclaredComposableMethod` cannot resolve JVM-private
composables (NoSuchMethodException), so private `@Preview` functions
that ClassGraph surfaced via `ignoreMethodVisibility()` were reaching
the daemon and failing at render time. Probe each private method
through the discovery pipeline and, if it would have produced a
preview, log a warning naming the function and pointing at the fix
(`make it internal or public`) instead of emitting it to the manifest.