### PR TITLE
Add reusable Codex PR review workflow (preview-gated) and docs

### DIFF
--- a/.github/workflows/codex-pr-review-reusable.yml
+++ b/.github/workflows/codex-pr-review-reusable.yml
@@ -1,0 +1,274 @@
+name: Codex PR Review (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      preview_status:
+        description: "Result of upstream preview job/workflow (e.g. success, failure, cancelled, skipped)."
+        required: true
+        type: string
+      preview_images_artifact:
+        description: "Artifact name containing preview images from the PR/head build."
+        required: false
+        type: string
+        default: compose-preview-images
+      preview_diff_artifact:
+        description: "Artifact name containing generated visual diff images."
+        required: false
+        type: string
+        default: compose-preview-diff-images
+      preview_baseline_artifact:
+        description: "Artifact name containing baseline preview images and/or metadata."
+        required: false
+        type: string
+        default: compose-preview-baseline
+      preview_metadata_artifact:
+        description: "Artifact name containing preview index/metadata JSON files."
+        required: false
+        type: string
+        default: compose-preview-metadata
+      strict_mode:
+        description: "Fail the workflow when Codex reports blocking visual regressions."
+        required: false
+        type: boolean
+        default: false
+      post_review_comment:
+        description: "Whether to post a PR comment with review output."
+        required: false
+        type: boolean
+        default: true
+      update_pr_branch:
+        description: "Attempt to commit review artifacts back to the PR branch; skips with warning when not permitted."
+        required: false
+        type: boolean
+        default: true
+      code_diff_paths:
+        description: "Optional newline-delimited path globs for code review focus."
+        required: false
+        type: string
+        default: ""
+    secrets:
+      codex_api_key:
+        description: "API key used by Codex review tooling."
+        required: true
+      github_token:
+        description: "Token used to read artifacts and write PR comments/checks."
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  codex-pr-review:
+    name: Codex PR review
+    runs-on: ubuntu-latest
+    outputs:
+      review_status: ${{ steps.set-status.outputs.review_status }}
+      blocking_findings: ${{ steps.set-status.outputs.blocking_findings }}
+      review_summary_path: ${{ steps.set-status.outputs.review_summary_path }}
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Java 21
+        uses: actions/setup-java@5ee0d849887c110cf94ae5f7d2aeb5b3f87f5f55 # v5.0.0
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@e6f91f20b04f46f0ad197610f2d91b7f68e0f04c # v3.2.2
+
+      - name: Install compose-preview-review skill
+        env:
+          SKILL_REPO: yschimke/compose-ai-tools
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install "codex-cli>=0.1.0"
+          codex skills install --github "$SKILL_REPO" --name compose-preview-review
+
+      - name: Capture PR code diff
+        id: code-diff
+        run: |
+          set -euo pipefail
+          mkdir -p review-input
+          git fetch --no-tags --prune --depth=1 origin "${{ github.base_ref }}"
+          git diff --unified=0 "origin/${{ github.base_ref }}...HEAD" > review-input/code.diff
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" > review-input/changed-files.txt
+          {
+            echo "code_diff_path=review-input/code.diff"
+            echo "changed_files_path=review-input/changed-files.txt"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download preview artifacts
+        if: ${{ inputs.preview_status == 'success' }}
+        uses: actions/download-artifact@95815c38cf65f0f7be28e0db867f65f0f4bb63f1 # v4.2.1
+        with:
+          path: review-input/previews
+          merge-multiple: false
+          pattern: |
+            ${{ inputs.preview_images_artifact }}
+            ${{ inputs.preview_diff_artifact }}
+            ${{ inputs.preview_baseline_artifact }}
+            ${{ inputs.preview_metadata_artifact }}
+
+      - name: Evaluate context readiness
+        id: context
+        run: |
+          set -euo pipefail
+          reason=""
+          if [[ "${{ inputs.preview_status }}" != "success" ]]; then
+            reason="preview workflow status was '${{ inputs.preview_status }}'"
+          elif [[ ! -d review-input/previews ]]; then
+            reason="preview artifacts were not downloaded"
+          fi
+
+          if [[ -n "$reason" ]]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "reason=$reason" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+            echo "reason=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Codex review (code + preview)
+        id: codex
+        if: ${{ steps.context.outputs.ready == 'true' }}
+        env:
+          CODEX_API_KEY: ${{ secrets.codex_api_key }}
+        run: |
+          set -euo pipefail
+          mkdir -p review-output
+          codex review \
+            --skill compose-preview-review \
+            --code-diff "${{ steps.code-diff.outputs.code_diff_path }}" \
+            --changed-files "${{ steps.code-diff.outputs.changed_files_path }}" \
+            --preview-dir review-input/previews \
+            --focus-paths "${{ inputs.code_diff_paths }}" \
+            --output-json review-output/codex-review.json \
+            --output-markdown review-output/codex-review.md
+
+      - name: Emit blocked status when context is missing
+        if: ${{ steps.context.outputs.ready != 'true' }}
+        run: |
+          set -euo pipefail
+          mkdir -p review-output
+          cat > review-output/codex-review.md <<EOF
+          ## Codex PR Review — Blocked
+
+          Codex review did not run because required preview context was unavailable.
+
+          **Reason:** ${{ steps.context.outputs.reason }}
+
+          ### Missing context / blocked checks
+          - Code review context: available
+          - Preview review context: unavailable
+          - Visual diff checks: blocked
+          EOF
+          cat > review-output/codex-review.json <<EOF
+          {"status":"blocked","blocking_findings":0,"reason":"${{ steps.context.outputs.reason }}"}
+          EOF
+
+      - name: Optionally update PR branch with review artifacts
+        if: ${{ inputs.update_pr_branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "::warning::Skipping PR branch update because event is ${{ github.event_name }} (not pull_request)."
+            exit 0
+          fi
+
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "::warning::Skipping PR branch update for fork PR (no safe push permission)."
+            exit 0
+          fi
+
+          branch="${{ github.event.pull_request.head.ref }}"
+          if [[ -z "$branch" ]]; then
+            echo "::warning::Skipping PR branch update because PR head ref is unavailable."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          mkdir -p .codex/review-output
+          cp review-output/codex-review.md .codex/review-output/codex-review.md
+          cp review-output/codex-review.json .codex/review-output/codex-review.json
+          git add .codex/review-output/codex-review.md .codex/review-output/codex-review.json
+
+          if git diff --cached --quiet; then
+            echo "No PR branch update needed; review artifacts unchanged."
+            exit 0
+          fi
+
+          git commit -m "chore: update codex review artifacts"
+          if ! git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:${branch}"; then
+            echo "::warning::Unable to push Codex review artifacts to PR branch (insufficient permissions or branch protection)."
+          fi
+
+      - name: Publish PR comment
+        if: ${{ inputs.post_review_comment }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.github_token }}
+          script: |
+            const fs = require('fs')
+            const body = fs.readFileSync('review-output/codex-review.md', 'utf8')
+            const marker = '<!-- codex-pr-review -->'
+            const fullBody = `${marker}\n${body}`
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const existing = comments.find((c) => c.body && c.body.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: fullBody,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: fullBody,
+              })
+            }
+
+      - name: Set outputs
+        id: set-status
+        run: |
+          set -euo pipefail
+          status=$(python - <<'PY'
+import json
+with open('review-output/codex-review.json', encoding='utf-8') as f:
+    data = json.load(f)
+print(data.get('status', 'unknown'))
+PY
+)
+          blocking=$(python - <<'PY'
+import json
+with open('review-output/codex-review.json', encoding='utf-8') as f:
+    data = json.load(f)
+print(int(data.get('blocking_findings', 0)))
+PY
+)
+          {
+            echo "review_status=$status"
+            echo "blocking_findings=$blocking"
+            echo "review_summary_path=review-output/codex-review.md"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Enforce strict mode
+        if: ${{ inputs.strict_mode && steps.set-status.outputs.blocking_findings != '0' }}
+        run: |
+          echo "Strict mode enabled and blocking findings were reported."
+          exit 1

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -1,0 +1,57 @@
+name: Codex PR Review
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codex-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Generate previews for review context
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Render Android sample previews
+        run: ./gradlew :samples:android:renderAllPreviews
+      - name: Render CMP sample previews
+        run: ./gradlew :samples:cmp:renderAllPreviews
+      - name: Upload preview images
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: compose-preview-images
+          path: |
+            samples/android/build/compose-previews/renders
+            samples/cmp/build/compose-previews/renders
+          if-no-files-found: warn
+      - name: Upload preview metadata
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: compose-preview-metadata
+          path: |
+            samples/android/build/compose-previews/**/*.json
+            samples/cmp/build/compose-previews/**/*.json
+          if-no-files-found: warn
+
+  codex-review:
+    name: Codex review (preview-gated)
+    needs: [preview]
+    uses: ./.github/workflows/codex-pr-review-reusable.yml
+    with:
+      preview_status: ${{ needs.preview.result }}
+      post_review_comment: true
+      strict_mode: false
+    secrets:
+      codex_api_key: ${{ secrets.CODEX_API_KEY }}
+      github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -1,32 +1,21 @@
-name: Preview Comment
+name: Preview Comment (Legacy / Manual)
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize]
-    paths-ignore:
-      - "skills/**"
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/integration.yml"
-      - ".github/workflows/preview-comment.yml"
+  workflow_dispatch:
 
-# Workflow-level: read only. Jobs that need to push renders or comment on
-# the PR widen below.
+# Superseded by codex-pr-review.yml + codex-pr-review-reusable.yml for PRs.
 permissions:
   contents: read
 
 concurrency:
-  group: preview-comment-${{ github.event.pull_request.number }}
+  group: preview-comment-manual
   cancel-in-progress: true
 
 jobs:
   compare:
-    name: Compare previews
+    name: Compare previews (legacy)
     runs-on: ubuntu-latest
     permissions:
-      # preview-comment composite action appends a commit to the shared
-      # compose-preview/pr branch and upserts a PR comment with
-      # before/after images.
       contents: write
       pull-requests: write
     steps:
@@ -36,5 +25,4 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/preview-comment
         with:
-          # See preview-baselines.yml for the source-vs-release rationale.
           cli-version: source

--- a/README.md
+++ b/README.md
@@ -105,3 +105,107 @@ Have one to add? Open a PR or [an issue](https://github.com/yschimke/compose-ai-
 - [Releases](https://github.com/yschimke/compose-ai-tools/releases) ·
   [Changelog](CHANGELOG.md) ·
   [License (Apache 2.0)](LICENSE)
+
+## Reusable Codex PR review workflow (Preview-gated)
+
+Use `.github/workflows/codex-pr-review-reusable.yml` to run Codex PR review **only after** preview generation succeeds and with both code + visual context.
+
+### Minimal caller setup
+This repository wires the reusable workflow in `.github/workflows/codex-pr-review.yml` using a `preview` job plus a thin `uses:` call to the reusable workflow.
+
+To avoid duplicate PR review comments, `.github/workflows/preview-comment.yml` is now kept as a legacy manual (`workflow_dispatch`) workflow.
+
+
+```yaml
+name: PR Review (Codex + Preview)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    outputs:
+      preview_status: ${{ job.status }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./gradlew :app:renderAllPreviews
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compose-preview-images
+          path: app/build/compose-previews/renders
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compose-preview-diff-images
+          path: app/build/compose-previews/diffs
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compose-preview-metadata
+          path: app/build/compose-previews/**/*.json
+
+  codex-review:
+    needs: [preview]
+    uses: yschimke/compose-ai-tools/.github/workflows/codex-pr-review-reusable.yml@main
+    with:
+      preview_status: ${{ needs.preview.result }}
+      strict_mode: true
+    secrets:
+      codex_api_key: ${{ secrets.CODEX_API_KEY }}
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Artifact contract
+
+- `compose-preview-images`: rendered head/PR preview images.
+- `compose-preview-diff-images`: visual diffs (baseline vs PR/head), if your preview pipeline generates them.
+- `compose-preview-baseline`: optional baseline images used to generate diffs.
+- `compose-preview-metadata`: preview index and mapping files (for example: preview id → file path/module).
+
+### Runtime/toolchain provided by reusable workflow
+
+- Java 21 (`actions/setup-java`, `JAVA_HOME` from the action).
+- Android SDK (`android-actions/setup-android`).
+- `compose-preview-review` skill installation from `yschimke/compose-ai-tools`.
+- Code diff capture (`git diff`) plus artifact download for visual review.
+
+### Failure modes / troubleshooting
+
+- **Preview failed/cancelled/skipped**: workflow posts a blocked comment and does not run Codex visual review.
+- **Artifacts missing**: workflow posts a blocked comment with “missing context” details.
+- **Strict mode enabled** + blocking findings: reusable workflow fails its check.
+- **PR branch update** (`update_pr_branch`, default `true`): workflow attempts to commit `.codex/review-output/{codex-review.md,codex-review.json}` to the PR branch; for fork PRs or restricted tokens it skips with a warning.
+- **No preview diffs available**: Codex still reviews code + available preview images and explicitly marks missing visual-diff context.
+
+### Optional integration patterns
+
+- `needs:` pattern (shown above): same workflow, same run.
+- `workflow_run` pattern: trigger a second workflow after preview workflow completion and pass `preview_status: success` plus artifact names into the reusable workflow call.
+
+### Example review comment template
+
+```md
+## Codex PR Review
+
+### Code findings
+- [blocking] `ui/ProfileCard.kt:84` Null-state branch removed; can crash in empty profile payload.
+- [warning] `ui/Theme.kt:42` Hard-coded color bypasses design token.
+
+### Preview findings
+- [blocking] `ProfileCard_Default.png` text overlaps avatar at 320dp width.
+- [warning] `SettingsScreen_Dark.png` contrast drop on secondary action.
+
+### Missing context / blocked checks
+- Baseline metadata for `WearSummaryPreview` missing.
+- Visual diff for `TabletLandscape` not present in uploaded artifacts.
+```
+
+### Validation recipe with intentional bad UI change
+
+1. Intentionally regress a composable (for example, shrink parent width and increase fixed text size to force clipping).
+2. Run your preview job to regenerate preview images and visual diffs.
+3. Open/update a PR and confirm:
+   - Preview job succeeds.
+   - Reusable Codex workflow runs after preview (`needs`/`workflow_run` gate).
+   - PR comment includes both code and preview findings.
+   - In strict mode, blocking visual regression findings fail the check.


### PR DESCRIPTION
### Motivation

- Provide a reusable, preview-gated GitHub Actions workflow that runs Codex PR review with both code and visual preview context to surface visual regressions alongside code findings.
- Support safe artifact handling and optional PR-branch commits of review artifacts while preventing duplicate PR comments from existing preview-comment flow.
- Document the new integration and usage patterns so repositories can easily call the reusable workflow with a minimal `preview` job.

### Description

- Add `/.github/workflows/codex-pr-review-reusable.yml` implementing a reusable workflow that sets up Java/Android, installs the `compose-preview-review` skill, captures `git diff`, downloads preview artifacts, runs `codex review`, writes `review-output` artifacts, optionally commits `.codex/review-output/*` to the PR branch, posts or updates a PR comment, and emits outputs plus an optional strict-mode failure via `inputs.strict_mode`.
- Add `/.github/workflows/codex-pr-review.yml` as a thin caller that renders previews, uploads preview artifacts, and invokes the reusable workflow with `uses:` and the preview job result.
- Change `/.github/workflows/preview-comment.yml` to a legacy/manual `workflow_dispatch` flow and rename the job/metadata to avoid duplicate automated PR comments when using the new reusable workflow.
- Update `README.md` with usage examples, artifact contract, runtime/toolchain notes, failure modes, and a validation recipe showing how to wire the reusable workflow.

### Testing

- No automated tests were executed as part of this change (these are CI workflow and documentation changes and must be validated by running the workflows on GitHub Actions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff13465e748324b47e784d55e1d191)