### PR TITLE
fix: correct YAML indentation in codex review reusable workflow

### DIFF
--- a/.github/workflows/codex-pr-review-reusable.yml
+++ b/.github/workflows/codex-pr-review-reusable.yml
@@ -354,19 +354,19 @@ jobs:
         run: |
           set -euo pipefail
           status=$(python - <<'PY'
-import json
-with open('review-output/codex-review.json', encoding='utf-8') as f:
-    data = json.load(f)
-print(data.get('status', 'unknown'))
-PY
-)
+          import json
+          with open('review-output/codex-review.json', encoding='utf-8') as f:
+              data = json.load(f)
+          print(data.get('status', 'unknown'))
+          PY
+          )
           blocking=$(python - <<'PY'
-import json
-with open('review-output/codex-review.json', encoding='utf-8') as f:
-    data = json.load(f)
-print(int(data.get('blocking_findings', 0)))
-PY
-)
+          import json
+          with open('review-output/codex-review.json', encoding='utf-8') as f:
+              data = json.load(f)
+          print(int(data.get('blocking_findings', 0)))
+          PY
+          )
           {
             echo "review_status=$status"
             echo "blocking_findings=$blocking"


### PR DESCRIPTION
### Motivation
- Fix a YAML parse error in the reusable GitHub Actions workflow where inline Python heredoc blocks under a `run: |` step were not indented correctly, causing a parser failure around line 357 of `.github/workflows/codex-pr-review-reusable.yml`.

### Description
- Adjusted indentation of the inline Python heredoc blocks in the `Set outputs` step so the Python snippets are nested under the `run: |` block and the workflow is valid YAML for GitHub Actions.

### Testing
- Parsed the updated workflow with the Ruby YAML loader using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/codex-pr-review-reusable.yml'); puts 'ok'"`, which returned `ok` indicating successful parsing.
- Attempted to parse with Python `yaml.safe_load` but this check failed due to the environment missing the `yaml` module, so the Ruby validation was used as the authoritative parse check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3a3366e88324a4b33730503d7db4)