### PR TITLE
fix(vscode): wire daemon data products into focus inspector reports

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -541,6 +541,23 @@ export async function activate(
                         nodes: decoded.nodes ?? undefined,
                     });
                 }
+                if (panel) {
+                    const payloads = dataProducts
+                        .map((dp) => ({
+                            kind: dp.kind,
+                            payload:
+                                dp.payload ??
+                                readJsonPath(dp.path, outputChannel),
+                        }))
+                        .filter((dp) => dp.payload !== undefined);
+                    if (payloads.length > 0) {
+                        panel.postMessage({
+                            command: "updateDataProducts",
+                            previewId,
+                            dataProducts: payloads,
+                        });
+                    }
+                }
             },
             onClasspathDirty: (moduleId, detail) => {
                 outputChannel.appendLine(

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -409,6 +409,11 @@ export type ExtensionToWebview =
           nodes?: AccessibilityNode[] | null;
       }
     | {
+          command: "updateDataProducts";
+          previewId: string;
+          dataProducts: { kind: string; payload: unknown }[];
+      }
+    | {
           command: "setImageError";
           previewId: string;
           captureIndex: number;

--- a/vscode-extension/src/webview/preview/focusInspector.ts
+++ b/vscode-extension/src/webview/preview/focusInspector.ts
@@ -67,6 +67,8 @@ export interface FocusInspectorConfig {
     getA11yFindings(previewId: string): readonly AccessibilityFinding[];
     /** Latest a11y hierarchy nodes for a preview. */
     getA11yNodes(previewId: string): readonly AccessibilityNode[];
+    /** Latest daemon data product payload for preview/kind. */
+    getDataProduct?(previewId: string, kind: string): unknown;
     /** `previewId` whose a11y overlay subscription is currently on. */
     getA11yOverlayId(): string | null;
     /** Whether [previewId] is currently in the live (interactive) set. */
@@ -663,7 +665,14 @@ export class FocusInspectorController {
         findings: readonly AccessibilityFinding[],
     ): { kind: string; presentation: ProductPresentation }[] {
         const nodes = this.config.getA11yNodes(previewId);
-        const ctx: PresenterContext = { card, preview, findings, nodes };
+        const ctx: PresenterContext = {
+            card,
+            preview,
+            findings,
+            nodes,
+            data: (kind: string) =>
+                this.config.getDataProduct?.(previewId, kind),
+        };
         const out: { kind: string; presentation: ProductPresentation }[] = [];
         // The error presenter is implicit: we always invoke it so a
         // render error surfaces even when the user hasn't enabled

--- a/vscode-extension/src/webview/preview/focusPresentation.ts
+++ b/vscode-extension/src/webview/preview/focusPresentation.ts
@@ -49,6 +49,8 @@ export interface PresenterContext {
     findings: readonly AccessibilityFinding[];
     /** Latest cached a11y hierarchy nodes, or empty. */
     nodes: readonly AccessibilityNode[];
+    /** Latest daemon data-product payload for this kind, if any. */
+    data?(kind: string): unknown;
 }
 
 /** Bag of contributions a presenter can make to one or more surfaces.
@@ -249,18 +251,56 @@ function a11yFindingsPresenter(
 }
 
 function composeThemePresenter(
-    _ctx: PresenterContext,
+    ctx: PresenterContext,
 ): ProductPresentation | null {
-    // Theme tokens are a placeholder until `compose/theme` lands as a
-    // real data product; the report mount is what we're proving here.
+    const payload = ctx.data?.("compose/theme") as
+        | {
+              colors?: Record<string, string>;
+              typography?: Record<string, string>;
+              shapes?: Record<string, string>;
+          }
+        | undefined;
+    if (!payload) {
+        const body = document.createElement("div");
+        body.className = "focus-report-empty";
+        body.textContent =
+            "Theme tokens will appear here when the daemon attaches `compose/theme`.";
+        return {
+            report: {
+                title: "Theme tokens",
+                summary: "Awaiting data",
+                body,
+            },
+        };
+    }
     const body = document.createElement("div");
-    body.className = "focus-report-empty";
-    body.textContent =
-        "Theme tokens will appear here when the daemon attaches `compose/theme`.";
+    const rows = document.createElement("ul");
+    rows.className = "focus-report-list";
+    const addSection = (title: string, values: Record<string, string> = {}) => {
+        const keys = Object.keys(values);
+        if (keys.length === 0) return;
+        const header = document.createElement("li");
+        header.textContent = title;
+        rows.appendChild(header);
+        for (const key of keys.sort()) {
+            const li = document.createElement("li");
+            li.textContent = `${key}: ${values[key]}`;
+            rows.appendChild(li);
+        }
+    };
+    addSection("Colors", payload.colors);
+    addSection("Typography", payload.typography);
+    addSection("Shapes", payload.shapes);
+    if (!rows.hasChildNodes()) {
+        body.className = "focus-report-empty";
+        body.textContent = "compose/theme payload was empty.";
+    } else {
+        body.appendChild(rows);
+    }
     return {
         report: {
             title: "Theme tokens",
-            summary: "Awaiting data",
+            summary: "Daemon data",
             body,
         },
     };

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -374,6 +374,7 @@ export class PreviewApp extends LitElement {
         let inspector!: FocusInspectorController;
         let liveState!: LiveStateController;
         let focusController!: FocusController;
+        const dataProductsByPreview = new Map<string, Map<string, unknown>>();
 
         inspector = new FocusInspectorController({
             el: focusInspector,
@@ -398,6 +399,8 @@ export class PreviewApp extends LitElement {
                     []
                 );
             },
+            getDataProduct: (previewId, kind) =>
+                dataProductsByPreview.get(previewId)?.get(kind),
             getA11yOverlayId: a11yOverlay,
             isLive: (id) => liveState.isLive(id),
             onToggleA11yOverlay: () => focusController.toggleA11yOverlay(),
@@ -702,6 +705,20 @@ export class PreviewApp extends LitElement {
             ensureNotBlank,
             applyA11yUpdate: (previewId, findings, nodes) =>
                 applyA11yUpdate(previewId, findings, nodes, cardBuilderConfig),
+            updateDataProducts: (previewId, dataProducts) => {
+                let byKind = dataProductsByPreview.get(previewId);
+                if (!byKind) {
+                    byKind = new Map();
+                    dataProductsByPreview.set(previewId, byKind);
+                }
+                for (const dp of dataProducts) {
+                    byKind.set(dp.kind, dp.payload);
+                }
+                const focused = focusController.focusedCard();
+                if (focused?.dataset.previewId === previewId) {
+                    inspector.render(focused);
+                }
+            },
             focusOnCard,
         };
         window.addEventListener("message", (event) => {

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -109,6 +109,10 @@ export interface PreviewMessageContext {
         findings: readonly AccessibilityFinding[] | null | undefined,
         nodes: readonly AccessibilityNode[] | null | undefined,
     ): void;
+    updateDataProducts(
+        previewId: string,
+        dataProducts: readonly { kind: string; payload: unknown }[],
+    ): void;
     focusOnCard(card: HTMLElement): void;
 }
 
@@ -151,6 +155,9 @@ export function handleExtensionMessage(
         }
         case "updateA11y":
             ctx.applyA11yUpdate(msg.previewId, msg.findings, msg.nodes);
+            return;
+        case "updateDataProducts":
+            ctx.updateDataProducts(msg.previewId, msg.dataProducts);
             return;
         case "setModules":
             // Module selector removed from UI — module is resolved from the


### PR DESCRIPTION
### Motivation
- Focus inspector presenters could not access daemon-attached data-product payloads (e.g. `compose/theme`), so reported legends/reports were limited to placeholders and a11y hierarchy only.
- The change aims to surface decoded per-preview/per-kind payloads to the webview inspector so presenters can render richer reports and overlays.

### Description
- Add a new `updateDataProducts` `ExtensionToWebview` message and emit it from `onDataProductsAttached` in the extension with decoded payloads when available.
- Cache per-preview / per-kind payloads in the webview runtime (`dataProductsByPreview` in `main.ts`) and re-render the focused inspector when fresh data arrives.
- Extend the `PreviewMessageContext` / `FocusInspectorConfig` with an optional `getDataProduct(previewId, kind)` hook and thread an optional `data(kind)` accessor into `PresenterContext` so presenters can read payloads safely.
- Update `focusInspector` to include the `data` accessor when building presenter contexts and fall back gracefully when the hook is absent.
- Upgrade the `compose/theme` presenter to render colors/typography/shapes sections from daemon payloads instead of only showing the placeholder text when data is present.
- Update types (`types.ts`), message dispatch (`messageHandlers.ts`), and extension wiring (`extension.ts`) to carry the new message and payload shape.

### Testing
- Ran formatter: `npm --prefix vscode-extension run format` succeeded.
- Built the webview: `npm --prefix vscode-extension run compile` succeeded after iterative fixes to TypeScript call-sites introduced by the new optional API.
- Exercised webview unit-test targets during development (`focusPresentation`, `focusInspectorToggle`, `focusInspectorPersistence`): these surfaced missing API type errors which were fixed, and the TypeScript build and test compile completed successfully after the fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff39b80dec83249bb9b62f96477666)