### PR TITLE
Add test for composable overload resolution with trailing default parameter

### DIFF
--- a/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategyPathologicalTest.kt
+++ b/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategyPathologicalTest.kt
@@ -1,0 +1,37 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.runtime.Composable
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PreviewRenderStrategyPathologicalTest {
+
+    private class DefaultArgPreviewHost {
+        @Suppress("unused")
+        @Composable
+        fun PreviewWithDefaultSuffix(prefix: String, suffix: String = "default") {
+            // no-op: test only verifies reflective method resolution shape
+            val ignored = prefix + suffix
+            check(ignored.isNotEmpty())
+        }
+
+        @Suppress("unused")
+        @Composable
+        fun PreviewWithDefaultSuffix(prefix: Int) {
+            check(prefix >= 0)
+        }
+    }
+
+    @Test
+    fun `findComposableMethodWithArgs resolves overload that leaves trailing default param unsupplied`() {
+        val method = findComposableMethodWithArgs(
+            clazz = DefaultArgPreviewHost::class.java,
+            name = "PreviewWithDefaultSuffix",
+            previewArgs = listOf("prefix"),
+        )
+
+        assertEquals("PreviewWithDefaultSuffix", method.asMethod().name)
+        assertArrayEquals(arrayOf(String::class.java), method.parameterTypes)
+    }
+}


### PR DESCRIPTION
### Motivation
- Add a unit test to verify reflective resolution picks the overload that leaves a trailing default parameter unsupplied for composable preview functions.

### Description
- Add `PreviewRenderStrategyPathologicalTest.kt` which defines a `DefaultArgPreviewHost` with two `@Composable` overloads and asserts that `findComposableMethodWithArgs` resolves the `String`-parameter overload when only `prefix` is supplied.

### Testing
- Added the unit test `PreviewRenderStrategyPathologicalTest` under `renderer-android` tests and no automated tests were executed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff66e3af7883248a6c43fe7fa969f9)