### PR TITLE
fix: sanitize preview name suffixes for render output paths

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -910,7 +910,7 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
-  fun `renderOutput strips common package prefix and sanitises spaces and parens`() {
+  fun `renderOutput strips common package prefix and sanitises path-unsafe preview names`() {
     val projectDir = createCmpTestProject()
 
     val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
@@ -933,7 +933,7 @@ class DiscoveryFunctionalTest {
           Box(modifier = Modifier.size(50.dp).background(Color.Red))
       }
 
-      @Preview(name = "plain")
+      @Preview(name = "plain/with slash")
       @Composable
       fun TileDarkStates() {
           Box(modifier = Modifier.size(50.dp).background(Color.Blue))
@@ -965,7 +965,8 @@ class DiscoveryFunctionalTest {
       .isEqualTo("renders/TileLightStates_tile_light_light.png")
 
     val dark = manifest.previews.single { it.functionName == "TileDarkStates" }
-    assertThat(dark.captures.single().renderOutput).isEqualTo("renders/TileDarkStates_plain.png")
+    assertThat(dark.captures.single().renderOutput)
+      .isEqualTo("renders/TileDarkStates_plain_with_slash.png")
   }
 
   @Test

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -1156,7 +1156,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
   // varies. Fall back to device + fontScale + uiMode only if neither name nor
   // group is present.
   private fun buildVariantSuffix(params: PreviewParams): String {
-    if (!params.name.isNullOrBlank()) return "_${params.name}"
+    if (!params.name.isNullOrBlank()) return "_${sanitizeForPath(params.name)}"
     if (!params.group.isNullOrBlank()) return "_${sanitizeForPath(params.group)}"
     val parts = mutableListOf<String>()
     params.device?.substringAfterLast(":")?.takeIf { it.isNotBlank() }?.let(parts::add)


### PR DESCRIPTION
### Motivation
- Preview `name` values containing path-unsafe characters (e.g. `/`) could be interpreted as path separators and break `renderOutput` file resolution, as reported in issue #990.
- Ensure variant suffixes derived from `@Preview(name = ...)` are made filesystem-safe before being used in output filenames.

### Description
- Sanitize preview name suffixes by calling `sanitizeForPath(params.name)` in `buildVariantSuffix` so `@Preview(name = ...)` is filtered before appending to the output stem.
- Updated the functional test `DiscoveryFunctionalTest` to add a preview whose name includes a slash (`@Preview(name = "plain/with slash")`) and assert the produced `renderOutput` becomes `renders/TileDarkStates_plain_with_slash.png`.
- Left the existing `sanitizeForPath` implementation intact to preserve the whitelist replacement behaviour for other unsafe characters.

### Testing
- Attempted to run formatting and the updated functional test with `./gradlew :gradle-plugin:ktfmtFormat :gradle-plugin:functionalTest --tests "ee.schimke.composeai.plugin.DiscoveryFunctionalTest.renderOutput strips common package prefix and sanitises path-unsafe preview names"`, but the run failed in this environment due to a missing Java 17 toolchain download configuration (toolchain URL not defined). 
- The change includes a targeted functional test that exercises the new behaviour and is expected to pass in CI where the Java toolchain is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8a02cc8c83249089ae6e98189ca1)