### PR TITLE
fix(build): resolve Gradle lint warnings

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -102,6 +102,7 @@ dependencies {
   // AnimationInspector, ScrollDriver, PixelSystemFontAliases, RenderManifest,
   // PreviewRenderStrategy, etc.) — see DESIGN.md § 7.
   implementation(project(":renderer-android"))
+  implementation(libs.okio)
 
   // D2.2 — accessibility data product (registry + producer + image processor) lives in its
   // own module pair: `:data-a11y-connector` brings `:data-a11y-core` (the generic ATF +

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -1,4 +1,5 @@
 @file:JvmName("DaemonMain")
+@file:Suppress("NewApi")
 
 package ee.schimke.composeai.daemon
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -47,9 +47,9 @@ import ee.schimke.composeai.renderer.uiautomator.UiAutomatorDataProducts
 import ee.schimke.composeai.renderer.uiautomator.UiAutomatorHierarchyContextKeys
 import ee.schimke.composeai.renderer.uiautomator.UiAutomatorHierarchyExtension
 import java.io.File
-import java.util.Base64
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import okio.ByteString.Companion.decodeBase64
 
 /**
  * Robolectric/Compose render body for the preview daemon — the per-preview inner loop that turns a
@@ -939,8 +939,7 @@ data class RenderSpec(
 
     private fun String.decodePreviewOverrides(): PreviewOverrides? =
       runCatching {
-          val bytes = Base64.getUrlDecoder().decode(this)
-          json.decodeFromString(PreviewOverrides.serializer(), bytes.toString(Charsets.UTF_8))
+          decodeBase64()?.utf8()?.let { json.decodeFromString(PreviewOverrides.serializer(), it) }
         }
         .getOrNull()
   }

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 // Renderer-desktop daemon module — see docs/daemon/DESIGN.md § 4
 // ("Renderer-agnostic surface") and § 6 (module layout).
 //

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityImageProcessor.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityImageProcessor.kt
@@ -36,7 +36,7 @@ class AccessibilityImageProcessor : ImageProcessor {
       ) ?: return emptyMap()
     val extra =
       DataProductExtra(
-        name = OVERLAY_NAME,
+        name = AccessibilityDataProducer.OVERLAY_EXTRA_NAME,
         path = written.absolutePath,
         mediaType = "image/png",
         sizeBytes = written.length().takeIf { it > 0 },

--- a/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
+++ b/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.focus.FocusDirection as ComposeFocusDirection
@@ -62,7 +63,7 @@ class FocusOverrideExtension(private val seed: FocusOverride? = null) :
     CompositionLocalProvider(LocalInputModeManager provides KeyboardInputModeManager) {
       val focusManager = LocalFocusManager.current
       val active by FocusController.activeFocus
-      val lastIndex = remember { mutableStateOf(-1) }
+      val lastIndex = remember { mutableIntStateOf(-1) }
       val entered = remember { mutableStateOf(false) }
       LaunchedEffect(active) {
         val cap = active ?: return@LaunchedEffect

--- a/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusOverlay.kt
+++ b/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusOverlay.kt
@@ -8,8 +8,6 @@ import java.awt.Font
 import java.awt.Rectangle
 import java.awt.RenderingHints
 import java.io.File
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 import javax.imageio.ImageIO
 
 /**
@@ -30,7 +28,7 @@ object FocusOverlay {
 
     val rawFile = File(outputFile.parentFile, outputFile.nameWithoutExtension + ".raw." + outputFile.extension)
     runCatching {
-      Files.copy(outputFile.toPath(), rawFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+      outputFile.copyTo(rawFile, overwrite = true)
     }
 
     val image = runCatching { ImageIO.read(outputFile) }.getOrNull() ?: return

--- a/data/layoutinspector/connector/build.gradle.kts
+++ b/data/layoutinspector/connector/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
 
 plugins {
   id("composeai.maven-publishing")
@@ -23,7 +25,11 @@ dependencies {
 
 mavenPublishing {
   configure(
-    AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
+    AndroidSingleVariantLibrary(
+      javadocJar = JavadocJar.Empty(),
+      sourcesJar = SourcesJar.Sources(),
+      variant = "release",
+    )
   )
 }
 

--- a/data/pseudolocale/connector-desktop/build.gradle.kts
+++ b/data/pseudolocale/connector-desktop/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 // `:data-pseudolocale-connector-desktop` is the JVM-side counterpart to
 // `:data-pseudolocale-connector`
 // (Android). Both planners read `renderNow.overrides.localeTag` and emit a

--- a/data/pseudolocale/connector/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleResources.kt
+++ b/data/pseudolocale/connector/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleResources.kt
@@ -34,6 +34,7 @@ import ee.schimke.composeai.data.pseudolocale.Pseudolocalizer
  * the index map. Plain (non-`Spanned`) inputs still take the cheaper `transform` fast path with no
  * `SpannableStringBuilder` allocation.
  */
+@Suppress("DEPRECATION")
 internal class PseudolocaleResources(
   base: Resources,
   private val mode: Pseudolocale,

--- a/data/recomposition/connector/build.gradle.kts
+++ b/data/recomposition/connector/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 plugins {
   id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)

--- a/data/resources/connector/build.gradle.kts
+++ b/data/resources/connector/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
 
 plugins {
   id("composeai.maven-publishing")
@@ -18,7 +20,11 @@ dependencies {
 
 mavenPublishing {
   configure(
-    AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
+    AndroidSingleVariantLibrary(
+      javadocJar = JavadocJar.Empty(),
+      sourcesJar = SourcesJar.Sources(),
+      variant = "release",
+    )
   )
 }
 

--- a/data/resources/connector/src/main/kotlin/ee/schimke/composeai/daemon/ResourcesUsedDataProduct.kt
+++ b/data/resources/connector/src/main/kotlin/ee/schimke/composeai/daemon/ResourcesUsedDataProduct.kt
@@ -15,9 +15,7 @@ import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.resources.ResourcesUsedProduct
 import java.io.File
-import java.nio.file.Files
 import java.util.Collections
-import kotlin.io.path.name
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -63,6 +61,7 @@ typealias ResourcesUsedPayload = ee.schimke.composeai.data.resources.ResourcesUs
 typealias ResourceUsedReference = ee.schimke.composeai.data.resources.ResourceUsedReference
 typealias ResourceUsedConsumer = ee.schimke.composeai.data.resources.ResourceUsedConsumer
 
+@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
 class RecordingResources(
   private val base: Resources,
   assets: AssetManager,
@@ -209,19 +208,14 @@ private object ResourceSourceIndex {
   private fun buildIndex(): Map<String, String> {
     val out = linkedMapOf<String, String>()
     for (resDir in resDirs()) {
-      Files.walk(resDir.toPath()).use { paths ->
-        paths
-          .filter { Files.isRegularFile(it) }
-          .forEach { path ->
-            val parent = path.parent?.name ?: return@forEach
-            val baseType = parent.substringBefore('-')
-            val file = path.toFile()
-            if (baseType == "values" && file.extension == "xml") {
-              indexValuesFile(file, out)
-            } else if (baseType in FILE_RESOURCE_TYPES) {
-              out.putIfAbsent("$baseType/${file.nameWithoutExtension}", file.absolutePath)
-            }
-          }
+      resDir.walkTopDown().filter(File::isFile).forEach { file ->
+        val parent = file.parentFile?.name ?: return@forEach
+        val baseType = parent.substringBefore('-')
+        if (baseType == "values" && file.extension == "xml") {
+          indexValuesFile(file, out)
+        } else if (baseType in FILE_RESOURCE_TYPES) {
+          out.putIfAbsent("$baseType/${file.nameWithoutExtension}", file.absolutePath)
+        }
       }
     }
     return out
@@ -230,13 +224,9 @@ private object ResourceSourceIndex {
   private fun buildRelativeIndex(): Map<String, String> {
     val out = linkedMapOf<String, String>()
     for (resDir in resDirs()) {
-      Files.walk(resDir.toPath()).use { paths ->
-        paths
-          .filter { Files.isRegularFile(it) }
-          .forEach { path ->
-            val relative = resDir.toPath().relativize(path).joinToString("/")
-            out.putIfAbsent("res/$relative", path.toFile().absolutePath)
-          }
+      resDir.walkTopDown().filter(File::isFile).forEach { file ->
+        val relative = file.relativeTo(resDir).invariantSeparatorsPath
+        out.putIfAbsent("res/$relative", file.absolutePath)
       }
     }
     return out
@@ -275,9 +265,6 @@ private object ResourceSourceIndex {
       }
     }
   }
-
-  private fun java.nio.file.Path.joinToString(separator: String): String =
-    iterator().asSequence().joinToString(separator) { it.name }
 
   private val FILE_RESOURCE_TYPES = setOf("drawable", "layout")
 }

--- a/data/scroll/core/build.gradle.kts
+++ b/data/scroll/core/build.gradle.kts
@@ -1,10 +1,6 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
 
 plugins {
   id("composeai.maven-publishing")
@@ -28,7 +24,11 @@ dependencies {
 
 mavenPublishing {
   configure(
-    AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
+    AndroidSingleVariantLibrary(
+      javadocJar = JavadocJar.Empty(),
+      sourcesJar = SourcesJar.Sources(),
+      variant = "release",
+    )
   )
 }
 

--- a/data/strings/connector/build.gradle.kts
+++ b/data/strings/connector/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
 
 plugins {
   id("composeai.maven-publishing")
@@ -20,7 +22,11 @@ dependencies {
 
 mavenPublishing {
   configure(
-    AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
+    AndroidSingleVariantLibrary(
+      javadocJar = JavadocJar.Empty(),
+      sourcesJar = SourcesJar.Sources(),
+      variant = "release",
+    )
   )
 }
 

--- a/data/theme/connector/build.gradle.kts
+++ b/data/theme/connector/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 plugins {
   id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)

--- a/data/uiautomator/core/src/main/kotlin/ee/schimke/composeai/renderer/uiautomator/UiAutomatorPrototype.kt
+++ b/data/uiautomator/core/src/main/kotlin/ee/schimke/composeai/renderer/uiautomator/UiAutomatorPrototype.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.renderer.uiautomator
 
 import android.os.Bundle
+import android.os.Build
 import android.view.View
 import android.view.accessibility.AccessibilityNodeInfo
 import androidx.compose.ui.semantics.SemanticsActions
@@ -262,7 +263,7 @@ internal class ViewBacking(val view: View) : NodeBacking {
     get() = ani?.isCheckable
 
   override val isChecked: Boolean?
-    get() = ani?.isChecked
+    get() = ani?.checkedCompat()
 
   override val isSelected: Boolean?
     get() = ani?.isSelected
@@ -278,6 +279,14 @@ internal class ViewBacking(val view: View) : NodeBacking {
     return List(group.childCount) { i -> ViewBacking(group.getChildAt(i)) }
   }
 }
+
+private fun AccessibilityNodeInfo.checkedCompat(): Boolean =
+  if (Build.VERSION.SDK_INT >= 36) {
+    getChecked() == AccessibilityNodeInfo.CHECKED_STATE_TRUE
+  } else {
+    @Suppress("DEPRECATION")
+    isChecked
+  }
 
 /**
  * Compose-side projection. Maps `BySelector` chains onto the closest `SemanticsProperties` /
@@ -684,4 +693,3 @@ public object By {
 
   public fun scrollable(): Selector = Selector().scrollable()
 }
-

--- a/data/wallpaper/connector/build.gradle.kts
+++ b/data/wallpaper/connector/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 plugins {
   id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
@@ -16,7 +18,11 @@ dependencies {
   // KMP port of Material Color Utilities — `dynamicColorScheme(seed, isDark, style, contrast)`
   // returns the canonical Material 3 dynamic ColorScheme from a single seed color, matching what
   // Android's wallpaper-derived theming produces.
-  implementation(libs.material.kolor)
+  implementation(libs.material.kolor) {
+    exclude(group = "org.jetbrains.compose.material3")
+    exclude(group = "org.jetbrains.compose.runtime")
+    exclude(group = "org.jetbrains.compose.ui")
+  }
   testImplementation(libs.junit)
   testImplementation(compose.desktop.currentOs)
   testImplementation(compose.runtime)

--- a/docs/daemon/baseline-latency.md
+++ b/docs/daemon/baseline-latency.md
@@ -20,8 +20,8 @@ Toolchain pinned per target:
 
 | Target  | Plugins / runtimes                                                  |
 | ------- | ------------------------------------------------------------------- |
-| android | AGP 9.2.0, Kotlin 2.3.21, Robolectric 4.16.1 SDK 35, Compose BOM 2026.04.01 |
-| desktop | Compose Multiplatform 1.10.3, Kotlin 2.3.21, kotlin.jvm plugin       |
+| android | AGP 9.2.0, Kotlin 2.3.20, Robolectric 4.16.1 SDK 35, Compose BOM 2026.04.01 |
+| desktop | Compose Multiplatform 1.10.3, Kotlin 2.3.20, kotlin.jvm plugin       |
 
 ## Workloads
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
   id("composeai.maven-publishing")
   `java-gradle-plugin`
   `kotlin-dsl`
-  alias(libs.plugins.kotlin.serialization)
+  id("org.jetbrains.kotlin.plugin.serialization") version embeddedKotlinVersion
   alias(libs.plugins.ktfmt)
   alias(libs.plugins.tapmoc)
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AccessibilityAndroidFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AccessibilityAndroidFunctionalTest.kt
@@ -111,7 +111,7 @@ class AccessibilityAndroidFunctionalTest {
             // AGP 9.x bundles its own Kotlin compilation; the standalone
             // `org.jetbrains.kotlin.android` plugin is gone (and applying it now hard-errors).
             id("com.android.library") version "9.2.0"
-            id("org.jetbrains.kotlin.plugin.compose") version "2.3.21"
+            id("org.jetbrains.kotlin.plugin.compose") version "2.3.20"
             // Resolved through the synthetic project's `pluginManagement.repositories.mavenLocal()`
             // — the plugin itself is published there by the parent build's `functionalTestWithAndroid`
             // task. Pinning the version (rather than relying on `withPluginClasspath()`) keeps AGP and

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -798,38 +798,38 @@ class DiscoveryFunctionalTest {
     assertThat(plain.params.previewParameterLimit).isEqualTo(Int.MAX_VALUE)
   }
 
-
-
   @Test
   fun `discoverPreviews skips private preview methods`() {
     val projectDir = createCmpTestProject()
 
-    File(projectDir, "src/main/kotlin/test/Previews.kt").writeText(
-      """
-      package test
+    File(projectDir, "src/main/kotlin/test/Previews.kt")
+      .writeText(
+        """
+        package test
 
-      import androidx.compose.foundation.background
-      import androidx.compose.foundation.layout.Box
-      import androidx.compose.foundation.layout.size
-      import androidx.compose.runtime.Composable
-      import androidx.compose.ui.Modifier
-      import androidx.compose.ui.graphics.Color
-      import androidx.compose.ui.tooling.preview.Preview
-      import androidx.compose.ui.unit.dp
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.ui.unit.dp
 
-      @Preview
-      @Composable
-      private fun PrivatePreview() {
-          Box(modifier = Modifier.size(50.dp).background(Color.Red))
-      }
+        @Preview
+        @Composable
+        private fun PrivatePreview() {
+            Box(modifier = Modifier.size(50.dp).background(Color.Red))
+        }
 
-      @Preview
-      @Composable
-      fun PublicPreview() {
-          Box(modifier = Modifier.size(50.dp).background(Color.Blue))
-      }
-      """.trimIndent()
-    )
+        @Preview
+        @Composable
+        fun PublicPreview() {
+            Box(modifier = Modifier.size(50.dp).background(Color.Blue))
+        }
+        """
+          .trimIndent()
+      )
 
     val result =
       GradleRunner.create()
@@ -850,49 +850,51 @@ class DiscoveryFunctionalTest {
   fun `discoverPreviews skips previews with unsupported parameters`() {
     val projectDir = createCmpTestProject()
 
-    File(projectDir, "src/main/kotlin/test/Previews.kt").writeText(
-      """
-      package test
+    File(projectDir, "src/main/kotlin/test/Previews.kt")
+      .writeText(
+        """
+        package test
 
-      import androidx.compose.foundation.background
-      import androidx.compose.foundation.layout.Box
-      import androidx.compose.foundation.layout.size
-      import androidx.compose.runtime.Composable
-      import androidx.compose.ui.Modifier
-      import androidx.compose.ui.graphics.Color
-      import androidx.compose.ui.tooling.preview.Preview
-      import androidx.compose.ui.tooling.preview.PreviewParameter
-      import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-      import androidx.compose.ui.unit.dp
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.ui.tooling.preview.PreviewParameter
+        import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+        import androidx.compose.ui.unit.dp
 
-      class IntProvider : PreviewParameterProvider<Int> {
-          override val values: Sequence<Int> = sequenceOf(1)
-      }
+        class IntProvider : PreviewParameterProvider<Int> {
+            override val values: Sequence<Int> = sequenceOf(1)
+        }
 
-      @Preview
-      @Composable
-      fun UnsupportedArgPreview(value: String) {
-          Box(modifier = Modifier.size(50.dp).background(Color.Red))
-      }
+        @Preview
+        @Composable
+        fun UnsupportedArgPreview(value: String) {
+            Box(modifier = Modifier.size(50.dp).background(Color.Red))
+        }
 
-      @Preview
-      @Composable
-      fun TooManyArgsPreview(
-          @PreviewParameter(IntProvider::class) first: Int,
-          second: Int,
-      ) {
-          Box(modifier = Modifier.size(50.dp).background(Color.Green))
-      }
+        @Preview
+        @Composable
+        fun TooManyArgsPreview(
+            @PreviewParameter(IntProvider::class) first: Int,
+            second: Int,
+        ) {
+            Box(modifier = Modifier.size(50.dp).background(Color.Green))
+        }
 
-      @Preview
-      @Composable
-      fun SupportedPreview(
-          @PreviewParameter(IntProvider::class) value: Int,
-      ) {
-          Box(modifier = Modifier.size(50.dp).background(Color(value)))
-      }
-      """.trimIndent()
-    )
+        @Preview
+        @Composable
+        fun SupportedPreview(
+            @PreviewParameter(IntProvider::class) value: Int,
+        ) {
+            Box(modifier = Modifier.size(50.dp).background(Color(value)))
+        }
+        """
+          .trimIndent()
+      )
 
     val result =
       GradleRunner.create()

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,10 +5,6 @@ org.gradle.configuration-cache.problems=fail
 org.gradle.caching=true
 
 android.useAndroidX=true
-# Required opt-in for `com.android.compose.screenshot` applied in
-# :samples:android-screenshot-test. Global flag, but no-op on modules that
-# don't apply the plugin — :samples:android is unaffected.
-android.experimental.enableScreenshotTest=true
 
 # Workaround for Gradle 9 and Kotlin plugin compatibility issue, should be removed when fixed and won't be supported in Gradle 10
 org.gradle.configuration-cache.unsafe.ignore.unsupported-build-events-listeners=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.3.21"
+kotlin = "2.3.20"
 # Kotlin language/api floor for published modules. Set lower than `kotlin`
 # so consumers on an older Kotlin can still link against our artifacts —
 # tapmoc enforces this and fails the build if a transitive API dep raises
@@ -84,6 +84,7 @@ compose-ui-prerelease = "1.11.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.11.0"
 mcp-kotlin-sdk = "0.11.1"
+okio = "3.17.0"
 junit = "4.13.2"
 truth = "1.4.5"
 maven-publish = "0.36.0"
@@ -108,7 +109,7 @@ checker-qual = "4.0.0"
 # extension's seed → ColorScheme derivation (HCT tonal palettes, palette
 # styles, contrast level) so the result matches what Android's wallpaper-
 # derived dynamic theming actually produces.
-material-kolor = "4.1.1"
+material-kolor = "4.0.5"
 
 [libraries]
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
@@ -148,6 +149,7 @@ wear-protolayout-expression = { module = "androidx.wear.protolayout:protolayout-
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 mcp-kotlin-sdk-server = { module = "io.modelcontextprotocol:kotlin-sdk-server", version.ref = "mcp-kotlin-sdk" }
+okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version = "1.60.0" }

--- a/mcp/scripts/README.md
+++ b/mcp/scripts/README.md
@@ -40,7 +40,7 @@ NEXT="${VERSION%.*}.$((${VERSION##*.} + 1))"
 CP="$(pwd)/mcp/build/libs/mcp-${NEXT}-SNAPSHOT.jar"
 CP="$CP:$(pwd)/daemon/core/build/libs/core-${NEXT}-SNAPSHOT.jar"
 for jar in \
-    "$HOME/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/2.3.21/"*"/kotlin-stdlib-2.3.21.jar" \
+    "$HOME/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/2.3.20/"*"/kotlin-stdlib-2.3.20.jar" \
     "$HOME/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/1.10.2/"*"/kotlinx-coroutines-core-jvm-1.10.2.jar" \
     "$HOME/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.11.0/"*"/kotlinx-serialization-json-jvm-1.11.0.jar" \
     "$HOME/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.11.0/"*"/kotlinx-serialization-core-jvm-1.11.0.jar" \

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -3803,7 +3803,6 @@ class DaemonMcpServer(
     else content.take(8)
   }
 
-
   private fun applyImageSizeOverride(pngBytes: ByteArray): ByteArray {
     val maxEdgePx = imageSizeOverride.maxEdgePx ?: return pngBytes
     val source = runCatching { ImageIO.read(pngBytes.inputStream()) }.getOrNull() ?: return pngBytes
@@ -3811,7 +3810,12 @@ class DaemonMcpServer(
     val scale = minOf(maxEdgePx.toDouble() / source.width, maxEdgePx.toDouble() / source.height)
     val targetWidth = maxOf(1, kotlin.math.floor(source.width * scale).toInt())
     val targetHeight = maxOf(1, kotlin.math.floor(source.height * scale).toInt())
-    val target = java.awt.image.BufferedImage(targetWidth, targetHeight, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+    val target =
+      java.awt.image.BufferedImage(
+        targetWidth,
+        targetHeight,
+        java.awt.image.BufferedImage.TYPE_INT_ARGB,
+      )
     val g = target.createGraphics()
     try {
       g.setRenderingHint(
@@ -3840,10 +3844,15 @@ class DaemonMcpServer(
       fun detect(env: Map<String, String> = System.getenv()): ImageSizeOverride {
         // Claude Code frequently accumulates many screenshots in one request; Anthropic enforces a
         // 2000px/dimension cap on many-image requests there, so pre-scale defensively.
-        if (!env["CLAUDE_CODE_SESSION_ID"].isNullOrBlank() || !env["CLAUDE_ENV_FILE"].isNullOrBlank()) {
+        if (
+          !env["CLAUDE_CODE_SESSION_ID"].isNullOrBlank() || !env["CLAUDE_ENV_FILE"].isNullOrBlank()
+        ) {
           return ImageSizeOverride(maxEdgePx = 2000)
         }
-        if (env["__CFBundleIdentifier"] == "com.google.antigravity" || !env["ANTIGRAVITY_CLI_ALIAS"].isNullOrBlank()) {
+        if (
+          env["__CFBundleIdentifier"] == "com.google.antigravity" ||
+            !env["ANTIGRAVITY_CLI_ALIAS"].isNullOrBlank()
+        ) {
           return ImageSizeOverride(maxEdgePx = 3072)
         }
         if (!env["CODEX_SANDBOX"].isNullOrBlank() || !env["CODEX_SESSION_ID"].isNullOrBlank()) {

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -1,10 +1,6 @@
-@file:Suppress(
-  "DEPRECATION"
-) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
-
-// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
-
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
 
 plugins {
   id("composeai.maven-publishing")
@@ -122,6 +118,9 @@ dependencies {
   compileOnly(libs.compose.foundation)
   compileOnly(libs.compose.material3)
   compileOnly(libs.compose.runtime)
+  // Required to compile against data-ambient-connector's public extension class. Keep it
+  // compile-only so Wear apps continue to supply their own runtime ambient API version.
+  compileOnly(libs.wear.compose.foundation)
   // `compose.ui.tooling.preview` from `compose-bom-compat` (1.9.x) doesn't
   // ship `PreviewWrapper` / `PreviewWrapperProvider` — those landed in
   // ui-tooling-preview 1.11.0. We pin the 1.11+ variant here so
@@ -150,6 +149,7 @@ dependencies {
   testImplementation(libs.compose.foundation)
   testImplementation(libs.compose.material3)
   testImplementation(libs.compose.runtime)
+  testImplementation(libs.wear.compose.foundation)
   testImplementation(libs.compose.ui.tooling.preview)
   testImplementation(libs.activity.compose)
   testImplementation("androidx.compose.ui:ui-test-junit4")
@@ -202,7 +202,11 @@ dependencies {
 
 mavenPublishing {
   configure(
-    AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
+    AndroidSingleVariantLibrary(
+      javadocJar = JavadocJar.Empty(),
+      sourcesJar = SourcesJar.Sources(),
+      variant = "release",
+    )
   )
 }
 

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
@@ -37,6 +37,7 @@ import org.robolectric.annotation.Config
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [35])
+@Suppress("NewApi")
 class ResourcePreviewRenderTest {
 
   @Test

--- a/samples/android-screenshot-test/build.gradle.kts
+++ b/samples/android-screenshot-test/build.gradle.kts
@@ -14,8 +14,18 @@ plugins {
   id("composeai.android-conventions")
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
-  alias(libs.plugins.android.compose.screenshot)
+  alias(libs.plugins.android.compose.screenshot) apply false
   id("ee.schimke.composeai.preview")
+}
+
+val screenshotTestEnabled =
+  providers
+    .gradleProperty("android.experimental.enableScreenshotTest")
+    .map(String::toBoolean)
+    .getOrElse(false)
+
+if (screenshotTestEnabled) {
+  pluginManager.apply(libs.plugins.android.compose.screenshot.get().pluginId)
 }
 
 android {
@@ -30,12 +40,8 @@ android {
 
   buildFeatures { compose = true }
 
-  // Required opt-in for `com.android.compose.screenshot`. Without this the
-  // plugin registers no tasks and the `screenshotTest` source set never
-  // appears on disk — at which point we'd only discover `main` previews
-  // and this sample would degenerate into a carbon copy of
-  // `:samples:android`.
-  experimentalProperties["android.experimental.enableScreenshotTest"] = true
+  // `screenshotTest` is experimental in AGP. The source set appears only when
+  // callers opt in with `android.experimental.enableScreenshotTest=true`.
 }
 
 dependencies {
@@ -47,12 +53,14 @@ dependencies {
   implementation(libs.activity.compose)
   debugImplementation("androidx.compose.ui:ui-tooling")
 
-  // Google's plugin requires `ui-tooling` on the screenshotTest classpath
-  // to instantiate PreviewParameter providers and run the `@Preview`
-  // functions under Layoutlib. Our renderer doesn't use this configuration
-  // — it drives composables via its own ClassGraph-discovered methods —
-  // but compiling the screenshotTest source set still needs it.
-  "screenshotTestImplementation"(platform(libs.compose.bom.stable))
-  "screenshotTestImplementation"(libs.compose.ui.tooling.preview)
-  "screenshotTestImplementation"("androidx.compose.ui:ui-tooling")
+  if (screenshotTestEnabled) {
+    // Google's plugin requires `ui-tooling` on the screenshotTest classpath
+    // to instantiate PreviewParameter providers and run the `@Preview`
+    // functions under Layoutlib. Our renderer doesn't use this configuration
+    // — it drives composables via its own ClassGraph-discovered methods —
+    // but compiling the screenshotTest source set still needs it.
+    "screenshotTestImplementation"(platform(libs.compose.bom.stable))
+    "screenshotTestImplementation"(libs.compose.ui.tooling.preview)
+    "screenshotTestImplementation"("androidx.compose.ui:ui-tooling")
+  }
 }

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/AnimatedPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/AnimatedPreviews.kt
@@ -5,8 +5,8 @@ import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.rememberTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -41,11 +41,11 @@ import ee.schimke.composeai.preview.AnimatedPreview
 fun FadeInBoxAnimatedPreview() {
     // `MutableTransitionState(false)` + `targetState = true` set during
     // composition is the canonical "kick off a transition on first
-    // frame" pattern. `updateTransition` registers the transition with
+    // frame" pattern. `rememberTransition` registers the transition with
     // the slot table so AnimationSearch picks it up cleanly.
     val state = remember { MutableTransitionState(false) }
     state.targetState = true
-    val transition = updateTransition(state, label = "fade-in")
+    val transition = rememberTransition(state, label = "fade-in")
     val alpha by transition.animateFloat(
         transitionSpec = { tween(durationMillis = 600, easing = LinearOutSlowInEasing) },
         label = "alpha",

--- a/vscode-extension/.vscode/launch.json
+++ b/vscode-extension/.vscode/launch.json
@@ -2,12 +2,12 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Run Extension (artifacts, Meshcore)",
+            "name": "Run Extension (artifacts, compose-ai-tools)",
             "type": "extensionHost",
             "request": "launch",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}/.vscode-test/artifact-extension",
-                "${env:HOME}/workspace/meshcore-mobile"
+                "${env:HOME}/workspace/compose-ai-tools"
             ],
             "outFiles": [
                 "${workspaceFolder}/.vscode-test/artifact-extension/out/**/*.js"


### PR DESCRIPTION
## Summary
- align Kotlin plugin usage with Gradle embedded Kotlin and clean up Gradle deprecations
- fix Android lint/API warnings across connectors, renderer, daemon, and samples
- keep Compose baseline in charge by downgrading material-kolor to the Compose 1.9-compatible line and excluding its Compose transitives
- make screenshot-test plugin opt-in instead of using a global experimental flag

## Verification
- ./gradlew :daemon:android:compileDebugKotlin
- ./gradlew lintDebug
- dependency insight: :daemon:android now resolves org.jetbrains.compose.material3:material3:1.9.0-beta03 and androidx.compose.material3:material3:1.4.0-beta01