### PR TITLE
fix(plugin): discover Compose previews with compiler params

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -6,6 +6,7 @@ import io.github.classgraph.AnnotationInfo
 import io.github.classgraph.ClassGraph
 import io.github.classgraph.ClassInfo
 import io.github.classgraph.MethodInfo
+import io.github.classgraph.MethodParameterInfo
 import io.github.classgraph.ScanResult
 import java.io.File
 import kotlinx.serialization.json.Json
@@ -104,6 +105,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     // `expect`/`actual` collapses onto the same `androidx...` class name on
     // every target we care about.
     private const val PREVIEW_PARAMETER_FQN = "androidx.compose.ui.tooling.preview.PreviewParameter"
+    private const val COMPOSER_FQN = "androidx.compose.runtime.Composer"
 
     internal const val TILE_PREVIEW_FQN = "androidx.wear.tiles.tooling.preview.Preview"
 
@@ -609,12 +611,26 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     method: MethodInfo,
     previewParameter: Pair<String, Int>?,
   ): Boolean {
-    val parameterCount = method.parameterInfo?.size ?: 0
-    if (parameterCount == 0) return false
+    val userParameters = userPreviewParameters(method)
+    if (userParameters.isEmpty()) return false
     // Current renderer contract: preview methods are either parameterless,
     // or take exactly one value sourced by @PreviewParameter.
-    return parameterCount != 1 || previewParameter == null
+    return userParameters.size != 1 || previewParameter == null
   }
+
+  private fun userPreviewParameters(method: MethodInfo): List<MethodParameterInfo> {
+    val params = method.parameterInfo?.toList() ?: return emptyList()
+    val composerIndex = params.indexOfLast { it.typeDescriptorName() == COMPOSER_FQN }
+    if (composerIndex == -1) return params
+    val compilerMaskParams = params.drop(composerIndex + 1)
+    if (compilerMaskParams.all { it.typeDescriptorName() == "int" }) {
+      return params.take(composerIndex)
+    }
+    return params
+  }
+
+  private fun MethodParameterInfo.typeDescriptorName(): String =
+    getTypeDescriptor().toString().removePrefix("class ")
 
   /**
    * Scans [method]'s parameters for `@PreviewParameter`. Returns the provider FQN + `limit` of the

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -167,7 +167,7 @@
         "watch:webview": "node esbuild.webview.mjs --watch",
         "format": "prettier --write --tab-width 4 package.json package-lock.json tsconfig.json tsconfig.webview.json README.md \"src/**/*.ts\" \"src/**/*.json\" \"media/**/*.css\"",
         "format:check": "prettier --check --tab-width 4 package.json package-lock.json tsconfig.json tsconfig.webview.json README.md \"src/**/*.ts\" \"src/**/*.json\" \"media/**/*.css\"",
-        "test": "npm run compile && mocha --exit 'out/test/!(electron)/**/*.test.js' 'out/test/*.test.js'",
+        "test": "npm run compile && mocha --exit out/test/runMocha.js",
         "test:electron": "npm run compile && node ./out/test/electron/runTest.js",
         "test:e2e": "npm run compile && COMPOSE_PREVIEW_E2E=1 node ./out/test/electron/runTest.js",
         "lint": "eslint src --ext ts",

--- a/vscode-extension/src/test/electron/runTest.ts
+++ b/vscode-extension/src/test/electron/runTest.ts
@@ -83,6 +83,7 @@ async function main(): Promise<void> {
             "--disable-updates",
         ],
         extensionTestsEnv: {
+            ELECTRON_RUN_AS_NODE: undefined,
             COMPOSE_PREVIEW_TEST_MODE: "1",
             ...(e2eMode ? { COMPOSE_PREVIEW_E2E: "1" } : {}),
         },

--- a/vscode-extension/src/test/runMocha.ts
+++ b/vscode-extension/src/test/runMocha.ts
@@ -1,0 +1,15 @@
+import * as path from "path";
+import { globSync } from "glob";
+
+const repoRoot = path.resolve(__dirname, "../..");
+const sourceTestRoot = path.join(repoRoot, "src", "test");
+const compiledTestRoot = path.join(repoRoot, "out", "test");
+
+const sourceTests = globSync("**/*.test.ts", {
+    cwd: sourceTestRoot,
+    ignore: ["electron/**"],
+});
+
+for (const sourceTest of sourceTests) {
+    require(path.join(compiledTestRoot, sourceTest.replace(/\.ts$/, ".js")));
+}

--- a/vscode-extension/src/webview/preview/focusInspector.ts
+++ b/vscode-extension/src/webview/preview/focusInspector.ts
@@ -419,7 +419,7 @@ export class FocusInspectorController {
     }
 
     private renderSuggestionRow(
-        suggestions: readonly string[],
+        visibleSuggestions: readonly string[],
         productByKind: ReadonlyMap<string, ProductDescriptor>,
         preview: PreviewInfo,
         previewId: string,
@@ -845,14 +845,6 @@ export class FocusInspectorController {
                 const dot = document.createElement("span");
                 dot.className = "focus-legend-dot";
                 li.appendChild(dot);
-                const rank = this.suggestedRankByKind.get(p.kind);
-                if (rank != null) {
-                    const badge = document.createElement("span");
-                    badge.className = "focus-product-suggested-rank";
-                    badge.textContent = String(rank);
-                    badge.title = `Suggested item #${rank}`;
-                    option.appendChild(badge);
-                }
                 const text = document.createElement("div");
                 text.className = "focus-legend-text";
                 const lab = document.createElement("div");
@@ -1110,7 +1102,7 @@ function actionButton(
 const BUILT_IN_PRODUCTS: ProductDescriptor[] = [
     {
         kind: "local/a11y/overlay",
-        label: "Accessibility",
+        label: "Accessibility overlay",
         icon: "eye",
         hint: "Overlay",
         cost: "expensive",


### PR DESCRIPTION
## Summary
- ignore the Compose compiler-added Composer/changed/default parameter suffix when validating preview method parameters
- restores discovery for Kotlin/Compose preview functions that compile to (Composer, Int) JVM methods
- fixes the Wear sample unit test path where renderBeforeUnitTests produced an empty previews.json and missing ambient PNGs

## Verification
- ./gradlew :samples:wear:testDebugUnitTest
- ./gradlew :gradle-plugin:functionalTest --tests 'ee.schimke.composeai.plugin.DiscoveryFunctionalTest.discoverPreviews finds annotated composables'