### PR TITLE
Add blessed Codex PR review workflow and gate existing review for trusted authors

### DIFF
--- a/.github/workflows/codex-pr-review-blessed.yml
+++ b/.github/workflows/codex-pr-review-blessed.yml
@@ -1,26 +1,51 @@
-name: Codex PR Review
+name: Codex PR Review (Blessed)
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened]
+  reaction:
+    types: [created]
 
 permissions:
   contents: read
+  pull-requests: read
+  issues: read
 
 concurrency:
-  group: codex-pr-review-${{ github.event.pull_request.number }}
+  group: codex-pr-review-blessed-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   preview:
-    name: Generate previews for review context
+    if: >-
+      github.event.action == 'created' &&
+      github.event.reaction.content == 'eyes' &&
+      github.event.sender.login == github.repository_owner &&
+      github.event.issue.pull_request &&
+      !(github.event.issue.user.login == github.repository_owner || contains(fromJson(vars.AI_REVIEW_TRUSTED_AUTHORS_JSON || '[]'), github.event.issue.user.login))
+    name: Generate previews for blessed PR review
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     steps:
+      - name: Resolve PR head ref
+        id: pr-head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pr_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          head_ref=$(python - <<'PY' "$pr_json"
+import json,sys
+print(json.loads(sys.argv[1])["head"]["ref"])
+PY
+)
+          echo "ref=$head_ref" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ steps.pr-head.outputs.ref }}
           persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Render Android sample previews
@@ -45,8 +70,8 @@ jobs:
           if-no-files-found: warn
 
   codex-review:
-    if: ${{ github.event.pull_request.user.login == github.repository_owner || contains(fromJson(vars.AI_REVIEW_TRUSTED_AUTHORS_JSON || '[]'), github.event.pull_request.user.login) }}
-    name: Codex review (preview-gated)
+    if: ${{ needs.preview.result == 'success' }}
+    name: Codex review (blessed, preview-gated)
     needs: [preview]
     uses: ./.github/workflows/codex-pr-review-reusable.yml
     with:


### PR DESCRIPTION
### Motivation
- Ensure repository-owner–blessed PRs from untrusted authors get preview images generated and a Codex review while keeping the main review workflow gated for trusted authors.

### Description
- Add new workflow `.github/workflows/codex-pr-review-blessed.yml` that runs when the repository owner reacts with `eyes` to a PR and the PR author is not the owner or in the `AI_REVIEW_TRUSTED_AUTHORS_JSON` list, generating previews and uploading preview artifacts before invoking the reusable Codex review workflow.
- In the new workflow, add steps to resolve the PR head ref via the GitHub API, checkout that ref, run setup actions, render Android and CMP previews via Gradle, and upload composed preview images and metadata as artifacts, with appropriate permissions and concurrency controls.
- Update `.github/workflows/codex-pr-review.yml` to gate the `codex-review` job so it only runs automatically for PRs authored by the repository owner or trusted authors, and set `update_pr_branch: false` for consistent behavior with the blessed workflow.

### Testing
- No automated tests were executed as part of this change; these are GitHub Actions workflow YAML updates and will be exercised by GitHub Actions when the configured events occur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffabcc12b4832491dd9bd6065b1819)