### PR TITLE
Add 'Blessed' reaction-triggered Codex PR review workflow and support for external PR head checkout

### DIFF
--- a/.github/workflows/codex-pr-review-blessed.yml
+++ b/.github/workflows/codex-pr-review-blessed.yml
@@ -1,0 +1,99 @@
+name: Codex PR Review (Blessed)
+
+on:
+  reaction:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+concurrency:
+  group: codex-pr-review-blessed-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    if: >-
+      github.event.action == 'created' &&
+      github.event.reaction.content == 'eyes' &&
+      github.event.sender.login == github.repository_owner &&
+      github.event.issue.pull_request &&
+      !(github.event.issue.user.login == github.repository_owner || contains(fromJson(vars.AI_REVIEW_TRUSTED_AUTHORS_JSON || '[]'), github.event.issue.user.login))
+    name: Generate previews for blessed PR review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      pr_head_repository: ${{ steps.pr-head.outputs.repository }}
+      pr_head_ref: ${{ steps.pr-head.outputs.ref }}
+      pr_base_ref: ${{ steps.pr-head.outputs.base_ref }}
+    steps:
+      - name: Resolve PR head/base metadata
+        id: pr-head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pr_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          readarray -t pr_info < <(python - <<'PY' "$pr_json"
+          import json,sys
+          d=json.loads(sys.argv[1])
+          print(d["head"]["ref"])
+          print(d["head"]["repo"]["full_name"])
+          print(d["base"]["ref"])
+          PY
+          )
+          echo "ref=${pr_info[0]}" >> "$GITHUB_OUTPUT"
+          echo "repository=${pr_info[1]}" >> "$GITHUB_OUTPUT"
+          echo "base_ref=${pr_info[2]}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ steps.pr-head.outputs.repository }}
+          ref: ${{ steps.pr-head.outputs.ref }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Render Android sample previews
+        run: ./gradlew :samples:android:renderAllPreviews
+      - name: Render CMP sample previews
+        run: ./gradlew :samples:cmp:renderAllPreviews
+      - name: Upload preview images
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: compose-preview-images
+          path: |
+            samples/android/build/compose-previews/renders
+            samples/cmp/build/compose-previews/renders
+          if-no-files-found: warn
+      - name: Upload preview metadata
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: compose-preview-metadata
+          path: |
+            samples/android/build/compose-previews/**/*.json
+            samples/cmp/build/compose-previews/**/*.json
+          if-no-files-found: warn
+
+  codex-review:
+    if: ${{ needs.preview.result == 'success' }}
+    name: Codex review (blessed, preview-gated)
+    needs: [preview]
+    uses: ./.github/workflows/codex-pr-review-reusable.yml
+    with:
+      preview_status: ${{ needs.preview.result }}
+      pr_head_repository: ${{ needs.preview.outputs.pr_head_repository }}
+      pr_head_ref: ${{ needs.preview.outputs.pr_head_ref }}
+      base_ref: ${{ needs.preview.outputs.pr_base_ref }}
+      post_review_comment: true
+      strict_mode: false
+      update_pr_branch: false
+    secrets:
+      codex_api_key: ${{ secrets.CODEX_API_KEY }}
+      claude_api_key: ${{ secrets.CLAUDE_API_KEY }}
+      gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+      github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codex-pr-review-reusable.yml
+++ b/.github/workflows/codex-pr-review-reusable.yml
@@ -52,6 +52,16 @@ on:
         required: false
         type: string
         default: ""
+      pr_head_repository:
+        description: "Optional repository (owner/name) for the PR head checkout."
+        required: false
+        type: string
+        default: ""
+      pr_head_ref:
+        description: "Optional ref (branch or SHA) for the PR head checkout."
+        required: false
+        type: string
+        default: ""
       codex_review_command:
         description: "Override command used when Codex API key is selected."
         required: false
@@ -98,6 +108,9 @@ jobs:
     steps:
       - name: Checkout PR HEAD
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.pr_head_repository != '' && inputs.pr_head_repository || github.repository }}
+          ref: ${{ inputs.pr_head_ref != '' && inputs.pr_head_ref || github.sha }}
 
       - name: Setup Java 21
         uses: actions/setup-java@5ee0d849887c110cf94ae5f7d2aeb5b3f87f5f55 # v5.0.0

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -45,6 +45,7 @@ jobs:
           if-no-files-found: warn
 
   codex-review:
+    if: ${{ github.event.pull_request.user.login == github.repository_owner || contains(fromJson(vars.AI_REVIEW_TRUSTED_AUTHORS_JSON || '[]'), github.event.pull_request.user.login) }}
     name: Codex review (preview-gated)
     needs: [preview]
     uses: ./.github/workflows/codex-pr-review-reusable.yml
@@ -52,6 +53,7 @@ jobs:
       preview_status: ${{ needs.preview.result }}
       post_review_comment: true
       strict_mode: false
+      update_pr_branch: false
     secrets:
       codex_api_key: ${{ secrets.CODEX_API_KEY }}
       claude_api_key: ${{ secrets.CLAUDE_API_KEY }}


### PR DESCRIPTION
### Motivation
- Provide a way for repository owners to trigger AI-powered preview+review runs on external-contributor PRs using an "eyes" reaction without granting write permissions. 
- Allow the reusable Codex review workflow to checkout a PR head from a different repository/ref for preview-generation workflows. 
- Restrict the default preview-gated review in `codex-pr-review.yml` to trusted authors and disable branch updates by default for these flows.

### Description
- Add a new workflow `codex-pr-review-blessed.yml` that triggers on a created `reaction` of type `eyes` by the repository owner and runs a `preview` job to render previews and upload artifacts, then invokes the reusable review workflow with the preview artifacts. 
- Wire the preview job to resolve PR head metadata using `gh api` and checkout the PR head repository/ref, render previews via `./gradlew :samples:...:renderAllPreviews`, and upload images/metadata as artifacts. 
- Update `codex-pr-review-reusable.yml` to accept new inputs `pr_head_repository` and `pr_head_ref` and use them in the `actions/checkout` step so reusable runs can checkout external PR heads. 
- Modify `codex-pr-review.yml` to tighten the `codex-review` job `if` condition to only run for the repository owner or trusted authors and to set `update_pr_branch: false` by default for these preview-gated reviews.

### Testing
- No unit or integration tests were added or modified in this change. 
- Changed workflow YAML was inspected for syntax and sensible input/step wiring locally. 
- These workflows will be exercised automatically by GitHub Actions when the configured events (`reaction`, `pull_request`, etc.) occur in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffabcc12b4832491dd9bd6065b1819)