### PR TITLE
fix: always advertise a11y data products

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -388,23 +388,25 @@ fun main(args: Array<String>) {
                 TextStringsDataProductRegistry(rootDir = dataRoot, previewIndex = previewIndex),
             )
           )
-          if (a11yPreviewExtensionEnabled) {
-            add(
-              Extension(
-                id = "a11y",
-                displayName = "Accessibility",
-                dataProductRegistry = AccessibilityDataProductRegistry(rootDir = dataRoot),
-                dataExtensionDescriptors = AccessibilityRecordingScriptEvents.descriptors,
-                previewExtensionDescriptors =
+          add(
+            Extension(
+              id = "a11y",
+              displayName = "Accessibility",
+              dataProductRegistry = AccessibilityDataProductRegistry(rootDir = dataRoot),
+              dataExtensionDescriptors = AccessibilityRecordingScriptEvents.descriptors,
+              previewExtensionDescriptors =
+                if (a11yPreviewExtensionEnabled) {
                   listOf(
                     AccessibilitySemanticsPreviewExtension.descriptor,
                     AtfChecksPreviewExtension.descriptor,
                     AccessibilityOverlayPreviewExtension.descriptor,
                     AccessibilityAnnotatedPreviewExtension.descriptor,
-                  ),
-              )
+                  )
+                } else {
+                  emptyList()
+                },
             )
-          }
+          )
           // UIAutomator-shaped script events (`uia.click`, `uia.inputText`, etc.) plus the
           // `uia/hierarchy` data product (#874). Always wired on the Android backend — the
           // dispatch path lives in RobolectricHost and the hierarchy producer ride along on


### PR DESCRIPTION
### Motivation
- Prevent `data/subscribe` failures (`kind not advertised`) when clients request accessibility data products while preview-side a11y wrappers are disabled by ensuring the daemon always advertises the `a11y` data products when `dataRoot` exists.

### Description
- Always register the `a11y` extension in `daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt` (so `a11y/atf` and `a11y/hierarchy` appear in the daemon capabilities), and keep the preview-side wrapper descriptors gated by `composeai.a11y.previewExtension.enabled` by setting `previewExtensionDescriptors` to either the list of descriptors or `emptyList()`.

### Testing
- Attempted to compile the Android daemon with `./gradlew :daemon:android:compileKotlin`, which failed in this environment due to the Java 17 toolchain download URL not being configured (toolchain auto-provisioning error), so no passing compile/test run could be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb87dc3848324806c7a4e99626a95)