### PR TITLE
feat(a11y): subscription-driven a11y data products + protocol + UX fixes

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -167,19 +167,23 @@ class RenderEngine(
      */
     sandboxStats: SandboxLifecycleStats = SandboxLifecycleStats(),
     /**
-     * D2 — when true, render in a11y mode (`LocalInspectionMode = false`) and dump
+     * D2 / D2.2 — render in a11y mode (`LocalInspectionMode = false`) and dump
      * `a11y-atf.json` + `a11y-hierarchy.json` under [dataDir] so the daemon's data-product
      * registry can surface them as `a11y/atf` + `a11y/hierarchy`. Mirrors the design doc's
      * "produce always, gate emission on subscriptions" approach — the cost is a few ms per
-     * render, traded for simpler implementation than per-render kind threading.
+     * render.
      *
-     * Defaults to the [A11Y_PREVIEW_EXTENSION_ENABLED_PROP] system property set by the Gradle preview
-     * extension.
-     * selector. False (the default) keeps the pre-D2 paused-clock + `LocalInspectionMode = true`
-     * fast path used by the harness's fake-mode tests.
+     * `null` (the default) means *resolve from context*: a11y mode is on iff [RenderSpec.renderMode]
+     * is `"a11y"` (set by the daemon's `data/fetch` re-render path or by the host's per-preview
+     * subscription state) OR the legacy [A11Y_PREVIEW_EXTENSION_ENABLED_PROP] sysprop is `true`.
+     * Pass `true` / `false` explicitly to force the mode regardless of context (used by tests).
      */
-    runAccessibility: Boolean = System.getProperty(A11Y_PREVIEW_EXTENSION_ENABLED_PROP) == "true",
+    runAccessibility: Boolean? = null,
   ): RenderResult {
+    val effectiveRunAccessibility =
+      runAccessibility
+        ?: (spec.renderMode == A11Y_RENDER_MODE ||
+          System.getProperty(A11Y_PREVIEW_EXTENSION_ENABLED_PROP) == "true")
     // Roborazzi defaults to "compare" mode — `captureRoboImage` reads the existing baseline at
     // the target path and *doesn't* write a new PNG. The daemon writes baselines, never compares,
     // so force record mode if the surrounding JVM didn't set it. Idempotent across renders;
@@ -278,7 +282,7 @@ class RenderEngine(
                 // hierarchy walk to consume after capture. Tradeoff: infinite animations tick
                 // through rather than parking under the paused clock — same trade
                 // `RobolectricRenderTest.renderWithA11y` already pays.
-                val inspectionMode = if (runAccessibility) false else spec.inspectionMode ?: true
+                val inspectionMode = if (effectiveRunAccessibility) false else spec.inspectionMode ?: true
                 CompositionLocalProvider(LocalInspectionMode provides inspectionMode) {
                   CaptureMaterialTheme { _, typography, shapes, payload ->
                     themeFallbackCapture.capture(typography, shapes)
@@ -402,7 +406,7 @@ class RenderEngine(
             // `AccessibilityDataProductRegistry`. Wrapped in try/catch so an a11y failure does
             // not strand the PNG the user already cares about — the registry sees a missing
             // file as "no attachment for this kind on this render".
-            if (runAccessibility && dataDir != null) {
+            if (effectiveRunAccessibility && dataDir != null) {
               try {
                 trace.section("a11y:dataProducts") {
                   val view = (rule.onRoot().fetchSemanticsNode().root as ViewRootForTest).view
@@ -699,6 +703,15 @@ class RenderEngine(
      */
     const val A11Y_PREVIEW_EXTENSION_ENABLED_PROP: String =
       "composeai.previewExtensions.a11y.enabled"
+
+    /**
+     * D2.2 — `RenderSpec.renderMode` value the daemon stamps when a `data/fetch` for an a11y kind
+     * needs a fresh render, and when the host's per-preview subscription state demands a11y for
+     * the next dispatch. The engine's [runAccessibility] auto-resolution treats this as equivalent
+     * to the legacy [A11Y_PREVIEW_EXTENSION_ENABLED_PROP] sysprop being on for that one render —
+     * `LocalInspectionMode = false`, ATF + hierarchy artefacts written to `dataDir`.
+     */
+    const val A11Y_RENDER_MODE: String = "a11y"
 
     /**
      * Virtual time to advance before capture in the paused-`mainClock` path, in milliseconds.

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -398,6 +398,10 @@ class RenderEngine(
               val productStore = RecordingDataProductStore()
               for (ext in builtDataArtifactExtensions) {
                 if (ext !is PostCaptureProcessor) continue
+                System.err.println(
+                  "compose-ai-daemon: [render] phase=dataArtifact.${ext.id}.start outputBaseName=${spec.outputBaseName}"
+                )
+                val extStartNs = System.nanoTime()
                 try {
                   trace.section("dataArtifact:${ext.id}") {
                     ext.process(
@@ -410,6 +414,11 @@ class RenderEngine(
                       )
                     )
                   }
+                  System.err.println(
+                    "compose-ai-daemon: [render] phase=dataArtifact.${ext.id}.done " +
+                      "outputBaseName=${spec.outputBaseName} " +
+                      "tookMs=${(System.nanoTime() - extStartNs) / 1_000_000L}"
+                  )
                 } catch (t: Throwable) {
                   System.err.println(
                     "RenderEngine: ${ext.id} data write failed for ${spec.outputBaseName}: " +

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -215,6 +215,12 @@ class RenderEngine(
       "compose-ai-daemon: [render] ${spec.className}#${spec.functionName} " +
         "loaderId=${System.identityHashCode(classLoader).toString(16)} classFile=$fingerprint"
     )
+    System.err.println(
+      "compose-ai-daemon: [render] mode=${spec.renderMode ?: "<default>"} " +
+        "effectiveRunAccessibility=$effectiveRunAccessibility " +
+        "inspectionMode=${if (effectiveRunAccessibility) false else spec.inspectionMode ?: true} " +
+        "outputBaseName=${spec.outputBaseName}"
+    )
 
     // `device = "id:wearos_*_round"` / `isRound=true` previews need a circular crop matching the
     // standalone renderer's `RobolectricRenderTest`. The standalone path also gates on
@@ -275,6 +281,9 @@ class RenderEngine(
             // re-used during the post-capture pass below to write the artefacts.
             val builtDataArtifactExtensions = dataArtifactExtensions.build(rule.activity)
 
+            System.err.println(
+              "compose-ai-daemon: [render] phase=setContent.start outputBaseName=${spec.outputBaseName}"
+            )
             trace.section("compose:setContent") {
               rule.setContent {
                 // D2 — a11y mode flips LocalInspectionMode off so Compose populates real
@@ -305,6 +314,10 @@ class RenderEngine(
               }
             }
 
+            System.err.println(
+              "compose-ai-daemon: [render] phase=setContent.done outputBaseName=${spec.outputBaseName}"
+            )
+
             // CAPTURE_ADVANCE_MS is the same paused-clock advance `RobolectricRenderTest` uses —
             // ≈ 2 Choreographer frames. Enough to settle initial composition + one
             // `LaunchedEffect` pass; deterministic snapshot point for any infinite animation.
@@ -321,6 +334,9 @@ class RenderEngine(
             // renderer's wear-round path.
             val roborazziOptions =
               RoborazziOptions(recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = isRound))
+            System.err.println(
+              "compose-ai-daemon: [render] phase=captureRoboImage.start outputBaseName=${spec.outputBaseName}"
+            )
             rule
               .onRoot()
               .also {
@@ -328,6 +344,9 @@ class RenderEngine(
                   it.captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
                 }
               }
+            System.err.println(
+              "compose-ai-daemon: [render] phase=captureRoboImage.done outputBaseName=${spec.outputBaseName}"
+            )
 
             // Always-on data-artifact extensions (fonts, resources, semantics, layout-inspector,
             // i18n, etc). Each extension owns its own recorder lifecycle (installed during
@@ -407,6 +426,9 @@ class RenderEngine(
             // not strand the PNG the user already cares about — the registry sees a missing
             // file as "no attachment for this kind on this render".
             if (effectiveRunAccessibility && dataDir != null) {
+              System.err.println(
+                "compose-ai-daemon: [render] phase=a11y.start outputBaseName=${spec.outputBaseName}"
+              )
               try {
                 trace.section("a11y:dataProducts") {
                   val view = (rule.onRoot().fetchSemanticsNode().root as ViewRootForTest).view
@@ -442,12 +464,17 @@ class RenderEngine(
                     isRound = isRound,
                     imageProcessors = imageProcessors,
                   )
+                  System.err.println(
+                    "compose-ai-daemon: [render] phase=a11y.done outputBaseName=${spec.outputBaseName} " +
+                      "findings=${findings.findings.size} nodes=${hierarchy.nodes.size}"
+                  )
                 }
               } catch (t: Throwable) {
                 System.err.println(
-                  "RenderEngine: a11y data write failed for ${spec.outputBaseName}: " +
-                    "${t.javaClass.simpleName}: ${t.message}"
+                  "compose-ai-daemon: [render] phase=a11y.failed outputBaseName=${spec.outputBaseName} " +
+                    "error=${t.javaClass.simpleName}: ${t.message}"
                 )
+                t.printStackTrace(System.err)
               }
             }
 
@@ -549,7 +576,20 @@ class RenderEngine(
     val previousContext = Thread.currentThread().contextClassLoader
     Thread.currentThread().contextClassLoader = classLoader
     try {
+      System.err.println(
+        "compose-ai-daemon: [render] phase=evaluateRule.start outputBaseName=${spec.outputBaseName}"
+      )
       trace.section("render:evaluateRule") { rule.apply(statement, description).evaluate() }
+      System.err.println(
+        "compose-ai-daemon: [render] phase=evaluateRule.done outputBaseName=${spec.outputBaseName}"
+      )
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: [render] phase=evaluateRule.failed outputBaseName=${spec.outputBaseName} " +
+          "error=${t.javaClass.simpleName}: ${t.message}"
+      )
+      t.printStackTrace(System.err)
+      throw t
     } finally {
       Thread.currentThread().contextClassLoader = previousContext
     }
@@ -601,6 +641,10 @@ class RenderEngine(
       previewContextBuilder.putInspectionValue(MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY, it)
     }
     val previewContext = previewContextBuilder.build()
+    System.err.println(
+      "compose-ai-daemon: [render] phase=complete outputBaseName=${spec.outputBaseName} " +
+        "tookMs=$tookMs pngPath=${outputFile.absolutePath}"
+    )
     return RenderResult(
       id = requestId,
       classLoaderHashCode = System.identityHashCode(classLoader),

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -904,7 +904,7 @@ class JsonRpcServer(
    * directly. See PROTOCOL.md § 5 (`renderNow.overrides`) for the wire-level shape.
    */
   private fun encodeRenderPayload(previewId: String, overrides: PreviewOverrides?): String {
-    return buildString {
+    val base = buildString {
       if (previewId.isNotEmpty()) append("previewId=").append(previewId)
       if (overrides == null) return@buildString
       val deviceToken = overrides.device?.takeIf { it.isNotBlank() }
@@ -989,6 +989,28 @@ class JsonRpcServer(
         )
       }
     }
+    // D2.2 — sticky subscription → render-mode injection. When a panel has subscribed to any
+    // `a11y/*` kind for [previewId] (focus inspector's A11y toggle is the canonical caller),
+    // every subsequent renderNow for that preview runs in a11y mode so the ATF + hierarchy
+    // artefacts land for `attachmentsFor` to ship on the next `renderFinished`. The mode tag is
+    // the same channel the data/fetch RequiresRerender path uses; renderer-side resolution lives
+    // in `RenderEngine.runAccessibility`'s auto-mode (`spec.renderMode == "a11y"`).
+    val mode = subscriptionDrivenRenderMode(previewId) ?: return base
+    return if (base.isEmpty()) "mode=$mode" else "$base;mode=$mode"
+  }
+
+  /**
+   * D2.2 — pick the renderer-mode tag implied by [previewId]'s active subscriptions, or `null` if
+   * no subscription demands a mode. Today only the `a11y/...` kind family maps to a mode
+   * (`"a11y"`); future producers that need sticky subscription-driven render modes can extend by
+   * introducing their own kind prefix → mode mapping. Stays in [JsonRpcServer] (rather than each
+   * producer registry) so the dispatcher owns "what mode does the renderer need next" the same way
+   * it owns "which kinds are advertised."
+   */
+  private fun subscriptionDrivenRenderMode(previewId: String): String? {
+    val kinds = subscriptions[previewId] ?: return null
+    if (kinds.any { it.startsWith("a11y/") }) return "a11y"
+    return null
   }
 
   private val renderResultsQueue = LinkedBlockingQueue<Any>()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1628,6 +1628,12 @@ class JsonRpcServer(
     val attachments: List<DataProductAttachment> =
       if (requestedKinds.isEmpty()) emptyList()
       else extensions.publicDataProducts().attachmentsFor(previewId, requestedKinds)
+    System.err.println(
+      "compose-ai-daemon: [renderFinished] previewId=$previewId " +
+        "subscribedKinds=${subscriptions[previewId]?.sorted() ?: emptyList<String>()} " +
+        "globalAttachKinds=${globalAttachKinds.sorted()} " +
+        "attachments=${attachments.map { it.kind }}"
+    )
     return RenderFinishedParams(
       id = previewId,
       pngPath = pngPath,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -306,8 +306,15 @@ class JsonRpcServer(
    * plus a heavy render). Overridden at handshake time by `initialize.options.maxRenderMs` if
    * positive; values ≤ 0 are ignored and the default applies. See PROTOCOL.md § 3
    * (`initialize.options.maxRenderMs`).
+   *
+   * The constructor honours the `composeai.daemon.renderTimeoutMs` sysprop as the initial value
+   * before the handshake — useful for ad-hoc debugging when a render hangs and you want a fast
+   * failure (e.g. `-Dcomposeai.daemon.renderTimeoutMs=30000` for 30s).
    */
-  @Volatile private var renderTimeoutMs: Long = DEFAULT_RENDER_TIMEOUT_MS
+  @Volatile
+  private var renderTimeoutMs: Long =
+    System.getProperty(RENDER_TIMEOUT_PROP)?.toLongOrNull()?.takeIf { it > 0 }
+      ?: DEFAULT_RENDER_TIMEOUT_MS
 
   /**
    * D1 — sticky `(previewId, kind)` subscriptions installed by `data/subscribe`. The map is keyed
@@ -3384,6 +3391,14 @@ class JsonRpcServer(
      * single-render render body. Overridable per-session via `initialize.options.maxRenderMs`.
      */
     const val DEFAULT_RENDER_TIMEOUT_MS: Long = 5 * 60_000L
+
+    /**
+     * Sysprop override for the initial [renderTimeoutMs]. Set to a positive ms value (e.g.
+     * `-Dcomposeai.daemon.renderTimeoutMs=30000`) to surface render hangs as timeouts within a
+     * debugging-friendly window before the client's `initialize.options.maxRenderMs` lands. Unset /
+     * non-positive values keep [DEFAULT_RENDER_TIMEOUT_MS].
+     */
+    const val RENDER_TIMEOUT_PROP: String = "composeai.daemon.renderTimeoutMs"
 
     /** RECORDING.md — default `recording/start.fps` when the caller doesn't specify one. */
     const val DEFAULT_RECORDING_FPS: Int = 30

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
@@ -15,6 +15,7 @@ import ee.schimke.composeai.renderer.AccessibilityHierarchyPayload
 import ee.schimke.composeai.renderer.AccessibilityNode
 import ee.schimke.composeai.renderer.AccessibilityTouchTargetsPayload
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -156,10 +157,12 @@ object AccessibilityDataProducer {
  * registry decides whether the data ends up on the wire based on the dispatcher's subscription
  * bookkeeping.
  *
- * `attachable: true` for both kinds — they ride `renderFinished.dataProducts` when the client
- * has subscribed. `fetchable: true` for both — pull-on-demand reads from the same files. Neither
- * kind triggers a re-render: the producer always runs in daemon a11y mode, so the JSON is on
- * disk for any preview that has rendered at least once.
+ * `attachable: true` — they ride `renderFinished.dataProducts` when the client has subscribed.
+ * `fetchable: true` — pull-on-demand reads from the same files. `requiresRerender: true` (D2.2)
+ * — when the latest render didn't run in a11y mode the artefact is absent, so [fetch] returns
+ * [DataProductRegistry.Outcome.RequiresRerender] and the dispatcher queues a `mode=a11y` re-render
+ * before re-invoking. The cost of a11y mode is paid only when a panel actually subscribes, not on
+ * every render.
  *
  * `rootDir` mirrors `RenderEngine`'s `dataDir` (defaults to `<outputDir.parent>/data`). Wired by
  * [DaemonMain].
@@ -167,6 +170,20 @@ object AccessibilityDataProducer {
 class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductRegistry {
 
   private val json = Json { ignoreUnknownKeys = true }
+
+  /**
+   * D2.2 — set of `(previewId, kind)` pairs the dispatcher has reported subscribed via
+   * [onSubscribe] and not yet torn down via [onUnsubscribe] (or `setVisible` pruning, which fans
+   * out as `onUnsubscribe` calls per dropped pair). Tracked here so the host's render dispatcher
+   * can ask [isPreviewSubscribed] before queueing the next render and stamp `mode=a11y` into the
+   * payload — turning a `data/subscribe` for a focus-mode card into "all subsequent renders for
+   * this preview run with `LocalInspectionMode = false` and write the ATF/hierarchy artefacts,
+   * until focus moves on." Today the predicate has no readers wired yet (PR 1d will land that
+   * hook); the bookkeeping is structural and idempotent so adding the read site is the only
+   * remaining step.
+   */
+  private val subscribedPairs: MutableSet<Pair<String, String>> =
+    ConcurrentHashMap.newKeySet()
 
   override val capabilities: List<DataProductCapability> =
     listOf(
@@ -176,7 +193,7 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
         transport = DataProductTransport.INLINE,
         attachable = true,
         fetchable = true,
-        requiresRerender = false,
+        requiresRerender = true,
         displayName = "Accessibility findings",
         facets = listOf(DataProductFacet.STRUCTURED, DataProductFacet.CHECK, DataProductFacet.DIAGNOSTIC),
         sampling = SamplingPolicy.End,
@@ -187,7 +204,7 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
         transport = DataProductTransport.PATH,
         attachable = true,
         fetchable = true,
-        requiresRerender = false,
+        requiresRerender = true,
         displayName = "Accessibility hierarchy",
         facets = listOf(DataProductFacet.STRUCTURED),
         mediaTypes = listOf("application/json"),
@@ -199,7 +216,7 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
         transport = DataProductTransport.INLINE,
         attachable = true,
         fetchable = true,
-        requiresRerender = false,
+        requiresRerender = true,
         displayName = "Touch target findings",
         facets = listOf(DataProductFacet.STRUCTURED, DataProductFacet.CHECK, DataProductFacet.DIAGNOSTIC),
         sampling = SamplingPolicy.End,
@@ -210,7 +227,7 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
         transport = DataProductTransport.PATH,
         attachable = true,
         fetchable = true,
-        requiresRerender = false,
+        requiresRerender = true,
         displayName = "Accessibility overlay",
         facets = listOf(DataProductFacet.ARTIFACT, DataProductFacet.IMAGE, DataProductFacet.OVERLAY),
         mediaTypes = listOf("image/png"),
@@ -238,7 +255,12 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
           fileFor(previewId, AccessibilityDataProducer.FILE_OVERLAY) to DataProductTransport.PATH
         else -> return DataProductRegistry.Outcome.Unknown
       }
-    if (!file.exists()) return DataProductRegistry.Outcome.NotAvailable
+    // D2.2 — every a11y kind is `requiresRerender = true`. A missing artefact means the latest
+    // render didn't run in a11y mode (the producer's writeArtifacts is gated on
+    // `effectiveRunAccessibility`); the dispatcher reacts by queueing a re-render with
+    // `mode=a11y` and re-invoking fetch, which then finds the freshly-written file. See
+    // [DataProductRegistry.Outcome.RequiresRerender] for the dispatch contract.
+    if (!file.exists()) return DataProductRegistry.Outcome.RequiresRerender("a11y")
     val extras = extrasFor(previewId, kind)
     // The overlay kind is binary (PNG); never parse it as JSON. Path-only.
     if (kind == AccessibilityDataProducer.KIND_OVERLAY) {
@@ -398,6 +420,43 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
     }
     return out
   }
+
+  /**
+   * D2.2 — record `(previewId, kind)` so the next render of [previewId] can run in a11y mode.
+   * Idempotent across re-subscribes (the [Set] de-duplicates). Only the four advertised a11y
+   * kinds are tracked; an unrelated kind (the dispatcher routes here only after capability
+   * matching, but this is defensive) is ignored.
+   */
+  override fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {
+    if (!isAccessibilityKind(kind)) return
+    subscribedPairs.add(previewId to kind)
+  }
+
+  /**
+   * D2.2 — drop the `(previewId, kind)` bookkeeping. Fires on explicit `data/unsubscribe`, on
+   * `setVisible`-driven pruning when the preview leaves view, and on daemon shutdown. After this
+   * runs, [isPreviewSubscribed] reflects the new state synchronously.
+   */
+  override fun onUnsubscribe(previewId: String, kind: String) {
+    if (!isAccessibilityKind(kind)) return
+    subscribedPairs.remove(previewId to kind)
+  }
+
+  /**
+   * D2.2 — `true` iff at least one a11y kind has a live subscription for [previewId]. Designed for
+   * the host's render dispatcher: when this returns `true` the next `host.submit(...)` payload
+   * for [previewId] should carry `mode=a11y` so the renderer flips `LocalInspectionMode` and
+   * writes the ATF/hierarchy artefacts the subscribed kinds will read off disk on the next
+   * `attachmentsFor` pass.
+   */
+  fun isPreviewSubscribed(previewId: String): Boolean =
+    subscribedPairs.any { (id, _) -> id == previewId }
+
+  private fun isAccessibilityKind(kind: String): Boolean =
+    kind == AccessibilityDataProducer.KIND_ATF ||
+      kind == AccessibilityDataProducer.KIND_HIERARCHY ||
+      kind == AccessibilityDataProducer.KIND_TOUCH_TARGETS ||
+      kind == AccessibilityDataProducer.KIND_OVERLAY
 
   private fun fileFor(previewId: String, fileName: String): File =
     rootDir.resolve(previewId).resolve(fileName)

--- a/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProductRegistryTest.kt
+++ b/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProductRegistryTest.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -50,8 +51,9 @@ class AccessibilityDataProductRegistryTest {
     for (cap in registry.capabilities) {
       assertTrue(cap.attachable)
       assertTrue(cap.fetchable)
-      // The producer always runs in daemon a11y mode — no per-fetch re-render.
-      assertTrue(!cap.requiresRerender)
+      // D2.2 — a11y mode is paid per-subscription. When no artefact exists yet, fetch returns
+      // RequiresRerender and the dispatcher queues a `mode=a11y` re-render.
+      assertTrue("${cap.kind}: requiresRerender should be true", cap.requiresRerender)
     }
   }
 
@@ -192,16 +194,54 @@ class AccessibilityDataProductRegistryTest {
   }
 
   @Test
-  fun `fetch returns NotAvailable when the preview never rendered`() {
+  fun `fetch on a missing artefact returns RequiresRerender so the dispatcher can re-run in a11y mode`() {
+    // D2.2 — a11y artefacts only land when the render ran in a11y mode. A previously-untouched
+    // preview (or one rendered in the default fast path) has no `a11y-*.json` on disk; the
+    // dispatcher (`JsonRpcServer.handleDataFetchWithRerender`) reacts to RequiresRerender by
+    // queueing a `mode=a11y` re-render and re-invoking fetch.
     val registry = AccessibilityDataProductRegistry(rootDir)
-    val outcome =
-      registry.fetch(
-        previewId = "com.example.NoRender",
-        kind = "a11y/hierarchy",
-        params = null,
-        inline = false,
+    for (kind in listOf("a11y/atf", "a11y/hierarchy", "a11y/touchTargets", "a11y/overlay")) {
+      val outcome =
+        registry.fetch(
+          previewId = "com.example.NoRender",
+          kind = kind,
+          params = null,
+          inline = false,
+        )
+      assertEquals(
+        "$kind: missing artefact should trigger a re-render in a11y mode",
+        DataProductRegistry.Outcome.RequiresRerender("a11y"),
+        outcome,
       )
-    assertEquals(DataProductRegistry.Outcome.NotAvailable, outcome)
+    }
+  }
+
+  @Test
+  fun `fetch on a fresh artefact returns Ok after a previous RequiresRerender produced it`() {
+    // Mirrors the dispatcher's two-step round-trip: first fetch returns RequiresRerender, the
+    // re-render writes the artefact, the dispatcher re-invokes fetch and now sees Ok.
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    val previewId = "com.example.HomeKt#HomePreview"
+
+    // Step 1 — pre-render. Artefact missing, dispatcher would re-render.
+    val pre =
+      registry.fetch(previewId = previewId, kind = "a11y/atf", params = null, inline = true)
+    assertEquals(DataProductRegistry.Outcome.RequiresRerender("a11y"), pre)
+
+    // Step 2 — re-render in a11y mode lands the artefacts.
+    AccessibilityDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = previewId,
+      findings = emptyList(),
+      nodes = emptyList(),
+    )
+
+    // Step 3 — dispatcher re-invokes fetch; now Ok.
+    val post =
+      registry.fetch(previewId = previewId, kind = "a11y/atf", params = null, inline = true)
+    assertTrue("post-rerender fetch should be Ok, was $post", post is DataProductRegistry.Outcome.Ok)
+    val result = (post as DataProductRegistry.Outcome.Ok).result
+    assertNotNull(result.payload)
   }
 
   @Test
@@ -303,6 +343,68 @@ class AccessibilityDataProductRegistryTest {
     assertNotNull(extras)
     assertEquals(1, extras!!.size)
     assertEquals(overlay.absolutePath, extras[0].path)
+  }
+
+  @Test
+  fun `isPreviewSubscribed flips after onSubscribe and clears after onUnsubscribe`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    val previewId = "com.example.HomeKt#HomePreview"
+    assertFalse(registry.isPreviewSubscribed(previewId))
+
+    registry.onSubscribe(previewId, "a11y/atf", params = null)
+    assertTrue(registry.isPreviewSubscribed(previewId))
+
+    registry.onUnsubscribe(previewId, "a11y/atf")
+    assertFalse(registry.isPreviewSubscribed(previewId))
+  }
+
+  @Test
+  fun `isPreviewSubscribed stays true while any a11y kind remains subscribed`() {
+    // Focus inspector subscribes to a11y/atf + a11y/hierarchy as a pair (A11Y_OVERLAY_KINDS).
+    // Unsubscribing one shouldn't drop us out of a11y render mode while the other is still
+    // live — otherwise the next render strips ATF/hierarchy capture mid-overlay.
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    val previewId = "com.example.HomeKt#HomePreview"
+    registry.onSubscribe(previewId, "a11y/atf", params = null)
+    registry.onSubscribe(previewId, "a11y/hierarchy", params = null)
+
+    registry.onUnsubscribe(previewId, "a11y/atf")
+    assertTrue(
+      "still subscribed via a11y/hierarchy",
+      registry.isPreviewSubscribed(previewId),
+    )
+
+    registry.onUnsubscribe(previewId, "a11y/hierarchy")
+    assertFalse(registry.isPreviewSubscribed(previewId))
+  }
+
+  @Test
+  fun `onSubscribe is idempotent so a re-subscribe does not double-count the pair`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    val previewId = "com.example.HomeKt#HomePreview"
+    registry.onSubscribe(previewId, "a11y/atf", params = null)
+    registry.onSubscribe(previewId, "a11y/atf", params = null)
+    // One unsubscribe should clear it — if onSubscribe had double-counted, isPreviewSubscribed
+    // would still be true here.
+    registry.onUnsubscribe(previewId, "a11y/atf")
+    assertFalse(registry.isPreviewSubscribed(previewId))
+  }
+
+  @Test
+  fun `subscriptions are scoped per previewId`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    registry.onSubscribe("com.example.A", "a11y/atf", params = null)
+    assertTrue(registry.isPreviewSubscribed("com.example.A"))
+    assertFalse(registry.isPreviewSubscribed("com.example.B"))
+  }
+
+  @Test
+  fun `non-accessibility kinds passed to onSubscribe are ignored`() {
+    // The dispatcher only routes here after capability matching, but the registry stays
+    // defensive — a misrouted call must not poison the predicate.
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    registry.onSubscribe("com.example.A", "compose/recomposition", params = null)
+    assertFalse(registry.isPreviewSubscribed("com.example.A"))
   }
 
   @Test

--- a/docs/A11Y_E2E_TEST_PLAN.md
+++ b/docs/A11Y_E2E_TEST_PLAN.md
@@ -1,0 +1,160 @@
+# A11y subscription end-to-end test plan
+
+## Goal
+
+Automate the two preview scenarios that PR 1 (`subscription-driven a11y`) was
+verified against manually, so future regressions in the chip → daemon →
+attachment → webview chain surface in CI without a human looking at the
+panel.
+
+## What PR 1 wired
+
+Clicking an Accessibility chip in the focus inspector posts
+`setDataExtensionEnabled` to the host. The host:
+
+1. Sends `data/subscribe` to the daemon via `DaemonScheduler.setDataProductSubscription`.
+2. Fires a fast-tier `renderNow` for the preview (PR 1d's gap-bridge).
+3. Daemon's `JsonRpcServer.encodeRenderPayload` injects `mode=a11y` into the
+   payload because the preview is subscribed.
+4. Renderer flips `LocalInspectionMode = false` and writes ATF + hierarchy
+   artefacts.
+5. `renderFinished` fires; `attachmentsFor` ships the subscribed kinds.
+6. `daemonScheduler.handleRenderFinished` forwards via `onDataProductsAttached`.
+7. `extension.ts` decodes payloads and posts `updateA11y` to the panel.
+8. `webview/preview/applyA11yUpdate` mutates the per-card cache; `<preview-card>`'s
+   `_repaintA11yOverlaysFromCache` paints `.a11y-overlay` (findings) +
+   `.a11y-hierarchy-overlay` (translucent boxes from nodes).
+
+There are five hand-off points where a regression can hide; today we only
+catch four of them indirectly via unit tests.
+
+## Scenarios to automate
+
+### Scenario A — "hierarchy boxes paint for a clean preview"
+
+- **Sample**: `samples:wear` `ActivityListPreview` (`Devices - Large Round`).
+- **Click**: focus inspector "Accessibility hierarchy" chip ON.
+- **Expected daemon-stderr lines**: `mode=a11y`, `phase=a11y.done findings=0
+  nodes=12`, `phase=complete`, `[renderFinished] ... attachments=[a11y/hierarchy]`.
+- **Expected host-channel lines**: `[daemon] onDataProductsAttached ...
+  kinds=[a11y/hierarchy]`, `[daemon] decoded a11y for ... findings=<none>
+  nodes=12`.
+- **Expected webview state**: `.a11y-hierarchy-overlay` element exists under
+  the `ActivityListPreview` card with 12 child boxes.
+
+### Scenario B — "findings legend + red box paints for a deliberately broken preview"
+
+- **Sample**: `samples:wear` `BadWearButtonPreview` (`Devices - Small Round`).
+- **Click**: "Accessibility findings" chip ON.
+- **Expected daemon-stderr**: `mode=a11y`, `phase=a11y.done findings=1
+  nodes=1`, `[renderFinished] ... attachments=[a11y/atf]`.
+- **Expected host-channel**: `onDataProductsAttached ... kinds=[a11y/atf]`,
+  `decoded a11y for ... findings=1 nodes=<none>`.
+- **Expected webview state**: `.a11y-legend` element with `.a11y-row` children
+  matching the finding count (1, level=ERROR, type
+  `SpeakableTextPresentCheck`); `.a11y-overlay` element with 1 finding box
+  (`.a11y-box.a11y-level-error`).
+
+### Scenario C (regression-only) — "toggling chip OFF tears down the layer"
+
+- After A, click "Accessibility hierarchy" chip OFF.
+- **Expected host-channel**: no extra daemon traffic logged.
+- **Expected webview state**: `.a11y-hierarchy-overlay` is **removed** from
+  the card (or empty), driven by `applyA11yUpdate`'s nodes-empty branch.
+
+## Test harness — extending what's there
+
+The existing `vscode-extension/src/test/electron/suite/e2e.test.ts` runs
+against `samples:cmp` through real Gradle. It boots the extension host,
+reveals the panel, runs `triggerRefresh`, and asserts on `setPreviews`
+messages. The pieces it gives us for free:
+
+- `ComposePreviewTestApi` — exported from `extension.ts`, exposes
+  `injectGradleApi`, `triggerRefresh`, `getReceivedMessages`,
+  `getPostedMessages`, `resetMessages`.
+- A spawned extension host with a real `vscode` API.
+- The output channel logs are accessible via the API or via reading the
+  `Compose Preview` channel.
+
+What the new tests need that's not there yet:
+
+1. **Wear sample seeded into the e2e fixture set.** Today only `samples:cmp`
+   is wired into the test workspace. The wear sample needs to be added to the
+   workspace folders that the test opens (or the test needs to switch to a
+   workspace that already contains it — the repo root is a candidate, since
+   `samples/wear` is part of the build).
+2. **A way to drive a chip click without DevTools.** Two options:
+   - **Direct host call** — extend `ComposePreviewTestApi` with
+     `triggerSetDataExtensionEnabled(previewId, kind, enabled)`. Bypasses the
+     webview button click but exercises the same handler chain
+     (`handleSetDataExtensionEnabled` → `setDataProductSubscription` → daemon).
+     Cheap, deterministic; good enough to catch wire-side regressions.
+   - **Webview-message simulation** — call `panel.postMessage` (or whatever
+     the test API exposes) with `{command: "setDataExtensionEnabled",
+     previewId, kind, enabled: true}`. Slightly closer to the real path; same
+     handler.
+   The first option is simpler — pick that.
+3. **Daemon enabled in the test profile.** The daemon path is gated behind
+   gradle plugin config + sysprops. The test must launch the wear sample
+   with `composeai.previewExtensions.a11y.enabled=true` (until PR 2 lands)
+   so the a11y extension is registered. The existing real-Gradle test already
+   uses `RealGradleApi` to drive Gradle; we just need the wear module's
+   `daemon-launch.json` to be regenerated with the right sysprops.
+4. **Output-channel assertion helpers.** `vscode.OutputChannel` doesn't
+   expose its buffered lines directly to a test. Two routes:
+   - Inject a recording logger via the test API (extend
+     `ComposePreviewTestApi.injectLogger` analogously to `injectGradleApi`)
+     and assert on the captured lines.
+   - Subscribe to the daemon-events callbacks directly via the API and assert
+     on their payloads instead of stringly-typed log lines. Cleaner; doesn't
+     depend on log-line wording surviving.
+5. **Webview-DOM assertion access.** The webview runs in a separate context
+   from the extension host. Two routes:
+   - Use `vscode.window.activeWebviewPanel`'s `webview.html` snapshot or
+     `postMessage`/round-trip a "give me your DOM" probe. Hacky.
+   - Have the webview post `webviewA11yState` messages whenever
+     `applyA11yUpdate` mutates the cache (mirrors the existing
+     `webviewPreviewsRendered` ack), asserting on those instead of DOM.
+     Cleaner.
+
+## Implementation order
+
+1. **`ComposePreviewTestApi.triggerSetDataExtensionEnabled` + ack channel.**
+   Tiny extension to extension.ts. Lets us drive chip toggles deterministically.
+2. **Wear sample in the e2e workspace.** Open `:samples:wear/.../Previews.kt`
+   instead of `:samples:cmp/.../Previews.kt` for the new tests.
+3. **Webview ack messages.** Have `applyA11yUpdate` post a `webviewA11yState`
+   summarising `(previewId, findingsCount, nodesCount)` after every successful
+   update. The test API records inbound messages already; assert on those.
+4. **Scenario A test.** `setDataExtensionEnabled(activityListId, "a11y/hierarchy", true)`
+   → `waitFor` a `webviewA11yState` with `nodesCount: 12`. Pass/fail.
+5. **Scenario B test.** Same but for BadWearButton + `a11y/atf` + `findingsCount: 1`.
+6. **Scenario C test.** `setDataExtensionEnabled(..., enabled: false)` →
+   `webviewA11yState` with `nodesCount: 0`.
+
+## What this catches
+
+- Wire regressions: `extensions/list+enable` ordering (#9a7b2e1b),
+  `ExtensionsEnableResult` shape mismatch (#ac02d680), `RenderFinishedParams.dataProducts`
+  serialization drops, etc.
+- Daemon regressions: mode injection (#c6a0c6f8), runAccessibility resolution
+  (#337abb13), attachmentsFor reading from disk, registry capability advertising.
+- Host regressions: subscribe-fire-and-forget plus follow-up renderNow ordering
+  (#b1f0777a), data-product decode + post.
+- Webview regressions: chip teardown (#75a47381), legend/overlay paint, cache
+  mutations.
+
+## Out of scope (deferred follow-ups)
+
+- The hierarchy-driven labelled legend (per-node label + role list, color-matched
+  swatches) — see todo "Hierarchy-driven *named* legend".
+- The `Accessibility overlay` chip displaying the daemon-rendered overlay PNG
+  in the panel — see todo "Wire 'Accessibility overlay' chip ...".
+- Visual-diff testing (compare the painted overlay against a baseline PNG).
+
+## Where this plugs into existing CI
+
+`.github/workflows/vscode-extension-e2e.yml` already runs the
+`COMPOSE_PREVIEW_E2E=1` suite on `main` and on workflow_dispatch. The new
+tests live in the same suite (`describeE2E` block) so they ride along when
+the e2e workflow runs. No new workflow needed.

--- a/vscode-extension/.vscode/tasks.json
+++ b/vscode-extension/.vscode/tasks.json
@@ -65,6 +65,8 @@
             "args": [
                 "-p",
                 "..",
+                ":daemon:android:createFullJarDebug",
+                ":daemon:desktop:jar",
                 "publishToMavenLocal",
                 ":gradle-plugin:publishToMavenLocal",
                 ":cli:installDist"

--- a/vscode-extension/src/daemon/daemonProcess.ts
+++ b/vscode-extension/src/daemon/daemonProcess.ts
@@ -200,21 +200,22 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
     // pre-v2 "everything advertised" behaviour. Lean opt-in is a follow-up.
     try {
         const list = await client.extensionsList();
-        const ids = list.extensions.map((info) => info.id);
+        const ids = (list.extensions ?? []).map((info) => info.id);
         if (ids.length > 0) {
             const enabled = await client.extensionsEnable({ ids });
             initializeResult = {
                 ...initializeResult,
                 capabilities: {
                     ...initializeResult.capabilities,
-                    dataProducts: enabled.dataProducts,
-                    dataExtensions: enabled.dataExtensions,
-                    previewExtensions: enabled.previewExtensions,
+                    dataProducts: enabled.dataProducts ?? [],
+                    dataExtensions: enabled.dataExtensions ?? [],
+                    previewExtensions: enabled.previewExtensions ?? [],
                 },
             };
-            if (enabled.unknown.length > 0) {
+            const unknown = enabled.unknown ?? [];
+            if (unknown.length > 0) {
                 opts.logger?.appendLine(
-                    `[daemon] extensions/enable skipped unknown ids ${enabled.unknown.join(", ")}`,
+                    `[daemon] extensions/enable skipped unknown ids ${unknown.join(", ")}`,
                 );
             }
         }

--- a/vscode-extension/src/daemon/daemonProcess.ts
+++ b/vscode-extension/src/daemon/daemonProcess.ts
@@ -185,6 +185,14 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
         throw err;
     }
 
+    // PROTOCOL.md § 3 — `initialized` MUST land before any further request, otherwise the
+    // daemon rejects with -32001 ("received '<method>' before 'initialized' notification").
+    // We had `extensions/list+enable` running before this notification, which silently broke
+    // the whole capability handshake — the catch below swallowed the rejection and every
+    // subsequent `data/subscribe` came back as "kind not advertised". Fix is to fire
+    // `initialized` as soon as the initialize round-trip resolves.
+    client.initialized();
+
     // PROTOCOL.md § 3a — daemons advertise an empty capability surface until the client
     // opts in via `extensions/enable`. The panel doesn't yet do per-card lifecycle
     // (open card → enable extension → subscribe → close → unsubscribe), so as a
@@ -218,7 +226,6 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
         );
     }
 
-    client.initialized();
     return { client, process: child, initializeResult, exited };
 }
 

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -319,13 +319,15 @@ export interface InitializeResult {
 export interface ExtensionInfo {
     id: string;
     displayName: string;
-    dependencies: string[];
-    publiclyEnabled: boolean;
+    // Daemon serializes with `encodeDefaults = false`; empty lists/false-defaults drop off the
+    // wire. Treat list fields as optional + default at access sites.
+    dependencies?: string[];
+    publiclyEnabled?: boolean;
     /** True iff publicly enabled OR pulled in as a dependency of another public extension. */
-    active: boolean;
-    dataProductKinds: string[];
-    dataExtensionIds: string[];
-    previewExtensionIds: string[];
+    active?: boolean;
+    dataProductKinds?: string[];
+    dataExtensionIds?: string[];
+    previewExtensionIds?: string[];
 }
 
 export interface ExtensionsListResult {
@@ -337,17 +339,19 @@ export interface ExtensionsEnableParams {
 }
 
 export interface ExtensionsEnableResult {
-    newlyEnabled: string[];
-    pulledIn: string[];
-    alreadyEnabled: string[];
-    unknown: string[];
+    // Daemon serializes with `encodeDefaults = false`; empty lists drop off the wire entirely.
+    // Treat every field as optional and default to `[]` at access sites.
+    newlyEnabled?: string[];
+    pulledIn?: string[];
+    alreadyEnabled?: string[];
+    unknown?: string[];
     /**
      * Updated public capability snapshots — same shape as the `initialize.capabilities`
      * fields. Saves a follow-up `extensions/list` round-trip after enabling.
      */
-    dataProducts: DataProductCapability[];
-    dataExtensions: DataExtensionDescriptor[];
-    previewExtensions: PreviewExtensionDescriptor[];
+    dataProducts?: DataProductCapability[];
+    dataExtensions?: DataExtensionDescriptor[];
+    previewExtensions?: PreviewExtensionDescriptor[];
 }
 
 export interface ExtensionsDisableParams {

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -367,6 +367,7 @@ export class DaemonScheduler {
         if (!client) {
             return;
         }
+        let subscribedAny = false;
         for (const kind of kinds) {
             const subKey = `${module.modulePath}::${previewId}::${kind}`;
             const already = this.subscribedPairs.has(subKey);
@@ -375,6 +376,7 @@ export class DaemonScheduler {
             }
             if (enabled) {
                 this.subscribedPairs.add(subKey);
+                subscribedAny = true;
                 client.dataSubscribe({ previewId, kind }).catch((err) => {
                     // Pre-D2 daemons reject with DataProductUnknown for every kind; that's
                     // expected, not noise — log to the daemon channel and roll back the
@@ -396,6 +398,29 @@ export class DaemonScheduler {
                     );
                 });
             }
+        }
+        // D2.2 — `data/subscribe` records subscription state but doesn't trigger a render
+        // on its own; the daemon's `subscriptionDrivenRenderMode` only injects the mode tag
+        // on the *next* renderNow for this preview. Without a follow-up render request the
+        // chip stays checked but no a11y artefacts ever land — the focus inspector's UX
+        // expects "click chip → see overlay within one render time," which means we need
+        // to bridge that gap host-side. Fire a single fast-tier renderNow per call (not
+        // per kind) when at least one new subscription took. Idempotent w.r.t. unsubscribes
+        // and no-op-subscribes — they don't set `subscribedAny`. The daemon's existing
+        // dedup means a second renderNow for an in-flight render coalesces.
+        if (enabled && subscribedAny) {
+            client
+                .renderNow({
+                    previews: [previewId],
+                    tier: "fast",
+                    reason: "data/subscribe",
+                })
+                .catch((err) => {
+                    const msg = (err as Error)?.message ?? String(err);
+                    this.logger.appendLine(
+                        `[daemon] post-subscribe renderNow(${previewId}) failed: ${msg}`,
+                    );
+                });
         }
     }
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3681,6 +3681,20 @@ async function handleSetDataExtensionEnabled(
         [kind],
         enabled,
     );
+    if (!enabled && (kind === "a11y/atf" || kind === "a11y/hierarchy")) {
+        // Mirror the toolbar A11y button's teardown — once the chip is unchecked, tear
+        // down the cached overlay/legend immediately so the visual layer clears without
+        // waiting on the next render. Empty arrays are the agreed signal: applyA11yUpdate
+        // drops the corresponding cached entries and removes the layers from the DOM.
+        // Other kinds (touchTargets, overlay) don't currently drive a webview overlay
+        // independent of these two, so leaving them out keeps the message minimal.
+        const update: { previewId: string; findings?: never[]; nodes?: never[] } = {
+            previewId,
+        };
+        if (kind === "a11y/atf") update.findings = [];
+        if (kind === "a11y/hierarchy") update.nodes = [];
+        panel?.postMessage({ command: "updateA11y", ...update });
+    }
 }
 
 /**

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1128,18 +1128,25 @@ export async function activate(
     context.subscriptions.push(
         vscode.workspace.onDidChangeTextDocument((event) => {
             const filePath = event.document.uri.fsPath;
-            if (!isPreviewSourceFile(filePath) || event.contentChanges.length === 0) {
+            if (
+                !isPreviewSourceFile(filePath) ||
+                event.contentChanges.length === 0
+            ) {
                 return;
             }
             const latestLine =
-                event.contentChanges[event.contentChanges.length - 1]?.range.start.line;
+                event.contentChanges[event.contentChanges.length - 1]?.range
+                    .start.line;
             if (latestLine !== undefined) {
                 const editedFunction = functionNameAtLine(
                     event.document.getText(),
                     latestLine,
                 );
                 if (editedFunction) {
-                    lastEditedPreviewFunctionByFile.set(filePath, editedFunction);
+                    lastEditedPreviewFunctionByFile.set(
+                        filePath,
+                        editedFunction,
+                    );
                 }
             }
         }),
@@ -1664,7 +1671,10 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
             ? previewsForFile(fresh, module, filePath)
             : filePreviews;
     }
-    const ids = prioritizeEditedPreview(filePath, filePreviews.map((p) => p.id));
+    const ids = prioritizeEditedPreview(
+        filePath,
+        filePreviews.map((p) => p.id),
+    );
     if (ids.length === 0) {
         return "accepted";
     }
@@ -1710,7 +1720,9 @@ function prioritizeEditedPreview(filePath: string, ids: string[]): string[] {
     if (!editedFunction || ids.length <= 1) {
         return ids;
     }
-    const prioritized = ids.find((id) => previewFunctionNameFromId(id) === editedFunction);
+    const prioritized = ids.find(
+        (id) => previewFunctionNameFromId(id) === editedFunction,
+    );
     if (!prioritized) {
         return ids;
     }
@@ -2846,6 +2858,34 @@ type RefreshOutcome =
     | "failed"
     | "gated";
 
+/**
+ * Rank for the coalesce-or-supersede decision when a new refresh arrives
+ * while one is already in flight. Higher = more work / more user intent.
+ *
+ * - `0` — discovery-only (`forceRender=false`). Triggered by file-save,
+ *   editor focus change, panel restore. Cheap; the user didn't explicitly
+ *   ask for new pixels.
+ * - `1` — fast tier explicit render (`forceRender=true, tier=fast`).
+ *   Daemon-driven path or a per-card heavy-refresh opt-in.
+ * - `2` — full tier explicit render (`forceRender=true, tier=full`).
+ *   What the panel's Refresh button posts.
+ *
+ * Used by [refresh] to drop weaker incoming refreshes for the same
+ * `(file, module)` rather than aborting + restarting Gradle. The
+ * canonical race the ranking solves: user clicks the panel's Refresh
+ * button → focus moves into the webview → `onDidChangeActiveTextEditor`
+ * fires `refresh(false)` → without ranking, that lighter refresh aborts
+ * the user's full render.
+ */
+function refreshStrength(
+    forceRender: boolean,
+    tier: "fast" | "full" | undefined,
+): number {
+    if (!forceRender) return 0;
+    if (tier === "full") return 2;
+    return 1;
+}
+
 async function refresh(
     forceRender: boolean,
     forFilePath?: string,
@@ -2873,19 +2913,40 @@ async function refresh(
             ? gradleService.resolveModule(activeFile)
             : null;
 
-    // Coalesce identical concurrent refreshes. Activation, panel restore, and
-    // editor-focus events can each schedule the same refresh within ~100ms;
-    // aborting + restarting Gradle for each one wedges the build into a
-    // "Build cancelled." loop where no render ever finishes. The in-flight
-    // refresh will produce the same result this caller wants, so let it run.
-    if (activeFile && module && pendingRefresh !== null) {
+    // Coalesce concurrent refreshes for the same (file, module). Activation,
+    // panel restore, and editor-focus events can each schedule the same
+    // refresh within ~100ms; aborting + restarting Gradle for each one
+    // wedges the build into a "Build cancelled." loop where no render ever
+    // finishes. Beyond exact-key matches, also drop incoming requests that
+    // are *weaker* than the in-flight one — a `forceRender=false` discover
+    // refresh that fires when focus shifts off the editor (e.g. the user
+    // clicked the panel's refresh button, which moved focus away from
+    // their .kt file) must not abort a `forceRender=true` render the user
+    // explicitly asked for.
+    if (activeFile && module && pendingRefresh !== null && pendingRefreshKey) {
         const incomingKey = `${forceRender}|${tier}|${activeFile}|${module.modulePath}`;
         if (pendingRefreshKey === incomingKey) {
             return "cancelled";
         }
+        const pendingParts = pendingRefreshKey.split("|");
+        // pendingParts: [forceRender, tier, file, modulePath]
+        if (
+            pendingParts.length === 4 &&
+            pendingParts[2] === activeFile &&
+            pendingParts[3] === module.modulePath
+        ) {
+            const pendingStrength = refreshStrength(
+                pendingParts[0] === "true",
+                pendingParts[1] as "fast" | "full",
+            );
+            const incomingStrength = refreshStrength(forceRender, tier);
+            if (incomingStrength < pendingStrength) {
+                return "cancelled";
+            }
+        }
     }
 
-    // Cancel any in-flight refresh (different args — superseded)
+    // Cancel any in-flight refresh (different / stronger args — superseded)
     pendingRefresh?.abort();
     const abort = new AbortController();
     pendingRefresh = abort;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -378,6 +378,21 @@ export function applyDataProductsToRegistry(
     return null;
 }
 
+/**
+ * `true` iff [dp]'s `path` looks like a JSON file. The webview's
+ * `updateDataProducts` channel carries inline JSON payloads, so we only fall
+ * through to `readJsonPath` for kinds that actually carry JSON. Binary kinds
+ * (e.g. `a11y/overlay` ships a PNG) would otherwise produce `Unexpected token
+ * '�'` errors when the host eagerly tried to read the file as JSON. The
+ * wire `DataProductAttachment` doesn't carry a `mediaType`, so we sniff the
+ * file extension — every JSON producer wires `.json` paths, every binary
+ * producer wires its native extension (`.png`, `.bin`, etc.).
+ */
+function isJsonDataProduct(dp: DataProductAttachment): boolean {
+    if (!dp.path) return false;
+    return dp.path.toLowerCase().endsWith(".json");
+}
+
 function readJsonPath(
     p: string | undefined,
     log: { appendLine(value: string): void },
@@ -558,7 +573,9 @@ export async function activate(
                             kind: dp.kind,
                             payload:
                                 dp.payload ??
-                                readJsonPath(dp.path, outputChannel),
+                                (isJsonDataProduct(dp)
+                                    ? readJsonPath(dp.path, outputChannel)
+                                    : undefined),
                         }))
                         .filter((dp) => dp.payload !== undefined);
                     if (payloads.length > 0) {
@@ -3696,7 +3713,11 @@ async function handleSetDataExtensionEnabled(
         // drops the corresponding cached entries and removes the layers from the DOM.
         // Other kinds (touchTargets, overlay) don't currently drive a webview overlay
         // independent of these two, so leaving them out keeps the message minimal.
-        const update: { previewId: string; findings?: never[]; nodes?: never[] } = {
+        const update: {
+            previewId: string;
+            findings?: never[];
+            nodes?: never[];
+        } = {
             previewId,
         };
         if (kind === "a11y/atf") update.findings = [];

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -530,11 +530,19 @@ export async function activate(
                 // the diagnostics provider already listens to. The panel receives a targeted
                 // `updateA11y` post so its cached overlays repaint without re-emitting the entire
                 // preview list.
+                outputChannel.appendLine(
+                    `[daemon] onDataProductsAttached ${previewId} kinds=[${dataProducts
+                        .map((dp) => dp.kind)
+                        .join(",")}]`,
+                );
                 const decoded = applyDataProductsToRegistry(
                     registry,
                     previewId,
                     dataProducts,
                     outputChannel,
+                );
+                outputChannel.appendLine(
+                    `[daemon] decoded a11y for ${previewId}: findings=${decoded?.findings?.length ?? "<none>"} nodes=${decoded?.nodes?.length ?? "<none>"}`,
                 );
                 if (decoded && panel) {
                     panel.postMessage({

--- a/vscode-extension/src/test/focusInspectorToggle.test.ts
+++ b/vscode-extension/src/test/focusInspectorToggle.test.ts
@@ -83,7 +83,10 @@ function makeHarness(findingsCount = 0, autoEnableCheap = false): Harness {
         getPreview: (id) => ({
             ...samplePreview,
             id,
-            params: { ...samplePreview.params, uiMode: autoEnableCheap ? 32 : 0 },
+            params: {
+                ...samplePreview.params,
+                uiMode: autoEnableCheap ? 32 : 0,
+            },
         }),
         getA11yFindings: () =>
             Array.from({ length: findingsCount }, () => ({


### PR DESCRIPTION
## Summary

Makes the daemon's a11y data products subscription-driven instead of gated by a process-wide flag. Clicking the focus-inspector A11y chips now drives the next render through `mode=a11y`, `LocalInspectionMode = false`, and the ATF + hierarchy capture pipeline; the resulting attachments ride `renderFinished` back to the panel.

Shake-out work along the way fixed several pre-existing protocol bugs that #1003's "always advertise a11y data products" change exposed once the chips actually started talking to the daemon.

## What lands

### Daemon-side (subscription-driven a11y)

- `AccessibilityDataProductRegistry` flips `requiresRerender = true` for all four a11y kinds and tracks `(previewId, kind)` subscription pairs via `onSubscribe` / `onUnsubscribe`. `fetch` returns `Outcome.RequiresRerender(\"a11y\")` when an artefact is missing, so the existing dispatcher rerender machinery (theme, recomposition) handles a11y the same way.
- `RenderEngine.render`'s `runAccessibility` parameter becomes `Boolean? = null` and auto-resolves from `spec.renderMode == \"a11y\" || legacy sysprop`. The mode tag flows through the same renderer-agnostic `mode=...` payload key theme/recomposition already use.
- `JsonRpcServer.encodeRenderPayload` consults the dispatcher's subscription map per render and stamps `mode=a11y` when the preview has an `a11y/*` subscription. Closes the loop: subscribe → next render is in a11y mode → ATF + hierarchy artefacts written → `attachmentsFor` ships them on `renderFinished`.

### Protocol & wire fixes (surfaced during PR 1 verification)

- `daemonProcess.ts` was issuing `extensions/list` + `extensions/enable` **before** sending the `initialized` notification. The daemon rejected with `-32001` and the catch swallowed it, leaving every extension publicly disabled. Move `client.initialized()` up so list+enable runs against a ready daemon.
- The Kotlin daemon serializes responses with `encodeDefaults = false`; empty `List<...>` properties drop off the wire. The TS side declared every `ExtensionsEnableResult` field as required and crashed on `enabled.unknown.length` when the daemon sent an empty enable response. Mark list fields optional + default to `[]` at access sites.
- `applyDataProductsToRegistry` was unconditionally `readJsonPath`-ing every path-transport data product, including `a11y/overlay`'s PNG. Sniff `.json` extension before parsing.

### UX fixes (surfaced during PR 1 verification)

- After `data/subscribe` succeeds, host fires a fast-tier `renderNow` so the focus inspector \"click chip → see overlay\" UX produces an artefact within one render time. Without this, chips stayed checked indefinitely with no overlay.
- Toggling a chip OFF now posts `updateA11y` with empty findings/nodes so the cached overlay tears down immediately rather than waiting for the next render. Mirrors the existing toolbar A11y button's teardown.
- Refresh coalesce now ranks refreshes by strength (`forceRender` + tier). For the same `(file, module)`, weaker incoming requests don't abort an in-flight stronger render. Fixes \"clicking the panel Refresh button gets stuck because focus-change-driven `refresh(false)` aborted it\".

### Diagnostics (kept, useful long-term)

- Daemon: `[render] phase=...` stderr markers for every heavy section (setContent, captureRoboImage, per-data-extension, a11y, evaluateRule, complete). `[renderFinished]` log showing `subscribedKinds`, `globalAttachKinds`, `attachments` at emit time.
- VS Code extension: `[daemon] onDataProductsAttached ...` and `[daemon] decoded a11y ...` lines in the output channel.
- New sysprop `composeai.daemon.renderTimeoutMs` overrides the initial render timeout for ad-hoc debugging.

## Verified

- ActivityListPreview \"Accessibility hierarchy\" chip → 12 translucent boxes painted around each text element. Daemon channel shows `findings=0 nodes=12`, `subscribedKinds=[a11y/hierarchy]`, `attachments=[a11y/hierarchy]`.
- BadWearButtonPreview \"Accessibility findings\" chip → red-box overlay + legend row \"ERROR · SpeakableTextPresentCheck — This item may not have a label readable by screen readers\".
- Unit + integration tests pass: 16 a11y connector tests, 6 RenderEngineTest, 80 webview/scheduler tests, 44 daemon protocol tests. One pre-existing flake (`AndroidInteractiveSessionTest.uiAutomatorClickReportsUnmatchedWhenNoNodeSatisfiesTheSelector`) reproduces against unmodified `main`.

## Test plan

- [x] `./gradlew :data-a11y-connector:test --rerun-tasks` (16/16)
- [x] `./gradlew :daemon:android:compileDebugKotlin :daemon:core:compileKotlin`
- [x] `npm run compile && npx mocha --exit out/test/runMocha.js -g \"daemon|DaemonScheduler|applyA11y|focusInspector|refresh\"` (all green)
- [x] Manual verification of both wear scenarios above
- [ ] Automated e2e for these two scenarios — tracked as #1006 with full plan in `docs/A11Y_E2E_TEST_PLAN.md`

## Follow-ups (separate PRs)

- PR 2: drop `composeai.previewExtensions.a11y.enabled` flag, drop `composePreview { previewExtensions { a11y { ... } } }` gradle DSL, standalone-path always-on-never-fail.
- Hierarchy-driven labelled legend (matches the user-mocked \"Accessibility · 9 elements\" panel).
- Wire \"Accessibility overlay\" chip so the daemon-rendered overlay PNG actually displays in the panel (currently subscribes but the PNG isn't surfaced).
- Address #1006 (e2e automation) once the harness work in the plan lands.