### PR TITLE
docs: add zero-code integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Working examples: [`samples/android/build.gradle.kts`](samples/android/build.gra
 [`samples/wear/build.gradle.kts`](samples/wear/build.gradle.kts),
 [`samples/cmp/build.gradle.kts`](samples/cmp/build.gradle.kts).
 
+### Zero-Code Integration (Alternative)
+
+You can apply the plugin dynamically without modifying the project's source code by using a Gradle init script. This is particularly useful for AI agents or when exploring the tool without committing changes to the repository.
+
+To use this method:
+1. Create a Gradle init script (e.g., `~/.gradle/init.d/compose-ai-tools.gradle`) that resolves the plugin and applies it to Android application projects.
+2. Control its application with an environment variable (e.g., `COMPOSE_AI_TOOLS=true`).
+
+See [skills/compose-preview/SKILL.md](skills/compose-preview/SKILL.md) for a sample init script and details.
+
 Then:
 
 ```sh

--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -167,6 +167,42 @@ composePreview {
 ```
 <!-- x-release-please-end -->
 
+### Zero-Code Integration (Alternative)
+
+You can apply the plugin dynamically without modifying the project's source code by using a Gradle init script. This is useful for agents operating in environments where they shouldn't or cannot modify the build files directly.
+
+Create a file named `~/.gradle/init.d/compose-ai-tools.gradle` with the following content:
+
+```groovy
+allprojects {
+    buildscript {
+        repositories {
+            gradlePluginPortal()
+            mavenCentral()
+        }
+        dependencies {
+            classpath "ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:latest.release"
+        }
+    }
+
+    afterEvaluate { project ->
+        if (System.getenv("COMPOSE_AI_TOOLS") == "true") {
+            if (project.plugins.hasPlugin("com.android.application")) {
+                if (!project.plugins.hasPlugin("ee.schimke.composeai.preview")) {
+                    project.pluginManager.apply("ee.schimke.composeai.preview")
+                    println "Applied ee.schimke.composeai.preview to ${project.name} via init script"
+                }
+            }
+        }
+    }
+}
+```
+
+To enable it, set the environment variable:
+```sh
+export COMPOSE_AI_TOOLS=true
+```
+
 CMP Desktop projects additionally need
 `implementation(compose.components.uiToolingPreview)` — the bundled `@Preview`
 annotation has `SOURCE` retention and is invisible to classpath scanning


### PR DESCRIPTION
## Summary / Goal

This PR adds documentation for an alternative "Zero-Code Integration" method for the `compose-preview` plugin. This method allows users to apply the plugin dynamically using a Gradle init script and an environment variable, without making any changes to the project's source code. 

This is useful for AI agents operating in environments where they shouldn't or cannot modify build files directly, users who want to explore the tool without committing changes to their repository, or users who repeatedly accidentally commit gradle configuration files to their repository, and then [have to revert](https://github.com/ithinkihaveacat/wear-os-samples/commit/b1e2375cd6fd1934d5051cc68de5ce9eaa54c2ec).

## Rationale & Safety

This change only adds documentation and does not affect the code or behavior of the project. It provides a useful alternative for users who cannot or do not want to modify their build files directly.

## Verification

I verified the documentation changes by reading the modified files and checking the links. I also verified the integration method itself manually on a sample project (`WearWidget`) in a separate workspace, confirming that it successfully discovers and renders previews when enabled via the init script.

`compose-preview doctor` also picks it up.
