### PR TITLE
feat(vscode): collapse @Preview variants by default, expand on filter

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -141,6 +141,11 @@
                     "default": false,
                     "description": "When the focus-mode inspector suggests a data extension that's cheap to compute (theme tokens, fonts, strings, layout tree), auto-enable it on first sight per module. Expensive layers (recomposition heatmap, render trace, accessibility re-render) are never auto-enabled and stay click-to-toggle. Suggestions themselves don't depend on this setting; only whether the suggestion auto-applies."
                 },
+                "composePreview.collapseVariants.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Collapse @Preview variants (multi-preview, @PreviewParameter, font/uiMode/device combinations) so only one card per function is shown when no function or group filter is active. Picking a specific function or group from the filter toolbar expands all variants for that selection. Turn off to always show every variant."
+                },
                 "composePreview.logging.level": {
                     "type": "string",
                     "enum": [

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -255,6 +255,12 @@ function autoEnableCheapEnabled(): boolean {
         .get<boolean>("autoEnableCheap.enabled", false);
 }
 
+function collapseVariantsEnabled(): boolean {
+    return vscode.workspace
+        .getConfiguration("composePreview")
+        .get<boolean>("collapseVariants.enabled", true);
+}
+
 /**
  * Show the remediation notification for a detected JdkImageError. The offered
  * "Open JDK setting" action reveals `java.import.gradle.java.home` — the
@@ -748,6 +754,7 @@ export async function activate(
         () => earlyFeaturesEnabled(),
         undefined,
         () => autoEnableCheapEnabled(),
+        () => collapseVariantsEnabled(),
     );
     if (isTestMode) {
         // Tap into every outgoing webview message so the test API can assert
@@ -1061,6 +1068,16 @@ export async function activate(
                 panel?.postMessage({
                     command: "setAutoEnableCheap",
                     enabled: autoEnableCheapEnabled(),
+                });
+            }
+            if (
+                event.affectsConfiguration(
+                    "composePreview.collapseVariants.enabled",
+                )
+            ) {
+                panel?.postMessage({
+                    command: "setCollapseVariants",
+                    enabled: collapseVariantsEnabled(),
                 });
             }
         }),

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -9,6 +9,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     private onMessage: (msg: WebviewToExtension) => void;
     private earlyFeaturesEnabled: () => boolean;
     private autoEnableCheapEnabled: () => boolean;
+    private collapseVariantsEnabled: () => boolean;
     private shouldRestoreVisibility: () => boolean;
 
     constructor(
@@ -17,11 +18,13 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         earlyFeaturesEnabled: () => boolean = () => false,
         shouldRestoreVisibility: () => boolean = () => false,
         autoEnableCheapEnabled: () => boolean = () => false,
+        collapseVariantsEnabled: () => boolean = () => true,
     ) {
         this.extensionUri = extensionUri;
         this.onMessage = onMessage;
         this.earlyFeaturesEnabled = earlyFeaturesEnabled;
         this.autoEnableCheapEnabled = autoEnableCheapEnabled;
+        this.collapseVariantsEnabled = collapseVariantsEnabled;
         this.shouldRestoreVisibility = shouldRestoreVisibility;
     }
 
@@ -55,6 +58,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const nonce = getNonce();
         const earlyFeaturesEnabled = this.earlyFeaturesEnabled();
         const autoEnableCheapEnabled = this.autoEnableCheapEnabled();
+        const collapseVariantsEnabled = this.collapseVariantsEnabled();
         const styleUri = webview.asWebviewUri(
             vscode.Uri.joinPath(this.extensionUri, "media", "preview.css"),
         );
@@ -84,6 +88,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     <preview-app
         data-early-features="${earlyFeaturesEnabled ? "true" : "false"}"
         data-auto-enable-cheap="${autoEnableCheapEnabled ? "true" : "false"}"
+        data-collapse-variants="${collapseVariantsEnabled ? "true" : "false"}"
     ></preview-app>
     <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>

--- a/vscode-extension/src/test/variantCollapse.test.ts
+++ b/vscode-extension/src/test/variantCollapse.test.ts
@@ -1,0 +1,93 @@
+import * as assert from "assert";
+import {
+    decideVariantCollapse,
+    type VariantCollapseCandidate,
+} from "../webview/preview/variantCollapse";
+
+const c = (id: string, functionKey: string): VariantCollapseCandidate => ({
+    id,
+    functionKey,
+});
+
+describe("decideVariantCollapse", () => {
+    it("is inactive when the feature is disabled", () => {
+        const decision = decideVariantCollapse({
+            collapseVariants: false,
+            fnFilter: "all",
+            groupFilter: "all",
+            candidates: [c("a", "k1"), c("b", "k1"), c("d", "k2")],
+        });
+        assert.strictEqual(decision.active, false);
+        assert.strictEqual(decision.hidden.size, 0);
+    });
+
+    it("is inactive when a function filter is narrowing", () => {
+        const decision = decideVariantCollapse({
+            collapseVariants: true,
+            fnFilter: "MyComposable",
+            groupFilter: "all",
+            candidates: [c("a", "k1"), c("b", "k1")],
+        });
+        assert.strictEqual(decision.active, false);
+        assert.strictEqual(decision.hidden.size, 0);
+    });
+
+    it("is inactive when a group filter is narrowing", () => {
+        const decision = decideVariantCollapse({
+            collapseVariants: true,
+            fnFilter: "all",
+            groupFilter: "dark",
+            candidates: [c("a", "k1"), c("b", "k1")],
+        });
+        assert.strictEqual(decision.active, false);
+        assert.strictEqual(decision.hidden.size, 0);
+    });
+
+    it("keeps the first variant per function key when active", () => {
+        const decision = decideVariantCollapse({
+            collapseVariants: true,
+            fnFilter: "all",
+            groupFilter: "all",
+            candidates: [
+                c("a-default", "fooKt::Foo"),
+                c("a-dark", "fooKt::Foo"),
+                c("a-large", "fooKt::Foo"),
+                c("b-default", "barKt::Bar"),
+                c("b-fontScale", "barKt::Bar"),
+            ],
+        });
+        assert.strictEqual(decision.active, true);
+        assert.deepStrictEqual(
+            [...decision.hidden].sort(),
+            ["a-dark", "a-large", "b-fontScale"].sort(),
+        );
+    });
+
+    it("treats different className+functionName pairs as independent", () => {
+        const decision = decideVariantCollapse({
+            collapseVariants: true,
+            fnFilter: "all",
+            groupFilter: "all",
+            candidates: [
+                c("a", "FileAKt::Same"),
+                c("b", "FileBKt::Same"),
+                c("c", "FileAKt::Same"),
+            ],
+        });
+        assert.strictEqual(decision.active, true);
+        // Only the third candidate is a duplicate of the first; the second
+        // is in a different class, so it survives.
+        assert.deepStrictEqual([...decision.hidden], ["c"]);
+    });
+
+    it("emits an empty hidden set when there are no candidates", () => {
+        const decision = decideVariantCollapse({
+            collapseVariants: true,
+            fnFilter: "all",
+            groupFilter: "all",
+            candidates: [],
+        });
+        assert.strictEqual(decision.active, true);
+        assert.strictEqual(decision.hidden.size, 0);
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -579,6 +579,15 @@ export type ExtensionToWebview =
      */
     | { command: "setAutoEnableCheap"; enabled: boolean }
     /**
+     * Reflects `composePreview.collapseVariants.enabled` from settings.
+     * When `true`, the preview grid shows only one card per function
+     * (`className + functionName`) while no function or group filter is
+     * active; picking a function or group from the toolbar expands all
+     * variants for that selection. Sent at panel boot and on settings
+     * change.
+     */
+    | { command: "setCollapseVariants"; enabled: boolean }
+    /**
      * Daemon capabilities for the active module — the kinds the daemon
      * can produce (`dataProducts`) and the data extensions registered
      * (`dataExtensions`). The focus inspector groups these into its

--- a/vscode-extension/src/webview/preview/components/PreviewGrid.ts
+++ b/vscode-extension/src/webview/preview/components/PreviewGrid.ts
@@ -27,11 +27,22 @@
 // Light DOM keeps `media/preview.css` rules targeting `.preview-grid`,
 // `.preview-card`, etc. applying unchanged.
 
+import { decideVariantCollapse } from "../variantCollapse";
+
 export type LayoutMode = "grid" | "flow" | "column" | "focus";
 
 export interface FilterValues {
     fn: string;
     group: string;
+}
+
+export interface ApplyFiltersOptions {
+    /** When true, collapse variants of the same function (same
+     *  className+functionName) so only the first card survives. Only takes
+     *  effect when neither the function nor the group filter is narrower
+     *  than `"all"` — picking a function or group is treated as an
+     *  explicit "show all variants for this selection" signal. */
+    collapseVariants?: boolean;
 }
 
 export class PreviewGrid extends HTMLElement {
@@ -84,17 +95,52 @@ export class PreviewGrid extends HTMLElement {
      * `filtered-out` class on each card based on the function/group
      * picks and returns how many ended up visible — callers use that
      * count to decide whether to surface the "no matches" banner.
+     *
+     * When `options.collapseVariants` is true and both filters are
+     * `"all"`, variants of the same function (matched on
+     * `data-class-name + data-function`) collapse to the first card —
+     * the rest pick up `filtered-out` (and an extra
+     * `collapsed-variant` class so callers can tell the two apart).
      */
-    applyFilters(filters: FilterValues): number {
+    applyFilters(
+        filters: FilterValues,
+        options: ApplyFiltersOptions = {},
+    ): number {
         const { fn, group } = filters;
-        let visibleCount = 0;
-        for (const card of this.getCards()) {
+        const cards = this.getCards();
+        const filterEligible: HTMLElement[] = [];
+        const matches = new Map<HTMLElement, boolean>();
+        for (const card of cards) {
             const cardFn = card.dataset.function ?? "";
             const cardGroup = card.dataset.group ?? "";
             const show =
                 (fn === "all" || cardFn === fn) &&
                 (group === "all" || cardGroup === group);
+            matches.set(card, show);
+            if (show) filterEligible.push(card);
+        }
+        const decision = decideVariantCollapse({
+            collapseVariants: !!options.collapseVariants,
+            fnFilter: fn,
+            groupFilter: group,
+            candidates: filterEligible.map((c) => ({
+                id: c.dataset.previewId ?? "",
+                functionKey:
+                    (c.dataset.className ?? "") +
+                    "::" +
+                    (c.dataset.function ?? ""),
+            })),
+        });
+        let visibleCount = 0;
+        for (const card of cards) {
+            const passes = matches.get(card) ?? false;
+            const collapsed =
+                passes &&
+                decision.active &&
+                decision.hidden.has(card.dataset.previewId ?? "");
+            const show = passes && !collapsed;
             card.classList.toggle("filtered-out", !show);
+            card.classList.toggle("collapsed-variant", collapsed);
             if (show) visibleCount++;
         }
         return visibleCount;

--- a/vscode-extension/src/webview/preview/filterController.ts
+++ b/vscode-extension/src/webview/preview/filterController.ts
@@ -40,6 +40,10 @@ export interface FilterControllerConfig {
     /** Re-apply layout after filter change — focus mode needs to
      *  recompute focusIndex bounds against the narrowed visible set. */
     applyLayout(): void;
+    /** Reflects `composePreview.collapseVariants.enabled`. When `true`,
+     *  the grid hides duplicate variants of the same function while no
+     *  function/group filter is narrowing the visible set. */
+    collapseVariants(): boolean;
 }
 
 export class FilterController {
@@ -71,10 +75,13 @@ export class FilterController {
      *  mode recomputes focusIndex bounds against the narrowed visible
      *  set). */
     apply(): void {
-        const visibleCount = this.config.grid.applyFilters({
-            fn: this.config.filterToolbar.getFunctionValue(),
-            group: this.config.filterToolbar.getGroupValue(),
-        });
+        const visibleCount = this.config.grid.applyFilters(
+            {
+                fn: this.config.filterToolbar.getFunctionValue(),
+                group: this.config.filterToolbar.getGroupValue(),
+            },
+            { collapseVariants: this.config.collapseVariants() },
+        );
 
         // Only own the message when we have a filter-specific thing to
         // say. When there are no previews at all, the extension owns

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -563,6 +563,15 @@ export class PreviewApp extends LitElement {
             applyLayout();
         });
 
+        // Mirror the gutter-icon `setFunctionFilter` path: persist the new
+        // function/group picks and re-run filtering so the grid updates.
+        // Without this, the dropdowns updated their internal state but
+        // nothing ever called `filterController.apply()`.
+        filterToolbar.addEventListener("filter-changed", () => {
+            saveFilterState();
+            applyFilters();
+        });
+
         btnPrev.addEventListener("click", () => navigateFocus(-1));
         btnNext.addEventListener("click", () => navigateFocus(1));
         btnDiffHead.addEventListener("click", () => requestFocusedDiff("head"));

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -254,6 +254,11 @@ export class PreviewApp extends LitElement {
         const initialEarlyFeaturesEnabled =
             this.dataset.earlyFeatures === "true";
         const initialAutoEnableCheap = this.dataset.autoEnableCheap === "true";
+        // Default true keeps the new collapse-by-default behaviour in
+        // ad-hoc test contexts (where the dataset attribute is missing);
+        // explicit `false` opts out.
+        const initialCollapseVariants =
+            this.dataset.collapseVariants !== "false";
         const vscode = getVsCodeApi<PersistedState>();
         const state: PersistedState = vscode.getState() ?? { filters: {} };
         // `earlyFeaturesEnabled` lives in `previewStore` so future
@@ -263,6 +268,7 @@ export class PreviewApp extends LitElement {
         previewStore.setState({
             earlyFeaturesEnabled: initialEarlyFeaturesEnabled,
             autoEnableCheapEnabled: initialAutoEnableCheap,
+            collapseVariantsEnabled: initialCollapseVariants,
         });
         const earlyFeatures = (): boolean =>
             previewStore.getState().earlyFeaturesEnabled;
@@ -513,6 +519,8 @@ export class PreviewApp extends LitElement {
             messageBanner,
             getAllPreviews: () => previewStore.getState().allPreviews,
             applyLayout: () => focusController.applyLayout(),
+            collapseVariants: () =>
+                previewStore.getState().collapseVariantsEnabled,
         });
 
         const staleBadge = new StaleBadgeController(vscode);

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -200,6 +200,14 @@ export function handleExtensionMessage(
         case "setAutoEnableCheap":
             previewStore.setState({ autoEnableCheapEnabled: !!msg.enabled });
             return;
+        case "setCollapseVariants":
+            previewStore.setState({
+                collapseVariantsEnabled: !!msg.enabled,
+            });
+            // Re-apply filters so the grid picks up the change without
+            // waiting for the user to touch the toolbar.
+            ctx.applyFilters();
+            return;
         case "setDaemonCapabilities":
             ctx.inspector.setProducts(
                 productsFromDaemonCapabilities(

--- a/vscode-extension/src/webview/preview/previewStore.ts
+++ b/vscode-extension/src/webview/preview/previewStore.ts
@@ -51,6 +51,16 @@ export interface PreviewState {
     autoEnableCheapEnabled: boolean;
 
     /**
+     * Reflects `composePreview.collapseVariants.enabled`. When `true`,
+     * `PreviewGrid.applyFilters` keeps only one card per function while
+     * neither the function nor the group filter is narrower than `"all"`
+     * — picking a function/group from the toolbar expands the variants
+     * for that selection. Updated at runtime by the
+     * `setCollapseVariants` extension message.
+     */
+    collapseVariantsEnabled: boolean;
+
+    /**
      * `previewId` of the card whose accessibility overlay subscription
      * is currently active, or `null` when no card is subscribed. Set by
      * `toggleA11yOverlay` and cleared on focus navigation, daemon
@@ -146,6 +156,7 @@ export interface PreviewState {
 const initialState: PreviewState = {
     earlyFeaturesEnabled: false,
     autoEnableCheapEnabled: false,
+    collapseVariantsEnabled: true,
     a11yOverlayPreviewId: null,
     focusedPreviewId: null,
     allPreviews: [],

--- a/vscode-extension/src/webview/preview/variantCollapse.ts
+++ b/vscode-extension/src/webview/preview/variantCollapse.ts
@@ -1,0 +1,65 @@
+// Variant-collapse decision helper. Pure function so it's testable
+// without a DOM — see `test/variantCollapse.test.ts`.
+//
+// When the user hasn't picked a function or group, we want to show one
+// representative card per function (className + functionName) instead of
+// every variant. Picking a function or group from the filter toolbar
+// expands the variants for that selection, so the helper short-circuits
+// to "no collapse" whenever either filter is narrower than "all".
+
+export interface VariantCollapseCandidate {
+    /** `className + "::" + functionName` — the grouping key. */
+    functionKey: string;
+    /** Whatever the caller uses to identify this card (a previewId works
+     *  fine — only used as the set entry the caller hides). */
+    id: string;
+}
+
+export interface VariantCollapseDecision {
+    /** Should collapse actually apply given current filters? */
+    active: boolean;
+    /** When `active`, the ids of cards to hide as duplicate variants. The
+     *  first occurrence of each `functionKey` survives. Empty otherwise. */
+    hidden: Set<string>;
+}
+
+export interface VariantCollapseInput {
+    collapseVariants: boolean;
+    /** Current function filter value — `"all"` means no narrowing. */
+    fnFilter: string;
+    /** Current group filter value — `"all"` means no narrowing. */
+    groupFilter: string;
+    /** Candidates in display order. Only entries that pass the filter
+     *  should be passed in — the helper assumes its input is already
+     *  filter-eligible. */
+    candidates: readonly VariantCollapseCandidate[];
+}
+
+/**
+ * Decide which candidate cards to hide when collapsing variants.
+ *
+ * Collapse is gated on both filters being `"all"` because the user
+ * picking a function or group is an explicit "I want to see all variants
+ * of this thing" signal.
+ */
+export function decideVariantCollapse(
+    input: VariantCollapseInput,
+): VariantCollapseDecision {
+    const active =
+        input.collapseVariants &&
+        input.fnFilter === "all" &&
+        input.groupFilter === "all";
+    if (!active) {
+        return { active: false, hidden: new Set() };
+    }
+    const seen = new Set<string>();
+    const hidden = new Set<string>();
+    for (const c of input.candidates) {
+        if (seen.has(c.functionKey)) {
+            hidden.add(c.id);
+        } else {
+            seen.add(c.functionKey);
+        }
+    }
+    return { active: true, hidden };
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -36,6 +36,7 @@
         "src/webview/preview/pointerGeometry.ts",
         "src/webview/preview/relativeSizing.ts",
         "src/webview/preview/staleBadgeDom.ts",
+        "src/webview/preview/variantCollapse.ts",
         "src/webview/preview/viewportTracker.ts",
         "src/webview/history/components/HistoryRow.ts",
         "src/webview/history/historyData.ts",


### PR DESCRIPTION
## Summary

- New setting `composePreview.collapseVariants.enabled` (default **on**) so the preview panel renders one representative card per `className + functionName` while no function or group filter is narrowing the view.
- Picking a function or group from the filter toolbar — including the gutter-icon hover path that fires `setFunctionFilter` — expands every variant for that selection, matching the "show all when one is selected" ask in #1027.
- Collapsed-but-filter-matching cards now also carry a `collapsed-variant` class so future CSS can distinguish them from genuine filter misses if needed.

## Implementation notes

- The collapse decision is a pure helper (`webview/preview/variantCollapse.ts`) so it's testable without a DOM. `PreviewGrid.applyFilters` calls it after filter matching, then toggles `filtered-out` / `collapsed-variant` as usual.
- Host plumbing mirrors the existing `earlyFeatures` / `autoEnableCheap` shapes: read in `extension.ts`, threaded through `PreviewPanel`'s constructor + HTML dataset, seeded into `previewStore` at boot, and synced on config change via a new `setCollapseVariants` extension message.

## Test plan

- [x] `npm test` (vscode-extension) — 744 + 6 new pass.
- [x] `npm run compile` clean for both host and webview tsconfigs.
- [x] `npm run format:check` clean.
- [ ] Open the panel against a module with multi-preview / @PreviewParameter cards: confirm one card per function with the setting on, all variants when picking a function from the filter, all variants with the setting off.

Closes #1027

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjjGNeVkcuErjYb5PrNWCg)_