### PR TITLE
fix: avoid patching apply-false root builds in CI fixture

### DIFF
--- a/.github/ci/patch-consumer.py
+++ b/.github/ci/patch-consumer.py
@@ -43,6 +43,14 @@ DIRECT_IDS = (
     "org.jetbrains.compose",
 )
 
+ID_DECL_RE = re.compile(
+    r"id\(\"(?P<id>[^\"]+)\"\)(?P<tail>[^\n]*)"
+)
+
+ALIAS_DECL_RE = re.compile(
+    r"alias\((?P<alias>[^)]+)\)(?P<tail>[^\n]*)"
+)
+
 # Convention-plugin alias patterns. We look for tokens that end with
 # `androidApplication`, `androidLibrary`, or `jetbrainsCompose` (case-sensitive,
 # camelCase boundary) inside the plugins block.
@@ -127,9 +135,16 @@ def is_candidate(path: Path) -> bool:
     if not m:
         return False
     block = m.group(1)
-    if any(s in block for s in DIRECT_IDS):
-        return True
-    return ALIAS_RE.search(block) is not None
+    for m in ID_DECL_RE.finditer(block):
+        if m.group("id") in DIRECT_IDS and "apply false" not in m.group("tail"):
+            return True
+
+    for m in ALIAS_DECL_RE.finditer(block):
+        alias = m.group("alias")
+        if ALIAS_RE.search(alias) and "apply false" not in m.group("tail"):
+            return True
+
+    return False
 
 
 def walk_and_patch(root: Path, version: str) -> int:


### PR DESCRIPTION
### Motivation
- CI fixture patcher was inserting `ee.schimke.composeai.preview` into root aggregator build scripts that only declare plugins with `apply false`, which caused the integration job to exercise the wrong project and produced empty preview manifests.

### Description
- Add explicit parsing for `id(...)` and `alias(...)` plugin declarations via `ID_DECL_RE` and `ALIAS_DECL_RE` and examine the trailing text of each declaration.
- Update `is_candidate(...)` to only treat a build file as patchable when a matching `id(...)` or `alias(...)` is present and the declaration does not include `apply false`.
- This change keeps the patcher focused on real Android/Compose modules (e.g. `app`) and prevents modifying root/plugin-catalog scripts.

### Testing
- Ran `python3 .github/ci/patch-consumer.py --walk .github/ci/fixtures/agp8-min --plugin-version 0.1.0-SNAPSHOT` and confirmed the tool patched only `app/build.gradle.kts` (success).
- Ran the patcher against a temporary copy (`tmp=$(mktemp -d) ... python3 .github/ci/patch-consumer.py --walk "$tmp" --plugin-version 0.1.0-SNAPSHOT`) and verified the plugin line via `rg` in the `app` module (success).
- Verified the patcher prints a single patched file and reports `patched=1 skipped=0` when run against the AGP fixture (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025fc364148324adc7503798ecdfd9)