### PR TITLE
Allow uppercase characters at the start of PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -43,7 +43,3 @@ jobs:
             style
             revert
           requireScope: false
-          subjectPattern: ^(?![A-Z]).+$
-          subjectPatternError: |
-            The subject "{subject}" found in the pull request title "{title}"
-            should start with a lowercase character.


### PR DESCRIPTION
Remove restriction on pull request title subject starting with a lowercase character.