### PR TITLE
fix(discovery): keep tile previews despite the unsupported-parameter gate

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -912,6 +912,86 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
+  fun `discoverPreviews keeps tile previews that take a Context parameter`() {
+    val projectDir = createCmpTestProject()
+
+    // Stub the tile @Preview annotation under its real FQN. CMP 1.10 (the
+    // version this fixture uses) doesn't ship `androidx.wear.tiles.tooling`,
+    // but discovery is FQN-driven — the stub exercises the same code path
+    // wear-os-samples' WearTilesKotlin hit when its tile previews started
+    // returning zero entries after PR #984's parameter gate landed.
+    val previewFqnDir = File(projectDir, "src/main/kotlin/androidx/wear/tiles/tooling/preview")
+    previewFqnDir.mkdirs()
+    File(previewFqnDir, "Preview.kt")
+      .writeText(
+        """
+        package androidx.wear.tiles.tooling.preview
+
+        @MustBeDocumented
+        @Retention(AnnotationRetention.BINARY)
+        @Repeatable
+        @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+        annotation class Preview(val name: String = "")
+        """
+          .trimIndent()
+      )
+
+    val srcFile = File(projectDir, "src/main/kotlin/test/Tiles.kt")
+    srcFile.writeText(
+      """
+      package test
+
+      import androidx.wear.tiles.tooling.preview.Preview
+
+      // Stand-in for `android.content.Context`. Discovery doesn't reflect
+      // parameter types beyond @PreviewParameter, so any single non-Composer
+      // parameter exercises the gate the same way the real tile-preview
+      // signature does.
+      class FakeContext
+
+      // Multi-preview meta-annotation expanding to two tile previews — the
+      // upstream WearTilesKotlin `MultiRoundDevicesWithFontScalePreviews`
+      // shape, minimised. Exercises the multi-preview branch of the tile
+      // exemption alongside the direct one below.
+      @Preview(name = "Small Round")
+      @Preview(name = "Large Round")
+      annotation class MultiRoundTiles
+
+      @MultiRoundTiles
+      fun MetaTilePreview(context: FakeContext) = "stub"
+
+      @Preview(name = "Direct")
+      fun DirectTilePreview(context: FakeContext) = "stub"
+      """
+        .trimIndent()
+    )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    // The "unsupported parameters" warning must NOT fire for tile previews —
+    // their (Context) parameter is part of the supported contract.
+    assertThat(result.output).doesNotContain("MetaTilePreview' — method has parameter(s)")
+    assertThat(result.output).doesNotContain("DirectTilePreview' — method has parameter(s)")
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val tilePreviews =
+      manifest.previews.filter {
+        it.functionName == "MetaTilePreview" || it.functionName == "DirectTilePreview"
+      }
+    assertThat(tilePreviews.map { it.functionName })
+      .containsExactly("MetaTilePreview", "MetaTilePreview", "DirectTilePreview")
+    assertThat(tilePreviews.map { it.params.kind }.toSet()).containsExactly(PreviewKind.TILE)
+  }
+
+  @Test
   fun `renderOutput strips common package prefix and sanitises path-unsafe preview names`() {
     val projectDir = createCmpTestProject()
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -531,7 +531,9 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     // multi-preview expansion — the provider is the same no matter which
     // @Preview drove the fan-out.
     val previewParameter = extractPreviewParameter(method)
-    val hasUnsupportedParameters = hasUnsupportedPreviewParameters(method, previewParameter)
+    val isTilePreview = isAnyTilePreviewAnnotation(annotations, scanResult)
+    val hasUnsupportedParameters =
+      !isTilePreview && hasUnsupportedPreviewParameters(method, previewParameter)
     if (hasUnsupportedParameters) {
       logger.warn(
         "composePreview: skipping @Preview '${classInfo.name}.${method.name}' — " +
@@ -608,6 +610,24 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         )
       }
     }
+  }
+
+  /**
+   * Tile previews ([TILE_PREVIEW_FQN]) take a single `(context: Context)` argument supplied by the
+   * renderer at run time; the @PreviewParameter contract that gates Compose previews doesn't apply
+   * to them. Walk direct annotations + multi-preview meta-annotations so a tile preview reached
+   * through a multi-preview alias (e.g. `@MultiRoundTilesPreviews`) is exempted too.
+   */
+  private fun isAnyTilePreviewAnnotation(
+    annotations: List<AnnotationInfo>,
+    scanResult: ScanResult,
+  ): Boolean {
+    if (collectDirectPreviews(annotations).any { it.name == TILE_PREVIEW_FQN }) return true
+    for (ann in annotations) {
+      val resolved = resolveMultiPreview(ann, scanResult, mutableSetOf())
+      if (resolved.any { it.name == TILE_PREVIEW_FQN }) return true
+    }
+    return false
   }
 
   private fun hasUnsupportedPreviewParameters(


### PR DESCRIPTION
## Summary

`DiscoverPreviewsTask.hasUnsupportedPreviewParameters` (added in #984) rejected every preview function whose single argument wasn't `@PreviewParameter`-driven — but tile previews legitimately take a `(context: Context)` parameter that the renderer supplies. The result was **zero tile entries discovered** in any module:

- Locally on `:samples:wear` — `HelloTilePreview` and `StepsTilePreview` never reach the manifest.
- In the integration matrix on `wear-os-samples (WearTilesKotlin)` — green until upstream PR [android/wear-os-samples#1369](https://github.com/android/wear-os-samples/pull/1369) (5 days ago) moved its 11 tiles to the standard `@Preview fun foo(context: Context): TilePreviewData` signature, then 0 previews ever since.

This PR exempts tile previews from the gate by looking at the method's `@Preview` annotations directly and through multi-preview meta-annotations (the `@MultiRoundTilesPreviews` shape). When any expansion targets `androidx.wear.tiles.tooling.preview.Preview`, the `(Context)` parameter is part of the supported contract.

After: `./gradlew :samples:wear:discoverPreviews` returns 21 previews (was 17), 4 of which are tiles.

## Test plan

- [x] `DiscoveryFunctionalTest.discoverPreviews keeps tile previews that take a Context parameter` — direct + multi-preview tile aliases assert into `previews.json` with `kind == TILE`.
- [x] Existing `DiscoveryFunctionalTest.discoverPreviews skips previews with unsupported parameters` still passes (the Compose-preview gate is unchanged).
- [ ] Integration matrix — `wear-os-samples (WearTilesKotlin)` should go green; tile-rendering requirement (`require_tile_render: true`) should also be satisfied since tiles now reach the manifest.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M5g1cgKtg4J99rdLFHqfQm)_