### PR TITLE
fix: resolve renderer jars lazily to avoid configuration-time warnings

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -917,10 +917,19 @@ internal object AndroidPreviewSupport {
               }
             }
             .files
-        // Callable defers `.files` resolution until the Test task queries
-        // this FileCollection, keeping the configuration lazy.
+        // Wire the zipTree expansion through `elements.map { ... }` so Gradle's
+        // task-graph walk sees a Provider (build-dependency-aware, value
+        // resolved lazily) instead of a Callable. A Callable here forces
+        // `rendererConfig` to resolve during task-graph construction —
+        // `DefaultConfigurableFileCollection.visitDependencies` unwraps Callables
+        // eagerly via `DeferredUtil.unpackNestableDeferred`, which calls into
+        // `rendererJars.getFiles()` and trips AGP's
+        // `DependencyResolutionChecks` "resolved during configuration time"
+        // warning (issue #1038). The Provider chain below participates in the
+        // build-dependency graph through `rendererJars.elements` without
+        // realising the configuration until task execution.
         project.files(
-          java.util.concurrent.Callable { rendererJars.files.map { project.zipTree(it) } }
+          rendererJars.elements.map { elements -> elements.map { project.zipTree(it.asFile) } }
         )
       }
 


### PR DESCRIPTION
## Summary
Replace eager `Callable`-based file resolution with a lazy `Provider` chain to prevent Gradle's dependency resolution checks from triggering during task-graph construction.

## Changes
- **Replaced `Callable` with `Provider` chain**: Changed from `java.util.concurrent.Callable { rendererJars.files.map { ... } }` to `rendererJars.elements.map { elements -> elements.map { ... } }`
- **Deferred configuration resolution**: The new approach uses Gradle's `elements` provider, which participates in the build-dependency graph without materializing the configuration until task execution time
- **Updated comment**: Clarified why the `Provider` approach is necessary, explaining that `Callable` unwrapping during `visitDependencies` was causing AGP's "resolved during configuration time" warning (issue #1038)

## Implementation Details
The key insight is that `DefaultConfigurableFileCollection.visitDependencies` eagerly unpacks `Callable` objects via `DeferredUtil.unpackNestableDeferred`, which forces immediate resolution of `rendererJars.files()`. By using `rendererJars.elements` (a `Provider`), the file collection participates in Gradle's task-dependency graph without forcing configuration-time resolution, deferring the actual file access until task execution.

https://claude.ai/code/session_01AvQneW2mu6PTkBRXkJSj1H