### PR TITLE
fix: pin androidx.activity to 1.10.0 for Robolectric compatibility

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -480,6 +480,30 @@ internal object AndroidPreviewSupport {
         "${variantName}Implementation",
         "androidx.customview:customview-poolingcontainer:1.0.0",
       )
+      // Pin `androidx.activity:activity` to a floor that exposes the
+      // `view_tree_on_back_pressed_dispatcher_owner` resource id. The
+      // renderer's test classpath pulls activity-compose ≥ 1.13 transitively
+      // (via roborazzi-compose), whose `ComponentActivity.initializeViewTreeOwners`
+      // → `ViewTreeOnBackPressedDispatcherOwner.set` reads
+      // `androidx.activity.R.id.view_tree_on_back_pressed_dispatcher_owner`
+      // (added in `androidx.activity:activity:1.5.0`). The merged unit-test
+      // resource APK is built from the consumer's MAIN variant, so on
+      // tile-only consumers whose main pulls only a legacy activity (e.g.
+      // wear-os-samples' WearTilesKotlin resolves `activity:1.1.0` via old
+      // transitives) the field is missing and Robolectric crashes the
+      // moment `createAndroidComposeRule<ComponentActivity>().setContent {}`
+      // runs:
+      //
+      //   `NoSuchFieldError: Class androidx.activity.R$id does not have
+      //   member field 'int view_tree_on_back_pressed_dispatcher_owner'`
+      //
+      // Same `${variantName}Implementation` floor pattern as the
+      // `androidx.core:core` and `customview-poolingcontainer` entries
+      // above — Gradle picks the max with consumer-aligned versions, so
+      // this is a no-op for Compose-app consumers that already get a
+      // newer activity transitively, and a fix for tile-only consumers
+      // that don't.
+      project.dependencies.add("${variantName}Implementation", "androidx.activity:activity:1.10.0")
       recordInjectedDependency(
         project,
         injectedDependencies,
@@ -516,6 +540,15 @@ internal object AndroidPreviewSupport {
         reason =
           "compose-ui's ViewCompositionStrategy reads androidx.customview.poolingcontainer.R.id.* from PoolingContainer.<clinit>; merged test APK needs the R class",
       )
+      recordInjectedDependency(
+        project,
+        injectedDependencies,
+        coordinate = "androidx.activity:activity:1.10.0",
+        configuration = "${variantName}Implementation",
+        outcome = "APPLIED",
+        reason =
+          "activity-compose 1.5+ on the renderer test classpath reads R.id.view_tree_on_back_pressed_dispatcher_owner via ViewTreeOnBackPressedDispatcherOwner.set (added in androidx.activity:activity:1.5.0); merged test APK needs the field so ComponentActivity.initializeViewTreeOwners doesn't NoSuchFieldError",
+      )
     } else {
       recordInjectedDependency(
         project,
@@ -550,6 +583,15 @@ internal object AndroidPreviewSupport {
         outcome = "SKIPPED_BY_CONFIG",
         reason =
           "manageDependencies=false; consumer must ensure androidx.customview:customview-poolingcontainer is on the main variant so the merged test APK includes its R class (referenced by compose-ui's PoolingContainer)",
+      )
+      recordInjectedDependency(
+        project,
+        injectedDependencies,
+        coordinate = "androidx.activity:activity:1.10.0",
+        configuration = "${variantName}Implementation",
+        outcome = "SKIPPED_BY_CONFIG",
+        reason =
+          "manageDependencies=false; consumer must ensure androidx.activity:activity >= 1.5.0 on the main variant so the merged test APK includes R.id.view_tree_on_back_pressed_dispatcher_owner (referenced by activity-compose's ComponentActivity.initializeViewTreeOwners)",
       )
     }
 


### PR DESCRIPTION
## Summary

Adds a dependency floor constraint on `androidx.activity:activity:1.10.0` to prevent `NoSuchFieldError` crashes when running Compose previews on tile-only consumers that transitively pull older versions of the activity library.

## Problem

The renderer's test classpath includes `activity-compose >= 1.13` (via roborazzi-compose), which calls `ViewTreeOnBackPressedDispatcherOwner.set` during `ComponentActivity.initializeViewTreeOwners`. This method reads the `view_tree_on_back_pressed_dispatcher_owner` resource ID, which was added in `androidx.activity:activity:1.5.0`.

For tile-only consumers (e.g., wear-os-samples' WearTilesKotlin) whose main variant only pulls legacy activity versions (e.g., `activity:1.1.0`), the merged unit-test resource APK lacks this resource ID. When Robolectric attempts to run `createAndroidComposeRule<ComponentActivity>().setContent {}`, it crashes with:

```
NoSuchFieldError: Class androidx.activity.R$id does not have member field 'int view_tree_on_back_pressed_dispatcher_owner'
```

## Changes

- **Inject `androidx.activity:activity:1.10.0`** into the `${variantName}Implementation` configuration when `manageDependencies=true`, using the same floor pattern as existing dependencies (`androidx.core:core` and `customview-poolingcontainer`)
- **Record dependency injection** with appropriate outcome and reason for both `manageDependencies=true` (APPLIED) and `manageDependencies=false` (SKIPPED_BY_CONFIG) cases
- Gradle's dependency resolution picks the maximum version, so this is a no-op for Compose-app consumers that already pull newer activity versions transitively, and a fix for tile-only consumers that don't

## Implementation Details

The floor constraint ensures the merged test APK includes the required resource ID without forcing unnecessary upgrades for consumers that already have compatible versions.

https://claude.ai/code/session_019dAP11SyQH7bdbyTCPHj6e