### PR TITLE
test: add e2e test for accessibility subscription chain

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -313,6 +313,18 @@ export interface ComposePreviewTestApi {
         force?: boolean,
         tier?: "fast" | "full",
     ): Promise<void>;
+    /**
+     * Drive a focus-inspector data-extension chip toggle from a test, by
+     * calling the same `handleSetDataExtensionEnabled` path the webview
+     * postMessage hits. Used by the a11y e2e tests to exercise the
+     * chip → daemon → attachment → webview chain without round-tripping
+     * through DevTools.
+     */
+    triggerSetDataExtensionEnabled(
+        previewId: string,
+        kind: string,
+        enabled: boolean,
+    ): Promise<void>;
     /** Snapshot of every panel message posted since [resetMessages]. */
     getPostedMessages(): unknown[];
     /**
@@ -1351,6 +1363,13 @@ export async function activate(
                 tier: "fast" | "full" = "full",
             ): Promise<void> {
                 return refresh(force, filePath, tier).then(() => {});
+            },
+            triggerSetDataExtensionEnabled(
+                previewId: string,
+                kind: string,
+                enabled: boolean,
+            ): Promise<void> {
+                return handleSetDataExtensionEnabled(previewId, kind, enabled);
             },
             getPostedMessages(): unknown[] {
                 return [...postedMessageLog];

--- a/vscode-extension/src/test/electron/realGradleApi.ts
+++ b/vscode-extension/src/test/electron/realGradleApi.ts
@@ -16,10 +16,17 @@ export class RealGradleApi implements GradleApi {
      * @param gradlewDir Absolute path to the directory containing the
      *                   `gradlew` script (the repo root).
      * @param onLog Optional sink for human-readable progress lines.
+     * @param extraArgs Extra CLI arguments appended to every `gradlew`
+     *                  invocation. Used by suites that need to set Gradle
+     *                  properties (`-Pfoo=bar`) without plumbing through
+     *                  `gradleService.ts`. Example: the wear a11y e2e
+     *                  passes `-PcomposePreview.previewExtensions.a11y.enableAllChecks=true`
+     *                  until #1009 lands the always-on daemon registry.
      */
     constructor(
         private readonly gradlewDir: string,
         private readonly onLog: (line: string) => void = () => {},
+        private readonly extraArgs: ReadonlyArray<string> = [],
     ) {}
 
     runTask(opts: {
@@ -37,7 +44,11 @@ export class RealGradleApi implements GradleApi {
             process.platform === "win32"
                 ? path.join(this.gradlewDir, "gradlew.bat")
                 : path.join(this.gradlewDir, "gradlew");
-        const gradleArgs = [opts.taskName, ...(opts.args ?? [])];
+        const gradleArgs = [
+            opts.taskName,
+            ...(opts.args ?? []),
+            ...this.extraArgs,
+        ];
         this.onLog(
             `[realGradleApi] ${gradlewPath} ${gradleArgs.join(" ")} (cwd=${opts.projectFolder})`,
         );

--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -1,0 +1,369 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import type { ComposePreviewTestApi } from "../../../extension";
+import { RealGradleApi } from "../realGradleApi";
+
+/**
+ * End-to-end test for the subscription-driven accessibility chain
+ * (issue #1006, follow-up to PR #1007). Drives the extension against a
+ * real Gradle build of `:samples:wear` so the full chip → daemon →
+ * attachment → webview chain is exercised: a focus-inspector chip
+ * toggle posts `setDataExtensionEnabled`, the daemon rerenders in
+ * `mode=a11y`, ships `a11y/atf` / `a11y/hierarchy` attachments via
+ * `renderFinished`, and the webview applies the resulting overlays.
+ *
+ * Gated on `COMPOSE_PREVIEW_E2E=1` alongside the existing real-Gradle
+ * suite in `e2e.test.ts`. Skipped silently in the fast suite (cold
+ * Gradle + first daemon spawn for wear runs multiple minutes).
+ *
+ * The verification surface is the `webviewA11yState` ack
+ * (webview→extension) the panel emits after `applyA11yUpdate`. Reading
+ * the webview's DOM directly is awkward across the extension-host /
+ * webview boundary, and asserting on the host-side `updateA11y` post
+ * alone wouldn't catch a webview-side regression in the cache write or
+ * overlay paint. Mirrors the `webviewPreviewsRendered` ack pattern the
+ * cmp e2e already uses.
+ *
+ * Setup: the daemon's accessibility data-product registry is still
+ * gated on `composeai.previewExtensions.a11y.enabled` (issue #1009
+ * removes that gate). Until then the test passes
+ * `-PcomposePreview.previewExtensions.a11y.enableAllChecks=true` via
+ * `RealGradleApi.extraArgs` so the wear daemon spawns with the registry
+ * registered. The focus-inspector chips themselves are gated on
+ * `composePreview.earlyFeatures.enabled`; the test flips it on at
+ * Global scope (isolated to `.vscode-test/user-data/`) and restores it
+ * after the run.
+ */
+
+const E2E = process.env.COMPOSE_PREVIEW_E2E === "1";
+const describeE2E = E2E ? describe : describe.skip;
+
+interface PostedMessage {
+    command: string;
+    [key: string]: unknown;
+}
+
+interface A11yStateAck extends PostedMessage {
+    command: "webviewA11yState";
+    previewId: string;
+    findingsCount: number | null;
+    nodesCount: number | null;
+}
+
+function findMessage(
+    messages: unknown[],
+    command: string,
+): PostedMessage | undefined {
+    return messages.find((m) => (m as PostedMessage).command === command) as
+        | PostedMessage
+        | undefined;
+}
+
+async function waitFor<T>(
+    description: string,
+    timeoutMs: number,
+    pollMs: number,
+    probe: () => T | undefined,
+): Promise<T> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const value = probe();
+        if (value !== undefined) {
+            return value;
+        }
+        await new Promise((r) => setTimeout(r, pollMs));
+    }
+    throw new Error(
+        `Timed out after ${timeoutMs}ms waiting for: ${description}`,
+    );
+}
+
+interface PreviewSummary {
+    id: string;
+    functionName: string;
+    params?: { device?: string | null; name?: string | null };
+}
+
+/**
+ * `@WearPreviewDevices` expands into multiple variants (one per round
+ * size). The plan calls out the "Large Round" variant for the hierarchy
+ * scenario, so prefer that; fall back to any variant if the device
+ * label naming changes upstream.
+ */
+function pickPreview(
+    previews: readonly PreviewSummary[],
+    functionName: string,
+    preferDeviceContains?: string,
+): PreviewSummary {
+    const candidates = previews.filter((p) => p.functionName === functionName);
+    assert.ok(
+        candidates.length > 0,
+        `expected at least one preview named ${functionName}; got ` +
+            previews
+                .map((p) => `${p.functionName}@${p.params?.device}`)
+                .join(", "),
+    );
+    if (preferDeviceContains) {
+        const preferred = candidates.find((p) =>
+            (p.params?.device ?? "").includes(preferDeviceContains),
+        );
+        if (preferred) return preferred;
+    }
+    return candidates[0];
+}
+
+describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
+    // The wear daemon's first cold render is the slowest path in the
+    // build: Robolectric + Wear material first-launch, plus an extra
+    // a11y-mode render after the chip subscribes. 15 minutes leaves
+    // head room on a fresh CI runner.
+    this.timeout(15 * 60_000);
+
+    let api: ComposePreviewTestApi;
+    let wearKotlinFile: string;
+    let priorEarlyFeatures: boolean | undefined;
+    let wearPreviews: PreviewSummary[];
+
+    before(async function () {
+        // Cold first-render bootstrap; each `it` reuses `wearPreviews`
+        // so the slow Gradle/daemon spin-up only happens once. Hook
+        // timeout matches the suite ceiling so the bootstrap render
+        // isn't truncated.
+        this.timeout(15 * 60_000);
+
+        const folders = vscode.workspace.workspaceFolders;
+        assert.ok(folders && folders.length > 0, "workspace must be open");
+        const repoRoot = folders[0].uri.fsPath;
+        wearKotlinFile = path.join(
+            repoRoot,
+            "samples",
+            "wear",
+            "src",
+            "main",
+            "kotlin",
+            "com",
+            "example",
+            "samplewear",
+            "Previews.kt",
+        );
+        assert.ok(
+            fs.existsSync(wearKotlinFile),
+            `expected wear sample file at ${wearKotlinFile}`,
+        );
+
+        // Focus-inspector chips + webview overlay painting are gated on
+        // earlyFeatures. Use Global scope so `@vscode/test-electron`'s
+        // isolated `.vscode-test/user-data/` holds the value and the
+        // repo's `.vscode/` stays clean. Restored in after().
+        const config = vscode.workspace.getConfiguration("composePreview");
+        priorEarlyFeatures = config.get<boolean>("earlyFeatures.enabled");
+        await config.update(
+            "earlyFeatures.enabled",
+            true,
+            vscode.ConfigurationTarget.Global,
+        );
+
+        const ext = vscode.extensions.getExtension<ComposePreviewTestApi>(
+            "yuri-schimke.compose-preview",
+        );
+        assert.ok(ext, "compose-preview extension must be present");
+        const exported = await ext.activate();
+        assert.ok(
+            exported,
+            "activate() must return ComposePreviewTestApi under COMPOSE_PREVIEW_TEST_MODE=1",
+        );
+        api = exported;
+        api.injectGradleApi(
+            new RealGradleApi(
+                repoRoot,
+                (line) => console.log(line),
+                // Until #1009 removes the daemon-side flag, the
+                // accessibility data-product registry only registers
+                // when this property resolves true. Otherwise the
+                // `data/subscribe` call succeeds but the registry has
+                // no a11y kinds to attach, so no `updateA11y` ever
+                // reaches the webview and the test times out.
+                [
+                    "-PcomposePreview.previewExtensions.a11y.enableAllChecks=true",
+                ],
+            ),
+        );
+
+        // One refresh bootstraps every `it`: the wear renderAllPreviews
+        // cold path is the slowest piece of the suite, so paying for it
+        // once and reusing the `setPreviews` payload keeps the total
+        // wall-clock close to a single render plus three chip toggles.
+        wearPreviews = await refreshAndGetPreviews(15 * 60_000);
+    });
+
+    after(async () => {
+        const config = vscode.workspace.getConfiguration("composePreview");
+        await config.update(
+            "earlyFeatures.enabled",
+            priorEarlyFeatures,
+            vscode.ConfigurationTarget.Global,
+        );
+    });
+
+    async function refreshAndGetPreviews(
+        timeoutMs: number,
+    ): Promise<PreviewSummary[]> {
+        api.resetMessages();
+        await api.triggerRefresh(wearKotlinFile, /* force */ true, "full");
+        const setPreviews = await waitFor(
+            "non-empty setPreviews for samples/wear",
+            timeoutMs,
+            500,
+            () => {
+                const m = findMessage(api.getPostedMessages(), "setPreviews");
+                if (!m) return undefined;
+                const previews = m.previews as PreviewSummary[] | undefined;
+                if (!previews || previews.length === 0) return undefined;
+                return m;
+            },
+        );
+        const previews = setPreviews.previews as PreviewSummary[];
+        console.log(
+            `[e2e-a11y] wear setPreviews carried ${previews.length} previews`,
+        );
+        return previews;
+    }
+
+    function findA11yAck(
+        previewId: string,
+        match: (ack: A11yStateAck) => boolean,
+    ): A11yStateAck | undefined {
+        const inbound = api.getReceivedMessages();
+        return inbound.find((raw) => {
+            const m = raw as PostedMessage;
+            return (
+                m.command === "webviewA11yState" &&
+                (m as A11yStateAck).previewId === previewId &&
+                match(m as A11yStateAck)
+            );
+        }) as A11yStateAck | undefined;
+    }
+
+    it("paints hierarchy overlay when the chip toggles ON for ActivityListPreview", async function () {
+        const target = pickPreview(
+            wearPreviews,
+            "ActivityListPreview",
+            "Large Round",
+        );
+        console.log(
+            `[e2e-a11y] subscribing a11y/hierarchy for ${target.functionName} (${target.params?.device})`,
+        );
+        api.resetMessages();
+
+        await api.triggerSetDataExtensionEnabled(
+            target.id,
+            "a11y/hierarchy",
+            true,
+        );
+
+        const ack = await waitFor(
+            `webviewA11yState with nodes for ${target.id}`,
+            this.timeout(),
+            500,
+            () =>
+                findA11yAck(
+                    target.id,
+                    (a) => typeof a.nodesCount === "number" && a.nodesCount > 0,
+                ),
+        );
+        // The plan called out 12 nodes for ActivityListPreview at the time
+        // of PR #1007's manual verification. Don't pin the literal — text
+        // content and Material defaults shift across compose-bom updates,
+        // and any positive count proves the chain is intact.
+        assert.ok(
+            (ack.nodesCount ?? 0) > 0,
+            `expected nodesCount > 0, got ${ack.nodesCount}`,
+        );
+        assert.strictEqual(
+            ack.findingsCount,
+            null,
+            "hierarchy-only update should leave findingsCount=null",
+        );
+    });
+
+    it("paints findings legend when the chip toggles ON for BadWearButtonPreview", async function () {
+        const target = pickPreview(wearPreviews, "BadWearButtonPreview");
+        console.log(
+            `[e2e-a11y] subscribing a11y/atf for ${target.functionName} (${target.params?.device})`,
+        );
+        api.resetMessages();
+
+        await api.triggerSetDataExtensionEnabled(target.id, "a11y/atf", true);
+
+        const ack = await waitFor(
+            `webviewA11yState with findings for ${target.id}`,
+            this.timeout(),
+            500,
+            () =>
+                findA11yAck(
+                    target.id,
+                    (a) =>
+                        typeof a.findingsCount === "number" &&
+                        a.findingsCount > 0,
+                ),
+        );
+        // `BadWearButtonPreview` is engineered to produce exactly one ATF
+        // finding (level=ERROR, type=SpeakableTextPresentCheck — the
+        // empty-label `Button`). Pin to 1 so a regression that produces
+        // *zero* findings (the chain silently dropping the attachment) or
+        // *multiple* (Material defaults changing what ATF flags) is loud.
+        assert.strictEqual(
+            ack.findingsCount,
+            1,
+            `expected exactly 1 finding for BadWearButtonPreview, got ${ack.findingsCount}`,
+        );
+        assert.strictEqual(
+            ack.nodesCount,
+            null,
+            "atf-only update should leave nodesCount=null",
+        );
+    });
+
+    it("tears down the hierarchy overlay when the chip toggles OFF", async function () {
+        const target = pickPreview(
+            wearPreviews,
+            "ActivityListPreview",
+            "Large Round",
+        );
+        api.resetMessages();
+
+        await api.triggerSetDataExtensionEnabled(
+            target.id,
+            "a11y/hierarchy",
+            true,
+        );
+        await waitFor(
+            `nodes-painted ack for ${target.id}`,
+            this.timeout(),
+            500,
+            () =>
+                findA11yAck(
+                    target.id,
+                    (a) => typeof a.nodesCount === "number" && a.nodesCount > 0,
+                ),
+        );
+
+        // Reset so the teardown ack isn't confused with the prior paint.
+        api.resetMessages();
+
+        await api.triggerSetDataExtensionEnabled(
+            target.id,
+            "a11y/hierarchy",
+            false,
+        );
+        const teardown = await waitFor(
+            `webviewA11yState teardown for ${target.id}`,
+            this.timeout(),
+            500,
+            () => findA11yAck(target.id, (a) => a.nodesCount === 0),
+        );
+        assert.strictEqual(teardown.nodesCount, 0);
+    });
+});

--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -52,15 +52,6 @@ interface A11yStateAck extends PostedMessage {
     nodesCount: number | null;
 }
 
-function findMessage(
-    messages: unknown[],
-    command: string,
-): PostedMessage | undefined {
-    return messages.find((m) => (m as PostedMessage).command === command) as
-        | PostedMessage
-        | undefined;
-}
-
 async function waitFor<T>(
     description: string,
     timeoutMs: number,
@@ -217,11 +208,19 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
             timeoutMs,
             500,
             () => {
-                const m = findMessage(api.getPostedMessages(), "setPreviews");
-                if (!m) return undefined;
-                const previews = m.previews as PreviewSummary[] | undefined;
-                if (!previews || previews.length === 0) return undefined;
-                return m;
+                // Scan in reverse for the latest non-empty setPreviews:
+                // the refresh flow can emit an initial empty/stale payload
+                // (cached-manifest replay) before the rendered manifest
+                // lands, and `Array.prototype.find` would lock onto the
+                // empty one forever.
+                const msgs = api.getPostedMessages();
+                for (let i = msgs.length - 1; i >= 0; i--) {
+                    const m = msgs[i] as PostedMessage;
+                    if (m.command !== "setPreviews") continue;
+                    const previews = m.previews as PreviewSummary[] | undefined;
+                    if (previews && previews.length > 0) return m;
+                }
+                return undefined;
             },
         );
         const previews = setPreviews.previews as PreviewSummary[];

--- a/vscode-extension/src/test/electron/suite/index.ts
+++ b/vscode-extension/src/test/electron/suite/index.ts
@@ -31,8 +31,11 @@ export async function run(): Promise<void> {
     // suite excludes it. Pattern selection here so each mode's run output
     // doesn't list "skipped" entries for the other mode's tests.
     const e2eMode = process.env.COMPOSE_PREVIEW_E2E === "1";
-    const pattern = e2eMode ? "**/e2e.test.js" : "**/*.test.js";
-    const ignore = e2eMode ? [] : ["**/e2e.test.js"];
+    // Match every `e2e*.test.js` so the slow suite can be split across
+    // files (`e2e.test.js`, `e2eA11y.test.js`, …) without having to
+    // restate file names here.
+    const pattern = e2eMode ? "**/e2e*.test.js" : "**/*.test.js";
+    const ignore = e2eMode ? [] : ["**/e2e*.test.js"];
     const files = await glob(pattern, { cwd: testsRoot, ignore });
     console.log(
         `[suite] discovered ${files.length} test file(s) in ${testsRoot} (e2e=${e2eMode})`,

--- a/vscode-extension/src/test/focusPresentation.test.ts
+++ b/vscode-extension/src/test/focusPresentation.test.ts
@@ -6,6 +6,7 @@
 import * as assert from "assert";
 import {
     _resetPresentersForTest,
+    _seedBuiltInPresentersForTest,
     getPresenter,
     registerPresenter,
 } from "../webview/preview/focusPresentation";
@@ -198,10 +199,19 @@ describe("focusPresentation registry", () => {
     it("_resetPresentersForTest empties the registry", () => {
         _resetPresentersForTest();
         assert.strictEqual(getPresenter("a11y/hierarchy"), undefined);
-        // Re-import to reseed for sibling tests in this file. Mocha
-        // doesn't reload modules across `describe` blocks, so mirror
-        // the side-effect register calls inline.
-        require("../webview/preview/focusPresentation");
+        // Reseed so sibling test files that depend on the built-ins
+        // (the "trusts a presenter that returns null" assertion in
+        // focusInspectorToggle.test is the canonical case) don't see
+        // an empty registry. A bare re-`require` here is a no-op
+        // (Node's module cache), and busting the cache creates a
+        // *second* copy of the registry the first import's
+        // `getPresenter` can't see — the only reliable restore is
+        // calling the seed helper directly.
+        _seedBuiltInPresentersForTest();
+        assert.ok(
+            getPresenter("a11y/hierarchy"),
+            "registry must be reseeded so the built-in a11y/hierarchy presenter is callable again",
+        );
     });
 });
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -656,6 +656,24 @@ export type WebviewToExtension =
      * full host→webview→DOM loop is regression-locked.
      */
     | { command: "webviewPreviewsRendered"; count: number }
+    /**
+     * Webview reports it has finished applying an `updateA11y` payload —
+     * sent from `messageHandlers.ts` after `applyA11yUpdate` mutates the
+     * per-card a11y caches. Mirrors `webviewPreviewsRendered`: lets e2e
+     * tests assert the chip → daemon → host → webview chain landed
+     * without scraping the DOM.
+     *
+     * `findingsCount` / `nodesCount` are `null` when that side wasn't part
+     * of the inbound update (so a `nodes`-only update doesn't masquerade
+     * as a 0-findings update). When present, the integer reflects the
+     * length of the array the webview just consumed.
+     */
+    | {
+          command: "webviewA11yState";
+          previewId: string;
+          findingsCount: number | null;
+          nodesCount: number | null;
+      }
     | { command: "openFile"; className: string; functionName: string }
     | { command: "selectModule"; value: string }
     /**

--- a/vscode-extension/src/webview/preview/focusPresentation.ts
+++ b/vscode-extension/src/webview/preview/focusPresentation.ts
@@ -128,6 +128,18 @@ export function _resetPresentersForTest(): void {
     registry.clear();
 }
 
+/**
+ * Visible for tests only — re-register the built-in presenters after a
+ * call to {@link _resetPresentersForTest}. Side-effect-only `require`
+ * of this module won't re-run the bottom-of-file `registerPresenter`
+ * calls (Node caches the module), and even busting the require cache
+ * creates a *second* copy of the registry — so the only reliable way
+ * to put the built-ins back is to call this helper directly.
+ */
+export function _seedBuiltInPresentersForTest(): void {
+    seedBuiltInPresenters();
+}
+
 // ---- Built-in presenters --------------------------------------------------
 //
 // Concrete presenters live alongside the framework so the registry is
@@ -137,11 +149,15 @@ export function _resetPresentersForTest(): void {
 // here is to prove each surface's mount works end-to-end, not to fake
 // data the daemon doesn't actually produce.
 
-registerPresenter("a11y/hierarchy", a11yHierarchyPresenter);
-registerPresenter("a11y/atf", a11yFindingsPresenter);
-registerPresenter("a11y/overlay", a11yOverlayPresenter);
-registerPresenter("compose/theme", composeThemePresenter);
-registerPresenter("local/render/error", renderErrorPresenter);
+function seedBuiltInPresenters(): void {
+    registerPresenter("a11y/hierarchy", a11yHierarchyPresenter);
+    registerPresenter("a11y/atf", a11yFindingsPresenter);
+    registerPresenter("a11y/overlay", a11yOverlayPresenter);
+    registerPresenter("compose/theme", composeThemePresenter);
+    registerPresenter("local/render/error", renderErrorPresenter);
+}
+
+seedBuiltInPresenters();
 
 function a11yHierarchyPresenter(
     ctx: PresenterContext,

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -155,6 +155,16 @@ export function handleExtensionMessage(
         }
         case "updateA11y":
             ctx.applyA11yUpdate(msg.previewId, msg.findings, msg.nodes);
+            ctx.vscode.postMessage({
+                command: "webviewA11yState",
+                previewId: msg.previewId,
+                findingsCount:
+                    msg.findings === undefined
+                        ? null
+                        : (msg.findings?.length ?? 0),
+                nodesCount:
+                    msg.nodes === undefined ? null : (msg.nodes?.length ?? 0),
+            });
             return;
         case "updateDataProducts":
             ctx.updateDataProducts(msg.previewId, msg.dataProducts);


### PR DESCRIPTION
Add end-to-end test suite for the accessibility (a11y) subscription chain that exercises the full path from focus-inspector chip toggle through daemon rendering to webview overlay application.

## Summary

This adds a new e2e test file (`e2eA11y.test.ts`) that validates the accessibility feature chain introduced in PR #1007. The test drives the extension against a real Gradle build of the wear sample, verifying that:

1. Toggling a focus-inspector chip on the webview triggers a `setDataExtensionEnabled` message
2. The daemon receives the subscription and rerenders in `mode=a11y`
3. Accessibility attachments (`a11y/atf` for findings, `a11y/hierarchy` for node overlays) flow back through the extension
4. The webview applies the overlays and reports completion via a new `webviewA11yState` ack message

## Key Changes

- **New e2e test suite** (`e2eA11y.test.ts`): Three test cases covering hierarchy overlay painting, findings legend painting, and overlay teardown. Gated on `COMPOSE_PREVIEW_E2E=1` environment variable and skipped in fast test runs due to cold Gradle/daemon startup overhead (~15 minutes).

- **Test API extension** (`extension.ts`): Added `triggerSetDataExtensionEnabled()` method to `ComposePreviewTestApi` so tests can drive chip toggles without round-tripping through DevTools.

- **Webview ack message** (`types.ts`, `messageHandlers.ts`): New `webviewA11yState` message type that the webview posts after applying an `updateA11y` payload, reporting the count of findings and hierarchy nodes applied. Mirrors the existing `webviewPreviewsRendered` ack pattern to let tests assert chain completion without DOM scraping.

- **Gradle API enhancement** (`realGradleApi.ts`): Added `extraArgs` parameter to `RealGradleApi` constructor to support passing Gradle properties (e.g., `-PcomposePreview.previewExtensions.a11y.enableAllChecks=true`) needed until issue #1009 removes the daemon-side feature gate.

- **Test suite configuration** (`suite/index.ts`): Updated glob pattern to match all `e2e*.test.js` files so the slow suite can be split across multiple files without duplication.

## Implementation Details

- The test enables `composePreview.earlyFeatures.enabled` at Global scope (isolated to test runner's user data) and restores the prior value after completion.
- Reuses a single cold Gradle render across all test cases via a `before()` hook to minimize total wall-clock time.
- Uses `waitFor()` polling to handle async daemon rendering and webview message delivery with configurable timeouts.
- Validates specific preview variants (e.g., "Large Round" device for wear) and falls back gracefully if device naming changes upstream.
- Pins expected findings count (1 for `BadWearButtonPreview`) to catch regressions in attachment delivery or Material defaults, but allows hierarchy node counts to vary.

https://claude.ai/code/session_01KquQeHQnD8mBsET1UruMNz