### PR TITLE
feat: generic fallback presenter and a11y/overlay PNG support

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -399,6 +399,49 @@ function isJsonDataProduct(dp: DataProductAttachment): boolean {
     return dp.path.toLowerCase().endsWith(".json");
 }
 
+/**
+ * `true` iff [dp]'s `path` looks like a PNG. Counterpart to
+ * [isJsonDataProduct]: binary data products (today `a11y/overlay`) flow
+ * through [readBinaryDataProductPayload] which base64-encodes the bytes
+ * so the webview can render them via a `data:` URI without needing
+ * webview-resource access. Other binary kinds (`.bin`, etc.) get
+ * filtered out — we only forward formats the webview can actually
+ * display.
+ */
+function isImageDataProduct(dp: DataProductAttachment): boolean {
+    if (!dp.path) return false;
+    return dp.path.toLowerCase().endsWith(".png");
+}
+
+/**
+ * Read a PNG-transport data product off disk and return the webview
+ * payload — `{ imageBase64, mediaType, sizeBytes }`. Returns
+ * `undefined` (logged) on read failure so the calling map step drops
+ * the entry rather than posting a half-formed payload. Investigation
+ * surface only: the panel renders the bytes in the focus inspector's
+ * Reports section behind a collapsed `<details>` so the structured
+ * a11y kinds stay the default review path.
+ */
+function readBinaryDataProductPayload(
+    dp: DataProductAttachment,
+    log: { appendLine(value: string): void },
+): { imageBase64: string; mediaType: string; sizeBytes: number } | undefined {
+    if (!dp.path) return undefined;
+    try {
+        const buf = fs.readFileSync(dp.path);
+        return {
+            imageBase64: buf.toString("base64"),
+            mediaType: "image/png",
+            sizeBytes: buf.length,
+        };
+    } catch (err) {
+        log.appendLine(
+            `[daemon] could not read data-product image at ${dp.path}: ${(err as Error).message}`,
+        );
+        return undefined;
+    }
+}
+
 function readJsonPath(
     p: string | undefined,
     log: { appendLine(value: string): void },
@@ -581,7 +624,12 @@ export async function activate(
                                 dp.payload ??
                                 (isJsonDataProduct(dp)
                                     ? readJsonPath(dp.path, outputChannel)
-                                    : undefined),
+                                    : isImageDataProduct(dp)
+                                      ? readBinaryDataProductPayload(
+                                            dp,
+                                            outputChannel,
+                                        )
+                                      : undefined),
                         }))
                         .filter((dp) => dp.payload !== undefined);
                     if (payloads.length > 0) {

--- a/vscode-extension/src/test/focusInspectorToggle.test.ts
+++ b/vscode-extension/src/test/focusInspectorToggle.test.ts
@@ -63,7 +63,11 @@ interface Harness {
     a11yClicks: number;
 }
 
-function makeHarness(findingsCount = 0, autoEnableCheap = false): Harness {
+function makeHarness(
+    findingsCount = 0,
+    autoEnableCheap = false,
+    dataByKind: Record<string, unknown> = {},
+): Harness {
     const toggles: ToggleEvent[] = [];
     let a11yClicks = 0;
 
@@ -74,6 +78,7 @@ function makeHarness(findingsCount = 0, autoEnableCheap = false): Harness {
     document.body.appendChild(card);
 
     const inspector = new FocusInspectorController({
+        getDataProduct: (_previewId, kind) => dataByKind[kind],
         el: container,
         earlyFeatures: () => true,
         autoEnableCheap: () => autoEnableCheap,
@@ -178,6 +183,77 @@ describe("focus inspector data-extension toggle", () => {
         assert.strictEqual(summary!.textContent, "Loading");
         const body = placeholderReport!.querySelector(".focus-report-body");
         assert.ok(body && body.textContent && body.textContent.length > 0);
+    });
+
+    it("falls back to a generic JSON dump for a no-presenter kind once data arrives", () => {
+        const h = makeHarness(0, false, {
+            "fonts/used": { families: ["Roboto", "Inter"], glyphCount: 42 },
+        });
+        h.inspector.render(h.card);
+        const fontsRow = findRowByLabel(h.container, "Fonts");
+        fontsRow.querySelector<HTMLInputElement>("input")!.click();
+        const report = h.container.querySelector(
+            '.focus-report[data-kind="fonts/used"]',
+        );
+        assert.ok(report, "expected a fonts/used report after toggle");
+        const summary = report!.querySelector(".focus-report-summary-hint");
+        assert.strictEqual(summary?.textContent, "Daemon data");
+        const pre = report!.querySelector("pre.focus-report-pre");
+        assert.ok(pre, "generic fallback should render the payload as <pre>");
+        assert.ok(pre!.textContent?.includes("Roboto"));
+        assert.ok(pre!.textContent?.includes("glyphCount"));
+    });
+
+    it("renders an <img> for a no-presenter kind whose payload looks like an image", () => {
+        const h = makeHarness(0, false, {
+            "fonts/used": {
+                imageBase64: "AAAA",
+                mediaType: "image/png",
+                sizeBytes: 1024,
+            },
+        });
+        h.inspector.render(h.card);
+        findRowByLabel(h.container, "Fonts")
+            .querySelector<HTMLInputElement>("input")!
+            .click();
+        const report = h.container.querySelector(
+            '.focus-report[data-kind="fonts/used"]',
+        );
+        assert.ok(report);
+        const img = report!.querySelector<HTMLImageElement>("img");
+        assert.ok(img, "image payload should render as an <img>");
+        assert.strictEqual(img!.src, "data:image/png;base64,AAAA");
+    });
+
+    it("trusts a presenter that returns null instead of stamping a Loading placeholder", () => {
+        // a11y/atf returns null when findings are empty — the local
+        // overlay layer handles the no-findings case visually, so we
+        // mustn't double-stamp a "Loading…" report under the inspector.
+        // This was the old "Loading… forever" UX before the trust-null
+        // fix landed.
+        const h = makeHarness();
+        // Built-in product list doesn't include a11y/atf — push it via
+        // setProducts so the inspector renders an enabled-able row.
+        h.inspector.setProducts([
+            {
+                kind: "a11y/atf",
+                label: "Accessibility findings",
+                icon: "eye",
+                cost: "expensive",
+                daemonBacked: true,
+            },
+        ]);
+        h.inspector.render(h.card);
+        const atfRow = findRowByLabel(h.container, "Accessibility findings");
+        atfRow.querySelector<HTMLInputElement>("input")!.click();
+        const report = h.container.querySelector(
+            '.focus-report[data-kind="a11y/atf"]',
+        );
+        assert.strictEqual(
+            report,
+            null,
+            "a11y/atf with no findings should NOT stamp a placeholder report",
+        );
     });
 
     it("does not fire onToggleDataExtension for the local a11y overlay chip", () => {

--- a/vscode-extension/src/test/focusPresentation.test.ts
+++ b/vscode-extension/src/test/focusPresentation.test.ts
@@ -49,6 +49,7 @@ function ctx(overrides?: {
     nodes?: readonly AccessibilityNode[];
     findings?: readonly AccessibilityFinding[];
     cardDataset?: Record<string, string>;
+    data?: (kind: string) => unknown;
 }) {
     const card = document.createElement("div");
     if (overrides?.cardDataset) {
@@ -59,6 +60,7 @@ function ctx(overrides?: {
         preview: samplePreview,
         findings: overrides?.findings ?? [],
         nodes: overrides?.nodes ?? [],
+        data: overrides?.data,
     };
 }
 
@@ -127,6 +129,44 @@ describe("focusPresentation registry", () => {
         assert.ok(result);
         assert.ok(result!.error);
         assert.strictEqual(result!.overlay, null);
+    });
+
+    it("a11y/overlay presenter returns null when no payload is cached", () => {
+        const overlay = getPresenter("a11y/overlay")!;
+        assert.strictEqual(overlay(ctx()), null);
+        // Wrong-shape payloads also fall through to null so the
+        // inspector renders the pending fallback instead of a broken
+        // <img>.
+        const malformed = overlay(ctx({ data: () => ({ imageBase64: 42 }) }));
+        assert.strictEqual(malformed, null);
+        const empty = overlay(ctx({ data: () => ({ imageBase64: "" }) }));
+        assert.strictEqual(empty, null);
+    });
+
+    it("a11y/overlay presenter emits a Report with the PNG when payload is present", () => {
+        const overlay = getPresenter("a11y/overlay")!;
+        const result = overlay(
+            ctx({
+                data: (kind) =>
+                    kind === "a11y/overlay"
+                        ? {
+                              imageBase64: "AAAA",
+                              mediaType: "image/png",
+                              sizeBytes: 4096,
+                          }
+                        : undefined,
+            }),
+        );
+        assert.ok(result);
+        assert.ok(result!.report);
+        assert.strictEqual(
+            result!.report!.title,
+            "Accessibility overlay (PNG)",
+        );
+        assert.strictEqual(result!.report!.summary, "4 kB");
+        const img = result!.report!.body.querySelector("img");
+        assert.ok(img);
+        assert.strictEqual(img!.src, "data:image/png;base64,AAAA");
     });
 
     it("renderErrorPresenter activates only when the card carries a render error", () => {

--- a/vscode-extension/src/webview/preview/focusInspector.ts
+++ b/vscode-extension/src/webview/preview/focusInspector.ts
@@ -730,24 +730,44 @@ export class FocusInspectorController {
         const enabled = this.enabledKindsFor(previewId);
         for (const kind of enabled) {
             const presenter = getPresenter(kind);
-            const presentation = presenter ? presenter(ctx) : null;
-            if (presentation) {
-                out.push({ kind, presentation });
+            // A registered presenter is authoritative — non-null
+            // contributions get slotted in, an intentional null means
+            // "I have nothing to add this render" (a11y/atf with no
+            // findings is the canonical case; the legend / overlay
+            // surfaces are empty by design). Don't fall back to a
+            // pending placeholder in that case — it'd surprise the
+            // user with a permanent "Loading…" for a kind the daemon
+            // already answered.
+            if (presenter) {
+                const presentation = presenter(ctx);
+                if (presentation) {
+                    out.push({ kind, presentation });
+                }
                 continue;
             }
-            // Toggle-on must always paint *something* so the user sees
-            // their click take effect even before the daemon answers.
-            // When the registered presenter (or the missing-presenter
-            // case) yields nothing, fall back to a "Loading…" report
-            // keyed off the descriptor we resolved for the bucket list.
             // Skip purely panel-side kinds — those either own their
             // own UI surface (a11y overlay, render-error banner) or
             // never produce daemon data we'd be waiting for.
             if (kind.startsWith("local/")) continue;
             const descriptor = productByKind.get(kind);
+            const data = ctx.data?.(kind);
+            // No registered presenter: render a generic payload-dump
+            // Report so every subscribed kind surfaces *something*
+            // useful — JSON pretty-print for structured data, an
+            // <img> for known image payloads. Keeps the panel
+            // unsurprising for kinds we haven't yet hand-rolled a
+            // presenter for, and gives consumers a flexible "what did
+            // the daemon attach?" investigation surface. When no data
+            // has arrived yet, fall through to the pending placeholder
+            // so the toggle still paints something.
+            const generic =
+                data !== undefined
+                    ? genericPresentation(kind, descriptor?.label, data)
+                    : null;
             out.push({
                 kind,
-                presentation: pendingPresentation(kind, descriptor?.label),
+                presentation:
+                    generic ?? pendingPresentation(kind, descriptor?.label),
             });
         }
         return out;
@@ -1048,6 +1068,75 @@ function sectionHeader(icon: string, label: string): HTMLElement {
  * pushes, and product-list changes.
  */
 const EMPTY_KIND_SET: ReadonlySet<string> = new Set();
+
+/**
+ * Build a generic Report contribution for a kind that has no registered
+ * presenter but does have a cached payload. Two shapes:
+ *
+ *  - Image payload (`{ imageBase64, mediaType? }`) — render as `<img>`
+ *    inside a collapsed `<details>` so the user can scrub through it
+ *    without it stealing focus from the structured surfaces.
+ *  - Anything else — JSON-stringify the value into a `<pre>` block.
+ *
+ * Returns `null` if the value is `null`, an empty object, or otherwise
+ * obviously empty so the caller can fall back to "no data" messaging.
+ * Other readers that want a polished view can register a kind-specific
+ * presenter — this is the unsurprising default.
+ */
+function genericPresentation(
+    kind: string,
+    label: string | undefined,
+    data: unknown,
+): ProductPresentation | null {
+    if (data === null) return null;
+    const display = label && label.length > 0 ? label : kind;
+    // Image-shaped payloads — same wire shape `extension.ts` produces
+    // for `.png` data products. Treat the payload as opaque bytes; if
+    // a `mediaType` isn't set we default to PNG because that's what
+    // every binary data product ships today.
+    if (typeof data === "object" && data !== null) {
+        const maybeImage = data as {
+            imageBase64?: unknown;
+            mediaType?: unknown;
+        };
+        if (
+            typeof maybeImage.imageBase64 === "string" &&
+            maybeImage.imageBase64.length > 0
+        ) {
+            const mediaType =
+                typeof maybeImage.mediaType === "string"
+                    ? maybeImage.mediaType
+                    : "image/png";
+            const body = document.createElement("div");
+            body.className = "focus-report-generic focus-report-generic-image";
+            const img = document.createElement("img");
+            img.className = "focus-report-overlay-img";
+            img.alt = display;
+            img.src = `data:${mediaType};base64,${maybeImage.imageBase64}`;
+            body.appendChild(img);
+            return { report: { title: display, body } };
+        }
+    }
+    let serialized: string;
+    try {
+        serialized = JSON.stringify(data, null, 2);
+    } catch {
+        // Unserialisable payloads (cycles, BigInt, etc.) — fall back
+        // to the runtime stringification rather than dropping the
+        // report entirely. The user still sees that data arrived.
+        serialized = String(data);
+    }
+    if (!serialized || serialized === "{}" || serialized === "[]") {
+        return null;
+    }
+    const body = document.createElement("div");
+    body.className = "focus-report-generic focus-report-generic-json";
+    const pre = document.createElement("pre");
+    pre.className = "focus-report-pre";
+    pre.textContent = serialized;
+    body.appendChild(pre);
+    return { report: { title: display, summary: "Daemon data", body } };
+}
 
 /**
  * Build a "Loading…" report contribution for a kind the user just

--- a/vscode-extension/src/webview/preview/focusPresentation.ts
+++ b/vscode-extension/src/webview/preview/focusPresentation.ts
@@ -139,6 +139,7 @@ export function _resetPresentersForTest(): void {
 
 registerPresenter("a11y/hierarchy", a11yHierarchyPresenter);
 registerPresenter("a11y/atf", a11yFindingsPresenter);
+registerPresenter("a11y/overlay", a11yOverlayPresenter);
 registerPresenter("compose/theme", composeThemePresenter);
 registerPresenter("local/render/error", renderErrorPresenter);
 
@@ -246,6 +247,59 @@ function a11yFindingsPresenter(
                 " finding" +
                 (findings.length === 1 ? "" : "s"),
             entries,
+        },
+    };
+}
+
+/**
+ * `a11y/overlay` — the daemon's annotated PNG. Rendered as a Report
+ * (collapsed `<details>`) rather than swapped onto the card so the
+ * structured a11y kinds (`a11y/atf` + `a11y/hierarchy`) remain the
+ * primary review surface. The PNG is here for investigations where a
+ * structured-only view isn't enough — e.g. reproducing what a CI PR
+ * preview reported.
+ *
+ * Wire payload is `{ imageBase64, mediaType, sizeBytes }`, posted from
+ * `extension.ts` after reading the path-transport PNG off disk.
+ */
+function a11yOverlayPresenter(
+    ctx: PresenterContext,
+): ProductPresentation | null {
+    const raw = ctx.data?.("a11y/overlay");
+    if (!raw || typeof raw !== "object") return null;
+    const data = raw as {
+        imageBase64?: unknown;
+        mediaType?: unknown;
+        sizeBytes?: unknown;
+    };
+    if (typeof data.imageBase64 !== "string" || data.imageBase64.length === 0) {
+        return null;
+    }
+    const mediaType =
+        typeof data.mediaType === "string" ? data.mediaType : "image/png";
+    const body = document.createElement("div");
+    body.className = "focus-report-overlay-png";
+    const note = document.createElement("p");
+    note.className = "focus-report-overlay-note";
+    note.textContent =
+        "Daemon-rendered annotated PNG. Useful for investigating what a CI " +
+        "preview reported; for routine review prefer the structured a11y " +
+        "kinds (findings + hierarchy) which drive the locally-painted overlay.";
+    const img = document.createElement("img");
+    img.className = "focus-report-overlay-img";
+    img.alt = "Accessibility overlay (annotated)";
+    img.src = `data:${mediaType};base64,${data.imageBase64}`;
+    body.appendChild(note);
+    body.appendChild(img);
+    const summary =
+        typeof data.sizeBytes === "number" && data.sizeBytes > 0
+            ? `${Math.max(1, Math.round(data.sizeBytes / 1024))} kB`
+            : undefined;
+    return {
+        report: {
+            title: "Accessibility overlay (PNG)",
+            summary,
+            body,
         },
     };
 }


### PR DESCRIPTION
## Summary

Adds a generic fallback presenter for data kinds without hand-rolled presenters, and introduces support for rendering daemon-generated annotated PNG overlays in the focus inspector.

## Key Changes

- **Generic fallback presenter** (`genericPresentation`): When a data kind has no registered presenter but cached payload data exists, render it as either:
  - An `<img>` element for image-shaped payloads (`{ imageBase64, mediaType? }`)
  - A JSON pretty-print `<pre>` block for structured data
  - Falls back to pending placeholder only when no data has arrived yet

- **Trust null returns from presenters**: Modified the render loop to distinguish between "presenter exists but returned null" (intentional, e.g., a11y/atf with no findings) and "no presenter registered" (fallback to generic). Prevents spurious "Loading…" placeholders for kinds the daemon has already answered.

- **a11y/overlay PNG presenter** (`a11yOverlayPresenter`): New presenter for the daemon's annotated accessibility PNG. Renders as a collapsed `<details>` report with file size summary, keeping structured a11y kinds (findings + hierarchy) as the primary review surface while providing the PNG for CI investigation.

- **Binary data product support** in extension: Added `isImageDataProduct` and `readBinaryDataProductPayload` to read PNG files off disk, base64-encode them, and post to the webview as `{ imageBase64, mediaType, sizeBytes }`.

- **Test coverage**: Added tests for generic JSON/image fallback rendering, image payload detection, and null-return trust behavior.

## Implementation Details

- The generic presenter handles unserialisable payloads (cycles, BigInt) by falling back to `String(data)` rather than dropping the report entirely.
- Empty objects/arrays (`{}`, `[]`) and `null` values return `null` from the generic presenter to avoid cluttering the UI.
- The a11y/overlay presenter includes an explanatory note directing users to prefer structured kinds for routine review.
- Test harness updated to accept `dataByKind` parameter for injecting mock payloads.

https://claude.ai/code/session_01UNd5Svxvn1e9Gdh61MGHZV