### PR TITLE
fix(vscode-extension): handle historyPruned + surface class-version errors

### DIFF
--- a/vscode-extension/src/classVersionErrorDetector.ts
+++ b/vscode-extension/src/classVersionErrorDetector.ts
@@ -1,0 +1,123 @@
+/**
+ * Scans Gradle output for `UnsupportedClassVersionError` — fires when Gradle
+ * is launched with a JDK whose `java` binary is older than the JDK that
+ * compiled the plugin / build-logic classes it now has to load.
+ *
+ * The decisive line shape is:
+ *
+ *     java.lang.UnsupportedClassVersionError: pkg/SomePlugin has been compiled
+ *     by a more recent version of the Java Runtime (class file version 69.0),
+ *     this version of the Java Runtime only recognizes class file versions up
+ *     to 65.0
+ *
+ * Class file version is `Java major + 44` (Java 21 = 65, Java 25 = 69), so
+ * we report Java-version equivalents to keep the remediation message
+ * actionable.
+ *
+ * Feed each `onOutput` chunk through {@link consume}. At the end of the build
+ * read {@link getFinding}; it returns `null` unless a class-version line was
+ * seen.
+ */
+
+export interface ClassVersionFinding {
+    /** Internal name of the class that failed to load (e.g. `ee/.../FooPlugin`). */
+    className: string;
+    /** Class file major version embedded in the bytecode (e.g. 69 for Java 25). */
+    compiledClassVersion: number;
+    /** Highest class file major version the runtime accepts (e.g. 65 for Java 21). */
+    runtimeMaxClassVersion: number;
+    /** Java major version that produced the bytecode. */
+    compiledJavaVersion: number;
+    /** Java major version of the running JVM. */
+    runtimeJavaVersion: number;
+}
+
+const CLASS_VERSION_RE =
+    /UnsupportedClassVersionError:\s+(\S+)\s+has been compiled by a more recent version of the Java Runtime \(class file version (\d+)\.\d+\), this version of the Java Runtime only recognizes class file versions up to (\d+)\.\d+/;
+
+const CLASSFILE_TO_JAVA_OFFSET = 44;
+
+export class ClassVersionErrorDetector {
+    private buffer = "";
+    private finding: ClassVersionFinding | null = null;
+
+    /**
+     * Accept a chunk of decoded stdout/stderr. Safe to call with partial
+     * lines — they're buffered until a newline arrives. No-op once a finding
+     * has been recorded.
+     */
+    consume(chunk: string): void {
+        if (this.finding) {
+            return;
+        }
+        this.buffer += chunk;
+        let nl = this.buffer.indexOf("\n");
+        while (nl !== -1) {
+            const line = this.buffer.slice(0, nl);
+            this.buffer = this.buffer.slice(nl + 1);
+            if (this.scanLine(line)) {
+                return;
+            }
+            nl = this.buffer.indexOf("\n");
+        }
+        // Same 16 KiB bound as JdkImageErrorDetector — a producer emitting
+        // megabytes without newlines shouldn't be able to grow the buffer
+        // unboundedly.
+        if (this.buffer.length > 16 * 1024) {
+            this.scanLine(this.buffer);
+            this.buffer = "";
+        }
+    }
+
+    /** Flush the residual buffer. Call once after the stream ends. */
+    end(): void {
+        if (this.finding || this.buffer.length === 0) {
+            this.buffer = "";
+            return;
+        }
+        this.scanLine(this.buffer);
+        this.buffer = "";
+    }
+
+    getFinding(): ClassVersionFinding | null {
+        return this.finding;
+    }
+
+    private scanLine(line: string): boolean {
+        const m = CLASS_VERSION_RE.exec(line);
+        if (!m) {
+            return false;
+        }
+        const compiledClassVersion = parseInt(m[2], 10);
+        const runtimeMaxClassVersion = parseInt(m[3], 10);
+        this.finding = {
+            className: m[1],
+            compiledClassVersion,
+            runtimeMaxClassVersion,
+            compiledJavaVersion:
+                compiledClassVersion - CLASSFILE_TO_JAVA_OFFSET,
+            runtimeJavaVersion:
+                runtimeMaxClassVersion - CLASSFILE_TO_JAVA_OFFSET,
+        };
+        return true;
+    }
+}
+
+/**
+ * Thrown by {@link GradleService} when the task failed AND the output
+ * contained an `UnsupportedClassVersionError`. Carries the finding so the
+ * extension can offer a Java-version remediation instead of a generic
+ * "Gradle task failed".
+ */
+export class ClassVersionError extends Error {
+    constructor(
+        readonly finding: ClassVersionFinding,
+        readonly task: string,
+    ) {
+        super(
+            `Gradle task ${task} failed: ${finding.className} needs Java ${finding.compiledJavaVersion}+, ` +
+                `but Gradle is running on Java ${finding.runtimeJavaVersion}.`,
+        );
+        this.name = "ClassVersionError";
+    }
+}

--- a/vscode-extension/src/daemon/daemonClient.ts
+++ b/vscode-extension/src/daemon/daemonClient.ts
@@ -10,6 +10,7 @@ import {
     DiscoveryUpdatedParams,
     FileChangedParams,
     HistoryAddedParams,
+    HistoryPrunedParams,
     HistoryDiffParams,
     HistoryDiffResult,
     HistoryListParams,
@@ -83,6 +84,9 @@ export interface DaemonClientEvents {
     /** Phase H2 — daemon emits this after writing each render's sidecar +
      *  index entry. Subscribers avoid polling `history/list`. */
     onHistoryAdded?: (params: HistoryAddedParams) => void;
+    /** Phase H4 — daemon emits this after a non-empty auto- or manual-prune
+     *  pass. Subscribers drop the removed IDs from any in-memory caches. */
+    onHistoryPruned?: (params: HistoryPrunedParams) => void;
     /** `composestream/1` — one frame on a live stream. See
      *  docs/daemon/STREAMING.md. The client routes these to the active
      *  webview's painter via the StreamClient + canvas pipeline. */
@@ -466,6 +470,9 @@ export class DaemonClient {
                 break;
             case "historyAdded":
                 this.events.onHistoryAdded?.(params as HistoryAddedParams);
+                break;
+            case "historyPruned":
+                this.events.onHistoryPruned?.(params as HistoryPrunedParams);
                 break;
             case "streamFrame":
                 this.events.onStreamFrame?.(params as StreamFrameParams);

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -660,6 +660,20 @@ export interface HistoryAddedParams {
     entry: unknown;
 }
 
+/**
+ * `historyPruned` notification (HISTORY.md). Emitted after a non-empty prune
+ * pass (auto-prune that actually removed entries, or `history/prune` manual
+ * call). Auto-prune passes that removed nothing produce no notification.
+ */
+export interface HistoryPrunedParams {
+    /** IDs of the entries that were removed. */
+    removedIds: string[];
+    /** Total bytes reclaimed across all removed entries' on-disk artifacts. */
+    freedBytes: number;
+    /** Why the prune ran. */
+    reason: "auto" | "manual";
+}
+
 // Data products (phase D1) — see docs/daemon/DATA-PRODUCTS.md.
 //
 // Three methods:

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -8,6 +8,7 @@ import {
     FileChangeType,
     FileKind,
     HistoryAddedParams,
+    HistoryPrunedParams,
     RenderFinishedParams,
     RenderTier,
     StreamFrameParams,
@@ -67,6 +68,9 @@ export interface SchedulerEvents {
     /** Phase H2 — daemon archived a render. Forwarded to the History
      *  panel; optional because the panel may not exist in test mode. */
     onHistoryAdded?: (moduleId: string, params: HistoryAddedParams) => void;
+    /** Phase H4 — daemon dropped one or more entries from disk. Subscribers
+     *  invalidate any cached IDs. Optional for the same reason. */
+    onHistoryPruned?: (moduleId: string, params: HistoryPrunedParams) => void;
     /**
      * `composestream/1` — daemon emitted a live frame. The scheduler
      * forwards it untouched; `extension.ts` routes it to the matching
@@ -500,6 +504,9 @@ export class DaemonScheduler {
             },
             onHistoryAdded: (params: HistoryAddedParams) => {
                 this.events.onHistoryAdded?.(moduleId, params);
+            },
+            onHistoryPruned: (params: HistoryPrunedParams) => {
+                this.events.onHistoryPruned?.(moduleId, params);
             },
             onStreamFrame: (params: StreamFrameParams) => {
                 this.events.onStreamFrame?.(moduleId, params);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -9,6 +9,7 @@ import {
     TaskCancelledError,
 } from "./gradleService";
 import { JdkImageError } from "./jdkImageErrorDetector";
+import { ClassVersionError } from "./classVersionErrorDetector";
 import { KotlinCompileError } from "./kotlinCompileErrorDetector";
 import {
     BUILD_SCRIPT_NAMES,
@@ -218,6 +219,9 @@ let warnedMissingPluginThisSession = false;
 /** Same idea for the jlink-missing notification: save-driven refreshes would
  *  otherwise re-surface it on every build after the user dismissed it. */
 let warnedJdkImageThisSession = false;
+/** Same idea for the class-version mismatch (build-logic compiled on a newer
+ *  JDK than Gradle is running). */
+let warnedClassVersionThisSession = false;
 // Decide whether a file "probably wants previews" with the plugin off. Kept
 // deliberately loose: the file just needs to contain the substring "Preview"
 // (covers `@Preview`, `@PreviewLightDark`, preview-tooling imports, and
@@ -289,6 +293,35 @@ function showJdkImageRemediation(err: JdkImageError): void {
                 );
             } else if (action === DOCS) {
                 void vscode.env.openExternal(vscode.Uri.parse(JDK_DOCS_URL));
+            }
+        });
+}
+
+/**
+ * Show the remediation notification for a class-version mismatch — Gradle is
+ * running on an older JDK than the one that compiled the project's build-logic
+ * / plugin classes. The "Open JDK setting" action opens
+ * `java.import.gradle.java.home`, the setting `vscjava.vscode-gradle` reads.
+ * De-duped per session.
+ */
+function showClassVersionRemediation(err: ClassVersionError): void {
+    if (warnedClassVersionThisSession) {
+        return;
+    }
+    warnedClassVersionThisSession = true;
+    const message =
+        `Compose Preview: Gradle needs Java ${err.finding.compiledJavaVersion}+ ` +
+        `to load ${err.finding.className}, but is running on Java ${err.finding.runtimeJavaVersion}. ` +
+        "Point Gradle at a newer JDK.";
+    const OPEN_SETTING = "Open JDK setting";
+    void vscode.window
+        .showErrorMessage(message, OPEN_SETTING)
+        .then((action) => {
+            if (action === OPEN_SETTING) {
+                void vscode.commands.executeCommand(
+                    "workbench.action.openSettings",
+                    "java.import.gradle.java.home",
+                );
             }
         });
 }
@@ -682,6 +715,14 @@ export async function activate(
                 // Phase H7 — daemon push: a fresh render landed and was archived. History is
                 // now focus-view-only; the live panel resolves it on demand when the user
                 // asks for a diff from the focused preview.
+                void params;
+            },
+            onHistoryPruned: (_moduleId, params) => {
+                // Counterpart to onHistoryAdded. Same focus-view-only policy — the live
+                // panel re-fetches on demand, so we don't push pruned IDs anywhere. Wired
+                // to silence "ignoring unknown notification: historyPruned" in the log and
+                // to keep the protocol surface complete if H14's cross-module timeline
+                // resurrects in-memory history caching.
                 void params;
             },
             onStreamFrame: (_moduleId, params) => {
@@ -1106,7 +1147,16 @@ export async function activate(
     // Refresh applied-markers in the background so future module resolution can
     // use the authoritative `applied.json` path. Doctor stays explicit via
     // `composePreview.runDoctor`.
-    void gradleService.bootstrapAppliedMarkers();
+    void gradleService.bootstrapAppliedMarkers((err) => {
+        // Bootstrap is fire-and-forget and the scan fallback covers most
+        // failures, but JDK-shape failures will keep biting on every render
+        // — surface them once, here, so users aren't stuck on opaque output.
+        if (err instanceof ClassVersionError) {
+            showClassVersionRemediation(err);
+        } else if (err instanceof JdkImageError) {
+            showJdkImageRemediation(err);
+        }
+    });
 
     context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration((event) => {
@@ -3558,6 +3608,21 @@ async function refresh(
             });
             panel.postMessage({ command: "clearProgress" });
             showJdkImageRemediation(err);
+            return "failed";
+        }
+        if (err instanceof ClassVersionError) {
+            logLine(
+                `FAILED (class version): ${err.finding.className} needs Java ${err.finding.compiledJavaVersion}+, ` +
+                    `Gradle is on Java ${err.finding.runtimeJavaVersion}`,
+            );
+            panel.postMessage({
+                command: "showMessage",
+                text:
+                    `Gradle needs Java ${err.finding.compiledJavaVersion}+ to load this project's build classes; ` +
+                    `it is running on Java ${err.finding.runtimeJavaVersion}. Configure a newer JDK to render previews.`,
+            });
+            panel.postMessage({ command: "clearProgress" });
+            showClassVersionRemediation(err);
             return "failed";
         }
         if (err instanceof KotlinCompileError) {

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -12,6 +12,10 @@ import {
 import { appliesPlugin, BUILD_SCRIPT_NAMES } from "./pluginDetection";
 import { JdkImageError, JdkImageErrorDetector } from "./jdkImageErrorDetector";
 import {
+    ClassVersionError,
+    ClassVersionErrorDetector,
+} from "./classVersionErrorDetector";
+import {
     KotlinCompileError,
     KotlinCompileErrorDetector,
 } from "./kotlinCompileErrorDetector";
@@ -864,13 +868,26 @@ export class GradleService {
      * Swallows failures — the scan fallback still produces a sensible list,
      * and we don't want a misconfigured workspace to fail activation.
      */
-    async bootstrapAppliedMarkers(): Promise<void> {
+    async bootstrapAppliedMarkers(
+        onTypedError?: (err: ClassVersionError | JdkImageError) => void,
+    ): Promise<void> {
         try {
             await this.runTask("composePreviewApplied");
         } catch (e) {
             this.logger.appendLine(
                 `[applied] composePreviewApplied bootstrap failed: ${(e as Error).message}`,
             );
+            // Bootstrap still swallows so the scan fallback can produce a
+            // sensible module list — but if Gradle bailed for a JDK reason
+            // that won't recover on its own, surface it to the caller. The
+            // user might never trigger a render that would otherwise raise
+            // it (e.g. activation-only sessions).
+            if (
+                onTypedError &&
+                (e instanceof ClassVersionError || e instanceof JdkImageError)
+            ) {
+                onTypedError(e);
+            }
         }
     }
 
@@ -948,6 +965,10 @@ export class GradleService {
         }
 
         const detector = new JdkImageErrorDetector();
+        // Catches the case where the JVM running Gradle is older than the
+        // JDK that compiled build-logic / the plugin — `UnsupportedClassVersionError`
+        // surfaces as an opaque "Could not execute build" without this.
+        const classVersionDetector = new ClassVersionErrorDetector();
         // Parse `e:` lines from the Kotlin compiler so the panel banner
         // can show structured errors when a build fails. Catches the
         // cross-file gap that the LSP-driven gate (compileErrors.ts)
@@ -990,6 +1011,7 @@ export class GradleService {
                         // normal level (the noisy lines are exactly the ones that
                         // contain the diagnostic).
                         detector.consume(decoded);
+                        classVersionDetector.consume(decoded);
                         kotlinDetector.consume(decoded);
                         const filtered =
                             this.logFilter.filterGradleChunk(decoded);
@@ -1020,6 +1042,7 @@ export class GradleService {
                         throw new TaskCancelledError(task);
                     }
                     detector.end();
+                    classVersionDetector.end();
                     kotlinDetector.end();
                     const finding = detector.getFinding();
                     if (finding) {
@@ -1027,6 +1050,11 @@ export class GradleService {
                         // gRPC "Could not execute build" message would just be
                         // noise next to it.
                         throw new JdkImageError(finding, task);
+                    }
+                    const classVersionFinding =
+                        classVersionDetector.getFinding();
+                    if (classVersionFinding) {
+                        throw new ClassVersionError(classVersionFinding, task);
                     }
                     const kotlinErrors = kotlinDetector.getErrors();
                     if (kotlinErrors.length > 0) {

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -5,6 +5,7 @@ import { CurrentRendersHistory } from "./daemon/currentRendersHistory";
 import {
     HistoryAddedParams,
     HistoryListResult,
+    HistoryPrunedParams,
     HistoryReadResult,
     HistorySourceKind,
 } from "./daemon/daemonProtocol";
@@ -90,6 +91,19 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
         this.view.webview.postMessage({
             command: "entryAdded",
             entry: params.entry,
+        });
+    }
+
+    /** Daemon push: one or more entries were pruned. Drops them from the
+     *  visible list so the user doesn't see ghost rows that resolve to
+     *  404s when they click. Drops cleanly when the panel isn't open. */
+    onHistoryPruned(params: HistoryPrunedParams): void {
+        if (!this.view || params.removedIds.length === 0) {
+            return;
+        }
+        this.view.webview.postMessage({
+            command: "entriesPruned",
+            removedIds: params.removedIds,
         });
     }
 

--- a/vscode-extension/src/test/classVersionErrorDetector.test.ts
+++ b/vscode-extension/src/test/classVersionErrorDetector.test.ts
@@ -1,0 +1,67 @@
+import * as assert from "assert";
+import { ClassVersionErrorDetector } from "../classVersionErrorDetector";
+
+// Real failure copy-pasted from the Output > Compose Preview channel — the
+// Gradle daemon on Java 21 tried to load build-logic compiled with Java 25.
+const FIXTURE_LINE =
+    "java.lang.UnsupportedClassVersionError: ee/schimke/composeai/buildlogic/ComposeAiJvmConventionsPlugin " +
+    "has been compiled by a more recent version of the Java Runtime (class file version 69.0), " +
+    "this version of the Java Runtime only recognizes class file versions up to 65.0";
+
+describe("ClassVersionErrorDetector", () => {
+    it("extracts class name + class file versions + Java versions", () => {
+        const d = new ClassVersionErrorDetector();
+        d.consume(FIXTURE_LINE + "\n");
+        const f = d.getFinding();
+        assert.notStrictEqual(f, null);
+        assert.strictEqual(
+            f!.className,
+            "ee/schimke/composeai/buildlogic/ComposeAiJvmConventionsPlugin",
+        );
+        assert.strictEqual(f!.compiledClassVersion, 69);
+        assert.strictEqual(f!.runtimeMaxClassVersion, 65);
+        // 69 - 44 = 25 (Java 25), 65 - 44 = 21 (Java 21).
+        assert.strictEqual(f!.compiledJavaVersion, 25);
+        assert.strictEqual(f!.runtimeJavaVersion, 21);
+    });
+
+    it("survives chunks that split mid-line", () => {
+        const d = new ClassVersionErrorDetector();
+        const mid = Math.floor(FIXTURE_LINE.length / 2);
+        d.consume(FIXTURE_LINE.slice(0, mid));
+        assert.strictEqual(d.getFinding(), null);
+        d.consume(FIXTURE_LINE.slice(mid) + "\n");
+        assert.notStrictEqual(d.getFinding(), null);
+    });
+
+    it("catches the line at end-of-stream without a trailing newline", () => {
+        const d = new ClassVersionErrorDetector();
+        d.consume(FIXTURE_LINE);
+        assert.strictEqual(d.getFinding(), null);
+        d.end();
+        assert.notStrictEqual(d.getFinding(), null);
+    });
+
+    it("returns null when the output is unrelated", () => {
+        const d = new ClassVersionErrorDetector();
+        d.consume(
+            "FAILURE: Build failed with an exception.\n> Could not resolve all files.\n",
+        );
+        d.end();
+        assert.strictEqual(d.getFinding(), null);
+    });
+
+    it("is idempotent after the first match", () => {
+        const d = new ClassVersionErrorDetector();
+        d.consume(FIXTURE_LINE + "\n");
+        const first = d.getFinding();
+        d.consume(
+            "java.lang.UnsupportedClassVersionError: pkg/Other has been compiled by a more recent " +
+                "version of the Java Runtime (class file version 70.0), this version of the Java " +
+                "Runtime only recognizes class file versions up to 65.0\n",
+        );
+        const second = d.getFinding();
+        assert.strictEqual(second!.className, first!.className);
+        assert.strictEqual(second!.compiledClassVersion, 69);
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -875,6 +875,7 @@ export type HistoryToWebview =
           result: { entries: HistoryEntry[]; totalCount?: number };
       }
     | { command: "entryAdded"; entry: HistoryEntry }
+    | { command: "entriesPruned"; removedIds: string[] }
     | { command: "setScopeLabel"; label: string }
     | { command: "showMessage"; text: string }
     | {

--- a/vscode-extension/src/webview/history/behavior.ts
+++ b/vscode-extension/src/webview/history/behavior.ts
@@ -245,6 +245,23 @@ export function setupHistoryBehavior(): void {
                     applyFilters();
                 }
                 break;
+            case "entriesPruned": {
+                const removed = new Set(msg.removedIds);
+                if (removed.size === 0) {
+                    break;
+                }
+                const before = entries.length;
+                entries = entries.filter((e) => !(e.id && removed.has(e.id)));
+                if (entries.length !== before) {
+                    if (entries.length === 0) {
+                        setMessage("No history yet for this preview / module.");
+                    }
+                    populateBranchFilter(entries);
+                    renderTimeline();
+                    applyFilters();
+                }
+                break;
+            }
             case "showMessage":
                 setMessage(msg.text || "");
                 break;


### PR DESCRIPTION
Two issues observed in the VS Code init log:

1. Daemon emits a `historyPruned` notification after auto- or manual-prune
   passes, but the extension logged `[daemon] ignoring unknown notification:
   historyPruned` because no case was wired. Adds the protocol type and
   wires it through daemonClient → daemonScheduler → extension (no-op,
   matching the existing `onHistoryAdded` focus-view-only policy) and the
   HistoryPanel → webview path (filters removed IDs out of the visible
   timeline) so the panel doesn't show ghost rows that 404 on click.

2. `composePreviewApplied` bootstrap failed with `UnsupportedClassVersionError`
   (Gradle on Java 21 trying to load build-logic compiled on Java 25) and
   was logged as a generic "bootstrap failed" with no remediation. Adds
   `ClassVersionErrorDetector` (paralleling JdkImageErrorDetector), throws
   a typed `ClassVersionError` from `runTask`, and surfaces a one-shot
   notification pointing at `java.import.gradle.java.home` with the
   required vs running Java versions in the message. `bootstrapAppliedMarkers`
   gets a callback so the activation-only path also shows it (the bootstrap
   itself still swallows so the scan fallback can produce a sensible module
   list).