### PR TITLE
feat: add variant count chip to collapsed preview cards

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1793,6 +1793,41 @@ body {
     font-variant-numeric: tabular-nums;
 }
 
+/* Surfaces "+N variants" on the surviving card when variant-collapse
+   hides duplicates. Without it the only path to the siblings is
+   picking the function in the toolbar dropdown — easy to miss when
+   identical-looking previews sit side by side. Anchored top-left so
+   it doesn't crowd the existing focus / animation icons on the right
+   of the title row. */
+.variant-count-chip {
+    position: absolute;
+    top: 6px;
+    left: 6px;
+    z-index: 2;
+    padding: 2px 6px;
+    border: 1px solid var(--card-border);
+    border-radius: 9999px;
+    background: var(--card-bg);
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 3px);
+    line-height: 1.3;
+    font-variant-numeric: tabular-nums;
+    cursor: pointer;
+    opacity: 0.85;
+    transition:
+        opacity 0.15s,
+        background 0.15s;
+}
+.variant-count-chip:hover {
+    opacity: 1;
+    background: var(--toolbar-hover);
+    color: var(--vscode-foreground);
+}
+.variant-count-chip:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 1px;
+}
+
 /* -- Animated card carousel ------------------------------------------ */
 
 /* Icon in the title row telegraphs "this preview has multiple captures"; the

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -142,6 +142,19 @@ export function buildPreviewCard(
     const card = document.createElement("preview-card") as PreviewCard;
     card.preview = p;
     card.config = config;
+    // Stamp the filter-critical attributes synchronously so the
+    // `applyFilters` call that handleSetPreviews fires immediately
+    // after renderPreviews can see them — populatePreviewCard runs
+    // from Lit's `firstUpdated()` which is scheduled on a microtask,
+    // so by the time it sets these the first applyFilters has already
+    // run against an empty grid (no `.preview-card` selector match,
+    // no dataset → variant collapse silently no-ops, all cards land
+    // visible until the next manifest reseed).
+    card.classList.add("preview-card");
+    card.dataset.previewId = p.id;
+    card.dataset.function = p.functionName;
+    card.dataset.group = p.params.group || "";
+    card.dataset.className = p.className;
     return card;
 }
 
@@ -168,10 +181,13 @@ export function populatePreviewCard(
     // (idiomatic `XxxPreviews.kt` / `screenshotTest` layout). The CSS hook lets
     // the panel render them under a "from elsewhere" treatment without changing
     // the message shape.
-    card.className =
-        "preview-card" +
-        (animated ? " animated-card" : "") +
-        (p.referenced ? " referenced" : "");
+    //
+    // Use classList rather than reassigning className so the eager
+    // `preview-card` class stamped in buildPreviewCard survives — the
+    // filter walker relies on it before this populate step has run.
+    card.classList.add("preview-card");
+    card.classList.toggle("animated-card", animated);
+    card.classList.toggle("referenced", !!p.referenced);
     card.id = "preview-" + sanitizeId(p.id);
     card.setAttribute("role", "listitem");
     card.dataset.function = p.functionName;

--- a/vscode-extension/src/webview/preview/components/FilterToolbar.ts
+++ b/vscode-extension/src/webview/preview/components/FilterToolbar.ts
@@ -36,10 +36,20 @@ export class FilterToolbar extends LitElement {
 
     setFunctionOptions(opts: readonly string[]): void {
         this.fnOptions = opts;
+        // Clamp the current value back to "all" if the new options no
+        // longer include it — otherwise the <select> falls back to
+        // rendering "All functions" while fnValue still holds the stale
+        // name, and applyFilters silently narrows to zero matches.
+        if (this.fnValue !== "all" && !opts.includes(this.fnValue)) {
+            this.fnValue = "all";
+        }
     }
 
     setGroupOptions(opts: readonly string[]): void {
         this.grpOptions = opts;
+        if (this.grpValue !== "all" && !opts.includes(this.grpValue)) {
+            this.grpValue = "all";
+        }
     }
 
     /**

--- a/vscode-extension/src/webview/preview/components/PreviewGrid.ts
+++ b/vscode-extension/src/webview/preview/components/PreviewGrid.ts
@@ -143,7 +143,70 @@ export class PreviewGrid extends HTMLElement {
             card.classList.toggle("collapsed-variant", collapsed);
             if (show) visibleCount++;
         }
+        this.updateVariantChips(filterEligible, decision.active);
         return visibleCount;
+    }
+
+    /**
+     * Mark the surviving card of each collapsed function-key with a
+     * "+N variants" chip — the only affordance pointing to siblings
+     * that variant-collapse hid. Clicking the chip dispatches a
+     * `variant-chip-clicked` event with the function name; the panel
+     * host listens for it and reuses the same setFunctionValue +
+     * applyFilters path the gutter-icon `setFunctionFilter` message
+     * already drives. Stays a no-op (and removes any pre-existing
+     * chips) when collapse isn't active, so picking a function or
+     * group from the toolbar leaves cards chip-free.
+     */
+    private updateVariantChips(
+        filterEligible: readonly HTMLElement[],
+        collapseActive: boolean,
+    ): void {
+        for (const card of this.getCards()) {
+            const chip = card.querySelector(".variant-count-chip");
+            if (chip) chip.remove();
+        }
+        if (!collapseActive) return;
+        const totals = new Map<string, number>();
+        const survivors = new Map<string, HTMLElement>();
+        for (const card of filterEligible) {
+            const key =
+                (card.dataset.className ?? "") +
+                "::" +
+                (card.dataset.function ?? "");
+            totals.set(key, (totals.get(key) ?? 0) + 1);
+            if (!survivors.has(key)) survivors.set(key, card);
+        }
+        for (const [key, card] of survivors) {
+            const total = totals.get(key) ?? 1;
+            if (total <= 1) continue;
+            const chip = document.createElement("button");
+            chip.type = "button";
+            chip.className = "variant-count-chip";
+            const others = total - 1;
+            chip.textContent =
+                "+" + others + (others === 1 ? " variant" : " variants");
+            const title =
+                "Show all " +
+                total +
+                " variants of " +
+                (card.dataset.function ?? "this preview");
+            chip.title = title;
+            chip.setAttribute("aria-label", title);
+            chip.addEventListener("click", (evt) => {
+                evt.stopPropagation();
+                const fn = card.dataset.function ?? "";
+                if (!fn) return;
+                card.dispatchEvent(
+                    new CustomEvent<{ fn: string }>("variant-chip-clicked", {
+                        detail: { fn },
+                        bubbles: true,
+                        composed: true,
+                    }),
+                );
+            });
+            card.appendChild(chip);
+        }
     }
 
     /**

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -572,6 +572,21 @@ export class PreviewApp extends LitElement {
             applyFilters();
         });
 
+        // The "+N variants" chip on a collapsed-variant survivor card
+        // is the only in-grid affordance pointing at hidden siblings.
+        // Clicking it narrows the function filter to that card's
+        // function, which disables variant collapse and reveals all
+        // variants — same trio the gutter-icon `setFunctionFilter`
+        // message handler runs.
+        grid.addEventListener("variant-chip-clicked", (evt) => {
+            const detail = (evt as CustomEvent<{ fn?: string }>).detail;
+            const fn = detail?.fn;
+            if (!fn) return;
+            filterToolbar.setFunctionValue(fn);
+            saveFilterState();
+            applyFilters();
+        });
+
         btnPrev.addEventListener("click", () => navigateFocus(-1));
         btnNext.addEventListener("click", () => navigateFocus(1));
         btnDiffHead.addEventListener("click", () => requestFocusedDiff("head"));


### PR DESCRIPTION
## Summary

Adds a "+N variants" chip to preview cards when variant collapse is active, providing an in-grid affordance to reveal hidden sibling variants. Clicking the chip narrows the function filter to show all variants of that function, matching the behavior of the gutter-icon filter.

## Key Changes

- **PreviewGrid.ts**: Added `updateVariantChips()` method that creates and manages variant count chips on surviving cards when collapse is active. Chips display the count of hidden variants and dispatch a `variant-chip-clicked` event when clicked.

- **preview.css**: Added styling for `.variant-count-chip` button with positioning (top-left), hover/focus states, and smooth transitions. Uses existing design tokens for consistency.

- **cardBuilder.ts**: Eagerly stamp filter-critical dataset attributes (`function`, `group`, `className`, `previewId`) and the `preview-card` class in `buildPreviewCard()` so they're available before `applyFilters()` runs. Updated `populatePreviewCard()` to use `classList` methods instead of reassigning `className` to preserve the early-stamped class.

- **main.ts**: Added event listener for `variant-chip-clicked` that calls `setFunctionValue()` and `applyFilters()` to reveal all variants of the selected function.

- **FilterToolbar.ts**: Added validation in `setFunctionOptions()` and `setGroupOptions()` to clamp filter values back to "all" if the new options no longer include the current selection, preventing silent filtering to zero matches.

## Implementation Details

The chip only appears when variant collapse is active and there are multiple variants of the same function. It's positioned top-left to avoid crowding existing focus/animation icons on the right. The implementation reuses the existing filter toolbar path (`setFunctionValue` + `applyFilters`) for consistency with the gutter-icon filter behavior.

https://claude.ai/code/session_016NFg3YjZ5gon1xBw7884oF