### PR TITLE
ci: Skip WearTilesKotlin tests on pull requests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -117,6 +117,13 @@ jobs:
     name: ${{ matrix.name }}
     needs: build-plugin
     runs-on: ubuntu-latest
+    env:
+      # Per-entry pull_request gate. Any matrix entry tagged `main_only: true`
+      # has every step skipped on pull_request events; the entry still runs on
+      # push to main, workflow_dispatch, and the weekly schedule. Used to keep
+      # the slower WearTilesKotlin tile-render coverage off the PR critical
+      # path while preserving it on trunk.
+      SKIP_ON_PR: ${{ matrix.main_only && github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -153,6 +160,12 @@ jobs:
             workdir: WearTilesKotlin
             module: app
             extra_gradle_args: ""
+            # Skip on pull_request to keep PR cycle time down. Still runs on
+            # push to main, workflow_dispatch, and the weekly schedule, so the
+            # tile-render regression coverage below is preserved on trunk.
+            # Every step in this job is gated on `!matrix.main_only ||
+            # github.event_name != 'pull_request'` to honor this flag.
+            main_only: true
             # Render in addition to discover — WearTilesKotlin uses an older
             # Compose BOM than our renderer, which previously exposed a latent
             # transitive-dep issue (activity-compose 1.13 → navigationevent
@@ -216,6 +229,7 @@ jobs:
           # Android source sets cleanly.
     steps:
       - name: Checkout ${{ matrix.repo }}
+        if: env.SKIP_ON_PR != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ matrix.repo }}
@@ -224,20 +238,24 @@ jobs:
           persist-credentials: false
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        if: env.SKIP_ON_PR != 'true'
         with:
           distribution: temurin
           java-version: 17
 
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        if: env.SKIP_ON_PR != 'true'
         with:
           cache-provider: basic
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: env.SKIP_ON_PR != 'true'
         with:
           name: compose-ai-bundle
           path: .
 
       - name: Install plugin, CLI, and init script
+        if: env.SKIP_ON_PR != 'true'
         run: |
           set -euo pipefail
           mkdir -p bundle
@@ -257,18 +275,21 @@ jobs:
           echo "$GITHUB_WORKSPACE/bundle/cli/bin" >> "$GITHUB_PATH"
 
       - name: Sanity check CLI
+        if: env.SKIP_ON_PR != 'true'
         run: compose-preview help
 
       - name: Make external gradlew executable
+        if: env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         run: chmod +x ./gradlew
 
       - name: Repo-specific pre-Gradle patches
-        if: matrix.pre_gradle_script != ''
+        if: matrix.pre_gradle_script != '' && env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         run: ${{ matrix.pre_gradle_script }}
 
       - name: Discover previews via Gradle
+        if: env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_AI_PLUGIN_VERSION: ${{ env.PLUGIN_VERSION }}
@@ -282,6 +303,7 @@ jobs:
             --stacktrace
 
       - name: Verify previews.json was produced
+        if: env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -303,7 +325,7 @@ jobs:
           fi
 
       - name: Render previews via Gradle
-        if: matrix.render
+        if: matrix.render && env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_AI_PLUGIN_VERSION: ${{ env.PLUGIN_VERSION }}
@@ -318,7 +340,7 @@ jobs:
             --stacktrace
 
       - name: Verify PNGs were produced
-        if: matrix.render
+        if: matrix.render && env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -336,7 +358,7 @@ jobs:
           printf '  %s\n' "${pngs[@]}"
 
       - name: Configure daemon in consumer build
-        if: matrix.daemon
+        if: matrix.daemon && env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -372,7 +394,7 @@ jobs:
           MATRIX_MODULE: ${{ matrix.module }}
 
       - name: Emit daemon launch descriptor (composePreviewDaemonStart)
-        if: matrix.daemon
+        if: matrix.daemon && env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_AI_PLUGIN_VERSION: ${{ env.PLUGIN_VERSION }}
@@ -385,7 +407,7 @@ jobs:
             --stacktrace
 
       - name: Daemon round-trip (spawn → render → edit → re-render)
-        if: matrix.daemon
+        if: matrix.daemon && env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_AI_PLUGIN_VERSION: ${{ env.PLUGIN_VERSION }}
@@ -418,7 +440,7 @@ jobs:
             --gradle-args "${{ matrix.extra_gradle_args }}"
 
       - name: Upload daemon launch descriptor
-        if: always() && matrix.daemon
+        if: always() && matrix.daemon && env.SKIP_ON_PR != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: daemon-launch-${{ matrix.slug }}
@@ -427,7 +449,7 @@ jobs:
           retention-days: 7
 
       - name: Verify at least one TILE preview was rendered
-        if: matrix.render && matrix.require_tile_render
+        if: matrix.render && matrix.require_tile_render && env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -459,7 +481,7 @@ jobs:
           PY
 
       - name: Upload previews.json
-        if: always()
+        if: always() && env.SKIP_ON_PR != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: previews-${{ matrix.slug }}
@@ -468,7 +490,7 @@ jobs:
           retention-days: 7
 
       - name: Upload rendered PNGs
-        if: always() && matrix.render
+        if: always() && matrix.render && env.SKIP_ON_PR != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: renders-${{ matrix.slug }}


### PR DESCRIPTION
Optimize CI cycle time for pull requests by skipping the slower WearTilesKotlin tile-render coverage while preserving it on trunk.

## Summary
This change introduces a per-matrix-entry gate to conditionally skip slower integration tests on pull requests. The WearTilesKotlin entry is marked as `main_only: true`, which causes all its steps to be skipped when triggered by a pull request event, while still running on pushes to main, workflow_dispatch, and the weekly schedule.

## Key Changes
- Added `SKIP_ON_PR` environment variable to the integration job that evaluates to `true` only for matrix entries tagged with `main_only: true` on pull request events
- Marked the WearTilesKotlin matrix entry with `main_only: true` to gate it from PR runs
- Added `if: env.SKIP_ON_PR != 'true'` conditions to all steps in the integration job to honor the skip flag
- Updated conditional logic on existing steps (render, daemon, artifact upload) to also check `env.SKIP_ON_PR`

## Implementation Details
The gating mechanism uses a combination of:
1. A matrix-level `main_only` flag that can be set per entry
2. An environment variable that evaluates the flag against the GitHub event type
3. Step-level `if` conditions that check this environment variable

This approach keeps the slower tile-render regression coverage on trunk while reducing PR feedback latency.

https://claude.ai/code/session_01XprwtYaevSu1sFXzu238t2