### PR TITLE
fix: reposition variant count chip to bottom-left

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1796,12 +1796,12 @@ body {
 /* Surfaces "+N variants" on the surviving card when variant-collapse
    hides duplicates. Without it the only path to the siblings is
    picking the function in the toolbar dropdown — easy to miss when
-   identical-looking previews sit side by side. Anchored top-left so
-   it doesn't crowd the existing focus / animation icons on the right
-   of the title row. */
+   identical-looking previews sit side by side. Anchored bottom-left,
+   on the same row as `.variant-badge` and the long-scroll page chip,
+   so it stays clear of the title and the focus / animation icons. */
 .variant-count-chip {
     position: absolute;
-    top: 6px;
+    bottom: 6px;
     left: 6px;
     z-index: 2;
     padding: 2px 6px;


### PR DESCRIPTION
## Summary
Repositioned the `.variant-count-chip` element from top-left to bottom-left positioning to prevent visual crowding with the focus and animation icons in the title row.

## Changes
- Changed `.variant-count-chip` positioning from `top: 6px` to `bottom: 6px`
- Updated the comment to reflect the new layout rationale: the chip now sits on the same row as `.variant-badge` and the long-scroll page chip, keeping it clear of the title and icon controls

## Details
The variant count chip displays "+N variants" on surviving cards when variant-collapse hides duplicates. By anchoring it to the bottom-left instead of top-left, it avoids overlapping with the focus and animation icons that appear on the right side of the title row, improving the visual layout of the card preview.

https://claude.ai/code/session_016mEaJNgEBxKbvCgwYkBvrb