### PR TITLE
feat: add hierarchy legend with per-node color swatches

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1965,15 +1965,27 @@ body {
 }
 .a11y-hierarchy-box {
     position: absolute;
-    border: 1px dashed rgba(80, 160, 255, 0.7);
-    background: rgba(80, 160, 255, 0.06);
+    border: 1px dashed var(--a11y-hier-color, rgba(80, 160, 255, 0.7));
+    background: color-mix(
+        in srgb,
+        var(--a11y-hier-color, rgba(80, 160, 255, 1)) 12%,
+        transparent
+    );
     border-radius: 1px;
     pointer-events: auto;
-    transition: background 120ms ease;
+    transition:
+        background 120ms ease,
+        box-shadow 120ms ease;
 }
-.a11y-hierarchy-box:hover {
-    background: rgba(80, 160, 255, 0.18);
-    border-color: rgba(80, 160, 255, 1);
+.a11y-hierarchy-box:hover,
+.a11y-hierarchy-box.a11y-active {
+    background: color-mix(
+        in srgb,
+        var(--a11y-hier-color, rgba(80, 160, 255, 1)) 28%,
+        transparent
+    );
+    border-color: var(--a11y-hier-color, rgba(80, 160, 255, 1));
+    box-shadow: 0 0 0 1px var(--a11y-hier-color, rgba(80, 160, 255, 1));
 }
 /* Nodes sitting under a focusable ancestor that already carries its own
  * contentDescription — TalkBack reads only the ancestor. Shown with a lighter
@@ -1981,7 +1993,7 @@ body {
  * separate stops". */
 .a11y-hierarchy-box.a11y-hierarchy-unmerged {
     border-style: dotted;
-    border-color: rgba(160, 200, 255, 0.5);
+    opacity: 0.6;
 }
 .a11y-box {
     position: absolute;
@@ -2080,4 +2092,30 @@ body {
 }
 .a11y-level-info {
     --a11y-color: #1976d2;
+}
+
+/* Hierarchy legend — one row per `a11y/hierarchy` node, swatch colour
+ * matches the corresponding `.a11y-hierarchy-box` via the shared
+ * `--a11y-hier-color` CSS custom property set in JS. */
+.a11y-hierarchy-row {
+    align-items: center;
+}
+.a11y-hierarchy-row.a11y-hierarchy-row-unmerged {
+    opacity: 0.7;
+}
+/* Tighten the gap between consecutive plain-text nodes so adjacent
+ * label-only rows visually group, mirroring the spatial pairing in
+ * the preview (e.g. "Morning run · 5.2 km · 28 min"). */
+.a11y-hierarchy-row-adjacent {
+    margin-top: -4px;
+    padding-top: 2px;
+}
+.a11y-swatch {
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    background: var(--a11y-hier-color, #888);
+    border: 1px solid rgba(0, 0, 0, 0.25);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.25);
+    flex-shrink: 0;
 }

--- a/vscode-extension/src/test/a11yOverlay.test.ts
+++ b/vscode-extension/src/test/a11yOverlay.test.ts
@@ -1,9 +1,11 @@
 import * as assert from "assert";
 import {
+    A11Y_HIERARCHY_PALETTE,
+    applyHierarchyOverlay,
+    buildA11yHierarchyLegend,
     buildA11yLegend,
     buildA11yOverlay,
     ensureHierarchyOverlay,
-    applyHierarchyOverlay,
 } from "../webview/preview/a11yOverlay";
 import type {
     AccessibilityFinding,
@@ -487,5 +489,194 @@ describe("applyHierarchyOverlay", () => {
             noDims.container.querySelectorAll(".a11y-hierarchy-box").length,
             0,
         );
+    });
+
+    it("stamps each box with data-node-idx and a palette-cycled --a11y-hier-color", () => {
+        const { card, container, img } = buildCardWithImage(100, 100);
+        ensureHierarchyOverlay(container);
+        const nodes = Array.from(
+            { length: A11Y_HIERARCHY_PALETTE.length + 1 },
+            (_, i) => node({ boundsInScreen: i + ",0,10,10" }),
+        );
+        applyHierarchyOverlay(card, nodes, img);
+        const boxes = container.querySelectorAll<HTMLElement>(
+            ".a11y-hierarchy-box",
+        );
+        assert.strictEqual(boxes.length, nodes.length);
+        boxes.forEach((b, idx) => {
+            assert.strictEqual(b.dataset.nodeIdx, String(idx));
+            assert.strictEqual(
+                b.style.getPropertyValue("--a11y-hier-color"),
+                A11Y_HIERARCHY_PALETTE[idx % A11Y_HIERARCHY_PALETTE.length],
+            );
+        });
+        // Palette wraps — index 0 and index palette.length share a colour.
+        assert.strictEqual(
+            boxes[0].style.getPropertyValue("--a11y-hier-color"),
+            boxes[A11Y_HIERARCHY_PALETTE.length].style.getPropertyValue(
+                "--a11y-hier-color",
+            ),
+        );
+    });
+});
+
+describe("buildA11yHierarchyLegend", () => {
+    it("returns a detached .a11y-legend.a11y-hierarchy-legend with header naming the element count", () => {
+        const card = document.createElement("div");
+        const legend = buildA11yHierarchyLegend(card, [
+            node(),
+            node({ label: "Cancel" }),
+        ]);
+        assert.strictEqual(legend.parentNode, null);
+        assert.ok(legend.classList.contains("a11y-legend"));
+        assert.ok(legend.classList.contains("a11y-hierarchy-legend"));
+        assert.strictEqual(
+            legend.querySelector(".a11y-legend-header")!.textContent,
+            "Accessibility · 2 elements",
+        );
+    });
+
+    it("renders the singular 'element' form when there is exactly one node", () => {
+        const legend = buildA11yHierarchyLegend(document.createElement("div"), [
+            node(),
+        ]);
+        assert.strictEqual(
+            legend.querySelector(".a11y-legend-header")!.textContent,
+            "Accessibility · 1 element",
+        );
+    });
+
+    it("renders one .a11y-hierarchy-row per node with swatch, data-node-idx, and palette-cycled --a11y-hier-color", () => {
+        const nodes = Array.from(
+            { length: A11Y_HIERARCHY_PALETTE.length + 2 },
+            (_, i) => node({ label: "Node " + i }),
+        );
+        const legend = buildA11yHierarchyLegend(
+            document.createElement("div"),
+            nodes,
+        );
+        const rows = legend.querySelectorAll<HTMLElement>(
+            ".a11y-hierarchy-row",
+        );
+        assert.strictEqual(rows.length, nodes.length);
+        rows.forEach((r, idx) => {
+            assert.strictEqual(r.dataset.nodeIdx, String(idx));
+            assert.strictEqual(
+                r.style.getPropertyValue("--a11y-hier-color"),
+                A11Y_HIERARCHY_PALETTE[idx % A11Y_HIERARCHY_PALETTE.length],
+            );
+            assert.ok(r.querySelector(".a11y-swatch"));
+        });
+    });
+
+    it("uses '(unlabelled)' fallback when label is empty/whitespace, otherwise the label as-is", () => {
+        const legend = buildA11yHierarchyLegend(document.createElement("div"), [
+            node({ label: "Submit" }),
+            node({ label: "" }),
+            node({ label: "   " }),
+        ]);
+        const titles = Array.from(
+            legend.querySelectorAll<HTMLElement>(
+                ".a11y-hierarchy-row .a11y-title",
+            ),
+        ).map((el) => el.textContent);
+        assert.deepStrictEqual(titles, [
+            "Submit",
+            "(unlabelled)",
+            "(unlabelled)",
+        ]);
+    });
+
+    it("renders subtitle joining role + states with ' · ', omitting it when both are absent", () => {
+        const legend = buildA11yHierarchyLegend(document.createElement("div"), [
+            node({ role: "Button", states: ["enabled", "focused"] }),
+            node({ role: "Image", states: [] }),
+            node({ role: null, states: ["selected"] }),
+            node({ role: null, states: [] }),
+        ]);
+        const rows = legend.querySelectorAll<HTMLElement>(
+            ".a11y-hierarchy-row",
+        );
+        assert.strictEqual(
+            rows[0].querySelector(".a11y-msg")!.textContent,
+            "Button · enabled, focused",
+        );
+        assert.strictEqual(
+            rows[1].querySelector(".a11y-msg")!.textContent,
+            "Image",
+        );
+        assert.strictEqual(
+            rows[2].querySelector(".a11y-msg")!.textContent,
+            "selected",
+        );
+        assert.strictEqual(
+            rows[3].querySelector(".a11y-msg"),
+            null,
+            "no role + no states → no subtitle element",
+        );
+    });
+
+    it("tags consecutive plain-text (no role, no states) rows with a11y-hierarchy-row-adjacent", () => {
+        const legend = buildA11yHierarchyLegend(document.createElement("div"), [
+            node({ label: "Today", role: null, states: [] }),
+            node({ label: "Morning run", role: null, states: [] }),
+            node({ label: "5.2 km", role: null, states: [] }),
+            node({ label: "Done", role: "Button", states: [] }),
+            node({ label: "Trailing", role: null, states: [] }),
+        ]);
+        const rows = legend.querySelectorAll<HTMLElement>(
+            ".a11y-hierarchy-row",
+        );
+        const adjacent = Array.from(rows).map((r) =>
+            r.classList.contains("a11y-hierarchy-row-adjacent"),
+        );
+        // idx 0 is first row (never adjacent), 1 & 2 follow plain-text → adjacent,
+        // 3 has role → not adjacent, 4 follows a role-bearing row → not adjacent.
+        assert.deepStrictEqual(adjacent, [false, true, true, false, false]);
+    });
+
+    it("flags unmerged nodes with .a11y-hierarchy-row-unmerged", () => {
+        const legend = buildA11yHierarchyLegend(document.createElement("div"), [
+            node({ merged: true }),
+            node({ merged: false }),
+        ]);
+        const rows = legend.querySelectorAll<HTMLElement>(
+            ".a11y-hierarchy-row",
+        );
+        assert.ok(!rows[0].classList.contains("a11y-hierarchy-row-unmerged"));
+        assert.ok(rows[1].classList.contains("a11y-hierarchy-row-unmerged"));
+    });
+
+    it("hover toggles .a11y-active on matching .a11y-hierarchy-row + .a11y-hierarchy-box inside the host card", () => {
+        const { card, container, img } = buildCardWithImage(100, 100);
+        ensureHierarchyOverlay(container);
+        const nodes = [
+            node({ label: "First", boundsInScreen: "0,0,10,10" }),
+            node({ label: "Second", boundsInScreen: "10,10,20,20" }),
+        ];
+        applyHierarchyOverlay(card, nodes, img);
+        const legend = buildA11yHierarchyLegend(card, nodes);
+        card.appendChild(legend);
+
+        const rows = legend.querySelectorAll<HTMLElement>(
+            ".a11y-hierarchy-row",
+        );
+        const boxes = card.querySelectorAll<HTMLElement>(".a11y-hierarchy-box");
+
+        rows[0].dispatchEvent(new Event("mouseenter"));
+        assert.ok(rows[0].classList.contains("a11y-active"));
+        assert.ok(boxes[0].classList.contains("a11y-active"));
+        assert.ok(!rows[1].classList.contains("a11y-active"));
+        assert.ok(!boxes[1].classList.contains("a11y-active"));
+
+        rows[1].dispatchEvent(new Event("mouseenter"));
+        assert.ok(!rows[0].classList.contains("a11y-active"));
+        assert.ok(!boxes[0].classList.contains("a11y-active"));
+        assert.ok(rows[1].classList.contains("a11y-active"));
+        assert.ok(boxes[1].classList.contains("a11y-active"));
+
+        rows[1].dispatchEvent(new Event("mouseleave"));
+        assert.ok(!rows[1].classList.contains("a11y-active"));
+        assert.ok(!boxes[1].classList.contains("a11y-active"));
     });
 });

--- a/vscode-extension/src/test/applyA11yUpdate.test.ts
+++ b/vscode-extension/src/test/applyA11yUpdate.test.ts
@@ -284,7 +284,7 @@ describe("applyA11yUpdate", () => {
         assert.strictEqual(cache.findings.get("com.example.A"), cachedBefore);
     });
 
-    it("ensures .a11y-hierarchy-overlay and writes the nodes cache when nodes are present", () => {
+    it("ensures .a11y-hierarchy-overlay, stamps the hierarchy legend, and writes the nodes cache when nodes are present", () => {
         const card = buildCard("com.example.A");
         const nodes = [buildNode("Button"), buildNode("Text")];
         const { config, cache } = buildConfig({
@@ -297,10 +297,58 @@ describe("applyA11yUpdate", () => {
         assert.ok(layer, ".a11y-hierarchy-overlay attached");
         assert.strictEqual(layer!.getAttribute("aria-hidden"), "true");
 
+        const legend = card.querySelector(".a11y-hierarchy-legend");
+        assert.ok(legend, ".a11y-hierarchy-legend stamped onto the card");
+        assert.strictEqual(
+            legend!.querySelectorAll(".a11y-hierarchy-row").length,
+            nodes.length,
+        );
+
         assert.deepStrictEqual(cache.nodes.get("com.example.A"), nodes);
     });
 
-    it("removes .a11y-hierarchy-overlay and clears the nodes cache when nodes is an empty array", () => {
+    it("re-stamps the hierarchy legend on a second nodes update rather than duplicating it", () => {
+        const card = buildCard("com.example.A");
+        const { config } = buildConfig({
+            previews: [buildPreviewInfo("com.example.A")],
+        });
+
+        applyA11yUpdate("com.example.A", undefined, [buildNode("A")], config);
+        applyA11yUpdate(
+            "com.example.A",
+            undefined,
+            [buildNode("X"), buildNode("Y"), buildNode("Z")],
+            config,
+        );
+
+        const legends = card.querySelectorAll(".a11y-hierarchy-legend");
+        assert.strictEqual(legends.length, 1);
+        assert.strictEqual(
+            legends[0].querySelectorAll(".a11y-hierarchy-row").length,
+            3,
+        );
+    });
+
+    it("does not stamp the hierarchy legend when a findings legend already exists (findings take precedence)", () => {
+        const card = buildCard("com.example.A");
+        const { config } = buildConfig({
+            previews: [buildPreviewInfo("com.example.A")],
+        });
+
+        applyA11yUpdate(
+            "com.example.A",
+            [buildFinding("ERROR", "x")],
+            [buildNode("Button")],
+            config,
+        );
+
+        assert.ok(
+            card.querySelector(".a11y-legend:not(.a11y-hierarchy-legend)"),
+        );
+        assert.strictEqual(card.querySelector(".a11y-hierarchy-legend"), null);
+    });
+
+    it("removes .a11y-hierarchy-overlay, drops the hierarchy legend, and clears the nodes cache when nodes is an empty array", () => {
         const card = buildCard("com.example.A");
         const { config, cache } = buildConfig({
             previews: [buildPreviewInfo("com.example.A")],
@@ -313,11 +361,13 @@ describe("applyA11yUpdate", () => {
             config,
         );
         assert.ok(card.querySelector(".a11y-hierarchy-overlay"));
+        assert.ok(card.querySelector(".a11y-hierarchy-legend"));
         assert.strictEqual(cache.nodes.size, 1);
 
         applyA11yUpdate("com.example.A", undefined, [], config);
 
         assert.strictEqual(card.querySelector(".a11y-hierarchy-overlay"), null);
+        assert.strictEqual(card.querySelector(".a11y-hierarchy-legend"), null);
         assert.strictEqual(cache.nodes.has("com.example.A"), false);
     });
 

--- a/vscode-extension/src/webview/preview/a11yOverlay.ts
+++ b/vscode-extension/src/webview/preview/a11yOverlay.ts
@@ -148,12 +148,35 @@ export function ensureHierarchyOverlay(container: Element | null): void {
 }
 
 /**
+ * Palette cycled per node index so legend swatches and overlay boxes
+ * share a colour. Eight perceptually-distinct hues — wraps with
+ * `% length` so node lists longer than the palette still get
+ * deterministic colours.
+ */
+export const A11Y_HIERARCHY_PALETTE: readonly string[] = [
+    "#e57373",
+    "#64b5f6",
+    "#81c784",
+    "#ffb74d",
+    "#ba68c8",
+    "#4db6ac",
+    "#f06292",
+    "#a1887f",
+];
+
+function colorForNodeIndex(idx: number): string {
+    return A11Y_HIERARCHY_PALETTE[idx % A11Y_HIERARCHY_PALETTE.length];
+}
+
+/**
  * Paints one translucent rectangle per accessibility-relevant node.
  * Uses the same `boundsInScreen` percent-of-natural translation as
  * the finding overlay, so the math stays trivial. Each box gets a
  * `title` summarising `label / role / states` so a hover yields the
  * same data TalkBack would announce, without baking any of it into
- * the PNG.
+ * the PNG. Per-node colour comes from `A11Y_HIERARCHY_PALETTE`
+ * (cycled by index) and is exposed via the `--a11y-hier-color` CSS
+ * custom property so `buildA11yHierarchyLegend` can match its swatch.
  */
 export function applyHierarchyOverlay(
     card: HTMLElement,
@@ -166,12 +189,14 @@ export function applyHierarchyOverlay(
     const natW = img.naturalWidth;
     const natH = img.naturalHeight;
     if (!natW || !natH) return;
-    nodes.forEach((n) => {
+    nodes.forEach((n, idx) => {
         const bounds = parseBounds(n.boundsInScreen);
         if (!bounds) return;
         const box = document.createElement("div");
         box.className =
             "a11y-hierarchy-box" + (n.merged ? "" : " a11y-hierarchy-unmerged");
+        box.dataset.nodeIdx = String(idx);
+        box.style.setProperty("--a11y-hier-color", colorForNodeIndex(idx));
         box.style.left = (bounds.left / natW) * 100 + "%";
         box.style.top = (bounds.top / natH) * 100 + "%";
         box.style.width = ((bounds.right - bounds.left) / natW) * 100 + "%";
@@ -183,6 +208,102 @@ export function applyHierarchyOverlay(
         if (tooltipParts.length) box.title = tooltipParts.join(" · ");
         overlay.appendChild(box);
     });
+}
+
+/**
+ * Builds the per-card hierarchy legend — one row per node carrying
+ * a colour swatch (matched to the corresponding `.a11y-hierarchy-box`
+ * via `--a11y-hier-color`), the node label (or "(unlabelled)" fallback),
+ * and a role/state subtitle. Parallel structure to `buildA11yLegend`;
+ * hovering a row highlights the matching overlay box via the shared
+ * `.a11y-active` class.
+ *
+ * Consecutive "plain text" nodes (label-only, no role or states) are
+ * tagged with `.a11y-hierarchy-row-adjacent` so the CSS can tighten
+ * the gap between them — mirroring how text-pairs like
+ * "Morning run · 5.2 km · 28 min" group spatially in the preview.
+ *
+ * Pre: caller has gated on `nodes.length > 0`.
+ */
+export function buildA11yHierarchyLegend(
+    card: HTMLElement,
+    nodes: readonly AccessibilityNode[],
+): HTMLElement {
+    const legend = document.createElement("div");
+    legend.className = "a11y-legend a11y-hierarchy-legend";
+    const header = document.createElement("div");
+    header.className = "a11y-legend-header";
+    const elementsWord = nodes.length === 1 ? "element" : "elements";
+    header.textContent = "Accessibility · " + nodes.length + " " + elementsWord;
+    legend.appendChild(header);
+    nodes.forEach((n, idx) => {
+        const row = document.createElement("div");
+        row.className = "a11y-row a11y-hierarchy-row";
+        if (!n.merged) row.classList.add("a11y-hierarchy-row-unmerged");
+        if (isPlainText(n) && idx > 0 && isPlainText(nodes[idx - 1])) {
+            row.classList.add("a11y-hierarchy-row-adjacent");
+        }
+        row.dataset.nodeIdx = String(idx);
+        row.style.setProperty("--a11y-hier-color", colorForNodeIndex(idx));
+
+        const swatch = document.createElement("span");
+        swatch.className = "a11y-swatch";
+        swatch.setAttribute("aria-hidden", "true");
+        row.appendChild(swatch);
+
+        const text = document.createElement("div");
+        text.className = "a11y-text";
+        const title = document.createElement("div");
+        title.className = "a11y-title";
+        title.textContent =
+            n.label && n.label.trim() ? n.label : "(unlabelled)";
+        text.appendChild(title);
+        const subtitleParts: string[] = [];
+        if (n.role) subtitleParts.push(n.role);
+        if (n.states && n.states.length)
+            subtitleParts.push(n.states.join(", "));
+        if (subtitleParts.length) {
+            const sub = document.createElement("div");
+            sub.className = "a11y-msg";
+            sub.textContent = subtitleParts.join(" · ");
+            text.appendChild(sub);
+        }
+        row.appendChild(text);
+
+        row.addEventListener("mouseenter", () =>
+            highlightA11yHierarchyNode(card, idx),
+        );
+        row.addEventListener("mouseleave", () =>
+            highlightA11yHierarchyNode(card, null),
+        );
+        legend.appendChild(row);
+    });
+    return legend;
+}
+
+function isPlainText(n: AccessibilityNode): boolean {
+    return !n.role && (!n.states || n.states.length === 0);
+}
+
+function highlightA11yHierarchyNode(
+    card: HTMLElement,
+    idx: number | null,
+): void {
+    for (const el of card.querySelectorAll(
+        ".a11y-hierarchy-row.a11y-active, .a11y-hierarchy-box.a11y-active",
+    )) {
+        el.classList.remove("a11y-active");
+    }
+    if (idx === null) return;
+    for (const el of card.querySelectorAll(
+        '.a11y-hierarchy-row[data-node-idx="' +
+            idx +
+            '"], .a11y-hierarchy-box[data-node-idx="' +
+            idx +
+            '"]',
+    )) {
+        el.classList.add("a11y-active");
+    }
 }
 
 /**

--- a/vscode-extension/src/webview/preview/applyA11yUpdate.ts
+++ b/vscode-extension/src/webview/preview/applyA11yUpdate.ts
@@ -13,7 +13,11 @@
 // re-exports the helper bound to the real `previewStore` mutators so
 // existing call sites are unchanged.
 
-import { buildA11yLegend, ensureHierarchyOverlay } from "./a11yOverlay";
+import {
+    buildA11yHierarchyLegend,
+    buildA11yLegend,
+    ensureHierarchyOverlay,
+} from "./a11yOverlay";
 import { sanitizeId } from "./cardData";
 import type {
     AccessibilityFinding,
@@ -122,6 +126,24 @@ export function applyA11yUpdate(
     if (nodes !== undefined) {
         if (nodes && nodes.length > 0) {
             ensureHierarchyOverlay(container);
+            // Stamp the hierarchy legend so the user sees the labelled
+            // node list as soon as data lands, even before the image
+            // decodes. The boxes themselves still paint from the
+            // mapsRevision bump below.
+            const existingHierarchyLegend = card.querySelector(
+                ".a11y-hierarchy-legend",
+            );
+            if (existingHierarchyLegend) existingHierarchyLegend.remove();
+            // Only stamp the hierarchy legend when there's no findings
+            // legend taking the slot — findings take precedence (they
+            // describe actionable issues; hierarchy is the structural
+            // backdrop). Once findings clear, a follow-up update or
+            // the nodes-still-present cache will re-stamp.
+            if (
+                !card.querySelector(".a11y-legend:not(.a11y-hierarchy-legend)")
+            ) {
+                card.appendChild(buildA11yHierarchyLegend(card, nodes));
+            }
             // Same pattern as findings above: store write fires the
             // mapsRevision bump, the component re-paints the layer
             // via `applyHierarchyOverlay`.
@@ -130,6 +152,10 @@ export function applyA11yUpdate(
             config.deleteCardA11yNodes(previewId);
             const layer = card.querySelector(".a11y-hierarchy-overlay");
             if (layer) layer.remove();
+            const hierarchyLegend = card.querySelector(
+                ".a11y-hierarchy-legend",
+            );
+            if (hierarchyLegend) hierarchyLegend.remove();
         }
     }
     if (config.inFocus() && config.focusedCard() === card) {


### PR DESCRIPTION
## Summary
Adds a new accessibility hierarchy legend that displays all nodes in a card with color-coded swatches, labels, and role/state information. The legend integrates with the existing hierarchy overlay boxes through a shared color palette and provides interactive hover highlighting.

## Key Changes

- **Color palette system**: Introduced `A11Y_HIERARCHY_PALETTE` with eight perceptually-distinct hues that cycle by node index, ensuring deterministic colors across legend swatches and overlay boxes
- **Enhanced hierarchy boxes**: Updated `applyHierarchyOverlay` to stamp each box with `data-node-idx` and the `--a11y-hier-color` CSS custom property for color coordination
- **New legend builder**: Implemented `buildA11yHierarchyLegend` that creates a legend with:
  - Per-node rows containing color swatch, label (with "(unlabelled)" fallback), and role/state subtitle
  - Visual grouping of consecutive plain-text nodes via `a11y-hierarchy-row-adjacent` class
  - Unmerged node flagging with reduced opacity
  - Interactive hover/mouseleave handlers that toggle `.a11y-active` on matching legend rows and overlay boxes
- **Integration with applyA11yUpdate**: Automatically stamps the hierarchy legend when nodes are present, replaces it on updates, and removes it when nodes clear; respects findings legend precedence (findings take the legend slot when present)
- **CSS styling**: Added hierarchy legend styles including swatch appearance, row spacing, and active state styling; updated hierarchy box styles to use the palette color variable and added box-shadow for active state

## Notable Implementation Details

- The `colorForNodeIndex` helper applies modulo arithmetic so node lists longer than the palette still get deterministic colors
- Plain-text detection (`isPlainText`) identifies nodes with no role and no states for adjacent row grouping
- The `highlightA11yHierarchyNode` function manages mutual exclusivity of active states across all legend rows and boxes in a card
- Legend is stamped early (before image decode) so users see the labeled node list immediately upon data arrival

https://claude.ai/code/session_018LFcspeRHYUhRhvyMXGPAS