### PR TITLE
feat: add compose/recomposition and render/trace presenters

### DIFF
--- a/vscode-extension/src/test/focusPresentation.test.ts
+++ b/vscode-extension/src/test/focusPresentation.test.ts
@@ -170,6 +170,198 @@ describe("focusPresentation registry", () => {
         assert.strictEqual(img!.src, "data:image/png;base64,AAAA");
     });
 
+    it("compose/recomposition returns null when no payload is cached", () => {
+        const recomp = getPresenter("compose/recomposition")!;
+        assert.strictEqual(recomp(ctx()), null);
+    });
+
+    it("compose/recomposition returns null when nodes is empty", () => {
+        const recomp = getPresenter("compose/recomposition")!;
+        const result = recomp(
+            ctx({
+                data: (kind) =>
+                    kind === "compose/recomposition"
+                        ? { mode: "snapshot", nodes: [] }
+                        : undefined,
+            }),
+        );
+        assert.strictEqual(result, null);
+    });
+
+    it("compose/recomposition sorts nodes by count desc and surfaces mode badge", () => {
+        const recomp = getPresenter("compose/recomposition")!;
+        const result = recomp(
+            ctx({
+                data: (kind) =>
+                    kind === "compose/recomposition"
+                        ? {
+                              mode: "delta",
+                              inputSeq: 42,
+                              nodes: [
+                                  { nodeId: "0xaaa", count: 3 },
+                                  { nodeId: "0xbbb", count: 17 },
+                                  { nodeId: "0xccc", count: 9 },
+                              ],
+                          }
+                        : undefined,
+            }),
+        );
+        assert.ok(result);
+        assert.ok(result!.legend);
+        assert.strictEqual(result!.legend!.entries.length, 3);
+        assert.strictEqual(result!.legend!.entries[0].label, "0xbbb");
+        assert.strictEqual(result!.legend!.entries[1].label, "0xccc");
+        assert.strictEqual(result!.legend!.entries[2].label, "0xaaa");
+        assert.ok(result!.legend!.summary!.includes("delta"));
+        assert.ok(result!.legend!.summary!.includes("input 42"));
+        assert.ok(result!.report);
+        const badge = result!.report!.body.querySelector(
+            ".focus-report-recomposition-mode",
+        );
+        assert.ok(badge);
+        assert.strictEqual(badge!.textContent, "delta");
+        const code = result!.report!.body.querySelector(
+            ".focus-report-recomposition-nodeid",
+        );
+        assert.ok(code);
+        assert.strictEqual(code!.textContent, "0xbbb");
+    });
+
+    it("compose/recomposition caps the visible list at top-N with a +N more affordance", () => {
+        const recomp = getPresenter("compose/recomposition")!;
+        const nodes = Array.from({ length: 15 }, (_, i) => ({
+            nodeId: "0x" + i,
+            count: i,
+        }));
+        const result = recomp(
+            ctx({
+                data: (kind) =>
+                    kind === "compose/recomposition"
+                        ? { mode: "snapshot", nodes }
+                        : undefined,
+            }),
+        );
+        assert.ok(result);
+        assert.strictEqual(result!.legend!.entries.length, 10);
+        const more = result!.report!.body.querySelector(
+            ".focus-report-recomposition-more",
+        );
+        assert.ok(more);
+        assert.strictEqual(more!.textContent, "+5 more");
+    });
+
+    it("compose/recomposition skips inputSeq when not in delta mode", () => {
+        const recomp = getPresenter("compose/recomposition")!;
+        const result = recomp(
+            ctx({
+                data: (kind) =>
+                    kind === "compose/recomposition"
+                        ? {
+                              mode: "snapshot",
+                              inputSeq: 99,
+                              nodes: [{ nodeId: "0xaaa", count: 1 }],
+                          }
+                        : undefined,
+            }),
+        );
+        assert.ok(result);
+        assert.ok(!result!.legend!.summary!.includes("input"));
+        const seq = result!.report!.body.querySelector(
+            ".focus-report-recomposition-inputseq",
+        );
+        assert.strictEqual(seq, null);
+    });
+
+    it("render/trace returns null when both phases and metrics are empty", () => {
+        const trace = getPresenter("render/trace")!;
+        assert.strictEqual(trace(ctx()), null);
+        const result = trace(
+            ctx({
+                data: (kind) =>
+                    kind === "render/trace"
+                        ? { totalMs: 0, phases: [], metrics: {} }
+                        : undefined,
+            }),
+        );
+        assert.strictEqual(result, null);
+    });
+
+    it("render/trace renders a phase bar and a totalMs summary", () => {
+        const trace = getPresenter("render/trace")!;
+        const result = trace(
+            ctx({
+                data: (kind) =>
+                    kind === "render/trace"
+                        ? {
+                              totalMs: 412,
+                              phases: [
+                                  {
+                                      name: "render",
+                                      startMs: 0,
+                                      durationMs: 412,
+                                  },
+                              ],
+                              metrics: { tookMs: 412 },
+                          }
+                        : undefined,
+            }),
+        );
+        assert.ok(result);
+        assert.ok(result!.report);
+        assert.strictEqual(result!.report!.summary, "412 ms");
+        const phases = result!.report!.body.querySelectorAll(
+            ".focus-report-render-trace-phase",
+        );
+        assert.strictEqual(phases.length, 1);
+        assert.strictEqual((phases[0] as HTMLElement).style.width, "100%");
+        // tookMs is suppressed because it duplicates totalMs.
+        const metrics = result!.report!.body.querySelector(
+            ".focus-report-render-trace-metrics",
+        );
+        assert.strictEqual(metrics, null);
+    });
+
+    it("render/trace surfaces non-tookMs metrics under the phases bar", () => {
+        const trace = getPresenter("render/trace")!;
+        const result = trace(
+            ctx({
+                data: (kind) =>
+                    kind === "render/trace"
+                        ? {
+                              totalMs: 30,
+                              phases: [
+                                  {
+                                      name: "compose",
+                                      startMs: 0,
+                                      durationMs: 10,
+                                  },
+                                  {
+                                      name: "measure",
+                                      startMs: 10,
+                                      durationMs: 20,
+                                  },
+                              ],
+                              metrics: {
+                                  tookMs: 30,
+                                  allocBytes: 1234,
+                                  gcMs: 2,
+                              },
+                          }
+                        : undefined,
+            }),
+        );
+        assert.ok(result);
+        const phases = result!.report!.body.querySelectorAll(
+            ".focus-report-render-trace-phase",
+        );
+        assert.strictEqual(phases.length, 2);
+        const dts = result!.report!.body.querySelectorAll(
+            ".focus-report-render-trace-metrics dt",
+        );
+        const keys = Array.from(dts).map((n) => n.textContent);
+        assert.deepStrictEqual(keys, ["allocBytes", "gcMs"]);
+    });
+
     it("renderErrorPresenter activates only when the card carries a render error", () => {
         const renderErr = getPresenter("local/render/error")!;
         assert.strictEqual(renderErr(ctx()), null);

--- a/vscode-extension/src/webview/preview/focusPresentation.ts
+++ b/vscode-extension/src/webview/preview/focusPresentation.ts
@@ -154,6 +154,8 @@ function seedBuiltInPresenters(): void {
     registerPresenter("a11y/atf", a11yFindingsPresenter);
     registerPresenter("a11y/overlay", a11yOverlayPresenter);
     registerPresenter("compose/theme", composeThemePresenter);
+    registerPresenter("compose/recomposition", composeRecompositionPresenter);
+    registerPresenter("render/trace", renderTracePresenter);
     registerPresenter("local/render/error", renderErrorPresenter);
 }
 
@@ -371,6 +373,259 @@ function composeThemePresenter(
         report: {
             title: "Theme tokens",
             summary: "Daemon data",
+            body,
+        },
+    };
+}
+
+/**
+ * `compose/recomposition` — top-N hottest scopes by recomposition count.
+ *
+ * Wire payload (see `RecompositionModels.kt`):
+ *   { mode: "delta" | "snapshot",
+ *     sinceFrameStreamId?: string,
+ *     inputSeq?: number,
+ *     nodes: [{ nodeId: string, count: number }, ...] }
+ *
+ * Empty `nodes` returns `null` so the inspector skips the Report row
+ * when the daemon answered "nothing recomposed." Until source-locations
+ * land (slot-table-derived file:line:column keys, tracked alongside
+ * `RecompositionDataProductRegistry`), there's no overlay — the legend
+ * is the primary surface and entries are kept copy-pasteable so users
+ * can paste `nodeId` into a renderer stack-trace search.
+ */
+function composeRecompositionPresenter(
+    ctx: PresenterContext,
+): ProductPresentation | null {
+    const raw = ctx.data?.("compose/recomposition");
+    if (!raw || typeof raw !== "object") return null;
+    const payload = raw as {
+        mode?: unknown;
+        sinceFrameStreamId?: unknown;
+        inputSeq?: unknown;
+        nodes?: unknown;
+    };
+    const nodes = Array.isArray(payload.nodes) ? payload.nodes : [];
+    const parsed: Array<{ nodeId: string; count: number }> = [];
+    for (const n of nodes) {
+        if (!n || typeof n !== "object") continue;
+        const node = n as { nodeId?: unknown; count?: unknown };
+        if (typeof node.nodeId !== "string" || node.nodeId.length === 0) {
+            continue;
+        }
+        if (typeof node.count !== "number" || !Number.isFinite(node.count)) {
+            continue;
+        }
+        parsed.push({ nodeId: node.nodeId, count: node.count });
+    }
+    if (parsed.length === 0) return null;
+
+    parsed.sort((a, b) => b.count - a.count);
+    const TOP_N = 10;
+    const top = parsed.slice(0, TOP_N);
+    const mode = typeof payload.mode === "string" ? payload.mode : "";
+    const inputSeq =
+        typeof payload.inputSeq === "number" &&
+        Number.isFinite(payload.inputSeq)
+            ? payload.inputSeq
+            : null;
+
+    const summaryParts: string[] = [];
+    if (mode) summaryParts.push(mode);
+    if (mode === "delta" && inputSeq !== null) {
+        summaryParts.push(`input ${inputSeq}`);
+    }
+    summaryParts.push(
+        parsed.length === 1 ? "1 node" : `${parsed.length} nodes`,
+    );
+    const summary = summaryParts.join(" · ");
+
+    const entries: LegendEntry[] = top.map((node, idx) => ({
+        id: "recomp-" + idx,
+        label: node.nodeId,
+        detail:
+            node.count === 1
+                ? "1 recomposition"
+                : `${node.count} recompositions`,
+        level: "info",
+    }));
+
+    const body = document.createElement("div");
+    body.className = "focus-report-recomposition";
+
+    const header = document.createElement("div");
+    header.className = "focus-report-recomposition-header";
+    if (mode) {
+        const badge = document.createElement("span");
+        badge.className = "focus-report-recomposition-mode";
+        badge.dataset.mode = mode;
+        badge.textContent = mode;
+        header.appendChild(badge);
+    }
+    if (mode === "delta" && inputSeq !== null) {
+        const seq = document.createElement("span");
+        seq.className = "focus-report-recomposition-inputseq";
+        seq.textContent = `inputSeq ${inputSeq}`;
+        header.appendChild(seq);
+    }
+    if (header.hasChildNodes()) body.appendChild(header);
+
+    const list = document.createElement("ol");
+    list.className = "focus-report-list focus-report-recomposition-list";
+    top.forEach((node, idx) => {
+        const li = document.createElement("li");
+        li.dataset.legendId = "recomp-" + idx;
+        const code = document.createElement("code");
+        code.className = "focus-report-recomposition-nodeid";
+        code.textContent = node.nodeId;
+        const count = document.createElement("span");
+        count.className = "focus-report-recomposition-count";
+        count.textContent = ` · ${node.count}`;
+        li.appendChild(code);
+        li.appendChild(count);
+        list.appendChild(li);
+    });
+    body.appendChild(list);
+
+    if (parsed.length > TOP_N) {
+        const more = document.createElement("div");
+        more.className = "focus-report-recomposition-more";
+        more.textContent = `+${parsed.length - TOP_N} more`;
+        body.appendChild(more);
+    }
+
+    return {
+        legend: {
+            title: "Recomposition",
+            summary,
+            entries,
+        },
+        report: {
+            title: "Recomposition",
+            summary,
+            body,
+        },
+    };
+}
+
+/**
+ * `render/trace` — phase timeline + total + metrics fallthrough.
+ *
+ * Wire payload (see `RenderTraceDataProduct.kt`):
+ *   { totalMs: number,
+ *     phases: [{ name: string, startMs: number, durationMs: number }, ...],
+ *     metrics: Record<string, number | string> }
+ *
+ * Today the daemon emits a single `render` phase covering the whole
+ * capture; multi-phase (compose / measure / draw / capture) is planned
+ * and the same code paints the breakdown when it lands. Empty `phases`
+ * AND empty `metrics` returns `null`. `metrics.tookMs` is suppressed
+ * because it's redundant with `totalMs`.
+ */
+function renderTracePresenter(
+    ctx: PresenterContext,
+): ProductPresentation | null {
+    const raw = ctx.data?.("render/trace");
+    if (!raw || typeof raw !== "object") return null;
+    const payload = raw as {
+        totalMs?: unknown;
+        phases?: unknown;
+        metrics?: unknown;
+    };
+    const totalMs =
+        typeof payload.totalMs === "number" && Number.isFinite(payload.totalMs)
+            ? payload.totalMs
+            : null;
+    const rawPhases = Array.isArray(payload.phases) ? payload.phases : [];
+    const phases: Array<{ name: string; startMs: number; durationMs: number }> =
+        [];
+    for (const p of rawPhases) {
+        if (!p || typeof p !== "object") continue;
+        const ph = p as {
+            name?: unknown;
+            startMs?: unknown;
+            durationMs?: unknown;
+        };
+        if (typeof ph.name !== "string" || ph.name.length === 0) continue;
+        if (
+            typeof ph.durationMs !== "number" ||
+            !Number.isFinite(ph.durationMs)
+        ) {
+            continue;
+        }
+        const startMs =
+            typeof ph.startMs === "number" && Number.isFinite(ph.startMs)
+                ? ph.startMs
+                : 0;
+        phases.push({ name: ph.name, startMs, durationMs: ph.durationMs });
+    }
+    const rawMetrics =
+        payload.metrics && typeof payload.metrics === "object"
+            ? (payload.metrics as Record<string, unknown>)
+            : {};
+    const metricsEntries: Array<[string, string | number]> = [];
+    for (const key of Object.keys(rawMetrics).sort()) {
+        if (key === "tookMs") continue; // redundant with totalMs
+        const value = rawMetrics[key];
+        if (typeof value === "string" || typeof value === "number") {
+            metricsEntries.push([key, value]);
+        }
+    }
+
+    if (phases.length === 0 && metricsEntries.length === 0) return null;
+
+    const body = document.createElement("div");
+    body.className = "focus-report-render-trace";
+
+    if (phases.length > 0) {
+        const maxDuration = phases.reduce(
+            (acc, p) => (p.durationMs > acc ? p.durationMs : acc),
+            0,
+        );
+        const chartScale = totalMs && totalMs > 0 ? totalMs : maxDuration;
+        const bar = document.createElement("div");
+        bar.className = "focus-report-render-trace-bar";
+        for (const phase of phases) {
+            const seg = document.createElement("div");
+            seg.className = "focus-report-render-trace-phase";
+            const pct =
+                chartScale > 0
+                    ? Math.max(
+                          0,
+                          Math.min(100, (phase.durationMs / chartScale) * 100),
+                      )
+                    : 0;
+            seg.style.width = pct + "%";
+            seg.style.background = "var(--vscode-progressBar-background)";
+            seg.title = `${phase.name}: ${phase.durationMs} ms`;
+            const label = document.createElement("span");
+            label.className = "focus-report-render-trace-phase-label";
+            label.textContent = `${phase.name} · ${phase.durationMs} ms`;
+            seg.appendChild(label);
+            bar.appendChild(seg);
+        }
+        body.appendChild(bar);
+    }
+
+    if (metricsEntries.length > 0) {
+        const dl = document.createElement("dl");
+        dl.className = "focus-report-render-trace-metrics";
+        for (const [key, value] of metricsEntries) {
+            const dt = document.createElement("dt");
+            dt.textContent = key;
+            const dd = document.createElement("dd");
+            dd.textContent = String(value);
+            dl.appendChild(dt);
+            dl.appendChild(dd);
+        }
+        body.appendChild(dl);
+    }
+
+    const summary = totalMs !== null ? `${totalMs} ms` : undefined;
+    return {
+        report: {
+            title: "Render trace",
+            summary,
             body,
         },
     };


### PR DESCRIPTION
Add two new data product presenters to the focus presentation system for displaying Compose recomposition metrics and render trace information.

## Summary
Registers and implements two new presenters in the focus presentation registry:
- `compose/recomposition`: displays top-N hottest scopes by recomposition count
- `render/trace`: displays render phase timeline and performance metrics

## Key Changes
- **compose/recomposition presenter**: 
  - Parses recomposition data with mode (delta/snapshot) and node IDs with counts
  - Sorts nodes by recomposition count (descending) and displays top 10
  - Shows mode badge and inputSeq in delta mode
  - Includes "+N more" affordance when results exceed top 10
  - Returns null for empty node lists to skip report row

- **render/trace presenter**:
  - Parses render phase timeline data with duration and metrics
  - Renders visual phase bar with proportional widths
  - Displays performance metrics (excluding redundant `tookMs`)
  - Shows total duration in summary
  - Returns null when both phases and metrics are empty

- **Test coverage**: Added comprehensive tests for both presenters covering:
  - Null/empty payload handling
  - Data sorting and filtering
  - Top-N capping with "+N more" display
  - Mode-specific behavior (delta vs snapshot)
  - Phase bar rendering and metrics display
  - Metric filtering (suppression of `tookMs`)

https://claude.ai/code/session_01St66VUNXzkSLc8TgiaMDuQ