### PR TITLE
docs: design for exposing all data extensions in VS Code panel

### DIFF
--- a/docs/design/EXTENSION_DATA_EXPOSURE.md
+++ b/docs/design/EXTENSION_DATA_EXPOSURE.md
@@ -82,25 +82,58 @@ Decisions:
 
 1. **Filter chip bar stays as row 1.** Function / group / layout
    selectors remain top-of-panel.
-2. **Secondary filters collapse into a "More" tab.** Anything that's
+2. **Bundle chips are the shortcuts.** Each bundle chip is a toggle —
+   pressing it on opens its tab; pressing it again (or closing the tab)
+   turns the bundle off and returns the panel to the plain-preview
+   default state. The chip + tab are two ends of the same toggle, not
+   two independent controls.
+3. **Tabs are dismissible.** Every data tab has a close (`×`)
+   affordance in the tab header. Closing the last data tab returns the
+   panel to "no inspector" — the preview grid is visible
+   unobstructed, no surface left dangling like today's hierarchy
+   legend with no dismiss path. The `…More` tab is the only
+   non-closable tab.
+4. **"No inspector" is the resting state.** With no bundle chips
+   pressed, no tab row is shown. The card overlays (`BoxOverlay`,
+   legends) are also cleared. This is the single source of truth for
+   "I want to look at the preview without any data surface on top of
+   it."
+5. **Secondary filters collapse into a "More" tab.** Anything that's
    not in the chip bar today and isn't yet enabled is hidden behind a
    single `…` tab so disabled rows don't push enabled data below the
    fold. Once enabled, a kind earns a tab and moves to the front.
-3. **Each enabled data extension owns one tab.** Two enabled = two
+6. **Each enabled data extension owns one tab.** Two enabled = two
    tabs, in the order they were enabled. Tab order is sticky per
    scope (re-uses the MRU machinery in `focusInspector.ts`).
-4. **Active tab body is a table, not a `<details>`.** No
+7. **Active tab body is a table, not a `<details>`.** No
    click-to-expand for the default view — the data the user just
    asked for must be on screen.
-5. **Last tab is always `…More` / settings.** Stable position so the
+8. **Last tab is always `…More` / settings.** Stable position so the
    user always knows where to find the extra filters and disabled
    kinds.
-6. **Overlay + legend live on the card,** unchanged from the current
+9. **Overlay + legend live on the card,** unchanged from the current
    focus-mode inspector — but available outside focus mode too, on
    whichever previews are currently selected.
-7. **JSON is a secondary action.** Each tab has a `Copy JSON` button
-   in the top-right of the table; that's the only path. No raw-JSON
-   default rendering anywhere.
+10. **JSON is a secondary action.** Each tab has a `Copy JSON` button
+    in the top-right of the table; that's the only path. No raw-JSON
+    default rendering anywhere.
+
+### Chip ↔ tab ↔ overlay state machine
+
+For each bundle:
+
+| Chip | Tab | Card overlay/legend |
+|---|---|---|
+| OFF (default) | not shown | not painted |
+| ON | shown; user can switch between active tabs | painted on focused/selected cards |
+| OFF via chip re-press | tab removed; if it was active, the next-most-recent active tab takes over (or no tab row if it was the last) | cleared |
+| OFF via tab `×` | identical to chip re-press | cleared |
+
+This is the **missing affordance** in today's panel: once a kind's
+overlay paints, the only way to dismiss it is to scroll back to the
+focus-inspector chip row and toggle it off — easy to miss. The tab's
+own `×` + the chip's toggle-off behaviour are redundant on purpose so
+the dismissal path is always visible from wherever the user's eye lands.
 
 ### Standardising overlay + legend
 

--- a/docs/design/EXTENSION_DATA_EXPOSURE.md
+++ b/docs/design/EXTENSION_DATA_EXPOSURE.md
@@ -1,0 +1,314 @@
+# Exposing data-extension output in the VS Code preview panel
+
+Working design for surfacing every data extension's output in the
+"Compose Preview" webview through one consistent shell, plus a per-kind
+catalogue of how each extension should present its data.
+
+## Goals
+
+- One presentation shell for every kind: **overlay + legend** on the
+  preview image, plus **a table** in a dedicated tab below the
+  toolbar. No bespoke UI per extension when the standard shell fits.
+- When the user toggles a kind on, the table appears immediately. No
+  expand / scroll. The table is **above** any not-yet-enabled filter
+  affordances.
+- Existing CLI / MCP-side rendered PNGs (e.g. `a11y/overlay`) stay
+  available, but as a secondary artefact — the locally-painted overlay
+  is the primary surface.
+- JSON is reachable per-tab via **Copy JSON** but never the default view.
+
+## Bundles (the default toggle is a cluster, not a kind)
+
+The user wants to see "a11y" or "theming", not a checklist of
+`a11y/atf` + `a11y/hierarchy` + `a11y/touchTargets`. Each cluster
+exposes one **bundle toggle** that turns on a sensible default
+combination, and an expander that reveals the individual kinds for
+power users.
+
+| Bundle | Default ON | Default OFF (in expander) |
+|---|---|---|
+| **A11y** | `a11y/atf` (findings), `a11y/hierarchy` (locally-painted overlay + legend) | `a11y/touchTargets`, `a11y/overlay` (daemon-rendered PNG — only useful when reproducing CI output) |
+| **Theming** | `compose/theme` | `compose/wallpaper` (it's an *input* override; only useful when actively tuning dynamic color) |
+| **Text / i18n** | `text/strings`, `fonts/used` | `i18n/translations` (heavier — Android-only, requires `res` scan), pseudolocale re-render toggle |
+| **Resources** | `resources/used` | — |
+| **Inspection** | `compose/semantics` (cheap projection) | `layout/inspector` (heavier — full hierarchy), `uia/hierarchy` (Android-only) |
+| **Performance** | — (all kinds are at least medium cost) | `compose/recomposition`, `render/trace`, `render/composeAiTrace` |
+| **Display** | — | `displayfilter/<id>` per filter |
+| **History** | `history/diff/regions` | — |
+| **Watch / Wear** | — | `compose/ambient` |
+| **Errors** | always implicit | `test/failure` postmortem fetch |
+
+Bundle UX rules:
+
+1. **Chip bar in the panel toolbar lists bundles, not kinds.** Toggling
+   the A11y chip turns on the default-ON kinds within the bundle.
+2. **One tab per *active* bundle**, not per-kind. The tab body
+   chooses how to lay out the union of enabled kinds (e.g. the A11y
+   tab shows hierarchy table + findings inline rather than two
+   separate tabs).
+3. **Expander inside the tab** ("Configure…") reveals checkboxes for
+   each kind in the bundle. Toggling a checkbox subscribes /
+   unsubscribes immediately. The default-ON kinds remain ON until
+   the user unchecks them.
+4. **Disabled kind from another bundle stays in the "…More" tab,** so
+   the chip bar doesn't grow with seldom-used toggles like
+   `a11y/overlay` PNG.
+5. **MRU follows the bundle.** Bundle ON ordering is what drives tab
+   placement; per-kind toggling inside an already-open bundle doesn't
+   reorder tabs.
+
+This keeps the common case ("show me a11y") one click and one tab,
+while the rare case ("I only want the daemon overlay PNG to compare
+to CI") is still reachable via the expander or the More tab.
+
+## UX shell
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ [filter chips: function ▾  group ▾]  [layout ▾]  […more filters]│  ← row 1
+├──────────────────────────────────────────────────────────────────┤
+│  ┌ Data tabs ───────────────────────────────────────────────┐    │
+│  │  Fonts │ Strings │ Theme │ Recomposition │ ...           │    │  ← row 2
+│  └────────────────────────────────────────────────────────── ┘    │
+│  ┌──── table for the active data tab ──────────── [Copy JSON]┐    │  ← row 3
+│  │ ...                                                       │    │
+│  └───────────────────────────────────────────────────────────┘    │
+├──────────────────────────────────────────────────────────────────┤
+│  [previews grid, each card paints overlay + legend for active tab]│
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Decisions:
+
+1. **Filter chip bar stays as row 1.** Function / group / layout
+   selectors remain top-of-panel.
+2. **Secondary filters collapse into a "More" tab.** Anything that's
+   not in the chip bar today and isn't yet enabled is hidden behind a
+   single `…` tab so disabled rows don't push enabled data below the
+   fold. Once enabled, a kind earns a tab and moves to the front.
+3. **Each enabled data extension owns one tab.** Two enabled = two
+   tabs, in the order they were enabled. Tab order is sticky per
+   scope (re-uses the MRU machinery in `focusInspector.ts`).
+4. **Active tab body is a table, not a `<details>`.** No
+   click-to-expand for the default view — the data the user just
+   asked for must be on screen.
+5. **Last tab is always `…More` / settings.** Stable position so the
+   user always knows where to find the extra filters and disabled
+   kinds.
+6. **Overlay + legend live on the card,** unchanged from the current
+   focus-mode inspector — but available outside focus mode too, on
+   whichever previews are currently selected.
+7. **JSON is a secondary action.** Each tab has a `Copy JSON` button
+   in the top-right of the table; that's the only path. No raw-JSON
+   default rendering anywhere.
+
+### Standardising overlay + legend
+
+Today `focusPresentation.ts` already defines the four surfaces a
+presenter can contribute to (overlay / legend / report / error). The
+proposal is:
+
+- Drop "report" as a primary surface; promote it into the **table tab**
+  surface managed by the panel shell.
+- Keep **overlay** (tinted box on the image) and **legend** (sidecar
+  list correlated by `data-overlay-id` / `data-legend-id`) as the
+  in-card surfaces. These are what `legendArrow.ts` already wires up.
+- Provide one shared `BoxOverlay` primitive that takes
+  `{ id, bounds, level?, color? }[]` and a matching `Legend` primitive
+  that takes `{ id, label, detail?, level? }[]`. Presenters that fit
+  the bounds-on-image model use these instead of hand-rolling DOM.
+  Presenters that don't (e.g. fonts, theme tokens, ambient state) skip
+  the overlay surface and only contribute a table.
+
+This is what most of the new per-kind issues need: their data already
+has bounds (`text/strings`, `resources/used`, `layout/inspector`,
+`compose/semantics`, `a11y/touchTargets`, `uia/hierarchy`,
+`history/diff/regions`) so they can ride the shared `BoxOverlay`
+without each writing their own DOM.
+
+## Per-extension presentation notes
+
+Each entry: **wire kind** · primary table columns · overlay support ·
+external links · cluster.
+
+### `a11y/atf` and `a11y/hierarchy` and `a11y/touchTargets`
+Cluster: **A11y** (#1010 covers hierarchy legend).
+
+- Table: `node`, `role`, `states`, `findings level`, `message`.
+- Overlay: one tinted box per node, level-coloured (error / warning /
+  info). Hover correlates with legend row.
+- Secondary: `a11y/overlay` PNG, shown as a *separate row* on the
+  card's options panel rather than mixed into the table. Only shown
+  when the daemon has it.
+
+### `compose/theme`
+Cluster: **Theming**.
+
+- Table tabs: `Colors` / `Typography` / `Shapes`.
+  - Colors: swatch · token name · hex · consumers (nodeIds).
+  - Typography: token name · family · size · weight · style ·
+    line-height · letter-spacing.
+  - Shapes: token name · resolved value.
+- Overlay: tint the boxes of nodes in `consumers[].nodeId` when a
+  token row is hovered (uses bounds from `compose/semantics` or
+  `layout/inspector` if available; otherwise legend-only).
+- Copy JSON.
+
+### `compose/wallpaper`
+Cluster: **Theming**.
+
+- Table: `seedColor` swatch · `isDark` · `paletteStyle` ·
+  `contrastLevel` · then the derived colour scheme as a swatch grid
+  identical to `compose/theme`'s Colors tab.
+- No overlay (it's an input override, not a per-node thing).
+
+### `fonts/used`
+Cluster: **Text / i18n**.
+
+- Table columns: `requestedFamily`, `resolvedFamily`, `weight`,
+  `style`, `sourceFile`, `fallback chain`, `consumers`.
+- **Reconstruct the request.** Show enough so a reader can recreate
+  the `Font(...)` call: family + weight + style + source file +
+  fallback chain are mandatory.
+- **Google Fonts preview.** When `requestedFamily` resolves on
+  `fonts.google.com`, render a tiny preview rendered with the
+  resolved family + weight in the table cell, and link the family
+  name to `https://fonts.google.com/specimen/<family>`. URL-encode the
+  family. No network call from the webview — preview uses the local
+  resolved font; the link is `target=_blank`-style (VS Code
+  `openExternal`).
+- Overlay: tint consumer nodes; legend rows match.
+
+### `text/strings` + `i18n/translations`
+Cluster: **Text / i18n**.
+
+- One tab for "Drawn text" (`text/strings` payload):
+  table columns `text`, `localeTag`, `fontScale`, `fontSize`,
+  `foreground`, `background`, `overflow`, `nodeId`. Overlay each row
+  by `boundsInScreen`. Sortable by `truncated` / `didOverflowWidth` /
+  `didOverflowHeight` so the user lands on truncation bugs.
+- One tab for "Translations" (`i18n/translations` payload):
+  table columns `rendered`, `resourceName`, `sourceFile`,
+  `supported locales` (count), `untranslated locales` (count + chip).
+- **Link to resource file.** `sourceFile` and `resourceName` open the
+  underlying `values*/strings.xml` via `vscode.openTextDocument` + a
+  search jump to the `<string name="...">` tag.
+- Locale picker in the header lets the user preview translations
+  inline without re-rendering.
+
+### `resources/used`
+Cluster: **Resources**.
+
+- Table: `resourceType`, `resourceName`, `packageName`, `resolvedValue`,
+  `resolvedFile`, `consumers`.
+- **Link to file.** `resolvedFile` opens the resource file directly;
+  for `string`/`color`/`dimen`/`drawable` types we resolve to the
+  best-match `values*/<file>.xml` and jump to the resource by name.
+- Overlay: tint consumer nodes when bounds are available (joined via
+  `compose/semantics` or `layout/inspector`).
+
+### `layout/inspector` + `compose/semantics`
+Cluster: **Inspection**.
+
+- Tree (collapsible) instead of a flat table — bounds, modifiers,
+  source refs. Each node row has an overlay handle.
+- Click a node row → tint its box on the preview + highlight ancestors
+  faintly (matches Android Studio's Layout Inspector flow).
+- Source-link column opens the file:line of the composable when the
+  daemon provides it.
+
+### `compose/recomposition`
+Cluster: **Performance** (already tracked in #1046).
+
+- Table: top-N nodes sorted by `count`, with `mode` (delta vs snapshot)
+  + `inputSeq` chip. Heat-map overlay deferred until the daemon ships
+  source coords (v2).
+
+### `render/trace` and `render/composeAiTrace`
+Cluster: **Performance** (`render/trace` tracked in #1047).
+
+- `render/trace`: horizontal bar chart of phases in the table tab,
+  plus a metrics key/value sub-table.
+- `render/composeAiTrace`: link to download/open in
+  [`ui.perfetto.dev`](https://ui.perfetto.dev) (Perfetto-importable
+  JSON). The table itself is a phase summary.
+
+### `compose/ambient`
+Cluster: **Watch / Wear**.
+
+- Single-row table (one preview = one ambient state). Columns:
+  `state`, `burnInProtectionRequired`, `deviceHasLowBitAmbient`,
+  `updateTimeMillis`. Badge in the legend showing the current state.
+
+### `displayfilter/<id>`
+Cluster: **Display**.
+
+- This isn't a typical extension: it produces post-process PNGs
+  rather than structured data. Table lists the active filters with a
+  thumbnail per filter. Clicking a row swaps the card preview to that
+  filtered render. No overlay.
+
+### `history/diff/regions`
+Cluster: **History / Diffs**.
+
+- Table: `baselineHistoryId`, then one row per region with
+  `bounds`, `pixelCount`, `avgDelta`. Overlay paints each region as a
+  tinted box — colour ramped by `avgDelta` so small drift fades.
+
+### `uia/hierarchy`
+Cluster: **Inspection / Automation**.
+
+- Table: `text`, `contentDescription`, `testTag`, `role`, supported
+  actions chips, `boundsInScreen`. Each row → tinted box overlay.
+- Copy-as-selector action on each row (builds the `By.testTag(...)` /
+  `By.text(...)` snippet inline).
+
+### `test/failure`
+Cluster: **Errors**.
+
+- Special-case: the panel banner already surfaces render errors. The
+  data table is the postmortem bundle — phase, error type/message,
+  stack frames. No overlay.
+
+### Pseudolocale (`en-XA`, `ar-XB`)
+Cluster: **Text / i18n**.
+
+- Not a data product per the catalogue (no kind), but it's a toggle
+  the panel should expose alongside the strings/i18n tab — a chip
+  that re-renders the preview with the pseudolocale applied. Table
+  view reuses `text/strings`.
+
+## Cluster summary
+
+Each cluster matches a **bundle** above, and gets its own tracking
+issue. Cluster A is the framework prerequisite for everything but the
+simplest swatch-only presenters.
+
+| Cluster | Bundle | Kinds | Existing issues |
+|---|---|---|---|
+| A | Panel shell — bundle chips, tabs, table, Copy JSON, shared overlay/legend primitive, "More" tab | (framework) | — |
+| B | A11y | `a11y/atf`, `a11y/hierarchy`, `a11y/touchTargets`, `a11y/overlay` | #1010 |
+| C | Theming | `compose/theme`, `compose/wallpaper` | — |
+| D | Text / i18n | `fonts/used`, `text/strings`, `i18n/translations`, pseudolocale | — |
+| E | Resources | `resources/used` | — |
+| F | Inspection | `layout/inspector`, `compose/semantics`, `uia/hierarchy` | — |
+| G | Performance | `compose/recomposition`, `render/trace`, `render/composeAiTrace` | #1046, #1047 |
+| H | Misc — Display / Ambient / History-diff / Errors | `displayfilter/*`, `compose/ambient`, `history/diff/regions`, `test/failure` | — |
+
+## Open questions
+
+1. **Multi-preview selection.** The current panel renders many cards
+   simultaneously. Does a kind's tab show the union across all
+   visible previews, or scope to the focused preview only? Default:
+   focused preview; fall back to "all visible" when no card is
+   focused.
+2. **Persistence.** Per-scope MRU of which kinds had tabs open
+   (re-use the focus-inspector MRU keying), so re-opening a panel
+   re-restores the layout.
+3. **Tab overflow.** If the user enables 6+ kinds, do tabs scroll
+   horizontally or collapse to a `…` overflow menu? Lean toward
+   horizontal scroll + a "Pin" affordance.
+4. **Copy JSON shape.** Whole-payload (scoped to the preview the user
+   is viewing) vs the table-as-rendered (post-sort, post-filter).
+   Default: whole-payload, since agents are the dominant Copy JSON
+   audience and they want the wire shape.

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2119,3 +2119,245 @@ body {
     box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.25);
     flex-shrink: 0;
 }
+
+/* ---------------------------------------------------------------
+ * Bundle chip bar + data tabs + data table (panel-shell #1054).
+ * The chip bar is the toggle row beneath the filter toolbar; the
+ * tab row appears only when at least one bundle is active. The
+ * close (×) on a tab is the dismiss path the user reaches when
+ * they're already focused on the data, mirroring the chip toggle.
+ * --------------------------------------------------------------- */
+.bundle-chip-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 4px 6px;
+    border-bottom: 1px solid var(--vscode-panel-border, transparent);
+}
+.bundle-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 12px;
+    border: 1px solid var(--vscode-button-border, transparent);
+    background: var(--vscode-button-secondaryBackground, transparent);
+    color: var(--vscode-button-secondaryForeground, inherit);
+    font-size: 12px;
+    cursor: pointer;
+}
+.bundle-chip:hover {
+    background: var(
+        --vscode-button-secondaryHoverBackground,
+        var(--vscode-button-secondaryBackground, transparent)
+    );
+}
+.bundle-chip.bundle-chip-on {
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border-color: var(--vscode-focusBorder, transparent);
+}
+.bundle-chip-label {
+    white-space: nowrap;
+}
+
+.data-tabs {
+    display: flex;
+    flex-direction: column;
+    border-bottom: 1px solid var(--vscode-panel-border, transparent);
+}
+.data-tab-strip {
+    display: flex;
+    gap: 2px;
+    padding: 0 4px;
+    background: var(--vscode-tab-inactiveBackground, transparent);
+}
+.data-tab-handle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 4px 2px 8px;
+    border-top: 2px solid transparent;
+    cursor: pointer;
+    background: transparent;
+    color: var(--vscode-tab-inactiveForeground, inherit);
+}
+.data-tab-handle-active {
+    border-top-color: var(--vscode-focusBorder, currentColor);
+    background: var(--vscode-tab-activeBackground, transparent);
+    color: var(--vscode-tab-activeForeground, inherit);
+}
+.data-tab-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: transparent;
+    border: none;
+    color: inherit;
+    padding: 2px 4px;
+    font: inherit;
+    cursor: pointer;
+}
+.data-tab-close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    padding: 2px;
+    border-radius: 2px;
+    cursor: pointer;
+    opacity: 0.6;
+}
+.data-tab-close:hover {
+    background: var(--vscode-toolbar-hoverBackground, transparent);
+    opacity: 1;
+}
+.data-tab-body {
+    padding: 6px 8px;
+}
+.data-tab-placeholder {
+    opacity: 0.6;
+    padding: 8px 0;
+}
+
+.data-table-shell {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.data-table-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+.data-table-title {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    font-weight: 600;
+}
+.data-table-summary {
+    opacity: 0.7;
+    font-weight: 400;
+}
+.data-table-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+.data-table-copy {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px;
+    border-radius: 2px;
+    border: 1px solid var(--vscode-button-border, transparent);
+    background: var(--vscode-button-secondaryBackground, transparent);
+    color: var(--vscode-button-secondaryForeground, inherit);
+    cursor: pointer;
+    font-size: 12px;
+}
+.data-table-grid {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+.data-table-grid th,
+.data-table-grid td {
+    padding: 3px 6px;
+    text-align: left;
+    border-bottom: 1px solid var(--vscode-panel-border, transparent);
+    vertical-align: top;
+}
+.data-table-row:hover,
+.data-table-row-active {
+    background: var(--vscode-list-hoverBackground, transparent);
+}
+.data-table-empty {
+    padding: 8px 0;
+    opacity: 0.6;
+}
+
+/* Shared box overlay primitive (used by every bundle with bounds). */
+.box-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+.overlay-box {
+    position: absolute;
+    pointer-events: auto;
+    border: 1px solid var(--overlay-color, var(--a11y-color, #1976d2));
+    background: color-mix(
+        in srgb,
+        var(--overlay-color, var(--a11y-color, #1976d2)) 18%,
+        transparent
+    );
+    box-sizing: border-box;
+}
+.overlay-box[data-level="error"] {
+    --overlay-color: #d32f2f;
+}
+.overlay-box[data-level="warning"] {
+    --overlay-color: #f57c00;
+}
+.overlay-box[data-level="info"] {
+    --overlay-color: #1976d2;
+}
+.overlay-box.overlay-box-active {
+    outline: 2px solid var(--overlay-color, currentColor);
+    z-index: 2;
+}
+
+/* A11y bundle row styling — swatches mirror the overlay colour. */
+.a11y-swatch-cell {
+    width: 16px;
+}
+.a11y-row-swatch {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    background: var(--overlay-color, #1976d2);
+}
+.a11y-row-swatch[data-level="error"] {
+    --overlay-color: #d32f2f;
+}
+.a11y-row-swatch[data-level="warning"] {
+    --overlay-color: #f57c00;
+}
+.a11y-row-swatch[data-level="info"] {
+    --overlay-color: #1976d2;
+}
+.a11y-label-stack {
+    display: flex;
+    flex-direction: column;
+}
+.a11y-row-role {
+    opacity: 0.7;
+    font-size: 11px;
+}
+.a11y-findings-cell {
+    text-align: right;
+}
+.a11y-findings-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    padding: 0 5px;
+    border-radius: 9px;
+    background: var(--overlay-color, #d32f2f);
+    color: white;
+    font-size: 11px;
+    font-weight: 700;
+}
+.a11y-findings-badge[data-level="error"] {
+    --overlay-color: #d32f2f;
+}
+.a11y-findings-badge[data-level="warning"] {
+    --overlay-color: #f57c00;
+}
+.a11y-findings-badge[data-level="info"] {
+    --overlay-color: #1976d2;
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3933,6 +3933,9 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 },
             );
             break;
+        case "copyToClipboard":
+            void vscode.env.clipboard.writeText(msg.text);
+            break;
     }
 }
 

--- a/vscode-extension/src/test/a11yBundlePresenter.test.ts
+++ b/vscode-extension/src/test/a11yBundlePresenter.test.ts
@@ -1,0 +1,126 @@
+// A11y bundle presenter (#1054 Cluster B). Pins the row + overlay
+// derivation, including the orphan-finding path that surfaces ATF
+// findings without a matching hierarchy node — regression coverage
+// for the codex review comment that blank-bounds findings were being
+// silently dropped when a hierarchy node also happened to have blank
+// bounds.
+
+import * as assert from "assert";
+import { computeA11yBundleData } from "../webview/preview/a11yBundlePresenter";
+import type {
+    AccessibilityFinding,
+    AccessibilityNode,
+} from "../webview/shared/types";
+
+function node(
+    overrides: Partial<AccessibilityNode> & { boundsInScreen?: string },
+): AccessibilityNode {
+    return {
+        label: overrides.label ?? "node",
+        role: overrides.role ?? "Button",
+        states: overrides.states ?? [],
+        merged: overrides.merged ?? true,
+        boundsInScreen: overrides.boundsInScreen ?? "0,0,10,10",
+    };
+}
+
+function finding(
+    overrides: Partial<AccessibilityFinding>,
+): AccessibilityFinding {
+    return {
+        level: overrides.level ?? "ERROR",
+        type: overrides.type ?? "ContrastCheck",
+        message: overrides.message ?? "low contrast",
+        viewDescription: overrides.viewDescription ?? null,
+        boundsInScreen: overrides.boundsInScreen ?? "0,0,10,10",
+    };
+}
+
+describe("computeA11yBundleData", () => {
+    it("emits one row per hierarchy node with palette colour and no level", () => {
+        const data = computeA11yBundleData(
+            [
+                node({ label: "Title", boundsInScreen: "0,0,10,10" }),
+                node({ label: "Body", boundsInScreen: "10,10,20,20" }),
+            ],
+            [],
+        );
+        assert.strictEqual(data.rows.length, 2);
+        assert.strictEqual(data.overlay.length, 2);
+        // Palette colour applied when no finding pins the level.
+        assert.ok(data.overlay[0].color);
+        assert.strictEqual(data.overlay[0].level, "info");
+    });
+
+    it("merges a matching finding's level onto its node row", () => {
+        const data = computeA11yBundleData(
+            [node({ boundsInScreen: "0,0,10,10" })],
+            [
+                finding({
+                    level: "ERROR",
+                    boundsInScreen: "0,0,10,10",
+                    message: "x",
+                }),
+            ],
+        );
+        assert.strictEqual(data.rows.length, 1);
+        assert.strictEqual(data.rows[0].findingCount, 1);
+        assert.strictEqual(data.rows[0].topFindingLevel, "error");
+        assert.strictEqual(data.overlay[0].level, "error");
+        // Findings pin the level so the palette colour is *not* set.
+        assert.strictEqual(data.overlay[0].color, undefined);
+    });
+
+    it("surfaces unmatched findings as orphan rows", () => {
+        const data = computeA11yBundleData(
+            [node({ boundsInScreen: "0,0,10,10" })],
+            [
+                finding({
+                    boundsInScreen: "100,100,110,110",
+                    level: "WARNING",
+                    type: "Touch",
+                }),
+            ],
+        );
+        // 1 hierarchy row + 1 orphan finding row.
+        assert.strictEqual(data.rows.length, 2);
+        const orphan = data.rows[1];
+        assert.ok(orphan.id.startsWith("a11y-finding-orphan-"));
+        assert.strictEqual(orphan.topFindingLevel, "warning");
+        // Hierarchy node has 0 findings (the orphan matched neither).
+        assert.strictEqual(data.rows[0].findingCount, 0);
+    });
+
+    it("does not drop a blank-bounds finding when a node also has blank bounds", () => {
+        // Codex review regression: matchedKeys used to include "" from
+        // the malformed node, masking the finding as 'already
+        // represented' even though it has nothing in common with it.
+        const data = computeA11yBundleData(
+            [node({ label: "broken", boundsInScreen: "" })],
+            [
+                finding({
+                    boundsInScreen: null,
+                    level: "ERROR",
+                    message: "no bounds",
+                }),
+            ],
+        );
+        // 1 hierarchy row + 1 orphan finding row — the finding is NOT
+        // matched against the empty-bounds node.
+        assert.strictEqual(data.rows.length, 2);
+        const orphan = data.rows.find((r) =>
+            r.id.startsWith("a11y-finding-orphan-"),
+        );
+        assert.ok(orphan, "blank-bounds finding must surface as an orphan row");
+        assert.strictEqual(orphan!.topFindingLevel, "error");
+    });
+
+    it("emits no overlay box for rows whose bounds did not parse", () => {
+        const data = computeA11yBundleData(
+            [node({ boundsInScreen: "not-a-rect" })],
+            [],
+        );
+        assert.strictEqual(data.rows.length, 1);
+        assert.strictEqual(data.overlay.length, 0);
+    });
+});

--- a/vscode-extension/src/test/applyA11yUpdate.test.ts
+++ b/vscode-extension/src/test/applyA11yUpdate.test.ts
@@ -10,9 +10,12 @@ import type {
     PreviewInfo,
 } from "../webview/shared/types";
 
-/** Build a `<div class="preview-card" id="preview-...">` with an
- *  `.image-container` child (where the a11y overlays land) and append
- *  it to `document.body`. Returns the card. */
+// Post-#1054 the labelled legend list is no longer painted inline on
+// the card — it now lives in the A11y bundle tab. These tests pin the
+// surviving on-card surfaces (the boxes-on-image overlay layer) and
+// the cache writes that feed both the bundle presenter and the
+// existing focus inspector.
+
 function buildCard(previewId: string): HTMLElement {
     const card = document.createElement("div");
     card.className = "preview-card";
@@ -25,9 +28,6 @@ function buildCard(previewId: string): HTMLElement {
     return card;
 }
 
-/** Minimal `PreviewInfo` shaped just enough for `buildA11yLegend` to
- *  consume it. The legend reads `id` for the row dataset and
- *  `a11yFindings` for the row content; nothing else is touched. */
 function buildPreviewInfo(id: string): PreviewInfo {
     return {
         id,
@@ -62,9 +62,6 @@ function buildNode(label: string): AccessibilityNode {
     };
 }
 
-/** Stand-in for the per-preview a11y caches in `previewStore`. The real
- *  store bumps a `mapsRevision` counter on every write — these helpers
- *  just record into plain Maps so tests can assert what was written. */
 interface CacheState {
     findings: Map<string, readonly AccessibilityFinding[]>;
     nodes: Map<string, readonly AccessibilityNode[]>;
@@ -139,14 +136,12 @@ describe("applyA11yUpdate", () => {
         );
 
         assert.strictEqual(card.querySelector(".a11y-overlay"), null);
-        assert.strictEqual(card.querySelector(".a11y-legend"), null);
         assert.strictEqual(card.querySelector(".a11y-hierarchy-overlay"), null);
         assert.strictEqual(cache.findings.size, 0);
         assert.strictEqual(cache.nodes.size, 0);
     });
 
     it("is a silent no-op when the previewId has no card in the DOM", () => {
-        // Stamp a different card so we can assert it was untouched.
         const other = buildCard("com.example.OTHER");
         const { config, cache } = buildConfig({
             previews: [buildPreviewInfo("com.example.GHOST")],
@@ -162,12 +157,11 @@ describe("applyA11yUpdate", () => {
         );
 
         assert.strictEqual(other.querySelector(".a11y-overlay"), null);
-        assert.strictEqual(other.querySelector(".a11y-legend"), null);
         assert.strictEqual(cache.findings.size, 0);
         assert.strictEqual(cache.nodes.size, 0);
     });
 
-    it("appends .a11y-overlay placeholder, stamps .a11y-legend, writes cache, and mutates the matching PreviewInfo when findings are present", () => {
+    it("appends .a11y-overlay placeholder, writes cache, and mutates the matching PreviewInfo when findings are present", () => {
         const card = buildCard("com.example.A");
         const preview = buildPreviewInfo("com.example.A");
         const findings = [
@@ -186,24 +180,18 @@ describe("applyA11yUpdate", () => {
         // The placeholder is empty — actual paint runs from the
         // PreviewCard's mapsRevision subscription, not from this helper.
         assert.strictEqual(overlay!.children.length, 0);
-
-        const legend = card.querySelector(".a11y-legend");
-        assert.ok(legend, ".a11y-legend stamped onto the card");
-        // Two findings → one header + two rows.
-        assert.strictEqual(
-            legend!.querySelectorAll(".a11y-row").length,
-            findings.length,
-        );
+        // Labelled legend list is no longer rendered on the card; it
+        // lives in the A11y bundle tab now.
+        assert.strictEqual(card.querySelector(".a11y-legend"), null);
 
         assert.deepStrictEqual(cache.findings.get("com.example.A"), findings);
-
         // The matching PreviewInfo has its a11yFindings field replaced
         // (with a fresh array, not the readonly arg directly).
         assert.deepStrictEqual(preview.a11yFindings, [...findings]);
         assert.notStrictEqual(preview.a11yFindings, findings);
     });
 
-    it("re-stamps the legend on a second call rather than duplicating it", () => {
+    it("does not duplicate the overlay placeholder on a second findings update", () => {
         const card = buildCard("com.example.A");
         const preview = buildPreviewInfo("com.example.A");
         const { config } = buildConfig({ previews: [preview] });
@@ -224,20 +212,14 @@ describe("applyA11yUpdate", () => {
             config,
         );
 
-        const legends = card.querySelectorAll(".a11y-legend");
-        assert.strictEqual(legends.length, 1);
-        assert.strictEqual(legends[0].querySelectorAll(".a11y-row").length, 2);
-        // The .a11y-overlay placeholder also stays unique (the helper
-        // only appends one when none exists).
         assert.strictEqual(card.querySelectorAll(".a11y-overlay").length, 1);
     });
 
-    it("removes overlay + legend and clears cache when findings is an empty array", () => {
+    it("removes overlay and clears cache when findings is an empty array", () => {
         const card = buildCard("com.example.A");
         const preview = buildPreviewInfo("com.example.A");
         const { config, cache } = buildConfig({ previews: [preview] });
 
-        // Stamp some findings first so there's something to remove.
         applyA11yUpdate(
             "com.example.A",
             [buildFinding("ERROR", "x")],
@@ -245,13 +227,11 @@ describe("applyA11yUpdate", () => {
             config,
         );
         assert.ok(card.querySelector(".a11y-overlay"));
-        assert.ok(card.querySelector(".a11y-legend"));
         assert.strictEqual(cache.findings.size, 1);
 
         applyA11yUpdate("com.example.A", [], undefined, config);
 
         assert.strictEqual(card.querySelector(".a11y-overlay"), null);
-        assert.strictEqual(card.querySelector(".a11y-legend"), null);
         assert.strictEqual(cache.findings.has("com.example.A"), false);
     });
 
@@ -260,23 +240,18 @@ describe("applyA11yUpdate", () => {
         const preview = buildPreviewInfo("com.example.A");
         const { config, cache } = buildConfig({ previews: [preview] });
 
-        // Seed findings.
         applyA11yUpdate(
             "com.example.A",
             [buildFinding("ERROR", "seed")],
             undefined,
             config,
         );
-        assert.ok(card.querySelector(".a11y-legend"));
+        assert.ok(card.querySelector(".a11y-overlay"));
         const cachedBefore = cache.findings.get("com.example.A");
 
         // Nodes-only update — findings side must not be touched.
         applyA11yUpdate("com.example.A", undefined, [buildNode("X")], config);
 
-        assert.ok(
-            card.querySelector(".a11y-legend"),
-            "legend not removed by a nodes-only update",
-        );
         assert.ok(
             card.querySelector(".a11y-overlay"),
             "overlay not removed by a nodes-only update",
@@ -284,7 +259,7 @@ describe("applyA11yUpdate", () => {
         assert.strictEqual(cache.findings.get("com.example.A"), cachedBefore);
     });
 
-    it("ensures .a11y-hierarchy-overlay, stamps the hierarchy legend, and writes the nodes cache when nodes are present", () => {
+    it("ensures .a11y-hierarchy-overlay layer and writes the nodes cache when nodes are present", () => {
         const card = buildCard("com.example.A");
         const nodes = [buildNode("Button"), buildNode("Text")];
         const { config, cache } = buildConfig({
@@ -296,59 +271,14 @@ describe("applyA11yUpdate", () => {
         const layer = card.querySelector(".a11y-hierarchy-overlay");
         assert.ok(layer, ".a11y-hierarchy-overlay attached");
         assert.strictEqual(layer!.getAttribute("aria-hidden"), "true");
-
-        const legend = card.querySelector(".a11y-hierarchy-legend");
-        assert.ok(legend, ".a11y-hierarchy-legend stamped onto the card");
-        assert.strictEqual(
-            legend!.querySelectorAll(".a11y-hierarchy-row").length,
-            nodes.length,
-        );
+        // Labelled hierarchy legend list lives in the A11y bundle tab,
+        // not on the card.
+        assert.strictEqual(card.querySelector(".a11y-hierarchy-legend"), null);
 
         assert.deepStrictEqual(cache.nodes.get("com.example.A"), nodes);
     });
 
-    it("re-stamps the hierarchy legend on a second nodes update rather than duplicating it", () => {
-        const card = buildCard("com.example.A");
-        const { config } = buildConfig({
-            previews: [buildPreviewInfo("com.example.A")],
-        });
-
-        applyA11yUpdate("com.example.A", undefined, [buildNode("A")], config);
-        applyA11yUpdate(
-            "com.example.A",
-            undefined,
-            [buildNode("X"), buildNode("Y"), buildNode("Z")],
-            config,
-        );
-
-        const legends = card.querySelectorAll(".a11y-hierarchy-legend");
-        assert.strictEqual(legends.length, 1);
-        assert.strictEqual(
-            legends[0].querySelectorAll(".a11y-hierarchy-row").length,
-            3,
-        );
-    });
-
-    it("does not stamp the hierarchy legend when a findings legend already exists (findings take precedence)", () => {
-        const card = buildCard("com.example.A");
-        const { config } = buildConfig({
-            previews: [buildPreviewInfo("com.example.A")],
-        });
-
-        applyA11yUpdate(
-            "com.example.A",
-            [buildFinding("ERROR", "x")],
-            [buildNode("Button")],
-            config,
-        );
-
-        assert.ok(
-            card.querySelector(".a11y-legend:not(.a11y-hierarchy-legend)"),
-        );
-        assert.strictEqual(card.querySelector(".a11y-hierarchy-legend"), null);
-    });
-
-    it("removes .a11y-hierarchy-overlay, drops the hierarchy legend, and clears the nodes cache when nodes is an empty array", () => {
+    it("removes .a11y-hierarchy-overlay and clears the nodes cache when nodes is an empty array", () => {
         const card = buildCard("com.example.A");
         const { config, cache } = buildConfig({
             previews: [buildPreviewInfo("com.example.A")],
@@ -361,13 +291,11 @@ describe("applyA11yUpdate", () => {
             config,
         );
         assert.ok(card.querySelector(".a11y-hierarchy-overlay"));
-        assert.ok(card.querySelector(".a11y-hierarchy-legend"));
         assert.strictEqual(cache.nodes.size, 1);
 
         applyA11yUpdate("com.example.A", undefined, [], config);
 
         assert.strictEqual(card.querySelector(".a11y-hierarchy-overlay"), null);
-        assert.strictEqual(card.querySelector(".a11y-hierarchy-legend"), null);
         assert.strictEqual(cache.nodes.has("com.example.A"), false);
     });
 
@@ -407,8 +335,8 @@ describe("applyA11yUpdate", () => {
         );
 
         assert.strictEqual(inspectorCalls.length, 0);
-        // Sanity: the matching card got its legend regardless.
-        assert.ok(cardA.querySelector(".a11y-legend"));
+        // Sanity: the matching card got its overlay placeholder regardless.
+        assert.ok(cardA.querySelector(".a11y-overlay"));
     });
 
     it("does NOT call inspector.render when not in focus mode even if focusedCard returns the matching card", () => {

--- a/vscode-extension/src/test/bundleController.test.ts
+++ b/vscode-extension/src/test/bundleController.test.ts
@@ -1,0 +1,144 @@
+// Bundle controller — chip ↔ tab ↔ overlay state machine that the
+// new panel shell drives (#1054). The screenshot complaint that
+// triggered this work was "there is no way to get back" once a
+// hierarchy view paints; these tests pin the dismiss paths so the
+// state machine can't regress that gap silently.
+
+import * as assert from "assert";
+import {
+    BundleController,
+    type BundleSnapshot,
+} from "../webview/preview/bundleController";
+import { defaultOnKindsFor } from "../webview/preview/bundleRegistry";
+
+interface CapturedToggle {
+    kind: string;
+    enabled: boolean;
+}
+
+function build(initial?: BundleSnapshot): {
+    controller: BundleController;
+    toggles: CapturedToggle[];
+    persisted: BundleSnapshot[];
+} {
+    const toggles: CapturedToggle[] = [];
+    const persisted: BundleSnapshot[] = [];
+    const controller = new BundleController(
+        {
+            setKindEnabled: (kind, enabled) => toggles.push({ kind, enabled }),
+            persist: (snap) => persisted.push(snap),
+        },
+        initial,
+    );
+    return { controller, toggles, persisted };
+}
+
+describe("BundleController", () => {
+    it("activates a bundle and subscribes its default-ON kinds", () => {
+        const { controller, toggles } = build();
+        controller.toggleBundle("a11y");
+        const expected = defaultOnKindsFor("a11y");
+        assert.ok(expected.length > 0, "registry should ship default-ON kinds");
+        assert.deepStrictEqual(
+            toggles.map((t) => ({ kind: t.kind, enabled: t.enabled })),
+            expected.map((kind) => ({ kind, enabled: true })),
+        );
+        assert.deepStrictEqual(controller.state().activeBundles, ["a11y"]);
+        assert.strictEqual(controller.state().activeTab, "a11y");
+    });
+
+    it("chip re-press dismisses the bundle and unsubscribes", () => {
+        const { controller, toggles } = build();
+        controller.toggleBundle("a11y");
+        toggles.length = 0;
+        controller.toggleBundle("a11y");
+        assert.ok(
+            toggles.every((t) => t.enabled === false),
+            "deactivation must unsubscribe every active kind",
+        );
+        assert.deepStrictEqual(controller.state().activeBundles, []);
+        assert.strictEqual(
+            controller.state().activeTab,
+            null,
+            "no inspector is the resting state once all bundles close",
+        );
+    });
+
+    it("tab × is identical to chip re-press (dismiss path redundancy)", () => {
+        const { controller, toggles } = build();
+        controller.toggleBundle("a11y");
+        const afterActivate = toggles.length;
+        controller.closeTab("a11y");
+        const closeToggles = toggles.slice(afterActivate);
+        assert.ok(closeToggles.length > 0);
+        assert.ok(closeToggles.every((t) => t.enabled === false));
+        assert.strictEqual(controller.state().activeTab, null);
+    });
+
+    it("re-activates with the prior per-kind set, not the bundle defaults", () => {
+        const { controller, toggles } = build();
+        controller.toggleBundle("a11y");
+        controller.setKindEnabled("a11y", "a11y/atf", false);
+        controller.closeTab("a11y");
+        toggles.length = 0;
+        controller.toggleBundle("a11y");
+        const reactivated = toggles.filter((t) => t.enabled).map((t) => t.kind);
+        assert.ok(
+            !reactivated.includes("a11y/atf"),
+            "user-disabled kind should stay off when the bundle re-opens",
+        );
+    });
+
+    it("MRU promotes the just-pressed bundle to the front of activeBundles", () => {
+        const { controller } = build();
+        controller.toggleBundle("a11y");
+        controller.toggleBundle("theming");
+        assert.deepStrictEqual(controller.state().activeBundles, [
+            "theming",
+            "a11y",
+        ]);
+    });
+
+    it("selectTab is rejected for inactive bundles", () => {
+        const { controller } = build();
+        controller.toggleBundle("a11y");
+        controller.selectTab("theming");
+        assert.strictEqual(controller.state().activeTab, "a11y");
+    });
+
+    it("activates the bundle when an external kind toggle subscribes", () => {
+        const { controller } = build();
+        controller.handleExternalKindToggle("a11y/hierarchy", true);
+        assert.ok(controller.state().activeBundles.includes("a11y"));
+        assert.strictEqual(controller.state().activeTab, "a11y");
+    });
+
+    it("persists a snapshot on every state change", () => {
+        const { controller, persisted } = build();
+        const before = persisted.length;
+        controller.toggleBundle("a11y");
+        assert.ok(persisted.length > before);
+        const snap = persisted[persisted.length - 1];
+        assert.deepStrictEqual(snap.activeBundles, ["a11y"]);
+        assert.strictEqual(snap.activeTab, "a11y");
+    });
+
+    it("restores from a snapshot, filtering stale kinds", () => {
+        const restored = build({
+            activeBundles: ["a11y"],
+            enabledKindsByBundle: {
+                a11y: ["a11y/atf", "fonts/used"], // fonts/used isn't in a11y
+            },
+            activeTab: "a11y",
+        });
+        const kinds = restored.controller.state().enabledKinds("a11y");
+        assert.ok(kinds.includes("a11y/atf"));
+        assert.ok(
+            !kinds.includes("fonts/used"),
+            "kinds outside the bundle must be filtered on restore",
+        );
+        // No subscriptions are replayed on restore — the bundle
+        // assumes the caller re-subscribes per its own readiness rules.
+        assert.deepStrictEqual(restored.toggles, []);
+    });
+});

--- a/vscode-extension/src/test/cardMetadata.test.ts
+++ b/vscode-extension/src/test/cardMetadata.test.ts
@@ -285,7 +285,11 @@ describe("refreshCardMetadata", () => {
         assert.strictEqual(stub.indicatorCalls, 1);
     });
 
-    it("rebuilds .a11y-legend / .a11y-overlay only when earlyFeatures is on and findings exist", () => {
+    it("rebuilds .a11y-overlay only when earlyFeatures is on and findings exist", () => {
+        // Post-#1054 the labelled legend list moved to the A11y bundle
+        // tab; only the boxes-on-image overlay layer is rebuilt on the
+        // card itself. The findings array still drives whether the
+        // overlay container exists, just without the inline legend.
         const findings: PreviewInfo["a11yFindings"] = [
             {
                 level: "WARNING",
@@ -300,26 +304,28 @@ describe("refreshCardMetadata", () => {
 
         const p1 = preview("preview:1", { a11yFindings: findings });
 
-        // earlyFeatures off — no legend / overlay even with findings.
+        // earlyFeatures off — no overlay even with findings.
         const offConfig = buildConfig({ earlyFeatures: false }).config;
         refreshCardMetadata(card, p1, offConfig);
-        assert.strictEqual(card.querySelector(".a11y-legend"), null);
         assert.strictEqual(card.querySelector(".a11y-overlay"), null);
 
-        // earlyFeatures on — legend appended, empty overlay container
-        // appended inside .image-container.
+        // earlyFeatures on — empty overlay container appended inside
+        // .image-container. No labelled legend on the card.
         const onConfig = buildConfig({ earlyFeatures: true }).config;
         refreshCardMetadata(card, p1, onConfig);
-        assert.ok(card.querySelector(".a11y-legend"));
         assert.ok(
             card.querySelector(".image-container .a11y-overlay"),
             "overlay container should be appended into .image-container",
         );
+        assert.strictEqual(
+            card.querySelector(".a11y-legend"),
+            null,
+            "labelled legend lives in the A11y bundle tab now (#1054)",
+        );
 
-        // Subsequent reseed with empty findings drops both layers.
+        // Subsequent reseed with empty findings drops the overlay.
         const p2 = preview("preview:1", { a11yFindings: [] });
         refreshCardMetadata(card, p2, onConfig);
-        assert.strictEqual(card.querySelector(".a11y-legend"), null);
         assert.strictEqual(card.querySelector(".a11y-overlay"), null);
     });
 });

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -868,7 +868,15 @@ export type WebviewToExtension =
           resourceName: string;
           resolvedFile: string | null;
           packageName: string | null;
-      };
+      }
+    /**
+     * Webview asks the extension host to write [text] to the system
+     * clipboard via `vscode.env.clipboard.writeText`. Used by the
+     * `<data-table>` `Copy JSON` action — `navigator.clipboard` is
+     * unavailable in some VS Code builds, so the round-trip through
+     * the host is the portable path.
+     */
+    | { command: "copyToClipboard"; text: string };
 
 /**
  * Narrow shape the History panel reads off each sidecar JSON entry. The

--- a/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
@@ -1,0 +1,205 @@
+// A11y bundle presenter — fills the "Accessibility" tab body in
+// `<data-tabs>` using the shared `<data-table>` primitive. Combines
+// `a11y/hierarchy` (one row per node) with `a11y/atf` (findings
+// merged onto the matching row when bounds align).
+//
+// The presenter is **stateless** — given the latest findings + nodes
+// from `previewStore` and the focused preview, it produces the table
+// rows and the overlay boxes. The caller (host shell wiring in
+// `main.ts`) is responsible for re-running this whenever the focused
+// preview, the cache, or the bundle's enabled-kinds set changes.
+
+import { html, type TemplateResult } from "lit";
+import type { AccessibilityFinding, AccessibilityNode } from "../shared/types";
+import type { DataTableColumn } from "./components/DataTable";
+import type { OverlayBox } from "./components/BoxOverlay";
+import { parseBounds } from "./cardData";
+
+export interface A11yRow {
+    id: string;
+    label: string;
+    role: string;
+    states: string;
+    merged: boolean;
+    findingCount: number;
+    topFindingLevel: "error" | "warning" | "info" | null;
+    boundsInScreen: string;
+    bounds: { left: number; top: number; right: number; bottom: number } | null;
+}
+
+export interface A11yBundleData {
+    rows: readonly A11yRow[];
+    overlay: readonly OverlayBox[];
+}
+
+const PALETTE = [
+    "#f28b82",
+    "#aecbfa",
+    "#a8dab5",
+    "#fdd663",
+    "#d7aefb",
+    "#fcad70",
+    "#80cbc4",
+    "#f6aea9",
+];
+
+export function computeA11yBundleData(
+    nodes: readonly AccessibilityNode[],
+    findings: readonly AccessibilityFinding[],
+): A11yBundleData {
+    const rows: A11yRow[] = [];
+    const overlay: OverlayBox[] = [];
+    const findingsByBoundsKey = groupFindingsByBoundsKey(findings);
+    const matchedKeys = new Set<string>();
+
+    nodes.forEach((node, idx) => {
+        const id = "a11y-" + idx;
+        const bounds = parseBounds(node.boundsInScreen);
+        const matchingFindings = bounds
+            ? (findingsByBoundsKey.get(boundsKey(node.boundsInScreen)) ?? [])
+            : [];
+        const top = topLevel(matchingFindings);
+        const row: A11yRow = {
+            id,
+            label: node.label || "(unlabelled)",
+            role: node.role ?? "",
+            states: node.states?.join(", ") ?? "",
+            merged: node.merged,
+            findingCount: matchingFindings.length,
+            topFindingLevel: top,
+            boundsInScreen: node.boundsInScreen,
+            bounds,
+        };
+        rows.push(row);
+        if (bounds) {
+            overlay.push({
+                id,
+                bounds,
+                level: top ?? "info",
+                color: top ? undefined : PALETTE[idx % PALETTE.length],
+                tooltip: tooltipFor(node),
+            });
+        }
+    });
+
+    // Append findings that didn't match a hierarchy node so we don't
+    // silently drop them — they show in the table with no overlay box.
+    nodes.forEach((n) => matchedKeys.add(boundsKey(n.boundsInScreen)));
+    findings.forEach((f, idx) => {
+        const fBounds = f.boundsInScreen ?? "";
+        if (matchedKeys.has(boundsKey(fBounds))) return;
+        const id = "a11y-finding-orphan-" + idx;
+        const bounds = parseBounds(fBounds);
+        const level = normLevel(f.level);
+        rows.push({
+            id,
+            label: f.viewDescription || "(no element)",
+            role: f.type,
+            states: "",
+            merged: true,
+            findingCount: 1,
+            topFindingLevel: level,
+            boundsInScreen: fBounds,
+            bounds,
+        });
+        if (bounds) {
+            overlay.push({
+                id,
+                bounds,
+                level,
+                tooltip: f.level + " · " + f.type + " · " + f.message,
+            });
+        }
+    });
+
+    return { rows, overlay };
+}
+
+export function a11yTableColumns(): readonly DataTableColumn<A11yRow>[] {
+    return [
+        {
+            header: "",
+            cellClass: "a11y-swatch-cell",
+            render: (row) => html`
+                <span
+                    class="a11y-row-swatch"
+                    data-level=${row.topFindingLevel ?? "info"}
+                ></span>
+            `,
+        },
+        {
+            header: "Label",
+            cellClass: "a11y-label-cell",
+            render: (row) => html`
+                <div class="a11y-label-stack">
+                    <strong>${row.label}</strong>
+                    ${row.role
+                        ? html`<span class="a11y-row-role">${row.role}</span>`
+                        : ""}
+                </div>
+            `,
+        },
+        {
+            header: "States",
+            render: (row) => row.states || "—",
+        },
+        {
+            header: "Findings",
+            cellClass: "a11y-findings-cell",
+            render: (row) =>
+                row.findingCount === 0
+                    ? "—"
+                    : html`<span
+                          class="a11y-findings-badge"
+                          data-level=${row.topFindingLevel ?? "info"}
+                          >${row.findingCount}</span
+                      >`,
+        },
+    ];
+}
+
+function topLevel(
+    findings: readonly AccessibilityFinding[],
+): "error" | "warning" | "info" | null {
+    if (findings.length === 0) return null;
+    let best: "error" | "warning" | "info" = "info";
+    for (const f of findings) {
+        const l = normLevel(f.level);
+        if (l === "error") return "error";
+        if (l === "warning") best = "warning";
+    }
+    return best;
+}
+
+function normLevel(s: string): "error" | "warning" | "info" {
+    const lower = (s || "").toLowerCase();
+    if (lower === "error") return "error";
+    if (lower === "warning" || lower === "warn") return "warning";
+    return "info";
+}
+
+function tooltipFor(node: AccessibilityNode): string {
+    const parts: string[] = [];
+    if (node.label) parts.push(node.label);
+    if (node.role) parts.push(node.role);
+    if (node.states?.length) parts.push(node.states.join(", "));
+    return parts.join(" · ");
+}
+
+function boundsKey(s: string): string {
+    return (s || "").trim();
+}
+
+function groupFindingsByBoundsKey(
+    findings: readonly AccessibilityFinding[],
+): Map<string, AccessibilityFinding[]> {
+    const out = new Map<string, AccessibilityFinding[]>();
+    for (const f of findings) {
+        const key = boundsKey(f.boundsInScreen ?? "");
+        if (!key) continue;
+        const list = out.get(key) ?? [];
+        list.push(f);
+        out.set(key, list);
+    }
+    return out;
+}

--- a/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
@@ -84,10 +84,18 @@ export function computeA11yBundleData(
 
     // Append findings that didn't match a hierarchy node so we don't
     // silently drop them — they show in the table with no overlay box.
-    nodes.forEach((n) => matchedKeys.add(boundsKey(n.boundsInScreen)));
+    // Empty / blank bounds keys are not real bounds, so they don't
+    // enter `matchedKeys` and a finding with blank bounds never
+    // short-circuits as "matched" against a node that also happened
+    // to have blank bounds (would silently hide accessibility issues).
+    nodes.forEach((n) => {
+        const key = boundsKey(n.boundsInScreen);
+        if (key) matchedKeys.add(key);
+    });
     findings.forEach((f, idx) => {
         const fBounds = f.boundsInScreen ?? "";
-        if (matchedKeys.has(boundsKey(fBounds))) return;
+        const fKey = boundsKey(fBounds);
+        if (fKey && matchedKeys.has(fKey)) return;
         const id = "a11y-finding-orphan-" + idx;
         const bounds = parseBounds(fBounds);
         const level = normLevel(f.level);

--- a/vscode-extension/src/webview/preview/applyA11yUpdate.ts
+++ b/vscode-extension/src/webview/preview/applyA11yUpdate.ts
@@ -13,11 +13,7 @@
 // re-exports the helper bound to the real `previewStore` mutators so
 // existing call sites are unchanged.
 
-import {
-    buildA11yHierarchyLegend,
-    buildA11yLegend,
-    ensureHierarchyOverlay,
-} from "./a11yOverlay";
+import { ensureHierarchyOverlay } from "./a11yOverlay";
 import { sanitizeId } from "./cardData";
 import type {
     AccessibilityFinding,
@@ -102,13 +98,13 @@ export function applyA11yUpdate(
                 overlay.setAttribute("aria-hidden", "true");
                 container.appendChild(overlay);
             }
-            const existingLegend = card.querySelector(".a11y-legend");
-            if (existingLegend) existingLegend.remove();
+            // Mutate the manifest entry's findings so downstream surfaces
+            // (focus inspector, bundle tab, hover-on-image badges) see the
+            // fresh list. The labelled legend is no longer painted inline
+            // on the card — it now lives in the A11y bundle tab (#1054),
+            // which is the only dismissible surface for the labelled list.
             const p = config.getAllPreviews().find((pp) => pp.id === previewId);
-            if (p) {
-                p.a11yFindings = [...findings];
-                card.appendChild(buildA11yLegend(card, p));
-            }
+            if (p) p.a11yFindings = [...findings];
             // Store write last — the `mapsRevision` bump triggers the
             // component's `_repaintA11yOverlaysFromCache()` which runs
             // `buildA11yOverlay` against the fresh findings. The
@@ -119,43 +115,22 @@ export function applyA11yUpdate(
             config.deleteCardA11yFindings(previewId);
             const overlay = card.querySelector(".a11y-overlay");
             if (overlay) overlay.remove();
-            const legend = card.querySelector(".a11y-legend");
-            if (legend) legend.remove();
         }
     }
     if (nodes !== undefined) {
         if (nodes && nodes.length > 0) {
             ensureHierarchyOverlay(container);
-            // Stamp the hierarchy legend so the user sees the labelled
-            // node list as soon as data lands, even before the image
-            // decodes. The boxes themselves still paint from the
-            // mapsRevision bump below.
-            const existingHierarchyLegend = card.querySelector(
-                ".a11y-hierarchy-legend",
-            );
-            if (existingHierarchyLegend) existingHierarchyLegend.remove();
-            // Only stamp the hierarchy legend when there's no findings
-            // legend taking the slot — findings take precedence (they
-            // describe actionable issues; hierarchy is the structural
-            // backdrop). Once findings clear, a follow-up update or
-            // the nodes-still-present cache will re-stamp.
-            if (
-                !card.querySelector(".a11y-legend:not(.a11y-hierarchy-legend)")
-            ) {
-                card.appendChild(buildA11yHierarchyLegend(card, nodes));
-            }
-            // Same pattern as findings above: store write fires the
-            // mapsRevision bump, the component re-paints the layer
-            // via `applyHierarchyOverlay`.
+            // The labelled hierarchy list moved to the A11y bundle tab
+            // (#1054). The card keeps only the spatial overlay layer
+            // (`.a11y-hierarchy-overlay`) — boxes are useful context
+            // regardless of whether the user has the bundle tab open,
+            // and they share the chip's dismiss path indirectly via the
+            // bundle controller's hierarchy-overlay teardown.
             config.setCardA11yNodes(previewId, nodes);
         } else {
             config.deleteCardA11yNodes(previewId);
             const layer = card.querySelector(".a11y-hierarchy-overlay");
             if (layer) layer.remove();
-            const hierarchyLegend = card.querySelector(
-                ".a11y-hierarchy-legend",
-            );
-            if (hierarchyLegend) hierarchyLegend.remove();
         }
     }
     if (config.inFocus() && config.focusedCard() === card) {

--- a/vscode-extension/src/webview/preview/bundleController.ts
+++ b/vscode-extension/src/webview/preview/bundleController.ts
@@ -1,0 +1,262 @@
+// Bundle controller — owns the chip ↔ tab ↔ overlay state machine that
+// the new panel shell drives.
+//
+// Three pieces of state:
+//
+//   1. `activeBundles` — the set of bundle ids whose chip is pressed.
+//      Order is sticky-MRU within `activeBundles` (re-press → move to
+//      front so the user's last toggle gets the tab focus).
+//   2. `enabledKindsByBundle` — per-bundle override of which kinds in
+//      that bundle are subscribed. Starts as the bundle's default-ON
+//      list; the "Configure…" expander mutates it.
+//   3. `activeTab` — id of the tab the user is currently viewing.
+//      Always a member of `activeBundles` or `null` (no data tabs).
+//
+// On state change, the controller emits a `bundle-state-changed`
+// CustomEvent so subscribers (the chip bar, the tab row, card overlays)
+// can re-render. The controller is the **only** writer of bundle state;
+// the chip bar and tab row dispatch user-action events back to it.
+
+import {
+    BUNDLES,
+    type BundleDescriptor,
+    type BundleId,
+    bundleForKind,
+    defaultOnKindsFor,
+    getBundle,
+} from "./bundleRegistry";
+
+export interface BundleControllerHost {
+    /** Send a `setDataExtensionEnabled` to the extension host. */
+    setKindEnabled(kind: string, enabled: boolean): void;
+    /** Persist a snapshot for restore across panel reload. */
+    persist(snapshot: BundleSnapshot): void;
+}
+
+/**
+ * Serialisable shape. Loaded on construction; written via
+ * `host.persist` on every state change.
+ */
+export interface BundleSnapshot {
+    /** Active bundle ids in MRU order, most-recent-first. */
+    activeBundles: BundleId[];
+    /** Per-bundle enabled-kinds override. Empty list = "no kinds in
+     *  this bundle subscribed" — different from "key absent" (use
+     *  defaults). */
+    enabledKindsByBundle: Partial<Record<BundleId, string[]>>;
+    /** Active tab id; falls back to `activeBundles[0]` if stale. */
+    activeTab: BundleId | null;
+}
+
+export type BundleStateListener = (state: BundleState) => void;
+
+export interface BundleState {
+    bundles: readonly BundleDescriptor[];
+    activeBundles: readonly BundleId[];
+    activeTab: BundleId | null;
+    enabledKinds(bundleId: BundleId): readonly string[];
+    /** All subscribed kinds across all active bundles, deduped. */
+    subscribedKinds(): readonly string[];
+}
+
+export class BundleController {
+    private active: BundleId[];
+    private enabled: Map<BundleId, string[]>;
+    private tab: BundleId | null;
+    private readonly listeners = new Set<BundleStateListener>();
+
+    constructor(
+        private readonly host: BundleControllerHost,
+        initial?: BundleSnapshot,
+    ) {
+        this.active =
+            initial?.activeBundles?.filter((id) => !!getBundle(id)) ?? [];
+        this.enabled = new Map();
+        if (initial?.enabledKindsByBundle) {
+            for (const [id, kinds] of Object.entries(
+                initial.enabledKindsByBundle,
+            )) {
+                const bundle = getBundle(id as BundleId);
+                if (!bundle || !kinds) continue;
+                // Filter to kinds the bundle actually owns — guards
+                // against catalogue drift on panel reload.
+                const filtered = kinds.filter((k) =>
+                    bundle.kinds.some((bk) => bk.kind === k),
+                );
+                this.enabled.set(bundle.id, filtered);
+            }
+        }
+        if (initial?.activeTab && this.active.includes(initial.activeTab)) {
+            this.tab = initial.activeTab;
+        } else {
+            this.tab = this.active[0] ?? null;
+        }
+    }
+
+    /** State snapshot for subscribers. */
+    state(): BundleState {
+        return {
+            bundles: BUNDLES,
+            activeBundles: this.active,
+            activeTab: this.tab,
+            enabledKinds: (id) => this.enabledKindsFor(id),
+            subscribedKinds: () => this.allSubscribed(),
+        };
+    }
+
+    onChange(listener: BundleStateListener): () => void {
+        this.listeners.add(listener);
+        return () => {
+            this.listeners.delete(listener);
+        };
+    }
+
+    /**
+     * Toggle a bundle chip. ON → subscribe default-ON kinds + open
+     * the tab; OFF → unsubscribe everything in the bundle + close
+     * the tab. Re-pressing an active chip is the "OFF via chip"
+     * branch in the design doc's state-machine table.
+     */
+    toggleBundle(id: BundleId): void {
+        const bundle = getBundle(id);
+        if (!bundle) return;
+        if (this.active.includes(id)) {
+            this.deactivate(id);
+        } else {
+            this.activate(id);
+        }
+    }
+
+    /**
+     * Tab close (`×`) — same behaviour as toggling the chip off. The
+     * design doc makes these redundant on purpose so the dismiss path
+     * is reachable from wherever the user's eye lands.
+     */
+    closeTab(id: BundleId): void {
+        if (this.active.includes(id)) this.deactivate(id);
+    }
+
+    /** Switch the visible tab. */
+    selectTab(id: BundleId | null): void {
+        if (id === null) {
+            this.tab = null;
+            this.fire();
+            return;
+        }
+        if (!this.active.includes(id)) return;
+        this.tab = id;
+        this.fire();
+    }
+
+    /**
+     * Per-kind toggle from the bundle's "Configure…" expander. The
+     * bundle stays active even if the user disables every kind —
+     * the chip remains pressed and the tab visible (so they can
+     * re-enable kinds without re-opening the bundle).
+     */
+    setKindEnabled(bundleId: BundleId, kind: string, enabled: boolean): void {
+        const bundle = getBundle(bundleId);
+        if (!bundle) return;
+        if (!bundle.kinds.some((k) => k.kind === kind)) return;
+        const current = [...this.enabledKindsFor(bundleId)];
+        const idx = current.indexOf(kind);
+        if (enabled && idx === -1) {
+            current.push(kind);
+        } else if (!enabled && idx !== -1) {
+            current.splice(idx, 1);
+        } else {
+            return;
+        }
+        this.enabled.set(bundleId, current);
+        this.host.setKindEnabled(kind, enabled);
+        this.fire();
+    }
+
+    /**
+     * Routes a daemon-side change of subscription back into the
+     * bundle state — keeps the controller honest when subscriptions
+     * are mutated outside the chip bar (e.g. the focus-inspector
+     * checkbox path still in use during migration).
+     */
+    handleExternalKindToggle(kind: string, enabled: boolean): void {
+        const id = bundleForKind(kind);
+        if (!id) return;
+        const current = [...this.enabledKindsFor(id)];
+        const idx = current.indexOf(kind);
+        const wasActive = this.active.includes(id);
+        let changed = false;
+        if (enabled && idx === -1) {
+            current.push(kind);
+            changed = true;
+        } else if (!enabled && idx !== -1) {
+            current.splice(idx, 1);
+            changed = true;
+        }
+        if (changed) this.enabled.set(id, current);
+        // Promote the bundle to active whenever an external path turns
+        // a kind on, even if the kind was already in the bundle's
+        // default-ON set — the user's intent ("I subscribed to X") is
+        // the same as toggling the chip on.
+        if (enabled && !wasActive) {
+            this.active = [id, ...this.active];
+            if (this.tab === null) this.tab = id;
+            this.fire();
+            return;
+        }
+        if (changed) this.fire();
+    }
+
+    private activate(id: BundleId): void {
+        // MRU: most-recently activated lives at index 0 so the chip
+        // bar shows it first.
+        this.active = [id, ...this.active.filter((x) => x !== id)];
+        const previouslyEnabled = this.enabled.get(id);
+        const kinds = previouslyEnabled ?? [...defaultOnKindsFor(id)];
+        this.enabled.set(id, kinds);
+        for (const k of kinds) this.host.setKindEnabled(k, true);
+        this.tab = id;
+        this.fire();
+    }
+
+    private deactivate(id: BundleId): void {
+        for (const k of this.enabledKindsFor(id)) {
+            this.host.setKindEnabled(k, false);
+        }
+        this.active = this.active.filter((x) => x !== id);
+        // Preserve the per-kind enable set on the dropped bundle so
+        // a re-press restores the user's last configuration rather
+        // than the bundle defaults. (Same intuition as a closed tab
+        // remembering its scroll position.)
+        if (this.tab === id) {
+            this.tab = this.active[0] ?? null;
+        }
+        this.fire();
+    }
+
+    private enabledKindsFor(id: BundleId): readonly string[] {
+        const stored = this.enabled.get(id);
+        if (stored) return stored;
+        return defaultOnKindsFor(id);
+    }
+
+    private allSubscribed(): readonly string[] {
+        const out = new Set<string>();
+        for (const id of this.active) {
+            for (const k of this.enabledKindsFor(id)) out.add(k);
+        }
+        return [...out];
+    }
+
+    private fire(): void {
+        const snapshot: BundleSnapshot = {
+            activeBundles: [...this.active],
+            enabledKindsByBundle: Object.fromEntries(
+                [...this.enabled.entries()].map(([k, v]) => [k, [...v]]),
+            ) as Partial<Record<BundleId, string[]>>,
+            activeTab: this.tab,
+        };
+        this.host.persist(snapshot);
+        const state = this.state();
+        for (const listener of this.listeners) listener(state);
+    }
+}

--- a/vscode-extension/src/webview/preview/bundleRegistry.ts
+++ b/vscode-extension/src/webview/preview/bundleRegistry.ts
@@ -1,0 +1,239 @@
+// Bundle registry — defines the cluster-level toggles (A11y, Theming,
+// Text/i18n, Resources, Inspection, Performance, Display, Watch,
+// History, Errors) that the chip bar and tab row drive.
+//
+// One bundle bundles several wire `kind`s. Default-ON kinds are
+// subscribed when the chip toggles on; expander-only kinds are
+// available via the per-tab "Configure…" expander.
+//
+// See `docs/design/EXTENSION_DATA_EXPOSURE.md` for the full design.
+
+export type BundleId =
+    | "a11y"
+    | "theming"
+    | "text"
+    | "resources"
+    | "inspection"
+    | "performance"
+    | "display"
+    | "watch"
+    | "history"
+    | "errors";
+
+export interface BundleKind {
+    /** Wire `kind` advertised by the daemon catalogue. */
+    kind: string;
+    /** Short human label used in the configure expander. */
+    label: string;
+    /** Whether the kind is auto-subscribed when the bundle chip is
+     *  toggled on. `false` = available only via the expander. */
+    defaultOn: boolean;
+}
+
+export interface BundleDescriptor {
+    id: BundleId;
+    /** Chip label and tab title. */
+    label: string;
+    /** Codicon name used in the chip + tab header. */
+    icon: string;
+    /** Kinds in this bundle, in display order. */
+    kinds: readonly BundleKind[];
+}
+
+/**
+ * Catalogue of bundles. Order is the default chip-bar order;
+ * runtime MRU may move active bundles to the front.
+ */
+export const BUNDLES: readonly BundleDescriptor[] = [
+    {
+        id: "a11y",
+        label: "Accessibility",
+        icon: "eye",
+        kinds: [
+            { kind: "a11y/hierarchy", label: "Hierarchy", defaultOn: true },
+            { kind: "a11y/atf", label: "Findings (ATF)", defaultOn: true },
+            {
+                kind: "a11y/touchTargets",
+                label: "Touch targets",
+                defaultOn: false,
+            },
+            {
+                kind: "a11y/overlay",
+                label: "Daemon overlay PNG",
+                defaultOn: false,
+            },
+        ],
+    },
+    {
+        id: "theming",
+        label: "Theming",
+        icon: "symbol-color",
+        kinds: [
+            { kind: "compose/theme", label: "Theme tokens", defaultOn: true },
+            { kind: "compose/wallpaper", label: "Wallpaper", defaultOn: false },
+        ],
+    },
+    {
+        id: "text",
+        label: "Text / i18n",
+        icon: "symbol-string",
+        kinds: [
+            { kind: "text/strings", label: "Drawn text", defaultOn: true },
+            { kind: "fonts/used", label: "Fonts", defaultOn: true },
+            {
+                kind: "i18n/translations",
+                label: "Translations",
+                defaultOn: false,
+            },
+        ],
+    },
+    {
+        id: "resources",
+        label: "Resources",
+        icon: "library",
+        kinds: [
+            {
+                kind: "resources/used",
+                label: "Resources used",
+                defaultOn: true,
+            },
+        ],
+    },
+    {
+        id: "inspection",
+        label: "Inspection",
+        icon: "search",
+        kinds: [
+            {
+                kind: "compose/semantics",
+                label: "Semantics",
+                defaultOn: true,
+            },
+            {
+                kind: "layout/inspector",
+                label: "Layout inspector",
+                defaultOn: false,
+            },
+            {
+                kind: "uia/hierarchy",
+                label: "UI Automator",
+                defaultOn: false,
+            },
+        ],
+    },
+    {
+        id: "performance",
+        label: "Performance",
+        icon: "pulse",
+        kinds: [
+            {
+                kind: "compose/recomposition",
+                label: "Recomposition",
+                defaultOn: false,
+            },
+            { kind: "render/trace", label: "Render trace", defaultOn: false },
+            {
+                kind: "render/composeAiTrace",
+                label: "Perfetto trace",
+                defaultOn: false,
+            },
+        ],
+    },
+    {
+        id: "display",
+        label: "Display",
+        icon: "device-desktop",
+        kinds: [
+            {
+                kind: "displayfilter/grayscale",
+                label: "Grayscale",
+                defaultOn: false,
+            },
+            {
+                kind: "displayfilter/invert",
+                label: "Invert",
+                defaultOn: false,
+            },
+        ],
+    },
+    {
+        id: "watch",
+        label: "Watch",
+        icon: "device-mobile",
+        kinds: [{ kind: "compose/ambient", label: "Ambient", defaultOn: true }],
+    },
+    {
+        id: "history",
+        label: "History",
+        icon: "git-compare",
+        kinds: [
+            {
+                kind: "history/diff/regions",
+                label: "Diff regions",
+                defaultOn: true,
+            },
+        ],
+    },
+    {
+        id: "errors",
+        label: "Errors",
+        icon: "error",
+        kinds: [
+            {
+                kind: "test/failure",
+                label: "Postmortem",
+                defaultOn: false,
+            },
+        ],
+    },
+];
+
+const BY_ID = new Map<BundleId, BundleDescriptor>(
+    BUNDLES.map((b) => [b.id, b]),
+);
+
+export function getBundle(id: BundleId): BundleDescriptor | undefined {
+    return BY_ID.get(id);
+}
+
+/**
+ * Bundle id that owns [kind], or `null` when no bundle in the catalogue
+ * advertises it. Two bundles can't claim the same kind — the registry
+ * is asserted unique below.
+ */
+export function bundleForKind(kind: string): BundleId | null {
+    for (const b of BUNDLES) {
+        for (const k of b.kinds) {
+            if (k.kind === kind) return b.id;
+        }
+    }
+    return null;
+}
+
+/**
+ * Default-ON kinds for [bundleId]. Used when toggling a chip on for
+ * the first time without per-kind overrides.
+ */
+export function defaultOnKindsFor(bundleId: BundleId): readonly string[] {
+    const b = BY_ID.get(bundleId);
+    if (!b) return [];
+    return b.kinds.filter((k) => k.defaultOn).map((k) => k.kind);
+}
+
+// Internal correctness check — duplicate kinds across bundles would
+// make `bundleForKind` ambiguous. Runs at module load; throws so a
+// catalogue typo doesn't reach production.
+(function assertUniqueKinds(): void {
+    const seen = new Map<string, BundleId>();
+    for (const b of BUNDLES) {
+        for (const k of b.kinds) {
+            const prior = seen.get(k.kind);
+            if (prior) {
+                throw new Error(
+                    `Kind ${k.kind} appears in both ${prior} and ${b.id} bundles`,
+                );
+            }
+            seen.set(k.kind, b.id);
+        }
+    }
+})();

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -18,7 +18,6 @@
 // it touches — the shared interface is the single source of truth for
 // the card's collaborator surface.
 
-import { buildA11yLegend } from "./a11yOverlay";
 import {
     applyA11yUpdate as applyA11yUpdateImpl,
     type A11yUpdateConfig as A11yUpdateConfigBase,
@@ -317,11 +316,15 @@ export function populatePreviewCard(
     // is on; the overlay layer's boxes get computed lazily once
     // the image is loaded (see buildA11yOverlay).
     if (config.earlyFeatures() && p.a11yFindings && p.a11yFindings.length > 0) {
+        // Stamp the empty overlay layer so `buildA11yOverlay` has a
+        // container to paint into once the image loads. The inline
+        // labelled legend moved to the A11y bundle tab (#1054) so the
+        // user has a dismiss path; only the boxes-on-image remain on
+        // the card itself.
         const overlay = document.createElement("div");
         overlay.className = "a11y-overlay";
         overlay.setAttribute("aria-hidden", "true");
         imgContainer.appendChild(overlay);
-        card.appendChild(buildA11yLegend(card, p));
     }
 
     const variantLabel = buildVariantLabel(p);

--- a/vscode-extension/src/webview/preview/cardMetadata.ts
+++ b/vscode-extension/src/webview/preview/cardMetadata.ts
@@ -19,7 +19,7 @@
 // in `cardBuilder.ts` (initial DOM build, which the `<preview-card>`
 // shell still reaches into during `firstUpdated`).
 
-import { buildA11yLegend, buildA11yOverlay } from "./a11yOverlay";
+import { buildA11yOverlay } from "./a11yOverlay";
 import {
     buildTooltip,
     buildVariantLabel,
@@ -110,14 +110,12 @@ export function refreshCardMetadata(
         badge.remove();
     }
 
-    // Refresh the a11y legend + overlay in place when findings
-    // change (e.g. toggling a11y on turns findings from null → list,
-    // or a fresh render updates the set). Tear down the old nodes
-    // and rebuild: simpler than reconciling row-by-row for what is
-    // a rare event.
-    const existingLegend = card.querySelector(".a11y-legend");
+    // Refresh the a11y overlay layer in place when findings change
+    // (e.g. toggling a11y on turns findings from null → list, or a
+    // fresh render updates the set). The labelled legend moved to the
+    // A11y bundle tab (#1054); the card itself keeps only the
+    // boxes-on-image overlay so spatial context survives.
     const existingOverlay = card.querySelector(".a11y-overlay");
-    if (existingLegend) existingLegend.remove();
     if (existingOverlay) existingOverlay.innerHTML = "";
     if (config.earlyFeatures() && p.a11yFindings && p.a11yFindings.length > 0) {
         const container = card.querySelector(".image-container");
@@ -127,8 +125,6 @@ export function refreshCardMetadata(
             overlay.setAttribute("aria-hidden", "true");
             container.appendChild(overlay);
         }
-        const legend = buildA11yLegend(card, p);
-        card.appendChild(legend);
         // Repopulate box geometry if the image is already loaded —
         // otherwise `paintCardCapture`'s store-write triggers a
         // re-paint via `<preview-card>`'s mapsRevision subscription.

--- a/vscode-extension/src/webview/preview/components/BoxOverlay.ts
+++ b/vscode-extension/src/webview/preview/components/BoxOverlay.ts
@@ -1,0 +1,124 @@
+// `<box-overlay>` — shared overlay primitive that paints percentage-
+// positioned tinted rectangles on top of a preview image. Used by
+// every per-bundle presenter that has bounds in the source-bitmap
+// pixel space (a11y, strings, resources, layout-inspector, uia,
+// history-diff). The card's `.image-container` provides the
+// reference frame; bounds are translated to percent-of-natural so the
+// overlay scales with the image without a resize handler.
+//
+// The component is data-driven (`setBoxes`) — no DOM building in
+// the host. The host updates the natural dimensions whenever the
+// underlying `<img>` resolves (`setNaturalSize`). Hover events fire
+// via `overlay-hovered` so the matching legend / table row can light
+// up via the shared `data-legend-id` ↔ `data-overlay-id` correlation.
+
+import { LitElement, html, type TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+
+export type OverlayLevel = "error" | "warning" | "info";
+
+export interface OverlayBox {
+    /** Correlates with `data-legend-id` on the matching legend / table row. */
+    id: string;
+    /** Bounds in source-bitmap pixels. */
+    bounds: {
+        left: number;
+        top: number;
+        right: number;
+        bottom: number;
+    };
+    /** Drives the `data-level` accent — error / warning / info palette. */
+    level?: OverlayLevel;
+    /** Optional override colour; takes precedence over `level`. */
+    color?: string;
+    /** Short tooltip shown on hover. */
+    tooltip?: string;
+}
+
+export interface OverlayHoveredDetail {
+    overlayId: string | null;
+}
+
+@customElement("box-overlay")
+export class BoxOverlay extends LitElement {
+    @state() private boxes: readonly OverlayBox[] = [];
+    @state() private naturalWidth = 0;
+    @state() private naturalHeight = 0;
+    @state() private activeOverlayId: string | null = null;
+
+    setBoxes(boxes: readonly OverlayBox[]): void {
+        this.boxes = boxes;
+    }
+
+    setNaturalSize(width: number, height: number): void {
+        this.naturalWidth = width;
+        this.naturalHeight = height;
+    }
+
+    /**
+     * Drive the highlight from an external source (e.g. legend
+     * hover). The internal hover state is mirrored so the user can
+     * still hover the overlay directly.
+     */
+    setActiveOverlayId(id: string | null): void {
+        this.activeOverlayId = id;
+    }
+
+    protected createRenderRoot(): HTMLElement {
+        return this;
+    }
+
+    protected render(): TemplateResult {
+        if (!this.naturalWidth || !this.naturalHeight) {
+            return html``;
+        }
+        return html`
+            <div class="box-overlay" aria-hidden="true">
+                ${this.boxes.map((b) => this.renderBox(b))}
+            </div>
+        `;
+    }
+
+    private renderBox(b: OverlayBox): TemplateResult {
+        const left = (b.bounds.left / this.naturalWidth) * 100;
+        const top = (b.bounds.top / this.naturalHeight) * 100;
+        const width =
+            ((b.bounds.right - b.bounds.left) / this.naturalWidth) * 100;
+        const height =
+            ((b.bounds.bottom - b.bounds.top) / this.naturalHeight) * 100;
+        const active = this.activeOverlayId === b.id;
+        const style = [
+            `left:${left}%`,
+            `top:${top}%`,
+            `width:${width}%`,
+            `height:${height}%`,
+            b.color ? `--overlay-color:${b.color}` : "",
+        ]
+            .filter(Boolean)
+            .join(";");
+        return html`
+            <div
+                class=${active
+                    ? "overlay-box overlay-box-active"
+                    : "overlay-box"}
+                data-overlay-id=${b.id}
+                data-level=${b.level ?? "info"}
+                style=${style}
+                title=${b.tooltip ?? ""}
+                @mouseenter=${() => this.onHover(b.id)}
+                @mouseleave=${() => this.onHover(null)}
+            ></div>
+        `;
+    }
+
+    private onHover(id: string | null): void {
+        this.activeOverlayId = id;
+        this.dispatchEvent(
+            new CustomEvent<OverlayHoveredDetail>("overlay-hovered", {
+                detail: { overlayId: id },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+}

--- a/vscode-extension/src/webview/preview/components/BundleChipBar.ts
+++ b/vscode-extension/src/webview/preview/components/BundleChipBar.ts
@@ -1,0 +1,77 @@
+// `<bundle-chip-bar>` — chip strip below the filter toolbar. Each chip
+// is a toggle for a data-extension bundle. Pressing a chip opens the
+// matching tab in `<data-tabs>` and starts subscriptions to the
+// bundle's default-ON kinds; re-pressing it tears them down. The chip
+// + the tab `×` are deliberately redundant so the dismiss path is
+// reachable from wherever the user's eye lands (see
+// `docs/design/EXTENSION_DATA_EXPOSURE.md` § "Chip ↔ tab ↔ overlay
+// state machine").
+//
+// The component is read-only state — `BundleController` owns the
+// truth and pushes updates via `setState`. User clicks fire
+// `bundle-toggled` events for the host to forward to the controller.
+
+import { LitElement, html, type TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import type { BundleDescriptor, BundleId } from "../bundleRegistry";
+
+export interface BundleToggledDetail {
+    id: BundleId;
+}
+
+@customElement("bundle-chip-bar")
+export class BundleChipBar extends LitElement {
+    @state() private bundles: readonly BundleDescriptor[] = [];
+    @state() private activeBundles: readonly BundleId[] = [];
+
+    setState(snapshot: {
+        bundles: readonly BundleDescriptor[];
+        activeBundles: readonly BundleId[];
+    }): void {
+        this.bundles = snapshot.bundles;
+        this.activeBundles = snapshot.activeBundles;
+    }
+
+    protected createRenderRoot(): HTMLElement {
+        return this;
+    }
+
+    protected render(): TemplateResult {
+        return html`
+            <div
+                class="bundle-chip-bar"
+                role="toolbar"
+                aria-label="Data extensions"
+            >
+                ${this.bundles.map((b) => this.renderChip(b))}
+            </div>
+        `;
+    }
+
+    private renderChip(b: BundleDescriptor): TemplateResult {
+        const pressed = this.activeBundles.includes(b.id);
+        return html`
+            <button
+                type="button"
+                class=${pressed ? "bundle-chip bundle-chip-on" : "bundle-chip"}
+                aria-pressed=${pressed ? "true" : "false"}
+                data-bundle=${b.id}
+                title=${b.label}
+                @click=${() => this.onClick(b.id)}
+            >
+                <i class=${"codicon codicon-" + b.icon} aria-hidden="true"></i>
+                <span class="bundle-chip-label">${b.label}</span>
+            </button>
+        `;
+    }
+
+    private onClick(id: BundleId): void {
+        this.dispatchEvent(
+            new CustomEvent<BundleToggledDetail>("bundle-toggled", {
+                detail: { id },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+}

--- a/vscode-extension/src/webview/preview/components/DataTable.ts
+++ b/vscode-extension/src/webview/preview/components/DataTable.ts
@@ -1,0 +1,182 @@
+// `<data-table>` — generic table primitive used by every per-cluster
+// bundle presenter. Column defs, row click → overlay highlight via
+// `data-overlay-id`, header `Copy JSON` button, optional secondary
+// actions slot. Bodies that need a different shape (tree, swatch grid)
+// build their own primitive instead — this one's only purpose is to
+// look identical across bundles.
+
+import { LitElement, html, nothing, type TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+export interface DataTableColumn<TRow> {
+    /** Header text. */
+    header: string;
+    /** Optional css class applied to `<th>` and each `<td>`. */
+    cellClass?: string;
+    /** Render the cell. Return a string for plain text, or a
+     *  `TemplateResult` for richer DOM (badges, swatches, links). */
+    render(row: TRow, rowIndex: number): TemplateResult | string;
+}
+
+export interface RowSelectedDetail<TRow> {
+    overlayId: string | null;
+    row: TRow;
+    index: number;
+}
+
+export interface CopyJsonDetail {
+    payload: unknown;
+}
+
+@customElement("data-table")
+export class DataTable<TRow = unknown> extends LitElement {
+    /** Table title shown in the header. */
+    @property({ type: String }) heading = "";
+    /** Optional one-line summary right of the heading (e.g. "12 nodes"). */
+    @property({ type: String }) summary = "";
+
+    @state() private columns: readonly DataTableColumn<TRow>[] = [];
+    @state() private rows: readonly TRow[] = [];
+    @state() private hoveredOverlayId: string | null = null;
+    /** Stable id per row used to correlate with `<box-overlay>`. */
+    private overlayId: (row: TRow, index: number) => string = (_row, index) =>
+        "row-" + index;
+    /** Whole-payload JSON shipped via `Copy JSON`. Defaults to `rows`. */
+    private jsonPayload: () => unknown = () => this.rows;
+
+    setColumns(cols: readonly DataTableColumn<TRow>[]): void {
+        this.columns = cols;
+    }
+
+    setRows(rows: readonly TRow[]): void {
+        this.rows = rows;
+    }
+
+    setOverlayId(fn: (row: TRow, index: number) => string): void {
+        this.overlayId = fn;
+    }
+
+    setJsonPayload(fn: () => unknown): void {
+        this.jsonPayload = fn;
+    }
+
+    /**
+     * Externally driven highlight — kept so the overlay-side hover
+     * (a box on the card) can light up the matching row. The opposite
+     * direction (row hover → overlay) is handled internally by
+     * dispatching `row-selected`.
+     */
+    setHoveredOverlayId(id: string | null): void {
+        this.hoveredOverlayId = id;
+    }
+
+    protected createRenderRoot(): HTMLElement {
+        return this;
+    }
+
+    protected render(): TemplateResult {
+        return html`
+            <div class="data-table-shell">
+                <div class="data-table-header">
+                    <div class="data-table-title">
+                        <span class="data-table-heading">${this.heading}</span>
+                        ${this.summary
+                            ? html`<span class="data-table-summary"
+                                  >· ${this.summary}</span
+                              >`
+                            : nothing}
+                    </div>
+                    <div class="data-table-actions">
+                        <slot name="actions"></slot>
+                        <button
+                            type="button"
+                            class="data-table-copy"
+                            title="Copy JSON to clipboard"
+                            aria-label="Copy JSON"
+                            @click=${this.onCopy}
+                        >
+                            <i
+                                class="codicon codicon-copy"
+                                aria-hidden="true"
+                            ></i>
+                            <span>Copy JSON</span>
+                        </button>
+                    </div>
+                </div>
+                ${this.rows.length === 0
+                    ? html`<div class="data-table-empty">No rows.</div>`
+                    : this.renderTable()}
+            </div>
+        `;
+    }
+
+    private renderTable(): TemplateResult {
+        return html`
+            <table class="data-table-grid">
+                <thead>
+                    <tr>
+                        ${this.columns.map(
+                            (c) =>
+                                html`<th class=${c.cellClass ?? ""}>
+                                    ${c.header}
+                                </th>`,
+                        )}
+                    </tr>
+                </thead>
+                <tbody>
+                    ${this.rows.map((row, idx) => this.renderRow(row, idx))}
+                </tbody>
+            </table>
+        `;
+    }
+
+    private renderRow(row: TRow, idx: number): TemplateResult {
+        const id = this.overlayId(row, idx);
+        const active = this.hoveredOverlayId === id;
+        return html`
+            <tr
+                class=${active
+                    ? "data-table-row data-table-row-active"
+                    : "data-table-row"}
+                data-legend-id=${id}
+                @mouseenter=${() => this.onRowHover(row, idx, id)}
+                @mouseleave=${() => this.onRowHover(row, idx, null)}
+            >
+                ${this.columns.map(
+                    (c) =>
+                        html`<td class=${c.cellClass ?? ""}>
+                            ${c.render(row, idx)}
+                        </td>`,
+                )}
+            </tr>
+        `;
+    }
+
+    private onRowHover(
+        row: TRow,
+        index: number,
+        overlayId: string | null,
+    ): void {
+        this.hoveredOverlayId = overlayId;
+        this.dispatchEvent(
+            new CustomEvent<RowSelectedDetail<TRow>>("row-selected", {
+                detail: { overlayId, row, index },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private onCopy(): void {
+        const payload = this.jsonPayload();
+        // The host wires the actual clipboard write — webview origin
+        // can't rely on `navigator.clipboard` in every VS Code build.
+        this.dispatchEvent(
+            new CustomEvent<CopyJsonDetail>("copy-json", {
+                detail: { payload },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+}

--- a/vscode-extension/src/webview/preview/components/DataTabs.ts
+++ b/vscode-extension/src/webview/preview/components/DataTabs.ts
@@ -1,0 +1,170 @@
+// `<data-tabs>` — tab row that appears below `<bundle-chip-bar>` when
+// at least one bundle is active. Each tab has a label and a close `×`
+// affordance; the `×` and the bundle chip's re-press are two redundant
+// ways to dismiss (design doc § "Chip ↔ tab ↔ overlay state machine").
+//
+// The active tab's body is provided by the host via `setTabBody(id, el)`
+// so each bundle can ship its own table/tree presenter without the
+// shell needing to know. Tab bodies are kept mounted across switches
+// so a slow-to-build presenter doesn't tear down on every click; only
+// the active body is `[hidden]=false`.
+//
+// When `activeBundles` is empty the component renders nothing — the
+// preview panel returns to its plain-preview resting state.
+
+import { LitElement, html, nothing, type TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import type { BundleDescriptor, BundleId } from "../bundleRegistry";
+
+export interface TabCloseDetail {
+    id: BundleId;
+}
+
+export interface TabSelectDetail {
+    id: BundleId;
+}
+
+@customElement("data-tabs")
+export class DataTabs extends LitElement {
+    @state() private bundles: readonly BundleDescriptor[] = [];
+    @state() private activeBundles: readonly BundleId[] = [];
+    @state() private activeTab: BundleId | null = null;
+    /** Per-bundle body elements supplied by the host. */
+    private bodies = new Map<BundleId, HTMLElement>();
+
+    setState(snapshot: {
+        bundles: readonly BundleDescriptor[];
+        activeBundles: readonly BundleId[];
+        activeTab: BundleId | null;
+    }): void {
+        this.bundles = snapshot.bundles;
+        this.activeBundles = snapshot.activeBundles;
+        this.activeTab = snapshot.activeTab;
+    }
+
+    /**
+     * Register a body element for [id]. Re-registering replaces the
+     * prior element. Passing `null` detaches.
+     */
+    setTabBody(id: BundleId, body: HTMLElement | null): void {
+        const existing = this.bodies.get(id);
+        if (existing && existing !== body) {
+            existing.remove();
+        }
+        if (body) {
+            this.bodies.set(id, body);
+        } else {
+            this.bodies.delete(id);
+        }
+        this.requestUpdate();
+    }
+
+    /** Visible for tests. */
+    getActiveTab(): BundleId | null {
+        return this.activeTab;
+    }
+
+    protected createRenderRoot(): HTMLElement {
+        return this;
+    }
+
+    protected render(): TemplateResult {
+        if (this.activeBundles.length === 0) {
+            return html`${nothing}`;
+        }
+        const ordered = this.bundles.filter((b) =>
+            this.activeBundles.includes(b.id),
+        );
+        return html`
+            <div
+                class="data-tabs"
+                role="tablist"
+                aria-label="Data extension tabs"
+            >
+                <div class="data-tab-strip">
+                    ${ordered.map((b) => this.renderTabHandle(b))}
+                </div>
+                <div class="data-tab-bodies">
+                    ${ordered.map((b) => this.renderTabBody(b))}
+                </div>
+            </div>
+        `;
+    }
+
+    private renderTabHandle(b: BundleDescriptor): TemplateResult {
+        const selected = b.id === this.activeTab;
+        return html`
+            <div
+                class=${selected
+                    ? "data-tab-handle data-tab-handle-active"
+                    : "data-tab-handle"}
+                role="tab"
+                aria-selected=${selected ? "true" : "false"}
+                data-bundle=${b.id}
+            >
+                <button
+                    type="button"
+                    class="data-tab-label"
+                    @click=${() => this.onSelect(b.id)}
+                >
+                    <i
+                        class=${"codicon codicon-" + b.icon}
+                        aria-hidden="true"
+                    ></i>
+                    <span>${b.label}</span>
+                </button>
+                <button
+                    type="button"
+                    class="data-tab-close"
+                    aria-label=${`Close ${b.label} tab`}
+                    title=${`Close ${b.label}`}
+                    @click=${(e: Event) => this.onClose(e, b.id)}
+                >
+                    <i class="codicon codicon-close" aria-hidden="true"></i>
+                </button>
+            </div>
+        `;
+    }
+
+    private renderTabBody(b: BundleDescriptor): TemplateResult {
+        const body = this.bodies.get(b.id);
+        const selected = b.id === this.activeTab;
+        return html`
+            <div
+                class="data-tab-body"
+                role="tabpanel"
+                data-bundle=${b.id}
+                ?hidden=${!selected}
+            >
+                ${body ?? this.placeholderBody(b)}
+            </div>
+        `;
+    }
+
+    private placeholderBody(b: BundleDescriptor): TemplateResult {
+        return html`
+            <div class="data-tab-placeholder">${b.label} is loading…</div>
+        `;
+    }
+
+    private onSelect(id: BundleId): void {
+        this.dispatchEvent(
+            new CustomEvent<TabSelectDetail>("tab-selected", {
+                detail: { id },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private onClose(evt: Event, id: BundleId): void {
+        evt.stopPropagation();
+        this.dispatchEvent(
+            new CustomEvent<TabCloseDetail>("tab-closed", {
+                detail: { id },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+}

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -27,7 +27,17 @@ import "./components/MessageBanner";
 import "./components/PreviewCard";
 import "./components/PreviewGrid";
 import "./components/ProgressBar";
+import "./components/BundleChipBar";
+import "./components/DataTabs";
+import "./components/DataTable";
+import "./components/BoxOverlay";
 import { PreviewGrid } from "./components/PreviewGrid";
+import { BundleChipBar } from "./components/BundleChipBar";
+import { DataTabs } from "./components/DataTabs";
+import { DataTable } from "./components/DataTable";
+import { BundleController, type BundleSnapshot } from "./bundleController";
+import type { BundleId } from "./bundleRegistry";
+import { a11yTableColumns, computeA11yBundleData } from "./a11yBundlePresenter";
 import { FilterController } from "./filterController";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
 import {
@@ -69,6 +79,12 @@ interface PersistedState {
      * but not extension reload — same lifecycle as `filters` / `layout`.
      */
     focusMruByScope?: Record<string, string[]>;
+    /**
+     * Bundle controller snapshot — chip ON/OFF state, per-bundle enabled
+     * kinds, and the active tab. Persists across panel hide/show so a
+     * reload doesn't snap the tab row back to "no inspector" mid-session.
+     */
+    bundles?: BundleSnapshot;
 }
 
 @customElement("preview-app")
@@ -90,6 +106,8 @@ export class PreviewApp extends LitElement {
     @query("#focus-inspector") private _focusInspector!: HTMLElement;
     @query("message-banner") private _messageBanner!: MessageBanner;
     @query("filter-toolbar") private _filterToolbar!: FilterToolbar;
+    @query("bundle-chip-bar") private _bundleChipBar!: BundleChipBar;
+    @query("data-tabs") private _dataTabs!: DataTabs;
     @query("#focus-controls") private _focusControls!: HTMLElement;
     @query("#btn-prev") private _btnPrev!: HTMLButtonElement;
     @query("#btn-next") private _btnNext!: HTMLButtonElement;
@@ -110,6 +128,8 @@ export class PreviewApp extends LitElement {
             <progress-bar></progress-bar>
             <compile-errors-banner></compile-errors-banner>
             <filter-toolbar></filter-toolbar>
+            <bundle-chip-bar></bundle-chip-bar>
+            <data-tabs></data-tabs>
 
             <message-banner></message-banner>
             <div id="focus-controls" class="focus-controls" hidden>
@@ -441,6 +461,122 @@ export class PreviewApp extends LitElement {
             },
         });
 
+        // Bundle controller — owns the chip ↔ tab ↔ overlay state machine
+        // for the new panel shell. Additive to the existing focus-inspector
+        // chrome; the two coexist during migration. The controller's
+        // `setKindEnabled` forwards through the same `setDataExtensionEnabled`
+        // wire message the inspector already uses, so subscriptions land in
+        // a single place.
+        const bundleChipBar = this._bundleChipBar;
+        const dataTabs = this._dataTabs;
+        const bundleController = new BundleController(
+            {
+                setKindEnabled: (kind, enabled) => {
+                    // Subscriptions are per-preview at the wire layer; we
+                    // forward against the focused preview when there is
+                    // one, otherwise the first visible card (the default
+                    // multi-preview scoping rule from the design doc).
+                    const target = currentBundleTarget();
+                    if (!target) return;
+                    vscode.postMessage({
+                        command: "setDataExtensionEnabled",
+                        previewId: target,
+                        kind,
+                        enabled,
+                    });
+                },
+                persist: (snapshot) => {
+                    state.bundles = snapshot;
+                    vscode.setState(state);
+                },
+            },
+            state.bundles,
+        );
+        const currentBundleTarget = (): string | null => {
+            const focused = focusController?.focusedCard?.();
+            if (focused?.dataset.previewId) return focused.dataset.previewId;
+            const visible = grid.querySelector<HTMLElement>(
+                ".preview-card[data-preview-id]",
+            );
+            return visible?.dataset.previewId ?? null;
+        };
+        // Per-bundle table elements. Created lazily on first use and
+        // re-rendered in-place on state change.
+        const bundleTables = new Map<BundleId, DataTable<unknown>>();
+        const a11yTable = (): DataTable<unknown> => {
+            let t = bundleTables.get("a11y");
+            if (t) return t;
+            t = document.createElement("data-table") as DataTable<unknown>;
+            t.heading = "Accessibility";
+            t.setColumns(
+                a11yTableColumns() as unknown as ReadonlyArray<
+                    import("./components/DataTable").DataTableColumn<unknown>
+                >,
+            );
+            bundleTables.set("a11y", t);
+            return t;
+        };
+        const refreshA11yBundle = (): void => {
+            const target = currentBundleTarget();
+            if (!target) return;
+            const store = previewStore.getState();
+            const nodes =
+                store.cardA11yNodes.get(target) ??
+                store.allPreviews.find((p) => p.id === target)?.a11yNodes ??
+                [];
+            const findings =
+                store.cardA11yFindings.get(target) ??
+                store.allPreviews.find((p) => p.id === target)?.a11yFindings ??
+                [];
+            const data = computeA11yBundleData(nodes, findings);
+            const table = a11yTable();
+            table.setRows(data.rows);
+            table.summary = data.rows.length + " elements";
+            table.setOverlayId(
+                (row) => (row as { id: string }).id ?? "a11y-row",
+            );
+            table.setJsonPayload(() => ({
+                previewId: target,
+                nodes,
+                findings,
+            }));
+            dataTabs.setTabBody("a11y", table);
+        };
+        const reflectBundleState = (): void => {
+            const s = bundleController.state();
+            bundleChipBar.setState({
+                bundles: s.bundles,
+                activeBundles: s.activeBundles,
+            });
+            dataTabs.setState({
+                bundles: s.bundles,
+                activeBundles: s.activeBundles,
+                activeTab: s.activeTab,
+            });
+            if (s.activeBundles.includes("a11y")) refreshA11yBundle();
+        };
+        bundleController.onChange(() => reflectBundleState());
+        reflectBundleState();
+        bundleChipBar.addEventListener("bundle-toggled", (evt) => {
+            const detail = (evt as CustomEvent<{ id: BundleId }>).detail;
+            bundleController.toggleBundle(detail.id);
+        });
+        dataTabs.addEventListener("tab-closed", (evt) => {
+            const detail = (evt as CustomEvent<{ id: BundleId }>).detail;
+            bundleController.closeTab(detail.id);
+        });
+        dataTabs.addEventListener("tab-selected", (evt) => {
+            const detail = (evt as CustomEvent<{ id: BundleId }>).detail;
+            bundleController.selectTab(detail.id);
+        });
+        dataTabs.addEventListener("copy-json", (evt) => {
+            const detail = (evt as CustomEvent<{ payload: unknown }>).detail;
+            vscode.postMessage({
+                command: "copyToClipboard",
+                text: JSON.stringify(detail.payload, null, 2),
+            });
+        });
+
         // Config for the interactive-input pointer machine. The predicate
         // unifies live/recording state — both forward pointer/wheel input
         // to the daemon — so the module doesn't need direct access to
@@ -736,8 +872,19 @@ export class PreviewApp extends LitElement {
             saveFilterState,
             restoreFilterState,
             ensureNotBlank,
-            applyA11yUpdate: (previewId, findings, nodes) =>
-                applyA11yUpdate(previewId, findings, nodes, cardBuilderConfig),
+            applyA11yUpdate: (previewId, findings, nodes) => {
+                applyA11yUpdate(previewId, findings, nodes, cardBuilderConfig);
+                // Refresh the A11y bundle tab body if it's active for
+                // this preview — keeps the table in sync with the
+                // incoming hierarchy/findings without waiting for the
+                // user to re-click the chip.
+                if (
+                    bundleController.state().activeBundles.includes("a11y") &&
+                    currentBundleTarget() === previewId
+                ) {
+                    refreshA11yBundle();
+                }
+            },
             updateDataProducts: (previewId, dataProducts) => {
                 let byKind = dataProductsByPreview.get(previewId);
                 if (!byKind) {
@@ -757,6 +904,15 @@ export class PreviewApp extends LitElement {
                 );
                 if (matches && focused) {
                     inspector.render(focused);
+                }
+                // Refresh bundle tab bodies that depend on this preview's
+                // data. Today only A11y has a bundle presenter; future
+                // clusters add their own refresh.
+                if (
+                    bundleController.state().activeBundles.includes("a11y") &&
+                    currentBundleTarget() === previewId
+                ) {
+                    refreshA11yBundle();
                 }
             },
             focusOnCard,

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -444,6 +444,14 @@ export class PreviewApp extends LitElement {
                     kind,
                     enabled,
                 });
+                // Mirror the toggle into BundleController so the chip
+                // bar / tab row stay in sync with subscriptions that
+                // originated outside the new shell (focus-inspector
+                // bucket checkboxes, suggestion chips). Without this
+                // hook, deactivating the bundle later could miss
+                // unsubscribing the kind, and the chip/tab state
+                // drifts from actual daemon subscriptions.
+                bundleController.handleExternalKindToggle(kind, enabled);
             },
             getScope: () => previewStore.getState().moduleDir,
             loadMru: (scope) => state.focusMruByScope?.[scope] ?? [],


### PR DESCRIPTION
Bundle-per-cluster chips, one tab per active bundle with a table
above-the-fold and a shared overlay+legend primitive on the cards.
Per-extension presentation notes covering fonts (Google Fonts
preview + link), strings/i18n (resource-file deep-links),
theming, recomposition, traces, ambient, history-diff and the
rest of the catalogue. Open questions on multi-preview scoping,
tab overflow and Copy JSON shape.