### PR TITLE
feat(vscode-extension): resources/used table with jump-to-resource-file

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -33,6 +33,7 @@ import {
     WebviewToExtension,
 } from "./types";
 import { formatRenderErrorMessage } from "./renderError";
+import { openResourceFile } from "./resourceFileResolver";
 import { captureLabel, withDataProductCaptures } from "./captureLabels";
 import { DaemonGate } from "./daemon/daemonGate";
 import { DataProductAttachment } from "./daemon/daemonProtocol";
@@ -3885,6 +3886,52 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                     msg.enabled,
                 );
             }
+            break;
+        case "openResourceFile":
+            void openResourceFile(
+                {
+                    resourceType: msg.resourceType,
+                    resourceName: msg.resourceName,
+                    resolvedFile: msg.resolvedFile,
+                    packageName: msg.packageName,
+                },
+                {
+                    fs: {
+                        findFiles: async (include, exclude, maxResults) => {
+                            const uris = await vscode.workspace.findFiles(
+                                include,
+                                exclude ?? undefined,
+                                maxResults,
+                            );
+                            return uris.map((u) => u.fsPath);
+                        },
+                        readTextFile: async (absolutePath) => {
+                            const doc =
+                                await vscode.workspace.openTextDocument(
+                                    absolutePath,
+                                );
+                            return doc.getText();
+                        },
+                        fileExists: (filePath) => {
+                            try {
+                                return fs.existsSync(filePath);
+                            } catch {
+                                return false;
+                            }
+                        },
+                        isAbsolutePath: (filePath) => path.isAbsolute(filePath),
+                    },
+                    openTextDocument: (absolutePath) =>
+                        Promise.resolve(
+                            vscode.workspace.openTextDocument(
+                                vscode.Uri.file(absolutePath),
+                            ),
+                        ),
+                    showTextDocument: (doc) =>
+                        Promise.resolve(vscode.window.showTextDocument(doc)),
+                    logLine: (message) => logLine(message),
+                },
+            );
             break;
     }
 }

--- a/vscode-extension/src/resourceFileResolver.ts
+++ b/vscode-extension/src/resourceFileResolver.ts
@@ -1,0 +1,111 @@
+// Host-side wrapper for `openResourceFile` messages from the
+// `resources/used` focus-mode table. Delegates resolution to the pure
+// `resourceFileResolverCore` module so the testable bits don't pull in
+// the `vscode` runtime module; this file owns the editor / workspace
+// API calls.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as vscode from "vscode";
+import {
+    findValuesEntry,
+    isValuesType,
+    type OpenResourceRequest,
+    resolveResourceFilePath,
+    type ResolverFs,
+} from "./resourceFileResolverCore";
+
+export type { OpenResourceRequest } from "./resourceFileResolverCore";
+
+/**
+ * Editor / workspace touch points the wrapper needs. Production wires
+ * the VS Code APIs directly (see `defaultDeps` below); the extension
+ * host's message handler hands in a logger so failures surface in the
+ * output channel.
+ */
+export interface ResourceFileResolverDeps {
+    fs: ResolverFs;
+    openTextDocument(absolutePath: string): Promise<vscode.TextDocument>;
+    showTextDocument(doc: vscode.TextDocument): Promise<vscode.TextEditor>;
+    logLine(message: string): void;
+}
+
+/**
+ * Main entry: resolve, open, select. Awaitable so callers (and tests)
+ * can sequence on completion; the message handler in `extension.ts`
+ * doesn't need the return value.
+ */
+export async function openResourceFile(
+    request: OpenResourceRequest,
+    deps: ResourceFileResolverDeps = defaultDeps,
+): Promise<void> {
+    const target = await resolveResourceFilePath(request, deps.fs);
+    if (!target) {
+        deps.logLine(
+            `openResourceFile: no match for ${request.resourceType}/${request.resourceName} ` +
+                `(resolvedFile=${request.resolvedFile ?? "<none>"})`,
+        );
+        return;
+    }
+    try {
+        const doc = await deps.openTextDocument(target);
+        const editor = await deps.showTextDocument(doc);
+        if (isValuesType(request.resourceType)) {
+            const range = findValuesEntry(
+                doc.getText(),
+                request.resourceType,
+                request.resourceName,
+            );
+            if (range) {
+                const start = doc.positionAt(range.start);
+                const end = doc.positionAt(range.end);
+                editor.selection = new vscode.Selection(start, end);
+                editor.revealRange(
+                    new vscode.Range(start, end),
+                    vscode.TextEditorRevealType.InCenter,
+                );
+            }
+        }
+    } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        deps.logLine(
+            `openResourceFile failed for ${request.resourceType}/${request.resourceName}: ${message}`,
+        );
+    }
+}
+
+const defaultFs: ResolverFs = {
+    findFiles: async (include, exclude, maxResults) => {
+        const uris = await vscode.workspace.findFiles(
+            include,
+            exclude ?? undefined,
+            maxResults,
+        );
+        return uris.map((u) => u.fsPath);
+    },
+    readTextFile: async (absolutePath) => {
+        const doc = await vscode.workspace.openTextDocument(absolutePath);
+        return doc.getText();
+    },
+    fileExists: (filePath) => {
+        try {
+            return fs.existsSync(filePath);
+        } catch {
+            return false;
+        }
+    },
+    isAbsolutePath: (filePath) => path.isAbsolute(filePath),
+};
+
+const defaultDeps: ResourceFileResolverDeps = {
+    fs: defaultFs,
+    openTextDocument: (absolutePath) =>
+        Promise.resolve(
+            vscode.workspace.openTextDocument(vscode.Uri.file(absolutePath)),
+        ),
+    showTextDocument: (doc) =>
+        Promise.resolve(vscode.window.showTextDocument(doc)),
+    logLine: () => {
+        // Default is silent — extension host injects a logger.
+    },
+};

--- a/vscode-extension/src/resourceFileResolverCore.ts
+++ b/vscode-extension/src/resourceFileResolverCore.ts
@@ -1,0 +1,198 @@
+// Pure host-side resolution logic for the `resources/used` deep-link.
+// Lives separately from `resourceFileResolver.ts` so unit tests can
+// drive it through stubs without `import * as vscode from "vscode"`,
+// which Mocha can't load outside the extension host. The thin
+// vscode wrapper (`openResourceFile`) closes over this module and
+// hands off to `vscode.workspace.openTextDocument` / editor APIs.
+//
+// Strategy mirrors `findManifestIconReferences`: regex against the
+// document text is enough for the AGP-emitted shapes, and skipping a
+// full XML parser keeps the resolver portable to a future CLI / MCP
+// surface where carrying a vscode runtime would be awkward.
+
+/**
+ * `(resourceType, resourceName, resolvedFile, packageName)` payload of
+ * the `openResourceFile` webview message — quoted here so the core
+ * module doesn't have to depend on the wider `WebviewToExtension`
+ * union just to type its inputs.
+ */
+export interface OpenResourceRequest {
+    resourceType: string;
+    resourceName: string;
+    resolvedFile: string | null | undefined;
+    packageName: string | null | undefined;
+}
+
+/**
+ * Filesystem / workspace operations the resolver needs. Implementors:
+ * production code wires VS Code's `workspace.findFiles` / `fs.existsSync`
+ * / `path.isAbsolute` (see `resourceFileResolver.ts`); tests hand in
+ * fully-deterministic stubs.
+ *
+ * `findFiles` returns absolute paths (the wire shape VS Code's
+ * `findFiles` exposes via `Uri.fsPath`) so the core module can keep
+ * working in string-land.
+ */
+export interface ResolverFs {
+    findFiles(
+        include: string,
+        exclude: string | null,
+        maxResults: number,
+    ): Promise<string[]>;
+    readTextFile(absolutePath: string): Promise<string>;
+    fileExists(absolutePath: string): boolean;
+    isAbsolutePath(filePath: string): boolean;
+}
+
+/**
+ * Values-style resource types whose entries live in a values XML file
+ * (`values/`, `values-night/`, `values-w600dp/`, ...) under a
+ * `<{type} name="…">` element. `array` is split into `<array>`,
+ * `<string-array>` and `<integer-array>` in the platform — the
+ * recorder collapses all three into the `array` type when recording,
+ * so we accept any of the three when searching back.
+ */
+const VALUES_TYPES = new Set([
+    "string",
+    "color",
+    "dimen",
+    "bool",
+    "integer",
+    "array",
+    "plurals",
+]);
+
+/**
+ * File-style resource types — entries live in their own files under
+ * `res/<type>...` named `<name>.<ext>`. The recorder emits absolute
+ * paths for these via `Resources.getValue` so the resolver almost
+ * always lands on path 1; the name-glob is a fallback for daemons
+ * that emit only the type+name pair.
+ */
+const FILE_TYPES = new Set([
+    "drawable",
+    "mipmap",
+    "raw",
+    "layout",
+    "menu",
+    "xml",
+    "font",
+    "anim",
+    "animator",
+    "interpolator",
+    "transition",
+]);
+
+/**
+ * Resolve [request] to an absolute filesystem path or `null` when no
+ * workspace file fits. Resolution order:
+ *
+ *   1. Absolute `resolvedFile` that exists on disk.
+ *   2. Project-relative `res/<rel>` path — glob `**\/<rel>` so
+ *      multi-module projects pick the right module's copy.
+ *   3. Type-aware fallback by name: values resources scan every
+ *      `values*` XML; file resources glob for `res/<type>*\/<name>.*`.
+ */
+export async function resolveResourceFilePath(
+    request: OpenResourceRequest,
+    fs: ResolverFs,
+): Promise<string | null> {
+    const resolvedFile = request.resolvedFile;
+    if (resolvedFile) {
+        if (fs.isAbsolutePath(resolvedFile) && fs.fileExists(resolvedFile)) {
+            return resolvedFile;
+        }
+        if (resolvedFile.startsWith("res/")) {
+            const matches = await fs.findFiles(
+                "**/" + resolvedFile,
+                "**/build/**",
+                1,
+            );
+            if (matches.length > 0) {
+                return matches[0];
+            }
+        }
+        if (fs.fileExists(resolvedFile)) {
+            return resolvedFile;
+        }
+    }
+    return resolveByName(request, fs);
+}
+
+async function resolveByName(
+    request: OpenResourceRequest,
+    fs: ResolverFs,
+): Promise<string | null> {
+    const type = request.resourceType;
+    if (isValuesType(type)) {
+        const candidates = await fs.findFiles(
+            "**/res/values*/**/*.xml",
+            "**/build/**",
+            64,
+        );
+        for (const candidate of candidates) {
+            const text = await fs.readTextFile(candidate);
+            if (findValuesEntry(text, type, request.resourceName)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+    if (FILE_TYPES.has(type)) {
+        const matches = await fs.findFiles(
+            `**/res/${type}*/${request.resourceName}.*`,
+            "**/build/**",
+            1,
+        );
+        if (matches.length > 0) {
+            return matches[0];
+        }
+    }
+    return null;
+}
+
+/** True iff [type] is one whose entries live in a values XML file. */
+export function isValuesType(type: string): boolean {
+    return VALUES_TYPES.has(type);
+}
+
+/**
+ * Find the byte range of the `name="…"` attribute that belongs to a
+ * resource of [type] [name] within [text]. Returns null when no match
+ * exists. Range covers just the attribute value (between the quotes)
+ * so the editor selection highlights the name itself.
+ *
+ * Exported for unit tests. The same regex strategy
+ * `findManifestIconReferences` uses — values XML files are simple
+ * enough that full parsing isn't worth the cost.
+ */
+export function findValuesEntry(
+    text: string,
+    type: string,
+    name: string,
+): { start: number; end: number } | null {
+    const elementPattern = elementPatternFor(type);
+    const escapedName = escapeRegExp(name);
+    const typed = new RegExp(
+        `<\\s*(?:${elementPattern})\\b[^>]*?\\bname\\s*=\\s*(["'])(${escapedName})\\1`,
+        "g",
+    );
+    const match = typed.exec(text);
+    if (match) {
+        const nameOffset = match[0].lastIndexOf(match[2]);
+        const start = match.index + nameOffset;
+        return { start, end: start + match[2].length };
+    }
+    return null;
+}
+
+function elementPatternFor(type: string): string {
+    if (type === "array") {
+        return "string-array|integer-array|array";
+    }
+    return escapeRegExp(type);
+}
+
+function escapeRegExp(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/vscode-extension/src/test/focusPresentation.test.ts
+++ b/vscode-extension/src/test/focusPresentation.test.ts
@@ -51,6 +51,7 @@ function ctx(overrides?: {
     findings?: readonly AccessibilityFinding[];
     cardDataset?: Record<string, string>;
     data?: (kind: string) => unknown;
+    postMessage?: (msg: unknown) => void;
 }) {
     const card = document.createElement("div");
     if (overrides?.cardDataset) {
@@ -62,6 +63,7 @@ function ctx(overrides?: {
         findings: overrides?.findings ?? [],
         nodes: overrides?.nodes ?? [],
         data: overrides?.data,
+        postMessage: overrides?.postMessage,
     };
 }
 
@@ -168,6 +170,111 @@ describe("focusPresentation registry", () => {
         const img = result!.report!.body.querySelector("img");
         assert.ok(img);
         assert.strictEqual(img!.src, "data:image/png;base64,AAAA");
+    });
+
+    it("resources/used presenter returns null without data", () => {
+        const presenter = getPresenter("resources/used")!;
+        assert.ok(presenter);
+        assert.strictEqual(presenter(ctx()), null);
+        // Empty / missing references → null so the inspector renders the
+        // pending placeholder rather than an empty table.
+        assert.strictEqual(
+            presenter(ctx({ data: () => ({ references: [] }) })),
+            null,
+        );
+        assert.strictEqual(
+            presenter(ctx({ data: () => ({ other: [] }) })),
+            null,
+        );
+    });
+
+    it("resources/used presenter renders a table with one row per reference", () => {
+        const presenter = getPresenter("resources/used")!;
+        const result = presenter(
+            ctx({
+                data: () => ({
+                    references: [
+                        {
+                            resourceType: "color",
+                            resourceName: "primary",
+                            packageName: "com.example.app",
+                            resolvedValue: "#FF112233",
+                            resolvedFile: "/abs/res/values/colors.xml",
+                            consumers: [{ nodeId: "a" }, { nodeId: "b" }],
+                        },
+                        {
+                            resourceType: "string",
+                            resourceName: "hello",
+                            packageName: "com.example.app",
+                            resolvedValue: "Hello",
+                            resolvedFile: null,
+                            consumers: [],
+                        },
+                    ],
+                }),
+            }),
+        );
+        assert.ok(result);
+        assert.ok(result!.report);
+        const table = result!.report!.body.querySelector("table")!;
+        assert.ok(table);
+        const rows = table.querySelectorAll("tbody tr");
+        assert.strictEqual(rows.length, 2);
+        // First row: color with swatch + value.
+        const swatch = rows[0].querySelector(".focus-report-swatch-sample");
+        assert.ok(swatch);
+        assert.strictEqual(
+            rows[0].querySelector(".focus-report-swatch-value")?.textContent,
+            "#FF112233",
+        );
+        // resolvedFile cell is a button (deep-link).
+        const fileBtn = rows[0]
+            .querySelectorAll("td")[4]
+            .querySelector("button");
+        assert.ok(fileBtn);
+        assert.strictEqual(fileBtn!.textContent, "/abs/res/values/colors.xml");
+        assert.strictEqual(rows[0].querySelectorAll("td")[5].textContent, "2");
+        // Second row: no resolvedFile → resourceName is the deep-link.
+        const nameBtn = rows[1]
+            .querySelectorAll("td")[1]
+            .querySelector("button");
+        assert.ok(nameBtn);
+        assert.strictEqual(nameBtn!.textContent, "hello");
+        assert.strictEqual(rows[1].querySelectorAll("td")[5].textContent, "");
+    });
+
+    it("resources/used presenter posts openResourceFile on cell click", () => {
+        const presenter = getPresenter("resources/used")!;
+        const posted: unknown[] = [];
+        const result = presenter(
+            ctx({
+                data: () => ({
+                    references: [
+                        {
+                            resourceType: "drawable",
+                            resourceName: "ic_launcher",
+                            packageName: "com.example.app",
+                            resolvedValue: null,
+                            resolvedFile:
+                                "/abs/res/drawable-xxhdpi/ic_launcher.png",
+                            consumers: [],
+                        },
+                    ],
+                }),
+                postMessage: (msg) => posted.push(msg),
+            }),
+        );
+        assert.ok(result);
+        const btn = result!.report!.body.querySelector("button")!;
+        btn.dispatchEvent(new Event("click"));
+        assert.strictEqual(posted.length, 1);
+        assert.deepStrictEqual(posted[0], {
+            command: "openResourceFile",
+            resourceType: "drawable",
+            resourceName: "ic_launcher",
+            resolvedFile: "/abs/res/drawable-xxhdpi/ic_launcher.png",
+            packageName: "com.example.app",
+        });
     });
 
     it("renderErrorPresenter activates only when the card carries a render error", () => {

--- a/vscode-extension/src/test/resourceFileResolver.test.ts
+++ b/vscode-extension/src/test/resourceFileResolver.test.ts
@@ -1,0 +1,243 @@
+// Unit tests for the `resources/used` resolver core. The core module
+// lives in pure string-land — no `vscode` runtime import — so Mocha
+// can drive it without an extension host. The thin `openResourceFile`
+// wrapper in `resourceFileResolver.ts` is covered by the e2e harness.
+
+import * as assert from "assert";
+import {
+    findValuesEntry,
+    isValuesType,
+    resolveResourceFilePath,
+    type ResolverFs,
+} from "../resourceFileResolverCore";
+
+interface FakeFs extends ResolverFs {
+    findFilesCalls: { include: string; exclude: string | null }[];
+}
+
+function buildFs(overrides?: {
+    files?: Record<string, string[]>;
+    contents?: Record<string, string>;
+    existing?: Set<string>;
+}): FakeFs {
+    const files = overrides?.files ?? {};
+    const contents = overrides?.contents ?? {};
+    const existing = overrides?.existing ?? new Set<string>();
+    const findFilesCalls: { include: string; exclude: string | null }[] = [];
+    return {
+        findFilesCalls,
+        findFiles: async (include, exclude) => {
+            findFilesCalls.push({ include, exclude });
+            return files[include] ?? [];
+        },
+        readTextFile: async (path) => contents[path] ?? "",
+        fileExists: (path) => existing.has(path),
+        isAbsolutePath: (path) => path.startsWith("/"),
+    };
+}
+
+describe("findValuesEntry", () => {
+    it("locates the value of a name attribute for a typed element", () => {
+        const text = `<resources>
+  <color name="primary">#FF112233</color>
+  <color name="secondary">#FF445566</color>
+</resources>`;
+        const range = findValuesEntry(text, "color", "secondary");
+        assert.ok(range);
+        assert.strictEqual(text.slice(range!.start, range!.end), "secondary");
+    });
+
+    it("returns null when the element type doesn't match", () => {
+        const text = `<resources>
+  <string name="primary">Hello</string>
+</resources>`;
+        assert.strictEqual(findValuesEntry(text, "color", "primary"), null);
+    });
+
+    it("accepts string-array, integer-array, and array when type is `array`", () => {
+        const text = `<resources>
+  <string-array name="seasons">
+    <item>Spring</item>
+  </string-array>
+  <integer-array name="counts" />
+  <array name="raw" />
+</resources>`;
+        assert.ok(findValuesEntry(text, "array", "seasons"));
+        assert.ok(findValuesEntry(text, "array", "counts"));
+        assert.ok(findValuesEntry(text, "array", "raw"));
+    });
+
+    it("tolerates extra attributes before the name attribute", () => {
+        const text = `<resources>
+  <color tools:override="true" name="primary">#FF000000</color>
+</resources>`;
+        const range = findValuesEntry(text, "color", "primary");
+        assert.ok(range);
+        assert.strictEqual(text.slice(range!.start, range!.end), "primary");
+    });
+
+    it("escapes regex metacharacters in the resource name", () => {
+        const text = `<resources>
+  <string name="foo.bar">Hello</string>
+</resources>`;
+        const range = findValuesEntry(text, "string", "foo.bar");
+        assert.ok(range);
+        // "foo.bar" the literal — confirms the regex didn't treat `.`
+        // as any-char and accidentally pick up a similarly-shaped name.
+        assert.strictEqual(text.slice(range!.start, range!.end), "foo.bar");
+    });
+});
+
+describe("isValuesType", () => {
+    it("recognises every Android values-style resource type", () => {
+        for (const type of [
+            "string",
+            "color",
+            "dimen",
+            "bool",
+            "integer",
+            "array",
+            "plurals",
+        ]) {
+            assert.strictEqual(isValuesType(type), true, type);
+        }
+    });
+
+    it("rejects file-style resource types", () => {
+        for (const type of [
+            "drawable",
+            "mipmap",
+            "raw",
+            "layout",
+            "menu",
+            "xml",
+        ]) {
+            assert.strictEqual(isValuesType(type), false, type);
+        }
+    });
+});
+
+describe("resolveResourceFilePath", () => {
+    it("returns the resolvedFile path when it's an existing absolute path", async () => {
+        const target = "/abs/app/src/main/res/values/colors.xml";
+        const fs = buildFs({ existing: new Set([target]) });
+        const result = await resolveResourceFilePath(
+            {
+                resourceType: "color",
+                resourceName: "primary",
+                resolvedFile: target,
+                packageName: "com.example.app",
+            },
+            fs,
+        );
+        assert.strictEqual(result, target);
+        assert.strictEqual(
+            fs.findFilesCalls.length,
+            0,
+            "absolute existing path should not need a workspace search",
+        );
+    });
+
+    it("globs the workspace for a project-relative res path", async () => {
+        const target = "/abs/app/src/main/res/values/strings.xml";
+        const fs = buildFs({
+            files: { "**/res/values/strings.xml": [target] },
+        });
+        const result = await resolveResourceFilePath(
+            {
+                resourceType: "string",
+                resourceName: "hello",
+                resolvedFile: "res/values/strings.xml",
+                packageName: "com.example.app",
+            },
+            fs,
+        );
+        assert.strictEqual(result, target);
+        assert.strictEqual(
+            fs.findFilesCalls[0].exclude,
+            "**/build/**",
+            "workspace globs must exclude build outputs",
+        );
+    });
+
+    it("falls back to a values-XML scan when resolvedFile is missing", async () => {
+        const valuesXml = "/abs/app/src/main/res/values/strings.xml";
+        const fs = buildFs({
+            files: { "**/res/values*/**/*.xml": [valuesXml] },
+            contents: {
+                [valuesXml]: `<resources>
+  <string name="hello">Hello</string>
+</resources>`,
+            },
+        });
+        const result = await resolveResourceFilePath(
+            {
+                resourceType: "string",
+                resourceName: "hello",
+                resolvedFile: null,
+                packageName: "com.example.app",
+            },
+            fs,
+        );
+        assert.strictEqual(result, valuesXml);
+    });
+
+    it("scans past values XMLs that don't carry the entry", async () => {
+        const wrong = "/abs/app/src/main/res/values/colors.xml";
+        const right = "/abs/app/src/main/res/values/strings.xml";
+        const fs = buildFs({
+            files: {
+                "**/res/values*/**/*.xml": [wrong, right],
+            },
+            contents: {
+                [wrong]: `<resources>
+  <color name="primary">#FF000000</color>
+</resources>`,
+                [right]: `<resources>
+  <string name="hello">Hello</string>
+</resources>`,
+            },
+        });
+        const result = await resolveResourceFilePath(
+            {
+                resourceType: "string",
+                resourceName: "hello",
+                resolvedFile: null,
+                packageName: "com.example.app",
+            },
+            fs,
+        );
+        assert.strictEqual(result, right);
+    });
+
+    it("falls back to a name-glob for file-style resource types", async () => {
+        const png = "/abs/app/src/main/res/drawable-xxhdpi/ic_launcher.png";
+        const fs = buildFs({
+            files: { "**/res/drawable*/ic_launcher.*": [png] },
+        });
+        const result = await resolveResourceFilePath(
+            {
+                resourceType: "drawable",
+                resourceName: "ic_launcher",
+                resolvedFile: null,
+                packageName: "com.example.app",
+            },
+            fs,
+        );
+        assert.strictEqual(result, png);
+    });
+
+    it("returns null when nothing resolves", async () => {
+        const fs = buildFs();
+        const result = await resolveResourceFilePath(
+            {
+                resourceType: "string",
+                resourceName: "absent",
+                resolvedFile: null,
+                packageName: null,
+            },
+            fs,
+        );
+        assert.strictEqual(result, null);
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -845,6 +845,29 @@ export type WebviewToExtension =
           previewId: string;
           kind: string;
           enabled: boolean;
+      }
+    /**
+     * Click on a `resources/used` table cell. The host resolves the
+     * `(resourceType, resourceName, resolvedFile, packageName)` tuple
+     * against the workspace and opens the right file in an editor:
+     *
+     *  - `string` / `color` / `dimen` / `bool` / `integer` / `array`:
+     *    open the best-match values XML file and select the matching
+     *    `<{type} name="…">` entry (or bare `name="…"` fallback).
+     *  - `drawable` / `mipmap` / `raw`: open the file directly.
+     *  - `layout` / `menu` / `xml`: open the file at the top.
+     *
+     * `resolvedFile` may be a daemon-emitted absolute path, a `res/…`
+     * project-relative path, or `null` (host falls back to a workspace
+     * glob keyed by name). `packageName` is the resource owner the
+     * daemon resolved — caller package wins over library / framework.
+     */
+    | {
+          command: "openResourceFile";
+          resourceType: string;
+          resourceName: string;
+          resolvedFile: string | null;
+          packageName: string | null;
       };
 
 /**

--- a/vscode-extension/src/webview/preview/focusInspector.ts
+++ b/vscode-extension/src/webview/preview/focusInspector.ts
@@ -70,6 +70,11 @@ export interface FocusInspectorConfig {
     getA11yNodes(previewId: string): readonly AccessibilityNode[];
     /** Latest daemon data product payload for preview/kind. */
     getDataProduct?(previewId: string, kind: string): unknown;
+    /** Forward a `WebviewToExtension` message back to the host. Used by
+     *  presenters that surface deep-links — e.g. `resources/used`'s
+     *  jump-to-resource cells. Optional so existing test harnesses
+     *  don't have to thread a stub through every case. */
+    postMessage?(msg: unknown): void;
     /** `previewId` whose a11y overlay subscription is currently on. */
     getA11yOverlayId(): string | null;
     /** Whether [previewId] is currently in the live (interactive) set. */
@@ -713,6 +718,7 @@ export class FocusInspectorController {
             nodes,
             data: (kind: string) =>
                 this.config.getDataProduct?.(previewId, kind),
+            postMessage: this.config.postMessage,
         };
         const out: { kind: string; presentation: ProductPresentation }[] = [];
         // The error presenter is implicit: we always invoke it so a

--- a/vscode-extension/src/webview/preview/focusPresentation.ts
+++ b/vscode-extension/src/webview/preview/focusPresentation.ts
@@ -51,6 +51,11 @@ export interface PresenterContext {
     nodes: readonly AccessibilityNode[];
     /** Latest daemon data-product payload for this kind, if any. */
     data?(kind: string): unknown;
+    /** Post a `WebviewToExtension` message back to the host. Optional so
+     *  presenter unit tests don't need to thread a stub through every
+     *  case — presenters that want deep-link behaviour should null-check
+     *  before calling. */
+    postMessage?(msg: unknown): void;
 }
 
 /** Bag of contributions a presenter can make to one or more surfaces.
@@ -154,6 +159,7 @@ function seedBuiltInPresenters(): void {
     registerPresenter("a11y/atf", a11yFindingsPresenter);
     registerPresenter("a11y/overlay", a11yOverlayPresenter);
     registerPresenter("compose/theme", composeThemePresenter);
+    registerPresenter("resources/used", resourcesUsedPresenter);
     registerPresenter("local/render/error", renderErrorPresenter);
 }
 
@@ -374,6 +380,232 @@ function composeThemePresenter(
             body,
         },
     };
+}
+
+/**
+ * `resources/used` — Android resources resolved while rendering. Surfaces
+ * a single `<table>` Report keyed by `(resourceType, resourceName,
+ * packageName)`, with deep-link cells that post `openResourceFile` so the
+ * extension host can jump to the values XML entry (string/color/dimen/…)
+ * or open the binary asset (drawable/mipmap/raw).
+ *
+ * Hover-overlay box correlation is gated on `resources/consumers` joins
+ * with `compose/semantics` bounds — out of scope for this presenter
+ * today, so the Legend / overlay surfaces stay empty. The table is the
+ * useful artefact: it's the surface that turns "what did this preview
+ * pull from `res/`?" from a build-output spelunk into one click.
+ */
+function resourcesUsedPresenter(
+    ctx: PresenterContext,
+): ProductPresentation | null {
+    const raw = ctx.data?.("resources/used");
+    if (!raw || typeof raw !== "object") return null;
+    const references = (raw as { references?: unknown }).references;
+    if (!Array.isArray(references) || references.length === 0) return null;
+
+    const rows: ResourceReferenceRow[] = [];
+    for (const item of references) {
+        if (!item || typeof item !== "object") continue;
+        const ref = item as Record<string, unknown>;
+        const resourceType =
+            typeof ref.resourceType === "string" ? ref.resourceType : "";
+        const resourceName =
+            typeof ref.resourceName === "string" ? ref.resourceName : "";
+        if (!resourceType || !resourceName) continue;
+        rows.push({
+            resourceType,
+            resourceName,
+            packageName:
+                typeof ref.packageName === "string" ? ref.packageName : "",
+            resolvedValue:
+                typeof ref.resolvedValue === "string"
+                    ? ref.resolvedValue
+                    : null,
+            resolvedFile:
+                typeof ref.resolvedFile === "string" ? ref.resolvedFile : null,
+            consumerCount: countConsumers(ref.consumers),
+        });
+    }
+    if (rows.length === 0) return null;
+
+    const body = renderResourcesUsedTable(rows, ctx);
+    return {
+        report: {
+            title: "Resources used",
+            summary:
+                rows.length + " reference" + (rows.length === 1 ? "" : "s"),
+            body,
+        },
+    };
+}
+
+interface ResourceReferenceRow {
+    resourceType: string;
+    resourceName: string;
+    packageName: string;
+    resolvedValue: string | null;
+    resolvedFile: string | null;
+    consumerCount: number;
+}
+
+function countConsumers(value: unknown): number {
+    if (!Array.isArray(value)) return 0;
+    return value.length;
+}
+
+/** Hex shapes the swatch cell recognises — `#RGB`, `#RGBA`, `#RRGGBB`,
+ *  `#AARRGGBB`. The Kotlin recorder normalises colours to `#AARRGGBB`
+ *  via `"#%08X".format(value)`, but be lenient about other shapes the
+ *  daemon (or a future producer) might emit. */
+const RESOURCE_HEX_COLOUR_RE =
+    /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+function renderResourcesUsedTable(
+    rows: readonly ResourceReferenceRow[],
+    ctx: PresenterContext,
+): HTMLElement {
+    const wrap = document.createElement("div");
+    wrap.className =
+        "focus-report-generic-wrap focus-report-resources-used-wrap";
+    const table = document.createElement("table");
+    table.className = "focus-report-generic focus-report-table";
+    table.dataset.kind = "resources/used";
+
+    const thead = document.createElement("thead");
+    const headRow = document.createElement("tr");
+    for (const col of [
+        "resourceType",
+        "resourceName",
+        "packageName",
+        "resolvedValue",
+        "resolvedFile",
+        "consumers",
+    ]) {
+        const th = document.createElement("th");
+        th.textContent = col;
+        headRow.appendChild(th);
+    }
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+
+    const tbody = document.createElement("tbody");
+    for (const row of rows) {
+        tbody.appendChild(renderResourcesRow(row, ctx));
+    }
+    table.appendChild(tbody);
+    wrap.appendChild(table);
+    return wrap;
+}
+
+function renderResourcesRow(
+    row: ResourceReferenceRow,
+    ctx: PresenterContext,
+): HTMLElement {
+    const tr = document.createElement("tr");
+    tr.dataset.resourceType = row.resourceType;
+    tr.dataset.resourceName = row.resourceName;
+
+    appendCell(tr, row.resourceType);
+
+    const nameCell = document.createElement("td");
+    // When no resolvedFile, fall back to making the name clickable —
+    // the host's resolver will glob the workspace for a match.
+    if (row.resolvedFile) {
+        nameCell.textContent = row.resourceName;
+    } else {
+        nameCell.appendChild(buildResourceLink(row.resourceName, row, ctx));
+    }
+    tr.appendChild(nameCell);
+
+    appendCell(tr, row.packageName);
+
+    tr.appendChild(buildResolvedValueCell(row));
+
+    const fileCell = document.createElement("td");
+    if (row.resolvedFile) {
+        fileCell.appendChild(buildResourceLink(row.resolvedFile, row, ctx));
+    } else {
+        fileCell.textContent = "";
+    }
+    tr.appendChild(fileCell);
+
+    appendCell(tr, row.consumerCount > 0 ? String(row.consumerCount) : "");
+    return tr;
+}
+
+function appendCell(tr: HTMLElement, text: string): void {
+    const td = document.createElement("td");
+    td.textContent = text;
+    tr.appendChild(td);
+}
+
+function buildResolvedValueCell(row: ResourceReferenceRow): HTMLElement {
+    const td = document.createElement("td");
+    const value = row.resolvedValue;
+    if (!value) {
+        return td;
+    }
+    if (row.resourceType === "color" && RESOURCE_HEX_COLOUR_RE.test(value)) {
+        const swatch = document.createElement("span");
+        swatch.className = "focus-report-swatch-sample";
+        swatch.style.backgroundColor = value;
+        swatch.title = value;
+        td.appendChild(swatch);
+        const text = document.createElement("span");
+        text.className = "focus-report-swatch-value";
+        text.textContent = value;
+        td.appendChild(text);
+        return td;
+    }
+    if (
+        (row.resourceType === "drawable" || row.resourceType === "mipmap") &&
+        row.resolvedFile &&
+        isRasterAsset(row.resolvedFile)
+    ) {
+        // Browsers in the webview only load images from approved URI
+        // schemes (the host's CSP). For now we stick with the path
+        // text; a future change can pre-bake a data: URI via the
+        // extension when the daemon attaches the asset bytes.
+        td.textContent = row.resolvedFile;
+        return td;
+    }
+    td.textContent = value;
+    return td;
+}
+
+function isRasterAsset(path: string): boolean {
+    const lower = path.toLowerCase();
+    return (
+        lower.endsWith(".png") ||
+        lower.endsWith(".webp") ||
+        lower.endsWith(".jpg") ||
+        lower.endsWith(".jpeg") ||
+        lower.endsWith(".gif")
+    );
+}
+
+function buildResourceLink(
+    text: string,
+    row: ResourceReferenceRow,
+    ctx: PresenterContext,
+): HTMLElement {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "focus-report-resource-link";
+    button.textContent = text;
+    button.title = "Open " + (row.resolvedFile || row.resourceName);
+    button.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        ctx.postMessage?.({
+            command: "openResourceFile",
+            resourceType: row.resourceType,
+            resourceName: row.resourceName,
+            resolvedFile: row.resolvedFile,
+            packageName: row.packageName,
+        });
+    });
+    return button;
 }
 
 function renderErrorPresenter(

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -407,6 +407,7 @@ export class PreviewApp extends LitElement {
             },
             getDataProduct: (previewId, kind) =>
                 dataProductsByPreview.get(previewId)?.get(kind),
+            postMessage: (msg) => vscode.postMessage(msg),
             getA11yOverlayId: a11yOverlay,
             isLive: (id) => liveState.isLive(id),
             onToggleA11yOverlay: () => focusController.toggleA11yOverlay(),


### PR DESCRIPTION
Adds a focused presenter for the resources/used data product: a
six-column table (resourceType, resourceName, packageName,
resolvedValue, resolvedFile, consumers) where the resolvedFile
(or resourceName when resolvedFile is empty) is a deep-link button.
Clicking emits an openResourceFile webview message; the host-side
resolver maps the (type, name, resolvedFile, package) tuple onto a
workspace file and opens it, jumping the editor selection to the
matching <{type} name="..."> entry for values resources or opening
file-style resources (drawable / mipmap / layout / ...) directly.

Color cells render a swatch alongside the hex value. The resolver
itself lives in a pure core module so it's unit-testable without
the vscode runtime; the thin wrapper file holds the editor /
workspace API calls.

Closes #1058.