### PR TITLE
feat(vscode-extension): inspection bundle presenters (semantics, layout, uia)

### DIFF
--- a/data/uiautomator/core/src/main/kotlin/ee/schimke/composeai/renderer/uiautomator/HierarchySelectorBuilder.kt
+++ b/data/uiautomator/core/src/main/kotlin/ee/schimke/composeai/renderer/uiautomator/HierarchySelectorBuilder.kt
@@ -1,0 +1,170 @@
+package ee.schimke.composeai.renderer.uiautomator
+
+/**
+ * Pure selector-builder for the `uia/hierarchy` data product (#1059). Given one node from a
+ * hierarchy snapshot plus the full node list, return a [Selector] / source-snippet that uniquely
+ * targets the node — the same logic the VS Code extension's `uiaSelector.ts` mirrors for its
+ * "Copy as selector" row action, factored out here so MCP / record-script paths can ship the same
+ * snippets without re-implementing the rules.
+ *
+ * # Priority
+ *
+ * 1. `testTag` when present and unique across [nodes].
+ * 2. `text` when present and unique.
+ * 3. `contentDescription` when present and unique.
+ * 4. Best non-unique anchor (`testTag` ▶ `text` ▶ `contentDescription`) plus the nearest
+ *    [UiAutomatorHierarchyNode.testTagAncestors] entry that disambiguates — chained as
+ *    `hasParent(By.testTag(...))`. We walk ancestors nearest → root-most because the narrowest
+ *    scope is the smallest selector that still locates the node.
+ *
+ * Returns `null` when every axis is blank — the node has nothing distinguishing to anchor against.
+ * Callers should fall back to a UI hint rather than emitting a useless `By` chain. Mirrors the TS
+ * implementation's null return so the two surfaces stay in lockstep.
+ */
+public object HierarchySelectorBuilder {
+
+  /**
+   * Build a runnable [Selector] for [node] from the [nodes] population it lives in. Used by paths
+   * that want the structured selector (record-script events, MCP). Roughly the same as
+   * [buildSelectorSnippet] but returns the structured form rather than a Kotlin-source string.
+   */
+  public fun buildSelector(
+    node: UiAutomatorHierarchyNode,
+    nodes: List<UiAutomatorHierarchyNode>,
+  ): Selector? {
+    val tag = node.testTag.nonBlank()
+    val text = node.text.nonBlank()
+    val desc = node.contentDescription.nonBlank()
+
+    if (tag != null && nodes.count { it.testTag.nonBlank() == tag } == 1) {
+      return Selector(res = TextMatch.Exact(tag))
+    }
+    if (text != null && nodes.count { it.text.nonBlank() == text } == 1) {
+      return Selector(text = TextMatch.Exact(text))
+    }
+    if (desc != null && nodes.count { it.contentDescription.nonBlank() == desc } == 1) {
+      return Selector(desc = TextMatch.Exact(desc))
+    }
+
+    val anchor = pickAnchor(node) ?: return null
+    val anchorSel = anchor.toSelector()
+    // Walk ancestors nearest → root-most. testTagAncestors is stored root-most → nearest, so
+    // iterate in reverse to find the smallest scope that disambiguates.
+    for (i in node.testTagAncestors.indices.reversed()) {
+      val parentTag = node.testTagAncestors[i].nonBlank() ?: continue
+      val matchCount =
+        nodes.count { other ->
+          anchor.matches(other) &&
+            other.testTagAncestors.any { it.nonBlank() == parentTag }
+        }
+      if (matchCount == 1) {
+        return anchorSel.copy(children = listOf(Selector(res = TextMatch.Exact(parentTag))))
+      }
+    }
+    // No ancestor disambiguates either — return the anchor alone so callers have somewhere to
+    // start, matching the TS fallback. The caller can refine further when the snippet is
+    // visibly ambiguous.
+    return anchorSel
+  }
+
+  /**
+   * Build a Kotlin-source selector snippet for [node]. Mirror of `buildSelectorSnippet` in
+   * `vscode-extension/src/webview/preview/uiaSelector.ts`. Stable, copy-paste-friendly format —
+   * `By.testTag("...")` / `By.text("...")` / `By.desc("...")`, optionally chained with
+   * `.hasParent(By.testTag("..."))`.
+   */
+  public fun buildSelectorSnippet(
+    node: UiAutomatorHierarchyNode,
+    nodes: List<UiAutomatorHierarchyNode>,
+  ): String? {
+    val tag = node.testTag.nonBlank()
+    val text = node.text.nonBlank()
+    val desc = node.contentDescription.nonBlank()
+
+    if (tag != null && nodes.count { it.testTag.nonBlank() == tag } == 1) {
+      return "By.testTag(${quote(tag)})"
+    }
+    if (text != null && nodes.count { it.text.nonBlank() == text } == 1) {
+      return "By.text(${quote(text)})"
+    }
+    if (desc != null && nodes.count { it.contentDescription.nonBlank() == desc } == 1) {
+      return "By.desc(${quote(desc)})"
+    }
+
+    val anchor = pickAnchor(node) ?: return null
+    for (i in node.testTagAncestors.indices.reversed()) {
+      val parentTag = node.testTagAncestors[i].nonBlank() ?: continue
+      val matchCount =
+        nodes.count { other ->
+          anchor.matches(other) &&
+            other.testTagAncestors.any { it.nonBlank() == parentTag }
+        }
+      if (matchCount == 1) {
+        return "${anchor.render()}.hasParent(By.testTag(${quote(parentTag)}))"
+      }
+    }
+    return anchor.render()
+  }
+
+  private fun pickAnchor(node: UiAutomatorHierarchyNode): Anchor? {
+    node.testTag.nonBlank()?.let {
+      return Anchor.Tag(it)
+    }
+    node.text.nonBlank()?.let {
+      return Anchor.Text(it)
+    }
+    node.contentDescription.nonBlank()?.let {
+      return Anchor.Desc(it)
+    }
+    return null
+  }
+
+  private sealed class Anchor {
+    abstract val value: String
+
+    abstract fun render(): String
+
+    abstract fun matches(node: UiAutomatorHierarchyNode): Boolean
+
+    abstract fun toSelector(): Selector
+
+    data class Tag(override val value: String) : Anchor() {
+      override fun render(): String = "By.testTag(${quote(value)})"
+
+      override fun matches(node: UiAutomatorHierarchyNode): Boolean =
+        node.testTag.nonBlank() == value
+
+      override fun toSelector(): Selector = Selector(res = TextMatch.Exact(value))
+    }
+
+    data class Text(override val value: String) : Anchor() {
+      override fun render(): String = "By.text(${quote(value)})"
+
+      override fun matches(node: UiAutomatorHierarchyNode): Boolean =
+        node.text.nonBlank() == value
+
+      override fun toSelector(): Selector = Selector(text = TextMatch.Exact(value))
+    }
+
+    data class Desc(override val value: String) : Anchor() {
+      override fun render(): String = "By.desc(${quote(value)})"
+
+      override fun matches(node: UiAutomatorHierarchyNode): Boolean =
+        node.contentDescription.nonBlank() == value
+
+      override fun toSelector(): Selector = Selector(desc = TextMatch.Exact(value))
+    }
+  }
+}
+
+private fun String?.nonBlank(): String? = this?.takeIf { it.isNotEmpty() }
+
+private fun quote(s: String): String {
+  val escaped =
+    s.replace("\\", "\\\\")
+      .replace("\"", "\\\"")
+      .replace("\n", "\\n")
+      .replace("\r", "\\r")
+      .replace("\t", "\\t")
+  return "\"$escaped\""
+}

--- a/data/uiautomator/core/src/main/kotlin/ee/schimke/composeai/renderer/uiautomator/UiAutomatorPrototype.kt
+++ b/data/uiautomator/core/src/main/kotlin/ee/schimke/composeai/renderer/uiautomator/UiAutomatorPrototype.kt
@@ -687,6 +687,14 @@ public object By {
 
   public fun res(value: String): Selector = Selector().res(value)
 
+  /**
+   * Convenience alias for [res] — Compose's stable per-node id is the `Modifier.testTag(...)`
+   * value, which the renderer surfaces as `viewIdResourceName` (matched by [res]). [HierarchySelectorBuilder]
+   * emits `By.testTag("…")` snippets through this method so the copied selector is directly
+   * runnable against the prototype.
+   */
+  public fun testTag(value: String): Selector = res(value)
+
   public fun clickable(): Selector = Selector().clickable()
 
   public fun checkable(): Selector = Selector().checkable()

--- a/data/uiautomator/core/src/test/kotlin/ee/schimke/composeai/renderer/uiautomator/HierarchySelectorBuilderTest.kt
+++ b/data/uiautomator/core/src/test/kotlin/ee/schimke/composeai/renderer/uiautomator/HierarchySelectorBuilderTest.kt
@@ -1,0 +1,145 @@
+package ee.schimke.composeai.renderer.uiautomator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HierarchySelectorBuilderTest {
+
+  private fun node(
+    text: String? = null,
+    contentDescription: String? = null,
+    testTag: String? = null,
+    testTagAncestors: List<String> = emptyList(),
+    role: String? = null,
+    actions: List<String> = emptyList(),
+    bounds: String = "0,0,100,100",
+  ): UiAutomatorHierarchyNode =
+    UiAutomatorHierarchyNode(
+      text = text,
+      contentDescription = contentDescription,
+      testTag = testTag,
+      testTagAncestors = testTagAncestors,
+      role = role,
+      actions = actions,
+      boundsInScreen = bounds,
+    )
+
+  @Test
+  fun `unique testTag wins`() {
+    val target = node(testTag = "submit", text = "Submit")
+    val nodes = listOf(target, node(testTag = "cancel", text = "Cancel"))
+    assertEquals(
+      "By.testTag(\"submit\")",
+      HierarchySelectorBuilder.buildSelectorSnippet(target, nodes),
+    )
+  }
+
+  @Test
+  fun `falls through to text when testTag is blank`() {
+    val target = node(text = "Submit")
+    val nodes = listOf(target, node(text = "Cancel"))
+    assertEquals(
+      "By.text(\"Submit\")",
+      HierarchySelectorBuilder.buildSelectorSnippet(target, nodes),
+    )
+  }
+
+  @Test
+  fun `falls through to contentDescription when text is missing too`() {
+    val target = node(contentDescription = "Submit form")
+    val nodes = listOf(target, node(contentDescription = "Cancel form"))
+    assertEquals(
+      "By.desc(\"Submit form\")",
+      HierarchySelectorBuilder.buildSelectorSnippet(target, nodes),
+    )
+  }
+
+  @Test
+  fun `non-unique text chains to nearest disambiguating ancestor`() {
+    val a =
+      node(
+        text = "Item",
+        testTagAncestors = listOf("screen", "list-A"),
+      )
+    val b =
+      node(
+        text = "Item",
+        testTagAncestors = listOf("screen", "list-B"),
+      )
+    val snippet = HierarchySelectorBuilder.buildSelectorSnippet(a, listOf(a, b))
+    assertEquals("By.text(\"Item\").hasParent(By.testTag(\"list-A\"))", snippet)
+  }
+
+  @Test
+  fun `nearest ancestor is preferred over root-most`() {
+    // The "screen" ancestor doesn't disambiguate (both rows share it).
+    // The "list-A" ancestor does. Builder should pick the nearest match.
+    val a = node(text = "Item", testTagAncestors = listOf("screen", "list-A"))
+    val b = node(text = "Item", testTagAncestors = listOf("screen", "list-B"))
+    val snippet = HierarchySelectorBuilder.buildSelectorSnippet(a, listOf(a, b))
+    assertEquals("By.text(\"Item\").hasParent(By.testTag(\"list-A\"))", snippet)
+  }
+
+  @Test
+  fun `blank ancestors are skipped during walk`() {
+    val a =
+      node(
+        text = "Item",
+        testTagAncestors = listOf("screen", "", "list-A"),
+      )
+    val b =
+      node(
+        text = "Item",
+        testTagAncestors = listOf("screen", "", "list-B"),
+      )
+    val snippet = HierarchySelectorBuilder.buildSelectorSnippet(a, listOf(a, b))
+    assertEquals("By.text(\"Item\").hasParent(By.testTag(\"list-A\"))", snippet)
+  }
+
+  @Test
+  fun `returns null when every axis is blank`() {
+    val target = node()
+    assertNull(HierarchySelectorBuilder.buildSelectorSnippet(target, listOf(target)))
+  }
+
+  @Test
+  fun `returns bare anchor when no ancestor disambiguates`() {
+    val a = node(text = "Item")
+    val b = node(text = "Item")
+    val snippet = HierarchySelectorBuilder.buildSelectorSnippet(a, listOf(a, b))
+    // Bare anchor — caller can refine, but we don't fabricate a fake chain.
+    assertEquals("By.text(\"Item\")", snippet)
+  }
+
+  @Test
+  fun `quote escapes special characters`() {
+    val target = node(text = "Line 1\nLine 2 with \"quotes\"")
+    val snippet = HierarchySelectorBuilder.buildSelectorSnippet(target, listOf(target))
+    assertEquals(
+      "By.text(\"Line 1\\nLine 2 with \\\"quotes\\\"\")",
+      snippet,
+    )
+  }
+
+  @Test
+  fun `buildSelector returns structured Selector mirroring snippet`() {
+    val target = node(testTag = "submit")
+    val sel = HierarchySelectorBuilder.buildSelector(target, listOf(target))
+    assertEquals(Selector(res = TextMatch.Exact("submit")), sel)
+  }
+
+  @Test
+  fun `buildSelector ancestor chain matches snippet shape`() {
+    val a = node(text = "Item", testTagAncestors = listOf("list-A"))
+    val b = node(text = "Item", testTagAncestors = listOf("list-B"))
+    val sel = HierarchySelectorBuilder.buildSelector(a, listOf(a, b))
+    assertEquals(
+      Selector(
+        text = TextMatch.Exact("Item"),
+        children = listOf(Selector(res = TextMatch.Exact("list-A"))),
+      ),
+      sel,
+    )
+  }
+}

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1172,6 +1172,150 @@ body {
     color: var(--vscode-focusBorder);
 }
 
+/* Inspection-bundle tree-table (compose/semantics, layout/inspector,
+   uia/hierarchy) — see inspectionTreeTable.ts. Shares
+   .focus-overlay-box with the a11y/hierarchy presenter so bound
+   highlights look consistent across kinds. */
+
+.inspection-tree {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: calc(var(--vscode-font-size) - 2px);
+}
+
+.inspection-tree-head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    justify-content: flex-end;
+}
+
+.inspection-tree-summary {
+    color: var(--text-secondary);
+    margin-right: auto;
+}
+
+.inspection-tree-copy-json {
+    align-items: center;
+    background: transparent;
+    border: 1px solid color-mix(in srgb, var(--card-border) 70%, transparent);
+    border-radius: 3px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    display: inline-flex;
+    font-size: calc(var(--vscode-font-size) - 3px);
+    gap: 4px;
+    padding: 1px 6px;
+}
+
+.inspection-tree-copy-json:hover {
+    background: color-mix(in srgb, var(--card-border) 20%, transparent);
+    color: var(--text-primary);
+}
+
+.inspection-tree-table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: calc(var(--vscode-font-size) - 2px);
+}
+
+.inspection-tree-table th,
+.inspection-tree-table td {
+    border-bottom: 1px solid
+        color-mix(in srgb, var(--card-border) 50%, transparent);
+    padding: 2px 6px;
+    text-align: left;
+    vertical-align: top;
+    overflow-wrap: anywhere;
+}
+
+.inspection-tree-table th {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.inspection-tree-expander-col,
+.inspection-tree-action-col {
+    width: 1%;
+    white-space: nowrap;
+}
+
+.inspection-tree-expander {
+    padding-right: 0 !important;
+}
+
+.inspection-tree-expand {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0 2px;
+}
+
+.inspection-tree-expand:hover {
+    color: var(--text-primary);
+}
+
+.inspection-tree-table tbody tr[data-has-overlay="true"]:hover {
+    background: color-mix(in srgb, var(--vscode-focusBorder) 10%, transparent);
+}
+
+.inspection-tree-action-btn {
+    align-items: center;
+    background: transparent;
+    border: 1px solid color-mix(in srgb, var(--card-border) 70%, transparent);
+    border-radius: 3px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    display: inline-flex;
+    font-size: calc(var(--vscode-font-size) - 3px);
+    gap: 4px;
+    padding: 1px 6px;
+}
+
+.inspection-tree-action-btn:hover {
+    background: color-mix(in srgb, var(--card-border) 20%, transparent);
+    color: var(--text-primary);
+}
+
+.inspection-source-link {
+    background: transparent;
+    border: none;
+    color: var(--vscode-textLink-foreground, #4f9cd9);
+    cursor: pointer;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    padding: 0;
+    text-align: left;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+}
+
+.inspection-source-link:hover {
+    color: var(--vscode-textLink-activeForeground, var(--text-primary));
+}
+
+.inspection-modifiers-more {
+    color: var(--text-secondary);
+    cursor: help;
+}
+
+.inspection-action-chips {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 2px;
+}
+
+.inspection-action-chip {
+    background: color-mix(in srgb, var(--card-border) 25%, transparent);
+    border-radius: 8px;
+    color: var(--text-primary);
+    font-size: calc(var(--vscode-font-size) - 3px);
+    padding: 0 6px;
+    white-space: nowrap;
+}
+
 /* -- Preview card ----------------------------------------------------- */
 
 .preview-card {

--- a/vscode-extension/src/test/helpers/clipboard.ts
+++ b/vscode-extension/src/test/helpers/clipboard.ts
@@ -1,0 +1,45 @@
+// Test helper — stub `navigator.clipboard.writeText` so the copy-to-
+// clipboard paths in inspectionTreeTable / inspectionPresenters can be
+// asserted against. happy-dom's `navigator` is a getter on globalThis,
+// so the property has to be poked via `Object.defineProperty` on the
+// navigator object itself rather than reassigning `globalThis.navigator`.
+
+export interface ClipboardStub {
+    /** Most recently captured text, populated when the SUT calls writeText. */
+    text: string;
+    restore(): void;
+}
+
+export function stubClipboard(): ClipboardStub {
+    const stub: ClipboardStub = {
+        text: "",
+        restore: () => {},
+    };
+    const previousDescriptor = Object.getOwnPropertyDescriptor(
+        navigator,
+        "clipboard",
+    );
+    Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        get: () => ({
+            writeText: async (t: string) => {
+                stub.text = t;
+            },
+        }),
+    });
+    stub.restore = () => {
+        if (previousDescriptor) {
+            Object.defineProperty(navigator, "clipboard", previousDescriptor);
+        } else {
+            delete (navigator as unknown as { clipboard?: unknown }).clipboard;
+        }
+    };
+    return stub;
+}
+
+/** Two-tick microtask flush — `await flushMicrotasks()` lets an `await`-chain
+ *  inside the SUT settle before the test inspects the captured state. */
+export async function flushMicrotasks(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+}

--- a/vscode-extension/src/test/inspectionPresenters.test.ts
+++ b/vscode-extension/src/test/inspectionPresenters.test.ts
@@ -1,0 +1,240 @@
+// Unit tests for the Inspection-bundle presenters (compose/semantics,
+// layout/inspector, uia/hierarchy). Verifies that each kind:
+//
+//   - returns null when its payload is missing (so the inspector falls
+//     through to the pending placeholder rather than a half-formed
+//     Report);
+//   - emits a Report whose body is the inspection tree-table;
+//   - paints an overlay layer of `data-overlay-id` boxes that the
+//     existing `LegendArrowController` can correlate with the table
+//     rows;
+//   - wires the row-action / source-link affordances (uia/hierarchy
+//     "Copy selector" and layout/inspector source-link, respectively).
+//
+// The post-`openSourceFile` path is exercised by stubbing
+// `window.acquireVsCodeApi`; the rest stays DOM-only.
+
+import * as assert from "assert";
+import {
+    getPresenter,
+    type PresenterContext,
+} from "../webview/preview/focusPresentation";
+// Side-effect import so registerInspectionPresenters has run by the time
+// the registry getter is hit, even if focusPresentation.ts's own seed
+// call hasn't fired in this test process yet.
+import "../webview/preview/inspectionPresenters";
+import type { PreviewInfo } from "../types";
+import { flushMicrotasks, stubClipboard } from "./helpers/clipboard";
+
+const baseParams: PreviewInfo["params"] = {
+    name: null,
+    device: null,
+    widthDp: 0,
+    heightDp: 0,
+    fontScale: 1.0,
+    showSystemUi: false,
+    showBackground: false,
+    backgroundColor: 0,
+    uiMode: 0,
+    locale: null,
+    group: null,
+};
+
+const samplePreview: PreviewInfo = {
+    id: "com.example.PreviewsKt.Sample",
+    functionName: "Sample",
+    className: "com.example.PreviewsKt",
+    sourceFile: "Previews.kt",
+    params: baseParams,
+    captures: [{ advanceTimeMillis: null, scroll: null, renderOutput: "x" }],
+};
+
+function ctx(data: (kind: string) => unknown): PresenterContext {
+    return {
+        card: document.createElement("div"),
+        preview: samplePreview,
+        findings: [],
+        nodes: [],
+        data,
+    };
+}
+
+describe("compose/semantics presenter", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("returns null when no payload is cached", () => {
+        const p = getPresenter("compose/semantics")!;
+        assert.strictEqual(p(ctx(() => undefined)), null);
+    });
+
+    it("renders a report with one row per semantics node and overlays bounds", () => {
+        const p = getPresenter("compose/semantics")!;
+        const payload = {
+            root: {
+                nodeId: "1",
+                boundsInRoot: "0,0,100,100",
+                label: "Sample",
+                role: "Button",
+                testTag: "submit",
+                mergeMode: "Merged",
+                clickable: true,
+                children: [
+                    {
+                        nodeId: "2",
+                        boundsInRoot: "10,10,40,40",
+                        label: "Inner",
+                    },
+                ],
+            },
+        };
+        const result = p(
+            ctx((kind) => (kind === "compose/semantics" ? payload : undefined)),
+        );
+        assert.ok(result);
+        assert.ok(result!.report);
+        const rows = result!.report!.body.querySelectorAll(
+            "tbody tr[data-legend-id]",
+        );
+        assert.strictEqual(rows.length, 2);
+        assert.strictEqual(rows[0].getAttribute("data-legend-id"), "1");
+        // Two parsed bounds → two overlay boxes.
+        const boxes = result!.overlay!.querySelectorAll("[data-overlay-id]");
+        assert.strictEqual(boxes.length, 2);
+        assert.strictEqual(boxes[0].getAttribute("data-overlay-id"), "1");
+        // Merged node lands on the warning palette.
+        assert.strictEqual(boxes[0].getAttribute("data-level"), "warning");
+    });
+});
+
+describe("layout/inspector presenter", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+        delete (window as unknown as { acquireVsCodeApi?: unknown })
+            .acquireVsCodeApi;
+    });
+
+    it("returns null when no payload is cached", () => {
+        const p = getPresenter("layout/inspector")!;
+        assert.strictEqual(p(ctx(() => undefined)), null);
+    });
+
+    it("emits a source-link button that posts openSourceFile when clicked", () => {
+        const posted: unknown[] = [];
+        (
+            window as unknown as { acquireVsCodeApi: () => unknown }
+        ).acquireVsCodeApi = () => ({
+            postMessage: (msg: unknown) => posted.push(msg),
+            getState: () => undefined,
+            setState: () => undefined,
+        });
+        const p = getPresenter("layout/inspector")!;
+        const payload = {
+            root: {
+                nodeId: "1",
+                component: "Column",
+                source: "Sample.kt:42",
+                bounds: { left: 0, top: 0, right: 100, bottom: 200 },
+                size: { width: 100, height: 200 },
+                modifiers: [
+                    { name: "padding", value: "8.dp" },
+                    { name: "fillMaxWidth" },
+                    { name: "background" },
+                    { name: "clickable" },
+                ],
+                children: [],
+            },
+        };
+        const result = p(
+            ctx((kind) => (kind === "layout/inspector" ? payload : undefined)),
+        );
+        assert.ok(result);
+        const link = result!.report!.body.querySelector<HTMLButtonElement>(
+            ".inspection-source-link",
+        )!;
+        assert.ok(link);
+        assert.strictEqual(link.textContent, "Sample.kt:42");
+        link.click();
+        assert.deepStrictEqual(posted, [
+            {
+                command: "openSourceFile",
+                fileName: "Sample.kt",
+                line: 42,
+                className: "com.example.PreviewsKt",
+            },
+        ]);
+        // Modifier-truncation chip: only the first three names inline,
+        // a `+N` chip behind a title-attribute tooltip for the rest.
+        const more = result!.report!.body.querySelector(
+            ".inspection-modifiers-more",
+        )!;
+        assert.ok(more);
+        assert.match(more.textContent ?? "", /^\s*\+1/);
+    });
+});
+
+describe("uia/hierarchy presenter", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("returns an empty-state report when the payload has no nodes", () => {
+        const p = getPresenter("uia/hierarchy")!;
+        const result = p(
+            ctx((kind) =>
+                kind === "uia/hierarchy" ? { nodes: [] } : undefined,
+            ),
+        );
+        assert.ok(result);
+        assert.ok(result!.report);
+        assert.strictEqual(result!.report!.summary, "No actionable nodes");
+        assert.strictEqual(result!.overlay, undefined);
+    });
+
+    it("paints one row per node and exposes the Copy selector action", async () => {
+        const p = getPresenter("uia/hierarchy")!;
+        const payload = {
+            nodes: [
+                {
+                    text: "Submit",
+                    testTag: "submit",
+                    boundsInScreen: "0,0,100,40",
+                    actions: ["click"],
+                },
+                {
+                    text: "Cancel",
+                    testTag: "cancel",
+                    boundsInScreen: "0,40,100,80",
+                    actions: ["click"],
+                },
+            ],
+        };
+        const captured = stubClipboard();
+        try {
+            const result = p(
+                ctx((kind) => (kind === "uia/hierarchy" ? payload : undefined)),
+            );
+            assert.ok(result);
+            const rows = result!.report!.body.querySelectorAll(
+                "tbody tr[data-legend-id]",
+            );
+            assert.strictEqual(rows.length, 2);
+            const actBtn = rows[0].querySelector<HTMLButtonElement>(
+                ".inspection-tree-action-btn",
+            )!;
+            actBtn.click();
+            await flushMicrotasks();
+            assert.strictEqual(captured.text, 'By.testTag("submit")');
+            const boxes =
+                result!.overlay!.querySelectorAll("[data-overlay-id]");
+            assert.strictEqual(boxes.length, 2);
+            assert.strictEqual(
+                boxes[0].getAttribute("data-overlay-id"),
+                "uia-0",
+            );
+        } finally {
+            captured.restore();
+        }
+    });
+});

--- a/vscode-extension/src/test/inspectionTreeTable.test.ts
+++ b/vscode-extension/src/test/inspectionTreeTable.test.ts
@@ -1,0 +1,175 @@
+// Unit tests for the inspection-bundle tree-table primitive. Verifies
+// row expand/collapse, hover-correlation hooks (data-legend-id /
+// data-has-overlay), the Copy JSON button, and the per-row action.
+
+import * as assert from "assert";
+import {
+    buildInspectionTreeTable,
+    stringify,
+    type TreeColumn,
+    type TreeTableNode,
+} from "../webview/preview/inspectionTreeTable";
+import { flushMicrotasks, stubClipboard } from "./helpers/clipboard";
+
+interface Row {
+    name: string;
+    bounds?: string;
+    children?: Row[];
+}
+
+const COLS: TreeColumn<Row>[] = [
+    { id: "name", label: "Name", render: (r) => r.name },
+    { id: "bounds", label: "Bounds", render: (r) => r.bounds ?? "—" },
+];
+
+describe("inspectionTreeTable", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("renders a flat tree with one row per node", () => {
+        const rows: TreeTableNode<Row>[] = [
+            { id: "a", data: { name: "A" } },
+            { id: "b", data: { name: "B" } },
+        ];
+        const el = buildInspectionTreeTable({
+            title: "Test",
+            columns: COLS,
+            rows,
+        });
+        document.body.appendChild(el);
+        const trs = el.querySelectorAll("tbody tr");
+        assert.strictEqual(trs.length, 2);
+        assert.strictEqual(trs[0].getAttribute("data-legend-id"), "a");
+        assert.strictEqual(trs[1].getAttribute("data-legend-id"), "b");
+    });
+
+    it("recurses children and indents by depth", () => {
+        const rows: TreeTableNode<Row>[] = [
+            {
+                id: "a",
+                data: { name: "A" },
+                children: [{ id: "a-1", data: { name: "A1" } }],
+            },
+        ];
+        const el = buildInspectionTreeTable({
+            title: "Test",
+            columns: COLS,
+            rows,
+        });
+        const trs = el.querySelectorAll("tbody tr");
+        assert.strictEqual(trs.length, 2);
+        assert.strictEqual(trs[0].getAttribute("data-depth"), "0");
+        assert.strictEqual(trs[1].getAttribute("data-depth"), "1");
+    });
+
+    it("collapses children when the expander is clicked", () => {
+        const rows: TreeTableNode<Row>[] = [
+            {
+                id: "a",
+                data: { name: "A" },
+                children: [{ id: "a-1", data: { name: "A1" } }],
+            },
+        ];
+        const el = buildInspectionTreeTable({
+            title: "Test",
+            columns: COLS,
+            rows,
+        });
+        document.body.appendChild(el);
+        const childRow = el.querySelector<HTMLElement>(
+            "tbody tr[data-legend-id='a-1']",
+        )!;
+        assert.strictEqual(childRow.hidden, false);
+        const expander = el.querySelector<HTMLButtonElement>(
+            ".inspection-tree-expand",
+        )!;
+        expander.click();
+        assert.strictEqual(childRow.hidden, true);
+        assert.strictEqual(expander.getAttribute("aria-expanded"), "false");
+        expander.click();
+        assert.strictEqual(childRow.hidden, false);
+        assert.strictEqual(expander.getAttribute("aria-expanded"), "true");
+    });
+
+    it("respects defaultExpandDepth=0 (root rows visible, children hidden)", () => {
+        const rows: TreeTableNode<Row>[] = [
+            {
+                id: "a",
+                data: { name: "A" },
+                children: [{ id: "a-1", data: { name: "A1" } }],
+            },
+        ];
+        const el = buildInspectionTreeTable({
+            title: "Test",
+            columns: COLS,
+            rows,
+            defaultExpandDepth: 0,
+        });
+        const childRow = el.querySelector<HTMLElement>(
+            "tbody tr[data-legend-id='a-1']",
+        )!;
+        assert.strictEqual(childRow.hidden, true);
+    });
+
+    it("stamps data-has-overlay when hasOverlayFor returns true", () => {
+        const rows: TreeTableNode<Row>[] = [
+            { id: "a", data: { name: "A", bounds: "0,0,10,10" } },
+            { id: "b", data: { name: "B" } },
+        ];
+        const el = buildInspectionTreeTable({
+            title: "Test",
+            columns: COLS,
+            rows,
+            hasOverlayFor: (r) => !!r.bounds,
+        });
+        const a = el.querySelector("tbody tr[data-legend-id='a']")!;
+        const b = el.querySelector("tbody tr[data-legend-id='b']")!;
+        assert.strictEqual(a.getAttribute("data-has-overlay"), "true");
+        assert.strictEqual(b.getAttribute("data-has-overlay"), null);
+    });
+
+    it("renders Copy JSON button that copies stringify(jsonForCopy())", async () => {
+        const payload = { foo: { bar: [1, 2, 3] } };
+        const captured = stubClipboard();
+        try {
+            const el = buildInspectionTreeTable({
+                title: "Test",
+                columns: COLS,
+                rows: [{ id: "a", data: { name: "A" } }],
+                jsonForCopy: () => payload,
+            });
+            document.body.appendChild(el);
+            const copyBtn = el.querySelector<HTMLButtonElement>(
+                ".inspection-tree-copy-json",
+            )!;
+            copyBtn.click();
+            await flushMicrotasks();
+            assert.strictEqual(captured.text, stringify(payload));
+        } finally {
+            captured.restore();
+        }
+    });
+
+    it("fires the row action with the row's data when clicked", () => {
+        let actionRow: Row | null = null;
+        const rows: TreeTableNode<Row>[] = [{ id: "a", data: { name: "A" } }];
+        const el = buildInspectionTreeTable({
+            title: "Test",
+            columns: COLS,
+            rows,
+            rowAction: {
+                icon: "copy",
+                label: "Copy",
+                onClick: (r) => {
+                    actionRow = r;
+                },
+            },
+        });
+        const btn = el.querySelector<HTMLButtonElement>(
+            ".inspection-tree-action-btn",
+        )!;
+        btn.click();
+        assert.deepStrictEqual(actionRow, { name: "A" });
+    });
+});

--- a/vscode-extension/src/test/uiaSelector.test.ts
+++ b/vscode-extension/src/test/uiaSelector.test.ts
@@ -1,0 +1,97 @@
+// Unit tests for the UI-Automator selector-snippet builder.
+// Lockstep mirror of `HierarchySelectorBuilderTest.kt`.
+
+import * as assert from "assert";
+import {
+    buildSelectorSnippet,
+    type UiaHierarchyNodeLite,
+} from "../webview/preview/uiaSelector";
+
+function node(overrides: Partial<UiaHierarchyNodeLite>): UiaHierarchyNodeLite {
+    return {
+        text: null,
+        contentDescription: null,
+        testTag: null,
+        testTagAncestors: [],
+        role: null,
+        ...overrides,
+    };
+}
+
+describe("uiaSelector.buildSelectorSnippet", () => {
+    it("prefers a unique testTag", () => {
+        const target = node({ testTag: "submit", text: "Submit" });
+        const nodes = [target, node({ testTag: "cancel", text: "Cancel" })];
+        assert.strictEqual(
+            buildSelectorSnippet(target, nodes),
+            'By.testTag("submit")',
+        );
+    });
+
+    it("falls back to text when testTag is missing", () => {
+        const target = node({ text: "Submit" });
+        const nodes = [target, node({ text: "Cancel" })];
+        assert.strictEqual(
+            buildSelectorSnippet(target, nodes),
+            'By.text("Submit")',
+        );
+    });
+
+    it("falls back to contentDescription as last single-axis option", () => {
+        const target = node({ contentDescription: "Submit form" });
+        const nodes = [target, node({ contentDescription: "Cancel form" })];
+        assert.strictEqual(
+            buildSelectorSnippet(target, nodes),
+            'By.desc("Submit form")',
+        );
+    });
+
+    it("chains nearest disambiguating ancestor when the anchor is non-unique", () => {
+        const a = node({
+            text: "Item",
+            testTagAncestors: ["screen", "list-A"],
+        });
+        const b = node({
+            text: "Item",
+            testTagAncestors: ["screen", "list-B"],
+        });
+        assert.strictEqual(
+            buildSelectorSnippet(a, [a, b]),
+            'By.text("Item").hasParent(By.testTag("list-A"))',
+        );
+    });
+
+    it("skips blank ancestor entries during the walk", () => {
+        const a = node({
+            text: "Item",
+            testTagAncestors: ["screen", "", "list-A"],
+        });
+        const b = node({
+            text: "Item",
+            testTagAncestors: ["screen", "", "list-B"],
+        });
+        assert.strictEqual(
+            buildSelectorSnippet(a, [a, b]),
+            'By.text("Item").hasParent(By.testTag("list-A"))',
+        );
+    });
+
+    it("returns null when every axis is blank", () => {
+        const target = node({});
+        assert.strictEqual(buildSelectorSnippet(target, [target]), null);
+    });
+
+    it("returns bare anchor when no ancestor disambiguates", () => {
+        const a = node({ text: "Item" });
+        const b = node({ text: "Item" });
+        assert.strictEqual(buildSelectorSnippet(a, [a, b]), 'By.text("Item")');
+    });
+
+    it("escapes quotes / newlines in the rendered snippet", () => {
+        const target = node({ text: 'Line 1\nLine 2 with "quotes"' });
+        assert.strictEqual(
+            buildSelectorSnippet(target, [target]),
+            'By.text("Line 1\\nLine 2 with \\"quotes\\"")',
+        );
+    });
+});

--- a/vscode-extension/src/webview/preview/focusPresentation.ts
+++ b/vscode-extension/src/webview/preview/focusPresentation.ts
@@ -38,6 +38,7 @@ import type {
     AccessibilityNode,
     PreviewInfo,
 } from "../shared/types";
+import { registerInspectionPresenters } from "./inspectionPresenters";
 
 export interface PresenterContext {
     /** The focused card element. Presenters that produce overlays
@@ -155,6 +156,13 @@ function seedBuiltInPresenters(): void {
     registerPresenter("a11y/overlay", a11yOverlayPresenter);
     registerPresenter("compose/theme", composeThemePresenter);
     registerPresenter("local/render/error", renderErrorPresenter);
+    // Inspection bundle (#1059) — side-effect import that calls
+    // `registerPresenter` for `compose/semantics`, `layout/inspector`,
+    // and `uia/hierarchy`. Re-running the seed after
+    // `_resetPresentersForTest` needs to reseed those too, so we call
+    // back into the module's idempotent `registerInspectionPresenters`
+    // here rather than relying on the top-level side effect.
+    registerInspectionPresenters();
 }
 
 seedBuiltInPresenters();

--- a/vscode-extension/src/webview/preview/inspectionPresenters.ts
+++ b/vscode-extension/src/webview/preview/inspectionPresenters.ts
@@ -1,0 +1,546 @@
+// Presenters for the Inspection-bundle data kinds — issue #1059.
+//
+//   - `compose/semantics`   — cheap SemanticsNode projection (testTag,
+//                             role, mergeMode, bounds, clickable).
+//   - `layout/inspector`    — full layout hierarchy with bounds,
+//                             constraints, modifiers, source refs.
+//   - `uia/hierarchy`       — UI Automator-shaped semantics nodes with
+//                             supported-action chips and a row-action
+//                             "Copy as selector".
+//
+// All three share the `buildInspectionTreeTable` primitive: a tree view
+// with collapsible rows, hover → overlay correlation via
+// `data-legend-id` / `data-overlay-id`, and a header "Copy JSON"
+// button. Each presenter narrows the column shape to what its payload
+// carries and paints its own overlay layer of `data-overlay-id` boxes
+// for the focus inspector to slot into the card's overlay stack.
+//
+// Side-effect import: the presenter functions register themselves via
+// `registerPresenter` at module load. `focusPresentation.ts` imports
+// this module from `seedBuiltInPresenters` so the registrations land
+// alongside the existing built-ins.
+
+import {
+    buildInspectionTreeTable,
+    stringify,
+    type TreeColumn,
+    type TreeTableNode,
+} from "./inspectionTreeTable";
+import {
+    registerPresenter,
+    type PresenterContext,
+    type ProductPresentation,
+} from "./focusPresentation";
+import { getVsCodeApi } from "../shared/vscode";
+import { buildSelectorSnippet } from "./uiaSelector";
+
+// ---- compose/semantics --------------------------------------------------
+
+interface ComposeSemanticsNode {
+    nodeId: string;
+    boundsInRoot: string;
+    label?: string | null;
+    text?: string | null;
+    role?: string | null;
+    testTag?: string | null;
+    mergeMode?: string | null;
+    clickable?: boolean;
+    children?: ComposeSemanticsNode[];
+}
+
+interface ComposeSemanticsPayload {
+    root: ComposeSemanticsNode;
+}
+
+function composeSemanticsPresenter(
+    ctx: PresenterContext,
+): ProductPresentation | null {
+    const payload = ctx.data?.("compose/semantics") as
+        | ComposeSemanticsPayload
+        | undefined;
+    if (!payload || !payload.root) return null;
+
+    const flat = flattenSemantics(payload.root);
+    const overlay = buildBoundsOverlay(
+        flat.map((entry) => ({
+            id: entry.id,
+            bounds: parseBounds(entry.node.boundsInRoot),
+            level: entry.node.mergeMode === "Merged" ? "warning" : "info",
+        })),
+    );
+
+    const columns: TreeColumn<ComposeSemanticsNode>[] = [
+        {
+            id: "label",
+            label: "Label",
+            render: (n) => n.label ?? n.text ?? "—",
+        },
+        { id: "role", label: "Role", render: (n) => n.role ?? "—" },
+        { id: "testTag", label: "Tag", render: (n) => n.testTag ?? "—" },
+        { id: "mergeMode", label: "Merge", render: (n) => n.mergeMode ?? "—" },
+        {
+            id: "clickable",
+            label: "Clickable",
+            render: (n) => (n.clickable ? "✓" : ""),
+        },
+    ];
+
+    const rows = [toTreeNode(payload.root, (n) => n.nodeId)];
+
+    const body = buildInspectionTreeTable<ComposeSemanticsNode>({
+        title: "Compose semantics",
+        summary: flat.length + " node" + (flat.length === 1 ? "" : "s"),
+        columns,
+        rows,
+        hasOverlayFor: (n) => parseBounds(n.boundsInRoot) !== null,
+        jsonForCopy: () => payload,
+    });
+
+    return {
+        overlay: overlay.boxCount > 0 ? overlay.el : null,
+        report: {
+            title: "Compose semantics",
+            summary: flat.length + " node" + (flat.length === 1 ? "" : "s"),
+            body,
+        },
+    };
+}
+
+// ---- layout/inspector ---------------------------------------------------
+
+interface LayoutInspectorBounds {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+}
+
+interface LayoutInspectorModifier {
+    name: string;
+    value?: string | null;
+    properties?: Record<string, string>;
+}
+
+interface LayoutInspectorNode {
+    nodeId: string;
+    component: string;
+    source?: string | null;
+    sourceInfo?: string | null;
+    bounds: LayoutInspectorBounds;
+    size?: { width: number; height: number };
+    constraints?: {
+        minWidth: number;
+        maxWidth?: number | null;
+        minHeight: number;
+        maxHeight?: number | null;
+    } | null;
+    modifiers?: LayoutInspectorModifier[];
+    children?: LayoutInspectorNode[];
+}
+
+interface LayoutInspectorPayload {
+    root: LayoutInspectorNode;
+}
+
+function layoutInspectorPresenter(
+    ctx: PresenterContext,
+): ProductPresentation | null {
+    const payload = ctx.data?.("layout/inspector") as
+        | LayoutInspectorPayload
+        | undefined;
+    if (!payload || !payload.root) return null;
+
+    const flat = flattenLayout(payload.root);
+    const overlay = buildBoundsOverlay(
+        flat.map((entry) => ({
+            id: entry.id,
+            bounds: entry.node.bounds,
+            level: "info",
+        })),
+    );
+
+    const className = ctx.preview.className;
+
+    const columns: TreeColumn<LayoutInspectorNode>[] = [
+        { id: "component", label: "Component", render: (n) => n.component },
+        {
+            id: "size",
+            label: "Size",
+            render: (n) => (n.size ? `${n.size.width}×${n.size.height}` : "—"),
+        },
+        {
+            id: "modifiers",
+            label: "Modifiers",
+            render: (n) => renderModifiers(n.modifiers ?? []),
+        },
+        {
+            id: "source",
+            label: "Source",
+            render: (n) => renderSourceLink(n.source, className),
+        },
+    ];
+
+    const rows = [toTreeNode(payload.root, (n) => n.nodeId)];
+
+    const body = buildInspectionTreeTable<LayoutInspectorNode>({
+        title: "Layout inspector",
+        summary: flat.length + " node" + (flat.length === 1 ? "" : "s"),
+        columns,
+        rows,
+        hasOverlayFor: () => true,
+        jsonForCopy: () => payload,
+    });
+
+    return {
+        overlay: overlay.boxCount > 0 ? overlay.el : null,
+        report: {
+            title: "Layout inspector",
+            summary: flat.length + " node" + (flat.length === 1 ? "" : "s"),
+            body,
+        },
+    };
+}
+
+// ---- uia/hierarchy ------------------------------------------------------
+
+interface UiaHierarchyNode {
+    text?: string | null;
+    contentDescription?: string | null;
+    testTag?: string | null;
+    testTagAncestors?: string[];
+    role?: string | null;
+    actions?: string[];
+    boundsInScreen: string;
+    merged?: boolean;
+}
+
+interface UiaHierarchyPayload {
+    nodes: UiaHierarchyNode[];
+}
+
+function uiaHierarchyPresenter(
+    ctx: PresenterContext,
+): ProductPresentation | null {
+    const payload = ctx.data?.("uia/hierarchy") as
+        | UiaHierarchyPayload
+        | undefined;
+    if (!payload || !Array.isArray(payload.nodes)) return null;
+
+    const nodes = payload.nodes;
+    if (nodes.length === 0) {
+        const empty = document.createElement("div");
+        empty.className = "focus-report-empty";
+        empty.textContent =
+            "No actionable semantics nodes in this preview. The UI Automator " +
+            "hierarchy filters out pure-layout / non-interactive nodes by default.";
+        return {
+            report: {
+                title: "UI Automator hierarchy",
+                summary: "No actionable nodes",
+                body: empty,
+            },
+        };
+    }
+
+    // The wire payload is flat — no children — so each node lands as a
+    // top-level row. Build an id from the array index so legend ↔
+    // overlay correlation has something stable; the payload itself
+    // doesn't carry one.
+    const rows: TreeTableNode<UiaHierarchyNode>[] = nodes.map((n, idx) => ({
+        id: "uia-" + idx,
+        data: n,
+    }));
+
+    const overlay = buildBoundsOverlay(
+        rows.map((r) => ({
+            id: r.id,
+            bounds: parseBounds(r.data.boundsInScreen),
+            level: "info",
+        })),
+    );
+
+    const columns: TreeColumn<UiaHierarchyNode>[] = [
+        { id: "text", label: "Text", render: (n) => n.text ?? "—" },
+        {
+            id: "contentDescription",
+            label: "Description",
+            render: (n) => n.contentDescription ?? "—",
+        },
+        { id: "testTag", label: "Tag", render: (n) => n.testTag ?? "—" },
+        { id: "role", label: "Role", render: (n) => n.role ?? "—" },
+        {
+            id: "actions",
+            label: "Actions",
+            render: (n) => renderActionChips(n.actions ?? []),
+        },
+    ];
+
+    const body = buildInspectionTreeTable<UiaHierarchyNode>({
+        title: "UI Automator hierarchy",
+        summary: nodes.length + " node" + (nodes.length === 1 ? "" : "s"),
+        columns,
+        rows,
+        hasOverlayFor: (n) => parseBounds(n.boundsInScreen) !== null,
+        jsonForCopy: () => payload,
+        rowAction: {
+            icon: "copy",
+            label: "Selector",
+            title: "Copy as By.testTag(...) selector",
+            onClick: (n) => {
+                const snippet = buildSelectorSnippet(n, nodes);
+                if (snippet) {
+                    void writeClipboard(snippet);
+                }
+            },
+        },
+    });
+
+    return {
+        overlay: overlay.boxCount > 0 ? overlay.el : null,
+        report: {
+            title: "UI Automator hierarchy",
+            summary: nodes.length + " node" + (nodes.length === 1 ? "" : "s"),
+            body,
+        },
+    };
+}
+
+// ---- registration -------------------------------------------------------
+
+/**
+ * Register the three Inspection-bundle presenters. Called by
+ * `focusPresentation.seedBuiltInPresenters` once the registry is ready
+ * (and again by `_seedBuiltInPresentersForTest`), so we don't fire on
+ * module load — that path would hit the circular import in TDZ before
+ * the registry `const` is initialised.
+ */
+export function registerInspectionPresenters(): void {
+    registerPresenter("compose/semantics", composeSemanticsPresenter);
+    registerPresenter("layout/inspector", layoutInspectorPresenter);
+    registerPresenter("uia/hierarchy", uiaHierarchyPresenter);
+}
+
+// ---- helpers ------------------------------------------------------------
+
+function toTreeNode<T extends { children?: T[] }>(
+    node: T,
+    idOf: (n: T) => string,
+): TreeTableNode<T> {
+    return {
+        id: idOf(node),
+        data: node,
+        children: (node.children ?? []).map((c) => toTreeNode(c, idOf)),
+    };
+}
+
+interface FlatEntry<T> {
+    id: string;
+    node: T;
+}
+
+function flattenSemantics(
+    root: ComposeSemanticsNode,
+    out: FlatEntry<ComposeSemanticsNode>[] = [],
+): FlatEntry<ComposeSemanticsNode>[] {
+    out.push({ id: root.nodeId, node: root });
+    for (const child of root.children ?? []) {
+        flattenSemantics(child, out);
+    }
+    return out;
+}
+
+function flattenLayout(
+    root: LayoutInspectorNode,
+    out: FlatEntry<LayoutInspectorNode>[] = [],
+): FlatEntry<LayoutInspectorNode>[] {
+    out.push({ id: root.nodeId, node: root });
+    for (const child of root.children ?? []) {
+        flattenLayout(child, out);
+    }
+    return out;
+}
+
+interface OverlayEntry {
+    id: string;
+    bounds:
+        | {
+              left: number;
+              top: number;
+              right: number;
+              bottom: number;
+          }
+        | null
+        | undefined;
+    level: "info" | "warning";
+}
+
+function buildBoundsOverlay(entries: readonly OverlayEntry[]): {
+    el: HTMLElement;
+    boxCount: number;
+} {
+    const el = document.createElement("div");
+    el.className = "focus-presentation-overlay focus-overlay-inspection";
+    let boxCount = 0;
+    for (const entry of entries) {
+        if (!entry.bounds) continue;
+        const box = document.createElement("div");
+        box.className = "focus-overlay-box";
+        box.dataset.overlayId = entry.id;
+        box.dataset.level = entry.level;
+        box.style.left = entry.bounds.left + "px";
+        box.style.top = entry.bounds.top + "px";
+        box.style.width = entry.bounds.right - entry.bounds.left + "px";
+        box.style.height = entry.bounds.bottom - entry.bounds.top + "px";
+        el.appendChild(box);
+        boxCount += 1;
+    }
+    return { el, boxCount };
+}
+
+function parseBounds(
+    s: string | null | undefined,
+): { left: number; top: number; right: number; bottom: number } | null {
+    if (!s) return null;
+    const parts = s.split(",").map((x) => parseInt(x.trim(), 10));
+    if (parts.length !== 4 || parts.some(Number.isNaN)) return null;
+    return {
+        left: parts[0],
+        top: parts[1],
+        right: parts[2],
+        bottom: parts[3],
+    };
+}
+
+function renderModifiers(
+    mods: readonly LayoutInspectorModifier[],
+): HTMLElement {
+    const span = document.createElement("span");
+    span.className = "inspection-modifiers";
+    if (mods.length === 0) {
+        span.textContent = "—";
+        return span;
+    }
+    // Show the first three names inline; if there are more, append a
+    // `+N` chip whose `title` is the full list. Truncation here is the
+    // norm — the daemon's layout/inspector typically emits 5–20
+    // modifiers per node and the row would otherwise blow out the
+    // column width.
+    const head = mods
+        .slice(0, 3)
+        .map((m) => m.name)
+        .join(" · ");
+    span.textContent = head;
+    if (mods.length > 3) {
+        const more = document.createElement("span");
+        more.className = "inspection-modifiers-more";
+        more.textContent = " +" + (mods.length - 3);
+        more.title = mods.map((m) => formatModifier(m)).join("\n");
+        span.appendChild(more);
+    }
+    return span;
+}
+
+function formatModifier(m: LayoutInspectorModifier): string {
+    if (m.value) return `${m.name}(${m.value})`;
+    const props = m.properties ?? {};
+    const keys = Object.keys(props);
+    if (keys.length === 0) return m.name;
+    return `${m.name}(${keys.map((k) => `${k}=${props[k]}`).join(", ")})`;
+}
+
+function renderSourceLink(
+    source: string | null | undefined,
+    className: string,
+): HTMLElement {
+    const span = document.createElement("span");
+    if (!source) {
+        span.textContent = "—";
+        return span;
+    }
+    const { file, line } = splitSource(source);
+    if (!file) {
+        span.textContent = source;
+        return span;
+    }
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "inspection-source-link";
+    btn.title = `Open ${source}`;
+    btn.textContent = source;
+    btn.addEventListener("click", (ev) => {
+        ev.stopPropagation();
+        try {
+            const api = getVsCodeApi();
+            api.postMessage({
+                command: "openSourceFile",
+                fileName: file,
+                line,
+                className,
+            });
+        } catch {
+            // No vscode handle (test env) — silently do nothing. The
+            // button still focuses, which is enough for keyboard
+            // testing without DOM-mocking the postMessage path.
+        }
+    });
+    span.appendChild(btn);
+    return span;
+}
+
+function splitSource(source: string): { file: string | null; line: number } {
+    // Layout-inspector source is "Foo.kt:42". `file` is the basename
+    // (matches the stack-trace fileName the existing `openSourceFile`
+    // handler expects); line is 1-based.
+    const idx = source.lastIndexOf(":");
+    if (idx < 0) return { file: source, line: 0 };
+    const file = source.slice(0, idx);
+    const line = parseInt(source.slice(idx + 1), 10);
+    if (Number.isNaN(line)) return { file: source, line: 0 };
+    return { file, line };
+}
+
+function renderActionChips(actions: readonly string[]): HTMLElement {
+    const span = document.createElement("span");
+    span.className = "inspection-action-chips";
+    if (actions.length === 0) {
+        span.textContent = "—";
+        return span;
+    }
+    for (const a of actions) {
+        const chip = document.createElement("span");
+        chip.className = "inspection-action-chip";
+        chip.dataset.action = a;
+        chip.textContent = a;
+        span.appendChild(chip);
+    }
+    return span;
+}
+
+async function writeClipboard(text: string): Promise<void> {
+    try {
+        const nav = (globalThis as { navigator?: Navigator }).navigator;
+        if (nav?.clipboard?.writeText) {
+            await nav.clipboard.writeText(text);
+            return;
+        }
+    } catch {
+        // fall through
+    }
+    try {
+        const ta = document.createElement("textarea");
+        ta.value = text;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+    } catch {
+        // give up
+    }
+}
+
+// `stringify` is re-exported so external callers (e.g. integration
+// tests) can format the same way the Copy JSON button does without
+// pulling in `JSON.stringify` defaults.
+export { stringify };

--- a/vscode-extension/src/webview/preview/inspectionTreeTable.ts
+++ b/vscode-extension/src/webview/preview/inspectionTreeTable.ts
@@ -1,0 +1,319 @@
+// Tree-table primitive used by the Inspection-bundle presenters
+// (`compose/semantics`, `layout/inspector`, `uia/hierarchy`).
+//
+// Each kind in the bundle is hierarchical (a semantics tree, a layout
+// tree, a filtered semantics-actionable subtree), and the differences
+// across kinds are only in the column shape: presenter declares the
+// columns, the primitive owns the rest — row expand/collapse, header
+// "Copy JSON" button, hover → overlay correlation via `data-legend-id`
+// (matched against `data-overlay-id` boxes by `LegendArrowController`,
+// the same wiring the a11y-hierarchy presenter uses), and the optional
+// per-row action chip (the `uia/hierarchy` presenter wires
+// "Copy selector" through it).
+//
+// Light DOM only — the inspector's CSS targets descendants by class.
+
+export interface TreeColumn<T> {
+    /** Stable id; lands on the column header / cell as `data-col`. */
+    id: string;
+    /** Header text. */
+    label: string;
+    /**
+     * Render the cell body. Returning a string emits a plain text node;
+     * returning an element gives the presenter full control (icons,
+     * truncation tooltips, the layout-inspector source-link button).
+     */
+    render(node: T): HTMLElement | string;
+    /** Optional extra class on the cell `<td>`. */
+    className?: string;
+}
+
+export interface TreeTableNode<T> {
+    /**
+     * Stable id used as `data-legend-id` on the row and as the
+     * matching `data-overlay-id` on overlay boxes the presenter
+     * paints separately. Must be unique within a tree.
+     */
+    id: string;
+    data: T;
+    children?: readonly TreeTableNode<T>[];
+}
+
+export interface TreeRowAction<T> {
+    icon: string;
+    label: string;
+    title?: string;
+    onClick(node: T, row: HTMLElement): void;
+}
+
+export interface TreeTableOptions<T> {
+    /** Block header, shown in the Report `<details>` summary by the inspector. */
+    title: string;
+    /** Optional one-liner shown next to the title. */
+    summary?: string;
+    columns: readonly TreeColumn<T>[];
+    /** Top-level rows. Each row recurses through `children`. */
+    rows: readonly TreeTableNode<T>[];
+    /**
+     * Payload to copy when the user clicks the header "Copy JSON" button.
+     * Returns the value to stringify; called lazily on click so the
+     * presenter can avoid eager serialisation on every render.
+     */
+    jsonForCopy?: () => unknown;
+    /**
+     * When defined, rows whose data has bounds shown as
+     * `data-has-overlay="true"` so CSS can paint an overlay handle. The
+     * actual overlay boxes are produced by the presenter (`overlay`
+     * surface in `ProductPresentation`) — this is just the visual cue.
+     */
+    hasOverlayFor?(node: T): boolean;
+    /**
+     * Optional per-row action — emitted as a button at the end of the
+     * row. Used by `uia/hierarchy` for "Copy as selector".
+     */
+    rowAction?: TreeRowAction<T>;
+    /** Default-expand to this depth. `-1` (default) means all open. */
+    defaultExpandDepth?: number;
+}
+
+/**
+ * Build the tree-table DOM. The returned element is meant to be slotted
+ * into a `PresentationReport.body`; presenters wrap it in their own
+ * `<details>` via the inspector's report surface.
+ */
+export function buildInspectionTreeTable<T>(
+    opts: TreeTableOptions<T>,
+): HTMLElement {
+    const container = document.createElement("div");
+    container.className = "inspection-tree";
+
+    const head = document.createElement("div");
+    head.className = "inspection-tree-head";
+    if (opts.summary) {
+        const sum = document.createElement("span");
+        sum.className = "inspection-tree-summary";
+        sum.textContent = opts.summary;
+        head.appendChild(sum);
+    }
+    if (opts.jsonForCopy) {
+        const copy = document.createElement("button");
+        copy.type = "button";
+        copy.className = "inspection-tree-copy-json";
+        copy.innerHTML =
+            '<i class="codicon codicon-json" aria-hidden="true"></i>';
+        const lab = document.createElement("span");
+        lab.textContent = "Copy JSON";
+        copy.appendChild(lab);
+        copy.title = "Copy the union of enabled kinds as JSON";
+        copy.addEventListener("click", () => {
+            const payload = opts.jsonForCopy!();
+            void copyToClipboard(stringify(payload));
+        });
+        head.appendChild(copy);
+    }
+    container.appendChild(head);
+
+    const table = document.createElement("table");
+    table.className = "inspection-tree-table";
+    const thead = document.createElement("thead");
+    const headerRow = document.createElement("tr");
+    const expanderHead = document.createElement("th");
+    expanderHead.className = "inspection-tree-expander-col";
+    expanderHead.setAttribute("aria-hidden", "true");
+    headerRow.appendChild(expanderHead);
+    for (const col of opts.columns) {
+        const th = document.createElement("th");
+        th.dataset.col = col.id;
+        if (col.className) th.classList.add(col.className);
+        th.textContent = col.label;
+        headerRow.appendChild(th);
+    }
+    if (opts.rowAction) {
+        const actionTh = document.createElement("th");
+        actionTh.className = "inspection-tree-action-col";
+        actionTh.setAttribute("aria-hidden", "true");
+        headerRow.appendChild(actionTh);
+    }
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    const tbody = document.createElement("tbody");
+    const expandDepth = opts.defaultExpandDepth ?? -1;
+    for (const node of opts.rows) {
+        appendRow(tbody, node, 0, expandDepth, opts);
+    }
+    table.appendChild(tbody);
+    container.appendChild(table);
+    return container;
+}
+
+function appendRow<T>(
+    tbody: HTMLElement,
+    node: TreeTableNode<T>,
+    depth: number,
+    expandDepth: number,
+    opts: TreeTableOptions<T>,
+): void {
+    const tr = document.createElement("tr");
+    tr.dataset.legendId = node.id;
+    tr.dataset.depth = String(depth);
+    if (opts.hasOverlayFor?.(node.data)) {
+        tr.dataset.hasOverlay = "true";
+    }
+    tr.tabIndex = 0;
+
+    const expanderTd = document.createElement("td");
+    expanderTd.className = "inspection-tree-expander";
+    const hasChildren = (node.children?.length ?? 0) > 0;
+    // Indent based on depth so nested rows visibly nest even though
+    // they live as siblings in the flat tbody — same trick the VS Code
+    // tree-view uses.
+    expanderTd.style.paddingLeft = depth * 16 + "px";
+    if (hasChildren) {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "inspection-tree-expand";
+        btn.setAttribute("aria-expanded", "false");
+        const icon = document.createElement("i");
+        icon.className = "codicon codicon-chevron-right";
+        icon.setAttribute("aria-hidden", "true");
+        btn.appendChild(icon);
+        expanderTd.appendChild(btn);
+        // Click is wired below once we've appended the child rows so
+        // we know what to toggle.
+    }
+    tr.appendChild(expanderTd);
+
+    for (const col of opts.columns) {
+        const td = document.createElement("td");
+        td.dataset.col = col.id;
+        if (col.className) td.classList.add(col.className);
+        const content = col.render(node.data);
+        if (typeof content === "string") {
+            td.textContent = content;
+        } else {
+            td.appendChild(content);
+        }
+        tr.appendChild(td);
+    }
+
+    if (opts.rowAction) {
+        const actTd = document.createElement("td");
+        actTd.className = "inspection-tree-action";
+        const action = opts.rowAction;
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "inspection-tree-action-btn";
+        btn.title = action.title ?? action.label;
+        btn.innerHTML =
+            '<i class="codicon codicon-' +
+            action.icon +
+            '" aria-hidden="true"></i>';
+        const lab = document.createElement("span");
+        lab.textContent = action.label;
+        btn.appendChild(lab);
+        btn.addEventListener("click", (ev) => {
+            ev.stopPropagation();
+            action.onClick(node.data, tr);
+        });
+        actTd.appendChild(btn);
+        tr.appendChild(actTd);
+    }
+
+    tbody.appendChild(tr);
+
+    if (!hasChildren) {
+        return;
+    }
+
+    const childRowStart = tbody.children.length;
+    for (const child of node.children!) {
+        appendRow(tbody, child, depth + 1, expandDepth, opts);
+    }
+    const childRowEnd = tbody.children.length;
+    const childRows: HTMLElement[] = [];
+    for (let i = childRowStart; i < childRowEnd; i++) {
+        childRows.push(tbody.children[i] as HTMLElement);
+    }
+    const initiallyOpen = expandDepth < 0 || depth < expandDepth;
+    setExpanded(tr, childRows, initiallyOpen);
+
+    const btn = tr.querySelector<HTMLElement>(".inspection-tree-expand")!;
+    btn.addEventListener("click", (ev) => {
+        ev.stopPropagation();
+        const open = btn.getAttribute("aria-expanded") === "true";
+        setExpanded(tr, childRows, !open);
+    });
+}
+
+function setExpanded(
+    parent: HTMLElement,
+    children: readonly HTMLElement[],
+    open: boolean,
+): void {
+    const btn = parent.querySelector<HTMLElement>(".inspection-tree-expand");
+    if (btn) {
+        btn.setAttribute("aria-expanded", open ? "true" : "false");
+        const icon = btn.querySelector<HTMLElement>(".codicon");
+        if (icon) {
+            icon.classList.toggle("codicon-chevron-right", !open);
+            icon.classList.toggle("codicon-chevron-down", open);
+        }
+    }
+    for (const row of children) {
+        // Hide the whole subtree, not just direct children — we own
+        // every descendant we appended after `parent`.
+        row.hidden = !open;
+        if (!open) {
+            // When collapsing, also fold any nested expanders so the
+            // re-open shows the depth-1 view rather than re-expanding
+            // everything the user had previously fanned out.
+            const nestedBtn = row.querySelector<HTMLElement>(
+                ".inspection-tree-expand[aria-expanded='true']",
+            );
+            if (nestedBtn) {
+                nestedBtn.setAttribute("aria-expanded", "false");
+                const icon = nestedBtn.querySelector<HTMLElement>(".codicon");
+                if (icon) {
+                    icon.classList.add("codicon-chevron-right");
+                    icon.classList.remove("codicon-chevron-down");
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Best-effort clipboard write. Falls back to a hidden `<textarea>` +
+ * `document.execCommand("copy")` when the async clipboard API is
+ * unavailable (older webviews / non-secure contexts). Failures swallow
+ * silently — the button has no visible result anyway.
+ */
+async function copyToClipboard(text: string): Promise<void> {
+    try {
+        const nav = (globalThis as { navigator?: Navigator }).navigator;
+        if (nav?.clipboard?.writeText) {
+            await nav.clipboard.writeText(text);
+            return;
+        }
+    } catch {
+        // fall through
+    }
+    try {
+        const ta = document.createElement("textarea");
+        ta.value = text;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+    } catch {
+        // give up
+    }
+}
+
+/** Stable JSON.stringify with a 2-space indent for human pasting. */
+export function stringify(value: unknown): string {
+    return JSON.stringify(value, null, 2);
+}

--- a/vscode-extension/src/webview/preview/uiaSelector.ts
+++ b/vscode-extension/src/webview/preview/uiaSelector.ts
@@ -1,0 +1,145 @@
+// Build the `By.testTag(...)` / `By.text(...)` / chained `hasParent(...)`
+// snippet the `uia/hierarchy` row action copies to the clipboard.
+//
+// Logic mirror of the Kotlin
+// `HierarchySelectorBuilder.buildSelectorSnippet`
+// (`data/uiautomator/core/.../HierarchySelectorBuilder.kt`) so the same
+// rules apply whether the user clicks "Copy selector" in VS Code or the
+// daemon emits a snippet through MCP. Keep the two in sync —
+// `HierarchySelectorBuilderTest.kt` and `uiaSelector.test.ts` are the
+// regression locks.
+
+export interface UiaHierarchyNodeLite {
+    text?: string | null;
+    contentDescription?: string | null;
+    testTag?: string | null;
+    testTagAncestors?: readonly string[];
+    role?: string | null;
+}
+
+/**
+ * Choose the smallest selector that uniquely identifies [node] in the
+ * full [nodes] list.
+ *
+ * Priority — same order the Kotlin helper applies:
+ *   1. `testTag` when present and unique.
+ *   2. `text` when present and unique.
+ *   3. `contentDescription` when present and unique.
+ *   4. Best non-unique anchor (`testTag` ▶ `text` ▶ `contentDescription`)
+ *      plus `hasParent(...)` chained from the nearest non-blank
+ *      `testTagAncestors` entry that actually disambiguates.
+ *
+ * Returns `null` when none of the above apply — the node has no
+ * distinguishing axis. Callers should fall back to a UI hint ("nothing
+ * unique to copy") rather than emitting a useless `By` chain.
+ */
+export function buildSelectorSnippet(
+    node: UiaHierarchyNodeLite,
+    nodes: readonly UiaHierarchyNodeLite[],
+): string | null {
+    const tag = nonBlank(node.testTag);
+    const text = nonBlank(node.text);
+    const desc = nonBlank(node.contentDescription);
+
+    if (tag && uniqueBy(nodes, (n) => nonBlank(n.testTag) === tag)) {
+        return `By.testTag(${quote(tag)})`;
+    }
+    if (text && uniqueBy(nodes, (n) => nonBlank(n.text) === text)) {
+        return `By.text(${quote(text)})`;
+    }
+    if (
+        desc &&
+        uniqueBy(nodes, (n) => nonBlank(n.contentDescription) === desc)
+    ) {
+        return `By.desc(${quote(desc)})`;
+    }
+
+    // Non-unique anchor — chain through ancestors. Walk from the
+    // nearest ancestor outward; the first one that uniquely identifies
+    // (this node + parentTag pair) wins.
+    const anchor = pickAnchor(node);
+    if (!anchor) return null;
+    const ancestors = node.testTagAncestors ?? [];
+    // testTagAncestors is root-most → nearest; iterate reverse so the
+    // nearest, narrowest scope is tried first.
+    for (let i = ancestors.length - 1; i >= 0; i--) {
+        const parentTag = nonBlank(ancestors[i]);
+        if (!parentTag) continue;
+        const matchCount = nodes.filter(
+            (n) =>
+                anchorMatches(n, anchor) &&
+                (n.testTagAncestors ?? []).some(
+                    (a) => nonBlank(a) === parentTag,
+                ),
+        ).length;
+        if (matchCount === 1) {
+            return `${renderAnchor(anchor)}.hasParent(By.testTag(${quote(parentTag)}))`;
+        }
+    }
+    // Even with an ancestor chain we can't disambiguate — return the
+    // anchor on its own so the user has something to start from; they
+    // can refine by adding more chains by hand.
+    return renderAnchor(anchor);
+}
+
+interface Anchor {
+    kind: "tag" | "text" | "desc";
+    value: string;
+}
+
+function pickAnchor(node: UiaHierarchyNodeLite): Anchor | null {
+    const tag = nonBlank(node.testTag);
+    if (tag) return { kind: "tag", value: tag };
+    const text = nonBlank(node.text);
+    if (text) return { kind: "text", value: text };
+    const desc = nonBlank(node.contentDescription);
+    if (desc) return { kind: "desc", value: desc };
+    return null;
+}
+
+function renderAnchor(a: Anchor): string {
+    switch (a.kind) {
+        case "tag":
+            return `By.testTag(${quote(a.value)})`;
+        case "text":
+            return `By.text(${quote(a.value)})`;
+        case "desc":
+            return `By.desc(${quote(a.value)})`;
+    }
+}
+
+function anchorMatches(n: UiaHierarchyNodeLite, a: Anchor): boolean {
+    switch (a.kind) {
+        case "tag":
+            return nonBlank(n.testTag) === a.value;
+        case "text":
+            return nonBlank(n.text) === a.value;
+        case "desc":
+            return nonBlank(n.contentDescription) === a.value;
+    }
+}
+
+function nonBlank(s: string | null | undefined): string | null {
+    if (!s) return null;
+    return s.length === 0 ? null : s;
+}
+
+function uniqueBy<T>(items: readonly T[], pred: (t: T) => boolean): boolean {
+    let n = 0;
+    for (const i of items) {
+        if (pred(i)) n += 1;
+        if (n > 1) return false;
+    }
+    return n === 1;
+}
+
+/** Kotlin-source-friendly string quoting — `"` plus standard escapes. */
+function quote(s: string): string {
+    const escaped = s
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '\\"')
+        .replace(/\n/g, "\\n")
+        .replace(/\r/g, "\\r")
+        .replace(/\t/g, "\\t");
+    return `"${escaped}"`;
+}


### PR DESCRIPTION
Wire `compose/semantics`, `layout/inspector`, and `uia/hierarchy` into
the focus inspector through a new tree-table primitive that mirrors the
Cluster A panel shell:

  - `inspectionTreeTable.ts` — reusable tree view with collapsible
    rows, per-row data-legend-id for the existing arrow correlator,
    header Copy JSON button, and an optional row action.
  - `inspectionPresenters.ts` — three presenters slotting into the
    existing focusPresentation registry. Each paints an overlay layer
    of bounded boxes plus a Report containing the tree-table.
  - `uiaSelector.ts` — TypeScript builder for the
    `By.testTag(...)` / `By.text(...).hasParent(...)` snippet copied by
    the uia/hierarchy row action.
  - `HierarchySelectorBuilder.kt` — pure-Kotlin mirror in
    `data/uiautomator/core` so MCP / record-script paths can ship the
    same selectors. `By.testTag(...)` added as a `By.res(...)` alias so
    the emitted snippets are directly runnable.

Layout-inspector source-link reuses the existing `openSourceFile`
message, so the resolver in extension.ts handles cross-file refs
without new host wiring. Inspection-tree CSS appended to preview.css.