### PR TITLE
feat(vscode-extension): add 'Configure…' expander to bundle tab bodies

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2505,3 +2505,64 @@ body {
 .a11y-findings-badge[data-level="info"] {
     --overlay-color: #1976d2;
 }
+
+/* "Configure…" expander inside a bundle tab body. Default closed —
+ * the chip already turned on the bundle's default-ON kinds, the
+ * expander is for power users who want to add a default-OFF kind or
+ * drop a default-ON one. */
+.bundle-tab-body {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.bundle-expander {
+    border-bottom: 1px solid var(--vscode-panel-border, transparent);
+    padding-bottom: 4px;
+}
+.bundle-expander-summary {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+    padding: 2px 4px;
+    font-size: 12px;
+    opacity: 0.85;
+    user-select: none;
+}
+.bundle-expander-summary:hover {
+    opacity: 1;
+}
+.bundle-expander-body {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 4px 6px 2px 18px;
+}
+.bundle-expander-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    cursor: pointer;
+}
+.bundle-expander-row input[type="checkbox"] {
+    flex-shrink: 0;
+}
+.bundle-expander-label {
+    font-weight: 500;
+}
+.bundle-expander-default {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0 4px;
+    border-radius: 8px;
+    background: var(--vscode-badge-background, rgba(127, 127, 127, 0.25));
+    color: var(--vscode-badge-foreground, inherit);
+    opacity: 0.85;
+}
+.bundle-expander-kind {
+    margin-left: auto;
+    font-size: 11px;
+    opacity: 0.55;
+}

--- a/vscode-extension/src/test/bundleExpander.test.ts
+++ b/vscode-extension/src/test/bundleExpander.test.ts
@@ -1,0 +1,162 @@
+// `<bundle-expander>` — the per-tab "Configure…" block that lets a
+// power user toggle individual kinds inside a bundle. Default-OFF
+// kinds (`a11y/touchTargets`, `a11y/overlay`, `compose/wallpaper`) only
+// reachable through this expander, so the checkbox wiring is load-
+// bearing UX.
+
+import * as assert from "assert";
+import { BUNDLES, getBundle } from "../webview/preview/bundleRegistry";
+
+// Importing the component for its side-effect registers the custom
+// element with `customElements.define`. Tests below stand up the
+// element via `document.createElement` and drive it through its public
+// setState / event surface.
+import "../webview/preview/components/BundleExpander";
+import type {
+    BundleExpander,
+    BundleKindToggledDetail,
+} from "../webview/preview/components/BundleExpander";
+
+function build(): BundleExpander {
+    const el = document.createElement("bundle-expander") as BundleExpander;
+    document.body.appendChild(el);
+    return el;
+}
+
+describe("BundleExpander", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("renders nothing until setState seeds a bundle id", async () => {
+        const el = build();
+        await el.updateComplete;
+        assert.strictEqual(
+            el.querySelector(".bundle-expander"),
+            null,
+            "expander must render nothing until bundle id is set",
+        );
+    });
+
+    it("renders one row per kind with the registry label", async () => {
+        const el = build();
+        const a11y = getBundle("a11y")!;
+        el.setState({
+            bundleId: "a11y",
+            kinds: a11y.kinds,
+            enabledKinds: ["a11y/hierarchy", "a11y/atf"],
+        });
+        await el.updateComplete;
+        const rows = el.querySelectorAll(".bundle-expander-row");
+        assert.strictEqual(rows.length, a11y.kinds.length);
+        const labels = Array.from(
+            el.querySelectorAll(".bundle-expander-label"),
+        ).map((n) => n.textContent);
+        for (const k of a11y.kinds) assert.ok(labels.includes(k.label));
+    });
+
+    it("checks the boxes for kinds in the enabled set", async () => {
+        const el = build();
+        const a11y = getBundle("a11y")!;
+        el.setState({
+            bundleId: "a11y",
+            kinds: a11y.kinds,
+            // Only one kind enabled — touchTargets, which is default-OFF.
+            enabledKinds: ["a11y/touchTargets"],
+        });
+        await el.updateComplete;
+        const checked = Array.from(
+            el.querySelectorAll<HTMLInputElement>("input[type=checkbox]"),
+        )
+            .filter((i) => i.checked)
+            .map((i) => i.dataset.kind);
+        assert.deepStrictEqual(checked, ["a11y/touchTargets"]);
+    });
+
+    it("dispatches kind-toggled when the user clicks a checkbox", async () => {
+        const el = build();
+        const a11y = getBundle("a11y")!;
+        el.setState({
+            bundleId: "a11y",
+            kinds: a11y.kinds,
+            enabledKinds: [],
+        });
+        await el.updateComplete;
+        const events: BundleKindToggledDetail[] = [];
+        el.addEventListener("kind-toggled", (e) =>
+            events.push((e as CustomEvent<BundleKindToggledDetail>).detail),
+        );
+        const overlayInput = el.querySelector<HTMLInputElement>(
+            'input[data-kind="a11y/overlay"]',
+        );
+        assert.ok(overlayInput);
+        overlayInput!.checked = true;
+        overlayInput!.dispatchEvent(new Event("change", { bubbles: true }));
+        assert.deepStrictEqual(events, [
+            { bundleId: "a11y", kind: "a11y/overlay", enabled: true },
+        ]);
+    });
+
+    it("dispatches kind-toggled with enabled=false on uncheck", async () => {
+        const el = build();
+        const a11y = getBundle("a11y")!;
+        el.setState({
+            bundleId: "a11y",
+            kinds: a11y.kinds,
+            enabledKinds: ["a11y/hierarchy"],
+        });
+        await el.updateComplete;
+        const events: BundleKindToggledDetail[] = [];
+        el.addEventListener("kind-toggled", (e) =>
+            events.push((e as CustomEvent<BundleKindToggledDetail>).detail),
+        );
+        const input = el.querySelector<HTMLInputElement>(
+            'input[data-kind="a11y/hierarchy"]',
+        );
+        assert.ok(input);
+        input!.checked = false;
+        input!.dispatchEvent(new Event("change", { bubbles: true }));
+        assert.deepStrictEqual(events, [
+            { bundleId: "a11y", kind: "a11y/hierarchy", enabled: false },
+        ]);
+    });
+
+    it("tags the default-ON kinds with a 'default' badge", async () => {
+        const el = build();
+        const a11y = getBundle("a11y")!;
+        el.setState({
+            bundleId: "a11y",
+            kinds: a11y.kinds,
+            enabledKinds: [],
+        });
+        await el.updateComplete;
+        const defaultOn = a11y.kinds.filter((k) => k.defaultOn);
+        assert.ok(
+            defaultOn.length > 0,
+            "registry should ship default-ON kinds",
+        );
+        const badges = el.querySelectorAll(".bundle-expander-default");
+        assert.strictEqual(badges.length, defaultOn.length);
+    });
+
+    it("covers every bundle in the registry (smoke)", async () => {
+        for (const b of BUNDLES) {
+            const el = build();
+            el.setState({
+                bundleId: b.id,
+                kinds: b.kinds,
+                enabledKinds: [],
+            });
+            await el.updateComplete;
+            assert.strictEqual(
+                el.querySelectorAll(".bundle-expander-row").length,
+                b.kinds.length,
+                `bundle ${b.id} should render one row per kind`,
+            );
+            el.remove();
+        }
+    });
+});

--- a/vscode-extension/src/webview/preview/components/BundleExpander.ts
+++ b/vscode-extension/src/webview/preview/components/BundleExpander.ts
@@ -1,0 +1,127 @@
+// `<bundle-expander>` — "Configure…" block that appears at the top of
+// any bundle's tab body (#1054). One row per kind in the bundle with a
+// checkbox; emits `kind-toggled` events the host forwards to
+// `BundleController.setKindEnabled`. Closed by default — the chip's
+// default-ON kinds are already subscribed, so most users never need to
+// open this. Power users open it to add a default-OFF kind (e.g.
+// `a11y/touchTargets`, `a11y/overlay` PNG, `compose/wallpaper`) or to
+// drop a default-ON kind they don't want.
+//
+// The expander is read-only state — `BundleController` is the truth.
+// The component reads `bundleId`, the list of bundle kinds, and the
+// current enabled set via `setState`; user clicks dispatch
+// `kind-toggled` events that the host forwards back to the controller.
+
+import { LitElement, html, type TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import type { BundleId, BundleKind } from "../bundleRegistry";
+
+export interface BundleKindToggledDetail {
+    bundleId: BundleId;
+    kind: string;
+    enabled: boolean;
+}
+
+@customElement("bundle-expander")
+export class BundleExpander extends LitElement {
+    @state() private bundleId: BundleId | null = null;
+    @state() private kinds: readonly BundleKind[] = [];
+    @state() private enabledKinds: ReadonlySet<string> = new Set();
+    /** Whether the `<details>` is open. Persisted by the host via the
+     *  same scoped MRU as the rest of the bundle state if desired;
+     *  defaults to closed because the default-ON kinds are already
+     *  subscribed and the common case is "leave it alone." */
+    @state() private opened = false;
+
+    setState(snapshot: {
+        bundleId: BundleId;
+        kinds: readonly BundleKind[];
+        enabledKinds: readonly string[];
+    }): void {
+        this.bundleId = snapshot.bundleId;
+        this.kinds = snapshot.kinds;
+        this.enabledKinds = new Set(snapshot.enabledKinds);
+    }
+
+    setOpened(opened: boolean): void {
+        this.opened = opened;
+    }
+
+    isOpened(): boolean {
+        return this.opened;
+    }
+
+    protected createRenderRoot(): HTMLElement {
+        return this;
+    }
+
+    protected render(): TemplateResult {
+        if (!this.bundleId || this.kinds.length === 0) {
+            return html``;
+        }
+        return html`
+            <details
+                class="bundle-expander"
+                ?open=${this.opened}
+                @toggle=${this.onToggle}
+            >
+                <summary class="bundle-expander-summary">
+                    <i
+                        class="codicon codicon-settings-gear"
+                        aria-hidden="true"
+                    ></i>
+                    <span>Configure</span>
+                </summary>
+                <div class="bundle-expander-body">
+                    ${this.kinds.map((k) => this.renderRow(k))}
+                </div>
+            </details>
+        `;
+    }
+
+    private renderRow(k: BundleKind): TemplateResult {
+        const checked = this.enabledKinds.has(k.kind);
+        const inputId = `bundle-kind-${this.bundleId}-${k.kind.replace(/[^a-z0-9]+/gi, "-")}`;
+        return html`
+            <label class="bundle-expander-row" for=${inputId}>
+                <input
+                    id=${inputId}
+                    type="checkbox"
+                    .checked=${checked}
+                    data-kind=${k.kind}
+                    @change=${(e: Event) => this.onCheckboxChanged(e, k.kind)}
+                />
+                <span class="bundle-expander-label">${k.label}</span>
+                ${k.defaultOn
+                    ? html`<span
+                          class="bundle-expander-default"
+                          title="On by default"
+                          >default</span
+                      >`
+                    : html``}
+                <code class="bundle-expander-kind">${k.kind}</code>
+            </label>
+        `;
+    }
+
+    private onToggle(e: Event): void {
+        const det = e.target as HTMLDetailsElement;
+        this.opened = det.open;
+    }
+
+    private onCheckboxChanged(evt: Event, kind: string): void {
+        if (!this.bundleId) return;
+        const target = evt.target as HTMLInputElement;
+        this.dispatchEvent(
+            new CustomEvent<BundleKindToggledDetail>("kind-toggled", {
+                detail: {
+                    bundleId: this.bundleId,
+                    kind,
+                    enabled: target.checked,
+                },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+}

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -31,12 +31,14 @@ import "./components/BundleChipBar";
 import "./components/DataTabs";
 import "./components/DataTable";
 import "./components/BoxOverlay";
+import "./components/BundleExpander";
 import { PreviewGrid } from "./components/PreviewGrid";
 import { BundleChipBar } from "./components/BundleChipBar";
 import { DataTabs } from "./components/DataTabs";
 import { DataTable } from "./components/DataTable";
+import { BundleExpander } from "./components/BundleExpander";
 import { BundleController, type BundleSnapshot } from "./bundleController";
-import type { BundleId } from "./bundleRegistry";
+import { getBundle, type BundleId } from "./bundleRegistry";
 import { a11yTableColumns, computeA11yBundleData } from "./a11yBundlePresenter";
 import { FilterController } from "./filterController";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
@@ -508,21 +510,73 @@ export class PreviewApp extends LitElement {
             );
             return visible?.dataset.previewId ?? null;
         };
-        // Per-bundle table elements. Created lazily on first use and
-        // re-rendered in-place on state change.
-        const bundleTables = new Map<BundleId, DataTable<unknown>>();
-        const a11yTable = (): DataTable<unknown> => {
-            let t = bundleTables.get("a11y");
-            if (t) return t;
-            t = document.createElement("data-table") as DataTable<unknown>;
-            t.heading = "Accessibility";
-            t.setColumns(
+        // Per-bundle tab bodies. Each entry holds the wrapper element
+        // we attach to `<data-tabs>` plus the `<bundle-expander>` /
+        // `<data-table>` children we refresh in place. Lazy-built on
+        // first activation so a panel that never touches a bundle
+        // doesn't pay the DOM cost.
+        interface BundleBody {
+            wrapper: HTMLElement;
+            expander: BundleExpander;
+            table: DataTable<unknown>;
+        }
+        const bundleBodies = new Map<BundleId, BundleBody>();
+        const buildBundleBody = (
+            id: BundleId,
+            heading: string,
+            columns: ReadonlyArray<
+                import("./components/DataTable").DataTableColumn<unknown>
+            >,
+        ): BundleBody => {
+            const wrapper = document.createElement("div");
+            wrapper.className = "bundle-tab-body";
+            wrapper.dataset.bundle = id;
+            const expander = document.createElement(
+                "bundle-expander",
+            ) as BundleExpander;
+            expander.addEventListener("kind-toggled", (evt) => {
+                const det = (
+                    evt as CustomEvent<
+                        import("./components/BundleExpander").BundleKindToggledDetail
+                    >
+                ).detail;
+                bundleController.setKindEnabled(
+                    det.bundleId,
+                    det.kind,
+                    det.enabled,
+                );
+            });
+            const table = document.createElement(
+                "data-table",
+            ) as DataTable<unknown>;
+            table.heading = heading;
+            table.setColumns(columns);
+            wrapper.appendChild(expander);
+            wrapper.appendChild(table);
+            return { wrapper, expander, table };
+        };
+        const a11yBody = (): BundleBody => {
+            let b = bundleBodies.get("a11y");
+            if (b) return b;
+            b = buildBundleBody(
+                "a11y",
+                "Accessibility",
                 a11yTableColumns() as unknown as ReadonlyArray<
                     import("./components/DataTable").DataTableColumn<unknown>
                 >,
             );
-            bundleTables.set("a11y", t);
-            return t;
+            bundleBodies.set("a11y", b);
+            return b;
+        };
+        const refreshExpanderFor = (id: BundleId): void => {
+            const body = bundleBodies.get(id);
+            const bundle = getBundle(id);
+            if (!body || !bundle) return;
+            body.expander.setState({
+                bundleId: id,
+                kinds: bundle.kinds,
+                enabledKinds: bundleController.state().enabledKinds(id),
+            });
         };
         const refreshA11yBundle = (): void => {
             const target = currentBundleTarget();
@@ -537,18 +591,19 @@ export class PreviewApp extends LitElement {
                 store.allPreviews.find((p) => p.id === target)?.a11yFindings ??
                 [];
             const data = computeA11yBundleData(nodes, findings);
-            const table = a11yTable();
-            table.setRows(data.rows);
-            table.summary = data.rows.length + " elements";
-            table.setOverlayId(
+            const body = a11yBody();
+            body.table.setRows(data.rows);
+            body.table.summary = data.rows.length + " elements";
+            body.table.setOverlayId(
                 (row) => (row as { id: string }).id ?? "a11y-row",
             );
-            table.setJsonPayload(() => ({
+            body.table.setJsonPayload(() => ({
                 previewId: target,
                 nodes,
                 findings,
             }));
-            dataTabs.setTabBody("a11y", table);
+            refreshExpanderFor("a11y");
+            dataTabs.setTabBody("a11y", body.wrapper);
         };
         const reflectBundleState = (): void => {
             const s = bundleController.state();


### PR DESCRIPTION
Adds the per-tab kind-override UI that #1054 left as a follow-up.
Each bundle tab body now has a <details> 'Configure…' block at the
top with one checkbox per kind in the bundle; toggling routes
through BundleController.setKindEnabled, mirroring the bundle's
external-toggle path so chip / tab / expander state stay in sync.

The expander is the only place to enable default-OFF kinds
(a11y/touchTargets, a11y/overlay PNG, compose/wallpaper, the
performance traces, etc.) without pressing each chip — keeps the
common case (just press the chip) one click while making the rare
case ("give me the daemon overlay PNG") reachable.

Wired into the A11y bundle tab body as the worked example. Other
clusters (Theming, Text/i18n, Performance, Display, Misc) pick up
the expander automatically once their tab body wires the same
buildBundleBody helper.

7 new tests cover the registry round-trip, checkbox state for
enabled/disabled kinds, toggle event payloads in both directions,
default-on badge, and per-bundle smoke.