### PR TITLE
feat(cli): doctor --daemon spawns each module's daemon to verify it starts

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSmokeCheck.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSmokeCheck.kt
@@ -1,0 +1,218 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.mcp.DaemonClientFactory
+import ee.schimke.composeai.mcp.DaemonLaunchDescriptor
+import ee.schimke.composeai.mcp.RegisteredProject
+import ee.schimke.composeai.mcp.SubprocessDaemonClientFactory
+import ee.schimke.composeai.mcp.WorkspaceId
+import java.io.File
+
+/**
+ * Opt-in liveness probe for the per-module preview daemon. The main `doctor` command runs this when
+ * the user passes `--daemon`: it parses the on-disk launch descriptor, forks the daemon JVM,
+ * completes the `initialize` round-trip, then asks it to shut down.
+ *
+ * The probe is gated behind a flag because spawning a real daemon is expensive — cold-start is
+ * ~600ms on Compose Desktop and 3-10s on the Android (Robolectric) backend, multiplied by the
+ * number of modules that apply the plugin. Plain `doctor` stays cheap; agents and humans who want
+ * an end-to-end "the daemon actually works" check ask for it explicitly.
+ *
+ * Implemented at the `DaemonClientFactory` seam rather than going through `DaemonSupervisor` so
+ * tests can substitute an in-memory factory without spinning up a subprocess.
+ */
+internal sealed interface DaemonSmokeOutcome {
+  /** Descriptor at `build/compose-previews/daemon-launch.json` was missing. */
+  data class DescriptorMissing(val expectedPath: File) : DaemonSmokeOutcome
+
+  /** Descriptor was present but JSON-malformed or missing required fields. */
+  data class DescriptorUnreadable(val descriptorPath: File, val reason: String) : DaemonSmokeOutcome
+
+  /** Descriptor parsed fine but its `enabled` flag is `false`. */
+  data class DescriptorDisabled(val descriptorPath: File) : DaemonSmokeOutcome
+
+  /** Daemon JVM never reached `initialize` (spawn or wire failure). */
+  data class SpawnFailed(val reason: String) : DaemonSmokeOutcome
+
+  /** Daemon reached `initialize` but the round-trip failed (timeout, error response). */
+  data class InitializeFailed(val elapsedMs: Long, val reason: String) : DaemonSmokeOutcome
+
+  /**
+   * Daemon initialised cleanly. [elapsedMs] is the wall-clock for the initialize round-trip alone
+   * (excludes JVM fork overhead); [daemonVersion] / [pid] / [protocolVersion] are echoed from the
+   * `InitializeResult` and shown in the doctor detail line.
+   */
+  data class Ok(
+    val elapsedMs: Long,
+    val daemonVersion: String,
+    val pid: Long,
+    val protocolVersion: Int,
+  ) : DaemonSmokeOutcome
+}
+
+/**
+ * Path to the daemon launch descriptor for [modulePath] under [projectDir]. Mirrors
+ * `DescriptorProvider.readingFromDisk()`'s convention: `:foo:bar` → `<projectDir>/foo/bar/...`.
+ * Module paths are gradle-style, with or without the leading colon.
+ */
+internal fun daemonDescriptorFile(projectDir: File, modulePath: String): File {
+  val trimmed = modulePath.trimStart(':')
+  val moduleDir =
+    if (trimmed.isEmpty()) projectDir
+    else File(projectDir, trimmed.replace(':', File.separatorChar))
+  return File(moduleDir, "build/compose-previews/daemon-launch.json")
+}
+
+/**
+ * Run the smoke test for one module. Returns a [DaemonSmokeOutcome] describing the result.
+ *
+ * [factory] defaults to the production subprocess factory; tests inject an in-memory factory.
+ * [workspaceName] is the project's root name (used for the synthesised [WorkspaceId] passed to the
+ * factory — production daemons don't care, but the [RegisteredProject] type wants something).
+ */
+internal fun runDaemonSmokeTest(
+  projectDir: File,
+  modulePath: String,
+  workspaceName: String = projectDir.name.ifBlank { "workspace" },
+  factory: DaemonClientFactory = SubprocessDaemonClientFactory(),
+): DaemonSmokeOutcome {
+  val descriptorFile = daemonDescriptorFile(projectDir, modulePath)
+  if (!descriptorFile.isFile) return DaemonSmokeOutcome.DescriptorMissing(descriptorFile)
+
+  val descriptor =
+    try {
+      DaemonLaunchDescriptor.parse(descriptorFile.readText())
+    } catch (e: Exception) {
+      return DaemonSmokeOutcome.DescriptorUnreadable(
+        descriptorPath = descriptorFile,
+        reason = e.message ?: e.javaClass.simpleName,
+      )
+    }
+
+  if (!descriptor.enabled) return DaemonSmokeOutcome.DescriptorDisabled(descriptorFile)
+
+  val canonicalRoot = runCatching { projectDir.canonicalFile }.getOrDefault(projectDir.absoluteFile)
+  val project =
+    RegisteredProject(
+      workspaceId = WorkspaceId.derive(workspaceName, canonicalRoot),
+      rootProjectName = workspaceName,
+      path = canonicalRoot,
+      knownModules = mutableListOf(),
+    )
+
+  val spawn =
+    try {
+      factory.spawn(project, descriptor)
+    } catch (e: Exception) {
+      return DaemonSmokeOutcome.SpawnFailed(reason = e.message ?: e.javaClass.simpleName)
+    }
+
+  val client = spawn.client(onNotification = { _, _ -> }, onClose = {})
+  val startNs = System.nanoTime()
+  return try {
+    val result =
+      client.initialize(
+        workspaceRoot = project.path.absolutePath,
+        moduleId = descriptor.modulePath,
+        moduleProjectDir = descriptor.workingDirectory,
+      )
+    val elapsedMs = (System.nanoTime() - startNs) / 1_000_000
+    DaemonSmokeOutcome.Ok(
+      elapsedMs = elapsedMs,
+      daemonVersion = result.daemonVersion,
+      pid = result.pid,
+      protocolVersion = result.protocolVersion,
+    )
+  } catch (e: Exception) {
+    val elapsedMs = (System.nanoTime() - startNs) / 1_000_000
+    DaemonSmokeOutcome.InitializeFailed(
+      elapsedMs = elapsedMs,
+      reason = e.message ?: e.javaClass.simpleName,
+    )
+  } finally {
+    runCatching { spawn.shutdown() }
+  }
+}
+
+/**
+ * Pure mapping from a smoke-test outcome to a [DoctorCheck]. Lifted out of [DoctorCommand] so the
+ * mapping can be unit-tested without spawning a daemon.
+ */
+internal fun interpretDaemonSmoke(modulePath: String, outcome: DaemonSmokeOutcome): DoctorCheck {
+  val id = "project.${modulePath.trimStart(':').ifEmpty { "root" }}.daemon-smoke"
+  val installRemediation =
+    DoctorRemediation(
+      summary = "Bootstrap the daemon descriptor first.",
+      commands = listOf("compose-preview mcp install"),
+    )
+  return when (outcome) {
+    is DaemonSmokeOutcome.DescriptorMissing ->
+      DoctorCheck(
+        id = id,
+        category = "project",
+        status = "error",
+        message = "$modulePath — daemon descriptor missing",
+        detail = "expected at ${outcome.expectedPath}",
+        remediation = installRemediation,
+      )
+    is DaemonSmokeOutcome.DescriptorUnreadable ->
+      DoctorCheck(
+        id = id,
+        category = "project",
+        status = "error",
+        message = "$modulePath — daemon descriptor unreadable",
+        detail = "${outcome.descriptorPath}: ${outcome.reason}",
+        remediation = installRemediation,
+      )
+    is DaemonSmokeOutcome.DescriptorDisabled ->
+      DoctorCheck(
+        id = id,
+        category = "project",
+        status = "error",
+        message = "$modulePath — daemon descriptor has enabled=false",
+        detail = "${outcome.descriptorPath} reports enabled=false; `mcp install` flips it",
+        remediation = installRemediation,
+      )
+    is DaemonSmokeOutcome.SpawnFailed ->
+      DoctorCheck(
+        id = id,
+        category = "project",
+        status = "error",
+        message = "$modulePath — daemon JVM failed to spawn",
+        detail = outcome.reason,
+        remediation =
+          DoctorRemediation(
+            summary =
+              "Check that the descriptor's javaLauncher is reachable and the project builds.",
+            commands = listOf("./gradlew :$modulePath:composePreviewDaemonStart"),
+          ),
+      )
+    is DaemonSmokeOutcome.InitializeFailed ->
+      DoctorCheck(
+        id = id,
+        category = "project",
+        status = "error",
+        message = "$modulePath — daemon initialize failed after ${outcome.elapsedMs}ms",
+        detail = outcome.reason,
+        remediation =
+          DoctorRemediation(
+            summary =
+              "Re-run discovery and the daemon bootstrap so the descriptor and classpath agree.",
+            commands =
+              listOf(
+                "./gradlew :$modulePath:discoverPreviews :$modulePath:composePreviewDaemonStart",
+                "compose-preview mcp install",
+              ),
+          ),
+      )
+    is DaemonSmokeOutcome.Ok ->
+      DoctorCheck(
+        id = id,
+        category = "project",
+        status = "ok",
+        message =
+          "$modulePath — daemon initialise OK in ${outcome.elapsedMs}ms" +
+            " (v${outcome.daemonVersion}, pid ${outcome.pid})",
+        detail = "protocol v${outcome.protocolVersion}",
+      )
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -40,6 +40,12 @@ import kotlinx.serialization.json.Json
  *   class an unfixed misconfig will surface at render time. Useful for humans first hitting a
  *   failure; noisy for agents.
  *
+ * Opt-in slow checks (off by default to keep the default invocation cheap):
+ * - `--daemon` (alias `--with-daemon`): also spawns each module's preview daemon JVM, completes the
+ *   `initialize` handshake, and tears it down. Catches descriptor / classpath / launcher
+ *   regressions that only surface at runtime. Costs ~600ms (Desktop) or 3-10s (Robolectric) per
+ *   module. Emits one `project.<module>.daemon-smoke` check per module.
+ *
  * Exits 0 when no errors (warnings OK), 1 when any check reports ERROR.
  */
 class DoctorCommand(args: List<String>) {
@@ -48,6 +54,14 @@ class DoctorCommand(args: List<String>) {
   private val explain = "--explain" in args
   private val verbose = "--verbose" in args || "-v" in args
   private val projectDirArg = args.flagValue("--project")
+
+  /**
+   * Opt-in: when set, [runProjectChecks] also spawns each module's daemon JVM, completes the
+   * `initialize` round-trip, and tears it down. Slow (~600ms desktop, 3-10s Robolectric per module)
+   * so it's a separate flag rather than part of the default battery. `--with-daemon` is the same
+   * flag — kept as an alias because both spellings turned up in early dogfooding.
+   */
+  private val checkDaemon = "--daemon" in args || "--with-daemon" in args
 
   /**
    * Version the CLI suggests in remediation messages ("install version X"). Comes from
@@ -415,6 +429,37 @@ class DoctorCommand(args: List<String>) {
       checkRenderPreviewsTask(modulePath, info)
       checkModuleCompat(modulePath, info)
       checkErrorSignatures(projectDir, modulePath)
+    }
+
+    if (checkDaemon) {
+      checkDaemonLiveness(projectDir, model.modules.keys)
+    } else if (model.modules.isNotEmpty()) {
+      addCheck(
+        DoctorCheck(
+          id = "project.daemon-smoke",
+          category = "project",
+          status = "skipped",
+          message = "daemon spawn check not run — pass `--daemon` to test it (slow)",
+          detail =
+            "spawns each module's daemon JVM and confirms `initialize` succeeds. " +
+              "Adds ~600ms (Desktop) or 3-10s (Android/Robolectric) per module.",
+        )
+      )
+    }
+  }
+
+  /**
+   * Opt-in spawn smoke test. For each [modulePaths] entry, locate the
+   * `build/compose-previews/daemon-launch.json` descriptor, fork the daemon JVM, run the
+   * `initialize` round-trip, and tear it down. Each module emits one
+   * `project.<module>.daemon-smoke` check; the per-module results are independent so a stale
+   * descriptor in one module doesn't suppress a clean spawn in another.
+   */
+  private fun checkDaemonLiveness(projectDir: File, modulePaths: Set<String>) {
+    if (modulePaths.isEmpty()) return
+    for (modulePath in modulePaths) {
+      val outcome = runDaemonSmokeTest(projectDir = projectDir, modulePath = modulePath)
+      addCheck(interpretDaemonSmoke(modulePath, outcome))
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -130,6 +130,10 @@ private fun printUsage() {
                            --rerun-tasks to Gradle so every input task re-executes. Does NOT
                            run :clean and does NOT touch build/classes/. Each use is logged
                            with a pointer to issue #924 — please report the freshness gap.
+      --daemon             doctor: also spawn each module's preview daemon and confirm the
+                           `initialize` round-trip succeeds. Adds ~600ms (Desktop) or 3-10s
+                           (Android/Robolectric) per module — opt-in because plain `doctor`
+                           stays cheap.
 
     OSC 9;4 terminal progress (native taskbar/tab progress bar) is on by
     default in a TTY and auto-disables when stdout is piped or redirected.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSmokeCheckTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSmokeCheckTest.kt
@@ -1,0 +1,408 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.mcp.DaemonClient
+import ee.schimke.composeai.mcp.DaemonClientFactory
+import ee.schimke.composeai.mcp.DaemonSpawn
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+class DaemonSmokeCheckTest {
+  private val tempDirs = mutableListOf<File>()
+
+  @AfterTest
+  fun cleanup() {
+    tempDirs.forEach { it.deleteRecursively() }
+  }
+
+  private fun newTempDir(): File {
+    val dir = Files.createTempDirectory("daemon-smoke-test").toFile()
+    tempDirs += dir
+    return dir
+  }
+
+  private fun writeDescriptor(modulePath: String, dir: File, body: String): File {
+    val moduleDir = File(dir, modulePath.trimStart(':').replace(':', File.separatorChar))
+    val descriptorDir = File(moduleDir, "build/compose-previews").apply { mkdirs() }
+    return File(descriptorDir, "daemon-launch.json").apply { writeText(body) }
+  }
+
+  private fun defaultDescriptorJson(modulePath: String, enabled: Boolean = true): String =
+    """
+    {
+      "schemaVersion": 1,
+      "modulePath": "$modulePath",
+      "variant": "debug",
+      "enabled": $enabled,
+      "mainClass": "fake.Main",
+      "classpath": [],
+      "jvmArgs": [],
+      "systemProperties": {},
+      "workingDirectory": "/tmp/fake",
+      "manifestPath": ""
+    }
+    """
+      .trimIndent()
+
+  // -- Pure interpretation tests --------------------------------------------
+
+  @Test
+  fun `descriptor missing maps to error with mcp install remediation`() {
+    val outcome = DaemonSmokeOutcome.DescriptorMissing(File("/some/path/daemon-launch.json"))
+    val check = interpretDaemonSmoke(":app", outcome)
+
+    assertEquals("project.app.daemon-smoke", check.id)
+    assertEquals("error", check.status)
+    assertTrue(check.message.contains("daemon descriptor missing"))
+    assertTrue(check.detail!!.contains("/some/path/daemon-launch.json"))
+    assertEquals("compose-preview mcp install", check.remediation?.commands?.single())
+  }
+
+  @Test
+  fun `descriptor unreadable maps to error with reason in detail`() {
+    val outcome =
+      DaemonSmokeOutcome.DescriptorUnreadable(File("/x/daemon-launch.json"), "bad JSON at line 4")
+    val check = interpretDaemonSmoke(":app", outcome)
+
+    assertEquals("error", check.status)
+    assertTrue(check.detail!!.contains("bad JSON at line 4"))
+  }
+
+  @Test
+  fun `descriptor disabled maps to error with mcp install remediation`() {
+    val outcome = DaemonSmokeOutcome.DescriptorDisabled(File("/x/daemon-launch.json"))
+    val check = interpretDaemonSmoke(":auth:composables", outcome)
+
+    assertEquals("project.auth:composables.daemon-smoke", check.id)
+    assertEquals("error", check.status)
+    assertTrue(check.message.contains("enabled=false"))
+    assertEquals("compose-preview mcp install", check.remediation?.commands?.single())
+  }
+
+  @Test
+  fun `spawn failure surfaces with composePreviewDaemonStart remediation`() {
+    val outcome = DaemonSmokeOutcome.SpawnFailed("Cannot run program 'java': not found")
+    val check = interpretDaemonSmoke(":app", outcome)
+
+    assertEquals("error", check.status)
+    assertTrue(check.message.contains("daemon JVM failed to spawn"))
+    val remediation = check.remediation
+    assertNotNull(remediation)
+    assertTrue(remediation.commands.any { it.contains("composePreviewDaemonStart") })
+  }
+
+  @Test
+  fun `initialize failure shows elapsed ms and re-bootstrap remediation`() {
+    val outcome =
+      DaemonSmokeOutcome.InitializeFailed(elapsedMs = 1234, reason = "timeout after 30s")
+    val check = interpretDaemonSmoke(":app", outcome)
+
+    assertEquals("error", check.status)
+    assertTrue(check.message.contains("1234ms"))
+    assertTrue(check.detail!!.contains("timeout after 30s"))
+    assertTrue(check.remediation!!.commands.any { it.contains("discoverPreviews") })
+  }
+
+  @Test
+  fun `ok outcome shows latency version and pid`() {
+    val outcome =
+      DaemonSmokeOutcome.Ok(elapsedMs = 580, daemonVersion = "1.2.3", pid = 42, protocolVersion = 2)
+    val check = interpretDaemonSmoke(":app", outcome)
+
+    assertEquals("ok", check.status)
+    assertTrue(check.message.contains("580ms"))
+    assertTrue(check.message.contains("v1.2.3"))
+    assertTrue(check.message.contains("pid 42"))
+    assertEquals("protocol v2", check.detail)
+  }
+
+  @Test
+  fun `root module path maps to project root daemon-smoke id`() {
+    val outcome =
+      DaemonSmokeOutcome.Ok(elapsedMs = 1, daemonVersion = "x", pid = 1, protocolVersion = 2)
+    val check = interpretDaemonSmoke(":", outcome)
+    assertEquals("project.root.daemon-smoke", check.id)
+  }
+
+  // -- daemonDescriptorFile path resolution ---------------------------------
+
+  @Test
+  fun `descriptor path mirrors gradle to filesystem convention`() {
+    val root = newTempDir()
+    assertEquals(
+      File(root, "auth/composables/build/compose-previews/daemon-launch.json"),
+      daemonDescriptorFile(root, ":auth:composables"),
+    )
+    assertEquals(
+      File(root, "app/build/compose-previews/daemon-launch.json"),
+      daemonDescriptorFile(root, "app"),
+    )
+    assertEquals(
+      File(root, "build/compose-previews/daemon-launch.json"),
+      daemonDescriptorFile(root, ":"),
+    )
+  }
+
+  // -- runDaemonSmokeTest descriptor branches -------------------------------
+
+  @Test
+  fun `runDaemonSmokeTest returns DescriptorMissing when file is absent`() {
+    val outcome = runDaemonSmokeTest(projectDir = newTempDir(), modulePath = ":app")
+    assertTrue(outcome is DaemonSmokeOutcome.DescriptorMissing)
+  }
+
+  @Test
+  fun `runDaemonSmokeTest returns DescriptorUnreadable on malformed JSON`() {
+    val dir = newTempDir()
+    writeDescriptor(":app", dir, "{ not valid json")
+
+    val factory = DaemonClientFactory { _, _ -> error("factory should not be called") }
+    val outcome = runDaemonSmokeTest(projectDir = dir, modulePath = ":app", factory = factory)
+    assertTrue(outcome is DaemonSmokeOutcome.DescriptorUnreadable)
+  }
+
+  @Test
+  fun `runDaemonSmokeTest short-circuits when enabled=false`() {
+    val dir = newTempDir()
+    writeDescriptor(":app", dir, defaultDescriptorJson(":app", enabled = false))
+
+    val factory = DaemonClientFactory { _, _ -> error("factory should not be called") }
+    val outcome = runDaemonSmokeTest(projectDir = dir, modulePath = ":app", factory = factory)
+    assertTrue(outcome is DaemonSmokeOutcome.DescriptorDisabled)
+  }
+
+  @Test
+  fun `runDaemonSmokeTest maps factory exceptions to SpawnFailed`() {
+    val dir = newTempDir()
+    writeDescriptor(":app", dir, defaultDescriptorJson(":app"))
+
+    val factory = DaemonClientFactory { _, _ -> throw RuntimeException("no /bin/java here") }
+    val outcome = runDaemonSmokeTest(projectDir = dir, modulePath = ":app", factory = factory)
+    val failed = outcome as DaemonSmokeOutcome.SpawnFailed
+    assertTrue(failed.reason.contains("no /bin/java here"))
+  }
+
+  // -- runDaemonSmokeTest end-to-end against a piped fake -------------------
+
+  @Test
+  fun `runDaemonSmokeTest reports Ok when fake daemon answers initialize`() {
+    val dir = newTempDir()
+    writeDescriptor(":app", dir, defaultDescriptorJson(":app"))
+
+    val fake = StubDaemonSpawn().also { it.start() }
+    try {
+      val factory = DaemonClientFactory { _, _ -> fake }
+      val outcome = runDaemonSmokeTest(projectDir = dir, modulePath = ":app", factory = factory)
+      val ok = outcome as DaemonSmokeOutcome.Ok
+      assertEquals("1.2.3-stub", ok.daemonVersion)
+      assertEquals(4321L, ok.pid)
+      assertEquals(2, ok.protocolVersion)
+      assertTrue(ok.elapsedMs >= 0)
+      assertEquals(1, fake.initializeCount.get())
+    } finally {
+      fake.shutdown()
+    }
+  }
+
+  @Test
+  fun `runDaemonSmokeTest reports InitializeFailed when fake returns an error response`() {
+    val dir = newTempDir()
+    writeDescriptor(":app", dir, defaultDescriptorJson(":app"))
+
+    val fake = StubDaemonSpawn(initializeError = "boom").also { it.start() }
+    try {
+      val factory = DaemonClientFactory { _, _ -> fake }
+      val outcome = runDaemonSmokeTest(projectDir = dir, modulePath = ":app", factory = factory)
+      val failed = outcome as DaemonSmokeOutcome.InitializeFailed
+      assertTrue(failed.reason.contains("boom"))
+    } finally {
+      fake.shutdown()
+    }
+  }
+}
+
+/**
+ * Minimal in-process daemon stand-in. Speaks the daemon protocol's `Content-Length` framed JSON-RPC
+ * over piped streams so the production [DaemonClient] can drive a real `initialize` round-trip in
+ * unit tests — no subprocess, no fixture dependency on the `:mcp` test sources.
+ *
+ * Hand-rolls just the two methods the smoke test exercises: `initialize` (success or error) and
+ * `shutdown` (always succeeds). Notifications (`initialized`, `exit`) are drained and ignored.
+ */
+private class StubDaemonSpawn(private val initializeError: String? = null) : DaemonSpawn {
+  private val mcpToDaemon = PipedOutputStream()
+  private val daemonReadIn = PipedInputStream(mcpToDaemon, 64 * 1024)
+  private val daemonToMcp = PipedOutputStream()
+  private val mcpReadIn = PipedInputStream(daemonToMcp, 64 * 1024)
+  private val running = AtomicBoolean(true)
+  private lateinit var _client: DaemonClient
+
+  val initializeCount = AtomicInteger(0)
+
+  fun start() {
+    Thread({ runReader() }, "stub-daemon-reader").apply {
+      isDaemon = true
+      start()
+    }
+  }
+
+  override val client: DaemonClient
+    get() = _client
+
+  override fun client(
+    onNotification: (method: String, params: JsonObject?) -> Unit,
+    onClose: () -> Unit,
+  ): DaemonClient {
+    _client =
+      DaemonClient(
+        input = mcpReadIn,
+        output = mcpToDaemon,
+        onNotification = onNotification,
+        onClose = onClose,
+        threadName = "stub-daemon-client",
+      )
+    return _client
+  }
+
+  override fun shutdown() {
+    if (!running.compareAndSet(true, false)) return
+    runCatching { daemonToMcp.close() }
+    runCatching { daemonReadIn.close() }
+  }
+
+  private fun runReader() {
+    try {
+      while (running.get()) {
+        val frame = readFrame(daemonReadIn) ?: return
+        val obj =
+          kotlinx.serialization.json.Json.parseToJsonElement(String(frame, Charsets.UTF_8))
+            .jsonObject
+        val id = obj["id"]?.jsonPrimitive?.long
+        val method = obj["method"]?.jsonPrimitive?.contentOrNull
+        if (id != null && method == "initialize") {
+          initializeCount.incrementAndGet()
+          if (initializeError != null) sendError(id, -32000, initializeError)
+          else sendOkInitialize(id)
+        } else if (id != null && method == "shutdown") {
+          sendResultNull(id)
+        }
+      }
+    } catch (_: IOException) {
+      // EOF on shutdown
+    }
+  }
+
+  private fun sendOkInitialize(id: Long) {
+    val payload = buildJsonObject {
+      put("jsonrpc", "2.0")
+      put("id", id)
+      putJsonObject("result") {
+        put("protocolVersion", 2)
+        put("daemonVersion", "1.2.3-stub")
+        put("pid", 4321L)
+        putJsonObject("capabilities") {
+          put("incrementalDiscovery", true)
+          put("sandboxRecycle", false)
+          put("leakDetection", JsonArray(emptyList()))
+        }
+        put("classpathFingerprint", "stub-fingerprint")
+        putJsonObject("manifest") {
+          put("path", "")
+          put("previewCount", 0)
+        }
+      }
+    }
+    sendFrame(payload.toString())
+  }
+
+  private fun sendResultNull(id: Long) {
+    val payload = buildJsonObject {
+      put("jsonrpc", "2.0")
+      put("id", id)
+      put("result", JsonNull)
+    }
+    sendFrame(payload.toString())
+  }
+
+  private fun sendError(id: Long, code: Int, message: String) {
+    val payload = buildJsonObject {
+      put("jsonrpc", "2.0")
+      put("id", id)
+      putJsonObject("error") {
+        put("code", code)
+        put("message", message)
+      }
+    }
+    sendFrame(payload.toString())
+  }
+
+  private fun sendFrame(jsonText: String) {
+    val bytes = jsonText.toByteArray(Charsets.UTF_8)
+    val header = "Content-Length: ${bytes.size}\r\n\r\n".toByteArray(Charsets.US_ASCII)
+    synchronized(daemonToMcp) {
+      daemonToMcp.write(header)
+      daemonToMcp.write(bytes)
+      daemonToMcp.flush()
+    }
+  }
+
+  private fun readFrame(input: InputStream): ByteArray? {
+    var contentLength = -1
+    val buf = ByteArrayOutputStream(64)
+    while (true) {
+      val line = readHeaderLine(input, buf) ?: return null
+      if (line.isEmpty()) break
+      val colon = line.indexOf(':')
+      if (colon <= 0) error("malformed header line: '$line'")
+      if (line.substring(0, colon).trim().equals("Content-Length", ignoreCase = true)) {
+        contentLength = line.substring(colon + 1).trim().toInt()
+      }
+    }
+    if (contentLength < 0) error("missing Content-Length")
+    val payload = ByteArray(contentLength)
+    var off = 0
+    while (off < contentLength) {
+      val n = input.read(payload, off, contentLength - off)
+      if (n < 0) return null
+      off += n
+    }
+    return payload
+  }
+
+  private fun readHeaderLine(input: InputStream, buf: ByteArrayOutputStream): String? {
+    buf.reset()
+    while (true) {
+      val b = input.read()
+      if (b < 0) return if (buf.size() == 0) null else buf.toString(Charsets.US_ASCII.name())
+      if (b == '\n'.code) {
+        val bytes = buf.toByteArray()
+        val end =
+          if (bytes.isNotEmpty() && bytes.last() == '\r'.code.toByte()) bytes.size - 1
+          else bytes.size
+        return String(bytes, 0, end, Charsets.US_ASCII)
+      }
+      buf.write(b)
+    }
+  }
+}


### PR DESCRIPTION
`compose-preview doctor` already covers the env and project static checks
but stops short of confirming the per-module preview daemon actually
launches. Add an opt-in `--daemon` (alias `--with-daemon`) flag that, for
each module applying the plugin, parses the on-disk launch descriptor,
forks the daemon JVM, completes the `initialize` round-trip, and tears
it down. Each module emits one `project.<module>.daemon-smoke` check
with the cold-start latency, daemon version, and pid on success — or an
actionable error (missing descriptor → `compose-preview mcp install`;
spawn failure → `composePreviewDaemonStart`; init failure → re-run
discovery + bootstrap) on failure.

Gated behind a flag because spawning a real daemon is expensive
(~600ms Compose Desktop, 3-10s Robolectric per module). Default `doctor`
output stays cheap; a `skipped` info line tells the user how to opt in.

Implemented at the `DaemonClientFactory` seam so unit tests substitute
an in-memory fake speaking the framed JSON-RPC protocol over piped
streams — no subprocess, no `:mcp` test-source dependency.