### PR TITLE
feat(vscode-extension): theming bundle — compose/theme tokens + wallpaper derived scheme

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2642,3 +2642,86 @@ body {
 .perf-perfetto-open:hover {
     background: var(--vscode-button-hoverBackground);
 }
+/* Theming bundle — Colors / Typography / Shapes share one table.
+ * The Section column doubles as a sub-heading; the swatch column
+ * carries the colour chip for color / seed rows. */
+.theming-section-cell {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    opacity: 0.65;
+    white-space: nowrap;
+}
+.theming-swatch-cell {
+    width: 28px;
+    padding-right: 0;
+}
+.theming-swatch {
+    display: inline-block;
+    width: 18px;
+    height: 18px;
+    border-radius: 4px;
+    border: 1px solid rgba(127, 127, 127, 0.45);
+    background-image:
+        linear-gradient(
+            45deg,
+            rgba(127, 127, 127, 0.18) 25%,
+            transparent 25%,
+            transparent 75%,
+            rgba(127, 127, 127, 0.18) 75%
+        ),
+        linear-gradient(
+            45deg,
+            rgba(127, 127, 127, 0.18) 25%,
+            transparent 25%,
+            transparent 75%,
+            rgba(127, 127, 127, 0.18) 75%
+        );
+    background-size: 8px 8px;
+    background-position:
+        0 0,
+        4px 4px;
+}
+.theming-swatch[data-source="seed"] {
+    outline: 1px dashed currentColor;
+    outline-offset: 1px;
+}
+.theming-swatch[data-source="wallpaper"] {
+    border-style: dashed;
+}
+.theming-name-cell {
+    min-width: 120px;
+}
+.theming-name-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+.theming-name-sub {
+    opacity: 0.7;
+    font-size: 11px;
+}
+.theming-hex {
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 12px;
+    opacity: 0.85;
+}
+.theming-value-cell {
+    min-width: 160px;
+}
+.theming-typography-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 2px 12px;
+    font-size: 12px;
+}
+.theming-typography-grid em {
+    font-style: normal;
+    opacity: 0.55;
+    margin-right: 4px;
+}
+.theming-consumers-cell {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    width: 80px;
+}

--- a/vscode-extension/src/test/themingBundlePresenter.test.ts
+++ b/vscode-extension/src/test/themingBundlePresenter.test.ts
@@ -1,0 +1,252 @@
+// Theming bundle presenter (#1056 Cluster C). Pins the row shape for
+// the Colors / Typography / Shapes sections plus the wallpaper-seed
+// prepend behaviour. The presenter is stateless so these tests work
+// on plain payload fixtures — no DOM, no daemon round-trip.
+
+import * as assert from "assert";
+import {
+    computeThemingBundleData,
+    type ThemePayload,
+    type ThemingColorRow,
+    type ThemingTypographyRow,
+    type ThemingSeedRow,
+    type WallpaperPayload,
+} from "../webview/preview/themingBundlePresenter";
+
+function theme(overrides?: Partial<ThemePayload>): ThemePayload {
+    return {
+        resolvedTokens: overrides?.resolvedTokens ?? {
+            colorScheme: {},
+            typography: {},
+            shapes: {},
+        },
+        consumers: overrides?.consumers ?? [],
+    };
+}
+
+function wallpaper(overrides?: Partial<WallpaperPayload>): WallpaperPayload {
+    return {
+        seedColor: "#FF8B5CF6",
+        isDark: false,
+        paletteStyle: "TONAL_SPOT",
+        contrastLevel: 0,
+        derivedColorScheme: {
+            primary: "#FF3700B3",
+            onPrimary: "#FFFFFFFF",
+        },
+        ...overrides,
+    };
+}
+
+describe("computeThemingBundleData", () => {
+    it("returns no rows when both payloads are null", () => {
+        const data = computeThemingBundleData(null, null, "preview-1");
+        assert.strictEqual(data.rows.length, 0);
+        assert.strictEqual(data.jsonPayload.previewId, "preview-1");
+        assert.strictEqual(data.jsonPayload.theme, null);
+        assert.strictEqual(data.jsonPayload.wallpaper, null);
+    });
+
+    it("round-trips a typography token's scalar attributes", () => {
+        const data = computeThemingBundleData(
+            theme({
+                resolvedTokens: {
+                    colorScheme: {},
+                    typography: {
+                        bodyLarge: {
+                            fontFamily: "Roboto",
+                            fontSize: 16,
+                            fontSizeUnit: "sp",
+                            fontWeight: "Normal",
+                            fontStyle: "Normal",
+                            lineHeight: 24,
+                            lineHeightUnit: "sp",
+                            letterSpacing: 0.5,
+                            letterSpacingUnit: "sp",
+                        },
+                    },
+                    shapes: {},
+                },
+            }),
+            null,
+        );
+        const typo = data.rows.find(
+            (r) => r.kind === "typography",
+        ) as ThemingTypographyRow;
+        assert.ok(typo, "bodyLarge typography row should be present");
+        assert.strictEqual(typo.name, "bodyLarge");
+        assert.strictEqual(typo.family, "Roboto");
+        assert.strictEqual(typo.size, "16sp");
+        assert.strictEqual(typo.weight, "Normal");
+        assert.strictEqual(typo.style, "Normal");
+        assert.strictEqual(typo.lineHeight, "24sp");
+        assert.strictEqual(typo.letterSpacing, "0.5sp");
+    });
+
+    it("formats null typography attributes as em dashes", () => {
+        const data = computeThemingBundleData(
+            theme({
+                resolvedTokens: {
+                    colorScheme: {},
+                    typography: {
+                        sparse: {
+                            fontFamily: null,
+                            fontSize: null,
+                            fontWeight: null,
+                        },
+                    },
+                    shapes: {},
+                },
+            }),
+            null,
+        );
+        const typo = data.rows[0] as ThemingTypographyRow;
+        assert.strictEqual(typo.family, "—");
+        assert.strictEqual(typo.size, "—");
+        assert.strictEqual(typo.weight, "—");
+        assert.strictEqual(typo.lineHeight, "—");
+    });
+
+    it("surfaces consumer counts on color rows from compose/theme", () => {
+        const data = computeThemingBundleData(
+            theme({
+                resolvedTokens: {
+                    colorScheme: {
+                        primary: "#FF1976D2",
+                        secondary: "#FF03DAC6",
+                    },
+                    typography: {},
+                    shapes: {},
+                },
+                consumers: [
+                    { nodeId: "n1", tokens: ["primary"] },
+                    { nodeId: "n2", tokens: ["primary", "secondary"] },
+                    { nodeId: "n3", tokens: ["primary"] },
+                ],
+            }),
+            null,
+        );
+        const primary = data.rows.find(
+            (r) => r.kind === "color" && r.name === "primary",
+        ) as ThemingColorRow;
+        const secondary = data.rows.find(
+            (r) => r.kind === "color" && r.name === "secondary",
+        ) as ThemingColorRow;
+        assert.strictEqual(primary.consumerCount, 3);
+        assert.strictEqual(secondary.consumerCount, 1);
+        assert.strictEqual(primary.source, "theme");
+    });
+
+    it("prepends a Seed row when wallpaper is present alongside theme", () => {
+        const data = computeThemingBundleData(
+            theme({
+                resolvedTokens: {
+                    colorScheme: { primary: "#FF1976D2" },
+                    typography: {},
+                    shapes: {},
+                },
+            }),
+            wallpaper({
+                seedColor: "#FF8B5CF6",
+                isDark: true,
+                paletteStyle: "VIBRANT",
+                contrastLevel: 0.5,
+                derivedColorScheme: { primary: "#FFAB47BC" },
+            }),
+        );
+        // First row must be the seed summary so the user reads top to
+        // bottom: "this seed produced this scheme, layered into these
+        // theme tokens."
+        const first = data.rows[0] as ThemingSeedRow;
+        assert.strictEqual(first.kind, "seed");
+        assert.strictEqual(first.section, "Colors");
+        assert.strictEqual(first.hex, "#FF8B5CF6");
+        assert.strictEqual(first.isDark, true);
+        assert.strictEqual(first.paletteStyle, "VIBRANT");
+        assert.strictEqual(first.contrastLevel, 0.5);
+        // Wallpaper-derived colour rows come next, tagged with the
+        // wallpaper source so the UI can badge them separately.
+        const wallpaperColors = data.rows.filter(
+            (r) => r.kind === "color" && r.source === "wallpaper",
+        );
+        assert.strictEqual(wallpaperColors.length, 1);
+        assert.strictEqual(
+            (wallpaperColors[0] as ThemingColorRow).name,
+            "primary",
+        );
+        // Theme colours follow with the `theme` source tag.
+        const themeColors = data.rows.filter(
+            (r) => r.kind === "color" && r.source === "theme",
+        );
+        assert.strictEqual(themeColors.length, 1);
+    });
+
+    it("omits the seed row entirely when wallpaper is null", () => {
+        const data = computeThemingBundleData(
+            theme({
+                resolvedTokens: {
+                    colorScheme: { primary: "#FF1976D2" },
+                    typography: {},
+                    shapes: {},
+                },
+            }),
+            null,
+        );
+        assert.ok(!data.rows.some((r) => r.kind === "seed"));
+        assert.ok(
+            !data.rows.some(
+                (r) => r.kind === "color" && r.source === "wallpaper",
+            ),
+        );
+    });
+
+    it("converts #AARRGGBB hex into a CSS-safe rgba swatch", () => {
+        const data = computeThemingBundleData(
+            theme({
+                resolvedTokens: {
+                    colorScheme: { primary: "#FF1976D2" },
+                    typography: {},
+                    shapes: {},
+                },
+            }),
+            null,
+        );
+        const color = data.rows[0] as ThemingColorRow;
+        // CSS doesn't parse `#AARRGGBB` — alpha lives at the end in CSS.
+        // The presenter has to translate or the swatch shows transparent.
+        assert.ok(color.swatchCss.startsWith("rgba("));
+        assert.ok(color.swatchCss.includes("25, 118, 210"));
+    });
+
+    it("emits shape rows in name-sorted order", () => {
+        const data = computeThemingBundleData(
+            theme({
+                resolvedTokens: {
+                    colorScheme: {},
+                    typography: {},
+                    shapes: {
+                        large: "RoundedCornerShape(16.dp)",
+                        small: "RoundedCornerShape(4.dp)",
+                        medium: "RoundedCornerShape(8.dp)",
+                    },
+                },
+            }),
+            null,
+        );
+        const shapeNames = data.rows
+            .filter((r) => r.kind === "shape")
+            .map((r) => r.name);
+        assert.deepStrictEqual(shapeNames, ["large", "medium", "small"]);
+    });
+
+    it("renders the derived scheme even when theme is null", () => {
+        // Wallpaper override can land before compose/theme on slow
+        // boots — surface what we have rather than blanking the tab.
+        const data = computeThemingBundleData(null, wallpaper());
+        assert.ok(data.rows.some((r) => r.kind === "seed"));
+        const derived = data.rows.filter(
+            (r) => r.kind === "color" && r.source === "wallpaper",
+        );
+        assert.strictEqual(derived.length, 2);
+    });
+});

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -46,6 +46,12 @@ import {
     renderPerfPlaceholder,
     renderPerformanceSections,
 } from "./performanceBundlePresenter";
+import {
+    computeThemingBundleData,
+    themingTableColumns,
+    type ThemePayload,
+    type WallpaperPayload,
+} from "./themingBundlePresenter";
 import { FilterController } from "./filterController";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
 import {
@@ -637,6 +643,19 @@ export class PreviewApp extends LitElement {
                 enabledKinds: bundleController.state().enabledKinds(id),
             });
         };
+        const themingBody = (): BundleBody => {
+            let b = bundleBodies.get("theming");
+            if (b) return b;
+            b = buildBundleBody(
+                "theming",
+                "Theming",
+                themingTableColumns() as unknown as ReadonlyArray<
+                    import("./components/DataTable").DataTableColumn<unknown>
+                >,
+            );
+            bundleBodies.set("theming", b);
+            return b;
+        };
         const refreshA11yBundle = (): void => {
             const target = currentBundleTarget();
             if (!target) return;
@@ -726,6 +745,54 @@ export class PreviewApp extends LitElement {
             }
             dataTabs.setTabBody("performance", body.wrapper);
         };
+        const refreshThemingBundle = (): void => {
+            const target = currentBundleTarget();
+            if (!target) return;
+            const byKind = dataProductsByPreview.get(target);
+            const theme =
+                (byKind?.get("compose/theme") as ThemePayload | undefined) ??
+                null;
+            const wallpaper =
+                (byKind?.get("compose/wallpaper") as
+                    | WallpaperPayload
+                    | undefined) ?? null;
+            const data = computeThemingBundleData(theme, wallpaper, target);
+            const body = themingBody();
+            const table = body.table;
+            table.setRows(data.rows);
+            // Summary mirrors the per-section row counts so the user
+            // gets a quick feel for token volume without expanding the
+            // table. Tags on each row let us count without double-
+            // counting the seed summary as a colour.
+            const colorCount = data.rows.filter(
+                (r) => (r as { kind?: string }).kind === "color",
+            ).length;
+            const typoCount = data.rows.filter(
+                (r) => (r as { kind?: string }).kind === "typography",
+            ).length;
+            const shapeCount = data.rows.filter(
+                (r) => (r as { kind?: string }).kind === "shape",
+            ).length;
+            table.summary =
+                colorCount +
+                " colour" +
+                (colorCount === 1 ? "" : "s") +
+                " · " +
+                typoCount +
+                " type · " +
+                shapeCount +
+                " shape" +
+                (shapeCount === 1 ? "" : "s");
+            // Theme tokens are global — no per-row overlay box — but
+            // `<data-table>` still wants a stable id per row for hover
+            // correlation with any future legend element.
+            table.setOverlayId(
+                (row) => (row as { id?: string }).id ?? "theming-row",
+            );
+            table.setJsonPayload(() => data.jsonPayload);
+            refreshExpanderFor("theming");
+            dataTabs.setTabBody("theming", body.wrapper);
+        };
         const reflectBundleState = (): void => {
             const s = bundleController.state();
             bundleChipBar.setState({
@@ -741,6 +808,7 @@ export class PreviewApp extends LitElement {
             if (s.activeBundles.includes("performance")) {
                 refreshPerformanceBundle();
             }
+            if (s.activeBundles.includes("theming")) refreshThemingBundle();
         };
         bundleController.onChange(() => reflectBundleState());
         reflectBundleState();
@@ -1112,6 +1180,17 @@ export class PreviewApp extends LitElement {
                     )
                 ) {
                     refreshPerformanceBundle();
+                }
+                if (
+                    matchesTarget &&
+                    activeBundles.includes("theming") &&
+                    dataProducts.some(
+                        (dp) =>
+                            dp.kind === "compose/theme" ||
+                            dp.kind === "compose/wallpaper",
+                    )
+                ) {
+                    refreshThemingBundle();
                 }
             },
             focusOnCard,

--- a/vscode-extension/src/webview/preview/themingBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/themingBundlePresenter.ts
@@ -1,0 +1,421 @@
+// Theming bundle presenter — fills the "Theming" tab body in
+// `<data-tabs>` using the shared `<data-table>` primitive. Combines
+// `compose/theme` (resolved Material 3 tokens grouped into Colors /
+// Typography / Shapes) with `compose/wallpaper` (seed colour + derived
+// scheme prepended to the Colors section).
+//
+// The presenter is **stateless** — given the latest payloads from
+// `dataProductsByPreview` for the focused preview, it produces table
+// rows. Caller wiring in `main.ts` is responsible for re-running this
+// whenever the focused preview, the bundle's active set, or an
+// incoming `compose/theme` / `compose/wallpaper` payload changes.
+//
+// Theme tokens are global, so this presenter emits NO overlay boxes —
+// `<box-overlay>` only paints rows with `boxes`, so a stable per-row
+// id is enough to keep `setOverlayId` happy for the shared primitive.
+
+import { html, type TemplateResult } from "lit";
+import type { DataTableColumn } from "./components/DataTable";
+
+/** Wire shape for one Material 3 typography token. Mirrors
+ *  `TypographyToken` in `Material3ThemeModels.kt`. */
+export interface TypographyToken {
+    fontFamily?: string | null;
+    fontSize?: number | null;
+    fontSizeUnit?: string | null;
+    fontWeight?: string | null;
+    fontStyle?: string | null;
+    lineHeight?: number | null;
+    lineHeightUnit?: string | null;
+    letterSpacing?: number | null;
+    letterSpacingUnit?: string | null;
+}
+
+/** Wire shape for one consumer node referencing one or more theme
+ *  tokens. Mirrors `ThemeConsumer` in `Material3ThemeModels.kt`. */
+export interface ThemeConsumer {
+    nodeId: string;
+    tokens: string[];
+}
+
+/** Wire shape for the resolved-tokens map. Mirrors
+ *  `ResolvedThemeTokens` in `Material3ThemeModels.kt`. */
+export interface ResolvedThemeTokens {
+    colorScheme: Record<string, string>;
+    typography: Record<string, TypographyToken>;
+    shapes: Record<string, string>;
+}
+
+/** Wire shape returned by `data/fetch?kind=compose/theme`. Mirrors
+ *  `ThemePayload` in `Material3ThemeModels.kt`. */
+export interface ThemePayload {
+    resolvedTokens: ResolvedThemeTokens;
+    consumers?: ThemeConsumer[];
+}
+
+/** Wire shape returned by `data/fetch?kind=compose/wallpaper`.
+ *  Mirrors `WallpaperPayload` in `WallpaperModels.kt`. */
+export interface WallpaperPayload {
+    seedColor: string;
+    isDark: boolean;
+    paletteStyle?: string;
+    contrastLevel?: number;
+    derivedColorScheme: Record<string, string>;
+}
+
+/** Discriminator for the table sections. Each row knows which section
+ *  heading it belongs under; the `<data-table>` primitive renders it
+ *  via the `section` column. */
+export type ThemingSection = "Colors" | "Typography" | "Shapes";
+
+/** Source of a Color row — used to badge wallpaper-derived rows
+ *  separately from the theme's own `colorScheme`. */
+export type ThemingColorSource = "theme" | "wallpaper" | "seed";
+
+/** Row union — Colors / Typography / Shapes share a single `<data-table>`
+ *  so the column factory can render mixed sections without juggling
+ *  three tables. Each variant tags itself with `kind` for the renderers. */
+export type ThemingRow =
+    | ThemingColorRow
+    | ThemingTypographyRow
+    | ThemingShapeRow
+    | ThemingSeedRow;
+
+export interface ThemingColorRow {
+    id: string;
+    section: "Colors";
+    kind: "color";
+    /** Token name (e.g. "primary", "onSurface"). */
+    name: string;
+    /** Hex string as published on the wire — typically `#AARRGGBB`. */
+    hex: string;
+    /** CSS-safe background colour derived from `hex`. */
+    swatchCss: string;
+    /** Number of `consumers[].nodeId` referencing this token; 0 when
+     *  the wallpaper-derived scheme has no consumer data. */
+    consumerCount: number;
+    /** Provenance of this row — `theme` from `compose/theme`,
+     *  `wallpaper` from the derived scheme. */
+    source: ThemingColorSource;
+}
+
+export interface ThemingTypographyRow {
+    id: string;
+    section: "Typography";
+    kind: "typography";
+    name: string;
+    family: string;
+    size: string;
+    weight: string;
+    style: string;
+    lineHeight: string;
+    letterSpacing: string;
+}
+
+export interface ThemingShapeRow {
+    id: string;
+    section: "Shapes";
+    kind: "shape";
+    name: string;
+    value: string;
+}
+
+/** Seed-color summary row prepended to Colors when wallpaper is
+ *  present. Carries the scalar wallpaper inputs (isDark / palette /
+ *  contrast) so callers don't have to dig them out of the JSON copy. */
+export interface ThemingSeedRow {
+    id: string;
+    section: "Colors";
+    kind: "seed";
+    name: string;
+    hex: string;
+    swatchCss: string;
+    isDark: boolean;
+    paletteStyle: string;
+    contrastLevel: number;
+}
+
+export interface ThemingBundleData {
+    rows: readonly ThemingRow[];
+    jsonPayload: {
+        previewId: string | null;
+        theme: ThemePayload | null;
+        wallpaper: WallpaperPayload | null;
+    };
+}
+
+/**
+ * Build the row + copy-JSON shape for the Theming bundle tab.
+ *
+ * Either payload may be null. When `compose/theme` is null but
+ * wallpaper is present, the derived scheme still surfaces under
+ * Colors (with a Seed row prepended) so the user gets feedback that
+ * the wallpaper override is live. When both are null the result has
+ * an empty `rows` array — `<data-table>` paints its empty-state
+ * placeholder in that case.
+ */
+export function computeThemingBundleData(
+    theme: ThemePayload | null | undefined,
+    wallpaper: WallpaperPayload | null | undefined,
+    previewId: string | null = null,
+): ThemingBundleData {
+    const rows: ThemingRow[] = [];
+    const consumerCount = countConsumersByToken(theme?.consumers ?? []);
+
+    // Seed + wallpaper-derived colours go first so the user reads top
+    // to bottom: "this seed produced this scheme, layered into these
+    // theme tokens." When wallpaper is absent we skip both rows.
+    if (wallpaper) {
+        rows.push({
+            id: "theming-seed",
+            section: "Colors",
+            kind: "seed",
+            name: "Wallpaper seed",
+            hex: wallpaper.seedColor,
+            swatchCss: cssColor(wallpaper.seedColor),
+            isDark: wallpaper.isDark,
+            paletteStyle: wallpaper.paletteStyle ?? "TONAL_SPOT",
+            contrastLevel:
+                typeof wallpaper.contrastLevel === "number"
+                    ? wallpaper.contrastLevel
+                    : 0,
+        });
+        const derived = wallpaper.derivedColorScheme ?? {};
+        for (const name of Object.keys(derived).sort()) {
+            const hex = derived[name];
+            rows.push({
+                id: "theming-wallpaper-color-" + name,
+                section: "Colors",
+                kind: "color",
+                name,
+                hex,
+                swatchCss: cssColor(hex),
+                consumerCount: 0,
+                source: "wallpaper",
+            });
+        }
+    }
+
+    // Theme `colorScheme` — one row per token. Sorted to keep the
+    // table stable across reorderings inside the wire payload (the
+    // Map serialisation order isn't load-bearing).
+    const scheme = theme?.resolvedTokens?.colorScheme ?? {};
+    for (const name of Object.keys(scheme).sort()) {
+        const hex = scheme[name];
+        rows.push({
+            id: "theming-color-" + name,
+            section: "Colors",
+            kind: "color",
+            name,
+            hex,
+            swatchCss: cssColor(hex),
+            consumerCount: consumerCount.get(name) ?? 0,
+            source: "theme",
+        });
+    }
+
+    const typography = theme?.resolvedTokens?.typography ?? {};
+    for (const name of Object.keys(typography).sort()) {
+        const tok = typography[name];
+        rows.push({
+            id: "theming-typography-" + name,
+            section: "Typography",
+            kind: "typography",
+            name,
+            family: tok.fontFamily ?? "—",
+            size: formatScalar(tok.fontSize, tok.fontSizeUnit),
+            weight: tok.fontWeight ?? "—",
+            style: tok.fontStyle ?? "—",
+            lineHeight: formatScalar(tok.lineHeight, tok.lineHeightUnit),
+            letterSpacing: formatScalar(
+                tok.letterSpacing,
+                tok.letterSpacingUnit,
+            ),
+        });
+    }
+
+    const shapes = theme?.resolvedTokens?.shapes ?? {};
+    for (const name of Object.keys(shapes).sort()) {
+        rows.push({
+            id: "theming-shape-" + name,
+            section: "Shapes",
+            kind: "shape",
+            name,
+            value: shapes[name],
+        });
+    }
+
+    return {
+        rows,
+        jsonPayload: {
+            previewId,
+            theme: theme ?? null,
+            wallpaper: wallpaper ?? null,
+        },
+    };
+}
+
+/**
+ * Column definitions for the Theming bundle table. Cells switch on
+ * the row's `kind` tag so a single `<data-table>` can paint Colors,
+ * Typography, Shapes, and the seed summary without three separate
+ * tables (the design doc treats the sections as a single tab body
+ * with sub-headings).
+ */
+export function themingTableColumns(): readonly DataTableColumn<ThemingRow>[] {
+    return [
+        {
+            header: "Section",
+            cellClass: "theming-section-cell",
+            render: (row) => sectionLabel(row),
+        },
+        {
+            header: "",
+            cellClass: "theming-swatch-cell",
+            render: (row) => renderSwatch(row),
+        },
+        {
+            header: "Name",
+            cellClass: "theming-name-cell",
+            render: (row) => renderName(row),
+        },
+        {
+            header: "Value",
+            cellClass: "theming-value-cell",
+            render: (row) => renderValue(row),
+        },
+        {
+            header: "Consumers",
+            cellClass: "theming-consumers-cell",
+            render: (row) => renderConsumers(row),
+        },
+    ];
+}
+
+function sectionLabel(row: ThemingRow): string {
+    if (row.kind === "seed") return "Seed";
+    return row.section;
+}
+
+function renderSwatch(row: ThemingRow): TemplateResult | string {
+    if (row.kind === "color" || row.kind === "seed") {
+        return html`<span
+            class="theming-swatch"
+            data-source=${row.kind === "seed"
+                ? "seed"
+                : (row as ThemingColorRow).source}
+            style=${"background-color: " + row.swatchCss}
+            title=${row.hex}
+        ></span>`;
+    }
+    return "";
+}
+
+function renderName(row: ThemingRow): TemplateResult {
+    if (row.kind === "seed") {
+        return html`<div class="theming-name-stack">
+            <strong>${row.name}</strong>
+            <span class="theming-name-sub"
+                >${row.isDark ? "dark" : "light"} ·
+                ${row.paletteStyle.toLowerCase()} · contrast
+                ${formatContrast(row.contrastLevel)}</span
+            >
+        </div>`;
+    }
+    if (row.kind === "color") {
+        return html`<div class="theming-name-stack">
+            <strong>${row.name}</strong>
+            ${row.source === "wallpaper"
+                ? html`<span class="theming-name-sub">from wallpaper</span>`
+                : ""}
+        </div>`;
+    }
+    return html`<strong>${row.name}</strong>`;
+}
+
+function renderValue(row: ThemingRow): TemplateResult | string {
+    if (row.kind === "color" || row.kind === "seed") {
+        return html`<code class="theming-hex">${row.hex}</code>`;
+    }
+    if (row.kind === "shape") {
+        return row.value || "—";
+    }
+    // Typography: stack the scalar attributes so the column doesn't
+    // sprawl. Tooltip shows the same info for narrow viewports.
+    return html`<div class="theming-typography-grid">
+        <span><em>family</em> ${row.family}</span>
+        <span><em>size</em> ${row.size}</span>
+        <span><em>weight</em> ${row.weight}</span>
+        <span><em>style</em> ${row.style}</span>
+        <span><em>line</em> ${row.lineHeight}</span>
+        <span><em>letter</em> ${row.letterSpacing}</span>
+    </div>`;
+}
+
+function renderConsumers(row: ThemingRow): string {
+    if (row.kind !== "color") return "—";
+    if (row.consumerCount === 0) return "—";
+    return String(row.consumerCount);
+}
+
+function countConsumersByToken(
+    consumers: readonly ThemeConsumer[],
+): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (const c of consumers) {
+        for (const t of c.tokens ?? []) {
+            counts.set(t, (counts.get(t) ?? 0) + 1);
+        }
+    }
+    return counts;
+}
+
+function formatScalar(
+    value: number | null | undefined,
+    unit: string | null | undefined,
+): string {
+    if (value === null || value === undefined || Number.isNaN(value)) {
+        return "—";
+    }
+    // Strip trailing zeros so 16.0 reads as "16" but 16.5 stays
+    // intact. Keeps the typography column scannable.
+    const trimmed = Number.isInteger(value)
+        ? value.toString()
+        : value.toFixed(2).replace(/\.?0+$/, "");
+    return unit ? trimmed + unit.toLowerCase() : trimmed;
+}
+
+function formatContrast(level: number): string {
+    if (Number.isInteger(level)) return level.toFixed(1);
+    return level.toFixed(2);
+}
+
+/**
+ * Coerce a `#AARRGGBB` wire colour into a CSS-safe `rgba(...)` so
+ * the swatch background renders identically regardless of whether
+ * the browser parses ARGB as `#AARRGGBB` (it doesn't — CSS expects
+ * `#RRGGBBAA`). Also tolerates `#RRGGBB` and `#RGB` shorthand for
+ * forward compatibility with future payload shapes.
+ */
+function cssColor(hex: string): string {
+    if (!hex || typeof hex !== "string") return "transparent";
+    const s = hex.trim();
+    if (!s.startsWith("#")) return s;
+    const body = s.slice(1);
+    if (body.length === 8) {
+        // #AARRGGBB (Compose / Android convention).
+        const a = parseInt(body.slice(0, 2), 16);
+        const r = parseInt(body.slice(2, 4), 16);
+        const g = parseInt(body.slice(4, 6), 16);
+        const b = parseInt(body.slice(6, 8), 16);
+        if ([a, r, g, b].some(Number.isNaN)) return s;
+        return `rgba(${r}, ${g}, ${b}, ${(a / 255).toFixed(3)})`;
+    }
+    if (body.length === 6) {
+        return s;
+    }
+    if (body.length === 3) {
+        return s;
+    }
+    return s;
+}


### PR DESCRIPTION
## Summary

Implements **Cluster C — Theming bundle** (#1056). The bundle's chip auto-subscribes `compose/theme`; `compose/wallpaper` is reachable through the bundle's Configure… expander (once #1075 lands).

Tab body is a three-section table:

- **Colors** — one row per token: swatch · token name · hex · consumer count from `ThemePayload.consumers`. When wallpaper is also enabled, prepends a "Seed" row with `seedColor` swatch, `isDark` / `paletteStyle` / `contrastLevel`, and the derived `colorScheme` entries tagged source=wallpaper.
- **Typography** — token · family · size + unit · weight · style · line-height · letter-spacing.
- **Shapes** — token · resolved value.

No `<box-overlay>` boxes — theme tokens are global, not per-node. `setOverlayId` still receives a stable per-row id so future legend correlation works.

Copy JSON ships `{ theme: ThemePayload | null, wallpaper: WallpaperPayload | null, previewId }`.

## Implementation notes

- The agent that wrote this saw the design doc reference `BundleExpander` / `buildBundleBody`, but those only exist on the unmerged #1075. The branch follows the on-main `bundleTables` / `a11yTable()` pattern; once #1075 lands the theming tab body will need a small follow-up to slot in `<bundle-expander>`.
- Hex translation handles `#AARRGGBB` → `rgba(...)` since CSS expects alpha at the end, not the start; falls back to the raw string for `#RRGGBB` / `#RGB`.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 858 passing (+9 in `computeThemingBundleData`)
- [ ] Verify Theming chip in panel: colors / typography / shapes sub-tables populate from the daemon's `compose/theme` payload; wallpaper-derived scheme prepends when enabled

Net: +839 / −5 LOC. Closes #1056.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcozQg6vaBFB5Y6vVsyuPH)_