### PR TITLE
feat(vscode-extension): performance bundle — migrate recomposition + render/trace + perfetto

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2566,3 +2566,161 @@ body {
     font-size: 11px;
     opacity: 0.55;
 }
+
+/* Performance bundle — stacked sub-sections (recomposition, render
+ * trace, Perfetto export). Each section has its own header so the tab
+ * scrolls naturally; the trace phase bar is the only chart-style
+ * surface in any bundle today, so the styling is local rather than a
+ * shared phase-bar primitive. */
+.perf-bundle-host {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 4px 0;
+}
+.perf-bundle-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.perf-section-header {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 12px;
+    font-weight: 600;
+}
+.perf-section-summary {
+    opacity: 0.7;
+    font-weight: 400;
+    font-size: 11px;
+}
+.perf-bundle-empty {
+    padding: 12px;
+    border: 1px dashed var(--vscode-panel-border, rgba(128, 128, 128, 0.3));
+    border-radius: 4px;
+    color: var(--vscode-descriptionForeground);
+    font-size: 12px;
+}
+.perf-bundle-empty-title {
+    margin: 0 0 4px;
+    font-weight: 600;
+}
+.perf-bundle-empty-detail {
+    margin: 0;
+    opacity: 0.85;
+}
+.perf-recomp-rank {
+    width: 24px;
+    opacity: 0.6;
+    text-align: right;
+}
+.perf-recomp-nodeid {
+    font-family: var(--vscode-editor-font-family, "SF Mono", Menlo, monospace);
+    font-size: 11px;
+    word-break: break-all;
+}
+.perf-recomp-count {
+    text-align: right;
+    width: 64px;
+}
+.perf-recomp-count-badge {
+    display: inline-block;
+    min-width: 28px;
+    padding: 1px 6px;
+    border-radius: 9px;
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+    font-size: 11px;
+    font-weight: 700;
+}
+.perf-recomp-more {
+    opacity: 0.7;
+    font-size: 11px;
+    padding: 0 8px;
+}
+.perf-chip-row {
+    display: inline-flex;
+    gap: 4px;
+}
+.perf-chip {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 9px;
+    font-size: 10px;
+    background: var(--vscode-editorWidget-background);
+    border: 1px solid var(--vscode-editorWidget-border, transparent);
+}
+.perf-chip[data-mode="delta"] {
+    background: var(--vscode-statusBarItem-prominentBackground, #1976d2);
+    color: var(--vscode-statusBarItem-prominentForeground, #fff);
+}
+.perf-chip-seq {
+    opacity: 0.85;
+}
+.perf-phase-bar {
+    display: flex;
+    width: 100%;
+    height: 22px;
+    background: var(--vscode-editorWidget-background, rgba(128, 128, 128, 0.1));
+    border-radius: 3px;
+    overflow: hidden;
+}
+.perf-phase-bar-segment {
+    position: relative;
+    display: flex;
+    align-items: center;
+    padding: 0 6px;
+    min-width: 2px;
+    background: var(--vscode-progressBar-background, #0e639c);
+    border-right: 1px solid var(--vscode-editor-background, #1e1e1e);
+    overflow: hidden;
+    white-space: nowrap;
+    color: var(--vscode-editor-background, #1e1e1e);
+    font-size: 10px;
+    font-weight: 600;
+}
+.perf-phase-bar-segment:last-child {
+    border-right: none;
+}
+.perf-phase-bar-segment-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.perf-metrics-list {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 2px 12px;
+    margin: 0;
+    font-size: 11px;
+}
+.perf-metrics-list dt {
+    opacity: 0.7;
+    font-family: var(--vscode-editor-font-family, "SF Mono", Menlo, monospace);
+}
+.perf-metrics-list dd {
+    margin: 0;
+}
+.perf-perfetto-summary {
+    font-size: 11px;
+    opacity: 0.85;
+}
+.perf-perfetto-top {
+    opacity: 0.85;
+}
+.perf-perfetto-open {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 3px;
+    border: 1px solid var(--vscode-button-border, transparent);
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    font-size: 11px;
+    cursor: pointer;
+    align-self: flex-start;
+}
+.perf-perfetto-open:hover {
+    background: var(--vscode-button-hoverBackground);
+}

--- a/vscode-extension/src/test/performanceBundlePresenter.test.ts
+++ b/vscode-extension/src/test/performanceBundlePresenter.test.ts
@@ -1,0 +1,225 @@
+// Performance bundle presenter (#1060 Cluster G). Pins the parsing of
+// all three wire kinds the bundle covers — `compose/recomposition`,
+// `render/trace`, and `render/composeAiTrace` — against empty,
+// populated, and key-field round-trip shapes. Layout/DOM lives behind
+// `renderPerformanceSections` and is exercised by the smoke harness;
+// these unit tests only assert the parsed payload shape since that's
+// what every other bundle test does (see `a11yBundlePresenter.test.ts`).
+
+import * as assert from "assert";
+import {
+    computePerformanceBundleData,
+    performanceTableColumns,
+} from "../webview/preview/performanceBundlePresenter";
+
+describe("computePerformanceBundleData — recomposition", () => {
+    it("returns null when payload is missing", () => {
+        const data = computePerformanceBundleData(null, null, null);
+        assert.strictEqual(data.recomposition, null);
+    });
+
+    it("returns null when nodes is empty (nothing recomposed)", () => {
+        const data = computePerformanceBundleData(
+            { mode: "delta", inputSeq: 7, nodes: [] },
+            null,
+            null,
+        );
+        assert.strictEqual(data.recomposition, null);
+    });
+
+    it("sorts rows by count desc and caps at TOP_N (10)", () => {
+        const nodes = Array.from({ length: 15 }, (_, i) => ({
+            nodeId: "node-" + i,
+            count: i + 1, // 1..15
+        }));
+        const data = computePerformanceBundleData(
+            { mode: "snapshot", nodes },
+            null,
+            null,
+        );
+        const r = data.recomposition;
+        assert.ok(r, "recomposition section must be present");
+        assert.strictEqual(r!.rows.length, 10);
+        // Sorted desc: top entry is the highest count.
+        assert.strictEqual(r!.rows[0].count, 15);
+        assert.strictEqual(r!.rows[0].nodeId, "node-14");
+        // Truncation surfaces the leftover for the "+N more" footer.
+        assert.strictEqual(r!.totalNodes, 15);
+        assert.strictEqual(r!.truncated, 5);
+    });
+
+    it("round-trips mode + inputSeq onto every row", () => {
+        const data = computePerformanceBundleData(
+            {
+                mode: "delta",
+                inputSeq: 42,
+                nodes: [
+                    { nodeId: "a", count: 3 },
+                    { nodeId: "b", count: 1 },
+                ],
+            },
+            null,
+            null,
+        );
+        const r = data.recomposition!;
+        assert.strictEqual(r.mode, "delta");
+        assert.strictEqual(r.inputSeq, 42);
+        for (const row of r.rows) {
+            assert.strictEqual(row.mode, "delta");
+            assert.strictEqual(row.inputSeq, 42);
+        }
+    });
+
+    it("drops nodes with non-finite count or empty nodeId", () => {
+        const data = computePerformanceBundleData(
+            {
+                mode: "snapshot",
+                nodes: [
+                    { nodeId: "good", count: 5 },
+                    { nodeId: "", count: 9 },
+                    { nodeId: "nan", count: Number.NaN },
+                    { count: 1 }, // missing nodeId
+                ],
+            },
+            null,
+            null,
+        );
+        const r = data.recomposition!;
+        assert.strictEqual(r.rows.length, 1);
+        assert.strictEqual(r.rows[0].nodeId, "good");
+    });
+});
+
+describe("computePerformanceBundleData — render/trace", () => {
+    it("returns null when payload is missing", () => {
+        const data = computePerformanceBundleData(null, null, null);
+        assert.strictEqual(data.renderTrace, null);
+    });
+
+    it("returns null when all fields are empty", () => {
+        const data = computePerformanceBundleData(
+            null,
+            { phases: [], metrics: {} },
+            null,
+        );
+        assert.strictEqual(data.renderTrace, null);
+    });
+
+    it("derives per-phase widthPct from totalMs as the chart scale", () => {
+        const data = computePerformanceBundleData(
+            null,
+            {
+                totalMs: 100,
+                phases: [
+                    { name: "compose", startMs: 0, durationMs: 25 },
+                    { name: "measure", startMs: 25, durationMs: 50 },
+                    { name: "draw", startMs: 75, durationMs: 25 },
+                ],
+                metrics: { frames: 1 },
+            },
+            null,
+        );
+        const rt = data.renderTrace!;
+        assert.strictEqual(rt.totalMs, 100);
+        assert.strictEqual(rt.phases.length, 3);
+        assert.strictEqual(rt.phases[0].widthPct, 25);
+        assert.strictEqual(rt.phases[1].widthPct, 50);
+        assert.strictEqual(rt.phases[2].widthPct, 25);
+        // tookMs would be redundant with totalMs, but `frames` survives.
+        assert.deepStrictEqual(
+            rt.metrics.map((m) => m.key),
+            ["frames"],
+        );
+    });
+
+    it("suppresses metrics.tookMs (redundant with totalMs)", () => {
+        const data = computePerformanceBundleData(
+            null,
+            {
+                totalMs: 10,
+                phases: [],
+                metrics: { tookMs: 10, otherStat: "yes" },
+            },
+            null,
+        );
+        const rt = data.renderTrace!;
+        const keys = rt.metrics.map((m) => m.key);
+        assert.ok(!keys.includes("tookMs"), "tookMs must be suppressed");
+        assert.deepStrictEqual(keys, ["otherStat"]);
+    });
+});
+
+describe("computePerformanceBundleData — composeAiTrace", () => {
+    it("returns null when payload is missing", () => {
+        const data = computePerformanceBundleData(null, null, null);
+        assert.strictEqual(data.composeAiTrace, null);
+    });
+
+    it("returns null when traceEvents is empty and no totalMs", () => {
+        const data = computePerformanceBundleData(null, null, {
+            traceEvents: [],
+        });
+        assert.strictEqual(data.composeAiTrace, null);
+    });
+
+    it("aggregates phase counts and exposes top-3 names", () => {
+        const data = computePerformanceBundleData(null, null, {
+            totalMs: 50,
+            traceEvents: [
+                { name: "compose", ph: "X" },
+                { name: "compose", ph: "X" },
+                { name: "measure", ph: "X" },
+                { name: "draw", ph: "X" },
+                { name: "compose", ph: "X" },
+                { name: "noise", ph: "I" }, // instant — filtered out
+                { ph: "X" }, // missing name — filtered out
+                "not-an-object",
+            ],
+        });
+        const summary = data.composeAiTrace!;
+        assert.strictEqual(summary.phaseCount, 3);
+        assert.strictEqual(summary.totalMs, 50);
+        // "compose" wins with 3, then measure(1), draw(1) — order
+        // between the 1-count phases is map-insertion stable.
+        assert.strictEqual(summary.topPhases[0], "compose (3)");
+        assert.strictEqual(summary.topPhases.length, 3);
+        // The raw payload rides along for the Open-in-Perfetto button
+        // so we don't redact it down to just the summary.
+        assert.ok(summary.rawPayload);
+    });
+
+    it("keeps rawPayload identity so the copy button ships the full JSON", () => {
+        const raw = {
+            traceEvents: [{ name: "compose", ph: "X" }],
+            totalMs: 12,
+        };
+        const data = computePerformanceBundleData(null, null, raw);
+        assert.strictEqual(data.composeAiTrace!.rawPayload, raw);
+    });
+});
+
+describe("performanceTableColumns", () => {
+    it("exposes the recomposition columns (#, Node, Count, Mode)", () => {
+        const cols = performanceTableColumns();
+        assert.deepStrictEqual(
+            cols.map((c) => c.header),
+            ["#", "Node", "Count", "Mode"],
+        );
+    });
+
+    it("renders the rank as the row index + 1", () => {
+        const cols = performanceTableColumns();
+        const rankCol = cols[0];
+        const out = rankCol.render(
+            {
+                id: "perf-recomp-0",
+                nodeId: "node",
+                count: 1,
+                mode: "",
+                inputSeq: null,
+            },
+            4,
+        );
+        assert.strictEqual(out, "5");
+    });
+});

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -40,6 +40,12 @@ import { BundleExpander } from "./components/BundleExpander";
 import { BundleController, type BundleSnapshot } from "./bundleController";
 import { getBundle, type BundleId } from "./bundleRegistry";
 import { a11yTableColumns, computeA11yBundleData } from "./a11yBundlePresenter";
+import {
+    computePerformanceBundleData,
+    performanceTableColumns,
+    renderPerfPlaceholder,
+    renderPerformanceSections,
+} from "./performanceBundlePresenter";
 import { FilterController } from "./filterController";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
 import {
@@ -568,6 +574,59 @@ export class PreviewApp extends LitElement {
             bundleBodies.set("a11y", b);
             return b;
         };
+        // Performance bundle body is shaped differently from the others
+        // — it stacks three sub-sections (recomposition table, render
+        // trace bar chart, Perfetto handoff) under the shared expander.
+        // We reuse the expander wiring from `buildBundleBody` but route
+        // section painting through `renderPerformanceSections` instead
+        // of the single `<data-table>` slot the other bundles use.
+        interface PerformanceBody {
+            wrapper: HTMLElement;
+            expander: BundleExpander;
+            recompTable: DataTable<unknown>;
+            host: HTMLElement;
+        }
+        let performanceCachedBody: PerformanceBody | null = null;
+        const performanceBody = (): PerformanceBody => {
+            if (performanceCachedBody) return performanceCachedBody;
+            const wrapper = document.createElement("div");
+            wrapper.className = "bundle-tab-body";
+            wrapper.dataset.bundle = "performance";
+            const expander = document.createElement(
+                "bundle-expander",
+            ) as BundleExpander;
+            expander.addEventListener("kind-toggled", (evt) => {
+                const det = (
+                    evt as CustomEvent<
+                        import("./components/BundleExpander").BundleKindToggledDetail
+                    >
+                ).detail;
+                bundleController.setKindEnabled(
+                    det.bundleId,
+                    det.kind,
+                    det.enabled,
+                );
+            });
+            // Recomposition uses the shared `<data-table>` so row hover
+            // and copy-JSON parity with the other bundles is automatic.
+            // Render trace + Perfetto don't fit the row model, so they
+            // paint their own DOM into `host` below.
+            const recompTable = document.createElement(
+                "data-table",
+            ) as DataTable<unknown>;
+            recompTable.heading = "Recomposition";
+            recompTable.setColumns(
+                performanceTableColumns() as unknown as ReadonlyArray<
+                    import("./components/DataTable").DataTableColumn<unknown>
+                >,
+            );
+            const host = document.createElement("section");
+            host.className = "perf-bundle-host";
+            wrapper.appendChild(expander);
+            wrapper.appendChild(host);
+            performanceCachedBody = { wrapper, expander, recompTable, host };
+            return performanceCachedBody;
+        };
         const refreshExpanderFor = (id: BundleId): void => {
             const body = bundleBodies.get(id);
             const bundle = getBundle(id);
@@ -605,6 +664,68 @@ export class PreviewApp extends LitElement {
             refreshExpanderFor("a11y");
             dataTabs.setTabBody("a11y", body.wrapper);
         };
+        const refreshPerformanceBundle = (): void => {
+            const target = currentBundleTarget();
+            if (!target) return;
+            const byKind = dataProductsByPreview.get(target);
+            const recompPayload = byKind?.get("compose/recomposition") ?? null;
+            const tracePayload = byKind?.get("render/trace") ?? null;
+            const perfettoPayload =
+                byKind?.get("render/composeAiTrace") ?? null;
+            const data = computePerformanceBundleData(
+                recompPayload,
+                tracePayload,
+                perfettoPayload,
+            );
+            const body = performanceBody();
+            // Sync the expander row regardless of payload — it's the
+            // user's only way to turn the default-OFF kinds on.
+            // `refreshExpanderFor` needs the entry registered in
+            // `bundleBodies` so it can read the cached BundleBody, but
+            // performance has its own cache. Hand-roll the equivalent
+            // setState call here.
+            const bundleDescriptor = getBundle("performance");
+            if (bundleDescriptor) {
+                body.expander.setState({
+                    bundleId: "performance",
+                    kinds: bundleDescriptor.kinds,
+                    enabledKinds: bundleController
+                        .state()
+                        .enabledKinds("performance"),
+                });
+            }
+            const enabledKinds = bundleController
+                .state()
+                .enabledKinds("performance");
+            const hasAnyPayload =
+                data.recomposition !== null ||
+                data.renderTrace !== null ||
+                data.composeAiTrace !== null;
+            if (enabledKinds.length === 0 && !hasAnyPayload) {
+                // Placeholder hint — every kind in this bundle is
+                // medium+ cost, so we don't auto-enable one on chip
+                // press. The user opens Configure… and picks.
+                renderPerfPlaceholder(body.host);
+            } else {
+                renderPerformanceSections(
+                    body.host,
+                    data,
+                    target,
+                    body.recompTable,
+                    (text) =>
+                        vscode.postMessage({
+                            command: "copyToClipboard",
+                            text,
+                        }),
+                    {
+                        recomposition: recompPayload,
+                        renderTrace: tracePayload,
+                        composeAiTrace: perfettoPayload,
+                    },
+                );
+            }
+            dataTabs.setTabBody("performance", body.wrapper);
+        };
         const reflectBundleState = (): void => {
             const s = bundleController.state();
             bundleChipBar.setState({
@@ -617,6 +738,9 @@ export class PreviewApp extends LitElement {
                 activeTab: s.activeTab,
             });
             if (s.activeBundles.includes("a11y")) refreshA11yBundle();
+            if (s.activeBundles.includes("performance")) {
+                refreshPerformanceBundle();
+            }
         };
         bundleController.onChange(() => reflectBundleState());
         reflectBundleState();
@@ -969,13 +1093,25 @@ export class PreviewApp extends LitElement {
                     inspector.render(focused);
                 }
                 // Refresh bundle tab bodies that depend on this preview's
-                // data. Today only A11y has a bundle presenter; future
-                // clusters add their own refresh.
-                if (
-                    bundleController.state().activeBundles.includes("a11y") &&
-                    currentBundleTarget() === previewId
-                ) {
+                // data. Each bundle gates on its own active flag so a
+                // preview that ships unrelated kinds doesn't redraw
+                // every open tab.
+                const activeBundles = bundleController.state().activeBundles;
+                const matchesTarget = currentBundleTarget() === previewId;
+                if (matchesTarget && activeBundles.includes("a11y")) {
                     refreshA11yBundle();
+                }
+                if (
+                    matchesTarget &&
+                    activeBundles.includes("performance") &&
+                    dataProducts.some(
+                        (dp) =>
+                            dp.kind === "compose/recomposition" ||
+                            dp.kind === "render/trace" ||
+                            dp.kind === "render/composeAiTrace",
+                    )
+                ) {
+                    refreshPerformanceBundle();
                 }
             },
             focusOnCard,

--- a/vscode-extension/src/webview/preview/performanceBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/performanceBundlePresenter.ts
@@ -1,0 +1,532 @@
+// Performance bundle presenter — fills the "Performance" tab body in
+// `<data-tabs>`. The bundle bundles three wire kinds that all answer
+// perf questions but with different shapes, so the tab body is a
+// stacked set of sub-sections rather than a single table:
+//
+//   * `compose/recomposition` — top-N hottest scopes by count
+//   * `render/trace` — phase bar chart + metrics fallthrough
+//   * `render/composeAiTrace` — summary + Perfetto handoff button
+//
+// Each sub-section renders independently when its payload is present;
+// when the chip is on but no kind is enabled the host shell shows a
+// hint to use the Configure expander (default-OFF for all three since
+// they're medium+ cost).
+//
+// The kind-specific renderers in `focusPresentation.ts` (recomposition,
+// render-trace) are intentionally left in place so the legacy focus
+// inspector keeps working through migration. Shape-wise this presenter
+// mirrors their parsing — same defensive `typeof` checks, same TOP_N,
+// same `metrics.tookMs` suppression.
+//
+// See `docs/design/EXTENSION_DATA_EXPOSURE.md` § Performance.
+
+import { html, type TemplateResult } from "lit";
+import type { DataTableColumn } from "./components/DataTable";
+
+export interface RecompositionRow {
+    id: string;
+    nodeId: string;
+    count: number;
+    mode: string;
+    inputSeq: number | null;
+}
+
+export interface RenderTracePhase {
+    name: string;
+    startMs: number;
+    durationMs: number;
+    /** Per-phase % of `chartScale`, pre-computed so the renderer
+     *  doesn't redo the divide on each paint. */
+    widthPct: number;
+}
+
+export interface RenderTraceMetric {
+    key: string;
+    value: string;
+}
+
+export interface RenderTraceSection {
+    totalMs: number | null;
+    phases: readonly RenderTracePhase[];
+    metrics: readonly RenderTraceMetric[];
+}
+
+export interface ComposeAiTraceSummary {
+    phaseCount: number;
+    totalMs: number | null;
+    topPhases: readonly string[];
+    /** Full payload kept around so the "Open in Perfetto" button can
+     *  ship JSON to the clipboard without re-fetching. */
+    rawPayload: unknown;
+}
+
+export interface PerformanceBundleData {
+    recomposition: {
+        rows: readonly RecompositionRow[];
+        mode: string;
+        inputSeq: number | null;
+        totalNodes: number;
+        truncated: number;
+    } | null;
+    renderTrace: RenderTraceSection | null;
+    composeAiTrace: ComposeAiTraceSummary | null;
+}
+
+const TOP_N_RECOMPOSITION = 10;
+const TOP_N_PERFETTO_PHASES = 3;
+
+/**
+ * Build the data behind the Performance tab body from the raw wire
+ * payloads. Each input may be `null`/missing — the corresponding
+ * section comes back as `null` when its payload didn't produce anything
+ * displayable (kept symmetric with the focus-inspector presenters so
+ * test fixtures port over).
+ */
+export function computePerformanceBundleData(
+    recompositionPayload: unknown,
+    traceP: unknown,
+    perfettoP: unknown,
+): PerformanceBundleData {
+    return {
+        recomposition: parseRecomposition(recompositionPayload),
+        renderTrace: parseRenderTrace(traceP),
+        composeAiTrace: parseComposeAiTrace(perfettoP),
+    };
+}
+
+/**
+ * Column shape for the recomposition sub-table. Sourced from the
+ * focus-inspector `composeRecompositionPresenter` registration in
+ * `focusPresentation.ts` — same nodeId / count split, with the mode
+ * and inputSeq lifted into the row so the column renderer can chip
+ * them for at-a-glance triage.
+ */
+export function performanceTableColumns(): readonly DataTableColumn<RecompositionRow>[] {
+    return [
+        {
+            header: "#",
+            cellClass: "perf-recomp-rank",
+            render: (_row, idx) => String(idx + 1),
+        },
+        {
+            header: "Node",
+            cellClass: "perf-recomp-node",
+            render: (row) =>
+                html`<code class="perf-recomp-nodeid">${row.nodeId}</code>`,
+        },
+        {
+            header: "Count",
+            cellClass: "perf-recomp-count",
+            render: (row) =>
+                html`<span class="perf-recomp-count-badge">${row.count}</span>`,
+        },
+        {
+            header: "Mode",
+            cellClass: "perf-recomp-mode",
+            render: (row) => renderModeCell(row),
+        },
+    ];
+}
+
+function renderModeCell(row: RecompositionRow): TemplateResult | string {
+    if (!row.mode && row.inputSeq === null) return "—";
+    const chips: TemplateResult[] = [];
+    if (row.mode) {
+        chips.push(
+            html`<span class="perf-chip" data-mode=${row.mode}
+                >${row.mode}</span
+            >`,
+        );
+    }
+    if (row.mode === "delta" && row.inputSeq !== null) {
+        chips.push(
+            html`<span class="perf-chip perf-chip-seq"
+                >input ${row.inputSeq}</span
+            >`,
+        );
+    }
+    return html`<div class="perf-chip-row">${chips}</div>`;
+}
+
+function parseRecomposition(
+    raw: unknown,
+): PerformanceBundleData["recomposition"] {
+    if (!raw || typeof raw !== "object") return null;
+    const payload = raw as {
+        mode?: unknown;
+        inputSeq?: unknown;
+        nodes?: unknown;
+    };
+    const nodes = Array.isArray(payload.nodes) ? payload.nodes : [];
+    const parsed: Array<{ nodeId: string; count: number }> = [];
+    for (const n of nodes) {
+        if (!n || typeof n !== "object") continue;
+        const node = n as { nodeId?: unknown; count?: unknown };
+        if (typeof node.nodeId !== "string" || node.nodeId.length === 0) {
+            continue;
+        }
+        if (typeof node.count !== "number" || !Number.isFinite(node.count)) {
+            continue;
+        }
+        parsed.push({ nodeId: node.nodeId, count: node.count });
+    }
+    if (parsed.length === 0) return null;
+    parsed.sort((a, b) => b.count - a.count);
+    const mode = typeof payload.mode === "string" ? payload.mode : "";
+    const inputSeq =
+        typeof payload.inputSeq === "number" &&
+        Number.isFinite(payload.inputSeq)
+            ? payload.inputSeq
+            : null;
+    const top = parsed.slice(0, TOP_N_RECOMPOSITION);
+    const rows: RecompositionRow[] = top.map((node, idx) => ({
+        id: "perf-recomp-" + idx,
+        nodeId: node.nodeId,
+        count: node.count,
+        mode,
+        inputSeq,
+    }));
+    return {
+        rows,
+        mode,
+        inputSeq,
+        totalNodes: parsed.length,
+        truncated: Math.max(0, parsed.length - TOP_N_RECOMPOSITION),
+    };
+}
+
+function parseRenderTrace(raw: unknown): RenderTraceSection | null {
+    if (!raw || typeof raw !== "object") return null;
+    const payload = raw as {
+        totalMs?: unknown;
+        phases?: unknown;
+        metrics?: unknown;
+    };
+    const totalMs =
+        typeof payload.totalMs === "number" && Number.isFinite(payload.totalMs)
+            ? payload.totalMs
+            : null;
+    const rawPhases = Array.isArray(payload.phases) ? payload.phases : [];
+    const phasesNoWidth: Array<{
+        name: string;
+        startMs: number;
+        durationMs: number;
+    }> = [];
+    for (const p of rawPhases) {
+        if (!p || typeof p !== "object") continue;
+        const ph = p as {
+            name?: unknown;
+            startMs?: unknown;
+            durationMs?: unknown;
+        };
+        if (typeof ph.name !== "string" || ph.name.length === 0) continue;
+        if (
+            typeof ph.durationMs !== "number" ||
+            !Number.isFinite(ph.durationMs)
+        ) {
+            continue;
+        }
+        const startMs =
+            typeof ph.startMs === "number" && Number.isFinite(ph.startMs)
+                ? ph.startMs
+                : 0;
+        phasesNoWidth.push({
+            name: ph.name,
+            startMs,
+            durationMs: ph.durationMs,
+        });
+    }
+    const maxDuration = phasesNoWidth.reduce(
+        (acc, p) => (p.durationMs > acc ? p.durationMs : acc),
+        0,
+    );
+    const chartScale = totalMs && totalMs > 0 ? totalMs : maxDuration;
+    const phases: RenderTracePhase[] = phasesNoWidth.map((p) => ({
+        ...p,
+        widthPct:
+            chartScale > 0
+                ? Math.max(0, Math.min(100, (p.durationMs / chartScale) * 100))
+                : 0,
+    }));
+
+    const rawMetrics =
+        payload.metrics && typeof payload.metrics === "object"
+            ? (payload.metrics as Record<string, unknown>)
+            : {};
+    const metrics: RenderTraceMetric[] = [];
+    for (const key of Object.keys(rawMetrics).sort()) {
+        if (key === "tookMs") continue; // redundant with totalMs
+        const value = rawMetrics[key];
+        if (typeof value === "string" || typeof value === "number") {
+            metrics.push({ key, value: String(value) });
+        }
+    }
+    if (phases.length === 0 && metrics.length === 0 && totalMs === null) {
+        return null;
+    }
+    return { totalMs, phases, metrics };
+}
+
+function parseComposeAiTrace(raw: unknown): ComposeAiTraceSummary | null {
+    if (!raw || typeof raw !== "object") return null;
+    // composeAiTrace mirrors the Perfetto JSON shape — it has a
+    // top-level array of trace events under `traceEvents`. We only
+    // need a summary here; the full payload rides along on
+    // `rawPayload` so the copy button doesn't have to round-trip
+    // through the daemon again.
+    const payload = raw as {
+        traceEvents?: unknown;
+        totalMs?: unknown;
+    };
+    const events = Array.isArray(payload.traceEvents)
+        ? payload.traceEvents
+        : [];
+    const phaseCounts = new Map<string, number>();
+    for (const e of events) {
+        if (!e || typeof e !== "object") continue;
+        const evt = e as { name?: unknown; ph?: unknown };
+        if (typeof evt.name !== "string" || evt.name.length === 0) continue;
+        // Count complete ("X") and begin ("B") events as phases — the
+        // common Perfetto shape Compose emits is "X" durations.
+        const ph = typeof evt.ph === "string" ? evt.ph : "";
+        if (ph && ph !== "X" && ph !== "B") continue;
+        phaseCounts.set(evt.name, (phaseCounts.get(evt.name) ?? 0) + 1);
+    }
+    const totalMs =
+        typeof payload.totalMs === "number" && Number.isFinite(payload.totalMs)
+            ? payload.totalMs
+            : null;
+    if (phaseCounts.size === 0 && totalMs === null) return null;
+    const topPhases = [...phaseCounts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, TOP_N_PERFETTO_PHASES)
+        .map(([name, count]) => `${name} (${count})`);
+    return {
+        phaseCount: phaseCounts.size,
+        totalMs,
+        topPhases,
+        rawPayload: raw,
+    };
+}
+
+/**
+ * Imperative host renderer that paints the stacked performance
+ * sub-sections into [host] given the computed [data]. Sections that
+ * have no payload are skipped — when none have any payload the caller
+ * (main.ts) shows a placeholder via {@link renderPerfPlaceholder}.
+ *
+ * The recomposition section reuses the shared `<data-table>` primitive
+ * (passed in as [recompTable]) so it gets the same row-hover, copy-JSON,
+ * and visual chrome as the other bundles. The render-trace and Perfetto
+ * sections paint their own DOM since they're not row-based.
+ */
+export function renderPerformanceSections(
+    host: HTMLElement,
+    data: PerformanceBundleData,
+    previewId: string,
+    // Caller hands us a `DataTable<unknown>` (shared primitive); we
+    // narrow internally without re-typing the element. Using an
+    // `unknown`-row shape here keeps the cast at the construction
+    // site (main.ts) instead of fighting the element's type
+    // parameter from the presenter side.
+    recompTable: {
+        setRows(rows: readonly unknown[]): void;
+        summary: string;
+        setOverlayId(fn: (row: unknown, idx: number) => string): void;
+        setJsonPayload(fn: () => unknown): void;
+    },
+    copyToClipboard: (text: string) => void,
+    rawPayloads: {
+        recomposition: unknown;
+        renderTrace: unknown;
+        composeAiTrace: unknown;
+    },
+): void {
+    // Tear down prior contents — sections may have toggled off since
+    // the last refresh, and we want a deterministic layout.
+    host.replaceChildren();
+
+    if (data.recomposition) {
+        const section = document.createElement("div");
+        section.className = "perf-bundle-section perf-bundle-recomposition";
+        const r = data.recomposition;
+        recompTable.setRows(r.rows as readonly unknown[]);
+        const summaryParts: string[] = [];
+        if (r.mode) summaryParts.push(r.mode);
+        if (r.mode === "delta" && r.inputSeq !== null) {
+            summaryParts.push("input " + r.inputSeq);
+        }
+        summaryParts.push(
+            r.totalNodes === 1 ? "1 node" : r.totalNodes + " nodes",
+        );
+        recompTable.summary = summaryParts.join(" · ");
+        recompTable.setOverlayId((row) => (row as RecompositionRow).id);
+        recompTable.setJsonPayload(() => ({
+            previewId,
+            recomposition: rawPayloads.recomposition,
+        }));
+        section.appendChild(recompTable as unknown as HTMLElement);
+        if (r.truncated > 0) {
+            const more = document.createElement("div");
+            more.className = "perf-recomp-more";
+            more.textContent =
+                "+" + r.truncated + " more (showing top " + r.rows.length + ")";
+            section.appendChild(more);
+        }
+        host.appendChild(section);
+    }
+
+    if (data.renderTrace) {
+        host.appendChild(renderRenderTraceSection(data.renderTrace));
+    }
+
+    if (data.composeAiTrace) {
+        host.appendChild(
+            renderComposeAiTraceSection(
+                data.composeAiTrace,
+                previewId,
+                rawPayloads,
+                copyToClipboard,
+            ),
+        );
+    }
+}
+
+/**
+ * Placeholder body when the chip is on but every kind is default-OFF
+ * and no payload has arrived. Hint the user to open Configure… in
+ * the tab header; the design doc specifies this rather than auto-
+ * enabling a kind, since every Performance kind has nontrivial cost.
+ */
+export function renderPerfPlaceholder(host: HTMLElement): void {
+    host.replaceChildren();
+    const div = document.createElement("div");
+    div.className = "perf-bundle-empty";
+    const title = document.createElement("p");
+    title.className = "perf-bundle-empty-title";
+    title.textContent = "Pick a perf kind in Configure…";
+    div.appendChild(title);
+    const detail = document.createElement("p");
+    detail.className = "perf-bundle-empty-detail";
+    detail.textContent =
+        "Recomposition counts, render trace, and Perfetto export are all " +
+        "off by default because they cost the daemon a render. " +
+        "Open the gear next to the tab to enable one.";
+    div.appendChild(detail);
+    host.appendChild(div);
+}
+
+function renderRenderTraceSection(trace: RenderTraceSection): HTMLElement {
+    const section = document.createElement("div");
+    section.className = "perf-bundle-section perf-bundle-render-trace";
+    const header = document.createElement("div");
+    header.className = "perf-section-header";
+    const title = document.createElement("span");
+    title.className = "perf-section-title";
+    title.textContent = "Render trace";
+    header.appendChild(title);
+    if (trace.totalMs !== null) {
+        const total = document.createElement("span");
+        total.className = "perf-section-summary";
+        total.textContent = trace.totalMs + " ms total";
+        header.appendChild(total);
+    }
+    section.appendChild(header);
+
+    if (trace.phases.length > 0) {
+        const bar = document.createElement("div");
+        bar.className = "perf-phase-bar";
+        for (const phase of trace.phases) {
+            const seg = document.createElement("div");
+            seg.className = "perf-phase-bar-segment";
+            seg.style.width = phase.widthPct + "%";
+            seg.title = phase.name + ": " + phase.durationMs + " ms";
+            const label = document.createElement("span");
+            label.className = "perf-phase-bar-segment-label";
+            label.textContent = phase.name + " · " + phase.durationMs + " ms";
+            seg.appendChild(label);
+            bar.appendChild(seg);
+        }
+        section.appendChild(bar);
+    }
+
+    if (trace.metrics.length > 0) {
+        const dl = document.createElement("dl");
+        dl.className = "perf-metrics-list";
+        for (const m of trace.metrics) {
+            const dt = document.createElement("dt");
+            dt.textContent = m.key;
+            const dd = document.createElement("dd");
+            dd.textContent = m.value;
+            dl.appendChild(dt);
+            dl.appendChild(dd);
+        }
+        section.appendChild(dl);
+    }
+    return section;
+}
+
+function renderComposeAiTraceSection(
+    summary: ComposeAiTraceSummary,
+    previewId: string,
+    rawPayloads: {
+        recomposition: unknown;
+        renderTrace: unknown;
+        composeAiTrace: unknown;
+    },
+    copyToClipboard: (text: string) => void,
+): HTMLElement {
+    const section = document.createElement("div");
+    section.className = "perf-bundle-section perf-bundle-perfetto";
+    const header = document.createElement("div");
+    header.className = "perf-section-header";
+    const title = document.createElement("span");
+    title.className = "perf-section-title";
+    title.textContent = "Perfetto trace";
+    header.appendChild(title);
+    section.appendChild(header);
+
+    const summaryRow = document.createElement("div");
+    summaryRow.className = "perf-perfetto-summary";
+    const phasesEl = document.createElement("span");
+    phasesEl.textContent =
+        summary.phaseCount === 1 ? "1 phase" : summary.phaseCount + " phases";
+    summaryRow.appendChild(phasesEl);
+    if (summary.totalMs !== null) {
+        const total = document.createElement("span");
+        total.textContent = " · " + summary.totalMs + " ms";
+        summaryRow.appendChild(total);
+    }
+    if (summary.topPhases.length > 0) {
+        const top = document.createElement("span");
+        top.className = "perf-perfetto-top";
+        top.textContent = " · top: " + summary.topPhases.join(", ");
+        summaryRow.appendChild(top);
+    }
+    section.appendChild(summaryRow);
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "perf-perfetto-open";
+    button.title =
+        "Copies the Perfetto-importable JSON to your clipboard. " +
+        "Paste it into https://ui.perfetto.dev to open the trace.";
+    const icon = document.createElement("i");
+    icon.className = "codicon codicon-cloud-upload";
+    icon.setAttribute("aria-hidden", "true");
+    button.appendChild(icon);
+    const label = document.createElement("span");
+    label.textContent = "Open in Perfetto";
+    button.appendChild(label);
+    button.addEventListener("click", () => {
+        const payload = {
+            previewId,
+            recomposition: rawPayloads.recomposition,
+            renderTrace: rawPayloads.renderTrace,
+            composeAiTrace: rawPayloads.composeAiTrace,
+        };
+        copyToClipboard(JSON.stringify(payload, null, 2));
+    });
+    section.appendChild(button);
+    return section;
+}


### PR DESCRIPTION
## Summary

Implements **Cluster G — Performance bundle** (#1060). Migrates the existing `compose/recomposition` + `render/trace` presenters that landed under the old `focusPresentation.ts` registry (#1063) into the new bundle tab, and adds a thin `render/composeAiTrace` Perfetto handoff.

Tab body is **stacked sub-sections** since the three kinds answer different questions but share the perf workflow:

- **`compose/recomposition`** — top-N rows sorted by `count` desc, with `mode` and `inputSeq` chips.
- **`render/trace`** — horizontal bar chart of phases (rect width ∝ `durationMs`) + a metrics key/value list. `metrics.tookMs` suppressed (redundant with `totalMs`).
- **`render/composeAiTrace`** — summary (phase count, total ms, top-3 phases) + an "Open in Perfetto" button that copies the Perfetto-importable JSON to the clipboard. The title text documents the `ui.perfetto.dev` paste flow.

When the chip is pressed but no kind is enabled, the tab body shows a "Pick a perf kind in Configure…" placeholder (Performance has no default-ON kinds — all medium+ cost).

The existing kind-specific presenters in `focusPresentation.ts` are **left alone** — they're still in use by the focus inspector, which coexists with the new shell during migration.

## Implementation notes

- Branch was written against current `origin/main`, before #1075's `BundleExpander` / `buildBundleBody` helpers landed; uses a custom `PerformanceBody` interface (wrapper + expander + recompTable + host) since the stacked-sections layout doesn't fit the single-`<data-table>` slot the other bundles use. Expander wiring duplicates `buildBundleBody`'s event handler.
- `composeAiTrace` parser assumes Perfetto `traceEvents` shape (the existing daemon wire kind isn't pinned to a specific schema yet); falls back to `null` rather than throwing if the shape differs.
- No overlay boxes — Performance has no per-node bounds today.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 871 passing (+13)
- [ ] Verify Performance chip in panel: empty tab + placeholder; toggling `compose/recomposition` populates top-N list; toggling `render/trace` shows phase bar chart; toggling `render/composeAiTrace` shows summary + Copy-to-Perfetto button

Net: +1056 / −5 LOC. Closes #1060.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcozQg6vaBFB5Y6vVsyuPH)_