### PR TITLE
fix(vscode-extension): perf bundle review followups from #1079 (Perfetto JSON + stale sections)

### DIFF
--- a/vscode-extension/src/test/perfettoHandoff.test.ts
+++ b/vscode-extension/src/test/perfettoHandoff.test.ts
@@ -1,0 +1,91 @@
+// Perfetto handoff: regression for the P1 review on PR #1079 — the
+// "Open in Perfetto" button must ship the raw composeAiTrace JSON,
+// not a wrapper object, or paste-into-ui.perfetto.dev fails.
+//
+// The button is built inside `renderPerformanceSections`, which is
+// otherwise pure DOM glue. We mount it into happy-dom, locate the
+// button, click it, and inspect the captured clipboard payload.
+
+import * as assert from "assert";
+import {
+    computePerformanceBundleData,
+    renderPerformanceSections,
+} from "../webview/preview/performanceBundlePresenter";
+import { DataTable } from "../webview/preview/components/DataTable";
+
+interface StubTable {
+    setRows(rows: readonly unknown[]): void;
+    setOverlayId(fn: (row: unknown, index: number) => string): void;
+    setJsonPayload(fn: () => unknown): void;
+    summary: string;
+}
+
+function stubTable(): StubTable {
+    return {
+        setRows: () => undefined,
+        setOverlayId: () => undefined,
+        setJsonPayload: () => undefined,
+        summary: "",
+    };
+}
+
+describe("Perfetto handoff (PR #1079 P1)", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("copies the raw composeAiTrace JSON, not a wrapper object", () => {
+        const traceEvents = [
+            { name: "frame", ph: "B", ts: 0, pid: 1, tid: 1 },
+            { name: "frame", ph: "E", ts: 16000, pid: 1, tid: 1 },
+        ];
+        const composeAiTrace = { traceEvents };
+        const data = computePerformanceBundleData(null, null, composeAiTrace);
+
+        const host = document.createElement("div");
+        document.body.appendChild(host);
+        let captured: string | null = null;
+        renderPerformanceSections(
+            host,
+            data,
+            "preview.id",
+            stubTable() as unknown as DataTable<unknown>,
+            (text) => {
+                captured = text;
+            },
+            {
+                recomposition: null,
+                renderTrace: null,
+                composeAiTrace,
+            },
+        );
+        const button = host.querySelector<HTMLButtonElement>(
+            "button.perf-perfetto-open",
+        );
+        assert.ok(button, "Perfetto button rendered");
+        button!.click();
+        assert.ok(captured, "clipboard write captured");
+        const parsed = JSON.parse(captured!);
+        assert.deepStrictEqual(
+            parsed,
+            composeAiTrace,
+            "clipboard payload must be the raw composeAiTrace, not a wrapper",
+        );
+        assert.ok(
+            !Object.prototype.hasOwnProperty.call(parsed, "previewId"),
+            "previewId wrapper field must not appear at top level",
+        );
+        assert.ok(
+            Object.prototype.hasOwnProperty.call(parsed, "traceEvents"),
+            "Perfetto-importable trace must expose traceEvents at the document root",
+        );
+    });
+
+    it("clipboard write is a clear no-op when no composeAiTrace payload arrived", () => {
+        const data = computePerformanceBundleData(null, null, null);
+        // No composeAiTrace data → section isn't even rendered, so
+        // the button can't be clicked. Sanity-check that the absence
+        // is visible to the host.
+        assert.strictEqual(data.composeAiTrace, null);
+    });
+});

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -687,10 +687,25 @@ export class PreviewApp extends LitElement {
             const target = currentBundleTarget();
             if (!target) return;
             const byKind = dataProductsByPreview.get(target);
-            const recompPayload = byKind?.get("compose/recomposition") ?? null;
-            const tracePayload = byKind?.get("render/trace") ?? null;
-            const perfettoPayload =
-                byKind?.get("render/composeAiTrace") ?? null;
+            // Gate each cached payload on the user's current
+            // enabled-kinds set — otherwise a kind the user has just
+            // unchecked still shows its cached section, breaking the
+            // immediate-unsubscribe contract the Configure expander
+            // promises. Cache stays intact (the daemon keeps the
+            // subscription open), but we render only what's enabled.
+            const enabledKinds = bundleController
+                .state()
+                .enabledKinds("performance");
+            const enabledSet = new Set(enabledKinds);
+            const recompPayload = enabledSet.has("compose/recomposition")
+                ? (byKind?.get("compose/recomposition") ?? null)
+                : null;
+            const tracePayload = enabledSet.has("render/trace")
+                ? (byKind?.get("render/trace") ?? null)
+                : null;
+            const perfettoPayload = enabledSet.has("render/composeAiTrace")
+                ? (byKind?.get("render/composeAiTrace") ?? null)
+                : null;
             const data = computePerformanceBundleData(
                 recompPayload,
                 tracePayload,
@@ -708,14 +723,9 @@ export class PreviewApp extends LitElement {
                 body.expander.setState({
                     bundleId: "performance",
                     kinds: bundleDescriptor.kinds,
-                    enabledKinds: bundleController
-                        .state()
-                        .enabledKinds("performance"),
+                    enabledKinds,
                 });
             }
-            const enabledKinds = bundleController
-                .state()
-                .enabledKinds("performance");
             const hasAnyPayload =
                 data.recomposition !== null ||
                 data.renderTrace !== null ||

--- a/vscode-extension/src/webview/preview/performanceBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/performanceBundlePresenter.ts
@@ -519,13 +519,16 @@ function renderComposeAiTraceSection(
     label.textContent = "Open in Perfetto";
     button.appendChild(label);
     button.addEventListener("click", () => {
-        const payload = {
-            previewId,
-            recomposition: rawPayloads.recomposition,
-            renderTrace: rawPayloads.renderTrace,
-            composeAiTrace: rawPayloads.composeAiTrace,
-        };
-        copyToClipboard(JSON.stringify(payload, null, 2));
+        // Ship the raw Perfetto-importable trace JSON only — paste-
+        // into-ui.perfetto.dev expects the trace at the document root
+        // (it scans for top-level `traceEvents` etc.), so wrapping it
+        // under `composeAiTrace` was a regression: the paste loaded
+        // as "not a trace." When the daemon hasn't attached a
+        // composeAiTrace payload yet, fall through to an empty
+        // string so the clipboard write is a clear no-op rather than
+        // shipping a misleading wrapper.
+        const trace = rawPayloads.composeAiTrace;
+        copyToClipboard(trace ? JSON.stringify(trace, null, 2) : "");
     });
     section.appendChild(button);
     return section;


### PR DESCRIPTION
## Summary

Addresses both Codex review comments on the already-merged #1079:

### P1 — `Open in Perfetto` shipped a wrapper instead of the trace

The button serialized `{ previewId, recomposition, renderTrace, composeAiTrace }` to the clipboard. `ui.perfetto.dev` expects a Perfetto-importable trace at the document root (it scans for top-level `traceEvents`), so every paste loaded as "not a trace." Fixed to copy `rawPayloads.composeAiTrace` only. When no `composeAiTrace` payload is attached yet, the clipboard write is a clear empty-string no-op rather than shipping a misleading wrapper.

### P2 — Stale perf sections after disabling a kind

`refreshPerformanceBundle` decided whether to show the empty-state placeholder based on cached payload presence, not on enabled kinds. After a user disabled all performance kinds in Configure…, previously cached sections kept rendering because `hasAnyPayload` was true — violating the immediate-unsubscribe contract the expander advertises.

Now each cached payload is gated on the user's current enabled-kinds set before being passed into `computePerformanceBundleData`, so unchecking a kind hides its section immediately. The cache itself stays intact (the daemon keeps the subscription open), so re-enabling restores the section without a re-fetch.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 868 passing (+2 new in `perfettoHandoff.test.ts`)
- [x] New regression mounts `renderPerformanceSections` in happy-dom, clicks the button, parses the captured clipboard text, asserts `traceEvents` lives at the document root and the wrapper `previewId` is gone.
- [ ] Manual: paste copied JSON into `ui.perfetto.dev` and confirm the trace loads.

Net: +121 / −17 LOC.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcozQg6vaBFB5Y6vVsyuPH)_