### PR TITLE
feat(vscode-extension): text/i18n bundle — fonts (google) + drawn text + translations

### DIFF
--- a/data/fonts/core/src/main/kotlin/ee/schimke/composeai/data/fonts/FontsUsedDataProduct.kt
+++ b/data/fonts/core/src/main/kotlin/ee/schimke/composeai/data/fonts/FontsUsedDataProduct.kt
@@ -7,7 +7,12 @@ import kotlinx.serialization.json.Json
 /** Path-backed producer for `fonts/used`, written by backend render loops in default mode. */
 object FontsUsedDataProducer {
   const val KIND: String = "fonts/used"
-  const val SCHEMA_VERSION: Int = 1
+  // Bumped to 2 in #1057 (Cluster D) for the optional `provider` field on
+  // `FontUsedEntry`. The field is open-ended (`"google"`, `"asset"`,
+  // `"system"`, omitted) and lets the VS Code Text/i18n bundle decide
+  // whether to render a Google Fonts external-link affordance without
+  // re-doing the bundled allowlist match for every paint.
+  const val SCHEMA_VERSION: Int = 2
   const val FILE: String = "fonts-used.json"
 
   val json: Json = Json {
@@ -39,4 +44,11 @@ data class FontUsedEntry(
   val sourceFile: String? = null,
   val fellBackFrom: List<String>? = null,
   val consumerNodeIds: List<String> = emptyList(),
+  /**
+   * Open-ended provenance tag for the resolved font. Today the renderer leaves this null; the
+   * Text/i18n VS Code bundle falls back to a bundled Google Fonts allowlist when this is unset.
+   * Expected values are `"google"`, `"asset"`, `"system"`. Schema-version-gated so older renderers
+   * serialise compatible payloads.
+   */
+  val provider: String? = null,
 )

--- a/data/fonts/core/src/test/kotlin/ee/schimke/composeai/data/fonts/FontProviderRoundtripTest.kt
+++ b/data/fonts/core/src/test/kotlin/ee/schimke/composeai/data/fonts/FontProviderRoundtripTest.kt
@@ -1,0 +1,91 @@
+package ee.schimke.composeai.data.fonts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Round-trip coverage for [FontUsedEntry.provider] added in #1057 (Cluster D).
+ *
+ * The field is open-ended; we exercise the three values the VS Code Text/i18n bundle reads
+ * (`"google"`, `"asset"`, `"system"`) plus the null default, and pin the schema-version bump so
+ * accidental rollbacks fail loudly.
+ */
+class FontProviderRoundtripTest {
+
+  private val json = FontsUsedDataProducer.json
+
+  @Test
+  fun `schema version is bumped to 2 for the provider field`() {
+    assertEquals(2, FontsUsedDataProducer.SCHEMA_VERSION)
+  }
+
+  @Test
+  fun `provider round-trips for google asset system and null`() {
+    val payload =
+      FontsUsedPayload(
+        listOf(
+          entry(requestedFamily = "Roboto", provider = "google"),
+          entry(requestedFamily = "ProductSans", provider = "asset"),
+          entry(requestedFamily = "monospace", provider = "system"),
+          entry(requestedFamily = "Inter", provider = null),
+        )
+      )
+    val encoded = json.encodeToString(FontsUsedPayload.serializer(), payload)
+    val decoded = json.decodeFromString(FontsUsedPayload.serializer(), encoded)
+    assertEquals(payload, decoded)
+    assertEquals("google", decoded.fonts[0].provider)
+    assertEquals("asset", decoded.fonts[1].provider)
+    assertEquals("system", decoded.fonts[2].provider)
+    assertNull(decoded.fonts[3].provider)
+  }
+
+  @Test
+  fun `payloads from schema-v1 producers (no provider) decode with provider=null`() {
+    // Synthesised v1 payload — no `provider` key at all. The decoder
+    // must accept it and surface the field as null for the allowlist
+    // fallback path.
+    val v1Json =
+      """{"fonts":[{"requestedFamily":"Roboto","resolvedFamily":"Roboto",""" +
+        """"weight":400,"style":"normal"}]}"""
+    val decoded = json.decodeFromString(FontsUsedPayload.serializer(), v1Json)
+    assertEquals(1, decoded.fonts.size)
+    assertNull(decoded.fonts[0].provider)
+  }
+
+  @Test
+  fun `encoded JSON includes provider when non-null and omits it when null`() {
+    val withGoogle =
+      json.encodeToString(
+        FontsUsedPayload.serializer(),
+        FontsUsedPayload(listOf(entry(provider = "google"))),
+      )
+    assertTrue(
+      "expected provider=google in JSON but got $withGoogle",
+      withGoogle.contains("\"provider\":\"google\""),
+    )
+    // `encodeDefaults = true` on FontsUsedDataProducer.json means null
+    // defaults are emitted; this test pins that, but more importantly
+    // pins that the key exists with the actual null value so the
+    // decoder side is symmetric.
+    val withoutProvider =
+      json.encodeToString(
+        FontsUsedPayload.serializer(),
+        FontsUsedPayload(listOf(entry(provider = null))),
+      )
+    assertTrue(
+      "expected provider key with null value but got $withoutProvider",
+      withoutProvider.contains("\"provider\":null"),
+    )
+  }
+
+  private fun entry(requestedFamily: String = "Roboto", provider: String? = null): FontUsedEntry =
+    FontUsedEntry(
+      requestedFamily = requestedFamily,
+      resolvedFamily = requestedFamily,
+      weight = 400,
+      style = "normal",
+      provider = provider,
+    )
+}

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2873,3 +2873,171 @@ body {
     word-break: break-word;
     opacity: 0.9;
 }
+
+/* -------------------------------------------------------------------------
+ * Text / i18n bundle (#1057). Three stacked sub-tables under one expander:
+ * drawn text, fonts, translations. Mirrors the Performance bundle layout
+ * but adds:
+ *   - colour swatches for fg/bg per drawn-text row
+ *   - a Google Fonts link affordance on the requestedFamily cell
+ *   - a preview cell that renders the resolved family in that font
+ *   - translation locale chips (supported count, untranslated count + tooltip)
+ * -------------------------------------------------------------------------*/
+
+.text-bundle-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.text-bundle-text-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.text-bundle-text-rendered {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 600;
+}
+
+.text-bundle-flag {
+    display: inline-block;
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 999px;
+    background: var(--vscode-inputValidation-warningBackground, #5a4400);
+    color: var(--vscode-inputValidation-warningForeground, #fff);
+    align-self: flex-start;
+}
+
+.text-bundle-locale-cell,
+.text-bundle-scale-cell,
+.text-bundle-size-cell,
+.text-bundle-overflow-cell {
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+
+.text-bundle-swatch-cell {
+    text-align: center;
+    width: 28px;
+}
+
+.text-bundle-swatch {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border-radius: 3px;
+    border: 1px solid var(--vscode-panel-border, #444);
+    vertical-align: middle;
+}
+
+.text-bundle-swatch[data-kind="fg"] {
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+}
+
+.text-bundle-nodeid {
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+}
+
+/* Fonts sub-table */
+
+.text-bundle-font-requested .text-bundle-google-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    border: 1px solid var(--vscode-button-border, transparent);
+    background: transparent;
+    color: var(--vscode-textLink-foreground);
+    cursor: pointer;
+    font: inherit;
+}
+
+.text-bundle-google-link:hover {
+    color: var(--vscode-textLink-activeForeground);
+    background: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+    text-decoration: underline;
+}
+
+.text-bundle-google-link .codicon {
+    font-size: 12px;
+}
+
+.text-bundle-font-preview {
+    font-size: 14px;
+    line-height: 1.2;
+    /* `font-family` set inline so the renderer's resolved family wins
+     * over the panel's default. Falls back to system-ui in cssFontStack. */
+}
+
+.text-bundle-fallback-chain {
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    white-space: nowrap;
+}
+
+.text-bundle-consumer-count {
+    display: inline-block;
+    min-width: 22px;
+    padding: 1px 6px;
+    border-radius: 999px;
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+    text-align: center;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+}
+
+/* Translations sub-table */
+
+.text-bundle-translation-text {
+    font-weight: 600;
+}
+
+.text-bundle-resource-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--vscode-textLink-foreground);
+    cursor: pointer;
+    font: inherit;
+}
+
+.text-bundle-resource-link:hover {
+    text-decoration: underline;
+    background: var(--vscode-toolbar-hoverBackground, rgba(90, 93, 94, 0.31));
+}
+
+.text-bundle-locale-chip {
+    display: inline-block;
+    min-width: 22px;
+    padding: 1px 8px;
+    border-radius: 999px;
+    text-align: center;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+}
+
+.text-bundle-locale-chip[data-tone="ok"] {
+    background: var(--vscode-testing-iconPassed, #388a34);
+    color: #fff;
+}
+
+.text-bundle-locale-chip[data-tone="warning"] {
+    background: var(--vscode-inputValidation-warningBackground, #5a4400);
+    color: var(--vscode-inputValidation-warningForeground, #fff);
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4113,6 +4113,16 @@ function handleWebviewMessage(msg: WebviewToExtension) {
         case "copyToClipboard":
             void vscode.env.clipboard.writeText(msg.text);
             break;
+        case "openExternal":
+            // Guard against arbitrary shell-outs from the webview —
+            // only `http(s)` URLs are honoured. The Text/i18n bundle's
+            // Google Fonts cell is the sole producer today; future
+            // affordances (Material Symbols, fonts.adobe.com, …) reuse
+            // this path.
+            if (typeof msg.url === "string" && /^https?:\/\//i.test(msg.url)) {
+                void vscode.env.openExternal(vscode.Uri.parse(msg.url));
+            }
+            break;
     }
 }
 

--- a/vscode-extension/src/test/textBundlePresenter.test.ts
+++ b/vscode-extension/src/test/textBundlePresenter.test.ts
@@ -1,0 +1,309 @@
+// Text / i18n bundle presenter (#1057 Cluster D). Pins the three
+// sub-section row shapes (drawn text, fonts, translations), the Google
+// Fonts allowlist + `provider="google"` short-circuit, the overlay
+// generation for truncated / overflowed text, and the wire payload
+// shapes that the host posts back for `openResourceFile` (translation
+// rows) and `openExternal` (Google Fonts cell).
+
+import * as assert from "assert";
+import {
+    computeTextBundleData,
+    cssFontStack,
+    googleFontsAllowlistSize,
+    googleFontsSpecimenUrl,
+    isGoogleFontFamily,
+    translationOpenResourcePayload,
+    type FontRow,
+    type TranslationRow,
+} from "../webview/preview/textBundlePresenter";
+
+function stringEntry(overrides: Record<string, unknown> = {}): unknown {
+    return {
+        nodeId: "node-1",
+        boundsInScreen: "0,0,100,30",
+        localeTag: "en-US",
+        fontScale: 1.0,
+        text: "Hello",
+        fontSize: "16sp",
+        foregroundColor: "#000000",
+        backgroundColor: "#ffffff",
+        ...overrides,
+    };
+}
+
+function fontEntry(overrides: Record<string, unknown> = {}): unknown {
+    return {
+        requestedFamily: "Roboto",
+        resolvedFamily: "Roboto",
+        weight: 400,
+        style: "normal",
+        consumerNodeIds: ["node-1"],
+        ...overrides,
+    };
+}
+
+function translationEntry(overrides: Record<string, unknown> = {}): unknown {
+    return {
+        rendered: "Hello",
+        resourceName: "R.string.hello",
+        sourceFile: "/abs/app/src/main/res/values/strings.xml",
+        boundsInScreen: "0,0,100,30",
+        translations: { "en-US": "Hello", "fr-FR": "Bonjour" },
+        untranslatedLocales: ["de-DE"],
+        ...overrides,
+    };
+}
+
+describe("computeTextBundleData", () => {
+    it("returns empty rows + empty overlay when all payloads are null", () => {
+        const data = computeTextBundleData(null, null, null);
+        assert.strictEqual(data.drawnText.length, 0);
+        assert.strictEqual(data.fonts.length, 0);
+        assert.strictEqual(data.translations.length, 0);
+        assert.strictEqual(data.overlay.length, 0);
+        // jsonPayload preserves nulls so the copy-JSON action stays
+        // round-trippable without conditional cases in the caller.
+        assert.strictEqual(data.jsonPayload.textStrings, null);
+        assert.strictEqual(data.jsonPayload.fontsUsed, null);
+        assert.strictEqual(data.jsonPayload.i18nTranslations, null);
+    });
+
+    it("populates drawn-text rows and flags overflow rows as warning overlays", () => {
+        const data = computeTextBundleData(
+            {
+                texts: [
+                    stringEntry({ nodeId: "node-a", text: "OK" }),
+                    stringEntry({
+                        nodeId: "node-b",
+                        text: "Truncated…",
+                        truncated: true,
+                        boundsInScreen: "10,10,50,30",
+                    }),
+                    stringEntry({
+                        nodeId: "node-c",
+                        text: "Too wide",
+                        didOverflowWidth: true,
+                        boundsInScreen: "5,5,200,40",
+                    }),
+                ],
+            },
+            null,
+            null,
+        );
+        assert.strictEqual(data.drawnText.length, 3);
+        assert.strictEqual(data.drawnText[0].text, "OK");
+        assert.strictEqual(data.drawnText[1].truncated, true);
+        assert.strictEqual(data.drawnText[2].didOverflowWidth, true);
+        // 3 rows have parseable bounds → 3 overlay boxes.
+        assert.strictEqual(data.overlay.length, 3);
+        // First row clean → info; the other two warn.
+        assert.strictEqual(data.overlay[0].level, "info");
+        assert.strictEqual(data.overlay[1].level, "warning");
+        assert.strictEqual(data.overlay[2].level, "warning");
+        // Tooltip carries the flag list so a hover surface shows why
+        // the row is highlighted.
+        assert.ok(data.overlay[1].tooltip?.includes("truncated"));
+        assert.ok(data.overlay[2].tooltip?.includes("overflow-w"));
+    });
+
+    it("matches Google Fonts via the bundled allowlist when provider is missing", () => {
+        const data = computeTextBundleData(
+            null,
+            { fonts: [fontEntry({ requestedFamily: "Roboto" })] },
+            null,
+        );
+        assert.strictEqual(data.fonts.length, 1);
+        const row = data.fonts[0] as FontRow;
+        assert.strictEqual(row.isGoogleFont, true);
+        assert.strictEqual(row.provider, null);
+        // A truly local family that isn't in the allowlist must NOT
+        // light up as a Google link.
+        const data2 = computeTextBundleData(
+            null,
+            { fonts: [fontEntry({ requestedFamily: "AcmeSans" })] },
+            null,
+        );
+        assert.strictEqual((data2.fonts[0] as FontRow).isGoogleFont, false);
+    });
+
+    it('honours an explicit provider="google" tag even when the family is not in the allowlist', () => {
+        const data = computeTextBundleData(
+            null,
+            {
+                fonts: [
+                    fontEntry({
+                        requestedFamily: "AcmeSans",
+                        provider: "google",
+                    }),
+                ],
+            },
+            null,
+        );
+        const row = data.fonts[0] as FontRow;
+        assert.strictEqual(row.isGoogleFont, true);
+        assert.strictEqual(row.provider, "google");
+    });
+
+    it("treats an explicit non-google provider as non-Google even for allowlisted names", () => {
+        // E.g. an asset font happens to be named "Roboto" — the
+        // producer's `provider="asset"` wins over the bundled allowlist
+        // so the cell doesn't link out.
+        const data = computeTextBundleData(
+            null,
+            {
+                fonts: [
+                    fontEntry({
+                        requestedFamily: "Roboto",
+                        provider: "asset",
+                    }),
+                ],
+            },
+            null,
+        );
+        const row = data.fonts[0] as FontRow;
+        assert.strictEqual(row.isGoogleFont, false);
+        assert.strictEqual(row.provider, "asset");
+    });
+
+    it("emits translation rows with locale counts derived from supportedLocales", () => {
+        const data = computeTextBundleData(null, null, {
+            supportedLocales: ["en-US", "fr-FR", "de-DE"],
+            renderedLocale: "en-US",
+            defaultLocale: "en-US",
+            strings: [translationEntry()],
+        });
+        assert.strictEqual(data.translations.length, 1);
+        const row = data.translations[0] as TranslationRow;
+        assert.strictEqual(row.rendered, "Hello");
+        assert.strictEqual(row.resourceName, "R.string.hello");
+        assert.strictEqual(row.supportedLocaleCount, 3);
+        assert.strictEqual(row.untranslatedLocaleCount, 1);
+        assert.deepStrictEqual(row.untranslatedLocales, ["de-DE"]);
+        // Translated locales are surfaced (sorted) so the chip tooltip
+        // is deterministic.
+        assert.deepStrictEqual(row.translatedLocales, ["en-US", "fr-FR"]);
+    });
+
+    it("builds the openResourceFile payload with resourceType=string and packageName=null", () => {
+        const data = computeTextBundleData(null, null, {
+            supportedLocales: ["en-US"],
+            renderedLocale: "en-US",
+            defaultLocale: "en-US",
+            strings: [
+                translationEntry({
+                    resourceName: "R.string.welcome",
+                    sourceFile: "/abs/strings.xml",
+                }),
+            ],
+        });
+        const payload = translationOpenResourcePayload(data.translations[0]);
+        // Strip `R.string.` so the host-side resolver finds the bare
+        // `<string name="welcome">` entry in the XML; without the
+        // prefix-strip the jump-to-resource action silently no-ops.
+        assert.deepStrictEqual(payload, {
+            command: "openResourceFile",
+            resourceType: "string",
+            resourceName: "welcome",
+            resolvedFile: "/abs/strings.xml",
+            packageName: null,
+        });
+    });
+
+    it("passes through resourceName when it lacks the R.string. prefix", () => {
+        const data = computeTextBundleData(null, null, {
+            supportedLocales: ["en-US"],
+            renderedLocale: "en-US",
+            defaultLocale: "en-US",
+            strings: [
+                translationEntry({
+                    resourceName: "bare_name",
+                    sourceFile: null,
+                }),
+            ],
+        });
+        const payload = translationOpenResourcePayload(data.translations[0]);
+        assert.strictEqual(payload.resourceName, "bare_name");
+    });
+
+    it("produces a fonts.google.com specimen URL with URI-encoded family names", () => {
+        // The `openExternal` payload is just `{ command, url }`; we pin
+        // the URL builder here since it's the one piece the cell uses
+        // when assembling the message.
+        assert.strictEqual(
+            googleFontsSpecimenUrl("Roboto"),
+            "https://fonts.google.com/specimen/Roboto",
+        );
+        assert.strictEqual(
+            googleFontsSpecimenUrl("Source Sans 3"),
+            "https://fonts.google.com/specimen/Source%20Sans%203",
+        );
+        // Allowlist size is bounded so accidental "every font in the
+        // world" regressions trip the test rather than the bundle size
+        // budget.
+        assert.ok(googleFontsAllowlistSize() >= 40);
+        assert.ok(googleFontsAllowlistSize() <= 80);
+    });
+
+    it("isGoogleFontFamily is case-insensitive against the allowlist", () => {
+        assert.strictEqual(isGoogleFontFamily("ROBOTO", null), true);
+        assert.strictEqual(isGoogleFontFamily("roboto", undefined), true);
+        assert.strictEqual(isGoogleFontFamily("Custom Family", null), false);
+        // Empty / missing provider should still consult the allowlist
+        // so v1 producers (no schema-v2 field) keep working.
+        assert.strictEqual(isGoogleFontFamily("Inter", null), true);
+    });
+
+    it("skips drawn-text rows with no nodeId so a malformed payload doesn't crash the table", () => {
+        const data = computeTextBundleData(
+            {
+                texts: [
+                    stringEntry({ nodeId: "node-1" }),
+                    // Missing nodeId — dropped.
+                    { boundsInScreen: "0,0,1,1", text: "ghost" },
+                    // Non-object — dropped.
+                    "not-an-object",
+                ],
+            },
+            null,
+            null,
+        );
+        assert.strictEqual(data.drawnText.length, 1);
+        assert.strictEqual(data.drawnText[0].nodeId, "node-1");
+    });
+
+    it("cssFontStack escapes both backslashes and quotes in family names", () => {
+        // CodeQL regression: backslashes were not escaped before the
+        // quoted CSS literal, so a malicious or pathological family
+        // (e.g. `a\"; color:red;`) could break out of the string. Quote
+        // *and* backslash escapes are now both applied; the resulting
+        // CSS literal must round-trip through a regex unescape to the
+        // original family.
+        const fam = 'has"quote and\\backslash';
+        const stack = cssFontStack(fam);
+        // Open with opening quote, end with the fallback stack.
+        assert.ok(
+            stack.startsWith('"'),
+            "result must start with a quoted family",
+        );
+        assert.ok(
+            stack.endsWith(", system-ui, sans-serif"),
+            "result must chain generic fallbacks",
+        );
+        // Pull the quoted segment and verify the literal escape
+        // sequences for both characters survived.
+        const quoted = stack.slice(0, stack.indexOf(", system-ui"));
+        assert.ok(
+            quoted.includes('\\"'),
+            "double-quote inside the family must be backslash-escaped",
+        );
+        assert.ok(
+            quoted.includes("\\\\"),
+            "backslash inside the family must be doubled",
+        );
+    });
+
+    it("cssFontStack passes generic families through unquoted", () => {
+        assert.strictEqual(cssFontStack("monospace"), "monospace");
+        assert.strictEqual(cssFontStack("serif"), "serif");
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -876,7 +876,17 @@ export type WebviewToExtension =
      * unavailable in some VS Code builds, so the round-trip through
      * the host is the portable path.
      */
-    | { command: "copyToClipboard"; text: string };
+    | { command: "copyToClipboard"; text: string }
+    /**
+     * Webview asks the extension host to open [url] in the user's
+     * external browser via `vscode.env.openExternal`. Used by the
+     * Text/i18n bundle's Google Fonts cell — clicking the requested
+     * family on a `provider="google"` (or allowlist-matched) row jumps
+     * to its `fonts.google.com/specimen/<family>` page. The host
+     * validates the URL is `http(s)` before opening to avoid being used
+     * as a generic shell-out from the webview.
+     */
+    | { command: "openExternal"; url: string };
 
 /**
  * Narrow shape the History panel reads off each sidecar JSON entry. The

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -74,6 +74,16 @@ import {
     renderHistoryDiffHeader,
     type HistoryDiffPayload,
 } from "./historyDiffBundlePresenter";
+import {
+    computeTextBundleData,
+    textBundleFontColumns,
+    textBundleStringColumns,
+    textBundleTranslationColumns,
+    translationOpenResourcePayload,
+    type DrawnTextRow,
+    type FontRow,
+    type TranslationRow,
+} from "./textBundlePresenter";
 import { FilterController } from "./filterController";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
 import {
@@ -655,6 +665,149 @@ export class PreviewApp extends LitElement {
             performanceCachedBody = { wrapper, expander, recompTable, host };
             return performanceCachedBody;
         };
+        // Text / i18n bundle body — three stacked sub-sections (drawn
+        // text, fonts, translations) under one expander, same shape as
+        // the Performance bundle. The expander toggles the default-OFF
+        // `i18n/translations` kind; drawn text + fonts are default-ON
+        // so they appear as soon as the chip is pressed.
+        interface TextBody {
+            wrapper: HTMLElement;
+            expander: BundleExpander;
+            stringsTable: DataTable<DrawnTextRow>;
+            fontsTable: DataTable<FontRow>;
+            translationsTable: DataTable<TranslationRow>;
+        }
+        let textCachedBody: TextBody | null = null;
+        const textBody = (): TextBody => {
+            if (textCachedBody) return textCachedBody;
+            const wrapper = document.createElement("div");
+            wrapper.className = "bundle-tab-body text-bundle-body";
+            wrapper.dataset.bundle = "text";
+            const expander = document.createElement(
+                "bundle-expander",
+            ) as BundleExpander;
+            expander.addEventListener("kind-toggled", (evt) => {
+                const det = (
+                    evt as CustomEvent<
+                        import("./components/BundleExpander").BundleKindToggledDetail
+                    >
+                ).detail;
+                bundleController.setKindEnabled(
+                    det.bundleId,
+                    det.kind,
+                    det.enabled,
+                );
+            });
+            const stringsTable = document.createElement(
+                "data-table",
+            ) as DataTable<DrawnTextRow>;
+            stringsTable.heading = "Drawn text";
+            stringsTable.setColumns(
+                textBundleStringColumns() as unknown as ReadonlyArray<
+                    import("./components/DataTable").DataTableColumn<DrawnTextRow>
+                >,
+            );
+            const fontsTable = document.createElement(
+                "data-table",
+            ) as DataTable<FontRow>;
+            fontsTable.heading = "Fonts";
+            fontsTable.setColumns(
+                textBundleFontColumns({
+                    openExternal: (url) =>
+                        vscode.postMessage({ command: "openExternal", url }),
+                }) as unknown as ReadonlyArray<
+                    import("./components/DataTable").DataTableColumn<FontRow>
+                >,
+            );
+            const translationsTable = document.createElement(
+                "data-table",
+            ) as DataTable<TranslationRow>;
+            translationsTable.heading = "Translations";
+            translationsTable.setColumns(
+                textBundleTranslationColumns({
+                    openResource: (row) =>
+                        vscode.postMessage(translationOpenResourcePayload(row)),
+                }) as unknown as ReadonlyArray<
+                    import("./components/DataTable").DataTableColumn<TranslationRow>
+                >,
+            );
+            wrapper.appendChild(expander);
+            wrapper.appendChild(stringsTable);
+            wrapper.appendChild(fontsTable);
+            wrapper.appendChild(translationsTable);
+            textCachedBody = {
+                wrapper,
+                expander,
+                stringsTable,
+                fontsTable,
+                translationsTable,
+            };
+            return textCachedBody;
+        };
+        const refreshTextBundle = (): void => {
+            const target = currentBundleTarget();
+            if (!target) return;
+            const byKind = dataProductsByPreview.get(target);
+            const stringsPayload = byKind?.get("text/strings") ?? null;
+            const fontsPayload = byKind?.get("fonts/used") ?? null;
+            const translationsPayload =
+                byKind?.get("i18n/translations") ?? null;
+            const data = computeTextBundleData(
+                stringsPayload,
+                fontsPayload,
+                translationsPayload,
+            );
+            const body = textBody();
+            const bundleDescriptor = getBundle("text");
+            if (bundleDescriptor) {
+                body.expander.setState({
+                    bundleId: "text",
+                    kinds: bundleDescriptor.kinds,
+                    enabledKinds: bundleController.state().enabledKinds("text"),
+                });
+            }
+            body.stringsTable.setRows(data.drawnText);
+            body.stringsTable.summary =
+                data.drawnText.length === 1
+                    ? "1 string"
+                    : data.drawnText.length + " strings";
+            body.stringsTable.setOverlayId((row) => row.id);
+            body.stringsTable.setJsonPayload(() => ({
+                previewId: target,
+                textStrings: data.jsonPayload.textStrings,
+            }));
+            body.fontsTable.setRows(data.fonts);
+            body.fontsTable.summary =
+                data.fonts.length === 1
+                    ? "1 font"
+                    : data.fonts.length + " fonts";
+            body.fontsTable.setOverlayId((row) => row.id);
+            body.fontsTable.setJsonPayload(() => ({
+                previewId: target,
+                fontsUsed: data.jsonPayload.fontsUsed,
+            }));
+            // Translations sub-table only mounts visibly when the kind is
+            // enabled. Setting rows on the cached element regardless is
+            // cheap and keeps the JSON-payload accessor in sync if the
+            // user later flips the expander on.
+            body.translationsTable.setRows(data.translations);
+            body.translationsTable.summary =
+                data.translations.length === 1
+                    ? "1 entry"
+                    : data.translations.length + " entries";
+            body.translationsTable.setOverlayId((row) => row.id);
+            body.translationsTable.setJsonPayload(() => ({
+                previewId: target,
+                i18nTranslations: data.jsonPayload.i18nTranslations,
+            }));
+            const enabledKinds = new Set(
+                bundleController.state().enabledKinds("text"),
+            );
+            body.translationsTable.hidden =
+                !enabledKinds.has("i18n/translations") &&
+                data.translations.length === 0;
+            dataTabs.setTabBody("text", body.wrapper);
+        };
         const refreshExpanderFor = (id: BundleId): void => {
             const body = bundleBodies.get(id);
             const bundle = getBundle(id);
@@ -1097,6 +1250,7 @@ export class PreviewApp extends LitElement {
             }
             if (s.activeBundles.includes("history")) refreshHistoryBundle();
             if (s.activeBundles.includes("errors")) refreshErrorsBundle();
+            if (s.activeBundles.includes("text")) refreshTextBundle();
         };
         bundleController.onChange(() => reflectBundleState());
         reflectBundleState();
@@ -1516,6 +1670,18 @@ export class PreviewApp extends LitElement {
                     )
                 ) {
                     refreshThemingBundle();
+                }
+                if (
+                    matchesTarget &&
+                    activeBundles.includes("text") &&
+                    dataProducts.some(
+                        (dp) =>
+                            dp.kind === "text/strings" ||
+                            dp.kind === "fonts/used" ||
+                            dp.kind === "i18n/translations",
+                    )
+                ) {
+                    refreshTextBundle();
                 }
             },
             focusOnCard,

--- a/vscode-extension/src/webview/preview/textBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/textBundlePresenter.ts
@@ -1,0 +1,743 @@
+// Text / i18n bundle presenter — fills the "Text / i18n" tab body in
+// `<data-tabs>` using three stacked `<data-table>` sub-sections, mirroring
+// the Performance bundle's "stacked sub-sections under one expander" shape.
+// Combines:
+//
+//   * `text/strings`       — drawn text per node (default-ON)
+//   * `fonts/used`         — fonts the renderer resolved (default-ON)
+//   * `i18n/translations`  — visible-string ↔ resource-id mapping
+//                            (expander-only / default-OFF)
+//
+// The presenter is **stateless**: given the three wire payloads it
+// returns the rows for each sub-table plus the overlay boxes the Text
+// chip paints over the focused preview (`truncated` / `didOverflow*`
+// rows light up as warnings). The caller (host shell wiring in
+// `main.ts`) is responsible for re-running this whenever the focused
+// preview, the cache, or the bundle's enabled-kinds set changes.
+//
+// See `docs/design/EXTENSION_DATA_EXPOSURE.md` § Text / i18n.
+
+import { html, type TemplateResult } from "lit";
+import type { DataTableColumn } from "./components/DataTable";
+import type { OverlayBox } from "./components/BoxOverlay";
+import { parseBounds } from "./cardData";
+
+// -------------------------------------------------------------------------
+// Row shapes
+// -------------------------------------------------------------------------
+
+export interface DrawnTextRow {
+    id: string;
+    nodeId: string;
+    text: string;
+    localeTag: string;
+    fontScale: number;
+    fontSize: string;
+    foreground: string | null;
+    background: string | null;
+    overflow: string | null;
+    truncated: boolean;
+    didOverflowWidth: boolean;
+    didOverflowHeight: boolean;
+    boundsInScreen: string;
+}
+
+export interface FontRow {
+    id: string;
+    requestedFamily: string;
+    resolvedFamily: string;
+    weight: number;
+    style: string;
+    sourceFile: string | null;
+    fellBackFromChain: string;
+    consumerCount: number;
+    /**
+     * True when the font is either tagged `provider="google"` by the
+     * producer (schema v2+) or — when the producer hasn't populated
+     * `provider` — the `requestedFamily` matches the bundled allowlist.
+     * The Google Fonts cell renders as a button that posts an
+     * `openExternal` message with the specimen URL.
+     */
+    isGoogleFont: boolean;
+    /**
+     * Source the renderer reported for the resolved font. Open-ended
+     * string; today's known values are `"google"`, `"asset"`, `"system"`,
+     * and `null` (omitted). Surfaced as a quiet chip when present so
+     * the user can tell a system fallback apart from a Google match.
+     */
+    provider: string | null;
+}
+
+export interface TranslationRow {
+    id: string;
+    rendered: string;
+    resourceName: string | null;
+    sourceFile: string | null;
+    supportedLocaleCount: number;
+    untranslatedLocaleCount: number;
+    untranslatedLocales: readonly string[];
+    /**
+     * Locales that DO have a translation — surfaced through the row's
+     * `(translated)` chip tooltip. Sorted alphabetically for stable test
+     * fixtures.
+     */
+    translatedLocales: readonly string[];
+}
+
+export interface TextBundleData {
+    drawnText: readonly DrawnTextRow[];
+    fonts: readonly FontRow[];
+    translations: readonly TranslationRow[];
+    overlay: readonly OverlayBox[];
+    jsonPayload: {
+        textStrings: unknown;
+        fontsUsed: unknown;
+        i18nTranslations: unknown;
+    };
+}
+
+// -------------------------------------------------------------------------
+// Bundled Google Fonts allowlist — used when the producer hasn't filled
+// in `FontUsedEntry.provider`. Curated from the Google Fonts "Popularity"
+// ranking; the list is intentionally small (top-N) so the bundle's JS
+// size stays trivial and a missed match falls back to a plain text cell
+// rather than the wrong external link. When the renderer learns to
+// detect provenance (#1057 follow-up) the producer will set
+// `provider = "google"` directly and this allowlist becomes a fallback.
+// -------------------------------------------------------------------------
+
+const GOOGLE_FONTS_ALLOWLIST: readonly string[] = [
+    "Roboto",
+    "Open Sans",
+    "Noto Sans",
+    "Montserrat",
+    "Lato",
+    "Poppins",
+    "Source Sans 3",
+    "Roboto Condensed",
+    "Inter",
+    "Material Icons",
+    "Material Symbols Outlined",
+    "Material Symbols Rounded",
+    "Material Symbols Sharp",
+    "Oswald",
+    "Raleway",
+    "Roboto Mono",
+    "Nunito",
+    "Nunito Sans",
+    "Roboto Slab",
+    "Ubuntu",
+    "Merriweather",
+    "Playfair Display",
+    "PT Sans",
+    "Rubik",
+    "Work Sans",
+    "Mukta",
+    "Fira Sans",
+    "Quicksand",
+    "Noto Serif",
+    "Hind",
+    "Heebo",
+    "Titillium Web",
+    "Karla",
+    "PT Serif",
+    "Barlow",
+    "Mulish",
+    "Dosis",
+    "Cabin",
+    "DM Sans",
+    "DM Serif Display",
+    "Manrope",
+    "Bebas Neue",
+    "Anton",
+    "Lora",
+    "IBM Plex Sans",
+    "IBM Plex Serif",
+    "IBM Plex Mono",
+    "Source Code Pro",
+    "Fira Code",
+    "JetBrains Mono",
+];
+
+const GOOGLE_FONTS_ALLOWLIST_LOWER = new Set(
+    GOOGLE_FONTS_ALLOWLIST.map((f) => f.toLowerCase()),
+);
+
+/** Allowlist size exposed for tests + the cluster-report. */
+export function googleFontsAllowlistSize(): number {
+    return GOOGLE_FONTS_ALLOWLIST.length;
+}
+
+/**
+ * True when the given font entry should render the Google Fonts
+ * external-link affordance. Honours the producer's `provider` field
+ * first; falls back to the bundled allowlist when it's missing.
+ */
+export function isGoogleFontFamily(
+    requestedFamily: string,
+    provider: string | null | undefined,
+): boolean {
+    if (provider === "google") return true;
+    if (provider) return false; // explicit non-google provider wins
+    return GOOGLE_FONTS_ALLOWLIST_LOWER.has(
+        (requestedFamily ?? "").toLowerCase(),
+    );
+}
+
+/**
+ * Build the Google Fonts specimen URL for a family. Exposed for tests
+ * + for the `openExternal` payload assembly.
+ */
+export function googleFontsSpecimenUrl(family: string): string {
+    return "https://fonts.google.com/specimen/" + encodeURIComponent(family);
+}
+
+// -------------------------------------------------------------------------
+// computeTextBundleData
+// -------------------------------------------------------------------------
+
+export function computeTextBundleData(
+    stringsPayload: unknown,
+    fontsPayload: unknown,
+    translationsPayload: unknown,
+): TextBundleData {
+    const drawnText = parseDrawnText(stringsPayload);
+    const fonts = parseFonts(fontsPayload);
+    const translations = parseTranslations(translationsPayload);
+    const overlay: OverlayBox[] = [];
+    for (const row of drawnText) {
+        const bounds = parseBounds(row.boundsInScreen);
+        if (!bounds) continue;
+        const flagged =
+            row.truncated || row.didOverflowWidth || row.didOverflowHeight;
+        overlay.push({
+            id: row.id,
+            bounds,
+            level: flagged ? "warning" : "info",
+            tooltip: tooltipFor(row),
+        });
+    }
+    return {
+        drawnText,
+        fonts,
+        translations,
+        overlay,
+        jsonPayload: {
+            textStrings: stringsPayload ?? null,
+            fontsUsed: fontsPayload ?? null,
+            i18nTranslations: translationsPayload ?? null,
+        },
+    };
+}
+
+function tooltipFor(row: DrawnTextRow): string {
+    const flags: string[] = [];
+    if (row.truncated) flags.push("truncated");
+    if (row.didOverflowWidth) flags.push("overflow-w");
+    if (row.didOverflowHeight) flags.push("overflow-h");
+    const head = row.text || "(empty)";
+    if (flags.length === 0) return head;
+    return head + " · " + flags.join(", ");
+}
+
+// -------------------------------------------------------------------------
+// Column factories (consumed by the main.ts host shell)
+// -------------------------------------------------------------------------
+
+export function textBundleStringColumns(): readonly DataTableColumn<DrawnTextRow>[] {
+    return [
+        {
+            header: "Text",
+            cellClass: "text-bundle-text-cell",
+            render: (row) =>
+                html`<div class="text-bundle-text-stack">
+                    <strong class="text-bundle-text-rendered"
+                        >${row.text || "(empty)"}</strong
+                    >
+                    ${row.truncated ||
+                    row.didOverflowWidth ||
+                    row.didOverflowHeight
+                        ? html`<span
+                              class="text-bundle-flag"
+                              data-level="warning"
+                              >${overflowBadge(row)}</span
+                          >`
+                        : ""}
+                </div>`,
+        },
+        {
+            header: "Locale",
+            cellClass: "text-bundle-locale-cell",
+            render: (row) => row.localeTag || "—",
+        },
+        {
+            header: "Scale",
+            cellClass: "text-bundle-scale-cell",
+            render: (row) =>
+                Number.isFinite(row.fontScale) ? row.fontScale.toFixed(2) : "—",
+        },
+        {
+            header: "Size",
+            cellClass: "text-bundle-size-cell",
+            render: (row) => row.fontSize || "—",
+        },
+        {
+            header: "Fg",
+            cellClass: "text-bundle-swatch-cell",
+            render: (row) => swatch(row.foreground, "fg"),
+        },
+        {
+            header: "Bg",
+            cellClass: "text-bundle-swatch-cell",
+            render: (row) => swatch(row.background, "bg"),
+        },
+        {
+            header: "Overflow",
+            cellClass: "text-bundle-overflow-cell",
+            render: (row) => row.overflow || "—",
+        },
+        {
+            header: "Node",
+            cellClass: "text-bundle-nodeid-cell",
+            render: (row) =>
+                html`<code class="text-bundle-nodeid">${row.nodeId}</code>`,
+        },
+    ];
+}
+
+function overflowBadge(row: DrawnTextRow): string {
+    const parts: string[] = [];
+    if (row.truncated) parts.push("truncated");
+    if (row.didOverflowWidth) parts.push("overflow-w");
+    if (row.didOverflowHeight) parts.push("overflow-h");
+    return parts.join(" · ");
+}
+
+function swatch(
+    value: string | null,
+    kind: "fg" | "bg",
+): TemplateResult | string {
+    if (!value) return "—";
+    return html`<span
+        class="text-bundle-swatch"
+        data-kind=${kind}
+        style="background:${value}"
+        title=${kind === "fg" ? "Foreground " + value : "Background " + value}
+    ></span>`;
+}
+
+export interface TextBundleFontColumnCallbacks {
+    /** Webview-style external-link callback. Forwarded by main.ts so the
+     *  host can post `openExternal` to the extension. */
+    openExternal(url: string): void;
+}
+
+export function textBundleFontColumns(
+    callbacks: TextBundleFontColumnCallbacks,
+): readonly DataTableColumn<FontRow>[] {
+    return [
+        {
+            header: "Requested",
+            cellClass: "text-bundle-font-requested",
+            render: (row) => requestedFamilyCell(row, callbacks),
+        },
+        {
+            header: "Resolved",
+            cellClass: "text-bundle-font-resolved",
+            render: (row) =>
+                html`<span
+                    class="text-bundle-font-preview"
+                    style="font-family: ${cssFontStack(row.resolvedFamily)}"
+                    title=${row.resolvedFamily}
+                    >${row.resolvedFamily}</span
+                >`,
+        },
+        {
+            header: "Weight",
+            cellClass: "text-bundle-font-weight",
+            render: (row) => String(row.weight),
+        },
+        {
+            header: "Style",
+            cellClass: "text-bundle-font-style",
+            render: (row) => row.style || "normal",
+        },
+        {
+            header: "Source",
+            cellClass: "text-bundle-font-source",
+            render: (row) => row.sourceFile || "—",
+        },
+        {
+            header: "Fallback",
+            cellClass: "text-bundle-font-fallback",
+            render: (row) =>
+                row.fellBackFromChain
+                    ? html`<span class="text-bundle-fallback-chain"
+                          >${row.fellBackFromChain}</span
+                      >`
+                    : "—",
+        },
+        {
+            header: "Used by",
+            cellClass: "text-bundle-font-consumers",
+            render: (row) =>
+                html`<span class="text-bundle-consumer-count"
+                    >${row.consumerCount}</span
+                >`,
+        },
+    ];
+}
+
+function requestedFamilyCell(
+    row: FontRow,
+    callbacks: TextBundleFontColumnCallbacks,
+): TemplateResult {
+    if (!row.isGoogleFont) {
+        return html`<span class="text-bundle-font-family"
+            >${row.requestedFamily}</span
+        >`;
+    }
+    const url = googleFontsSpecimenUrl(row.requestedFamily);
+    return html`<button
+        type="button"
+        class="text-bundle-google-link"
+        title=${"Open " + row.requestedFamily + " on fonts.google.com"}
+        @click=${(ev: Event) => {
+            ev.preventDefault();
+            ev.stopPropagation();
+            callbacks.openExternal(url);
+        }}
+    >
+        <i class="codicon codicon-link-external" aria-hidden="true"></i>
+        <span>${row.requestedFamily}</span>
+    </button>`;
+}
+
+/**
+ * CSS `font-family` stack for the resolved-family preview cell. The
+ * family may contain spaces, so we quote it and chain a couple of
+ * generic fallbacks so the preview never paints in the panel's monospace
+ * default when the family is unavailable to the webview.
+ */
+export function cssFontStack(resolved: string): string {
+    const trimmed = (resolved ?? "").trim();
+    if (!trimmed) return "system-ui, sans-serif";
+    // Already a generic — no quoting.
+    if (
+        trimmed === "sans-serif" ||
+        trimmed === "serif" ||
+        trimmed === "monospace" ||
+        trimmed === "cursive" ||
+        trimmed === "fantasy"
+    ) {
+        return trimmed;
+    }
+    // CSS strings need both backslashes and double-quotes escaped —
+    // a font family containing `\\` or `"` would otherwise break out
+    // of the quoted literal and produce malformed CSS (CodeQL flagged
+    // backslashes specifically). Backslash MUST be replaced first so
+    // we don't double-escape the backslashes we introduce for `"`.
+    const safe = trimmed.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    return '"' + safe + '", system-ui, sans-serif';
+}
+
+export interface TextBundleTranslationColumnCallbacks {
+    /** Open the underlying resource definition in the workspace. */
+    openResource(row: TranslationRow): void;
+}
+
+export function textBundleTranslationColumns(
+    callbacks: TextBundleTranslationColumnCallbacks,
+): readonly DataTableColumn<TranslationRow>[] {
+    return [
+        {
+            header: "Rendered",
+            cellClass: "text-bundle-translation-rendered",
+            render: (row) =>
+                html`<strong class="text-bundle-translation-text"
+                    >${row.rendered || "(empty)"}</strong
+                >`,
+        },
+        {
+            header: "Resource",
+            cellClass: "text-bundle-translation-resource",
+            render: (row) => resourceCell(row, callbacks),
+        },
+        {
+            header: "Locales",
+            cellClass: "text-bundle-translation-locales",
+            render: (row) =>
+                html`<span
+                    class="text-bundle-locale-chip"
+                    data-tone="supported"
+                    title=${row.translatedLocales.length === 0
+                        ? "No translations recorded"
+                        : "Translated: " + row.translatedLocales.join(", ")}
+                    >${row.supportedLocaleCount}</span
+                >`,
+        },
+        {
+            header: "Untranslated",
+            cellClass: "text-bundle-translation-untranslated",
+            render: (row) =>
+                row.untranslatedLocaleCount === 0
+                    ? html`<span
+                          class="text-bundle-locale-chip"
+                          data-tone="ok"
+                          title="Fully translated"
+                          >0</span
+                      >`
+                    : html`<span
+                          class="text-bundle-locale-chip"
+                          data-tone="warning"
+                          title=${"Missing: " +
+                          row.untranslatedLocales.join(", ")}
+                          >${row.untranslatedLocaleCount}</span
+                      >`,
+        },
+    ];
+}
+
+function resourceCell(
+    row: TranslationRow,
+    callbacks: TextBundleTranslationColumnCallbacks,
+): TemplateResult | string {
+    if (!row.resourceName) return "—";
+    const canOpen = !!row.sourceFile;
+    if (!canOpen) {
+        return html`<span class="text-bundle-translation-resource-name"
+            >${row.resourceName}</span
+        >`;
+    }
+    return html`<button
+        type="button"
+        class="text-bundle-resource-link"
+        title=${"Open " + row.sourceFile}
+        @click=${(ev: Event) => {
+            ev.preventDefault();
+            ev.stopPropagation();
+            callbacks.openResource(row);
+        }}
+    >
+        <i class="codicon codicon-go-to-file" aria-hidden="true"></i>
+        <span>${row.resourceName}</span>
+    </button>`;
+}
+
+// -------------------------------------------------------------------------
+// Parsers — defensive `typeof` / `Array.isArray` checks so a daemon
+// schema drift drops the offending row rather than NaN-ing the body.
+// -------------------------------------------------------------------------
+
+function parseDrawnText(raw: unknown): DrawnTextRow[] {
+    if (!raw || typeof raw !== "object") return [];
+    const payload = raw as { texts?: unknown };
+    const rawTexts = Array.isArray(payload.texts) ? payload.texts : [];
+    const rows: DrawnTextRow[] = [];
+    rawTexts.forEach((t, idx) => {
+        if (!t || typeof t !== "object") return;
+        const e = t as {
+            text?: unknown;
+            semanticsText?: unknown;
+            semanticsLabel?: unknown;
+            inputText?: unknown;
+            editableText?: unknown;
+            localeTag?: unknown;
+            fontScale?: unknown;
+            fontSize?: unknown;
+            foregroundColor?: unknown;
+            backgroundColor?: unknown;
+            overflow?: unknown;
+            truncated?: unknown;
+            didOverflowWidth?: unknown;
+            didOverflowHeight?: unknown;
+            nodeId?: unknown;
+            boundsInScreen?: unknown;
+        };
+        // Prefer the rendered `text` first; fall back to semantics /
+        // input text when the daemon couldn't extract drawn glyphs
+        // (rare, but seen on `BasicTextField`). Stringly-typed so an
+        // unexpected non-string value gets treated as missing.
+        const text =
+            firstString([
+                e.text,
+                e.semanticsText,
+                e.semanticsLabel,
+                e.editableText,
+                e.inputText,
+            ]) ?? "";
+        const nodeId = typeof e.nodeId === "string" ? e.nodeId : "";
+        if (!nodeId) return;
+        const boundsInScreen =
+            typeof e.boundsInScreen === "string" ? e.boundsInScreen : "";
+        rows.push({
+            id: "text-string-" + idx,
+            nodeId,
+            text,
+            localeTag: typeof e.localeTag === "string" ? e.localeTag : "",
+            fontScale:
+                typeof e.fontScale === "number" && Number.isFinite(e.fontScale)
+                    ? e.fontScale
+                    : 1,
+            fontSize: typeof e.fontSize === "string" ? e.fontSize : "",
+            foreground:
+                typeof e.foregroundColor === "string"
+                    ? e.foregroundColor
+                    : null,
+            background:
+                typeof e.backgroundColor === "string"
+                    ? e.backgroundColor
+                    : null,
+            overflow: typeof e.overflow === "string" ? e.overflow : null,
+            truncated: e.truncated === true,
+            didOverflowWidth: e.didOverflowWidth === true,
+            didOverflowHeight: e.didOverflowHeight === true,
+            boundsInScreen,
+        });
+    });
+    return rows;
+}
+
+function firstString(values: readonly unknown[]): string | null {
+    for (const v of values) {
+        if (typeof v === "string" && v.length > 0) return v;
+    }
+    return null;
+}
+
+function parseFonts(raw: unknown): FontRow[] {
+    if (!raw || typeof raw !== "object") return [];
+    const payload = raw as { fonts?: unknown };
+    const rawFonts = Array.isArray(payload.fonts) ? payload.fonts : [];
+    const rows: FontRow[] = [];
+    rawFonts.forEach((f, idx) => {
+        if (!f || typeof f !== "object") return;
+        const e = f as {
+            requestedFamily?: unknown;
+            resolvedFamily?: unknown;
+            weight?: unknown;
+            style?: unknown;
+            sourceFile?: unknown;
+            fellBackFrom?: unknown;
+            consumerNodeIds?: unknown;
+            provider?: unknown;
+        };
+        const requestedFamily =
+            typeof e.requestedFamily === "string" ? e.requestedFamily : "";
+        if (!requestedFamily) return;
+        const resolvedFamily =
+            typeof e.resolvedFamily === "string"
+                ? e.resolvedFamily
+                : requestedFamily;
+        const provider = typeof e.provider === "string" ? e.provider : null;
+        const fellBack = Array.isArray(e.fellBackFrom)
+            ? (e.fellBackFrom.filter((x) => typeof x === "string") as string[])
+            : [];
+        const consumers = Array.isArray(e.consumerNodeIds)
+            ? e.consumerNodeIds.filter((x) => typeof x === "string").length
+            : 0;
+        rows.push({
+            id: "font-" + idx,
+            requestedFamily,
+            resolvedFamily,
+            weight:
+                typeof e.weight === "number" && Number.isFinite(e.weight)
+                    ? e.weight
+                    : 400,
+            style: typeof e.style === "string" ? e.style : "normal",
+            sourceFile: typeof e.sourceFile === "string" ? e.sourceFile : null,
+            fellBackFromChain: fellBack.join(" → "),
+            consumerCount: consumers,
+            isGoogleFont: isGoogleFontFamily(requestedFamily, provider),
+            provider,
+        });
+    });
+    return rows;
+}
+
+function parseTranslations(raw: unknown): TranslationRow[] {
+    if (!raw || typeof raw !== "object") return [];
+    const payload = raw as {
+        strings?: unknown;
+        supportedLocales?: unknown;
+    };
+    const rawSupported = Array.isArray(payload.supportedLocales)
+        ? (payload.supportedLocales.filter(
+              (x) => typeof x === "string",
+          ) as string[])
+        : [];
+    const rawStrings = Array.isArray(payload.strings) ? payload.strings : [];
+    const rows: TranslationRow[] = [];
+    rawStrings.forEach((s, idx) => {
+        if (!s || typeof s !== "object") return;
+        const e = s as {
+            rendered?: unknown;
+            resourceName?: unknown;
+            sourceFile?: unknown;
+            translations?: unknown;
+            untranslatedLocales?: unknown;
+        };
+        const rendered = typeof e.rendered === "string" ? e.rendered : "";
+        const resourceName =
+            typeof e.resourceName === "string" ? e.resourceName : null;
+        const sourceFile =
+            typeof e.sourceFile === "string" ? e.sourceFile : null;
+        const translations =
+            e.translations && typeof e.translations === "object"
+                ? (e.translations as Record<string, unknown>)
+                : {};
+        const translatedLocales = Object.keys(translations)
+            .filter((k) => typeof translations[k] === "string")
+            .sort();
+        const untranslated = Array.isArray(e.untranslatedLocales)
+            ? (e.untranslatedLocales.filter(
+                  (x) => typeof x === "string",
+              ) as string[])
+            : [];
+        const supportedCount =
+            rawSupported.length > 0
+                ? rawSupported.length
+                : translatedLocales.length + untranslated.length;
+        rows.push({
+            id: "i18n-" + idx,
+            rendered,
+            resourceName,
+            sourceFile,
+            supportedLocaleCount: supportedCount,
+            untranslatedLocaleCount: untranslated.length,
+            untranslatedLocales: untranslated,
+            translatedLocales,
+        });
+    });
+    return rows;
+}
+
+/**
+ * Convenience for main.ts — assemble the `openResourceFile` wire payload
+ * for a translation row. Centralised here so the host shell wiring
+ * stays a one-liner.
+ */
+export function translationOpenResourcePayload(row: TranslationRow): {
+    command: "openResourceFile";
+    resourceType: "string";
+    resourceName: string;
+    resolvedFile: string | null;
+    packageName: null;
+} {
+    // `i18n/translations` ships names as `R.string.<name>`, but the
+    // extension-side resolver matches `<string name="…">` entries by
+    // bare name. Strip the `R.string.` prefix so the jump-to-resource
+    // action finds the entry; otherwise the resolver scans for
+    // `<string name="R.string.sign_in">` and silently no-ops.
+    const raw = row.resourceName ?? "";
+    const bareName = raw.startsWith("R.string.")
+        ? raw.slice("R.string.".length)
+        : raw;
+    return {
+        command: "openResourceFile",
+        resourceType: "string",
+        resourceName: bareName,
+        resolvedFile: row.sourceFile,
+        packageName: null,
+    };
+}


### PR DESCRIPTION
## Summary

Implements **Cluster D — Text / i18n bundle** (#1057). Three stacked sub-sections in one tab body, plus a daemon-side schema bump for `FontUsedEntry.provider`.

### Drawn text (`text/strings`, default ON)
Row per `TextStringEntry` with `text`, `localeTag`, `fontScale`, `fontSize`, `foreground`/`background` swatch cells, `overflow`, `nodeId`. Rows whose `truncated` / `didOverflowWidth` / `didOverflowHeight` flags are set get `level=warning` on their overlay box so layout bugs surface at-a-glance.

### Fonts (`fonts/used`, default ON)
Row per `FontUsedEntry` with `requestedFamily`, `resolvedFamily`, `weight`, `style`, `sourceFile`, `fellBackFrom` chain, consumer count. **Google Fonts handling**: when `provider === "google"` OR (provider missing AND family appears in the bundled 50-name allowlist), the requestedFamily cell exposes a `codicon-link-external` button that posts the new `openExternal` webview→extension message with URL `https://fonts.google.com/specimen/<URI-encoded family>`. Cell preview uses the resolved family via CSS `font-family` — no network call from the webview.

### Translations (`i18n/translations`, expander-only)
Row per `I18nVisibleString` with `rendered`, `resourceName`, `sourceFile`, supported-locales count chip, untranslated-locales count + tooltip. `sourceFile` + `resourceName` posts an `openResourceFile` message (reusing the wire kind from #1066) to jump to the matching `<string name="…">` in the resource XML.

### Daemon-side schema bump

`FontUsedEntry.provider: String? = null` added in `data/fonts/core`; `SCHEMA_VERSION` bumps 1 → 2. Values open-ended (`"google"`, `"asset"`, `"system"`, or omitted). Producer side doesn't populate it yet — webview's allowlist fallback covers the common case until a follow-up renderer-side detection lands.

### Wire surface

New `openExternal` webview→extension message; handler in `extension.ts` guards on `http(s)` URLs only.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 867 passing (+10 in `computeTextBundleData`)
- [x] 4 Kotlin round-trip tests in `FontProviderRoundtripTest.kt` cover schema-version pin, all provider values + null, v1-no-provider decode (forward-compat)
- [ ] `./gradlew :data-fonts-core:test` — could not be exercised in the agent sandbox (JDK toolchain pinned to 17, auto-download disabled); shape matches existing `data/*/core` tests
- [ ] Verify Text bundle in panel: chip opens tab; drawn-text rows mark truncation warnings; fonts with Google Fonts allowlist match show the link button; translations expander toggles `i18n/translations`

Net: +1446 / −2 LOC. Closes #1057.

## Notes / compromises

- Google Fonts cell uses an inline link button rather than a Perfetto-style modal handoff — feels right for a single-URL action.
- No locale picker yet — the translations sub-table lists counts only. Per-locale re-render is a follow-up; needs daemon-side `i18n/translations` re-subscription support.
- Resolved-family preview cell uses webview-local `font-family` only — no data-URI sideload of the resolved font bytes, so unusual asset fonts fall back to the panel's system stack.
- `provider` field is schema-only — the renderer still emits null; allowlist fallback handles the common case.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcozQg6vaBFB5Y6vVsyuPH)_