### PR TITLE
docs: document auto-inject plugin and minimal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Working examples: [`samples/android/build.gradle.kts`](samples/android/build.gra
 
 ### Zero-Code Integration (Alternative)
 
-You can apply the plugin dynamically without modifying the project's source code by using a Gradle init script. This is particularly useful for AI agents or when exploring the tool without committing changes to the repository.
+You can apply the plugin dynamically without modifying the project's source code by using a Gradle init script. This is particularly useful for AI agents on the CLI, in CI, or when exploring the tool without committing changes to the repository.
+
+> **VS Code users:** the [`Compose Preview` extension](vscode-extension/) already auto-injects via `--init-script` on every Gradle invocation it makes — you don't need a global `~/.gradle/init.d/` script. The instructions below are for command-line and CI flows that don't go through the extension.
 
 To use this method:
 1. Create a Gradle init script (e.g., `~/.gradle/init.d/compose-ai-tools.gradle`) that resolves the plugin and applies it to Android application projects.

--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -170,6 +170,8 @@ composePreview {
 
 You can apply the plugin dynamically without modifying the project's source code by using a Gradle init script. This is useful for agents operating in environments where they shouldn't or cannot modify the build files directly.
 
+> **VS Code users:** the [`Compose Preview` extension](../../vscode-extension/) already passes a bundled init script via `--init-script` on every Gradle invocation it makes, so its renders pick up Android / Compose projects with no extra setup. The instructions below are for CLI and CI flows that go through `./gradlew` directly.
+
 Create a file named `~/.gradle/init.d/compose-ai-tools.gradle` with the following content:
 
 ```groovy

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -32,7 +32,15 @@ renders them to PNG, and the extension loads those PNGs into a webview.
 
 ## Apply the Gradle plugin
 
-Add
+The extension auto-applies the Compose Preview plugin to any module that
+already applies `com.android.application`, `com.android.library`, or
+`org.jetbrains.compose` — no `build.gradle.kts` edit needed. A bundled init
+script is passed to every Gradle invocation via `--init-script` and pulls
+the plugin from Maven Central. Workspaces that don't apply one of those host
+plugins fall back to **minimal mode** (see below); workspaces that apply the
+plugin explicitly continue to work the same way.
+
+To opt in manually instead, add
 [`ee.schimke.composeai.preview`](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin)
 to the module whose previews you want to render:
 
@@ -52,6 +60,25 @@ The plugin is on Maven Central, so no extra repository setup is needed when
 [project README](https://github.com/yschimke/compose-ai-tools#setup) for
 snapshot builds.
 
+To disable auto-inject and require an explicit plugin application, set
+`composePreview.autoInject.enabled` to `false`.
+
+## Minimal mode
+
+When no module in the workspace applies the Compose Preview plugin (and
+auto-inject can't attach onto an Android / Compose host plugin), the
+extension boots into **minimal mode**: the preview daemon, data extensions
+(a11y overlays, hierarchy, focus-mode inspector layers), and live /
+interactive previews are all disabled, and renders no longer fire
+automatically on save. Click the refresh button (or run
+`Compose Preview: Refresh Previews` / `Render All Previews`) to render.
+
+Override via `composePreview.mode`: `auto` (default) picks based on the
+workspace, `minimal` forces the gradle-only path, `full` forces the daemon
+backend. After a Gradle sync writes the authoritative plugin-applied
+markers, the extension offers a one-click reload if a switch to full mode
+becomes possible.
+
 ## Usage
 
 1. Open a Kotlin project that applies the Compose Preview Gradle plugin.
@@ -68,10 +95,12 @@ snapshot builds.
 
 ### Settings
 
-| Setting                        | Default  | Description                                                                                                                                                                                                                                                                                                                                  |
-| ------------------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `composePreview.variant`       | `debug`  | Build variant to use for preview rendering (Android).                                                                                                                                                                                                                                                                                        |
-| `composePreview.logging.level` | `normal` | Verbosity for the "Compose Preview" output channel. `quiet` shows only errors and the BUILD outcome; `normal` keeps active task headers and summary lines but drops UP-TO-DATE/SKIPPED noise, configuration-cache bookkeeping, and dedupes the repeated Roborazzi ActionBar warnings; `verbose` shows every line from Gradle and the daemon. |
+| Setting                             | Default  | Description                                                                                                                                                                                                                                                                                                                                  |
+| ----------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `composePreview.mode`               | `auto`   | Backend mode: `auto` picks `full` when the plugin is applied (or can be auto-injected onto an Android / Compose host), else `minimal`. Force `full` or `minimal` to override. Requires a window reload to take effect.                                                                                                                       |
+| `composePreview.autoInject.enabled` | `true`   | Pass the bundled init script via `--init-script` so the plugin auto-applies to Android / Compose projects. Disable to keep Gradle invocations untouched and require manual `id("ee.schimke.composeai.preview")` setup.                                                                                                                       |
+| `composePreview.variant`            | `debug`  | Build variant to use for preview rendering (Android).                                                                                                                                                                                                                                                                                        |
+| `composePreview.logging.level`      | `normal` | Verbosity for the "Compose Preview" output channel. `quiet` shows only errors and the BUILD outcome; `normal` keeps active task headers and summary lines but drops UP-TO-DATE/SKIPPED noise, configuration-cache bookkeeping, and dedupes the repeated Roborazzi ActionBar warnings; `verbose` shows every line from Gradle and the daemon. |
 
 ## Links
 


### PR DESCRIPTION
Update documentation to explain the auto-inject plugin feature and minimal mode fallback for the VS Code extension.

## Summary
This PR documents two key features of the Compose Preview VS Code extension:
1. **Auto-inject plugin**: The extension now automatically applies the Compose Preview plugin to Android/Compose projects via a bundled init script, eliminating the need for manual `build.gradle.kts` edits in most cases.
2. **Minimal mode**: When the plugin cannot be auto-injected, the extension falls back to a limited mode with Gradle-only rendering and no live previews.

## Key changes
- **vscode-extension/README.md**: 
  - Explain auto-inject behavior and when it applies
  - Document the new `composePreview.mode` and `composePreview.autoInject.enabled` settings
  - Add "Minimal mode" section describing the fallback behavior and configuration options
  - Update settings table with new configuration options

- **README.md**: 
  - Clarify that zero-code integration via init scripts is for CLI/CI flows, not VS Code users
  - Add note that VS Code extension already handles auto-inject internally

- **skills/compose-preview/SKILL.md**: 
  - Add similar clarification that the init script instructions are for CLI/CI, not VS Code users
  - Reference the VS Code extension's built-in auto-inject capability

These changes help users understand when and how the plugin is applied, and what to expect in minimal mode scenarios.

https://claude.ai/code/session_01S8vAhS151LNK42GjqnnpYj