### PR TITLE
feat(vscode-extension): paint history-diff overlay on focused card

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2497,6 +2497,7 @@ body {
     padding: 4px 0;
 }
 .perf-bundle-section {
+}
 /* ---- Display bundle (displayfilter/*) -------------------------------- */
 .displayfilter-thumb-cell {
     width: 32px;
@@ -2842,6 +2843,7 @@ body {
     text-align: right;
     font-variant-numeric: tabular-nums;
     width: 80px;
+}
 .errors-key-cell {
     width: 30%;
 }
@@ -3040,4 +3042,16 @@ body {
 .text-bundle-locale-chip[data-tone="warning"] {
     background: var(--vscode-inputValidation-warningBackground, #5a4400);
     color: var(--vscode-inputValidation-warningForeground, #fff);
+}
+
+/* Per-bundle `<box-overlay>` mounted inside `.image-container` (one
+ * layer per bundle, keyed on `data-bundle`). Sits above the image but
+ * below other DOM in the container so badges and codicons remain
+ * clickable. Pointer-events on the overlay itself stay none — the
+ * inner `.overlay-box` opts back in for hover correlation. */
+.bundle-card-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 2;
 }

--- a/vscode-extension/src/test/cardBundleOverlay.test.ts
+++ b/vscode-extension/src/test/cardBundleOverlay.test.ts
@@ -1,0 +1,169 @@
+// Per-card bundle overlay paint (#1054 follow-up). Pins the
+// stamp / clear cycle for the per-bundle `<box-overlay>` layer that
+// `cardBundleOverlay.ts` mounts inside `.image-container` so each
+// bundle's tinted boxes appear on the focused card without
+// clobbering siblings from other bundles.
+//
+// History-diff is the first consumer; the same helper backs future
+// migrations (a11y, text-overflow). Tests target the helper directly
+// rather than going through `main.ts` so the focused-card lookup
+// stays mockable via `document.body.innerHTML` fixtures.
+
+import * as assert from "assert";
+import {
+    clearBundleBoxes,
+    findCardElement,
+    paintBundleBoxes,
+} from "../webview/preview/cardBundleOverlay";
+import { sanitizeId } from "../webview/preview/cardData";
+// Import for side-effect: registers `<box-overlay>` with
+// `customElements.define`. Without this the createElement returns a
+// plain HTMLElement and `setBoxes` is undefined.
+import "../webview/preview/components/BoxOverlay";
+import type {
+    BoxOverlay,
+    OverlayBox,
+} from "../webview/preview/components/BoxOverlay";
+
+function buildCard(previewId: string): HTMLElement {
+    const card = document.createElement("div");
+    card.className = "preview-card";
+    card.id = "preview-" + sanitizeId(previewId);
+    card.dataset.previewId = previewId;
+    const container = document.createElement("div");
+    container.className = "image-container";
+    const img = document.createElement("img");
+    // happy-dom doesn't decode bytes, so seed naturalWidth/Height
+    // via the shape downstream tests reuse — `Object.defineProperty`
+    // is the supported escape hatch.
+    Object.defineProperty(img, "naturalWidth", { value: 200 });
+    Object.defineProperty(img, "naturalHeight", { value: 100 });
+    Object.defineProperty(img, "complete", { value: true });
+    container.appendChild(img);
+    card.appendChild(container);
+    document.body.appendChild(card);
+    return card;
+}
+
+function box(
+    id: string,
+    level: "error" | "warning" | "info" = "info",
+): OverlayBox {
+    return {
+        id,
+        bounds: { left: 0, top: 0, right: 50, bottom: 25 },
+        level,
+    };
+}
+
+describe("cardBundleOverlay", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("findCardElement resolves the card by its sanitized id", () => {
+        const card = buildCard("com.example.PreviewKt.Sample");
+        assert.strictEqual(
+            findCardElement("com.example.PreviewKt.Sample"),
+            card,
+        );
+        assert.strictEqual(findCardElement("missing"), null);
+    });
+
+    it("paintBundleBoxes mounts a `<box-overlay>` keyed on the bundle id", () => {
+        const card = buildCard("p:1");
+        paintBundleBoxes(card, "history", [box("region-0"), box("region-1")]);
+        const overlays = card.querySelectorAll<BoxOverlay>(
+            "box-overlay[data-bundle='history']",
+        );
+        assert.strictEqual(overlays.length, 1, "exactly one history layer");
+        assert.ok(
+            overlays[0].classList.contains("bundle-card-overlay"),
+            "shared CSS class so the layer sits at z-index above the image",
+        );
+    });
+
+    it("re-paints the same layer in place rather than stacking new mounts", () => {
+        const card = buildCard("p:1");
+        paintBundleBoxes(card, "history", [box("a")]);
+        paintBundleBoxes(card, "history", [box("b"), box("c")]);
+        const overlays = card.querySelectorAll(
+            "box-overlay[data-bundle='history']",
+        );
+        assert.strictEqual(overlays.length, 1);
+    });
+
+    it("paints two distinct layers when two different bundles paint", () => {
+        const card = buildCard("p:1");
+        paintBundleBoxes(card, "history", [box("region-0")]);
+        paintBundleBoxes(card, "a11y", [box("a11y-0")]);
+        assert.strictEqual(
+            card.querySelectorAll("box-overlay[data-bundle='history']").length,
+            1,
+        );
+        assert.strictEqual(
+            card.querySelectorAll("box-overlay[data-bundle='a11y']").length,
+            1,
+        );
+    });
+
+    it("clearBundleBoxes(card, id) removes only that bundle's layer", () => {
+        const card = buildCard("p:1");
+        paintBundleBoxes(card, "history", [box("region-0")]);
+        paintBundleBoxes(card, "a11y", [box("a11y-0")]);
+        clearBundleBoxes(card, "history");
+        assert.strictEqual(
+            card.querySelectorAll("box-overlay[data-bundle='history']").length,
+            0,
+        );
+        assert.strictEqual(
+            card.querySelectorAll("box-overlay[data-bundle='a11y']").length,
+            1,
+            "other bundles' layers must survive the targeted teardown",
+        );
+    });
+
+    it("clearBundleBoxes(null, id) removes the bundle's layer from every card", () => {
+        const cardA = buildCard("p:a");
+        const cardB = buildCard("p:b");
+        paintBundleBoxes(cardA, "history", [box("ra")]);
+        paintBundleBoxes(cardB, "history", [box("rb")]);
+        clearBundleBoxes(null, "history");
+        assert.strictEqual(
+            document.querySelectorAll("box-overlay[data-bundle='history']")
+                .length,
+            0,
+        );
+    });
+
+    it("paintBundleBoxes with empty boxes clears the layer in place (re-add later still works)", () => {
+        const card = buildCard("p:1");
+        paintBundleBoxes(card, "history", [box("a")]);
+        paintBundleBoxes(card, "history", []);
+        // The empty-set path keeps the wrapper mounted (so a follow-up
+        // refresh reuses it), but `<box-overlay>.setBoxes([])` makes
+        // it produce zero `.overlay-box` children.
+        const layer = card.querySelector("box-overlay[data-bundle='history']");
+        assert.ok(layer, "empty paint should not unmount the layer");
+        // Subsequent non-empty refresh repopulates the same node.
+        paintBundleBoxes(card, "history", [box("b"), box("c")]);
+        assert.strictEqual(
+            card.querySelectorAll("box-overlay[data-bundle='history']").length,
+            1,
+            "still one layer after the empty-then-full cycle",
+        );
+    });
+
+    it("no-ops when the card has no `.image-container`", () => {
+        const card = document.createElement("div");
+        card.className = "preview-card";
+        document.body.appendChild(card);
+        assert.doesNotThrow(() =>
+            paintBundleBoxes(card, "history", [box("a")]),
+        );
+        assert.strictEqual(card.querySelectorAll("box-overlay").length, 0);
+    });
+});

--- a/vscode-extension/src/webview/preview/cardBundleOverlay.ts
+++ b/vscode-extension/src/webview/preview/cardBundleOverlay.ts
@@ -1,0 +1,111 @@
+// Per-card bundle overlay paint — stamps `<box-overlay>` elements
+// inside a focused preview card's `.image-container` so any active
+// bundle whose data carries bounds (history-diff regions,
+// future: a11y migration off `applyHierarchyOverlay`, text overflow
+// rectangles) shows tinted boxes on the rendered preview.
+//
+// Initial slice (#1054 follow-up) is focused-only and per-bundle:
+// the host calls `paintBundleBoxes(card, bundleId, boxes)` from each
+// bundle's refresh function, and `clearBundleBoxes(card?, bundleId)`
+// from the bundle's deactivation path. Multiple bundles can paint at
+// once — each gets its own `<box-overlay>` layer keyed on
+// `data-bundle`. Generalising to grid-mode selection (paint on every
+// visible card) is a follow-up; this slice closes the gap on the
+// focused card only, mirroring how a11y already paints today via
+// `applyHierarchyOverlay`.
+
+import { BoxOverlay, type OverlayBox } from "./components/BoxOverlay";
+import { sanitizeId } from "./cardData";
+
+/**
+ * Find the card element for [previewId] in the grid. Mirrors the
+ * id-construction the rest of the panel uses (`sanitizeId(previewId)`
+ * via `populatePreviewCard`). Returns `null` when the card hasn't been
+ * rendered yet — callers no-op silently in that case.
+ */
+export function findCardElement(previewId: string): HTMLElement | null {
+    return document.getElementById("preview-" + sanitizeId(previewId));
+}
+
+/**
+ * Mount or update the per-bundle `<box-overlay>` layer on [card]. The
+ * layer is keyed on `data-bundle=${bundleId}` so multiple bundles can
+ * coexist without clobbering each other's boxes.
+ *
+ * Empty `boxes` clears the layer in place rather than removing the DOM
+ * — the next non-empty refresh repopulates it without thrash, matching
+ * `BoxOverlay.setBoxes`'s own no-op behaviour.
+ *
+ * Natural dimensions come from the card's `<img>`. When the image
+ * hasn't loaded yet we attach a one-time `load` listener so the layer
+ * paints once the bytes land — same pattern
+ * `_repaintA11yOverlaysFromCache` uses.
+ */
+export function paintBundleBoxes(
+    card: HTMLElement,
+    bundleId: string,
+    boxes: readonly OverlayBox[],
+): void {
+    const container = card.querySelector<HTMLElement>(".image-container");
+    if (!container) return;
+    const overlay = ensureBundleOverlayLayer(container, bundleId);
+    overlay.setBoxes(boxes);
+    const img = card.querySelector<HTMLImageElement>(".image-container img");
+    if (!img) return;
+    if (img.complete && img.naturalWidth > 0) {
+        overlay.setNaturalSize(img.naturalWidth, img.naturalHeight);
+        return;
+    }
+    // Image not yet decoded — defer to the load event. Guard against
+    // stacking listeners across rapid refreshes via a per-bundle
+    // dataset flag on the `<img>`.
+    const flag = "bundleOverlayPaint_" + bundleId.replace(/[^a-z0-9]/gi, "_");
+    if (img.dataset[flag] === "1") return;
+    img.dataset[flag] = "1";
+    img.addEventListener(
+        "load",
+        () => {
+            delete img.dataset[flag];
+            const stillThere = container.querySelector<BoxOverlay>(
+                'box-overlay[data-bundle="' + bundleId + '"]',
+            );
+            if (stillThere && img.naturalWidth > 0) {
+                stillThere.setNaturalSize(img.naturalWidth, img.naturalHeight);
+            }
+        },
+        { once: true },
+    );
+}
+
+/**
+ * Tear down the per-bundle layer on [card] (or every card when
+ * omitted). Called from each bundle's deactivation path so chip
+ * dismissal clears the boxes from every card the bundle touched —
+ * preserves the chip-toggle = full-teardown contract from
+ * `docs/design/EXTENSION_DATA_EXPOSURE.md`.
+ */
+export function clearBundleBoxes(
+    card: HTMLElement | null,
+    bundleId: string,
+): void {
+    const root = card ?? document;
+    const layers = root.querySelectorAll(
+        'box-overlay[data-bundle="' + bundleId + '"]',
+    );
+    for (const layer of Array.from(layers)) layer.remove();
+}
+
+function ensureBundleOverlayLayer(
+    container: HTMLElement,
+    bundleId: string,
+): BoxOverlay {
+    const existing = container.querySelector<BoxOverlay>(
+        'box-overlay[data-bundle="' + bundleId + '"]',
+    );
+    if (existing) return existing;
+    const overlay = document.createElement("box-overlay") as BoxOverlay;
+    overlay.dataset.bundle = bundleId;
+    overlay.classList.add("bundle-card-overlay");
+    container.appendChild(overlay);
+    return overlay;
+}

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -37,6 +37,11 @@ import { BundleChipBar } from "./components/BundleChipBar";
 import { DataTabs } from "./components/DataTabs";
 import { DataTable } from "./components/DataTable";
 import { BundleExpander } from "./components/BundleExpander";
+import {
+    clearBundleBoxes,
+    findCardElement,
+    paintBundleBoxes,
+} from "./cardBundleOverlay";
 import { BundleController, type BundleSnapshot } from "./bundleController";
 import { getBundle, type BundleId } from "./bundleRegistry";
 import { a11yTableColumns, computeA11yBundleData } from "./a11yBundlePresenter";
@@ -1167,12 +1172,11 @@ export class PreviewApp extends LitElement {
             }));
             refreshExpanderFor("history");
             dataTabs.setTabBody("history", host);
-            // The overlay array is computed via `data.overlay` and is
-            // intentionally not stamped onto the card here — the
-            // panel's per-card overlay stack is still being unified
-            // (see the A11y bundle for the matching gap). Test-side
-            // assertions cover the array shape directly.
-            void data.overlay;
+            // Paint the per-region tinted boxes on the focused card.
+            // Empty array clears in place; the bundle-deactivation
+            // path in `reflectBundleState` removes the layer entirely.
+            const card = findCardElement(target);
+            if (card) paintBundleBoxes(card, "history", data.overlay);
         };
 
         // ---- Errors bundle (test/failure) ----------------------------------
@@ -1248,7 +1252,15 @@ export class PreviewApp extends LitElement {
             } else {
                 clearAllAmbientBadges();
             }
-            if (s.activeBundles.includes("history")) refreshHistoryBundle();
+            if (s.activeBundles.includes("history")) {
+                refreshHistoryBundle();
+            } else {
+                // Tear down the per-card box-overlay layer on every
+                // card the bundle painted into. Mirrors the
+                // ambient-badge teardown above so chip dismissal
+                // wipes every bundle-attached card surface.
+                clearBundleBoxes(null, "history");
+            }
             if (s.activeBundles.includes("errors")) refreshErrorsBundle();
             if (s.activeBundles.includes("text")) refreshTextBundle();
         };


### PR DESCRIPTION
## Summary

Closes the per-card overlay-stack gap that #1078 left as a TODO. The history bundle's per-region tinted boxes now appear on the focused preview card in addition to the legend table.

Adds `cardBundleOverlay.ts` with three exports designed for any bundle to call:

- **`findCardElement(previewId)`** — resolve via the same `sanitizeId(...)` the rest of the panel uses.
- **`paintBundleBoxes(card, bundleId, boxes)`** — mount or update a `<box-overlay data-bundle=...>` layer inside `.image-container`, re-using the existing layer on subsequent refreshes (no DOM thrash). Defers natural-size assignment until the `<img>` loads using a per-bundle dataset flag so rapid refreshes don't stack load listeners.
- **`clearBundleBoxes(card | null, bundleId)`** — tear down on one card or every card. Called from the bundle-deactivation path in `reflectBundleState` so chip dismissal wipes every card the bundle touched.

History bundle wires both:
- `refreshHistoryBundle` paints `data.overlay` on the focused card
- `reflectBundleState`'s history `else` branch clears with `clearBundleBoxes(null, "history")`

Other bundles opt in by calling the same helper — keyed-by-`data-bundle` so they coexist without clobbering each other.

CSS adds `.bundle-card-overlay` (z-index:2 — above the image, below clickable badges). Drive-by fixes for two unclosed-brace squash artefacts in `preview.css` that prettier started rejecting (`.perf-bundle-section`, `.theming-consumers-cell`).

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 956 passing (+8 new in `cardBundleOverlay.test.ts`)
- [x] Tests cover: lookup, mount, in-place re-paint, two-bundle coexistence, single-bundle teardown, all-cards teardown, empty-then-full cycle, no-image-container no-op
- [ ] Verify in panel: toggle History bundle on a focused preview with diff regions; tinted boxes appear on the card; closing the chip clears them

## Follow-ups (out of scope)

- Generalising to grid-mode (paint on every visible card, not just focused) — needs a `BundleController.subscribedKindsForPreview(previewId)` hook plus a new `selection` concept; deferred.
- Migrating A11y bundle to use this helper instead of `applyHierarchyOverlay` so the legacy a11yOverlay.ts code can be deleted.
- Text/i18n overflow rectangles — same wiring once #1081 lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcozQg6vaBFB5Y6vVsyuPH)_