### PR TITLE
feat(vscode-extension): A11y bundle paints overlay via cardBundleOverlay

### DIFF
--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -862,6 +862,16 @@ export class PreviewApp extends LitElement {
             }));
             refreshExpanderFor("a11y");
             dataTabs.setTabBody("a11y", body.wrapper);
+            // Paint the merged hierarchy + findings overlay on the
+            // focused card via the new bundle-overlay helper. Mirrors
+            // the history-diff wiring from PR #1086 — chip dismissal
+            // clears the layer in `reflectBundleState`'s else-branch
+            // below. Coexists with the legacy `applyHierarchyOverlay`
+            // path in `PreviewCard._repaintA11yOverlaysFromCache` for
+            // now; a follow-up will remove the legacy paint once the
+            // new path is verified end-to-end.
+            const card = findCardElement(target);
+            if (card) paintBundleBoxes(card, "a11y", data.overlay);
         };
         const refreshPerformanceBundle = (): void => {
             const target = currentBundleTarget();
@@ -1241,7 +1251,11 @@ export class PreviewApp extends LitElement {
                 activeBundles: s.activeBundles,
                 activeTab: s.activeTab,
             });
-            if (s.activeBundles.includes("a11y")) refreshA11yBundle();
+            if (s.activeBundles.includes("a11y")) {
+                refreshA11yBundle();
+            } else {
+                clearBundleBoxes(null, "a11y");
+            }
             if (s.activeBundles.includes("performance")) {
                 refreshPerformanceBundle();
             }


### PR DESCRIPTION
## Summary

Wires the A11y bundle into the per-card overlay helper that landed in #1086. `refreshA11yBundle` now calls `paintBundleBoxes` with the merged hierarchy + findings overlay; `reflectBundleState`'s a11y `else`-branch calls `clearBundleBoxes(null, "a11y")` on deactivation so the chip controls overlay visibility.

Coexists with the legacy `applyHierarchyOverlay` path in `PreviewCard._repaintA11yOverlaysFromCache` for now — both paint into different DOM layers (`<box-overlay data-bundle="a11y">` vs `.a11y-hierarchy-overlay`). A follow-up PR will delete the legacy path once this one is verified end-to-end in the panel, finally closing the "no way to get back" UX gap from the original screenshot complaint where a11y boxes stayed visible regardless of chip state.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 956 passing (no new tests; helper covered by `cardBundleOverlay.test.ts` from #1086, overlay computation by `a11yBundlePresenter.test.ts`)
- [ ] Verify in panel: toggle A11y chip on a preview with hierarchy data; the new `<box-overlay data-bundle="a11y">` layer appears in the image-container. Toggle chip off; the layer is removed.

Net: +15 / −1 LOC. Sets up the legacy-paint removal PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcozQg6vaBFB5Y6vVsyuPH)_