### PR TITLE
refactor: improve AI provider detection and trigger conditions

### DIFF
--- a/.github/workflows/codex-pr-review-blessed.yml
+++ b/.github/workflows/codex-pr-review-blessed.yml
@@ -1,7 +1,7 @@
 name: Codex PR Review (Blessed)
 
 on:
-  reaction:
+  issue_comment:
     types: [created]
 
 permissions:
@@ -17,9 +17,9 @@ jobs:
   preview:
     if: >-
       github.event.action == 'created' &&
-      github.event.reaction.content == 'eyes' &&
-      github.event.sender.login == github.repository_owner &&
       github.event.issue.pull_request &&
+      github.event.sender.login == github.repository_owner &&
+      startsWith(github.event.comment.body, '/codex-review') &&
       !(github.event.issue.user.login == github.repository_owner || contains(fromJson(vars.AI_REVIEW_TRUSTED_AUTHORS_JSON || '[]'), github.event.issue.user.login))
     name: Generate previews for blessed PR review
     runs-on: ubuntu-latest

--- a/.github/workflows/codex-pr-review-reusable.yml
+++ b/.github/workflows/codex-pr-review-reusable.yml
@@ -121,8 +121,22 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
+      - name: Detect AI provider keys
+        id: keys
+        env:
+          CODEX_KEY: ${{ secrets.codex_api_key }}
+          CLAUDE_KEY: ${{ secrets.claude_api_key }}
+          GEMINI_KEY: ${{ secrets.gemini_api_key }}
+        run: |
+          set -euo pipefail
+          {
+            echo "has_codex=$([[ -n "$CODEX_KEY" ]] && echo true || echo false)"
+            echo "has_claude=$([[ -n "$CLAUDE_KEY" ]] && echo true || echo false)"
+            echo "has_gemini=$([[ -n "$GEMINI_KEY" ]] && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Install compose-preview-review skill (Codex)
-        if: ${{ secrets.codex_api_key != '' }}
+        if: ${{ steps.keys.outputs.has_codex == 'true' }}
         env:
           SKILL_REPO: yschimke/compose-ai-tools
         run: |


### PR DESCRIPTION
## Summary
Refactors the Codex PR review workflows to improve AI provider key detection and updates the blessed workflow trigger mechanism for better reliability and maintainability.

## Key Changes

- **Enhanced AI provider detection**: Added a dedicated step in the reusable workflow that detects which AI provider keys (Codex, Claude, Gemini) are available by checking secrets, storing results in step outputs for conditional job execution
- **Fixed secret comparison**: Replaced direct secret comparison (`secrets.codex_api_key != ''`) with output-based condition (`steps.keys.outputs.has_codex == 'true'`) to avoid GitHub Actions secret masking issues
- **Updated blessed workflow trigger**: Changed from `reaction` event (eyes emoji) to `issue_comment` event with `/codex-review` command prefix for more explicit and user-friendly triggering
- **Improved condition ordering**: Reordered the job conditions in blessed workflow for better readability and logical flow

## Implementation Details

The new provider detection step uses shell conditionals to safely check for secret presence and outputs boolean values that can be reliably used in downstream conditional expressions. This approach avoids the pitfall of comparing secrets directly in `if` conditions, which can cause unexpected behavior due to GitHub's secret masking mechanism.

The trigger change from reaction-based to comment-based with a command prefix provides clearer intent and better user experience, as users can explicitly request a review with `/codex-review` rather than relying on emoji reactions.

https://claude.ai/code/session_01FHomhEGcdUru1hUVzJeoD5