### PR TITLE
fix(vscode-extension): hide data-extensions chip bar outside focus mode

### DIFF
--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -45,6 +45,10 @@ export interface FocusControllerConfig {
     /** `<div id="focus-controls">` — the focus-mode toolbar container.
      *  Toggled `hidden` based on layout mode. */
     focusControls: HTMLElement;
+    /** `<bundle-chip-bar>` — data-extensions chip strip. Visible only in
+     *  focus layout; the bundles only act on the focused preview, so the
+     *  strip would mislead outside focus mode. */
+    bundleChipBar: HTMLElement;
     /** `<div id="focus-position">` — the "N / M" position indicator. */
     focusPosition: HTMLElement;
     btnPrev: HTMLButtonElement;
@@ -184,6 +188,7 @@ export class FocusController {
         const mode = this.config.filterToolbar.getLayoutValue();
         this.config.grid.setLayoutMode(mode);
         this.config.focusControls.hidden = mode !== "focus";
+        this.config.bundleChipBar.hidden = mode !== "focus";
 
         if (mode === "focus") {
             const visible = this.getVisibleCards();

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -179,7 +179,7 @@ export class PreviewApp extends LitElement {
             <progress-bar></progress-bar>
             <compile-errors-banner></compile-errors-banner>
             <filter-toolbar></filter-toolbar>
-            <bundle-chip-bar></bundle-chip-bar>
+            <bundle-chip-bar hidden></bundle-chip-bar>
             <data-tabs></data-tabs>
 
             <message-banner></message-banner>
@@ -1330,6 +1330,7 @@ export class PreviewApp extends LitElement {
             grid,
             filterToolbar,
             focusControls,
+            bundleChipBar,
             focusPosition,
             btnPrev,
             btnNext,


### PR DESCRIPTION
The bundle chips drive subscriptions on the focused preview, so showing
the strip in grid/flow/column mode is misleading — clicks have no
target outside of focus. Hide the bar alongside the focus toolbar.