### PR TITLE
feat(vscode-extension): consume v2 dataExtensionReports manifest map

### DIFF
--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -8,6 +8,7 @@ import {
     PreviewManifest,
     PreviewRenderError,
     ResourceManifest,
+    manifestReportsView,
 } from "./types";
 import {
     appliesInjectableHostPlugin,
@@ -543,16 +544,15 @@ export class GradleService {
                     );
                 }
             }
-            // Enrich each preview with a11y findings when the module has the
-            // sidecar report. Always follow the manifest's pointer rather than
-            // probing for the file: disabling the Gradle option must cleanly
-            // remove findings from the UI without a stale opt-in run
-            // haunting us.
-            if (manifest.accessibilityReport) {
-                const byId = this.readA11yById(
-                    module,
-                    manifest.accessibilityReport,
-                );
+            // Enrich each preview with a11y findings when the module has the sidecar report.
+            // Read through `manifestReportsView` so v1 plugins (only `accessibilityReport`
+            // populated) and v2 plugins (the `dataExtensionReports` map) both surface uniformly
+            // — the unified view returns `{}` when neither is set, and the loop naturally
+            // leaves `a11yFindings = null` on every preview.
+            const reports = manifestReportsView(manifest);
+            const a11yPointer = reports["a11y"] ?? null;
+            if (a11yPointer) {
+                const byId = this.readA11yById(module, a11yPointer);
                 for (const p of manifest.previews) {
                     const entry = byId[p.id];
                     p.a11yFindings = entry?.findings ?? [];

--- a/vscode-extension/src/test/manifestReportsView.test.ts
+++ b/vscode-extension/src/test/manifestReportsView.test.ts
@@ -1,0 +1,72 @@
+import * as assert from "assert";
+import { manifestReportsView, PreviewManifest } from "../types";
+
+/**
+ * Mirrors `PreviewManifestReportsViewTest` on the CLI side. The Gradle plugin emits both the v2
+ * `dataExtensionReports` map and the legacy v1 `accessibilityReport` field for one release of
+ * transition; this helper unifies them so every other consumer in the extension only deals with
+ * the map. Tests pin all three on-disk shapes (v1-only, v2-only, both) plus the empty case.
+ */
+describe("manifestReportsView", () => {
+    const baseManifest: PreviewManifest = {
+        module: "sample",
+        variant: "debug",
+        previews: [],
+    };
+
+    it("returns the dataExtensionReports map verbatim when only v2 is set", () => {
+        const view = manifestReportsView({
+            ...baseManifest,
+            dataExtensionReports: { a11y: "accessibility.json" },
+        });
+        assert.deepStrictEqual(view, { a11y: "accessibility.json" });
+    });
+
+    it("synthesises an a11y entry from the legacy accessibilityReport field", () => {
+        // Mimics a manifest written by a pre-v2 plugin: only `accessibilityReport` populated.
+        // The extension must still surface findings — `gradleService.refreshManifest` reads
+        // through this view and would otherwise leave `a11yFindings` null.
+        const view = manifestReportsView({
+            ...baseManifest,
+            accessibilityReport: "accessibility.json",
+        });
+        assert.deepStrictEqual(view, { a11y: "accessibility.json" });
+    });
+
+    it("returns an empty object when neither field is set", () => {
+        const view = manifestReportsView(baseManifest);
+        assert.deepStrictEqual(view, {});
+    });
+
+    it("returns an empty object when v2 is an empty map and v1 is absent", () => {
+        const view = manifestReportsView({
+            ...baseManifest,
+            dataExtensionReports: {},
+        });
+        assert.deepStrictEqual(view, {});
+    });
+
+    it("prefers the v2 map over the legacy field when both are set", () => {
+        // The Gradle plugin sets both during the v1→v2 mirror window. If they ever drift (e.g. a
+        // pre-release plugin with a buggy mirror), the v2 map is the source of truth — same
+        // semantics as the CLI's `PreviewManifest.reportsView` getter.
+        const view = manifestReportsView({
+            ...baseManifest,
+            dataExtensionReports: { a11y: "v2-path.json" },
+            accessibilityReport: "v1-path.json",
+        });
+        assert.deepStrictEqual(view, { a11y: "v2-path.json" });
+    });
+
+    it("returns a defensive copy so callers can mutate freely", () => {
+        const dataExtensionReports = { a11y: "accessibility.json" };
+        const view = manifestReportsView({
+            ...baseManifest,
+            dataExtensionReports,
+        });
+        view["theme"] = "theme.json";
+        assert.deepStrictEqual(dataExtensionReports, {
+            a11y: "accessibility.json",
+        });
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -126,10 +126,9 @@ export interface PreviewInfo {
     /** Annotation-sourced data products, such as long and scrolling screenshots. */
     dataProducts?: PreviewDataProduct[];
     /**
-     * Populated by the extension from the sidecar accessibility.json referenced
-     * in [PreviewManifest.accessibilityReport]. `null`/`undefined` means
-     * accessibility checks were disabled for this module; an empty array means
-     * checks ran and found nothing.
+     * Populated by the extension from the sidecar accessibility.json pointed at by the `"a11y"`
+     * entry of [manifestReportsView]. `null`/`undefined` means accessibility checks were
+     * disabled for this module; an empty array means checks ran and found nothing.
      */
     a11yFindings?: AccessibilityFinding[] | null;
     /** Absolute path to the annotated screenshot (clean PNG + overlay legend), when findings exist. */
@@ -190,8 +189,42 @@ export interface PreviewManifest {
     module: string;
     variant: string;
     previews: PreviewInfo[];
-    /** Relative path (from `previews.json`) to the sidecar a11y report, or null. */
+    /**
+     * v2 wire format. Map of extension id (e.g. `"a11y"`) → relative path from `previews.json`
+     * to that extension's aggregated sidecar JSON. Empty/absent when no extension produced a
+     * canned report. Consumers should read through [manifestReportsView] rather than touching
+     * either field directly so a v1 plugin (only [accessibilityReport] populated) still surfaces
+     * as `{ "a11y": "accessibility.json" }`.
+     */
+    dataExtensionReports?: Record<string, string> | null;
+    /**
+     * **Deprecated** — v1 mirror of `dataExtensionReports["a11y"]`. The Gradle plugin emits both
+     * fields during the v1↔v2 transition so older clients keep working; new code reads through
+     * [manifestReportsView]. Remove once the consumer floor moves past v1.
+     */
     accessibilityReport?: string | null;
+}
+
+/**
+ * Unified view of [PreviewManifest.dataExtensionReports] + [PreviewManifest.accessibilityReport].
+ * Always prefer the v2 map when present; synthesise a single `{a11y: <path>}` entry from the v1
+ * field otherwise. Returns an empty object when neither is set — callers can iterate the keys
+ * unconditionally and let the strategy layer no-op on its absence.
+ */
+export function manifestReportsView(
+    manifest: Pick<
+        PreviewManifest,
+        "dataExtensionReports" | "accessibilityReport"
+    >,
+): Record<string, string> {
+    const v2 = manifest.dataExtensionReports;
+    if (v2 && Object.keys(v2).length > 0) {
+        return { ...v2 };
+    }
+    if (manifest.accessibilityReport) {
+        return { a11y: manifest.accessibilityReport };
+    }
+    return {};
 }
 
 export interface AccessibilityFinding {


### PR DESCRIPTION
Mirrors the CLI's v1↔v2 wire-format support added in PR #1083. The
Gradle plugin emits both `dataExtensionReports: Map<String, String>`
(v2) and the legacy `accessibilityReport: String?` (v1 mirror) for one
transition release; the extension now reads through a
`manifestReportsView` helper that returns the v2 map when present and
synthesises a `{a11y: <path>}` entry from the legacy field otherwise.

`gradleService.ts` switches the a11y enrichment path to read via the
helper; behaviour is unchanged for v1 manifests (still finds the
sidecar, populates `a11yFindings`/`a11yAnnotatedPath`) and now also
works against v2 manifests (which will land when v1 mirroring is
eventually dropped from the plugin).

Tests pin all four wire shapes: v2-only, v1-only, both-set
(v2 wins), and neither. Defensive-copy semantics asserted so callers
can mutate the view without leaking back into the manifest.

No behavioural change to the daemon path — daemon already routes a11y
through `previewRegistry.setA11y` from typed data-product payloads,
not the manifest pointer. The doc reference there was already
correct.