### PR TITLE
feat(vscode-extension): Text bundle paints overflow boxes via cardBundleOverlay

### DIFF
--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -812,6 +812,13 @@ export class PreviewApp extends LitElement {
                 !enabledKinds.has("i18n/translations") &&
                 data.translations.length === 0;
             dataTabs.setTabBody("text", body.wrapper);
+            // Paint the per-row overflow / truncation overlay on the
+            // focused card. Same wiring as A11y (#1087) + history-diff
+            // (#1086) — `cardBundleOverlay.paintBundleBoxes` keyed on
+            // the `text` bundle id. Chip dismissal clears the layer
+            // via the bundle-off branch in `reflectBundleState`.
+            const card = findCardElement(target);
+            if (card) paintBundleBoxes(card, "text", data.overlay);
         };
         const refreshExpanderFor = (id: BundleId): void => {
             const body = bundleBodies.get(id);
@@ -1276,7 +1283,11 @@ export class PreviewApp extends LitElement {
                 clearBundleBoxes(null, "history");
             }
             if (s.activeBundles.includes("errors")) refreshErrorsBundle();
-            if (s.activeBundles.includes("text")) refreshTextBundle();
+            if (s.activeBundles.includes("text")) {
+                refreshTextBundle();
+            } else {
+                clearBundleBoxes(null, "text");
+            }
         };
         bundleController.onChange(() => reflectBundleState());
         reflectBundleState();


### PR DESCRIPTION
## Summary

Wires the Text/i18n bundle's text-overflow overlay (rows whose `truncated` / `didOverflowWidth` / `didOverflowHeight` flags fired, computed in `computeTextBundleData` as level=warning boxes) into the per-card overlay helper from #1086.

`refreshTextBundle` now calls `paintBundleBoxes(card, "text", data.overlay)`; `reflectBundleState`'s `text` else-branch calls `clearBundleBoxes(null, "text")` so the chip controls overlay visibility. Same pattern A11y followed in #1087 and history-diff in #1086 — third bundle on the helper, three more to migrate (Resources / Inspection / Theming) if/when they grow per-row bounds.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 954 passing (no new tests; helper covered by `cardBundleOverlay.test.ts` from #1086, overlay computation by `textBundlePresenter.test.ts` from #1081)
- [ ] Verify in panel: toggle Text bundle on a preview with a truncated/overflowed `text/strings` row; warning-tinted boxes appear on those bounds. Toggle chip off; boxes gone.

Net: +12 / −1 LOC.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcozQg6vaBFB5Y6vVsyuPH)_