### PR TITLE
refactor: migrate accessibility report to generic extension reports map

### DIFF
--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -197,6 +197,11 @@ class CopyAnnotatedTest(unittest.TestCase):
                 _preview(id="x.Bad_small_round", function="Bad",
                          render="renders/Bad_small.png"),
             ],
+            # `a11y-report.py` reads `accessibility.json` directly, so neither field is
+            # strictly required for this fixture — both are written to mirror what the v2
+            # plugin emits in production so this test catches accidental drift if the
+            # script ever migrates to the manifest pointer.
+            "dataExtensionReports": {"a11y": "accessibility.json"},
             "accessibilityReport": "accessibility.json",
         }))
         (self.build / "accessibility.json").write_text(json.dumps({

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -142,7 +142,9 @@ private const val UI_MODE_NIGHT_YES: Int = 0x20
 
 /**
  * Wire-shape of `previews.json`'s top-level object — only the fields the index needs. The plugin
- * also writes `module`, `variant`, and `accessibilityReport`; those are ignored on parse.
+ * also writes `module`, `variant`, `dataExtensionReports`, and the legacy `accessibilityReport`
+ * mirror; all of those are ignored on parse here (the daemon routes per-extension reports through
+ * typed data-product payloads rather than the manifest pointer).
  */
 @Serializable
 private data class PreviewManifestDto(val previews: List<PreviewInfoDto> = emptyList())

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -110,12 +110,19 @@ data class RenderManifest(
     val variant: String,
     val previews: List<RenderPreviewEntry>,
     /**
-     * Relative path (from this manifest's parent directory) to a sidecar
-     * [AccessibilityReport] JSON file, when accessibility checks are enabled.
-     * `null` means the feature is off for this module — tools should treat the
-     * absence of this pointer as "no a11y data" rather than probing for the
-     * file on disk.
+     * Generic per-extension report pointer map. Keys are extension ids (e.g. `"a11y"`),
+     * values are module-relative paths from this manifest to that extension's aggregated
+     * sidecar JSON. Mirror of the plugin-side `PreviewManifest.dataExtensionReports`. The
+     * renderer doesn't consume either of these pointer fields today — they're parsed for
+     * wire-format completeness so a future renderer-side strategy lookup has the data on
+     * hand. See `PreviewManifest.reportsView` (CLI) for the unified read path.
      */
+    val dataExtensionReports: Map<String, String> = emptyMap(),
+    /**
+     * **Deprecated** — v1 mirror of `dataExtensionReports["a11y"]`, kept until the consumer
+     * floor moves past the v1 shape. New code should rely on the map instead.
+     */
+    @Deprecated("Use dataExtensionReports[\"a11y\"]; this field is a back-compat mirror.")
     val accessibilityReport: String? = null,
 )
 


### PR DESCRIPTION
## Summary
Refactors the accessibility report field in `RenderManifest` from a single `accessibilityReport` string pointer to a generic `dataExtensionReports` map that can hold multiple extension-specific report pointers. The legacy field is retained as a deprecated back-compat mirror.

## Changes
- **RenderManifest**: Added `dataExtensionReports: Map<String, String>` to hold per-extension report pointers (e.g., `"a11y"` → `"accessibility.json"`). Marked the existing `accessibilityReport` field as `@Deprecated` with guidance to use the map instead.
- **PreviewIndex**: Updated documentation to clarify that the daemon ignores both `dataExtensionReports` and the legacy `accessibilityReport` fields during manifest parsing, routing extension reports through typed data-product payloads instead.
- **test_a11y_report.py**: Updated test fixture to emit both the new `dataExtensionReports` map and the legacy `accessibilityReport` field, ensuring test coverage mirrors v2 plugin production behavior and catches accidental drift if the script migrates to manifest pointers in the future.

## Implementation Details
- The new `dataExtensionReports` map defaults to an empty map for backward compatibility.
- Both fields are currently parsed for wire-format completeness; the renderer doesn't consume them today, but the data is available for future renderer-side strategy lookups.
- The deprecation mirrors the plugin-side `PreviewManifest` structure, maintaining alignment across the codebase.

https://claude.ai/code/session_01N2XWSiDo47dVvMXg5tyCTC