### PR TITLE
feat(vscode-extension): …More tab for disabled bundles

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2198,6 +2198,49 @@ body {
     opacity: 0.6;
     padding: 8px 0;
 }
+/* `…More` tab — stable trailing tab listing disabled bundles. */
+.data-tab-handle-more {
+    margin-left: auto;
+    opacity: 0.8;
+}
+.data-tab-handle-more.data-tab-handle-active {
+    opacity: 1;
+}
+.data-tab-body-more {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.data-tab-more-header {
+    font-weight: 600;
+    opacity: 0.8;
+    padding: 2px 0;
+}
+.data-tab-more-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+.data-tab-more-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border-radius: 3px;
+    border: 1px solid var(--vscode-panel-border, transparent);
+    background: var(--vscode-button-secondaryBackground, transparent);
+    color: var(--vscode-button-secondaryForeground, inherit);
+    cursor: pointer;
+    font: inherit;
+    font-size: 12px;
+}
+.data-tab-more-row:hover {
+    background: var(--vscode-list-hoverBackground, transparent);
+}
+.data-tab-more-row-hint {
+    opacity: 0.6;
+    font-size: 11px;
+}
 
 .data-table-shell {
     display: flex;

--- a/vscode-extension/src/test/dataTabs.test.ts
+++ b/vscode-extension/src/test/dataTabs.test.ts
@@ -1,0 +1,189 @@
+// `<data-tabs>` — verifies the stable trailing `…More` tab that lists
+// every currently-disabled bundle. See
+// `docs/design/EXTENSION_DATA_EXPOSURE.md` § "UX shell" item 8.
+
+import * as assert from "assert";
+import { BUNDLES } from "../webview/preview/bundleRegistry";
+import type { BundleId } from "../webview/preview/bundleRegistry";
+
+// Importing the component registers the custom element with
+// `customElements.define`. Tests drive it through `setState` + DOM.
+import "../webview/preview/components/DataTabs";
+import type {
+    BundleToggledDetail,
+    DataTabs,
+    TabSelectDetail,
+} from "../webview/preview/components/DataTabs";
+
+function build(): DataTabs {
+    const el = document.createElement("data-tabs") as DataTabs;
+    document.body.appendChild(el);
+    return el;
+}
+
+function moreHandle(el: DataTabs): HTMLElement | null {
+    return el.querySelector<HTMLElement>('[data-bundle="__more"]');
+}
+
+function moreBody(el: DataTabs): HTMLElement | null {
+    return el.querySelector<HTMLElement>(
+        '.data-tab-body[data-bundle="__more"]',
+    );
+}
+
+describe("DataTabs `…More` tab", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("renders the `…More` tab with no active bundles", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: [],
+            activeTab: null,
+        });
+        await el.updateComplete;
+        const more = moreHandle(el);
+        assert.ok(more, "…More handle must render with no active bundles");
+        const handles = el.querySelectorAll(".data-tab-handle");
+        assert.strictEqual(
+            handles.length,
+            1,
+            "only the …More handle should render when no bundles are active",
+        );
+    });
+
+    it("places `…More` last when other tabs are active", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: ["a11y", "theming"],
+            activeTab: "a11y",
+        });
+        await el.updateComplete;
+        const handles = Array.from(
+            el.querySelectorAll<HTMLElement>(".data-tab-handle"),
+        );
+        // Two bundle handles + one …More handle.
+        assert.strictEqual(handles.length, 3);
+        const ids = handles.map((h) => h.getAttribute("data-bundle"));
+        assert.deepStrictEqual(ids, ["a11y", "theming", "__more"]);
+    });
+
+    it("lists every inactive bundle by registry id in the `…More` body", async () => {
+        const el = build();
+        const active: BundleId[] = ["a11y", "errors"];
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: active,
+            activeTab: "a11y",
+        });
+        await el.updateComplete;
+        const body = moreBody(el);
+        assert.ok(body, "…More body must render");
+        const rows = Array.from(
+            body!.querySelectorAll<HTMLElement>(".data-tab-more-row"),
+        );
+        const rowIds = rows.map((r) => r.getAttribute("data-bundle"));
+        const expected = BUNDLES.map((b) => b.id).filter(
+            (id) => !active.includes(id),
+        );
+        assert.deepStrictEqual(rowIds, expected);
+    });
+
+    it("dispatches `bundle-toggled` with the row's id when clicked", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: [],
+            activeTab: null,
+        });
+        await el.updateComplete;
+        const events: BundleToggledDetail[] = [];
+        el.addEventListener("bundle-toggled", (e) =>
+            events.push((e as CustomEvent<BundleToggledDetail>).detail),
+        );
+        const row = el.querySelector<HTMLButtonElement>(
+            '.data-tab-more-row[data-bundle="theming"]',
+        );
+        assert.ok(row, "theming row must render");
+        row!.click();
+        assert.deepStrictEqual(events, [{ id: "theming" }]);
+    });
+
+    it("has no close `×` button on the `…More` handle", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: ["a11y"],
+            activeTab: "a11y",
+        });
+        await el.updateComplete;
+        const more = moreHandle(el);
+        assert.ok(more);
+        const close = more!.querySelector(".data-tab-close");
+        assert.strictEqual(
+            close,
+            null,
+            "…More tab must be the only non-closable tab",
+        );
+    });
+
+    it("shows the 'Everything's on' placeholder when no bundle is disabled", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: BUNDLES.map((b) => b.id),
+            activeTab: "a11y",
+        });
+        await el.updateComplete;
+        const body = moreBody(el);
+        assert.ok(body);
+        const rows = body!.querySelectorAll(".data-tab-more-row");
+        assert.strictEqual(
+            rows.length,
+            0,
+            "no disabled-bundle rows when every bundle is active",
+        );
+        const empty = body!.querySelector(".data-table-empty");
+        assert.ok(
+            empty && /everything/i.test(empty.textContent ?? ""),
+            "placeholder copy must mention everything being on",
+        );
+    });
+
+    it("dispatches `tab-selected` with id=null when the `…More` handle is clicked", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: ["a11y"],
+            activeTab: "a11y",
+        });
+        await el.updateComplete;
+        const events: TabSelectDetail[] = [];
+        el.addEventListener("tab-selected", (e) =>
+            events.push((e as CustomEvent<TabSelectDetail>).detail),
+        );
+        const label =
+            moreHandle(el)!.querySelector<HTMLButtonElement>(".data-tab-label");
+        assert.ok(label);
+        label!.click();
+        assert.deepStrictEqual(events, [{ id: null }]);
+    });
+
+    it("marks the `…More` handle aria-selected when no bundle tab is active", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: [],
+            activeTab: null,
+        });
+        await el.updateComplete;
+        const more = moreHandle(el);
+        assert.strictEqual(more!.getAttribute("aria-selected"), "true");
+    });
+});

--- a/vscode-extension/src/webview/preview/components/DataTabs.ts
+++ b/vscode-extension/src/webview/preview/components/DataTabs.ts
@@ -1,5 +1,5 @@
-// `<data-tabs>` — tab row that appears below `<bundle-chip-bar>` when
-// at least one bundle is active. Each tab has a label and a close `×`
+// `<data-tabs>` — tab row that appears below `<bundle-chip-bar>`.
+// Each active bundle gets a tab with a label and a close `×`
 // affordance; the `×` and the bundle chip's re-press are two redundant
 // ways to dismiss (design doc § "Chip ↔ tab ↔ overlay state machine").
 //
@@ -9,10 +9,15 @@
 // so a slow-to-build presenter doesn't tear down on every click; only
 // the active body is `[hidden]=false`.
 //
-// When `activeBundles` is empty the component renders nothing — the
-// preview panel returns to its plain-preview resting state.
+// A trailing **`…More`** tab is always rendered in the last position,
+// even when no bundle is active. It's the only non-closable tab and
+// lists every currently-disabled bundle as a clickable row that emits
+// `bundle-toggled` — re-using the chip-bar event so the host doesn't
+// need new wiring (design doc § "UX shell", item 8: "Last tab is always
+// `…More` / settings. Stable position so the user always knows where
+// to find the extra filters and disabled kinds.").
 
-import { LitElement, html, nothing, type TemplateResult } from "lit";
+import { LitElement, html, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { BundleDescriptor, BundleId } from "../bundleRegistry";
 
@@ -21,8 +26,21 @@ export interface TabCloseDetail {
 }
 
 export interface TabSelectDetail {
+    /** `null` selects the `…More` tab (no bundle owns it). */
+    id: BundleId | null;
+}
+
+/** Re-export of the chip-bar event's detail shape — the `…More` rows
+ *  fire the same event so the host's existing `bundle-toggled` listener
+ *  handles activation without new wiring. */
+export interface BundleToggledDetail {
     id: BundleId;
 }
+
+/** Sentinel value for the `…More` tab's selection state. The host
+ *  controller's `activeTab` is a `BundleId | null`; `null` is the
+ *  `…More` tab. */
+export const MORE_TAB = null;
 
 @customElement("data-tabs")
 export class DataTabs extends LitElement {
@@ -69,11 +87,14 @@ export class DataTabs extends LitElement {
     }
 
     protected render(): TemplateResult {
-        if (this.activeBundles.length === 0) {
-            return html`${nothing}`;
-        }
         const ordered = this.bundles.filter((b) =>
             this.activeBundles.includes(b.id),
+        );
+        const moreSelected =
+            this.activeTab === null ||
+            !this.activeBundles.includes(this.activeTab);
+        const disabled = this.bundles.filter(
+            (b) => !this.activeBundles.includes(b.id),
         );
         return html`
             <div
@@ -83,9 +104,11 @@ export class DataTabs extends LitElement {
             >
                 <div class="data-tab-strip">
                     ${ordered.map((b) => this.renderTabHandle(b))}
+                    ${this.renderMoreHandle(moreSelected)}
                 </div>
                 <div class="data-tab-bodies">
                     ${ordered.map((b) => this.renderTabBody(b))}
+                    ${this.renderMoreBody(disabled, moreSelected)}
                 </div>
             </div>
         `;
@@ -126,6 +149,32 @@ export class DataTabs extends LitElement {
         `;
     }
 
+    private renderMoreHandle(selected: boolean): TemplateResult {
+        // No close button — `…More` is the stable trailing tab; the
+        // design doc makes it the only non-closable tab so the user
+        // always has somewhere to find disabled bundles.
+        return html`
+            <div
+                class=${selected
+                    ? "data-tab-handle data-tab-handle-more data-tab-handle-active"
+                    : "data-tab-handle data-tab-handle-more"}
+                role="tab"
+                aria-selected=${selected ? "true" : "false"}
+                data-bundle="__more"
+            >
+                <button
+                    type="button"
+                    class="data-tab-label"
+                    @click=${() => this.onSelect(null)}
+                    title="Show disabled bundles"
+                >
+                    <i class="codicon codicon-ellipsis" aria-hidden="true"></i>
+                    <span>More</span>
+                </button>
+            </div>
+        `;
+    }
+
     private renderTabBody(b: BundleDescriptor): TemplateResult {
         const body = this.bodies.get(b.id);
         const selected = b.id === this.activeTab;
@@ -141,13 +190,55 @@ export class DataTabs extends LitElement {
         `;
     }
 
+    private renderMoreBody(
+        disabled: readonly BundleDescriptor[],
+        selected: boolean,
+    ): TemplateResult {
+        return html`
+            <div
+                class="data-tab-body data-tab-body-more"
+                role="tabpanel"
+                data-bundle="__more"
+                ?hidden=${!selected}
+            >
+                <div class="data-tab-more-header">Disabled bundles</div>
+                ${disabled.length === 0
+                    ? html`
+                          <div class="data-table-empty">Everything's on.</div>
+                      `
+                    : html`
+                          <div class="data-tab-more-list">
+                              ${disabled.map((b) => this.renderMoreRow(b))}
+                          </div>
+                      `}
+            </div>
+        `;
+    }
+
+    private renderMoreRow(b: BundleDescriptor): TemplateResult {
+        return html`
+            <button
+                type="button"
+                class="data-tab-more-row"
+                data-bundle=${b.id}
+                title=${`Enable ${b.label}`}
+                aria-label=${`Enable ${b.label}`}
+                @click=${() => this.onMoreActivate(b.id)}
+            >
+                <i class=${"codicon codicon-" + b.icon} aria-hidden="true"></i>
+                <span class="data-tab-more-row-label">${b.label}</span>
+                <span class="data-tab-more-row-hint">click to enable</span>
+            </button>
+        `;
+    }
+
     private placeholderBody(b: BundleDescriptor): TemplateResult {
         return html`
             <div class="data-tab-placeholder">${b.label} is loading…</div>
         `;
     }
 
-    private onSelect(id: BundleId): void {
+    private onSelect(id: BundleId | null): void {
         this.dispatchEvent(
             new CustomEvent<TabSelectDetail>("tab-selected", {
                 detail: { id },
@@ -161,6 +252,20 @@ export class DataTabs extends LitElement {
         evt.stopPropagation();
         this.dispatchEvent(
             new CustomEvent<TabCloseDetail>("tab-closed", {
+                detail: { id },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private onMoreActivate(id: BundleId): void {
+        // Re-use the chip-bar's `bundle-toggled` event so the host's
+        // existing controller wiring activates the bundle. Once the
+        // controller fires `bundle-state-changed`, `setState` re-renders
+        // and the bundle's own tab takes over.
+        this.dispatchEvent(
+            new CustomEvent<BundleToggledDetail>("bundle-toggled", {
                 detail: { id },
                 bubbles: true,
                 composed: true,

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -1295,12 +1295,19 @@ export class PreviewApp extends LitElement {
             const detail = (evt as CustomEvent<{ id: BundleId }>).detail;
             bundleController.toggleBundle(detail.id);
         });
+        // The `…More` tab's rows fire the same `bundle-toggled` event
+        // as the chip bar so the controller activates the bundle via
+        // the existing path — no new wiring needed.
+        dataTabs.addEventListener("bundle-toggled", (evt) => {
+            const detail = (evt as CustomEvent<{ id: BundleId }>).detail;
+            bundleController.toggleBundle(detail.id);
+        });
         dataTabs.addEventListener("tab-closed", (evt) => {
             const detail = (evt as CustomEvent<{ id: BundleId }>).detail;
             bundleController.closeTab(detail.id);
         });
         dataTabs.addEventListener("tab-selected", (evt) => {
-            const detail = (evt as CustomEvent<{ id: BundleId }>).detail;
+            const detail = (evt as CustomEvent<{ id: BundleId | null }>).detail;
             bundleController.selectTab(detail.id);
         });
         dataTabs.addEventListener("copy-json", (evt) => {


### PR DESCRIPTION
## Summary

Adds the "stable trailing tab" the #1054 design doc promised. `<data-tabs>` now always renders a `…More` tab even when no other bundles are active, so the user always has a one-click reveal of the full bundle catalogue. The tab is the only non-closable tab — no `×` — and clicking a row inside it activates that bundle.

## Changes

- **`DataTabs.ts`** — drops the empty-state `nothing` guard so the panel always renders the row; adds `renderMoreHandle` + `renderMoreBody` + `renderMoreRow`; allows `tab-selected` to carry `id: null` for the `…More` sentinel; emits `bundle-toggled` from `…More` rows so the existing chip-bar wiring activates the bundle without new host plumbing. Exports `BundleToggledDetail` and a `MORE_TAB = null` sentinel.
- **`main.ts`** — adds a `bundle-toggled` listener on `dataTabs` (forwards to `BundleController.toggleBundle`) and widens the `tab-selected` cast to `BundleId | null`.
- **`preview.css`** — `.data-tab-handle-more` pins the tab right via `margin-left:auto`, plus body / header / row / placeholder styles. Reuses `.data-table-empty` for the "Everything's on" placeholder.

## UX choices

- Icon: `codicon-ellipsis` (matches the `…More` naming).
- Tab label: `More` (the `…` is conveyed by the icon).
- Row hint: `click to enable` (small/dimmed) so chips don't read as static badges.
- Empty placeholder: `Everything's on.`
- `…More` pinned right via `margin-left:auto`, sits after all active-bundle tabs in tab order.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 952 passing (+8 new in `dataTabs.test.ts`)
- [x] Tests cover: renders with no active bundles, last position when others active, lists every inactive bundle, click dispatches `bundle-toggled`, no `×`, "Everything's on" placeholder.
- [ ] Verify in panel: open with no bundles → `…More` tab visible → click → list of all bundles → click one row → bundle activates, tab appears, row disappears from `…More`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcozQg6vaBFB5Y6vVsyuPH)_