### PR TITLE
feat(vscode-extension): one-click Perfetto handoff — copy trace and open ui.perfetto.dev

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2722,6 +2722,16 @@ body {
 .perf-perfetto-open:hover {
     background: var(--vscode-button-hoverBackground);
 }
+/* Inline status under the "Open in Perfetto" button — quiet hint
+ * that the trace was copied and the user should paste into the
+ * just-opened Perfetto UI tab. Persistent rather than auto-faded
+ * so the user can re-read it after switching tabs and back. */
+.perf-perfetto-status {
+    font-size: 11px;
+    opacity: 0.75;
+    margin-top: 4px;
+    min-height: 1em;
+}
 /* Theming bundle — Colors / Typography / Shapes share one table.
  * The Section column doubles as a sub-heading; the swatch column
  * carries the colour chip for color / seed rows. */

--- a/vscode-extension/src/test/perfettoHandoff.test.ts
+++ b/vscode-extension/src/test/perfettoHandoff.test.ts
@@ -1,10 +1,13 @@
 // Perfetto handoff: regression for the P1 review on PR #1079 — the
 // "Open in Perfetto" button must ship the raw composeAiTrace JSON,
-// not a wrapper object, or paste-into-ui.perfetto.dev fails.
+// not a wrapper object, or paste-into-ui.perfetto.dev fails. The
+// click also opens the Perfetto UI in the user's browser so the
+// flow is one-click: copy + open, paste in the just-opened tab.
 //
 // The button is built inside `renderPerformanceSections`, which is
 // otherwise pure DOM glue. We mount it into happy-dom, locate the
-// button, click it, and inspect the captured clipboard payload.
+// button, click it, and inspect the captured clipboard + openExternal
+// payloads.
 
 import * as assert from "assert";
 import {
@@ -87,5 +90,99 @@ describe("Perfetto handoff (PR #1079 P1)", () => {
         // the button can't be clicked. Sanity-check that the absence
         // is visible to the host.
         assert.strictEqual(data.composeAiTrace, null);
+    });
+
+    it("click writes clipboard AND opens ui.perfetto.dev (in that order)", () => {
+        const traceEvents = [{ name: "frame", ph: "B", ts: 0, pid: 1, tid: 1 }];
+        const composeAiTrace = { traceEvents };
+        const data = computePerformanceBundleData(null, null, composeAiTrace);
+
+        const host = document.createElement("div");
+        document.body.appendChild(host);
+        const events: Array<
+            { kind: "clip"; text: string } | { kind: "open"; url: string }
+        > = [];
+        renderPerformanceSections(
+            host,
+            data,
+            "preview.id",
+            stubTable() as unknown as DataTable<unknown>,
+            (text) => events.push({ kind: "clip", text }),
+            {
+                recomposition: null,
+                renderTrace: null,
+                composeAiTrace,
+            },
+            (url) => events.push({ kind: "open", url }),
+        );
+        const button = host.querySelector<HTMLButtonElement>(
+            "button.perf-perfetto-open",
+        );
+        assert.ok(button, "Perfetto button rendered");
+        button!.click();
+        assert.strictEqual(events.length, 2, "exactly two side effects fired");
+        assert.strictEqual(
+            events[0].kind,
+            "clip",
+            "clipboard write fires first",
+        );
+        assert.strictEqual(events[1].kind, "open", "openExternal fires second");
+        assert.strictEqual(
+            (events[1] as { kind: "open"; url: string }).url,
+            "https://ui.perfetto.dev",
+            "openExternal URL is the bare Perfetto UI origin (no trailing slash, no ?url=)",
+        );
+        const status = host.querySelector<HTMLElement>(".perf-perfetto-status");
+        assert.ok(status, "status row rendered");
+        assert.match(
+            status!.textContent ?? "",
+            /Paste with Cmd\/Ctrl-V/,
+            "status hint tells the user where to paste",
+        );
+    });
+
+    it("when composeAiTrace payload is missing, clipboard write is empty AND no openExternal fires", () => {
+        // Synthesise a summary with no `traceEvents` so the section
+        // still renders (it does when `phaseCount` or `totalMs` is
+        // present), but `rawPayloads.composeAiTrace` is null — the
+        // path the click handler guards against.
+        const composeAiTrace = { traceEvents: [], totalMs: 5 };
+        const data = computePerformanceBundleData(null, null, composeAiTrace);
+        assert.ok(data.composeAiTrace, "summary rendered for totalMs-only");
+
+        const host = document.createElement("div");
+        document.body.appendChild(host);
+        const events: Array<
+            { kind: "clip"; text: string } | { kind: "open"; url: string }
+        > = [];
+        renderPerformanceSections(
+            host,
+            data,
+            "preview.id",
+            stubTable() as unknown as DataTable<unknown>,
+            (text) => events.push({ kind: "clip", text }),
+            {
+                recomposition: null,
+                renderTrace: null,
+                composeAiTrace: null,
+            },
+            (url) => events.push({ kind: "open", url }),
+        );
+        const button = host.querySelector<HTMLButtonElement>(
+            "button.perf-perfetto-open",
+        );
+        assert.ok(button, "Perfetto button rendered");
+        button!.click();
+        assert.strictEqual(events.length, 1, "only one side effect fires");
+        assert.strictEqual(events[0].kind, "clip", "clipboard fired");
+        assert.strictEqual(
+            (events[0] as { kind: "clip"; text: string }).text,
+            "",
+            "clipboard write is the empty string",
+        );
+        assert.ok(
+            !events.some((e) => e.kind === "open"),
+            "no openExternal fires when there's nothing to paste",
+        );
     });
 });

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -1015,6 +1015,11 @@ export class PreviewApp extends LitElement {
                         renderTrace: tracePayload,
                         composeAiTrace: perfettoPayload,
                     },
+                    (url) =>
+                        vscode.postMessage({
+                            command: "openExternal",
+                            url,
+                        }),
                 );
             }
             dataTabs.setTabBody("performance", body.wrapper);

--- a/vscode-extension/src/webview/preview/performanceBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/performanceBundlePresenter.ts
@@ -341,6 +341,7 @@ export function renderPerformanceSections(
         renderTrace: unknown;
         composeAiTrace: unknown;
     },
+    openExternal?: (url: string) => void,
 ): void {
     // Tear down prior contents — sections may have toggled off since
     // the last refresh, and we want a deterministic layout.
@@ -387,6 +388,7 @@ export function renderPerformanceSections(
                 previewId,
                 rawPayloads,
                 copyToClipboard,
+                openExternal,
             ),
         );
     }
@@ -475,6 +477,7 @@ function renderComposeAiTraceSection(
         composeAiTrace: unknown;
     },
     copyToClipboard: (text: string) => void,
+    openExternal?: (url: string) => void,
 ): HTMLElement {
     const section = document.createElement("div");
     section.className = "perf-bundle-section perf-bundle-perfetto";
@@ -509,8 +512,8 @@ function renderComposeAiTraceSection(
     button.type = "button";
     button.className = "perf-perfetto-open";
     button.title =
-        "Copies the Perfetto-importable JSON to your clipboard. " +
-        "Paste it into https://ui.perfetto.dev to open the trace.";
+        "Copies the trace to your clipboard and opens ui.perfetto.dev. " +
+        "Paste with Cmd/Ctrl-V to load.";
     const icon = document.createElement("i");
     icon.className = "codicon codicon-cloud-upload";
     icon.setAttribute("aria-hidden", "true");
@@ -518,6 +521,21 @@ function renderComposeAiTraceSection(
     const label = document.createElement("span");
     label.textContent = "Open in Perfetto";
     button.appendChild(label);
+
+    // Inline status hint below the button — `ui.perfetto.dev` won't
+    // fetch a `vscode://` or `file:` URL from disk (CORS), so the
+    // documented `?url=…` ingestion path doesn't apply to traces
+    // sourced from this extension's storage. We keep the UX
+    // one-click by pairing the clipboard write with opening the
+    // Perfetto UI in the browser, and the user pastes with
+    // Cmd/Ctrl-V on the just-opened tab.
+    const status = document.createElement("div");
+    status.className = "perf-perfetto-status";
+    status.setAttribute("role", "status");
+    status.setAttribute("aria-live", "polite");
+    section.appendChild(button);
+    section.appendChild(status);
+
     button.addEventListener("click", () => {
         // Ship the raw Perfetto-importable trace JSON only — paste-
         // into-ui.perfetto.dev expects the trace at the document root
@@ -526,10 +544,21 @@ function renderComposeAiTraceSection(
         // as "not a trace." When the daemon hasn't attached a
         // composeAiTrace payload yet, fall through to an empty
         // string so the clipboard write is a clear no-op rather than
-        // shipping a misleading wrapper.
+        // shipping a misleading wrapper. In the no-payload case we
+        // also suppress the `openExternal` — there's nothing to
+        // paste, so opening a browser tab would be pointless.
         const trace = rawPayloads.composeAiTrace;
-        copyToClipboard(trace ? JSON.stringify(trace, null, 2) : "");
+        if (trace) {
+            copyToClipboard(JSON.stringify(trace, null, 2));
+            if (openExternal) {
+                openExternal("https://ui.perfetto.dev");
+            }
+            status.textContent =
+                "Trace copied. Paste with Cmd/Ctrl-V in the page that just opened.";
+        } else {
+            copyToClipboard("");
+            status.textContent = "";
+        }
     });
-    section.appendChild(button);
     return section;
 }


### PR DESCRIPTION
## Summary

Makes "Open in Perfetto" one click instead of one click + manual browser-tab open. The button now copies the trace JSON to the clipboard AND opens `https://ui.perfetto.dev` in the browser via `openExternal`. A small inline-status line under the button tells the user where to paste.

## Why not `?url=` ingestion

The design doc and PR #1080 both flagged `https://ui.perfetto.dev/#!/?url=<encoded>` as a follow-up. Confirmed not viable: `ui.perfetto.dev` cross-origin-fetches the `?url=` target, and both `vscode://` and `file://` URIs are CORS-blocked. Documented in the click-handler comment.

## Changes

- **`performanceBundlePresenter.ts`** — `renderComposeAiTraceSection` accepts an optional `openExternal` callback. Click handler now `copyToClipboard(...)` + `openExternal("https://ui.perfetto.dev")` when a payload exists; empty clipboard + suppressed openExternal when missing. New `.perf-perfetto-status role="status"` element.
- **`main.ts`** — passes a 7th arg that posts `{ command: "openExternal", url }`.
- **`preview.css`** — quiet style for `.perf-perfetto-status` (11px, opacity 0.75, persistent).

## UX copy

- Button title: `"Copies the trace to your clipboard and opens ui.perfetto.dev. Paste with Cmd/Ctrl-V to load."`
- Inline status (under the button): `"Trace copied. Paste with Cmd/Ctrl-V in the page that just opened."`

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 966 passing (+2 new in `perfettoHandoff.test.ts`)
- [x] Tests cover: click writes clipboard + openExternal in order, exact URL `https://ui.perfetto.dev` (no trailing slash, no `?url=`), inline-status text rendered, missing-payload suppression (no browser tab for nothing).
- [ ] Verify in panel: enable `render/composeAiTrace` in Performance bundle Configure expander, click button → trace copied AND `ui.perfetto.dev` opens; paste with Cmd/Ctrl-V loads the trace.

Net: +148 / −7 LOC.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcozQg6vaBFB5Y6vVsyuPH)_