### PR TITLE
feat(vscode-extension): data-URI font preview in Text bundle

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -34,6 +34,7 @@ import {
 } from "./types";
 import { formatRenderErrorMessage } from "./renderError";
 import { openResourceFile } from "./resourceFileResolver";
+import { readFontPreview, resolveFontPreviewPath } from "./fontPreviewLoader";
 import { captureLabel, withDataProductCaptures } from "./captureLabels";
 import {
     DaemonGate,
@@ -4123,7 +4124,40 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 void vscode.env.openExternal(vscode.Uri.parse(msg.url));
             }
             break;
+        case "loadFontPreview":
+            void handleLoadFontPreview(msg);
+            break;
     }
+}
+
+/**
+ * Reads an absolute font-file path off disk, base64-encodes it, and
+ * posts `fontPreviewBytes` back to the webview. Rejections (path
+ * outside the workspace, unsupported extension, missing file, > 5 MB,
+ * I/O error) all resolve as `dataUri: null` so the webview just leaves
+ * the system-font fallback in place — there's no user-visible error
+ * surface for "the font preview couldn't be hydrated".
+ *
+ * Validation is delegated to `resolveFontPreviewPath` (pure, unit-
+ * tested) so the wire handler stays a thin orchestrator.
+ */
+async function handleLoadFontPreview(
+    msg: Extract<WebviewToExtension, { command: "loadFontPreview" }>,
+): Promise<void> {
+    const workspaceRoot =
+        vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? null;
+    const resolved = resolveFontPreviewPath(msg.sourceFile, workspaceRoot);
+    const dataUri = resolved
+        ? await readFontPreview(resolved, (absPath) =>
+              fs.promises.readFile(absPath),
+          )
+        : null;
+    panel?.postMessage({
+        command: "fontPreviewBytes",
+        previewId: msg.previewId,
+        fontRowId: msg.fontRowId,
+        dataUri,
+    });
 }
 
 /**

--- a/vscode-extension/src/fontPreviewLoader.ts
+++ b/vscode-extension/src/fontPreviewLoader.ts
@@ -1,0 +1,98 @@
+// Host-side reader for the Text/i18n bundle's data-URI font preview.
+//
+// The webview's resolved-family preview cell uses CSS
+// `font-family: <resolvedFamily>` which only paints in the real font when
+// the webview already has it on its system stack. Asset / google-
+// downloaded fonts silently fall back to the panel's system default — so
+// the webview asks the host to read the bytes via `loadFontPreview` and
+// the host responds with a base64 `data:` URI keyed to the row that
+// requested it. The webview then injects a `@font-face` rule and swaps
+// `style.fontFamily` over to the injected family.
+//
+// Validation lives in `resolveFontPreviewPath` (pure — testable without a
+// running VS Code instance); the actual `fs.readFile` + base64-encode
+// step lives in `readFontPreview` and takes an injected reader so the
+// test can pin its own bytes without touching disk.
+
+import * as path from "path";
+
+/** Map from `.ttf` / `.otf` / `.woff` / `.woff2` to its IANA media-type.
+ *  Anything else resolves the request to `dataUri: null` so a stray
+ *  `.xml` font descriptor doesn't end up base64-encoded as
+ *  `font/unknown`. */
+const FONT_MIME_BY_EXT: Readonly<Record<string, string>> = {
+    ".ttf": "font/ttf",
+    ".otf": "font/otf",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+};
+
+/** 5 MB cap. Larger files still validate as paths but the read step
+ *  resolves to `dataUri: null` so a pathological asset can't pin the
+ *  panel by streaming hundreds of MB into a data URI. */
+export const MAX_FONT_PREVIEW_BYTES = 5 * 1024 * 1024;
+
+export interface FontPreviewPath {
+    /** Absolute, normalised path under the workspace root. */
+    absolutePath: string;
+    /** IANA media type derived from the extension. */
+    mime: string;
+}
+
+/**
+ * Validates that [sourceFile] is an absolute path under [workspaceRoot]
+ * (no path-traversal) AND has a supported font extension. Returns the
+ * resolved path + media-type on success, or `null` when the caller
+ * should respond with `dataUri: null`.
+ *
+ * Pure — exposed so a unit test can pin the rejection cases without
+ * spinning up a workspace.
+ */
+export function resolveFontPreviewPath(
+    sourceFile: string | null | undefined,
+    workspaceRoot: string | null | undefined,
+): FontPreviewPath | null {
+    if (!sourceFile || typeof sourceFile !== "string") return null;
+    if (!workspaceRoot || typeof workspaceRoot !== "string") return null;
+    if (!path.isAbsolute(sourceFile)) return null;
+    const normalised = path.normalize(sourceFile);
+    const root = path.normalize(workspaceRoot);
+    // Append a separator so `/foo/bar-evil` doesn't get accepted under
+    // root `/foo/bar`. `path.relative` then has to produce a path that
+    // doesn't begin with `..` and isn't absolute.
+    const rel = path.relative(root, normalised);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
+    const ext = path.extname(normalised).toLowerCase();
+    const mime = FONT_MIME_BY_EXT[ext];
+    if (!mime) return null;
+    return { absolutePath: normalised, mime };
+}
+
+/** Injected reader so tests can pin bytes without touching disk. */
+export type ReadFileBytes = (
+    absolutePath: string,
+) => Promise<Uint8Array | Buffer>;
+
+/**
+ * Reads [resolved.absolutePath] as base64 and returns a `data:` URI of
+ * the form `data:<mime>;base64,<encoded>`. Returns `null` when the read
+ * fails or the file exceeds [MAX_FONT_PREVIEW_BYTES] — the caller (the
+ * `loadFontPreview` message handler) posts `dataUri: null` in either
+ * case so the webview leaves the system-font fallback in place.
+ */
+export async function readFontPreview(
+    resolved: FontPreviewPath,
+    readFileBytes: ReadFileBytes,
+): Promise<string | null> {
+    try {
+        const buf = await readFileBytes(resolved.absolutePath);
+        if (buf.byteLength > MAX_FONT_PREVIEW_BYTES) return null;
+        const base64 =
+            buf instanceof Buffer
+                ? buf.toString("base64")
+                : Buffer.from(buf).toString("base64");
+        return "data:" + resolved.mime + ";base64," + base64;
+    } catch {
+        return null;
+    }
+}

--- a/vscode-extension/src/test/textBundlePresenter.test.ts
+++ b/vscode-extension/src/test/textBundlePresenter.test.ts
@@ -9,6 +9,8 @@ import * as assert from "assert";
 import {
     computeTextBundleData,
     cssFontStack,
+    cssFontStackForPreview,
+    fontPreviewFamilyName,
     googleFontsAllowlistSize,
     googleFontsSpecimenUrl,
     isGoogleFontFamily,
@@ -16,6 +18,12 @@ import {
     type FontRow,
     type TranslationRow,
 } from "../webview/preview/textBundlePresenter";
+import {
+    MAX_FONT_PREVIEW_BYTES,
+    readFontPreview,
+    resolveFontPreviewPath,
+} from "../fontPreviewLoader";
+import * as path from "path";
 
 function stringEntry(overrides: Record<string, unknown> = {}): unknown {
     return {
@@ -269,5 +277,126 @@ describe("computeTextBundleData", () => {
     it("cssFontStack passes generic families through unquoted", () => {
         assert.strictEqual(cssFontStack("monospace"), "monospace");
         assert.strictEqual(cssFontStack("serif"), "serif");
+    });
+
+    it("cssFontStackForPreview prepends the synthetic family when bytes have loaded", () => {
+        // Pins the cache lookup vs the loading state: in the loading
+        // state (no bytes yet) the cell renders against the CSS-only
+        // fallback, identical to what `cssFontStack` returns. Once the
+        // host has responded with bytes, the synthetic
+        // `preview-<rowId>` family is prepended so the `@font-face`
+        // rule wins in the font-family chain.
+        const loading = cssFontStackForPreview("font-0", "Roboto", {
+            hasBytes: false,
+        });
+        assert.strictEqual(loading, cssFontStack("Roboto"));
+        const loaded = cssFontStackForPreview("font-0", "Roboto", {
+            hasBytes: true,
+        });
+        assert.ok(
+            loaded.startsWith('"preview-font-0", '),
+            "synthetic family must be first in the stack",
+        );
+        assert.ok(
+            loaded.endsWith(cssFontStack("Roboto")),
+            "the resolved-family CSS stack must remain as a fallback",
+        );
+        assert.strictEqual(fontPreviewFamilyName("font-0"), "preview-font-0");
+    });
+});
+
+describe("fontPreviewLoader", () => {
+    const root = process.platform === "win32" ? "C:\\ws" : "/ws";
+
+    it("rejects paths outside the workspace root (no path-traversal)", () => {
+        const evil = path.join(root, "..", "etc", "passwd.ttf");
+        assert.strictEqual(resolveFontPreviewPath(evil, root), null);
+    });
+
+    it("rejects relative paths", () => {
+        assert.strictEqual(
+            resolveFontPreviewPath("res/font/roboto.ttf", root),
+            null,
+        );
+    });
+
+    it("rejects unsupported extensions", () => {
+        // `.xml` font descriptors (Android `res/font/foo.xml`) point at
+        // the real face but are NOT themselves the bytes — refuse them
+        // so the response stays `dataUri: null` and the webview keeps
+        // the CSS-only fallback.
+        const xml = path.join(root, "res", "font", "roboto.xml");
+        assert.strictEqual(resolveFontPreviewPath(xml, root), null);
+    });
+
+    it("accepts a supported font extension inside the workspace", () => {
+        const ttf = path.join(root, "app", "fonts", "Inter.ttf");
+        const resolved = resolveFontPreviewPath(ttf, root);
+        assert.ok(resolved);
+        assert.strictEqual(resolved!.mime, "font/ttf");
+        assert.strictEqual(resolved!.absolutePath, path.normalize(ttf));
+    });
+
+    it("maps each supported extension to its IANA media type", () => {
+        const cases: ReadonlyArray<[string, string]> = [
+            ["a.ttf", "font/ttf"],
+            ["a.otf", "font/otf"],
+            ["a.woff", "font/woff"],
+            ["a.woff2", "font/woff2"],
+            // Casing tolerance — Android assets occasionally ship as
+            // `Roboto-Regular.TTF`.
+            ["a.WOFF2", "font/woff2"],
+        ];
+        for (const [name, mime] of cases) {
+            const resolved = resolveFontPreviewPath(
+                path.join(root, name),
+                root,
+            );
+            assert.ok(resolved, "should resolve " + name);
+            assert.strictEqual(resolved!.mime, mime);
+        }
+    });
+
+    it("rejects null / empty sourceFile or workspaceRoot", () => {
+        assert.strictEqual(resolveFontPreviewPath(null, root), null);
+        assert.strictEqual(resolveFontPreviewPath(undefined, root), null);
+        assert.strictEqual(resolveFontPreviewPath("", root), null);
+        assert.strictEqual(
+            resolveFontPreviewPath(path.join(root, "a.ttf"), null),
+            null,
+        );
+    });
+
+    it("readFontPreview base64-encodes the bytes into a data URI", async () => {
+        const bytes = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+        const dataUri = await readFontPreview(
+            { absolutePath: "/whatever.ttf", mime: "font/ttf" },
+            async () => bytes,
+        );
+        assert.strictEqual(
+            dataUri,
+            "data:font/ttf;base64," + bytes.toString("base64"),
+        );
+    });
+
+    it("readFontPreview resolves to null on read failure", async () => {
+        const dataUri = await readFontPreview(
+            { absolutePath: "/whatever.ttf", mime: "font/ttf" },
+            async () => {
+                throw new Error("ENOENT");
+            },
+        );
+        assert.strictEqual(dataUri, null);
+    });
+
+    it("readFontPreview rejects files larger than the 5 MB cap", async () => {
+        // Synthesise an over-cap buffer cheaply by lying about its
+        // length — we never inspect the bytes past the size check.
+        const oversize = Buffer.alloc(MAX_FONT_PREVIEW_BYTES + 1);
+        const dataUri = await readFontPreview(
+            { absolutePath: "/big.ttf", mime: "font/ttf" },
+            async () => oversize,
+        );
+        assert.strictEqual(dataUri, null);
     });
 });

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -633,6 +633,21 @@ export type ExtensionToWebview =
           moduleId: string;
           dataProducts: DaemonDataProductCapability[];
           dataExtensions: DaemonDataExtensionDescriptor[];
+      }
+    /**
+     * Host's response to `loadFontPreview`: the requested font's bytes
+     * as a base64 `data:` URI, or `null` when the file couldn't be read
+     * (path outside the workspace root, missing, unsupported extension,
+     * > 5 MB cap). The webview routes the bytes into a panel-side cache
+     * keyed by `(previewId, fontRowId)` and injects a `@font-face` rule
+     * so the resolved-family preview cell paints in the real font
+     * rather than the panel's system fallback.
+     */
+    | {
+          command: "fontPreviewBytes";
+          previewId: string;
+          fontRowId: string;
+          dataUri: string | null;
       };
 
 /**
@@ -912,7 +927,28 @@ export type WebviewToExtension =
      * validates the URL is `http(s)` before opening to avoid being used
      * as a generic shell-out from the webview.
      */
-    | { command: "openExternal"; url: string };
+    | { command: "openExternal"; url: string }
+    /**
+     * Text/i18n bundle's fonts sub-table is asking the host to read a
+     * font file from disk so the resolved-family preview cell can paint
+     * in the real face via a base64 data-URI `@font-face`. The CSS
+     * `font-family: <resolvedFamily>` fallback only works for fonts the
+     * webview already has on its system stack; asset / downloaded
+     * fonts silently render in the default. The host responds with
+     * `fontPreviewBytes { previewId, fontRowId, dataUri | null }`.
+     *
+     * `sourceFile` must be an absolute path inside the workspace root;
+     * the host rejects path-traversal and anything outside the first
+     * workspace folder. Supported extensions: `.ttf`, `.otf`, `.woff`,
+     * `.woff2`. Reads larger than 5 MB or any I/O error resolve as
+     * `dataUri: null`.
+     */
+    | {
+          command: "loadFontPreview";
+          previewId: string;
+          fontRowId: string;
+          sourceFile: string;
+      };
 
 /**
  * Narrow shape the History panel reads off each sidecar JSON entry. The

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -462,6 +462,84 @@ export class PreviewApp extends LitElement {
         let liveState!: LiveStateController;
         let focusController!: FocusController;
         const dataProductsByPreview = new Map<string, Map<string, unknown>>();
+        // Panel-side cache for the Text/i18n bundle's data-URI font
+        // preview path. Keyed by `(previewId, fontRowId)` because two
+        // previews owned by the same module can carry the same row id
+        // but resolve different bytes; the row-id-only fallback would
+        // race. `undefined` → not yet requested, `null` → host said no
+        // (file missing / not allowed / > 5 MB), `string` → data URI.
+        const fontPreviewBytesByPreview = new Map<
+            string,
+            Map<string, string | null>
+        >();
+        // In-flight `loadFontPreview` requests so we don't pile up
+        // duplicate messages while the host is still reading. Cleared
+        // when the response lands.
+        const fontPreviewPending = new Set<string>();
+        const fontPreviewKey = (previewId: string, rowId: string): string =>
+            previewId + " " + rowId;
+        // Idempotent `@font-face` injector — keyed on `(previewId, rowId)`
+        // so the same row's bytes only land in the document head once.
+        // Lives on a single `<style>` element with `data-font-preview`
+        // so dev-tools shows the whole set in one place.
+        const fontFaceEmitted = new Set<string>();
+        const ensureFontFaceStyleElement = (): HTMLStyleElement => {
+            let el = document.querySelector(
+                "style[data-font-preview]",
+            ) as HTMLStyleElement | null;
+            if (!el) {
+                el = document.createElement("style");
+                el.setAttribute("data-font-preview", "");
+                document.head.appendChild(el);
+            }
+            return el;
+        };
+        const injectFontFace = (
+            previewId: string,
+            rowId: string,
+            dataUri: string,
+        ): void => {
+            const key = fontPreviewKey(previewId, rowId);
+            if (fontFaceEmitted.has(key)) return;
+            fontFaceEmitted.add(key);
+            const style = ensureFontFaceStyleElement();
+            // `preview-<rowId>` is the synthetic family name the
+            // resolved-family cell renders against; rowId is internal
+            // ("font-0", "font-1", …) so no escaping needed today, but
+            // we still wrap it in a regex-safe identifier check at
+            // injection time by quoting in the CSS literal.
+            style.appendChild(
+                document.createTextNode(
+                    '@font-face { font-family: "preview-' +
+                        rowId +
+                        '"; src: url("' +
+                        dataUri +
+                        '"); }\n',
+                ),
+            );
+        };
+        const loadFontPreview = (rowId: string, sourceFile: string): void => {
+            const target = currentBundleTarget();
+            if (!target) return;
+            const key = fontPreviewKey(target, rowId);
+            if (fontPreviewPending.has(key)) return;
+            const bucket = fontPreviewBytesByPreview.get(target);
+            if (bucket && bucket.has(rowId)) return;
+            fontPreviewPending.add(key);
+            vscode.postMessage({
+                command: "loadFontPreview",
+                previewId: target,
+                fontRowId: rowId,
+                sourceFile,
+            });
+        };
+        const fontPreviewDataUri = (
+            rowId: string,
+        ): string | null | undefined => {
+            const target = currentBundleTarget();
+            if (!target) return undefined;
+            return fontPreviewBytesByPreview.get(target)?.get(rowId);
+        };
 
         inspector = new FocusInspectorController({
             el: focusInspector,
@@ -756,6 +834,8 @@ export class PreviewApp extends LitElement {
                 textBundleFontColumns({
                     openExternal: (url) =>
                         vscode.postMessage({ command: "openExternal", url }),
+                    loadFontPreview,
+                    fontPreviewDataUri,
                 }) as unknown as ReadonlyArray<
                     import("./components/DataTable").DataTableColumn<FontRow>
                 >,
@@ -1923,6 +2003,35 @@ export class PreviewApp extends LitElement {
                     )
                 ) {
                     refreshInspectionBundle();
+                }
+            },
+            applyFontPreviewBytes: (previewId, fontRowId, dataUri) => {
+                // Stash the response (null included — represents "host
+                // tried and the file couldn't be read"; we cache that
+                // negative result so we don't retry on every re-render).
+                let bucket = fontPreviewBytesByPreview.get(previewId);
+                if (!bucket) {
+                    bucket = new Map();
+                    fontPreviewBytesByPreview.set(previewId, bucket);
+                }
+                bucket.set(fontRowId, dataUri);
+                fontPreviewPending.delete(fontPreviewKey(previewId, fontRowId));
+                // Inject the `@font-face` rule into the document head
+                // when we have bytes. On null we leave the CSS-only
+                // fallback in place — the cell already paints in the
+                // resolved family stack.
+                if (typeof dataUri === "string" && dataUri.length > 0) {
+                    injectFontFace(previewId, fontRowId, dataUri);
+                }
+                // Re-render the Text bundle if we're showing the
+                // preview the bytes belong to. Other previews don't
+                // need a redraw — their cache entries are independent
+                // and they re-render on their own bundle target swap.
+                if (
+                    bundleController.state().activeBundles.includes("text") &&
+                    currentBundleTarget() === previewId
+                ) {
+                    refreshTextBundle();
                 }
             },
             focusOnCard,

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -113,6 +113,18 @@ export interface PreviewMessageContext {
         previewId: string,
         dataProducts: readonly { kind: string; payload: unknown }[],
     ): void;
+    /**
+     * Host responded to a `loadFontPreview` request. The behaviour
+     * layer stashes the data URI (or `null` on failure) in the
+     * panel-side cache, injects the corresponding `@font-face` when
+     * non-null, and re-renders the Text/i18n bundle so the resolved-
+     * family cell picks up the new family. Wired by main.ts.
+     */
+    applyFontPreviewBytes(
+        previewId: string,
+        fontRowId: string,
+        dataUri: string | null,
+    ): void;
     focusOnCard(card: HTMLElement): void;
 }
 
@@ -173,6 +185,13 @@ export function handleExtensionMessage(
                 previewId: msg.previewId,
                 kinds: msg.dataProducts.map((dp) => dp.kind),
             });
+            return;
+        case "fontPreviewBytes":
+            ctx.applyFontPreviewBytes(
+                msg.previewId,
+                msg.fontRowId,
+                msg.dataUri,
+            );
             return;
         case "setModules":
             // Module selector removed from UI — module is resolved from the

--- a/vscode-extension/src/webview/preview/textBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/textBundlePresenter.ts
@@ -326,6 +326,23 @@ export interface TextBundleFontColumnCallbacks {
     /** Webview-style external-link callback. Forwarded by main.ts so the
      *  host can post `openExternal` to the extension. */
     openExternal(url: string): void;
+    /**
+     * Webview-style font-preview hydration callback. Forwarded by
+     * main.ts so the host can post `loadFontPreview` to the extension.
+     * The cell's `data-font-row-id` attribute lets the response-side
+     * `fontPreviewBytes` handler find the right `<span>` to flip from
+     * the system-font fallback to the injected `@font-face` family.
+     * Optional for backwards compat with callers that pre-date the
+     * data-URI preview path; cell falls back to CSS-only behaviour.
+     */
+    loadFontPreview?(rowId: string, sourceFile: string): void;
+    /**
+     * Cache lookup keyed by row id. Returns the data-URI the host
+     * responded with on a previous render's `loadFontPreview` (or
+     * `null` for "we tried and the file couldn't be read" — distinct
+     * from `undefined` which means "we haven't asked yet").
+     */
+    fontPreviewDataUri?(rowId: string): string | null | undefined;
 }
 
 export function textBundleFontColumns(
@@ -340,13 +357,7 @@ export function textBundleFontColumns(
         {
             header: "Resolved",
             cellClass: "text-bundle-font-resolved",
-            render: (row) =>
-                html`<span
-                    class="text-bundle-font-preview"
-                    style="font-family: ${cssFontStack(row.resolvedFamily)}"
-                    title=${row.resolvedFamily}
-                    >${row.resolvedFamily}</span
-                >`,
+            render: (row) => resolvedFamilyPreviewCell(row, callbacks),
         },
         {
             header: "Weight",
@@ -407,6 +418,76 @@ function requestedFamilyCell(
         <i class="codicon codicon-link-external" aria-hidden="true"></i>
         <span>${row.requestedFamily}</span>
     </button>`;
+}
+
+/**
+ * CSS family prefix the webview injects via `@font-face` when the host
+ * has supplied a data-URI for a given row. Kept stable so the host-
+ * side cache, the cell renderer, and the unit test all agree on the
+ * synthetic family name without re-deriving it from row state.
+ */
+export function fontPreviewFamilyName(rowId: string): string {
+    return "preview-" + rowId;
+}
+
+/**
+ * Resolved-family preview cell. When the row's bytes have been hydrated
+ * by `loadFontPreview` (the cache lookup returns a non-null/undefined
+ * data URI), we render the cell in the injected `@font-face` family —
+ * which paints in the real face even when the webview doesn't already
+ * have it on its system stack. Otherwise we render in the CSS-only
+ * `font-family: <resolvedFamily>` stack (works for system fonts, the
+ * silent fallback for asset / google-downloaded fonts that prompted
+ * this whole path).
+ *
+ * The cell carries `data-font-row-id` so the bytes-arrival handler in
+ * `main.ts` can find the right `<span>` to swap once the host
+ * responds; we also kick a load on first paint when bytes haven't been
+ * requested yet.
+ */
+function resolvedFamilyPreviewCell(
+    row: FontRow,
+    callbacks: TextBundleFontColumnCallbacks,
+): TemplateResult {
+    const cached = callbacks.fontPreviewDataUri?.(row.id);
+    const fontFamily = cssFontStackForPreview(row.id, row.resolvedFamily, {
+        hasBytes: typeof cached === "string" && cached.length > 0,
+    });
+    // Kick a load on first paint of a row that has a source file but
+    // hasn't been requested yet. `cached === undefined` means "we've
+    // never asked"; `null` means "we asked and the host said no" —
+    // don't retry in either failure mode so a broken path doesn't busy
+    // the host. Producer-side `sourceFile` is the only signal we have
+    // for "this font lives on disk and is worth hydrating".
+    if (cached === undefined && row.sourceFile && callbacks.loadFontPreview) {
+        callbacks.loadFontPreview(row.id, row.sourceFile);
+    }
+    return html`<span
+        class="text-bundle-font-preview"
+        data-font-row-id=${row.id}
+        style="font-family: ${fontFamily}"
+        title=${row.resolvedFamily}
+        >${row.resolvedFamily}</span
+    >`;
+}
+
+/**
+ * CSS `font-family` stack for the resolved-family preview cell when
+ * the host has already supplied a data-URI for [rowId]. Prepends the
+ * synthetic `preview-<rowId>` family ahead of the resolved-family
+ * fallback so the `@font-face` rule wins; falls back to the CSS-only
+ * stack when `hasBytes` is false. Exposed so tests can pin the cache-
+ * lookup-vs-loading-state behaviour without going through the cell
+ * renderer.
+ */
+export function cssFontStackForPreview(
+    rowId: string,
+    resolved: string,
+    state: { hasBytes: boolean },
+): string {
+    const fallback = cssFontStack(resolved);
+    if (!state.hasBytes) return fallback;
+    return '"' + fontPreviewFamilyName(rowId) + '", ' + fallback;
 }
 
 /**


### PR DESCRIPTION
## Summary

The Text/i18n bundle's fonts sub-table preview cell currently uses CSS `font-family: <resolvedFamily>`, which only works for fonts the webview's system stack already has. Asset / Google-downloaded fonts silently fell back to the system font. This PR sideloads the actual font bytes via a data-URI `@font-face` so the preview renders with the real glyphs.

## Wire surface

Two new messages on the discriminated unions in `types.ts`:
- **Webview → Extension** `loadFontPreview { previewId, fontRowId, sourceFile }`
- **Extension → Webview** `fontPreviewBytes { previewId, fontRowId, dataUri | null }`

## Extension side

- `fontPreviewLoader.ts` (new): pure `resolveFontPreviewPath` validator + injectable `readFontPreview`. Path must resolve under `vscode.workspace.workspaceFolders[0].uri.fsPath`, no `..` traversal, no absolutely-outside-workspace paths. 5 MB read cap. Extension → MIME map: `.ttf` → `font/ttf`, `.otf` → `font/otf`, `.woff` → `font/woff`, `.woff2` → `font/woff2`. Anything else → `dataUri: null`.
- `extension.ts` adds the `loadFontPreview` handler that orchestrates resolve → read → base64 → post `fontPreviewBytes`.

## Webview side

- `textBundlePresenter.ts` — `resolvedFamilyPreviewCell` renders `data-font-row-id` and kicks the load callback on first paint when the cache miss is `undefined`. New `cssFontStackForPreview` + `fontPreviewFamilyName` helpers compose the per-row `@font-face` family name with the system fallback chain.
- `messageHandlers.ts` dispatches `fontPreviewBytes` to `applyFontPreviewBytes` on the message context.
- `main.ts` owns the `fontPreviewBytesByPreview` cache (keyed `(previewId, fontRowId)`), an in-flight `Set` to debounce concurrent renders, an idempotent `injectFontFace` that writes one `<style data-font-preview>` element to `<head>`, and the `applyFontPreviewBytes` wiring (stash → inject → `refreshTextBundle` when bytes belong to the focused target). Negative results (null data URI) are cached so a missing/blocked file isn't re-requested on every render.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 974 passing (+10 new: 1 `cssFontStackForPreview` + 9 `fontPreviewLoader`)
- [x] Tests cover: path-traversal reject, relative-path reject, unsupported extension, ext→MIME mapping incl. case folding, null guards, base64 round-trip, read failure, 5 MB cap, cache-vs-loading state
- [ ] Verify in panel: open a preview using a non-system font (e.g. project asset Roboto). Toggle Text bundle, open fonts sub-table → preview cell now renders with the actual font glyphs.

Net: +514 / −8 LOC.

## Notes

- Workspace-root resolution falls back to `null` when no folder is open — the loader returns `dataUri: null` rather than reading from arbitrary paths.
- The `data-font-row-id` attribute is present for future direct-DOM swaps, but today the cell update is driven by re-rendering through `refreshTextBundle` (Lit picks up the new `style.fontFamily` automatically).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LcozQg6vaBFB5Y6vVsyuPH)_