### PR TITLE
fix(vscode-extension): surface refresh and hide extensions UI in minimal mode

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2720,3 +2720,45 @@ body {
     pointer-events: none;
     z-index: 2;
 }
+
+/* -- Minimal mode ----------------------------------------------------- */
+
+/* Data extensions are disabled in minimal mode — hide the chip strip and
+   the tab row outright so the grid view doesn't show controls that can't
+   do anything. The focus-mode `bundleChipBar.hidden` toggle still runs but
+   loses against this rule via `!important`. */
+preview-app[data-minimal-mode="true"] bundle-chip-bar,
+preview-app[data-minimal-mode="true"] data-tabs {
+    display: none !important;
+}
+
+/* In-view "Refresh previews" call to action — minimal mode disables
+   auto-render on save, so we surface the manual refresh in the panel body
+   rather than relying on the title-bar icon. */
+.minimal-refresh-bar {
+    display: flex;
+    justify-content: center;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--card-border);
+}
+.minimal-refresh-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    height: var(--control-height);
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border: 1px solid var(--vscode-button-border, transparent);
+    border-radius: 2px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: var(--vscode-font-size);
+}
+.minimal-refresh-button:hover {
+    background: var(--vscode-button-hoverBackground);
+}
+.minimal-refresh-button:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 1px;
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1014,6 +1014,7 @@ export async function activate(
         undefined,
         () => autoEnableCheapEnabled(),
         () => collapseVariantsEnabled(),
+        () => inMinimalMode(),
     );
     if (isTestMode) {
         // Tap into every outgoing webview message so the test API can assert
@@ -3942,6 +3943,12 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             if (selectedModule) {
                 refresh(false);
             }
+            break;
+        case "requestRefresh":
+            // In-view refresh button (minimal mode). Mirrors the
+            // `composePreview.refresh` command path so the title-bar
+            // icon and the body-level button behave identically.
+            void refresh(true, currentScopeFile ?? undefined);
             break;
         case "refreshHeavy": {
             // Click on a faded heavy card opts it into full-tier renders for

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -10,6 +10,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     private earlyFeaturesEnabled: () => boolean;
     private autoEnableCheapEnabled: () => boolean;
     private collapseVariantsEnabled: () => boolean;
+    private minimalModeEnabled: () => boolean;
     private shouldRestoreVisibility: () => boolean;
 
     constructor(
@@ -19,12 +20,14 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         shouldRestoreVisibility: () => boolean = () => false,
         autoEnableCheapEnabled: () => boolean = () => false,
         collapseVariantsEnabled: () => boolean = () => true,
+        minimalModeEnabled: () => boolean = () => false,
     ) {
         this.extensionUri = extensionUri;
         this.onMessage = onMessage;
         this.earlyFeaturesEnabled = earlyFeaturesEnabled;
         this.autoEnableCheapEnabled = autoEnableCheapEnabled;
         this.collapseVariantsEnabled = collapseVariantsEnabled;
+        this.minimalModeEnabled = minimalModeEnabled;
         this.shouldRestoreVisibility = shouldRestoreVisibility;
     }
 
@@ -59,6 +62,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const earlyFeaturesEnabled = this.earlyFeaturesEnabled();
         const autoEnableCheapEnabled = this.autoEnableCheapEnabled();
         const collapseVariantsEnabled = this.collapseVariantsEnabled();
+        const minimalModeEnabled = this.minimalModeEnabled();
         const styleUri = webview.asWebviewUri(
             vscode.Uri.joinPath(this.extensionUri, "media", "preview.css"),
         );
@@ -89,6 +93,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         data-early-features="${earlyFeaturesEnabled ? "true" : "false"}"
         data-auto-enable-cheap="${autoEnableCheapEnabled ? "true" : "false"}"
         data-collapse-variants="${collapseVariantsEnabled ? "true" : "false"}"
+        data-minimal-mode="${minimalModeEnabled ? "true" : "false"}"
     ></preview-app>
     <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -736,6 +736,15 @@ export type WebviewToExtension =
      */
     | { command: "refreshHeavy"; previewId: string }
     /**
+     * Minimal-mode user clicked the in-view "Refresh previews" button.
+     * Extension responds with the same code path as
+     * `composePreview.refresh` — re-run discovery + render against the
+     * current scope file. Separate command from `refreshHeavy` so the
+     * extension can distinguish whole-panel manual refresh from a single
+     * faded-card click.
+     */
+    | { command: "requestRefresh" }
+    /**
      * Webview reports current geometric visibility of preview cards plus
      * cards it predicts will scroll into view next based on scroll velocity
      * and direction. Consumed by the daemon scheduler — see

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -185,12 +185,32 @@ export class PreviewApp extends LitElement {
     @query("#focus-position") private _focusPosition!: HTMLElement;
 
     protected render(): TemplateResult {
+        const minimal = this.dataset.minimalMode === "true";
         return html`
             <progress-bar></progress-bar>
             <compile-errors-banner></compile-errors-banner>
             <filter-toolbar></filter-toolbar>
             <bundle-chip-bar hidden></bundle-chip-bar>
             <data-tabs></data-tabs>
+            ${minimal
+                ? html`
+                      <div class="minimal-refresh-bar">
+                          <button
+                              type="button"
+                              id="btn-minimal-refresh"
+                              class="minimal-refresh-button"
+                              title="Re-run renderAllPreviews"
+                              aria-label="Refresh previews"
+                          >
+                              <i
+                                  class="codicon codicon-refresh"
+                                  aria-hidden="true"
+                              ></i>
+                              <span>Refresh previews</span>
+                          </button>
+                      </div>
+                  `
+                : ""}
 
             <message-banner></message-banner>
             <div id="focus-controls" class="focus-controls" hidden>
@@ -340,7 +360,22 @@ export class PreviewApp extends LitElement {
         // explicit `false` opts out.
         const initialCollapseVariants =
             this.dataset.collapseVariants !== "false";
+        const minimalMode = this.dataset.minimalMode === "true";
         const vscode = getVsCodeApi<PersistedState>();
+        if (minimalMode) {
+            // Minimal mode hides the extension chrome (bundle chip bar +
+            // data tabs) since data extensions are disabled — see CSS rule.
+            // Wire the in-view "Refresh previews" button to post a refresh
+            // request so the user doesn't have to hunt for the title-bar
+            // icon. The button only exists in minimal mode (rendered above
+            // in `render()`); the existing title-bar refresh command stays
+            // available too.
+            this.querySelector<HTMLButtonElement>(
+                "#btn-minimal-refresh",
+            )?.addEventListener("click", () => {
+                vscode.postMessage({ command: "requestRefresh" });
+            });
+        }
         const state: PersistedState = vscode.getState() ?? { filters: {} };
         // `earlyFeaturesEnabled` lives in `previewStore` so future
         // components can subscribe to it without going through this


### PR DESCRIPTION
Minimal mode disables data extensions and auto-render on save, but the
panel still rendered the bundle chip bar / data tabs and put the only
refresh affordance in the view title. Hide the extension chrome and add
an in-view "Refresh previews" button so the manual render path is
obvious without hunting for the title-bar icon.

Closes #1105