### PR TITLE
fix(ci): drop fetched agent-audit script into expected 3-deep path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,12 +142,15 @@ jobs:
       - name: Fetch agent audit script from yschimke/skills
         # The script lives in the sibling skills repo since it's part of the
         # compose-preview-review skill bundle; fetch the pinned ref so CI
-        # exercises the same harness the skill ships.
+        # exercises the same harness the skill ships. Drop it at the same
+        # 3-deep path the script expects (Path(__file__).parents[3] == repo
+        # root) so SAMPLE/OUT/CLI resolve to the workspace checkout.
         run: |
-          curl -fsSL -o /tmp/run-agent-audit-samples.py \
+          mkdir -p skills/compose-preview-review/scripts
+          curl -fsSL -o skills/compose-preview-review/scripts/run-agent-audit-samples.py \
             "https://raw.githubusercontent.com/yschimke/skills/main/skills/compose-preview-review/scripts/run-agent-audit-samples.py"
       - name: Run agent audit sample scripts
-        run: python3 /tmp/run-agent-audit-samples.py
+        run: python3 skills/compose-preview-review/scripts/run-agent-audit-samples.py
       - name: Upload agent audit outputs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
After the skills move to yschimke/skills, the CI workflow started fetching
run-agent-audit-samples.py to /tmp/. The script resolves the repo root with
Path(__file__).resolve().parents[3], which now lands at "/" instead of the
workspace — so SAMPLE, OUT, and CLI point at nonexistent paths and the job
fails immediately. Download into skills/compose-preview-review/scripts/
inside the workspace so parents[3] resolves to the checkout root again.