### PR TITLE
feat(cli): auto-inject the preview plugin via --init-script

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -1,0 +1,134 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Auto-inject the `ee.schimke.composeai.preview` Gradle plugin into the user's build via
+ * `--init-script`, so the CLI works against projects that haven't manually applied the plugin in
+ * their `build.gradle.kts`.
+ *
+ * Mirrors the VS Code extension's [`initScript.ts`] auto-inject path — see that file's kdoc for the
+ * rationale (`pluginManager.withPlugin` over `afterEvaluate`, why we resolve via Gradle Plugin
+ * Portal + Maven Central + Google) and the CI variant at
+ * `.github/ci/apply-compose-ai.init.gradle.kts`. The init script is idempotent — if the user
+ * already applies the plugin manually, `plugins.hasPlugin(...)` short-circuits and it's a no-op.
+ *
+ * Opt-out:
+ * - `--no-auto-inject` on any CLI invocation, or
+ * - `COMPOSE_PREVIEW_NO_AUTO_INJECT=1` in the environment.
+ */
+const val INIT_SCRIPT_FILENAME = "apply-compose-ai-preview.init.gradle.kts"
+
+/**
+ * Renders the Kotlin-DSL init-script body with [pluginVersion] baked in. Pure function so unit
+ * tests can assert the wire shape without going through the filesystem. Kept in lockstep with the
+ * VS Code extension's `renderInitScript`.
+ */
+internal fun renderInitScript(pluginVersion: String): String =
+  """// Compose Preview auto-inject init script.
+//
+// Materialised by the compose-preview CLI and passed via --init-script on
+// every Gradle invocation the CLI makes. Applies ee.schimke.composeai.preview
+// (version pinned to $pluginVersion) to every project that already applies
+// com.android.application, com.android.library, or org.jetbrains.compose —
+// so consumers don't have to edit their build files. Disable per-run with
+// --no-auto-inject or COMPOSE_PREVIEW_NO_AUTO_INJECT=1.
+//
+// Application uses pluginManager.withPlugin(...) (not afterEvaluate) so AGP
+// finalizeDsl / onVariants callbacks register before the DSL lock.
+
+val pluginVersion = "$pluginVersion"
+
+allprojects {
+    buildscript {
+        repositories {
+            gradlePluginPortal()
+            mavenCentral()
+            google()
+        }
+        dependencies {
+            add(
+                "classpath",
+                "ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:${'$'}pluginVersion",
+            )
+        }
+    }
+
+    fun applyComposeAiPreview() {
+        if (plugins.hasPlugin("ee.schimke.composeai.preview")) return
+        pluginManager.apply("ee.schimke.composeai.preview")
+    }
+
+    pluginManager.withPlugin("com.android.application") { applyComposeAiPreview() }
+    pluginManager.withPlugin("com.android.library") { applyComposeAiPreview() }
+    pluginManager.withPlugin("org.jetbrains.compose") { applyComposeAiPreview() }
+}
+"""
+
+/**
+ * Writes the rendered init script into [storageDir] iff its contents differ from what's already
+ * there. Returns the absolute path Gradle should receive via `--init-script`. Idempotent:
+ * re-running with the same plugin version leaves the file untouched (and its mtime, which keeps
+ * Gradle's configuration cache happy).
+ */
+internal fun materializeInitScript(storageDir: File, pluginVersion: String): File {
+  storageDir.mkdirs()
+  val target = File(storageDir, INIT_SCRIPT_FILENAME)
+  val desired = renderInitScript(pluginVersion)
+  val existing = if (target.isFile) runCatching { target.readText() }.getOrNull() else null
+  if (existing != desired) target.writeText(desired)
+  return target
+}
+
+/** Stable 16-char hex digest of the rendered script. Useful for tests / cache-bust diagnostics. */
+internal fun initScriptDigest(pluginVersion: String): String {
+  val bytes =
+    MessageDigest.getInstance("SHA-256").digest(renderInitScript(pluginVersion).toByteArray())
+  return bytes.joinToString("") { "%02x".format(it) }.take(16)
+}
+
+/**
+ * Default per-version storage directory under the user home, picked so multiple CLI versions can
+ * coexist without racing on the same file path. Mirrors VS Code's `globalStorageUri` approach.
+ *
+ * Honours `XDG_CACHE_HOME` when set (Linux/BSD), else falls back to `~/.compose-preview/init`.
+ */
+internal fun defaultInitScriptStorageDir(version: String): File {
+  val xdg = System.getenv("XDG_CACHE_HOME")?.takeIf { it.isNotBlank() }
+  val base =
+    if (xdg != null) File(xdg, "compose-preview/init")
+    else File(System.getProperty("user.home"), ".compose-preview/init")
+  return File(base, version)
+}
+
+/**
+ * Returns the `--init-script <path>` arguments to prepend to every Gradle invocation, or an empty
+ * list when auto-inject is disabled. Materialises the script on first call.
+ *
+ * Opt-out (any one of these disables auto-inject):
+ * - `--no-auto-inject` in [args],
+ * - `COMPOSE_PREVIEW_NO_AUTO_INJECT=1` in the environment.
+ *
+ * Failures (storage dir not writable, disk full) are swallowed with a stderr note and downgrade to
+ * "no auto-inject" — the CLI continues with whatever the user has manually configured.
+ */
+internal fun autoInjectInitScriptArgs(
+  args: List<String>,
+  pluginVersion: String = BUNDLE_VERSION,
+  storageDir: File = defaultInitScriptStorageDir(pluginVersion),
+  env: (String) -> String? = System::getenv,
+  stderr: (String) -> Unit = System.err::println,
+): List<String> {
+  if ("--no-auto-inject" in args) return emptyList()
+  if (env("COMPOSE_PREVIEW_NO_AUTO_INJECT") == "1") return emptyList()
+  return try {
+    val path = materializeInitScript(storageDir, pluginVersion)
+    listOf("--init-script", path.absolutePath)
+  } catch (e: Exception) {
+    stderr(
+      "compose-preview: auto-inject disabled — could not materialise init script in $storageDir: ${e.message}"
+    )
+    emptyList()
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -15,8 +15,12 @@ import java.security.MessageDigest
  * already applies the plugin manually, `plugins.hasPlugin(...)` short-circuits and it's a no-op.
  *
  * Opt-out:
- * - `--no-auto-inject` on any CLI invocation, or
- * - `COMPOSE_PREVIEW_NO_AUTO_INJECT=1` in the environment.
+ * - `--no-auto-inject` on any CLI invocation,
+ * - `COMPOSE_PREVIEW_NO_AUTO_INJECT=1` in the environment, or
+ * - the project root's `settings.gradle[.kts]` already includes the plugin's source build via
+ *   `includeBuild("gradle-plugin")` — i.e. this CLI is being driven against the compose-ai-tools
+ *   repo's own samples (or a fork doing the same). Adding a Maven-resolved classpath alongside an
+ *   included build would conflict.
  */
 const val INIT_SCRIPT_FILENAME = "apply-compose-ai-preview.init.gradle.kts"
 
@@ -108,7 +112,9 @@ internal fun defaultInitScriptStorageDir(version: String): File {
  *
  * Opt-out (any one of these disables auto-inject):
  * - `--no-auto-inject` in [args],
- * - `COMPOSE_PREVIEW_NO_AUTO_INJECT=1` in the environment.
+ * - `COMPOSE_PREVIEW_NO_AUTO_INJECT=1` in the environment,
+ * - [projectRoot]'s `settings.gradle[.kts]` declares `includeBuild("gradle-plugin")` (the
+ *   compose-ai-tools dev-loop layout — running the CLI against its own samples).
  *
  * Failures (storage dir not writable, disk full) are swallowed with a stderr note and downgrade to
  * "no auto-inject" — the CLI continues with whatever the user has manually configured.
@@ -118,10 +124,12 @@ internal fun autoInjectInitScriptArgs(
   pluginVersion: String = BUNDLE_VERSION,
   storageDir: File = defaultInitScriptStorageDir(pluginVersion),
   env: (String) -> String? = System::getenv,
+  projectRoot: File? = null,
   stderr: (String) -> Unit = System.err::println,
 ): List<String> {
   if ("--no-auto-inject" in args) return emptyList()
   if (env("COMPOSE_PREVIEW_NO_AUTO_INJECT") == "1") return emptyList()
+  if (projectRoot != null && hasIncludedPluginBuild(projectRoot)) return emptyList()
   return try {
     val path = materializeInitScript(storageDir, pluginVersion)
     listOf("--init-script", path.absolutePath)
@@ -131,4 +139,20 @@ internal fun autoInjectInitScriptArgs(
     )
     emptyList()
   }
+}
+
+/**
+ * True when [projectRoot]'s settings file declares `includeBuild("gradle-plugin")` (Kotlin or
+ * Groovy DSL, single or double quotes, with or without surrounding whitespace). Used to short-
+ * circuit auto-inject in the compose-ai-tools repo itself — the agent-audit-samples CI job and any
+ * local `./samples/...` development loop drive the CLI against this same root, and stacking a
+ * Maven-resolved classpath dep on top of the included build conflicts with it.
+ *
+ * Visible for tests.
+ */
+internal fun hasIncludedPluginBuild(projectRoot: File): Boolean {
+  val candidates =
+    listOf(File(projectRoot, "settings.gradle.kts"), File(projectRoot, "settings.gradle"))
+  val pattern = Regex("""includeBuild\s*\(\s*["']gradle-plugin["']\s*\)""")
+  return candidates.any { it.isFile && pattern.containsMatchIn(it.readText()) }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -342,7 +342,11 @@ abstract class Command(protected val args: List<String>) {
           System.err.println("Cannot find Gradle project root (no gradlew found)")
           exitProcess(1)
         }
-    val connection = withGradleStdout(silenceStdout) { GradleConnection(root, verbose, progress) }
+    val injectArgs = autoInjectInitScriptArgs(args)
+    val connection =
+      withGradleStdout(silenceStdout) {
+        GradleConnection(root, verbose, progress, extraArguments = injectArgs)
+      }
     connection.use(block)
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -342,7 +342,7 @@ abstract class Command(protected val args: List<String>) {
           System.err.println("Cannot find Gradle project root (no gradlew found)")
           exitProcess(1)
         }
-    val injectArgs = autoInjectInitScriptArgs(args)
+    val injectArgs = autoInjectInitScriptArgs(args, projectRoot = root)
     val connection =
       withGradleStdout(silenceStdout) {
         GradleConnection(root, verbose, progress, extraArguments = injectArgs)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -48,7 +48,7 @@ import kotlinx.serialization.json.Json
  *
  * Exits 0 when no errors (warnings OK), 1 when any check reports ERROR.
  */
-class DoctorCommand(args: List<String>) {
+class DoctorCommand(private val args: List<String>) {
   private val jsonOut = "--json" in args
   private val reportOut = "--report" in args
   private val explain = "--explain" in args
@@ -308,15 +308,20 @@ class DoctorCommand(args: List<String>) {
     var gradleAccessFailure: GradleAccessFailure? = null
     val model =
       try {
-        GradleConnection(projectDir, verbose = verbose).use { gc ->
-          // Daemon-JVM + Gradle-version snapshot. Runs first so other
-          // project-scope checks can compare against the daemon's JDK
-          // (e.g. flagging test worker mismatch in #142).
-          checkGradleDaemon(gc)
-          gc.runBuildAction(GatherComposePreviewModelAction()).also {
-            gradleAccessFailure = gc.lastModelAccessFailure
+        GradleConnection(
+            projectDir,
+            verbose = verbose,
+            extraArguments = autoInjectInitScriptArgs(args),
+          )
+          .use { gc ->
+            // Daemon-JVM + Gradle-version snapshot. Runs first so other
+            // project-scope checks can compare against the daemon's JDK
+            // (e.g. flagging test worker mismatch in #142).
+            checkGradleDaemon(gc)
+            gc.runBuildAction(GatherComposePreviewModelAction()).also {
+              gradleAccessFailure = gc.lastModelAccessFailure
+            }
           }
-        }
       } catch (e: Exception) {
         addCheck(
           DoctorCheck(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -311,7 +311,7 @@ class DoctorCommand(private val args: List<String>) {
         GradleConnection(
             projectDir,
             verbose = verbose,
-            extraArguments = autoInjectInitScriptArgs(args),
+            extraArguments = autoInjectInitScriptArgs(args, projectRoot = projectDir),
           )
           .use { gc ->
             // Daemon-JVM + Gradle-version snapshot. Runs first so other

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -38,6 +38,13 @@ class GradleConnection(
   private val projectDir: File,
   private val verbose: Boolean,
   private val progress: Boolean = false,
+  /**
+   * Arguments prepended to every Tooling-API invocation this connection makes — `withArguments` on
+   * `BuildLauncher`, `ModelBuilder`, and `BuildActionExecuter`. Today the CLI seeds this with
+   * `--init-script <path>` so the compose-preview plugin is auto-applied to projects that haven't
+   * manually wired it in their `build.gradle.kts`. See [autoInjectInitScriptArgs] for the source.
+   */
+  private val extraArguments: List<String> = emptyList(),
 ) : AutoCloseable {
   private val connector = GradleConnector.newConnector().forProjectDirectory(projectDir)
   private val connection = connector.connect()
@@ -123,8 +130,9 @@ class GradleConnection(
     return try {
       val launcher =
         connection.newBuild().forTasks(*tasks).withCancellationToken(tokenSource.token())
-      if (arguments.isNotEmpty()) {
-        launcher.withArguments(arguments)
+      val combinedArguments = extraArguments + arguments
+      if (combinedArguments.isNotEmpty()) {
+        launcher.withArguments(combinedArguments)
       }
 
       if (verbose) {
@@ -313,6 +321,7 @@ class GradleConnection(
         .action(action)
         .withCancellationToken(tokenSource.token())
         .apply {
+          if (extraArguments.isNotEmpty()) withArguments(extraArguments)
           if (verbose) {
             setStandardOutput(System.err)
             setStandardError(System.err)
@@ -344,9 +353,11 @@ class GradleConnection(
    */
   fun buildEnvironment(): org.gradle.tooling.model.build.BuildEnvironment? {
     return try {
-      connection.model(org.gradle.tooling.model.build.BuildEnvironment::class.java).get().also {
-        modelAccessFailure = null
-      }
+      connection
+        .model(org.gradle.tooling.model.build.BuildEnvironment::class.java)
+        .apply { if (extraArguments.isNotEmpty()) withArguments(extraArguments) }
+        .get()
+        .also { modelAccessFailure = null }
     } catch (e: Exception) {
       recordModelAccessFailure("BuildEnvironment", e)
       if (verbose) System.err.println("Could not query BuildEnvironment: ${e.message}")
@@ -367,7 +378,11 @@ class GradleConnection(
    */
   fun findPreviewModules(): List<PreviewModule> {
     return try {
-      val model = connection.model(org.gradle.tooling.model.GradleProject::class.java).get()
+      val model =
+        connection
+          .model(org.gradle.tooling.model.GradleProject::class.java)
+          .apply { if (extraArguments.isNotEmpty()) withArguments(extraArguments) }
+          .get()
       modelAccessFailure = null
       val modules = mutableListOf<PreviewModule>()
       fun visit(project: org.gradle.tooling.model.GradleProject) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -149,6 +149,16 @@ private fun printUsage() {
                            `initialize` round-trip succeeds. Adds ~600ms (Desktop) or 3-10s
                            (Android/Robolectric) per module — opt-in because plain `doctor`
                            stays cheap.
+      --no-auto-inject     Skip auto-injecting the `ee.schimke.composeai.preview` plugin
+                           via a Gradle init script. By default the CLI ships a bundled
+                           init script and passes it via `--init-script` on every Gradle
+                           invocation, so projects that already apply
+                           `com.android.application`, `com.android.library`, or
+                           `org.jetbrains.compose` pick up the preview plugin without an
+                           edit to `build.gradle.kts`. Set this when the plugin is
+                           already wired manually and you don't want the bundled
+                           classpath dependency added. `COMPOSE_PREVIEW_NO_AUTO_INJECT=1`
+                           is an equivalent environment-variable escape hatch.
 
     OSC 9;4 terminal progress (native taskbar/tab progress bar) is on by
     default in a TTY and auto-disables when stdout is piped or redirected.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -128,7 +128,7 @@ internal class McpCommand(args: List<String>) {
       GradleConnection(
         projectDir,
         verbose = "--verbose" in args || "-v" in args,
-        extraArguments = autoInjectInitScriptArgs(args),
+        extraArguments = autoInjectInitScriptArgs(args, projectRoot = projectDir),
       )
     connection.use { gc ->
       val allModules = gc.findPreviewModules()
@@ -348,7 +348,11 @@ internal class McpCommand(args: List<String>) {
     val moduleFilter = args.flagValuesAll("--module").map { it.removePrefix(":") }.toSet()
 
     val connection =
-      GradleConnection(projectDir, verbose = false, extraArguments = autoInjectInitScriptArgs(args))
+      GradleConnection(
+        projectDir,
+        verbose = false,
+        extraArguments = autoInjectInitScriptArgs(args, projectRoot = projectDir),
+      )
     connection.use { gc ->
       val allModules = gc.findPreviewModules()
       val modules =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -124,7 +124,12 @@ internal class McpCommand(args: List<String>) {
     val projectDir = resolveProjectDir(args)
     val moduleFilter = args.flagValuesAll("--module").map { it.removePrefix(":") }.toSet()
 
-    val connection = GradleConnection(projectDir, verbose = "--verbose" in args || "-v" in args)
+    val connection =
+      GradleConnection(
+        projectDir,
+        verbose = "--verbose" in args || "-v" in args,
+        extraArguments = autoInjectInitScriptArgs(args),
+      )
     connection.use { gc ->
       val allModules = gc.findPreviewModules()
       val modules =
@@ -342,7 +347,8 @@ internal class McpCommand(args: List<String>) {
     val projectDir = resolveProjectDir(args)
     val moduleFilter = args.flagValuesAll("--module").map { it.removePrefix(":") }.toSet()
 
-    val connection = GradleConnection(projectDir, verbose = false)
+    val connection =
+      GradleConnection(projectDir, verbose = false, extraArguments = autoInjectInitScriptArgs(args))
     connection.use { gc ->
       val allModules = gc.findPreviewModules()
       val modules =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -1,0 +1,199 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class AutoInjectTest {
+  private val tempDirs = mutableListOf<File>()
+
+  @AfterTest
+  fun cleanup() {
+    tempDirs.forEach { it.deleteRecursively() }
+  }
+
+  private fun tempDir(prefix: String = "compose-preview-autoinject-"): File =
+    Files.createTempDirectory(prefix).toFile().also { tempDirs += it }
+
+  @Test
+  fun `init script bakes the plugin version into the source`() {
+    val script = renderInitScript("9.9.9-test")
+    assertTrue(
+      script.contains("val pluginVersion = \"9.9.9-test\""),
+      "expected the plugin version to be interpolated into the script",
+    )
+    assertTrue(
+      script.contains(
+        "ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:\$pluginVersion"
+      ),
+      "expected the buildscript classpath coordinate to reference the pinned coordinate",
+    )
+  }
+
+  @Test
+  fun `init script applies on each injectable host plugin`() {
+    val script = renderInitScript("1.0.0")
+    for (id in listOf("com.android.application", "com.android.library", "org.jetbrains.compose")) {
+      assertTrue(
+        script.contains("pluginManager.withPlugin(\"$id\") { applyComposeAiPreview() }"),
+        "expected withPlugin hook for $id",
+      )
+    }
+  }
+
+  @Test
+  fun `init script guards against double-apply with hasPlugin check`() {
+    val script = renderInitScript("1.0.0")
+    assertTrue(
+      script.contains("if (plugins.hasPlugin(\"ee.schimke.composeai.preview\")) return"),
+      "expected an idempotent hasPlugin guard so manually-applied projects stay no-op",
+    )
+  }
+
+  @Test
+  fun `init script avoids afterEvaluate which would miss AGP DSL lock`() {
+    val script = renderInitScript("1.0.0")
+    assertFalse(
+      script.contains("afterEvaluate("),
+      "init script must not call afterEvaluate(...) — AGP's finalizeDsl runs first",
+    )
+    assertFalse(
+      script.contains("afterEvaluate {"),
+      "init script must not use the afterEvaluate { ... } block form",
+    )
+  }
+
+  @Test
+  fun `materializeInitScript writes script to storage dir`() {
+    val dir = tempDir()
+    val target = materializeInitScript(dir, "1.2.3")
+    assertEquals(File(dir, INIT_SCRIPT_FILENAME).absolutePath, target.absolutePath)
+    assertEquals(renderInitScript("1.2.3"), target.readText())
+  }
+
+  @Test
+  fun `materializeInitScript creates the storage dir if missing`() {
+    val dir = File(tempDir(), "nested/storage/compose-preview")
+    assertFalse(dir.exists())
+    val target = materializeInitScript(dir, "1.0.0")
+    assertTrue(dir.isDirectory)
+    assertTrue(target.isFile)
+  }
+
+  @Test
+  fun `materializeInitScript is idempotent — same version leaves the file untouched`() {
+    val dir = tempDir()
+    val first = materializeInitScript(dir, "1.0.0")
+    // Bump mtime forward so a rewrite would be observable.
+    val futureMs = first.lastModified() + 5_000L
+    assertTrue(first.setLastModified(futureMs))
+    val mtimeBefore = first.lastModified()
+    val second = materializeInitScript(dir, "1.0.0")
+    assertEquals(first.absolutePath, second.absolutePath)
+    assertEquals(
+      mtimeBefore,
+      second.lastModified(),
+      "expected no rewrite when contents are unchanged",
+    )
+  }
+
+  @Test
+  fun `materializeInitScript rewrites when the plugin version changes`() {
+    val dir = tempDir()
+    materializeInitScript(dir, "1.0.0")
+    val target = materializeInitScript(dir, "2.0.0")
+    val onDisk = target.readText()
+    assertTrue(onDisk.contains("val pluginVersion = \"2.0.0\""))
+    assertFalse(onDisk.contains("val pluginVersion = \"1.0.0\""))
+  }
+
+  @Test
+  fun `initScriptDigest is stable across calls`() {
+    assertEquals(initScriptDigest("1.0.0"), initScriptDigest("1.0.0"))
+  }
+
+  @Test
+  fun `initScriptDigest differs across plugin versions`() {
+    assertNotEquals(initScriptDigest("1.0.0"), initScriptDigest("1.0.1"))
+  }
+
+  @Test
+  fun `initScriptDigest is 16 hex chars`() {
+    val digest = initScriptDigest("1.0.0")
+    assertEquals(16, digest.length)
+    assertTrue(digest.matches(Regex("^[0-9a-f]{16}$")))
+  }
+
+  @Test
+  fun `autoInjectInitScriptArgs returns --init-script flag pair by default`() {
+    val storage = tempDir()
+    val args =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "1.0.0",
+        storageDir = storage,
+        env = { null },
+      )
+    assertEquals(2, args.size)
+    assertEquals("--init-script", args[0])
+    assertEquals(File(storage, INIT_SCRIPT_FILENAME).absolutePath, args[1])
+    assertTrue(File(args[1]).isFile)
+  }
+
+  @Test
+  fun `autoInjectInitScriptArgs honours --no-auto-inject`() {
+    val storage = tempDir()
+    val args =
+      autoInjectInitScriptArgs(
+        args = listOf("--no-auto-inject"),
+        pluginVersion = "1.0.0",
+        storageDir = storage,
+        env = { null },
+      )
+    assertTrue(args.isEmpty())
+    assertFalse(
+      File(storage, INIT_SCRIPT_FILENAME).exists(),
+      "should not materialise script when auto-inject is disabled",
+    )
+  }
+
+  @Test
+  fun `autoInjectInitScriptArgs honours COMPOSE_PREVIEW_NO_AUTO_INJECT env var`() {
+    val storage = tempDir()
+    val args =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "1.0.0",
+        storageDir = storage,
+        env = { name -> if (name == "COMPOSE_PREVIEW_NO_AUTO_INJECT") "1" else null },
+      )
+    assertTrue(args.isEmpty())
+  }
+
+  @Test
+  fun `autoInjectInitScriptArgs swallows materialise failures and downgrades to no-inject`() {
+    // Point storage at a path that can't be created: a regular file masquerading as a parent dir.
+    val parent = tempDir()
+    val blocker = File(parent, "blocker").apply { writeText("not a directory") }
+    val unwritable = File(blocker, "child")
+    val warnings = mutableListOf<String>()
+    val args =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "1.0.0",
+        storageDir = unwritable,
+        env = { null },
+        stderr = { warnings += it },
+      )
+    assertTrue(args.isEmpty())
+    assertTrue(
+      warnings.any { it.contains("auto-inject disabled") },
+      "expected a stderr note about the disabled auto-inject path; got $warnings",
+    )
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -176,6 +176,115 @@ class AutoInjectTest {
   }
 
   @Test
+  fun `autoInjectInitScriptArgs skips when project root includeBuilds gradle-plugin (Kotlin DSL, double quotes)`() {
+    val storage = tempDir()
+    val projectRoot = tempDir()
+    File(projectRoot, "settings.gradle.kts")
+      .writeText(
+        """
+        rootProject.name = "demo"
+        includeBuild("gradle-plugin")
+        include(":app")
+        """
+          .trimIndent()
+      )
+    val out =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "1.0.0",
+        storageDir = storage,
+        env = { null },
+        projectRoot = projectRoot,
+      )
+    assertTrue(
+      out.isEmpty(),
+      "expected no --init-script when the plugin is supplied via includeBuild; got $out",
+    )
+    assertFalse(File(storage, INIT_SCRIPT_FILENAME).exists())
+  }
+
+  @Test
+  fun `autoInjectInitScriptArgs skips when project root includeBuilds gradle-plugin (Groovy DSL, single quotes)`() {
+    val storage = tempDir()
+    val projectRoot = tempDir()
+    File(projectRoot, "settings.gradle").writeText("includeBuild 'gradle-plugin'\n")
+    // settings.gradle (Groovy) uses no parens for single-arg method calls — fall through to the
+    // negative case; auto-inject stays on. This documents the heuristic's known scope: parens are
+    // mandatory in our regex. Bare-call Groovy users hit the env-var or flag opt-outs instead.
+    val out =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "1.0.0",
+        storageDir = storage,
+        env = { null },
+        projectRoot = projectRoot,
+      )
+    assertEquals(listOf("--init-script", File(storage, INIT_SCRIPT_FILENAME).absolutePath), out)
+
+    // Same root with parens — should skip.
+    File(projectRoot, "settings.gradle").writeText("includeBuild('gradle-plugin')\n")
+    val out2 =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "1.0.0",
+        storageDir = tempDir(),
+        env = { null },
+        projectRoot = projectRoot,
+      )
+    assertTrue(out2.isEmpty())
+  }
+
+  @Test
+  fun `autoInjectInitScriptArgs stays on when project root includeBuilds something else`() {
+    val storage = tempDir()
+    val projectRoot = tempDir()
+    File(projectRoot, "settings.gradle.kts")
+      .writeText(
+        """
+        rootProject.name = "demo"
+        pluginManagement { includeBuild("build-logic") }
+        include(":app")
+        """
+          .trimIndent()
+      )
+    val out =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "1.0.0",
+        storageDir = storage,
+        env = { null },
+        projectRoot = projectRoot,
+      )
+    assertEquals(listOf("--init-script", File(storage, INIT_SCRIPT_FILENAME).absolutePath), out)
+  }
+
+  @Test
+  fun `hasIncludedPluginBuild matches the compose-ai-tools repo's own settings file shape`() {
+    val projectRoot = tempDir()
+    File(projectRoot, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+          includeBuild("build-logic")
+        }
+        rootProject.name = "compose-ai-tools"
+        includeBuild("gradle-plugin")
+        include(":cli")
+        include(":samples:android")
+        """
+          .trimIndent()
+      )
+    assertTrue(hasIncludedPluginBuild(projectRoot))
+  }
+
+  @Test
+  fun `hasIncludedPluginBuild returns false when no settings file mentions gradle-plugin`() {
+    val projectRoot = tempDir()
+    File(projectRoot, "settings.gradle.kts").writeText("rootProject.name = \"demo\"\n")
+    assertFalse(hasIncludedPluginBuild(projectRoot))
+  }
+
+  @Test
   fun `autoInjectInitScriptArgs swallows materialise failures and downgrades to no-inject`() {
     // Point storage at a path that can't be created: a regular file masquerading as a parent dir.
     val parent = tempDir()


### PR DESCRIPTION
Mirror the VS Code extension's auto-inject path so the CLI works
against projects that haven't manually applied
`ee.schimke.composeai.preview` in their `build.gradle.kts`. On every
Tooling-API invocation the CLI now passes `--init-script <path>` to a
materialised init script that applies the plugin to any project that
already applies `com.android.application`, `com.android.library`, or
`org.jetbrains.compose`. The script's `plugins.hasPlugin(...)` guard
keeps it idempotent for projects that wire the plugin manually.

Opt-out via `--no-auto-inject` or `COMPOSE_PREVIEW_NO_AUTO_INJECT=1`.