### PR TITLE
fix(vscode-extension): keep last image on minimal-mode save and add apply-plugin link

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2732,14 +2732,40 @@ preview-app[data-minimal-mode="true"] data-tabs {
     display: none !important;
 }
 
-/* In-view "Refresh previews" call to action — minimal mode disables
-   auto-render on save, so we surface the manual refresh in the panel body
-   rather than relying on the title-bar icon. */
+/* In-view minimal-mode banner — surfaces the manual refresh, explains why
+   saves don't auto-render, and links to the build script so the user can
+   apply the Compose Preview plugin (which enables full mode). */
 .minimal-refresh-bar {
     display: flex;
-    justify-content: center;
-    padding: 6px 8px;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 10px;
     border-bottom: 1px solid var(--card-border);
+}
+.minimal-refresh-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: var(--vscode-font-size);
+    line-height: 1.35;
+}
+.minimal-refresh-hint {
+    color: var(--vscode-descriptionForeground);
+}
+.minimal-save-pending {
+    color: var(
+        --vscode-notificationsWarningIcon-foreground,
+        var(--vscode-editorWarning-foreground)
+    );
+}
+.minimal-save-pending[hidden] {
+    display: none;
+}
+.minimal-refresh-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
 }
 .minimal-refresh-button {
     display: inline-flex;
@@ -2759,6 +2785,24 @@ preview-app[data-minimal-mode="true"] data-tabs {
     background: var(--vscode-button-hoverBackground);
 }
 .minimal-refresh-button:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 1px;
+}
+.minimal-apply-link {
+    background: transparent;
+    border: none;
+    padding: 0;
+    color: var(--vscode-textLink-foreground);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: var(--vscode-font-size);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+.minimal-apply-link:hover {
+    color: var(--vscode-textLink-activeForeground);
+}
+.minimal-apply-link:focus-visible {
     outline: 1px solid var(--vscode-focusBorder);
     outline-offset: 1px;
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1506,10 +1506,15 @@ export async function activate(
             }
             // Minimal mode: renders are manual — the refresh button is the
             // only trigger. Track the file as "seen" so a later toggle of the
-            // setting doesn't fire a stale "first save" burst, but skip the
-            // refresh itself.
+            // setting doesn't fire a stale "first save" burst, and tell the
+            // panel a save is pending so the in-view banner can explain why
+            // the existing image isn't refreshing. Crucially: do NOT post
+            // `setLoading` / `markAllLoading` / `clearAll` — those would
+            // replace the existing render with a placeholder; the panel
+            // should keep the last-good image until the user clicks Refresh.
             if (minimal) {
                 firstSaveSeen.add(doc.uri.fsPath);
+                panel?.postMessage({ command: "minimalSavePending" });
                 return;
             }
             // Time the user-perceived edit→update journey from the save
@@ -3946,7 +3951,23 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             // In-view refresh button (minimal mode). Mirrors the
             // `composePreview.refresh` command path so the title-bar
             // icon and the body-level button behave identically.
+            // Clear the pending-save hint up front — the refresh that's
+            // about to fire will post `setPreviews` on success, but a
+            // failed/cancelled refresh would otherwise leave the hint
+            // stuck on a state the user just acted on.
+            panel?.postMessage({ command: "minimalSavePendingClear" });
             void refresh(true, currentScopeFile ?? undefined);
+            break;
+        case "openModuleBuildFile":
+            // Minimal-mode "Apply plugin" link in the in-view banner.
+            // Opens the active module's build script so the user can add
+            // `id("ee.schimke.composeai.preview")` and reload into full
+            // mode. Routes through the same command the missing-plugin
+            // setup notification uses so the two surfaces stay aligned.
+            void vscode.commands.executeCommand(
+                "composePreview.openModuleBuildFile",
+                currentScopeFile ?? undefined,
+            );
             break;
         case "refreshHeavy": {
             // Click on a faded heavy card opts it into full-tier renders for

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3455,11 +3455,16 @@ async function refresh(
     // If we already have previews on screen, use a stealth refresh:
     // keep the current cards visible and show per-card spinners rather than
     // clearing the view. Only show a full "Building..." message on first load.
-    const showLoadingOverlay = opts.showLoadingOverlay !== false;
+    // Minimal mode is even quieter: renders are manual and any background
+    // refresh (`webviewReady` replay, editor-focus change) must not dim or
+    // skeleton-out the existing cards. Skip both overlays so the panel keeps
+    // the last-good image until the user explicitly clicks Refresh.
+    const showLoadingOverlay =
+        opts.showLoadingOverlay !== false && !inMinimalMode();
     if (hasPreviewsLoaded && showLoadingOverlay) {
         panel.postMessage({ command: "markAllLoading" });
     } else {
-        if (!hasPreviewsLoaded) {
+        if (!hasPreviewsLoaded && !inMinimalMode()) {
             panel.postMessage({ command: "setLoading" });
         }
     }
@@ -3900,9 +3905,19 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             // hidden when `onLanguage:kotlin` activated us). Replay the
             // stateful messages from current state so the grid populates even
             // when the user opens the panel after the first refresh ran.
+            //
+            // Minimal mode is manual-only: a visibility cycle that disposes
+            // the webview must not silently retrigger a Gradle round-trip
+            // (which dims cards / shows skeletons). Replay from the on-disk
+            // cache only — if there's nothing cached the panel stays empty
+            // until the user clicks Refresh.
             sendModuleList();
             if (currentScopeFile) {
-                void refresh(false, currentScopeFile);
+                if (inMinimalMode()) {
+                    void preloadCachedPreviews(currentScopeFile);
+                } else {
+                    void refresh(false, currentScopeFile);
+                }
             }
             break;
         case "webviewPreviewsRendered":

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -469,6 +469,17 @@ export type ExtensionToWebview =
     | { command: "setModules"; modules: string[]; selected: string }
     | { command: "setFunctionFilter"; functionName: string }
     /**
+     * Minimal-mode signal: the user saved a source file but the extension
+     * deliberately did not auto-render. The webview marks the in-view
+     * minimal-mode banner with a "saved changes pending" hint so the user
+     * knows why the existing image isn't refreshing on its own. Cleared by
+     * the next `setPreviews` (a manual refresh just completed).
+     */
+    | { command: "minimalSavePending" }
+    /** Counterpart to `minimalSavePending` — clears the pending-save hint
+     *  without waiting for a refresh to complete. */
+    | { command: "minimalSavePendingClear" }
+    /**
      * Drives the slim progress bar at the top of the panel. `percent` is
      * monotonic within a refresh and clamped to [0, 1]; `label` is the
      * user-facing phase name ("Compiling Kotlin", "Rendering previews"…).
@@ -744,6 +755,14 @@ export type WebviewToExtension =
      * faded-card click.
      */
     | { command: "requestRefresh" }
+    /**
+     * Minimal-mode user clicked the "Apply plugin" link in the panel's
+     * minimal-mode banner. Extension routes to
+     * `composePreview.openModuleBuildFile` against the current scope file
+     * so the user can add `id("ee.schimke.composeai.preview")` to enable
+     * full mode (daemon + auto-render on save).
+     */
+    | { command: "openModuleBuildFile" }
     /**
      * Webview reports current geometric visibility of preview cards plus
      * cards it predicts will scroll into view next based on scroll velocity

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -194,20 +194,52 @@ export class PreviewApp extends LitElement {
             <data-tabs></data-tabs>
             ${minimal
                 ? html`
-                      <div class="minimal-refresh-bar">
-                          <button
-                              type="button"
-                              id="btn-minimal-refresh"
-                              class="minimal-refresh-button"
-                              title="Re-run renderAllPreviews"
-                              aria-label="Refresh previews"
-                          >
-                              <i
-                                  class="codicon codicon-refresh"
-                                  aria-hidden="true"
-                              ></i>
-                              <span>Refresh previews</span>
-                          </button>
+                      <div
+                          class="minimal-refresh-bar"
+                          id="minimal-refresh-bar"
+                          role="region"
+                          aria-label="Minimal mode"
+                      >
+                          <div class="minimal-refresh-text">
+                              <strong>Minimal mode</strong>
+                              <span class="minimal-refresh-hint"
+                                  >Renders don't auto-update on save. Click
+                                  Refresh to apply changes, or apply the Compose
+                                  Preview Gradle plugin to enable
+                                  auto-render.</span
+                              >
+                              <span
+                                  class="minimal-save-pending"
+                                  id="minimal-save-pending"
+                                  hidden
+                                  >Saved changes pending — click Refresh
+                                  previews.</span
+                              >
+                          </div>
+                          <div class="minimal-refresh-actions">
+                              <button
+                                  type="button"
+                                  id="btn-minimal-refresh"
+                                  class="minimal-refresh-button"
+                                  title="Re-run renderAllPreviews"
+                                  aria-label="Refresh previews"
+                              >
+                                  <i
+                                      class="codicon codicon-refresh"
+                                      aria-hidden="true"
+                                  ></i>
+                                  <span>Refresh previews</span>
+                              </button>
+                              <button
+                                  type="button"
+                                  id="btn-minimal-apply-plugin"
+                                  class="minimal-apply-link"
+                                  title="Open this module's build script to apply the Compose Preview plugin"
+                                  aria-label="Apply Compose Preview plugin to project"
+                              >
+                                  Apply plugin to project
+                              </button>
+                          </div>
                       </div>
                   `
                 : ""}
@@ -370,10 +402,37 @@ export class PreviewApp extends LitElement {
             // icon. The button only exists in minimal mode (rendered above
             // in `render()`); the existing title-bar refresh command stays
             // available too.
+            const pending = this.querySelector<HTMLElement>(
+                "#minimal-save-pending",
+            );
             this.querySelector<HTMLButtonElement>(
                 "#btn-minimal-refresh",
             )?.addEventListener("click", () => {
+                if (pending) pending.hidden = true;
                 vscode.postMessage({ command: "requestRefresh" });
+            });
+            this.querySelector<HTMLButtonElement>(
+                "#btn-minimal-apply-plugin",
+            )?.addEventListener("click", () => {
+                vscode.postMessage({ command: "openModuleBuildFile" });
+            });
+            // Toggle the "Saved changes pending" hint based on extension
+            // signals. The extension fires `minimalSavePending` from the
+            // save handler when it deliberately skips an auto-render so
+            // the user understands why the existing image isn't updating;
+            // a follow-up `setPreviews` (manual refresh completed) or an
+            // explicit `minimalSavePendingClear` puts the hint away.
+            window.addEventListener("message", (event: MessageEvent) => {
+                const data = event.data as { command?: string };
+                if (!pending) return;
+                if (data?.command === "minimalSavePending") {
+                    pending.hidden = false;
+                } else if (
+                    data?.command === "minimalSavePendingClear" ||
+                    data?.command === "setPreviews"
+                ) {
+                    pending.hidden = true;
+                }
             });
         }
         const state: PersistedState = vscode.getState() ?? { filters: {} };

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -276,10 +276,13 @@ export function handleExtensionMessage(
         case "clearProgress":
         case "setCompileErrors":
         case "clearCompileErrors":
+        case "minimalSavePending":
+        case "minimalSavePendingClear":
             // Handled directly by Lit components (`<message-banner>`,
-            // `<progress-bar>`, `<compile-errors-banner>`) — they listen on
-            // `window` for these and the dispatcher does not duplicate the
-            // routing.
+            // `<progress-bar>`, `<compile-errors-banner>`,
+            // `<preview-app>`'s minimal-mode banner) — they listen on
+            // `window` for these and the dispatcher does not duplicate
+            // the routing.
             return;
         default:
             return assertNever(msg);


### PR DESCRIPTION
In minimal mode the save handler now posts a `minimalSavePending` signal
to the webview instead of leaving the user to guess why nothing happened.
The in-view banner gains an explanation ("Renders don't auto-update on
save…"), a "Saved changes pending" hint that lights up on save and
clears on Refresh, and an "Apply plugin to project" link that opens the
active module's build script so the user can switch into full mode.

The existing image stays in place: no setLoading / markAllLoading /
clearAll are posted on save in minimal mode.