### PR TITLE
fix(vscode-extension): hide data tabs outside focus mode and drop the More tab

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1892,49 +1892,6 @@ body {
     opacity: 0.6;
     padding: 8px 0;
 }
-/* `…More` tab — stable trailing tab listing disabled bundles. */
-.data-tab-handle-more {
-    margin-left: auto;
-    opacity: 0.8;
-}
-.data-tab-handle-more.data-tab-handle-active {
-    opacity: 1;
-}
-.data-tab-body-more {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
-.data-tab-more-header {
-    font-weight: 600;
-    opacity: 0.8;
-    padding: 2px 0;
-}
-.data-tab-more-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-}
-.data-tab-more-row {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 8px;
-    border-radius: 3px;
-    border: 1px solid var(--vscode-panel-border, transparent);
-    background: var(--vscode-button-secondaryBackground, transparent);
-    color: var(--vscode-button-secondaryForeground, inherit);
-    cursor: pointer;
-    font: inherit;
-    font-size: 12px;
-}
-.data-tab-more-row:hover {
-    background: var(--vscode-list-hoverBackground, transparent);
-}
-.data-tab-more-row-hint {
-    opacity: 0.6;
-    font-size: 11px;
-}
 
 .data-table-shell {
     display: flex;

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1804,41 +1804,36 @@ body {
 .bundle-chip-bar {
     display: flex;
     flex-wrap: wrap;
-    gap: 4px;
-    padding: 4px 6px;
-    border-bottom: 1px solid var(--vscode-panel-border, transparent);
+    gap: 2px;
+    padding: 2px 6px;
+    border-top: 1px solid var(--vscode-panel-border, transparent);
 }
 .bundle-chip {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    padding: 2px 8px;
-    border-radius: 12px;
-    border: 1px solid var(--vscode-button-border, transparent);
-    background: var(--vscode-button-secondaryBackground, transparent);
-    color: var(--vscode-button-secondaryForeground, inherit);
-    font-size: 12px;
+    justify-content: center;
+    padding: 2px 4px;
+    border-radius: 3px;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--vscode-foreground, inherit);
+    opacity: 0.65;
     cursor: pointer;
 }
 .bundle-chip:hover {
-    background: var(
-        --vscode-button-secondaryHoverBackground,
-        var(--vscode-button-secondaryBackground, transparent)
-    );
+    background: var(--vscode-toolbar-hoverBackground, transparent);
+    opacity: 1;
 }
 .bundle-chip.bundle-chip-on {
-    background: var(--vscode-button-background);
-    color: var(--vscode-button-foreground);
+    background: var(--vscode-toolbar-activeBackground, transparent);
+    color: var(--vscode-foreground, inherit);
     border-color: var(--vscode-focusBorder, transparent);
-}
-.bundle-chip-label {
-    white-space: nowrap;
+    opacity: 1;
 }
 
 .data-tabs {
     display: flex;
     flex-direction: column;
-    border-bottom: 1px solid var(--vscode-panel-border, transparent);
 }
 .data-tab-strip {
     display: flex;

--- a/vscode-extension/src/test/dataTabs.test.ts
+++ b/vscode-extension/src/test/dataTabs.test.ts
@@ -1,17 +1,17 @@
-// `<data-tabs>` — verifies the stable trailing `…More` tab that lists
-// every currently-disabled bundle. See
-// `docs/design/EXTENSION_DATA_EXPOSURE.md` § "UX shell" item 8.
+// `<data-tabs>` — verifies the active-bundle tab row. Enabling /
+// disabling bundles is owned by `<bundle-chip-bar>`; this component
+// only mirrors the active set, so the suite focuses on render
+// presence and the close + select events.
 
 import * as assert from "assert";
 import { BUNDLES } from "../webview/preview/bundleRegistry";
-import type { BundleId } from "../webview/preview/bundleRegistry";
 
 // Importing the component registers the custom element with
 // `customElements.define`. Tests drive it through `setState` + DOM.
 import "../webview/preview/components/DataTabs";
 import type {
-    BundleToggledDetail,
     DataTabs,
+    TabCloseDetail,
     TabSelectDetail,
 } from "../webview/preview/components/DataTabs";
 
@@ -21,17 +21,7 @@ function build(): DataTabs {
     return el;
 }
 
-function moreHandle(el: DataTabs): HTMLElement | null {
-    return el.querySelector<HTMLElement>('[data-bundle="__more"]');
-}
-
-function moreBody(el: DataTabs): HTMLElement | null {
-    return el.querySelector<HTMLElement>(
-        '.data-tab-body[data-bundle="__more"]',
-    );
-}
-
-describe("DataTabs `…More` tab", () => {
+describe("DataTabs", () => {
     beforeEach(() => {
         document.body.innerHTML = "";
     });
@@ -39,7 +29,7 @@ describe("DataTabs `…More` tab", () => {
         document.body.innerHTML = "";
     });
 
-    it("renders the `…More` tab with no active bundles", async () => {
+    it("renders nothing when no bundles are active", async () => {
         const el = build();
         el.setState({
             bundles: BUNDLES,
@@ -47,17 +37,52 @@ describe("DataTabs `…More` tab", () => {
             activeTab: null,
         });
         await el.updateComplete;
-        const more = moreHandle(el);
-        assert.ok(more, "…More handle must render with no active bundles");
-        const handles = el.querySelectorAll(".data-tab-handle");
         assert.strictEqual(
-            handles.length,
-            1,
-            "only the …More handle should render when no bundles are active",
+            el.querySelector(".data-tabs"),
+            null,
+            "no tab strip when no bundles are active",
         );
+        assert.strictEqual(el.querySelectorAll(".data-tab-handle").length, 0);
     });
 
-    it("places `…More` last when other tabs are active", async () => {
+    it("renders one handle per active bundle, in registry order", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: ["theming", "a11y"],
+            activeTab: "a11y",
+        });
+        await el.updateComplete;
+        const handles = Array.from(
+            el.querySelectorAll<HTMLElement>(".data-tab-handle"),
+        );
+        const ids = handles.map((h) => h.getAttribute("data-bundle"));
+        // BUNDLES order, filtered to active.
+        const expected = BUNDLES.map((b) => b.id).filter((id) =>
+            ["theming", "a11y"].includes(id),
+        );
+        assert.deepStrictEqual(ids, expected);
+    });
+
+    it("marks the active tab aria-selected", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: ["a11y", "theming"],
+            activeTab: "theming",
+        });
+        await el.updateComplete;
+        const a11y = el.querySelector<HTMLElement>(
+            '.data-tab-handle[data-bundle="a11y"]',
+        );
+        const theming = el.querySelector<HTMLElement>(
+            '.data-tab-handle[data-bundle="theming"]',
+        );
+        assert.strictEqual(a11y!.getAttribute("aria-selected"), "false");
+        assert.strictEqual(theming!.getAttribute("aria-selected"), "true");
+    });
+
+    it("dispatches `tab-selected` when a handle's label is clicked", async () => {
         const el = build();
         el.setState({
             bundles: BUNDLES,
@@ -65,125 +90,35 @@ describe("DataTabs `…More` tab", () => {
             activeTab: "a11y",
         });
         await el.updateComplete;
-        const handles = Array.from(
-            el.querySelectorAll<HTMLElement>(".data-tab-handle"),
-        );
-        // Two bundle handles + one …More handle.
-        assert.strictEqual(handles.length, 3);
-        const ids = handles.map((h) => h.getAttribute("data-bundle"));
-        assert.deepStrictEqual(ids, ["a11y", "theming", "__more"]);
-    });
-
-    it("lists every inactive bundle by registry id in the `…More` body", async () => {
-        const el = build();
-        const active: BundleId[] = ["a11y", "errors"];
-        el.setState({
-            bundles: BUNDLES,
-            activeBundles: active,
-            activeTab: "a11y",
-        });
-        await el.updateComplete;
-        const body = moreBody(el);
-        assert.ok(body, "…More body must render");
-        const rows = Array.from(
-            body!.querySelectorAll<HTMLElement>(".data-tab-more-row"),
-        );
-        const rowIds = rows.map((r) => r.getAttribute("data-bundle"));
-        const expected = BUNDLES.map((b) => b.id).filter(
-            (id) => !active.includes(id),
-        );
-        assert.deepStrictEqual(rowIds, expected);
-    });
-
-    it("dispatches `bundle-toggled` with the row's id when clicked", async () => {
-        const el = build();
-        el.setState({
-            bundles: BUNDLES,
-            activeBundles: [],
-            activeTab: null,
-        });
-        await el.updateComplete;
-        const events: BundleToggledDetail[] = [];
-        el.addEventListener("bundle-toggled", (e) =>
-            events.push((e as CustomEvent<BundleToggledDetail>).detail),
-        );
-        const row = el.querySelector<HTMLButtonElement>(
-            '.data-tab-more-row[data-bundle="theming"]',
-        );
-        assert.ok(row, "theming row must render");
-        row!.click();
-        assert.deepStrictEqual(events, [{ id: "theming" }]);
-    });
-
-    it("has no close `×` button on the `…More` handle", async () => {
-        const el = build();
-        el.setState({
-            bundles: BUNDLES,
-            activeBundles: ["a11y"],
-            activeTab: "a11y",
-        });
-        await el.updateComplete;
-        const more = moreHandle(el);
-        assert.ok(more);
-        const close = more!.querySelector(".data-tab-close");
-        assert.strictEqual(
-            close,
-            null,
-            "…More tab must be the only non-closable tab",
-        );
-    });
-
-    it("shows the 'Everything's on' placeholder when no bundle is disabled", async () => {
-        const el = build();
-        el.setState({
-            bundles: BUNDLES,
-            activeBundles: BUNDLES.map((b) => b.id),
-            activeTab: "a11y",
-        });
-        await el.updateComplete;
-        const body = moreBody(el);
-        assert.ok(body);
-        const rows = body!.querySelectorAll(".data-tab-more-row");
-        assert.strictEqual(
-            rows.length,
-            0,
-            "no disabled-bundle rows when every bundle is active",
-        );
-        const empty = body!.querySelector(".data-table-empty");
-        assert.ok(
-            empty && /everything/i.test(empty.textContent ?? ""),
-            "placeholder copy must mention everything being on",
-        );
-    });
-
-    it("dispatches `tab-selected` with id=null when the `…More` handle is clicked", async () => {
-        const el = build();
-        el.setState({
-            bundles: BUNDLES,
-            activeBundles: ["a11y"],
-            activeTab: "a11y",
-        });
-        await el.updateComplete;
         const events: TabSelectDetail[] = [];
         el.addEventListener("tab-selected", (e) =>
             events.push((e as CustomEvent<TabSelectDetail>).detail),
         );
-        const label =
-            moreHandle(el)!.querySelector<HTMLButtonElement>(".data-tab-label");
+        const label = el.querySelector<HTMLButtonElement>(
+            '.data-tab-handle[data-bundle="theming"] .data-tab-label',
+        );
         assert.ok(label);
         label!.click();
-        assert.deepStrictEqual(events, [{ id: null }]);
+        assert.deepStrictEqual(events, [{ id: "theming" }]);
     });
 
-    it("marks the `…More` handle aria-selected when no bundle tab is active", async () => {
+    it("dispatches `tab-closed` when the × button is clicked", async () => {
         const el = build();
         el.setState({
             bundles: BUNDLES,
-            activeBundles: [],
-            activeTab: null,
+            activeBundles: ["a11y", "theming"],
+            activeTab: "a11y",
         });
         await el.updateComplete;
-        const more = moreHandle(el);
-        assert.strictEqual(more!.getAttribute("aria-selected"), "true");
+        const events: TabCloseDetail[] = [];
+        el.addEventListener("tab-closed", (e) =>
+            events.push((e as CustomEvent<TabCloseDetail>).detail),
+        );
+        const close = el.querySelector<HTMLButtonElement>(
+            '.data-tab-handle[data-bundle="a11y"] .data-tab-close',
+        );
+        assert.ok(close);
+        close!.click();
+        assert.deepStrictEqual(events, [{ id: "a11y" }]);
     });
 });

--- a/vscode-extension/src/webview/preview/components/BundleChipBar.ts
+++ b/vscode-extension/src/webview/preview/components/BundleChipBar.ts
@@ -1,11 +1,11 @@
-// `<bundle-chip-bar>` — chip strip below the filter toolbar. Each chip
-// is a toggle for a data-extension bundle. Pressing a chip opens the
-// matching tab in `<data-tabs>` and starts subscriptions to the
-// bundle's default-ON kinds; re-pressing it tears them down. The chip
-// + the tab `×` are deliberately redundant so the dismiss path is
-// reachable from wherever the user's eye lands (see
-// `docs/design/EXTENSION_DATA_EXPOSURE.md` § "Chip ↔ tab ↔ overlay
-// state machine").
+// `<bundle-chip-bar>` — chip strip rendered below the preview grid in
+// focus mode. Each chip is an icon-only toggle for a data-extension
+// bundle. Pressing a chip opens the matching tab in `<data-tabs>` and
+// starts subscriptions to the bundle's default-ON kinds; re-pressing
+// it tears them down. The chip + the tab `×` are deliberately
+// redundant so the dismiss path is reachable from wherever the user's
+// eye lands (see `docs/design/EXTENSION_DATA_EXPOSURE.md` § "Chip ↔
+// tab ↔ overlay state machine").
 //
 // The component is read-only state — `BundleController` owns the
 // truth and pushes updates via `setState`. User clicks fire
@@ -55,12 +55,12 @@ export class BundleChipBar extends LitElement {
                 type="button"
                 class=${pressed ? "bundle-chip bundle-chip-on" : "bundle-chip"}
                 aria-pressed=${pressed ? "true" : "false"}
+                aria-label=${b.label}
                 data-bundle=${b.id}
                 title=${b.label}
                 @click=${() => this.onClick(b.id)}
             >
                 <i class=${"codicon codicon-" + b.icon} aria-hidden="true"></i>
-                <span class="bundle-chip-label">${b.label}</span>
             </button>
         `;
     }

--- a/vscode-extension/src/webview/preview/components/DataTabs.ts
+++ b/vscode-extension/src/webview/preview/components/DataTabs.ts
@@ -9,13 +9,9 @@
 // so a slow-to-build presenter doesn't tear down on every click; only
 // the active body is `[hidden]=false`.
 //
-// A trailing **`…More`** tab is always rendered in the last position,
-// even when no bundle is active. It's the only non-closable tab and
-// lists every currently-disabled bundle as a clickable row that emits
-// `bundle-toggled` — re-using the chip-bar event so the host doesn't
-// need new wiring (design doc § "UX shell", item 8: "Last tab is always
-// `…More` / settings. Stable position so the user always knows where
-// to find the extra filters and disabled kinds.").
+// Enabling/disabling bundles is owned by `<bundle-chip-bar>`; the tab
+// row only mirrors the active set so we don't surface duplicate
+// enable/disable affordances inside focus mode.
 
 import { LitElement, html, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
@@ -26,21 +22,9 @@ export interface TabCloseDetail {
 }
 
 export interface TabSelectDetail {
-    /** `null` selects the `…More` tab (no bundle owns it). */
+    /** `null` means no tab is selected (no active bundles). */
     id: BundleId | null;
 }
-
-/** Re-export of the chip-bar event's detail shape — the `…More` rows
- *  fire the same event so the host's existing `bundle-toggled` listener
- *  handles activation without new wiring. */
-export interface BundleToggledDetail {
-    id: BundleId;
-}
-
-/** Sentinel value for the `…More` tab's selection state. The host
- *  controller's `activeTab` is a `BundleId | null`; `null` is the
- *  `…More` tab. */
-export const MORE_TAB = null;
 
 @customElement("data-tabs")
 export class DataTabs extends LitElement {
@@ -90,12 +74,9 @@ export class DataTabs extends LitElement {
         const ordered = this.bundles.filter((b) =>
             this.activeBundles.includes(b.id),
         );
-        const moreSelected =
-            this.activeTab === null ||
-            !this.activeBundles.includes(this.activeTab);
-        const disabled = this.bundles.filter(
-            (b) => !this.activeBundles.includes(b.id),
-        );
+        if (ordered.length === 0) {
+            return html``;
+        }
         return html`
             <div
                 class="data-tabs"
@@ -104,11 +85,9 @@ export class DataTabs extends LitElement {
             >
                 <div class="data-tab-strip">
                     ${ordered.map((b) => this.renderTabHandle(b))}
-                    ${this.renderMoreHandle(moreSelected)}
                 </div>
                 <div class="data-tab-bodies">
                     ${ordered.map((b) => this.renderTabBody(b))}
-                    ${this.renderMoreBody(disabled, moreSelected)}
                 </div>
             </div>
         `;
@@ -149,32 +128,6 @@ export class DataTabs extends LitElement {
         `;
     }
 
-    private renderMoreHandle(selected: boolean): TemplateResult {
-        // No close button — `…More` is the stable trailing tab; the
-        // design doc makes it the only non-closable tab so the user
-        // always has somewhere to find disabled bundles.
-        return html`
-            <div
-                class=${selected
-                    ? "data-tab-handle data-tab-handle-more data-tab-handle-active"
-                    : "data-tab-handle data-tab-handle-more"}
-                role="tab"
-                aria-selected=${selected ? "true" : "false"}
-                data-bundle="__more"
-            >
-                <button
-                    type="button"
-                    class="data-tab-label"
-                    @click=${() => this.onSelect(null)}
-                    title="Show disabled bundles"
-                >
-                    <i class="codicon codicon-ellipsis" aria-hidden="true"></i>
-                    <span>More</span>
-                </button>
-            </div>
-        `;
-    }
-
     private renderTabBody(b: BundleDescriptor): TemplateResult {
         const body = this.bodies.get(b.id);
         const selected = b.id === this.activeTab;
@@ -187,48 +140,6 @@ export class DataTabs extends LitElement {
             >
                 ${body ?? this.placeholderBody(b)}
             </div>
-        `;
-    }
-
-    private renderMoreBody(
-        disabled: readonly BundleDescriptor[],
-        selected: boolean,
-    ): TemplateResult {
-        return html`
-            <div
-                class="data-tab-body data-tab-body-more"
-                role="tabpanel"
-                data-bundle="__more"
-                ?hidden=${!selected}
-            >
-                <div class="data-tab-more-header">Disabled bundles</div>
-                ${disabled.length === 0
-                    ? html`
-                          <div class="data-table-empty">Everything's on.</div>
-                      `
-                    : html`
-                          <div class="data-tab-more-list">
-                              ${disabled.map((b) => this.renderMoreRow(b))}
-                          </div>
-                      `}
-            </div>
-        `;
-    }
-
-    private renderMoreRow(b: BundleDescriptor): TemplateResult {
-        return html`
-            <button
-                type="button"
-                class="data-tab-more-row"
-                data-bundle=${b.id}
-                title=${`Enable ${b.label}`}
-                aria-label=${`Enable ${b.label}`}
-                @click=${() => this.onMoreActivate(b.id)}
-            >
-                <i class=${"codicon codicon-" + b.icon} aria-hidden="true"></i>
-                <span class="data-tab-more-row-label">${b.label}</span>
-                <span class="data-tab-more-row-hint">click to enable</span>
-            </button>
         `;
     }
 
@@ -252,20 +163,6 @@ export class DataTabs extends LitElement {
         evt.stopPropagation();
         this.dispatchEvent(
             new CustomEvent<TabCloseDetail>("tab-closed", {
-                detail: { id },
-                bubbles: true,
-                composed: true,
-            }),
-        );
-    }
-
-    private onMoreActivate(id: BundleId): void {
-        // Re-use the chip-bar's `bundle-toggled` event so the host's
-        // existing controller wiring activates the bundle. Once the
-        // controller fires `bundle-state-changed`, `setState` re-renders
-        // and the bundle's own tab takes over.
-        this.dispatchEvent(
-            new CustomEvent<BundleToggledDetail>("bundle-toggled", {
                 detail: { id },
                 bubbles: true,
                 composed: true,

--- a/vscode-extension/src/webview/preview/components/DataTabs.ts
+++ b/vscode-extension/src/webview/preview/components/DataTabs.ts
@@ -1,7 +1,8 @@
-// `<data-tabs>` — tab row that appears below `<bundle-chip-bar>`.
-// Each active bundle gets a tab with a label and a close `×`
-// affordance; the `×` and the bundle chip's re-press are two redundant
-// ways to dismiss (design doc § "Chip ↔ tab ↔ overlay state machine").
+// `<data-tabs>` — active-bundle tab row that appears below
+// `<bundle-chip-bar>` (under the preview grid in focus mode). Each
+// active bundle gets a tab with a label and a close `×` affordance;
+// the `×` and the bundle chip's re-press are two redundant ways to
+// dismiss (design doc § "Chip ↔ tab ↔ overlay state machine").
 //
 // The active tab's body is provided by the host via `setTabBody(id, el)`
 // so each bundle can ship its own table/tree presenter without the

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -45,13 +45,13 @@ export interface FocusControllerConfig {
     /** `<div id="focus-controls">` — the focus-mode toolbar container.
      *  Toggled `hidden` based on layout mode. */
     focusControls: HTMLElement;
-    /** `<bundle-chip-bar>` — data-extensions chip strip. Visible only in
-     *  focus layout; the bundles only act on the focused preview, so the
-     *  strip would mislead outside focus mode. */
+    /** `<bundle-chip-bar>` — data-extensions chip strip, rendered below
+     *  the preview grid. Visible only in focus layout; the bundles only
+     *  act on the focused preview, so the strip would mislead outside
+     *  focus mode. */
     bundleChipBar: HTMLElement;
-    /** `<data-tabs>` — active-bundle tab row. Same focus-only visibility
-     *  rule as `bundleChipBar`: bundle data is per-focused-preview, so
-     *  the row would have nothing meaningful to show in grid/flow/column. */
+    /** `<data-tabs>` — active-bundle tab row, rendered below the chip
+     *  strip. Same focus-only visibility rule as `bundleChipBar`. */
     dataTabs: HTMLElement;
     /** `<div id="focus-position">` — the "N / M" position indicator. */
     focusPosition: HTMLElement;

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -49,6 +49,10 @@ export interface FocusControllerConfig {
      *  focus layout; the bundles only act on the focused preview, so the
      *  strip would mislead outside focus mode. */
     bundleChipBar: HTMLElement;
+    /** `<data-tabs>` — active-bundle tab row. Same focus-only visibility
+     *  rule as `bundleChipBar`: bundle data is per-focused-preview, so
+     *  the row would have nothing meaningful to show in grid/flow/column. */
+    dataTabs: HTMLElement;
     /** `<div id="focus-position">` — the "N / M" position indicator. */
     focusPosition: HTMLElement;
     btnPrev: HTMLButtonElement;
@@ -189,6 +193,7 @@ export class FocusController {
         this.config.grid.setLayoutMode(mode);
         this.config.focusControls.hidden = mode !== "focus";
         this.config.bundleChipBar.hidden = mode !== "focus";
+        this.config.dataTabs.hidden = mode !== "focus";
 
         if (mode === "focus") {
             const visible = this.getVisibleCards();

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -191,7 +191,7 @@ export class PreviewApp extends LitElement {
             <compile-errors-banner></compile-errors-banner>
             <filter-toolbar></filter-toolbar>
             <bundle-chip-bar hidden></bundle-chip-bar>
-            <data-tabs></data-tabs>
+            <data-tabs hidden></data-tabs>
             ${minimal
                 ? html`
                       <div
@@ -1605,13 +1605,6 @@ export class PreviewApp extends LitElement {
             const detail = (evt as CustomEvent<{ id: BundleId }>).detail;
             bundleController.toggleBundle(detail.id);
         });
-        // The `…More` tab's rows fire the same `bundle-toggled` event
-        // as the chip bar so the controller activates the bundle via
-        // the existing path — no new wiring needed.
-        dataTabs.addEventListener("bundle-toggled", (evt) => {
-            const detail = (evt as CustomEvent<{ id: BundleId }>).detail;
-            bundleController.toggleBundle(detail.id);
-        });
         dataTabs.addEventListener("tab-closed", (evt) => {
             const detail = (evt as CustomEvent<{ id: BundleId }>).detail;
             bundleController.closeTab(detail.id);
@@ -1673,6 +1666,7 @@ export class PreviewApp extends LitElement {
             filterToolbar,
             focusControls,
             bundleChipBar,
+            dataTabs,
             focusPosition,
             btnPrev,
             btnNext,

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -190,8 +190,6 @@ export class PreviewApp extends LitElement {
             <progress-bar></progress-bar>
             <compile-errors-banner></compile-errors-banner>
             <filter-toolbar></filter-toolbar>
-            <bundle-chip-bar hidden></bundle-chip-bar>
-            <data-tabs hidden></data-tabs>
             ${minimal
                 ? html`
                       <div
@@ -374,6 +372,8 @@ export class PreviewApp extends LitElement {
                 role="list"
                 aria-label="Preview cards"
             ></preview-grid>
+            <bundle-chip-bar hidden></bundle-chip-bar>
+            <data-tabs hidden></data-tabs>
             <div
                 id="focus-inspector"
                 class="focus-inspector"


### PR DESCRIPTION
The `…More` tab and its "Disabled bundles" body duplicated the bundle
chip bar — both let you enable a disabled bundle, and the chip bar is
the more discoverable affordance. Outside focus mode the data tabs had
nothing meaningful to show anyway (bundles are per-focused-preview),
so the row was pure clutter on grid/flow/column layouts.

Hide `<data-tabs>` whenever `<bundle-chip-bar>` is hidden, drop the
More tab handle and disabled-bundles body, and render nothing when no
bundle tab is active. The tab row now only appears in focus mode and
only when at least one bundle is on.