### PR TITLE
fix(vscode-extension): show bundle labels next to chip icons

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1805,19 +1805,20 @@ body {
     display: flex;
     flex-wrap: wrap;
     gap: 2px;
-    padding: 2px 6px;
+    padding: 4px 6px;
     border-top: 1px solid var(--vscode-panel-border, transparent);
 }
 .bundle-chip {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    padding: 2px 4px;
+    gap: 4px;
+    padding: 2px 6px;
     border-radius: 3px;
     border: 1px solid transparent;
     background: transparent;
     color: var(--vscode-foreground, inherit);
-    opacity: 0.65;
+    font-size: 12px;
+    opacity: 0.75;
     cursor: pointer;
 }
 .bundle-chip:hover {
@@ -1829,6 +1830,9 @@ body {
     color: var(--vscode-foreground, inherit);
     border-color: var(--vscode-focusBorder, transparent);
     opacity: 1;
+}
+.bundle-chip-label {
+    white-space: nowrap;
 }
 
 .data-tabs {

--- a/vscode-extension/src/webview/preview/components/BundleChipBar.ts
+++ b/vscode-extension/src/webview/preview/components/BundleChipBar.ts
@@ -1,5 +1,5 @@
 // `<bundle-chip-bar>` — chip strip rendered below the preview grid in
-// focus mode. Each chip is an icon-only toggle for a data-extension
+// focus mode. Each chip is an icon + label toggle for a data-extension
 // bundle. Pressing a chip opens the matching tab in `<data-tabs>` and
 // starts subscriptions to the bundle's default-ON kinds; re-pressing
 // it tears them down. The chip + the tab `×` are deliberately
@@ -55,12 +55,12 @@ export class BundleChipBar extends LitElement {
                 type="button"
                 class=${pressed ? "bundle-chip bundle-chip-on" : "bundle-chip"}
                 aria-pressed=${pressed ? "true" : "false"}
-                aria-label=${b.label}
                 data-bundle=${b.id}
                 title=${b.label}
                 @click=${() => this.onClick(b.id)}
             >
                 <i class=${"codicon codicon-" + b.icon} aria-hidden="true"></i>
+                <span class="bundle-chip-label">${b.label}</span>
             </button>
         `;
     }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -1603,7 +1603,21 @@ export class PreviewApp extends LitElement {
         reflectBundleState();
         bundleChipBar.addEventListener("bundle-toggled", (evt) => {
             const detail = (evt as CustomEvent<{ id: BundleId }>).detail;
+            const wasActive = bundleController
+                .state()
+                .activeBundles.includes(detail.id);
             bundleController.toggleBundle(detail.id);
+            // Chip + tabs sit below the preview, so a fresh activation
+            // can scroll off-screen on tall previews. Bring the new tab
+            // body into view so the click has visible feedback.
+            if (!wasActive) {
+                requestAnimationFrame(() => {
+                    dataTabs.scrollIntoView({
+                        behavior: "smooth",
+                        block: "nearest",
+                    });
+                });
+            }
         });
         dataTabs.addEventListener("tab-closed", (evt) => {
             const detail = (evt as CustomEvent<{ id: BundleId }>).detail;


### PR DESCRIPTION
Icon-only chips made enabling a bundle a guessing game. Bring the
label back next to the icon while keeping the flat (non-pill) toolbar
treatment, so the bar reads as "Accessibility, Theming, Text/i18n…"
instead of an unmarked icon row but still avoids the chunky pill
styling that pushed the original strip onto three rows.