### PR TITLE
fix(vscode-extension): swap minimal→full backend in place when auto-inject reveals the plugin

### DIFF
--- a/vscode-extension/src/composePreviewMode.ts
+++ b/vscode-extension/src/composePreviewMode.ts
@@ -34,11 +34,12 @@ export interface ResolvedMode {
  * gradle-service slice. Auto-mode picks `"full"` only when at least one
  * workspace module already applies `ee.schimke.composeai.preview` (text scan
  * or `applied.json` marker); otherwise it falls back to `"minimal"`. Auto-inject
- * onto an Android / Compose host doesn't preemptively flip the mode — the
- * plugin isn't actually applied until Gradle runs the init script, so spawning
- * a daemon at activation would fail (no `daemon-launch.json` yet). The
- * post-Gradle-sync re-evaluation handles the upgrade: once `applied.json`
- * markers exist, the extension offers a one-click reload into full mode.
+ * onto an Android / Compose host doesn't preemptively flip the mode here — the
+ * plugin isn't actually applied until Gradle runs the init script, so the
+ * activation-time call has no marker to read. The post-Gradle-sync
+ * re-evaluation handles the upgrade: once `applied.json` markers exist,
+ * `extension.ts` re-wires the daemon backend in place (no window reload), and
+ * the panel webview drops its minimal-mode banner via `setMinimalMode`.
  */
 export function resolveModeFromSettings(
     settings: {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -83,7 +83,11 @@ import {
     writeRenderFreshnessStamp,
 } from "./renderFreshness";
 import { BUNDLED_PLUGIN_VERSION, materializeInitScript } from "./initScript";
-import { ResolvedMode, resolveModeFromSettings } from "./composePreviewMode";
+import {
+    ComposePreviewMode,
+    ResolvedMode,
+    resolveModeFromSettings,
+} from "./composePreviewMode";
 
 const DEBOUNCE_MS = 1500;
 // Edits to the currently-scoped preview file (e.g. Claude Code's Edit tool
@@ -309,9 +313,10 @@ function autoInjectEnabled(): boolean {
  * [onDiagnosticsChanged], the stale-source kicker inside [refresh]) can gate
  * themselves without reading the user setting again.
  *
- * `daemonGate` is set during activation and never re-assigned, so this is a
- * stable signal for the session — matching the rest of the mode contract
- * which requires a window reload to switch.
+ * `daemonGate` may be re-assigned mid-session when the post-bootstrap
+ * re-evaluation upgrades a workspace from minimal to full mode in process
+ * (auto-inject path). Callers read this predicate on every check so the
+ * answer tracks the live backend.
  */
 function inMinimalMode(): boolean {
     return daemonGate?.spawnsDaemons === false;
@@ -681,293 +686,318 @@ export async function activate(
     // gradle-only gate; the save handler additionally skips auto-rendering in
     // minimal mode so the user drives renders manually via the refresh button.
     const initialMode = resolveMode(gradleService);
-    const minimal = initialMode.mode === "minimal";
     outputChannel.appendLine(
         `[startup] mode=${initialMode.mode} reason=${initialMode.reason}`,
     );
-    if (minimal) {
+    if (initialMode.mode === "minimal") {
         outputChannel.appendLine(
             "[startup] minimal mode: gradle-only backend — daemon, data extensions and live previews disabled, renders are manual",
         );
     }
-    daemonGate = minimal
-        ? new GradleOnlyDaemonGate()
-        : new LiveDaemonGate(workspaceRoot, "0.1.0", outputChannel, logFilter);
-    daemonScheduler = minimal
-        ? new GradleOnlyDaemonScheduler()
-        : new LiveDaemonScheduler(
-              daemonGate,
-              {
-                  onPreviewImageReady: (moduleId, previewId, imageBase64) => {
-                      // First image after a save closes the edit→update journey
-                      // for this module. Live-stream frames from an interactive
-                      // session also funnel through this callback, but they can
-                      // only fire after the user already saw a complete render —
-                      // any pending journey timer has already been cleared, so the
-                      // `endEditJourney` no-ops in that path.
-                      endEditJourney(moduleId);
-                      if (!panel) {
-                          return;
-                      }
-                      if (
-                          activeInteractiveStreams.has(previewId) &&
-                          logFilter.shouldEmitVerbose()
-                      ) {
-                          logLine(
-                              `[interactive] frame ${previewId} bytes=${imageBase64.length}`,
-                          );
-                      }
-                      // Capture index 0 — the daemon's v1 renderFinished targets the
-                      // representative capture only. Multi-capture (animated) renders
-                      // still come through the Gradle path; the daemon's predictive
-                      // pre-warm focuses on the cheap interactive loop.
-                      panel.postMessage({
-                          command: "updateImage",
+    // Encapsulates gate + scheduler construction so the post-Gradle-sync
+    // re-evaluation can swap the backend in place when auto-inject reveals a
+    // workspace is actually full-mode-eligible. Closures inside the
+    // [LiveDaemonScheduler] callbacks capture activate-scope state directly,
+    // which is why this lives inline rather than as a module function.
+    const wireBackend = (targetMode: ComposePreviewMode): void => {
+        const isMinimal = targetMode === "minimal";
+        daemonGate = isMinimal
+            ? new GradleOnlyDaemonGate()
+            : new LiveDaemonGate(
+                  workspaceRoot,
+                  "0.1.0",
+                  outputChannel,
+                  logFilter,
+              );
+        daemonScheduler = isMinimal
+            ? new GradleOnlyDaemonScheduler()
+            : new LiveDaemonScheduler(
+                  daemonGate,
+                  {
+                      onPreviewImageReady: (
+                          moduleId,
                           previewId,
-                          captureIndex: 0,
-                          imageData: imageBase64,
-                      });
-                  },
-                  onRenderFailed: (_moduleId, previewId, message) => {
-                      if (!panel) {
-                          return;
-                      }
-                      panel.postMessage({
-                          command: "setImageError",
-                          previewId,
-                          captureIndex: 0,
-                          message,
-                          replaceExisting: false,
-                      });
-                  },
-                  onDataProductsAttached: (
-                      _moduleId,
-                      previewId,
-                      dataProducts,
-                  ) => {
-                      // D2 — route the data products attached to this render. For path-transport kinds
-                      // (`a11y/hierarchy`) we read the JSON off disk; inline kinds (`a11y/atf`) carry
-                      // their payload in `dp.payload`. The registry update fires `onDidChange`, which
-                      // the diagnostics provider already listens to. The panel receives a targeted
-                      // `updateA11y` post so its cached overlays repaint without re-emitting the entire
-                      // preview list.
-                      outputChannel.appendLine(
-                          `[daemon] onDataProductsAttached ${previewId} kinds=[${dataProducts
-                              .map((dp) => dp.kind)
-                              .join(
-                                  ",",
-                              )}] panel=${panel ? "live" : "missing"} transports=[${dataProducts
-                              .map(
-                                  (dp) =>
-                                      `${dp.kind}:${dp.payload !== undefined ? "inline" : dp.path ? "path" : "empty"}`,
-                              )
-                              .join(",")}]`,
-                      );
-                      const decoded = applyDataProductsToRegistry(
-                          registry,
+                          imageBase64,
+                      ) => {
+                          // First image after a save closes the edit→update journey
+                          // for this module. Live-stream frames from an interactive
+                          // session also funnel through this callback, but they can
+                          // only fire after the user already saw a complete render —
+                          // any pending journey timer has already been cleared, so the
+                          // `endEditJourney` no-ops in that path.
+                          endEditJourney(moduleId);
+                          if (!panel) {
+                              return;
+                          }
+                          if (
+                              activeInteractiveStreams.has(previewId) &&
+                              logFilter.shouldEmitVerbose()
+                          ) {
+                              logLine(
+                                  `[interactive] frame ${previewId} bytes=${imageBase64.length}`,
+                              );
+                          }
+                          // Capture index 0 — the daemon's v1 renderFinished targets the
+                          // representative capture only. Multi-capture (animated) renders
+                          // still come through the Gradle path; the daemon's predictive
+                          // pre-warm focuses on the cheap interactive loop.
+                          panel.postMessage({
+                              command: "updateImage",
+                              previewId,
+                              captureIndex: 0,
+                              imageData: imageBase64,
+                          });
+                      },
+                      onRenderFailed: (_moduleId, previewId, message) => {
+                          if (!panel) {
+                              return;
+                          }
+                          panel.postMessage({
+                              command: "setImageError",
+                              previewId,
+                              captureIndex: 0,
+                              message,
+                              replaceExisting: false,
+                          });
+                      },
+                      onDataProductsAttached: (
+                          _moduleId,
                           previewId,
                           dataProducts,
-                          outputChannel,
-                      );
-                      outputChannel.appendLine(
-                          `[daemon] decoded a11y for ${previewId}: findings=${decoded?.findings?.length ?? "<none>"} nodes=${decoded?.nodes?.length ?? "<none>"}`,
-                      );
-                      if (decoded && panel) {
-                          panel.postMessage({
-                              command: "updateA11y",
-                              previewId,
-                              findings: decoded.findings ?? undefined,
-                              nodes: decoded.nodes ?? undefined,
-                          });
-                      }
-                      if (panel) {
-                          const payloads = dataProducts
-                              .map((dp) => ({
-                                  kind: dp.kind,
-                                  payload:
-                                      dp.payload ??
-                                      (isJsonDataProduct(dp)
-                                          ? readJsonPath(dp.path, outputChannel)
-                                          : isImageDataProduct(dp)
-                                            ? readBinaryDataProductPayload(
-                                                  dp,
-                                                  outputChannel,
-                                              )
-                                            : undefined),
-                              }))
-                              .filter((dp) => dp.payload !== undefined);
-                          const dropped = dataProducts.length - payloads.length;
+                      ) => {
+                          // D2 — route the data products attached to this render. For path-transport kinds
+                          // (`a11y/hierarchy`) we read the JSON off disk; inline kinds (`a11y/atf`) carry
+                          // their payload in `dp.payload`. The registry update fires `onDidChange`, which
+                          // the diagnostics provider already listens to. The panel receives a targeted
+                          // `updateA11y` post so its cached overlays repaint without re-emitting the entire
+                          // preview list.
                           outputChannel.appendLine(
-                              `[daemon] updateDataProducts post for ${previewId}: ` +
-                                  `forwarding=${payloads.length} dropped=${dropped} ` +
-                                  `kinds=[${payloads.map((p) => p.kind).join(",")}]` +
-                                  (dropped > 0
-                                      ? ` droppedKinds=[${dataProducts
-                                            .filter(
-                                                (dp) =>
-                                                    !payloads.some(
-                                                        (p) =>
-                                                            p.kind === dp.kind,
-                                                    ),
-                                            )
-                                            .map(
-                                                (dp) =>
-                                                    `${dp.kind}(path=${dp.path ?? "<none>"})`,
-                                            )
-                                            .join(",")}]`
-                                      : ""),
+                              `[daemon] onDataProductsAttached ${previewId} kinds=[${dataProducts
+                                  .map((dp) => dp.kind)
+                                  .join(
+                                      ",",
+                                  )}] panel=${panel ? "live" : "missing"} transports=[${dataProducts
+                                  .map(
+                                      (dp) =>
+                                          `${dp.kind}:${dp.payload !== undefined ? "inline" : dp.path ? "path" : "empty"}`,
+                                  )
+                                  .join(",")}]`,
                           );
-                          if (payloads.length > 0) {
+                          const decoded = applyDataProductsToRegistry(
+                              registry,
+                              previewId,
+                              dataProducts,
+                              outputChannel,
+                          );
+                          outputChannel.appendLine(
+                              `[daemon] decoded a11y for ${previewId}: findings=${decoded?.findings?.length ?? "<none>"} nodes=${decoded?.nodes?.length ?? "<none>"}`,
+                          );
+                          if (decoded && panel) {
                               panel.postMessage({
-                                  command: "updateDataProducts",
+                                  command: "updateA11y",
                                   previewId,
-                                  dataProducts: payloads,
+                                  findings: decoded.findings ?? undefined,
+                                  nodes: decoded.nodes ?? undefined,
                               });
                           }
-                      } else {
+                          if (panel) {
+                              const payloads = dataProducts
+                                  .map((dp) => ({
+                                      kind: dp.kind,
+                                      payload:
+                                          dp.payload ??
+                                          (isJsonDataProduct(dp)
+                                              ? readJsonPath(
+                                                    dp.path,
+                                                    outputChannel,
+                                                )
+                                              : isImageDataProduct(dp)
+                                                ? readBinaryDataProductPayload(
+                                                      dp,
+                                                      outputChannel,
+                                                  )
+                                                : undefined),
+                                  }))
+                                  .filter((dp) => dp.payload !== undefined);
+                              const dropped =
+                                  dataProducts.length - payloads.length;
+                              outputChannel.appendLine(
+                                  `[daemon] updateDataProducts post for ${previewId}: ` +
+                                      `forwarding=${payloads.length} dropped=${dropped} ` +
+                                      `kinds=[${payloads.map((p) => p.kind).join(",")}]` +
+                                      (dropped > 0
+                                          ? ` droppedKinds=[${dataProducts
+                                                .filter(
+                                                    (dp) =>
+                                                        !payloads.some(
+                                                            (p) =>
+                                                                p.kind ===
+                                                                dp.kind,
+                                                        ),
+                                                )
+                                                .map(
+                                                    (dp) =>
+                                                        `${dp.kind}(path=${dp.path ?? "<none>"})`,
+                                                )
+                                                .join(",")}]`
+                                          : ""),
+                              );
+                              if (payloads.length > 0) {
+                                  panel.postMessage({
+                                      command: "updateDataProducts",
+                                      previewId,
+                                      dataProducts: payloads,
+                                  });
+                              }
+                          } else {
+                              outputChannel.appendLine(
+                                  `[daemon] updateDataProducts skipped for ${previewId}: panel not yet wired`,
+                              );
+                          }
+                      },
+                      onClasspathDirty: (moduleId, detail) => {
                           outputChannel.appendLine(
-                              `[daemon] updateDataProducts skipped for ${previewId}: panel not yet wired`,
+                              `[daemon] classpath dirty for ${moduleId}: ${detail} — falling back to Gradle`,
                           );
-                      }
-                  },
-                  onClasspathDirty: (moduleId, detail) => {
-                      outputChannel.appendLine(
-                          `[daemon] classpath dirty for ${moduleId}: ${detail} — falling back to Gradle`,
-                      );
-                      clearDaemonShownPreviewWarmScopes(moduleId);
-                      // Daemon will exit on its own (PROTOCOL.md § 6); the channel-
-                      // closed handler in DaemonGate evicts the entry. Next save runs
-                      // Gradle, which re-bootstraps a fresh daemon when the user
-                      // re-enables it via composePreviewDaemonStart.
-                      // Drop the interactive-mode availability so any open LIVE chip
-                      // disables itself instead of streaming stale frames from a
-                      // soon-to-die daemon.
-                      publishInteractiveAvailability(moduleId);
-                  },
-                  onDiscoveryUpdated: (moduleId, params) => {
-                      // Daemon emits this only when the in-memory preview index drifted
-                      // (added / removed / changed against the snapshot it held before
-                      // the save). Identity-only saves are silent. Apply the diff to
-                      // the extension-side mirror used for daemon focus computation —
-                      // we deliberately don't post a "loading" or progress message;
-                      // the user already saw the new PNG arrive via `renderFinished`,
-                      // and a webview reshape is only needed when the preview set
-                      // actually changed.
-                      applyDiscoveryDiff(moduleId, params);
-                  },
-                  onHistoryAdded: (_moduleId, params) => {
-                      // Phase H7 — daemon push: a fresh render landed and was archived. History is
-                      // now focus-view-only; the live panel resolves it on demand when the user
-                      // asks for a diff from the focused preview.
-                      void params;
-                  },
-                  onHistoryPruned: (_moduleId, params) => {
-                      // Counterpart to onHistoryAdded. Same focus-view-only policy — the live
-                      // panel re-fetches on demand, so we don't push pruned IDs anywhere. Wired
-                      // to silence "ignoring unknown notification: historyPruned" in the log and
-                      // to keep the protocol surface complete if H14's cross-module timeline
-                      // resurrects in-memory history caching.
-                      void params;
-                  },
-                  onStreamFrame: (_moduleId, params) => {
-                      // `composestream/1` — daemon emitted a frame on a live stream. Look up the
-                      // owning previewId by frameStreamId; drop frames whose stream id we never
-                      // minted (idempotent on a stale stream from a previous daemon lifetime).
-                      const previewId = streamFrameIdToPreviewId.get(
-                          params.frameStreamId,
-                      );
-                      if (!previewId) {
-                          return;
-                      }
-                      if (!panel) {
-                          return;
-                      }
-                      panel.postMessage({
-                          command: "streamFrame",
-                          previewId,
-                          frameStreamId: params.frameStreamId,
-                          seq: params.seq,
-                          ptsMillis: params.ptsMillis,
-                          widthPx: params.widthPx,
-                          heightPx: params.heightPx,
-                          codec: params.codec,
-                          keyframe: params.keyframe,
-                          final: params.final,
-                          payloadBase64: params.payloadBase64,
-                      });
-                      if (params.final === true) {
-                          streamFrameIdToPreviewId.delete(params.frameStreamId);
-                          activeStreamFrameStreams.delete(previewId);
-                      }
-                  },
-                  onChannelClosed: (moduleId) => {
-                      clearDaemonShownPreviewWarmScopes(moduleId);
-                      // Daemon's stdio channel closed (process exit, classpath dirty,
-                      // spawn died). frameStreamIds don't survive a JVM restart, so
-                      // drop every entry in `activeInteractiveStreams` whose previewId
-                      // belongs to this module. Without this, a click landing after
-                      // the daemon respawned would carry a stale streamId the new
-                      // JVM never minted, and v2 dispatch would silently drop. The
-                      // extension's `previewModuleMap` still resolves correctly post-
-                      // respawn so the lookup uses today's mapping.
-                      const stale: string[] = [];
-                      for (const previewId of activeInteractiveStreams.keys()) {
-                          if (
-                              previewModuleMap.get(previewId)?.modulePath ===
-                              moduleId
-                          ) {
-                              stale.push(previewId);
+                          clearDaemonShownPreviewWarmScopes(moduleId);
+                          // Daemon will exit on its own (PROTOCOL.md § 6); the channel-
+                          // closed handler in DaemonGate evicts the entry. Next save runs
+                          // Gradle, which re-bootstraps a fresh daemon when the user
+                          // re-enables it via composePreviewDaemonStart.
+                          // Drop the interactive-mode availability so any open LIVE chip
+                          // disables itself instead of streaming stale frames from a
+                          // soon-to-die daemon.
+                          publishInteractiveAvailability(moduleId);
+                      },
+                      onDiscoveryUpdated: (moduleId, params) => {
+                          // Daemon emits this only when the in-memory preview index drifted
+                          // (added / removed / changed against the snapshot it held before
+                          // the save). Identity-only saves are silent. Apply the diff to
+                          // the extension-side mirror used for daemon focus computation —
+                          // we deliberately don't post a "loading" or progress message;
+                          // the user already saw the new PNG arrive via `renderFinished`,
+                          // and a webview reshape is only needed when the preview set
+                          // actually changed.
+                          applyDiscoveryDiff(moduleId, params);
+                      },
+                      onHistoryAdded: (_moduleId, params) => {
+                          // Phase H7 — daemon push: a fresh render landed and was archived. History is
+                          // now focus-view-only; the live panel resolves it on demand when the user
+                          // asks for a diff from the focused preview.
+                          void params;
+                      },
+                      onHistoryPruned: (_moduleId, params) => {
+                          // Counterpart to onHistoryAdded. Same focus-view-only policy — the live
+                          // panel re-fetches on demand, so we don't push pruned IDs anywhere. Wired
+                          // to silence "ignoring unknown notification: historyPruned" in the log and
+                          // to keep the protocol surface complete if H14's cross-module timeline
+                          // resurrects in-memory history caching.
+                          void params;
+                      },
+                      onStreamFrame: (_moduleId, params) => {
+                          // `composestream/1` — daemon emitted a frame on a live stream. Look up the
+                          // owning previewId by frameStreamId; drop frames whose stream id we never
+                          // minted (idempotent on a stale stream from a previous daemon lifetime).
+                          const previewId = streamFrameIdToPreviewId.get(
+                              params.frameStreamId,
+                          );
+                          if (!previewId) {
+                              return;
                           }
-                      }
-                      for (const previewId of stale) {
-                          activeInteractiveStreams.delete(previewId);
-                      }
-                      // Same hygiene for `composestream/1` streams — frameStreamIds don't survive
-                      // a daemon respawn either, so a `requestStreamStop` against a stale id would
-                      // be a wasted notification at best, mis-routed at worst.
-                      for (const previewId of [
-                          ...activeStreamFrameStreams.keys(),
-                      ]) {
-                          if (
-                              previewModuleMap.get(previewId)?.modulePath !==
-                              moduleId
-                          ) {
-                              continue;
+                          if (!panel) {
+                              return;
                           }
-                          const sid = activeStreamFrameStreams.get(previewId);
-                          activeStreamFrameStreams.delete(previewId);
-                          if (sid) streamFrameIdToPreviewId.delete(sid);
-                          panel?.postMessage({
-                              command: "streamStopped",
+                          panel.postMessage({
+                              command: "streamFrame",
                               previewId,
+                              frameStreamId: params.frameStreamId,
+                              seq: params.seq,
+                              ptsMillis: params.ptsMillis,
+                              widthPx: params.widthPx,
+                              heightPx: params.heightPx,
+                              codec: params.codec,
+                              keyframe: params.keyframe,
+                              final: params.final,
+                              payloadBase64: params.payloadBase64,
                           });
-                      }
-                      for (const previewId of [
-                          ...activeRecordingSessions.keys(),
-                      ]) {
-                          if (
-                              previewModuleMap.get(previewId)?.modulePath ===
-                              moduleId
-                          ) {
-                              activeRecordingSessions.delete(previewId);
-                              activeRecordingFormats.delete(previewId);
+                          if (params.final === true) {
+                              streamFrameIdToPreviewId.delete(
+                                  params.frameStreamId,
+                              );
+                              activeStreamFrameStreams.delete(previewId);
+                          }
+                      },
+                      onChannelClosed: (moduleId) => {
+                          clearDaemonShownPreviewWarmScopes(moduleId);
+                          // Daemon's stdio channel closed (process exit, classpath dirty,
+                          // spawn died). frameStreamIds don't survive a JVM restart, so
+                          // drop every entry in `activeInteractiveStreams` whose previewId
+                          // belongs to this module. Without this, a click landing after
+                          // the daemon respawned would carry a stale streamId the new
+                          // JVM never minted, and v2 dispatch would silently drop. The
+                          // extension's `previewModuleMap` still resolves correctly post-
+                          // respawn so the lookup uses today's mapping.
+                          const stale: string[] = [];
+                          for (const previewId of activeInteractiveStreams.keys()) {
+                              if (
+                                  previewModuleMap.get(previewId)
+                                      ?.modulePath === moduleId
+                              ) {
+                                  stale.push(previewId);
+                              }
+                          }
+                          for (const previewId of stale) {
+                              activeInteractiveStreams.delete(previewId);
+                          }
+                          // Same hygiene for `composestream/1` streams — frameStreamIds don't survive
+                          // a daemon respawn either, so a `requestStreamStop` against a stale id would
+                          // be a wasted notification at best, mis-routed at worst.
+                          for (const previewId of [
+                              ...activeStreamFrameStreams.keys(),
+                          ]) {
+                              if (
+                                  previewModuleMap.get(previewId)
+                                      ?.modulePath !== moduleId
+                              ) {
+                                  continue;
+                              }
+                              const sid =
+                                  activeStreamFrameStreams.get(previewId);
+                              activeStreamFrameStreams.delete(previewId);
+                              if (sid) streamFrameIdToPreviewId.delete(sid);
                               panel?.postMessage({
-                                  command: "clearRecording",
+                                  command: "streamStopped",
                                   previewId,
                               });
                           }
-                      }
-                      updateInteractiveStatus();
-                      if (stale.length > 0) {
-                          logLine(
-                              `[interactive] daemon channel closed for ${moduleId}; ` +
-                                  `dropped ${stale.length} stale stream(s): ${stale.join(", ")}`,
-                          );
-                      }
+                          for (const previewId of [
+                              ...activeRecordingSessions.keys(),
+                          ]) {
+                              if (
+                                  previewModuleMap.get(previewId)
+                                      ?.modulePath === moduleId
+                              ) {
+                                  activeRecordingSessions.delete(previewId);
+                                  activeRecordingFormats.delete(previewId);
+                                  panel?.postMessage({
+                                      command: "clearRecording",
+                                      previewId,
+                                  });
+                              }
+                          }
+                          updateInteractiveStatus();
+                          if (stale.length > 0) {
+                              logLine(
+                                  `[interactive] daemon channel closed for ${moduleId}; ` +
+                                      `dropped ${stale.length} stale stream(s): ${stale.join(", ")}`,
+                              );
+                          }
+                      },
                   },
-              },
-              outputChannel,
-          );
+                  outputChannel,
+              );
+    };
+    wireBackend(initialMode.mode);
 
     // Status-bar slot for daemon lifecycle. Hidden when the daemon flag is
     // off or no module is currently warming. Surfacing the cold-bootstrap
@@ -1013,6 +1043,7 @@ export async function activate(
         () => autoEnableCheapEnabled(),
         () => collapseVariantsEnabled(),
         () => inMinimalMode(),
+        () => autoInjectEnabled(),
     );
     if (isTestMode) {
         // Tap into every outgoing webview message so the test API can assert
@@ -1307,10 +1338,15 @@ export async function activate(
     //
     // The same bootstrap is the trigger for the post-sync mode re-evaluation:
     // text-scan fallbacks miss version-catalog aliases / convention-plugin
-    // setups, so a workspace can boot into minimal mode and only learn that
-    // the plugin *is* applied once Gradle writes its markers. When that
-    // happens (and the user hasn't pinned the setting), prompt for a reload
-    // to flip into full mode.
+    // setups, AND the bundled auto-inject init script applies the plugin to
+    // Android/Compose hosts that never literally `id(...)` it themselves. In
+    // both cases the workspace can boot into minimal mode and only learn that
+    // the plugin *is* applied once Gradle writes its `applied.json` markers.
+    // When that happens (and the user hasn't pinned the setting), swap the
+    // backend in place — the daemon is spawned lazily, so re-wiring the gate
+    // and scheduler is enough; no window reload is needed. Re-wiring happens
+    // before the panel sees its first preview request, which keeps the swap
+    // invisible to the user in the typical case.
     void gradleService
         .bootstrapAppliedMarkers((err) => {
             if (err instanceof ClassVersionError) {
@@ -1319,7 +1355,7 @@ export async function activate(
                 showJdkImageRemediation(err);
             }
         })
-        .then(() => {
+        .then(async () => {
             if (!gradleService) {
                 return;
             }
@@ -1330,27 +1366,28 @@ export async function activate(
             ) {
                 return;
             }
-            // Activation guessed minimal, but markers now show a plugin is
-            // applied — offer to reload for full mode. The opposite swing
-            // (full → minimal post-sync) shouldn't happen because the
-            // signals are monotonic: `findPreviewModules()` only grows
-            // entries after a bootstrap, never loses them.
+            // Activation guessed minimal, but markers now show a plugin
+            // is applied. The opposite swing (full → minimal post-sync)
+            // can't happen because the signals are monotonic:
+            // `findPreviewModules()` only grows entries after a
+            // bootstrap, never loses them.
             outputChannel.appendLine(
-                `[startup] mode re-eval after bootstrap: ${initialMode.mode} → ${post.mode} (${post.reason}); offering reload`,
+                `[startup] mode re-eval after bootstrap: ${initialMode.mode} → ${post.mode} (${post.reason}); re-wiring backend in place`,
             );
-            const RELOAD = "Reload to enable full mode";
-            void vscode.window
-                .showInformationMessage(
-                    "Compose Preview detected the plugin is applied. Reload the window to switch from minimal to full mode (daemon, data extensions, live previews).",
-                    RELOAD,
-                )
-                .then((action) => {
-                    if (action === RELOAD) {
-                        void vscode.commands.executeCommand(
-                            "workbench.action.reloadWindow",
-                        );
-                    }
-                });
+            const previousGate = daemonGate;
+            wireBackend(post.mode);
+            // Tell the panel (if already open) to drop the minimal-mode
+            // banner and re-render the full-mode chrome. The apply-plugin
+            // link disappears with the banner.
+            panel?.postMessage({
+                command: "setMinimalMode",
+                minimal: post.mode === "minimal",
+            });
+            // Dispose the old gate after the swap so any in-flight gate
+            // calls finish against their original instance. The
+            // gradle-only gate's dispose is a no-op; the reverse
+            // direction is unreachable per the monotonicity argument.
+            await previousGate?.dispose();
         });
 
     context.subscriptions.push(
@@ -1512,7 +1549,7 @@ export async function activate(
             // `setLoading` / `markAllLoading` / `clearAll` — those would
             // replace the existing render with a placeholder; the panel
             // should keep the last-good image until the user clicks Refresh.
-            if (minimal) {
+            if (inMinimalMode()) {
                 firstSaveSeen.add(doc.uri.fsPath);
                 panel?.postMessage({ command: "minimalSavePending" });
                 return;
@@ -1556,7 +1593,7 @@ export async function activate(
     // build completed. In minimal mode every render is manual, so the watcher
     // never enqueues a refresh.
     const onWatcherEvent = (uri: vscode.Uri) => {
-        if (minimal) {
+        if (inMinimalMode()) {
             return;
         }
         if (isSourceFile(uri.fsPath)) {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -11,6 +11,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     private autoEnableCheapEnabled: () => boolean;
     private collapseVariantsEnabled: () => boolean;
     private minimalModeEnabled: () => boolean;
+    private autoInjectEnabled: () => boolean;
     private shouldRestoreVisibility: () => boolean;
 
     constructor(
@@ -21,6 +22,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         autoEnableCheapEnabled: () => boolean = () => false,
         collapseVariantsEnabled: () => boolean = () => true,
         minimalModeEnabled: () => boolean = () => false,
+        autoInjectEnabled: () => boolean = () => true,
     ) {
         this.extensionUri = extensionUri;
         this.onMessage = onMessage;
@@ -28,6 +30,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         this.autoEnableCheapEnabled = autoEnableCheapEnabled;
         this.collapseVariantsEnabled = collapseVariantsEnabled;
         this.minimalModeEnabled = minimalModeEnabled;
+        this.autoInjectEnabled = autoInjectEnabled;
         this.shouldRestoreVisibility = shouldRestoreVisibility;
     }
 
@@ -63,6 +66,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const autoEnableCheapEnabled = this.autoEnableCheapEnabled();
         const collapseVariantsEnabled = this.collapseVariantsEnabled();
         const minimalModeEnabled = this.minimalModeEnabled();
+        const autoInjectEnabled = this.autoInjectEnabled();
         const styleUri = webview.asWebviewUri(
             vscode.Uri.joinPath(this.extensionUri, "media", "preview.css"),
         );
@@ -94,6 +98,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         data-auto-enable-cheap="${autoEnableCheapEnabled ? "true" : "false"}"
         data-collapse-variants="${collapseVariantsEnabled ? "true" : "false"}"
         data-minimal-mode="${minimalModeEnabled ? "true" : "false"}"
+        data-auto-inject="${autoInjectEnabled ? "true" : "false"}"
     ></preview-app>
     <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>

--- a/vscode-extension/src/test/modeResolver.test.ts
+++ b/vscode-extension/src/test/modeResolver.test.ts
@@ -55,11 +55,11 @@ describe("resolveModeFromSettings", () => {
         it("picks minimal mode when the plugin is not applied, even if an Android / Compose host is present", () => {
             // Auto-inject onto a host plugin doesn't preemptively flip to full
             // mode: the plugin is only applied once Gradle runs the bundled
-            // init script and writes `applied.json` markers. Spawning the
-            // daemon before that would fail (no `daemon-launch.json` yet) —
-            // the post-Gradle-sync re-evaluation handles the upgrade via a
-            // one-click reload notification once markers prove the plugin is
-            // applied.
+            // init script and writes `applied.json` markers. The
+            // post-Gradle-sync re-evaluation in `extension.ts` handles the
+            // upgrade by re-wiring the daemon backend in place once markers
+            // prove the plugin is applied — no window reload, and the panel
+            // webview drops its minimal banner via `setMinimalMode`.
             const result = resolveModeFromSettings(
                 { mode: "auto" },
                 gradleStub({}),

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -480,6 +480,15 @@ export type ExtensionToWebview =
      *  without waiting for a refresh to complete. */
     | { command: "minimalSavePendingClear" }
     /**
+     * Switch the panel between minimal-mode chrome (the manual-refresh banner)
+     * and full-mode chrome at runtime. Posted by the post-Gradle-sync mode
+     * re-evaluation when the bundled auto-inject init script reveals that the
+     * workspace is full-mode-eligible after all — the extension re-wires the
+     * daemon backend in place, and this message tells the webview to drop the
+     * minimal banner so the user doesn't have to reload the window.
+     */
+    | { command: "setMinimalMode"; minimal: boolean }
+    /**
      * Drives the slim progress bar at the top of the panel. `percent` is
      * monotonic within a refresh and clamped to [0, 1]; `label` is the
      * user-facing phase name ("Compiling Kotlin", "Rendering previews"…).

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -186,6 +186,12 @@ export class PreviewApp extends LitElement {
 
     protected render(): TemplateResult {
         const minimal = this.dataset.minimalMode === "true";
+        // When the bundled auto-inject init script handles the plugin, the
+        // "Apply plugin to project" link is misleading: the extension already
+        // applies it on every Gradle run, and the button's only effect is to
+        // open the build script. Hide it in that case so users aren't nudged
+        // toward an edit they don't need to make.
+        const autoInject = this.dataset.autoInject !== "false";
         return html`
             <progress-bar></progress-bar>
             <compile-errors-banner></compile-errors-banner>
@@ -230,15 +236,19 @@ export class PreviewApp extends LitElement {
                                   ></i>
                                   <span>Refresh previews</span>
                               </button>
-                              <button
-                                  type="button"
-                                  id="btn-minimal-apply-plugin"
-                                  class="minimal-apply-link"
-                                  title="Open this module's build script to apply the Compose Preview plugin"
-                                  aria-label="Apply Compose Preview plugin to project"
-                              >
-                                  Apply plugin to project
-                              </button>
+                              ${autoInject
+                                  ? ""
+                                  : html`
+                                        <button
+                                            type="button"
+                                            id="btn-minimal-apply-plugin"
+                                            class="minimal-apply-link"
+                                            title="Open this module's build script to apply the Compose Preview plugin"
+                                            aria-label="Apply Compose Preview plugin to project"
+                                        >
+                                            Apply plugin to project
+                                        </button>
+                                    `}
                           </div>
                       </div>
                   `
@@ -394,6 +404,21 @@ export class PreviewApp extends LitElement {
             this.dataset.collapseVariants !== "false";
         const minimalMode = this.dataset.minimalMode === "true";
         const vscode = getVsCodeApi<PersistedState>();
+        // Listen for runtime mode flips from the extension (post-Gradle-sync
+        // re-evaluation that upgrades minimal -> full once `applied.json`
+        // markers prove the plugin is applied). Flip the dataset attribute and
+        // request a Lit re-render so the minimal banner disappears without a
+        // window reload. The other direction is unreachable per the
+        // monotonicity argument in `extension.ts`.
+        window.addEventListener("message", (event: MessageEvent) => {
+            const data = event.data as { command?: string; minimal?: boolean };
+            if (data?.command !== "setMinimalMode") return;
+            const next = data.minimal === true ? "true" : "false";
+            if (this.dataset.minimalMode !== next) {
+                this.dataset.minimalMode = next;
+                this.requestUpdate();
+            }
+        });
         if (minimalMode) {
             // Minimal mode hides the extension chrome (bundle chip bar +
             // data tabs) since data extensions are disabled — see CSS rule.

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -278,6 +278,7 @@ export function handleExtensionMessage(
         case "clearCompileErrors":
         case "minimalSavePending":
         case "minimalSavePendingClear":
+        case "setMinimalMode":
             // Handled directly by Lit components (`<message-banner>`,
             // `<progress-bar>`, `<compile-errors-banner>`,
             // `<preview-app>`'s minimal-mode banner) — they listen on


### PR DESCRIPTION
## Summary

The auto-inject init script applies `ee.schimke.composeai.preview` to Android / Compose hosts on every Gradle invocation, so on a fresh-open workspace the activation-time text scan picks minimal mode, the bootstrap run writes the `applied.json` markers, and the post-sync re-eval flips to full — every single open. Today that flip is gated behind a "Reload to enable full mode" prompt, which the user has to accept on every workspace open (and again after any `gradle clean` that wipes the markers).

- Re-wire the daemon gate + scheduler in place after the bootstrap re-eval, instead of prompting for a window reload. The daemon is spawned lazily on first preview request, so building a new `LiveDaemonGate` / `LiveDaemonScheduler` after the bootstrap completes is enough.
- New `setMinimalMode` webview message tells the panel (if already open) to drop the minimal banner and re-render the full-mode chrome via Lit's `requestUpdate()`.
- Hide the "Apply plugin to project" link in the minimal banner when auto-inject is enabled — it opens the build script but doesn't insert anything, which is misleading when the extension is already applying the plugin.

## Test plan

- [x] `npm run compile` (host + webview typecheck) clean
- [x] `npm run format:check` clean
- [x] `npm test` — 915 mocha tests pass
- [ ] Manual: open a fresh Android workspace with `composePreview.mode=auto` and `autoInject.enabled=true` — confirm the panel comes up in minimal mode, then silently switches to full after the bootstrap run with no reload prompt
- [ ] Manual: with `autoInject.enabled=false`, confirm the minimal banner still shows the "Apply plugin to project" link and the existing reload-less upgrade path still works for build-script-applied workspaces
- [ ] Manual: open a non-Compose workspace and confirm it stays in minimal mode (no spurious upgrade)
- [ ] `npm run test:electron` (needs network for VS Code download — not runnable in this sandbox)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCuJA8k2jCQiqbKJr98eHv)_