### PR TITLE
feat(vscode-extension): typed event bus for webview CustomEvents

### DIFF
--- a/vscode-extension/src/test/eventBusContract.test.ts
+++ b/vscode-extension/src/test/eventBusContract.test.ts
@@ -5,10 +5,9 @@
 // webview source tree and asserts that for every `emit("name", …)`
 // callsite there is at least one matching `on("name", …)` callsite.
 // Catches the "producer ships, consumer never wired" regression
-// class that prompted the bus (#1118-ish): the two sides live in
-// files that don't import each other and each have their own green
-// unit tests, so type checking + per-component tests can't see the
-// gap.
+// class that prompted the bus: the two sides live in files that
+// don't import each other and each have their own green unit tests,
+// so type checking + per-component tests can't see the gap.
 //
 // The check is intentionally static (file scan, no runtime mount):
 //
@@ -30,37 +29,166 @@ import { globSync } from "glob";
 
 // `__dirname` resolves to `out/test` at runtime since tests run from
 // compiled JS, but the contract scans `.ts` source files — walk up to
-// the extension root and into `src/webview` so the regex sees the
+// the extension root and into `src/webview` so the scanner sees the
 // authored callsites, not the emitted JS (which loses `as` casts and
 // changes some shapes).
 const EXTENSION_ROOT = path.resolve(__dirname, "..", "..");
 const WEBVIEW_ROOT = path.join(EXTENSION_ROOT, "src", "webview");
 const EVENT_BUS_FILE = path.join(WEBVIEW_ROOT, "shared", "eventBus.ts");
 
-// Match `emit(target, "name", …)` and `on(target, "name", …)` where
-// the name is a string literal. The first arg can be any expression;
-// we don't care what target the event is dispatched on. Multi-line
-// args are fine — the regex only needs the leading `emit(` / `on(`
-// followed by anything up to the first quoted literal that ends in
-// `,`. Restricting the second arg to `[^,]*` would break for cases
-// like `emit(target, "name", …)` with detail objects on the same
-// line; here we just locate the quoted literal directly.
-// Negative lookbehind rejects `foo.emit(...)` / `foo.on(...)` style
-// method calls so the contract only counts bare `emit` / `on` imports
-// from the bus.
-const EMIT_RE = /(?<![.\w])emit\s*\([^)]*?["']([\w-]+)["']/g;
-const ON_RE = /(?<![.\w])on\s*\([^)]*?["']([\w-]+)["']/g;
+/**
+ * Locate every `<fnName>(…, "<event-name>", …)` call in [source]
+ * and return the event names. Walks balanced parens and string
+ * literals so callsites whose first argument contains expressions
+ * — `emit(currentBundleTarget(), "kind-toggled", detail)`,
+ * `on(getName("x"), "name", …)`, multi-line argument lists —
+ * are matched correctly. A regex with `[^)]*?` between the open
+ * paren and the event-name literal stops at the first `)`, which
+ * silently skips those valid callsites; the parser below treats
+ * parens / strings / template literals as real tokens.
+ *
+ * The matching rule:
+ *
+ *   1. Find an occurrence of `<fnName>(` not preceded by a word
+ *      character or `.` (so `addon(` and `bus.on(` don't match
+ *      `on(`, and likewise for `emit`).
+ *   2. From inside the paren, skip the first argument by walking
+ *      until a comma at depth 0, treating `(){}[]"'`/template
+ *      strings as balanced groups.
+ *   3. Skip whitespace; expect a string literal next; record the
+ *      literal as the event name. Anything else means the call
+ *      doesn't match the bus shape, so skip it.
+ */
+export function scanCallsites(source: string, fnName: string): string[] {
+    const names: string[] = [];
+    const headerRe = new RegExp(`(?<![.\\w])${fnName}\\s*\\(`, "g");
+    let m: RegExpExecArray | null;
+    while ((m = headerRe.exec(source)) !== null) {
+        const afterOpen = m.index + m[0].length;
+        const commaAt = findFirstCommaAtDepth0(source, afterOpen);
+        if (commaAt === -1) continue;
+        const nameStart = skipWhitespace(source, commaAt + 1);
+        const name = readStringLiteral(source, nameStart);
+        if (name === null) continue;
+        if (!/^[\w-]+$/.test(name)) continue;
+        names.push(name);
+    }
+    return names;
+}
 
-function scan(files: readonly string[], re: RegExp): Map<string, string[]> {
+/**
+ * Scan from [start] (just inside the open paren) until we hit a
+ * `,` at the same nesting depth as where we started. Returns the
+ * index of that comma, or -1 if the call has only one argument
+ * (close paren reached first). Treats nested parens, brackets,
+ * braces, single / double / backtick strings as balanced groups
+ * so commas inside them don't terminate the scan.
+ *
+ * Template-string `${…}` interpolations would technically need
+ * recursive balancing, but bus callsites don't put templates in
+ * the first argument; if that ever changes, extend the inner
+ * skip to recurse into `${`.
+ */
+function findFirstCommaAtDepth0(source: string, start: number): number {
+    let depth = 0;
+    let i = start;
+    while (i < source.length) {
+        const c = source[i];
+        if (c === '"' || c === "'" || c === "`") {
+            i = skipStringLiteral(source, i);
+            continue;
+        }
+        if (c === "/" && source[i + 1] === "/") {
+            // Line comment — skip to newline so a `,` inside a
+            // comment doesn't fool us.
+            const nl = source.indexOf("\n", i);
+            i = nl === -1 ? source.length : nl + 1;
+            continue;
+        }
+        if (c === "/" && source[i + 1] === "*") {
+            const end = source.indexOf("*/", i + 2);
+            i = end === -1 ? source.length : end + 2;
+            continue;
+        }
+        if (c === "(" || c === "[" || c === "{") {
+            depth++;
+        } else if (c === ")" || c === "]" || c === "}") {
+            if (depth === 0) return -1;
+            depth--;
+        } else if (c === "," && depth === 0) {
+            return i;
+        }
+        i++;
+    }
+    return -1;
+}
+
+/**
+ * Walk past a string literal that begins at [i] (the index of the
+ * opening quote). Returns the index just after the closing quote.
+ * Handles backslash escapes; does not recurse into `${…}` because
+ * bus callsites don't put template interpolations in the first
+ * argument.
+ */
+function skipStringLiteral(source: string, i: number): number {
+    const quote = source[i];
+    let j = i + 1;
+    while (j < source.length) {
+        const c = source[j];
+        if (c === "\\") {
+            j += 2;
+            continue;
+        }
+        if (c === quote) return j + 1;
+        j++;
+    }
+    return source.length;
+}
+
+function skipWhitespace(source: string, i: number): number {
+    while (i < source.length && /\s/.test(source[i])) i++;
+    return i;
+}
+
+/**
+ * Read a string literal starting at [i] (the index of the opening
+ * quote). Returns the content between the quotes, or `null` if
+ * [i] isn't pointed at a quote. Only handles plain `"…"` and
+ * `'…'` — backtick template strings are excluded because event
+ * names are required to be plain string literals (the typed
+ * `WebviewEventMap` keys can't be template-interpolated anyway).
+ */
+function readStringLiteral(source: string, i: number): string | null {
+    const quote = source[i];
+    if (quote !== '"' && quote !== "'") return null;
+    let j = i + 1;
+    const out: string[] = [];
+    while (j < source.length) {
+        const c = source[j];
+        if (c === "\\") {
+            // Don't bother decoding escapes — event names use
+            // word characters and `-` only, so a `\` in the
+            // literal makes it not a valid event name and the
+            // caller's regex check rejects it.
+            out.push(c, source[j + 1] ?? "");
+            j += 2;
+            continue;
+        }
+        if (c === quote) return out.join("");
+        out.push(c);
+        j++;
+    }
+    return null;
+}
+
+function scanFiles(
+    files: readonly string[],
+    fnName: string,
+): Map<string, string[]> {
     const found = new Map<string, string[]>();
     for (const f of files) {
         const src = fs.readFileSync(f, "utf8");
-        // Reset the lastIndex on each file since we're reusing the
-        // global regex object across iterations.
-        const localRe = new RegExp(re.source, re.flags);
-        let m: RegExpExecArray | null;
-        while ((m = localRe.exec(src)) !== null) {
-            const name = m[1];
+        for (const name of scanCallsites(src, fnName)) {
             const sites = found.get(name) ?? [];
             sites.push(path.relative(WEBVIEW_ROOT, f));
             found.set(name, sites);
@@ -84,8 +212,8 @@ describe("event bus contract", () => {
     });
 
     it("every emit() name has at least one matching on() listener", () => {
-        const emitted = scan(files, EMIT_RE);
-        const consumed = scan(files, ON_RE);
+        const emitted = scanFiles(files, "emit");
+        const consumed = scanFiles(files, "on");
         const orphans: string[] = [];
         for (const [name, sites] of emitted) {
             if (!consumed.has(name)) {
@@ -106,8 +234,8 @@ describe("event bus contract", () => {
     });
 
     it("every on() name has at least one matching emit() producer", () => {
-        const emitted = scan(files, EMIT_RE);
-        const consumed = scan(files, ON_RE);
+        const emitted = scanFiles(files, "emit");
+        const consumed = scanFiles(files, "on");
         const dead: string[] = [];
         for (const [name, sites] of consumed) {
             if (!emitted.has(name)) {
@@ -124,5 +252,91 @@ describe("event bus contract", () => {
                 `producer in src/webview. Either remove the listener or wire ` +
                 `up the missing producer.`,
         );
+    });
+
+    // Scanner self-tests. Each fixture exercises a shape the old
+    // regex (`[^)]*?` between header and event name) silently
+    // skipped, so a regression to that pattern fails here loudly
+    // before falling out as a false-negative orphan check.
+    describe("scanCallsites", () => {
+        it("matches the baseline shape", () => {
+            assert.deepStrictEqual(
+                scanCallsites(`emit(target, "kind-toggled", det);`, "emit"),
+                ["kind-toggled"],
+            );
+        });
+
+        it("matches when the first argument contains a call expression", () => {
+            assert.deepStrictEqual(
+                scanCallsites(
+                    `emit(currentBundleTarget(), "kind-toggled", det);`,
+                    "emit",
+                ),
+                ["kind-toggled"],
+            );
+        });
+
+        it("matches when the first argument has nested parens", () => {
+            assert.deepStrictEqual(
+                scanCallsites(
+                    `emit(scope.lookup(getId(card)), "tab-selected", { id });`,
+                    "emit",
+                ),
+                ["tab-selected"],
+            );
+        });
+
+        it("does not pick a string inside the first argument", () => {
+            // `getName("inner")` should be skipped; the event name
+            // is the literal at the second-argument position.
+            assert.deepStrictEqual(
+                scanCallsites(
+                    `emit(getName("inner"), "outer-event", det);`,
+                    "emit",
+                ),
+                ["outer-event"],
+            );
+        });
+
+        it("handles multi-line argument lists", () => {
+            const src = [
+                "emit(",
+                "    target,",
+                '    "kind-toggled",',
+                "    {",
+                "        bundleId,",
+                "        kind,",
+                "        enabled: true,",
+                "    },",
+                ");",
+            ].join("\n");
+            assert.deepStrictEqual(scanCallsites(src, "emit"), [
+                "kind-toggled",
+            ]);
+        });
+
+        it("rejects method-call shapes like foo.emit(...)", () => {
+            assert.deepStrictEqual(
+                scanCallsites(`bus.emit(target, "ghost", det);`, "emit"),
+                [],
+            );
+        });
+
+        it("rejects word-extended names like addon(...) for fnName 'on'", () => {
+            assert.deepStrictEqual(
+                scanCallsites(`addon(target, "ghost", h);`, "on"),
+                [],
+            );
+        });
+
+        it("matches on() with parens in the first argument", () => {
+            assert.deepStrictEqual(
+                scanCallsites(
+                    `on(document.querySelector("input"), "kind-toggled", h);`,
+                    "on",
+                ),
+                ["kind-toggled"],
+            );
+        });
     });
 });

--- a/vscode-extension/src/test/eventBusContract.test.ts
+++ b/vscode-extension/src/test/eventBusContract.test.ts
@@ -1,0 +1,128 @@
+// Contract test for `webview/shared/eventBus`.
+//
+// The bus replaces raw `dispatchEvent`/`addEventListener` for app
+// events with typed `emit` / `on` wrappers. This test reads the
+// webview source tree and asserts that for every `emit("name", …)`
+// callsite there is at least one matching `on("name", …)` callsite.
+// Catches the "producer ships, consumer never wired" regression
+// class that prompted the bus (#1118-ish): the two sides live in
+// files that don't import each other and each have their own green
+// unit tests, so type checking + per-component tests can't see the
+// gap.
+//
+// The check is intentionally static (file scan, no runtime mount):
+//
+//   - It runs in milliseconds and needs no DOM bootstrap.
+//   - It exercises the source tree as written, not what happens to
+//     execute in `firstUpdated`, so dead-code listeners attached
+//     behind a feature flag are still treated as wired.
+//
+// The trade-off is that the test only checks events flowing through
+// `emit`/`on`. Pre-existing `new CustomEvent("foo", …)` callsites are
+// invisible to it; migrating them one-at-a-time onto the bus is the
+// follow-up work. The point of this PR is to make the contract
+// available so the next event added doesn't repeat the regression.
+
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import { globSync } from "glob";
+
+// `__dirname` resolves to `out/test` at runtime since tests run from
+// compiled JS, but the contract scans `.ts` source files — walk up to
+// the extension root and into `src/webview` so the regex sees the
+// authored callsites, not the emitted JS (which loses `as` casts and
+// changes some shapes).
+const EXTENSION_ROOT = path.resolve(__dirname, "..", "..");
+const WEBVIEW_ROOT = path.join(EXTENSION_ROOT, "src", "webview");
+const EVENT_BUS_FILE = path.join(WEBVIEW_ROOT, "shared", "eventBus.ts");
+
+// Match `emit(target, "name", …)` and `on(target, "name", …)` where
+// the name is a string literal. The first arg can be any expression;
+// we don't care what target the event is dispatched on. Multi-line
+// args are fine — the regex only needs the leading `emit(` / `on(`
+// followed by anything up to the first quoted literal that ends in
+// `,`. Restricting the second arg to `[^,]*` would break for cases
+// like `emit(target, "name", …)` with detail objects on the same
+// line; here we just locate the quoted literal directly.
+// Negative lookbehind rejects `foo.emit(...)` / `foo.on(...)` style
+// method calls so the contract only counts bare `emit` / `on` imports
+// from the bus.
+const EMIT_RE = /(?<![.\w])emit\s*\([^)]*?["']([\w-]+)["']/g;
+const ON_RE = /(?<![.\w])on\s*\([^)]*?["']([\w-]+)["']/g;
+
+function scan(files: readonly string[], re: RegExp): Map<string, string[]> {
+    const found = new Map<string, string[]>();
+    for (const f of files) {
+        const src = fs.readFileSync(f, "utf8");
+        // Reset the lastIndex on each file since we're reusing the
+        // global regex object across iterations.
+        const localRe = new RegExp(re.source, re.flags);
+        let m: RegExpExecArray | null;
+        while ((m = localRe.exec(src)) !== null) {
+            const name = m[1];
+            const sites = found.get(name) ?? [];
+            sites.push(path.relative(WEBVIEW_ROOT, f));
+            found.set(name, sites);
+        }
+    }
+    return found;
+}
+
+describe("event bus contract", () => {
+    const files = globSync("**/*.ts", {
+        cwd: WEBVIEW_ROOT,
+        absolute: true,
+        ignore: ["**/*.test.ts"],
+    }).filter((f) => f !== EVENT_BUS_FILE);
+
+    it("scans webview source files", () => {
+        assert.ok(
+            files.length > 0,
+            `expected to scan webview .ts files under ${WEBVIEW_ROOT}`,
+        );
+    });
+
+    it("every emit() name has at least one matching on() listener", () => {
+        const emitted = scan(files, EMIT_RE);
+        const consumed = scan(files, ON_RE);
+        const orphans: string[] = [];
+        for (const [name, sites] of emitted) {
+            if (!consumed.has(name)) {
+                orphans.push(
+                    `  - "${name}" emitted by ${sites.join(", ")} has no on() listener`,
+                );
+            }
+        }
+        assert.strictEqual(
+            orphans.length,
+            0,
+            `Orphan events found:\n${orphans.join("\n")}\n` +
+                `Each emit() callsite must have at least one matching on() ` +
+                `listener somewhere in src/webview. Add the listener or, if ` +
+                `the event is intentionally fire-and-forget, drop the emit ` +
+                `call and the WebviewEventMap entry.`,
+        );
+    });
+
+    it("every on() name has at least one matching emit() producer", () => {
+        const emitted = scan(files, EMIT_RE);
+        const consumed = scan(files, ON_RE);
+        const dead: string[] = [];
+        for (const [name, sites] of consumed) {
+            if (!emitted.has(name)) {
+                dead.push(
+                    `  - "${name}" listened on by ${sites.join(", ")} but no emit() producer`,
+                );
+            }
+        }
+        assert.strictEqual(
+            dead.length,
+            0,
+            `Dead listeners found:\n${dead.join("\n")}\n` +
+                `Each on() callsite must have at least one matching emit() ` +
+                `producer in src/webview. Either remove the listener or wire ` +
+                `up the missing producer.`,
+        );
+    });
+});

--- a/vscode-extension/src/webview/preview/components/BundleExpander.ts
+++ b/vscode-extension/src/webview/preview/components/BundleExpander.ts
@@ -15,6 +15,7 @@
 import { LitElement, html, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import type { BundleId, BundleKind } from "../bundleRegistry";
+import { emit } from "../../shared/eventBus";
 
 export interface BundleKindToggledDetail {
     bundleId: BundleId;
@@ -112,16 +113,10 @@ export class BundleExpander extends LitElement {
     private onCheckboxChanged(evt: Event, kind: string): void {
         if (!this.bundleId) return;
         const target = evt.target as HTMLInputElement;
-        this.dispatchEvent(
-            new CustomEvent<BundleKindToggledDetail>("kind-toggled", {
-                detail: {
-                    bundleId: this.bundleId,
-                    kind,
-                    enabled: target.checked,
-                },
-                bubbles: true,
-                composed: true,
-            }),
-        );
+        emit(this, "kind-toggled", {
+            bundleId: this.bundleId,
+            kind,
+            enabled: target.checked,
+        });
     }
 }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -50,6 +50,7 @@ import {
 import type { OverlayBox } from "./components/BoxOverlay";
 import { BundleController, type BundleSnapshot } from "./bundleController";
 import { getBundle, type BundleId } from "./bundleRegistry";
+import { on } from "../shared/eventBus";
 import { a11yTableColumns, computeA11yBundleData } from "./a11yBundlePresenter";
 import {
     computePerformanceBundleData,
@@ -763,12 +764,7 @@ export class PreviewApp extends LitElement {
             const expander = document.createElement(
                 "bundle-expander",
             ) as BundleExpander;
-            expander.addEventListener("kind-toggled", (evt) => {
-                const det = (
-                    evt as CustomEvent<
-                        import("./components/BundleExpander").BundleKindToggledDetail
-                    >
-                ).detail;
+            on(expander, "kind-toggled", (det) => {
                 bundleController.setKindEnabled(
                     det.bundleId,
                     det.kind,
@@ -818,12 +814,7 @@ export class PreviewApp extends LitElement {
             const expander = document.createElement(
                 "bundle-expander",
             ) as BundleExpander;
-            expander.addEventListener("kind-toggled", (evt) => {
-                const det = (
-                    evt as CustomEvent<
-                        import("./components/BundleExpander").BundleKindToggledDetail
-                    >
-                ).detail;
+            on(expander, "kind-toggled", (det) => {
                 bundleController.setKindEnabled(
                     det.bundleId,
                     det.kind,
@@ -871,12 +862,7 @@ export class PreviewApp extends LitElement {
             const expander = document.createElement(
                 "bundle-expander",
             ) as BundleExpander;
-            expander.addEventListener("kind-toggled", (evt) => {
-                const det = (
-                    evt as CustomEvent<
-                        import("./components/BundleExpander").BundleKindToggledDetail
-                    >
-                ).detail;
+            on(expander, "kind-toggled", (det) => {
                 bundleController.setKindEnabled(
                     det.bundleId,
                     det.kind,
@@ -1496,12 +1482,7 @@ export class PreviewApp extends LitElement {
             const expander = document.createElement(
                 "bundle-expander",
             ) as BundleExpander;
-            expander.addEventListener("kind-toggled", (evt) => {
-                const det = (
-                    evt as CustomEvent<
-                        import("./components/BundleExpander").BundleKindToggledDetail
-                    >
-                ).detail;
+            on(expander, "kind-toggled", (det) => {
                 bundleController.setKindEnabled(
                     det.bundleId,
                     det.kind,

--- a/vscode-extension/src/webview/shared/eventBus.ts
+++ b/vscode-extension/src/webview/shared/eventBus.ts
@@ -1,0 +1,86 @@
+// Typed event bus for webview CustomEvents.
+//
+// Webview components dispatch CustomEvents that the host wires up in
+// `main.ts`. The event name and detail shape are a stringly-typed
+// contract — two files that don't import each other and that each have
+// their own green unit tests can quietly drift apart (producer ships,
+// consumer never wired). The bus replaces raw `dispatchEvent`/
+// `addEventListener` for app events with a small typed wrapper around
+// `WebviewEventMap`, and a static test (`eventBusContract.test.ts`)
+// asserts every `emit("name", …)` site has at least one matching
+// `on("name", …)` site somewhere in the webview source tree.
+//
+// New events: add the name and detail type to `WebviewEventMap`. The
+// `emit`/`on` calls are then type-checked at compile time, and the
+// contract test fails if either side is missing.
+//
+// This is opt-in: pre-existing `new CustomEvent("foo", …)` /
+// `addEventListener("foo", …)` callsites are left alone; the contract
+// test only checks events that flow through `emit`/`on`. Migrate one
+// event at a time.
+
+import type { BundleKindToggledDetail } from "../preview/components/BundleExpander";
+
+/**
+ * Central registry of typed app events. Each key is the event name
+ * passed to `dispatchEvent`; each value is the `CustomEvent.detail`
+ * shape. Adding a new entry here is the only "registration" step —
+ * the static contract test reads `emit`/`on` callsites directly from
+ * source, so there is no runtime side-effect required at module load.
+ */
+export interface WebviewEventMap {
+    "kind-toggled": BundleKindToggledDetail;
+}
+
+export type WebviewEventName = keyof WebviewEventMap;
+
+interface EmitOptions {
+    /** Default `true` — matches the previous `dispatchEvent` calls. */
+    bubbles?: boolean;
+    /** Default `true` — matches the previous `dispatchEvent` calls. */
+    composed?: boolean;
+}
+
+/**
+ * Dispatch a typed `CustomEvent` on [target]. Drop-in replacement for
+ * `target.dispatchEvent(new CustomEvent(name, { detail, bubbles, composed }))`
+ * — the bubbles/composed defaults match the previous callsites so the
+ * migration is mechanical.
+ */
+export function emit<K extends WebviewEventName>(
+    target: EventTarget,
+    name: K,
+    detail: WebviewEventMap[K],
+    options: EmitOptions = {},
+): void {
+    target.dispatchEvent(
+        new CustomEvent<WebviewEventMap[K]>(name, {
+            detail,
+            bubbles: options.bubbles ?? true,
+            composed: options.composed ?? true,
+        }),
+    );
+}
+
+/**
+ * Subscribe to a typed event on [target]. The handler is invoked with
+ * the typed detail and the underlying `CustomEvent` (some callsites
+ * need `evt.target` or `evt.stopPropagation`). Returns an unsubscribe
+ * function for callers that want one; existing callsites that don't
+ * bother with teardown work unchanged.
+ */
+export function on<K extends WebviewEventName>(
+    target: EventTarget,
+    name: K,
+    handler: (
+        detail: WebviewEventMap[K],
+        evt: CustomEvent<WebviewEventMap[K]>,
+    ) => void,
+): () => void {
+    const wrapped = (evt: Event): void => {
+        const ce = evt as CustomEvent<WebviewEventMap[K]>;
+        handler(ce.detail, ce);
+    };
+    target.addEventListener(name, wrapped);
+    return () => target.removeEventListener(name, wrapped);
+}


### PR DESCRIPTION
## Summary

Adds `src/webview/shared/eventBus.ts` — typed `emit` / `on` wrappers around a central `WebviewEventMap` — plus a static contract test that scans the webview source tree and asserts every `emit("name", …)` has at least one matching `on("name", …)`.

Migrates `kind-toggled` end-to-end as the first event (BundleExpander emit, four listener sites in `main.ts`). Other CustomEvent callsites are left alone; the migration is opt-in and the next event moves over in its own PR.

## Motivation

CustomEvent names are stringly-typed contracts between two files that don't import each other. Each side gets its own green unit test, so type checking and per-component tests can't see when the producer ships and the consumer never gets wired. The orphan check makes that gap loud at PR time.

Honest scoping note: this is part 1 of 3. It catches the "producer-only" regression class. It does **not** catch today's specific data-extension-toggle bug, which is a runtime drop (`currentBundleTarget()` returning null and swallowing the post) — a wired listener with no observable effect. That class is what the smoke-test PR is for. End-to-end Playwright coverage is filed as a follow-up issue.

## Test plan

- [x] `npm test` — 915 passing locally, includes the three new contract assertions
- [x] Verified the orphan check fires by injecting a fake `emit(target, "ghost-event", …)` callsite and confirming the test fails with a useful message before reverting
- [x] `npm run compile:webview` produces a bundle the same size as before
- [x] `npm run format:check` clean
- [ ] Click through each data-extension tab's Configure expander in a packaged extension build (manual — the runtime bug is out of scope for this PR; this is a refactor + safety net)

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_