### PR TITLE
fix(daemon): route TILE-kind previews through TilePreviewComposable

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -512,6 +512,7 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
     fontScale = params.fontScale ?: defaults.fontScale,
     uiMode = uiMode,
     orientation = defaults.orientation,
+    kind = params.kind ?: defaults.kind,
   )
 }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -129,6 +129,11 @@ class PreviewManifestRouter(
       inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
       inbound["overrides"]?.let { append("overrides=").append(it).append(';') }
       inbound["mode"]?.let { append("mode=").append(it).append(';') }
+      // Manifest-resolved kind forwards through verbatim; an inbound `kind=` override (rare —
+      // currently only test fixtures emit one) wins for parity with the other override fields.
+      (inbound["kind"] ?: resolved.kind)?.takeIf { it.isNotBlank() }?.let {
+        append("kind=").append(it).append(';')
+      }
       append("outputBaseName=").append(resolved.outputBaseName)
     }
   }
@@ -171,6 +176,7 @@ private fun PreviewManifestEntry.renderSpec(): RenderSpec {
     backgroundColor = resolved.backgroundColor,
     device = resolved.device,
     outputBaseName = resolved.outputBaseName,
+    kind = resolved.kind,
   )
 }
 
@@ -215,6 +221,12 @@ data class PreviewManifestEntry(
    */
   val device: String? = null,
   val outputBaseName: String? = null,
+  /**
+   * Flat-schema sibling of [PreviewParamsEntry.kind] — see kdoc there. Harness fixtures that
+   * use the flat shape can supply this directly; the production gradle plugin writes it under
+   * `params.kind` instead. [resolved] consults the flat field first, then the nested one.
+   */
+  val kind: String? = null,
 ) {
   fun resolved(): ResolvedRenderParams {
     val p = params
@@ -224,6 +236,7 @@ data class PreviewManifestEntry(
     val showBackground = showBackground ?: p?.showBackground ?: true
     val backgroundColor = backgroundColor ?: p?.backgroundColor ?: 0L
     val device = device ?: p?.device
+    val kind = kind ?: p?.kind
     return ResolvedRenderParams(
       widthPx = widthPx,
       heightPx = heightPx,
@@ -232,6 +245,7 @@ data class PreviewManifestEntry(
       backgroundColor = backgroundColor,
       device = device,
       outputBaseName = outputBaseName ?: id,
+      kind = kind,
     )
   }
 }
@@ -251,6 +265,13 @@ data class PreviewParamsEntry(
   val density: Float? = null,
   val showBackground: Boolean = false,
   val backgroundColor: Long = 0L,
+  /**
+   * `"COMPOSE"` / `"TILE"` — mirrors `ee.schimke.composeai.plugin.PreviewKind`. Forwarded through
+   * the router so the daemon's render path can dispatch tile previews to
+   * `renderer.TilePreviewComposable` instead of the Compose-method reflection path (which
+   * throws `NoSuchMethodException` on a non-composable tile entrypoint).
+   */
+  val kind: String? = null,
 )
 
 /** Output of [PreviewManifestEntry.resolved] — flat, fully-defaulted, ready to format into a
@@ -263,4 +284,5 @@ data class ResolvedRenderParams(
   val backgroundColor: Long,
   val device: String?,
   val outputBaseName: String,
+  val kind: String? = null,
 )

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -198,9 +198,16 @@ class RenderEngine(
     val slotTableCapture = PreviewSlotTableCapture()
     val themeFallbackCapture = MaterialThemeFallbackCapture()
 
+    val isTile = spec.kind.equals(TILE_KIND, ignoreCase = true)
     val clazz = trace.section("classloader:loadPreviewClass") { Class.forName(spec.className, true, classLoader) }
-    val composableMethod: ComposableMethod =
-      trace.section("compose:resolveComposable") { clazz.getDeclaredComposableMethod(spec.functionName) }
+    // Tile previews are non-composable top-level functions returning
+    // `TilePreviewData`; routing them through `getDeclaredComposableMethod` would throw
+    // `NoSuchMethodException` (the Compose-method lookup expects `(Composer, Int, …)` trailing
+    // params). The tile path skips composable resolution entirely and paints the inflated tile
+    // View through [renderer.TilePreviewComposable] in the setContent body below.
+    val composableMethod: ComposableMethod? =
+      if (isTile) null
+      else trace.section("compose:resolveComposable") { clazz.getDeclaredComposableMethod(spec.functionName) }
 
     // Self-diagnostic — surfaces in the VS Code extension's output channel as `[daemon stderr] …`.
     // Pairs with `[classloader] swap requested` / `allocate child loader` lines from
@@ -304,7 +311,23 @@ class RenderEngine(
                       renderMode = spec.renderMode,
                       sink = RecordingExtensionCompositionSink(),
                     ) {
-                      Box(modifier = Modifier.fillMaxSize()) { InvokeComposable(composableMethod) }
+                      Box(modifier = Modifier.fillMaxSize()) {
+                        if (isTile) {
+                          // Non-composable @Preview from `androidx.wear.tiles.tooling.preview` —
+                          // mirrors the standalone renderer's `TilePreviewStrategy`. The
+                          // inflated tile View lands inside the `Box` via `AndroidView`, so
+                          // captureRoboImage walks the same Compose tree as for composable previews.
+                          ee.schimke.composeai.renderer.TilePreviewComposable(
+                            className = spec.className,
+                            functionName = spec.functionName,
+                            widthDp = pxToDp(spec.widthPx, spec.density),
+                            heightDp = pxToDp(spec.heightPx, spec.density),
+                            device = spec.device,
+                          )
+                        } else {
+                          InvokeComposable(composableMethod!!)
+                        }
+                      }
                     }
                   }
                   InspectablePreviewContent(slotTableCapture, content)
@@ -755,6 +778,14 @@ class RenderEngine(
     const val A11Y_RENDER_MODE: String = "a11y"
 
     /**
+     * `RenderSpec.kind` value flagging a tile preview (non-composable function returning
+     * `androidx.wear.tiles.tooling.preview.TilePreviewData`). Mirrors
+     * `ee.schimke.composeai.plugin.PreviewKind.TILE` so a manifest-emitted value round-trips
+     * unchanged through the daemon's render path.
+     */
+    const val TILE_KIND: String = "TILE"
+
+    /**
      * Virtual time to advance before capture in the paused-`mainClock` path, in milliseconds.
      * Mirrors `RobolectricRenderTest.CAPTURE_ADVANCE_MS` exactly so daemon-rendered PNGs match
      * the standalone JUnit path's settle point.
@@ -917,6 +948,12 @@ data class RenderSpec(
    * adding a new override-driven feature is purely a connector concern.
    */
   val overrides: PreviewOverrides? = null,
+  /**
+   * Preview flavour, mirroring `ee.schimke.composeai.plugin.PreviewKind` (`"COMPOSE"` / `"TILE"`).
+   * Drives renderer selection: `"TILE"` routes through [renderer.TilePreviewComposable] instead of
+   * the Compose-method reflection path. `null` and `"COMPOSE"` both render as a normal @Composable.
+   */
+  val kind: String? = null,
 ) {
 
   enum class SpecUiMode {
@@ -983,6 +1020,7 @@ data class RenderSpec(
         captureAdvanceMs = map["captureAdvanceMs"]?.toLongOrNull()?.takeIf { it > 0L },
         inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull(),
         overrides = map["overrides"]?.decodePreviewOverrides(),
+        kind = map["kind"]?.takeIf { it.isNotBlank() },
       )
     }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -323,6 +323,12 @@ class RenderEngine(
                             widthDp = pxToDp(spec.widthPx, spec.density),
                             heightDp = pxToDp(spec.heightPx, spec.density),
                             device = spec.device,
+                            // Same per-render child loader the compose path uses for
+                            // `getDeclaredComposableMethod` above; without it
+                            // `findTilePreviewMethod` would `Class.forName` against the parent
+                            // loader and either miss user classes (under isolation) or render
+                            // stale bytecode after an edit.
+                            classLoader = classLoader,
                           )
                         } else {
                           InvokeComposable(composableMethod!!)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -123,6 +123,16 @@ data class PreviewParamsDto(
    * plugin's annotation reader hands back the raw `0xAARRGGBB` value.
    */
   val backgroundColor: Long? = null,
+  /**
+   * Preview flavour — mirrors `ee.schimke.composeai.plugin.PreviewKind` (`"COMPOSE"` / `"TILE"`).
+   * String-typed so the daemon's renderer-agnostic surface doesn't depend on the plugin's enum;
+   * `null` and `"COMPOSE"` both mean the default Compose path. `"TILE"` routes through the
+   * tile-render strategy on the Android backend (top-level
+   * `@androidx.wear.tiles.tooling.preview.Preview` functions are not `@Composable`, so the
+   * Compose-method reflection path throws `NoSuchMethodException` unless the renderer is told to
+   * dispatch differently).
+   */
+  val kind: String? = null,
 )
 
 /**

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -171,6 +171,12 @@ private object TilePreviewStrategy : PreviewRenderStrategy {
         // `@PreviewParameter` doesn't apply to tile previews — discovery
         // drops the provider FQN for `PreviewKind.TILE`, so this list is
         // always empty here.
-        TilePreviewComposable(preview, widthDp, heightDp)
+        TilePreviewComposable(
+            className = preview.className,
+            functionName = preview.functionName,
+            widthDp = widthDp,
+            heightDp = heightDp,
+            device = preview.params.device,
+        )
     }
 }

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
@@ -41,6 +41,14 @@ fun TilePreviewComposable(
     widthDp: Int,
     heightDp: Int,
     device: String? = null,
+    /**
+     * Classloader used to resolve [className]. `null` defers to the caller-thread context
+     * classloader (the standalone renderer path's user classes share the test classpath, so
+     * `Class.forName(name)` finds them). The daemon path passes the per-render child loader so
+     * tile previews resolve against freshly-recompiled user bytecode after every save instead of
+     * the parent loader's stale copy — see [RenderEngine][ee.schimke.composeai.daemon.RenderEngine].
+     */
+    classLoader: ClassLoader? = null,
 ) {
     val context = LocalContext.current
     AndroidView(
@@ -60,7 +68,7 @@ fun TilePreviewComposable(
                 // tile itself.
                 setBackgroundColor(Color.BLACK)
             }
-            renderTileInto(context, className, functionName, widthDp, heightDp, device, parent)
+            renderTileInto(context, className, functionName, widthDp, heightDp, device, classLoader, parent)
             parent
         },
     )
@@ -73,9 +81,10 @@ private fun renderTileInto(
     widthDp: Int,
     heightDp: Int,
     device: String?,
+    classLoader: ClassLoader?,
     parent: FrameLayout,
 ) {
-    val data = invokeTilePreviewFunction(context, className, functionName)
+    val data = invokeTilePreviewFunction(context, className, functionName, classLoader)
 
     val deviceParams = buildDeviceParameters(widthDp, heightDp, device)
 
@@ -127,8 +136,9 @@ private fun invokeTilePreviewFunction(
     context: Context,
     className: String,
     functionName: String,
+    classLoader: ClassLoader?,
 ): TilePreviewData {
-    val method = findTilePreviewMethod(className, functionName)
+    val method = findTilePreviewMethod(className, functionName, classLoader)
     method.isAccessible = true
     val result = when (method.parameterTypes.size) {
         0 -> method.invoke(null)
@@ -147,9 +157,14 @@ private fun invokeTilePreviewFunction(
  * Kotlin compiler places top-level functions on a synthetic `${File}Kt` class
  * (matching the `className` our discovery records). We prefer an overload that
  * takes a `Context` if present, falling back to a no-arg overload.
+ *
+ * [classLoader] threads through the daemon's per-render child loader so a tile preview resolves
+ * against freshly-recompiled user bytecode after every save; `null` falls back to the
+ * default `Class.forName(name)` behaviour (caller-thread context classloader), which is what the
+ * standalone renderer needs.
  */
-private fun findTilePreviewMethod(className: String, functionName: String): Method {
-    val cls = Class.forName(className)
+private fun findTilePreviewMethod(className: String, functionName: String, classLoader: ClassLoader?): Method {
+    val cls = if (classLoader != null) Class.forName(className, true, classLoader) else Class.forName(className)
     val candidates = cls.declaredMethods.filter { it.name == functionName }
     if (candidates.isEmpty()) {
         error("No method '$functionName' on '$className'")

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
@@ -35,10 +35,12 @@ import java.util.concurrent.TimeUnit
  * classes are actually present.
  */
 @Composable
-internal fun TilePreviewComposable(
-    preview: RenderPreviewEntry,
+fun TilePreviewComposable(
+    className: String,
+    functionName: String,
     widthDp: Int,
     heightDp: Int,
+    device: String? = null,
 ) {
     val context = LocalContext.current
     AndroidView(
@@ -58,7 +60,7 @@ internal fun TilePreviewComposable(
                 // tile itself.
                 setBackgroundColor(Color.BLACK)
             }
-            renderTileInto(context, preview, widthDp, heightDp, parent)
+            renderTileInto(context, className, functionName, widthDp, heightDp, device, parent)
             parent
         },
     )
@@ -66,14 +68,16 @@ internal fun TilePreviewComposable(
 
 private fun renderTileInto(
     context: Context,
-    preview: RenderPreviewEntry,
+    className: String,
+    functionName: String,
     widthDp: Int,
     heightDp: Int,
+    device: String?,
     parent: FrameLayout,
 ) {
-    val data = invokeTilePreviewFunction(context, preview)
+    val data = invokeTilePreviewFunction(context, className, functionName)
 
-    val deviceParams = buildDeviceParameters(widthDp, heightDp, preview.params.device)
+    val deviceParams = buildDeviceParameters(widthDp, heightDp, device)
 
     val tileRequest = RequestBuilders.TileRequest.Builder()
         .setDeviceConfiguration(deviceParams)
@@ -90,7 +94,7 @@ private fun renderTileInto(
         ?.timelineEntries
         ?.firstOrNull()
         ?.layout
-        ?: error("TilePreview '${preview.functionName}' produced no layout (empty timeline)")
+        ?: error("TilePreview '$functionName' produced no layout (empty timeline)")
 
     // Inline executor — Robolectric has the main looper paused, so posting
     // to a background thread and awaiting back on main would deadlock. Inflating
@@ -107,7 +111,7 @@ private fun renderTileInto(
     val renderer = TileRenderer(context, Runnable::run) { _ -> /* no-op loader */ }
     val view = renderer.inflateAsync(layout, resources, parent)
         .get(10, TimeUnit.SECONDS)
-        ?: error("TileRenderer returned no view for preview '${preview.functionName}'")
+        ?: error("TileRenderer returned no view for preview '$functionName'")
 
     // Tile inflation defaults to WRAP_CONTENT, which collapses against an
     // AndroidView that's still measuring. Mirror `TileServiceViewAdapter`:
@@ -121,20 +125,21 @@ private fun renderTileInto(
 
 private fun invokeTilePreviewFunction(
     context: Context,
-    preview: RenderPreviewEntry,
+    className: String,
+    functionName: String,
 ): TilePreviewData {
-    val method = findTilePreviewMethod(preview.className, preview.functionName)
+    val method = findTilePreviewMethod(className, functionName)
     method.isAccessible = true
     val result = when (method.parameterTypes.size) {
         0 -> method.invoke(null)
         1 -> method.invoke(null, context)
         else -> error(
-            "TilePreview '${preview.functionName}' has unsupported signature; " +
+            "TilePreview '$functionName' has unsupported signature; " +
                 "expected 0 or 1 (Context) parameters, found ${method.parameterTypes.size}"
         )
     }
     return result as? TilePreviewData
-        ?: error("TilePreview '${preview.functionName}' did not return TilePreviewData")
+        ?: error("TilePreview '$functionName' did not return TilePreviewData")
 }
 
 /**


### PR DESCRIPTION
The daemon's RenderEngine called Class.getDeclaredComposableMethod for
every preview, which throws NoSuchMethodException on tile preview
functions (top-level fun foo(context: Context): TilePreviewData — not
@Composable). Standalone Gradle renders dispatched on PreviewKind
already; the daemon path didn't carry kind through, so a tile preview
rendered via the daemon failed before setContent.

Carry kind end-to-end:
- PreviewParamsDto / PreviewManifestEntry / RenderSpec gain a
  String-typed kind field; payload (de)serialization round-trips it.
- RenderEngine.render skips composable-method resolution and paints
  TilePreviewComposable inside the setContent body when
  spec.kind == "TILE".
- TilePreviewComposable is now public and takes primitive args
  (className/functionName/widthDp/heightDp/device) so both the
  standalone strategy and the daemon can call it without constructing
  a RenderPreviewEntry.