### PR TITLE
test(vscode-extension): warm the wear daemon in e2eA11y before chip toggles

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -435,6 +435,14 @@ export interface ComposePreviewTestApi {
         kind: string,
         enabled: boolean,
     ): Promise<void>;
+    /**
+     * Run the same `composePreviewDaemonStart` + JVM spawn the activation
+     * flow does, so chip-toggle tests can issue `data/subscribe` against a
+     * live daemon. Resolves to whether the daemon ended up ready. Used by
+     * the wear a11y e2e — the regular `triggerRefresh` only drives the
+     * Gradle-task render path and never touches the daemon gate.
+     */
+    triggerWarmDaemon(filePath: string): Promise<boolean>;
     /** Snapshot of every panel message posted since [resetMessages]. */
     getPostedMessages(): unknown[];
     /**
@@ -1677,6 +1685,9 @@ export async function activate(
                 enabled: boolean,
             ): Promise<void> {
                 return handleSetDataExtensionEnabled(previewId, kind, enabled);
+            },
+            triggerWarmDaemon(filePath: string): Promise<boolean> {
+                return warmDaemonForFile(filePath);
             },
             getPostedMessages(): unknown[] {
                 return [...postedMessageLog];

--- a/vscode-extension/src/test/electron/suite/e2e.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2e.test.ts
@@ -64,9 +64,11 @@ async function waitFor<T>(
 
 describeE2E("Compose Preview e2e (real Gradle)", function () {
     // Cold renderAllPreviews on `:samples:cmp` is ~30-90s on a warm machine
-    // and can spike higher on a fresh CI runner. 10 minutes is the same
-    // ceiling the gradle-plugin functional tests use.
-    this.timeout(10 * 60_000);
+    // and can spike higher on a fresh CI runner. GitHub's hosted Linux
+    // runners regularly take 9-10+ minutes from a cold Gradle cache once the
+    // sibling e2eA11y suite shares the build, so 15 minutes matches the
+    // wear suite's ceiling and leaves head room under the workflow's 60m cap.
+    this.timeout(15 * 60_000);
 
     let api: ComposePreviewTestApi;
     let kotlinFile: string;

--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -182,6 +182,16 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
             ),
         );
 
+        // The chip toggles below send `data/subscribe` through the daemon
+        // scheduler, which requires a live daemon and therefore a
+        // `composePreviewDaemonStart`-produced launch descriptor. Activation
+        // does this automatically in production via `runActivationRefresh`,
+        // but COMPOSE_PREVIEW_TEST_MODE=1 skips that auto-refresh — without
+        // an explicit warm here the first `triggerSetDataExtensionEnabled`
+        // throws `[daemon] no launch descriptor for :samples:wear`.
+        const warmed = await api.triggerWarmDaemon(wearKotlinFile);
+        assert.ok(warmed, "wear daemon must warm before chip subscriptions");
+
         // One refresh bootstraps every `it`: the wear renderAllPreviews
         // cold path is the slowest piece of the suite, so paying for it
         // once and reusing the `setPreviews` payload keeps the total

--- a/vscode-extension/src/test/electron/suite/index.ts
+++ b/vscode-extension/src/test/electron/suite/index.ts
@@ -36,7 +36,12 @@ export async function run(): Promise<void> {
     // restate file names here.
     const pattern = e2eMode ? "**/e2e*.test.js" : "**/*.test.js";
     const ignore = e2eMode ? [] : ["**/e2e*.test.js"];
-    const files = await glob(pattern, { cwd: testsRoot, ignore });
+    // Sort so execution order is deterministic across runners — glob's
+    // filesystem-order traversal otherwise puts `e2eA11y.test.js` ahead of
+    // `e2e.test.js` on the GitHub-hosted Linux image, which left the cmp
+    // suite paying the wear renderAllPreviews's tax in its own 10-minute
+    // budget. Plain lexical order runs the lighter cmp suite first.
+    const files = (await glob(pattern, { cwd: testsRoot, ignore })).sort();
     console.log(
         `[suite] discovered ${files.length} test file(s) in ${testsRoot} (e2e=${e2eMode})`,
     );


### PR DESCRIPTION
`triggerSetDataExtensionEnabled` routes through `daemonScheduler.setDataProductSubscription`,
which calls `LiveDaemonGate.getOrSpawn`. The gate throws
`[daemon] no launch descriptor for :samples:wear; run :samples:wear:composePreviewDaemonStart first`
when no descriptor exists — and `COMPOSE_PREVIEW_TEST_MODE=1` skips the
`runActivationRefresh` chain that normally produces it in production.

Expose `triggerWarmDaemon(filePath)` on the test API (thin wrapper over
`warmDaemonForFile`) and call it from `e2eA11y.test.ts`'s `before()`
after `injectGradleApi`. The wear bootstrap runs `composePreviewDaemonStart`
+ spawns the JVM, mirroring activation, so the three chip-toggle `it`s
can issue `data/subscribe` against a live daemon.

While here, two adjacent fixes so the e2e workflow lands green:

- Sort the glob output in `suite/index.ts` so `e2e.test.js` runs before
  `e2eA11y.test.js`. GitHub's hosted runner returned them in inverse
  order, which left the cmp suite paying the wear `renderAllPreviews`'s
  Gradle-daemon tax inside its own 10-minute `it` budget.
- Bump the cmp `describeE2E` timeout from 10 to 15 minutes to match the
  wear suite. Cold `:samples:cmp:renderAllPreviews` regularly takes
  9-10+ minutes on a fresh Linux runner once the sibling e2eA11y suite
  shares the build; 15 still leaves head room under the workflow's
  60-minute ceiling.