### PR TITLE
fix(vscode-extension): wire Resources bundle, gate bundle UI on earlyFeatures, satisfy webview CSP

### DIFF
--- a/vscode-extension/src/test/bundleController.test.ts
+++ b/vscode-extension/src/test/bundleController.test.ts
@@ -64,6 +64,31 @@ describe("BundleController", () => {
         );
     });
 
+    it("deactivateAll drops every active bundle and unsubscribes their kinds", () => {
+        const { controller, toggles } = build();
+        controller.toggleBundle("a11y");
+        controller.toggleBundle("theming");
+        toggles.length = 0;
+        controller.deactivateAll();
+        assert.deepStrictEqual(controller.state().activeBundles, []);
+        assert.strictEqual(controller.state().activeTab, null);
+        assert.ok(
+            toggles.length > 0,
+            "deactivateAll must unsubscribe each previously active kind",
+        );
+        assert.ok(
+            toggles.every((t) => t.enabled === false),
+            "every host call from deactivateAll must be an unsubscribe",
+        );
+    });
+
+    it("deactivateAll on an empty controller is a no-op", () => {
+        const { controller, toggles } = build();
+        controller.deactivateAll();
+        assert.deepStrictEqual(controller.state().activeBundles, []);
+        assert.strictEqual(toggles.length, 0);
+    });
+
     it("tab × is identical to chip re-press (dismiss path redundancy)", () => {
         const { controller, toggles } = build();
         controller.toggleBundle("a11y");

--- a/vscode-extension/src/test/resourcesBundlePresenter.test.ts
+++ b/vscode-extension/src/test/resourcesBundlePresenter.test.ts
@@ -1,0 +1,103 @@
+// Resources bundle presenter — pins the wire-payload → row mapping
+// for the new `<data-table>`-based Resources tab. Mirrors the
+// defensive parse the legacy `focusPresentation.resourcesUsedPresenter`
+// does so a malformed daemon payload doesn't blank the panel.
+
+import * as assert from "assert";
+import { computeResourcesBundleData } from "../webview/preview/resourcesBundlePresenter";
+
+describe("computeResourcesBundleData", () => {
+    it("emits no rows for a null payload", () => {
+        const data = computeResourcesBundleData(null);
+        assert.strictEqual(data.rows.length, 0);
+    });
+
+    it("emits no rows for a payload missing references", () => {
+        const data = computeResourcesBundleData({ something: "else" });
+        assert.strictEqual(data.rows.length, 0);
+    });
+
+    it("emits one row per well-formed reference", () => {
+        const data = computeResourcesBundleData({
+            references: [
+                {
+                    resourceType: "drawable",
+                    resourceName: "ic_launcher",
+                    packageName: "com.example",
+                    resolvedFile: "/abs/path/ic_launcher.xml",
+                    consumers: [{ nodeId: "n1" }, { nodeId: "n2" }],
+                },
+                {
+                    resourceType: "string",
+                    resourceName: "app_name",
+                    packageName: "com.example",
+                    resolvedValue: "Demo",
+                    consumers: [{ nodeId: "n3" }],
+                },
+            ],
+        });
+        assert.strictEqual(data.rows.length, 2);
+        assert.strictEqual(data.rows[0].resourceType, "drawable");
+        assert.strictEqual(data.rows[0].resourceName, "ic_launcher");
+        assert.strictEqual(
+            data.rows[0].resolvedFile,
+            "/abs/path/ic_launcher.xml",
+        );
+        assert.strictEqual(data.rows[0].resolvedValue, null);
+        assert.strictEqual(data.rows[0].consumerCount, 2);
+        assert.strictEqual(data.rows[1].resolvedValue, "Demo");
+        assert.strictEqual(data.rows[1].resolvedFile, null);
+        assert.strictEqual(data.rows[1].consumerCount, 1);
+    });
+
+    it("skips entries missing type or name", () => {
+        const data = computeResourcesBundleData({
+            references: [
+                { resourceType: "drawable" },
+                { resourceName: "missing_type" },
+                {
+                    resourceType: "color",
+                    resourceName: "primary",
+                    resolvedValue: "#FF0000",
+                },
+            ],
+        });
+        assert.strictEqual(data.rows.length, 1);
+        assert.strictEqual(data.rows[0].resourceName, "primary");
+    });
+
+    it("defaults packageName / consumerCount when fields are absent", () => {
+        const data = computeResourcesBundleData({
+            references: [
+                {
+                    resourceType: "string",
+                    resourceName: "no_meta",
+                    resolvedValue: "x",
+                },
+            ],
+        });
+        assert.strictEqual(data.rows[0].packageName, "");
+        assert.strictEqual(data.rows[0].consumerCount, 0);
+    });
+
+    it("emits stable ids derived from index + type + name", () => {
+        const data = computeResourcesBundleData({
+            references: [
+                {
+                    resourceType: "string",
+                    resourceName: "title",
+                    resolvedValue: "Hi",
+                },
+                {
+                    resourceType: "string",
+                    resourceName: "title",
+                    resolvedValue: "Bye",
+                },
+            ],
+        });
+        // Index disambiguates duplicate (type, name) pairs.
+        assert.notStrictEqual(data.rows[0].id, data.rows[1].id);
+        assert.ok(data.rows[0].id.startsWith("resource-0-string-title"));
+        assert.ok(data.rows[1].id.startsWith("resource-1-string-title"));
+    });
+});

--- a/vscode-extension/src/webview/preview/bundleController.ts
+++ b/vscode-extension/src/webview/preview/bundleController.ts
@@ -136,6 +136,21 @@ export class BundleController {
         if (this.active.includes(id)) this.deactivate(id);
     }
 
+    /**
+     * Drop every active bundle. Used when `composePreview.early
+     * Features.enabled` is toggled off mid-session — the chip bar /
+     * tab row go `hidden`, and this unsubscribes from every kind so
+     * the daemon stops streaming data products the user can no longer
+     * see. Re-enabling the flag leaves the user back at "no active
+     * bundles" rather than restoring stale state from before the
+     * disable.
+     */
+    deactivateAll(): void {
+        for (const id of [...this.active]) {
+            this.deactivate(id);
+        }
+    }
+
     /** Switch the visible tab. */
     selectTab(id: BundleId | null): void {
         if (id === null) {

--- a/vscode-extension/src/webview/preview/components/BoxOverlay.ts
+++ b/vscode-extension/src/webview/preview/components/BoxOverlay.ts
@@ -14,6 +14,7 @@
 
 import { LitElement, html, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { ref } from "lit/directives/ref.js";
 
 export type OverlayLevel = "error" | "warning" | "info";
 
@@ -87,23 +88,34 @@ export class BoxOverlay extends LitElement {
         const height =
             ((b.bounds.bottom - b.bounds.top) / this.naturalHeight) * 100;
         const active = this.activeOverlayId === b.id;
-        const style = [
-            `left:${left}%`,
-            `top:${top}%`,
-            `width:${width}%`,
-            `height:${height}%`,
-            b.color ? `--overlay-color:${b.color}` : "",
-        ]
-            .filter(Boolean)
-            .join(";");
+        // VS Code's webview CSP rejects inline `style=` attributes
+        // (style-src lacks `'unsafe-inline'`), and Lit's `styleMap`
+        // directive sets the attribute the same way — both get
+        // blocked. Setting the styles via the CSSOM (`element.style
+        // .foo = …`) in a `ref` callback is a separate code path
+        // CSP doesn't intercept, so we apply position / size /
+        // optional colour there instead.
+        const applyStyle = (el: Element | undefined): void => {
+            if (!el) return;
+            const e = el as HTMLDivElement;
+            e.style.left = `${left}%`;
+            e.style.top = `${top}%`;
+            e.style.width = `${width}%`;
+            e.style.height = `${height}%`;
+            if (b.color) {
+                e.style.setProperty("--overlay-color", b.color);
+            } else {
+                e.style.removeProperty("--overlay-color");
+            }
+        };
         return html`
             <div
+                ${ref(applyStyle)}
                 class=${active
                     ? "overlay-box overlay-box-active"
                     : "overlay-box"}
                 data-overlay-id=${b.id}
                 data-level=${b.level ?? "info"}
-                style=${style}
                 title=${b.tooltip ?? ""}
                 @mouseenter=${() => this.onHover(b.id)}
                 @mouseleave=${() => this.onHover(null)}

--- a/vscode-extension/src/webview/preview/components/ProgressBar.ts
+++ b/vscode-extension/src/webview/preview/components/ProgressBar.ts
@@ -9,7 +9,7 @@
 import { LitElement, html, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-import { styleMap } from "lit/directives/style-map.js";
+import { ref } from "lit/directives/ref.js";
 
 interface SetProgressMessage {
     command: "setProgress";
@@ -182,8 +182,18 @@ export class ProgressBar extends LitElement {
                 <div class="progress-track">
                     <div
                         class="progress-fill"
-                        style=${styleMap({
-                            width: `${(pct * 100).toFixed(1)}%`,
+                        ${ref((el) => {
+                            // VS Code's webview CSP (`style-src
+                            // ${cspSource} 'nonce-${nonce}'`) blocks
+                            // both `style="…"` attributes and Lit's
+                            // `styleMap` directive (which writes the
+                            // attribute under the hood). Setting
+                            // `el.style.width` via the CSSOM is not
+                            // controlled by `style-src` and works
+                            // without `'unsafe-inline'`.
+                            if (!el) return;
+                            (el as HTMLDivElement).style.width =
+                                `${(pct * 100).toFixed(1)}%`;
                         })}
                     ></div>
                 </div>

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -192,8 +192,15 @@ export class FocusController {
         const mode = this.config.filterToolbar.getLayoutValue();
         this.config.grid.setLayoutMode(mode);
         this.config.focusControls.hidden = mode !== "focus";
-        this.config.bundleChipBar.hidden = mode !== "focus";
-        this.config.dataTabs.hidden = mode !== "focus";
+        // The data-extension chip bar + tab row are an early-features
+        // surface — gating them here so the strip never paints below
+        // the preview when the setting is off. When the user toggles
+        // early features mid-session, `handleSetEarlyFeatures` calls
+        // `applyLayout` again, so visibility tracks the flag without a
+        // panel reload.
+        const showBundleUi = mode === "focus" && this.config.earlyFeatures();
+        this.config.bundleChipBar.hidden = !showBundleUi;
+        this.config.dataTabs.hidden = !showBundleUi;
 
         if (mode === "focus") {
             const visible = this.getVisibleCards();

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -75,6 +75,10 @@ import {
     displayFilterTableColumns,
 } from "./displayFilterBundlePresenter";
 import {
+    computeResourcesBundleData,
+    resourcesTableColumns,
+} from "./resourcesBundlePresenter";
+import {
     computeErrorsBundleData,
     errorsTableColumns,
     renderErrorsStackFrames,
@@ -1242,6 +1246,44 @@ export class PreviewApp extends LitElement {
             dataTabs.setTabBody("display", body.wrapper);
         };
 
+        // ---- Resources bundle (resources/used) -----------------------------
+        const resourcesBodyBuilt = (): BundleBody => {
+            let b = bundleBodies.get("resources");
+            if (b) return b;
+            b = buildBundleBody(
+                "resources",
+                "Resources used",
+                resourcesTableColumns() as unknown as ReadonlyArray<
+                    import("./components/DataTable").DataTableColumn<unknown>
+                >,
+            );
+            bundleBodies.set("resources", b);
+            return b;
+        };
+        const refreshResourcesBundle = (): void => {
+            const target = currentBundleTarget();
+            if (!target) return;
+            const byKind = dataProductsByPreview.get(target);
+            const payload = byKind?.get("resources/used") ?? null;
+            const data = computeResourcesBundleData(payload);
+            const body = resourcesBodyBuilt();
+            const table = body.table;
+            table.setRows(data.rows);
+            table.summary =
+                data.rows.length +
+                " reference" +
+                (data.rows.length === 1 ? "" : "s");
+            table.setOverlayId(
+                (row) => (row as { id: string }).id ?? "resource-row",
+            );
+            table.setJsonPayload(() => ({
+                previewId: target,
+                payload,
+            }));
+            refreshExpanderFor("resources");
+            dataTabs.setTabBody("resources", body.wrapper);
+        };
+
         // ---- Watch bundle (compose/ambient) --------------------------------
         const ambientBodyBuilt = (): BundleBody => {
             let b = bundleBodies.get("watch");
@@ -1551,6 +1593,7 @@ export class PreviewApp extends LitElement {
             }
             if (s.activeBundles.includes("theming")) refreshThemingBundle();
             if (s.activeBundles.includes("display")) refreshDisplayBundle();
+            if (s.activeBundles.includes("resources")) refreshResourcesBundle();
             if (s.activeBundles.includes("watch")) {
                 refreshWatchBundle();
             } else {
@@ -2040,6 +2083,13 @@ export class PreviewApp extends LitElement {
                 ) {
                     refreshInspectionBundle();
                 }
+                if (
+                    matchesTarget &&
+                    activeBundles.includes("resources") &&
+                    dataProducts.some((dp) => dp.kind === "resources/used")
+                ) {
+                    refreshResourcesBundle();
+                }
             },
             applyFontPreviewBytes: (previewId, fontRowId, dataUri) => {
                 // Stash the response (null included — represents "host
@@ -2071,6 +2121,7 @@ export class PreviewApp extends LitElement {
                 }
             },
             focusOnCard,
+            deactivateAllBundles: () => bundleController.deactivateAll(),
         };
         window.addEventListener("message", (event) => {
             handleExtensionMessage(event.data, messageContext);

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -119,6 +119,13 @@ export interface PreviewMessageContext {
         dataUri: string | null,
     ): void;
     focusOnCard(card: HTMLElement): void;
+    /**
+     * Drop every active bundle. Called when
+     * `composePreview.earlyFeatures.enabled` is toggled off so the
+     * bundle UI (chip bar / tabs / per-card overlays) tears down
+     * along with the rest of the early-features surface.
+     */
+    deactivateAllBundles(): void;
 }
 
 /** Methods the dispatcher needs from `<filter-toolbar>`. The component
@@ -600,6 +607,7 @@ function handleSetEarlyFeatures(
             ctx.setA11yOverlayId(null);
         }
         ctx.liveState.handleEarlyFeaturesDisabled();
+        ctx.deactivateAllBundles();
     }
     ctx.applyLayout();
 }

--- a/vscode-extension/src/webview/preview/resourcesBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/resourcesBundlePresenter.ts
@@ -1,0 +1,128 @@
+// Resources bundle presenter — fills the "Resources" tab body with
+// one row per `(resourceType, resourceName, packageName)` triple the
+// daemon emits via the `resources/used` data product. The wire shape
+// mirrors `ResourcesUsedDataProduct.kt`:
+//
+//   { references: [{ resourceType, resourceName, packageName,
+//                    resolvedValue, resolvedFile, consumers }, ...] }
+//
+// resolvedValue is non-null for values like strings / colors / dimens;
+// resolvedFile is non-null for binary assets (drawable / mipmap / raw)
+// where the resource resolves to a file on disk. The legacy focus-
+// inspector presenter at `focusPresentation.ts:408` already handles
+// click-through deep-linking — that path stays in use for the inspector
+// chrome; this presenter feeds the new `<data-table>`-based bundle UI.
+//
+// No overlay layer: a resource is not bound to a single rectangle on
+// the canvas (a string is used by N text nodes; a drawable by M image
+// nodes). Hover correlation with `compose/semantics` consumer bounds
+// is a follow-up.
+
+import { html, type TemplateResult } from "lit";
+import type { DataTableColumn } from "./components/DataTable";
+
+export interface ResourceUsedRow {
+    /** Stable id for `<data-table>` row hover / overlay correlation. */
+    id: string;
+    resourceType: string;
+    resourceName: string;
+    packageName: string;
+    /** Pre-formatted resolved value (string / color / dimen). `null`
+     *  when the resource is a binary file. */
+    resolvedValue: string | null;
+    /** Filesystem path the resource resolved to. `null` for values. */
+    resolvedFile: string | null;
+    /** Number of node references that consumed this resource. */
+    consumerCount: number;
+}
+
+export interface ResourcesBundleData {
+    rows: readonly ResourceUsedRow[];
+}
+
+/**
+ * Defensive parse — the daemon payload shape can drift across
+ * versions, and presenters in this tree treat unknown / malformed
+ * fields as "skip the row" rather than crash the panel. Matches the
+ * legacy `resourcesUsedPresenter` in `focusPresentation.ts`.
+ */
+export function computeResourcesBundleData(
+    payload: unknown,
+): ResourcesBundleData {
+    if (!payload || typeof payload !== "object") return { rows: [] };
+    const references = (payload as { references?: unknown }).references;
+    if (!Array.isArray(references)) return { rows: [] };
+    const rows: ResourceUsedRow[] = [];
+    for (let i = 0; i < references.length; i++) {
+        const item = references[i];
+        if (!item || typeof item !== "object") continue;
+        const ref = item as Record<string, unknown>;
+        const resourceType =
+            typeof ref.resourceType === "string" ? ref.resourceType : "";
+        const resourceName =
+            typeof ref.resourceName === "string" ? ref.resourceName : "";
+        if (!resourceType || !resourceName) continue;
+        rows.push({
+            id: "resource-" + i + "-" + resourceType + "-" + resourceName,
+            resourceType,
+            resourceName,
+            packageName:
+                typeof ref.packageName === "string" ? ref.packageName : "",
+            resolvedValue:
+                typeof ref.resolvedValue === "string"
+                    ? ref.resolvedValue
+                    : null,
+            resolvedFile:
+                typeof ref.resolvedFile === "string" ? ref.resolvedFile : null,
+            consumerCount: Array.isArray(ref.consumers)
+                ? ref.consumers.length
+                : 0,
+        });
+    }
+    return { rows };
+}
+
+export function resourcesTableColumns(): readonly DataTableColumn<ResourceUsedRow>[] {
+    return [
+        {
+            header: "Type",
+            cellClass: "resource-type-cell",
+            render: (row) => html`<code>${row.resourceType}</code>`,
+        },
+        {
+            header: "Name",
+            cellClass: "resource-name-cell",
+            render: (row) => row.resourceName,
+        },
+        {
+            header: "Package",
+            cellClass: "resource-package-cell",
+            render: (row) =>
+                row.packageName ? html`<code>${row.packageName}</code>` : "—",
+        },
+        {
+            header: "Resolved",
+            cellClass: "resource-resolved-cell",
+            render: (row) => renderResolved(row),
+        },
+        {
+            header: "Uses",
+            cellClass: "resource-uses-cell",
+            render: (row) => String(row.consumerCount),
+        },
+    ];
+}
+
+function renderResolved(row: ResourceUsedRow): TemplateResult | string {
+    if (row.resolvedValue !== null) {
+        return html`<span class="resource-resolved-value"
+            >${row.resolvedValue}</span
+        >`;
+    }
+    if (row.resolvedFile !== null) {
+        return html`<code class="resource-resolved-file"
+            >${row.resolvedFile}</code
+        >`;
+    }
+    return "—";
+}


### PR DESCRIPTION
## Summary

Three coupled fixes for the user-reported "nothing happens when I toggle Resources in the Focus view, tab stuck on 'Resources is loading…'":

1. **Resources bundle wiring.** `reflectBundleState` had branches for every bundle except `resources`, so when the chip activated, the controller knew about it but `dataTabs.setTabBody("resources", …)` was never called and `DataTabs.placeholderBody()` kept rendering `${b.label} is loading…` forever. Adds the presenter, body builder, refresh function, `reflectBundleState` branch, and `updateDataProducts` refresh trigger — same shape as the existing bundles.

2. **`earlyFeatures` gating of the bundle UI.** The chip bar + data tabs were only gated on `mode === "focus"` and not on `earlyFeatures()`. When the setting was off, the chips still painted and the controller still posted `setDataExtensionEnabled` on click — and any in-flight subscriptions kept streaming after the user disabled the flag. `focusController.applyLayout` now gates on `earlyFeatures()` too, and `handleSetEarlyFeatures` calls `BundleController.deactivateAll()` so the disable path unsubscribes every active kind. Re-enabling lands at "no active bundles" instead of restoring a stale session.

3. **CSP inline-style fix.** VS Code's webview CSP is `style-src ${cspSource} 'nonce-${nonce}'` — no `'unsafe-inline'`, so any `style="…"` attribute (including Lit's `styleMap` directive, which writes the attribute under the hood) gets rejected. `BoxOverlay` (per-instance position/size/colour) and `ProgressBar` (per-frame width) move to a `ref` callback that sets properties via the CSSOM (`el.style.left = …`). The CSSOM API is a separate code path `style-src` doesn't control, so no CSP relaxation is needed.

## Followup

The streaming-painter `createImageBitmap InvalidStateError` reported in the same session is filed separately as it's unrelated to the bundle path (PNG decode error on a malformed frame). See follow-up issue.

## Test plan

- [x] `npm test` — 942 passing (8 new specs covering the presenter and `deactivateAll`)
- [x] `npm run compile:webview` — bundle produced
- [x] `npm run format:check` clean
- [ ] Manual: with `composePreview.earlyFeatures.enabled = true`, click Resources chip in Focus view → tab populates with a table of `(type, name, package, resolved, uses)` instead of "Resources is loading…"
- [ ] Manual: toggle `earlyFeatures.enabled` off → chip bar + data tabs disappear, console shows no CSP `style-src` violations, daemon subscriptions tear down

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_