### PR TITLE
build: pin build-logic to JDK 17 toolchain

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins { `kotlin-dsl` }
 
+kotlin { jvmToolchain(17) }
+
 dependencies {
   implementation("com.android.tools.build:gradle:${libs.versions.agp.get()}")
   implementation("com.gradleup.tapmoc:tapmoc-gradle-plugin:${libs.versions.tapmoc.get()}")


### PR DESCRIPTION
Without an explicit toolchain, build-logic compiles with whatever JVM
launches Gradle, so a run on JDK 25 can poison the build cache with v69
classfiles that fail to load on daemons running older JDKs. Pinning to
17 (matching consumer modules) makes the cache key include the target
JVM and keeps bytecode stable across machines.