### PR TITLE
feat(vscode-extension): render a11y/touchTargets in the Accessibility bundle tab

### DIFF
--- a/vscode-extension/src/test/a11yBundlePresenter.test.ts
+++ b/vscode-extension/src/test/a11yBundlePresenter.test.ts
@@ -6,11 +6,27 @@
 // bounds.
 
 import * as assert from "assert";
-import { computeA11yBundleData } from "../webview/preview/a11yBundlePresenter";
+import {
+    computeA11yBundleData,
+    type AccessibilityTouchTarget,
+} from "../webview/preview/a11yBundlePresenter";
 import type {
     AccessibilityFinding,
     AccessibilityNode,
 } from "../webview/shared/types";
+
+function touchTarget(
+    overrides: Partial<AccessibilityTouchTarget>,
+): AccessibilityTouchTarget {
+    return {
+        nodeId: overrides.nodeId ?? "node-1",
+        boundsInScreen: overrides.boundsInScreen ?? "0,0,10,10",
+        widthDp: overrides.widthDp ?? 40,
+        heightDp: overrides.heightDp ?? 40,
+        findings: overrides.findings ?? [],
+        overlappingNodeIds: overrides.overlappingNodeIds,
+    };
+}
 
 function node(
     overrides: Partial<AccessibilityNode> & { boundsInScreen?: string },
@@ -122,5 +138,100 @@ describe("computeA11yBundleData", () => {
         );
         assert.strictEqual(data.rows.length, 1);
         assert.strictEqual(data.overlay.length, 0);
+    });
+
+    it("merges a touch target's size and findings onto the matching hierarchy row", () => {
+        const data = computeA11yBundleData(
+            [node({ label: "Tap me", boundsInScreen: "0,0,10,10" })],
+            [],
+            [
+                touchTarget({
+                    boundsInScreen: "0,0,10,10",
+                    widthDp: 32,
+                    heightDp: 32,
+                    findings: ["TouchTargetTooSmall"],
+                }),
+            ],
+        );
+        assert.strictEqual(data.rows.length, 1);
+        assert.strictEqual(data.rows[0].touchTargetSizeDp, "32×32 dp");
+        // Touch-target findings bump level to "warning" (not "error" —
+        // ATF errors still dominate, but a missing-ATF target should
+        // not silently look "info").
+        assert.strictEqual(data.rows[0].topFindingLevel, "warning");
+        assert.strictEqual(data.rows[0].findingCount, 1);
+    });
+
+    it("does not downgrade an ATF error when a touch target also applies", () => {
+        const data = computeA11yBundleData(
+            [node({ boundsInScreen: "0,0,10,10" })],
+            [
+                finding({
+                    boundsInScreen: "0,0,10,10",
+                    level: "ERROR",
+                    message: "low contrast",
+                }),
+            ],
+            [
+                touchTarget({
+                    boundsInScreen: "0,0,10,10",
+                    findings: ["TouchTargetOverlap"],
+                }),
+            ],
+        );
+        // Error from ATF wins; touch-target finding adds to the count.
+        assert.strictEqual(data.rows[0].topFindingLevel, "error");
+        assert.strictEqual(data.rows[0].findingCount, 2);
+    });
+
+    it("emits an orphan row for a touch target with findings and no matching node", () => {
+        const data = computeA11yBundleData(
+            [node({ boundsInScreen: "0,0,10,10" })],
+            [],
+            [
+                touchTarget({
+                    boundsInScreen: "100,100,140,140",
+                    findings: ["TouchTargetTooSmall"],
+                }),
+            ],
+        );
+        // 1 hierarchy row + 1 touch-target orphan.
+        assert.strictEqual(data.rows.length, 2);
+        const orphan = data.rows[1];
+        assert.ok(orphan.id.startsWith("a11y-touchtarget-orphan-"));
+        assert.strictEqual(orphan.topFindingLevel, "warning");
+    });
+
+    it("ignores touch targets that have no findings (still useful in the JSON payload, not as a row)", () => {
+        // Pure-shape targets (size info, no rule trip) don't deserve
+        // their own orphan row — they'd just be noise. They DO merge
+        // onto matching hierarchy rows for the size column.
+        const data = computeA11yBundleData(
+            [],
+            [],
+            [
+                touchTarget({
+                    boundsInScreen: "0,0,10,10",
+                    findings: [],
+                }),
+            ],
+        );
+        assert.strictEqual(data.rows.length, 0);
+    });
+
+    it("includes the touch-target size in the overlay tooltip when one matches", () => {
+        const data = computeA11yBundleData(
+            [node({ label: "Btn", boundsInScreen: "0,0,10,10" })],
+            [],
+            [
+                touchTarget({
+                    boundsInScreen: "0,0,10,10",
+                    widthDp: 48,
+                    heightDp: 48,
+                    findings: [],
+                }),
+            ],
+        );
+        assert.ok(data.overlay[0].tooltip?.includes("48×48 dp"));
     });
 });

--- a/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
@@ -1,19 +1,39 @@
 // A11y bundle presenter — fills the "Accessibility" tab body in
 // `<data-tabs>` using the shared `<data-table>` primitive. Combines
 // `a11y/hierarchy` (one row per node) with `a11y/atf` (findings
-// merged onto the matching row when bounds align).
+// merged onto the matching row when bounds align) and
+// `a11y/touchTargets` (per-target size + WCAG findings merged onto
+// the matching row by nodeId, or surfaced as orphan rows when the
+// target has no matching hierarchy node).
 //
 // The presenter is **stateless** — given the latest findings + nodes
-// from `previewStore` and the focused preview, it produces the table
-// rows and the overlay boxes. The caller (host shell wiring in
-// `main.ts`) is responsible for re-running this whenever the focused
-// preview, the cache, or the bundle's enabled-kinds set changes.
+// + touchTargets from `previewStore` / the per-card cache and the
+// focused preview, it produces the table rows and the overlay boxes.
+// The caller (host shell wiring in `main.ts`) is responsible for re-
+// running this whenever the focused preview, the cache, or the
+// bundle's enabled-kinds set changes.
 
 import { html, type TemplateResult } from "lit";
 import type { AccessibilityFinding, AccessibilityNode } from "../shared/types";
 import type { DataTableColumn } from "./components/DataTable";
 import type { OverlayBox } from "./components/BoxOverlay";
 import { parseBounds } from "./cardData";
+
+/**
+ * Wire shape for `a11y/touchTargets` — mirrors
+ * `AccessibilityTouchTargetsPayload` in `AccessibilityModels.kt`. A
+ * target's `findings` are rule-name strings (e.g.
+ * `"TouchTargetTooSmall"`); the presenter does not interpret them
+ * beyond "non-empty list ⇒ warn-level row".
+ */
+export interface AccessibilityTouchTarget {
+    nodeId: string;
+    boundsInScreen: string;
+    widthDp: number;
+    heightDp: number;
+    findings: readonly string[];
+    overlappingNodeIds?: readonly string[];
+}
 
 export interface A11yRow {
     id: string;
@@ -25,6 +45,10 @@ export interface A11yRow {
     topFindingLevel: "error" | "warning" | "info" | null;
     boundsInScreen: string;
     bounds: { left: number; top: number; right: number; bottom: number } | null;
+    /** Pre-formatted touch-target size, populated when this row has
+     *  a corresponding `a11y/touchTargets` entry. `null` otherwise —
+     *  the "Size" column renders a dash. */
+    touchTargetSizeDp: string | null;
 }
 
 export interface A11yBundleData {
@@ -46,11 +70,23 @@ const PALETTE = [
 export function computeA11yBundleData(
     nodes: readonly AccessibilityNode[],
     findings: readonly AccessibilityFinding[],
+    touchTargets: readonly AccessibilityTouchTarget[] = [],
 ): A11yBundleData {
     const rows: A11yRow[] = [];
     const overlay: OverlayBox[] = [];
     const findingsByBoundsKey = groupFindingsByBoundsKey(findings);
     const matchedKeys = new Set<string>();
+    // Index touch targets by bounds string — the daemon emits both
+    // the hierarchy and the targets keyed on the same source bounds,
+    // so we can merge per-node without exposing the daemon-internal
+    // nodeId (which the hierarchy nodes don't carry in this surface).
+    const targetByBounds = new Map<string, AccessibilityTouchTarget>();
+    for (const t of touchTargets) {
+        if (t && typeof t.boundsInScreen === "string") {
+            targetByBounds.set(boundsKey(t.boundsInScreen), t);
+        }
+    }
+    const consumedTargets = new Set<AccessibilityTouchTarget>();
 
     nodes.forEach((node, idx) => {
         const id = "a11y-" + idx;
@@ -58,17 +94,24 @@ export function computeA11yBundleData(
         const matchingFindings = bounds
             ? (findingsByBoundsKey.get(boundsKey(node.boundsInScreen)) ?? [])
             : [];
-        const top = topLevel(matchingFindings);
+        const target = targetByBounds.get(boundsKey(node.boundsInScreen));
+        if (target) consumedTargets.add(target);
+        const targetFindingCount = target?.findings?.length ?? 0;
+        const top = mergeLevel(
+            topLevel(matchingFindings),
+            targetFindingCount > 0 ? "warning" : null,
+        );
         const row: A11yRow = {
             id,
             label: node.label || "(unlabelled)",
             role: node.role ?? "",
             states: node.states?.join(", ") ?? "",
             merged: node.merged,
-            findingCount: matchingFindings.length,
+            findingCount: matchingFindings.length + targetFindingCount,
             topFindingLevel: top,
             boundsInScreen: node.boundsInScreen,
             bounds,
+            touchTargetSizeDp: target ? formatTargetSize(target) : null,
         };
         rows.push(row);
         if (bounds) {
@@ -77,7 +120,7 @@ export function computeA11yBundleData(
                 bounds,
                 level: top ?? "info",
                 color: top ? undefined : PALETTE[idx % PALETTE.length],
-                tooltip: tooltipFor(node),
+                tooltip: tooltipFor(node, target),
             });
         }
     });
@@ -109,6 +152,7 @@ export function computeA11yBundleData(
             topFindingLevel: level,
             boundsInScreen: fBounds,
             bounds,
+            touchTargetSizeDp: null,
         });
         if (bounds) {
             overlay.push({
@@ -120,7 +164,64 @@ export function computeA11yBundleData(
         }
     });
 
+    // Touch targets that didn't match any hierarchy node — surface
+    // them as orphan rows so the subscription isn't silently dropped.
+    // Same intuition as orphan ATF findings above: better to show "we
+    // got data here that we can't correlate" than to hide it.
+    touchTargets.forEach((t, idx) => {
+        if (!t || consumedTargets.has(t)) return;
+        const findingsCount = t.findings?.length ?? 0;
+        if (findingsCount === 0) return;
+        const tKey = boundsKey(t.boundsInScreen);
+        // If the target's bounds already match a hierarchy node we
+        // know about, the merge path above handled it; this branch is
+        // for the residual case where the bounds string differs.
+        if (tKey && matchedKeys.has(tKey)) return;
+        const id = "a11y-touchtarget-orphan-" + idx;
+        const bounds = parseBounds(t.boundsInScreen ?? "");
+        rows.push({
+            id,
+            label: t.nodeId ? "node " + t.nodeId : "(touch target)",
+            role: "TouchTarget",
+            states: t.findings.join(", "),
+            merged: true,
+            findingCount: findingsCount,
+            topFindingLevel: "warning",
+            boundsInScreen: t.boundsInScreen ?? "",
+            bounds,
+            touchTargetSizeDp: formatTargetSize(t),
+        });
+        if (bounds) {
+            overlay.push({
+                id,
+                bounds,
+                level: "warning",
+                tooltip:
+                    "Touch target · " +
+                    formatTargetSize(t) +
+                    " · " +
+                    t.findings.join(", "),
+            });
+        }
+    });
+
     return { rows, overlay };
+}
+
+function mergeLevel(
+    a: "error" | "warning" | "info" | null,
+    b: "error" | "warning" | "info" | null,
+): "error" | "warning" | "info" | null {
+    if (a === "error" || b === "error") return "error";
+    if (a === "warning" || b === "warning") return "warning";
+    if (a === "info" || b === "info") return "info";
+    return null;
+}
+
+function formatTargetSize(t: AccessibilityTouchTarget): string {
+    const w = Number.isFinite(t.widthDp) ? Math.round(t.widthDp) : 0;
+    const h = Number.isFinite(t.heightDp) ? Math.round(t.heightDp) : 0;
+    return `${w}×${h} dp`;
 }
 
 export function a11yTableColumns(): readonly DataTableColumn<A11yRow>[] {
@@ -150,6 +251,11 @@ export function a11yTableColumns(): readonly DataTableColumn<A11yRow>[] {
         {
             header: "States",
             render: (row) => row.states || "—",
+        },
+        {
+            header: "Size",
+            cellClass: "a11y-size-cell",
+            render: (row) => row.touchTargetSizeDp ?? "—",
         },
         {
             header: "Findings",
@@ -186,11 +292,18 @@ function normLevel(s: string): "error" | "warning" | "info" {
     return "info";
 }
 
-function tooltipFor(node: AccessibilityNode): string {
+function tooltipFor(
+    node: AccessibilityNode,
+    target: AccessibilityTouchTarget | undefined,
+): string {
     const parts: string[] = [];
     if (node.label) parts.push(node.label);
     if (node.role) parts.push(node.role);
     if (node.states?.length) parts.push(node.states.join(", "));
+    if (target) {
+        parts.push(formatTargetSize(target));
+        if (target.findings.length > 0) parts.push(target.findings.join(", "));
+    }
     return parts.join(" · ");
 }
 

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -1029,13 +1029,26 @@ export class PreviewApp extends LitElement {
                 [];
             return { nodes, findings };
         };
+        const a11yTouchTargetsForCard = (
+            previewId: string,
+        ): readonly import("./a11yBundlePresenter").AccessibilityTouchTarget[] => {
+            const byKind = dataProductsByPreview.get(previewId);
+            const raw = byKind?.get("a11y/touchTargets") as
+                | { targets?: unknown }
+                | undefined;
+            const targets = raw?.targets;
+            if (!Array.isArray(targets)) return [];
+            return targets as readonly import("./a11yBundlePresenter").AccessibilityTouchTarget[];
+        };
         const refreshA11yBundle = (): void => {
             const target = currentBundleTarget();
             if (!target) return;
             const targetSrc = a11yDataForCard(target);
+            const touchTargets = a11yTouchTargetsForCard(target);
             const data = computeA11yBundleData(
                 targetSrc.nodes,
                 targetSrc.findings,
+                touchTargets,
             );
             const body = a11yBody();
             body.table.setRows(data.rows);
@@ -1047,6 +1060,7 @@ export class PreviewApp extends LitElement {
                 previewId: target,
                 nodes: targetSrc.nodes,
                 findings: targetSrc.findings,
+                touchTargets,
             }));
             refreshExpanderFor("a11y");
             dataTabs.setTabBody("a11y", body.wrapper);
@@ -1062,7 +1076,9 @@ export class PreviewApp extends LitElement {
             paintOverlaysForBundle("a11y", (previewId) => {
                 if (previewId === target) return data.overlay;
                 const src = a11yDataForCard(previewId);
-                return computeA11yBundleData(src.nodes, src.findings).overlay;
+                const tts = a11yTouchTargetsForCard(previewId);
+                return computeA11yBundleData(src.nodes, src.findings, tts)
+                    .overlay;
             });
         };
         const refreshPerformanceBundle = (): void => {


### PR DESCRIPTION
## Summary

`a11y/touchTargets` was the only kind in the bundle registry with no presenter anywhere — defined and toggleable via Configure, but the data arrived in the per-preview cache and went nowhere. This wires it through the Accessibility bundle tab.

Audit context: I asked an explore agent to walk every kind in `bundleRegistry` and report whether it has a renderer in (a) the legacy focus-inspector presenters or (b) the new bundle-tab refresh functions. `a11y/touchTargets` was the single confirmed gap; every other kind is rendered in at least one surface.

## What changes

`computeA11yBundleData` takes a third argument (the touch-targets list, defaulted to `[]` so call sites without it stay working). For each target, the presenter:

- Merges into the matching hierarchy row by `boundsInScreen`. Adds a new "Size" column (`widthDp × heightDp`); bumps `topFindingLevel` to `warning` when the target carries WCAG findings; ATF `error` findings still dominate the level when both apply.
- Increments `findingCount` so the existing badge surfaces touch-target issues — no separate column.
- Surfaces orphan touch-targets with findings as their own rows, same intuition as the existing orphan-ATF path.
- Skips targets with no findings as orphan rows (would be noise) but still uses them for the size column on matching rows.
- Appends target size to the overlay tooltip when one matches.

`refreshA11yBundle` reads `a11y/touchTargets` from `dataProductsByPreview`. The existing `updateDataProducts` branch that triggers refresh when a11y is active is already unconditional on which kind arrived, so no separate trigger is needed.

## Test plan

- [x] `npm test` — 947 passing (5 new specs)
- [x] `npm run format:check` clean
- [ ] Manual: enable Accessibility chip in Focus view, open Configure, tick "Touch targets". Confirm: rows that have a corresponding touch target show a size like "48×48 dp" in the new Size column; rows that have findings like "TouchTargetTooSmall" get a warning-level badge; the overlay tooltip on those rows includes the size.

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_