### PR TITLE
feat(vscode-extension): add headless preview-harness for design iteration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ node_modules/
 vscode-extension/out/
 vscode-extension/.vscode-test/
 vscode-extension/media/webview/
+vscode-extension/preview-harness/out/
 *.vsix
 
 # Python (for .github/actions/lib/ scripts and their tests)

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -21,6 +21,7 @@
                 "happy-dom": "^20.9.0",
                 "lit": "^3.2.0",
                 "mocha": "^11.0.0",
+                "playwright": "~1.56.0",
                 "prettier": "^3.8.3",
                 "typescript": "^6.0.0"
             },
@@ -2557,6 +2558,21 @@
                 "node": ">=14.14"
             }
         },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4415,6 +4431,38 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.56.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+            "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.56.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.56.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+            "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/pluralize": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -196,7 +196,8 @@
         "test:electron": "npm run compile && node ./out/test/electron/runTest.js",
         "test:e2e": "npm run compile && COMPOSE_PREVIEW_E2E=1 node ./out/test/electron/runTest.js",
         "lint": "eslint src --ext ts",
-        "package": "npm run compile && vsce package --no-dependencies"
+        "package": "npm run compile && vsce package --no-dependencies",
+        "harness:snapshot": "node esbuild.webview.mjs && node preview-harness/snapshot.mjs"
     },
     "devDependencies": {
         "@happy-dom/global-registrator": "^20.9.0",
@@ -211,6 +212,7 @@
         "happy-dom": "^20.9.0",
         "lit": "^3.2.0",
         "mocha": "^11.0.0",
+        "playwright": "~1.56.0",
         "prettier": "^3.8.3",
         "typescript": "^6.0.0"
     },

--- a/vscode-extension/preview-harness/README.md
+++ b/vscode-extension/preview-harness/README.md
@@ -1,0 +1,88 @@
+# Preview view harness
+
+A lightweight "Compose Preview" for the VS Code panel itself. Renders the
+real `<preview-app>` Lit element in headless Chromium, driven by fixture
+JSON, and writes a PNG per `(fixture × theme)` pair. Use it to iterate on
+panel design — accessibility extension layouts, focus mode chrome, error
+states — without rebuilding the extension and reattaching to a host.
+
+## Run
+
+```sh
+npm run harness:snapshot         # build the bundle + capture all fixtures
+node preview-harness/snapshot.mjs --fixture grid-default --theme dark
+```
+
+PNGs land in `preview-harness/out/` (gitignored).
+
+To preview interactively, serve the extension root and open
+`http://localhost:.../preview-harness/index.html`:
+
+```sh
+npx --yes http-server -c-1 .       # from vscode-extension/
+```
+
+## How it works
+
+1. `scenario.html` is a static page that loads `media/preview.css`,
+   `media/codicon.css`, and the harness's `vscode-theme.css` (VS Code's
+   CSS custom property defaults for the dark + light themes).
+2. `vscode-api.js` installs a stub `acquireVsCodeApi()` so `getVsCodeApi()`
+   resolves outside a real webview. Posted messages land in
+   `window.__composePreviewHarness.postedMessageLog` for inspection.
+3. The page fetches the named fixture, stamps its `dataset.*` onto a
+   freshly-created `<preview-app>` element (BEFORE injecting `preview.js`
+   so Lit's `firstUpdated` reads the intended boot flags), then injects
+   the bundle.
+4. After `customElements.whenDefined('preview-app')` and the element's
+   first `updateComplete`, the page replays `fixture.messages` via
+   `window.postMessage(...)` — the same path the real webview takes for
+   `setPreviews` / `updateImage` / etc.
+5. `snapshot.mjs` spins up a tiny `http.createServer` (so `fetch()`
+   works — `file://` blocks it in Chromium), drives Playwright through
+   each fixture/theme, waits for `__composePreviewHarness.ready` plus
+   any in-flight CSS animations, and writes a full-page PNG.
+
+## Adding a fixture
+
+Drop `preview-harness/fixtures/<name>.json` with shape:
+
+```json
+{
+    "description": "What this scenario shows",
+    "dataset": {
+        "earlyFeatures": "false",
+        "autoEnableCheap": "false",
+        "collapseVariants": "false",
+        "minimalMode": "false",
+        "autoInject": "true"
+    },
+    "messages": [
+        { "command": "setPreviews", "moduleDir": "...", "previews": [...], "heavyStaleIds": [] },
+        { "command": "updateImage", "previewId": "...", "captureIndex": 0, "imageData": "<raw base64>" }
+    ]
+}
+```
+
+`messages` are `ExtensionToWebview` payloads (see
+`src/types.ts`). `updateImage.imageData` is **raw base64** — the card
+prepends `data:<mime>;base64,` itself. For repeatable bytes, write a
+generator next to the fixture (`grid-default.gen.mjs` is the template)
+and check it into git alongside the JSON it emits.
+
+## Fidelity caveats
+
+This is a design preview, not a substitute for `test:electron`. Drift
+sources:
+
+- **Theme tokens** are VS Code's defaults frozen into `vscode-theme.css`.
+  Real VS Code installs can swap the colour theme and the panel will
+  follow; the harness will not.
+- **CSP** is the http server's default (anything goes). The live webview
+  enforces a strict policy.
+- **Host messaging** is purely scripted. The harness can't exercise
+  daemon round-trips or the focus/diff flows that depend on the
+  extension replying.
+
+When a new `--vscode-*` token starts appearing in `media/preview.css`,
+add a value for it in `vscode-theme.css` (both dark and light blocks).

--- a/vscode-extension/preview-harness/fixtures/grid-default.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/grid-default.gen.mjs
@@ -1,0 +1,154 @@
+// Generator for `grid-default.json`. Run with:
+//   node preview-harness/fixtures/grid-default.gen.mjs > preview-harness/fixtures/grid-default.json
+//
+// Emits a `setPreviews` plus per-preview `updateImage` so the panel
+// renders with solid-color placeholder PNGs — enough to discuss
+// layout, chrome, and typography without rebuilding the Android
+// sample to get real captures.
+//
+// updateImage.imageData is RAW base64 (no `data:` prefix) — the
+// webview's `paintCardCapture` prepends `data:<mime>;base64,` itself.
+
+import { deflateSync } from "node:zlib";
+
+function crc32(buf) {
+    const t = new Uint32Array(256);
+    for (let n = 0; n < 256; n++) {
+        let c = n;
+        for (let k = 0; k < 8; k++)
+            c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+        t[n] = c >>> 0;
+    }
+    let c = 0xffffffff;
+    for (const b of buf) c = t[(c ^ b) & 0xff] ^ (c >>> 8);
+    return (c ^ 0xffffffff) >>> 0;
+}
+
+function solidPngBase64(w, h, r, g, b) {
+    const raw = Buffer.alloc(h * (1 + w * 3));
+    for (let y = 0; y < h; y++) {
+        let off = y * (1 + w * 3);
+        raw[off++] = 0; // PNG scanline filter: None
+        for (let x = 0; x < w; x++) {
+            raw[off++] = r;
+            raw[off++] = g;
+            raw[off++] = b;
+        }
+    }
+    function chunk(type, payload) {
+        const len = Buffer.alloc(4);
+        len.writeUInt32BE(payload.length, 0);
+        const tb = Buffer.from(type, "ascii");
+        const crc = Buffer.alloc(4);
+        crc.writeUInt32BE(crc32(Buffer.concat([tb, payload])), 0);
+        return Buffer.concat([len, tb, payload, crc]);
+    }
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(w, 0);
+    ihdr.writeUInt32BE(h, 4);
+    ihdr[8] = 8; // bit depth
+    ihdr[9] = 2; // colour type: RGB
+    const png = Buffer.concat([
+        Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+        chunk("IHDR", ihdr),
+        chunk("IDAT", deflateSync(raw)),
+        chunk("IEND", Buffer.alloc(0)),
+    ]);
+    return png.toString("base64");
+}
+
+const previews = [
+    {
+        id: "com.example.PreviewsKt.RedBoxPreview_Red Box",
+        fn: "RedBoxPreview",
+        cls: "com.example.PreviewsKt",
+        file: "Previews.kt",
+        name: "Red Box",
+        group: "colors",
+        rgb: [244, 67, 54],
+    },
+    {
+        id: "com.example.PreviewsKt.BlueBoxPreview_Blue Box",
+        fn: "BlueBoxPreview",
+        cls: "com.example.PreviewsKt",
+        file: "Previews.kt",
+        name: "Blue Box",
+        group: "colors",
+        rgb: [33, 150, 243],
+    },
+    {
+        id: "com.example.MainKt.GreetingPreview",
+        fn: "GreetingPreview",
+        cls: "com.example.MainKt",
+        file: "Main.kt",
+        name: null,
+        group: null,
+        rgb: [33, 33, 33],
+    },
+    {
+        id: "com.example.PreviewsKt.RedBoxPreview_Dark Mode",
+        fn: "RedBoxPreview",
+        cls: "com.example.PreviewsKt",
+        file: "Previews.kt",
+        name: "Dark Mode",
+        group: "colors",
+        rgb: [63, 63, 63],
+        uiMode: 32,
+    },
+];
+
+const setPreviews = {
+    command: "setPreviews",
+    moduleDir: "/workspace/sample-android",
+    heavyStaleIds: [],
+    previews: previews.map((p) => ({
+        id: p.id,
+        functionName: p.fn,
+        className: p.cls,
+        sourceFile: p.file,
+        params: {
+            name: p.name,
+            device: null,
+            widthDp: 0,
+            heightDp: 0,
+            fontScale: 1.0,
+            showSystemUi: false,
+            showBackground: true,
+            backgroundColor: 0,
+            uiMode: p.uiMode ?? 0,
+            locale: null,
+            group: p.group,
+        },
+        captures: [
+            {
+                advanceTimeMillis: null,
+                scroll: null,
+                renderOutput: `renders/${p.id}.png`,
+                label: "",
+            },
+        ],
+    })),
+};
+
+const updates = previews.map((p) => ({
+    command: "updateImage",
+    previewId: p.id,
+    captureIndex: 0,
+    imageData: solidPngBase64(160, 200, p.rgb[0], p.rgb[1], p.rgb[2]),
+}));
+
+const fixture = {
+    name: "grid-default",
+    description:
+        "Four-card grid: three color variants plus a greeting, after setPreviews + per-card updateImage.",
+    dataset: {
+        earlyFeatures: "false",
+        autoEnableCheap: "false",
+        collapseVariants: "false",
+        minimalMode: "false",
+        autoInject: "true",
+    },
+    messages: [setPreviews, ...updates],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/grid-default.json
+++ b/vscode-extension/preview-harness/fixtures/grid-default.json
@@ -1,0 +1,152 @@
+{
+    "name": "grid-default",
+    "description": "Four-card grid: three color variants plus a greeting, after setPreviews + per-card updateImage.",
+    "dataset": {
+        "earlyFeatures": "false",
+        "autoEnableCheap": "false",
+        "collapseVariants": "false",
+        "minimalMode": "false",
+        "autoInject": "true"
+    },
+    "messages": [
+        {
+            "command": "setPreviews",
+            "moduleDir": "/workspace/sample-android",
+            "heavyStaleIds": [],
+            "previews": [
+                {
+                    "id": "com.example.PreviewsKt.RedBoxPreview_Red Box",
+                    "functionName": "RedBoxPreview",
+                    "className": "com.example.PreviewsKt",
+                    "sourceFile": "Previews.kt",
+                    "params": {
+                        "name": "Red Box",
+                        "device": null,
+                        "widthDp": 0,
+                        "heightDp": 0,
+                        "fontScale": 1,
+                        "showSystemUi": false,
+                        "showBackground": true,
+                        "backgroundColor": 0,
+                        "uiMode": 0,
+                        "locale": null,
+                        "group": "colors"
+                    },
+                    "captures": [
+                        {
+                            "advanceTimeMillis": null,
+                            "scroll": null,
+                            "renderOutput": "renders/com.example.PreviewsKt.RedBoxPreview_Red Box.png",
+                            "label": ""
+                        }
+                    ]
+                },
+                {
+                    "id": "com.example.PreviewsKt.BlueBoxPreview_Blue Box",
+                    "functionName": "BlueBoxPreview",
+                    "className": "com.example.PreviewsKt",
+                    "sourceFile": "Previews.kt",
+                    "params": {
+                        "name": "Blue Box",
+                        "device": null,
+                        "widthDp": 0,
+                        "heightDp": 0,
+                        "fontScale": 1,
+                        "showSystemUi": false,
+                        "showBackground": true,
+                        "backgroundColor": 0,
+                        "uiMode": 0,
+                        "locale": null,
+                        "group": "colors"
+                    },
+                    "captures": [
+                        {
+                            "advanceTimeMillis": null,
+                            "scroll": null,
+                            "renderOutput": "renders/com.example.PreviewsKt.BlueBoxPreview_Blue Box.png",
+                            "label": ""
+                        }
+                    ]
+                },
+                {
+                    "id": "com.example.MainKt.GreetingPreview",
+                    "functionName": "GreetingPreview",
+                    "className": "com.example.MainKt",
+                    "sourceFile": "Main.kt",
+                    "params": {
+                        "name": null,
+                        "device": null,
+                        "widthDp": 0,
+                        "heightDp": 0,
+                        "fontScale": 1,
+                        "showSystemUi": false,
+                        "showBackground": true,
+                        "backgroundColor": 0,
+                        "uiMode": 0,
+                        "locale": null,
+                        "group": null
+                    },
+                    "captures": [
+                        {
+                            "advanceTimeMillis": null,
+                            "scroll": null,
+                            "renderOutput": "renders/com.example.MainKt.GreetingPreview.png",
+                            "label": ""
+                        }
+                    ]
+                },
+                {
+                    "id": "com.example.PreviewsKt.RedBoxPreview_Dark Mode",
+                    "functionName": "RedBoxPreview",
+                    "className": "com.example.PreviewsKt",
+                    "sourceFile": "Previews.kt",
+                    "params": {
+                        "name": "Dark Mode",
+                        "device": null,
+                        "widthDp": 0,
+                        "heightDp": 0,
+                        "fontScale": 1,
+                        "showSystemUi": false,
+                        "showBackground": true,
+                        "backgroundColor": 0,
+                        "uiMode": 32,
+                        "locale": null,
+                        "group": "colors"
+                    },
+                    "captures": [
+                        {
+                            "advanceTimeMillis": null,
+                            "scroll": null,
+                            "renderOutput": "renders/com.example.PreviewsKt.RedBoxPreview_Dark Mode.png",
+                            "label": ""
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "command": "updateImage",
+            "previewId": "com.example.PreviewsKt.RedBoxPreview_Red Box",
+            "captureIndex": 0,
+            "imageData": "iVBORw0KGgoAAAANSUhEUgAAAKAAAADICAIAAADgCn1NAAAB40lEQVR4nO3RAQkAIBDAwE9lAfu3MYApRBgHF2CwOXsRNt8LeMrgOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjLpHCQ29ortX/AAAAAElFTkSuQmCC"
+        },
+        {
+            "command": "updateImage",
+            "previewId": "com.example.PreviewsKt.BlueBoxPreview_Blue Box",
+            "captureIndex": 0,
+            "imageData": "iVBORw0KGgoAAAANSUhEUgAAAKAAAADICAIAAADgCn1NAAAB4klEQVR4nO3RAQkAIBDAwK9iaYtawBQijIMLMNisfQib7wU8ZXCcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEGxxkcZ3CcwXEXNtMOMfbvdYUAAAAASUVORK5CYII="
+        },
+        {
+            "command": "updateImage",
+            "previewId": "com.example.MainKt.GreetingPreview",
+            "captureIndex": 0,
+            "imageData": "iVBORw0KGgoAAAANSUhEUgAAAKAAAADICAIAAADgCn1NAAAB30lEQVR4nO3RAQkAMAzAsFmZf5NTcQ4lUVDoLGnzO4C3DI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOO4AQhhZ0YeLpq4AAAAASUVORK5CYII="
+        },
+        {
+            "command": "updateImage",
+            "previewId": "com.example.PreviewsKt.RedBoxPreview_Dark Mode",
+            "captureIndex": 0,
+            "imageData": "iVBORw0KGgoAAAANSUhEUgAAAKAAAADICAIAAADgCn1NAAAB30lEQVR4nO3RAQkAMAzAsDmbf1dTcQ4lUVDoLGnzO4C3DI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOM7gOIPjDI4zOO4AtBtOZQJm65QAAAAASUVORK5CYII="
+        }
+    ]
+}

--- a/vscode-extension/preview-harness/index.html
+++ b/vscode-extension/preview-harness/index.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Compose Preview — design harness</title>
+        <style>
+            body {
+                margin: 0;
+                font-family:
+                    -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+                background: #181818;
+                color: #ddd;
+            }
+            header {
+                padding: 16px 24px;
+                border-bottom: 1px solid #333;
+            }
+            header h1 {
+                margin: 0;
+                font-size: 16px;
+                font-weight: 600;
+            }
+            header p {
+                margin: 4px 0 0;
+                color: #999;
+                font-size: 12px;
+            }
+            .grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+                gap: 24px;
+                padding: 24px;
+            }
+            .card {
+                background: #1f1f1f;
+                border: 1px solid #333;
+                border-radius: 6px;
+                overflow: hidden;
+                display: flex;
+                flex-direction: column;
+            }
+            .card h2 {
+                margin: 0;
+                padding: 8px 12px;
+                font-size: 12px;
+                font-weight: 600;
+                background: #252526;
+                border-bottom: 1px solid #333;
+                display: flex;
+                justify-content: space-between;
+                gap: 8px;
+            }
+            .card h2 small {
+                font-weight: 400;
+                color: #999;
+            }
+            .frame {
+                width: 100%;
+                height: 520px;
+                border: 0;
+                background: #1f1f1f;
+            }
+        </style>
+    </head>
+    <body>
+        <header>
+            <h1>Compose Preview — design harness</h1>
+            <p>
+                Static renders of the VS Code preview panel, driven by fixture
+                JSON. Edit a fixture in <code>fixtures/</code> and refresh.
+            </p>
+        </header>
+        <div class="grid">
+            <div class="card">
+                <h2>grid-default <small>dark · 1024×720</small></h2>
+                <iframe
+                    class="frame"
+                    src="./scenario.html?fixture=grid-default&theme=dark"
+                ></iframe>
+            </div>
+            <div class="card">
+                <h2>grid-default <small>light · 1024×720</small></h2>
+                <iframe
+                    class="frame"
+                    src="./scenario.html?fixture=grid-default&theme=light"
+                ></iframe>
+            </div>
+        </div>
+    </body>
+</html>

--- a/vscode-extension/preview-harness/scenario.html
+++ b/vscode-extension/preview-harness/scenario.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en" data-vscode-theme="dark">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Compose Preview — scenario</title>
+
+        <!-- Match the live webview's chrome: codicons, the panel CSS, and the
+             VS Code theme tokens it depends on. preview.css ships with the
+             extension under `media/`; the harness loads it via a relative
+             path so we never diverge from production. -->
+        <link rel="stylesheet" href="../media/codicon.css" />
+        <link rel="stylesheet" href="./vscode-theme.css" />
+        <link rel="stylesheet" href="../media/preview.css" />
+
+        <!-- The shim must run before preview.js loads, so getVsCodeApi()
+             finds window.acquireVsCodeApi on its first call. -->
+        <script src="./vscode-api.js"></script>
+    </head>
+    <body>
+        <!-- Boot sequence:
+             1. Fetch the fixture.
+             2. Inject `<preview-app>` with its dataset already stamped, so
+                Lit's `firstUpdated` reads the intended boot flags (without
+                this, `data-collapse-variants` defaults to true and only the
+                first variant of each function renders).
+             3. Inject `preview.js`. The bundle's `customElements.define`
+                upgrades the existing `<preview-app>` instance, which then
+                runs `firstUpdated` and attaches the window-message listener.
+             4. After the element's first render settles, replay each fixture
+                message via `window.postMessage` exactly as VS Code does. -->
+        <script type="module">
+            const params = new URLSearchParams(location.search);
+            const fixture = params.get("fixture") ?? "grid-default";
+            const theme = params.get("theme") ?? "dark";
+            document.documentElement.dataset.vscodeTheme = theme;
+
+            const harness = (window.__composePreviewHarness ??= {});
+            harness.fixture = fixture;
+            harness.ready = false;
+
+            async function loadScript(src) {
+                return new Promise((res, rej) => {
+                    const s = document.createElement("script");
+                    s.src = src;
+                    s.onload = res;
+                    s.onerror = () => rej(new Error("failed to load " + src));
+                    document.body.appendChild(s);
+                });
+            }
+
+            async function run() {
+                const res = await fetch(`./fixtures/${fixture}.json`, {
+                    cache: "no-store",
+                });
+                if (!res.ok) {
+                    document.body.textContent = `fixture not found: ${fixture}`;
+                    return;
+                }
+                const data = await res.json();
+                harness.fixtureData = data;
+
+                const app = document.createElement("preview-app");
+                for (const [k, v] of Object.entries(data.dataset ?? {})) {
+                    app.dataset[k] = v;
+                }
+                document.body.appendChild(app);
+
+                await loadScript("../media/webview/preview.js");
+                await customElements.whenDefined("preview-app");
+                await app.updateComplete;
+
+                for (const msg of data.messages ?? []) {
+                    window.postMessage(msg, "*");
+                }
+                // Let the dispatcher run, the cards re-render, and the
+                // <img>s decode the new data URIs before signalling ready.
+                await new Promise((r) => requestAnimationFrame(r));
+                await new Promise((r) => requestAnimationFrame(r));
+                const imgs = Array.from(
+                    document.querySelectorAll(".preview-card img"),
+                );
+                await Promise.all(
+                    imgs.map((img) =>
+                        img.complete && img.naturalWidth > 0
+                            ? Promise.resolve()
+                            : new Promise((r) => {
+                                  img.addEventListener("load", r, {
+                                      once: true,
+                                  });
+                                  img.addEventListener("error", r, {
+                                      once: true,
+                                  });
+                              }),
+                    ),
+                );
+                // Wait for any in-flight CSS animations (the `fadeIn` on
+                // freshly-painted preview <img>s, transitions on bundle
+                // chips, etc.) to settle so the screenshot isn't a
+                // mid-frame grab of the 0.2s opacity ramp.
+                if (typeof document.getAnimations === "function") {
+                    await Promise.all(
+                        document
+                            .getAnimations()
+                            .map((a) => a.finished.catch(() => {})),
+                    );
+                }
+                harness.ready = true;
+            }
+            run().catch((err) => {
+                console.error(err);
+                document.body.textContent = String(err);
+            });
+        </script>
+    </body>
+</html>

--- a/vscode-extension/preview-harness/snapshot.mjs
+++ b/vscode-extension/preview-harness/snapshot.mjs
@@ -1,0 +1,154 @@
+// Headless capture of the preview-harness scenarios.
+//
+// Spins up a tiny static HTTP server rooted at the extension dir (so
+// the scenario page can fetch fixtures — Chromium blocks `fetch()` on
+// `file://`), drives Playwright through each `(fixture × theme)` pair,
+// waits for the harness's `ready` flag to flip, then writes a PNG into
+// `preview-harness/out/`.
+//
+// Usage:
+//   node esbuild.webview.mjs           # rebuild bundle first
+//   node preview-harness/snapshot.mjs  # captures all scenarios
+//
+// Override the matrix:
+//   node preview-harness/snapshot.mjs --fixture grid-default --theme dark
+
+import { chromium } from "playwright";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve, relative, normalize, sep } from "node:path";
+import { mkdir, readdir, readFile, stat } from "node:fs/promises";
+import { createServer } from "node:http";
+
+const harnessDir = dirname(fileURLToPath(import.meta.url));
+const extensionRoot = resolve(harnessDir, "..");
+const outDir = resolve(harnessDir, "out");
+
+const mimeByExt = {
+    ".html": "text/html; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".mjs": "text/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+    ".ttf": "font/ttf",
+    ".map": "application/json; charset=utf-8",
+};
+
+function startServer(root) {
+    return new Promise((resolveServer) => {
+        const server = createServer(async (req, res) => {
+            try {
+                const url = new URL(req.url, "http://localhost");
+                const rel = decodeURIComponent(url.pathname).replace(
+                    /^\/+/,
+                    "",
+                );
+                const target = normalize(resolve(root, rel));
+                if (
+                    relative(root, target).startsWith("..") ||
+                    target === root + sep + ".." // safety
+                ) {
+                    res.writeHead(403);
+                    res.end("forbidden");
+                    return;
+                }
+                let filePath = target;
+                try {
+                    const s = await stat(filePath);
+                    if (s.isDirectory()) {
+                        filePath = resolve(filePath, "index.html");
+                    }
+                } catch {
+                    res.writeHead(404);
+                    res.end("not found: " + rel);
+                    return;
+                }
+                const ext = filePath.slice(filePath.lastIndexOf("."));
+                const body = await readFile(filePath);
+                res.writeHead(200, {
+                    "content-type":
+                        mimeByExt[ext] ?? "application/octet-stream",
+                    "cache-control": "no-store",
+                });
+                res.end(body);
+            } catch (err) {
+                res.writeHead(500);
+                res.end(String(err));
+            }
+        });
+        server.listen(0, "127.0.0.1", () => {
+            const addr = server.address();
+            resolveServer({
+                origin: `http://127.0.0.1:${addr.port}`,
+                close: () => new Promise((r) => server.close(r)),
+            });
+        });
+    });
+}
+
+function arg(name, fallback) {
+    const i = process.argv.indexOf("--" + name);
+    return i >= 0 ? process.argv[i + 1] : fallback;
+}
+
+const explicitFixture = arg("fixture", null);
+const explicitTheme = arg("theme", null);
+const viewport = {
+    width: Number(arg("width", 1024)),
+    height: Number(arg("height", 720)),
+};
+
+async function listFixtures() {
+    if (explicitFixture) return [explicitFixture];
+    const entries = await readdir(resolve(harnessDir, "fixtures"));
+    return entries
+        .filter((e) => e.endsWith(".json"))
+        .map((e) => e.replace(/\.json$/, ""));
+}
+
+const themes = explicitTheme ? [explicitTheme] : ["dark", "light"];
+
+await mkdir(outDir, { recursive: true });
+const fixtures = await listFixtures();
+// Serve from the extension root so the scenario page can reach both
+// `preview-harness/...` and `../media/...` via the same origin.
+const server = await startServer(extensionRoot);
+const browser = await chromium.launch();
+
+try {
+    for (const fixture of fixtures) {
+        for (const theme of themes) {
+            const context = await browser.newContext({ viewport });
+            const page = await context.newPage();
+            page.on("pageerror", (err) =>
+                console.error(`[${fixture}/${theme}] pageerror:`, err.message),
+            );
+            page.on("console", (msg) => {
+                if (msg.type() === "error") {
+                    console.error(`[${fixture}/${theme}] console:`, msg.text());
+                }
+            });
+
+            const url = new URL(
+                server.origin + "/preview-harness/scenario.html",
+            );
+            url.searchParams.set("fixture", fixture);
+            url.searchParams.set("theme", theme);
+            await page.goto(url.href);
+
+            await page.waitForFunction(
+                () => window.__composePreviewHarness?.ready === true,
+                { timeout: 10_000 },
+            );
+
+            const outPath = resolve(outDir, `${fixture}.${theme}.png`);
+            await page.screenshot({ path: outPath, fullPage: true });
+            console.log(`wrote ${outPath}`);
+            await context.close();
+        }
+    }
+} finally {
+    await browser.close();
+    await server.close();
+}

--- a/vscode-extension/preview-harness/vscode-api.js
+++ b/vscode-extension/preview-harness/vscode-api.js
@@ -1,0 +1,39 @@
+// Shim that replaces VS Code's `acquireVsCodeApi()` for the in-browser
+// preview harness. The real API only exists inside a VS Code webview;
+// the harness runs in a plain Chromium page, so we install a stub that
+// captures `postMessage` calls (so we can assert on them later) and
+// uses sessionStorage for `getState` / `setState` parity.
+//
+// MUST be loaded BEFORE the bundled `preview.js` so `getVsCodeApi()`
+// finds `window.acquireVsCodeApi` on first call.
+
+(function () {
+    const stateKey = "compose-preview-harness-state";
+    const log = [];
+    window.__composePreviewHarness = window.__composePreviewHarness ?? {};
+    window.__composePreviewHarness.postedMessageLog = log;
+
+    window.acquireVsCodeApi = function () {
+        return {
+            postMessage(msg) {
+                log.push(msg);
+            },
+            getState() {
+                try {
+                    const raw = sessionStorage.getItem(stateKey);
+                    return raw ? JSON.parse(raw) : undefined;
+                } catch {
+                    return undefined;
+                }
+            },
+            setState(state) {
+                try {
+                    sessionStorage.setItem(stateKey, JSON.stringify(state));
+                } catch {
+                    // ignore
+                }
+                return state;
+            },
+        };
+    };
+})();

--- a/vscode-extension/preview-harness/vscode-theme.css
+++ b/vscode-extension/preview-harness/vscode-theme.css
@@ -1,0 +1,111 @@
+/* VS Code "Dark Modern" theme tokens for the preview harness.
+ * Values are the ones VS Code's built-in dark theme resolves to —
+ * good enough for design discussions outside a real webview.
+ *
+ * Toggle the dark/light root via `<html data-vscode-theme="light">` —
+ * the `[data-vscode-theme="light"]` block below overrides the dark
+ * values where they differ.
+ *
+ * Drift policy: when preview.css starts using a new --vscode-* token,
+ * add it here. There is no live link to VS Code's source. */
+
+:root {
+    color-scheme: dark;
+
+    --vscode-font-family:
+        -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
+        Helvetica, Arial, sans-serif;
+    --vscode-font-size: 13px;
+    --vscode-editor-font-family: "SF Mono", Monaco, Menlo, Consolas, monospace;
+
+    --vscode-foreground: #cccccc;
+    --vscode-descriptionForeground: #9d9d9d;
+    --vscode-errorForeground: #f48771;
+    --vscode-focusBorder: #007fd4;
+    --vscode-icon-foreground: #c5c5c5;
+    --vscode-textLink-foreground: #3794ff;
+    --vscode-textLink-activeForeground: #3794ff;
+
+    --vscode-editor-background: #1f1f1f;
+    --vscode-editor-inactiveSelectionBackground: #3a3d41;
+    --vscode-editorWidget-background: #252526;
+    --vscode-editorWidget-foreground: #cccccc;
+    --vscode-editorWidget-border: #454545;
+
+    --vscode-panel-border: #2b2b2b;
+
+    --vscode-list-hoverBackground: #2a2d2e;
+    --vscode-toolbar-hoverBackground: rgba(90, 93, 94, 0.31);
+    --vscode-toolbar-activeBackground: rgba(99, 102, 103, 0.31);
+
+    --vscode-button-background: #0e639c;
+    --vscode-button-foreground: #ffffff;
+    --vscode-button-hoverBackground: #1177bb;
+    --vscode-button-border: transparent;
+    --vscode-button-secondaryBackground: #3a3d41;
+    --vscode-button-secondaryForeground: #cccccc;
+
+    --vscode-dropdown-background: #3c3c3c;
+    --vscode-dropdown-foreground: #f0f0f0;
+    --vscode-dropdown-border: #3c3c3c;
+    --vscode-dropdown-listBackground: #3c3c3c;
+
+    --vscode-badge-background: #4d4d4d;
+    --vscode-badge-foreground: #ffffff;
+
+    --vscode-progressBar-background: #0e70c0;
+
+    --vscode-tab-activeBackground: #1f1f1f;
+    --vscode-tab-activeForeground: #ffffff;
+    --vscode-tab-inactiveBackground: #2d2d2d;
+    --vscode-tab-inactiveForeground: #9d9d9d;
+
+    --vscode-statusBarItem-prominentBackground: #0e639c;
+    --vscode-statusBarItem-prominentForeground: #ffffff;
+
+    --vscode-editorInfo-foreground: #3794ff;
+    --vscode-editorWarning-foreground: #cca700;
+    --vscode-notificationsWarningIcon-foreground: #cca700;
+    --vscode-testing-iconPassed: #73c991;
+    --vscode-charts-green: #89d185;
+
+    --vscode-inputValidation-errorBackground: #5a1d1d;
+    --vscode-inputValidation-errorForeground: #cccccc;
+    --vscode-inputValidation-errorBorder: #be1100;
+    --vscode-inputValidation-warningBackground: #352a05;
+    --vscode-inputValidation-warningForeground: #cccccc;
+}
+
+[data-vscode-theme="light"] {
+    color-scheme: light;
+
+    --vscode-foreground: #3b3b3b;
+    --vscode-descriptionForeground: #717171;
+    --vscode-errorForeground: #a1260d;
+    --vscode-icon-foreground: #424242;
+
+    --vscode-editor-background: #ffffff;
+    --vscode-editor-inactiveSelectionBackground: #e5ebf1;
+    --vscode-editorWidget-background: #f8f8f8;
+    --vscode-editorWidget-foreground: #3b3b3b;
+    --vscode-editorWidget-border: #c8c8c8;
+
+    --vscode-panel-border: #e5e5e5;
+    --vscode-list-hoverBackground: #e8e8e8;
+
+    --vscode-button-background: #005fb8;
+    --vscode-button-foreground: #ffffff;
+    --vscode-button-hoverBackground: #0258a8;
+    --vscode-button-secondaryBackground: #e5e5e5;
+    --vscode-button-secondaryForeground: #3b3b3b;
+
+    --vscode-dropdown-background: #ffffff;
+    --vscode-dropdown-foreground: #3b3b3b;
+    --vscode-dropdown-border: #cecece;
+    --vscode-dropdown-listBackground: #ffffff;
+
+    --vscode-tab-activeBackground: #ffffff;
+    --vscode-tab-activeForeground: #3b3b3b;
+    --vscode-tab-inactiveBackground: #ececec;
+    --vscode-tab-inactiveForeground: #717171;
+}


### PR DESCRIPTION
## Summary

- Adds `preview-harness/`: a static page that boots the real `<preview-app>` Lit bundle in headless Chromium with a stubbed `acquireVsCodeApi()` and VS Code theme tokens, replaying `ExtensionToWebview` fixture messages so the panel renders without a VS Code host.
- Captures one PNG per `(fixture × theme)` via Playwright — design-review aid for new panel features (e.g. accessibility extensions) before any production code lands.
- `grid-default` is the seed fixture: a four-card grid driven by `setPreviews` + per-card `updateImage` with synthesised colour-block PNGs (raw base64; the card prepends `data:<mime>;base64,` itself).
- Pinned `playwright` to `~1.56.0` so the bundled chromium revision matches CI/dev environments.

Wired via `npm run harness:snapshot`. Outputs land in `preview-harness/out/` (gitignored). Fidelity caveats are in `preview-harness/README.md` — design preview, not a substitute for `test:electron`.

## Test plan

- [ ] `npm run harness:snapshot` produces `preview-harness/out/grid-default.{dark,light}.png` with four colour-block cards.
- [ ] `npm test` stays green (no regressions in the existing webview/DOM tests).
- [ ] Open `preview-harness/index.html` via `npx http-server -c-1 .` and confirm both iframes render.
- [ ] Edit a value in `vscode-theme.css` (e.g. `--vscode-editor-background`) and confirm the snapshot reflects it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZueDM4HQktvumMmHqxg1p)_