### PR TITLE
feat(vscode-extension): generic bundle-legend panel beside the focused preview

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -371,6 +371,114 @@ body {
 .preview-grid.layout-focus {
     display: block;
 }
+
+/* Focus-stage flex layout: preview-grid on the left, bundle-legend
+ * column on the right. Outside of focus mode the legend stays hidden
+ * (host gates via `[hidden]`) so the stage falls back to a plain
+ * block layout matching the pre-legend behaviour.  */
+.focus-stage {
+    display: contents;
+}
+.focus-stage:has(.focus-stage-legend:not([hidden])) {
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    gap: 12px;
+}
+.focus-stage:has(.focus-stage-legend:not([hidden])) > .preview-grid {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.focus-stage-legend {
+    flex: 0 0 280px;
+    max-width: 320px;
+    max-height: 70vh;
+    overflow: auto;
+    border: 1px solid var(--card-border, rgba(127, 127, 127, 0.2));
+    border-radius: 4px;
+    background: var(--vscode-editor-background, transparent);
+}
+.focus-stage-legend[hidden] {
+    display: none;
+}
+.bundle-legend-panel {
+    display: flex;
+    flex-direction: column;
+}
+.bundle-legend-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--card-border, rgba(127, 127, 127, 0.2));
+    font-weight: 600;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--vscode-descriptionForeground, currentColor);
+}
+.bundle-legend-count {
+    font-weight: 400;
+    opacity: 0.7;
+}
+.bundle-legend-list {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+}
+.bundle-legend-entry {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 6px 10px;
+    cursor: pointer;
+    transition: background-color 80ms ease-out;
+}
+.bundle-legend-entry:hover,
+.bundle-legend-entry-active {
+    background: var(--vscode-list-hoverBackground, rgba(127, 127, 127, 0.1));
+}
+.bundle-legend-entry:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder, currentColor);
+    outline-offset: -1px;
+}
+.bundle-legend-swatch {
+    flex: 0 0 12px;
+    width: 12px;
+    height: 12px;
+    margin-top: 3px;
+    border-radius: 2px;
+    background: var(--legend-swatch-color, var(--swatch-fallback, #1976d2));
+    border: 1px solid
+        var(--legend-swatch-color, var(--swatch-fallback, #1976d2));
+}
+.bundle-legend-swatch[data-level="error"] {
+    --swatch-fallback: #d32f2f;
+}
+.bundle-legend-swatch[data-level="warning"] {
+    --swatch-fallback: #f57c00;
+}
+.bundle-legend-swatch[data-level="info"] {
+    --swatch-fallback: #1976d2;
+}
+.bundle-legend-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+.bundle-legend-label {
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.bundle-legend-detail {
+    font-size: 11px;
+    opacity: 0.75;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 .preview-grid.layout-focus .preview-card.hidden-by-focus {
     display: none;
 }

--- a/vscode-extension/src/test/bundleLegend.test.ts
+++ b/vscode-extension/src/test/bundleLegend.test.ts
@@ -1,0 +1,166 @@
+// `<bundle-legend>` — side-panel legend rendered beside the focused
+// preview. The host populates per-bundle slices via
+// `setBundleEntries`; `showBundle` swaps which slice is visible.
+// These tests pin the slice-swap behaviour, the hover/select event
+// contract, and the empty-slice / cleared-slice hide paths.
+
+import * as assert from "assert";
+import "../webview/preview/components/BundleLegend";
+import type {
+    BundleLegend,
+    BundleLegendEntry,
+    BundleLegendHoveredDetail,
+    BundleLegendSelectedDetail,
+} from "../webview/preview/components/BundleLegend";
+
+function entry(over: Partial<BundleLegendEntry>): BundleLegendEntry {
+    return {
+        id: over.id ?? "id-1",
+        label: over.label ?? "Label",
+        detail: over.detail,
+        level: over.level ?? "info",
+        color: over.color,
+    };
+}
+
+function build(): BundleLegend {
+    const el = document.createElement("bundle-legend") as BundleLegend;
+    document.body.appendChild(el);
+    return el;
+}
+
+describe("BundleLegend", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("renders nothing until a bundle is shown", async () => {
+        const el = build();
+        el.setBundleEntries("a11y", "Accessibility", [entry({})]);
+        await el.updateComplete;
+        assert.strictEqual(
+            el.querySelector(".bundle-legend-panel"),
+            null,
+            "legend must stay empty until showBundle() picks a slice",
+        );
+    });
+
+    it("showBundle swaps which slice renders and returns the entry count", async () => {
+        const el = build();
+        el.setBundleEntries("a11y", "Accessibility", [
+            entry({ id: "n0", label: "Title" }),
+            entry({ id: "n1", label: "Body" }),
+        ]);
+        el.setBundleEntries("inspection", "Inspection", [
+            entry({ id: "s0", label: "Semantics" }),
+        ]);
+        const a11yCount = el.showBundle("a11y");
+        await el.updateComplete;
+        assert.strictEqual(a11yCount, 2);
+        const labels = Array.from(
+            el.querySelectorAll(".bundle-legend-label"),
+        ).map((n) => n.textContent);
+        assert.deepStrictEqual(labels, ["Title", "Body"]);
+        const inspCount = el.showBundle("inspection");
+        await el.updateComplete;
+        assert.strictEqual(inspCount, 1);
+        const after = Array.from(
+            el.querySelectorAll(".bundle-legend-label"),
+        ).map((n) => n.textContent);
+        assert.deepStrictEqual(after, ["Semantics"]);
+    });
+
+    it("showBundle(null) hides the legend and returns 0", async () => {
+        const el = build();
+        el.setBundleEntries("a11y", "Accessibility", [entry({})]);
+        el.showBundle("a11y");
+        await el.updateComplete;
+        assert.ok(el.querySelector(".bundle-legend-panel"));
+        const cleared = el.showBundle(null);
+        await el.updateComplete;
+        assert.strictEqual(cleared, 0);
+        assert.strictEqual(el.querySelector(".bundle-legend-panel"), null);
+    });
+
+    it("clearBundle drops the slice and hides the panel if it was active", async () => {
+        const el = build();
+        el.setBundleEntries("a11y", "Accessibility", [entry({})]);
+        el.showBundle("a11y");
+        await el.updateComplete;
+        el.clearBundle("a11y");
+        await el.updateComplete;
+        assert.strictEqual(
+            el.querySelector(".bundle-legend-panel"),
+            null,
+            "clearing the active slice must hide the panel",
+        );
+    });
+
+    it("hover fires legend-hovered with the entry id, mouseleave fires with null", async () => {
+        const el = build();
+        el.setBundleEntries("a11y", "Accessibility", [
+            entry({ id: "node-7", label: "Tap me" }),
+        ]);
+        el.showBundle("a11y");
+        await el.updateComplete;
+        const captured: (string | null)[] = [];
+        el.addEventListener("legend-hovered", (evt) => {
+            captured.push(
+                (evt as CustomEvent<BundleLegendHoveredDetail>).detail.entryId,
+            );
+        });
+        const row = el.querySelector<HTMLElement>(".bundle-legend-entry")!;
+        row.dispatchEvent(new Event("mouseenter", { bubbles: true }));
+        row.dispatchEvent(new Event("mouseleave", { bubbles: true }));
+        assert.deepStrictEqual(captured, ["node-7", null]);
+    });
+
+    it("click fires legend-selected with the entry id", async () => {
+        const el = build();
+        el.setBundleEntries("inspection", "Inspection", [
+            entry({ id: "sem-3" }),
+        ]);
+        el.showBundle("inspection");
+        await el.updateComplete;
+        let detail: BundleLegendSelectedDetail | null = null;
+        el.addEventListener("legend-selected", (evt) => {
+            detail = (evt as CustomEvent<BundleLegendSelectedDetail>).detail;
+        });
+        const row = el.querySelector<HTMLElement>(".bundle-legend-entry")!;
+        row.click();
+        assert.deepStrictEqual(detail, { entryId: "sem-3" });
+    });
+
+    it("setActiveEntryId mirrors a host-driven highlight onto the matching row", async () => {
+        const el = build();
+        el.setBundleEntries("a11y", "Accessibility", [
+            entry({ id: "a" }),
+            entry({ id: "b" }),
+        ]);
+        el.showBundle("a11y");
+        await el.updateComplete;
+        el.setActiveEntryId("b");
+        await el.updateComplete;
+        const active = el.querySelector(".bundle-legend-entry-active");
+        assert.ok(active);
+        assert.strictEqual(active!.getAttribute("data-legend-id"), "b");
+    });
+
+    it("setBundleEntries on the currently-shown bundle re-renders without an extra showBundle call", async () => {
+        const el = build();
+        el.setBundleEntries("a11y", "Accessibility", [
+            entry({ id: "n0", label: "Old" }),
+        ]);
+        el.showBundle("a11y");
+        await el.updateComplete;
+        el.setBundleEntries("a11y", "Accessibility", [
+            entry({ id: "n0", label: "New" }),
+        ]);
+        await el.updateComplete;
+        const label = el.querySelector(".bundle-legend-label");
+        assert.strictEqual(label?.textContent, "New");
+    });
+});

--- a/vscode-extension/src/test/bundleLegendTarget.test.ts
+++ b/vscode-extension/src/test/bundleLegendTarget.test.ts
@@ -1,0 +1,101 @@
+// Regression test for the bundle-legend ↔ table-row lookup. The
+// previous implementation called `document.querySelector` with a
+// pair of comma-separated selectors that matched both overlay boxes
+// (inside `<preview-grid>`) and table rows (inside `<data-tabs>`).
+// Document-order means the overlay box won every time, so clicking
+// a legend entry scrolled the preview image instead of the table
+// row — defeating the point of the click. `findLegendTarget` scopes
+// the lookup to the `<data-tabs>` subtree so the overlay box is out
+// of reach by construction.
+
+import * as assert from "assert";
+import { findLegendTarget } from "../webview/preview/bundleLegendTarget";
+
+function buildShell(): HTMLElement {
+    // Mirror the production DOM order: preview-grid (with overlay
+    // boxes) comes *before* data-tabs (with the table rows). Each
+    // surface has the same `data-bundle` and the overlay shares the
+    // entry id as `data-overlay-id`; the table row uses
+    // `data-legend-id`. The buggy selector picked the overlay.
+    document.body.innerHTML = `
+        <div id="preview-grid">
+            <div class="preview-card">
+                <box-overlay data-bundle="a11y">
+                    <div class="overlay-box" data-overlay-id="row-3"></div>
+                </box-overlay>
+            </div>
+        </div>
+        <data-tabs>
+            <div class="data-tab-body" data-bundle="a11y">
+                <div class="bundle-tab-body" data-bundle="a11y">
+                    <table>
+                        <tr id="target-row" data-legend-id="row-3"></tr>
+                    </table>
+                </div>
+            </div>
+        </data-tabs>
+    `;
+    return document.querySelector<HTMLElement>("data-tabs")!;
+}
+
+describe("findLegendTarget", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("returns the table row inside the data-tabs subtree, not the overlay box above", () => {
+        const dataTabs = buildShell();
+        const target = findLegendTarget(dataTabs, "a11y", "row-3");
+        assert.ok(target, "expected a target for entry row-3");
+        assert.strictEqual(
+            target!.id,
+            "target-row",
+            "must scope to the data-tabs subtree so the overlay box doesn't win",
+        );
+    });
+
+    it("falls back to data-overlay-id inside the tab body when no data-legend-id matches", () => {
+        // Legacy tables that haven't wired the legend-id mirroring
+        // still expose `data-overlay-id` on rows for the existing
+        // hover correlation. The fallback should match those too —
+        // but only inside the tab body, never the preview overlay.
+        document.body.innerHTML = `
+            <div id="preview-grid">
+                <div class="preview-card">
+                    <box-overlay data-bundle="text">
+                        <div data-overlay-id="row-9"></div>
+                    </box-overlay>
+                </div>
+            </div>
+            <data-tabs>
+                <div class="data-tab-body" data-bundle="text">
+                    <table>
+                        <tr id="legacy-row" data-overlay-id="row-9"></tr>
+                    </table>
+                </div>
+            </data-tabs>
+        `;
+        const dataTabs = document.querySelector<HTMLElement>("data-tabs")!;
+        const target = findLegendTarget(dataTabs, "text", "row-9");
+        assert.ok(target);
+        assert.strictEqual(target!.id, "legacy-row");
+    });
+
+    it("returns null when the active tab has no body in the data-tabs subtree", () => {
+        document.body.innerHTML = `<data-tabs></data-tabs>`;
+        const dataTabs = document.querySelector<HTMLElement>("data-tabs")!;
+        const target = findLegendTarget(dataTabs, "a11y", "row-3");
+        assert.strictEqual(target, null);
+    });
+
+    it("returns null when the tab body has no matching row id", () => {
+        document.body.innerHTML = `
+            <data-tabs>
+                <div data-bundle="a11y"></div>
+            </data-tabs>
+        `;
+        const dataTabs = document.querySelector<HTMLElement>("data-tabs")!;
+        const target = findLegendTarget(dataTabs, "a11y", "row-3");
+        assert.strictEqual(target, null);
+    });
+});

--- a/vscode-extension/src/webview/preview/bundleLegendTarget.ts
+++ b/vscode-extension/src/webview/preview/bundleLegendTarget.ts
@@ -1,0 +1,31 @@
+// Resolve the DOM target for a `legend-selected` event so the host
+// can call `scrollIntoView` on it. The lookup is intentionally
+// scoped to the `<data-tabs>` subtree — never the whole document —
+// because `<box-overlay>` elements painted on top of the preview
+// image carry the same `data-bundle` attribute as the bundle's tab
+// body, and the overlay descendants carry the same
+// `data-overlay-id` as the table row's `data-legend-id`. A
+// document-wide selector returns the first match in tree order,
+// which puts the overlay box (high in the DOM, above `<data-tabs>`)
+// ahead of the table row — `scrollIntoView` then runs on the
+// overlay and the table row never moves.
+//
+// Two surfaces are accepted inside the tab body: `data-legend-id`
+// (the canonical one, set via `<data-table>.setOverlayId`) and
+// `data-overlay-id` (the fallback for tables that haven't wired the
+// mirroring yet — kept so the host doesn't crash on rows from
+// pre-legend bundles).
+
+export function findLegendTarget(
+    dataTabs: HTMLElement,
+    bundleId: string,
+    entryId: string,
+): HTMLElement | null {
+    const tabBody = dataTabs.querySelector<HTMLElement>(
+        `[data-bundle="${bundleId}"]`,
+    );
+    if (!tabBody) return null;
+    return tabBody.querySelector<HTMLElement>(
+        `[data-legend-id="${entryId}"], [data-overlay-id="${entryId}"]`,
+    );
+}

--- a/vscode-extension/src/webview/preview/components/BundleLegend.ts
+++ b/vscode-extension/src/webview/preview/components/BundleLegend.ts
@@ -1,0 +1,248 @@
+// `<bundle-legend>` — side panel beside the focused preview that
+// surfaces per-overlay info the user needs to read at a glance:
+// colour swatch (matching the overlay box on the preview image), a
+// label, and a short subtitle. Generic across bundles — each bundle's
+// refresh function can populate entries for its kind, and the legend
+// renders the entries that belong to the currently-active tab.
+//
+// Visibility rules (gated by the host shell in `main.ts`):
+//
+//   - Only in focus layout — grid mode doesn't have a notion of "the"
+//     preview to highlight against.
+//   - Only when `composePreview.earlyFeatures.enabled` is true — the
+//     legend rides the same gate as the rest of the bundle UI.
+//   - Only when the active tab's bundle has supplied entries — empty
+//     space next to the preview is just visual noise.
+//
+// Correlation contract (`id` shared across surfaces):
+//
+//   - Hovering an entry dispatches `legend-hovered` with the entry
+//     id. Host wires that to the per-bundle `<box-overlay>`'s
+//     `setActiveOverlayId` so the matching overlay box lights up on
+//     the preview.
+//   - Clicking an entry dispatches `legend-selected` with the entry
+//     id. Host scrolls the matching row in the bundle's
+//     `<data-table>` into view (host may also expand a detail panel).
+//   - Hosts that drive the highlight from the other side (e.g. user
+//     hovers an overlay box on the preview) call `setActiveEntryId`
+//     to mirror the highlight on the legend.
+
+import { LitElement, html, type TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { ref } from "lit/directives/ref.js";
+
+export interface BundleLegendEntry {
+    /** Same id used for `data-overlay-id` on the matching overlay box
+     *  and `data-legend-id` on the matching `<data-table>` row, so
+     *  hover / scroll correlation is symmetric across the three
+     *  surfaces. */
+    id: string;
+    label: string;
+    /** Short subtitle. For a11y this is `role · key states`; other
+     *  bundles can put whatever short tag is useful (e.g. a perf
+     *  bundle could show `12 recompositions`). Empty / omitted hides
+     *  the subtitle row. */
+    detail?: string;
+    /** Drives the swatch accent. Matches the existing overlay
+     *  palette (`error` / `warning` / `info`) so the colour the user
+     *  sees on the preview matches the legend. */
+    level: "error" | "warning" | "info";
+    /** Optional explicit colour. Takes precedence over `level` for
+     *  the swatch fill — used by bundles that paint individual
+     *  palette colours (a11y info nodes) rather than a fixed level
+     *  tint. */
+    color?: string;
+}
+
+export interface BundleLegendHoveredDetail {
+    /** `null` on `mouseleave` so the host can clear the active
+     *  overlay highlight. */
+    entryId: string | null;
+}
+
+export interface BundleLegendSelectedDetail {
+    entryId: string;
+}
+
+@customElement("bundle-legend")
+export class BundleLegend extends LitElement {
+    /** Bundle id whose entries are currently being shown. Display-only
+     *  metadata — the host decides which bundle owns the legend at
+     *  any moment (typically the active tab). */
+    @state() private bundleLabel = "";
+    @state() private entries: readonly BundleLegendEntry[] = [];
+    @state() private activeEntryId: string | null = null;
+    /** Per-bundle entries, keyed by bundle id. Lets each bundle's
+     *  refresh function set its entries without coordinating with
+     *  the others; `showBundle` then surfaces one bundle at a time. */
+    private entriesByBundle = new Map<string, readonly BundleLegendEntry[]>();
+    private labelsByBundle = new Map<string, string>();
+
+    /**
+     * Stash [entries] for [bundleId]. Does not change which bundle
+     * is currently displayed; call `showBundle` to swap.
+     */
+    setBundleEntries(
+        bundleId: string,
+        bundleLabel: string,
+        entries: readonly BundleLegendEntry[],
+    ): void {
+        this.entriesByBundle.set(bundleId, entries);
+        this.labelsByBundle.set(bundleId, bundleLabel);
+        // If the host happened to be showing this bundle already,
+        // mirror the update without waiting for an explicit
+        // `showBundle` call.
+        if (this.bundleLabel === bundleLabel) {
+            this.entries = entries;
+        }
+    }
+
+    /**
+     * Drop a bundle's entries entirely — wired to the bundle's
+     * chip-off / deactivation path so dismissing the bundle clears
+     * its legend slice. Hides the legend if the dropped bundle was
+     * the one being shown.
+     */
+    clearBundle(bundleId: string): void {
+        const wasShowing =
+            this.labelsByBundle.get(bundleId) === this.bundleLabel;
+        this.entriesByBundle.delete(bundleId);
+        this.labelsByBundle.delete(bundleId);
+        if (wasShowing) {
+            this.bundleLabel = "";
+            this.entries = [];
+        }
+    }
+
+    /**
+     * Switch the visible legend slice to [bundleId]. Pass `null` to
+     * hide the legend entirely (no active tab, or active tab is a
+     * bundle that doesn't supply legend entries). Returns the number
+     * of entries now showing so the host can toggle the panel's
+     * `hidden` flag without reaching into private state.
+     */
+    showBundle(bundleId: string | null): number {
+        if (bundleId === null) {
+            this.bundleLabel = "";
+            this.entries = [];
+            return 0;
+        }
+        this.bundleLabel = this.labelsByBundle.get(bundleId) ?? "";
+        const next = this.entriesByBundle.get(bundleId) ?? [];
+        this.entries = next;
+        return next.length;
+    }
+
+    /**
+     * Drive the highlight from an external source — e.g. the user
+     * hovers an overlay box on the preview and the host calls this
+     * to mirror the highlight on the legend side.
+     */
+    setActiveEntryId(id: string | null): void {
+        this.activeEntryId = id;
+    }
+
+    protected createRenderRoot(): HTMLElement {
+        return this;
+    }
+
+    protected render(): TemplateResult {
+        if (this.entries.length === 0) {
+            return html``;
+        }
+        return html`
+            <div
+                class="bundle-legend-panel"
+                role="region"
+                aria-label=${`${this.bundleLabel || "Bundle"} legend`}
+            >
+                <header class="bundle-legend-header">
+                    <span>${this.bundleLabel || "Legend"}</span>
+                    <span class="bundle-legend-count"
+                        >${this.entries.length}</span
+                    >
+                </header>
+                <ol class="bundle-legend-list">
+                    ${this.entries.map((e) => this.renderEntry(e))}
+                </ol>
+            </div>
+        `;
+    }
+
+    private renderEntry(e: BundleLegendEntry): TemplateResult {
+        const active = e.id === this.activeEntryId;
+        const applySwatchStyle = (el: Element | undefined): void => {
+            // VS Code's webview CSP rejects inline `style=` attributes
+            // (see #1124 BoxOverlay / ProgressBar fix). Set custom
+            // properties via the CSSOM in a ref callback so the
+            // swatch colour can come from the entry's own palette
+            // pick rather than a fixed-set `data-level` mapping.
+            if (!el) return;
+            const sw = el as HTMLSpanElement;
+            if (e.color) {
+                sw.style.setProperty("--legend-swatch-color", e.color);
+            } else {
+                sw.style.removeProperty("--legend-swatch-color");
+            }
+        };
+        return html`
+            <li
+                class=${active
+                    ? "bundle-legend-entry bundle-legend-entry-active"
+                    : "bundle-legend-entry"}
+                data-legend-id=${e.id}
+                tabindex="0"
+                role="button"
+                @mouseenter=${() => this.onHover(e.id)}
+                @mouseleave=${() => this.onHover(null)}
+                @focus=${() => this.onHover(e.id)}
+                @blur=${() => this.onHover(null)}
+                @click=${() => this.onSelect(e.id)}
+                @keydown=${(evt: KeyboardEvent) => this.onKeydown(evt, e.id)}
+            >
+                <span
+                    ${ref(applySwatchStyle)}
+                    class="bundle-legend-swatch"
+                    data-level=${e.level}
+                    aria-hidden="true"
+                ></span>
+                <div class="bundle-legend-text">
+                    <strong class="bundle-legend-label">${e.label}</strong>
+                    ${e.detail
+                        ? html`<span class="bundle-legend-detail"
+                              >${e.detail}</span
+                          >`
+                        : ""}
+                </div>
+            </li>
+        `;
+    }
+
+    private onHover(id: string | null): void {
+        this.activeEntryId = id;
+        this.dispatchEvent(
+            new CustomEvent<BundleLegendHoveredDetail>("legend-hovered", {
+                detail: { entryId: id },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private onSelect(id: string): void {
+        this.dispatchEvent(
+            new CustomEvent<BundleLegendSelectedDetail>("legend-selected", {
+                detail: { entryId: id },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private onKeydown(evt: KeyboardEvent, id: string): void {
+        if (evt.key === "Enter" || evt.key === " ") {
+            evt.preventDefault();
+            this.onSelect(id);
+        }
+    }
+}

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -46,6 +46,7 @@ import {
     BundleLegend,
     type BundleLegendEntry,
 } from "./components/BundleLegend";
+import { findLegendTarget } from "./bundleLegendTarget";
 import {
     clearBundleBoxes,
     getVisiblePreviewIds,
@@ -1769,17 +1770,12 @@ export class PreviewApp extends LitElement {
                     import("./components/BundleLegend").BundleLegendSelectedDetail
                 >
             ).detail;
-            // Scroll the matching row in the active bundle's table
-            // into view. `data-legend-id` matches the row's overlay
-            // id, set via `<data-table>.setOverlayId`. Falling back
-            // to the row's `id` attribute covers tables that haven't
-            // wired the legend-id mirroring.
-            const row = document.querySelector<HTMLElement>(
-                `[data-bundle="${bundleController.state().activeTab}"] ` +
-                    `[data-legend-id="${det.entryId}"], ` +
-                    `[data-bundle="${bundleController.state().activeTab}"] ` +
-                    `[data-overlay-id="${det.entryId}"]`,
-            );
+            const tab = bundleController.state().activeTab;
+            if (!tab) return;
+            // Scoped to the `<data-tabs>` subtree — see
+            // `bundleLegendTarget.ts` for why a document-wide
+            // selector picks the overlay box instead of the table row.
+            const row = findLegendTarget(dataTabs, tab, det.entryId);
             row?.scrollIntoView({ block: "nearest", behavior: "smooth" });
         });
         bundleChipBar.addEventListener("bundle-toggled", (evt) => {

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -36,11 +36,16 @@ import "./components/DataTabs";
 import "./components/DataTable";
 import "./components/BoxOverlay";
 import "./components/BundleExpander";
+import "./components/BundleLegend";
 import { PreviewGrid } from "./components/PreviewGrid";
 import { BundleChipBar } from "./components/BundleChipBar";
 import { DataTabs } from "./components/DataTabs";
 import { DataTable } from "./components/DataTable";
 import { BundleExpander } from "./components/BundleExpander";
+import {
+    BundleLegend,
+    type BundleLegendEntry,
+} from "./components/BundleLegend";
 import {
     clearBundleBoxes,
     getVisiblePreviewIds,
@@ -174,6 +179,7 @@ export class PreviewApp extends LitElement {
     @query("filter-toolbar") private _filterToolbar!: FilterToolbar;
     @query("bundle-chip-bar") private _bundleChipBar!: BundleChipBar;
     @query("data-tabs") private _dataTabs!: DataTabs;
+    @query("#bundle-legend") private _bundleLegend!: BundleLegend;
     @query("#focus-controls") private _focusControls!: HTMLElement;
     @query("#btn-prev") private _btnPrev!: HTMLButtonElement;
     @query("#btn-next") private _btnNext!: HTMLButtonElement;
@@ -382,11 +388,18 @@ export class PreviewApp extends LitElement {
                     <i class="codicon codicon-close" aria-hidden="true"></i>
                 </button>
             </div>
-            <preview-grid
-                id="preview-grid"
-                role="list"
-                aria-label="Preview cards"
-            ></preview-grid>
+            <div class="focus-stage">
+                <preview-grid
+                    id="preview-grid"
+                    role="list"
+                    aria-label="Preview cards"
+                ></preview-grid>
+                <bundle-legend
+                    id="bundle-legend"
+                    class="focus-stage-legend"
+                    hidden
+                ></bundle-legend>
+            </div>
             <bundle-chip-bar hidden></bundle-chip-bar>
             <data-tabs hidden></data-tabs>
             <div
@@ -687,6 +700,7 @@ export class PreviewApp extends LitElement {
         // a single place.
         const bundleChipBar = this._bundleChipBar;
         const dataTabs = this._dataTabs;
+        const bundleLegend = this._bundleLegend;
         const bundleController = new BundleController(
             {
                 setKindEnabled: (kind, enabled) => {
@@ -1064,6 +1078,33 @@ export class PreviewApp extends LitElement {
             }));
             refreshExpanderFor("a11y");
             dataTabs.setTabBody("a11y", body.wrapper);
+            // Populate the shared bundle legend with the same rows so
+            // the overlay-box on the preview, the legend swatch, and
+            // the data-table row all share the `id` for hover /
+            // selection correlation. Other bundles with overlay
+            // boxes (inspection, history-diff) wire their entries
+            // the same way; the legend swaps slices based on the
+            // active tab.
+            const legendEntries: BundleLegendEntry[] = data.rows
+                .filter((row) => row.bounds !== null)
+                .map((row, idx) => ({
+                    id: row.id,
+                    label: row.label,
+                    detail: a11yLegendDetail(row),
+                    level: row.topFindingLevel ?? "info",
+                    color:
+                        row.topFindingLevel === null
+                            ? A11Y_LEGEND_PALETTE[
+                                  idx % A11Y_LEGEND_PALETTE.length
+                              ]
+                            : undefined,
+                }));
+            bundleLegend.setBundleEntries(
+                "a11y",
+                "Accessibility",
+                legendEntries,
+            );
+            reflectLegendActiveTab();
             // Paint the merged hierarchy + findings overlay. In focus
             // mode only the focused card paints; in grid mode every
             // visible card paints with its own per-card data. Realises
@@ -1588,6 +1629,51 @@ export class PreviewApp extends LitElement {
             });
         };
 
+        // Compact "role · states" subtitle for the a11y legend entries.
+        // Mirror of the legacy `a11yHierarchyPresenter` detail string
+        // so users see the same short tag in both surfaces.
+        const a11yLegendDetail = (row: {
+            role: string;
+            states: string;
+            touchTargetSizeDp: string | null;
+        }): string => {
+            const parts: string[] = [];
+            if (row.role) parts.push(row.role);
+            if (row.states) parts.push(row.states);
+            if (row.touchTargetSizeDp) parts.push(row.touchTargetSizeDp);
+            return parts.join(" · ");
+        };
+        // Palette colours for info-level a11y entries — keep the
+        // legend swatch in sync with the overlay's per-node colour
+        // pick. Matches the `PALETTE` constant in
+        // `a11yBundlePresenter.ts`.
+        const A11Y_LEGEND_PALETTE: readonly string[] = [
+            "#f28b82",
+            "#aecbfa",
+            "#a8dab5",
+            "#fdd663",
+            "#d7aefb",
+            "#fcad70",
+            "#80cbc4",
+            "#f6aea9",
+        ];
+        // Show the legend slice for the currently active tab. Called
+        // from each bundle's refresh after it stashes its entries,
+        // and from `reflectBundleState` when the tab switches.
+        const reflectLegendActiveTab = (): void => {
+            const tab = bundleController.state().activeTab;
+            const showBundleUi = focusController.inFocus() && earlyFeatures();
+            if (!showBundleUi || !tab) {
+                bundleLegend.showBundle(null);
+                bundleLegend.hidden = true;
+                return;
+            }
+            const count = bundleLegend.showBundle(tab);
+            // Hidden when the active bundle has no entries (e.g. the
+            // Perf tab — no overlay boxes to legend) so the empty
+            // panel doesn't reserve layout space next to the preview.
+            bundleLegend.hidden = count === 0;
+        };
         const reflectBundleState = (): void => {
             const s = bundleController.state();
             bundleChipBar.setState({
@@ -1639,9 +1725,63 @@ export class PreviewApp extends LitElement {
                 // surface.
                 clearBundleBoxes(null, "inspection");
             }
+            // Drop legend slices for bundles that are no longer
+            // active so re-pressing the chip starts from a clean
+            // state, and refresh the visible slice to track the
+            // current tab.
+            for (const b of s.bundles) {
+                if (!s.activeBundles.includes(b.id)) {
+                    bundleLegend.clearBundle(b.id);
+                }
+            }
+            reflectLegendActiveTab();
         };
         bundleController.onChange(() => reflectBundleState());
         reflectBundleState();
+        // Mirror hover between the legend and the per-bundle overlay
+        // layer. Only the *focused* card has a `<box-overlay>`
+        // currently rendering the active bundle's boxes, so we hop to
+        // it via the focusController and call `setActiveOverlayId`
+        // on the layer that matches the active tab.
+        const overlayLayerForActiveTab = ():
+            | import("./components/BoxOverlay").BoxOverlay
+            | null => {
+            const tab = bundleController.state().activeTab;
+            if (!tab) return null;
+            const card = focusController.focusedCard();
+            if (!card) return null;
+            return card.querySelector<
+                import("./components/BoxOverlay").BoxOverlay
+            >(`box-overlay[data-bundle="${tab}"]`);
+        };
+        bundleLegend.addEventListener("legend-hovered", (evt) => {
+            const det = (
+                evt as CustomEvent<
+                    import("./components/BundleLegend").BundleLegendHoveredDetail
+                >
+            ).detail;
+            const layer = overlayLayerForActiveTab();
+            if (layer) layer.setActiveOverlayId(det.entryId);
+        });
+        bundleLegend.addEventListener("legend-selected", (evt) => {
+            const det = (
+                evt as CustomEvent<
+                    import("./components/BundleLegend").BundleLegendSelectedDetail
+                >
+            ).detail;
+            // Scroll the matching row in the active bundle's table
+            // into view. `data-legend-id` matches the row's overlay
+            // id, set via `<data-table>.setOverlayId`. Falling back
+            // to the row's `id` attribute covers tables that haven't
+            // wired the legend-id mirroring.
+            const row = document.querySelector<HTMLElement>(
+                `[data-bundle="${bundleController.state().activeTab}"] ` +
+                    `[data-legend-id="${det.entryId}"], ` +
+                    `[data-bundle="${bundleController.state().activeTab}"] ` +
+                    `[data-overlay-id="${det.entryId}"]`,
+            );
+            row?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+        });
         bundleChipBar.addEventListener("bundle-toggled", (evt) => {
             const detail = (evt as CustomEvent<{ id: BundleId }>).detail;
             const wasActive = bundleController


### PR DESCRIPTION
## Summary

Adds `<bundle-legend>`, a side panel beside the focused preview that surfaces the per-overlay critical info you wanted to read at a glance — colour swatch matching the overlay box on the preview image, label, and a short subtitle. Generic across bundles per your follow-up: each bundle's refresh function stashes its entries via `setBundleEntries(bundleId, label, entries)` and the host swaps the visible slice on tab change.

Wires Accessibility as the first consumer. Text / history-diff / inspection (the other bundles that paint overlay boxes) can adopt the same API additively in follow-ups — they keep working unchanged until they do.

## What the user sees

In focus mode + earlyFeatures on + Accessibility chip pressed:

- Tinted overlay boxes on the preview image (already there; this PR doesn't change that path).
- A 280px legend column on the right of the preview, listing each node with a colour swatch + label + `role · states · touchTargetSize`.
- Hovering a legend entry lights up the matching overlay box on the preview. Clicking scrolls the matching row in the a11y data-table into view.

In grid mode, off-bundle, or with earlyFeatures off, the legend stays `[hidden]` and the focus-stage falls back to its previous block layout.

## How it stays generic

- `<bundle-legend>` doesn't know about a11y. The component takes opaque `BundleLegendEntry` records keyed by bundle id.
- Each bundle's refresh function does the bundle-specific mapping (a11y rows → entries with role/states subtitle; future bundles do their own).
- `clearBundle(bundleId)` is wired into `reflectBundleState`'s deactivation path so chip-off drops the slice; re-pressing repopulates from scratch.

## Known follow-ups (from your original ask)

- Tree restructure of the a11y rows (`merged: false` nodes as visual children of the nearest merged ancestor). Wire format is flat, so this is heuristic — punted to its own PR so the legend lands first.
- Row-click → detail panel showing all fields for the selected node. Punted because it needs a `<data-table>` API extension worth its own review.
- Adopt the legend API in text / history-diff / inspection refresh functions. One-line `setBundleEntries` each; just needs the per-bundle label decision.

## Test plan

- [x] `npm test` — 955 passing (8 new specs on the component covering slice swap, hover, select, clear, host-driven highlight, mid-show entry update)
- [x] `npm run compile:webview` clean
- [x] `npm run format:check` clean
- [ ] Manual: enable Accessibility chip in Focus view with earlyFeatures on, confirm legend panel renders to the right of the preview, hovering an entry highlights the matching overlay box on the image, clicking scrolls the corresponding table row into view

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_