### PR TITLE
feat(vscode-extension): add a11y-findings preview-harness fixture

### DIFF
--- a/vscode-extension/preview-harness/README.md
+++ b/vscode-extension/preview-harness/README.md
@@ -60,15 +60,28 @@ Drop `preview-harness/fixtures/<name>.json` with shape:
     "messages": [
         { "command": "setPreviews", "moduleDir": "...", "previews": [...], "heavyStaleIds": [] },
         { "command": "updateImage", "previewId": "...", "captureIndex": 0, "imageData": "<raw base64>" }
+    ],
+    "actions": [
+        { "click": ".preview-card[data-preview-id=\"...\"] .card-focus-btn" },
+        { "click": "bundle-chip-bar button[data-bundle=\"a11y\"]" }
     ]
 }
 ```
 
 `messages` are `ExtensionToWebview` payloads (see
 `src/types.ts`). `updateImage.imageData` is **raw base64** — the card
-prepends `data:<mime>;base64,` itself. For repeatable bytes, write a
-generator next to the fixture (`grid-default.gen.mjs` is the template)
-and check it into git alongside the JSON it emits.
+prepends `data:<mime>;base64,` itself.
+
+`actions` replay user-style interactions after the manifest has
+rendered, using CSS selectors against the panel's light DOM. Use
+them to drive flows that the extension would normally trigger through
+clicks — e.g. entering focus mode via `.card-focus-btn`, activating a
+data extension via the bundle chip bar. Today the only action type is
+`{ "click": "<selector>" }`.
+
+For repeatable bytes, write a generator next to the fixture
+(`grid-default.gen.mjs` is the template) and check it into git
+alongside the JSON it emits.
 
 ## Fidelity caveats
 

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.gen.mjs
@@ -1,0 +1,283 @@
+// Generator for `a11y-findings.json`. Run with:
+//   node preview-harness/fixtures/a11y-findings.gen.mjs > preview-harness/fixtures/a11y-findings.json
+//
+// Drives focus mode + the Accessibility bundle so the rendered card
+// shows the `<box-overlay>` layer painted by `refreshA11yBundle`, plus
+// the data tab with the hierarchy/findings table. Uses a 360×600
+// stylised-mobile mock PNG so finding bounds line up with visible UI
+// shapes (header, two buttons, footer) — useful when discussing the
+// design treatment for ATF violations.
+
+import { deflateSync } from "node:zlib";
+
+function crc32(buf) {
+    const t = new Uint32Array(256);
+    for (let n = 0; n < 256; n++) {
+        let c = n;
+        for (let k = 0; k < 8; k++)
+            c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+        t[n] = c >>> 0;
+    }
+    let c = 0xffffffff;
+    for (const b of buf) c = t[(c ^ b) & 0xff] ^ (c >>> 8);
+    return (c ^ 0xffffffff) >>> 0;
+}
+
+function encodePng(width, height, pixels) {
+    const raw = Buffer.alloc(height * (1 + width * 3));
+    for (let y = 0; y < height; y++) {
+        let off = y * (1 + width * 3);
+        raw[off++] = 0;
+        for (let x = 0; x < width; x++) {
+            const i = (y * width + x) * 3;
+            raw[off++] = pixels[i];
+            raw[off++] = pixels[i + 1];
+            raw[off++] = pixels[i + 2];
+        }
+    }
+    function chunk(type, payload) {
+        const len = Buffer.alloc(4);
+        len.writeUInt32BE(payload.length, 0);
+        const tb = Buffer.from(type, "ascii");
+        const crc = Buffer.alloc(4);
+        crc.writeUInt32BE(crc32(Buffer.concat([tb, payload])), 0);
+        return Buffer.concat([len, tb, payload, crc]);
+    }
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(width, 0);
+    ihdr.writeUInt32BE(height, 4);
+    ihdr[8] = 8;
+    ihdr[9] = 2;
+    return Buffer.concat([
+        Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+        chunk("IHDR", ihdr),
+        chunk("IDAT", deflateSync(raw)),
+        chunk("IEND", Buffer.alloc(0)),
+    ]).toString("base64");
+}
+
+// 360×600 stylised mobile mock. Coordinates below match these regions.
+const W = 360;
+const H = 600;
+const HEADER_H = 80;
+const FOOTER_TOP = 520;
+const BTN_Y = 240;
+const BTN_H = 56;
+const BTN1 = { left: 40, top: BTN_Y, right: 160, bottom: BTN_Y + BTN_H };
+const BTN2 = { left: 200, top: BTN_Y, right: 320, bottom: BTN_Y + BTN_H };
+const HEADER = { left: 0, top: 0, right: W, bottom: HEADER_H };
+const FOOTER = { left: 0, top: FOOTER_TOP, right: W, bottom: H };
+const ROOT = { left: 0, top: 0, right: W, bottom: H };
+
+function inRect(x, y, r) {
+    return x >= r.left && x < r.right && y >= r.top && y < r.bottom;
+}
+
+const pixels = new Uint8Array(W * H * 3);
+for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+        let r = 245;
+        let g = 246;
+        let b = 250;
+        if (inRect(x, y, HEADER)) {
+            r = 60;
+            g = 90;
+            b = 168;
+        } else if (inRect(x, y, BTN1)) {
+            // Visually-small primary button (too small for touch target).
+            r = 14;
+            g = 99;
+            b = 156;
+        } else if (inRect(x, y, BTN2)) {
+            // Icon-only button (missing contentDescription).
+            r = 220;
+            g = 220;
+            b = 220;
+        } else if (inRect(x, y, FOOTER)) {
+            // Footer text in low-contrast grey on light bg.
+            r = 200;
+            g = 200;
+            b = 200;
+        }
+        const i = (y * W + x) * 3;
+        pixels[i] = r;
+        pixels[i + 1] = g;
+        pixels[i + 2] = b;
+    }
+}
+
+function bounds(r) {
+    return `${r.left},${r.top},${r.right},${r.bottom}`;
+}
+
+const FOCUS_ID = "com.example.OnboardingKt.WelcomeScreenPreview";
+
+const nodes = [
+    {
+        label: "Welcome screen",
+        role: "container",
+        states: [],
+        merged: false,
+        boundsInScreen: bounds(ROOT),
+    },
+    {
+        label: "Welcome to Compose AI Tools",
+        role: "headline",
+        states: ["focusable"],
+        merged: false,
+        boundsInScreen: bounds(HEADER),
+    },
+    {
+        label: "Get started",
+        role: "button",
+        states: ["clickable", "focusable"],
+        merged: false,
+        boundsInScreen: bounds(BTN1),
+    },
+    {
+        label: "",
+        role: "button",
+        states: ["clickable", "focusable"],
+        merged: false,
+        boundsInScreen: bounds(BTN2),
+    },
+    {
+        label: "By continuing you agree to our terms",
+        role: "text",
+        states: [],
+        merged: false,
+        boundsInScreen: bounds(FOOTER),
+    },
+];
+
+const findings = [
+    {
+        level: "ERROR",
+        type: "SpeakableTextPresent",
+        message: "Image-only button has no contentDescription.",
+        viewDescription: "ImageButton",
+        boundsInScreen: bounds(BTN2),
+    },
+    {
+        level: "WARNING",
+        type: "TouchTargetSize",
+        message:
+            "Touch target is 120×56dp. Material guidance recommends at least 48×48dp on each side; this clears height but the width / spacing leaves the tap area cramped on small screens.",
+        viewDescription: "Button",
+        boundsInScreen: bounds(BTN1),
+    },
+    {
+        level: "WARNING",
+        type: "TextContrast",
+        message:
+            "Footer text uses #C8C8C8 on #F5F6FA — contrast ratio 1.4:1, below the WCAG AA 4.5:1 threshold for body copy.",
+        viewDescription: "TextView",
+        boundsInScreen: bounds(FOOTER),
+    },
+];
+
+const focused = {
+    id: FOCUS_ID,
+    functionName: "WelcomeScreenPreview",
+    className: "com.example.OnboardingKt",
+    sourceFile: "Onboarding.kt",
+    params: {
+        name: null,
+        device: null,
+        widthDp: W,
+        heightDp: H,
+        fontScale: 1.0,
+        showSystemUi: false,
+        showBackground: true,
+        backgroundColor: 0,
+        uiMode: 0,
+        locale: null,
+        group: null,
+    },
+    captures: [
+        {
+            advanceTimeMillis: null,
+            scroll: null,
+            renderOutput: `renders/${FOCUS_ID}.png`,
+            label: "",
+        },
+    ],
+    a11yFindings: findings,
+    a11yNodes: nodes,
+};
+
+const sibling = {
+    id: "com.example.OnboardingKt.SettingsScreenPreview",
+    functionName: "SettingsScreenPreview",
+    className: "com.example.OnboardingKt",
+    sourceFile: "Onboarding.kt",
+    params: {
+        name: null,
+        device: null,
+        widthDp: W,
+        heightDp: H,
+        fontScale: 1.0,
+        showSystemUi: false,
+        showBackground: true,
+        backgroundColor: 0,
+        uiMode: 0,
+        locale: null,
+        group: null,
+    },
+    captures: [
+        {
+            advanceTimeMillis: null,
+            scroll: null,
+            renderOutput: `renders/${"com.example.OnboardingKt.SettingsScreenPreview"}.png`,
+            label: "",
+        },
+    ],
+};
+
+const setPreviews = {
+    command: "setPreviews",
+    moduleDir: "/workspace/sample-android",
+    heavyStaleIds: [],
+    previews: [focused, sibling],
+};
+
+const fixture = {
+    name: "a11y-findings",
+    description:
+        "Focused card with three Accessibility Test Framework findings (one ERROR, two WARNINGs) overlaid on a stylised mobile mock. Drives focus mode and activates the Accessibility bundle so the chip bar, data tab, and on-image box-overlay all paint.",
+    dataset: {
+        // `earlyFeatures` is the gate for the chip bar + data tabs.
+        earlyFeatures: "true",
+        autoEnableCheap: "false",
+        collapseVariants: "false",
+        minimalMode: "false",
+        autoInject: "true",
+    },
+    messages: [
+        setPreviews,
+        {
+            command: "updateImage",
+            previewId: focused.id,
+            captureIndex: 0,
+            imageData: encodePng(W, H, pixels),
+        },
+        // The sibling stays as a skeleton — we want focus mode to take
+        // over the layout so its image never needs to land.
+    ],
+    actions: [
+        // Focus the WelcomeScreen card via its .card-focus-btn (the
+        // explicit handle from `cardBuilder`). Clicking the image
+        // would toggle interactive mode instead, which isn't what we
+        // want here.
+        {
+            click: `.preview-card[data-preview-id="${focused.id}"] .card-focus-btn`,
+        },
+        // Activate the Accessibility bundle — chip is keyed by
+        // `data-bundle="a11y"` per BundleChipBar.renderChip.
+        {
+            click: `bundle-chip-bar button[data-bundle="a11y"]`,
+        },
+    ],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.json
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.json
@@ -1,0 +1,148 @@
+{
+    "name": "a11y-findings",
+    "description": "Focused card with three Accessibility Test Framework findings (one ERROR, two WARNINGs) overlaid on a stylised mobile mock. Drives focus mode and activates the Accessibility bundle so the chip bar, data tab, and on-image box-overlay all paint.",
+    "dataset": {
+        "earlyFeatures": "true",
+        "autoEnableCheap": "false",
+        "collapseVariants": "false",
+        "minimalMode": "false",
+        "autoInject": "true"
+    },
+    "messages": [
+        {
+            "command": "setPreviews",
+            "moduleDir": "/workspace/sample-android",
+            "heavyStaleIds": [],
+            "previews": [
+                {
+                    "id": "com.example.OnboardingKt.WelcomeScreenPreview",
+                    "functionName": "WelcomeScreenPreview",
+                    "className": "com.example.OnboardingKt",
+                    "sourceFile": "Onboarding.kt",
+                    "params": {
+                        "name": null,
+                        "device": null,
+                        "widthDp": 360,
+                        "heightDp": 600,
+                        "fontScale": 1,
+                        "showSystemUi": false,
+                        "showBackground": true,
+                        "backgroundColor": 0,
+                        "uiMode": 0,
+                        "locale": null,
+                        "group": null
+                    },
+                    "captures": [
+                        {
+                            "advanceTimeMillis": null,
+                            "scroll": null,
+                            "renderOutput": "renders/com.example.OnboardingKt.WelcomeScreenPreview.png",
+                            "label": ""
+                        }
+                    ],
+                    "a11yFindings": [
+                        {
+                            "level": "ERROR",
+                            "type": "SpeakableTextPresent",
+                            "message": "Image-only button has no contentDescription.",
+                            "viewDescription": "ImageButton",
+                            "boundsInScreen": "200,240,320,296"
+                        },
+                        {
+                            "level": "WARNING",
+                            "type": "TouchTargetSize",
+                            "message": "Touch target is 120×56dp. Material guidance recommends at least 48×48dp on each side; this clears height but the width / spacing leaves the tap area cramped on small screens.",
+                            "viewDescription": "Button",
+                            "boundsInScreen": "40,240,160,296"
+                        },
+                        {
+                            "level": "WARNING",
+                            "type": "TextContrast",
+                            "message": "Footer text uses #C8C8C8 on #F5F6FA — contrast ratio 1.4:1, below the WCAG AA 4.5:1 threshold for body copy.",
+                            "viewDescription": "TextView",
+                            "boundsInScreen": "0,520,360,600"
+                        }
+                    ],
+                    "a11yNodes": [
+                        {
+                            "label": "Welcome screen",
+                            "role": "container",
+                            "states": [],
+                            "merged": false,
+                            "boundsInScreen": "0,0,360,600"
+                        },
+                        {
+                            "label": "Welcome to Compose AI Tools",
+                            "role": "headline",
+                            "states": ["focusable"],
+                            "merged": false,
+                            "boundsInScreen": "0,0,360,80"
+                        },
+                        {
+                            "label": "Get started",
+                            "role": "button",
+                            "states": ["clickable", "focusable"],
+                            "merged": false,
+                            "boundsInScreen": "40,240,160,296"
+                        },
+                        {
+                            "label": "",
+                            "role": "button",
+                            "states": ["clickable", "focusable"],
+                            "merged": false,
+                            "boundsInScreen": "200,240,320,296"
+                        },
+                        {
+                            "label": "By continuing you agree to our terms",
+                            "role": "text",
+                            "states": [],
+                            "merged": false,
+                            "boundsInScreen": "0,520,360,600"
+                        }
+                    ]
+                },
+                {
+                    "id": "com.example.OnboardingKt.SettingsScreenPreview",
+                    "functionName": "SettingsScreenPreview",
+                    "className": "com.example.OnboardingKt",
+                    "sourceFile": "Onboarding.kt",
+                    "params": {
+                        "name": null,
+                        "device": null,
+                        "widthDp": 360,
+                        "heightDp": 600,
+                        "fontScale": 1,
+                        "showSystemUi": false,
+                        "showBackground": true,
+                        "backgroundColor": 0,
+                        "uiMode": 0,
+                        "locale": null,
+                        "group": null
+                    },
+                    "captures": [
+                        {
+                            "advanceTimeMillis": null,
+                            "scroll": null,
+                            "renderOutput": "renders/com.example.OnboardingKt.SettingsScreenPreview.png",
+                            "label": ""
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "command": "updateImage",
+            "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+            "captureIndex": 0,
+            "imageData": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC"
+        }
+    ],
+    "actions": [
+        {
+            "click": ".preview-card[data-preview-id=\"com.example.OnboardingKt.WelcomeScreenPreview\"] .card-focus-btn"
+        },
+        {
+            "click": "bundle-chip-bar button[data-bundle=\"a11y\"]"
+        }
+    ]
+}

--- a/vscode-extension/preview-harness/index.html
+++ b/vscode-extension/preview-harness/index.html
@@ -85,6 +85,20 @@
                     src="./scenario.html?fixture=grid-default&theme=light"
                 ></iframe>
             </div>
+            <div class="card">
+                <h2>a11y-findings <small>dark · 1024×720</small></h2>
+                <iframe
+                    class="frame"
+                    src="./scenario.html?fixture=a11y-findings&theme=dark"
+                ></iframe>
+            </div>
+            <div class="card">
+                <h2>a11y-findings <small>light · 1024×720</small></h2>
+                <iframe
+                    class="frame"
+                    src="./scenario.html?fixture=a11y-findings&theme=light"
+                ></iframe>
+            </div>
         </div>
     </body>
 </html>

--- a/vscode-extension/preview-harness/scenario.html
+++ b/vscode-extension/preview-harness/scenario.html
@@ -73,8 +73,26 @@
                 for (const msg of data.messages ?? []) {
                     window.postMessage(msg, "*");
                 }
-                // Let the dispatcher run, the cards re-render, and the
-                // <img>s decode the new data URIs before signalling ready.
+                await settle();
+
+                // After the manifest has rendered, replay user-style
+                // interactions — clicking a card's focus button, a
+                // bundle chip, a filter toolbar option, etc. Each
+                // action targets the panel's light DOM by CSS
+                // selector so fixtures don't have to know about the
+                // controller graph behind the elements.
+                for (const action of data.actions ?? []) {
+                    await runAction(action);
+                    await settle();
+                }
+
+                harness.ready = true;
+            }
+
+            async function settle() {
+                // postMessage / click handlers post microtasks then
+                // Lit re-renders on rAF. Two rAFs is enough for the
+                // dispatcher's downstream paths to land DOM.
                 await new Promise((r) => requestAnimationFrame(r));
                 await new Promise((r) => requestAnimationFrame(r));
                 const imgs = Array.from(
@@ -82,7 +100,15 @@
                 );
                 await Promise.all(
                     imgs.map((img) =>
-                        img.complete && img.naturalWidth > 0
+                        // `complete` is true once the browser has
+                        // either decoded the bytes or given up
+                        // (naturalWidth = 0 on error). Either way
+                        // there is nothing left to wait on — gating
+                        // on `naturalWidth > 0` would hang on cards
+                        // whose `<img src="renders/foo.png">` 404s
+                        // because the harness server doesn't ship
+                        // those files.
+                        img.complete
                             ? Promise.resolve()
                             : new Promise((r) => {
                                   img.addEventListener("load", r, {
@@ -94,19 +120,39 @@
                               }),
                     ),
                 );
-                // Wait for any in-flight CSS animations (the `fadeIn` on
-                // freshly-painted preview <img>s, transitions on bundle
-                // chips, etc.) to settle so the screenshot isn't a
-                // mid-frame grab of the 0.2s opacity ramp.
+                // Wait for any in-flight CSS animations (the `fadeIn`
+                // on freshly-painted preview <img>s, chip / tab
+                // transitions, etc.) to settle so the screenshot
+                // isn't a mid-frame grab. Skip infinite animations
+                // (the skeleton shimmer on cards that haven't
+                // received an `updateImage` runs forever, and
+                // `.finished` would never resolve).
                 if (typeof document.getAnimations === "function") {
+                    const finite = document.getAnimations().filter((a) => {
+                        const t = a.effect?.getTiming?.();
+                        return t && t.iterations !== Infinity;
+                    });
                     await Promise.all(
-                        document
-                            .getAnimations()
-                            .map((a) => a.finished.catch(() => {})),
+                        finite.map((a) => a.finished.catch(() => {})),
                     );
                 }
-                harness.ready = true;
             }
+
+            async function runAction(action) {
+                if (action.click) {
+                    const el = document.querySelector(action.click);
+                    if (!el) {
+                        throw new Error(
+                            "click: selector matched no element: " +
+                                action.click,
+                        );
+                    }
+                    el.click();
+                    return;
+                }
+                throw new Error("unknown action: " + JSON.stringify(action));
+            }
+
             run().catch((err) => {
                 console.error(err);
                 document.body.textContent = String(err);


### PR DESCRIPTION
Stacked on #1129 — once that auto-merges the diff here collapses to just the a11y additions.

## Summary

- Adds `a11y-findings.json` + generator: a focused mobile-shaped card with three ATF findings (one ERROR, two WARNINGs) plus a five-node hierarchy. After the manifest renders, the scenario clicks `.card-focus-btn` to enter focus mode and the `bundle-chip-bar` chip to activate the Accessibility bundle, so the snapshot captures the `<box-overlay>` painted on the card image, the data tab with the hierarchy + findings table, and the chip / focus chrome around it.
- Extends `scenario.html` with an `actions` array — `{ "click": "<selector>" }` entries replayed after `messages` against the panel's light DOM. Covers any flow the extension would normally trigger via a real user click without baking the controller graph into fixtures.
- Fixes two latent hangs in `settle()` discovered while wiring this fixture:
  - Used to wait on `<img>`s that already 404'd — `naturalWidth === 0` after `complete` set, but the `load`/`error` listeners we attached afterwards never fired again. Now only gates on `complete`.
  - Used to await `.finished` on every running animation, including the skeleton's `shimmer 1.5s infinite` on cards without a follow-up `updateImage`. Now filters animations to finite iteration counts.

## Test plan

- [ ] `npm run harness:snapshot` produces `a11y-findings.{dark,light}.png` showing the overlay layer + Accessibility tab populated with 5 rows (one orphan finding).
- [ ] Opening `preview-harness/index.html` shows the new iframe rendered with the same content.
- [ ] `npm test` stays green.
- [ ] Once #1129 squash-merges, the diff on this PR collapses to only the a11y additions (`fixtures/a11y-findings.*`, `actions` block, `settle()` fixes, README + index entries).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZueDM4HQktvumMmHqxg1p)_