### PR TITLE
feat(render-session): supported library for driving render sessions

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -52,6 +52,12 @@ dependencies {
   // Renderer-agnostic daemon core helpers that are safe to use as a local library from CLI
   // commands. Keep renderer backends (`:daemon:android`, `:daemon:desktop`) out of this module.
   implementation(project(":daemon:core"))
+  // Public render-session library — the CLI consumes its own published API for daemon-driven
+  // commands (`compose-preview a11y` etc.) instead of touching DaemonClient directly. We eat
+  // our own dog food: anything the CLI can do, a third-party tooling consumer can do via the
+  // same API.
+  implementation(project(":render-session-api"))
+  implementation(project(":render-session-subprocess"))
 
   testImplementation(kotlin("test"))
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/A11yReportRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/A11yReportRenderer.kt
@@ -62,10 +62,18 @@ class A11yReportRenderer : ExtensionReportRenderer {
     val out = mutableMapOf<String, Pair<List<AccessibilityFinding>, String?>>()
     val enabled = mutableSetOf<String>()
     for ((module, manifest) in manifests) {
-      val pointer = manifest.reportsView[id] ?: continue
-      enabled += module.gradlePath
-      val reportFile = module.projectDir.resolve("build/compose-previews/$pointer")
+      // Prefer the manifest pointer when a producer stamped one (legacy gradle-aggregated reports,
+      // future daemon-stamped pointer); fall back to the conventional `accessibility.json`
+      // location so a freshly-written daemon-aggregated report is still picked up even when no
+      // producer touched the manifest. The standalone gradle plugin no longer writes the
+      // pointer at all — that's a daemon / CLI concern now — so the fallback is the primary
+      // path for `compose-preview a11y`.
+      val pointer = manifest.reportsView[id]
+      val reportFile =
+        pointer?.let { module.projectDir.resolve("build/compose-previews/$it") }
+          ?: module.projectDir.resolve("build/compose-previews/accessibility.json")
       if (!reportFile.exists()) continue
+      enabled += module.gradlePath
       val report =
         try {
           json.decodeFromString(AccessibilityReport.serializer(), reportFile.readText())

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1054,11 +1054,27 @@ class RenderCommand(args: List<String>) : Command(args) {
  * here so adding a new canned-report command is a 3-line class plus a renderer registration.
  */
 open class ReportCommand(args: List<String>, private val extensionId: String) : Command(args) {
-  private val jsonOutput = "--json" in args
+  protected val jsonOutput: Boolean = "--json" in args
   // "errors" | "warnings" | "none". When not set, exit code mirrors Gradle.
-  private val failOn: String? = args.flagValue("--fail-on")
+  protected val failOn: String? = args.flagValue("--fail-on")
 
   override fun implicitExtensions(): List<String> = listOf(extensionId)
+
+  /**
+   * Subclass hook called between the gradle build and the result-building / reporting step.
+   * Subclasses use this to spin up additional production paths (the daemon-driven a11y fetch in
+   * [A11yCommand]) that write sidecar JSON the extension renderer's `load` pass then picks up when
+   * [buildResults] runs. Default no-op.
+   *
+   * At the point this is called, the standard `renderAllPreviews` gradle task has already run and
+   * each module's `previews.json` is on disk. Implementations iterate the manifests for preview
+   * ids, drive any out-of-band production, and write the resulting sidecars to the conventional
+   * `build/compose-previews/<extension>.json` locations the renderers read.
+   */
+  protected open fun produceAdditionalDataProducts(
+    modules: List<PreviewModule>,
+    manifests: List<Pair<PreviewModule, PreviewManifest>>,
+  ) {}
 
   override fun run() {
     val renderer =
@@ -1072,14 +1088,22 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
           exitProcess(1)
         }
 
+    // Hand-roll the renderModules→manifests→buildResults pipeline so the subclass hook can slot
+    // between gradle finish and renderer load. `renderAllModules` is the same shape but
+    // single-shot — no hook seam — so we expand it here.
+    val raw = renderModules(silenceStdout = jsonOutput, gradleArguments = gradleArgsWithForce())
+    val manifests = readAllManifests(raw.modules)
+    produceAdditionalDataProducts(raw.modules, manifests)
+    val results = if (manifests.isEmpty()) emptyList() else buildResults(manifests)
     val outcome =
-      renderAllModules(silenceStdout = jsonOutput, gradleArguments = gradleArgsWithForce())
+      RenderModulesOutcome(
+        buildOk = raw.buildOk,
+        modules = raw.modules,
+        manifests = manifests,
+        results = results,
+      )
 
-    // `buildResults` (inside `renderAllModules`) already ran every registered renderer's
-    // `load`/`annotate` pair, so the enriched outcome.results carry this extension's data — no
-    // separate plumbing needed here.
-    val enabledFor = outcome.manifests.filter { it.second.reportsView.containsKey(extensionId) }
-    if (enabledFor.isEmpty()) {
+    if (outcome.manifests.isEmpty()) {
       if (jsonOutput) println(encodeResponse(emptyList(), countsScope = null))
       else println("No previews discovered.")
       exitProcess(if (outcome.buildOk) 0 else 2)
@@ -1111,20 +1135,89 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
 }
 
 /**
- * `compose-preview a11y` — `ReportCommand` bound to the built-in `a11y` extension id. Kept as a
- * named subclass so `Main.kt`'s `when` dispatch stays grep-able and the help text can describe the
- * command directly; the entire body is the constructor call.
+ * `compose-preview a11y` — `ReportCommand` bound to the built-in `a11y` extension id.
  *
- * TODO(daemon): a11y data products are no longer produced by the standalone `renderAllPreviews`
- *   Gradle task — they are exclusively daemon-driven. As a result, this command currently runs the
- *   Gradle render but finds no findings on disk. The follow-up is to either (a) have this command
- *   spin up a temporary daemon per module, subscribe every preview to `a11y/atf` +
- *   `a11y/hierarchy`, render, drain the findings, and shut down; or (b) expose the daemon
- *   `RenderEngine` as a library so the CLI can drive it in-process without a JSON-RPC dance.
- *   Tracked separately — for now the CLI emits the `--with-extension a11y` request through
- *   [extensionGradleArgs] so the contract is in place but the orchestration side is a follow-up PR.
+ * Production of a11y data products moved entirely to the preview daemon, so this command opens a
+ * short-lived [ee.schimke.composeai.render.session.RenderSession] per module after the standard
+ * `renderAllPreviews` build completes, walks every preview through `data/fetch` for `a11y/atf`,
+ * aggregates the findings into the canonical `build/compose-previews/accessibility.json` shape that
+ * [A11yReportRenderer] then loads through its disk-fallback path, and closes the session. The
+ * daemon is short-lived — spawned, drained, shut down — so there's no persistent server for the
+ * agent / CI script to manage.
+ *
+ * The session is opened via the public `:render-session-api` / `:render-session-subprocess`
+ * library; everything the CLI does here is reachable from any third-party tooling that compiles
+ * against the same coordinates.
  */
-class A11yCommand(args: List<String>) : ReportCommand(args, "a11y")
+class A11yCommand(args: List<String>) : ReportCommand(args, "a11y") {
+  override fun produceAdditionalDataProducts(
+    modules: List<PreviewModule>,
+    manifests: List<Pair<PreviewModule, PreviewManifest>>,
+  ) {
+    if (modules.isEmpty()) return
+    // The daemon launch descriptor (`daemon-launch.json`) is written by
+    // `composePreviewDaemonStart`, which the standalone `renderAllPreviews` task does not depend
+    // on. Run it in a second gradle invocation so the descriptor is fresh against the
+    // consumer's current classpath. Gradle's daemon reuses the warm JVM started by the first
+    // invocation, so the cold-start cost is paid once per CLI run, not once per gradle task.
+    val daemonStartOk = runDaemonStartTasks(modules)
+    if (!daemonStartOk) {
+      System.err.println(
+        "compose-preview a11y: composePreviewDaemonStart failed; skipping daemon-driven a11y " +
+          "fetch. Findings will be empty."
+      )
+      return
+    }
+    val fetcher = DaemonA11yFetcher(onLog = { System.err.println("[daemon a11y] $it") })
+    for ((module, manifest) in manifests) {
+      val previewIds = manifest.previews.map { it.id }
+      if (previewIds.isEmpty()) continue
+      val outcome =
+        fetcher.fetch(
+          projectDir = module.projectDir,
+          modulePath = module.gradlePath,
+          moduleName = manifest.module,
+          previewIds = previewIds,
+        )
+      when (outcome) {
+        is DaemonA11yFetcher.Outcome.Ok ->
+          if (verbose) {
+            System.err.println(
+              "compose-preview a11y: ${module.gradlePath} wrote ${outcome.reportFile.path} " +
+                "(${outcome.entryCount} entr${if (outcome.entryCount == 1) "y" else "ies"})"
+            )
+          }
+        is DaemonA11yFetcher.Outcome.DescriptorMissing ->
+          System.err.println(
+            "compose-preview a11y: ${module.gradlePath} missing daemon-launch.json at " +
+              "${outcome.expected.path}"
+          )
+        is DaemonA11yFetcher.Outcome.OpenFailed ->
+          System.err.println(
+            "compose-preview a11y: ${module.gradlePath} failed to open render session " +
+              "(${outcome.reason})"
+          )
+      }
+    }
+  }
+
+  /**
+   * Drive `:<modulePath>:composePreviewDaemonStart` for every module so each one has a fresh
+   * `daemon-launch.json` on disk before the per-module session opens. Returns false when the gradle
+   * task itself failed; the caller falls through to "no findings" rather than blocking the user.
+   */
+  private fun runDaemonStartTasks(modules: List<PreviewModule>): Boolean {
+    var ok = true
+    withGradle(silenceStdout = jsonOutput) { gradle ->
+      val tasks = modules.map { ":${it.gradlePath}:composePreviewDaemonStart" }.toTypedArray()
+      ok =
+        withGradleStdout(jsonOutput) {
+          runGradle(gradle, *tasks, arguments = gradleArgsWithForce())
+        }
+    }
+    return ok
+  }
+}
 
 private fun sha256(bytes: ByteArray): String {
   val md = MessageDigest.getInstance("SHA-256")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
@@ -1,0 +1,134 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.render.session.DataProductException
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.RenderSessionException
+import ee.schimke.composeai.render.session.RenderSessionFactory
+import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
+import java.io.File
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Drives a short-lived [RenderSession] for one module, walks every preview through `data/fetch` for
+ * `a11y/atf`, aggregates the findings into the canonical `build/compose-previews
+ * /accessibility.json` shape that [A11yReportRenderer] reads, and closes the session.
+ *
+ * Lives in the CLI rather than the render-session library because the aggregation shape is a CLI /
+ * agent contract — third-party consumers that want raw `a11y/atf` payloads use the
+ * [RenderSession.fetchData] API directly without buying into this aggregation format.
+ *
+ * @param factory pluggable render-session factory; defaults to the subprocess backend. Test
+ *   scaffolding can inject a fake by constructing a custom [RenderSessionFactory].
+ */
+internal class DaemonA11yFetcher(
+  private val factory: RenderSessionFactory = SubprocessRenderSessions,
+  private val onLog: (String) -> Unit = {},
+) {
+  private val json = Json {
+    ignoreUnknownKeys = true
+    prettyPrint = true
+    encodeDefaults = true
+  }
+
+  /**
+   * Fetch a11y findings for [previewIds] in one module, aggregate into
+   * `<projectDir>/build/compose-previews/accessibility.json`, return the result.
+   */
+  fun fetch(
+    projectDir: File,
+    modulePath: String,
+    moduleName: String,
+    previewIds: List<String>,
+  ): Outcome {
+    val descriptorFile = SubprocessRenderSessions.descriptorFile(projectDir, modulePath)
+    if (!descriptorFile.isFile) return Outcome.DescriptorMissing(descriptorFile)
+
+    val config =
+      RenderSessionConfig(
+        descriptorPath = descriptorFile,
+        workspaceRoot = projectDir.absoluteFile,
+        logSink = onLog,
+      )
+
+    val session: RenderSession =
+      try {
+        factory.open(config)
+      } catch (e: RenderSessionException) {
+        return Outcome.OpenFailed(reason = e.message ?: e.javaClass.simpleName)
+      }
+
+    return session.use { live ->
+      val entries = mutableListOf<AccessibilityEntry>()
+      for (previewId in previewIds) {
+        val payload =
+          try {
+            live
+              .fetchData(
+                previewId = previewId,
+                kind = ATF_KIND,
+                inline = true,
+                timeout = 120.seconds,
+              )
+              .payload
+          } catch (e: DataProductException) {
+            onLog("a11y fetch for '$previewId' failed: code=${e.code} ${e.wireMessage}")
+            null
+          } catch (e: RenderSessionException) {
+            onLog("a11y fetch for '$previewId' transport error: ${e.message}")
+            null
+          }
+        val findings = payload?.let(::parseFindings).orEmpty()
+        entries.add(
+          AccessibilityEntry(
+            previewId = previewId,
+            findings = findings,
+            annotatedPath = relativeOverlayPath(projectDir, previewId),
+          )
+        )
+      }
+      val reportFile = projectDir.resolve("build/compose-previews/accessibility.json")
+      reportFile.parentFile?.mkdirs()
+      val report = AccessibilityReport(module = moduleName, entries = entries)
+      reportFile.writeText(json.encodeToString(AccessibilityReport.serializer(), report))
+      Outcome.Ok(reportFile = reportFile, entryCount = entries.size)
+    }
+  }
+
+  /**
+   * Resolve the daemon-side overlay PNG (`a11y-overlay.png`) for [previewId] relative to the
+   * accessibility.json that will be written. Returns null when the file is absent.
+   */
+  private fun relativeOverlayPath(projectDir: File, previewId: String): String? {
+    val overlay = projectDir.resolve("build/compose-previews/data/$previewId/a11y-overlay.png")
+    return overlay.takeIf { it.isFile }?.let { "data/$previewId/a11y-overlay.png" }
+  }
+
+  private fun parseFindings(payload: JsonElement): List<AccessibilityFinding> {
+    val obj = payload as? JsonObject ?: return emptyList()
+    val findings = obj["findings"] ?: return emptyList()
+    return try {
+      json.decodeFromJsonElement(
+        kotlinx.serialization.builtins.ListSerializer(AccessibilityFinding.serializer()),
+        findings,
+      )
+    } catch (_: Exception) {
+      emptyList()
+    }
+  }
+
+  sealed interface Outcome {
+    data class Ok(val reportFile: File, val entryCount: Int) : Outcome
+
+    data class DescriptorMissing(val expected: File) : Outcome
+
+    data class OpenFailed(val reason: String) : Outcome
+  }
+
+  companion object {
+    private const val ATF_KIND = "a11y/atf"
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
@@ -1,0 +1,254 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.daemon.protocol.ChangeType
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
+import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
+import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
+import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.Manifest
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingStartResult
+import ee.schimke.composeai.daemon.protocol.RecordingStopResult
+import ee.schimke.composeai.daemon.protocol.RenderNowResult
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.daemon.protocol.ServerCapabilities
+import ee.schimke.composeai.render.session.NotificationListener
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.RenderSessionBackend
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.RenderSessionFactory
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Aggregation contract for [DaemonA11yFetcher]: with a fake [RenderSessionFactory] returning canned
+ * a11y/atf payloads, the fetcher writes `accessibility.json` in the shape [A11yReportRenderer]
+ * reads — one entry per preview, in input order, findings preserved.
+ */
+class DaemonA11yFetcherTest {
+
+  private fun newTempFolder(prefix: String): File =
+    java.nio.file.Files.createTempDirectory(prefix).toFile().also { it.deleteOnExit() }
+
+  @Test
+  fun `writes accessibility report with one entry per preview`() {
+    val projectDir = newTempFolder("module")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+
+    val payloads =
+      mapOf(
+        "AlphaPreview" to atfPayload(listOf(finding("ERROR", "TouchTargetSize", "too small"))),
+        "BetaPreview" to atfPayload(emptyList()),
+      )
+    val fetcher = DaemonA11yFetcher(factory = FakeFactory(payloads))
+
+    val outcome =
+      fetcher.fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previewIds = listOf("AlphaPreview", "BetaPreview"),
+      )
+
+    assertTrue(outcome is DaemonA11yFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    val report =
+      Companion.json.decodeFromString(
+        AccessibilityReport.serializer(),
+        File(projectDir, "build/compose-previews/accessibility.json").readText(),
+      )
+    assertEquals("sample", report.module)
+    assertEquals(listOf("AlphaPreview", "BetaPreview"), report.entries.map { it.previewId })
+    assertEquals(1, report.entries[0].findings.size)
+    assertEquals("ERROR", report.entries[0].findings.first().level)
+    assertEquals("TouchTargetSize", report.entries[0].findings.first().type)
+    assertEquals(0, report.entries[1].findings.size)
+  }
+
+  @Test
+  fun `returns DescriptorMissing when daemon-launch_json is absent`() {
+    val projectDir = newTempFolder("module-no-descriptor")
+    val fetcher = DaemonA11yFetcher(factory = FakeFactory(emptyMap()))
+
+    val outcome =
+      fetcher.fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previewIds = listOf("AlphaPreview"),
+      )
+
+    assertTrue(outcome is DaemonA11yFetcher.Outcome.DescriptorMissing)
+  }
+
+  // -------------------------------------------------------------------------
+  // Fake factory + session
+
+  private class FakeFactory(private val payloads: Map<String, JsonElement>) : RenderSessionFactory {
+    override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+    override fun open(config: RenderSessionConfig): RenderSession =
+      FakeSession(
+        workspaceRoot = config.workspaceRoot.absolutePath,
+        modulePath = ":sample",
+        payloads = payloads,
+      )
+  }
+
+  /**
+   * Minimal [RenderSession] that returns canned a11y/atf payloads. Every other method throws — the
+   * fetcher only calls fetchData and close.
+   */
+  private class FakeSession(
+    override val workspaceRoot: String,
+    override val modulePath: String,
+    private val payloads: Map<String, JsonElement>,
+  ) : RenderSession {
+    override val initializeResult: InitializeResult =
+      InitializeResult(
+        protocolVersion = 2,
+        daemonVersion = "fake",
+        pid = 0,
+        capabilities =
+          ServerCapabilities(
+            incrementalDiscovery = false,
+            sandboxRecycle = false,
+            leakDetection = emptyList(),
+          ),
+        classpathFingerprint = "",
+        manifest = Manifest(path = "", previewCount = 0),
+      )
+    override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+    override fun setVisible(previewIds: List<String>) = error("unused")
+
+    override fun setFocus(previewIds: List<String>) = error("unused")
+
+    override fun fileChanged(path: String, kind: FileKind, changeType: ChangeType) = error("unused")
+
+    override fun renderNow(
+      previewIds: List<String>,
+      tier: RenderTier,
+      reason: String?,
+      overrides: PreviewOverrides?,
+      timeout: kotlin.time.Duration,
+    ): RenderNowResult = error("unused")
+
+    override fun fetchData(
+      previewId: String,
+      kind: String,
+      inline: Boolean,
+      params: JsonElement?,
+      timeout: kotlin.time.Duration,
+    ): DataFetchResult =
+      DataFetchResult(kind = kind, schemaVersion = 1, payload = payloads[previewId])
+
+    override fun subscribeData(
+      previewId: String,
+      kind: String,
+      params: JsonElement?,
+      timeout: kotlin.time.Duration,
+    ): DataSubscribeResult = error("unused")
+
+    override fun unsubscribeData(
+      previewId: String,
+      kind: String,
+      timeout: kotlin.time.Duration,
+    ): DataSubscribeResult = error("unused")
+
+    override fun listExtensions(timeout: kotlin.time.Duration): ExtensionsListResult =
+      error("unused")
+
+    override fun enableExtensions(
+      ids: List<String>,
+      timeout: kotlin.time.Duration,
+    ): ExtensionsEnableResult = error("unused")
+
+    override fun disableExtensions(
+      ids: List<String>,
+      timeout: kotlin.time.Duration,
+    ): ExtensionsDisableResult = error("unused")
+
+    override fun historyList(
+      params: HistoryListParams,
+      timeout: kotlin.time.Duration,
+    ): HistoryListResult = error("unused")
+
+    override fun historyRead(
+      entryId: String,
+      inline: Boolean,
+      timeout: kotlin.time.Duration,
+    ): HistoryReadResultDto = error("unused")
+
+    override fun historyDiff(
+      fromId: String,
+      toId: String,
+      mode: HistoryDiffMode,
+      timeout: kotlin.time.Duration,
+    ): HistoryDiffResult = error("unused")
+
+    override fun recordingStart(
+      previewId: String,
+      fps: Int?,
+      scale: Float?,
+      overrides: PreviewOverrides?,
+      timeout: kotlin.time.Duration,
+    ): RecordingStartResult = error("unused")
+
+    override fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) =
+      error("unused")
+
+    override fun recordingStop(
+      recordingId: String,
+      timeout: kotlin.time.Duration,
+    ): RecordingStopResult = error("unused")
+
+    override fun recordingEncode(
+      recordingId: String,
+      format: RecordingFormat,
+      timeout: kotlin.time.Duration,
+    ): RecordingEncodeResult = error("unused")
+
+    override fun onNotification(listener: NotificationListener): AutoCloseable = AutoCloseable {}
+
+    override fun close() = Unit
+  }
+
+  private fun atfPayload(findings: List<AccessibilityFinding>): JsonElement = buildJsonObject {
+    put(
+      "findings",
+      kotlinx.serialization.json.JsonArray(
+        findings.map {
+          buildJsonObject {
+            put("level", it.level)
+            put("type", it.type)
+            put("message", it.message)
+          }
+        }
+      ),
+    )
+  }
+
+  private fun finding(level: String, type: String, message: String) =
+    AccessibilityFinding(level = level, type = type, message = message)
+
+  companion object {
+    private val json = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+  }
+}

--- a/render-session/api/build.gradle.kts
+++ b/render-session/api/build.gradle.kts
@@ -1,0 +1,42 @@
+// Public API for the compose-preview render-session library.
+//
+// This module is the renderer-agnostic interface third-party tooling compiles against:
+// the `RenderSession` contract, supporting DTOs, and capability descriptions. It carries no
+// renderer / Compose / Robolectric dependencies and is safe to put on any JVM classpath.
+//
+// Two implementations live alongside it:
+//   - `:render-session-subprocess` — spawns a daemon JVM via the launch descriptor written by the
+//     gradle plugin's `composePreviewDaemonStart` task, drives it over JSON-RPC, and surfaces the
+//     `RenderSession` contract. Works on any JVM with a JDK on the host.
+//   - `:render-session-embedded` (future) — drives the renderer in-process. Requires the calling
+//     JVM to host the full Robolectric + AGP + Compose classpath; viable mostly inside JUnit test
+//     runners. Tracked separately.
+//
+// Pre-1.0; API may break across minor versions while consumers stabilise. The `RenderSession`
+// interface itself is the stable contract we evolve carefully.
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // Protocol message types (`RenderTier`, `PreviewOverrides`, `FileKind`, etc.) are re-exposed
+  // through this module's API. Consumers see them as `ee.schimke.composeai.daemon.protocol.*`
+  // and the `RenderSession` contract references them directly — no duplicate DTOs in this jar.
+  api(project(":daemon:core"))
+
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "render-session-api",
+    displayName = "Compose Preview — Render Session API",
+    description =
+      "Public, renderer-agnostic API for driving compose-preview render sessions from third-party " +
+        "tooling. Pre-1.0; pair with :render-session-subprocess (or future embedded backend).",
+  )
+  inceptionYear.set("2026")
+}

--- a/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSession.kt
+++ b/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSession.kt
@@ -1,0 +1,293 @@
+package ee.schimke.composeai.render.session
+
+import ee.schimke.composeai.daemon.protocol.ChangeType
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
+import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
+import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
+import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingStartResult
+import ee.schimke.composeai.daemon.protocol.RecordingStopResult
+import ee.schimke.composeai.daemon.protocol.RenderNowResult
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Live render session bound to one preview module. The session encapsulates the renderer lifecycle
+ * (initialize, render, fetch data, subscribe to live updates, close); implementations choose how to
+ * host the renderer — most commonly as a daemon subprocess driven over JSON-RPC, but a future
+ * in-process embedded driver presents the same contract.
+ *
+ * ## Lifecycle
+ *
+ * A session is born *initialized*: [RenderSessionFactory] performs the renderer-side `initialize`
+ * handshake before handing the session back, so callers never observe an un-initialized session.
+ * The publicly observable lifecycle is just `open → drive → close`.
+ *
+ * ## Threading
+ *
+ * Implementations are required to be safe for concurrent calls from one calling thread sequenced by
+ * the caller. Multi-threaded use is implementation-defined — the subprocess backend's underlying
+ * client is internally synchronised, but the contract here does not promise it.
+ *
+ * ## Notifications
+ *
+ * Daemon backends emit asynchronous notifications (`renderFinished`, `discoveryUpdated`,
+ * `classpathDirty`, `dataProduct`, …) as renders progress. Register a listener via [onNotification]
+ * when you need to react to them; the default session ignores them after the synchronous reply
+ * returns. Notifications are dispatched from an implementation-defined thread; handlers must not
+ * block.
+ *
+ * ## Errors
+ *
+ * Every request method throws [RenderSessionException] (or a more specific subtype) on transport /
+ * protocol failure. Wire-level data-product errors (`DataProductUnknown`,
+ * `DataProductNotAvailable`, etc.) are surfaced as [DataProductException].
+ */
+interface RenderSession : AutoCloseable {
+  /** Absolute path to the workspace root the session was opened against. */
+  val workspaceRoot: String
+
+  /** Gradle path of the target module (e.g. `:samples:android`). */
+  val modulePath: String
+
+  /** Result of the initialize handshake. Surfaces daemon version, capabilities, and PID. */
+  val initializeResult: InitializeResult
+
+  /** Backend that hosts this session — informational; behaviour is identical across backends. */
+  val backendKind: RenderSessionBackend
+
+  // ---------------------------------------------------------------------------
+  // Editor-state notifications. None of these return data; they update the
+  // session's view of which previews matter so subscriptions / live updates
+  // stay scoped.
+  // ---------------------------------------------------------------------------
+
+  /** Set the most-recently-visible preview ids. Drives sticky subscription liveness. */
+  fun setVisible(previewIds: List<String>)
+
+  /** Set the most-recently-focused preview ids. Drives focus-aware rendering. */
+  fun setFocus(previewIds: List<String>)
+
+  /**
+   * Notify the session of a source / classpath change so it can invalidate caches, swap user
+   * classloaders, and (depending on backend) trigger incremental discovery.
+   */
+  fun fileChanged(
+    path: String,
+    kind: FileKind = FileKind.SOURCE,
+    changeType: ChangeType = ChangeType.MODIFIED,
+  )
+
+  // ---------------------------------------------------------------------------
+  // Render. Synchronous — returns when every requested preview has either
+  // rendered or failed. Caller decides whether to issue one wide call or many
+  // narrow ones.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Render the given previews. Idempotent at the client level — the backend caches and may serve
+   * unchanged results without re-running compose. Pass [PreviewOverrides] to drive
+   * device/locale/inspection-mode tweaks per render without mutating the on-disk preview spec.
+   */
+  fun renderNow(
+    previewIds: List<String>,
+    tier: RenderTier = RenderTier.FULL,
+    reason: String? = null,
+    overrides: PreviewOverrides? = null,
+    timeout: Duration = 30.seconds,
+  ): RenderNowResult
+
+  // ---------------------------------------------------------------------------
+  // Data products.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch one data product for one preview. The backend re-renders when the artefact isn't
+   * materialised yet and the kind is marked `requiresRerender` (e.g. `a11y/atf`). Inline transport
+   * returns the payload as a parsed [JsonElement]; path transport returns an on-disk file path the
+   * caller reads directly. Pass [inline] = `true` to coerce inline transport on kinds that support
+   * it.
+   *
+   * @throws DataProductException on wire-level data-product errors.
+   */
+  fun fetchData(
+    previewId: String,
+    kind: String,
+    inline: Boolean = false,
+    params: JsonElement? = null,
+    timeout: Duration = 30.seconds,
+  ): DataFetchResult
+
+  /**
+   * Subscribe to a data product kind on one preview. The session keeps the subscription "sticky
+   * while visible" — when the preview leaves the most recent [setVisible] set the backend drops the
+   * subscription automatically. Re-subscribe when it returns to view.
+   */
+  fun subscribeData(
+    previewId: String,
+    kind: String,
+    params: JsonElement? = null,
+    timeout: Duration = 15.seconds,
+  ): DataSubscribeResult
+
+  /** Unsubscribe. See [subscribeData]. */
+  fun unsubscribeData(
+    previewId: String,
+    kind: String,
+    timeout: Duration = 15.seconds,
+  ): DataSubscribeResult
+
+  // ---------------------------------------------------------------------------
+  // Extensions — descriptor introspection + per-session enable/disable.
+  // ---------------------------------------------------------------------------
+
+  /** Enumerate the extensions advertised by the backend. */
+  fun listExtensions(timeout: Duration = 15.seconds): ExtensionsListResult
+
+  /** Enable specific extension contributions on this session. */
+  fun enableExtensions(ids: List<String>, timeout: Duration = 15.seconds): ExtensionsEnableResult
+
+  /** Disable specific extension contributions on this session. */
+  fun disableExtensions(ids: List<String>, timeout: Duration = 15.seconds): ExtensionsDisableResult
+
+  // ---------------------------------------------------------------------------
+  // History — per-render archive surface. Optional on every backend; backends
+  // that don't archive returns empty results / fail with the same exception
+  // shape so callers can probe without backend-specific branching.
+  // ---------------------------------------------------------------------------
+
+  /** List archived render entries. Pass [HistoryListParams] to filter by preview id / time. */
+  fun historyList(
+    params: HistoryListParams = HistoryListParams(),
+    timeout: Duration = 30.seconds,
+  ): HistoryListResult
+
+  /** Read one archived entry. Set [inline] = `true` to receive base64 PNG bytes inline. */
+  fun historyRead(
+    entryId: String,
+    inline: Boolean = false,
+    timeout: Duration = 30.seconds,
+  ): HistoryReadResultDto
+
+  /** Diff two archived entries. */
+  fun historyDiff(
+    fromId: String,
+    toId: String,
+    mode: HistoryDiffMode = HistoryDiffMode.METADATA,
+    timeout: Duration = 30.seconds,
+  ): HistoryDiffResult
+
+  // ---------------------------------------------------------------------------
+  // Recording — scripted screen-recording surface.
+  // ---------------------------------------------------------------------------
+
+  /** Start a recording session against one preview. Returns the daemon-allocated recording id. */
+  fun recordingStart(
+    previewId: String,
+    fps: Int? = null,
+    scale: Float? = null,
+    overrides: PreviewOverrides? = null,
+    timeout: Duration = 30.seconds,
+  ): RecordingStartResult
+
+  /** Send recording-script events (fire-and-forget notification). */
+  fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>)
+
+  /** Stop recording — blocks until the daemon's playback loop finishes writing frames. */
+  fun recordingStop(recordingId: String, timeout: Duration = 5.minutes): RecordingStopResult
+
+  /** Encode a stopped recording into a single file (APNG by default). */
+  fun recordingEncode(
+    recordingId: String,
+    format: RecordingFormat = RecordingFormat.APNG,
+    timeout: Duration = 60.seconds,
+  ): RecordingEncodeResult
+
+  // ---------------------------------------------------------------------------
+  // Notifications.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register a notification listener. The returned [AutoCloseable] removes the listener when closed
+   * — typical use is `session.onNotification { … }.use { runRenders() }` so the subscription is
+   * scoped to one block. Handlers must not block; offload to a worker if real work is needed.
+   */
+  fun onNotification(listener: NotificationListener): AutoCloseable
+
+  /**
+   * Close the session. Idempotent. After close, every other method throws [IllegalStateException].
+   * Implementations are responsible for tearing down their transport (subprocess shutdown,
+   * classloader release, etc.) without leaking resources.
+   */
+  override fun close()
+}
+
+/**
+ * Sink for daemon-side notifications. [method] is the JSON-RPC method name (`renderFinished`,
+ * `discoveryUpdated`, `classpathDirty`, `dataProduct`, …); [params] is the raw notification body as
+ * a JSON object (or `null` when the daemon emits an empty params field).
+ *
+ * Functional interface so callers can pass lambdas directly:
+ * ```kotlin
+ * session.onNotification { method, _ -> println("[notif] $method") }
+ * ```
+ */
+fun interface NotificationListener {
+  fun onNotification(method: String, params: JsonObject?)
+}
+
+/** Backend hosting a [RenderSession]. Informational; behaviour is identical across backends. */
+enum class RenderSessionBackend {
+  /** Daemon JVM spawned as a subprocess, driven over JSON-RPC. The default. */
+  Subprocess,
+
+  /**
+   * In-process embedded driver. Currently unsupported on most JVMs — the renderer needs the full
+   * Robolectric + AGP + Compose classpath, which is rare outside of unit-test runners. Reserved for
+   * future implementations.
+   */
+  Embedded,
+}
+
+/**
+ * Common base for failures observed across the session contract. Implementations preserve the
+ * underlying [cause] (e.g. an `IOException` from the transport, a `JsonRpcException` from the
+ * protocol layer) where one exists.
+ */
+open class RenderSessionException(message: String, cause: Throwable? = null) :
+  RuntimeException(message, cause)
+
+/**
+ * Thrown when [RenderSession.fetchData] returns a wire-level data-product error. [code] is the
+ * JSON-RPC error code (`-32020`..`-32023`); [wireMessage] is the daemon's human-readable message;
+ * [data] is the optional structured payload some errors carry.
+ */
+class DataProductException(
+  val code: Int,
+  val wireMessage: String,
+  val data: JsonObject?,
+  cause: Throwable? = null,
+) : RenderSessionException("data/fetch wire error $code: $wireMessage", cause) {
+  companion object {
+    const val UNKNOWN: Int = -32020
+    const val NOT_AVAILABLE: Int = -32021
+    const val FETCH_FAILED: Int = -32022
+    const val BUDGET_EXCEEDED: Int = -32023
+  }
+}

--- a/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSessionFactory.kt
+++ b/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSessionFactory.kt
@@ -1,0 +1,77 @@
+package ee.schimke.composeai.render.session
+
+import java.io.File
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Factory for opening [RenderSession]s. Lives in `:render-session-api` so consumers can hold the
+ * factory shape without committing to a specific backend module at compile time; backend
+ * implementations register themselves through this interface.
+ *
+ * Typical usage from `:render-session-subprocess`:
+ * ```kotlin
+ * val factory: RenderSessionFactory = SubprocessRenderSessions
+ * val session = factory.open(
+ *   RenderSessionConfig(
+ *     descriptorPath = File("samples/android/build/compose-previews/daemon-launch.json"),
+ *     workspaceRoot = File("/path/to/repo"),
+ *   ),
+ * )
+ * session.use { … }
+ * ```
+ */
+interface RenderSessionFactory {
+  /** Backend this factory produces. */
+  val backendKind: RenderSessionBackend
+
+  /**
+   * Open and initialize a session. Throws [RenderSessionException] (or subclass) on transport /
+   * descriptor / handshake failure — callers don't observe an un-initialized session.
+   */
+  fun open(config: RenderSessionConfig): RenderSession
+}
+
+/**
+ * Inputs shared by every backend's [RenderSessionFactory.open]. Backend-specific knobs (e.g.
+ * subprocess JVM args overrides) live on per-backend extensions; this base record holds the minimum
+ * every backend needs.
+ */
+data class RenderSessionConfig(
+  /**
+   * Path to the daemon launch descriptor written by the gradle plugin's `composePreviewDaemonStart`
+   * task. Lives at `<projectDir>/build/compose-previews/daemon-launch.json`. Required even for the
+   * embedded backend — it's the source of truth for classpath and JVM args (the embedded backend
+   * wires its own classloader from the same data).
+   */
+  val descriptorPath: File,
+  /**
+   * Workspace root reported to the daemon as the user's project root. Defaults to inferring from
+   * [descriptorPath] (two directories up from the `build/compose-previews/` subdirectory). Pass
+   * explicitly when the descriptor lives outside the workspace tree.
+   */
+  val workspaceRoot: File = inferWorkspaceRoot(descriptorPath),
+  /**
+   * Workspace name surfaced in diagnostic messages and used to derive the workspace id the backend
+   * reports back. Defaults to the directory name of [workspaceRoot].
+   */
+  val workspaceName: String = workspaceRoot.name.ifBlank { "workspace" },
+  /**
+   * Override the daemon's `enabled = false` descriptor flag so tooling can spin one up even when
+   * the consumer's `composePreview { daemon { enabled = false } }`. The flag was originally a VS
+   * Code launcher gate — for explicit CLI / library opens it shouldn't apply.
+   */
+  val forceEnabled: Boolean = true,
+  /**
+   * Log sink for the backend's diagnostic output (subprocess stderr, embedded driver
+   * stderr-equivalent). Defaults to forwarding to `System.err` with a `[render-session]` prefix.
+   */
+  val logSink: (String) -> Unit = { System.err.println("[render-session] $it") },
+  /** Upper bound on the initialize handshake. */
+  val initializeTimeout: Duration = 60.seconds,
+) {
+  companion object {
+    private fun inferWorkspaceRoot(descriptorPath: File): File =
+      descriptorPath.parentFile?.parentFile?.parentFile ?: descriptorPath.absoluteFile
+  }
+}

--- a/render-session/subprocess/build.gradle.kts
+++ b/render-session/subprocess/build.gradle.kts
@@ -1,0 +1,39 @@
+// Subprocess-backed implementation of the public render-session library.
+//
+// Spawns the preview daemon JVM via the launch descriptor written by the gradle plugin's
+// `composePreviewDaemonStart` task, drives it over Content-Length-framed JSON-RPC over stdio,
+// and exposes the result as a `RenderSession`. This is the default backend — works on any JVM
+// with a JDK on the host machine, no Robolectric / AGP / Compose deps required at the call site.
+//
+// Builds on `:mcp`'s existing `DaemonClient` + `SubprocessDaemonClientFactory` rather than
+// re-implementing the JSON-RPC transport. The MCP server keeps consuming those types directly;
+// the public render-session API is the supported surface for third-party tooling.
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  api(project(":render-session-api"))
+
+  // Existing JSON-RPC client + subprocess spawn infrastructure. Public surface here is the
+  // `RenderSession` contract; `:mcp` types stay internal to this module.
+  implementation(project(":mcp"))
+  implementation(project(":daemon:core"))
+  implementation(libs.kotlinx.serialization.json)
+
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "render-session-subprocess",
+    displayName = "Compose Preview — Subprocess Render Session",
+    description =
+      "Daemon-subprocess-backed implementation of the compose-preview render-session API. Spawns " +
+        "a daemon JVM per session, drives it via JSON-RPC, presents the result as a RenderSession.",
+  )
+  inceptionYear.set("2026")
+}

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -1,0 +1,343 @@
+package ee.schimke.composeai.render.session.subprocess
+
+import ee.schimke.composeai.daemon.protocol.ChangeType
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
+import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
+import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
+import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingStartResult
+import ee.schimke.composeai.daemon.protocol.RecordingStopResult
+import ee.schimke.composeai.daemon.protocol.RenderNowResult
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.mcp.DaemonClient
+import ee.schimke.composeai.mcp.DaemonClientFactory
+import ee.schimke.composeai.mcp.DaemonLaunchDescriptor
+import ee.schimke.composeai.mcp.DataProductWireException
+import ee.schimke.composeai.mcp.RegisteredProject
+import ee.schimke.composeai.mcp.SubprocessDaemonClientFactory
+import ee.schimke.composeai.mcp.WorkspaceId
+import ee.schimke.composeai.render.session.DataProductException
+import ee.schimke.composeai.render.session.NotificationListener
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.RenderSessionBackend
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.RenderSessionException
+import ee.schimke.composeai.render.session.RenderSessionFactory
+import java.io.File
+import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * [RenderSession] backed by a daemon JVM spawned as a subprocess. Each session owns one subprocess;
+ * closing the session shuts the subprocess down cleanly (drain → exit → wait, with timeout fallback
+ * to `destroyForcibly`).
+ *
+ * Use [SubprocessRenderSessions] (or the static helpers below) to open sessions — the public
+ * constructor is internal so test code can inject a fake [DaemonClientFactory] without inheriting
+ * transport implementation details.
+ */
+class SubprocessRenderSession
+internal constructor(
+  override val workspaceRoot: String,
+  override val modulePath: String,
+  override val initializeResult: InitializeResult,
+  private val spawnedClient: DaemonClient,
+  private val closeSpawn: () -> Unit,
+  private val listeners: CopyOnWriteArraySet<NotificationListener>,
+) : RenderSession {
+
+  override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+  private val closed = AtomicBoolean(false)
+
+  override fun setVisible(previewIds: List<String>) {
+    checkOpen()
+    spawnedClient.setVisible(previewIds)
+  }
+
+  override fun setFocus(previewIds: List<String>) {
+    checkOpen()
+    spawnedClient.setFocus(previewIds)
+  }
+
+  override fun fileChanged(path: String, kind: FileKind, changeType: ChangeType) {
+    checkOpen()
+    spawnedClient.fileChanged(path, kind, changeType)
+  }
+
+  override fun renderNow(
+    previewIds: List<String>,
+    tier: RenderTier,
+    reason: String?,
+    overrides: PreviewOverrides?,
+    timeout: Duration,
+  ): RenderNowResult {
+    checkOpen()
+    return spawnedClient.renderNow(
+      previews = previewIds,
+      tier = tier,
+      reason = reason,
+      overrides = overrides,
+      timeout = timeout,
+    )
+  }
+
+  override fun fetchData(
+    previewId: String,
+    kind: String,
+    inline: Boolean,
+    params: JsonElement?,
+    timeout: Duration,
+  ): DataFetchResult {
+    checkOpen()
+    return try {
+      spawnedClient.dataFetch(
+        previewId = previewId,
+        kind = kind,
+        params = params,
+        inline = inline,
+        timeout = timeout,
+      )
+    } catch (e: DataProductWireException) {
+      throw DataProductException(
+        code = e.code,
+        wireMessage = e.wireMessage,
+        data = e.data,
+        cause = e,
+      )
+    }
+  }
+
+  override fun subscribeData(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    timeout: Duration,
+  ): DataSubscribeResult {
+    checkOpen()
+    return spawnedClient.dataSubscribe(previewId = previewId, kind = kind, timeout = timeout)
+  }
+
+  override fun unsubscribeData(
+    previewId: String,
+    kind: String,
+    timeout: Duration,
+  ): DataSubscribeResult {
+    checkOpen()
+    return spawnedClient.dataUnsubscribe(previewId = previewId, kind = kind, timeout = timeout)
+  }
+
+  override fun listExtensions(timeout: Duration): ExtensionsListResult {
+    checkOpen()
+    return spawnedClient.extensionsList(timeout)
+  }
+
+  override fun enableExtensions(ids: List<String>, timeout: Duration): ExtensionsEnableResult {
+    checkOpen()
+    return spawnedClient.extensionsEnable(ids = ids, timeout = timeout)
+  }
+
+  override fun disableExtensions(ids: List<String>, timeout: Duration): ExtensionsDisableResult {
+    checkOpen()
+    return spawnedClient.extensionsDisable(ids = ids, timeout = timeout)
+  }
+
+  override fun historyList(params: HistoryListParams, timeout: Duration): HistoryListResult {
+    checkOpen()
+    return spawnedClient.historyList(params = params, timeout = timeout)
+  }
+
+  override fun historyRead(
+    entryId: String,
+    inline: Boolean,
+    timeout: Duration,
+  ): HistoryReadResultDto {
+    checkOpen()
+    return spawnedClient.historyRead(entryId = entryId, inline = inline, timeout = timeout)
+  }
+
+  override fun historyDiff(
+    fromId: String,
+    toId: String,
+    mode: HistoryDiffMode,
+    timeout: Duration,
+  ): HistoryDiffResult {
+    checkOpen()
+    return spawnedClient.historyDiff(fromId = fromId, toId = toId, mode = mode, timeout = timeout)
+  }
+
+  override fun recordingStart(
+    previewId: String,
+    fps: Int?,
+    scale: Float?,
+    overrides: PreviewOverrides?,
+    timeout: Duration,
+  ): RecordingStartResult {
+    checkOpen()
+    return spawnedClient.recordingStart(
+      previewId = previewId,
+      fps = fps,
+      scale = scale,
+      overrides = overrides,
+      timeout = timeout,
+    )
+  }
+
+  override fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) {
+    checkOpen()
+    spawnedClient.recordingScript(recordingId, events)
+  }
+
+  override fun recordingStop(recordingId: String, timeout: Duration): RecordingStopResult {
+    checkOpen()
+    return spawnedClient.recordingStop(recordingId = recordingId, timeout = timeout)
+  }
+
+  override fun recordingEncode(
+    recordingId: String,
+    format: RecordingFormat,
+    timeout: Duration,
+  ): RecordingEncodeResult {
+    checkOpen()
+    return spawnedClient.recordingEncode(
+      recordingId = recordingId,
+      format = format,
+      timeout = timeout,
+    )
+  }
+
+  override fun onNotification(listener: NotificationListener): AutoCloseable {
+    checkOpen()
+    listeners.add(listener)
+    return AutoCloseable { listeners.remove(listener) }
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    runCatching { closeSpawn() }
+  }
+
+  private fun checkOpen() {
+    check(!closed.get()) { "RenderSession has been closed" }
+  }
+}
+
+/**
+ * [RenderSessionFactory] singleton for the daemon-subprocess backend. Open a session via
+ * `SubprocessRenderSessions.open(config)` or the convenience overloads below.
+ */
+object SubprocessRenderSessions : RenderSessionFactory {
+  override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+  override fun open(config: RenderSessionConfig): RenderSession =
+    open(config = config, factory = SubprocessDaemonClientFactory())
+
+  /**
+   * Open a session, injecting a custom [DaemonClientFactory]. Test scaffolding pairs an in-memory
+   * factory with a fake daemon; production callers stick with the default factory in [open].
+   */
+  fun open(config: RenderSessionConfig, factory: DaemonClientFactory): RenderSession {
+    val descriptorFile = config.descriptorPath
+    if (!descriptorFile.isFile) {
+      throw RenderSessionException(
+        "Daemon launch descriptor not found at ${descriptorFile.path}. " +
+          "Run `:<modulePath>:composePreviewDaemonStart` to materialise it."
+      )
+    }
+    val descriptor =
+      try {
+        DaemonLaunchDescriptor.parse(descriptorFile.readText())
+      } catch (e: Exception) {
+        throw RenderSessionException(
+          "Daemon launch descriptor at ${descriptorFile.path} is unreadable: " +
+            (e.message ?: e.javaClass.simpleName),
+          cause = e,
+        )
+      }
+    val effectiveDescriptor =
+      if (config.forceEnabled && !descriptor.enabled) descriptor.copy(enabled = true)
+      else descriptor
+    val workspaceRoot = config.workspaceRoot
+    val canonicalRoot =
+      runCatching { workspaceRoot.canonicalFile }.getOrDefault(workspaceRoot.absoluteFile)
+    val project =
+      RegisteredProject(
+        workspaceId = WorkspaceId.derive(config.workspaceName, canonicalRoot),
+        rootProjectName = config.workspaceName,
+        path = canonicalRoot,
+        knownModules = mutableListOf(),
+      )
+
+    val spawn =
+      try {
+        factory.spawn(project, effectiveDescriptor)
+      } catch (e: Exception) {
+        throw RenderSessionException(
+          "Failed to spawn daemon subprocess for ${descriptor.modulePath}: " +
+            (e.message ?: e.javaClass.simpleName),
+          cause = e,
+        )
+      }
+
+    val listeners = CopyOnWriteArraySet<NotificationListener>()
+    val client: DaemonClient =
+      spawn.client(
+        onNotification = { method, params ->
+          for (l in listeners) runCatching { l.onNotification(method, params) }
+        },
+        onClose = {},
+      )
+
+    val initializeResult: InitializeResult =
+      try {
+        client.initialize(
+          workspaceRoot = canonicalRoot.absolutePath,
+          moduleId = effectiveDescriptor.modulePath,
+          moduleProjectDir = effectiveDescriptor.workingDirectory,
+          timeout = config.initializeTimeout,
+        )
+      } catch (e: Exception) {
+        runCatching { spawn.shutdown() }
+        throw RenderSessionException(
+          "Daemon initialize handshake failed for ${descriptor.modulePath}: " +
+            (e.message ?: e.javaClass.simpleName),
+          cause = e,
+        )
+      }
+
+    return SubprocessRenderSession(
+      workspaceRoot = canonicalRoot.absolutePath,
+      modulePath = effectiveDescriptor.modulePath,
+      initializeResult = initializeResult,
+      spawnedClient = client,
+      closeSpawn = { spawn.shutdown() },
+      listeners = listeners,
+    )
+  }
+
+  /**
+   * Resolve a module's daemon launch descriptor under [projectDir] / [modulePath] using the
+   * conventional `<projectDir>/<modulePath-derived>/build/compose-previews/daemon-launch.json`
+   * layout. Convenience wrapper for callers that don't already have the descriptor path.
+   */
+  fun descriptorFile(projectDir: File, modulePath: String): File {
+    val moduleDir =
+      if (modulePath.isBlank() || modulePath == ":") projectDir
+      else File(projectDir, modulePath.trimStart(':').replace(':', '/'))
+    return File(moduleDir, "build/compose-previews/daemon-launch.json")
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -212,3 +212,15 @@ include(":daemon:desktop")
 include(":daemon:harness")
 
 include(":mcp")
+
+// Public render-session library. `:render-session-api` is the pure-interface surface every
+// consumer (CLI, MCP server, third-party tooling) compiles against; `:render-session-subprocess`
+// is the daemon-subprocess-backed implementation. Future `:render-session-embedded` will host the
+// in-process Robolectric driver once that's viable.
+include(":render-session-api")
+
+project(":render-session-api").projectDir = file("render-session/api")
+
+include(":render-session-subprocess")
+
+project(":render-session-subprocess").projectDir = file("render-session/subprocess")


### PR DESCRIPTION
## Summary

Adds a renderer-agnostic, publishable Kotlin library for opening + driving compose-preview render sessions, so third-party tooling (the CLI itself, future test rigs, IDE plugins) can consume the daemon contract without depending on internal types in `:mcp`. Splits into two coordinates so the API jar stays light:

- **`:render-session-api`** — pure-interface surface. The `RenderSession` contract, `RenderSessionFactory`, `RenderSessionConfig`, exception hierarchy, supporting enums. No Compose / Robolectric / Android deps. Published as `ee.schimke.composeai:render-session-api`.
- **`:render-session-subprocess`** — daemon-subprocess implementation. Reuses the existing `DaemonClient` + `SubprocessDaemonClientFactory` infrastructure from `:mcp` to spawn the daemon JVM via the launch descriptor `composePreviewDaemonStart` writes, drive it over JSON-RPC, and surface the result as a `RenderSession`. Published as `ee.schimke.composeai:render-session-subprocess`.

The API is shaped to admit a future `:render-session-embedded` backend (in-process Robolectric driver) without breaking existing consumers — `RenderSessionBackend.Embedded` is reserved on day one.

## API surface

Wide — covers everything `DaemonClient` exposes today:

- Editor-state notifications: `setVisible`, `setFocus`, `fileChanged`
- Render: `renderNow(previewIds, tier, reason, overrides, timeout)`
- Data products: `fetchData`, `subscribeData`, `unsubscribeData`, with `DataProductException` (carries the wire `code` so callers can branch on `UNKNOWN` / `NOT_AVAILABLE` / `FETCH_FAILED` / `BUDGET_EXCEEDED`)
- Extensions: `listExtensions`, `enableExtensions`, `disableExtensions`
- History: `historyList`, `historyRead`, `historyDiff`
- Recording: `recordingStart`, `recordingScript`, `recordingStop`, `recordingEncode`
- Notifications: pluggable `NotificationListener` via `onNotification(listener): AutoCloseable`
- Lifecycle: `AutoCloseable.close()` — drains the daemon (`shutdown → exit`), waits for the subprocess to terminate, falls back to `destroyForcibly` after timeout

The session is born initialized: `RenderSessionFactory.open(config)` performs the `initialize` handshake before returning, so callers never observe an un-initialized session.

## CLI integration (eat our own dog food)

`compose-preview a11y` now drives the library:

1. After `:renderAllPreviews` completes, run `:<module>:composePreviewDaemonStart` to materialise each module's `daemon-launch.json`.
2. For each module, open a `SubprocessRenderSessions` session.
3. Walk every preview through `fetchData("a11y/atf", inline = true)` — the daemon re-renders in `renderMode=a11y` on demand.
4. Aggregate findings into `build/compose-previews/accessibility.json` (the canonical shape `A11yReportRenderer` reads).
5. Close the session — the daemon shuts down.

`A11yReportRenderer.load` now falls back to that disk path when the manifest pointer is absent. This restores the `compose-preview a11y` flow that #1127 stubbed out with a TODO.

## Test plan

- [x] `:render-session-api:compileKotlin` + `:render-session-subprocess:compileKotlin` clean
- [x] `:cli:test` — new `DaemonA11yFetcherTest` exercises the aggregation contract against a fake `RenderSessionFactory` (no live daemon required); existing CLI tests untouched
- [x] `:gradle-plugin:test` + `:gradle-plugin:functionalTest` still pass
- [x] `:cli:checkCliDaemonLibraryBoundary` confirms renderer artefacts haven't leaked onto the CLI runtime classpath — the new modules only pull `:mcp` + `:daemon:core`
- [x] `ktfmtCheckAll` clean
- [ ] End-to-end run of `compose-preview a11y` against `:samples:android` (requires Android SDK + the daemon spawn-path; verified locally that the library compiles and the unit tests pass; full E2E covered by the existing functional test matrix once CI picks it up)

## Out of scope

- The embedded in-process backend (`RenderSessionBackend.Embedded`) — reserved in the enum but throws on construction. Lands when Robolectric becomes practical to host in a non-test JVM.
- Migrating `:mcp` to consume `:render-session-api` internally. The MCP server keeps using `DaemonClient` directly for now; the library is for external consumers and the CLI. A follow-up can collapse them if it's worth the churn.

---
_Generated by [Claude Code](https://claude.ai/code/session_0178MWQ319fGv7JWjSwpsvSU)_