### PR TITLE
fix(gradle-plugin): inject compose-ui floor on main variant for tile-only consumers

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -116,13 +116,6 @@ jobs:
     name: ${{ matrix.name }}
     needs: build-plugin
     runs-on: ubuntu-latest
-    env:
-      # Per-entry pull_request gate. Any matrix entry tagged `main_only: true`
-      # has every step skipped on pull_request events; the entry still runs on
-      # push to main, workflow_dispatch, and the weekly schedule. Used to keep
-      # the slower WearTilesKotlin tile-render coverage off the PR critical
-      # path while preserving it on trunk.
-      SKIP_ON_PR: ${{ matrix.main_only && github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -159,12 +152,6 @@ jobs:
             workdir: WearTilesKotlin
             module: app
             extra_gradle_args: ""
-            # Skip on pull_request to keep PR cycle time down. Still runs on
-            # push to main, workflow_dispatch, and the weekly schedule, so the
-            # tile-render regression coverage below is preserved on trunk.
-            # Every step in this job is gated on `!matrix.main_only ||
-            # github.event_name != 'pull_request'` to honor this flag.
-            main_only: true
             # Render in addition to discover — WearTilesKotlin uses an older
             # Compose BOM than our renderer, which previously exposed a latent
             # transitive-dep issue (activity-compose 1.13 → navigationevent
@@ -228,7 +215,6 @@ jobs:
           # Android source sets cleanly.
     steps:
       - name: Checkout ${{ matrix.repo }}
-        if: env.SKIP_ON_PR != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ matrix.repo }}
@@ -237,24 +223,20 @@ jobs:
           persist-credentials: false
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        if: env.SKIP_ON_PR != 'true'
         with:
           distribution: temurin
           java-version: 17
 
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-        if: env.SKIP_ON_PR != 'true'
         with:
           cache-provider: basic
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        if: env.SKIP_ON_PR != 'true'
         with:
           name: compose-ai-bundle
           path: .
 
       - name: Install plugin, CLI, and init script
-        if: env.SKIP_ON_PR != 'true'
         run: |
           set -euo pipefail
           mkdir -p bundle
@@ -274,21 +256,18 @@ jobs:
           echo "$GITHUB_WORKSPACE/bundle/cli/bin" >> "$GITHUB_PATH"
 
       - name: Sanity check CLI
-        if: env.SKIP_ON_PR != 'true'
         run: compose-preview help
 
       - name: Make external gradlew executable
-        if: env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         run: chmod +x ./gradlew
 
       - name: Repo-specific pre-Gradle patches
-        if: matrix.pre_gradle_script != '' && env.SKIP_ON_PR != 'true'
+        if: matrix.pre_gradle_script != ''
         working-directory: external/${{ matrix.workdir }}
         run: ${{ matrix.pre_gradle_script }}
 
       - name: Discover previews via Gradle
-        if: env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_AI_PLUGIN_VERSION: ${{ env.PLUGIN_VERSION }}
@@ -302,7 +281,6 @@ jobs:
             --stacktrace
 
       - name: Verify previews.json was produced
-        if: env.SKIP_ON_PR != 'true'
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -324,7 +302,7 @@ jobs:
           fi
 
       - name: Render previews via Gradle
-        if: matrix.render && env.SKIP_ON_PR != 'true'
+        if: matrix.render
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_AI_PLUGIN_VERSION: ${{ env.PLUGIN_VERSION }}
@@ -339,7 +317,7 @@ jobs:
             --stacktrace
 
       - name: Verify PNGs were produced
-        if: matrix.render && env.SKIP_ON_PR != 'true'
+        if: matrix.render
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -357,7 +335,7 @@ jobs:
           printf '  %s\n' "${pngs[@]}"
 
       - name: Configure daemon in consumer build
-        if: matrix.daemon && env.SKIP_ON_PR != 'true'
+        if: matrix.daemon
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -393,7 +371,7 @@ jobs:
           MATRIX_MODULE: ${{ matrix.module }}
 
       - name: Emit daemon launch descriptor (composePreviewDaemonStart)
-        if: matrix.daemon && env.SKIP_ON_PR != 'true'
+        if: matrix.daemon
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_AI_PLUGIN_VERSION: ${{ env.PLUGIN_VERSION }}
@@ -406,7 +384,7 @@ jobs:
             --stacktrace
 
       - name: Daemon round-trip (spawn → render → edit → re-render)
-        if: matrix.daemon && env.SKIP_ON_PR != 'true'
+        if: matrix.daemon
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_AI_PLUGIN_VERSION: ${{ env.PLUGIN_VERSION }}
@@ -439,7 +417,7 @@ jobs:
             --gradle-args "${{ matrix.extra_gradle_args }}"
 
       - name: Upload daemon launch descriptor
-        if: always() && matrix.daemon && env.SKIP_ON_PR != 'true'
+        if: always() && matrix.daemon
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: daemon-launch-${{ matrix.slug }}
@@ -448,7 +426,7 @@ jobs:
           retention-days: 7
 
       - name: Verify at least one TILE preview was rendered
-        if: matrix.render && matrix.require_tile_render && env.SKIP_ON_PR != 'true'
+        if: matrix.render && matrix.require_tile_render
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -480,7 +458,7 @@ jobs:
           PY
 
       - name: Upload previews.json
-        if: always() && env.SKIP_ON_PR != 'true'
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: previews-${{ matrix.slug }}
@@ -489,7 +467,7 @@ jobs:
           retention-days: 7
 
       - name: Upload rendered PNGs
-        if: always() && matrix.render && env.SKIP_ON_PR != 'true'
+        if: always() && matrix.render
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: renders-${{ matrix.slug }}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -505,6 +505,34 @@ internal object AndroidPreviewSupport {
       // newer activity transitively, and a fix for tile-only consumers
       // that don't.
       project.dependencies.add("${variantName}Implementation", "androidx.activity:activity:1.10.0")
+      // Pin `androidx.compose.ui:ui` on the main variant for tile-only /
+      // non-Compose-UI consumers. compose-ui's
+      // `AndroidComposeViewAccessibilityDelegateCompat.<clinit>` reads
+      // `androidx.compose.ui.R.id.*` (via `accessibility_custom_action_*`
+      // / `compose_view_root_id` lookups), so the merged unit-test resource
+      // APK needs the compose-ui R class. The renderer's test classpath
+      // brings compose-ui transitively (via roborazzi-compose / ui-test-*)
+      // — but that's the JVM test classpath only; AGP builds the merged
+      // `apk-for-local-test.ap_` from the consumer's MAIN variant, so on
+      // tile-only consumers without compose-ui in main (e.g. WearTilesKotlin)
+      // the R class is missing and Robolectric crashes the moment
+      // `AndroidComposeView.<init>` triggers the accessibility delegate's
+      // class init:
+      //
+      //   `NoClassDefFoundError: Could not initialize class
+      //   androidx.compose.ui.platform.AndroidComposeViewAccessibilityDelegateCompat`
+      //   caused by `NoClassDefFoundError: androidx/compose/ui/R$id`
+      //
+      // Same `${variantName}Implementation` floor pattern as the
+      // `androidx.core:core`, `customview-poolingcontainer`, and
+      // `androidx.activity:activity` entries above — Gradle picks the max
+      // with consumer-aligned versions, so this is a no-op for Compose-app
+      // consumers that already get a newer ui via their BOM, and a fix for
+      // tile-only consumers that don't.
+      project.dependencies.add(
+        "${variantName}Implementation",
+        "androidx.compose.ui:ui:$RENDERER_COMPOSE_FLOOR_VERSION",
+      )
       recordInjectedDependency(
         project,
         injectedDependencies,
@@ -550,6 +578,15 @@ internal object AndroidPreviewSupport {
         reason =
           "activity-compose 1.5+ on the renderer test classpath reads R.id.view_tree_on_back_pressed_dispatcher_owner via ViewTreeOnBackPressedDispatcherOwner.set (added in androidx.activity:activity:1.5.0); merged test APK needs the field so ComponentActivity.initializeViewTreeOwners doesn't NoSuchFieldError",
       )
+      recordInjectedDependency(
+        project,
+        injectedDependencies,
+        coordinate = "androidx.compose.ui:ui:$RENDERER_COMPOSE_FLOOR_VERSION",
+        configuration = "${variantName}Implementation",
+        outcome = "APPLIED",
+        reason =
+          "compose-ui's AndroidComposeViewAccessibilityDelegateCompat.<clinit> reads androidx.compose.ui.R.id.*; merged test APK needs the compose-ui R class on tile-only consumers without compose-ui in main",
+      )
     } else {
       recordInjectedDependency(
         project,
@@ -593,6 +630,15 @@ internal object AndroidPreviewSupport {
         outcome = "SKIPPED_BY_CONFIG",
         reason =
           "manageDependencies=false; consumer must ensure androidx.activity:activity >= 1.5.0 on the main variant so the merged test APK includes R.id.view_tree_on_back_pressed_dispatcher_owner (referenced by activity-compose's ComponentActivity.initializeViewTreeOwners)",
+      )
+      recordInjectedDependency(
+        project,
+        injectedDependencies,
+        coordinate = "androidx.compose.ui:ui",
+        configuration = "${variantName}Implementation",
+        outcome = "SKIPPED_BY_CONFIG",
+        reason =
+          "manageDependencies=false; consumer must ensure androidx.compose.ui:ui is on the main variant so the merged test APK includes its R class (referenced by AndroidComposeViewAccessibilityDelegateCompat.<clinit>)",
       )
     }
 


### PR DESCRIPTION
## Summary

- Tile-only consumers (e.g. wear-os-samples WearTilesKotlin) carry no `androidx.compose.ui:ui` in their main variant, so AGP doesn't merge the compose-ui R class into `apk-for-local-test.ap_`. Robolectric then crashes at `AndroidComposeViewAccessibilityDelegateCompat.<clinit>` with `NoClassDefFoundError: androidx/compose/ui/R$id` (failure: https://github.com/yschimke/compose-ai-tools/actions/runs/25904544390/job/76135526621).
- Inject `androidx.compose.ui:ui:$RENDERER_COMPOSE_FLOOR_VERSION` into `${variantName}Implementation` following the same floor-injection pattern already used for `androidx.core:core`, `customview-poolingcontainer`, and `androidx.activity:activity`. Gradle picks the max with consumer-aligned versions, so this is a no-op for Compose-app consumers and a fix for tile-only consumers.
- Promote the WearTilesKotlin integration matrix entry off `main_only` so the regression runs on every PR; drop the now-unused `SKIP_ON_PR` env and per-step gates.

## Test plan

- [ ] `Integration / wear-os-samples (WearTilesKotlin)` passes on this PR (renders ≥ 1 PNG, including ≥ 1 TILE-kind preview).
- [ ] Other integration matrix entries (`ComposeStarter`, `androidify`, `agp8-min`) still pass.