### PR TITLE
fix(vscode-extension): guard reflectLegendActiveTab against focusController TDZ

### DIFF
--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -1663,7 +1663,14 @@ export class PreviewApp extends LitElement {
         // and from `reflectBundleState` when the tab switches.
         const reflectLegendActiveTab = (): void => {
             const tab = bundleController.state().activeTab;
-            const showBundleUi = focusController.inFocus() && earlyFeatures();
+            // `focusController` is assigned later in `firstUpdated`,
+            // and `reflectBundleState()` runs once at the bottom of
+            // bundle setup before that assignment lands — guard so
+            // the initial call (always with no active tab) doesn't
+            // dereference an undefined controller. Subsequent
+            // refresh calls run after the assignment.
+            const inFocus = focusController?.inFocus() === true;
+            const showBundleUi = inFocus && earlyFeatures();
             if (!showBundleUi || !tab) {
                 bundleLegend.showBundle(null);
                 bundleLegend.hidden = true;


### PR DESCRIPTION
## Summary

Followup to #1130. The `reflectLegendActiveTab` call inside `reflectBundleState` reads `focusController.inFocus()` to decide whether to show the legend. `reflectBundleState()` runs once at the bottom of bundle setup inside `firstUpdated`, but the `focusController = new FocusController(...)` assignment lands ~200 lines further down — so the initial call dereferenced an undefined controller.

Caught when running the new `a11y-findings` preview-harness fixture from #1131:

```
TypeError: Cannot read properties of undefined (reading 'inFocus')
  at firstUpdated …
```

Guard the read with `focusController?.inFocus() === true`. The initial call always has no active tab (bundles aren't activated yet at boot), so the legend stays hidden regardless of controller readiness. Subsequent refresh calls fire from event handlers that run after assignment.

## Verification

Snapshot from the `a11y-findings` fixture, dark theme — legend renders to the right of the preview, swatches match the overlay tint, error/warning levels colour-coded:

[a11y-findings.dark](attachment-pending)

Light theme renders the same shape with the VS Code light palette.

## Test plan

- [x] `npm test` — 959 passing
- [x] `npm run harness:snapshot -- --fixture a11y-findings` — both `.dark.png` and `.light.png` produced cleanly, no TypeError in console
- [x] `npm run format:check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_