### PR TITLE
fix(ci): drive a11y-report action via compose-preview a11y

### DIFF
--- a/.github/actions/a11y-report/action.yml
+++ b/.github/actions/a11y-report/action.yml
@@ -28,19 +28,29 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Render previews with a11y opted in
+    - name: Build the CLI
+      shell: bash
+      run: |
+        set -euo pipefail
+        # The daemon-driven a11y path lives in `compose-preview a11y`; install the locally-built
+        # CLI so the action runs the same code that ships in the release tarball. Mirrors the
+        # `:cli:installDist` step the consumer install script does.
+        ./gradlew :cli:installDist --no-daemon
+
+    - name: Render previews and produce a11y findings
       shell: bash
       env:
         MODULE: ${{ inputs.module }}
       run: |
         set -euo pipefail
-        # a11y is opt-in (default off). Forward the same Gradle property the CLI's
-        # `compose-preview a11y` / `--with-extension a11y` paths set so the renderer writes
-        # ATF findings + the annotated overlay PNG, and `aggregateAccessibility` rolls them
-        # into the `accessibility.json` the python helper reads below.
-        ./gradlew ":${MODULE}:renderAllPreviews" \
-          -PcomposePreview.previewExtensions.a11y.enableAllChecks=true \
-          --no-daemon
+        # ATF findings + the annotated overlay PNG are daemon-only now (see #1127). The CLI's
+        # `compose-preview a11y` command opens a short-lived render session per module, fetches
+        # `a11y/atf` for every preview, and writes `accessibility.json` next to the renders
+        # tree — exactly the file the python helper below reads. The legacy
+        # `-PcomposePreview.previewExtensions.a11y.enableAllChecks=true` Gradle property
+        # is gone; the CLI is the only on-ramp.
+        cli/build/install/compose-preview/bin/compose-preview a11y \
+          --module ":${MODULE}"
 
     - name: Copy annotated PNGs and emit findings.json
       shell: bash


### PR DESCRIPTION
## Summary

The `.github/actions/a11y-report` action shelled out via:

```yaml
./gradlew :samples:wear:renderAllPreviews \
  -PcomposePreview.previewExtensions.a11y.enableAllChecks=true
```

Both the property and the standalone Gradle ATF path were removed in #1127 when a11y production moved to the preview daemon. The action has been silently emitting empty `accessibility.json` for every push to `main` and every PR since — the baseline branch on `compose-preview/a11y/main` and the PR-comment workflow have been showing "no findings" regardless of what the sample actually exposes.

Replaces the gradle invocation with `compose-preview a11y --module :samples:wear`, preceded by `:cli:installDist` so the action runs the same CLI binary the release tarball ships. The python helper that reads `accessibility.json` is untouched — the on-disk shape is identical to what `aggregateAccessibility` used to produce.

## Test plan

- [x] End-to-end verified locally against `:samples:android` (the canary `BadButtonPreview` surfaces `SpeakableTextPresentCheck` ERROR exactly as the test was designed to expose).
- [ ] PR run will exercise the action on `:samples:wear` via this workflow itself — first concrete signal that `BadWearButtonPreview` re-surfaces.
- [ ] On merge, the baseline run pushes a non-empty `findings.json` to `compose-preview/a11y/main` for the first time since #1127.

## Notes

- The other "daemon-driven `compose-preview a11y` functional test" follow-up still stands as a `:gradle-plugin:functionalTest` belt-and-braces over this CI flow; deferred per scope discussion.
- Consumer-facing docs at [`yschimke/skills`](https://github.com/yschimke/skills) (`compose-preview/references/a11y.md` and `compose-preview-review/references/ci-previews.md`) still reference the removed gradle DSL / property. A companion issue against that repo is forthcoming.

---
_Generated by [Claude Code](https://claude.ai/code/session_0178MWQ319fGv7JWjSwpsvSU)_