### PR TITLE
feat(vscode-extension): row-click detail panel for the Accessibility bundle

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -479,6 +479,82 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+/* `<bundle-row-detail>` — appears below a bundle's `<data-table>`
+ * when the user clicks a row. Generic across bundles; today only the
+ * Accessibility bundle populates it. Hidden by default (host calls
+ * `clear()` which renders nothing). */
+.bundle-row-detail-panel {
+    margin-top: 8px;
+    padding: 8px 10px;
+    border: 1px solid var(--card-border, rgba(127, 127, 127, 0.2));
+    border-radius: 4px;
+    background: var(--vscode-editor-background, transparent);
+}
+.bundle-row-detail-header {
+    /* Preserve the row's original case in the panel title — the
+     * label often carries semantic info (parentheses, punctuation,
+     * acronyms) that gets mangled by a uniform uppercase transform.
+     * Section headings inside the panel still uppercase via
+     * `.bundle-row-detail-section-heading`. */
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--vscode-foreground, currentColor);
+    margin-bottom: 6px;
+}
+.bundle-row-detail-section {
+    margin-top: 6px;
+}
+.bundle-row-detail-section:first-of-type {
+    margin-top: 0;
+}
+.bundle-row-detail-section-heading {
+    margin: 4px 0 4px 0;
+    font-size: 11px;
+    font-weight: 600;
+    opacity: 0.75;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+.bundle-row-detail-list {
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    column-gap: 12px;
+    row-gap: 2px;
+}
+.bundle-row-detail-entry {
+    display: contents;
+}
+.bundle-row-detail-key {
+    font-weight: 500;
+    opacity: 0.85;
+}
+.bundle-row-detail-value {
+    margin: 0;
+}
+.bundle-row-detail-value code {
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 12px;
+}
+
+/* Pinned-row visual state on `<data-table>` rows (separate from the
+ * hover highlight so the user's selection stays visible while they
+ * mouse over other rows). Inset-left bar gives a clear "this row is
+ * selected" anchor that survives across light / dark themes; the
+ * background tint is a secondary cue. */
+.data-table-row-selected td {
+    background: var(
+        --vscode-list-activeSelectionBackground,
+        rgba(80, 130, 200, 0.18)
+    );
+    color: var(--vscode-list-activeSelectionForeground, currentColor);
+}
+.data-table-row-selected td:first-child {
+    box-shadow: inset 3px 0 0 var(--vscode-focusBorder, #4d9fec);
+}
+
 .preview-grid.layout-focus .preview-card.hidden-by-focus {
     display: none;
 }

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.gen.mjs
@@ -277,6 +277,14 @@ const fixture = {
         {
             click: `bundle-chip-bar button[data-bundle="a11y"]`,
         },
+        // Click the row for the ERROR finding (unlabelled image
+        // button) so the snapshot exercises the row-click → detail
+        // panel path. `data-legend-id` matches the bundle row's
+        // overlay id; the unlabelled-button row is the 4th node in
+        // the hierarchy so its id is `a11y-3`.
+        {
+            click: `[data-bundle="a11y"] tr[data-legend-id="a11y-3"]`,
+        },
     ],
 };
 

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.json
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.json
@@ -1,148 +1,159 @@
 {
-    "name": "a11y-findings",
-    "description": "Focused card with three Accessibility Test Framework findings (one ERROR, two WARNINGs) overlaid on a stylised mobile mock. Drives focus mode and activates the Accessibility bundle so the chip bar, data tab, and on-image box-overlay all paint.",
-    "dataset": {
-        "earlyFeatures": "true",
-        "autoEnableCheap": "false",
-        "collapseVariants": "false",
-        "minimalMode": "false",
-        "autoInject": "true"
+  "name": "a11y-findings",
+  "description": "Focused card with three Accessibility Test Framework findings (one ERROR, two WARNINGs) overlaid on a stylised mobile mock. Drives focus mode and activates the Accessibility bundle so the chip bar, data tab, and on-image box-overlay all paint.",
+  "dataset": {
+    "earlyFeatures": "true",
+    "autoEnableCheap": "false",
+    "collapseVariants": "false",
+    "minimalMode": "false",
+    "autoInject": "true"
+  },
+  "messages": [
+    {
+      "command": "setPreviews",
+      "moduleDir": "/workspace/sample-android",
+      "heavyStaleIds": [],
+      "previews": [
+        {
+          "id": "com.example.OnboardingKt.WelcomeScreenPreview",
+          "functionName": "WelcomeScreenPreview",
+          "className": "com.example.OnboardingKt",
+          "sourceFile": "Onboarding.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.OnboardingKt.WelcomeScreenPreview.png",
+              "label": ""
+            }
+          ],
+          "a11yFindings": [
+            {
+              "level": "ERROR",
+              "type": "SpeakableTextPresent",
+              "message": "Image-only button has no contentDescription.",
+              "viewDescription": "ImageButton",
+              "boundsInScreen": "200,240,320,296"
+            },
+            {
+              "level": "WARNING",
+              "type": "TouchTargetSize",
+              "message": "Touch target is 120×56dp. Material guidance recommends at least 48×48dp on each side; this clears height but the width / spacing leaves the tap area cramped on small screens.",
+              "viewDescription": "Button",
+              "boundsInScreen": "40,240,160,296"
+            },
+            {
+              "level": "WARNING",
+              "type": "TextContrast",
+              "message": "Footer text uses #C8C8C8 on #F5F6FA — contrast ratio 1.4:1, below the WCAG AA 4.5:1 threshold for body copy.",
+              "viewDescription": "TextView",
+              "boundsInScreen": "0,520,360,600"
+            }
+          ],
+          "a11yNodes": [
+            {
+              "label": "Welcome screen",
+              "role": "container",
+              "states": [],
+              "merged": false,
+              "boundsInScreen": "0,0,360,600"
+            },
+            {
+              "label": "Welcome to Compose AI Tools",
+              "role": "headline",
+              "states": [
+                "focusable"
+              ],
+              "merged": false,
+              "boundsInScreen": "0,0,360,80"
+            },
+            {
+              "label": "Get started",
+              "role": "button",
+              "states": [
+                "clickable",
+                "focusable"
+              ],
+              "merged": false,
+              "boundsInScreen": "40,240,160,296"
+            },
+            {
+              "label": "",
+              "role": "button",
+              "states": [
+                "clickable",
+                "focusable"
+              ],
+              "merged": false,
+              "boundsInScreen": "200,240,320,296"
+            },
+            {
+              "label": "By continuing you agree to our terms",
+              "role": "text",
+              "states": [],
+              "merged": false,
+              "boundsInScreen": "0,520,360,600"
+            }
+          ]
+        },
+        {
+          "id": "com.example.OnboardingKt.SettingsScreenPreview",
+          "functionName": "SettingsScreenPreview",
+          "className": "com.example.OnboardingKt",
+          "sourceFile": "Onboarding.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.OnboardingKt.SettingsScreenPreview.png",
+              "label": ""
+            }
+          ]
+        }
+      ]
     },
-    "messages": [
-        {
-            "command": "setPreviews",
-            "moduleDir": "/workspace/sample-android",
-            "heavyStaleIds": [],
-            "previews": [
-                {
-                    "id": "com.example.OnboardingKt.WelcomeScreenPreview",
-                    "functionName": "WelcomeScreenPreview",
-                    "className": "com.example.OnboardingKt",
-                    "sourceFile": "Onboarding.kt",
-                    "params": {
-                        "name": null,
-                        "device": null,
-                        "widthDp": 360,
-                        "heightDp": 600,
-                        "fontScale": 1,
-                        "showSystemUi": false,
-                        "showBackground": true,
-                        "backgroundColor": 0,
-                        "uiMode": 0,
-                        "locale": null,
-                        "group": null
-                    },
-                    "captures": [
-                        {
-                            "advanceTimeMillis": null,
-                            "scroll": null,
-                            "renderOutput": "renders/com.example.OnboardingKt.WelcomeScreenPreview.png",
-                            "label": ""
-                        }
-                    ],
-                    "a11yFindings": [
-                        {
-                            "level": "ERROR",
-                            "type": "SpeakableTextPresent",
-                            "message": "Image-only button has no contentDescription.",
-                            "viewDescription": "ImageButton",
-                            "boundsInScreen": "200,240,320,296"
-                        },
-                        {
-                            "level": "WARNING",
-                            "type": "TouchTargetSize",
-                            "message": "Touch target is 120×56dp. Material guidance recommends at least 48×48dp on each side; this clears height but the width / spacing leaves the tap area cramped on small screens.",
-                            "viewDescription": "Button",
-                            "boundsInScreen": "40,240,160,296"
-                        },
-                        {
-                            "level": "WARNING",
-                            "type": "TextContrast",
-                            "message": "Footer text uses #C8C8C8 on #F5F6FA — contrast ratio 1.4:1, below the WCAG AA 4.5:1 threshold for body copy.",
-                            "viewDescription": "TextView",
-                            "boundsInScreen": "0,520,360,600"
-                        }
-                    ],
-                    "a11yNodes": [
-                        {
-                            "label": "Welcome screen",
-                            "role": "container",
-                            "states": [],
-                            "merged": false,
-                            "boundsInScreen": "0,0,360,600"
-                        },
-                        {
-                            "label": "Welcome to Compose AI Tools",
-                            "role": "headline",
-                            "states": ["focusable"],
-                            "merged": false,
-                            "boundsInScreen": "0,0,360,80"
-                        },
-                        {
-                            "label": "Get started",
-                            "role": "button",
-                            "states": ["clickable", "focusable"],
-                            "merged": false,
-                            "boundsInScreen": "40,240,160,296"
-                        },
-                        {
-                            "label": "",
-                            "role": "button",
-                            "states": ["clickable", "focusable"],
-                            "merged": false,
-                            "boundsInScreen": "200,240,320,296"
-                        },
-                        {
-                            "label": "By continuing you agree to our terms",
-                            "role": "text",
-                            "states": [],
-                            "merged": false,
-                            "boundsInScreen": "0,520,360,600"
-                        }
-                    ]
-                },
-                {
-                    "id": "com.example.OnboardingKt.SettingsScreenPreview",
-                    "functionName": "SettingsScreenPreview",
-                    "className": "com.example.OnboardingKt",
-                    "sourceFile": "Onboarding.kt",
-                    "params": {
-                        "name": null,
-                        "device": null,
-                        "widthDp": 360,
-                        "heightDp": 600,
-                        "fontScale": 1,
-                        "showSystemUi": false,
-                        "showBackground": true,
-                        "backgroundColor": 0,
-                        "uiMode": 0,
-                        "locale": null,
-                        "group": null
-                    },
-                    "captures": [
-                        {
-                            "advanceTimeMillis": null,
-                            "scroll": null,
-                            "renderOutput": "renders/com.example.OnboardingKt.SettingsScreenPreview.png",
-                            "label": ""
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "command": "updateImage",
-            "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
-            "captureIndex": 0,
-            "imageData": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC"
-        }
-    ],
-    "actions": [
-        {
-            "click": ".preview-card[data-preview-id=\"com.example.OnboardingKt.WelcomeScreenPreview\"] .card-focus-btn"
-        },
-        {
-            "click": "bundle-chip-bar button[data-bundle=\"a11y\"]"
-        }
-    ]
+    {
+      "command": "updateImage",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "captureIndex": 0,
+      "imageData": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC"
+    }
+  ],
+  "actions": [
+    {
+      "click": ".preview-card[data-preview-id=\"com.example.OnboardingKt.WelcomeScreenPreview\"] .card-focus-btn"
+    },
+    {
+      "click": "bundle-chip-bar button[data-bundle=\"a11y\"]"
+    },
+    {
+      "click": "[data-bundle=\"a11y\"] tr[data-legend-id=\"a11y-3\"]"
+    }
+  ]
 }

--- a/vscode-extension/src/test/a11yRowDetail.test.ts
+++ b/vscode-extension/src/test/a11yRowDetail.test.ts
@@ -1,0 +1,193 @@
+// Tests for `buildA11yRowDetail`. The helper produces the
+// `<bundle-row-detail>` sections shown when the user clicks a row
+// in the Accessibility tab. The bundle row carries the count of
+// matching findings but not their messages, so the detail builder
+// re-joins against the source findings list (and the touch-targets
+// list) using bounds — same join key the presenter uses.
+
+import * as assert from "assert";
+import { buildA11yRowDetail } from "../webview/preview/a11yRowDetail";
+import type {
+    A11yRow,
+    AccessibilityTouchTarget,
+} from "../webview/preview/a11yBundlePresenter";
+import type { AccessibilityFinding } from "../webview/shared/types";
+
+function row(over: Partial<A11yRow>): A11yRow {
+    return {
+        id: over.id ?? "a11y-0",
+        label: over.label ?? "Title",
+        role: over.role ?? "Button",
+        states: over.states ?? "",
+        merged: over.merged ?? true,
+        findingCount: over.findingCount ?? 0,
+        topFindingLevel: over.topFindingLevel ?? null,
+        boundsInScreen: over.boundsInScreen ?? "0,0,10,10",
+        bounds: over.bounds ?? { left: 0, top: 0, right: 10, bottom: 10 },
+        touchTargetSizeDp: over.touchTargetSizeDp ?? null,
+    };
+}
+
+function finding(over: Partial<AccessibilityFinding>): AccessibilityFinding {
+    return {
+        level: over.level ?? "ERROR",
+        type: over.type ?? "ContrastCheck",
+        message: over.message ?? "Insufficient contrast ratio",
+        viewDescription: over.viewDescription ?? null,
+        boundsInScreen: over.boundsInScreen ?? "0,0,10,10",
+    };
+}
+
+function touchTarget(
+    over: Partial<AccessibilityTouchTarget>,
+): AccessibilityTouchTarget {
+    return {
+        nodeId: over.nodeId ?? "node-1",
+        boundsInScreen: over.boundsInScreen ?? "0,0,10,10",
+        widthDp: over.widthDp ?? 32,
+        heightDp: over.heightDp ?? 32,
+        findings: over.findings ?? [],
+        overlappingNodeIds: over.overlappingNodeIds,
+    };
+}
+
+describe("buildA11yRowDetail", () => {
+    it("always emits an Element section with role + focus target + bounds", () => {
+        const sections = buildA11yRowDetail(
+            row({ role: "Button", states: "clickable" }),
+            [],
+            [],
+        );
+        const element = sections.find((s) => s.heading === "Element");
+        assert.ok(element);
+        const labels = element!.entries.map((e) => e.label);
+        assert.ok(labels.includes("Role"));
+        assert.ok(labels.includes("Focus target"));
+        assert.ok(labels.includes("States"));
+        assert.ok(labels.includes("Bounds"));
+    });
+
+    it("labels the focus target as 'no (child of merged)' when row.merged is false", () => {
+        const sections = buildA11yRowDetail(row({ merged: false }), [], []);
+        const element = sections.find((s) => s.heading === "Element")!;
+        const focus = element.entries.find((e) => e.label === "Focus target")!;
+        assert.strictEqual(
+            String(focus.value).includes("no"),
+            true,
+            "unmerged rows must read as a child of a merged parent",
+        );
+    });
+
+    it("adds a Findings (ATF) section with one entry per matching finding", () => {
+        const sections = buildA11yRowDetail(
+            row({ boundsInScreen: "0,0,10,10" }),
+            [
+                finding({
+                    level: "ERROR",
+                    boundsInScreen: "0,0,10,10",
+                    message: "contrast",
+                }),
+                finding({
+                    level: "WARNING",
+                    boundsInScreen: "0,0,10,10",
+                    message: "label",
+                }),
+                finding({
+                    level: "ERROR",
+                    boundsInScreen: "99,99,109,109",
+                    message: "out of band",
+                }),
+            ],
+            [],
+        );
+        const f = sections.find((s) => s.heading === "Findings (ATF)");
+        assert.ok(f);
+        assert.strictEqual(f!.entries.length, 2);
+        assert.strictEqual(f!.entries[0].label, "ERROR");
+        assert.strictEqual(f!.entries[1].label, "WARNING");
+    });
+
+    it("skips the Findings section when no finding matches the row's bounds", () => {
+        const sections = buildA11yRowDetail(
+            row({ boundsInScreen: "0,0,10,10" }),
+            [finding({ boundsInScreen: "100,100,200,200" })],
+            [],
+        );
+        assert.strictEqual(
+            sections.find((s) => s.heading === "Findings (ATF)"),
+            undefined,
+        );
+    });
+
+    it("emits a Touch target section when a target matches the row's bounds", () => {
+        const sections = buildA11yRowDetail(
+            row({ touchTargetSizeDp: "32×32 dp" }),
+            [],
+            [
+                touchTarget({
+                    boundsInScreen: "0,0,10,10",
+                    widthDp: 32,
+                    heightDp: 32,
+                    findings: ["TouchTargetTooSmall"],
+                    overlappingNodeIds: ["other-1"],
+                }),
+            ],
+        );
+        const tt = sections.find((s) => s.heading === "Touch target");
+        assert.ok(tt);
+        const labels = tt!.entries.map((e) => e.label);
+        assert.deepStrictEqual(labels, ["Size", "Issues", "Overlaps"]);
+    });
+
+    it("omits Issues and Overlaps when the touch target has no findings or overlap data", () => {
+        const sections = buildA11yRowDetail(
+            row({ touchTargetSizeDp: "48×48 dp" }),
+            [],
+            [touchTarget({ findings: [] })],
+        );
+        const tt = sections.find((s) => s.heading === "Touch target")!;
+        assert.strictEqual(tt.entries.length, 1);
+        assert.strictEqual(tt.entries[0].label, "Size");
+    });
+
+    it("skips the Touch target section entirely when no target matches", () => {
+        const sections = buildA11yRowDetail(
+            row({ boundsInScreen: "0,0,10,10" }),
+            [],
+            [touchTarget({ boundsInScreen: "100,100,140,140" })],
+        );
+        assert.strictEqual(
+            sections.find((s) => s.heading === "Touch target"),
+            undefined,
+        );
+    });
+
+    it("surfaces an orphan finding row via the Findings section (its own bounds self-match)", () => {
+        // Orphan finding rows have role = f.type; the join finds the
+        // finding by its own bounds and shows the full message
+        // alongside the level — the table only carried the count.
+        const findings = [
+            finding({
+                level: "WARNING",
+                type: "TouchTargetSize",
+                boundsInScreen: "50,50,60,60",
+                message: "Tap target 24×24dp is below 48dp minimum",
+            }),
+        ];
+        const sections = buildA11yRowDetail(
+            row({
+                id: "a11y-finding-orphan-0",
+                label: "(no element)",
+                role: "TouchTargetSize",
+                merged: true,
+                topFindingLevel: "warning",
+                boundsInScreen: "50,50,60,60",
+            }),
+            findings,
+            [],
+        );
+        const f = sections.find((s) => s.heading === "Findings (ATF)");
+        assert.ok(f);
+        assert.strictEqual(f!.entries[0].label, "WARNING");
+    });
+});

--- a/vscode-extension/src/test/bundleRowDetail.test.ts
+++ b/vscode-extension/src/test/bundleRowDetail.test.ts
@@ -1,0 +1,116 @@
+// `<bundle-row-detail>` — passive renderer for the detail panel
+// below a bundle tab's data-table. These tests pin the empty-sections
+// hide path, the section / entry rendering shape, and the clear()
+// teardown.
+
+import * as assert from "assert";
+import "../webview/preview/components/BundleRowDetail";
+import type {
+    BundleRowDetail,
+    BundleRowDetailSection,
+} from "../webview/preview/components/BundleRowDetail";
+
+function build(): BundleRowDetail {
+    const el = document.createElement("bundle-row-detail") as BundleRowDetail;
+    document.body.appendChild(el);
+    return el;
+}
+
+describe("BundleRowDetail", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("renders nothing until setDetail provides sections", async () => {
+        const el = build();
+        await el.updateComplete;
+        assert.strictEqual(
+            el.querySelector(".bundle-row-detail-panel"),
+            null,
+            "panel must stay hidden until a section is supplied",
+        );
+    });
+
+    it("renders one <section> per supplied section, with header + section heading", async () => {
+        const el = build();
+        const sections: BundleRowDetailSection[] = [
+            {
+                heading: "Element",
+                entries: [
+                    { label: "Role", value: "Button" },
+                    { label: "Bounds", value: "0,0,10,10" },
+                ],
+            },
+            {
+                heading: "Findings",
+                entries: [{ label: "ERROR", value: "Low contrast" }],
+            },
+        ];
+        el.setDetail("Tap me", sections);
+        await el.updateComplete;
+        const panel = el.querySelector(".bundle-row-detail-panel");
+        assert.ok(panel, "panel must render once setDetail seeds sections");
+        const headings = Array.from(
+            el.querySelectorAll(".bundle-row-detail-section-heading"),
+        ).map((n) => n.textContent);
+        assert.deepStrictEqual(headings, ["Element", "Findings"]);
+        const headerText = el.querySelector(
+            ".bundle-row-detail-header span",
+        )?.textContent;
+        assert.strictEqual(headerText, "Tap me");
+    });
+
+    it("skips empty sections so a partial detail doesn't render a blank heading", async () => {
+        const el = build();
+        el.setDetail("Whatever", [
+            { heading: "Element", entries: [{ label: "Role", value: "x" }] },
+            { heading: "Findings", entries: [] },
+        ]);
+        await el.updateComplete;
+        const headings = Array.from(
+            el.querySelectorAll(".bundle-row-detail-section-heading"),
+        ).map((n) => n.textContent);
+        assert.deepStrictEqual(headings, ["Element"]);
+    });
+
+    it("clear() drops the panel and re-hides the host element", async () => {
+        const el = build();
+        el.setDetail("Tap me", [
+            { heading: "Element", entries: [{ label: "Role", value: "x" }] },
+        ]);
+        await el.updateComplete;
+        assert.ok(el.querySelector(".bundle-row-detail-panel"));
+        el.clear();
+        await el.updateComplete;
+        assert.strictEqual(
+            el.querySelector(".bundle-row-detail-panel"),
+            null,
+            "clear() must remove the panel so the host's layout reclaims the space",
+        );
+    });
+
+    it("renders key/value pairs from each entry inside a dl.bundle-row-detail-list", async () => {
+        const el = build();
+        el.setDetail("Tap me", [
+            {
+                heading: "Element",
+                entries: [
+                    { label: "Role", value: "Button" },
+                    { label: "States", value: "clickable, focusable" },
+                ],
+            },
+        ]);
+        await el.updateComplete;
+        const dts = Array.from(
+            el.querySelectorAll(".bundle-row-detail-key"),
+        ).map((n) => n.textContent?.trim());
+        const dds = Array.from(
+            el.querySelectorAll(".bundle-row-detail-value"),
+        ).map((n) => n.textContent?.trim());
+        assert.deepStrictEqual(dts, ["Role", "States"]);
+        assert.deepStrictEqual(dds, ["Button", "clickable, focusable"]);
+    });
+});

--- a/vscode-extension/src/webview/preview/a11yRowDetail.ts
+++ b/vscode-extension/src/webview/preview/a11yRowDetail.ts
@@ -1,0 +1,108 @@
+// Build the `<bundle-row-detail>` sections shown when the user
+// clicks an a11y row in the data table. Surfaces the full per-node
+// info that the table can't fit in its columns — bounds, every
+// matching ATF finding's message, touch-target rule findings, raw
+// node-state strings. Pure on its inputs so it's straightforward to
+// unit-test against the same fixture shapes the bundle presenter
+// uses.
+
+import { html } from "lit";
+import type { AccessibilityFinding } from "../shared/types";
+import type { AccessibilityTouchTarget, A11yRow } from "./a11yBundlePresenter";
+import type {
+    BundleRowDetailEntry,
+    BundleRowDetailSection,
+} from "./components/BundleRowDetail";
+
+export function buildA11yRowDetail(
+    row: A11yRow,
+    findings: readonly AccessibilityFinding[],
+    touchTargets: readonly AccessibilityTouchTarget[],
+): readonly BundleRowDetailSection[] {
+    const sections: BundleRowDetailSection[] = [];
+
+    // ---- Element ------------------------------------------------------
+    const elementEntries: BundleRowDetailEntry[] = [];
+    if (row.role) elementEntries.push({ label: "Role", value: row.role });
+    elementEntries.push({
+        label: "Focus target",
+        value: row.merged ? "yes (TalkBack stop)" : "no (child of merged)",
+    });
+    if (row.states) {
+        elementEntries.push({
+            label: "States",
+            value: row.states,
+        });
+    }
+    if (row.boundsInScreen) {
+        elementEntries.push({
+            label: "Bounds",
+            value: html`<code>${row.boundsInScreen}</code>`,
+        });
+    }
+    sections.push({ heading: "Element", entries: elementEntries });
+
+    // ---- Findings (ATF) ----------------------------------------------
+    // The bundle row carries `findingCount` but not the per-finding
+    // messages — pull them from the source list by matching on
+    // bounds, same join key `computeA11yBundleData` uses. Orphan
+    // findings (no matching hierarchy node) are surfaced this way
+    // too because the orphan row's own bounds match the finding.
+    const matchedFindings = findings.filter(
+        (f) =>
+            !!row.boundsInScreen &&
+            (f.boundsInScreen ?? "") === row.boundsInScreen,
+    );
+    if (matchedFindings.length > 0) {
+        sections.push({
+            heading: "Findings (ATF)",
+            entries: matchedFindings.map((f) => ({
+                label: f.level,
+                value: html`<span class="row-detail-finding-message"
+                        >${f.message}</span
+                    >
+                    <span class="row-detail-finding-type"
+                        >· <code>${f.type}</code></span
+                    >`,
+            })),
+        });
+    }
+
+    // ---- Touch target -------------------------------------------------
+    const target = touchTargets.find(
+        (t) =>
+            !!row.boundsInScreen &&
+            (t.boundsInScreen ?? "") === row.boundsInScreen,
+    );
+    if (target) {
+        const targetEntries: BundleRowDetailEntry[] = [
+            {
+                label: "Size",
+                value: row.touchTargetSizeDp ?? formatSize(target),
+            },
+        ];
+        if (target.findings.length > 0) {
+            targetEntries.push({
+                label: "Issues",
+                value: target.findings.join(", "),
+            });
+        }
+        if (target.overlappingNodeIds && target.overlappingNodeIds.length > 0) {
+            targetEntries.push({
+                label: "Overlaps",
+                value: html`<code
+                    >${target.overlappingNodeIds.join(", ")}</code
+                >`,
+            });
+        }
+        sections.push({ heading: "Touch target", entries: targetEntries });
+    }
+
+    return sections;
+}
+
+function formatSize(t: AccessibilityTouchTarget): string {
+    const w = Number.isFinite(t.widthDp) ? Math.round(t.widthDp) : 0;
+    const h = Number.isFinite(t.heightDp) ? Math.round(t.heightDp) : 0;
+    return `${w}×${h} dp`;
+}

--- a/vscode-extension/src/webview/preview/components/BundleRowDetail.ts
+++ b/vscode-extension/src/webview/preview/components/BundleRowDetail.ts
@@ -1,0 +1,96 @@
+// `<bundle-row-detail>` — generic detail panel rendered below a
+// bundle tab's `<data-table>` when the user clicks a row. The host
+// supplies one or more sections (a short headline plus a list of
+// label/value entries each); the component just renders the
+// structure. Used by the a11y bundle today; any other bundle whose
+// rows have richer-than-table info can wire the same way by
+// listening for `<data-table>`'s `row-clicked` event and calling
+// `setSections` here.
+//
+// The detail surface is intentionally a passive renderer — no row-
+// state lives inside the component. Persistent click selection is
+// owned by `<data-table>` (`selectedOverlayId`); the host calls
+// `setSections([])` when the user re-clicks to deselect, and the
+// component hides itself.
+
+import { LitElement, html, type TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+
+export interface BundleRowDetailEntry {
+    label: string;
+    /** Plain text or a pre-built template (for code spans / links /
+     *  swatches). The host decides; the component just slots it in. */
+    value: string | TemplateResult;
+}
+
+export interface BundleRowDetailSection {
+    /** Short section heading, e.g. `"Hierarchy"`, `"Findings"`. */
+    heading: string;
+    entries: readonly BundleRowDetailEntry[];
+}
+
+@customElement("bundle-row-detail")
+export class BundleRowDetail extends LitElement {
+    // `title` is already a public string on `HTMLElement` (tooltip
+    // text); use a distinct private name to avoid the type clash.
+    @state() private detailTitle = "";
+    @state() private sections: readonly BundleRowDetailSection[] = [];
+
+    setDetail(
+        title: string,
+        sections: readonly BundleRowDetailSection[],
+    ): void {
+        this.detailTitle = title;
+        this.sections = sections;
+    }
+
+    clear(): void {
+        this.detailTitle = "";
+        this.sections = [];
+    }
+
+    protected createRenderRoot(): HTMLElement {
+        return this;
+    }
+
+    protected render(): TemplateResult {
+        if (this.sections.length === 0) {
+            return html``;
+        }
+        return html`
+            <div
+                class="bundle-row-detail-panel"
+                role="region"
+                aria-label=${this.detailTitle || "Row detail"}
+            >
+                <header class="bundle-row-detail-header">
+                    <span>${this.detailTitle || "Detail"}</span>
+                </header>
+                ${this.sections.map((s) => this.renderSection(s))}
+            </div>
+        `;
+    }
+
+    private renderSection(s: BundleRowDetailSection): TemplateResult {
+        if (s.entries.length === 0) return html``;
+        return html`
+            <section class="bundle-row-detail-section">
+                <h4 class="bundle-row-detail-section-heading">${s.heading}</h4>
+                <dl class="bundle-row-detail-list">
+                    ${s.entries.map(
+                        (e) => html`
+                            <div class="bundle-row-detail-entry">
+                                <dt class="bundle-row-detail-key">
+                                    ${e.label}
+                                </dt>
+                                <dd class="bundle-row-detail-value">
+                                    ${e.value}
+                                </dd>
+                            </div>
+                        `,
+                    )}
+                </dl>
+            </section>
+        `;
+    }
+}

--- a/vscode-extension/src/webview/preview/components/DataTable.ts
+++ b/vscode-extension/src/webview/preview/components/DataTable.ts
@@ -24,6 +24,18 @@ export interface RowSelectedDetail<TRow> {
     index: number;
 }
 
+/** Click on a row — drives a persistent detail panel selection, in
+ *  contrast to `row-selected` which fires on hover and just lights
+ *  up the matching overlay box. */
+export interface RowClickedDetail<TRow> {
+    /** `null` when the user clicked the already-selected row, i.e.
+     *  the table is interpreting the click as "deselect". The host
+     *  uses this to hide / reset its detail panel. */
+    overlayId: string | null;
+    row: TRow | null;
+    index: number | null;
+}
+
 export interface CopyJsonDetail {
     payload: unknown;
 }
@@ -38,6 +50,10 @@ export class DataTable<TRow = unknown> extends LitElement {
     @state() private columns: readonly DataTableColumn<TRow>[] = [];
     @state() private rows: readonly TRow[] = [];
     @state() private hoveredOverlayId: string | null = null;
+    /** Persistent click-driven selection. Distinct from
+     *  `hoveredOverlayId` so a hover doesn't visually clear the
+     *  user's pinned row. */
+    @state() private selectedOverlayId: string | null = null;
     /** Stable id per row used to correlate with `<box-overlay>`. */
     private overlayId: (row: TRow, index: number) => string = (_row, index) =>
         "row-" + index;
@@ -68,6 +84,17 @@ export class DataTable<TRow = unknown> extends LitElement {
      */
     setHoveredOverlayId(id: string | null): void {
         this.hoveredOverlayId = id;
+    }
+
+    /**
+     * Externally driven pinned-row selection — e.g. the host wants
+     * to clear the click-selection from outside (a new bundle
+     * refresh, the user dismissing a detail panel). The opposite
+     * direction (click → host) is handled internally by dispatching
+     * `row-clicked`.
+     */
+    setSelectedOverlayId(id: string | null): void {
+        this.selectedOverlayId = id;
     }
 
     protected createRenderRoot(): HTMLElement {
@@ -132,15 +159,21 @@ export class DataTable<TRow = unknown> extends LitElement {
 
     private renderRow(row: TRow, idx: number): TemplateResult {
         const id = this.overlayId(row, idx);
-        const active = this.hoveredOverlayId === id;
+        const hovered = this.hoveredOverlayId === id;
+        const selected = this.selectedOverlayId === id;
+        // `data-table-row-selected` is intentionally orthogonal to
+        // `data-table-row-active` (hover) so the user's pinned row
+        // stays highlighted even while they hover other rows.
+        const cls = ["data-table-row"];
+        if (hovered) cls.push("data-table-row-active");
+        if (selected) cls.push("data-table-row-selected");
         return html`
             <tr
-                class=${active
-                    ? "data-table-row data-table-row-active"
-                    : "data-table-row"}
+                class=${cls.join(" ")}
                 data-legend-id=${id}
                 @mouseenter=${() => this.onRowHover(row, idx, id)}
                 @mouseleave=${() => this.onRowHover(row, idx, null)}
+                @click=${() => this.onRowClick(row, idx, id)}
             >
                 ${this.columns.map(
                     (c) =>
@@ -160,6 +193,30 @@ export class DataTable<TRow = unknown> extends LitElement {
         this.hoveredOverlayId = overlayId;
         this.dispatchEvent(
             new CustomEvent<RowSelectedDetail<TRow>>("row-selected", {
+                detail: { overlayId, row, index },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private onRowClick(row: TRow, index: number, overlayId: string): void {
+        // Re-clicking the pinned row deselects (host hides the
+        // detail panel). New row = swap selection.
+        if (this.selectedOverlayId === overlayId) {
+            this.selectedOverlayId = null;
+            this.dispatchEvent(
+                new CustomEvent<RowClickedDetail<TRow>>("row-clicked", {
+                    detail: { overlayId: null, row: null, index: null },
+                    bubbles: true,
+                    composed: true,
+                }),
+            );
+            return;
+        }
+        this.selectedOverlayId = overlayId;
+        this.dispatchEvent(
+            new CustomEvent<RowClickedDetail<TRow>>("row-clicked", {
                 detail: { overlayId, row, index },
                 bubbles: true,
                 composed: true,

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -37,6 +37,7 @@ import "./components/DataTable";
 import "./components/BoxOverlay";
 import "./components/BundleExpander";
 import "./components/BundleLegend";
+import "./components/BundleRowDetail";
 import { PreviewGrid } from "./components/PreviewGrid";
 import { BundleChipBar } from "./components/BundleChipBar";
 import { DataTabs } from "./components/DataTabs";
@@ -46,6 +47,10 @@ import {
     BundleLegend,
     type BundleLegendEntry,
 } from "./components/BundleLegend";
+import type {
+    BundleRowDetail,
+    BundleRowDetailSection,
+} from "./components/BundleRowDetail";
 import { findLegendTarget } from "./bundleLegendTarget";
 import {
     clearBundleBoxes,
@@ -58,6 +63,7 @@ import { BundleController, type BundleSnapshot } from "./bundleController";
 import { getBundle, type BundleId } from "./bundleRegistry";
 import { wireExpanderToController } from "./bundleExpanderWiring";
 import { a11yTableColumns, computeA11yBundleData } from "./a11yBundlePresenter";
+import { buildA11yRowDetail } from "./a11yRowDetail";
 import {
     computePerformanceBundleData,
     performanceTableColumns,
@@ -768,6 +774,12 @@ export class PreviewApp extends LitElement {
             wrapper: HTMLElement;
             expander: BundleExpander;
             table: DataTable<unknown>;
+            /** Detail panel rendered below the table when the user
+             *  clicks a row. Hidden until the host calls
+             *  `rowDetail.setDetail(...)` in the bundle's
+             *  `row-clicked` listener. Generic across bundles —
+             *  each bundle decides what fields to surface. */
+            rowDetail: BundleRowDetail;
         }
         const bundleBodies = new Map<BundleId, BundleBody>();
         const buildBundleBody = (
@@ -789,9 +801,13 @@ export class PreviewApp extends LitElement {
             ) as DataTable<unknown>;
             table.heading = heading;
             table.setColumns(columns);
+            const rowDetail = document.createElement(
+                "bundle-row-detail",
+            ) as BundleRowDetail;
             wrapper.appendChild(expander);
             wrapper.appendChild(table);
-            return { wrapper, expander, table };
+            wrapper.appendChild(rowDetail);
+            return { wrapper, expander, table, rowDetail };
         };
         const a11yBody = (): BundleBody => {
             let b = bundleBodies.get("a11y");
@@ -803,6 +819,30 @@ export class PreviewApp extends LitElement {
                     import("./components/DataTable").DataTableColumn<unknown>
                 >,
             );
+            // Wire row click → detail panel. The listener is attached
+            // once (body is cached for the panel lifetime) and reads
+            // the last-refresh data product context from
+            // `a11yLastRefresh`. `row-clicked` carries `row: null`
+            // when the user re-clicks the selected row to deselect.
+            b.table.addEventListener("row-clicked", (evt) => {
+                const det = (
+                    evt as CustomEvent<
+                        import("./components/DataTable").RowClickedDetail<
+                            import("./a11yBundlePresenter").A11yRow
+                        >
+                    >
+                ).detail;
+                if (!det.row) {
+                    b!.rowDetail.clear();
+                    return;
+                }
+                const sections = buildA11yRowDetail(
+                    det.row,
+                    a11yLastRefresh?.findings ?? [],
+                    a11yLastRefresh?.touchTargets ?? [],
+                );
+                b!.rowDetail.setDetail(det.row.label, sections);
+            });
             bundleBodies.set("a11y", b);
             return b;
         };
@@ -1055,6 +1095,14 @@ export class PreviewApp extends LitElement {
             if (!Array.isArray(targets)) return [];
             return targets as readonly import("./a11yBundlePresenter").AccessibilityTouchTarget[];
         };
+        // Captures the last refresh's per-preview a11y context so the
+        // body's `row-clicked` listener (attached once in
+        // `a11yBody()`) can build the detail panel from the freshest
+        // data without re-attaching on every refresh.
+        let a11yLastRefresh: {
+            findings: readonly AccessibilityFinding[];
+            touchTargets: readonly import("./a11yBundlePresenter").AccessibilityTouchTarget[];
+        } | null = null;
         const refreshA11yBundle = (): void => {
             const target = currentBundleTarget();
             if (!target) return;
@@ -1077,6 +1125,13 @@ export class PreviewApp extends LitElement {
                 findings: targetSrc.findings,
                 touchTargets,
             }));
+            // Stash for the row-click listener installed in
+            // `a11yBody()`. Drop any stale selection so the detail
+            // panel doesn't point at row indices the new data may
+            // have renumbered.
+            a11yLastRefresh = { findings: targetSrc.findings, touchTargets };
+            body.table.setSelectedOverlayId(null);
+            body.rowDetail.clear();
             refreshExpanderFor("a11y");
             dataTabs.setTabBody("a11y", body.wrapper);
             // Populate the shared bundle legend with the same rows so


### PR DESCRIPTION
## Summary

Follow-up to #1130 (legend) — the "selecting a row, show a table with all a11y info for that node" piece of the original three-part ask. The table fits five columns, so bounds, overlap lists, and full ATF messages live in a click-revealed detail panel below the table.

## What's in here

### Generic
- `<bundle-row-detail>` — passive Lit renderer for `{ heading, entries[{label, value}] }` sections. Renders nothing until the host calls `setDetail`; `clear()` re-hides. Any bundle whose rows need more than their columns can wire it the same way.
- `<data-table>` gets a `row-clicked` event + persistent `selectedOverlayId` state. Distinct from the existing `row-selected` (hover) so the pinned row stays highlighted while the user hovers other rows. Re-clicking the selected row deselects.

### A11y-specific
- `buildA11yRowDetail(row, findings, touchTargets)` — pure helper that joins the bundle row back to its source data by bounds (same join key the presenter uses) and produces Element / Findings (ATF) / Touch target sections.
- `main.ts`: a11y body builder wires the listener once, refresh updates the captured source context so the detail panel always reflects the freshest data.

### Harness
- `a11y-findings` fixture grows a third action: click the `(unlabelled)` row so the snapshot captures the detail panel populated with the ELEMENT block + ATF `SpeakableTextPresent` error.

### Polish
- Selected-row CSS: left-edge bar + subtle bg tint. Survives both themes.
- Detail-panel title preserves original case (`(unlabelled)` doesn't get mangled by uppercase transform).

## Test plan

- [x] `npm test` — 972 passing (13 new: 5 `<bundle-row-detail>` + 8 `buildA11yRowDetail`)
- [x] `npm run format:check` clean
- [x] `npm run harness:snapshot -- --fixture a11y-findings` — both dark and light render the detail panel populated with role / focus target / states / bounds / full finding message
- [ ] Manual: in focus mode with a11y active, click rows to expand detail, re-click to deselect, click different rows to swap selection

Snapshot of the dark theme attached for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_