### PR TITLE
feat(render-session): in-process Compose Desktop backend

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -9,6 +9,8 @@ import ee.schimke.composeai.daemon.history.HistoryPruneConfig
 import ee.schimke.composeai.data.render.RenderPreviewExtension
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
 import java.nio.file.Path
 
 /**
@@ -48,11 +50,50 @@ import java.nio.file.Path
  */
 fun main(args: Array<String>) {
   // Capture the real stdout *before* swapping. Whatever uses `System.out` after this line lands on
-  // stderr; the JSON-RPC channel is the captured `realOut`.
+  // stderr; the JSON-RPC channel is the captured `realOut`. Embedded-mode callers (see
+  // `:render-session-embedded-desktop`) skip this swap and the SIGTERM hook entirely by invoking
+  // [runDaemon] directly with their own piped streams — `main(...)` is the subprocess entry
+  // point only.
   val realOut = System.out
   System.setOut(System.err)
 
   System.err.println("compose-ai-tools desktop daemon: hello (args=${args.toList()})")
+
+  runDaemon(
+    input = System.`in`,
+    output = realOut,
+    installSigtermHook = true,
+    onExit = { code -> System.exit(code) },
+  )
+}
+
+/**
+ * Renderer / extension / host / JSON-RPC-server setup, parameterised over the transport streams and
+ * the SIGTERM-hook policy so embedded mode can drive the same daemon body in-process.
+ *
+ * **Subprocess mode** (the canonical path) is `fun main()` above: real stdio is swapped, the
+ * SIGTERM hook is installed, [runDaemon] is invoked with `System.in` and the captured `realOut`,
+ * and the JSON-RPC server blocks the calling thread until `shutdown` + `exit`.
+ *
+ * **Embedded mode** runs this function on a background thread with [input] and [output] connected
+ * to in-memory piped streams; the calling thread holds the other ends of those pipes and drives the
+ * daemon via a `DaemonClient`. SIGTERM is the caller's concern in that shape — they own the thread
+ * and can cancel it via `client.shutdownAndExit()` which causes the JSON-RPC server's read loop to
+ * return cleanly. Setting [installSigtermHook] to false on the embedded path avoids leaking a
+ * per-session hook onto the JVM's shutdown machinery.
+ *
+ * All other configuration (preview index path, history dir, classpath fingerprint sources) is read
+ * from system properties exactly as before — the embedded session is responsible for setting these
+ * from the daemon launch descriptor before invoking. This is the only constraint on multi-session
+ * reuse: sysprops are JVM-global, so two embedded sessions in the same JVM cannot point at
+ * different `previews.json` files simultaneously without external synchronisation.
+ */
+fun runDaemon(
+  input: InputStream,
+  output: OutputStream,
+  installSigtermHook: Boolean,
+  onExit: (Int) -> Unit = { code -> System.exit(code) },
+) {
 
   // D-harness.v1.5a — when the harness drives real-mode runs it sets
   // `composeai.harness.previewsManifest=<json>` so the daemon can resolve the protocol-level
@@ -336,8 +377,8 @@ fun main(args: Array<String>) {
 
   val server =
     JsonRpcServer(
-      input = System.`in`,
-      output = realOut,
+      input = input,
+      output = output,
       host = host,
       daemonVersion = DaemonVersion.value,
       classpathFingerprint = classpathFingerprint,
@@ -345,9 +386,12 @@ fun main(args: Array<String>) {
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
       extensions = extensions,
+      onExit = onExit,
     )
 
-  installSigtermShutdownHook(host, originalStdin = System.`in`)
+  if (installSigtermHook) {
+    installSigtermShutdownHook(host, originalStdin = input)
+  }
 
   try {
     server.run() // blocks until the client closes the wire

--- a/render-session/embedded-desktop/build.gradle.kts
+++ b/render-session/embedded-desktop/build.gradle.kts
@@ -1,0 +1,58 @@
+// In-process Compose Multiplatform Desktop backend for the render-session library.
+//
+// Hosts `:daemon:desktop`'s `runDaemon(...)` on a background thread, with the JSON-RPC transport
+// wired to in-memory piped streams. The calling JVM holds the client end of those pipes via a
+// `DaemonClient` and surfaces it as a `RenderSession` — same protocol, same wire format, no
+// subprocess fork.
+//
+// **When to use this vs `:render-session-subprocess`**
+//
+// - **Embedded (this module):** the calling JVM gains the full Compose Desktop + Skiko + daemon
+//   runtime at session-open time. Best for JUnit pixel-test rigs, IDE plugins, or any host that
+//   already runs Compose Desktop and wants to avoid the JVM-fork startup cost (~1–2s saved per
+//   session).
+// - **Subprocess (`:render-session-subprocess`):** the calling JVM stays minimal. The renderer runs
+//   in its own forked JVM with whatever JVM args the daemon launch descriptor prescribes. Best for
+//   thin CLIs and tooling that doesn't want the runtime footprint, or that needs JVM args
+//   (`--add-opens`, custom GC settings) that can't be applied to a running JVM.
+//
+// **Limitations**
+//
+// 1. The Android Robolectric backend has *no* embedded equivalent — the sandbox bootstrap is too
+//    invasive. Calling `EmbeddedDesktopRenderSessions.open(...)` against an Android module fails
+//    cleanly.
+// 2. Multiple embedded sessions in the same JVM share system-property state — descriptor sysprops
+//    (`composeai.daemon.previewsJsonPath`, history dir, etc.) are JVM-global. One session at a
+//    time is safe; concurrent sessions against different modules need external coordination.
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  api(project(":render-session-api"))
+
+  // The actual daemon entry point we run on a background thread, plus the JSON-RPC client we
+  // wrap the calling end of the pipes with.
+  implementation(project(":daemon:desktop"))
+  implementation(project(":daemon:core"))
+  implementation(project(":mcp"))
+  implementation(libs.kotlinx.serialization.json)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "render-session-embedded-desktop",
+    displayName = "Compose Preview — Embedded Desktop Render Session",
+    description =
+      "In-process Compose Multiplatform Desktop backend for the compose-preview render-session " +
+        "API. Hosts the daemon's JSON-RPC server in the calling JVM via piped streams; no " +
+        "subprocess fork. Pairs with :render-session-api.",
+  )
+  inceptionYear.set("2026")
+}

--- a/render-session/embedded-desktop/src/main/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSession.kt
+++ b/render-session/embedded-desktop/src/main/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSession.kt
@@ -1,0 +1,406 @@
+package ee.schimke.composeai.render.session.embedded
+
+import ee.schimke.composeai.daemon.protocol.ChangeType
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
+import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
+import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
+import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingStartResult
+import ee.schimke.composeai.daemon.protocol.RecordingStopResult
+import ee.schimke.composeai.daemon.protocol.RenderNowResult
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.daemon.runDaemon
+import ee.schimke.composeai.mcp.DaemonClient
+import ee.schimke.composeai.mcp.DaemonLaunchDescriptor
+import ee.schimke.composeai.mcp.DataProductWireException
+import ee.schimke.composeai.render.session.DataProductException
+import ee.schimke.composeai.render.session.NotificationListener
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.RenderSessionBackend
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.RenderSessionException
+import ee.schimke.composeai.render.session.RenderSessionFactory
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * [RenderSession] backed by an in-process Compose Multiplatform Desktop daemon. The session spawns
+ * a single background thread that runs `:daemon:desktop`'s `runDaemon(...)` against piped streams;
+ * the calling thread holds the other end of those pipes via a `DaemonClient` and delegates every
+ * protocol call straight through. No subprocess fork; no JSON-RPC bytes ever leave the JVM.
+ *
+ * Use [EmbeddedDesktopRenderSessions] to open instances; the constructor is internal so test fakes
+ * can be wired without consumers seeing the transport plumbing.
+ *
+ * ## Lifecycle
+ *
+ * On [close] (or via try-with-resources), the session:
+ * 1. Sends `shutdown` + `exit` to the daemon via the client (`DaemonClient.shutdownAndExit`).
+ * 2. Joins the daemon thread, bounded by [SHUTDOWN_JOIN_TIMEOUT_MS]. If the thread doesn't exit
+ *    cleanly within that window we interrupt it and continue — the calling thread isn't held
+ *    hostage by a misbehaving renderer.
+ * 3. Closes both pipe pairs so neither side leaks file descriptors.
+ *
+ * After close every other method throws `IllegalStateException`.
+ */
+class EmbeddedDesktopRenderSession
+internal constructor(
+  override val workspaceRoot: String,
+  override val modulePath: String,
+  override val initializeResult: InitializeResult,
+  private val client: DaemonClient,
+  private val daemonThread: Thread,
+  private val pipesToClose: List<AutoCloseable>,
+  private val systemPropertyRestores: List<() -> Unit>,
+  private val listeners: CopyOnWriteArraySet<NotificationListener>,
+) : RenderSession {
+
+  override val backendKind: RenderSessionBackend = RenderSessionBackend.Embedded
+
+  private val closed = AtomicBoolean(false)
+
+  override fun setVisible(previewIds: List<String>) {
+    checkOpen()
+    client.setVisible(previewIds)
+  }
+
+  override fun setFocus(previewIds: List<String>) {
+    checkOpen()
+    client.setFocus(previewIds)
+  }
+
+  override fun fileChanged(path: String, kind: FileKind, changeType: ChangeType) {
+    checkOpen()
+    client.fileChanged(path, kind, changeType)
+  }
+
+  override fun renderNow(
+    previewIds: List<String>,
+    tier: RenderTier,
+    reason: String?,
+    overrides: PreviewOverrides?,
+    timeout: Duration,
+  ): RenderNowResult {
+    checkOpen()
+    return client.renderNow(
+      previews = previewIds,
+      tier = tier,
+      reason = reason,
+      overrides = overrides,
+      timeout = timeout,
+    )
+  }
+
+  override fun fetchData(
+    previewId: String,
+    kind: String,
+    inline: Boolean,
+    params: JsonElement?,
+    timeout: Duration,
+  ): DataFetchResult {
+    checkOpen()
+    return try {
+      client.dataFetch(
+        previewId = previewId,
+        kind = kind,
+        params = params,
+        inline = inline,
+        timeout = timeout,
+      )
+    } catch (e: DataProductWireException) {
+      throw DataProductException(
+        code = e.code,
+        wireMessage = e.wireMessage,
+        data = e.data,
+        cause = e,
+      )
+    }
+  }
+
+  override fun subscribeData(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    timeout: Duration,
+  ): DataSubscribeResult {
+    checkOpen()
+    return client.dataSubscribe(previewId = previewId, kind = kind, timeout = timeout)
+  }
+
+  override fun unsubscribeData(
+    previewId: String,
+    kind: String,
+    timeout: Duration,
+  ): DataSubscribeResult {
+    checkOpen()
+    return client.dataUnsubscribe(previewId = previewId, kind = kind, timeout = timeout)
+  }
+
+  override fun listExtensions(timeout: Duration): ExtensionsListResult {
+    checkOpen()
+    return client.extensionsList(timeout)
+  }
+
+  override fun enableExtensions(ids: List<String>, timeout: Duration): ExtensionsEnableResult {
+    checkOpen()
+    return client.extensionsEnable(ids = ids, timeout = timeout)
+  }
+
+  override fun disableExtensions(ids: List<String>, timeout: Duration): ExtensionsDisableResult {
+    checkOpen()
+    return client.extensionsDisable(ids = ids, timeout = timeout)
+  }
+
+  override fun historyList(params: HistoryListParams, timeout: Duration): HistoryListResult {
+    checkOpen()
+    return client.historyList(params = params, timeout = timeout)
+  }
+
+  override fun historyRead(
+    entryId: String,
+    inline: Boolean,
+    timeout: Duration,
+  ): HistoryReadResultDto {
+    checkOpen()
+    return client.historyRead(entryId = entryId, inline = inline, timeout = timeout)
+  }
+
+  override fun historyDiff(
+    fromId: String,
+    toId: String,
+    mode: HistoryDiffMode,
+    timeout: Duration,
+  ): HistoryDiffResult {
+    checkOpen()
+    return client.historyDiff(fromId = fromId, toId = toId, mode = mode, timeout = timeout)
+  }
+
+  override fun recordingStart(
+    previewId: String,
+    fps: Int?,
+    scale: Float?,
+    overrides: PreviewOverrides?,
+    timeout: Duration,
+  ): RecordingStartResult {
+    checkOpen()
+    return client.recordingStart(
+      previewId = previewId,
+      fps = fps,
+      scale = scale,
+      overrides = overrides,
+      timeout = timeout,
+    )
+  }
+
+  override fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) {
+    checkOpen()
+    client.recordingScript(recordingId, events)
+  }
+
+  override fun recordingStop(recordingId: String, timeout: Duration): RecordingStopResult {
+    checkOpen()
+    return client.recordingStop(recordingId = recordingId, timeout = timeout)
+  }
+
+  override fun recordingEncode(
+    recordingId: String,
+    format: RecordingFormat,
+    timeout: Duration,
+  ): RecordingEncodeResult {
+    checkOpen()
+    return client.recordingEncode(recordingId = recordingId, format = format, timeout = timeout)
+  }
+
+  override fun onNotification(listener: NotificationListener): AutoCloseable {
+    checkOpen()
+    listeners.add(listener)
+    return AutoCloseable { listeners.remove(listener) }
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    runCatching { client.shutdownAndExit() }
+    runCatching { daemonThread.join(SHUTDOWN_JOIN_TIMEOUT_MS) }
+    if (daemonThread.isAlive) {
+      // Interrupt as a last resort — the join's grace window already passed. The pipes
+      // close below will tear the read loop down regardless.
+      daemonThread.interrupt()
+    }
+    pipesToClose.forEach { runCatching { it.close() } }
+    runCatching { client.close() }
+    // Restore any system properties the session set during open. LIFO so nested sessions
+    // (against the same JVM, serially) restore in the right order.
+    systemPropertyRestores.asReversed().forEach { runCatching { it.invoke() } }
+  }
+
+  private fun checkOpen() {
+    check(!closed.get()) { "RenderSession has been closed" }
+  }
+
+  companion object {
+    private const val SHUTDOWN_JOIN_TIMEOUT_MS: Long = 30_000L
+  }
+}
+
+/**
+ * [RenderSessionFactory] singleton for the in-process Compose Multiplatform Desktop backend. Builds
+ * an [EmbeddedDesktopRenderSession] from a [RenderSessionConfig] by hosting `:daemon:desktop`'s
+ * [runDaemon] on a background thread with piped streams.
+ */
+object EmbeddedDesktopRenderSessions : RenderSessionFactory {
+  override val backendKind: RenderSessionBackend = RenderSessionBackend.Embedded
+
+  override fun open(config: RenderSessionConfig): RenderSession {
+    val descriptorFile = config.descriptorPath
+    if (!descriptorFile.isFile) {
+      throw RenderSessionException(
+        "Daemon launch descriptor not found at ${descriptorFile.path}. " +
+          "Run `:<modulePath>:composePreviewDaemonStart` to materialise it."
+      )
+    }
+    val descriptor =
+      try {
+        DaemonLaunchDescriptor.parse(descriptorFile.readText())
+      } catch (e: Exception) {
+        throw RenderSessionException(
+          "Daemon launch descriptor at ${descriptorFile.path} is unreadable: " +
+            (e.message ?: e.javaClass.simpleName),
+          cause = e,
+        )
+      }
+
+    // Apply the descriptor's system properties to the calling JVM. These drive PreviewIndex
+    // lookup, history paths, classpath fingerprint sources etc. — the daemon code reads them
+    // directly via `System.getProperty(...)`. The restores list is executed at close() so the
+    // calling JVM doesn't accumulate sysprops over multiple session lifetimes.
+    val restores = mutableListOf<() -> Unit>()
+    for ((k, v) in descriptor.systemProperties) {
+      val previous = System.getProperty(k)
+      System.setProperty(k, v)
+      val restore: () -> Unit =
+        if (previous == null) {
+          {
+            System.clearProperty(k)
+            Unit
+          }
+        } else {
+          {
+            System.setProperty(k, previous)
+            Unit
+          }
+        }
+      restores += restore
+    }
+
+    val workspaceRoot = config.workspaceRoot
+    val canonicalRoot =
+      runCatching { workspaceRoot.canonicalFile }.getOrDefault(workspaceRoot.absoluteFile)
+
+    // Two piped pairs: client→server (request channel) and server→client (response channel).
+    // We don't share a single pipe because reads + writes from the same thread would deadlock
+    // — the JSON-RPC server blocks reading requests while the client blocks waiting for
+    // responses.
+    val clientToServerSink = PipedOutputStream()
+    val clientToServerSource = PipedInputStream(clientToServerSink)
+    val serverToClientSink = PipedOutputStream()
+    val serverToClientSource = PipedInputStream(serverToClientSink)
+    val pipesToClose: List<AutoCloseable> =
+      listOf(clientToServerSink, clientToServerSource, serverToClientSink, serverToClientSource)
+
+    val daemonThread =
+      Thread(
+          {
+            try {
+              runDaemon(
+                input = clientToServerSource,
+                output = serverToClientSink,
+                installSigtermHook = false,
+                // CRITICAL: embedded mode shares the JVM with the caller. The daemon's default
+                // `onExit` calls `System.exit(...)` when the JSON-RPC `exit` notification arrives
+                // — that would terminate the calling JVM (test runners, IDE plugins, etc.) mid-
+                // operation. Swallow the exit code; the calling thread joins the daemon thread
+                // shortly after sending `exit` and observes a clean termination.
+                onExit = { _ -> },
+              )
+            } catch (t: Throwable) {
+              config.logSink("daemon thread terminated: ${t.javaClass.simpleName}: ${t.message}")
+            }
+          },
+          "compose-preview-embedded-daemon",
+        )
+        .apply {
+          isDaemon = true
+          start()
+        }
+
+    val listeners = CopyOnWriteArraySet<NotificationListener>()
+    val client =
+      DaemonClient(
+        input = serverToClientSource,
+        output = clientToServerSink,
+        onNotification = { method, params ->
+          for (l in listeners) runCatching { l.onNotification(method, params) }
+        },
+        onClose = {},
+      )
+
+    val initializeResult: InitializeResult =
+      try {
+        client.initialize(
+          workspaceRoot = canonicalRoot.absolutePath,
+          moduleId = descriptor.modulePath,
+          moduleProjectDir = descriptor.workingDirectory,
+          timeout = config.initializeTimeout,
+        )
+      } catch (e: Exception) {
+        // Tear down everything we constructed so far before throwing.
+        runCatching { client.shutdownAndExit() }
+        runCatching { daemonThread.join(5_000) }
+        if (daemonThread.isAlive) daemonThread.interrupt()
+        pipesToClose.forEach { runCatching { it.close() } }
+        runCatching { client.close() }
+        restores.asReversed().forEach { runCatching { it.invoke() } }
+        throw RenderSessionException(
+          "Embedded daemon initialize handshake failed for ${descriptor.modulePath}: " +
+            (e.message ?: e.javaClass.simpleName),
+          cause = e,
+        )
+      }
+
+    return EmbeddedDesktopRenderSession(
+      workspaceRoot = canonicalRoot.absolutePath,
+      modulePath = descriptor.modulePath,
+      initializeResult = initializeResult,
+      client = client,
+      daemonThread = daemonThread,
+      pipesToClose = pipesToClose,
+      systemPropertyRestores = restores,
+      listeners = listeners,
+    )
+  }
+
+  /**
+   * Quick liveness check — used by tests + callers that want to surface a clearer error before
+   * paying the open cost when the daemon classpath isn't on the calling JVM (e.g. someone added the
+   * API jar but forgot the embedded-desktop coordinate). Returns `true` only when the desktop
+   * daemon entry point is reachable via reflection.
+   */
+  fun isAvailable(): Boolean =
+    runCatching { Class.forName("ee.schimke.composeai.daemon.DaemonMain") }.isSuccess
+}

--- a/render-session/embedded-desktop/src/test/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopEndToEndTest.kt
+++ b/render-session/embedded-desktop/src/test/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopEndToEndTest.kt
@@ -1,0 +1,75 @@
+package ee.schimke.composeai.render.session.embedded
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import java.io.File
+import org.junit.Test
+
+/**
+ * Integration coverage for the embedded Compose Desktop backend against the in-repo `:samples:cmp`
+ * daemon descriptor. The test self-skips when the descriptor isn't on disk — the build it depends
+ * on is `./gradlew :samples:cmp:composePreviewDaemonStart`, run separately or by CI before this
+ * test fires.
+ *
+ * What's exercised: the full handshake (open + initialize), one read-only protocol call
+ * (`extensions/list`), and graceful close. The point is to prove the round-trip works without
+ * pulling the whole render-and-fetch flow into a unit test — that surface is huge and rendering a
+ * real preview from inside the test JVM would force the test runner to host the full Compose
+ * Desktop + Skiko classpath, which is an order of magnitude more class-loading than this module
+ * already pays.
+ */
+class EmbeddedDesktopEndToEndTest {
+
+  @Test
+  fun `opens session against samples_cmp and lists extensions`() {
+    val descriptor = locateSamplesCmpDescriptor()
+    val previews = File(descriptor.parentFile, "previews.json")
+    if (!descriptor.isFile || !previews.isFile) {
+      System.err.println(
+        "[EmbeddedDesktopEndToEndTest] skipping — descriptor or previews.json missing " +
+          "(run `:samples:cmp:composePreviewDaemonStart` + `:samples:cmp:discoverPreviews`)"
+      )
+      return
+    }
+
+    EmbeddedDesktopRenderSessions.open(
+        RenderSessionConfig(
+          descriptorPath = descriptor,
+          workspaceRoot = projectRoot(),
+          workspaceName = "compose-ai-tools",
+        )
+      )
+      .use { session ->
+        assertThat(session.modulePath).isEqualTo(":samples:cmp")
+        assertThat(session.initializeResult.daemonVersion).isNotEmpty()
+
+        // The desktop daemon always advertises at least `device/clip` + `device/background` —
+        // confirming the handshake came back with a populated extension descriptor rather than
+        // the empty default the wire defaults to on parse-only failures.
+        val ids = session.listExtensions().extensions.map { it.id }.toSet()
+        assertThat(ids).contains("device/clip")
+        assertThat(ids).contains("device/background")
+      }
+  }
+
+  private fun locateSamplesCmpDescriptor(): File {
+    val repoRoot = projectRoot()
+    return File(repoRoot, "samples/cmp/build/compose-previews/daemon-launch.json")
+  }
+
+  /**
+   * Walk up from the test JVM's working dir until we find the repo's `settings.gradle.kts`. The
+   * test classpath places the working dir somewhere under `render-session/embedded-desktop/` during
+   * gradle runs, but absolute paths matter for the descriptor lookup.
+   */
+  private fun projectRoot(): File {
+    var dir: File? = File(".").canonicalFile
+    while (dir != null) {
+      if (File(dir, "settings.gradle.kts").isFile) return dir
+      dir = dir.parentFile
+    }
+    error(
+      "Could not locate repo root (no settings.gradle.kts ancestor of ${File(".").canonicalFile})"
+    )
+  }
+}

--- a/render-session/embedded-desktop/src/test/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSessionTest.kt
+++ b/render-session/embedded-desktop/src/test/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSessionTest.kt
@@ -1,0 +1,72 @@
+package ee.schimke.composeai.render.session.embedded
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.render.session.RenderSessionBackend
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.RenderSessionException
+import java.io.File
+import org.junit.Test
+
+/**
+ * Smoke coverage for the embedded Desktop backend. Opening a real session needs the daemon-launch
+ * descriptor produced by `composePreviewDaemonStart` against the in-repo `:samples:cmp` module,
+ * which isn't built in the unit-test classpath — that side is exercised end-to-end by
+ * `:samples:cmp:renderAllPreviews` runs once we wire one up.
+ *
+ * These tests cover the error-handling and contract surface that doesn't need a live daemon:
+ * descriptor-missing, the `isAvailable()` probe, the `RenderSessionBackend.Embedded` advertisement.
+ */
+class EmbeddedDesktopRenderSessionTest {
+
+  @Test
+  fun `backend kind is Embedded`() {
+    assertThat(EmbeddedDesktopRenderSessions.backendKind).isEqualTo(RenderSessionBackend.Embedded)
+  }
+
+  @Test
+  fun `isAvailable returns true when the daemon classpath is on the calling JVM`() {
+    // This module has `:daemon:desktop` on its runtime classpath, so the probe must resolve.
+    assertThat(EmbeddedDesktopRenderSessions.isAvailable()).isTrue()
+  }
+
+  @Test
+  fun `open throws cleanly when the descriptor file is missing`() {
+    val tempDir = java.nio.file.Files.createTempDirectory("embedded-desktop-test").toFile()
+    tempDir.deleteOnExit()
+    val missingDescriptor = File(tempDir, "build/compose-previews/daemon-launch.json")
+
+    val ex =
+      runCatching {
+          EmbeddedDesktopRenderSessions.open(
+            RenderSessionConfig(descriptorPath = missingDescriptor, workspaceRoot = tempDir)
+          )
+        }
+        .exceptionOrNull()
+
+    assertThat(ex).isInstanceOf(RenderSessionException::class.java)
+    assertThat(ex!!.message).contains("Daemon launch descriptor not found")
+    assertThat(ex.message).contains(missingDescriptor.path)
+  }
+
+  @Test
+  fun `open throws cleanly when the descriptor is unreadable JSON`() {
+    val tempDir = java.nio.file.Files.createTempDirectory("embedded-desktop-test-bad").toFile()
+    tempDir.deleteOnExit()
+    val badDescriptor =
+      File(tempDir, "build/compose-previews/daemon-launch.json").apply {
+        parentFile.mkdirs()
+        writeText("not valid json {")
+      }
+
+    val ex =
+      runCatching {
+          EmbeddedDesktopRenderSessions.open(
+            RenderSessionConfig(descriptorPath = badDescriptor, workspaceRoot = tempDir)
+          )
+        }
+        .exceptionOrNull()
+
+    assertThat(ex).isInstanceOf(RenderSessionException::class.java)
+    assertThat(ex!!.message).contains("unreadable")
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -224,3 +224,12 @@ project(":render-session-api").projectDir = file("render-session/api")
 include(":render-session-subprocess")
 
 project(":render-session-subprocess").projectDir = file("render-session/subprocess")
+
+// In-process Compose Multiplatform Desktop backend for the render-session library. Hosts the
+// daemon's `JsonRpcServer` + `DesktopHost` in the calling JVM via piped streams instead of forking
+// a subprocess. Trades classpath footprint (the calling JVM picks up Skiko + Compose Desktop) for
+// dramatically faster session startup. Embedders that don't want the runtime footprint stick with
+// `:render-session-subprocess`.
+include(":render-session-embedded-desktop")
+
+project(":render-session-embedded-desktop").projectDir = file("render-session/embedded-desktop")


### PR DESCRIPTION
## Summary

Adds `:render-session-embedded-desktop`, a new render-session library backend that hosts `:daemon:desktop`'s `runDaemon(...)` inside the calling JVM via in-memory piped streams instead of forking a subprocess. The session presents the same `RenderSession` contract as the existing `:render-session-subprocess` backend — same protocol, same wire format, identical method surface — so consumers swap one factory call for another.

```kotlin
EmbeddedDesktopRenderSessions
  .open(RenderSessionConfig(descriptorPath = File("samples/cmp/build/compose-previews/daemon-launch.json")))
  .use { session ->
    session.renderNow(listOf("MyPreview"))
    val findings = session.fetchData("MyPreview", "a11y/atf", inline = true)
    // …
  }
```

## When to use this vs `:render-session-subprocess`

- **Embedded (this PR):** the calling JVM gains the full Compose Desktop + Skiko + daemon runtime at session-open time. Best for JUnit pixel-test rigs, IDE plugins, or any host already running Compose Desktop. Trades classpath footprint for ~1–2s saved per session open.
- **Subprocess (`:render-session-subprocess`):** the calling JVM stays minimal. The renderer runs in its own forked JVM with whatever JVM args the daemon launch descriptor prescribes. Best for thin CLIs and tooling that doesn't want the runtime footprint, or that needs JVM args (`--add-opens`, custom GC settings) that can't be applied to a running JVM.

The Android (Robolectric) side has no embedded equivalent and isn't attempted — the sandbox bootstrap is too invasive to host alongside arbitrary caller code. Boundaries are documented in the new module's build script.

## Required `:daemon:desktop` changes

Two surgical touches, both backwards-compatible:

1. **Extracted `fun main(args)` body into `fun runDaemon(input, output, installSigtermHook, onExit)`** so embedded mode drives the same setup without `System.in` / `System.out` or process-global state. Subprocess `main()` is now a 6-line wrapper that captures realStdout, swaps `System.out` → `System.err`, and calls `runDaemon` with subprocess defaults (`installSigtermHook = true`, `onExit = System::exit`).
2. **Plumbed `JsonRpcServer.onExit` through `runDaemon` as a parameter.** The daemon's `exit` notification handler defaults to `System.exit(...)`, which would terminate the *calling* JVM in embedded mode. Embedded sessions pass a no-op `onExit` so close cleans up the daemon thread without taking down the host process. (This was the bug that initially made my e2e test always report `<skipped/>` — the test JVM was exiting before JUnit could record the result.)

## Sysprop overlay + restore

Daemon configuration (`composeai.daemon.previewsJsonPath`, history dir, classpath fingerprint sources) reads from system properties. The embedded factory overlays the descriptor's `systemProperties` onto the calling JVM at `open(...)` and restores them on `close()` — LIFO so nested sessions restore in the right order. Sysprops are JVM-global so concurrent sessions against different modules need external coordination; documented on the new module.

## Test plan

- [x] `EmbeddedDesktopRenderSessionTest` — contract-only coverage: backend-kind advertisement, `isAvailable()` probe, descriptor-missing + unreadable-JSON paths.
- [x] `EmbeddedDesktopEndToEndTest` — opens a real session against `:samples:cmp`'s daemon descriptor (self-skips when `composePreviewDaemonStart` + `discoverPreviews` haven't materialised the inputs), drives the `initialize` handshake and `extensions/list`, asserts `device/clip` + `device/background` come back. End-to-end verified locally: handshake completes in ~800ms.
- [x] `ktfmtCheckAll` clean.
- [x] `:cli:checkCliDaemonLibraryBoundary` still passes — the CLI's runtime classpath isn't touched.

## Out of scope

- `:mcp` migration to consume `:render-session-*`. Existing server stays on `DaemonClient`; library is for external consumers. Optional follow-up.
- Wire `EmbeddedDesktopRenderSessions` as a CI-side smoke test against `:samples:cmp:renderAllPreviews` outputs — once we have a real consumer driving it, that test gates regressions in the daemon's wire shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_0178MWQ319fGv7JWjSwpsvSU)_