### PR TITLE
feat(vscode-extension): adopt bundle-legend in Inspection / Text / History bundles

### DIFF
--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -1021,6 +1021,12 @@ export class PreviewApp extends LitElement {
                 !enabledKinds.has("i18n/translations") &&
                 data.translations.length === 0;
             dataTabs.setTabBody("text", body.wrapper);
+            bundleLegend.setBundleEntries(
+                "text",
+                "Text / i18n",
+                overlayToLegendEntries(data.overlay),
+            );
+            reflectLegendActiveTab();
             // Paint per-row overflow / truncation overlays. Focus
             // mode paints only the focused card; grid mode paints
             // every visible card from its own
@@ -1530,6 +1536,12 @@ export class PreviewApp extends LitElement {
             }));
             refreshExpanderFor("history");
             dataTabs.setTabBody("history", host);
+            bundleLegend.setBundleEntries(
+                "history",
+                "History diff",
+                overlayToLegendEntries(data.overlay),
+            );
+            reflectLegendActiveTab();
             // Paint the per-region tinted boxes. Focus mode paints
             // only the focused card; grid mode paints every visible
             // card from its own `history/diff/regions` payload. Empty
@@ -1670,6 +1682,12 @@ export class PreviewApp extends LitElement {
                 body.host.appendChild(wrap);
             }
             dataTabs.setTabBody("inspection", body.wrapper);
+            bundleLegend.setBundleEntries(
+                "inspection",
+                "Inspection",
+                overlayToLegendEntries(data.overlay),
+            );
+            reflectLegendActiveTab();
             // Paint the merged + de-duped overlay. In focus mode only
             // the focused card paints; in grid mode every visible card
             // paints with its own per-card data via the grid-aware
@@ -1699,6 +1717,27 @@ export class PreviewApp extends LitElement {
             if (row.touchTargetSizeDp) parts.push(row.touchTargetSizeDp);
             return parts.join(" · ");
         };
+        // Generic mapping from a bundle's `OverlayBox[]` to legend
+        // entries. Tooltips on overlay boxes are already shaped as
+        // `label · detail · …`, so splitting on ` · ` gives a clean
+        // bold label + muted subtitle without bespoke per-bundle
+        // wiring. Bundles that want a richer label / detail (e.g.
+        // a11y carries `touchTargetSizeDp` separately) compose
+        // their own; this is the common case.
+        const overlayToLegendEntries = (
+            boxes: readonly OverlayBox[],
+        ): BundleLegendEntry[] =>
+            boxes.map((b) => {
+                const tooltip = b.tooltip ?? "";
+                const parts = tooltip.split(" · ");
+                return {
+                    id: b.id,
+                    label: parts[0] || b.id,
+                    detail: parts.slice(1).join(" · "),
+                    level: b.level ?? "info",
+                    color: b.color,
+                };
+            });
         // Palette colours for info-level a11y entries — keep the
         // legend swatch in sync with the overlay's per-node colour
         // pick. Matches the `PALETTE` constant in


### PR DESCRIPTION
## Summary

Mechanical follow-on to #1130 (`<bundle-legend>` primitive) and #1140 (a11y tree complete). Adopts the legend in the three other overlay-painting bundles — **Inspection** (semantics / layout-inspector / uia-hierarchy), **Text/i18n** (overflow / truncation overlays), **History diff** (added / removed / modified regions) — so the swatch ↔ overlay correlation works regardless of which tab is active.

## What changes

Each bundle's `data.overlay` already carries `{ id, level, color, tooltip }` per region — the legend's exact shape. A tiny `overlayToLegendEntries` helper in `main.ts` splits the tooltip on ` · ` (the convention inspection / text / history already use: `label · role · testTag` etc.) to produce `label` / `detail`. No per-bundle shaping needed.

Each refresh function calls `bundleLegend.setBundleEntries(id, label, entries)` then `reflectLegendActiveTab()`. The legend's existing tab-swap path (via `bundleController.onChange`) does the rest.

A11y keeps its bespoke mapping because its rows carry extra fields (`touchTargetSizeDp`) that don't live on the overlay box.

## What's deferred

Row-click → detail panel for **Inspection** is **not** in this PR: inspection renders rows in a tree-table primitive (`inspectionTreeTable`), not the shared `<data-table>` whose `row-clicked` event #1138 wired. Plumbing the detail click through the tree-table needs a separate design (either teach tree-table the same event or extract the row-id mapping into a shared lookup). Tracked as a follow-up.

Text and history-diff use `<data-table>`, so they get row-click detail "for free" once their `buildA11yRowDetail`-equivalent helpers are written — also a follow-up.

## Test plan

- [x] `npm test` — 974 passing, no regressions
- [x] `npm run compile:webview` clean
- [x] `npm run format:check` clean
- [x] `npm run harness:snapshot -- --fixture a11y-findings` re-renders identically — no regression on the existing snapshot
- [ ] Manual: activate Inspection / Text / History chips in focus mode, confirm the legend column populates with the bundle's overlay entries and swaps slices on tab change

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_