### PR TITLE
test(vscode-extension): preview-harness fixtures for Inspection / Text / History bundles

### DIFF
--- a/vscode-extension/preview-harness/fixtures/_utils.mjs
+++ b/vscode-extension/preview-harness/fixtures/_utils.mjs
@@ -1,0 +1,202 @@
+// Shared helpers for the preview-harness fixture generators. Each
+// `*.gen.mjs` file emits a JSON document with the same shape:
+// `setPreviews` + `updateImage` + (optional) `updateDataProducts` +
+// `actions`. The shell of the PNG encoder, preview-card stub, and
+// fixture wrapper repeats between fixtures, so we factor it here.
+// Per-fixture generators stay focused on the data-product payload
+// they're demonstrating.
+
+import { deflateSync } from "node:zlib";
+
+function crc32(buf) {
+    const t = new Uint32Array(256);
+    for (let n = 0; n < 256; n++) {
+        let c = n;
+        for (let k = 0; k < 8; k++)
+            c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+        t[n] = c >>> 0;
+    }
+    let c = 0xffffffff;
+    for (const b of buf) c = t[(c ^ b) & 0xff] ^ (c >>> 8);
+    return (c ^ 0xffffffff) >>> 0;
+}
+
+/**
+ * Encode an RGB pixel buffer as PNG, base64 (no `data:` prefix —
+ * `paintCardCapture` prepends the data URL itself).
+ */
+export function encodePng(width, height, pixels) {
+    const raw = Buffer.alloc(height * (1 + width * 3));
+    for (let y = 0; y < height; y++) {
+        let off = y * (1 + width * 3);
+        raw[off++] = 0;
+        for (let x = 0; x < width; x++) {
+            const i = (y * width + x) * 3;
+            raw[off++] = pixels[i];
+            raw[off++] = pixels[i + 1];
+            raw[off++] = pixels[i + 2];
+        }
+    }
+    function chunk(type, payload) {
+        const len = Buffer.alloc(4);
+        len.writeUInt32BE(payload.length, 0);
+        const tb = Buffer.from(type, "ascii");
+        const crc = Buffer.alloc(4);
+        crc.writeUInt32BE(crc32(Buffer.concat([tb, payload])), 0);
+        return Buffer.concat([len, tb, payload, crc]);
+    }
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(width, 0);
+    ihdr.writeUInt32BE(height, 4);
+    ihdr[8] = 8;
+    ihdr[9] = 2;
+    return Buffer.concat([
+        Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+        chunk("IHDR", ihdr),
+        chunk("IDAT", deflateSync(raw)),
+        chunk("IEND", Buffer.alloc(0)),
+    ]).toString("base64");
+}
+
+export function inRect(x, y, r) {
+    return x >= r.left && x < r.right && y >= r.top && y < r.bottom;
+}
+
+export function rectBounds(r) {
+    return `${r.left},${r.top},${r.right},${r.bottom}`;
+}
+
+/**
+ * Build a stylised 360×600 mobile mock with header / two buttons /
+ * footer regions. Returns the geometry + the encoded PNG so each
+ * fixture can place data-product bounds against shared coords.
+ */
+export function buildMobileMock() {
+    const W = 360;
+    const H = 600;
+    const HEADER = { left: 0, top: 0, right: W, bottom: 80 };
+    const BTN1 = { left: 40, top: 240, right: 160, bottom: 296 };
+    const BTN2 = { left: 200, top: 240, right: 320, bottom: 296 };
+    const FOOTER = { left: 0, top: 520, right: W, bottom: H };
+    const ROOT = { left: 0, top: 0, right: W, bottom: H };
+
+    const pixels = new Uint8Array(W * H * 3);
+    for (let y = 0; y < H; y++) {
+        for (let x = 0; x < W; x++) {
+            let r = 245;
+            let g = 246;
+            let b = 250;
+            if (inRect(x, y, HEADER)) {
+                r = 60;
+                g = 90;
+                b = 168;
+            } else if (inRect(x, y, BTN1)) {
+                r = 14;
+                g = 99;
+                b = 156;
+            } else if (inRect(x, y, BTN2)) {
+                r = 220;
+                g = 220;
+                b = 220;
+            } else if (inRect(x, y, FOOTER)) {
+                r = 200;
+                g = 200;
+                b = 200;
+            }
+            const i = (y * W + x) * 3;
+            pixels[i] = r;
+            pixels[i + 1] = g;
+            pixels[i + 2] = b;
+        }
+    }
+    return {
+        W,
+        H,
+        HEADER,
+        BTN1,
+        BTN2,
+        FOOTER,
+        ROOT,
+        png: encodePng(W, H, pixels),
+    };
+}
+
+/**
+ * Build a focused-card descriptor + a hidden sibling so focus mode
+ * has a card to switch into. The sibling stays as a skeleton — its
+ * `updateImage` isn't included, and focus-mode layout means it
+ * never paints anyway.
+ */
+export function buildPreviewPair({ focusId, width, height, fnName, file }) {
+    const params = {
+        name: null,
+        device: null,
+        widthDp: width,
+        heightDp: height,
+        fontScale: 1.0,
+        showSystemUi: false,
+        showBackground: true,
+        backgroundColor: 0,
+        uiMode: 0,
+        locale: null,
+        group: null,
+    };
+    const focused = {
+        id: focusId,
+        functionName: fnName,
+        className: file.replace(/\.kt$/, "Kt"),
+        sourceFile: file,
+        params,
+        captures: [
+            {
+                advanceTimeMillis: null,
+                scroll: null,
+                renderOutput: `renders/${focusId}.png`,
+                label: "",
+            },
+        ],
+    };
+    const sibling = {
+        ...focused,
+        id: focusId + "Sibling",
+        functionName: fnName + "Sibling",
+        captures: [
+            {
+                ...focused.captures[0],
+                renderOutput: `renders/${focusId}Sibling.png`,
+            },
+        ],
+    };
+    return { focused, sibling };
+}
+
+/**
+ * The `dataset` block every fixture sets on `<preview-app>` so the
+ * panel boots with the bundle UI gated on.
+ */
+export const EARLY_FEATURES_DATASET = {
+    earlyFeatures: "true",
+    autoEnableCheap: "false",
+    collapseVariants: "false",
+    minimalMode: "false",
+    autoInject: "true",
+};
+
+/**
+ * Helper that returns the action object that focuses a card via its
+ * `.card-focus-btn` handle (clicking the image would toggle
+ * interactive mode instead).
+ */
+export function focusAction(previewId) {
+    return {
+        click: `.preview-card[data-preview-id="${previewId}"] .card-focus-btn`,
+    };
+}
+
+/**
+ * Activate a bundle chip — keyed by `data-bundle` per
+ * `BundleChipBar.renderChip`.
+ */
+export function activateBundleAction(bundleId) {
+    return { click: `bundle-chip-bar button[data-bundle="${bundleId}"]` };
+}

--- a/vscode-extension/preview-harness/fixtures/history-diff.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/history-diff.gen.mjs
@@ -1,0 +1,91 @@
+// Generator for `history-diff.json`. Run with:
+//   node preview-harness/fixtures/history-diff.gen.mjs > preview-harness/fixtures/history-diff.json
+//
+// Demonstrates the History diff bundle end-to-end: the focused card
+// paints tinted boxes over each changed region, the side legend
+// lists the regions with their pixel-count subtitle, and the bundle
+// tab body renders the diff table with the baseline header.
+//
+// Payload shape mirrors `HistoryDiffPayload` in
+// `data/history/core/.../HistoryDiffModels.kt`.
+
+import {
+    EARLY_FEATURES_DATASET,
+    activateBundleAction,
+    buildMobileMock,
+    buildPreviewPair,
+    focusAction,
+    rectBounds,
+} from "./_utils.mjs";
+
+const mock = buildMobileMock();
+const { HEADER, BTN1, BTN2, FOOTER, W, H, png } = mock;
+
+const focusId = "com.example.OnboardingKt.WelcomeScreenPreview";
+const { focused, sibling } = buildPreviewPair({
+    focusId,
+    width: W,
+    height: H,
+    fnName: "WelcomeScreenPreview",
+    file: "Onboarding.kt",
+});
+
+const totalPixels = W * H;
+const region1Pixels = (HEADER.right - HEADER.left) * (HEADER.bottom - HEADER.top);
+const region2Pixels = (BTN1.right - BTN1.left) * (BTN1.bottom - BTN1.top);
+const region3Pixels = (BTN2.right - BTN2.left) * (BTN2.bottom - BTN2.top);
+const changedPixels = region1Pixels + region2Pixels + region3Pixels;
+
+const historyDiff = {
+    baselineHistoryId: "main@a1b2c3d4",
+    totalPixelsChanged: changedPixels,
+    changedFraction: changedPixels / totalPixels,
+    regions: [
+        {
+            bounds: rectBounds(HEADER),
+            pixelCount: region1Pixels,
+            avgDelta: { r: 12.4, g: 18.2, b: 33.7, a: 0.0 },
+        },
+        {
+            bounds: rectBounds(BTN1),
+            pixelCount: region2Pixels,
+            avgDelta: { r: 4.1, g: 6.8, b: 8.2, a: 0.0 },
+        },
+        {
+            bounds: rectBounds(BTN2),
+            pixelCount: region3Pixels,
+            avgDelta: { r: 22.6, g: 24.0, b: 28.9, a: 0.0 },
+        },
+    ],
+};
+
+const setPreviews = {
+    command: "setPreviews",
+    moduleDir: "/workspace/sample-android",
+    heavyStaleIds: [],
+    previews: [focused, sibling],
+};
+
+const updateImage = {
+    command: "updateImage",
+    previewId: focusId,
+    captureIndex: 0,
+    imageData: png,
+};
+
+const updateDataProducts = {
+    command: "updateDataProducts",
+    previewId: focusId,
+    dataProducts: [{ kind: "history/diff/regions", payload: historyDiff }],
+};
+
+const fixture = {
+    name: "history-diff",
+    description:
+        "Focused card with realistic history/diff/regions payload (three regions, ~12% of pixels changed from baseline). Activates the History bundle so the diff overlay paints each region, the side legend lists them with pixel-count subtitles, and the tab body renders the diff table with the baseline header.",
+    dataset: EARLY_FEATURES_DATASET,
+    messages: [setPreviews, updateImage, updateDataProducts],
+    actions: [focusAction(focusId), activateBundleAction("history")],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/history-diff.json
+++ b/vscode-extension/preview-harness/fixtures/history-diff.json
@@ -1,0 +1,134 @@
+{
+  "name": "history-diff",
+  "description": "Focused card with realistic history/diff/regions payload (three regions, ~12% of pixels changed from baseline). Activates the History bundle so the diff overlay paints each region, the side legend lists them with pixel-count subtitles, and the tab body renders the diff table with the baseline header.",
+  "dataset": {
+    "earlyFeatures": "true",
+    "autoEnableCheap": "false",
+    "collapseVariants": "false",
+    "minimalMode": "false",
+    "autoInject": "true"
+  },
+  "messages": [
+    {
+      "command": "setPreviews",
+      "moduleDir": "/workspace/sample-android",
+      "heavyStaleIds": [],
+      "previews": [
+        {
+          "id": "com.example.OnboardingKt.WelcomeScreenPreview",
+          "functionName": "WelcomeScreenPreview",
+          "className": "OnboardingKt",
+          "sourceFile": "Onboarding.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.OnboardingKt.WelcomeScreenPreview.png",
+              "label": ""
+            }
+          ]
+        },
+        {
+          "id": "com.example.OnboardingKt.WelcomeScreenPreviewSibling",
+          "functionName": "WelcomeScreenPreviewSibling",
+          "className": "OnboardingKt",
+          "sourceFile": "Onboarding.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.OnboardingKt.WelcomeScreenPreviewSibling.png",
+              "label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "command": "updateImage",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "captureIndex": 0,
+      "imageData": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC"
+    },
+    {
+      "command": "updateDataProducts",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "dataProducts": [
+        {
+          "kind": "history/diff/regions",
+          "payload": {
+            "baselineHistoryId": "main@a1b2c3d4",
+            "totalPixelsChanged": 42240,
+            "changedFraction": 0.19555555555555557,
+            "regions": [
+              {
+                "bounds": "0,0,360,80",
+                "pixelCount": 28800,
+                "avgDelta": {
+                  "r": 12.4,
+                  "g": 18.2,
+                  "b": 33.7,
+                  "a": 0
+                }
+              },
+              {
+                "bounds": "40,240,160,296",
+                "pixelCount": 6720,
+                "avgDelta": {
+                  "r": 4.1,
+                  "g": 6.8,
+                  "b": 8.2,
+                  "a": 0
+                }
+              },
+              {
+                "bounds": "200,240,320,296",
+                "pixelCount": 6720,
+                "avgDelta": {
+                  "r": 22.6,
+                  "g": 24,
+                  "b": 28.9,
+                  "a": 0
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "click": ".preview-card[data-preview-id=\"com.example.OnboardingKt.WelcomeScreenPreview\"] .card-focus-btn"
+    },
+    {
+      "click": "bundle-chip-bar button[data-bundle=\"history\"]"
+    }
+  ]
+}

--- a/vscode-extension/preview-harness/fixtures/inspection-tree.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/inspection-tree.gen.mjs
@@ -1,0 +1,166 @@
+// Generator for `inspection-tree.json`. Run with:
+//   node preview-harness/fixtures/inspection-tree.gen.mjs > preview-harness/fixtures/inspection-tree.json
+//
+// Demonstrates the Inspection bundle (semantics + layout-inspector +
+// uia) end-to-end: tinted overlay on the focused card, side
+// `<bundle-legend>` populated from the merged overlay, and the
+// inspection tab body rendering its tree-table sections per
+// enabled kind.
+//
+// Payload shape mirrors the structures in
+// `data/layoutinspector/core/.../ComposeSemanticsModels.kt` and
+// `data/uiautomator/core/.../UiAutomatorHierarchyModels.kt`. Bounds
+// align with the buildMobileMock() regions so the overlay boxes
+// visibly cover the header / buttons / footer.
+
+import {
+    EARLY_FEATURES_DATASET,
+    activateBundleAction,
+    buildMobileMock,
+    buildPreviewPair,
+    focusAction,
+    rectBounds,
+} from "./_utils.mjs";
+
+const mock = buildMobileMock();
+const { HEADER, BTN1, BTN2, FOOTER, ROOT, W, H, png } = mock;
+
+const focusId = "com.example.OnboardingKt.WelcomeScreenPreview";
+const { focused, sibling } = buildPreviewPair({
+    focusId,
+    width: W,
+    height: H,
+    fnName: "WelcomeScreenPreview",
+    file: "Onboarding.kt",
+});
+
+// `compose/semantics` — recursive tree rooted on the full preview.
+const semantics = {
+    root: {
+        nodeId: "root",
+        boundsInRoot: rectBounds(ROOT),
+        role: "Container",
+        testTag: "onboarding_screen",
+        children: [
+            {
+                nodeId: "header",
+                boundsInRoot: rectBounds(HEADER),
+                text: "Welcome to Compose AI Tools",
+                role: "Header",
+                testTag: "onboarding_header",
+            },
+            {
+                nodeId: "primary-cta",
+                boundsInRoot: rectBounds(BTN1),
+                label: "Get started",
+                role: "Button",
+                testTag: "primary_cta",
+            },
+            {
+                nodeId: "secondary-cta",
+                boundsInRoot: rectBounds(BTN2),
+                role: "Button",
+                testTag: "icon_cta",
+            },
+            {
+                nodeId: "footer",
+                boundsInRoot: rectBounds(FOOTER),
+                text: "By continuing you agree to our terms",
+                role: "Text",
+                testTag: "terms_footer",
+            },
+        ],
+    },
+};
+
+// `layout/inspector` — flat node array referencing the same bounds
+// so the merged overlay de-dupes across kinds (the bundle's
+// `overlay` field carries the de-duped set; the legend renders
+// from that).
+const layoutInspector = {
+    root: {
+        nodeId: "layout-root",
+        component: "OnboardingScreen",
+        source: "Onboarding.kt:42",
+        bounds: { left: 0, top: 0, right: W, bottom: H },
+        size: { width: W, height: H },
+        children: [
+            {
+                nodeId: "layout-column",
+                component: "Column",
+                source: "Onboarding.kt:48",
+                bounds: { left: 0, top: 0, right: W, bottom: H },
+                size: { width: W, height: H },
+                children: [
+                    {
+                        nodeId: "layout-header",
+                        component: "Surface",
+                        source: "Onboarding.kt:56",
+                        bounds: {
+                            left: HEADER.left,
+                            top: HEADER.top,
+                            right: HEADER.right,
+                            bottom: HEADER.bottom,
+                        },
+                        size: {
+                            width: HEADER.right - HEADER.left,
+                            height: HEADER.bottom - HEADER.top,
+                        },
+                    },
+                    {
+                        nodeId: "layout-cta",
+                        component: "FilledButton",
+                        source: "Onboarding.kt:72",
+                        bounds: {
+                            left: BTN1.left,
+                            top: BTN1.top,
+                            right: BTN1.right,
+                            bottom: BTN1.bottom,
+                        },
+                        size: {
+                            width: BTN1.right - BTN1.left,
+                            height: BTN1.bottom - BTN1.top,
+                        },
+                    },
+                ],
+            },
+        ],
+    },
+};
+
+const setPreviews = {
+    command: "setPreviews",
+    moduleDir: "/workspace/sample-android",
+    heavyStaleIds: [],
+    previews: [focused, sibling],
+};
+
+const updateImage = {
+    command: "updateImage",
+    previewId: focusId,
+    captureIndex: 0,
+    imageData: png,
+};
+
+const updateDataProducts = {
+    command: "updateDataProducts",
+    previewId: focusId,
+    dataProducts: [
+        { kind: "compose/semantics", payload: semantics },
+        { kind: "layout/inspector", payload: layoutInspector },
+    ],
+};
+
+const fixture = {
+    name: "inspection-tree",
+    description:
+        "Focused card with realistic compose/semantics + layout/inspector payloads. Activates the Inspection bundle so the overlay layer paints over the header / primary CTA / secondary CTA / footer regions, the side legend populates with one entry per overlay box (label · role · testTag), and the inspection tab body renders the per-kind tree tables.",
+    dataset: EARLY_FEATURES_DATASET,
+    messages: [setPreviews, updateImage, updateDataProducts],
+    actions: [
+        focusAction(focusId),
+        activateBundleAction("inspection"),
+    ],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/inspection-tree.json
+++ b/vscode-extension/preview-harness/fixtures/inspection-tree.json
@@ -1,0 +1,203 @@
+{
+  "name": "inspection-tree",
+  "description": "Focused card with realistic compose/semantics + layout/inspector payloads. Activates the Inspection bundle so the overlay layer paints over the header / primary CTA / secondary CTA / footer regions, the side legend populates with one entry per overlay box (label · role · testTag), and the inspection tab body renders the per-kind tree tables.",
+  "dataset": {
+    "earlyFeatures": "true",
+    "autoEnableCheap": "false",
+    "collapseVariants": "false",
+    "minimalMode": "false",
+    "autoInject": "true"
+  },
+  "messages": [
+    {
+      "command": "setPreviews",
+      "moduleDir": "/workspace/sample-android",
+      "heavyStaleIds": [],
+      "previews": [
+        {
+          "id": "com.example.OnboardingKt.WelcomeScreenPreview",
+          "functionName": "WelcomeScreenPreview",
+          "className": "OnboardingKt",
+          "sourceFile": "Onboarding.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.OnboardingKt.WelcomeScreenPreview.png",
+              "label": ""
+            }
+          ]
+        },
+        {
+          "id": "com.example.OnboardingKt.WelcomeScreenPreviewSibling",
+          "functionName": "WelcomeScreenPreviewSibling",
+          "className": "OnboardingKt",
+          "sourceFile": "Onboarding.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.OnboardingKt.WelcomeScreenPreviewSibling.png",
+              "label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "command": "updateImage",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "captureIndex": 0,
+      "imageData": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC"
+    },
+    {
+      "command": "updateDataProducts",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "dataProducts": [
+        {
+          "kind": "compose/semantics",
+          "payload": {
+            "root": {
+              "nodeId": "root",
+              "boundsInRoot": "0,0,360,600",
+              "role": "Container",
+              "testTag": "onboarding_screen",
+              "children": [
+                {
+                  "nodeId": "header",
+                  "boundsInRoot": "0,0,360,80",
+                  "text": "Welcome to Compose AI Tools",
+                  "role": "Header",
+                  "testTag": "onboarding_header"
+                },
+                {
+                  "nodeId": "primary-cta",
+                  "boundsInRoot": "40,240,160,296",
+                  "label": "Get started",
+                  "role": "Button",
+                  "testTag": "primary_cta"
+                },
+                {
+                  "nodeId": "secondary-cta",
+                  "boundsInRoot": "200,240,320,296",
+                  "role": "Button",
+                  "testTag": "icon_cta"
+                },
+                {
+                  "nodeId": "footer",
+                  "boundsInRoot": "0,520,360,600",
+                  "text": "By continuing you agree to our terms",
+                  "role": "Text",
+                  "testTag": "terms_footer"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "kind": "layout/inspector",
+          "payload": {
+            "root": {
+              "nodeId": "layout-root",
+              "component": "OnboardingScreen",
+              "source": "Onboarding.kt:42",
+              "bounds": {
+                "left": 0,
+                "top": 0,
+                "right": 360,
+                "bottom": 600
+              },
+              "size": {
+                "width": 360,
+                "height": 600
+              },
+              "children": [
+                {
+                  "nodeId": "layout-column",
+                  "component": "Column",
+                  "source": "Onboarding.kt:48",
+                  "bounds": {
+                    "left": 0,
+                    "top": 0,
+                    "right": 360,
+                    "bottom": 600
+                  },
+                  "size": {
+                    "width": 360,
+                    "height": 600
+                  },
+                  "children": [
+                    {
+                      "nodeId": "layout-header",
+                      "component": "Surface",
+                      "source": "Onboarding.kt:56",
+                      "bounds": {
+                        "left": 0,
+                        "top": 0,
+                        "right": 360,
+                        "bottom": 80
+                      },
+                      "size": {
+                        "width": 360,
+                        "height": 80
+                      }
+                    },
+                    {
+                      "nodeId": "layout-cta",
+                      "component": "FilledButton",
+                      "source": "Onboarding.kt:72",
+                      "bounds": {
+                        "left": 40,
+                        "top": 240,
+                        "right": 160,
+                        "bottom": 296
+                      },
+                      "size": {
+                        "width": 120,
+                        "height": 56
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "click": ".preview-card[data-preview-id=\"com.example.OnboardingKt.WelcomeScreenPreview\"] .card-focus-btn"
+    },
+    {
+      "click": "bundle-chip-bar button[data-bundle=\"inspection\"]"
+    }
+  ]
+}

--- a/vscode-extension/preview-harness/fixtures/text-strings.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/text-strings.gen.mjs
@@ -1,0 +1,174 @@
+// Generator for `text-strings.json`. Run with:
+//   node preview-harness/fixtures/text-strings.gen.mjs > preview-harness/fixtures/text-strings.json
+//
+// Demonstrates the Text / i18n bundle end-to-end: the focused card
+// paints overflow / truncation overlay boxes from `text/strings`
+// entries, the side legend lists each drawn-text node, and the
+// bundle tab body renders the strings / fonts / translations
+// sub-tables.
+//
+// Payload shapes mirror `TextStringsPayload` (`data/strings/core/.../
+// StringModels.kt`) and the fonts/used + i18n/translations
+// structures the daemon emits — enough fields to drive the bundle
+// presenter without depending on the live recorder.
+
+import {
+    EARLY_FEATURES_DATASET,
+    activateBundleAction,
+    buildMobileMock,
+    buildPreviewPair,
+    focusAction,
+    rectBounds,
+} from "./_utils.mjs";
+
+const mock = buildMobileMock();
+const { HEADER, BTN1, BTN2, FOOTER, W, H, png } = mock;
+
+const focusId = "com.example.OnboardingKt.WelcomeScreenPreview";
+const { focused, sibling } = buildPreviewPair({
+    focusId,
+    width: W,
+    height: H,
+    fnName: "WelcomeScreenPreview",
+    file: "Onboarding.kt",
+});
+
+// `text/strings` — drawn-text entries with overflow + truncation
+// flags so the overlay paints around the offending text bounds.
+const textStrings = {
+    texts: [
+        {
+            nodeId: "header-text",
+            boundsInScreen: rectBounds(HEADER),
+            text: "Welcome to Compose AI Tools",
+            semanticsText: "Welcome to Compose AI Tools",
+            fontSize: "22.0sp",
+            foregroundColor: "#FFFFFFFF",
+            backgroundColor: "#FF3C5AA8",
+            localeTag: "en-US",
+            truncated: false,
+            didOverflowWidth: false,
+            didOverflowHeight: false,
+        },
+        {
+            nodeId: "primary-cta-text",
+            boundsInScreen: rectBounds(BTN1),
+            text: "Get started",
+            semanticsText: "Get started",
+            fontSize: "16.0sp",
+            foregroundColor: "#FFFFFFFF",
+            backgroundColor: "#FF0E639C",
+            localeTag: "en-US",
+            truncated: false,
+            didOverflowWidth: false,
+            didOverflowHeight: false,
+        },
+        {
+            nodeId: "footer-text",
+            boundsInScreen: rectBounds(FOOTER),
+            text: "By continuing you agree to our terms and conditions of service",
+            semanticsText:
+                "By continuing you agree to our terms and conditions of service",
+            fontSize: "12.0sp",
+            foregroundColor: "#FFC8C8C8",
+            backgroundColor: "#FFF5F6FA",
+            localeTag: "en-US",
+            truncated: true,
+            didOverflowWidth: true,
+            didOverflowHeight: false,
+            overflow: "ellipsis",
+        },
+    ],
+};
+
+// `fonts/used` — three resolved families.
+const fontsUsed = {
+    fonts: [
+        {
+            requestedFamily: "Inter",
+            resolvedFamily: "Inter",
+            weight: 400,
+            style: "normal",
+            sourceFile: "fonts/Inter-Regular.ttf",
+            consumerNodeIds: ["header-text", "primary-cta-text"],
+        },
+        {
+            requestedFamily: "Inter",
+            resolvedFamily: "Inter",
+            weight: 600,
+            style: "normal",
+            sourceFile: "fonts/Inter-SemiBold.ttf",
+            consumerNodeIds: ["header-text"],
+        },
+        {
+            requestedFamily: "SystemFallback",
+            resolvedFamily: "Roboto",
+            fellBackFrom: ["MissingFont"],
+            weight: 400,
+            style: "normal",
+            consumerNodeIds: ["footer-text"],
+        },
+    ],
+};
+
+// `i18n/translations` — one entry per node so the configure
+// expander has translations to render once the user opts in.
+const i18nTranslations = {
+    translations: [
+        {
+            nodeId: "header-text",
+            key: "onboarding.title",
+            sourceLocale: "en-US",
+            translations: {
+                "en-US": "Welcome to Compose AI Tools",
+                "es-ES": "Bienvenido a Compose AI Tools",
+                "ja-JP": "Compose AI Tools へようこそ",
+            },
+        },
+        {
+            nodeId: "primary-cta-text",
+            key: "onboarding.cta.primary",
+            sourceLocale: "en-US",
+            translations: {
+                "en-US": "Get started",
+                "es-ES": "Empezar",
+                "ja-JP": "始める",
+            },
+        },
+    ],
+};
+
+const setPreviews = {
+    command: "setPreviews",
+    moduleDir: "/workspace/sample-android",
+    heavyStaleIds: [],
+    previews: [focused, sibling],
+};
+
+const updateImage = {
+    command: "updateImage",
+    previewId: focusId,
+    captureIndex: 0,
+    imageData: png,
+};
+
+const updateDataProducts = {
+    command: "updateDataProducts",
+    previewId: focusId,
+    dataProducts: [
+        { kind: "text/strings", payload: textStrings },
+        { kind: "fonts/used", payload: fontsUsed },
+        { kind: "i18n/translations", payload: i18nTranslations },
+    ],
+};
+
+const fixture = {
+    name: "text-strings",
+    description:
+        "Focused card with realistic text/strings + fonts/used + i18n/translations payloads. Activates the Text / i18n bundle so the overflow/truncation overlay paints over the footer, the side legend lists each drawn-text entry, and the tab body renders the strings + fonts sub-tables.",
+    dataset: EARLY_FEATURES_DATASET,
+    messages: [setPreviews, updateImage, updateDataProducts],
+    actions: [focusAction(focusId), activateBundleAction("text")],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/text-strings.json
+++ b/vscode-extension/preview-harness/fixtures/text-strings.json
@@ -1,0 +1,208 @@
+{
+  "name": "text-strings",
+  "description": "Focused card with realistic text/strings + fonts/used + i18n/translations payloads. Activates the Text / i18n bundle so the overflow/truncation overlay paints over the footer, the side legend lists each drawn-text entry, and the tab body renders the strings + fonts sub-tables.",
+  "dataset": {
+    "earlyFeatures": "true",
+    "autoEnableCheap": "false",
+    "collapseVariants": "false",
+    "minimalMode": "false",
+    "autoInject": "true"
+  },
+  "messages": [
+    {
+      "command": "setPreviews",
+      "moduleDir": "/workspace/sample-android",
+      "heavyStaleIds": [],
+      "previews": [
+        {
+          "id": "com.example.OnboardingKt.WelcomeScreenPreview",
+          "functionName": "WelcomeScreenPreview",
+          "className": "OnboardingKt",
+          "sourceFile": "Onboarding.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.OnboardingKt.WelcomeScreenPreview.png",
+              "label": ""
+            }
+          ]
+        },
+        {
+          "id": "com.example.OnboardingKt.WelcomeScreenPreviewSibling",
+          "functionName": "WelcomeScreenPreviewSibling",
+          "className": "OnboardingKt",
+          "sourceFile": "Onboarding.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.OnboardingKt.WelcomeScreenPreviewSibling.png",
+              "label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "command": "updateImage",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "captureIndex": 0,
+      "imageData": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC"
+    },
+    {
+      "command": "updateDataProducts",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "dataProducts": [
+        {
+          "kind": "text/strings",
+          "payload": {
+            "texts": [
+              {
+                "nodeId": "header-text",
+                "boundsInScreen": "0,0,360,80",
+                "text": "Welcome to Compose AI Tools",
+                "semanticsText": "Welcome to Compose AI Tools",
+                "fontSize": "22.0sp",
+                "foregroundColor": "#FFFFFFFF",
+                "backgroundColor": "#FF3C5AA8",
+                "localeTag": "en-US",
+                "truncated": false,
+                "didOverflowWidth": false,
+                "didOverflowHeight": false
+              },
+              {
+                "nodeId": "primary-cta-text",
+                "boundsInScreen": "40,240,160,296",
+                "text": "Get started",
+                "semanticsText": "Get started",
+                "fontSize": "16.0sp",
+                "foregroundColor": "#FFFFFFFF",
+                "backgroundColor": "#FF0E639C",
+                "localeTag": "en-US",
+                "truncated": false,
+                "didOverflowWidth": false,
+                "didOverflowHeight": false
+              },
+              {
+                "nodeId": "footer-text",
+                "boundsInScreen": "0,520,360,600",
+                "text": "By continuing you agree to our terms and conditions of service",
+                "semanticsText": "By continuing you agree to our terms and conditions of service",
+                "fontSize": "12.0sp",
+                "foregroundColor": "#FFC8C8C8",
+                "backgroundColor": "#FFF5F6FA",
+                "localeTag": "en-US",
+                "truncated": true,
+                "didOverflowWidth": true,
+                "didOverflowHeight": false,
+                "overflow": "ellipsis"
+              }
+            ]
+          }
+        },
+        {
+          "kind": "fonts/used",
+          "payload": {
+            "fonts": [
+              {
+                "requestedFamily": "Inter",
+                "resolvedFamily": "Inter",
+                "weight": 400,
+                "style": "normal",
+                "sourceFile": "fonts/Inter-Regular.ttf",
+                "consumerNodeIds": [
+                  "header-text",
+                  "primary-cta-text"
+                ]
+              },
+              {
+                "requestedFamily": "Inter",
+                "resolvedFamily": "Inter",
+                "weight": 600,
+                "style": "normal",
+                "sourceFile": "fonts/Inter-SemiBold.ttf",
+                "consumerNodeIds": [
+                  "header-text"
+                ]
+              },
+              {
+                "requestedFamily": "SystemFallback",
+                "resolvedFamily": "Roboto",
+                "fellBackFrom": [
+                  "MissingFont"
+                ],
+                "weight": 400,
+                "style": "normal",
+                "consumerNodeIds": [
+                  "footer-text"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "kind": "i18n/translations",
+          "payload": {
+            "translations": [
+              {
+                "nodeId": "header-text",
+                "key": "onboarding.title",
+                "sourceLocale": "en-US",
+                "translations": {
+                  "en-US": "Welcome to Compose AI Tools",
+                  "es-ES": "Bienvenido a Compose AI Tools",
+                  "ja-JP": "Compose AI Tools へようこそ"
+                }
+              },
+              {
+                "nodeId": "primary-cta-text",
+                "key": "onboarding.cta.primary",
+                "sourceLocale": "en-US",
+                "translations": {
+                  "en-US": "Get started",
+                  "es-ES": "Empezar",
+                  "ja-JP": "始める"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "click": ".preview-card[data-preview-id=\"com.example.OnboardingKt.WelcomeScreenPreview\"] .card-focus-btn"
+    },
+    {
+      "click": "bundle-chip-bar button[data-bundle=\"text\"]"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-on to #1142: now that Inspection / Text / History adopted the `<bundle-legend>` primitive, each gets its own preview-harness fixture so the wiring is verifiable from a snapshot the same way `a11y-findings` is.

Three new fixtures, each carrying realistic payloads that mirror the wire models in `data/<bundle>/core/.../*Models.kt`:

- **`inspection-tree`** — `compose/semantics` + `layout/inspector` over a 360×600 mock. Legend shows 5 entries (Container / Header / Get started / Button / Text) with role · testTag subtitles; semantics tree-table populated.
- **`text-strings`** — `text/strings` + `fonts/used` + `i18n/translations`. Legend shows three drawn-text entries (footer carries the `truncated · overflow-w` subtitle); body renders Drawn text + Fonts sub-tables.
- **`history-diff`** — `history/diff/regions` with three changed regions. Legend shows `Δ avg · pixel-count` per region; body renders the baseline header + diff regions table.

Each fixture's overlay paints over the focused card's mock-mobile regions (header / two buttons / footer) so the swatch ↔ overlay-box correlation is visible.

## Refactor

The PNG generator + 360×600 mobile-mock builder + focused-preview-pair scaffolding moved to `preview-harness/fixtures/_utils.mjs` so the three new fixtures stay ~150 lines each. The existing `a11y-findings.gen.mjs` is left untouched on purpose to keep this PR's review surface focused on the new fixtures — a separate cleanup can migrate it onto `_utils.mjs` later.

## Test plan

- [x] `node preview-harness/fixtures/<name>.gen.mjs > preview-harness/fixtures/<name>.json` for each
- [x] `npm run harness:snapshot -- --fixture inspection-tree | text-strings | history-diff` — all six PNGs render with the legend column populated and the bundle tab body visible
- [x] `npm test` — 974 passing, no regressions
- [x] `npm run format:check` clean

Snapshots attached below for each bundle.

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_