### PR TITLE
feat(mcp): expose RenderSession view on SupervisedDaemon

### DIFF
--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -48,6 +48,10 @@ dependencies {
   // For DaemonClasspathDescriptor (read at supervisor spawn time) and the protocol message types
   // exchanged with daemon JVMs.
   implementation(project(":daemon:core"))
+  // Public render-session API. `SupervisedDaemon` exposes a `RenderSession` view of its private
+  // `DaemonClient` so callers that prefer the published library surface have a path. The
+  // implementation stays internal to `:mcp` for now — the supervisor owns subprocess lifecycle.
+  implementation(project(":render-session-api"))
 
   testImplementation(libs.junit)
   testImplementation(libs.truth)

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClientRenderSession.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClientRenderSession.kt
@@ -1,0 +1,214 @@
+package ee.schimke.composeai.mcp
+
+import ee.schimke.composeai.daemon.protocol.ChangeType
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
+import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
+import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
+import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingStartResult
+import ee.schimke.composeai.daemon.protocol.RecordingStopResult
+import ee.schimke.composeai.daemon.protocol.RenderNowResult
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.render.session.DataProductException
+import ee.schimke.composeai.render.session.NotificationListener
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.RenderSessionBackend
+import java.util.concurrent.CopyOnWriteArraySet
+import kotlin.time.Duration
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Internal view that adapts a [DaemonClient] to the public [RenderSession] surface. Lifecycle is
+ * owned by the supervising [SupervisedDaemon] — calling [close] on this view does *not* shut the
+ * daemon down (other callers may be sharing it). The supervisor's `shutdown`/`detachSpawn` is the
+ * single seam that tears down the underlying subprocess.
+ *
+ * This is the "surface-only migration" half of the render-session library work: the MCP server
+ * keeps using [DaemonClient] directly for its own lifecycle plumbing (replicas, classpath dirty
+ * respawn, per-preview routing), but consumers that prefer the published library can ask the
+ * supervisor for [SupervisedDaemon.session] and drive the daemon through the same [RenderSession]
+ * contract `:render-session-subprocess` and `:render-session-embedded-desktop` expose.
+ *
+ * Notification fan-out: [onNotification] registrations are aggregated locally and replayed from
+ * whatever sink the supervisor's existing `onNotification` callback routes through. New listeners
+ * see notifications fired *after* registration; missed events from before are not replayed.
+ */
+internal class DaemonClientRenderSession(
+  override val workspaceRoot: String,
+  override val modulePath: String,
+  override val initializeResult: InitializeResult,
+  private val client: DaemonClient,
+  private val notificationFanout: NotificationFanout,
+) : RenderSession {
+
+  override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+  override fun setVisible(previewIds: List<String>) = client.setVisible(previewIds)
+
+  override fun setFocus(previewIds: List<String>) = client.setFocus(previewIds)
+
+  override fun fileChanged(path: String, kind: FileKind, changeType: ChangeType) =
+    client.fileChanged(path, kind, changeType)
+
+  override fun renderNow(
+    previewIds: List<String>,
+    tier: RenderTier,
+    reason: String?,
+    overrides: PreviewOverrides?,
+    timeout: Duration,
+  ): RenderNowResult =
+    client.renderNow(
+      previews = previewIds,
+      tier = tier,
+      reason = reason,
+      overrides = overrides,
+      timeout = timeout,
+    )
+
+  override fun fetchData(
+    previewId: String,
+    kind: String,
+    inline: Boolean,
+    params: JsonElement?,
+    timeout: Duration,
+  ): DataFetchResult =
+    try {
+      client.dataFetch(
+        previewId = previewId,
+        kind = kind,
+        params = params,
+        inline = inline,
+        timeout = timeout,
+      )
+    } catch (e: DataProductWireException) {
+      throw DataProductException(
+        code = e.code,
+        wireMessage = e.wireMessage,
+        data = e.data,
+        cause = e,
+      )
+    }
+
+  override fun subscribeData(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    timeout: Duration,
+  ): DataSubscribeResult =
+    client.dataSubscribe(previewId = previewId, kind = kind, timeout = timeout)
+
+  override fun unsubscribeData(
+    previewId: String,
+    kind: String,
+    timeout: Duration,
+  ): DataSubscribeResult =
+    client.dataUnsubscribe(previewId = previewId, kind = kind, timeout = timeout)
+
+  override fun listExtensions(timeout: Duration): ExtensionsListResult =
+    client.extensionsList(timeout)
+
+  override fun enableExtensions(ids: List<String>, timeout: Duration): ExtensionsEnableResult =
+    client.extensionsEnable(ids = ids, timeout = timeout)
+
+  override fun disableExtensions(ids: List<String>, timeout: Duration): ExtensionsDisableResult =
+    client.extensionsDisable(ids = ids, timeout = timeout)
+
+  override fun historyList(params: HistoryListParams, timeout: Duration): HistoryListResult =
+    client.historyList(params = params, timeout = timeout)
+
+  override fun historyRead(
+    entryId: String,
+    inline: Boolean,
+    timeout: Duration,
+  ): HistoryReadResultDto =
+    client.historyRead(entryId = entryId, inline = inline, timeout = timeout)
+
+  override fun historyDiff(
+    fromId: String,
+    toId: String,
+    mode: HistoryDiffMode,
+    timeout: Duration,
+  ): HistoryDiffResult =
+    client.historyDiff(fromId = fromId, toId = toId, mode = mode, timeout = timeout)
+
+  override fun recordingStart(
+    previewId: String,
+    fps: Int?,
+    scale: Float?,
+    overrides: PreviewOverrides?,
+    timeout: Duration,
+  ): RecordingStartResult =
+    client.recordingStart(
+      previewId = previewId,
+      fps = fps,
+      scale = scale,
+      overrides = overrides,
+      timeout = timeout,
+    )
+
+  override fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) =
+    client.recordingScript(recordingId, events)
+
+  override fun recordingStop(recordingId: String, timeout: Duration): RecordingStopResult =
+    client.recordingStop(recordingId = recordingId, timeout = timeout)
+
+  override fun recordingEncode(
+    recordingId: String,
+    format: RecordingFormat,
+    timeout: Duration,
+  ): RecordingEncodeResult =
+    client.recordingEncode(recordingId = recordingId, format = format, timeout = timeout)
+
+  override fun onNotification(listener: NotificationListener): AutoCloseable =
+    notificationFanout.register(listener)
+
+  /**
+   * No-op. The supervisor owns the underlying daemon's lifecycle — closing this view doesn't shut
+   * the daemon down because other callers may be sharing the same client. Use
+   * [DaemonSupervisor.shutdown] (or let the supervised daemon's `classpathDirty` respawn happen)
+   * when you actually want the JVM to go away.
+   */
+  override fun close() {
+    // intentional no-op — see KDoc.
+  }
+}
+
+/**
+ * Fan-out registry for the supervisor's notification stream. [SupervisedDaemon] installs a single
+ * sink on the underlying [DaemonClient]'s `onNotification` callback at spawn time and pipes every
+ * event into [dispatch]; [DaemonClientRenderSession.onNotification] uses [register] to add a
+ * listener that sees subsequent events.
+ *
+ * Lifetime is the supervised daemon's: cleared by [DaemonSupervisor.shutdown] /
+ * [SupervisedDaemon.detachSpawn]. Listeners that hold onto the [AutoCloseable] handle after
+ * shutdown observe no further events; calling `close()` on a stale handle is harmless.
+ */
+internal class NotificationFanout {
+  private val listeners = CopyOnWriteArraySet<NotificationListener>()
+
+  fun register(listener: NotificationListener): AutoCloseable {
+    listeners.add(listener)
+    return AutoCloseable { listeners.remove(listener) }
+  }
+
+  fun dispatch(method: String, params: JsonObject?) {
+    for (l in listeners) runCatching { l.onNotification(method, params) }
+  }
+
+  fun clear() {
+    listeners.clear()
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -215,6 +215,10 @@ class DaemonSupervisor(
       },
     )
     supervised.attachSpawn(spawn)
+    // Capture the workspace root before initialize so the `session` view's
+    // `RenderSession.workspaceRoot` returns a real absolute path even if a caller reaches the
+    // session getter before the runCatching block below populates `initializeResult`.
+    supervised.workspaceRootPath = project.path.absolutePath
     runCatching {
         val result =
           spawn.client.initialize(
@@ -459,6 +463,14 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
   internal var initializeResult: ee.schimke.composeai.daemon.protocol.InitializeResult? = null
 
   /**
+   * Canonical workspace-root path the supervised daemon was spawned against — backing for the
+   * [session] view's [ee.schimke.composeai.render.session.RenderSession.workspaceRoot]. Captured
+   * from the [RegisteredProject.path] at spawn time so the public API returns a real absolute path
+   * instead of a placeholder. Cleared by [detachSpawn] when the spawn tears down.
+   */
+  @Volatile internal var workspaceRootPath: String? = null
+
+  /**
    * Notification fan-out installed by [DaemonSupervisor.spawn]. The supervisor's existing
    * `onNotification` callback dispatches both into its own [NotificationRouter] and into this
    * fanout; [session] consumers can register listeners via
@@ -491,13 +503,13 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
           ?: error(
             "SupervisedDaemon($workspaceId/$modulePath): initialize handshake hasn't completed"
           )
-      // `workspaceRoot` is reconstructible from the descriptor's working directory the supervisor
-      // owns; the supervisor itself doesn't store the canonical root on the daemon. The session
-      // view reports the workspace from the initialize round-trip's reflected fields instead —
-      // good enough for diagnostics and matches what `:render-session-subprocess` returns.
-      val workspaceRoot = ""
+      val root =
+        workspaceRootPath
+          ?: error(
+            "SupervisedDaemon($workspaceId/$modulePath): workspaceRootPath not captured at spawn"
+          )
       return DaemonClientRenderSession(
-        workspaceRoot = workspaceRoot,
+        workspaceRoot = root,
         modulePath = modulePath,
         initializeResult = init,
         client = s.client,
@@ -544,6 +556,7 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
     if (this.spawn !== s) return false
     this.spawn = null
     this.initializeResult = null
+    this.workspaceRootPath = null
     notificationFanout.clear()
     return true
   }
@@ -552,6 +565,7 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
     val s = spawn ?: return
     spawn = null
     initializeResult = null
+    workspaceRootPath = null
     notificationFanout.clear()
     runCatching { s.shutdown() }
   }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -201,7 +201,13 @@ class DaemonSupervisor(
     // (1 + replicasPerDaemon) × per-sandbox-boot.
     val spawn = clientFactory.spawn(project, descriptor)
     spawn.client(
-      onNotification = { method, params -> router.dispatch(supervised, method, params) },
+      onNotification = { method, params ->
+        router.dispatch(supervised, method, params)
+        // Fan out to any RenderSession listeners registered via `supervised.session
+        // .onNotification(...)`. Mirrors the router dispatch but reaches a different
+        // subscriber pool (the public-API consumers, not the MCP-internal routing).
+        supervised.notificationFanout.dispatch(method, params)
+      },
       onClose = {
         if (supervised.detachSpawn(spawn)) {
           router.dispatchClose(supervised)
@@ -217,6 +223,10 @@ class DaemonSupervisor(
             moduleProjectDir = descriptor.workingDirectory,
             attachDataProducts = globalAttachDataProducts.takeIf { it.isNotEmpty() },
           )
+        // Cache the full result so the public RenderSession view (`supervised.session`) can
+        // expose it through `RenderSession.initializeResult`. Subsequent successful re-spawns
+        // (classpathDirty respawn path) overwrite this with the fresh handshake's result.
+        supervised.initializeResult = result
         // PROTOCOL.md § 3a — the daemon comes up with every extension inactive so
         // `initialize.capabilities.dataProducts` / `dataExtensions` / `previewExtensions` are
         // empty.
@@ -440,6 +450,62 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
     }
 
   /**
+   * Cached `initialize` round-trip result — backing for the [session] view's
+   * [RenderSession.initializeResult]. Populated by [DaemonSupervisor.spawn] right after the
+   * handshake; cleared by [detachSpawn]. `@Volatile` for the same reasons [spawn] is — read on the
+   * caller thread, written on the spawn coroutine.
+   */
+  @Volatile
+  internal var initializeResult: ee.schimke.composeai.daemon.protocol.InitializeResult? = null
+
+  /**
+   * Notification fan-out installed by [DaemonSupervisor.spawn]. The supervisor's existing
+   * `onNotification` callback dispatches both into its own [NotificationRouter] and into this
+   * fanout; [session] consumers can register listeners via
+   * [ee.schimke.composeai.render.session.RenderSession.onNotification] without disturbing the
+   * router's own subscriber set.
+   */
+  internal val notificationFanout: NotificationFanout = NotificationFanout()
+
+  /**
+   * Public [RenderSession] view of this supervised daemon. Surface-only migration of `:mcp` onto
+   * the published render-session library — third-party consumers that compile against
+   * `:render-session-api` can drive the daemon through the same contract `:render-session-
+   * subprocess` and `:render-session-embedded-desktop` expose, without seeing the internal
+   * [DaemonClient].
+   *
+   * Lifecycle is owned by the supervisor: `close()` on the returned session is a no-op (other
+   * callers may be sharing the same client). The supervisor's [shutdown] / [detachSpawn] is the
+   * single seam that tears down the daemon JVM.
+   *
+   * Each access returns a fresh view object — the underlying state ([client], [initializeResult],
+   * [notificationFanout]) is shared. Throws if the spawn / initialize handshake hasn't completed
+   * yet (same precondition as [client]).
+   */
+  val session: ee.schimke.composeai.render.session.RenderSession
+    get() {
+      val s = spawn
+      check(s != null) { "SupervisedDaemon($workspaceId/$modulePath): no spawn attached yet" }
+      val init =
+        initializeResult
+          ?: error(
+            "SupervisedDaemon($workspaceId/$modulePath): initialize handshake hasn't completed"
+          )
+      // `workspaceRoot` is reconstructible from the descriptor's working directory the supervisor
+      // owns; the supervisor itself doesn't store the canonical root on the daemon. The session
+      // view reports the workspace from the initialize round-trip's reflected fields instead —
+      // good enough for diagnostics and matches what `:render-session-subprocess` returns.
+      val workspaceRoot = ""
+      return DaemonClientRenderSession(
+        workspaceRoot = workspaceRoot,
+        modulePath = modulePath,
+        initializeResult = init,
+        client = s.client,
+        notificationFanout = notificationFanout,
+      )
+    }
+
+  /**
    * Snapshot of every active client — for fan-out APIs (e.g. `fileChanged`, `setVisible`). Always a
    * singleton list under Layer 3; kept as a list for source-compatibility with callers that iterate
    * it (they keep working unchanged).
@@ -477,12 +543,16 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
   internal fun detachSpawn(s: DaemonSpawn): Boolean {
     if (this.spawn !== s) return false
     this.spawn = null
+    this.initializeResult = null
+    notificationFanout.clear()
     return true
   }
 
   fun shutdown() {
     val s = spawn ?: return
     spawn = null
+    initializeResult = null
+    notificationFanout.clear()
     runCatching { s.shutdown() }
   }
 }


### PR DESCRIPTION
## Summary

Adds a `session: RenderSession` getter on `SupervisedDaemon` that adapts its existing `DaemonClient` to the public render-session library contract. **Surface-only migration**: `:mcp` keeps using `DaemonClient` directly for the lifecycle plumbing it owns (replicas, classpath dirty respawn, per-preview routing), but consumers that prefer the published library can drive the same daemon through the contract that `:render-session-subprocess` and `:render-session-embedded-desktop` expose.

```kotlin
val supervised = supervisor.daemonFor(project, modulePath)
supervised.session.use { session ->
  session.renderNow(listOf("MyPreview"))
  val findings = session.fetchData("MyPreview", "a11y/atf", inline = true)
  // …
}
// `close()` is a no-op — supervisor owns the daemon's lifecycle.
```

## What changed

- **New internal `DaemonClientRenderSession`** (in `:mcp`) wraps a `DaemonClient` and delegates every `RenderSession` method to it. `close()` is a no-op — the supervisor owns lifecycle. Same delegate pattern as `SubprocessRenderSession` / `EmbeddedDesktopRenderSession`; duplicated rather than factored out because lifting `DaemonClient` out of `:mcp` is a bigger refactor with no behaviour win.

- **`SupervisedDaemon`** gains:
  - `internal var initializeResult: InitializeResult?` populated by `DaemonSupervisor.spawn` right after the handshake, cleared on detach/shutdown — backing for the session's `initializeResult` field.
  - `internal val notificationFanout` — CopyOnWriteArraySet-backed registry the spawn callback dispatches into alongside the existing `NotificationRouter`. `RenderSession` consumers register via `session.onNotification(...)` without touching the router's subscriber set.
  - `val session: RenderSession` getter — fresh view per access; shared underlying state.

## What did NOT change

- `DaemonMcpServer` and the supervisor's own call sites keep using `client: DaemonClient` directly. Behaviour identical, zero risk to the VS Code path.
- No new public types in `:render-session-api` / `:render-session-*`.
- `DaemonClient` stays internal to `:mcp`. Lifting it out would let the embedded/subprocess backends share the same delegate, but that's a bigger refactor for the same behaviour.

## Test plan

- [x] `:mcp:test` — passes everything except `DaemonMcpServerTest.initialize and tools list returns expected tool surface`, which **fails on `main` too** (pre-existing expected-list drift around the `enable_extensions` tool — unrelated to this change). Confirmed by running on a clean `git stash`'d tree.
- [x] `:render-session-{api,subprocess,embedded-desktop}:test` + `:cli:test` all pass.
- [x] `ktfmtCheckAll` clean.

## Out of scope

- Migrating `DaemonMcpServer`'s ~25 `client.foo()` call sites to `session.foo()`. Same behaviour, but a meaningful diff with real risk to the VS Code path; not worth doing without a concrete consumer asking for it.
- Lifting `DaemonClient` out of `:mcp`. Would let `SubprocessRenderSession` and `EmbeddedDesktopRenderSession` share the delegate logic with `DaemonClientRenderSession`. Tracked as a future cleanup; not blocked by anything.

---
_Generated by [Claude Code](https://claude.ai/code/session_0178MWQ319fGv7JWjSwpsvSU)_