### PR TITLE
feat(vscode-extension): row-click detail for Text and Inspection bundles

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -544,6 +544,22 @@ body {
  * mouse over other rows). Inset-left bar gives a clear "this row is
  * selected" anchor that survives across light / dark themes; the
  * background tint is a secondary cue. */
+/* Pinned-row visual state for the bespoke inspection tree-table.
+ * Lives alongside the `<data-table>` selection CSS (`.data-table-
+ * row-selected`) so both surfaces look consistent — the tree-table
+ * doesn't dispatch `row-clicked`, but the bundle host applies this
+ * class via a delegated click handler. */
+.inspection-tree-row-selected td {
+    background: var(
+        --vscode-list-activeSelectionBackground,
+        rgba(80, 130, 200, 0.18)
+    );
+    color: var(--vscode-list-activeSelectionForeground, currentColor);
+}
+.inspection-tree-row-selected td:first-child {
+    box-shadow: inset 3px 0 0 var(--vscode-focusBorder, #4d9fec);
+}
+
 .data-table-row-selected td {
     background: var(
         --vscode-list-activeSelectionBackground,

--- a/vscode-extension/preview-harness/fixtures/inspection-tree.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/inspection-tree.gen.mjs
@@ -160,6 +160,13 @@ const fixture = {
     actions: [
         focusAction(focusId),
         activateBundleAction("inspection"),
+        // Click the primary-CTA row in the semantics tree-table so
+        // the snapshot exercises the bespoke delegated click handler
+        // wired in `inspectionBody()`. Row ids are namespaced by
+        // kind (`nsId("semantics", node.nodeId)`).
+        {
+            click: `[data-bundle="inspection"] tr[data-legend-id="semantics-primary-cta"]`,
+        },
     ],
 };
 

--- a/vscode-extension/preview-harness/fixtures/inspection-tree.json
+++ b/vscode-extension/preview-harness/fixtures/inspection-tree.json
@@ -198,6 +198,9 @@
     },
     {
       "click": "bundle-chip-bar button[data-bundle=\"inspection\"]"
+    },
+    {
+      "click": "[data-bundle=\"inspection\"] tr[data-legend-id=\"semantics-primary-cta\"]"
     }
   ]
 }

--- a/vscode-extension/preview-harness/fixtures/text-strings.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/text-strings.gen.mjs
@@ -168,7 +168,17 @@ const fixture = {
         "Focused card with realistic text/strings + fonts/used + i18n/translations payloads. Activates the Text / i18n bundle so the overflow/truncation overlay paints over the footer, the side legend lists each drawn-text entry, and the tab body renders the strings + fonts sub-tables.",
     dataset: EARLY_FEATURES_DATASET,
     messages: [setPreviews, updateImage, updateDataProducts],
-    actions: [focusAction(focusId), activateBundleAction("text")],
+    actions: [
+        focusAction(focusId),
+        activateBundleAction("text"),
+        // Click the footer drawn-text row (the truncated / overflow
+        // one) so the snapshot exercises the row → detail panel
+        // wiring. Row ids are positional in the presenter
+        // (`text-string-${idx}`); footer is the third entry.
+        {
+            click: `[data-bundle="text"] tr[data-legend-id="text-string-2"]`,
+        },
+    ],
 };
 
 process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/text-strings.json
+++ b/vscode-extension/preview-harness/fixtures/text-strings.json
@@ -203,6 +203,9 @@
     },
     {
       "click": "bundle-chip-bar button[data-bundle=\"text\"]"
+    },
+    {
+      "click": "[data-bundle=\"text\"] tr[data-legend-id=\"text-string-2\"]"
     }
   ]
 }

--- a/vscode-extension/src/test/inspectionRowDetail.test.ts
+++ b/vscode-extension/src/test/inspectionRowDetail.test.ts
@@ -1,0 +1,269 @@
+// Tests for `buildInspectionRowDetail`. Three kinds of records
+// (compose/semantics, layout/inspector, uia/hierarchy) each have
+// their own per-kind builder; the dispatcher just switches on
+// `record.kind`.
+
+import * as assert from "assert";
+import {
+    buildInspectionRowDetail,
+    inspectionRowTitle,
+} from "../webview/preview/inspectionRowDetail";
+import type {
+    ComposeSemanticsNode,
+    LayoutInspectorNode,
+    UiaHierarchyNode,
+} from "../webview/preview/inspectionPresenters";
+
+function semanticsNode(
+    over: Partial<ComposeSemanticsNode>,
+): ComposeSemanticsNode {
+    return {
+        nodeId: over.nodeId ?? "sn-1",
+        boundsInRoot: over.boundsInRoot ?? "0,0,10,10",
+        label: over.label ?? null,
+        text: over.text ?? null,
+        role: over.role ?? null,
+        testTag: over.testTag ?? null,
+        mergeMode: over.mergeMode ?? null,
+        clickable: over.clickable,
+        children: over.children,
+    };
+}
+
+function layoutNode(over: Partial<LayoutInspectorNode>): LayoutInspectorNode {
+    return {
+        nodeId: over.nodeId ?? "ln-1",
+        component: over.component ?? "Box",
+        source: over.source ?? null,
+        sourceInfo: over.sourceInfo ?? null,
+        bounds: over.bounds ?? { left: 0, top: 0, right: 100, bottom: 40 },
+        size: over.size,
+        constraints: over.constraints,
+        modifiers: over.modifiers,
+        children: over.children,
+    };
+}
+
+function uiaNode(over: Partial<UiaHierarchyNode>): UiaHierarchyNode {
+    return {
+        text: over.text ?? null,
+        contentDescription: over.contentDescription ?? null,
+        testTag: over.testTag ?? null,
+        testTagAncestors: over.testTagAncestors,
+        role: over.role ?? null,
+        actions: over.actions,
+        boundsInScreen: over.boundsInScreen ?? "0,0,10,10",
+        merged: over.merged,
+    };
+}
+
+describe("buildInspectionRowDetail — compose/semantics", () => {
+    it("emits an Identity section with node id + bounds", () => {
+        const sections = buildInspectionRowDetail({
+            kind: "compose/semantics",
+            node: semanticsNode({}),
+        });
+        const id = sections.find((s) => s.heading === "Identity");
+        assert.ok(id);
+        const labels = id!.entries.map((e) => e.label);
+        assert.ok(labels.includes("Node id"));
+        assert.ok(labels.includes("Bounds"));
+    });
+
+    it("includes role / test tag / merge mode when present", () => {
+        const sections = buildInspectionRowDetail({
+            kind: "compose/semantics",
+            node: semanticsNode({
+                role: "Button",
+                testTag: "primary_cta",
+                mergeMode: "Merged",
+            }),
+        });
+        const labels = sections
+            .find((s) => s.heading === "Identity")!
+            .entries.map((e) => e.label);
+        assert.ok(labels.includes("Role"));
+        assert.ok(labels.includes("Test tag"));
+        assert.ok(labels.includes("Merge mode"));
+    });
+
+    it("skips Semantics text and Flags sections when nothing applies", () => {
+        const sections = buildInspectionRowDetail({
+            kind: "compose/semantics",
+            node: semanticsNode({}),
+        });
+        assert.strictEqual(
+            sections.find((s) => s.heading === "Semantics text"),
+            undefined,
+        );
+        assert.strictEqual(
+            sections.find((s) => s.heading === "Flags"),
+            undefined,
+        );
+    });
+
+    it("emits Flags when clickable is true", () => {
+        const sections = buildInspectionRowDetail({
+            kind: "compose/semantics",
+            node: semanticsNode({ clickable: true }),
+        });
+        const flags = sections.find((s) => s.heading === "Flags");
+        assert.ok(flags);
+        assert.strictEqual(flags!.entries[0].label, "Clickable");
+    });
+});
+
+describe("buildInspectionRowDetail — layout/inspector", () => {
+    it("always emits an Identity section with component + node id", () => {
+        const sections = buildInspectionRowDetail({
+            kind: "layout/inspector",
+            node: layoutNode({ component: "Column" }),
+        });
+        const id = sections.find((s) => s.heading === "Identity")!;
+        const comp = id.entries.find((e) => e.label === "Component");
+        assert.strictEqual(comp?.value, "Column");
+    });
+
+    it("emits Bounds + Size + Constraints together in Layout", () => {
+        const sections = buildInspectionRowDetail({
+            kind: "layout/inspector",
+            node: layoutNode({
+                size: { width: 100, height: 40 },
+                constraints: {
+                    minWidth: 0,
+                    maxWidth: 200,
+                    minHeight: 0,
+                    maxHeight: null,
+                },
+            }),
+        });
+        const layout = sections.find((s) => s.heading === "Layout")!;
+        const labels = layout.entries.map((e) => e.label);
+        assert.ok(labels.includes("Bounds"));
+        assert.ok(labels.includes("Size"));
+        assert.ok(labels.includes("Constraints"));
+        const constraints = layout.entries.find(
+            (e) => e.label === "Constraints",
+        );
+        assert.ok(String(constraints!.value).includes("∞"));
+    });
+
+    it("emits one Modifiers entry per modifier when present", () => {
+        const sections = buildInspectionRowDetail({
+            kind: "layout/inspector",
+            node: layoutNode({
+                modifiers: [
+                    { name: "padding", value: "16dp" },
+                    { name: "fillMaxWidth" },
+                ],
+            }),
+        });
+        const mods = sections.find((s) => s.heading === "Modifiers")!;
+        assert.strictEqual(mods.entries.length, 2);
+        assert.strictEqual(mods.entries[1].value, "—");
+    });
+});
+
+describe("buildInspectionRowDetail — uia/hierarchy", () => {
+    it("emits Identity with bounds + role + test-tag ancestors when present", () => {
+        const sections = buildInspectionRowDetail({
+            kind: "uia/hierarchy",
+            node: uiaNode({
+                role: "Button",
+                testTag: "btn",
+                testTagAncestors: ["root", "screen"],
+            }),
+        });
+        const id = sections.find((s) => s.heading === "Identity")!;
+        const labels = id.entries.map((e) => e.label);
+        assert.ok(labels.includes("Role"));
+        assert.ok(labels.includes("Test tag"));
+        assert.ok(labels.includes("Tag ancestors"));
+    });
+
+    it("emits Content only when text or description is non-null", () => {
+        const empty = buildInspectionRowDetail({
+            kind: "uia/hierarchy",
+            node: uiaNode({}),
+        });
+        assert.strictEqual(
+            empty.find((s) => s.heading === "Content"),
+            undefined,
+        );
+        const filled = buildInspectionRowDetail({
+            kind: "uia/hierarchy",
+            node: uiaNode({ text: "Hello" }),
+        });
+        assert.ok(filled.find((s) => s.heading === "Content"));
+    });
+
+    it("emits Actions section when the node carries an actions list", () => {
+        const sections = buildInspectionRowDetail({
+            kind: "uia/hierarchy",
+            node: uiaNode({ actions: ["click", "long-click"] }),
+        });
+        const actions = sections.find((s) => s.heading === "Actions");
+        assert.ok(actions);
+        assert.ok(String(actions!.entries[0].value).includes("click"));
+    });
+});
+
+describe("inspectionRowTitle", () => {
+    it("falls back through label / text / testTag / nodeId for semantics", () => {
+        assert.strictEqual(
+            inspectionRowTitle({
+                kind: "compose/semantics",
+                node: semanticsNode({ label: "Done" }),
+            }),
+            "Done",
+        );
+        assert.strictEqual(
+            inspectionRowTitle({
+                kind: "compose/semantics",
+                node: semanticsNode({ text: "World" }),
+            }),
+            "World",
+        );
+        assert.strictEqual(
+            inspectionRowTitle({
+                kind: "compose/semantics",
+                node: semanticsNode({ nodeId: "only-this" }),
+            }),
+            "only-this",
+        );
+    });
+
+    it("uses component for layout rows and falls through to nodeId", () => {
+        assert.strictEqual(
+            inspectionRowTitle({
+                kind: "layout/inspector",
+                node: layoutNode({ component: "Surface" }),
+            }),
+            "Surface",
+        );
+    });
+
+    it("falls through text / description / testTag for uia rows", () => {
+        assert.strictEqual(
+            inspectionRowTitle({
+                kind: "uia/hierarchy",
+                node: uiaNode({ text: "Click me" }),
+            }),
+            "Click me",
+        );
+        assert.strictEqual(
+            inspectionRowTitle({
+                kind: "uia/hierarchy",
+                node: uiaNode({ contentDescription: "Add to cart" }),
+            }),
+            "Add to cart",
+        );
+        assert.strictEqual(
+            inspectionRowTitle({
+                kind: "uia/hierarchy",
+                node: uiaNode({}),
+            }),
+            "(uia node)",
+        );
+    });
+});

--- a/vscode-extension/src/test/textRowDetail.test.ts
+++ b/vscode-extension/src/test/textRowDetail.test.ts
@@ -1,0 +1,212 @@
+// Tests for the Text / i18n bundle row-detail helpers. Each helper
+// is a pure function on the row shape — no DOM needed — so the
+// assertions match against the produced `BundleRowDetailSection[]`
+// directly.
+
+import * as assert from "assert";
+import {
+    buildDrawnTextRowDetail,
+    buildFontRowDetail,
+    buildTranslationRowDetail,
+} from "../webview/preview/textRowDetail";
+import type {
+    DrawnTextRow,
+    FontRow,
+    TranslationRow,
+} from "../webview/preview/textBundlePresenter";
+
+function drawnText(over: Partial<DrawnTextRow>): DrawnTextRow {
+    return {
+        id: over.id ?? "text-0",
+        nodeId: over.nodeId ?? "node-1",
+        text: over.text ?? "Welcome",
+        localeTag: over.localeTag ?? "en-US",
+        fontScale: over.fontScale ?? 1,
+        fontSize: over.fontSize ?? "16.0sp",
+        foreground: over.foreground ?? "#FF111111",
+        background: over.background ?? "#FFFFFFFF",
+        overflow: over.overflow ?? null,
+        truncated: over.truncated ?? false,
+        didOverflowWidth: over.didOverflowWidth ?? false,
+        didOverflowHeight: over.didOverflowHeight ?? false,
+        boundsInScreen: over.boundsInScreen ?? "0,0,100,40",
+    };
+}
+
+function font(over: Partial<FontRow>): FontRow {
+    return {
+        id: over.id ?? "font-0",
+        requestedFamily: over.requestedFamily ?? "Inter",
+        resolvedFamily: over.resolvedFamily ?? "Inter",
+        weight: over.weight ?? 400,
+        style: over.style ?? "normal",
+        sourceFile: over.sourceFile ?? "fonts/Inter-Regular.ttf",
+        fellBackFromChain: over.fellBackFromChain ?? "",
+        consumerCount: over.consumerCount ?? 1,
+        isGoogleFont: over.isGoogleFont ?? false,
+    };
+}
+
+function translation(over: Partial<TranslationRow>): TranslationRow {
+    return {
+        id: over.id ?? "tx-0",
+        rendered: over.rendered ?? "Welcome",
+        resourceName: over.resourceName ?? "app_welcome",
+        sourceFile: over.sourceFile ?? "res/values/strings.xml",
+        supportedLocaleCount: over.supportedLocaleCount ?? 3,
+        untranslatedLocaleCount: over.untranslatedLocaleCount ?? 0,
+        untranslatedLocales: over.untranslatedLocales ?? [],
+        translatedLocales: over.translatedLocales ?? [
+            "en-US",
+            "es-ES",
+            "ja-JP",
+        ],
+    };
+}
+
+describe("buildDrawnTextRowDetail", () => {
+    it("always emits a Text section with the rendered string + node id + locale + bounds", () => {
+        const sections = buildDrawnTextRowDetail(
+            drawnText({ text: "Hi", nodeId: "n7", localeTag: "fr-FR" }),
+        );
+        const text = sections.find((s) => s.heading === "Text");
+        assert.ok(text);
+        const labels = text!.entries.map((e) => e.label);
+        assert.ok(labels.includes("Rendered"));
+        assert.ok(labels.includes("Node id"));
+        assert.ok(labels.includes("Locale"));
+        assert.ok(labels.includes("Bounds"));
+    });
+
+    it("emits a Style section only when at least one style field is non-default", () => {
+        const sections = buildDrawnTextRowDetail(
+            drawnText({ fontSize: "24.0sp", foreground: "#FF000000" }),
+        );
+        assert.ok(sections.find((s) => s.heading === "Style"));
+    });
+
+    it("omits the Layout section when no overflow / truncation flag is set", () => {
+        const sections = buildDrawnTextRowDetail(drawnText({}));
+        assert.strictEqual(
+            sections.find((s) => s.heading === "Layout"),
+            undefined,
+        );
+    });
+
+    it("emits a Layout section listing each tripped flag", () => {
+        const sections = buildDrawnTextRowDetail(
+            drawnText({
+                truncated: true,
+                didOverflowWidth: true,
+                overflow: "ellipsis",
+            }),
+        );
+        const layout = sections.find((s) => s.heading === "Layout");
+        assert.ok(layout);
+        const labels = layout!.entries.map((e) => e.label);
+        assert.ok(labels.includes("Truncated"));
+        assert.ok(labels.includes("Overflowed width"));
+        assert.ok(labels.includes("Overflow mode"));
+    });
+
+    it("includes Font scale only when it differs from 1.0×", () => {
+        const noScale = buildDrawnTextRowDetail(drawnText({ fontScale: 1 }));
+        assert.ok(
+            !noScale
+                .find((s) => s.heading === "Style")!
+                .entries.some((e) => e.label === "Font scale"),
+        );
+        const scaled = buildDrawnTextRowDetail(drawnText({ fontScale: 1.3 }));
+        assert.ok(
+            scaled
+                .find((s) => s.heading === "Style")!
+                .entries.some((e) => e.label === "Font scale"),
+        );
+    });
+});
+
+describe("buildFontRowDetail", () => {
+    it("emits Family / Variant / Source sections in that order", () => {
+        const sections = buildFontRowDetail(font({}));
+        const headings = sections.map((s) => s.heading);
+        assert.deepStrictEqual(headings, ["Family", "Variant", "Source"]);
+    });
+
+    it("adds a Fallback entry when the resolved family differs from the request", () => {
+        const sections = buildFontRowDetail(
+            font({
+                requestedFamily: "MissingFont",
+                resolvedFamily: "Roboto",
+                fellBackFromChain: "MissingFont → Roboto",
+            }),
+        );
+        const family = sections.find((s) => s.heading === "Family")!;
+        const fallback = family.entries.find((e) => e.label === "Fallback");
+        assert.ok(fallback);
+        assert.ok(String(fallback!.value).includes("MissingFont"));
+    });
+
+    it("pluralises the consumer count", () => {
+        const one = buildFontRowDetail(font({ consumerCount: 1 }));
+        const two = buildFontRowDetail(font({ consumerCount: 4 }));
+        const oneVal = one
+            .find((s) => s.heading === "Source")!
+            .entries.find((e) => e.label === "Used by")!.value;
+        const twoVal = two
+            .find((s) => s.heading === "Source")!
+            .entries.find((e) => e.label === "Used by")!.value;
+        assert.strictEqual(oneVal, "1 node");
+        assert.strictEqual(twoVal, "4 nodes");
+    });
+
+    it("flags Google Fonts membership", () => {
+        const sections = buildFontRowDetail(font({ isGoogleFont: true }));
+        const gf = sections
+            .find((s) => s.heading === "Source")!
+            .entries.find((e) => e.label === "Google Fonts");
+        assert.strictEqual(gf?.value, "yes");
+    });
+});
+
+describe("buildTranslationRowDetail", () => {
+    it("emits Entry / Locales sections in that order", () => {
+        const sections = buildTranslationRowDetail(translation({}));
+        const headings = sections.map((s) => s.heading);
+        assert.deepStrictEqual(headings, ["Entry", "Locales"]);
+    });
+
+    it("lists translated locales joined when present", () => {
+        const sections = buildTranslationRowDetail(
+            translation({
+                translatedLocales: ["en-US", "fr-FR"],
+            }),
+        );
+        const translated = sections
+            .find((s) => s.heading === "Locales")!
+            .entries.find((e) => e.label === "Translated");
+        assert.strictEqual(translated?.value, "en-US, fr-FR");
+    });
+
+    it("falls back to the untranslated count when the list is empty", () => {
+        const sections = buildTranslationRowDetail(
+            translation({
+                untranslatedLocaleCount: 5,
+                untranslatedLocales: [],
+            }),
+        );
+        const untranslated = sections
+            .find((s) => s.heading === "Locales")!
+            .entries.find((e) => e.label === "Untranslated");
+        assert.strictEqual(untranslated?.value, "5");
+    });
+
+    it("includes a Source file row when the payload supplies one", () => {
+        const sections = buildTranslationRowDetail(
+            translation({ sourceFile: "res/values/strings.xml" }),
+        );
+        const sourceFile = sections
+            .find((s) => s.heading === "Entry")!
+            .entries.find((e) => e.label === "Source file");
+        assert.ok(sourceFile);
+    });
+});

--- a/vscode-extension/src/webview/preview/inspectionPresenters.ts
+++ b/vscode-extension/src/webview/preview/inspectionPresenters.ts
@@ -38,7 +38,7 @@ import { parseBounds as parseCardBounds } from "./cardData";
 
 // ---- compose/semantics --------------------------------------------------
 
-interface ComposeSemanticsNode {
+export interface ComposeSemanticsNode {
     nodeId: string;
     boundsInRoot: string;
     label?: string | null;
@@ -123,7 +123,7 @@ interface LayoutInspectorModifier {
     properties?: Record<string, string>;
 }
 
-interface LayoutInspectorNode {
+export interface LayoutInspectorNode {
     nodeId: string;
     component: string;
     source?: string | null;
@@ -205,7 +205,7 @@ function layoutInspectorPresenter(
 
 // ---- uia/hierarchy ------------------------------------------------------
 
-interface UiaHierarchyNode {
+export interface UiaHierarchyNode {
     text?: string | null;
     contentDescription?: string | null;
     testTag?: string | null;
@@ -586,7 +586,26 @@ export interface InspectionBundleData {
      * is missing / malformed.
      */
     overlay: readonly OverlayBox[];
+    /**
+     * Lookup from the namespaced row id (same string used as
+     * `data-legend-id` on the tree-table row and as `data-overlay-id`
+     * on the matching overlay box) back to the originating per-kind
+     * node record. Used by the host's row-click handler to surface a
+     * detail panel via `buildInspectionRowDetail` without having to
+     * re-walk the per-kind payload trees.
+     */
+    nodeById: ReadonlyMap<string, InspectionNodeRecord>;
 }
+
+/**
+ * Discriminated record produced by each per-kind data builder so the
+ * detail panel can dispatch by `kind` without knowing the per-kind
+ * node shape.
+ */
+export type InspectionNodeRecord =
+    | { kind: "compose/semantics"; node: ComposeSemanticsNode }
+    | { kind: "layout/inspector"; node: LayoutInspectorNode }
+    | { kind: "uia/hierarchy"; node: UiaHierarchyNode };
 
 export type InspectionKind =
     | "compose/semantics"
@@ -618,31 +637,32 @@ export function computeInspectionBundleData(
         data: InspectionKindData;
     }> = [];
 
+    const nodeById = new Map<string, InspectionNodeRecord>();
     if (enabledKinds.has("compose/semantics")) {
         const payload = getPayload("compose/semantics") as
             | ComposeSemanticsPayload
             | undefined;
-        const data = computeComposeSemanticsBundleData(payload);
+        const data = computeComposeSemanticsBundleData(payload, nodeById);
         if (data) sections.push({ kind: "compose/semantics", data });
     }
     if (enabledKinds.has("layout/inspector")) {
         const payload = getPayload("layout/inspector") as
             | LayoutInspectorPayload
             | undefined;
-        const data = computeLayoutInspectorBundleData(payload);
+        const data = computeLayoutInspectorBundleData(payload, nodeById);
         if (data) sections.push({ kind: "layout/inspector", data });
     }
     if (enabledKinds.has("uia/hierarchy")) {
         const payload = getPayload("uia/hierarchy") as
             | UiaHierarchyPayload
             | undefined;
-        const data = computeUiaHierarchyBundleData(payload);
+        const data = computeUiaHierarchyBundleData(payload, nodeById);
         if (data) sections.push({ kind: "uia/hierarchy", data });
     }
 
     const overlay = mergeOverlayBoxes(sections.map((s) => s.data.overlay));
 
-    return { sections, overlay };
+    return { sections, overlay, nodeById };
 }
 
 /** Dedupe overlay boxes by `id`, preserving first-seen order. */
@@ -663,15 +683,18 @@ function mergeOverlayBoxes(
 
 function computeComposeSemanticsBundleData(
     payload: ComposeSemanticsPayload | undefined,
+    nodeById: Map<string, InspectionNodeRecord>,
 ): InspectionKindData | null {
     if (!payload || !payload.root) return null;
     const flat = flattenSemantics(payload.root);
     const overlay: OverlayBox[] = [];
     for (const entry of flat) {
+        const id = nsId("semantics", entry.id);
+        nodeById.set(id, { kind: "compose/semantics", node: entry.node });
         const bounds = parseCardBounds(entry.node.boundsInRoot);
         if (!bounds) continue;
         overlay.push({
-            id: nsId("semantics", entry.id),
+            id,
             bounds,
             level: "info",
             tooltip: semanticsTooltip(entry.node),
@@ -707,11 +730,14 @@ function computeComposeSemanticsBundleData(
 
 function computeLayoutInspectorBundleData(
     payload: LayoutInspectorPayload | undefined,
+    nodeById: Map<string, InspectionNodeRecord>,
 ): InspectionKindData | null {
     if (!payload || !payload.root) return null;
     const flat = flattenLayout(payload.root);
     const overlay: OverlayBox[] = [];
     for (const entry of flat) {
+        const id = nsId("layout", entry.id);
+        nodeById.set(id, { kind: "layout/inspector", node: entry.node });
         const b = entry.node.bounds;
         if (
             !b ||
@@ -723,7 +749,7 @@ function computeLayoutInspectorBundleData(
             continue;
         }
         overlay.push({
-            id: nsId("layout", entry.id),
+            id,
             bounds: {
                 left: b.left,
                 top: b.top,
@@ -762,6 +788,7 @@ function computeLayoutInspectorBundleData(
 
 function computeUiaHierarchyBundleData(
     payload: UiaHierarchyPayload | undefined,
+    nodeById: Map<string, InspectionNodeRecord>,
 ): InspectionKindData | null {
     if (!payload || !Array.isArray(payload.nodes)) return null;
     const nodes = payload.nodes;
@@ -771,10 +798,12 @@ function computeUiaHierarchyBundleData(
         data: n,
     }));
     for (let i = 0; i < nodes.length; i++) {
+        const id = nsId("uia", i + "");
+        nodeById.set(id, { kind: "uia/hierarchy", node: nodes[i] });
         const bounds = parseCardBounds(nodes[i].boundsInScreen);
         if (!bounds) continue;
         overlay.push({
-            id: nsId("uia", i + ""),
+            id,
             bounds,
             level: "info",
             tooltip: uiaTooltip(nodes[i]),

--- a/vscode-extension/src/webview/preview/inspectionRowDetail.ts
+++ b/vscode-extension/src/webview/preview/inspectionRowDetail.ts
@@ -1,0 +1,200 @@
+// Build `<bundle-row-detail>` sections for an Inspection-bundle row.
+// One discriminated union (`InspectionNodeRecord`) carries the
+// per-kind node payload; this helper switches on `kind` and emits
+// the relevant detail sections (Identity / Layout / Modifiers /
+// Selectors etc.) per kind.
+//
+// Pure helper — host wires the body-host delegated click listener
+// to call this with the record looked up via
+// `InspectionBundleData.nodeById`.
+
+import { html } from "lit";
+import type { InspectionNodeRecord } from "./inspectionPresenters";
+import type { BundleRowDetailSection } from "./components/BundleRowDetail";
+
+export function buildInspectionRowDetail(
+    record: InspectionNodeRecord,
+): readonly BundleRowDetailSection[] {
+    switch (record.kind) {
+        case "compose/semantics":
+            return buildSemanticsDetail(record.node);
+        case "layout/inspector":
+            return buildLayoutDetail(record.node);
+        case "uia/hierarchy":
+            return buildUiaDetail(record.node);
+    }
+}
+
+export function inspectionRowTitle(record: InspectionNodeRecord): string {
+    switch (record.kind) {
+        case "compose/semantics":
+            return (
+                record.node.label ??
+                record.node.text ??
+                record.node.testTag ??
+                record.node.nodeId
+            );
+        case "layout/inspector":
+            return record.node.component || record.node.nodeId;
+        case "uia/hierarchy":
+            return (
+                record.node.text ??
+                record.node.contentDescription ??
+                record.node.testTag ??
+                "(uia node)"
+            );
+    }
+}
+
+function buildSemanticsDetail(
+    node: import("./inspectionPresenters").ComposeSemanticsNode,
+): readonly BundleRowDetailSection[] {
+    const sections: BundleRowDetailSection[] = [];
+
+    const identity: {
+        label: string;
+        value: string | import("lit").TemplateResult;
+    }[] = [
+        { label: "Node id", value: html`<code>${node.nodeId}</code>` },
+        { label: "Bounds", value: html`<code>${node.boundsInRoot}</code>` },
+    ];
+    if (node.role) identity.push({ label: "Role", value: node.role });
+    if (node.testTag) {
+        identity.push({
+            label: "Test tag",
+            value: html`<code>${node.testTag}</code>`,
+        });
+    }
+    if (node.mergeMode) {
+        identity.push({ label: "Merge mode", value: node.mergeMode });
+    }
+    sections.push({ heading: "Identity", entries: identity });
+
+    const semText: { label: string; value: string }[] = [];
+    if (node.label) semText.push({ label: "Label", value: node.label });
+    if (node.text) semText.push({ label: "Text", value: node.text });
+    if (semText.length > 0) {
+        sections.push({ heading: "Semantics text", entries: semText });
+    }
+
+    const flags: { label: string; value: string }[] = [];
+    if (node.clickable) flags.push({ label: "Clickable", value: "yes" });
+    if (flags.length > 0) {
+        sections.push({ heading: "Flags", entries: flags });
+    }
+
+    return sections;
+}
+
+function buildLayoutDetail(
+    node: import("./inspectionPresenters").LayoutInspectorNode,
+): readonly BundleRowDetailSection[] {
+    const sections: BundleRowDetailSection[] = [];
+
+    const identity: {
+        label: string;
+        value: string | import("lit").TemplateResult;
+    }[] = [
+        { label: "Component", value: node.component },
+        { label: "Node id", value: html`<code>${node.nodeId}</code>` },
+    ];
+    if (node.source) {
+        identity.push({
+            label: "Source",
+            value: html`<code>${node.source}</code>`,
+        });
+    }
+    if (node.sourceInfo) {
+        identity.push({ label: "Source info", value: node.sourceInfo });
+    }
+    sections.push({ heading: "Identity", entries: identity });
+
+    const b = node.bounds;
+    const layout: { label: string; value: string }[] = [
+        {
+            label: "Bounds",
+            value: `${b.left},${b.top}–${b.right},${b.bottom}`,
+        },
+    ];
+    if (node.size) {
+        layout.push({
+            label: "Size",
+            value: `${node.size.width}×${node.size.height}`,
+        });
+    }
+    if (node.constraints) {
+        const c = node.constraints;
+        const max = (v: number | null | undefined): string =>
+            v == null ? "∞" : v.toString();
+        layout.push({
+            label: "Constraints",
+            value: `min ${c.minWidth}×${c.minHeight} · max ${max(c.maxWidth)}×${max(c.maxHeight)}`,
+        });
+    }
+    sections.push({ heading: "Layout", entries: layout });
+
+    const mods = node.modifiers ?? [];
+    if (mods.length > 0) {
+        sections.push({
+            heading: "Modifiers",
+            entries: mods.map((m) => ({
+                label: m.name,
+                value: m.value ?? "—",
+            })),
+        });
+    }
+
+    return sections;
+}
+
+function buildUiaDetail(
+    node: import("./inspectionPresenters").UiaHierarchyNode,
+): readonly BundleRowDetailSection[] {
+    const sections: BundleRowDetailSection[] = [];
+
+    const identity: {
+        label: string;
+        value: string | import("lit").TemplateResult;
+    }[] = [
+        {
+            label: "Bounds",
+            value: html`<code>${node.boundsInScreen}</code>`,
+        },
+    ];
+    if (node.role) identity.push({ label: "Role", value: node.role });
+    if (node.testTag) {
+        identity.push({
+            label: "Test tag",
+            value: html`<code>${node.testTag}</code>`,
+        });
+    }
+    if (node.testTagAncestors && node.testTagAncestors.length > 0) {
+        identity.push({
+            label: "Tag ancestors",
+            value: node.testTagAncestors.join(" › "),
+        });
+    }
+    sections.push({ heading: "Identity", entries: identity });
+
+    const content: { label: string; value: string }[] = [];
+    if (node.text) content.push({ label: "Text", value: node.text });
+    if (node.contentDescription) {
+        content.push({
+            label: "Description",
+            value: node.contentDescription,
+        });
+    }
+    if (content.length > 0) {
+        sections.push({ heading: "Content", entries: content });
+    }
+
+    const actions = node.actions ?? [];
+    if (actions.length > 0) {
+        sections.push({
+            heading: "Actions",
+            entries: [{ label: "Available", value: actions.join(", ") }],
+        });
+    }
+
+    return sections;
+}

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -65,6 +65,15 @@ import { wireExpanderToController } from "./bundleExpanderWiring";
 import { a11yTableColumns, computeA11yBundleData } from "./a11yBundlePresenter";
 import { buildA11yRowDetail } from "./a11yRowDetail";
 import {
+    buildDrawnTextRowDetail,
+    buildFontRowDetail,
+    buildTranslationRowDetail,
+} from "./textRowDetail";
+import {
+    buildInspectionRowDetail,
+    inspectionRowTitle,
+} from "./inspectionRowDetail";
+import {
     computePerformanceBundleData,
     performanceTableColumns,
     renderPerfPlaceholder,
@@ -899,6 +908,11 @@ export class PreviewApp extends LitElement {
             stringsTable: DataTable<DrawnTextRow>;
             fontsTable: DataTable<FontRow>;
             translationsTable: DataTable<TranslationRow>;
+            /** Shared `<bundle-row-detail>` panel rendered below the
+             *  three sub-tables — any of them dispatches `row-clicked`
+             *  into this panel via the listener wired in `textBody()`.
+             *  Same pattern as the a11y bundle. */
+            rowDetail: BundleRowDetail;
         }
         let textCachedBody: TextBody | null = null;
         const textBody = (): TextBody => {
@@ -945,16 +959,78 @@ export class PreviewApp extends LitElement {
                     import("./components/DataTable").DataTableColumn<TranslationRow>
                 >,
             );
+            const rowDetail = document.createElement(
+                "bundle-row-detail",
+            ) as BundleRowDetail;
             wrapper.appendChild(expander);
             wrapper.appendChild(stringsTable);
             wrapper.appendChild(fontsTable);
             wrapper.appendChild(translationsTable);
+            wrapper.appendChild(rowDetail);
+            // Wire each sub-table's row-clicked event to the shared
+            // detail panel. The three tables carry different row
+            // shapes, so each listener routes to the matching
+            // `buildXxxRowDetail` helper; deselect (row=null) clears.
+            const onTextRowClick = <T extends { id: string }>(
+                evt: Event,
+                build: (row: T) => readonly BundleRowDetailSection[],
+                titleOf: (row: T) => string,
+            ): void => {
+                const det = (
+                    evt as CustomEvent<
+                        import("./components/DataTable").RowClickedDetail<T>
+                    >
+                ).detail;
+                if (!det.row) {
+                    rowDetail.clear();
+                    return;
+                }
+                rowDetail.setDetail(titleOf(det.row), build(det.row));
+                // Clear any other table's pinned selection so only
+                // the just-clicked row stays highlighted.
+                if (det !== null) clearOtherTextSelections(evt.target);
+            };
+            const clearOtherTextSelections = (
+                target: EventTarget | null,
+            ): void => {
+                if (target !== stringsTable) {
+                    stringsTable.setSelectedOverlayId(null);
+                }
+                if (target !== fontsTable) {
+                    fontsTable.setSelectedOverlayId(null);
+                }
+                if (target !== translationsTable) {
+                    translationsTable.setSelectedOverlayId(null);
+                }
+            };
+            stringsTable.addEventListener("row-clicked", (evt) =>
+                onTextRowClick<DrawnTextRow>(
+                    evt,
+                    buildDrawnTextRowDetail,
+                    (r) => r.text || "(drawn text)",
+                ),
+            );
+            fontsTable.addEventListener("row-clicked", (evt) =>
+                onTextRowClick<FontRow>(
+                    evt,
+                    buildFontRowDetail,
+                    (r) => r.requestedFamily,
+                ),
+            );
+            translationsTable.addEventListener("row-clicked", (evt) =>
+                onTextRowClick<TranslationRow>(
+                    evt,
+                    buildTranslationRowDetail,
+                    (r) => r.resourceName ?? r.rendered ?? "(translation)",
+                ),
+            );
             textCachedBody = {
                 wrapper,
                 expander,
                 stringsTable,
                 fontsTable,
                 translationsTable,
+                rowDetail,
             };
             return textCachedBody;
         };
@@ -1020,6 +1096,12 @@ export class PreviewApp extends LitElement {
             body.translationsTable.hidden =
                 !enabledKinds.has("i18n/translations") &&
                 data.translations.length === 0;
+            // Drop any pinned row selection so the detail panel
+            // doesn't point at renumbered rows after the refresh.
+            body.stringsTable.setSelectedOverlayId(null);
+            body.fontsTable.setSelectedOverlayId(null);
+            body.translationsTable.setSelectedOverlayId(null);
+            body.rowDetail.clear();
             dataTabs.setTabBody("text", body.wrapper);
             bundleLegend.setBundleEntries(
                 "text",
@@ -1621,7 +1703,34 @@ export class PreviewApp extends LitElement {
             wrapper: HTMLElement;
             expander: BundleExpander;
             host: HTMLElement;
+            /** Shared `<bundle-row-detail>` panel rendered below the
+             *  per-kind tree-table sections. The inspection refresh
+             *  attaches a delegated click handler on `host` (since
+             *  tree-table rows don't dispatch `row-clicked` like
+             *  `<data-table>` does) and looks the clicked row's
+             *  node up by `data-legend-id`. */
+            rowDetail: BundleRowDetail;
         }
+        // The inspection tree-tables don't dispatch `row-clicked`
+        // (they're a bespoke primitive, not `<data-table>`), so the
+        // body-level click handler reads the freshest payload's
+        // `nodeById` lookup from here.
+        let inspectionLastNodeById: ReadonlyMap<
+            string,
+            import("./inspectionPresenters").InspectionNodeRecord
+        > | null = null;
+        let inspectionSelectedRowId: string | null = null;
+        const applyInspectionRowSelection = (row: HTMLElement | null): void => {
+            if (!inspectionCachedBody) return;
+            for (const prev of Array.from(
+                inspectionCachedBody.host.querySelectorAll<HTMLElement>(
+                    "tr.inspection-tree-row-selected",
+                ),
+            )) {
+                prev.classList.remove("inspection-tree-row-selected");
+            }
+            if (row) row.classList.add("inspection-tree-row-selected");
+        };
         let inspectionCachedBody: InspectionBody | null = null;
         const inspectionBody = (): InspectionBody => {
             if (inspectionCachedBody) return inspectionCachedBody;
@@ -1634,9 +1743,40 @@ export class PreviewApp extends LitElement {
             wireExpanderToController(expander, bundleController);
             const host = document.createElement("section");
             host.className = "inspection-bundle-host";
+            const rowDetail = document.createElement(
+                "bundle-row-detail",
+            ) as BundleRowDetail;
+            // Delegated row click handler — finds the nearest <tr>
+            // with `data-legend-id`, looks up the node record from
+            // the last refresh, and dispatches to
+            // `buildInspectionRowDetail`. Re-clicking the selected
+            // row deselects (panel cleared).
+            host.addEventListener("click", (evt) => {
+                const target = evt.target;
+                if (!(target instanceof Element)) return;
+                const row = target.closest<HTMLElement>("tr[data-legend-id]");
+                if (!row || !host.contains(row)) return;
+                const id = row.dataset.legendId ?? "";
+                if (!id) return;
+                if (inspectionSelectedRowId === id) {
+                    inspectionSelectedRowId = null;
+                    applyInspectionRowSelection(null);
+                    rowDetail.clear();
+                    return;
+                }
+                const record = inspectionLastNodeById?.get(id);
+                if (!record) return;
+                inspectionSelectedRowId = id;
+                applyInspectionRowSelection(row);
+                rowDetail.setDetail(
+                    inspectionRowTitle(record),
+                    buildInspectionRowDetail(record),
+                );
+            });
             wrapper.appendChild(expander);
             wrapper.appendChild(host);
-            inspectionCachedBody = { wrapper, expander, host };
+            wrapper.appendChild(rowDetail);
+            inspectionCachedBody = { wrapper, expander, host, rowDetail };
             return inspectionCachedBody;
         };
         const refreshInspectionBundle = (): void => {
@@ -1681,6 +1821,14 @@ export class PreviewApp extends LitElement {
                 wrap.appendChild(section.data.body);
                 body.host.appendChild(wrap);
             }
+            // Stash the per-id node lookup so the body-host click
+            // handler can dispatch the detail panel without re-
+            // walking the per-kind trees. Drop any prior selection
+            // since the new payload may have renumbered the rows.
+            inspectionLastNodeById = data.nodeById;
+            inspectionSelectedRowId = null;
+            applyInspectionRowSelection(null);
+            body.rowDetail.clear();
             dataTabs.setTabBody("inspection", body.wrapper);
             bundleLegend.setBundleEntries(
                 "inspection",

--- a/vscode-extension/src/webview/preview/textRowDetail.ts
+++ b/vscode-extension/src/webview/preview/textRowDetail.ts
@@ -1,0 +1,185 @@
+// Build `<bundle-row-detail>` sections for the Text / i18n bundle.
+// One pure helper per row shape (`DrawnTextRow`, `FontRow`,
+// `TranslationRow`); the host wires each table's `row-clicked` event
+// to the matching helper and pipes the result through
+// `BundleRowDetail.setDetail`.
+
+import { html } from "lit";
+import type {
+    DrawnTextRow,
+    FontRow,
+    TranslationRow,
+} from "./textBundlePresenter";
+import type { BundleRowDetailSection } from "./components/BundleRowDetail";
+
+export function buildDrawnTextRowDetail(
+    row: DrawnTextRow,
+): readonly BundleRowDetailSection[] {
+    const sections: BundleRowDetailSection[] = [];
+
+    // ---- Text ---------------------------------------------------------
+    sections.push({
+        heading: "Text",
+        entries: [
+            { label: "Rendered", value: row.text || "—" },
+            { label: "Node id", value: html`<code>${row.nodeId}</code>` },
+            { label: "Locale", value: row.localeTag || "—" },
+            {
+                label: "Bounds",
+                value: row.boundsInScreen
+                    ? html`<code>${row.boundsInScreen}</code>`
+                    : "—",
+            },
+        ],
+    });
+
+    // ---- Style --------------------------------------------------------
+    const styleEntries: { label: string; value: string }[] = [];
+    if (row.fontSize)
+        styleEntries.push({ label: "Font size", value: row.fontSize });
+    if (Number.isFinite(row.fontScale) && row.fontScale !== 1) {
+        styleEntries.push({
+            label: "Font scale",
+            value: row.fontScale.toString() + "×",
+        });
+    }
+    if (row.foreground !== null) {
+        styleEntries.push({ label: "Foreground", value: row.foreground });
+    }
+    if (row.background !== null) {
+        styleEntries.push({ label: "Background", value: row.background });
+    }
+    if (styleEntries.length > 0) {
+        sections.push({ heading: "Style", entries: styleEntries });
+    }
+
+    // ---- Layout / overflow -------------------------------------------
+    const layoutEntries: { label: string; value: string }[] = [];
+    if (row.overflow) {
+        layoutEntries.push({ label: "Overflow mode", value: row.overflow });
+    }
+    if (row.truncated) {
+        layoutEntries.push({ label: "Truncated", value: "yes" });
+    }
+    if (row.didOverflowWidth) {
+        layoutEntries.push({ label: "Overflowed width", value: "yes" });
+    }
+    if (row.didOverflowHeight) {
+        layoutEntries.push({ label: "Overflowed height", value: "yes" });
+    }
+    if (layoutEntries.length > 0) {
+        sections.push({ heading: "Layout", entries: layoutEntries });
+    }
+
+    return sections;
+}
+
+export function buildFontRowDetail(
+    row: FontRow,
+): readonly BundleRowDetailSection[] {
+    const sections: BundleRowDetailSection[] = [];
+
+    // ---- Family -------------------------------------------------------
+    const familyEntries: { label: string; value: string }[] = [
+        { label: "Requested", value: row.requestedFamily },
+        { label: "Resolved", value: row.resolvedFamily },
+    ];
+    if (row.resolvedFamily !== row.requestedFamily) {
+        familyEntries.push({
+            label: "Fallback",
+            value:
+                row.fellBackFromChain ||
+                "(no chain reported; resolved family differs from request)",
+        });
+    } else if (row.fellBackFromChain) {
+        familyEntries.push({
+            label: "Fallback chain",
+            value: row.fellBackFromChain,
+        });
+    }
+    sections.push({ heading: "Family", entries: familyEntries });
+
+    // ---- Variant ------------------------------------------------------
+    sections.push({
+        heading: "Variant",
+        entries: [
+            { label: "Weight", value: row.weight.toString() },
+            { label: "Style", value: row.style },
+        ],
+    });
+
+    // ---- Source -------------------------------------------------------
+    const sourceEntries: {
+        label: string;
+        value: string | import("lit").TemplateResult;
+    }[] = [];
+    if (row.sourceFile) {
+        sourceEntries.push({
+            label: "Source file",
+            value: html`<code>${row.sourceFile}</code>`,
+        });
+    }
+    sourceEntries.push({
+        label: "Google Fonts",
+        value: row.isGoogleFont ? "yes" : "no",
+    });
+    sourceEntries.push({
+        label: "Used by",
+        value:
+            row.consumerCount === 1 ? "1 node" : row.consumerCount + " nodes",
+    });
+    sections.push({ heading: "Source", entries: sourceEntries });
+
+    return sections;
+}
+
+export function buildTranslationRowDetail(
+    row: TranslationRow,
+): readonly BundleRowDetailSection[] {
+    const sections: BundleRowDetailSection[] = [];
+
+    // ---- Entry --------------------------------------------------------
+    const entryEntries: {
+        label: string;
+        value: string | import("lit").TemplateResult;
+    }[] = [{ label: "Rendered", value: row.rendered || "—" }];
+    if (row.resourceName) {
+        entryEntries.push({
+            label: "Resource",
+            value: html`<code>${row.resourceName}</code>`,
+        });
+    }
+    if (row.sourceFile) {
+        entryEntries.push({
+            label: "Source file",
+            value: html`<code>${row.sourceFile}</code>`,
+        });
+    }
+    sections.push({ heading: "Entry", entries: entryEntries });
+
+    // ---- Locales ------------------------------------------------------
+    const localeEntries: { label: string; value: string }[] = [
+        {
+            label: "Supported",
+            value: row.supportedLocaleCount.toString(),
+        },
+    ];
+    if (row.translatedLocales.length > 0) {
+        localeEntries.push({
+            label: "Translated",
+            value: row.translatedLocales.join(", "),
+        });
+    }
+    if (row.untranslatedLocaleCount > 0) {
+        localeEntries.push({
+            label: "Untranslated",
+            value:
+                row.untranslatedLocales.length > 0
+                    ? row.untranslatedLocales.join(", ")
+                    : row.untranslatedLocaleCount.toString(),
+        });
+    }
+    sections.push({ heading: "Locales", entries: localeEntries });
+
+    return sections;
+}


### PR DESCRIPTION
## Summary

Closes #1145 (Text path) and #1146 (Inspection path) — adds the click-to-reveal `<bundle-row-detail>` panel to both bundles, matching the Accessibility wiring from #1138.

## Text / i18n

`textRowDetail.ts` exports three pure builders, one per sub-table row shape (`DrawnTextRow` / `FontRow` / `TranslationRow`). All three tables share one `<bundle-row-detail>` panel; clicking a row in one swaps the panel and clears the pinned selection on the other two so the visual cue tracks the last click. Detail content per kind:

- **Drawn text** — Text section (rendered / node id / locale / bounds), Style section (font size / scale / fg / bg, only when non-default), Layout section (overflow + truncation flags, only when tripped).
- **Fonts** — Family (requested vs resolved, fallback chain when they disagree), Variant (weight + style), Source (sourceFile / Google Fonts membership / pluralised consumer count).
- **Translations** — Entry (rendered + resource + source file), Locales (supported count + translated list + untranslated list or count fallback).

## Inspection

Tricky case from #1146 — inspection renders rows in `inspectionTreeTable`, not the shared `<data-table>`, so `row-clicked` doesn't fire. Picked **option 1** from the issue's discussion: kept the tree-table primitive untouched, taught the bundle host to do the lookup itself.

`InspectionBundleData` gains a `nodeById: ReadonlyMap<string, InspectionNodeRecord>` populated by each per-kind compute function. The discriminated record carries `{ kind, node }` so the row detail can dispatch without re-walking the per-kind payload trees.

`inspectionRowDetail.ts` switches on `record.kind`:

- **semantics** — Identity (node id / bounds / role / test tag / merge mode), Semantics text (label + text when present), Flags (clickable).
- **layout/inspector** — Identity (component + node id + source + source info), Layout (bounds + size + constraints with `∞` for null max), Modifiers (one entry per modifier).
- **uia/hierarchy** — Identity (bounds + role + test tag + tag ancestors), Content (text + content description), Actions (joined list).

`inspectionBody()` attaches a delegated click on `host` that finds the nearest `tr[data-legend-id]`, looks the node up in `nodeById`, and dispatches. Re-clicking the selected row deselects. Pinned selection uses a new `.inspection-tree-row-selected` class that mirrors the `<data-table>` styling so both surfaces look consistent in both themes.

## Tests + snapshots

26 new unit specs (13 text + 13 inspection) cover the per-row section shape, no-match skips, title fallbacks, orphan paths, and pluralisation. **1000 passing total.**

`text-strings` and `inspection-tree` harness fixtures grow a row-click action so the regenerated snapshots demonstrate the detail panel populated end-to-end. CSS selection bar visible on the selected row in both bundles.

## Test plan

- [x] `npm test` — 1000 passing
- [x] `npm run format:check` clean
- [x] `npm run harness:snapshot` — all three updated fixtures render with the populated detail panel
- [ ] Manual: click rows in Text and Inspection tabs in a real preview, confirm the detail panel populates, re-click deselects, switching rows swaps

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_