### PR TITLE
feat(vscode-extension): row-click detail for the History diff bundle

### DIFF
--- a/vscode-extension/preview-harness/fixtures/history-diff.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/history-diff.gen.mjs
@@ -85,7 +85,17 @@ const fixture = {
         "Focused card with realistic history/diff/regions payload (three regions, ~12% of pixels changed from baseline). Activates the History bundle so the diff overlay paints each region, the side legend lists them with pixel-count subtitles, and the tab body renders the diff table with the baseline header.",
     dataset: EARLY_FEATURES_DATASET,
     messages: [setPreviews, updateImage, updateDataProducts],
-    actions: [focusAction(focusId), activateBundleAction("history")],
+    actions: [
+        focusAction(focusId),
+        activateBundleAction("history"),
+        // Click the highest-Δ region (index 2) so the snapshot
+        // exercises the row → detail panel wiring. Row ids are
+        // positional in the presenter
+        // (`history-diff-region-${idx}`).
+        {
+            click: `[data-bundle="history"] tr[data-legend-id="history-diff-region-2"]`,
+        },
+    ],
 };
 
 process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/history-diff.json
+++ b/vscode-extension/preview-harness/fixtures/history-diff.json
@@ -129,6 +129,9 @@
     },
     {
       "click": "bundle-chip-bar button[data-bundle=\"history\"]"
+    },
+    {
+      "click": "[data-bundle=\"history\"] tr[data-legend-id=\"history-diff-region-2\"]"
     }
   ]
 }

--- a/vscode-extension/src/test/historyRowDetail.test.ts
+++ b/vscode-extension/src/test/historyRowDetail.test.ts
@@ -1,0 +1,154 @@
+// Tests for `buildHistoryRowDetail`. The bundle row carries the
+// Euclidean Δ magnitude only; the detail helper re-joins against
+// the source payload to surface per-channel deltas and shared
+// baseline-history context.
+
+import * as assert from "assert";
+import { buildHistoryRowDetail } from "../webview/preview/historyRowDetail";
+import type {
+    HistoryDiffPayload,
+    HistoryDiffRow,
+} from "../webview/preview/historyDiffBundlePresenter";
+
+function row(over: Partial<HistoryDiffRow>): HistoryDiffRow {
+    return {
+        id: over.id ?? "history-diff-region-0",
+        bounds:
+            over.bounds === undefined
+                ? { left: 0, top: 0, right: 100, bottom: 80 }
+                : over.bounds,
+        boundsLabel: over.boundsLabel ?? "0,0,100,80",
+        pixelCount: over.pixelCount ?? 8000,
+        deltaMagnitude: over.deltaMagnitude ?? 40.3,
+        intensity: over.intensity ?? 0.12,
+    };
+}
+
+function payload(over: Partial<HistoryDiffPayload>): HistoryDiffPayload {
+    // Honour `undefined` explicitly so tests can drop the
+    // baselineHistoryId / regions to exercise the no-context paths.
+    return {
+        baselineHistoryId:
+            "baselineHistoryId" in over
+                ? over.baselineHistoryId
+                : "main@a1b2c3d4",
+        totalPixelsChanged: over.totalPixelsChanged ?? 42240,
+        changedFraction: over.changedFraction ?? 0.1956,
+        regions:
+            "regions" in over
+                ? over.regions
+                : [
+                      {
+                          bounds: "0,0,100,80",
+                          pixelCount: 8000,
+                          avgDelta: { r: 12.4, g: 18.2, b: 33.7, a: 0.0 },
+                      },
+                  ],
+    };
+}
+
+describe("buildHistoryRowDetail", () => {
+    it("always emits a Region section with bounds + pixels + Δ + intensity", () => {
+        const sections = buildHistoryRowDetail(row({}), payload({}), 0);
+        const region = sections.find((s) => s.heading === "Region");
+        assert.ok(region);
+        const labels = region!.entries.map((e) => e.label);
+        assert.ok(labels.includes("Bounds"));
+        assert.ok(labels.includes("Pixels changed"));
+        assert.ok(labels.includes("Δ magnitude"));
+        assert.ok(labels.includes("Intensity"));
+    });
+
+    it("formats Δ magnitude to one decimal place and intensity as a percentage", () => {
+        const sections = buildHistoryRowDetail(
+            row({ deltaMagnitude: 43.85, intensity: 0.234 }),
+            payload({}),
+            0,
+        );
+        const region = sections.find((s) => s.heading === "Region")!;
+        const delta = region.entries.find((e) => e.label === "Δ magnitude");
+        const intensity = region.entries.find((e) => e.label === "Intensity");
+        assert.strictEqual(delta?.value, "43.9");
+        assert.strictEqual(intensity?.value, "23%");
+    });
+
+    it("pulls per-channel deltas from the payload by row index", () => {
+        const sections = buildHistoryRowDetail(
+            row({}),
+            payload({
+                regions: [
+                    {
+                        bounds: "0,0,100,80",
+                        pixelCount: 8000,
+                        avgDelta: { r: 12.4, g: 18.2, b: 33.7, a: 0.0 },
+                    },
+                    {
+                        bounds: "100,0,200,80",
+                        pixelCount: 4000,
+                        avgDelta: { r: 5.5, g: 5.0, b: 5.0, a: 0.0 },
+                    },
+                ],
+            }),
+            1,
+        );
+        const channels = sections.find((s) => s.heading === "Channel deltas");
+        assert.ok(channels);
+        const red = channels!.entries.find((e) => e.label === "Δ red");
+        assert.strictEqual(red?.value, "5.5");
+    });
+
+    it("skips the Channel deltas section when no avgDelta is present", () => {
+        const sections = buildHistoryRowDetail(
+            row({}),
+            payload({
+                regions: [{ bounds: "0,0,100,80", pixelCount: 8000 }],
+            }),
+            0,
+        );
+        assert.strictEqual(
+            sections.find((s) => s.heading === "Channel deltas"),
+            undefined,
+        );
+    });
+
+    it("emits a Baseline section with the history id + changed fraction when present", () => {
+        const sections = buildHistoryRowDetail(
+            row({}),
+            payload({
+                baselineHistoryId: "main@d34db33f",
+                changedFraction: 0.42,
+            }),
+            0,
+        );
+        const baseline = sections.find((s) => s.heading === "Baseline");
+        assert.ok(baseline);
+        const fraction = baseline!.entries.find(
+            (e) => e.label === "Changed fraction",
+        );
+        assert.strictEqual(fraction?.value, "42.00%");
+    });
+
+    it("skips the Baseline section when baselineHistoryId is absent", () => {
+        const sections = buildHistoryRowDetail(
+            row({}),
+            payload({ baselineHistoryId: undefined }),
+            0,
+        );
+        assert.strictEqual(
+            sections.find((s) => s.heading === "Baseline"),
+            undefined,
+        );
+    });
+
+    it("renders pixel counts with thousands separators", () => {
+        const sections = buildHistoryRowDetail(
+            row({ pixelCount: 28800 }),
+            payload({}),
+            0,
+        );
+        const px = sections
+            .find((s) => s.heading === "Region")!
+            .entries.find((e) => e.label === "Pixels changed");
+        assert.strictEqual(px?.value, (28800).toLocaleString());
+    });
+});

--- a/vscode-extension/src/webview/preview/historyRowDetail.ts
+++ b/vscode-extension/src/webview/preview/historyRowDetail.ts
@@ -1,0 +1,104 @@
+// Build `<bundle-row-detail>` sections for the History diff bundle.
+// Pure helper — host wires the data-table's `row-clicked` listener
+// to call this with the row + the source payload so the detail
+// panel can show per-channel deltas (not on the bundle row) and the
+// baseline-history context shared by every region.
+
+import { html, type TemplateResult } from "lit";
+import type {
+    HistoryDiffPayload,
+    HistoryDiffRow,
+} from "./historyDiffBundlePresenter";
+import type { BundleRowDetailSection } from "./components/BundleRowDetail";
+
+export function buildHistoryRowDetail(
+    row: HistoryDiffRow,
+    payload: HistoryDiffPayload | null | undefined,
+    rowIndex: number,
+): readonly BundleRowDetailSection[] {
+    const sections: BundleRowDetailSection[] = [];
+
+    // ---- Region ------------------------------------------------------
+    const regionEntries: {
+        label: string;
+        value: string | TemplateResult;
+    }[] = [
+        {
+            label: "Bounds",
+            value: row.boundsLabel
+                ? html`<code>${row.boundsLabel}</code>`
+                : "—",
+        },
+        {
+            label: "Pixels changed",
+            value: row.pixelCount.toLocaleString(),
+        },
+        {
+            label: "Δ magnitude",
+            value: row.deltaMagnitude.toFixed(1),
+        },
+        {
+            label: "Intensity",
+            value: (row.intensity * 100).toFixed(0) + "%",
+        },
+    ];
+    sections.push({ heading: "Region", entries: regionEntries });
+
+    // ---- Channel deltas ---------------------------------------------
+    // The bundle row carries the Euclidean magnitude but not the
+    // per-channel breakdown; re-join against the source payload to
+    // surface r/g/b/a. Order matches the wire payload's index — the
+    // bundle row's `id` is `history-diff-region-${idx}`, so the
+    // caller passes that index directly.
+    const region = payload?.regions?.[rowIndex];
+    if (region?.avgDelta) {
+        const d = region.avgDelta;
+        const channelEntries: { label: string; value: string }[] = [];
+        if (typeof d.r === "number") {
+            channelEntries.push({ label: "Δ red", value: d.r.toFixed(1) });
+        }
+        if (typeof d.g === "number") {
+            channelEntries.push({ label: "Δ green", value: d.g.toFixed(1) });
+        }
+        if (typeof d.b === "number") {
+            channelEntries.push({ label: "Δ blue", value: d.b.toFixed(1) });
+        }
+        if (typeof d.a === "number") {
+            channelEntries.push({ label: "Δ alpha", value: d.a.toFixed(1) });
+        }
+        if (channelEntries.length > 0) {
+            sections.push({
+                heading: "Channel deltas",
+                entries: channelEntries,
+            });
+        }
+    }
+
+    // ---- Baseline context -------------------------------------------
+    if (payload?.baselineHistoryId) {
+        const baselineEntries: {
+            label: string;
+            value: string | TemplateResult;
+        }[] = [
+            {
+                label: "History id",
+                value: html`<code>${payload.baselineHistoryId}</code>`,
+            },
+        ];
+        if (typeof payload.totalPixelsChanged === "number") {
+            baselineEntries.push({
+                label: "Total pixels",
+                value: payload.totalPixelsChanged.toLocaleString(),
+            });
+        }
+        if (typeof payload.changedFraction === "number") {
+            baselineEntries.push({
+                label: "Changed fraction",
+                value: (payload.changedFraction * 100).toFixed(2) + "%",
+            });
+        }
+        sections.push({ heading: "Baseline", entries: baselineEntries });
+    }
+
+    return sections;
+}

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -73,6 +73,7 @@ import {
     buildInspectionRowDetail,
     inspectionRowTitle,
 } from "./inspectionRowDetail";
+import { buildHistoryRowDetail } from "./historyRowDetail";
 import {
     computePerformanceBundleData,
     performanceTableColumns,
@@ -1569,6 +1570,13 @@ export class PreviewApp extends LitElement {
         };
 
         // ---- History bundle (history/diff/regions) -------------------------
+        // Captures the freshest history payload so the body's
+        // `row-clicked` listener (attached once in
+        // `historyDiffBodyBuilt`) can rebuild the detail panel —
+        // specifically the per-channel deltas, which the bundle row
+        // doesn't carry — against the current data without re-
+        // attaching on every refresh.
+        let historyLastPayload: HistoryDiffPayload | null = null;
         const historyDiffBodyBuilt = (): BundleBody => {
             let b = bundleBodies.get("history");
             if (b) return b;
@@ -1579,6 +1587,32 @@ export class PreviewApp extends LitElement {
                     import("./components/DataTable").DataTableColumn<unknown>
                 >,
             );
+            // Wire row click → detail panel, mirroring a11y. The
+            // bundle row carries the Euclidean Δ magnitude only;
+            // the detail builder re-joins against
+            // `historyLastPayload` for per-channel deltas plus the
+            // shared baseline-history context.
+            b.table.addEventListener("row-clicked", (evt) => {
+                const det = (
+                    evt as CustomEvent<
+                        import("./components/DataTable").RowClickedDetail<
+                            import("./historyDiffBundlePresenter").HistoryDiffRow
+                        >
+                    >
+                ).detail;
+                if (!det.row || det.index === null) {
+                    b!.rowDetail.clear();
+                    return;
+                }
+                b!.rowDetail.setDetail(
+                    det.row.boundsLabel || "Region " + (det.index + 1),
+                    buildHistoryRowDetail(
+                        det.row,
+                        historyLastPayload,
+                        det.index,
+                    ),
+                );
+            });
             bundleBodies.set("history", b);
             return b;
         };
@@ -1616,6 +1650,13 @@ export class PreviewApp extends LitElement {
                 previewId: target,
                 payload,
             }));
+            // Stash for the row-click listener installed once in
+            // `historyDiffBodyBuilt()`. Drop the prior selection so
+            // the detail panel doesn't point at row indices the new
+            // payload may have renumbered.
+            historyLastPayload = payload;
+            body.table.setSelectedOverlayId(null);
+            body.rowDetail.clear();
             refreshExpanderFor("history");
             dataTabs.setTabBody("history", host);
             bundleLegend.setBundleEntries(


### PR DESCRIPTION
## Summary

Closes the second half of #1145 (#1148 took Text; this finishes History) — and with it, every overlay-painting bundle (a11y / text / inspection / history) has the row-click detail panel.

## Helper

`historyRowDetail.ts` exposes `buildHistoryRowDetail(row, payload, rowIndex)`:

- **Region** — bounds (raw label as `<code>`), pixel count with thousands separators, Δ magnitude (1 decimal), intensity as `%`.
- **Channel deltas** — re-joins against `payload.regions[rowIndex]` for per-channel Δ values. The bundle row only carries the Euclidean magnitude; skips entirely when no `avgDelta` is on the wire.
- **Baseline** — `baselineHistoryId`, total pixels (formatted), `changedFraction` as a percentage. Skips when no baseline id is supplied.

## Wiring

`historyDiffBodyBuilt()` attaches the `row-clicked` listener once (the body is cached for panel lifetime) and reads the freshest payload from `historyLastPayload`. Each refresh clears the pinned selection + detail so a stale row doesn't point at the new payload's renumbered indices. Same pattern as a11y / text.

## Tests + snapshot

Seven new specs cover Region section shape, per-channel join by index, no-deltas / no-baseline skip paths, decimal + percentage formatting, and thousands-separator on pixel counts. **1007 passing.**

`history-diff` harness fixture grows a row-click action targeting region 2 (the highest-Δ block over BTN2). Regenerated snapshot shows the populated detail panel with Region / Channel deltas / Baseline sections plus the consistent `.data-table-row-selected` left-bar visual.

## Bundle-UI track status

After this lands, **all four overlay-painting bundles** (a11y / text / inspection / history) carry the legend + tree (a11y only) + row-click detail. Open work remaining: #1123 (Playwright e2e) and #1125 (createImageBitmap noise).

## Test plan

- [x] `npm test` — 1007 passing
- [x] `npm run format:check` clean
- [x] `npm run harness:snapshot -- --fixture history-diff` renders cleanly with the populated detail panel
- [ ] Manual: click rows in the History tab in a real preview, confirm detail panel populates per-channel deltas + baseline context, re-click deselects

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_