### PR TITLE
test(gradle-plugin): end-to-end CLI a11y test via daemon-driven flow

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,14 +40,52 @@ tasks.register("ktfmtFormatAll") {
   allprojects.forEach { dependsOn(it.taskPath("ktfmtFormat")) }
 }
 
-// `functionalTestWithAndroid` previously orchestrated the publish-then-test dance for
-// `AccessibilityAndroidFunctionalTest`. That test has been removed — a11y is now produced
-// exclusively by the daemon, so there is no standalone-gradle-render path to assert on. The
-// task is kept as a no-op alias for `:gradle-plugin:functionalTest` so CI / docs that still
-// reference it don't break; future Android-flavour functional tests can re-establish the
-// publish closure here when they land.
+// Convenience entrypoint for `CliA11yEndToEndFunctionalTest`. The test runs an Android-flavour
+// synthetic project through the CLI's daemon-driven a11y flow, which needs:
+//   1. The `renderer-android` AAR closure published to mavenLocal so the synthetic Android
+//      library resolves it through its own `pluginManagement.repositories.mavenLocal()`.
+//   2. The `:gradle-plugin` itself published to mavenLocal for the same reason (the test's
+//      synthetic `plugins { id("ee.schimke.composeai.preview") version "<v>" }` block looks
+//      it up by coordinate).
+//   3. The `compose-preview` CLI binary built via `:cli:installDist` — the test shells out to
+//      it as the actual `compose-preview a11y` subject.
+//
+// Wired from the *parent* build so the `dependsOn` chain flows parent → child (the standard
+// direction); the included `gradle-plugin` build expresses the test's own data (the synthetic
+// project's source files) inline.
+//
+// The publish set is the closure of renderer-android's compile/runtime project deps:
+//   :renderer-android
+//     api :data-a11y-core
+//       api :data-render-core
+//     implementation :data-render-core
+//     implementation :data-scroll-core
+//       api :data-render-core
+//       api :data-render-compose
+//         api :data-render-core
+val androidFunctionalTestPublishTargets =
+  listOf(
+    ":renderer-android",
+    ":data-a11y-core",
+    ":data-render-core",
+    ":data-render-compose",
+    ":data-scroll-core",
+  )
+
 tasks.register("functionalTestWithAndroid") {
   group = "verification"
-  description = "Alias for :gradle-plugin:functionalTest (kept for backwards-compat)."
+  description =
+    "Publishes renderer-android (+ transitive internal modules) and the gradle plugin itself " +
+      "to mavenLocal, builds the compose-preview CLI binary via `:cli:installDist`, then runs " +
+      "gradle-plugin's functionalTest with the opt-in `cli.a11y.e2e=true` flag set so " +
+      "`CliA11yEndToEndFunctionalTest` actually fires."
+  androidFunctionalTestPublishTargets.forEach { dependsOn("$it:publishToMavenLocal") }
+  // The synthetic Android-library project resolves our plugin through its own
+  // `plugins { id("ee.schimke.composeai.preview") version "<v>" }` block (so AGP and our plugin
+  // share one classloader hierarchy). That requires the plugin to be in mavenLocal before the
+  // functional test starts.
+  dependsOn(gradle.includedBuild("gradle-plugin").task(":publishToMavenLocal"))
+  // The CLI binary the test invokes — built into `cli/build/install/compose-preview/bin/`.
+  dependsOn(":cli:installDist")
   dependsOn(gradle.includedBuild("gradle-plugin").task(":functionalTest"))
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -63,13 +63,11 @@ val functionalTestTask =
     classpath = functionalTest.runtimeClasspath
     useJUnit()
 
-    // `AccessibilityAndroidFunctionalTest` used to require a `publishToMavenLocal` pre-step so
-    // its synthetic `com.android.library` project could resolve the renderer AAR closure from
-    // `~/.m2`. That test was removed when a11y moved to be daemon-only — no remaining
-    // functional test depends on mavenLocal artefacts. The `mustRunAfter` is kept so that, if
-    // someone schedules `publishToMavenLocal` alongside `functionalTest` from CI for any
-    // reason, the publish still runs first.
-
+    // `CliA11yEndToEndFunctionalTest` (and any future Android-flavour functional test) requires
+    // a `publishToMavenLocal` pre-step so its synthetic `com.android.library` project can
+    // resolve the renderer AAR closure from `~/.m2`. The `mustRunAfter` ensures the publish
+    // runs first when both are scheduled in one Gradle invocation (the
+    // `functionalTestWithAndroid` task in the root build does exactly this).
     mustRunAfter("publishToMavenLocal")
 
     // Surface the host's `~/.m2/repository`, the plugin's compile-time version, and the Android
@@ -83,6 +81,21 @@ val functionalTestTask =
     // neither is set — the test then `assumeFalse`s out so devs without an SDK don't see a hard
     // failure.
     systemProperty("ee.schimke.composeai.functionalTest.androidSdkDir", resolveAndroidSdk(rootDir))
+    // Opt-in `cli.a11y.e2e=true` gate for the daemon-spawn round-trip
+    // (`CliA11yEndToEndFunctionalTest`). Default off — the test cold-starts a Robolectric JVM
+    // per render and a daemon JVM per module, so it's too slow for `./gradlew check`. CI runs
+    // it via the root build's `functionalTestWithAndroid` task with the flag flipped on.
+    val cliA11yE2E = providers.gradleProperty("cli.a11y.e2e").orNull == "true"
+    systemProperty("composeai.functionalTest.cliA11yE2E", cliA11yE2E.toString())
+    // Path to the compose-preview CLI binary built by `:cli:installDist`. The test invokes it
+    // directly as a subprocess — that's the actual subject of the e2e. Empty string when the
+    // binary hasn't been built; the test self-skips. The root build wires the dependency.
+    val cliBinary =
+      rootDir.parentFile?.resolve("cli/build/install/compose-preview/bin/compose-preview")
+    systemProperty(
+      "composeai.functionalTest.cliBinary",
+      if (cliBinary?.isFile == true) cliBinary.absolutePath else "",
+    )
   }
 
 tasks.check { dependsOn(functionalTestTask) }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/CliA11yEndToEndFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/CliA11yEndToEndFunctionalTest.kt
@@ -1,0 +1,263 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import java.io.File
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end functional coverage for `compose-preview a11y` driven through the actual CLI binary
+ * against a synthetic Android-library project. Closes the gap [CliA11yInputsFunctionalTest] doesn't
+ * (that test only pins the Gradle-side inputs the CLI consumes); this one spawns the daemon JVM via
+ * the CLI's `RenderSession` flow and asserts the produced `accessibility.json` actually carries the
+ * canary `BadButtonPreview` finding.
+ *
+ * Gating — three layers, evaluated in order so the failure mode is informative:
+ *
+ * 1. **`cli.a11y.e2e=true` Gradle property must be set.** This test cold-starts a Robolectric JVM
+ *    per render and a daemon JVM per module — too slow for `./gradlew check`. CI runs it via the
+ *    root build's `functionalTestWithAndroid` task with the flag flipped on.
+ * 2. **Android SDK must be reachable.** `assumeTrue` skip when missing, so dev environments without
+ *    an SDK don't see a hard failure.
+ * 3. **renderer-android AAR + plugin marker + CLI binary must be in their expected locations.**
+ *    Hard failures here — past the SDK gate, the caller is committed to running the test, and a
+ *    sibling-task race (publishes vs. this test) would silently green if `assumeTrue` swallowed it.
+ *
+ * No `withPluginClasspath()` — the synthetic project resolves AGP and our plugin through its own
+ * `plugins { ... }` block via `pluginManagement.repositories.mavenLocal()`, so they share one
+ * classloader hierarchy. `withPluginClasspath()` would load them twice on different loaders and
+ * break `AndroidComponentsExtension` identity checks.
+ */
+class CliA11yEndToEndFunctionalTest {
+
+  @get:Rule val tempDir: TemporaryFolder = TemporaryFolder()
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private val cliA11yE2E: Boolean =
+    System.getProperty("composeai.functionalTest.cliA11yE2E", "false") == "true"
+
+  private val cliBinary: String = System.getProperty("composeai.functionalTest.cliBinary", "")
+
+  private val mavenLocal: String =
+    System.getProperty("ee.schimke.composeai.functionalTest.mavenLocal", "")
+
+  private val pluginVersion: String =
+    System.getProperty("ee.schimke.composeai.functionalTest.pluginVersion", "")
+
+  private val androidSdkDir: String =
+    System.getProperty("ee.schimke.composeai.functionalTest.androidSdkDir", "")
+
+  @Test
+  fun `compose-preview a11y surfaces BadButtonPreview finding via daemon-driven flow`() {
+    assumeTrue("Skipping: -Pcli.a11y.e2e=true not set", cliA11yE2E)
+    assumeTrue(
+      "Skipping: no Android SDK reachable via ANDROID_HOME / local.properties",
+      androidSdkDir.isNotBlank() && File(androidSdkDir).isDirectory,
+    )
+
+    // Past the opt-in + SDK gates the caller is committed to Android coverage — anything else
+    // missing is a setup error in the parent build's `functionalTestWithAndroid` chain, not
+    // something the dev environment should silently skip past.
+    assertWithMessage("CLI binary path not surfaced via system property")
+      .that(cliBinary)
+      .isNotEmpty()
+    val cli = File(cliBinary)
+    assertWithMessage(
+        "CLI binary $cliBinary missing — did `:cli:installDist` run? Use " +
+          "`./gradlew functionalTestWithAndroid`"
+      )
+      .that(cli.isFile)
+      .isTrue()
+    val rendererAar =
+      File(mavenLocal, "ee/schimke/composeai/renderer-android/$pluginVersion")
+        .listFiles { f -> f.extension == "aar" }
+        ?.firstOrNull()
+    assertWithMessage(
+        "renderer-android-$pluginVersion.aar in mavenLocal " +
+          "(did `:renderer-android:publishToMavenLocal` run?)"
+      )
+      .that(rendererAar)
+      .isNotNull()
+
+    val projectDir = createAndroidTestProject()
+
+    // 1. Materialise the descriptor + previews.json. The CLI's a11y path runs the same gradle
+    // tasks under the hood (via Tooling API), but invoking them here separately means we
+    // observe the gradle phase isolated from the daemon phase — failure attribution is cleaner.
+    val gradleResult =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments(
+          ":discoverPreviews",
+          ":composePreviewDaemonStart",
+          ":renderAllPreviews",
+          "--stacktrace",
+        )
+        .forwardOutput()
+        .build()
+    assertThat(gradleResult.output).doesNotContain("BUILD FAILED")
+
+    // 2. Invoke the CLI binary directly. `--module ":"` because the synthetic project is a
+    // single-module Gradle build (root project IS the module). The CLI's a11y command spawns
+    // its own daemon via the descriptor, fetches `a11y/atf` per preview, and writes
+    // `accessibility.json` next to `previews.json`.
+    val builder =
+      ProcessBuilder(cli.absolutePath, "a11y", "--module", ":", "--verbose")
+        .directory(projectDir)
+        .redirectErrorStream(true)
+    builder.environment()["ANDROID_HOME"] = androidSdkDir
+    val process = builder.start()
+    val output = process.inputStream.bufferedReader().use { it.readText() }
+    val exitCode = process.waitFor()
+    assertWithMessage("compose-preview a11y output:\n$output").that(exitCode).isEqualTo(0)
+
+    // 3. accessibility.json should exist and contain the BadButtonPreview finding.
+    val accessibilityJson = File(projectDir, "build/compose-previews/accessibility.json")
+    assertWithMessage("accessibility.json should exist after `compose-preview a11y`")
+      .that(accessibilityJson.exists())
+      .isTrue()
+
+    val report = json.parseToJsonElement(accessibilityJson.readText()).jsonObject
+    val entries = report["entries"]?.jsonArray ?: error("accessibility.json has no entries field")
+    val findings =
+      entries
+        .map { it.jsonObject }
+        .flatMap { it["findings"]?.jsonArray?.toList() ?: emptyList() }
+        .map { it.jsonObject }
+
+    // The deliberate `BadButtonPreview` (20dp Button, no contentDescription) reliably trips at
+    // least `SpeakableTextPresentCheck`. ATF may surface additional findings (TouchTarget,
+    // ContrastRatio) — assert on the canary alone so future ATF library updates that add
+    // findings don't break the test.
+    val types = findings.map { it["type"]?.jsonPrimitive?.content }.toSet()
+    assertWithMessage("a11y findings types: $types\nfull output:\n$output")
+      .that(types)
+      .contains("SpeakableTextPresentCheck")
+  }
+
+  /**
+   * Synthetic single-module Android library project. The plugin is resolved from mavenLocal so
+   * AGP + our plugin share one classloader; `local.properties` carries the Android SDK path so
+   * AGP's resource pipeline initialises cleanly.
+   */
+  private fun createAndroidTestProject(): File {
+    val projectDir = tempDir.root
+
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenLocal()
+                mavenCentral()
+            }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenLocal()
+                mavenCentral()
+            }
+        }
+        rootProject.name = "cli-a11y-e2e"
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "local.properties").writeText("sdk.dir=$androidSdkDir\n")
+
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        plugins {
+            id("com.android.library") version "9.2.0"
+            id("org.jetbrains.kotlin.plugin.compose") version "2.3.20"
+            id("ee.schimke.composeai.preview") version "$pluginVersion"
+        }
+
+        android {
+            namespace = "ee.schimke.composeai.functionaltest.clia11y"
+            compileSdk = 36
+            defaultConfig { minSdk = 24 }
+            buildFeatures { compose = true }
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+            testOptions { unitTests.isIncludeAndroidResources = true }
+        }
+
+        kotlin {
+            jvmToolchain(17)
+        }
+
+        composePreview {
+            // Need the daemon enabled so `composePreviewDaemonStart` produces a launchable
+            // descriptor (the CLI's `compose-preview a11y` spawns the daemon from it).
+            daemon { enabled.set(true) }
+        }
+
+        dependencies {
+            implementation(platform("androidx.compose:compose-bom:2026.04.01"))
+            implementation("androidx.compose.ui:ui")
+            implementation("androidx.compose.ui:ui-tooling-preview")
+            implementation("androidx.compose.material3:material3")
+            implementation("androidx.compose.foundation:foundation")
+            debugImplementation("androidx.compose.ui:ui-tooling")
+        }
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "gradle.properties")
+      .writeText(
+        """
+        org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+        android.useAndroidX=true
+        """
+          .trimIndent()
+      )
+
+    val srcDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/functionaltest/clia11y")
+    srcDir.mkdirs()
+    File(srcDir, "BadButtonPreview.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.functionaltest.clia11y
+
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.material3.Button
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.ui.unit.dp
+
+        /**
+         * Deliberately-broken preview — a 20dp Material Button with no content description. ATF
+         * reliably flags `SpeakableTextPresentCheck` (no accessible label); often also flags
+         * `TouchTargetSize` (below 48dp). Mirrors `BadButtonPreview` in `:samples:android`.
+         */
+        @Preview(name = "Bad Button", showBackground = true, backgroundColor = 0xFFFFFFFF)
+        @Composable
+        fun BadButtonPreview() {
+            Button(onClick = {}, modifier = Modifier.size(20.dp)) {}
+        }
+        """
+          .trimIndent()
+      )
+
+    return projectDir
+  }
+}


### PR DESCRIPTION
## Summary

Adds `CliA11yEndToEndFunctionalTest` under `:gradle-plugin:functionalTest` that drives the actual `compose-preview` CLI binary against a synthetic Android-library project — the daemon spawns, fetches `a11y/atf` per preview, and the test asserts the canary `BadButtonPreview` finding (`SpeakableTextPresentCheck`) appears in the produced `accessibility.json`. Closes the gap [`CliA11yInputsFunctionalTest`](https://github.com/yschimke/compose-ai-tools/blob/main/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/CliA11yInputsFunctionalTest.kt) doesn't — that test only pins the Gradle-side inputs.

## Gating

Three layers, evaluated in order so the failure mode is informative:

1. **`-Pcli.a11y.e2e=true` opt-in.** Default off — the test cold-starts a Robolectric JVM per render and a daemon JVM per module, way too slow for `./gradlew check`. The root build's `functionalTestWithAndroid` task flips the flag.
2. **Android SDK must be reachable** via `ANDROID_HOME` / `ANDROID_SDK_ROOT` / `local.properties`. `assumeTrue` skip on dev environments without an SDK.
3. **CLI binary + renderer-android AAR + plugin marker must be in their expected locations.** Past the SDK gate these are hard failures — a sibling-task race in `functionalTestWithAndroid`'s publish chain would silently green if `assumeTrue` swallowed it.

Verified locally: default `./gradlew :gradle-plugin:functionalTest` self-skips with "Skipping: -Pcli.a11y.e2e=true not set"; the rest of the functional suite stays green.

## Required parent-build wiring

Restores the `androidFunctionalTestPublishTargets` publish closure + `functionalTestWithAndroid` task that #1127 trimmed to a no-op alias when `AccessibilityAndroidFunctionalTest` was deleted. The orchestrator now depends on:

- `:renderer-android:publishToMavenLocal` + transitive `:data-*` modules → the synthetic project resolves the AAR closure from `~/.m2`.
- `:gradle-plugin:publishToMavenLocal` → the synthetic `plugins { id("ee.schimke.composeai.preview") version "<v>" }` block looks up the marker.
- `:cli:installDist` → builds `cli/build/install/compose-preview/bin/compose-preview`, the binary the test invokes as a subprocess.
- `gradle-plugin:functionalTest` → the test itself.

## `:gradle-plugin:build.gradle.kts` wiring

Two new system properties surfaced on the functionalTest JVM:

- `composeai.functionalTest.cliA11yE2E` — the opt-in flag.
- `composeai.functionalTest.cliBinary` — absolute path to the CLI binary under `cli/build/install/`. Empty when `:cli:installDist` hasn't run; the test self-skips with a clear message.

## Test plan

- [x] Default `./gradlew :gradle-plugin:functionalTest` — `CliA11yEndToEndFunctionalTest` self-skips. Verified locally (`<skipped/>` with the expected message).
- [x] Full `:gradle-plugin:functionalTest` suite still green.
- [x] `ktfmtCheckAll` clean.
- [ ] CI's `functionalTestWithAndroid` job will exercise the e2e against a real Android SDK on a follow-up CI run. The existing `a11y-report.yml` already runs the same shape against `:samples:wear` on every PR; this is the synthetic-project counterpart that runs on every push, not just PRs to a content branch.

## Out of scope

- A CMP-flavour equivalent — CMP has no a11y data product registered today.
- Asserting on additional findings (`TouchTargetSize`, `ContrastRatio`). ATF library upgrades could add or rename those; sticking to the `SpeakableTextPresentCheck` canary keeps the test resilient.

---
_Generated by [Claude Code](https://claude.ai/code/session_0178MWQ319fGv7JWjSwpsvSU)_