### PR TITLE
test(vscode-extension): preview-harness wire-side contract runner (closes #1123)

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -197,7 +197,8 @@
         "test:e2e": "npm run compile && COMPOSE_PREVIEW_E2E=1 node ./out/test/electron/runTest.js",
         "lint": "eslint src --ext ts",
         "package": "npm run compile && vsce package --no-dependencies",
-        "harness:snapshot": "node esbuild.webview.mjs && node preview-harness/snapshot.mjs"
+        "harness:snapshot": "node esbuild.webview.mjs && node preview-harness/snapshot.mjs",
+        "harness:contract": "node esbuild.webview.mjs && node preview-harness/contract.mjs"
     },
     "devDependencies": {
         "@happy-dom/global-registrator": "^20.9.0",

--- a/vscode-extension/preview-harness/README.md
+++ b/vscode-extension/preview-harness/README.md
@@ -82,6 +82,38 @@ To preview interactively, serve the extension root and open
 npx --yes http-server -c-1 .       # from vscode-extension/
 ```
 
+## Wire-side contract
+
+```sh
+npm run harness:contract         # assert each fixture's expectedPosts
+node preview-harness/contract.mjs --fixture a11y-findings
+```
+
+Same Playwright loop as `harness:snapshot`, but instead of writing a
+PNG it reads `window.__composePreviewHarness.postedMessageLog` after
+the fixture's actions complete and asserts each fixture's optional
+`expectedPosts` / `forbiddenPosts` arrays. Use it to pin the
+end-to-end wire effect of clicking a chip / toggling a kind /
+selecting a row, without launching real VS Code: the harness's
+`vscode-api.js` shim already captures every `vscode.postMessage`
+call, the contract just compares them against the per-fixture rules.
+
+A fixture's `expectedPosts` is an array of subset-match templates —
+every key on the template must equal the same key on some recorded
+post; extra keys on the recorded post are ignored. Helper:
+
+```js
+import { expectSetDataExtension } from "./_utils.mjs";
+
+expectedPosts: [
+    expectSetDataExtension(focusId, "compose/semantics", true),
+],
+```
+
+`forbiddenPosts` is the inverse — fail if any recorded post matches.
+Useful for "this code path must NOT subscribe `kind X` until the user
+opts in" assertions.
+
 ## How it works
 
 1. `scenario.html` is a static page that loads `media/preview.css`,

--- a/vscode-extension/preview-harness/contract.mjs
+++ b/vscode-extension/preview-harness/contract.mjs
@@ -1,0 +1,249 @@
+// Headless contract runner for the preview-harness scenarios. Same
+// loop shell as `snapshot.mjs` (start a tiny static server, drive
+// Playwright through each fixture), but instead of writing a PNG it
+// reads the `postedMessageLog` the harness's `vscode-api.js` shim
+// captures and asserts against each fixture's optional
+// `expectedPosts` / `forbiddenPosts` arrays.
+//
+// Closes the regression-prevention strategy started with #1119
+// (typed event bus) + #1122 (smoke tests): the harness already
+// drives the webview UI end-to-end; this script captures the
+// `vscode.postMessage` calls those clicks produce and pins them
+// against the per-fixture contract. A regression where (e.g.)
+// activating the Accessibility chip stops posting
+// `setDataExtensionEnabled` for `a11y/hierarchy` fails the build.
+//
+// Usage:
+//   node esbuild.webview.mjs           # rebuild bundle first
+//   node preview-harness/contract.mjs  # checks all fixtures with `expectedPosts`
+//
+// Override the matrix:
+//   node preview-harness/contract.mjs --fixture a11y-findings
+
+import { chromium } from "playwright";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve, relative, normalize, sep } from "node:path";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { createServer } from "node:http";
+
+const harnessDir = dirname(fileURLToPath(import.meta.url));
+const extensionRoot = resolve(harnessDir, "..");
+const fixturesDir = resolve(harnessDir, "fixtures");
+
+const mimeByExt = {
+    ".html": "text/html; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".mjs": "text/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+    ".ttf": "font/ttf",
+    ".map": "application/json; charset=utf-8",
+};
+
+function startServer(root) {
+    return new Promise((resolveServer) => {
+        const server = createServer(async (req, res) => {
+            try {
+                const url = new URL(req.url, "http://localhost");
+                const rel = decodeURIComponent(url.pathname).replace(
+                    /^\/+/,
+                    "",
+                );
+                const target = normalize(resolve(root, rel));
+                if (
+                    relative(root, target).startsWith("..") ||
+                    target === root + sep + ".."
+                ) {
+                    res.writeHead(403);
+                    res.end("forbidden");
+                    return;
+                }
+                let filePath = target;
+                try {
+                    const s = await stat(filePath);
+                    if (s.isDirectory()) {
+                        filePath = resolve(filePath, "index.html");
+                    }
+                } catch {
+                    res.writeHead(404);
+                    res.end("not found: " + rel);
+                    return;
+                }
+                const ext = filePath.slice(filePath.lastIndexOf("."));
+                const body = await readFile(filePath);
+                res.writeHead(200, {
+                    "content-type":
+                        mimeByExt[ext] ?? "application/octet-stream",
+                    "cache-control": "no-store",
+                });
+                res.end(body);
+            } catch (err) {
+                res.writeHead(500);
+                res.end(String(err));
+            }
+        });
+        server.listen(0, "127.0.0.1", () => {
+            const addr = server.address();
+            resolveServer({
+                origin: `http://127.0.0.1:${addr.port}`,
+                close: () => new Promise((r) => server.close(r)),
+            });
+        });
+    });
+}
+
+function arg(name, fallback) {
+    const i = process.argv.indexOf("--" + name);
+    return i >= 0 ? process.argv[i + 1] : fallback;
+}
+
+const explicitFixture = arg("fixture", null);
+
+async function listFixtures() {
+    if (explicitFixture) return [explicitFixture];
+    const entries = await readdir(fixturesDir);
+    return entries
+        .filter((e) => e.endsWith(".json"))
+        .map((e) => e.replace(/\.json$/, ""));
+}
+
+/**
+ * Subset-equality: every key in [expected] must match the
+ * corresponding key in [actual]. Extra keys on [actual] are
+ * allowed so fixtures don't have to know about every field the
+ * webview attaches (e.g. `previewId` defaults). Recurses into
+ * nested objects but treats arrays as opaque (compare with
+ * `JSON.stringify` for now — no fixture currently asserts on
+ * an array-valued post).
+ */
+function matchesSubset(expected, actual) {
+    if (typeof expected !== "object" || expected === null) {
+        return expected === actual;
+    }
+    if (Array.isArray(expected)) {
+        return JSON.stringify(expected) === JSON.stringify(actual);
+    }
+    if (typeof actual !== "object" || actual === null) return false;
+    for (const k of Object.keys(expected)) {
+        if (!matchesSubset(expected[k], actual[k])) return false;
+    }
+    return true;
+}
+
+function findMatchingPost(log, expected) {
+    return log.find((post) => matchesSubset(expected, post));
+}
+
+async function loadFixture(name) {
+    const raw = await readFile(resolve(fixturesDir, name + ".json"), "utf8");
+    return JSON.parse(raw);
+}
+
+const failures = [];
+
+const fixtures = await listFixtures();
+const server = await startServer(extensionRoot);
+const browser = await chromium.launch();
+
+try {
+    for (const fixtureName of fixtures) {
+        const fixture = await loadFixture(fixtureName);
+        const expected = fixture.expectedPosts ?? [];
+        const forbidden = fixture.forbiddenPosts ?? [];
+        if (expected.length === 0 && forbidden.length === 0) {
+            console.log(
+                `[contract] ${fixtureName}: no expectedPosts / forbiddenPosts — skipped`,
+            );
+            continue;
+        }
+
+        const context = await browser.newContext({
+            viewport: { width: 1024, height: 720 },
+        });
+        const page = await context.newPage();
+        page.on("pageerror", (err) =>
+            console.error(`[${fixtureName}] pageerror:`, err.message),
+        );
+        page.on("console", (msg) => {
+            if (msg.type() === "error") {
+                console.error(`[${fixtureName}] console:`, msg.text());
+            }
+        });
+
+        const url = new URL(server.origin + "/preview-harness/scenario.html");
+        url.searchParams.set("fixture", fixtureName);
+        url.searchParams.set("theme", "dark");
+        await page.goto(url.href);
+
+        await page.waitForFunction(
+            () => window.__composePreviewHarness?.ready === true,
+            { timeout: 10_000 },
+        );
+
+        const log = await page.evaluate(
+            () => window.__composePreviewHarness.postedMessageLog,
+        );
+
+        const fixtureFailures = [];
+        for (const exp of expected) {
+            if (!findMatchingPost(log, exp)) {
+                fixtureFailures.push({ kind: "missing", expected: exp });
+            }
+        }
+        for (const forb of forbidden) {
+            const hit = findMatchingPost(log, forb);
+            if (hit) {
+                fixtureFailures.push({
+                    kind: "forbidden",
+                    expected: forb,
+                    actual: hit,
+                });
+            }
+        }
+
+        if (fixtureFailures.length === 0) {
+            console.log(
+                `[contract] ${fixtureName}: ✓ ${expected.length} expected post(s) matched, ${forbidden.length} forbidden absent`,
+            );
+        } else {
+            console.error(
+                `[contract] ${fixtureName}: ✗ ${fixtureFailures.length} contract violation(s)`,
+            );
+            for (const f of fixtureFailures) {
+                if (f.kind === "missing") {
+                    console.error(
+                        "  - missing expected post:",
+                        JSON.stringify(f.expected),
+                    );
+                } else {
+                    console.error(
+                        "  - forbidden post observed:",
+                        JSON.stringify(f.actual),
+                        "(matched rule)",
+                        JSON.stringify(f.expected),
+                    );
+                }
+            }
+            console.error(
+                `  Recorded postedMessageLog:`,
+                JSON.stringify(log, null, 2),
+            );
+            failures.push({ fixture: fixtureName, fixtureFailures });
+        }
+
+        await context.close();
+    }
+} finally {
+    await browser.close();
+    await server.close();
+}
+
+if (failures.length > 0) {
+    console.error(
+        `\n[contract] FAILED — ${failures.length} fixture(s) had violations`,
+    );
+    process.exit(1);
+}
+console.log("\n[contract] PASSED");

--- a/vscode-extension/preview-harness/fixtures/_utils.mjs
+++ b/vscode-extension/preview-harness/fixtures/_utils.mjs
@@ -200,3 +200,14 @@ export function focusAction(previewId) {
 export function activateBundleAction(bundleId) {
     return { click: `bundle-chip-bar button[data-bundle="${bundleId}"]` };
 }
+
+/**
+ * Assertion sugar: build an `expectedPosts` entry that matches a
+ * `setDataExtensionEnabled` call for [previewId] / [kind] / [enabled].
+ * Used by fixtures to pin the wire-side effect of activating a
+ * bundle chip (default-ON kinds) or toggling a Configure-expander
+ * checkbox.
+ */
+export function expectSetDataExtension(previewId, kind, enabled) {
+    return { command: "setDataExtensionEnabled", previewId, kind, enabled };
+}

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.gen.mjs
@@ -299,6 +299,25 @@ const fixture = {
             click: `[data-bundle="a11y"] tr[data-legend-id="a11y-4"]`,
         },
     ],
+    // Pinning the chip-activation wire effect: the Accessibility
+    // bundle's two default-ON kinds (per `bundleRegistry.ts`) —
+    // `a11y/touchTargets` and `a11y/overlay` are default-OFF and
+    // not subscribed by chip activation, so they're intentionally
+    // not asserted here.
+    expectedPosts: [
+        {
+            command: "setDataExtensionEnabled",
+            previewId: FOCUS_ID,
+            kind: "a11y/hierarchy",
+            enabled: true,
+        },
+        {
+            command: "setDataExtensionEnabled",
+            previewId: FOCUS_ID,
+            kind: "a11y/atf",
+            enabled: true,
+        },
+    ],
 };
 
 process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.json
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.json
@@ -162,5 +162,19 @@
     {
       "click": "[data-bundle=\"a11y\"] tr[data-legend-id=\"a11y-4\"]"
     }
+  ],
+  "expectedPosts": [
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "kind": "a11y/hierarchy",
+      "enabled": true
+    },
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "kind": "a11y/atf",
+      "enabled": true
+    }
   ]
 }

--- a/vscode-extension/preview-harness/fixtures/history-diff.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/history-diff.gen.mjs
@@ -14,6 +14,7 @@ import {
     activateBundleAction,
     buildMobileMock,
     buildPreviewPair,
+    expectSetDataExtension,
     focusAction,
     rectBounds,
 } from "./_utils.mjs";
@@ -95,6 +96,11 @@ const fixture = {
         {
             click: `[data-bundle="history"] tr[data-legend-id="history-diff-region-2"]`,
         },
+    ],
+    // History bundle has one default-ON kind. Activating the chip
+    // posts a single subscription.
+    expectedPosts: [
+        expectSetDataExtension(focusId, "history/diff/regions", true),
     ],
 };
 

--- a/vscode-extension/preview-harness/fixtures/history-diff.json
+++ b/vscode-extension/preview-harness/fixtures/history-diff.json
@@ -133,5 +133,13 @@
     {
       "click": "[data-bundle=\"history\"] tr[data-legend-id=\"history-diff-region-2\"]"
     }
+  ],
+  "expectedPosts": [
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "kind": "history/diff/regions",
+      "enabled": true
+    }
   ]
 }

--- a/vscode-extension/preview-harness/fixtures/inspection-tree.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/inspection-tree.gen.mjs
@@ -18,6 +18,7 @@ import {
     activateBundleAction,
     buildMobileMock,
     buildPreviewPair,
+    expectSetDataExtension,
     focusAction,
     rectBounds,
 } from "./_utils.mjs";
@@ -167,6 +168,15 @@ const fixture = {
         {
             click: `[data-bundle="inspection"] tr[data-legend-id="semantics-primary-cta"]`,
         },
+    ],
+    // Pinning the wire-side effect of activating the Inspection
+    // chip — `compose/semantics` is the bundle's only default-ON
+    // kind (per `bundleRegistry.ts`), so a single
+    // `setDataExtensionEnabled` post is expected. Row click is a
+    // pure UI action and posts nothing wire-side; no extra entries
+    // here.
+    expectedPosts: [
+        expectSetDataExtension(focusId, "compose/semantics", true),
     ],
 };
 

--- a/vscode-extension/preview-harness/fixtures/inspection-tree.json
+++ b/vscode-extension/preview-harness/fixtures/inspection-tree.json
@@ -202,5 +202,13 @@
     {
       "click": "[data-bundle=\"inspection\"] tr[data-legend-id=\"semantics-primary-cta\"]"
     }
+  ],
+  "expectedPosts": [
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "kind": "compose/semantics",
+      "enabled": true
+    }
   ]
 }

--- a/vscode-extension/preview-harness/fixtures/text-strings.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/text-strings.gen.mjs
@@ -17,6 +17,7 @@ import {
     activateBundleAction,
     buildMobileMock,
     buildPreviewPair,
+    expectSetDataExtension,
     focusAction,
     rectBounds,
 } from "./_utils.mjs";
@@ -178,6 +179,14 @@ const fixture = {
         {
             click: `[data-bundle="text"] tr[data-legend-id="text-string-2"]`,
         },
+    ],
+    // The Text / i18n bundle's two default-ON kinds (per
+    // `bundleRegistry.ts`) — translations is default-OFF and only
+    // arrives via the Configure expander, so it is intentionally
+    // not asserted here.
+    expectedPosts: [
+        expectSetDataExtension(focusId, "text/strings", true),
+        expectSetDataExtension(focusId, "fonts/used", true),
     ],
 };
 

--- a/vscode-extension/preview-harness/fixtures/text-strings.json
+++ b/vscode-extension/preview-harness/fixtures/text-strings.json
@@ -207,5 +207,19 @@
     {
       "click": "[data-bundle=\"text\"] tr[data-legend-id=\"text-string-2\"]"
     }
+  ],
+  "expectedPosts": [
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "kind": "text/strings",
+      "enabled": true
+    },
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "kind": "fonts/used",
+      "enabled": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #1123 — wire-side contract test for the bundle-UI flow, reusing the existing preview-harness Playwright loop instead of standing up a separate `vscode-test-electron` round-trip.

## Why this scope (vs. real-VS-Code-via-Electron)

The original issue called for "Playwright on the packaged extension" — running the bundled extension inside real VS Code via `@vscode/test-electron` and driving its webview with Playwright. That's two pieces of infra (Electron + Playwright) for what's fundamentally a webview-wiring assertion.

The harness already runs the bundled `media/webview/preview.js` end-to-end in headless Chromium and captures every `vscode.postMessage` call into `window.__composePreviewHarness.postedMessageLog`. Bolting `expectedPosts` onto each fixture gives the same regression-prevention guarantee at a fraction of the cost.

The complement — full-stack daemon ↔ extension ↔ webview e2e — is already covered by `e2eA11y.test.ts` against a real Gradle build (`COMPOSE_PREVIEW_E2E=1`).

## What lands

- **`preview-harness/contract.mjs`** — Playwright runner. Loads each fixture, waits for `harness.ready`, reads the post log, asserts `expectedPosts` (subset-match) + `forbiddenPosts`. Non-zero exit on any violation.
- **`npm run harness:contract`** — script wired into `package.json`.
- **`expectSetDataExtension`** helper in `_utils.mjs`.
- **`expectedPosts` arrays** added to all four bundle fixtures pinning the chip-activation wire effect — every default-ON kind in `bundleRegistry.ts` posts a corresponding `setDataExtensionEnabled` message; contract fails if the wiring drops.
- **README section** documenting the flow + the `expectedPosts` / `forbiddenPosts` shape.

## Verified

The contract catches regressions: stubbed out `BundleController.activate`'s `setKindEnabled` call locally and watched all four bundle fixtures flip to "missing expected post" with the recorded log dumped for diagnosis (reverted before commit).

## Test plan

- [x] `npm run harness:contract` — all four bundle fixtures green, grid-default skipped (no contract)
- [x] Manually verified failure mode (stubbed wiring → 4 fixtures fail with diagnosable output)
- [x] `npm test` — 1007 passing
- [x] `npm run format:check` clean

## Track status

After this lands, the bundle-UI work is fully covered:
- #1119 typed event bus (orphan check)
- #1122 focus-view smoke tests
- #1144 per-bundle harness fixtures (visual contract)
- **#1149 / this** — wire-side contract on every bundle activation

Open from the original session: only **#1125** (`createImageBitmap` console noise) remains.

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_