### PR TITLE
fix(vscode-extension): silence expected createImageBitmap noise in the stream painter (closes #1125)

### DIFF
--- a/vscode-extension/src/test/streamingPainter.test.ts
+++ b/vscode-extension/src/test/streamingPainter.test.ts
@@ -1,0 +1,232 @@
+// Tests for the streaming-painter console-noise guards added in
+// the #1125 fix. Two paths matter:
+//
+//   1. Zero-byte `payloadBase64` short-circuits before
+//      `createImageBitmap` is even called — historically the
+//      decoder rejected with `InvalidStateError` and logged at
+//      `console.error`, which read like a real failure.
+//   2. A `createImageBitmap` rejection that arrives *after* the
+//      entry was detached downgrades to `console.debug` — the
+//      detach-mid-decode race is expected when the user
+//      navigates away while a stream is in flight.
+//
+// `paint()` is private and the `attach()` path needs a real
+// CanvasRenderingContext2D that happy-dom doesn't provide, so the
+// tests reach for the painter's `entries` map directly and inject a
+// stub entry — same trick we use elsewhere when testing private
+// helpers behind class boundaries.
+
+import * as assert from "assert";
+import { StreamingPainter } from "../webview/preview/streamingPainter";
+
+interface CapturedConsole {
+    errors: unknown[][];
+    debugs: unknown[][];
+    restore: () => void;
+}
+
+function captureConsole(): CapturedConsole {
+    const errors: unknown[][] = [];
+    const debugs: unknown[][] = [];
+    const origError = console.error;
+    const origDebug = console.debug;
+    console.error = (...args: unknown[]) => errors.push(args);
+    console.debug = (...args: unknown[]) => debugs.push(args);
+    return {
+        errors,
+        debugs,
+        restore() {
+            console.error = origError;
+            console.debug = origDebug;
+        },
+    };
+}
+
+interface PainterInternals {
+    entries: Map<string, object>;
+    paint: (e: object, f: Record<string, unknown>) => void;
+}
+
+function asInternals(painter: StreamingPainter): PainterInternals {
+    return painter as unknown as PainterInternals;
+}
+
+function stubEntry(): object {
+    // The painter's `paint()` only touches the entry fields the
+    // success path needs (canvas, ctx, anchor, paintedSeq). The
+    // tests below never reach the success path — they exercise the
+    // zero-byte guard and the rejection handler — so a minimal stub
+    // is enough.
+    return {
+        canvas: { width: 0, height: 0 },
+        ctx: {} as unknown,
+        anchor: null,
+        pendingFinal: false,
+        paintedSeq: -1,
+    };
+}
+
+function stubCreateImageBitmap(
+    impl: (...args: unknown[]) => unknown,
+): () => void {
+    const orig = (globalThis as unknown as { createImageBitmap?: unknown })
+        .createImageBitmap;
+    (
+        globalThis as unknown as { createImageBitmap: unknown }
+    ).createImageBitmap = impl;
+    return () => {
+        if (orig === undefined) {
+            delete (globalThis as unknown as { createImageBitmap?: unknown })
+                .createImageBitmap;
+        } else {
+            (
+                globalThis as unknown as { createImageBitmap: unknown }
+            ).createImageBitmap = orig;
+        }
+    };
+}
+
+describe("StreamingPainter — paint() console-noise guards", () => {
+    it("skips zero-byte payloads without calling createImageBitmap", () => {
+        const cap = captureConsole();
+        let createCalls = 0;
+        const restoreCreate = stubCreateImageBitmap(() => {
+            createCalls += 1;
+            return Promise.reject(new Error("should not have been called"));
+        });
+        try {
+            const painter = new StreamingPainter();
+            const frameStreamId = "stream-zero";
+            const entry = stubEntry();
+            asInternals(painter).entries.set(frameStreamId, entry);
+            asInternals(painter).paint(entry, {
+                frameStreamId,
+                seq: 0,
+                ptsMillis: 0,
+                widthPx: 100,
+                heightPx: 100,
+                codec: "png",
+                keyframe: true,
+                final: false,
+                payloadBase64: "",
+            });
+            assert.strictEqual(
+                createCalls,
+                0,
+                "createImageBitmap must not be called for zero-byte payloads",
+            );
+            assert.strictEqual(
+                cap.errors.length,
+                0,
+                `expected no console.error, got ${JSON.stringify(cap.errors)}`,
+            );
+            assert.strictEqual(cap.debugs.length, 1);
+            assert.ok(
+                String(cap.debugs[0][0]).includes("zero-byte payload"),
+                "debug message must name the zero-byte case",
+            );
+        } finally {
+            restoreCreate();
+            cap.restore();
+        }
+    });
+
+    it("downgrades createImageBitmap rejections to debug after the entry is detached", async () => {
+        const cap = captureConsole();
+        let rejectFn: ((err: Error) => void) | null = null;
+        const restoreCreate = stubCreateImageBitmap(
+            () =>
+                new Promise((_resolve, rej) => {
+                    rejectFn = rej as (err: Error) => void;
+                }),
+        );
+        try {
+            const painter = new StreamingPainter();
+            const frameStreamId = "stream-detach";
+            const entry = stubEntry();
+            asInternals(painter).entries.set(frameStreamId, entry);
+            asInternals(painter).paint(entry, {
+                frameStreamId,
+                seq: 0,
+                ptsMillis: 0,
+                widthPx: 100,
+                heightPx: 100,
+                codec: "png",
+                keyframe: true,
+                final: false,
+                payloadBase64: "abc=",
+            });
+            // Simulate detach mid-decode — production triggers this
+            // when `streamStopped` arrives between dispatching the
+            // frame and the decoder resolving.
+            asInternals(painter).entries.delete(frameStreamId);
+            assert.ok(rejectFn, "createImageBitmap should have been invoked");
+            (rejectFn as (err: Error) => void)(
+                new Error("The source image could not be decoded."),
+            );
+            await Promise.resolve();
+            await Promise.resolve();
+            assert.strictEqual(
+                cap.errors.length,
+                0,
+                `expected no console.error after detach race, got ${JSON.stringify(cap.errors)}`,
+            );
+            assert.ok(
+                cap.debugs.some((args) =>
+                    String(args[0]).includes("decode rejected after detach"),
+                ),
+                `debug log must name the detach race; saw ${JSON.stringify(cap.debugs)}`,
+            );
+        } finally {
+            restoreCreate();
+            cap.restore();
+        }
+    });
+
+    it("still logs error when the rejection arrives while the entry is live", async () => {
+        const cap = captureConsole();
+        let rejectFn: ((err: Error) => void) | null = null;
+        const restoreCreate = stubCreateImageBitmap(
+            () =>
+                new Promise((_resolve, rej) => {
+                    rejectFn = rej as (err: Error) => void;
+                }),
+        );
+        try {
+            const painter = new StreamingPainter();
+            const frameStreamId = "stream-live";
+            const entry = stubEntry();
+            asInternals(painter).entries.set(frameStreamId, entry);
+            asInternals(painter).paint(entry, {
+                frameStreamId,
+                seq: 0,
+                ptsMillis: 0,
+                widthPx: 100,
+                heightPx: 100,
+                codec: "png",
+                keyframe: true,
+                final: false,
+                payloadBase64: "abc=",
+            });
+            assert.ok(rejectFn, "createImageBitmap should have been invoked");
+            // Entry stays live — this is the genuine "bytes weren't
+            // decodable" case the user can act on. Keep the error log.
+            (rejectFn as (err: Error) => void)(
+                new Error("The source image could not be decoded."),
+            );
+            await Promise.resolve();
+            await Promise.resolve();
+            assert.strictEqual(
+                cap.errors.length,
+                1,
+                `expected one console.error, got ${JSON.stringify(cap.errors)}`,
+            );
+            assert.ok(
+                String(cap.errors[0][0]).includes("createImageBitmap failed"),
+            );
+        } finally {
+            restoreCreate();
+            cap.restore();
+        }
+    });
+});

--- a/vscode-extension/src/webview/preview/streamingPainter.ts
+++ b/vscode-extension/src/webview/preview/streamingPainter.ts
@@ -199,6 +199,22 @@ export class StreamingPainter {
             // leave the current bitmap in place. No paint cost.
             return;
         }
+        if (frame.payloadBase64.length === 0) {
+            // Zero-byte payload — the daemon shouldn't emit these, but
+            // handing an empty Blob to `createImageBitmap` rejects with
+            // `InvalidStateError: The source image could not be decoded`,
+            // which is alarming console noise for what is structurally
+            // a no-op. Drop the frame quietly; the next non-empty frame
+            // paints over it.
+            console.debug(
+                "compose-ai stream painter: skipping zero-byte payload",
+                {
+                    frameStreamId: frame.frameStreamId,
+                    seq: frame.seq,
+                },
+            );
+            return;
+        }
         const blob = base64ToBlob(
             frame.payloadBase64,
             mimeForCodec(frame.codec),
@@ -206,9 +222,10 @@ export class StreamingPainter {
         // createImageBitmap returns a Promise resolved on the decode worker.
         // The next rAF tick consults `entry.anchor` so the paint thread is
         // never blocked on decode.
+        const frameStreamId = frame.frameStreamId;
         void createImageBitmap(blob).then(
             (bitmap) => {
-                if (!this.entries.has(frame.frameStreamId)) {
+                if (!this.entries.has(frameStreamId)) {
                     // Detached while we were decoding — drop the bitmap.
                     bitmap.close?.();
                     return;
@@ -256,6 +273,25 @@ export class StreamingPainter {
                 }
             },
             (err) => {
+                // Detached mid-decode is an expected race — `streamStopped`
+                // arrives between the `createImageBitmap` call and its
+                // resolution, the entry vanishes, and the still-in-flight
+                // decode trips `InvalidStateError` on bytes that became
+                // orphaned. Downgrade those to `debug`; only log `error`
+                // for the genuine "the bytes that crossed the wire weren't
+                // decodable" case the user can actually do something
+                // about.
+                if (!this.entries.has(frameStreamId)) {
+                    console.debug(
+                        "compose-ai stream painter: decode rejected after detach",
+                        {
+                            frameStreamId,
+                            seq: frame.seq,
+                            err: err instanceof Error ? err.message : err,
+                        },
+                    );
+                    return;
+                }
                 console.error(
                     `compose-ai stream painter: createImageBitmap failed`,
                     err,


### PR DESCRIPTION
## Summary

Closes #1125. Two console-noise sources in `streamingPainter.paint()`:

### Zero-byte payloads short-circuit
The decoder rejected with `InvalidStateError: The source image could not be decoded.` on empty Blobs and logged at `console.error`. Alarming for what is structurally a no-op. The daemon shouldn't emit these, but a defensive guard is cheap and stops the noise immediately. Downgraded to a single `console.debug` carrying the frame id + seq.

### Detach-mid-decode races downgrade to debug
When `streamStopped` arrives between dispatching the frame and the decoder resolving, the entry vanishes and the still-in-flight decoder trips `InvalidStateError` on bytes that became orphaned — an expected race the user can't act on. The success path already gates on `this.entries.has(frameStreamId)`; the rejection path now checks the same and logs at `debug` instead of `error`.

**Genuine "bytes weren't decodable" rejections (entry still live) keep the original `error` log** so a real producer regression stays loud. Tested explicitly.

## Test plan

- [x] `npm test` — 1010 passing (3 new specs: zero-byte short-circuit, detach-race downgrade, still-live error path)
- [x] `npm run format:check` clean
- [x] `npm run compile:webview` clean

## Track status

After this lands, every issue filed during the original Compose Preview session is closed:

- #1119 typed event bus ✅
- #1122 focus-view smoke tests ✅
- #1123 wire-side contract ✅ (#1151, awaiting merge)
- #1124 Resources + earlyFeatures + CSP ✅
- #1125 streaming-painter noise ✅ (this PR)
- #1128 a11y/touchTargets ✅
- #1130 bundle-legend ✅
- #1135 TDZ guard ✅
- #1138 a11y row-click detail ✅
- #1140 a11y tree indent ✅
- #1142 legend adoption ✅
- #1144 per-bundle fixtures ✅
- #1145 text + history row-detail ✅ (#1148 + #1149)
- #1146 inspection row-detail ✅ (#1148)

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_