### PR TITLE
ci(vscode-extension): gate harness contract on PR + add forbiddenPosts to bundle fixtures

### DIFF
--- a/.github/actions/vscode-preview-baselines/action.yml
+++ b/.github/actions/vscode-preview-baselines/action.yml
@@ -45,6 +45,16 @@ runs:
       working-directory: vscode-extension
       run: npm run harness:snapshot
 
+    # Wire-side contract — same Playwright loop as the snapshot,
+    # asserts each fixture's `expectedPosts` / `forbiddenPosts`
+    # match the actual `vscode.postMessage` calls. Failing here on
+    # a baseline run flags a regression that landed without a
+    # contract violation surfacing via the per-PR action.
+    - name: Run harness contract
+      shell: bash
+      working-directory: vscode-extension
+      run: npm run harness:contract
+
     - name: Stage baselines
       shell: bash
       env:

--- a/.github/actions/vscode-preview-comment/action.yml
+++ b/.github/actions/vscode-preview-comment/action.yml
@@ -56,6 +56,18 @@ runs:
       working-directory: vscode-extension
       run: npm run harness:snapshot
 
+    # Wire-side contract for the bundle UI flow — asserts each
+    # fixture's `expectedPosts` / `forbiddenPosts` match the actual
+    # `vscode.postMessage` calls the fixture's actions produced.
+    # Same Playwright loop as `harness:snapshot`, no extra setup.
+    # Catches regressions where (e.g.) activating the Accessibility
+    # chip stops posting `setDataExtensionEnabled` for a default-ON
+    # kind — a visual diff alone wouldn't surface that.
+    - name: Run harness contract
+      shell: bash
+      working-directory: vscode-extension
+      run: npm run harness:contract
+
     - name: Fetch baselines
       shell: bash
       env:

--- a/vscode-extension/preview-harness/fixtures/_utils.mjs
+++ b/vscode-extension/preview-harness/fixtures/_utils.mjs
@@ -211,3 +211,18 @@ export function activateBundleAction(bundleId) {
 export function expectSetDataExtension(previewId, kind, enabled) {
     return { command: "setDataExtensionEnabled", previewId, kind, enabled };
 }
+
+/**
+ * Assertion sugar for `forbiddenPosts`: assert that a chip
+ * activation did NOT subscribe a default-OFF kind. The contract
+ * runner subset-matches this against every recorded post and
+ * fails if it finds one.
+ */
+export function forbidSetDataExtensionEnabled(previewId, kind) {
+    return {
+        command: "setDataExtensionEnabled",
+        previewId,
+        kind,
+        enabled: true,
+    };
+}

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.gen.mjs
@@ -300,10 +300,7 @@ const fixture = {
         },
     ],
     // Pinning the chip-activation wire effect: the Accessibility
-    // bundle's two default-ON kinds (per `bundleRegistry.ts`) —
-    // `a11y/touchTargets` and `a11y/overlay` are default-OFF and
-    // not subscribed by chip activation, so they're intentionally
-    // not asserted here.
+    // bundle's two default-ON kinds (per `bundleRegistry.ts`).
     expectedPosts: [
         {
             command: "setDataExtensionEnabled",
@@ -315,6 +312,25 @@ const fixture = {
             command: "setDataExtensionEnabled",
             previewId: FOCUS_ID,
             kind: "a11y/atf",
+            enabled: true,
+        },
+    ],
+    // The remaining a11y kinds are default-OFF — chip activation
+    // must not subscribe them. Touching them flips into expensive
+    // daemon work (touch-target geometry pass + Paparazzi-style
+    // PNG render) that the user should opt into via the Configure
+    // expander, never as a side-effect of pressing the chip.
+    forbiddenPosts: [
+        {
+            command: "setDataExtensionEnabled",
+            previewId: FOCUS_ID,
+            kind: "a11y/touchTargets",
+            enabled: true,
+        },
+        {
+            command: "setDataExtensionEnabled",
+            previewId: FOCUS_ID,
+            kind: "a11y/overlay",
             enabled: true,
         },
     ],

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.json
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.json
@@ -176,5 +176,19 @@
       "kind": "a11y/atf",
       "enabled": true
     }
+  ],
+  "forbiddenPosts": [
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "kind": "a11y/touchTargets",
+      "enabled": true
+    },
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "kind": "a11y/overlay",
+      "enabled": true
+    }
   ]
 }

--- a/vscode-extension/preview-harness/fixtures/inspection-tree.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/inspection-tree.gen.mjs
@@ -20,6 +20,7 @@ import {
     buildPreviewPair,
     expectSetDataExtension,
     focusAction,
+    forbidSetDataExtensionEnabled,
     rectBounds,
 } from "./_utils.mjs";
 
@@ -177,6 +178,16 @@ const fixture = {
     // here.
     expectedPosts: [
         expectSetDataExtension(focusId, "compose/semantics", true),
+    ],
+    // The other two Inspection kinds are default-OFF in
+    // `bundleRegistry.ts` — chip activation must not subscribe
+    // them. The fixture preloads `layout/inspector` data for the
+    // tree to render once the user opts in via the Configure
+    // expander; subscribing it on chip activation would burn
+    // daemon CPU on a kind nobody asked for.
+    forbiddenPosts: [
+        forbidSetDataExtensionEnabled(focusId, "layout/inspector"),
+        forbidSetDataExtensionEnabled(focusId, "uia/hierarchy"),
     ],
 };
 

--- a/vscode-extension/preview-harness/fixtures/inspection-tree.json
+++ b/vscode-extension/preview-harness/fixtures/inspection-tree.json
@@ -210,5 +210,19 @@
       "kind": "compose/semantics",
       "enabled": true
     }
+  ],
+  "forbiddenPosts": [
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "kind": "layout/inspector",
+      "enabled": true
+    },
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "kind": "uia/hierarchy",
+      "enabled": true
+    }
   ]
 }

--- a/vscode-extension/preview-harness/fixtures/text-strings.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/text-strings.gen.mjs
@@ -19,6 +19,7 @@ import {
     buildPreviewPair,
     expectSetDataExtension,
     focusAction,
+    forbidSetDataExtensionEnabled,
     rectBounds,
 } from "./_utils.mjs";
 
@@ -188,6 +189,11 @@ const fixture = {
         expectSetDataExtension(focusId, "text/strings", true),
         expectSetDataExtension(focusId, "fonts/used", true),
     ],
+    // `i18n/translations` is default-OFF — chip activation must not
+    // subscribe it. The fixture preloads the payload so the
+    // Translations sub-table can render once the user opts in via
+    // the Configure expander.
+    forbiddenPosts: [forbidSetDataExtensionEnabled(focusId, "i18n/translations")],
 };
 
 process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/text-strings.json
+++ b/vscode-extension/preview-harness/fixtures/text-strings.json
@@ -221,5 +221,13 @@
       "kind": "fonts/used",
       "enabled": true
     }
+  ],
+  "forbiddenPosts": [
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
+      "kind": "i18n/translations",
+      "enabled": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Two complementary changes that turn the harness contract runner from a manual-only check into a real PR gate.

### CI gating

Both existing harness actions (`vscode-preview-comment` for the per-PR diff, `vscode-preview-baselines` for the main-branch baseline) already run `npm run harness:snapshot` with Playwright fully set up. This adds an `npm run harness:contract` step right after the snapshot — same browser, no extra setup cost. Failing the contract fails the action, which fails the PR.

The triggers stay scoped to `vscode-extension/src/webview/**`, `media/**`, `preview-harness/**` so changes outside the panel don't pay for it.

### `forbiddenPosts` on every bundle fixture

`expectedPosts` already pin the chip-activation effect for each bundle's default-ON kinds. The complement was missing: chip activation must **not** subscribe default-OFF kinds. Those are power-user opt-ins via the Configure expander, and quietly flipping them on is exactly the regression the contract should catch (daemon CPU goes through the roof on a kind nobody asked for).

A new `forbidSetDataExtensionEnabled(previewId, kind)` helper. Each bundle fixture asserts the default-OFF kinds for its bundle (per `bundleRegistry.ts`) are absent from the recorded log:

| Fixture | Forbidden |
|---|---|
| `a11y-findings` | `a11y/touchTargets`, `a11y/overlay` |
| `inspection-tree` | `layout/inspector`, `uia/hierarchy` |
| `text-strings` | `i18n/translations` |
| `history-diff` | (single default-ON kind — nothing to forbid) |

## Test plan

- [x] `npm run harness:contract` — all four fixtures green: a11y `2/2`, inspection `1/2`, text `2/1`, history `1/0` (expected matched / forbidden absent)
- [x] `npm test` — 1007 passing
- [x] `npm run format:check` clean
- [x] CI workflow yaml validated by inspection (action.yml step inserted between existing snapshot and baseline-fetch steps; same shell/working-dir as neighbouring steps)

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFfNNobXDehqo5NGun3Vc)_