### PR TITLE
test(mcp): include enable_extensions in DaemonMcpServerTest tool surface

### DIFF
--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -107,6 +107,7 @@ class DaemonMcpServerTest {
         "history_diff",
         "list_data_products",
         "list_extension_commands",
+        "enable_extensions",
         "run_extension_command",
         "get_preview_data",
         "subscribe_preview_data",


### PR DESCRIPTION
## Summary

`DaemonMcpServerTest.initialize and tools list returns expected tool surface` has been failing on `main` since `enable_extensions` was added to the server's tool surface — the test's `assertThat(names).containsExactly(...)` expected list was never updated alongside the registration. (I'd been working around this in my other `:mcp` PRs by noting the failure as pre-existing; this is the one-line fix to clear it.)

Truth's `containsExactly` matches set-equality (order-independent), so the only correction needed is appending `"enable_extensions"` to the expected list.

## Test plan

- [x] `:mcp:test --tests "*DaemonMcpServerTest.initialize and tools list returns expected tool surface*"` passes.
- [x] Full `:mcp:test` suite green.
- [x] `ktfmtCheckAll` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_0178MWQ319fGv7JWjSwpsvSU)_