### PR TITLE
refactor(render-session): share DaemonClientRenderSession delegate

### DIFF
--- a/render-session/embedded-desktop/build.gradle.kts
+++ b/render-session/embedded-desktop/build.gradle.kts
@@ -35,7 +35,12 @@ dependencies {
   api(project(":render-session-api"))
 
   // The actual daemon entry point we run on a background thread, plus the JSON-RPC client we
-  // wrap the calling end of the pipes with.
+  // wrap the calling end of the pipes with. `:render-session-subprocess` is depended on for
+  // the shared `DaemonClientRenderSession` delegate (and the `NotificationFanout` helper) — the
+  // class is transport-agnostic, just needs a `DaemonClient` and a `closeAction` lambda. The
+  // subprocess module is currently the canonical home for the delegate; consumers stay light
+  // because they pull in its single transport-shared file plus the API jar, not its factory.
+  implementation(project(":render-session-subprocess"))
   implementation(project(":daemon:desktop"))
   implementation(project(":daemon:core"))
   implementation(project(":mcp"))

--- a/render-session/embedded-desktop/src/main/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSession.kt
+++ b/render-session/embedded-desktop/src/main/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSession.kt
@@ -1,267 +1,36 @@
 package ee.schimke.composeai.render.session.embedded
 
-import ee.schimke.composeai.daemon.protocol.ChangeType
-import ee.schimke.composeai.daemon.protocol.DataFetchResult
-import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
-import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
-import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
-import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
-import ee.schimke.composeai.daemon.protocol.FileKind
-import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
-import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
-import ee.schimke.composeai.daemon.protocol.HistoryListParams
-import ee.schimke.composeai.daemon.protocol.HistoryListResult
-import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
 import ee.schimke.composeai.daemon.protocol.InitializeResult
-import ee.schimke.composeai.daemon.protocol.PreviewOverrides
-import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
-import ee.schimke.composeai.daemon.protocol.RecordingFormat
-import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
-import ee.schimke.composeai.daemon.protocol.RecordingStartResult
-import ee.schimke.composeai.daemon.protocol.RecordingStopResult
-import ee.schimke.composeai.daemon.protocol.RenderNowResult
-import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.daemon.runDaemon
 import ee.schimke.composeai.mcp.DaemonClient
 import ee.schimke.composeai.mcp.DaemonLaunchDescriptor
-import ee.schimke.composeai.mcp.DataProductWireException
-import ee.schimke.composeai.render.session.DataProductException
-import ee.schimke.composeai.render.session.NotificationListener
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionBackend
 import ee.schimke.composeai.render.session.RenderSessionConfig
 import ee.schimke.composeai.render.session.RenderSessionException
 import ee.schimke.composeai.render.session.RenderSessionFactory
+import ee.schimke.composeai.render.session.subprocess.DaemonClientRenderSession
+import ee.schimke.composeai.render.session.subprocess.NotificationFanout
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
-import java.util.concurrent.CopyOnWriteArraySet
-import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.time.Duration
-import kotlinx.serialization.json.JsonElement
-
-/**
- * [RenderSession] backed by an in-process Compose Multiplatform Desktop daemon. The session spawns
- * a single background thread that runs `:daemon:desktop`'s `runDaemon(...)` against piped streams;
- * the calling thread holds the other end of those pipes via a `DaemonClient` and delegates every
- * protocol call straight through. No subprocess fork; no JSON-RPC bytes ever leave the JVM.
- *
- * Use [EmbeddedDesktopRenderSessions] to open instances; the constructor is internal so test fakes
- * can be wired without consumers seeing the transport plumbing.
- *
- * ## Lifecycle
- *
- * On [close] (or via try-with-resources), the session:
- * 1. Sends `shutdown` + `exit` to the daemon via the client (`DaemonClient.shutdownAndExit`).
- * 2. Joins the daemon thread, bounded by [SHUTDOWN_JOIN_TIMEOUT_MS]. If the thread doesn't exit
- *    cleanly within that window we interrupt it and continue — the calling thread isn't held
- *    hostage by a misbehaving renderer.
- * 3. Closes both pipe pairs so neither side leaks file descriptors.
- *
- * After close every other method throws `IllegalStateException`.
- */
-class EmbeddedDesktopRenderSession
-internal constructor(
-  override val workspaceRoot: String,
-  override val modulePath: String,
-  override val initializeResult: InitializeResult,
-  private val client: DaemonClient,
-  private val daemonThread: Thread,
-  private val pipesToClose: List<AutoCloseable>,
-  private val systemPropertyRestores: List<() -> Unit>,
-  private val listeners: CopyOnWriteArraySet<NotificationListener>,
-) : RenderSession {
-
-  override val backendKind: RenderSessionBackend = RenderSessionBackend.Embedded
-
-  private val closed = AtomicBoolean(false)
-
-  override fun setVisible(previewIds: List<String>) {
-    checkOpen()
-    client.setVisible(previewIds)
-  }
-
-  override fun setFocus(previewIds: List<String>) {
-    checkOpen()
-    client.setFocus(previewIds)
-  }
-
-  override fun fileChanged(path: String, kind: FileKind, changeType: ChangeType) {
-    checkOpen()
-    client.fileChanged(path, kind, changeType)
-  }
-
-  override fun renderNow(
-    previewIds: List<String>,
-    tier: RenderTier,
-    reason: String?,
-    overrides: PreviewOverrides?,
-    timeout: Duration,
-  ): RenderNowResult {
-    checkOpen()
-    return client.renderNow(
-      previews = previewIds,
-      tier = tier,
-      reason = reason,
-      overrides = overrides,
-      timeout = timeout,
-    )
-  }
-
-  override fun fetchData(
-    previewId: String,
-    kind: String,
-    inline: Boolean,
-    params: JsonElement?,
-    timeout: Duration,
-  ): DataFetchResult {
-    checkOpen()
-    return try {
-      client.dataFetch(
-        previewId = previewId,
-        kind = kind,
-        params = params,
-        inline = inline,
-        timeout = timeout,
-      )
-    } catch (e: DataProductWireException) {
-      throw DataProductException(
-        code = e.code,
-        wireMessage = e.wireMessage,
-        data = e.data,
-        cause = e,
-      )
-    }
-  }
-
-  override fun subscribeData(
-    previewId: String,
-    kind: String,
-    params: JsonElement?,
-    timeout: Duration,
-  ): DataSubscribeResult {
-    checkOpen()
-    return client.dataSubscribe(previewId = previewId, kind = kind, timeout = timeout)
-  }
-
-  override fun unsubscribeData(
-    previewId: String,
-    kind: String,
-    timeout: Duration,
-  ): DataSubscribeResult {
-    checkOpen()
-    return client.dataUnsubscribe(previewId = previewId, kind = kind, timeout = timeout)
-  }
-
-  override fun listExtensions(timeout: Duration): ExtensionsListResult {
-    checkOpen()
-    return client.extensionsList(timeout)
-  }
-
-  override fun enableExtensions(ids: List<String>, timeout: Duration): ExtensionsEnableResult {
-    checkOpen()
-    return client.extensionsEnable(ids = ids, timeout = timeout)
-  }
-
-  override fun disableExtensions(ids: List<String>, timeout: Duration): ExtensionsDisableResult {
-    checkOpen()
-    return client.extensionsDisable(ids = ids, timeout = timeout)
-  }
-
-  override fun historyList(params: HistoryListParams, timeout: Duration): HistoryListResult {
-    checkOpen()
-    return client.historyList(params = params, timeout = timeout)
-  }
-
-  override fun historyRead(
-    entryId: String,
-    inline: Boolean,
-    timeout: Duration,
-  ): HistoryReadResultDto {
-    checkOpen()
-    return client.historyRead(entryId = entryId, inline = inline, timeout = timeout)
-  }
-
-  override fun historyDiff(
-    fromId: String,
-    toId: String,
-    mode: HistoryDiffMode,
-    timeout: Duration,
-  ): HistoryDiffResult {
-    checkOpen()
-    return client.historyDiff(fromId = fromId, toId = toId, mode = mode, timeout = timeout)
-  }
-
-  override fun recordingStart(
-    previewId: String,
-    fps: Int?,
-    scale: Float?,
-    overrides: PreviewOverrides?,
-    timeout: Duration,
-  ): RecordingStartResult {
-    checkOpen()
-    return client.recordingStart(
-      previewId = previewId,
-      fps = fps,
-      scale = scale,
-      overrides = overrides,
-      timeout = timeout,
-    )
-  }
-
-  override fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) {
-    checkOpen()
-    client.recordingScript(recordingId, events)
-  }
-
-  override fun recordingStop(recordingId: String, timeout: Duration): RecordingStopResult {
-    checkOpen()
-    return client.recordingStop(recordingId = recordingId, timeout = timeout)
-  }
-
-  override fun recordingEncode(
-    recordingId: String,
-    format: RecordingFormat,
-    timeout: Duration,
-  ): RecordingEncodeResult {
-    checkOpen()
-    return client.recordingEncode(recordingId = recordingId, format = format, timeout = timeout)
-  }
-
-  override fun onNotification(listener: NotificationListener): AutoCloseable {
-    checkOpen()
-    listeners.add(listener)
-    return AutoCloseable { listeners.remove(listener) }
-  }
-
-  override fun close() {
-    if (!closed.compareAndSet(false, true)) return
-    runCatching { client.shutdownAndExit() }
-    runCatching { daemonThread.join(SHUTDOWN_JOIN_TIMEOUT_MS) }
-    if (daemonThread.isAlive) {
-      // Interrupt as a last resort — the join's grace window already passed. The pipes
-      // close below will tear the read loop down regardless.
-      daemonThread.interrupt()
-    }
-    pipesToClose.forEach { runCatching { it.close() } }
-    runCatching { client.close() }
-    // Restore any system properties the session set during open. LIFO so nested sessions
-    // (against the same JVM, serially) restore in the right order.
-    systemPropertyRestores.asReversed().forEach { runCatching { it.invoke() } }
-  }
-
-  private fun checkOpen() {
-    check(!closed.get()) { "RenderSession has been closed" }
-  }
-
-  companion object {
-    private const val SHUTDOWN_JOIN_TIMEOUT_MS: Long = 30_000L
-  }
-}
 
 /**
  * [RenderSessionFactory] singleton for the in-process Compose Multiplatform Desktop backend. Builds
- * an [EmbeddedDesktopRenderSession] from a [RenderSessionConfig] by hosting `:daemon:desktop`'s
- * [runDaemon] on a background thread with piped streams.
+ * a [DaemonClientRenderSession] from a [RenderSessionConfig] by hosting `:daemon:desktop`'s
+ * [runDaemon] on a background thread with piped streams. The session itself (the protocol delegate)
+ * is shared with the subprocess and MCP backends — only the transport (in-process pipes vs.
+ * subprocess stdio) and lifecycle (daemon-thread join vs. subprocess shutdown) differ.
+ *
+ * ## Lifecycle
+ *
+ * On [RenderSession.close]:
+ * 1. Send `shutdown` + `exit` to the daemon via the client.
+ * 2. Join the daemon thread, bounded by [SHUTDOWN_JOIN_TIMEOUT_MS]. If the thread doesn't exit
+ *    cleanly within that window we interrupt it and continue — the calling thread isn't held
+ *    hostage by a misbehaving renderer.
+ * 3. Close both pipe pairs so neither side leaks file descriptors.
+ * 4. Restore any system properties the session set during open (LIFO so nested sessions in the same
+ *    JVM restore in the right order).
  */
 object EmbeddedDesktopRenderSessions : RenderSessionFactory {
   override val backendKind: RenderSessionBackend = RenderSessionBackend.Embedded
@@ -332,10 +101,10 @@ object EmbeddedDesktopRenderSessions : RenderSessionFactory {
                 output = serverToClientSink,
                 installSigtermHook = false,
                 // CRITICAL: embedded mode shares the JVM with the caller. The daemon's default
-                // `onExit` calls `System.exit(...)` when the JSON-RPC `exit` notification arrives
-                // — that would terminate the calling JVM (test runners, IDE plugins, etc.) mid-
-                // operation. Swallow the exit code; the calling thread joins the daemon thread
-                // shortly after sending `exit` and observes a clean termination.
+                // `onExit` calls `System.exit(...)` when the JSON-RPC `exit` notification
+                // arrives — that would terminate the calling JVM (test runners, IDE plugins,
+                // etc.) mid-operation. Swallow the exit code; the calling thread joins the
+                // daemon thread shortly after sending `exit` and observes a clean termination.
                 onExit = { _ -> },
               )
             } catch (t: Throwable) {
@@ -349,14 +118,12 @@ object EmbeddedDesktopRenderSessions : RenderSessionFactory {
           start()
         }
 
-    val listeners = CopyOnWriteArraySet<NotificationListener>()
+    val fanout = NotificationFanout()
     val client =
       DaemonClient(
         input = serverToClientSource,
         output = clientToServerSink,
-        onNotification = { method, params ->
-          for (l in listeners) runCatching { l.onNotification(method, params) }
-        },
+        onNotification = { method, params -> fanout.dispatch(method, params) },
         onClose = {},
       )
 
@@ -383,15 +150,22 @@ object EmbeddedDesktopRenderSessions : RenderSessionFactory {
         )
       }
 
-    return EmbeddedDesktopRenderSession(
+    return DaemonClientRenderSession(
       workspaceRoot = canonicalRoot.absolutePath,
       modulePath = descriptor.modulePath,
       initializeResult = initializeResult,
+      backendKind = RenderSessionBackend.Embedded,
       client = client,
-      daemonThread = daemonThread,
-      pipesToClose = pipesToClose,
-      systemPropertyRestores = restores,
-      listeners = listeners,
+      notificationFanout = fanout,
+      closeAction = {
+        runCatching { client.shutdownAndExit() }
+        runCatching { daemonThread.join(SHUTDOWN_JOIN_TIMEOUT_MS) }
+        if (daemonThread.isAlive) daemonThread.interrupt()
+        pipesToClose.forEach { runCatching { it.close() } }
+        runCatching { client.close() }
+        fanout.clear()
+        restores.asReversed().forEach { runCatching { it.invoke() } }
+      },
     )
   }
 
@@ -403,4 +177,6 @@ object EmbeddedDesktopRenderSessions : RenderSessionFactory {
    */
   fun isAvailable(): Boolean =
     runCatching { Class.forName("ee.schimke.composeai.daemon.DaemonMain") }.isSuccess
+
+  private const val SHUTDOWN_JOIN_TIMEOUT_MS: Long = 30_000L
 }

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/DaemonClientRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/DaemonClientRenderSession.kt
@@ -1,0 +1,256 @@
+package ee.schimke.composeai.render.session.subprocess
+
+import ee.schimke.composeai.daemon.protocol.ChangeType
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
+import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
+import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
+import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingStartResult
+import ee.schimke.composeai.daemon.protocol.RecordingStopResult
+import ee.schimke.composeai.daemon.protocol.RenderNowResult
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.mcp.DaemonClient
+import ee.schimke.composeai.mcp.DataProductWireException
+import ee.schimke.composeai.render.session.DataProductException
+import ee.schimke.composeai.render.session.NotificationListener
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.RenderSessionBackend
+import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Canonical [RenderSession] implementation backed by a JSON-RPC [DaemonClient]. Shared by every
+ * backend that ultimately drives a daemon over the same protocol — today: the subprocess backend in
+ * this module, the embedded-desktop backend in `:render-session-embedded-desktop`, and the MCP
+ * supervisor's `SupervisedDaemon.session` view in `:mcp`.
+ *
+ * **What this class owns**: the transport-agnostic surface. Every [RenderSession] method delegates
+ * to the supplied [client]. [DataProductWireException]s from the client surface as the public
+ * [DataProductException]. Notifications fan out through [notificationFanout].
+ *
+ * **What it does NOT own**: subprocess lifecycle, classloader management, or anything else
+ * backend-specific. The caller passes a [closeAction] lambda that's invoked exactly once on the
+ * first [close] — that's where the subprocess backend tears down `DaemonSpawn`, the embedded
+ * backend joins its daemon thread and closes pipes, and the MCP supervisor's view leaves the daemon
+ * running (no-op close).
+ *
+ * Pre-1.0 surface. The public constructor lets new backends construct one without owning a copy of
+ * the ~150 LOC of pass-through delegate methods.
+ */
+class DaemonClientRenderSession(
+  override val workspaceRoot: String,
+  override val modulePath: String,
+  override val initializeResult: InitializeResult,
+  override val backendKind: RenderSessionBackend,
+  private val client: DaemonClient,
+  private val notificationFanout: NotificationFanout,
+  private val closeAction: () -> Unit,
+) : RenderSession {
+
+  private val closed = AtomicBoolean(false)
+
+  override fun setVisible(previewIds: List<String>) {
+    checkOpen()
+    client.setVisible(previewIds)
+  }
+
+  override fun setFocus(previewIds: List<String>) {
+    checkOpen()
+    client.setFocus(previewIds)
+  }
+
+  override fun fileChanged(path: String, kind: FileKind, changeType: ChangeType) {
+    checkOpen()
+    client.fileChanged(path, kind, changeType)
+  }
+
+  override fun renderNow(
+    previewIds: List<String>,
+    tier: RenderTier,
+    reason: String?,
+    overrides: PreviewOverrides?,
+    timeout: Duration,
+  ): RenderNowResult {
+    checkOpen()
+    return client.renderNow(
+      previews = previewIds,
+      tier = tier,
+      reason = reason,
+      overrides = overrides,
+      timeout = timeout,
+    )
+  }
+
+  override fun fetchData(
+    previewId: String,
+    kind: String,
+    inline: Boolean,
+    params: JsonElement?,
+    timeout: Duration,
+  ): DataFetchResult {
+    checkOpen()
+    return try {
+      client.dataFetch(
+        previewId = previewId,
+        kind = kind,
+        params = params,
+        inline = inline,
+        timeout = timeout,
+      )
+    } catch (e: DataProductWireException) {
+      throw DataProductException(
+        code = e.code,
+        wireMessage = e.wireMessage,
+        data = e.data,
+        cause = e,
+      )
+    }
+  }
+
+  override fun subscribeData(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    timeout: Duration,
+  ): DataSubscribeResult {
+    checkOpen()
+    return client.dataSubscribe(previewId = previewId, kind = kind, timeout = timeout)
+  }
+
+  override fun unsubscribeData(
+    previewId: String,
+    kind: String,
+    timeout: Duration,
+  ): DataSubscribeResult {
+    checkOpen()
+    return client.dataUnsubscribe(previewId = previewId, kind = kind, timeout = timeout)
+  }
+
+  override fun listExtensions(timeout: Duration): ExtensionsListResult {
+    checkOpen()
+    return client.extensionsList(timeout)
+  }
+
+  override fun enableExtensions(ids: List<String>, timeout: Duration): ExtensionsEnableResult {
+    checkOpen()
+    return client.extensionsEnable(ids = ids, timeout = timeout)
+  }
+
+  override fun disableExtensions(ids: List<String>, timeout: Duration): ExtensionsDisableResult {
+    checkOpen()
+    return client.extensionsDisable(ids = ids, timeout = timeout)
+  }
+
+  override fun historyList(params: HistoryListParams, timeout: Duration): HistoryListResult {
+    checkOpen()
+    return client.historyList(params = params, timeout = timeout)
+  }
+
+  override fun historyRead(
+    entryId: String,
+    inline: Boolean,
+    timeout: Duration,
+  ): HistoryReadResultDto {
+    checkOpen()
+    return client.historyRead(entryId = entryId, inline = inline, timeout = timeout)
+  }
+
+  override fun historyDiff(
+    fromId: String,
+    toId: String,
+    mode: HistoryDiffMode,
+    timeout: Duration,
+  ): HistoryDiffResult {
+    checkOpen()
+    return client.historyDiff(fromId = fromId, toId = toId, mode = mode, timeout = timeout)
+  }
+
+  override fun recordingStart(
+    previewId: String,
+    fps: Int?,
+    scale: Float?,
+    overrides: PreviewOverrides?,
+    timeout: Duration,
+  ): RecordingStartResult {
+    checkOpen()
+    return client.recordingStart(
+      previewId = previewId,
+      fps = fps,
+      scale = scale,
+      overrides = overrides,
+      timeout = timeout,
+    )
+  }
+
+  override fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) {
+    checkOpen()
+    client.recordingScript(recordingId, events)
+  }
+
+  override fun recordingStop(recordingId: String, timeout: Duration): RecordingStopResult {
+    checkOpen()
+    return client.recordingStop(recordingId = recordingId, timeout = timeout)
+  }
+
+  override fun recordingEncode(
+    recordingId: String,
+    format: RecordingFormat,
+    timeout: Duration,
+  ): RecordingEncodeResult {
+    checkOpen()
+    return client.recordingEncode(recordingId = recordingId, format = format, timeout = timeout)
+  }
+
+  override fun onNotification(listener: NotificationListener): AutoCloseable {
+    checkOpen()
+    return notificationFanout.register(listener)
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    runCatching { closeAction() }
+  }
+
+  private fun checkOpen() {
+    check(!closed.get()) { "RenderSession has been closed" }
+  }
+}
+
+/**
+ * Fan-out registry for the notification stream a [DaemonClientRenderSession] wraps. The owner of
+ * the underlying [DaemonClient] installs a single sink on its `onNotification` callback and pipes
+ * every event into [dispatch]; consumers register listeners via [RenderSession.onNotification]
+ * (which delegates to [register]). Lifetime is the owner's: `clear()` on teardown so stale handles
+ * to `close()` are harmless after the underlying daemon goes away.
+ */
+class NotificationFanout {
+  private val listeners = CopyOnWriteArraySet<NotificationListener>()
+
+  fun register(listener: NotificationListener): AutoCloseable {
+    listeners.add(listener)
+    return AutoCloseable { listeners.remove(listener) }
+  }
+
+  fun dispatch(method: String, params: JsonObject?) {
+    for (l in listeners) runCatching { l.onNotification(method, params) }
+  }
+
+  fun clear() {
+    listeners.clear()
+  }
+}

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -1,244 +1,26 @@
 package ee.schimke.composeai.render.session.subprocess
 
-import ee.schimke.composeai.daemon.protocol.ChangeType
-import ee.schimke.composeai.daemon.protocol.DataFetchResult
-import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
-import ee.schimke.composeai.daemon.protocol.ExtensionsDisableResult
-import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
-import ee.schimke.composeai.daemon.protocol.ExtensionsListResult
-import ee.schimke.composeai.daemon.protocol.FileKind
-import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
-import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
-import ee.schimke.composeai.daemon.protocol.HistoryListParams
-import ee.schimke.composeai.daemon.protocol.HistoryListResult
-import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
 import ee.schimke.composeai.daemon.protocol.InitializeResult
-import ee.schimke.composeai.daemon.protocol.PreviewOverrides
-import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
-import ee.schimke.composeai.daemon.protocol.RecordingFormat
-import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
-import ee.schimke.composeai.daemon.protocol.RecordingStartResult
-import ee.schimke.composeai.daemon.protocol.RecordingStopResult
-import ee.schimke.composeai.daemon.protocol.RenderNowResult
-import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.mcp.DaemonClient
 import ee.schimke.composeai.mcp.DaemonClientFactory
 import ee.schimke.composeai.mcp.DaemonLaunchDescriptor
-import ee.schimke.composeai.mcp.DataProductWireException
 import ee.schimke.composeai.mcp.RegisteredProject
 import ee.schimke.composeai.mcp.SubprocessDaemonClientFactory
 import ee.schimke.composeai.mcp.WorkspaceId
-import ee.schimke.composeai.render.session.DataProductException
-import ee.schimke.composeai.render.session.NotificationListener
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionBackend
 import ee.schimke.composeai.render.session.RenderSessionConfig
 import ee.schimke.composeai.render.session.RenderSessionException
 import ee.schimke.composeai.render.session.RenderSessionFactory
 import java.io.File
-import java.util.concurrent.CopyOnWriteArraySet
-import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.time.Duration
-import kotlinx.serialization.json.JsonElement
-
-/**
- * [RenderSession] backed by a daemon JVM spawned as a subprocess. Each session owns one subprocess;
- * closing the session shuts the subprocess down cleanly (drain → exit → wait, with timeout fallback
- * to `destroyForcibly`).
- *
- * Use [SubprocessRenderSessions] (or the static helpers below) to open sessions — the public
- * constructor is internal so test code can inject a fake [DaemonClientFactory] without inheriting
- * transport implementation details.
- */
-class SubprocessRenderSession
-internal constructor(
-  override val workspaceRoot: String,
-  override val modulePath: String,
-  override val initializeResult: InitializeResult,
-  private val spawnedClient: DaemonClient,
-  private val closeSpawn: () -> Unit,
-  private val listeners: CopyOnWriteArraySet<NotificationListener>,
-) : RenderSession {
-
-  override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
-
-  private val closed = AtomicBoolean(false)
-
-  override fun setVisible(previewIds: List<String>) {
-    checkOpen()
-    spawnedClient.setVisible(previewIds)
-  }
-
-  override fun setFocus(previewIds: List<String>) {
-    checkOpen()
-    spawnedClient.setFocus(previewIds)
-  }
-
-  override fun fileChanged(path: String, kind: FileKind, changeType: ChangeType) {
-    checkOpen()
-    spawnedClient.fileChanged(path, kind, changeType)
-  }
-
-  override fun renderNow(
-    previewIds: List<String>,
-    tier: RenderTier,
-    reason: String?,
-    overrides: PreviewOverrides?,
-    timeout: Duration,
-  ): RenderNowResult {
-    checkOpen()
-    return spawnedClient.renderNow(
-      previews = previewIds,
-      tier = tier,
-      reason = reason,
-      overrides = overrides,
-      timeout = timeout,
-    )
-  }
-
-  override fun fetchData(
-    previewId: String,
-    kind: String,
-    inline: Boolean,
-    params: JsonElement?,
-    timeout: Duration,
-  ): DataFetchResult {
-    checkOpen()
-    return try {
-      spawnedClient.dataFetch(
-        previewId = previewId,
-        kind = kind,
-        params = params,
-        inline = inline,
-        timeout = timeout,
-      )
-    } catch (e: DataProductWireException) {
-      throw DataProductException(
-        code = e.code,
-        wireMessage = e.wireMessage,
-        data = e.data,
-        cause = e,
-      )
-    }
-  }
-
-  override fun subscribeData(
-    previewId: String,
-    kind: String,
-    params: JsonElement?,
-    timeout: Duration,
-  ): DataSubscribeResult {
-    checkOpen()
-    return spawnedClient.dataSubscribe(previewId = previewId, kind = kind, timeout = timeout)
-  }
-
-  override fun unsubscribeData(
-    previewId: String,
-    kind: String,
-    timeout: Duration,
-  ): DataSubscribeResult {
-    checkOpen()
-    return spawnedClient.dataUnsubscribe(previewId = previewId, kind = kind, timeout = timeout)
-  }
-
-  override fun listExtensions(timeout: Duration): ExtensionsListResult {
-    checkOpen()
-    return spawnedClient.extensionsList(timeout)
-  }
-
-  override fun enableExtensions(ids: List<String>, timeout: Duration): ExtensionsEnableResult {
-    checkOpen()
-    return spawnedClient.extensionsEnable(ids = ids, timeout = timeout)
-  }
-
-  override fun disableExtensions(ids: List<String>, timeout: Duration): ExtensionsDisableResult {
-    checkOpen()
-    return spawnedClient.extensionsDisable(ids = ids, timeout = timeout)
-  }
-
-  override fun historyList(params: HistoryListParams, timeout: Duration): HistoryListResult {
-    checkOpen()
-    return spawnedClient.historyList(params = params, timeout = timeout)
-  }
-
-  override fun historyRead(
-    entryId: String,
-    inline: Boolean,
-    timeout: Duration,
-  ): HistoryReadResultDto {
-    checkOpen()
-    return spawnedClient.historyRead(entryId = entryId, inline = inline, timeout = timeout)
-  }
-
-  override fun historyDiff(
-    fromId: String,
-    toId: String,
-    mode: HistoryDiffMode,
-    timeout: Duration,
-  ): HistoryDiffResult {
-    checkOpen()
-    return spawnedClient.historyDiff(fromId = fromId, toId = toId, mode = mode, timeout = timeout)
-  }
-
-  override fun recordingStart(
-    previewId: String,
-    fps: Int?,
-    scale: Float?,
-    overrides: PreviewOverrides?,
-    timeout: Duration,
-  ): RecordingStartResult {
-    checkOpen()
-    return spawnedClient.recordingStart(
-      previewId = previewId,
-      fps = fps,
-      scale = scale,
-      overrides = overrides,
-      timeout = timeout,
-    )
-  }
-
-  override fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) {
-    checkOpen()
-    spawnedClient.recordingScript(recordingId, events)
-  }
-
-  override fun recordingStop(recordingId: String, timeout: Duration): RecordingStopResult {
-    checkOpen()
-    return spawnedClient.recordingStop(recordingId = recordingId, timeout = timeout)
-  }
-
-  override fun recordingEncode(
-    recordingId: String,
-    format: RecordingFormat,
-    timeout: Duration,
-  ): RecordingEncodeResult {
-    checkOpen()
-    return spawnedClient.recordingEncode(
-      recordingId = recordingId,
-      format = format,
-      timeout = timeout,
-    )
-  }
-
-  override fun onNotification(listener: NotificationListener): AutoCloseable {
-    checkOpen()
-    listeners.add(listener)
-    return AutoCloseable { listeners.remove(listener) }
-  }
-
-  override fun close() {
-    if (!closed.compareAndSet(false, true)) return
-    runCatching { closeSpawn() }
-  }
-
-  private fun checkOpen() {
-    check(!closed.get()) { "RenderSession has been closed" }
-  }
-}
 
 /**
  * [RenderSessionFactory] singleton for the daemon-subprocess backend. Open a session via
  * `SubprocessRenderSessions.open(config)` or the convenience overloads below.
+ *
+ * Constructs a [DaemonClientRenderSession] from the daemon launch descriptor at
+ * [RenderSessionConfig.descriptorPath] — the heavy lifting (subprocess fork, JSON-RPC handshake)
+ * happens before the factory returns, so consumers never see an un-initialized session.
  */
 object SubprocessRenderSessions : RenderSessionFactory {
   override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
@@ -293,12 +75,10 @@ object SubprocessRenderSessions : RenderSessionFactory {
         )
       }
 
-    val listeners = CopyOnWriteArraySet<NotificationListener>()
+    val fanout = NotificationFanout()
     val client: DaemonClient =
       spawn.client(
-        onNotification = { method, params ->
-          for (l in listeners) runCatching { l.onNotification(method, params) }
-        },
+        onNotification = { method, params -> fanout.dispatch(method, params) },
         onClose = {},
       )
 
@@ -319,13 +99,17 @@ object SubprocessRenderSessions : RenderSessionFactory {
         )
       }
 
-    return SubprocessRenderSession(
+    return DaemonClientRenderSession(
       workspaceRoot = canonicalRoot.absolutePath,
       modulePath = effectiveDescriptor.modulePath,
       initializeResult = initializeResult,
-      spawnedClient = client,
-      closeSpawn = { spawn.shutdown() },
-      listeners = listeners,
+      backendKind = RenderSessionBackend.Subprocess,
+      client = client,
+      notificationFanout = fanout,
+      closeAction = {
+        runCatching { spawn.shutdown() }
+        fanout.clear()
+      },
     )
   }
 


### PR DESCRIPTION
## Summary

Consolidates the ~150 LOC of pass-through `RenderSession` delegate methods that previously lived in two copies (`SubprocessRenderSession` in `:render-session-subprocess`, `EmbeddedDesktopRenderSession` in `:render-session-embedded-desktop`) into a single public `DaemonClientRenderSession` class living in `:render-session-subprocess`.

The class is transport-agnostic — it accepts a `DaemonClient`, a `NotificationFanout`, and a `closeAction` lambda. Each backend's factory constructs one with its own close semantics:

- **Subprocess** (`SubprocessRenderSessions.open`): `closeAction = { spawn.shutdown(); fanout.clear() }`
- **Embedded** (`EmbeddedDesktopRenderSessions.open`): `closeAction = { client.shutdownAndExit(); thread.join(); pipes.close(); restoreSysprops() }`

`:render-session-embedded-desktop` gains an `implementation` dep on `:render-session-subprocess` to reach the delegate.

## What's not in this PR

The third copy of the delegate that lives in `:mcp` (the supervisor's `SupervisedDaemon.session` view) stays where it is. Having `:mcp` depend on `:render-session-subprocess` would create a cycle: `:render-session-subprocess` already depends on `:mcp` for `DaemonClient`. Lifting `DaemonClient` out of `:mcp` to break the cycle is a substantial refactor across many files and out of scope for this PR.

Net: 2 copies → 1 for subprocess + embedded; `:mcp` still keeps its own (slightly different — no-op close because supervisor owns lifecycle). Future cleanup would lift `DaemonClient` into a neutral module so all three backends share.

## Diff stats

```
4 files changed, 309 insertions(+), 488 deletions(-)
```

Net –179 LOC.

## Test plan

- [x] `:render-session-subprocess:test` passes.
- [x] `:render-session-embedded-desktop:test` passes (including the end-to-end test that opens a real session against `:samples:cmp` — the round-trip through `runDaemon` confirms the shared delegate handles the embedded transport correctly).
- [x] `:mcp:test` passes (its own copy of the delegate is unaffected).
- [x] `:cli:test` passes (uses `SubprocessRenderSessions`).
- [x] `ktfmtCheckAll` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_0178MWQ319fGv7JWjSwpsvSU)_