### PR TITLE
fix: suppress JDK 24+ restricted method warnings from Gradle Tooling API

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -28,6 +28,11 @@ base { archivesName.set("compose-preview") }
 application {
   applicationName = "compose-preview"
   mainClass.set("ee.schimke.composeai.cli.MainKt")
+  // The Tooling API loads gradle-dist's native-platform jar into our JVM, which
+  // calls `System.load`. On JDK 24+ that prints a 4-line restricted-method
+  // warning on every CLI invocation. Pre-declaring native access for the
+  // unnamed module (where Tooling API + native-platform live) silences it.
+  applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")
 }
 
 // Note: don't set `archiveFileName` directly — Gradle's distribution plugin


### PR DESCRIPTION
## Summary
Adds JVM argument to suppress restricted method access warnings that appear on JDK 24+ when the Gradle Tooling API loads native-platform libraries.

## Changes
- Added `--enable-native-access=ALL-UNNAMED` to `applicationDefaultJvmArgs` in the CLI application configuration
- This pre-declares native access for the unnamed module where Tooling API and native-platform libraries execute, preventing 4-line warning messages on every CLI invocation

## Details
The Gradle Tooling API loads gradle-dist's native-platform jar, which calls `System.load()`. On JDK 24+, this triggers a restricted method warning. By enabling native access for the unnamed module at startup, we silence these warnings without affecting functionality.

https://claude.ai/code/session_01JzhLiDdF6p8u1TUf9TZUyA