### PR TITLE
feat: add portable preview bundle support (PNG+ZIP polyglot)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -6,17 +6,18 @@ import java.util.zip.ZipInputStream
 import kotlin.system.exitProcess
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonClassDiscriminator
 
 /**
- * `compose-preview bundle <pack|inspect|extract>` — produce and inspect portable preview bundles.
+ * `compose-preview bundle <pack|inspect|extract|render>` — produce, inspect, and play portable
+ * preview bundles.
  *
  * # Bundle file shape
  *
  * The bundle is a PNG + ZIP polyglot. The leading bytes are a valid PNG (the cover preview's
  * rendered image — Finder, Preview.app, GitHub, Slack all show it as an image). The trailing bytes
- * are a standard zip archive that any tooling (this CLI, VS Code, `unzip`, your zip library) reads
- * via the EOCD signature `PK\x05\x06`. See `PreviewBundleFormat.kt` in the plugin module for the
- * in-repo schema definitions.
+ * are a standard zip archive that any tooling reads via the EOCD signature `PK\x05\x06`. See
+ * `PreviewBundleFormat.kt` in the plugin module for the in-repo schema definitions.
  *
  * # Subcommands
  *
@@ -25,10 +26,14 @@ import kotlinx.serialization.json.Json
  *   first id becomes the cover. `--no-render` skips the render step and packs with a stub gray
  *   cover.
  * - **`inspect`** — open a bundle file and print its `bundle.json` + `report.json` summary,
- *   including the minimization report (how many module classes were kept vs total, how many jars
- *   were kept vs dropped, total bytes saved). Read-only.
- * - **`extract`** — extract the zip portion of a bundle into a directory. Useful for forensic
- *   inspection and for the VS Code extension's preview opener.
+ *   including the minimization report (how many module classes were kept vs total, which Maven
+ *   coordinates contribute reachable classes). Read-only.
+ * - **`extract`** — extract the zip portion of a bundle into a directory. Each entry's path is
+ *   validated to live inside the target dir — `../` traversal in a hostile bundle is rejected.
+ * - **`render`** — re-render the bundle's previews from a packed `.png`, not from a Gradle module.
+ *   v1 is a stub: it extracts the bundle, prints the manifest + resolved classpath, and tells you
+ *   what *would* render. Actual rendering (resolving Maven coords + spawning DesktopRendererMain)
+ *   is the next milestone.
  */
 class BundleCommand(args: List<String>) : Command(args) {
 
@@ -38,6 +43,7 @@ class BundleCommand(args: List<String>) : Command(args) {
       "pack" -> PackSubcommand(args.drop(args.indexOf(sub) + 1)).run()
       "inspect" -> InspectSubcommand(args.drop(args.indexOf(sub) + 1)).run()
       "extract" -> ExtractSubcommand(args.drop(args.indexOf(sub) + 1)).run()
+      "render" -> RenderSubcommand(args.drop(args.indexOf(sub) + 1)).run()
       null,
       "help",
       "--help",
@@ -62,14 +68,15 @@ class BundleCommand(args: List<String>) : Command(args) {
         compose-preview bundle pack [--module <name>] [--id <preview>...] [-o <file.png>] [--no-render]
         compose-preview bundle inspect <bundle.png>
         compose-preview bundle extract <bundle.png> [-o <dir>]
+        compose-preview bundle render  <bundle.png> [-o <dir>]   (v1: stub — prints what would render)
 
       Pack flags:
         --id <preview-id>   Preview to include. Repeatable. First is the cover. Default: all.
         -o, --output <file> Output file path. Default: <module>/build/compose-previews/bundle.png.
         --no-render         Skip renderPreviews — pack with a stub gray cover.
 
-      Inspect / extract flags:
-        -o, --output <dir>  (extract only) Directory to extract into. Default: alongside the bundle.
+      Inspect / extract / render flags:
+        -o, --output <dir>  Directory to extract / render into. Default: alongside the bundle.
       """
         .trimIndent()
     )
@@ -96,9 +103,6 @@ private class PackSubcommand(private val args: List<String>) {
       }
       if (verbose) add("--verbose")
     }
-    // Reuse the existing Command plumbing for module resolution. Wrap in an anonymous shim so we
-    // get `withGradle`, `resolveModules`, and the auto-inject init-script flow without duplicating
-    // 80 lines of boilerplate.
     object : Command(cmdArgs) {
         override fun run() {
           withGradle { gradle ->
@@ -138,7 +142,7 @@ private class PackSubcommand(private val args: List<String>) {
               exitProcess(1)
             }
 
-            val report =
+            val meta =
               try {
                 BundleReader.readMetadata(resolvedOutput)
               } catch (e: Exception) {
@@ -147,7 +151,7 @@ private class PackSubcommand(private val args: List<String>) {
                 )
                 exitProcess(1)
               }
-            printPackSummary(resolvedOutput, report)
+            printPackSummary(resolvedOutput, meta)
           }
         }
       }
@@ -160,7 +164,11 @@ private class PackSubcommand(private val args: List<String>) {
     println(
       "  previews:      ${meta.manifest.previewIds.size} (cover=${meta.manifest.coverPreviewId})"
     )
-    println("  classpath:     ${meta.manifest.classpath.size} entries")
+    val mavenCount = meta.manifest.classpath.count { it is BundleReader.ClasspathEntry.Maven }
+    val projectCount = meta.manifest.classpath.count { it is BundleReader.ClasspathEntry.Project }
+    println(
+      "  classpath:     ${meta.manifest.classpath.size} entries (Maven=$mavenCount, inlined=$projectCount)"
+    )
     val r = meta.report
     if (r != null) {
       println("  entry classes: ${r.entryClassFqns.size}")
@@ -170,9 +178,8 @@ private class PackSubcommand(private val args: List<String>) {
       println(
         "  module:        ${r.moduleClasses.reachableClasses} / ${r.moduleClasses.totalClasses} classes kept, ${r.moduleClasses.packedBytes} B packed"
       )
-      val kept = r.libraryJars.count { it.kept }
-      val droppedBytes = r.libraryJars.filter { !it.kept }.sumOf { it.originalBytes }
-      println("  jars:          $kept / ${r.libraryJars.size} kept, ${droppedBytes} B dropped")
+      val kept = r.dependencies.count { it.kept }
+      println("  deps:          $kept / ${r.dependencies.size} contributed reachable classes")
     }
   }
 }
@@ -190,7 +197,10 @@ private class InspectSubcommand(private val args: List<String>) {
       exitProcess(1)
     }
     val meta = BundleReader.readMetadata(file)
-    val pretty = Json { prettyPrint = true }
+    val pretty = Json {
+      prettyPrint = true
+      classDiscriminator = "kind"
+    }
     println("file: ${file.absolutePath}")
     println("size: ${file.length()} bytes")
     println("--- bundle.json ---")
@@ -217,24 +227,97 @@ private class ExtractSubcommand(private val args: List<String>) {
     }
     val target =
       File(
-        outDir ?: file.absoluteFile.parent.toString() + "/${file.nameWithoutExtension}-extracted"
-      )
+          outDir
+            ?: (file.absoluteFile.parent.toString() + "/${file.nameWithoutExtension}-extracted")
+        )
+        .absoluteFile
     target.mkdirs()
     val zipBytes = BundleReader.extractZipBytes(file)
-    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
-      while (true) {
-        val entry = zin.nextEntry ?: break
-        val out = File(target, entry.name)
-        if (entry.isDirectory) {
-          out.mkdirs()
-        } else {
-          out.parentFile?.mkdirs()
-          out.outputStream().use { sink -> zin.copyTo(sink) }
-        }
-        zin.closeEntry()
+    safeExtractZip(zipBytes, target)
+    println("extracted ${file.name} → ${target.path}")
+  }
+}
+
+private class RenderSubcommand(private val args: List<String>) {
+  fun run() {
+    val path = args.firstOrNull { !it.startsWith("-") }
+    val outDir = args.flagValue("--output") ?: args.flagValue("-o")
+    if (path == null) {
+      System.err.println("Usage: compose-preview bundle render <bundle.png> [-o <dir>]")
+      exitProcess(64)
+    }
+    val file = File(path)
+    if (!file.isFile) {
+      System.err.println("Not a file: $path")
+      exitProcess(1)
+    }
+    val target =
+      File(outDir ?: (file.absoluteFile.parent.toString() + "/${file.nameWithoutExtension}-render"))
+        .absoluteFile
+    target.mkdirs()
+
+    val zipBytes = BundleReader.extractZipBytes(file)
+    val extractDir = File(target, "_bundle").apply { mkdirs() }
+    safeExtractZip(zipBytes, extractDir)
+
+    val meta = BundleReader.readMetadata(file)
+    println("bundle:   ${file.path}")
+    println("backend:  ${meta.manifest.backend}")
+    println("previews: ${meta.manifest.previewIds.joinToString()}")
+    println("extracted to: ${extractDir.path}")
+    println()
+    println("Resolved classpath (player would load in this order):")
+    for (entry in meta.manifest.classpath) {
+      when (entry) {
+        is BundleReader.ClasspathEntry.Module ->
+          println("  [module]  ${File(extractDir, entry.path).absolutePath}")
+        is BundleReader.ClasspathEntry.Maven ->
+          println(
+            "  [maven]   ${entry.group}:${entry.artifact}:${entry.version}@${entry.type}  (unresolved)"
+          )
+        is BundleReader.ClasspathEntry.Project ->
+          println("  [project] ${entry.path}  →  ${File(extractDir, entry.inlinedAs).absolutePath}")
       }
     }
-    println("extracted ${file.name} → ${target.path}")
+    println()
+    System.err.println(
+      "bundle render: v1 stub — Maven coordinate resolution + DesktopRendererMain spawn not wired yet."
+    )
+    System.err.println(
+      "Next milestone: resolve coordinates against ~/.m2 / Maven Central, then spawn the bundled renderer-desktop."
+    )
+  }
+}
+
+/**
+ * Extracts a zip safely — every entry's resolved target path is verified to live inside [target].
+ * Defeats Zip Slip (`../../etc/passwd`-style entry names) reported by CodeQL / Codex on the v1
+ * extract path; same call site is shared by `extract` and `render`.
+ */
+private fun safeExtractZip(zipBytes: ByteArray, target: File) {
+  val canonicalTarget = target.canonicalFile
+  ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+    while (true) {
+      val entry = zin.nextEntry ?: break
+      val candidate = File(target, entry.name).canonicalFile
+      // Reject anything resolving outside the target dir, regardless of whether the entry's name
+      // happens to be relative ("foo/..//bar") or absolute on some platforms.
+      if (
+        candidate != canonicalTarget &&
+          !candidate.path.startsWith(canonicalTarget.path + File.separator)
+      ) {
+        throw SecurityException(
+          "bundle entry escapes target dir: ${entry.name} → ${candidate.path}"
+        )
+      }
+      if (entry.isDirectory) {
+        candidate.mkdirs()
+      } else {
+        candidate.parentFile?.mkdirs()
+        candidate.outputStream().use { sink -> zin.copyTo(sink) }
+      }
+      zin.closeEntry()
+    }
   }
 }
 
@@ -253,10 +336,32 @@ internal object BundleReader {
     val backend: String,
     val previewIds: List<String>,
     val coverPreviewId: String?,
-    val classpath: List<String>,
+    val classpath: List<ClasspathEntry>,
     val modulePath: String,
     val producedBy: String,
   )
+
+  @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+  @Serializable
+  @JsonClassDiscriminator("kind")
+  sealed interface ClasspathEntry {
+    @Serializable
+    @kotlinx.serialization.SerialName("module")
+    data class Module(val path: String) : ClasspathEntry
+
+    @Serializable
+    @kotlinx.serialization.SerialName("maven")
+    data class Maven(
+      val group: String,
+      val artifact: String,
+      val version: String,
+      val type: String,
+    ) : ClasspathEntry
+
+    @Serializable
+    @kotlinx.serialization.SerialName("project")
+    data class Project(val path: String, val inlinedAs: String) : ClasspathEntry
+  }
 
   @Serializable
   data class Report(
@@ -264,16 +369,17 @@ internal object BundleReader {
     val reachableClassCount: Int,
     val totalScannedClassCount: Int,
     val moduleClasses: ModuleClasses,
-    val libraryJars: List<LibraryJar>,
+    val dependencies: List<DependencyDecision>,
   )
 
   @Serializable
   data class ModuleClasses(val totalClasses: Int, val reachableClasses: Int, val packedBytes: Long)
 
   @Serializable
-  data class LibraryJar(
+  data class DependencyDecision(
     val sourcePath: String,
-    val bundledAs: String?,
+    val coordinate: String?,
+    val projectPath: String?,
     val totalClasses: Int,
     val reachableClasses: Int,
     val originalBytes: Long,
@@ -282,7 +388,10 @@ internal object BundleReader {
 
   data class Metadata(val manifest: Manifest, val report: Report?)
 
-  private val json = Json { ignoreUnknownKeys = true }
+  private val json = Json {
+    ignoreUnknownKeys = true
+    classDiscriminator = "kind"
+  }
 
   fun readMetadata(file: File): Metadata {
     val zipBytes = extractZipBytes(file)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -1,0 +1,349 @@
+package ee.schimke.composeai.cli
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipInputStream
+import kotlin.system.exitProcess
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * `compose-preview bundle <pack|inspect|extract>` — produce and inspect portable preview bundles.
+ *
+ * # Bundle file shape
+ *
+ * The bundle is a PNG + ZIP polyglot. The leading bytes are a valid PNG (the cover preview's
+ * rendered image — Finder, Preview.app, GitHub, Slack all show it as an image). The trailing bytes
+ * are a standard zip archive that any tooling (this CLI, VS Code, `unzip`, your zip library) reads
+ * via the EOCD signature `PK\x05\x06`. See `PreviewBundleFormat.kt` in the plugin module for the
+ * in-repo schema definitions.
+ *
+ * # Subcommands
+ *
+ * - **`pack`** — runs `renderPreviews` (for the cover) and `composePreviewBundle` against a Gradle
+ *   module and writes the resulting `.png` polyglot. Selection is via repeatable `--id` flags; the
+ *   first id becomes the cover. `--no-render` skips the render step and packs with a stub gray
+ *   cover.
+ * - **`inspect`** — open a bundle file and print its `bundle.json` + `report.json` summary,
+ *   including the minimization report (how many module classes were kept vs total, how many jars
+ *   were kept vs dropped, total bytes saved). Read-only.
+ * - **`extract`** — extract the zip portion of a bundle into a directory. Useful for forensic
+ *   inspection and for the VS Code extension's preview opener.
+ */
+class BundleCommand(args: List<String>) : Command(args) {
+
+  override fun run() {
+    val sub = args.firstOrNull { !it.startsWith("-") }
+    when (sub) {
+      "pack" -> PackSubcommand(args.drop(args.indexOf(sub) + 1)).run()
+      "inspect" -> InspectSubcommand(args.drop(args.indexOf(sub) + 1)).run()
+      "extract" -> ExtractSubcommand(args.drop(args.indexOf(sub) + 1)).run()
+      null,
+      "help",
+      "--help",
+      "-h" -> {
+        printHelp()
+        if (sub == null) exitProcess(64)
+      }
+      else -> {
+        System.err.println("Unknown bundle subcommand: $sub")
+        printHelp()
+        exitProcess(64)
+      }
+    }
+  }
+
+  private fun printHelp() {
+    println(
+      """
+      compose-preview bundle — portable preview bundles (PNG+ZIP polyglot)
+
+      Usage:
+        compose-preview bundle pack [--module <name>] [--id <preview>...] [-o <file.png>] [--no-render]
+        compose-preview bundle inspect <bundle.png>
+        compose-preview bundle extract <bundle.png> [-o <dir>]
+
+      Pack flags:
+        --id <preview-id>   Preview to include. Repeatable. First is the cover. Default: all.
+        -o, --output <file> Output file path. Default: <module>/build/compose-previews/bundle.png.
+        --no-render         Skip renderPreviews — pack with a stub gray cover.
+
+      Inspect / extract flags:
+        -o, --output <dir>  (extract only) Directory to extract into. Default: alongside the bundle.
+      """
+        .trimIndent()
+    )
+  }
+}
+
+private class PackSubcommand(private val args: List<String>) {
+  private val module: String? = args.flagValue("--module")
+  private val output: String? = args.flagValue("--output") ?: args.flagValue("-o")
+  private val noRender: Boolean = "--no-render" in args
+  private val verbose: Boolean = "--verbose" in args || "-v" in args
+  private val ids: List<String> =
+    args
+      .flagValuesAll("--id")
+      .flatMap { it.split(',') }
+      .map { it.trim() }
+      .filter { it.isNotEmpty() }
+
+  fun run() {
+    val cmdArgs = buildList {
+      module?.let {
+        add("--module")
+        add(it)
+      }
+      if (verbose) add("--verbose")
+    }
+    // Reuse the existing Command plumbing for module resolution. Wrap in an anonymous shim so we
+    // get `withGradle`, `resolveModules`, and the auto-inject init-script flow without duplicating
+    // 80 lines of boilerplate.
+    object : Command(cmdArgs) {
+        override fun run() {
+          withGradle { gradle ->
+            val modules = resolveModules(gradle)
+            if (modules.size != 1) {
+              System.err.println(
+                "bundle pack expects exactly one module; found ${modules.size}. Use --module to disambiguate."
+              )
+              exitProcess(1)
+            }
+            val target = modules.single()
+            val resolvedOutput =
+              output?.let { File(it).absoluteFile }
+                ?: target.projectDir.resolve("build/compose-previews/bundle.png")
+            resolvedOutput.parentFile?.mkdirs()
+
+            val gradleArgs = buildList {
+              if (ids.isNotEmpty()) add("-PbundlePreviewIds=${ids.joinToString(",")}")
+              add("-PbundleOutput=${resolvedOutput.absolutePath}")
+            }
+            val tasks =
+              buildList {
+                  if (!noRender) add(":${target.gradlePath}:renderPreviews")
+                  add(":${target.gradlePath}:composePreviewBundle")
+                }
+                .toTypedArray()
+            val ok = runGradle(gradle, *tasks, arguments = gradleArgsWithForce(gradleArgs))
+            if (!ok) {
+              System.err.println("Gradle bundle task failed.")
+              exitProcess(1)
+            }
+
+            if (!resolvedOutput.isFile) {
+              System.err.println(
+                "Bundle task reported success but ${resolvedOutput.path} is missing."
+              )
+              exitProcess(1)
+            }
+
+            val report =
+              try {
+                BundleReader.readMetadata(resolvedOutput)
+              } catch (e: Exception) {
+                System.err.println(
+                  "Wrote ${resolvedOutput.path} (${resolvedOutput.length()} bytes) but failed to read it back: ${e.message}"
+                )
+                exitProcess(1)
+              }
+            printPackSummary(resolvedOutput, report)
+          }
+        }
+      }
+      .run()
+  }
+
+  private fun printPackSummary(file: File, meta: BundleReader.Metadata) {
+    println("wrote ${file.path} (${file.length()} bytes)")
+    println("  schema:        v${meta.manifest.schemaVersion}, backend=${meta.manifest.backend}")
+    println(
+      "  previews:      ${meta.manifest.previewIds.size} (cover=${meta.manifest.coverPreviewId})"
+    )
+    println("  classpath:     ${meta.manifest.classpath.size} entries")
+    val r = meta.report
+    if (r != null) {
+      println("  entry classes: ${r.entryClassFqns.size}")
+      println(
+        "  reachable:     ${r.reachableClassCount} / ${r.totalScannedClassCount} classes scanned"
+      )
+      println(
+        "  module:        ${r.moduleClasses.reachableClasses} / ${r.moduleClasses.totalClasses} classes kept, ${r.moduleClasses.packedBytes} B packed"
+      )
+      val kept = r.libraryJars.count { it.kept }
+      val droppedBytes = r.libraryJars.filter { !it.kept }.sumOf { it.originalBytes }
+      println("  jars:          $kept / ${r.libraryJars.size} kept, ${droppedBytes} B dropped")
+    }
+  }
+}
+
+private class InspectSubcommand(private val args: List<String>) {
+  fun run() {
+    val path = args.firstOrNull { !it.startsWith("-") }
+    if (path == null) {
+      System.err.println("Usage: compose-preview bundle inspect <bundle.png>")
+      exitProcess(64)
+    }
+    val file = File(path)
+    if (!file.isFile) {
+      System.err.println("Not a file: $path")
+      exitProcess(1)
+    }
+    val meta = BundleReader.readMetadata(file)
+    val pretty = Json { prettyPrint = true }
+    println("file: ${file.absolutePath}")
+    println("size: ${file.length()} bytes")
+    println("--- bundle.json ---")
+    println(pretty.encodeToString(BundleReader.Manifest.serializer(), meta.manifest))
+    if (meta.report != null) {
+      println("--- report.json ---")
+      println(pretty.encodeToString(BundleReader.Report.serializer(), meta.report))
+    }
+  }
+}
+
+private class ExtractSubcommand(private val args: List<String>) {
+  fun run() {
+    val path = args.firstOrNull { !it.startsWith("-") }
+    val outDir = args.flagValue("--output") ?: args.flagValue("-o")
+    if (path == null) {
+      System.err.println("Usage: compose-preview bundle extract <bundle.png> [-o <dir>]")
+      exitProcess(64)
+    }
+    val file = File(path)
+    if (!file.isFile) {
+      System.err.println("Not a file: $path")
+      exitProcess(1)
+    }
+    val target =
+      File(
+        outDir ?: file.absoluteFile.parent.toString() + "/${file.nameWithoutExtension}-extracted"
+      )
+    target.mkdirs()
+    val zipBytes = BundleReader.extractZipBytes(file)
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        val out = File(target, entry.name)
+        if (entry.isDirectory) {
+          out.mkdirs()
+        } else {
+          out.parentFile?.mkdirs()
+          out.outputStream().use { sink -> zin.copyTo(sink) }
+        }
+        zin.closeEntry()
+      }
+    }
+    println("extracted ${file.name} → ${target.path}")
+  }
+}
+
+/**
+ * In-CLI mirror of the bundle's on-disk schema. We re-declare the data classes here (rather than
+ * dragging the gradle-plugin module onto the CLI's compile classpath) because the CLI links against
+ * a different module graph; the schema is tiny and rarely changes.
+ *
+ * Keep field names in lockstep with `PreviewBundleFormat.kt` in `:gradle-plugin`.
+ */
+internal object BundleReader {
+
+  @Serializable
+  data class Manifest(
+    val schemaVersion: Int,
+    val backend: String,
+    val previewIds: List<String>,
+    val coverPreviewId: String?,
+    val classpath: List<String>,
+    val modulePath: String,
+    val producedBy: String,
+  )
+
+  @Serializable
+  data class Report(
+    val entryClassFqns: List<String>,
+    val reachableClassCount: Int,
+    val totalScannedClassCount: Int,
+    val moduleClasses: ModuleClasses,
+    val libraryJars: List<LibraryJar>,
+  )
+
+  @Serializable
+  data class ModuleClasses(val totalClasses: Int, val reachableClasses: Int, val packedBytes: Long)
+
+  @Serializable
+  data class LibraryJar(
+    val sourcePath: String,
+    val bundledAs: String?,
+    val totalClasses: Int,
+    val reachableClasses: Int,
+    val originalBytes: Long,
+    val kept: Boolean,
+  )
+
+  data class Metadata(val manifest: Manifest, val report: Report?)
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  fun readMetadata(file: File): Metadata {
+    val zipBytes = extractZipBytes(file)
+    var manifest: Manifest? = null
+    var report: Report? = null
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        when (entry.name) {
+          "bundle.json" ->
+            manifest =
+              json.decodeFromString(Manifest.serializer(), zin.readBytes().toString(Charsets.UTF_8))
+          "report.json" ->
+            report =
+              json.decodeFromString(Report.serializer(), zin.readBytes().toString(Charsets.UTF_8))
+        }
+        zin.closeEntry()
+      }
+    }
+    return Metadata(
+      manifest = manifest ?: throw IllegalArgumentException("bundle.json missing in ${file.path}"),
+      report = report,
+    )
+  }
+
+  /** Polyglot-aware zip extraction; mirrors [extractZipBytes] in the plugin module. */
+  fun extractZipBytes(file: File): ByteArray {
+    val bytes = file.readBytes()
+    if (bytes.size < 8) {
+      throw IllegalArgumentException("not a bundle: ${file.path} is too small (${bytes.size}B)")
+    }
+    if (bytes[0] == 0x50.toByte() && bytes[1] == 0x4B.toByte()) return bytes
+    if (isPngSignature(bytes)) {
+      val zipStart = pngLength(bytes)
+      return bytes.copyOfRange(zipStart, bytes.size)
+    }
+    throw IllegalArgumentException(
+      "not a bundle: ${file.path} — leading bytes match neither PNG nor ZIP"
+    )
+  }
+
+  private val PNG_SIG = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
+
+  private fun isPngSignature(bytes: ByteArray): Boolean {
+    if (bytes.size < PNG_SIG.size) return false
+    for (i in PNG_SIG.indices) if (bytes[i] != PNG_SIG[i]) return false
+    return true
+  }
+
+  private fun pngLength(bytes: ByteArray): Int {
+    var offset = PNG_SIG.size
+    while (offset < bytes.size) {
+      val length =
+        ((bytes[offset].toInt() and 0xff) shl 24) or
+          ((bytes[offset + 1].toInt() and 0xff) shl 16) or
+          ((bytes[offset + 2].toInt() and 0xff) shl 8) or
+          (bytes[offset + 3].toInt() and 0xff)
+      val type = String(bytes, offset + 4, 4, Charsets.US_ASCII)
+      offset += 4 + 4 + length + 4
+      if (type == "IEND") return offset
+    }
+    throw IllegalArgumentException("truncated PNG: IEND not found before EOF")
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -76,6 +76,7 @@ fun main(args: Array<String>) {
     "devices" -> DevicesCommand(allArgs).run()
     "share-gist" -> ShareGistCommand(allArgs).run()
     "publish-images" -> PublishImagesCommand(allArgs).run()
+    "bundle" -> BundleCommand(allArgs).run()
     "mcp" -> McpCommand(allArgs).run()
     "update" -> UpdateCommand(allArgs).run()
     "version" -> println("compose-preview $BUNDLE_VERSION")
@@ -114,6 +115,7 @@ private fun printUsage() {
       devices          List known @Preview(device=...) ids and resolved geometry
       share-gist       Create a gist from a markdown file plus image attachments
       publish-images   Push a directory of rendered PNGs to a shared branch (default compose-preview/pr)
+      bundle           Pack selected previews + minimal classpath into a portable PNG+ZIP polyglot
       mcp              MCP server lifecycle: serve | install | doctor (see `mcp help`)
       update           Re-run the bootstrap installer to pull the latest release
       version          Print the installed bundle version and exit

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -5,6 +5,9 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.zip.ZipInputStream
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
@@ -167,10 +170,14 @@ class BundleFunctionalTest {
     val eocdIndex = indexOf(bytes, zipEocd)
     assertThat(eocdIndex).isGreaterThan(0)
 
-    // 3. Bundle entries.
+    // 3. Bundle entries — manifest + filtered previews + minimized module jar + audit report.
     val entries = listEntries(bundle)
     assertThat(entries)
       .containsAtLeast("bundle.json", "previews.json", "classes/app.jar", "report.json")
+    // 4. No `libs/` directory: third-party jars must be listed as Maven coords, not inlined.
+    //    (Project deps would land under `libs/`, but the synthetic test project has none.)
+    val libsEntries = entries.filter { it.startsWith("libs/") }
+    assertThat(libsEntries).isEmpty()
   }
 
   @Test
@@ -215,7 +222,7 @@ class BundleFunctionalTest {
   }
 
   @Test
-  fun `minimization report counts entry classes and dropped jars`() {
+  fun `minimization report counts entry classes and dropped deps`() {
     val projectDir = createTestProject()
     val redId = "test.RedKt.RedBoxPreview"
 
@@ -235,14 +242,54 @@ class BundleFunctionalTest {
     // Module: 1 kept (RedKt) out of 2 (RedKt + BlueKt).
     assertThat(report.moduleClasses.totalClasses).isEqualTo(2)
     assertThat(report.moduleClasses.reachableClasses).isEqualTo(1)
-    // Library jars: at least one was kept (compose-runtime/ui/foundation are reachable).
-    val kept = report.libraryJars.count { it.kept }
+    // Deps: at least one Maven dep contributed reachable classes (compose-runtime/ui/foundation).
+    val kept = report.dependencies.count { it.kept }
     assertThat(kept).isGreaterThan(0)
-    // And, crucially for the "small and shareable" goal: at least one jar was dropped (not every
-    // transitive dep of compose-desktop is reachable from a single coloured box). If this fires,
+    // And, crucially for the "small and shareable" goal: at least one dep was dropped — not every
+    // transitive dep of compose-desktop is reachable from a single coloured box. If this fires,
     // closure is going way too wide.
-    val dropped = report.libraryJars.count { !it.kept }
+    val dropped = report.dependencies.count { !it.kept }
     assertThat(dropped).isGreaterThan(0)
+  }
+
+  @Test
+  fun `bundle manifest lists Maven coordinates not inlined jars`() {
+    val projectDir = createTestProject()
+    val redId = "test.RedKt.RedBoxPreview"
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewBundle", "-PbundlePreviewIds=$redId")
+      .withPluginClasspath()
+      .build()
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    val bundleJsonBytes = readZipEntry(bundle, "bundle.json")
+    assertThat(bundleJsonBytes).isNotNull()
+    val classpathArray =
+      json
+        .parseToJsonElement(bundleJsonBytes!!.toString(Charsets.UTF_8))
+        .jsonObject["classpath"]!!
+        .jsonArray
+
+    val kinds = classpathArray.map { it.jsonObject["kind"]!!.jsonPrimitive.content }
+    // First entry is always the inlined consumer module.
+    assertThat(kinds.first()).isEqualTo("module")
+    // The rest should be Maven coords — synthetic test project has no project deps.
+    val nonModuleKinds = kinds.drop(1).toSet()
+    assertThat(nonModuleKinds).contains("maven")
+    assertThat(nonModuleKinds).doesNotContain("project")
+
+    // Spot-check at least one well-formed Maven entry (compose-runtime is a near-certainty).
+    val mavenEntries = classpathArray.filter {
+      it.jsonObject["kind"]!!.jsonPrimitive.content == "maven"
+    }
+    assertThat(mavenEntries).isNotEmpty()
+    val first = mavenEntries.first().jsonObject
+    assertThat(first["group"]!!.jsonPrimitive.content).isNotEmpty()
+    assertThat(first["artifact"]!!.jsonPrimitive.content).isNotEmpty()
+    assertThat(first["version"]!!.jsonPrimitive.content).isNotEmpty()
+    assertThat(first["type"]!!.jsonPrimitive.content).isEqualTo("jar")
   }
 
   private fun listEntries(file: File): Set<String> = listEntries(extractZipBytes(file))

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -1,0 +1,307 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipInputStream
+import kotlinx.serialization.json.Json
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end coverage for `composePreviewBundle`:
+ * 1. Bundle output is a valid PNG (file-magic + viewer compatibility).
+ * 2. Bundle output is a valid zip (every reader finds the EOCD).
+ * 3. Bundle includes `bundle.json`, `previews.json`, `classes/app.jar`, `report.json`.
+ * 4. Selection works — packing one preview filters the manifest to that preview only.
+ * 5. **Minimization is effective** — bundling one preview from a multi-preview module drops the
+ *    other preview's class file from `classes/app.jar`.
+ */
+class BundleFunctionalTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  /**
+   * Two preview files in different classes (`RedKt`, `BlueKt`) so we can prove minimization
+   * actually drops the un-selected class.
+   */
+  private fun createTestProject(): File {
+    val projectDir = tempDir.root
+
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
+            }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
+            }
+        }
+        rootProject.name = "test-bundle"
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.uiTooling)
+            implementation(compose.components.uiToolingPreview)
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    srcDir.mkdirs()
+    File(srcDir, "Red.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.unit.dp
+
+        @Preview
+        @Composable
+        fun RedBoxPreview() {
+            Box(modifier = Modifier.size(100.dp).background(Color.Red))
+        }
+        """
+          .trimIndent()
+      )
+    File(srcDir, "Blue.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.unit.dp
+
+        @Preview
+        @Composable
+        fun BlueBoxPreview() {
+            Box(modifier = Modifier.size(100.dp).background(Color.Blue))
+        }
+        """
+          .trimIndent()
+      )
+
+    return projectDir
+  }
+
+  @Test
+  fun `composePreviewBundle produces a PNG+ZIP polyglot`() {
+    val projectDir = createTestProject()
+    val redId = "test.RedKt.RedBoxPreview"
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewBundle", "-PbundlePreviewIds=$redId", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":composePreviewBundle")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    assertThat(bundle.exists()).isTrue()
+    val bytes = bundle.readBytes()
+
+    // 1. PNG signature.
+    assertThat(bytes.take(8))
+      .containsExactly(
+        (-119).toByte(),
+        'P'.code.toByte(),
+        'N'.code.toByte(),
+        'G'.code.toByte(),
+        '\r'.code.toByte(),
+        '\n'.code.toByte(),
+        26.toByte(),
+        '\n'.code.toByte(),
+      )
+      .inOrder()
+
+    // 2. ZIP EOCD signature appears somewhere in the trailing bytes.
+    val zipEocd = byteArrayOf(0x50, 0x4B, 0x05, 0x06)
+    val eocdIndex = indexOf(bytes, zipEocd)
+    assertThat(eocdIndex).isGreaterThan(0)
+
+    // 3. Bundle entries.
+    val entries = listEntries(bundle)
+    assertThat(entries)
+      .containsAtLeast("bundle.json", "previews.json", "classes/app.jar", "report.json")
+  }
+
+  @Test
+  fun `composePreviewBundle filters previews_json to selected ids`() {
+    val projectDir = createTestProject()
+    val redId = "test.RedKt.RedBoxPreview"
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewBundle", "-PbundlePreviewIds=$redId")
+      .withPluginClasspath()
+      .build()
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    val previewsJson = readZipEntry(bundle, "previews.json")
+    assertThat(previewsJson).isNotNull()
+    val manifest =
+      json.decodeFromString(PreviewManifest.serializer(), previewsJson!!.toString(Charsets.UTF_8))
+    assertThat(manifest.previews.map { it.id }).containsExactly(redId)
+  }
+
+  @Test
+  fun `minimization drops non-selected preview classes from the module jar`() {
+    val projectDir = createTestProject()
+    val redId = "test.RedKt.RedBoxPreview"
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewBundle", "-PbundlePreviewIds=$redId", "--stacktrace")
+      .withPluginClasspath()
+      .build()
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    val appJarBytes = readZipEntry(bundle, "classes/app.jar")
+    assertThat(appJarBytes).isNotNull()
+
+    val classesInAppJar = listEntries(appJarBytes!!).filter { it.endsWith(".class") }.toSet()
+    // RedKt must be present (it's the selected preview's enclosing class).
+    assertThat(classesInAppJar).contains("test/RedKt.class")
+    // BlueKt must NOT be present — it's unreachable from RedBoxPreview's closure.
+    assertThat(classesInAppJar).doesNotContain("test/BlueKt.class")
+  }
+
+  @Test
+  fun `minimization report counts entry classes and dropped jars`() {
+    val projectDir = createTestProject()
+    val redId = "test.RedKt.RedBoxPreview"
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewBundle", "-PbundlePreviewIds=$redId")
+      .withPluginClasspath()
+      .build()
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    val reportBytes = readZipEntry(bundle, "report.json")
+    assertThat(reportBytes).isNotNull()
+    val report =
+      json.decodeFromString(MinimizationReport.serializer(), reportBytes!!.toString(Charsets.UTF_8))
+
+    assertThat(report.entryClassFqns).containsExactly("test.RedKt")
+    // Module: 1 kept (RedKt) out of 2 (RedKt + BlueKt).
+    assertThat(report.moduleClasses.totalClasses).isEqualTo(2)
+    assertThat(report.moduleClasses.reachableClasses).isEqualTo(1)
+    // Library jars: at least one was kept (compose-runtime/ui/foundation are reachable).
+    val kept = report.libraryJars.count { it.kept }
+    assertThat(kept).isGreaterThan(0)
+    // And, crucially for the "small and shareable" goal: at least one jar was dropped (not every
+    // transitive dep of compose-desktop is reachable from a single coloured box). If this fires,
+    // closure is going way too wide.
+    val dropped = report.libraryJars.count { !it.kept }
+    assertThat(dropped).isGreaterThan(0)
+  }
+
+  private fun listEntries(file: File): Set<String> = listEntries(extractZipBytes(file))
+
+  private fun listEntries(zipBytes: ByteArray): Set<String> {
+    val names = mutableSetOf<String>()
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        names += entry.name
+        zin.closeEntry()
+      }
+    }
+    return names
+  }
+
+  private fun readZipEntry(file: File, name: String): ByteArray? =
+    readZipEntry(extractZipBytes(file), name)
+
+  private fun readZipEntry(zipBytes: ByteArray, name: String): ByteArray? {
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        if (entry.name == name) {
+          val out = zin.readBytes()
+          zin.closeEntry()
+          return out
+        }
+        zin.closeEntry()
+      }
+    }
+    return null
+  }
+
+  private fun extractZipBytes(file: File): ByteArray {
+    val bytes = file.readBytes()
+    if (bytes[0] == 0x50.toByte() && bytes[1] == 0x4B.toByte()) return bytes
+    // PNG header — walk chunks to IEND.
+    var offset = 8
+    while (offset < bytes.size) {
+      val length =
+        ((bytes[offset].toInt() and 0xff) shl 24) or
+          ((bytes[offset + 1].toInt() and 0xff) shl 16) or
+          ((bytes[offset + 2].toInt() and 0xff) shl 8) or
+          (bytes[offset + 3].toInt() and 0xff)
+      val type = String(bytes, offset + 4, 4, Charsets.US_ASCII)
+      offset += 4 + 4 + length + 4
+      if (type == "IEND") return bytes.copyOfRange(offset, bytes.size)
+    }
+    error("PNG IEND not found in $file")
+  }
+
+  private fun indexOf(haystack: ByteArray, needle: ByteArray): Int {
+    outer@ for (i in 0..haystack.size - needle.size) {
+      for (j in needle.indices) {
+        if (haystack[i + j] != needle[j]) continue@outer
+      }
+      return i
+    }
+    return -1
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -1,0 +1,401 @@
+package ee.schimke.composeai.plugin
+
+import io.github.classgraph.ClassGraph
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.imageio.ImageIO
+import kotlinx.serialization.json.Json
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Pack a portable preview bundle — a PNG+ZIP polyglot containing the selected previews' metadata,
+ * the minimal set of consumer classes reachable from those previews, the runtime jars that
+ * contribute to the closure, and a minimization report. See [PreviewBundleFormat] for the on-disk
+ * layout.
+ *
+ * The closure walk is driven by ClassGraph's inter-class dependency map: starting from each
+ * selected preview's enclosing class FQN, we BFS through every class the closure references and
+ * collect the set. Module classes are repacked per-class (small, ours, safe to surgically prune).
+ * Third-party jars are included whole when they contribute ≥1 reachable class — stripping inside a
+ * jar is risky (lambdas, kotlin metadata, resources, services) and the per-jar size win is the
+ * dominant lever anyway.
+ */
+abstract class BundlePreviewTask : DefaultTask() {
+
+  /**
+   * `previews.json` produced by [DiscoverPreviewsTask]. The task reads it to (a) resolve the
+   * selected ids' enclosing class FQNs (the closure entry points) and (b) write a filtered copy
+   * into the bundle.
+   */
+  @get:InputFile
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val previewsJson: RegularFileProperty
+
+  /**
+   * Consumer module's class dirs (`build/classes/kotlin/jvm/main`, etc.). Walked for per-class
+   * minimization — only `.class` files for reachable FQNs land in `classes/app.jar`. Module
+   * resources directory is taken separately via [moduleResourcesDir] when present.
+   */
+  @get:Classpath abstract val moduleClassDirs: ConfigurableFileCollection
+
+  /**
+   * Consumer module's processed resources directory (e.g. `build/processedResources/jvm/main`).
+   * Bundled wholesale alongside the minimized classes — resources are typically small, and
+   * string-id references in bytecode make them hard to prune deterministically.
+   */
+  @get:InputDirectory
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val moduleResourcesDir: DirectoryProperty
+
+  /**
+   * Third-party runtime classpath jars. Each is included whole into `libs/` if and only if the
+   * closure walk lands on at least one of its classes.
+   */
+  @get:Classpath abstract val dependencyJars: ConfigurableFileCollection
+
+  /**
+   * Renders directory from the preceding `renderPreviews` task. The cover preview's PNG is read
+   * from here and prepended to the polyglot; when missing or empty, the task emits a stub gray PNG
+   * so the bundle is still well-formed (and `file(1)` still reports PNG).
+   *
+   * Marked `@Internal` because the dir may legitimately not exist (bundling without a prior render
+   * is a supported v1 flow). Tracking it as an `@InputDirectory @Optional` errors out when Gradle
+   * resolves the property to a path on disk that doesn't yet exist. The bundle is still re-packed
+   * whenever the upstream `discoverPreviews` output or the classpath change.
+   */
+  @get:Internal abstract val rendersDir: DirectoryProperty
+
+  /**
+   * Preview ids to include. First entry is the cover. Empty means "all previews in the manifest";
+   * passing the empty list intentionally — most callers will populate this from CLI input.
+   */
+  @get:Input abstract val previewIds: ListProperty<String>
+
+  /** Gradle module path, recorded into the bundle for forensics. */
+  @get:Input abstract val modulePath: Property<String>
+
+  /** Producer-version string for diagnostics, e.g. "compose-preview $BUNDLE_VERSION". */
+  @get:Input abstract val producedBy: Property<String>
+
+  /** Backend identifier. v1 = "desktop". */
+  @get:Input abstract val backend: Property<String>
+
+  /** Output `.png` polyglot file. */
+  @get:OutputFile abstract val output: RegularFileProperty
+
+  @TaskAction
+  fun pack() {
+    val manifestFile = previewsJson.get().asFile
+    val manifest = JSON.decodeFromString(PreviewManifest.serializer(), manifestFile.readText())
+    val selected = resolveSelection(manifest, previewIds.get())
+    val coverId = selected.first().id
+    val entryClassFqns = selected.map { it.className }.toSet()
+
+    val classDirsList = moduleClassDirs.files.filter { it.exists() && it.isDirectory }
+    val jarsList = dependencyJars.files.filter { it.isFile && it.name.endsWith(".jar") }
+    val scanPaths = (classDirsList + jarsList).map { it.absolutePath }
+
+    val closure = closureWalk(scanPaths, entryClassFqns)
+
+    val moduleClassFqns = collectClassFqns(classDirsList)
+    val reachableModuleClasses = moduleClassFqns intersect closure.reachable
+    val keptModuleClassFiles = packModuleClasses(classDirsList, reachableModuleClasses)
+
+    val keptJars = jarsList.mapNotNull { jar ->
+      val totals = closure.perElement[jar.absolutePath]
+      val total = totals?.total ?: 0
+      val reachable = totals?.reachable ?: 0
+      val keep = reachable > 0
+      LibraryJarDecision(
+        sourcePath = jar.absolutePath,
+        bundledAs = if (keep) "libs/${dedupeJarName(jar.name)}" else null,
+        totalClasses = total,
+        reachableClasses = reachable,
+        originalBytes = jar.length(),
+        kept = keep,
+      )
+    }
+
+    val classpathOrder = mutableListOf("classes/app.jar")
+    keptJars.filter { it.kept }.forEach { classpathOrder += it.bundledAs!! }
+
+    val appJarBytes = buildJar(keptModuleClassFiles, moduleResourcesDir.orNull?.asFile)
+    val report =
+      MinimizationReport(
+        entryClassFqns = entryClassFqns.sorted(),
+        reachableClassCount = closure.reachable.size,
+        totalScannedClassCount = closure.totalScanned,
+        moduleClasses =
+          ModuleClassesStats(
+            totalClasses = moduleClassFqns.size,
+            reachableClasses = reachableModuleClasses.size,
+            packedBytes = appJarBytes.size.toLong(),
+          ),
+        libraryJars = keptJars,
+      )
+
+    val bundle =
+      BundleManifest(
+        schemaVersion = BUNDLE_SCHEMA_VERSION,
+        backend = backend.get(),
+        previewIds = selected.map { it.id },
+        coverPreviewId = coverId,
+        classpath = classpathOrder,
+        modulePath = modulePath.get(),
+        producedBy = producedBy.get(),
+      )
+
+    val filteredManifest = manifest.copy(previews = selected)
+    val zipBytes =
+      buildZip(
+        bundleJson = JSON.encodeToString(BundleManifest.serializer(), bundle),
+        previewsJson = JSON.encodeToString(PreviewManifest.serializer(), filteredManifest),
+        appJar = appJarBytes,
+        keptJars = keptJars.filter { it.kept },
+        report = JSON.encodeToString(MinimizationReport.serializer(), report),
+      )
+
+    val coverPng = resolveCoverPng(selected.first())
+    val outFile = output.get().asFile
+    writePngZipPolyglot(coverPng, zipBytes, outFile)
+
+    logger.lifecycle(
+      "composePreviewBundle — wrote ${outFile.name} (${outFile.length()} bytes)\n" +
+        "  entry classes:        ${report.entryClassFqns.size}\n" +
+        "  reachable classes:    ${report.reachableClassCount} / ${report.totalScannedClassCount}\n" +
+        "  module classes kept:  ${report.moduleClasses.reachableClasses} / ${report.moduleClasses.totalClasses}\n" +
+        "  jars kept:            ${report.libraryJars.count { it.kept }} / ${report.libraryJars.size}\n" +
+        "  bytes saved (jars):   ${report.libraryJars.filter { !it.kept }.sumOf { it.originalBytes }}"
+    )
+  }
+
+  private fun resolveSelection(manifest: PreviewManifest, ids: List<String>): List<PreviewInfo> {
+    if (ids.isEmpty()) {
+      if (manifest.previews.isEmpty()) {
+        throw GradleException(
+          "composePreviewBundle: previews.json is empty — nothing to bundle. Run discoverPreviews first."
+        )
+      }
+      return manifest.previews
+    }
+    val byId = manifest.previews.associateBy { it.id }
+    val resolved = ids.map { id ->
+      byId[id]
+        ?: throw GradleException(
+          "composePreviewBundle: preview id not found: $id\nAvailable: ${byId.keys.sorted().joinToString()}"
+        )
+    }
+    return resolved
+  }
+
+  private fun resolveCoverPng(cover: PreviewInfo): ByteArray {
+    val rendersRoot = rendersDir.orNull?.asFile
+    if (rendersRoot != null) {
+      val candidate =
+        cover.captures.firstOrNull()?.renderOutput?.let { rel ->
+          // `renderOutput` is module-relative under `build/compose-previews/`, e.g.
+          // `renders/<id>.png`. The rendersDir input points at the `renders/` dir itself.
+          val name = rel.substringAfterLast('/')
+          File(rendersRoot, name)
+        }
+      if (candidate != null && candidate.isFile && candidate.length() > 0) {
+        return candidate.readBytes()
+      }
+    }
+    return STUB_GRAY_PNG
+  }
+
+  private fun packModuleClasses(
+    classDirs: List<File>,
+    reachable: Set<String>,
+  ): Map<String, ByteArray> {
+    val result = LinkedHashMap<String, ByteArray>()
+    for (root in classDirs) {
+      root
+        .walkTopDown()
+        .filter { it.isFile && it.name.endsWith(".class") }
+        .forEach { f ->
+          val rel = f.relativeTo(root).path.replace(File.separatorChar, '/')
+          val fqn = rel.removeSuffix(".class").replace('/', '.')
+          if (fqn in reachable) {
+            result[rel] = f.readBytes()
+          }
+        }
+    }
+    return result
+  }
+
+  private fun collectClassFqns(classDirs: List<File>): Set<String> {
+    val result = mutableSetOf<String>()
+    for (root in classDirs) {
+      root
+        .walkTopDown()
+        .filter { it.isFile && it.name.endsWith(".class") }
+        .forEach { f ->
+          val rel = f.relativeTo(root).path.replace(File.separatorChar, '/')
+          result += rel.removeSuffix(".class").replace('/', '.')
+        }
+    }
+    return result
+  }
+
+  private fun buildJar(classes: Map<String, ByteArray>, resourcesDir: File?): ByteArray {
+    val baos = ByteArrayOutputStream()
+    ZipOutputStream(baos).use { zip ->
+      classes.forEach { (path, bytes) -> zip.writeFile(path, bytes) }
+      if (resourcesDir != null && resourcesDir.isDirectory) {
+        resourcesDir
+          .walkTopDown()
+          .filter { it.isFile }
+          .forEach { f ->
+            val rel = f.relativeTo(resourcesDir).path.replace(File.separatorChar, '/')
+            if (rel !in classes) zip.writeFile(rel, f.readBytes())
+          }
+      }
+    }
+    return baos.toByteArray()
+  }
+
+  private fun buildZip(
+    bundleJson: String,
+    previewsJson: String,
+    appJar: ByteArray,
+    keptJars: List<LibraryJarDecision>,
+    report: String,
+  ): ByteArray {
+    val baos = ByteArrayOutputStream()
+    val usedNames = mutableSetOf<String>()
+    ZipOutputStream(baos).use { zip ->
+      zip.writeFile("bundle.json", bundleJson.toByteArray(Charsets.UTF_8))
+      zip.writeFile("previews.json", previewsJson.toByteArray(Charsets.UTF_8))
+      zip.writeFile("classes/app.jar", appJar)
+      keptJars.forEach { decision ->
+        val bundled = decision.bundledAs ?: return@forEach
+        // dedupeJarName already ran on the manifest entry, but defend against duplicates
+        // sneaking in via a renamed manifest path during refactor.
+        if (bundled in usedNames) return@forEach
+        usedNames += bundled
+        zip.writeFile(bundled, File(decision.sourcePath).readBytes())
+      }
+      zip.writeFile("report.json", report.toByteArray(Charsets.UTF_8))
+    }
+    return baos.toByteArray()
+  }
+
+  private fun ZipOutputStream.writeFile(path: String, bytes: ByteArray) {
+    putNextEntry(ZipEntry(path))
+    write(bytes)
+    closeEntry()
+  }
+
+  /**
+   * Two consumer dependencies can resolve to jars with the same basename (e.g. two
+   * `kotlinx-coroutines-core-jvm-…` from different configurations); dedupe by suffixing a counter
+   * when a collision is detected. Order matches the input classpath, so the renderer's load order
+   * is preserved.
+   */
+  private val seenJarNames = mutableMapOf<String, Int>()
+
+  private fun dedupeJarName(name: String): String {
+    val count = seenJarNames.getOrDefault(name, 0)
+    seenJarNames[name] = count + 1
+    return if (count == 0) name else name.removeSuffix(".jar") + "-$count.jar"
+  }
+
+  private data class PerElementCount(val reachable: Int, val total: Int)
+
+  private data class Closure(
+    val reachable: Set<String>,
+    val perElement: Map<String, PerElementCount>,
+    val totalScanned: Int,
+  )
+
+  private fun closureWalk(scanPaths: List<String>, entries: Set<String>): Closure {
+    if (scanPaths.isEmpty()) {
+      return Closure(reachable = entries.toSet(), perElement = emptyMap(), totalScanned = 0)
+    }
+    ClassGraph()
+      .enableAllInfo()
+      .enableInterClassDependencies()
+      .overrideClasspath(scanPaths)
+      .ignoreParentClassLoaders()
+      .scan()
+      .use { scan ->
+        val depMap = scan.classDependencyMap
+        val all = scan.allClasses
+        val visited = mutableSetOf<String>()
+        val queue = ArrayDeque<String>()
+        // Seed with every class in the enclosing FQN's compilation unit — Kotlin top-level
+        // functions live on `FooKt` and their generated companions (`ComposableSingletons$FooKt`,
+        // `FooKt$lambda-1`, …) share the prefix. Adding them all up front means we don't depend on
+        // ClassGraph having an edge from the FooKt class to its lambda inner classes (it usually
+        // does, but the seed is cheap insurance).
+        for (entry in entries) {
+          for (ci in all) {
+            if (ci.name == entry || ci.name.startsWith("$entry$")) {
+              if (visited.add(ci.name)) queue += ci.name
+            }
+          }
+        }
+        while (queue.isNotEmpty()) {
+          val current = queue.removeFirst()
+          val ci = scan.getClassInfo(current) ?: continue
+          val deps = depMap[ci] ?: continue
+          for (dep in deps) {
+            if (visited.add(dep.name)) queue += dep.name
+          }
+        }
+        val perElementReachable = HashMap<String, IntArray>() // [reachable, total]
+        for (ci in all) {
+          val file = ci.classpathElementFile?.absolutePath ?: continue
+          val counts = perElementReachable.getOrPut(file) { IntArray(2) }
+          counts[1]++
+          if (ci.name in visited) counts[0]++
+        }
+        return Closure(
+          reachable = visited,
+          perElement = perElementReachable.mapValues { (_, c) -> PerElementCount(c[0], c[1]) },
+          totalScanned = all.size,
+        )
+      }
+  }
+
+  private companion object {
+    val JSON = Json {
+      prettyPrint = true
+      encodeDefaults = true
+    }
+
+    /**
+     * 1×1 gray PNG built on demand. Used as the cover when no rendered PNG is available — file(1)
+     * still reports PNG and viewers render a single neutral pixel, conveying "no render yet".
+     */
+    val STUB_GRAY_PNG: ByteArray by lazy {
+      val img = BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB)
+      img.setRGB(0, 0, 0x808080)
+      val baos = ByteArrayOutputStream()
+      ImageIO.write(img, "png", baos)
+      baos.toByteArray()
+    }
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -14,6 +14,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
@@ -28,16 +29,27 @@ import org.gradle.api.tasks.TaskAction
 
 /**
  * Pack a portable preview bundle — a PNG+ZIP polyglot containing the selected previews' metadata,
- * the minimal set of consumer classes reachable from those previews, the runtime jars that
- * contribute to the closure, and a minimization report. See [PreviewBundleFormat] for the on-disk
- * layout.
+ * the minimal set of consumer classes reachable from those previews, a **list** of Maven
+ * coordinates the player resolves at open time, and a minimization report. See
+ * [PreviewBundleFormat] for the on-disk layout.
  *
- * The closure walk is driven by ClassGraph's inter-class dependency map: starting from each
- * selected preview's enclosing class FQN, we BFS through every class the closure references and
- * collect the set. Module classes are repacked per-class (small, ours, safe to surgically prune).
- * Third-party jars are included whole when they contribute ≥1 reachable class — stripping inside a
- * jar is risky (lambdas, kotlin metadata, resources, services) and the per-jar size win is the
- * dominant lever anyway.
+ * # Dependency strategy
+ *
+ * Only consumer-module bytecode is inlined into the bundle (`classes/app.jar`, minimized to classes
+ * reachable from the selected previews). Every Maven-resolved runtime dependency is recorded as a
+ * `ClasspathEntry.Maven` coordinate — not bundled — so the bundle stays small enough to share over
+ * chat / paste into a gist. The player resolves the coordinates from the consumer's normal Gradle
+ * repos at open time. Project deps that have no Maven coordinate (transitive `:my-lib` references
+ * inside the consumer's build) fall back to being inlined as `ClasspathEntry.Project(inlinedAs =
+ * "libs/<name>.jar")` so the bundle is still self-contained for offline use.
+ *
+ * # Closure walk
+ *
+ * Classpath minimization is driven by ClassGraph's inter-class dependency map. We BFS from each
+ * selected preview's enclosing class FQN through every class the closure references. Module classes
+ * are repacked per-class (small, ours, safe to surgically prune); third-party deps appear in
+ * `report.json` with their reachability counts but only the kept ones are recorded in the
+ * manifest's classpath (deps with no reachable class don't make it to the player at all).
  */
 abstract class BundlePreviewTask : DefaultTask() {
 
@@ -68,10 +80,24 @@ abstract class BundlePreviewTask : DefaultTask() {
   abstract val moduleResourcesDir: DirectoryProperty
 
   /**
-   * Third-party runtime classpath jars. Each is included whole into `libs/` if and only if the
-   * closure walk lands on at least one of its classes.
+   * Third-party runtime classpath jars. Used to drive the ClassGraph closure walk and to look up
+   * source coordinates via [dependencyCoordinates] — jars themselves are NOT inlined into the
+   * bundle (apart from project-dep fallbacks).
    */
   @get:Classpath abstract val dependencyJars: ConfigurableFileCollection
+
+  /**
+   * Map of `dependencyJar absolute path → coordinate string`. Encoded as a single string so it
+   * round-trips through Gradle's MapProperty serialization. Format:
+   * - `"maven:<group>:<artifact>:<version>:<type>"` for Maven-resolved deps (`type` is `jar` /
+   *   `aar`).
+   * - `"project:<gradle path>"` for local project deps (these get inlined into the bundle).
+   *
+   * Jars not present in this map are treated as anonymous file-collection inputs (rare — typically
+   * a JBR / boot-classpath jar). They're inlined as `project`-style with a synthetic `:anon` path
+   * so the player can still load them, but the manifest entry is flagged.
+   */
+  @get:Input abstract val dependencyCoordinates: MapProperty<String, String>
 
   /**
    * Renders directory from the preceding `renderPreviews` task. The cover preview's PNG is read
@@ -120,26 +146,13 @@ abstract class BundlePreviewTask : DefaultTask() {
     val moduleClassFqns = collectClassFqns(classDirsList)
     val reachableModuleClasses = moduleClassFqns intersect closure.reachable
     val keptModuleClassFiles = packModuleClasses(classDirsList, reachableModuleClasses)
-
-    val keptJars = jarsList.mapNotNull { jar ->
-      val totals = closure.perElement[jar.absolutePath]
-      val total = totals?.total ?: 0
-      val reachable = totals?.reachable ?: 0
-      val keep = reachable > 0
-      LibraryJarDecision(
-        sourcePath = jar.absolutePath,
-        bundledAs = if (keep) "libs/${dedupeJarName(jar.name)}" else null,
-        totalClasses = total,
-        reachableClasses = reachable,
-        originalBytes = jar.length(),
-        kept = keep,
-      )
-    }
-
-    val classpathOrder = mutableListOf("classes/app.jar")
-    keptJars.filter { it.kept }.forEach { classpathOrder += it.bundledAs!! }
-
     val appJarBytes = buildJar(keptModuleClassFiles, moduleResourcesDir.orNull?.asFile)
+
+    val coordMap = dependencyCoordinates.getOrElse(emptyMap())
+    val depDecisions = buildDepDecisions(jarsList, closure.perElement, coordMap)
+    val classpathEntries = buildClasspathEntries(depDecisions)
+    val inlinedProjectJars = inlinedProjectJars(jarsList, depDecisions)
+
     val report =
       MinimizationReport(
         entryClassFqns = entryClassFqns.sorted(),
@@ -151,7 +164,7 @@ abstract class BundlePreviewTask : DefaultTask() {
             reachableClasses = reachableModuleClasses.size,
             packedBytes = appJarBytes.size.toLong(),
           ),
-        libraryJars = keptJars,
+        dependencies = depDecisions,
       )
 
     val bundle =
@@ -160,7 +173,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         backend = backend.get(),
         previewIds = selected.map { it.id },
         coverPreviewId = coverId,
-        classpath = classpathOrder,
+        classpath = classpathEntries,
         modulePath = modulePath.get(),
         producedBy = producedBy.get(),
       )
@@ -171,7 +184,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         bundleJson = JSON.encodeToString(BundleManifest.serializer(), bundle),
         previewsJson = JSON.encodeToString(PreviewManifest.serializer(), filteredManifest),
         appJar = appJarBytes,
-        keptJars = keptJars.filter { it.kept },
+        inlinedProjectJars = inlinedProjectJars,
         report = JSON.encodeToString(MinimizationReport.serializer(), report),
       )
 
@@ -179,13 +192,17 @@ abstract class BundlePreviewTask : DefaultTask() {
     val outFile = output.get().asFile
     writePngZipPolyglot(coverPng, zipBytes, outFile)
 
+    val mavenKept = classpathEntries.count { it is ClasspathEntry.Maven }
+    val projectInlined = classpathEntries.count { it is ClasspathEntry.Project }
+    val depsDropped = depDecisions.count { !it.kept }
     logger.lifecycle(
       "composePreviewBundle — wrote ${outFile.name} (${outFile.length()} bytes)\n" +
         "  entry classes:        ${report.entryClassFqns.size}\n" +
         "  reachable classes:    ${report.reachableClassCount} / ${report.totalScannedClassCount}\n" +
         "  module classes kept:  ${report.moduleClasses.reachableClasses} / ${report.moduleClasses.totalClasses}\n" +
-        "  jars kept:            ${report.libraryJars.count { it.kept }} / ${report.libraryJars.size}\n" +
-        "  bytes saved (jars):   ${report.libraryJars.filter { !it.kept }.sumOf { it.originalBytes }}"
+        "  Maven deps listed:    $mavenKept\n" +
+        "  Project deps inlined: $projectInlined\n" +
+        "  deps dropped:         $depsDropped (no reachable classes)"
     )
   }
 
@@ -259,6 +276,77 @@ abstract class BundlePreviewTask : DefaultTask() {
     return result
   }
 
+  private fun buildDepDecisions(
+    jars: List<File>,
+    perElement: Map<String, PerElementCount>,
+    coordMap: Map<String, String>,
+  ): List<DependencyDecision> = jars.map { jar ->
+    val totals = perElement[jar.absolutePath]
+    val reachable = totals?.reachable ?: 0
+    val total = totals?.total ?: 0
+    val rawCoord = coordMap[jar.absolutePath]
+    val mavenCoord = rawCoord?.takeIf { it.startsWith("maven:") }?.removePrefix("maven:")
+    val projectPath = rawCoord?.takeIf { it.startsWith("project:") }?.removePrefix("project:")
+    DependencyDecision(
+      sourcePath = jar.absolutePath,
+      coordinate = mavenCoord,
+      projectPath = projectPath,
+      totalClasses = total,
+      reachableClasses = reachable,
+      originalBytes = jar.length(),
+      kept = reachable > 0,
+    )
+  }
+
+  private fun buildClasspathEntries(deps: List<DependencyDecision>): List<ClasspathEntry> {
+    val result = mutableListOf<ClasspathEntry>(ClasspathEntry.Module(path = "classes/app.jar"))
+    for (dep in deps) {
+      if (!dep.kept) continue
+      val coord = dep.coordinate
+      if (coord != null) {
+        result += parseMavenCoord(coord)
+      } else {
+        val inlined = "libs/${dedupeJarName(File(dep.sourcePath).name)}"
+        result += ClasspathEntry.Project(path = dep.projectPath ?: ":anon", inlinedAs = inlined)
+      }
+    }
+    return result
+  }
+
+  private fun inlinedProjectJars(
+    jars: List<File>,
+    deps: List<DependencyDecision>,
+  ): Map<String, File> {
+    val byPath = jars.associateBy { it.absolutePath }
+    val result = LinkedHashMap<String, File>()
+    seenJarNames.clear()
+    for (dep in deps) {
+      if (!dep.kept) continue
+      if (dep.coordinate != null) continue
+      val src = byPath[dep.sourcePath] ?: continue
+      val inlined = "libs/${dedupeJarName(src.name)}"
+      result[inlined] = src
+    }
+    seenJarNames.clear()
+    return result
+  }
+
+  /**
+   * Parse `"<group>:<artifact>:<version>:<type>"` (the post-prefix shape produced by the plugin
+   * registration's `ResolvedArtifactResult` → coord encoder). Falls back to `type = "jar"` when the
+   * coordinate omits the trailing packaging.
+   */
+  private fun parseMavenCoord(coord: String): ClasspathEntry.Maven {
+    val parts = coord.split(':')
+    require(parts.size >= 3) { "composePreviewBundle: malformed Maven coordinate: $coord" }
+    return ClasspathEntry.Maven(
+      group = parts[0],
+      artifact = parts[1],
+      version = parts[2],
+      type = parts.getOrNull(3) ?: "jar",
+    )
+  }
+
   private fun buildJar(classes: Map<String, ByteArray>, resourcesDir: File?): ByteArray {
     val baos = ByteArrayOutputStream()
     ZipOutputStream(baos).use { zip ->
@@ -280,23 +368,15 @@ abstract class BundlePreviewTask : DefaultTask() {
     bundleJson: String,
     previewsJson: String,
     appJar: ByteArray,
-    keptJars: List<LibraryJarDecision>,
+    inlinedProjectJars: Map<String, File>,
     report: String,
   ): ByteArray {
     val baos = ByteArrayOutputStream()
-    val usedNames = mutableSetOf<String>()
     ZipOutputStream(baos).use { zip ->
       zip.writeFile("bundle.json", bundleJson.toByteArray(Charsets.UTF_8))
       zip.writeFile("previews.json", previewsJson.toByteArray(Charsets.UTF_8))
       zip.writeFile("classes/app.jar", appJar)
-      keptJars.forEach { decision ->
-        val bundled = decision.bundledAs ?: return@forEach
-        // dedupeJarName already ran on the manifest entry, but defend against duplicates
-        // sneaking in via a renamed manifest path during refactor.
-        if (bundled in usedNames) return@forEach
-        usedNames += bundled
-        zip.writeFile(bundled, File(decision.sourcePath).readBytes())
-      }
+      inlinedProjectJars.forEach { (path, file) -> zip.writeFile(path, file.readBytes()) }
       zip.writeFile("report.json", report.toByteArray(Charsets.UTF_8))
     }
     return baos.toByteArray()
@@ -309,10 +389,9 @@ abstract class BundlePreviewTask : DefaultTask() {
   }
 
   /**
-   * Two consumer dependencies can resolve to jars with the same basename (e.g. two
-   * `kotlinx-coroutines-core-jvm-…` from different configurations); dedupe by suffixing a counter
-   * when a collision is detected. Order matches the input classpath, so the renderer's load order
-   * is preserved.
+   * Two project deps can resolve to jars with the same basename; dedupe by suffixing a counter.
+   * Used only for the rare project-dep inline path — Maven coords don't collide because the
+   * resolver guarantees a unique (group, artifact, version) per file.
    */
   private val seenJarNames = mutableMapOf<String, Int>()
 
@@ -384,6 +463,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     val JSON = Json {
       prettyPrint = true
       encodeDefaults = true
+      classDiscriminator = "kind"
     }
 
     /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -197,20 +197,63 @@ internal object ComposePreviewTasks {
     val pluginVersionProperty = PluginVersion.value
 
     val artifactTypeAttr = Attribute.of("artifactType", String::class.java)
-    val depJarFiles =
-      project.configurations.findByName(resolveDependencyConfigName())?.let { config ->
-        // `artifactType=jar` view: AAR consumers transform to extracted classes.jar; pure JVM
-        // consumers pass through. Either way we get real jars on the closure walk.
-        config.incoming.artifactView { attributes.attribute(artifactTypeAttr, "jar") }.files
-      }
+    val depConfig = project.configurations.findByName(resolveDependencyConfigName())
+    val depJarFiles = depConfig?.let { config ->
+      // `artifactType=jar` view: AAR consumers transform to extracted classes.jar; pure JVM
+      // consumers pass through. Either way we get real jars on the closure walk.
+      config.incoming.artifactView { attributes.attribute(artifactTypeAttr, "jar") }.files
+    }
+    // Map each resolved dependency jar to a coordinate string the task action can fold into
+    // `bundle.json`'s `classpath`:
+    // - `maven:<group>:<artifact>:<version>:jar` for Maven-resolved deps (the player resolves at
+    //   open time — small bundle, no inlined jars).
+    // - `project:<gradle path>` for project-local deps (the task inlines those into the bundle
+    //   since they can't be re-resolved from Maven).
+    //
+    // Resolution happens via `Provider` transformations, so this stays config-cache-safe.
+    val coordMapProvider: Provider<Map<String, String>> =
+      depConfig?.incoming?.artifacts?.resolvedArtifacts?.map { artifacts ->
+        artifacts.associate { artifact ->
+          val id = artifact.id.componentIdentifier
+          val value =
+            when (id) {
+              is org.gradle.api.artifacts.component.ModuleComponentIdentifier ->
+                "maven:${id.group}:${id.module}:${id.version}:jar"
+              is org.gradle.api.artifacts.component.ProjectComponentIdentifier ->
+                "project:${id.projectPath}"
+              else -> "unknown:${id.displayName}"
+            }
+          artifact.file.absolutePath to value
+        }
+      } ?: project.providers.provider { emptyMap<String, String>() }
+
     val defaultOutput = previewOutputDir.map { it.file("bundle.png").asFile }
     val resolvedOutput = outputProperty.map { java.io.File(it) }.orElse(defaultOutput)
+
+    // Consumer-module resources directory. The Kotlin / Compose plugins write `src/main/resources/`
+    // (string ids referenced from bytecode via Compose Resources, fonts, etc.) into the standard
+    // `build/resources/main` (kotlin("jvm")) or `build/processedResources/<sourceSet>/main` (KMP).
+    // Wire whichever exists so packed bundles still contain classpath resources the closure walk
+    // can't introspect. Task action treats a missing dir as "no resources" (the `@Optional` +
+    // `orNull?.isDirectory` check inside `buildJar`).
+    val moduleResourcesDirProvider: Provider<Directory> =
+      project.providers.provider {
+        val candidates =
+          listOf(
+            project.layout.buildDirectory.dir("resources/main").orNull,
+            project.layout.buildDirectory.dir("processedResources/jvm/main").orNull,
+            project.layout.buildDirectory.dir("processedResources/desktop/main").orNull,
+          )
+        candidates.firstOrNull { it != null && it.asFile.isDirectory }
+      }
 
     project.tasks.register("composePreviewBundle", BundlePreviewTask::class.java) {
       onlyIf { extension.enabled.get() }
       previewsJson.set(previewOutputDir.map { it.file("previews.json") })
       moduleClassDirs.from(sourceClassDirs)
+      moduleResourcesDir.set(moduleResourcesDirProvider)
       depJarFiles?.let { dependencyJars.from(it) }
+      dependencyCoordinates.set(coordMapProvider)
       // Renders dir is wired conditionally — when renderPreviews has run, the dir exists and
       // contains PNGs. Use orNull semantics: missing dir = stub cover.
       rendersDir.set(previewOutputDir.map { it.dir("renders") })

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -150,6 +150,15 @@ internal object ComposePreviewTasks {
       )
     }
 
+    registerBundleTask(
+      project = project,
+      extension = extension,
+      previewOutputDir = previewOutputDir,
+      sourceClassDirs = sourceClassDirs,
+      resolveDependencyConfigName = resolveDependencyConfigName,
+      discoverTaskName = "discoverPreviews",
+    )
+
     registerDesktopDaemonStartTask(
       project,
       extension,
@@ -157,6 +166,65 @@ internal object ComposePreviewTasks {
       sourceClassDirs,
       resolveDependencyConfigName,
     )
+  }
+
+  /**
+   * Register `composePreviewBundle` — packs the consumer module + selected previews into a portable
+   * PNG+ZIP polyglot. Inputs reuse the existing `previews.json` from `discoverPreviews` and the
+   * same module class dirs + runtime classpath that `renderPreviews` consumes; the cover PNG is
+   * read from the `renders/` directory when present (lazy — task still runs in "no-render" mode and
+   * writes a stub gray PNG cover).
+   *
+   * Selection comes from project properties (`-PbundlePreviewIds=…`) or CLI input. The bundle task
+   * does NOT depend on `renderPreviews` — bundling without pre-rendering is the common case for the
+   * CLI's "pack and share" flow. Callers who want the cover populated should run `renderPreviews`
+   * first (the CLI shells through `renderPreviews composePreviewBundle` as a single Gradle
+   * invocation).
+   */
+  private fun registerBundleTask(
+    project: Project,
+    extension: PreviewExtension,
+    previewOutputDir: Provider<Directory>,
+    sourceClassDirs: FileCollection,
+    resolveDependencyConfigName: () -> String,
+    discoverTaskName: String,
+  ) {
+    val previewIdsProperty: Provider<List<String>> =
+      project.providers.gradleProperty("bundlePreviewIds").map { raw ->
+        raw.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+      }
+    val outputProperty: Provider<String> = project.providers.gradleProperty("bundleOutput")
+    val pluginVersionProperty = PluginVersion.value
+
+    val artifactTypeAttr = Attribute.of("artifactType", String::class.java)
+    val depJarFiles =
+      project.configurations.findByName(resolveDependencyConfigName())?.let { config ->
+        // `artifactType=jar` view: AAR consumers transform to extracted classes.jar; pure JVM
+        // consumers pass through. Either way we get real jars on the closure walk.
+        config.incoming.artifactView { attributes.attribute(artifactTypeAttr, "jar") }.files
+      }
+    val defaultOutput = previewOutputDir.map { it.file("bundle.png").asFile }
+    val resolvedOutput = outputProperty.map { java.io.File(it) }.orElse(defaultOutput)
+
+    project.tasks.register("composePreviewBundle", BundlePreviewTask::class.java) {
+      onlyIf { extension.enabled.get() }
+      previewsJson.set(previewOutputDir.map { it.file("previews.json") })
+      moduleClassDirs.from(sourceClassDirs)
+      depJarFiles?.let { dependencyJars.from(it) }
+      // Renders dir is wired conditionally — when renderPreviews has run, the dir exists and
+      // contains PNGs. Use orNull semantics: missing dir = stub cover.
+      rendersDir.set(previewOutputDir.map { it.dir("renders") })
+      previewIds.set(previewIdsProperty.orElse(emptyList()))
+      modulePath.set(project.path)
+      backend.set("desktop")
+      producedBy.set("compose-preview $pluginVersionProperty")
+      output.set(project.layout.file(resolvedOutput))
+      group = "compose preview"
+      description = "Pack selected previews + minimal classpath into a portable PNG+ZIP polyglot."
+      // No dependsOn renderPreviews — bundle without a render is valid (stub cover). Callers wire
+      // explicitly when they want a real cover.
+      dependsOn(discoverTaskName)
+    }
   }
 
   /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -1,0 +1,163 @@
+package ee.schimke.composeai.plugin
+
+import java.io.File
+import kotlinx.serialization.Serializable
+
+/**
+ * On-disk format for `compose-preview` bundles — portable, self-contained artefacts that record one
+ * or more `@Preview` composables together with the minimal classpath needed to re-render them.
+ *
+ * # File shape
+ *
+ * The bundle is a **PNG + ZIP polyglot**:
+ * 1. Bytes `0..n` are a valid PNG (the cover image — the first selected preview's rendered output,
+ *    or a placeholder when no render is available). Finder, Preview.app, browsers, GitHub, Slack —
+ *    every PNG viewer renders the leading image.
+ * 2. Bytes `n+1..EOF` are a standard ZIP archive. ZIP parsers scan backwards from EOF for the
+ *    End-Of-Central-Directory signature (`PK\x05\x06`), so the leading PNG bytes are invisible to
+ *    them. `unzip foo.png` works; so does any library zip reader.
+ *
+ * `file(1)` reports "PNG image data". The same file opened with `compose-preview bundle open` (or
+ * via the VS Code extension) extracts the appended zip and loads the bundle.
+ *
+ * # ZIP layout
+ *
+ * ```
+ * bundle.json              — manifest (this file's [BundleManifest])
+ * previews.json            — filtered to selected preview ids; same shape as the original
+ * classes/app.jar          — consumer module bytecode, MINIMIZED to classes reachable from the
+ *                            selected previews (plus all module resources)
+ * libs/<name>.jar          — third-party jars from the runtime classpath that contain ≥1 reachable
+ *                            class. Whole jars; we don't strip inside them
+ * renders/<preview-id>.png — optional pre-rendered cache, off by default in v1
+ * report.json              — [MinimizationReport] for transparency on what was kept vs dropped
+ * ```
+ */
+@Serializable
+data class BundleManifest(
+  val schemaVersion: Int,
+  /** Backend the bundle was packed for. v1 = "desktop"; "android" follows. */
+  val backend: String,
+  /** Selected preview ids (matches `previews.json[].id`). First entry = cover. */
+  val previewIds: List<String>,
+  /** Preview id whose PNG forms the polyglot's leading bytes. Usually `previewIds[0]`. */
+  val coverPreviewId: String?,
+  /**
+   * Classpath entries inside the bundle, in load order. Each is a posix-style relative path —
+   * `classes/app.jar` first, then `libs/<name>.jar` for each kept third-party jar. The player
+   * extracts the zip, resolves these to absolute paths, and hands them to the renderer.
+   */
+  val classpath: List<String>,
+  /** Source Gradle path that produced the bundle, e.g. `:samples:cmp`. */
+  val modulePath: String,
+  /** `BUNDLE_VERSION`-shaped identifier of the producer for diagnostics. */
+  val producedBy: String,
+)
+
+const val BUNDLE_SCHEMA_VERSION: Int = 1
+
+/**
+ * Diagnostic record describing how aggressive the minimization was. Always written into the bundle
+ * as `report.json` so users can audit whether the closure walk was effective.
+ */
+@Serializable
+data class MinimizationReport(
+  val entryClassFqns: List<String>,
+  val reachableClassCount: Int,
+  val totalScannedClassCount: Int,
+  val moduleClasses: ModuleClassesStats,
+  val libraryJars: List<LibraryJarDecision>,
+)
+
+@Serializable
+data class ModuleClassesStats(
+  val totalClasses: Int,
+  val reachableClasses: Int,
+  val packedBytes: Long,
+)
+
+@Serializable
+data class LibraryJarDecision(
+  /** Original absolute path the jar was resolved from. Useful for forensic comparison. */
+  val sourcePath: String,
+  /** Posix relative path inside the bundle, or `null` when dropped. */
+  val bundledAs: String?,
+  val totalClasses: Int,
+  val reachableClasses: Int,
+  val originalBytes: Long,
+  /** `true` when the jar contributed at least one class to the closure. */
+  val kept: Boolean,
+)
+
+/**
+ * Writes a PNG + ZIP polyglot. The leading bytes are [coverPng] verbatim; the appended bytes are
+ * [zipBytes] verbatim. Both inputs must already be valid in their respective formats; this writer
+ * does not reframe chunks or rewrite the zip's central directory.
+ *
+ * Most image viewers and zip readers tolerate trailing/leading extra bytes respectively, so the raw
+ * concatenation is enough to satisfy both formats. ZIP's End-Of-Central-Directory record is
+ * searched from EOF (which is in the appended zip), and PNG's chunk loop terminates at the IEND
+ * record (which is inside [coverPng]). See: <https://en.wikipedia.org/wiki/Polyglot_(computing)>.
+ */
+internal fun writePngZipPolyglot(coverPng: ByteArray, zipBytes: ByteArray, out: File) {
+  out.parentFile?.mkdirs()
+  out.outputStream().use { stream ->
+    stream.write(coverPng)
+    stream.write(zipBytes)
+  }
+}
+
+/**
+ * Reads a bundle file produced by [writePngZipPolyglot] (or a plain `.zip`) and returns the zip
+ * bytes. Detects the PNG signature on the leading bytes and seeks past the IEND chunk to find the
+ * zip start; plain zips (signature `PK\x03\x04`) are returned as-is.
+ *
+ * Throws [IllegalArgumentException] when neither signature is found.
+ */
+internal fun extractZipBytes(file: File): ByteArray {
+  val bytes = file.readBytes()
+  if (bytes.size < 8) {
+    throw IllegalArgumentException("not a bundle: ${file.path} is too small (${bytes.size}B)")
+  }
+  // Plain zip — return verbatim.
+  if (bytes[0] == 0x50.toByte() && bytes[1] == 0x4B.toByte()) {
+    return bytes
+  }
+  // PNG polyglot — walk chunks until IEND, return the trailing bytes as zip.
+  if (isPngSignature(bytes)) {
+    val zipStart = pngLength(bytes)
+    return bytes.copyOfRange(zipStart, bytes.size)
+  }
+  throw IllegalArgumentException(
+    "not a bundle: ${file.path} — leading bytes match neither PNG (\\x89PNG…) nor ZIP (PK\\x03\\x04)"
+  )
+}
+
+private val PNG_SIGNATURE: ByteArray =
+  byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10) // 0x89 P N G \r \n SUB \n
+
+private fun isPngSignature(bytes: ByteArray): Boolean {
+  if (bytes.size < PNG_SIGNATURE.size) return false
+  for (i in PNG_SIGNATURE.indices) if (bytes[i] != PNG_SIGNATURE[i]) return false
+  return true
+}
+
+/**
+ * Returns the byte offset of the first byte past the PNG's IEND chunk — equivalently, the length of
+ * the leading PNG in the polyglot. Each chunk is `[length:4][type:4][data:length][crc:4]`; the
+ * stream ends after IEND's CRC.
+ */
+private fun pngLength(bytes: ByteArray): Int {
+  var offset = PNG_SIGNATURE.size
+  while (offset < bytes.size) {
+    val length =
+      ((bytes[offset].toInt() and 0xff) shl 24) or
+        ((bytes[offset + 1].toInt() and 0xff) shl 16) or
+        ((bytes[offset + 2].toInt() and 0xff) shl 8) or
+        (bytes[offset + 3].toInt() and 0xff)
+    val type = String(bytes, offset + 4, 4, Charsets.US_ASCII)
+    offset += 4 + 4 + length + 4
+    if (type == "IEND") return offset
+  }
+  throw IllegalArgumentException("truncated PNG: IEND not found before EOF")
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -2,23 +2,24 @@ package ee.schimke.composeai.plugin
 
 import java.io.File
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
 
 /**
  * On-disk format for `compose-preview` bundles — portable, self-contained artefacts that record one
- * or more `@Preview` composables together with the minimal classpath needed to re-render them.
+ * or more `@Preview` composables together with the **minimal** classpath needed to re-render them.
  *
  * # File shape
  *
  * The bundle is a **PNG + ZIP polyglot**:
  * 1. Bytes `0..n` are a valid PNG (the cover image — the first selected preview's rendered output,
- *    or a placeholder when no render is available). Finder, Preview.app, browsers, GitHub, Slack —
- *    every PNG viewer renders the leading image.
+ *    or a stub gray placeholder). Finder, Preview.app, browsers, GitHub, Slack — every PNG viewer
+ *    renders the leading image.
  * 2. Bytes `n+1..EOF` are a standard ZIP archive. ZIP parsers scan backwards from EOF for the
  *    End-Of-Central-Directory signature (`PK\x05\x06`), so the leading PNG bytes are invisible to
- *    them. `unzip foo.png` works; so does any library zip reader.
+ *    them. `unzip foo.png` works.
  *
- * `file(1)` reports "PNG image data". The same file opened with `compose-preview bundle open` (or
- * via the VS Code extension) extracts the appended zip and loads the bundle.
+ * `file(1)` reports "PNG image data". The same file opened by `compose-preview bundle open` (or the
+ * VS Code extension) extracts the appended zip and rehydrates the preview.
  *
  * # ZIP layout
  *
@@ -27,11 +28,17 @@ import kotlinx.serialization.Serializable
  * previews.json            — filtered to selected preview ids; same shape as the original
  * classes/app.jar          — consumer module bytecode, MINIMIZED to classes reachable from the
  *                            selected previews (plus all module resources)
- * libs/<name>.jar          — third-party jars from the runtime classpath that contain ≥1 reachable
- *                            class. Whole jars; we don't strip inside them
- * renders/<preview-id>.png — optional pre-rendered cache, off by default in v1
- * report.json              — [MinimizationReport] for transparency on what was kept vs dropped
+ * report.json              — [MinimizationReport]: which deps contributed reachable classes
  * ```
+ *
+ * **Notably absent:** there is no `libs/` directory. Maven / Google-resolvable dependencies are
+ * recorded as coordinates in [BundleManifest.classpath]; the player (`compose-preview bundle open`,
+ * VS Code extension) re-resolves them from the consumer's normal Gradle / Maven repos at open time.
+ * That keeps a one-preview bundle ~100 KB instead of dragging the whole Compose graph in.
+ *
+ * For Android backends, [ClasspathEntry.Maven.type] = `"aar"` records that the player must resolve
+ * the **unprocessed** AAR (not the extracted classes.jar) so AGP's artifact transforms run as they
+ * would in a normal build.
  */
 @Serializable
 data class BundleManifest(
@@ -43,16 +50,63 @@ data class BundleManifest(
   /** Preview id whose PNG forms the polyglot's leading bytes. Usually `previewIds[0]`. */
   val coverPreviewId: String?,
   /**
-   * Classpath entries inside the bundle, in load order. Each is a posix-style relative path —
-   * `classes/app.jar` first, then `libs/<name>.jar` for each kept third-party jar. The player
-   * extracts the zip, resolves these to absolute paths, and hands them to the renderer.
+   * Classpath in load order. First entry is always [ClasspathEntry.Module] for the inlined
+   * `classes/app.jar`; remaining entries are typically [ClasspathEntry.Maven] coordinates the
+   * player resolves at open time. [ClasspathEntry.Project] is the escape hatch for local /
+   * unresolvable artifacts that had to be inlined alongside the app jar.
    */
-  val classpath: List<String>,
+  val classpath: List<ClasspathEntry>,
   /** Source Gradle path that produced the bundle, e.g. `:samples:cmp`. */
   val modulePath: String,
   /** `BUNDLE_VERSION`-shaped identifier of the producer for diagnostics. */
   val producedBy: String,
 )
+
+/** Discriminator field `kind`, values: `module`, `maven`, `project`. */
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+@Serializable
+@JsonClassDiscriminator("kind")
+sealed interface ClasspathEntry {
+  /** The minimized consumer-module jar inlined inside the bundle. */
+  @Serializable
+  @kotlinx.serialization.SerialName("module")
+  data class Module(
+    /** Posix relative path inside the bundle zip, e.g. `classes/app.jar`. */
+    val path: String
+  ) : ClasspathEntry
+
+  /**
+   * A Maven (or Google Maven, JitPack, …) coordinate the player resolves at open time. Encoded as
+   * separate fields rather than a `group:artifact:version` string so consumers can pick a subset
+   * (e.g. only allow certain groups) without re-parsing.
+   */
+  @Serializable
+  @kotlinx.serialization.SerialName("maven")
+  data class Maven(
+    val group: String,
+    val artifact: String,
+    val version: String,
+    /**
+     * Packaging the player must resolve. `"jar"` for pure-JVM deps (desktop), `"aar"` for Android
+     * library archives — the player resolves the unprocessed AAR so AGP can run its normal
+     * artifact-transform pipeline.
+     */
+    val type: String,
+  ) : ClasspathEntry
+
+  /**
+   * Project-local dep that had no Maven coordinate. The bundle inlines it alongside the consumer
+   * jar so the artefact stays self-contained even when consumed offline.
+   */
+  @Serializable
+  @kotlinx.serialization.SerialName("project")
+  data class Project(
+    /** Gradle path of the producing project, e.g. `:my-lib`. Informational. */
+    val path: String,
+    /** Posix relative path inside the bundle zip, e.g. `libs/my-lib.jar`. */
+    val inlinedAs: String,
+  ) : ClasspathEntry
+}
 
 const val BUNDLE_SCHEMA_VERSION: Int = 1
 
@@ -66,7 +120,8 @@ data class MinimizationReport(
   val reachableClassCount: Int,
   val totalScannedClassCount: Int,
   val moduleClasses: ModuleClassesStats,
-  val libraryJars: List<LibraryJarDecision>,
+  /** One entry per resolved runtime dep — kept ones list as [ClasspathEntry] in the manifest. */
+  val dependencies: List<DependencyDecision>,
 )
 
 @Serializable
@@ -77,15 +132,19 @@ data class ModuleClassesStats(
 )
 
 @Serializable
-data class LibraryJarDecision(
-  /** Original absolute path the jar was resolved from. Useful for forensic comparison. */
+data class DependencyDecision(
+  /** Original absolute path the dep resolved to (jar file). Useful for forensic comparison. */
   val sourcePath: String,
-  /** Posix relative path inside the bundle, or `null` when dropped. */
-  val bundledAs: String?,
+  /**
+   * Maven coordinate string `group:artifact:version[:type]` when known; `null` for project deps.
+   */
+  val coordinate: String?,
+  /** Gradle project path for project deps; `null` for Maven deps. */
+  val projectPath: String?,
   val totalClasses: Int,
   val reachableClasses: Int,
   val originalBytes: Long,
-  /** `true` when the jar contributed at least one class to the closure. */
+  /** `true` when the dep contributed at least one class to the closure (and is in `classpath`). */
   val kept: Boolean,
 )
 
@@ -119,11 +178,9 @@ internal fun extractZipBytes(file: File): ByteArray {
   if (bytes.size < 8) {
     throw IllegalArgumentException("not a bundle: ${file.path} is too small (${bytes.size}B)")
   }
-  // Plain zip — return verbatim.
   if (bytes[0] == 0x50.toByte() && bytes[1] == 0x4B.toByte()) {
     return bytes
   }
-  // PNG polyglot — walk chunks until IEND, return the trailing bytes as zip.
   if (isPngSignature(bytes)) {
     val zipStart = pngLength(bytes)
     return bytes.copyOfRange(zipStart, bytes.size)


### PR DESCRIPTION
## Summary

Adds end-to-end support for packing Compose previews into portable, shareable bundles — PNG+ZIP polyglots that embed the cover preview's rendered image, the minimal set of reachable classes, and a minimization report.

## Key Changes

- **`BundlePreviewTask`** (gradle-plugin): New Gradle task that performs aggressive closure-walk minimization using ClassGraph. Walks inter-class dependencies from selected preview entry points, collects reachable classes, repacks module bytecode per-class, and includes third-party jars whole when they contribute ≥1 reachable class. Outputs a PNG+ZIP polyglot with `bundle.json`, `previews.json`, `classes/app.jar`, `libs/*.jar`, and `report.json`.

- **`PreviewBundleFormat`** (gradle-plugin): Schema definitions for the bundle's on-disk layout (`BundleManifest`, `MinimizationReport`, `LibraryJarDecision`, etc.) and polyglot I/O helpers (`writePngZipPolyglot`, `extractZipBytes`). Includes detailed documentation of the PNG+ZIP format and zip entry structure.

- **`BundleCommand`** (cli): New CLI command with three subcommands:
  - `pack`: Runs `renderPreviews` (optional) and `composePreviewBundle` against a Gradle module; accepts repeatable `--id` flags for preview selection and `--no-render` to skip rendering.
  - `inspect`: Opens a bundle and prints `bundle.json` + `report.json` summary with minimization stats.
  - `extract`: Extracts the zip portion of a bundle into a directory for forensic inspection.

- **`BundleReader`** (cli): In-CLI mirror of the bundle schema (re-declared to avoid dragging gradle-plugin onto the CLI's compile classpath). Provides `readMetadata()` and `extractZipBytes()` for polyglot-aware bundle reading.

- **`ComposePreviewTasks.registerBundleTask()`** (gradle-plugin): Wires up the `composePreviewBundle` task with inputs from `discoverPreviews` (manifest), module class dirs, runtime classpath, and optional renders directory. Supports selection via `-PbundlePreviewIds=…` property and output path via `-PbundleOutput=…`.

- **`BundleFunctionalTest`** (gradle-plugin): End-to-end test coverage verifying:
  - Bundle output is a valid PNG (file magic + viewer compatibility).
  - Bundle output is a valid zip (EOCD signature readable).
  - Bundle includes required entries (`bundle.json`, `previews.json`, `classes/app.jar`, `report.json`).
  - Selection filters `previews.json` to selected ids only.
  - **Minimization is effective**: bundling one preview from a multi-preview module drops the other preview's class file from `classes/app.jar`.
  - Minimization report counts entry classes and dropped jars correctly.

- **`Main.kt`** (cli): Registers `bundle` command in the CLI dispatcher.

## Notable Implementation Details

- **Polyglot format**: PNG bytes (0..n) followed by ZIP bytes (n+1..EOF). ZIP parsers scan backwards from EOF for the EOCD signature, so leading PNG bytes are invisible to them. `file(1)` reports "PNG image data"; `unzip foo.png` works.

- **Closure walk**: ClassGraph's inter-class dependency map drives the walk. Starting from each selected preview's enclosing class FQN, BFS through every class the closure references. Kotlin top-level functions live on `FooKt` and their generated companions (`ComposableSingletons$FooKt`, `FooKt$lambda-1`, …) are seeded up front.

- **Per-class minimization for modules**: Only `.class` files for reachable FQNs land in `classes/app.jar`. Module resources are bundled wholesale (resources are typically small; string-id references in bytecode make them hard to prune deterministically).

- **Whole-jar inclusion for

https://claude.ai/code/session_011Y1vuwt2pQeeMjvqycNHNT