### PR TITLE
feat(cli): bundle render — re-render a packed .png outside any Gradle project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,29 @@ jobs:
       - name: Build CLI
         run: ./gradlew :cli:build
 
+  bundle-render:
+    name: Bundle Render E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      # End-to-end: pack a bundle from a synthetic Compose Desktop project, then re-render it
+      # outside of any Gradle project by spawning the actual CLI binary against the packed PNG.
+      # The aggregate task pre-publishes the plugin to mavenLocal (so the synthetic project's
+      # `id("ee.schimke.composeai.preview") version "<v>"` resolves) and builds the CLI install
+      # dist (so the `bundle render` subprocess has its `lib-renderer/` companion). Opt-in via
+      # `-Pbundle.render.e2e=true` because the test cold-starts Compose Desktop per preview.
+      - name: Bundle render e2e
+        run: ./gradlew functionalTestWithBundleRender -Pbundle.render.e2e=true --stacktrace
+      - name: Upload functionalTest reports on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bundle-render-functional-test-reports
+          path: gradle-plugin/build/reports/tests/functionalTest/
+
   agent-audit-samples:
     name: Agent Audit Samples
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,3 +89,18 @@ tasks.register("functionalTestWithAndroid") {
   dependsOn(":cli:installDist")
   dependsOn(gradle.includedBuild("gradle-plugin").task(":functionalTest"))
 }
+
+tasks.register("functionalTestWithBundleRender") {
+  group = "verification"
+  description =
+    "Publishes the gradle plugin to mavenLocal and builds the compose-preview CLI binary " +
+      "(`:cli:installDist`), then runs gradle-plugin's functionalTest with the opt-in " +
+      "`bundle.render.e2e=true` flag set so `BundleRenderEndToEndFunctionalTest` actually fires."
+  // Synthetic Compose Desktop project resolves the plugin from mavenLocal via the same
+  // `id(...) version "<v>"` block the a11y e2e uses; pre-publish or `BUILD FAILED`.
+  dependsOn(gradle.includedBuild("gradle-plugin").task(":publishToMavenLocal"))
+  // CLI binary at `cli/build/install/compose-preview/bin/compose-preview`, plus the
+  // `lib-renderer/` sibling dir the renderer subprocess loads.
+  dependsOn(":cli:installDist")
+  dependsOn(gradle.includedBuild("gradle-plugin").task(":functionalTest"))
+}

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -46,6 +46,20 @@ tasks.named<Tar>("distTar") {
   compression = Compression.GZIP
 }
 
+// Sidecar configuration carrying the desktop renderer + its Compose Multiplatform runtime. Lives
+// OUTSIDE `runtimeClasspath` so [CheckCliDaemonLibraryBoundary] keeps holding: the CLI's own JVM
+// never loads renderer classes (no version-skew risk against consumer Compose), and the renderer
+// only runs in the subprocess spawned by `compose-preview bundle render`.
+//
+// Resolved files are copied into `cli/build/install/compose-preview/lib-renderer/` by the
+// distribution wiring below, and located at runtime via `APP_HOME/lib-renderer/` (the same env
+// var the generated `bin/compose-preview` script exports for its own classpath).
+val composePreviewRenderer =
+  configurations.create("composePreviewRenderer") {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+  }
+
 dependencies {
   implementation(libs.kotlinx.serialization.json)
   implementation("org.gradle:gradle-tooling-api:9.3.1")
@@ -64,7 +78,15 @@ dependencies {
   implementation(project(":render-session-api"))
   implementation(project(":render-session-subprocess"))
 
+  // `compose-preview bundle render` ships the desktop renderer + its full Compose Multiplatform
+  // runtime in `lib-renderer/`. Subprocess only; never on the CLI's own classpath.
+  add("composePreviewRenderer", project(":renderer-desktop"))
+
   testImplementation(kotlin("test"))
+}
+
+distributions {
+  named("main") { contents { into("lib-renderer") { from(composePreviewRenderer) } } }
 }
 
 tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -239,6 +239,8 @@ private class ExtractSubcommand(private val args: List<String>) {
 }
 
 private class RenderSubcommand(private val args: List<String>) {
+  private val verbose: Boolean = "--verbose" in args || "-v" in args
+
   fun run() {
     val path = args.firstOrNull { !it.startsWith("-") }
     val outDir = args.flagValue("--output") ?: args.flagValue("-o")
@@ -256,36 +258,29 @@ private class RenderSubcommand(private val args: List<String>) {
         .absoluteFile
     target.mkdirs()
 
-    val zipBytes = BundleReader.extractZipBytes(file)
-    val extractDir = File(target, "_bundle").apply { mkdirs() }
-    safeExtractZip(zipBytes, extractDir)
+    val renderer = BundleRenderer(bundleFile = file, outputDir = target, verbose = verbose)
+    val result =
+      try {
+        renderer.run()
+      } catch (e: Exception) {
+        System.err.println("bundle render failed: ${e.message}")
+        if (verbose) e.printStackTrace()
+        exitProcess(1)
+      }
 
-    val meta = BundleReader.readMetadata(file)
-    println("bundle:   ${file.path}")
-    println("backend:  ${meta.manifest.backend}")
-    println("previews: ${meta.manifest.previewIds.joinToString()}")
-    println("extracted to: ${extractDir.path}")
-    println()
-    println("Resolved classpath (player would load in this order):")
-    for (entry in meta.manifest.classpath) {
-      when (entry) {
-        is BundleReader.ClasspathEntry.Module ->
-          println("  [module]  ${File(extractDir, entry.path).absolutePath}")
-        is BundleReader.ClasspathEntry.Maven ->
-          println(
-            "  [maven]   ${entry.group}:${entry.artifact}:${entry.version}@${entry.type}  (unresolved)"
-          )
-        is BundleReader.ClasspathEntry.Project ->
-          println("  [project] ${entry.path}  →  ${File(extractDir, entry.inlinedAs).absolutePath}")
+    println(
+      "rendered ${result.succeeded.size} / ${result.previewCount} preview(s) → ${target.path}"
+    )
+    for (rendered in result.succeeded) {
+      println("  ok    ${rendered.id}  →  ${rendered.outputFile.name}")
+    }
+    for (failure in result.failed) {
+      println("  FAIL  ${failure.id}  (exit=${failure.exitCode})")
+      if (verbose) {
+        for (line in failure.tail.lines()) println("        $line")
       }
     }
-    println()
-    System.err.println(
-      "bundle render: v1 stub — Maven coordinate resolution + DesktopRendererMain spawn not wired yet."
-    )
-    System.err.println(
-      "Next milestone: resolve coordinates against ~/.m2 / Maven Central, then spawn the bundled renderer-desktop."
-    )
+    if (!result.allOk) exitProcess(1)
   }
 }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -1,0 +1,309 @@
+package ee.schimke.composeai.cli
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import kotlinx.serialization.json.Json
+
+/**
+ * Re-renders a packed `.png` (PNG+ZIP polyglot bundle) outside of any Gradle project: extract the
+ * appended zip, expand `classes/app.jar` into a temp classes dir, spawn `DesktopRendererMain` as a
+ * subprocess per preview with the renderer classpath shipped alongside the CLI (`lib-renderer/`).
+ *
+ * # Why subprocess-per-preview
+ *
+ * The renderer brings the full Compose Multiplatform Desktop + Skiko runtime — too much to load
+ * into the CLI's own classpath (see the `CheckCliDaemonLibraryBoundary` guard in
+ * `cli/build.gradle.kts`). Isolating each render in a subprocess JVM also matches what
+ * `RenderPreviewsTask` does today, so the call shape (args / JVM flags / output convention) stays
+ * familiar. The cost — JVM cold-start per preview — is acceptable for the "open and look" flow; the
+ * daemon path is reserved for editor-driven hot loops.
+ *
+ * # Classpath
+ *
+ * The subprocess JVM's classpath = extracted `classes/app.jar` directory + every jar in
+ * `<APP_HOME>/lib-renderer/`. The bundled renderer's transitive Compose Multiplatform graph
+ * supplies every Compose API the app classes resolve against. The bundle's recorded Maven
+ * coordinates are NOT downloaded for v1 — the renderer's own Compose version wins, relying on
+ * Compose's binary-compatibility story across point releases. A bundle compiled against compose
+ * 1.10.x renders fine against the CLI's bundled 1.10.x; future major-version skew will need a
+ * resolver pass.
+ *
+ * # Renderer / Java location
+ *
+ * The generated `bin/compose-preview` script exports `APP_HOME` pointing at the install root.
+ * `lib-renderer/` lives next to `lib/` (the CLI's own classpath). The Java binary is the same one
+ * running the CLI — `java.home/bin/java`. Both are overridable via system properties for tests
+ * (`composeai.cli.appHome`, `composeai.cli.javaBinary`).
+ */
+class BundleRenderer(
+  private val bundleFile: File,
+  private val outputDir: File,
+  private val verbose: Boolean = false,
+  private val logSink: (String) -> Unit = { System.err.println(it) },
+) {
+
+  /** Outcome of one bundle render — surfaced for the CLI's exit-code logic and test assertions. */
+  data class Result(
+    val previewCount: Int,
+    val succeeded: List<RenderedPreview>,
+    val failed: List<FailedPreview>,
+  ) {
+    val allOk: Boolean
+      get() = failed.isEmpty()
+  }
+
+  data class RenderedPreview(val id: String, val outputFile: File)
+
+  data class FailedPreview(val id: String, val exitCode: Int, val tail: String)
+
+  fun run(): Result {
+    if (!bundleFile.isFile) {
+      throw IllegalArgumentException("not a file: ${bundleFile.path}")
+    }
+    val workDir = createTempWorkDir()
+    val classesDir = workDir.resolve("classes").apply { mkdirs() }
+    val zipBytes = BundleReader.extractZipBytes(bundleFile)
+    val (bundleJsonBytes, previewsJsonBytes) = expandAppJarAndReadManifests(zipBytes, classesDir)
+
+    val manifest = BUNDLE_JSON.decodeFromString(BundleReader.Manifest.serializer(), bundleJsonBytes)
+    val previews = MANIFEST_JSON.decodeFromString(PreviewManifest.serializer(), previewsJsonBytes)
+
+    if (manifest.backend != "desktop") {
+      throw UnsupportedOperationException(
+        "bundle render: backend '${manifest.backend}' not supported yet (v1 = desktop only)"
+      )
+    }
+
+    val rendererJars = locateRendererClasspath()
+    if (rendererJars.isEmpty()) {
+      throw IllegalStateException(
+        "bundle render: no renderer jars found. Looked in `${rendererClasspathSearchDescription()}`; " +
+          "either build the CLI via `./gradlew :cli:installDist` or set `-Dcomposeai.cli.appHome=<install-root>`."
+      )
+    }
+    val classpathString =
+      (listOf(classesDir) + rendererJars).joinToString(File.pathSeparator) { it.absolutePath }
+
+    outputDir.mkdirs()
+    val succeeded = mutableListOf<RenderedPreview>()
+    val failed = mutableListOf<FailedPreview>()
+    for (preview in previews.previews) {
+      val outFile = outputDir.resolve(safeFilename(preview.id) + ".png")
+      val (exitCode, tail) = spawnRenderer(classpathString, preview, outFile)
+      if (exitCode == 0 && outFile.isFile && outFile.length() > 0) {
+        succeeded += RenderedPreview(preview.id, outFile)
+        if (verbose) logSink("rendered ${preview.id} → ${outFile.path}")
+      } else {
+        failed += FailedPreview(preview.id, exitCode, tail)
+        logSink("FAILED ${preview.id} (exit=$exitCode)")
+        if (verbose) logSink(tail)
+      }
+    }
+    return Result(previewCount = previews.previews.size, succeeded = succeeded, failed = failed)
+  }
+
+  private fun expandAppJarAndReadManifests(
+    zipBytes: ByteArray,
+    classesDir: File,
+  ): Pair<String, String> {
+    var bundleJson: String? = null
+    var previewsJson: String? = null
+    var appJarBytes: ByteArray? = null
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        when (entry.name) {
+          "bundle.json" -> bundleJson = zin.readBytes().toString(Charsets.UTF_8)
+          "previews.json" -> previewsJson = zin.readBytes().toString(Charsets.UTF_8)
+          "classes/app.jar" -> appJarBytes = zin.readBytes()
+        }
+        zin.closeEntry()
+      }
+    }
+    val bundleJsonNonNull =
+      requireNotNull(bundleJson) { "bundle render: bundle.json missing in ${bundleFile.path}" }
+    val previewsJsonNonNull =
+      requireNotNull(previewsJson) { "bundle render: previews.json missing in ${bundleFile.path}" }
+    val appJarBytesNonNull =
+      requireNotNull(appJarBytes) { "bundle render: classes/app.jar missing in ${bundleFile.path}" }
+    expandJarBytes(appJarBytesNonNull, classesDir)
+    return bundleJsonNonNull to previewsJsonNonNull
+  }
+
+  /**
+   * Unpack [appJarBytes] (a JAR-format zip) into [targetDir]. Each entry's resolved path is
+   * verified to live inside [targetDir] — defeats Zip Slip on a malformed/hostile bundle, same
+   * defense as `safeExtractZip` in BundleCommand.
+   */
+  private fun expandJarBytes(appJarBytes: ByteArray, targetDir: File) {
+    val canonicalTarget = targetDir.canonicalFile
+    ZipInputStream(ByteArrayInputStream(appJarBytes)).use { zin ->
+      while (true) {
+        val entry: ZipEntry = zin.nextEntry ?: break
+        val candidate = File(targetDir, entry.name).canonicalFile
+        if (
+          candidate != canonicalTarget &&
+            !candidate.path.startsWith(canonicalTarget.path + File.separator)
+        ) {
+          throw SecurityException(
+            "bundle render: app jar entry escapes target dir: ${entry.name} → ${candidate.path}"
+          )
+        }
+        if (entry.isDirectory) {
+          candidate.mkdirs()
+        } else {
+          candidate.parentFile?.mkdirs()
+          candidate.outputStream().use { sink -> zin.copyTo(sink) }
+        }
+        zin.closeEntry()
+      }
+    }
+  }
+
+  private fun spawnRenderer(
+    classpath: String,
+    preview: PreviewInfo,
+    outFile: File,
+  ): Pair<Int, String> {
+    val args = buildRendererArgs(preview, outFile)
+    val javaBin = locateJava()
+    val pb =
+      ProcessBuilder(
+          javaBin,
+          "--enable-native-access=ALL-UNNAMED",
+          "-cp",
+          classpath,
+          "ee.schimke.composeai.renderer.DesktopRendererMainKt",
+        )
+        .command()
+        .toMutableList()
+        .apply { addAll(args) }
+        .let { ProcessBuilder(it) }
+    pb.redirectErrorStream(true)
+    val proc = pb.start()
+    val output = proc.inputStream.bufferedReader().readText()
+    val exitCode = proc.waitFor()
+    val tail = output.lines().takeLast(20).joinToString("\n")
+    return exitCode to tail
+  }
+
+  private fun buildRendererArgs(preview: PreviewInfo, outFile: File): List<String> {
+    // DesktopRendererMain arg positions (see renderer-desktop/DesktopRendererMain.kt):
+    //  0 className  1 functionName  2 widthPx  3 heightPx  4 density  5 showBackground
+    //  6 backgroundColor  7 outputFile  8 wrapperClassName  9 wrapWidth  10 wrapHeight
+    //  11 previewParameterProviderFqn  12 previewParameterLimit  13 locale
+    //
+    // Sizing: the bundle's previews.json carries discovery-resolved widthDp/heightDp/density
+    // when a `@Preview(device=...)` or explicit dims are present. When unset, fall back to a
+    // wrap-content sandbox (400×800 dp @ 2.625× default density = 1050×2100 px) and let the
+    // renderer's wrap flags crop to the composable's intrinsic size on both axes.
+    val widthDp = preview.params.widthDp ?: 400
+    val heightDp = preview.params.heightDp ?: 800
+    val density = preview.params.density ?: DEFAULT_DENSITY
+    val widthPx = (widthDp * density).toInt().coerceAtLeast(1)
+    val heightPx = (heightDp * density).toInt().coerceAtLeast(1)
+    val wrapWidth = preview.params.widthDp == null
+    val wrapHeight = preview.params.heightDp == null
+    return listOf(
+      preview.className,
+      preview.functionName,
+      widthPx.toString(),
+      heightPx.toString(),
+      density.toString(),
+      preview.params.showBackground.toString(),
+      preview.params.backgroundColor.toString(),
+      outFile.absolutePath,
+      preview.params.wrapperClassName.orEmpty(),
+      wrapWidth.toString(),
+      wrapHeight.toString(),
+      preview.params.previewParameterProviderClassName.orEmpty(),
+      preview.params.previewParameterLimit.toString(),
+      preview.params.locale.orEmpty(),
+    )
+  }
+
+  /**
+   * Locate the bundled renderer's classpath. In order:
+   * 1. `-Dcomposeai.cli.libRendererDir=<dir>` — explicit override for tests / dev runs.
+   * 2. `$APP_HOME/lib-renderer/` — the gradle `application` start script exports `APP_HOME`.
+   * 3. `<classpath-jar-parent>/../lib-renderer/` — walking from a CLI jar location for IDE runs.
+   */
+  private fun locateRendererClasspath(): List<File> {
+    val override = System.getProperty("composeai.cli.libRendererDir")
+    val appHome = System.getProperty("composeai.cli.appHome") ?: System.getenv("APP_HOME")
+    val candidates =
+      listOfNotNull(
+          override?.let { File(it) },
+          appHome?.let { File(it, "lib-renderer") },
+          inferLibRendererFromClasspath(),
+        )
+        .distinct()
+    val firstExistingDir = candidates.firstOrNull { it.isDirectory } ?: return emptyList()
+    return firstExistingDir
+      .listFiles { f -> f.isFile && f.name.endsWith(".jar") }
+      ?.sortedBy { it.name }
+      .orEmpty()
+  }
+
+  private fun rendererClasspathSearchDescription(): String {
+    val override = System.getProperty("composeai.cli.libRendererDir")
+    val appHome = System.getProperty("composeai.cli.appHome") ?: System.getenv("APP_HOME")
+    return listOfNotNull(
+        override?.let { "-Dcomposeai.cli.libRendererDir=$it" },
+        appHome?.let { "$it/lib-renderer" },
+        "<classpath-parent>/../lib-renderer",
+      )
+      .joinToString(" or ")
+  }
+
+  private fun inferLibRendererFromClasspath(): File? {
+    val cp = System.getProperty("java.class.path") ?: return null
+    val firstEntry = cp.split(File.pathSeparator).firstOrNull { it.endsWith(".jar") } ?: return null
+    val libDir = File(firstEntry).parentFile ?: return null
+    val installRoot = libDir.parentFile ?: return null
+    val candidate = File(installRoot, "lib-renderer")
+    return candidate.takeIf { it.isDirectory }
+  }
+
+  private fun locateJava(): String {
+    System.getProperty("composeai.cli.javaBinary")?.let {
+      return it
+    }
+    val javaHome = System.getProperty("java.home") ?: error("java.home not set")
+    val bin = File(javaHome, "bin/java")
+    if (bin.isFile) return bin.absolutePath
+    val winBin = File(javaHome, "bin/java.exe")
+    if (winBin.isFile) return winBin.absolutePath
+    return bin.absolutePath // best effort; the spawn will surface the failure
+  }
+
+  private fun createTempWorkDir(): File {
+    val dir = java.nio.file.Files.createTempDirectory("compose-preview-bundle-render-").toFile()
+    Runtime.getRuntime().addShutdownHook(Thread { dir.deleteRecursively() })
+    return dir
+  }
+
+  /** Strip filesystem-hostile characters from a preview id. */
+  private fun safeFilename(id: String): String =
+    id
+      .map { c ->
+        when {
+          c.isLetterOrDigit() || c in "._-" -> c
+          else -> '_'
+        }
+      }
+      .joinToString("")
+
+  companion object {
+    /** Compose Desktop's default density = 2.625× (~xxhdpi). Same constant as the renderer. */
+    private const val DEFAULT_DENSITY: Float = 2.625f
+
+    private val BUNDLE_JSON = Json {
+      ignoreUnknownKeys = true
+      classDiscriminator = "kind"
+    }
+    private val MANIFEST_JSON = Json { ignoreUnknownKeys = true }
+  }
+}

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -87,6 +87,11 @@ val functionalTestTask =
     // it via the root build's `functionalTestWithAndroid` task with the flag flipped on.
     val cliA11yE2E = providers.gradleProperty("cli.a11y.e2e").orNull == "true"
     systemProperty("composeai.functionalTest.cliA11yE2E", cliA11yE2E.toString())
+    // Opt-in `bundle.render.e2e=true` gate for [BundleRenderEndToEndFunctionalTest]. Spawns
+    // Compose Desktop JVM per preview (~1-2s cold start), too slow for the default check loop.
+    // Root build's `functionalTestWithBundleRender` task flips this on.
+    val bundleRenderE2E = providers.gradleProperty("bundle.render.e2e").orNull == "true"
+    systemProperty("composeai.functionalTest.cliBundleRender", bundleRenderE2E.toString())
     // Path to the compose-preview CLI binary built by `:cli:installDist`. The test invokes it
     // directly as a subprocess — that's the actual subject of the e2e. Empty string when the
     // binary hasn't been built; the test self-skips. The root build wires the dependency.

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleRenderEndToEndFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleRenderEndToEndFunctionalTest.kt
@@ -1,0 +1,201 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import java.io.File
+import javax.imageio.ImageIO
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end coverage for `compose-preview bundle render` driven through the actual CLI binary.
+ * Validates the full "pack a bundle from a Gradle project → carry it elsewhere → re-render outside
+ * of any Gradle project" flow this PR adds.
+ *
+ * Gating — three layers, evaluated in order so the failure mode is informative:
+ * 1. **`bundle.render.e2e=true` Gradle property must be set.** The test spawns a subprocess JVM per
+ *    preview (cold-start Compose Desktop ~1-2s), too slow for default `./gradlew check`. The root
+ *    build's `functionalTestWithBundleRender` task flips this on.
+ * 2. **CLI binary must exist.** `:cli:installDist` is a hard prerequisite of the wrapping task. A
+ *    missing binary past the property gate is a setup error, not a dev-environment skip.
+ * 3. **Renderer jars must be present in `<install>/lib-renderer/`.** Sanity check on the
+ *    distribution layout — if the renderer config didn't get copied, every render will fail with
+ *    `ClassNotFoundException: DesktopRendererMainKt`. Catch it upfront with a clearer message.
+ *
+ * No `withPluginClasspath()` for the pack step — the synthetic Compose Desktop project resolves our
+ * plugin from `mavenLocal()`, the same shape `CliA11yEndToEndFunctionalTest` uses.
+ */
+class BundleRenderEndToEndFunctionalTest {
+
+  @get:Rule val tempDir: TemporaryFolder = TemporaryFolder()
+
+  private val bundleRenderE2E: Boolean =
+    System.getProperty("composeai.functionalTest.cliBundleRender", "false") == "true"
+
+  private val cliBinary: String = System.getProperty("composeai.functionalTest.cliBinary", "")
+
+  private val pluginVersion: String =
+    System.getProperty("ee.schimke.composeai.functionalTest.pluginVersion", "")
+
+  @Test
+  fun `compose-preview bundle render produces real PNGs from a packed bundle`() {
+    assumeTrue("Skipping: -Pbundle.render.e2e=true not set", bundleRenderE2E)
+
+    assertWithMessage("CLI binary path not surfaced via system property")
+      .that(cliBinary)
+      .isNotEmpty()
+    val cli = File(cliBinary)
+    assertWithMessage(
+        "CLI binary $cliBinary missing — did `:cli:installDist` run? Use " +
+          "`./gradlew functionalTestWithBundleRender`"
+      )
+      .that(cli.isFile)
+      .isTrue()
+    val libRenderer = cli.parentFile.parentFile.resolve("lib-renderer")
+    assertWithMessage(
+        "lib-renderer dir missing in CLI distribution at ${libRenderer.path} — the cli build " +
+          "didn't include `composePreviewRenderer` configuration outputs."
+      )
+      .that(libRenderer.isDirectory)
+      .isTrue()
+    assertWithMessage("lib-renderer is empty — renderer-desktop and its Compose deps not copied")
+      .that(libRenderer.listFiles { f -> f.name.endsWith(".jar") }.orEmpty().asList())
+      .isNotEmpty()
+
+    val projectDir = createDesktopProject()
+    val previewId = "test.PreviewsKt.SimpleBoxPreview"
+
+    // Pack the bundle via the real Gradle task — same code path users hit.
+    val pack =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments(
+          "renderPreviews",
+          "composePreviewBundle",
+          "-PbundlePreviewIds=$previewId",
+          "--stacktrace",
+        )
+        .forwardOutput()
+        .build()
+    assertThat(pack.output).doesNotContain("BUILD FAILED")
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    assertWithMessage("composePreviewBundle output missing").that(bundle.isFile).isTrue()
+
+    val renderOut = File(projectDir, "render-out").apply { mkdirs() }
+
+    val builder =
+      ProcessBuilder(
+          cli.absolutePath,
+          "bundle",
+          "render",
+          bundle.absolutePath,
+          "-o",
+          renderOut.absolutePath,
+          "--verbose",
+        )
+        .directory(projectDir)
+        .redirectErrorStream(true)
+    val proc = builder.start()
+    val output = proc.inputStream.bufferedReader().use { it.readText() }
+    val exitCode = proc.waitFor()
+    assertWithMessage("compose-preview bundle render output:\n$output").that(exitCode).isEqualTo(0)
+
+    val rendered = renderOut.listFiles { f -> f.extension == "png" }.orEmpty()
+    assertWithMessage("no PNGs in $renderOut\noutput:\n$output").that(rendered).isNotEmpty()
+
+    // Verify the produced PNG is a real Compose render — non-zero size and parseable by ImageIO.
+    val first = rendered.single()
+    assertThat(first.length()).isGreaterThan(0L)
+    val img = ImageIO.read(first)
+    assertWithMessage("ImageIO failed to parse ${first.path}").that(img).isNotNull()
+    // Default wrap-content sandbox is 400×800 dp @ 2.625× = 1050×2100 px. SimpleBoxPreview
+    // doesn't override dimensions, so the renderer's wrap flags crop to the box's intrinsic size
+    // — but the canvas dimensions are at most the sandbox bounds.
+    assertThat(img.width).isAtMost(1050)
+    assertThat(img.height).isAtMost(2100)
+  }
+
+  private fun createDesktopProject(): File {
+    val projectDir = tempDir.root
+
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                mavenLocal()
+                google()
+                mavenCentral()
+            }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                mavenLocal()
+                google()
+                mavenCentral()
+            }
+        }
+        rootProject.name = "bundle-render-e2e"
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview") version "$pluginVersion"
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.uiTooling)
+            implementation(compose.components.uiToolingPreview)
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    srcDir.mkdirs()
+    File(srcDir, "Previews.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.unit.dp
+
+        @Preview
+        @Composable
+        fun SimpleBoxPreview() {
+            Box(modifier = Modifier.size(120.dp).background(Color(0xFF3F51B5)))
+        }
+        """
+          .trimIndent()
+      )
+
+    return projectDir
+  }
+}


### PR DESCRIPTION
Adds `compose-preview bundle render <bundle.png> -o <dir>` that extracts the
PNG+ZIP polyglot, expands the inlined `classes/app.jar` into a temp classes
directory, and spawns `DesktopRendererMain` as a subprocess per preview with
a classpath of `extracted-classes + cli-install/lib-renderer/*.jar`.

# Distribution

`:cli/build.gradle.kts` adds a `composePreviewRenderer` configuration carrying
`project(":renderer-desktop")` + its full Compose Multiplatform + Skiko
runtime. Its files are copied into `cli/build/install/compose-preview/lib-renderer/`
by the `distributions { main { contents { into("lib-renderer") { ... } } } }`
hook — sibling of `lib/` so the existing `CheckCliDaemonLibraryBoundary`
guard keeps holding (renderer classes never touch the CLI's own classpath).
Adds ~38 MB to the install, loaded only in the subprocess JVM.

# Wiring

The subprocess classpath is built at runtime from `$APP_HOME/lib-renderer/`
(the env var the gradle-generated start script exports) plus the extracted
app-jar. Test overrides exist for both via `-Dcomposeai.cli.libRendererDir=`
and `-Dcomposeai.cli.appHome=`. Renderer args (`className`, `widthPx`,
`density`, wrap flags, locale, ...) follow the same positional order
`RenderPreviewsTask` uses, so the renderer behaves identically packed vs.
in-project.

Bundle's recorded Maven coords are NOT downloaded for v1 — the renderer's
bundled Compose graph supplies every API the app classes resolve against
(Compose's binary-compatibility story across point releases). A bundle
compiled against compose 1.10.x renders fine against the CLI's bundled
1.10.x; cross-major-version skew is a future resolver pass.

# Empirical sizes (samples/cmp)

- 1 preview (AppPreview)  → bundle.png:  16,277 bytes
- 7 previews (all)        → bundle.png:  32,428 bytes

Verified end-to-end locally: packing samples/cmp's AppPreview produces a
16 KB bundle, then `compose-preview bundle render bundle.png -o /tmp/out`
spawns DesktopRendererMain and writes a 14,935-byte 1050x2100 PNG matching
the source preview.

# CI test

`BundleRenderEndToEndFunctionalTest` packs a bundle from a synthetic
Compose Desktop project, then spawns the actual `compose-preview bundle
render` CLI binary against it and asserts a real PNG is produced.

Gated behind `-Pbundle.render.e2e=true`; the root build's
`functionalTestWithBundleRender` aggregate flips it on after pre-publishing
the plugin and installing the CLI distribution. New CI job `Bundle Render
E2E` in ci.yml runs that aggregate on every PR. Local run: 3m49s wall.