### PR TITLE
feat(bundle-viewer): single-window desktop app that opens & renders bundles live

### DIFF
--- a/bundle-viewer/build.gradle.kts
+++ b/bundle-viewer/build.gradle.kts
@@ -1,0 +1,39 @@
+@file:Suppress("DEPRECATION")
+
+plugins {
+  id("composeai.jvm-conventions")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.compiler)
+  application
+}
+
+application {
+  applicationName = "compose-preview-viewer"
+  mainClass.set("ee.schimke.composeai.viewer.MainKt")
+  // Compose Multiplatform Desktop's Skiko loader uses `System.load` for native libs. JDK 24+
+  // would otherwise print a 4-line warning on every launch; pre-declaring native access for the
+  // unnamed module silences it.
+  applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")
+}
+
+dependencies {
+  // Full Compose Desktop runtime — the viewer composes the bundle's `@Preview` composable LIVE
+  // inside its own Window, so every Compose API the bundle's classes resolve against has to be
+  // on the parent classloader. Bundle's classes load via a child URLClassLoader (see
+  // `BundleLoader.kt`); parent-loader Compose wins on every shared symbol.
+  implementation(compose.desktop.currentOs)
+  implementation(compose.runtime)
+  implementation(compose.ui)
+  implementation(compose.foundation)
+  implementation(compose.material3)
+  // `androidx.compose.ui.tooling.preview.Preview` lives here. Bundles compiled against the
+  // standard Compose `@Preview` annotation only resolve when this artifact is on the classpath.
+  implementation(compose.components.uiToolingPreview)
+
+  implementation(libs.kotlinx.serialization.json)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+}

--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/BundleLoader.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/BundleLoader.kt
@@ -1,0 +1,221 @@
+package ee.schimke.composeai.viewer
+
+import androidx.compose.runtime.reflect.ComposableMethod
+import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.util.zip.ZipInputStream
+import kotlinx.serialization.json.Json
+
+/**
+ * Opens a `compose-preview` bundle (PNG+ZIP polyglot) and exposes its `@Preview` composables ready
+ * to invoke inside an active Compose composition.
+ *
+ * # Classloading
+ *
+ * The bundle's inlined `classes/app.jar` is written to a temp file (URLClassLoader needs a URL, and
+ * a `file:` URL is simpler than a `jar:` polyglot URL). A child [URLClassLoader] loads it with the
+ * viewer's own classloader as parent — every `androidx.compose.*` symbol the bundle's code
+ * references resolves against the viewer's bundled Compose runtime, so the composer state is shared
+ * and `@Composable` invocation works across the loader boundary.
+ *
+ * # Lifecycle
+ *
+ * Call [close] to release the URLClassLoader (mandatory on Windows before the temp app.jar can be
+ * deleted) and remove the extraction dir. Designed for swap-on-drop: closing a previous
+ * [LoadedBundle] before constructing the next one avoids accumulating loaders / temp files in
+ * long-running sessions.
+ */
+data class LoadedBundle(
+  val sourceFile: File,
+  val bundleManifest: BundleManifest,
+  val previewManifest: PreviewManifest,
+  val previews: List<LoadedPreview>,
+  val coverPreview: LoadedPreview,
+  private val classLoader: URLClassLoader,
+  private val workDir: File,
+) : AutoCloseable {
+  override fun close() {
+    runCatching { classLoader.close() }
+    runCatching { workDir.deleteRecursively() }
+  }
+}
+
+/** One preview ready to invoke via [ComposableMethod.invoke] inside an active composition. */
+data class LoadedPreview(
+  val info: PreviewInfo,
+  /** Resolved enclosing class loaded via the bundle's child classloader. */
+  val ownerClass: Class<*>,
+  /**
+   * Result of [getDeclaredComposableMethod]. Nullable when resolution fails (e.g. the preview uses
+   * `@PreviewParameter` or non-default arguments — the viewer's v1 ignores those and surfaces a
+   * clear error instead of crashing the window).
+   */
+  val composableMethod: ComposableMethod?,
+  /** Reason resolution failed, when [composableMethod] is null. Human-readable, English. */
+  val errorMessage: String?,
+)
+
+/**
+ * Parses [bundleFile] and returns a [LoadedBundle]. Throws [IllegalArgumentException] if the file
+ * isn't a recognised polyglot or zip, [IllegalStateException] when required entries are absent.
+ * Per-preview resolution failures are recorded inside [LoadedPreview.errorMessage] rather than
+ * aborting the whole load.
+ */
+fun loadBundle(bundleFile: File): LoadedBundle {
+  require(bundleFile.isFile) { "not a file: ${bundleFile.path}" }
+
+  val zipBytes = extractZipBytes(bundleFile)
+  val workDir = Files.createTempDirectory("compose-preview-viewer-").toFile()
+  val appJarFile = File(workDir, "app.jar")
+  var bundleJson: String? = null
+  var previewsJson: String? = null
+  ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+    while (true) {
+      val entry = zin.nextEntry ?: break
+      when (entry.name) {
+        "bundle.json" -> bundleJson = zin.readBytes().toString(Charsets.UTF_8)
+        "previews.json" -> previewsJson = zin.readBytes().toString(Charsets.UTF_8)
+        "classes/app.jar" -> appJarFile.outputStream().use { sink -> zin.copyTo(sink) }
+      }
+      zin.closeEntry()
+    }
+  }
+  val bundleJsonNonNull = requireNotNull(bundleJson) { "bundle.json missing in ${bundleFile.path}" }
+  val previewsJsonNonNull =
+    requireNotNull(previewsJson) { "previews.json missing in ${bundleFile.path}" }
+  check(appJarFile.isFile) { "classes/app.jar missing in ${bundleFile.path}" }
+
+  val bundleManifest = JSON.decodeFromString(BundleManifest.serializer(), bundleJsonNonNull)
+  val previewManifest = JSON.decodeFromString(PreviewManifest.serializer(), previewsJsonNonNull)
+  if (previewManifest.previews.isEmpty()) {
+    workDir.deleteRecursively()
+    throw IllegalStateException("bundle has no previews: ${bundleFile.path}")
+  }
+
+  val parentLoader = LoadedBundle::class.java.classLoader
+  val classLoader = URLClassLoader(arrayOf(appJarFile.toURI().toURL()), parentLoader)
+
+  val loadedPreviews = previewManifest.previews.map { info -> resolvePreview(info, classLoader) }
+  val cover =
+    loadedPreviews.firstOrNull { it.info.id == bundleManifest.coverPreviewId }
+      ?: loadedPreviews.first()
+
+  return LoadedBundle(
+    sourceFile = bundleFile,
+    bundleManifest = bundleManifest,
+    previewManifest = previewManifest,
+    previews = loadedPreviews,
+    coverPreview = cover,
+    classLoader = classLoader,
+    workDir = workDir,
+  )
+}
+
+private fun resolvePreview(info: PreviewInfo, classLoader: ClassLoader): LoadedPreview {
+  val ownerClass =
+    try {
+      Class.forName(info.className, true, classLoader)
+    } catch (e: Throwable) {
+      return LoadedPreview(
+        info = info,
+        ownerClass = Any::class.java, // placeholder — never read when method is null
+        composableMethod = null,
+        errorMessage =
+          "Could not load class ${info.className}: ${e.javaClass.simpleName}: ${e.message}",
+      )
+    }
+
+  // Resolution mirrors the renderer's reflective lookup. Composables with `@PreviewParameter` or
+  // wrapper providers are out of scope for v1 — fall through to a friendly error so the window
+  // shows what went wrong instead of crashing on `IllegalArgumentException`.
+  if (info.params.previewParameterProviderClassName != null) {
+    return LoadedPreview(
+      info = info,
+      ownerClass = ownerClass,
+      composableMethod = null,
+      errorMessage =
+        "@PreviewParameter previews are not supported in the viewer v1 — render them via the " +
+          "CLI (`compose-preview bundle render ${info.id}`) instead.",
+    )
+  }
+
+  val method =
+    try {
+      ownerClass.getDeclaredComposableMethod(info.functionName)
+    } catch (e: NoSuchMethodException) {
+      return LoadedPreview(
+        info = info,
+        ownerClass = ownerClass,
+        composableMethod = null,
+        errorMessage =
+          "No composable method '${info.functionName}' on ${info.className} — was the preview " +
+            "compiled with non-default parameters?",
+      )
+    } catch (e: Throwable) {
+      return LoadedPreview(
+        info = info,
+        ownerClass = ownerClass,
+        composableMethod = null,
+        errorMessage =
+          "${e.javaClass.simpleName} resolving ${info.className}.${info.functionName}: ${e.message}",
+      )
+    }
+  return LoadedPreview(
+    info = info,
+    ownerClass = ownerClass,
+    composableMethod = method,
+    errorMessage = null,
+  )
+}
+
+/**
+ * Reads [bundleFile] and returns the trailing zip bytes. Detects the PNG signature and walks chunks
+ * to the IEND marker; plain zips (signature `PK\x03\x04`) are returned as-is.
+ *
+ * Mirrors the same routine in `:cli/BundleCommand.kt` — duplicated rather than depended on to keep
+ * the viewer's module graph clean.
+ */
+private fun extractZipBytes(file: File): ByteArray {
+  val bytes = file.readBytes()
+  require(bytes.size >= 8) { "not a bundle: ${file.path} is too small (${bytes.size} bytes)" }
+  if (bytes[0] == 0x50.toByte() && bytes[1] == 0x4B.toByte()) return bytes
+  if (!isPngSignature(bytes)) {
+    throw IllegalArgumentException(
+      "not a bundle: ${file.path} — leading bytes match neither PNG (\\x89PNG…) nor ZIP " +
+        "(PK\\x03\\x04)"
+    )
+  }
+  val zipStart = pngLength(bytes)
+  return bytes.copyOfRange(zipStart, bytes.size)
+}
+
+private val PNG_SIG: ByteArray = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
+
+private fun isPngSignature(bytes: ByteArray): Boolean {
+  if (bytes.size < PNG_SIG.size) return false
+  for (i in PNG_SIG.indices) if (bytes[i] != PNG_SIG[i]) return false
+  return true
+}
+
+private fun pngLength(bytes: ByteArray): Int {
+  var offset = PNG_SIG.size
+  while (offset < bytes.size) {
+    val length =
+      ((bytes[offset].toInt() and 0xff) shl 24) or
+        ((bytes[offset + 1].toInt() and 0xff) shl 16) or
+        ((bytes[offset + 2].toInt() and 0xff) shl 8) or
+        (bytes[offset + 3].toInt() and 0xff)
+    val type = String(bytes, offset + 4, 4, Charsets.US_ASCII)
+    offset += 4 + 4 + length + 4
+    if (type == "IEND") return offset
+  }
+  throw IllegalArgumentException("truncated PNG: IEND not found before EOF")
+}
+
+internal val JSON = Json {
+  ignoreUnknownKeys = true
+  classDiscriminator = "kind"
+}

--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Main.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Main.kt
@@ -1,0 +1,243 @@
+package ee.schimke.composeai.viewer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.reflect.ComposableMethod
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.rememberWindowState
+import java.awt.datatransfer.DataFlavor
+import java.awt.dnd.DnDConstants
+import java.awt.dnd.DropTarget
+import java.awt.dnd.DropTargetAdapter
+import java.awt.dnd.DropTargetDropEvent
+import java.io.File
+
+/**
+ * Compose Preview Viewer — a one-window desktop app that opens a `compose-preview` bundle (PNG+ZIP
+ * polyglot) and renders its `@Preview` composable LIVE inside the window. State, recomposition,
+ * animations all tick as they would in the source app; the viewer is a thin Window shell around a
+ * reflective composable invocation against the bundle's classloader.
+ *
+ * # Modes
+ *
+ * - **CLI arg**: `compose-preview-viewer foo.png` opens the bundle on startup. Useful for
+ *   double-click associations and shell scripting.
+ * - **Drag-and-drop**: launching with no args opens an empty drop-target window. Dropping a `.png`
+ *   polyglot loads it, swapping the live preview and resizing the window to the preview's declared
+ *   size.
+ *
+ * # Window sizing
+ *
+ * On bundle load, [previewSize] computes a `DpSize` from the preview's `params.widthDp` /
+ * `params.heightDp` (defaulting to 400×800 dp wrap-content for previews that didn't pin a device).
+ * The window state is mutated so the OS chrome includes the preview at its declared dimensions —
+ * same shape `@Preview` viewers in Android Studio show.
+ */
+fun main(args: Array<String>) {
+  val initial = args.firstOrNull()?.let { File(it) }?.takeIf { it.isFile }
+  application {
+    var loadedBundle by remember { mutableStateOf<LoadedBundle?>(null) }
+    var loadError by remember { mutableStateOf<String?>(null) }
+    val windowState = rememberWindowState(width = INITIAL_WIDTH, height = INITIAL_HEIGHT)
+
+    // Load the file the CLI handed us on first composition. Errors land in [loadError]; the
+    // window opens regardless so the user can drop a fresh bundle.
+    LaunchedEffect(Unit) {
+      if (initial != null) {
+        try {
+          loadedBundle = loadBundle(initial)
+          loadError = null
+        } catch (e: Throwable) {
+          loadError = "Could not load ${initial.path}: ${e.message}"
+        }
+      }
+    }
+
+    // Resize the window to the preview's declared size whenever a fresh bundle lands. We
+    // observe [loadedBundle]'s cover here rather than at load-site so a drop-while-running
+    // swap repaints the window without an explicit recomputation.
+    LaunchedEffect(loadedBundle) {
+      val cover = loadedBundle?.coverPreview ?: return@LaunchedEffect
+      val size = previewSize(cover)
+      windowState.size = size
+    }
+
+    val title =
+      when {
+        loadError != null -> "compose-preview viewer — error"
+        loadedBundle != null -> "compose-preview — ${loadedBundle?.coverPreview?.info?.id}"
+        else -> "compose-preview viewer — drop a bundle .png to begin"
+      }
+
+    Window(onCloseRequest = ::exitApplication, state = windowState, title = title) {
+      // Wire a Swing/AWT DropTarget once — Compose Desktop's `Modifier.dragAndDropTarget` is
+      // newer but the AWT API is universally available and works around the entire window
+      // rather than a single composable. Cleared on dispose.
+      val composeWindow = window
+      DisposableEffect(composeWindow) {
+        val target =
+          DropTarget(
+            composeWindow,
+            object : DropTargetAdapter() {
+              override fun drop(event: DropTargetDropEvent) {
+                event.acceptDrop(DnDConstants.ACTION_COPY)
+                val files =
+                  try {
+                    @Suppress("UNCHECKED_CAST")
+                    event.transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<File>
+                  } catch (e: Exception) {
+                    event.dropComplete(false)
+                    loadError = "drop: ${e.message}"
+                    return
+                  }
+                event.dropComplete(true)
+                val file = files.firstOrNull() ?: return
+                try {
+                  val next = loadBundle(file)
+                  loadedBundle?.close()
+                  loadedBundle = next
+                  loadError = null
+                } catch (e: Throwable) {
+                  loadError = "Could not load ${file.path}: ${e.message}"
+                }
+              }
+            },
+          )
+        composeWindow.dropTarget = target
+        onDispose { composeWindow.dropTarget = null }
+      }
+
+      Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        ViewerContent(loadedBundle = loadedBundle, loadError = loadError)
+      }
+    }
+  }
+}
+
+@Composable
+private fun ViewerContent(loadedBundle: LoadedBundle?, loadError: String?) {
+  when {
+    loadError != null -> ErrorPanel(loadError)
+    loadedBundle == null -> EmptyDropPanel()
+    else -> {
+      val preview = loadedBundle.coverPreview
+      val method = preview.composableMethod
+      if (method == null) {
+        ErrorPanel(preview.errorMessage ?: "Could not resolve preview.")
+      } else {
+        LivePreview(method, preview.info)
+      }
+    }
+  }
+}
+
+@Composable
+private fun LivePreview(method: ComposableMethod, info: PreviewInfo) {
+  val background =
+    if (info.params.showBackground && info.params.backgroundColor != 0L)
+      Color(info.params.backgroundColor.toULong())
+    else MaterialTheme.colorScheme.surface
+  Box(
+    modifier = Modifier.fillMaxSize().background(background),
+    contentAlignment = Alignment.Center,
+  ) {
+    InvokeComposable(method)
+  }
+}
+
+/**
+ * Reflective invocation site — the method gets called from inside an active composition so the
+ * bundle's `@Composable` function gets the composer state Compose expects. Loaded via the bundle's
+ * child classloader; the parent has the viewer's Compose runtime, so the composer symbol is shared
+ * and the call is a normal composable invocation as far as the runtime is concerned.
+ */
+@Composable
+private fun InvokeComposable(method: ComposableMethod) {
+  method.invoke(currentComposer, null)
+}
+
+@Composable
+private fun EmptyDropPanel() {
+  Column(
+    modifier = Modifier.fillMaxSize().padding(PaddingValues(32.dp)),
+    verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(
+      text = "Drop a `compose-preview` bundle here",
+      style = MaterialTheme.typography.headlineSmall,
+      textAlign = TextAlign.Center,
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    Text(
+      text = "Or launch with `compose-preview-viewer <bundle.png>`.",
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      textAlign = TextAlign.Center,
+    )
+  }
+}
+
+@Composable
+private fun ErrorPanel(message: String) {
+  Column(
+    modifier = Modifier.fillMaxSize().padding(PaddingValues(32.dp)),
+    verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(
+      text = "Cannot show preview",
+      style = MaterialTheme.typography.headlineSmall,
+      color = MaterialTheme.colorScheme.error,
+      textAlign = TextAlign.Center,
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    Text(
+      text = message,
+      modifier = Modifier.fillMaxWidth(),
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurface,
+      textAlign = TextAlign.Center,
+    )
+  }
+}
+
+/**
+ * Resolve the [DpSize] the window should adopt for [preview]. Pinned dimensions from the
+ * `@Preview(widthDp = .., heightDp = ..)` annotation win; absent ones fall back to the same
+ * wrap-content sandbox (400×800 dp) the renderer uses. The 200-dp floor avoids unusable tiny
+ * windows for previews that pin extreme dimensions.
+ */
+private fun previewSize(preview: LoadedPreview): DpSize {
+  val widthDp = (preview.info.params.widthDp ?: 400).coerceAtLeast(200)
+  val heightDp = (preview.info.params.heightDp ?: 800).coerceAtLeast(200)
+  return DpSize(widthDp.dp, heightDp.dp)
+}
+
+private val INITIAL_WIDTH = 480.dp
+private val INITIAL_HEIGHT = 720.dp

--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
@@ -1,0 +1,78 @@
+package ee.schimke.composeai.viewer
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
+
+/**
+ * On-disk shape mirrors `gradle-plugin/PreviewBundleFormat.kt` and `gradle-plugin/PreviewData.kt`.
+ * Duplicated here (rather than depending on either source module) so the viewer's runtime classpath
+ * stays minimal — bundle parsing is tiny and rarely changes.
+ *
+ * Keep field names in lockstep with the plugin-side definitions; `ignoreUnknownKeys = true` makes
+ * forward-compat round-trips safe.
+ */
+@Serializable
+data class BundleManifest(
+  val schemaVersion: Int,
+  val backend: String,
+  val previewIds: List<String>,
+  val coverPreviewId: String?,
+  val classpath: List<ClasspathEntry>,
+  val modulePath: String,
+  val producedBy: String,
+)
+
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+@Serializable
+@JsonClassDiscriminator("kind")
+sealed interface ClasspathEntry {
+  @Serializable
+  @kotlinx.serialization.SerialName("module")
+  data class Module(val path: String) : ClasspathEntry
+
+  @Serializable
+  @kotlinx.serialization.SerialName("maven")
+  data class Maven(val group: String, val artifact: String, val version: String, val type: String) :
+    ClasspathEntry
+
+  @Serializable
+  @kotlinx.serialization.SerialName("project")
+  data class Project(val path: String, val inlinedAs: String) : ClasspathEntry
+}
+
+@Serializable
+data class PreviewManifest(
+  val module: String = "",
+  val variant: String = "",
+  val previews: List<PreviewInfo>,
+  val dataExtensionReports: Map<String, String> = emptyMap(),
+)
+
+@Serializable
+data class PreviewInfo(
+  val id: String,
+  val functionName: String,
+  val className: String,
+  val sourceFile: String? = null,
+  val params: PreviewParams = PreviewParams(),
+)
+
+@Serializable
+data class PreviewParams(
+  val name: String? = null,
+  val device: String? = null,
+  val widthDp: Int? = null,
+  val heightDp: Int? = null,
+  val density: Float? = null,
+  val fontScale: Float = 1.0f,
+  val showSystemUi: Boolean = false,
+  val showBackground: Boolean = false,
+  val backgroundColor: Long = 0,
+  val uiMode: Int = 0,
+  val locale: String? = null,
+  val group: String? = null,
+  val wrapperClassName: String? = null,
+  val previewParameterProviderClassName: String? = null,
+  val previewParameterLimit: Int = Int.MAX_VALUE,
+  val kind: String = "COMPOSE",
+)

--- a/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/BundleLoaderTest.kt
+++ b/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/BundleLoaderTest.kt
@@ -1,0 +1,212 @@
+package ee.schimke.composeai.viewer
+
+import com.google.common.truth.Truth.assertThat
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlinx.serialization.json.Json
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Unit coverage for [loadBundle] — exercises the bundle-on-disk happy path, the schema mirror's
+ * `kind`-discriminated polymorphic deserialisation, and per-preview error reporting when a declared
+ * preview class isn't in `classes/app.jar`. UI behaviour (`Window`, drop target, live composition)
+ * is harder to cover without a display server and is exercised at the integration level via the
+ * headless xvfb smoke shown in the PR description.
+ */
+class BundleLoaderTest {
+
+  @get:Rule val tempDir: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `loadBundle parses a minimal png-zip polyglot bundle`() {
+    val bundle = writeMinimalBundle(includeAppClass = false)
+
+    val loaded = loadBundle(bundle)
+    try {
+      assertThat(loaded.bundleManifest.schemaVersion).isEqualTo(1)
+      assertThat(loaded.bundleManifest.backend).isEqualTo("desktop")
+      assertThat(loaded.bundleManifest.previewIds).containsExactly("test.PreviewsKt.MissingPreview")
+      assertThat(loaded.bundleManifest.classpath).hasSize(2)
+      assertThat(loaded.bundleManifest.classpath[0]).isInstanceOf(ClasspathEntry.Module::class.java)
+      val maven = loaded.bundleManifest.classpath[1] as ClasspathEntry.Maven
+      assertThat(maven.group).isEqualTo("androidx.compose.ui")
+      assertThat(maven.type).isEqualTo("jar")
+
+      assertThat(loaded.previewManifest.previews).hasSize(1)
+      assertThat(loaded.coverPreview.info.id).isEqualTo("test.PreviewsKt.MissingPreview")
+      // Class is absent in the bundle so resolution must surface an error rather than crash.
+      assertThat(loaded.coverPreview.composableMethod).isNull()
+      assertThat(loaded.coverPreview.errorMessage).contains("test.PreviewsKt")
+    } finally {
+      loaded.close()
+    }
+  }
+
+  @Test
+  fun `loadBundle rejects non-bundle files`() {
+    val txt = tempDir.newFile("not-a-bundle.txt").apply { writeText("hello world") }
+
+    val ex =
+      runCatching { loadBundle(txt) }.exceptionOrNull()
+        ?: error("expected loadBundle to throw on non-bundle input")
+    assertThat(ex).isInstanceOf(IllegalArgumentException::class.java)
+  }
+
+  /**
+   * Build a tiny but well-formed PNG+ZIP polyglot. The PNG is just a sanity 1×1 cover; the zip
+   * carries the manifests + an empty `classes/app.jar` so resolution exercises the
+   * "class-not-found" branch deterministically.
+   */
+  private fun writeMinimalBundle(includeAppClass: Boolean): File {
+    val zipBytes = ByteArrayOutputStream()
+    ZipOutputStream(zipBytes).use { zip ->
+      val bundleJson =
+        Json.encodeToString(
+          BundleManifest.serializer(),
+          BundleManifest(
+            schemaVersion = 1,
+            backend = "desktop",
+            previewIds = listOf("test.PreviewsKt.MissingPreview"),
+            coverPreviewId = "test.PreviewsKt.MissingPreview",
+            classpath =
+              listOf(
+                ClasspathEntry.Module(path = "classes/app.jar"),
+                ClasspathEntry.Maven(
+                  group = "androidx.compose.ui",
+                  artifact = "ui-desktop",
+                  version = "1.10.3",
+                  type = "jar",
+                ),
+              ),
+            modulePath = ":test",
+            producedBy = "test-suite",
+          ),
+        )
+      zip.putNextEntry(ZipEntry("bundle.json"))
+      zip.write(bundleJson.toByteArray(Charsets.UTF_8))
+      zip.closeEntry()
+
+      val previewsJson =
+        Json.encodeToString(
+          PreviewManifest.serializer(),
+          PreviewManifest(
+            module = "test",
+            variant = "desktop",
+            previews =
+              listOf(
+                PreviewInfo(
+                  id = "test.PreviewsKt.MissingPreview",
+                  functionName = "MissingPreview",
+                  className = "test.PreviewsKt",
+                )
+              ),
+          ),
+        )
+      zip.putNextEntry(ZipEntry("previews.json"))
+      zip.write(previewsJson.toByteArray(Charsets.UTF_8))
+      zip.closeEntry()
+
+      // Empty jar — just enough to satisfy the "classes/app.jar must be present" precondition.
+      val emptyJarBytes = ByteArrayOutputStream()
+      ZipOutputStream(emptyJarBytes).use { /* no entries */ }
+      zip.putNextEntry(ZipEntry("classes/app.jar"))
+      zip.write(emptyJarBytes.toByteArray())
+      zip.closeEntry()
+    }
+
+    // Synthesise a 1×1 PNG header so the polyglot is recognised by `extractZipBytes`. Same byte
+    // sequence the plugin's stub gray cover would produce — see PreviewBundleFormat.kt.
+    val pngHeader = stubPng1x1()
+    val out = tempDir.newFile("bundle.png")
+    out.outputStream().use { sink ->
+      sink.write(pngHeader)
+      sink.write(zipBytes.toByteArray())
+    }
+    return out
+  }
+
+  /**
+   * Minimal valid 1×1 PNG. Hand-rolled (CRCs included) so the test doesn't need `BufferedImage` /
+   * `ImageIO` plumbing — the file just needs the PNG signature + a valid IHDR chain so the polyglot
+   * extractor can locate the IEND boundary.
+   */
+  private fun stubPng1x1(): ByteArray {
+    // Pre-computed by running `BufferedImage(1,1).also { it.setRGB(0,0,0x808080) }` through
+    // `ImageIO.write(_, "png", baos)` and copying the bytes. Stable across Java releases.
+    return byteArrayOf(
+      -119,
+      80,
+      78,
+      71,
+      13,
+      10,
+      26,
+      10,
+      0,
+      0,
+      0,
+      13,
+      73,
+      72,
+      68,
+      82,
+      0,
+      0,
+      0,
+      1,
+      0,
+      0,
+      0,
+      1,
+      8,
+      2,
+      0,
+      0,
+      0,
+      -112,
+      119,
+      83,
+      -34,
+      0,
+      0,
+      0,
+      12,
+      73,
+      68,
+      65,
+      84,
+      8,
+      -41,
+      99,
+      -8,
+      -65,
+      -65,
+      63,
+      0,
+      5,
+      -2,
+      2,
+      -2,
+      -86,
+      -54,
+      -3,
+      -103,
+      0,
+      0,
+      0,
+      0,
+      73,
+      69,
+      78,
+      68,
+      -82,
+      66,
+      96,
+      -126,
+    )
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,8 @@ includeBuild("gradle-plugin")
 
 include(":cli")
 
+include(":bundle-viewer")
+
 include(":preview-annotations")
 
 include(":samples:android")


### PR DESCRIPTION
## Summary

New `:bundle-viewer` module — a one-window Compose Multiplatform Desktop app that opens a `compose-preview` bundle (PNG+ZIP polyglot) and renders its `@Preview` composable **live** inside the window. State, recomposition, animations all tick as they would in the source app, unlike `bundle render` which captures static PNGs.

Two open paths:
- **CLI arg**: `compose-preview-viewer foo.png` — useful for double-click file associations and shell scripts.
- **Drag-and-drop**: launching with no args opens an empty drop-target window. Dropping a `.png` polyglot loads it, swapping the live preview and resizing the window to the preview's declared dimensions.

## How the live rendering works

1. The bundle's inlined `classes/app.jar` is written to a temp file (URLClassLoader needs a URL — file URL is simpler than the polyglot's `jar:` form).
2. A child `URLClassLoader` loads it with the viewer's own classloader as parent. Every `androidx.compose.*` symbol the bundle's code references resolves against the viewer's bundled Compose Multiplatform Desktop runtime, so the composer state is shared and `@Composable` invocation works across the loader boundary.
3. The preview's enclosing class + function are located by name, `androidx.compose.runtime.reflect.getDeclaredComposableMethod` gets the `ComposableMethod`, and `method.invoke(currentComposer, null)` inside the Window's content tree runs it live.

## Window sizing

`@Preview(widthDp, heightDp)` pins both dimensions when set; missing dims fall back to a 400×800 dp wrap-content sandbox with a 200-dp floor so extreme small pins don't produce unusable windows. The `WindowState` updates whenever a new bundle lands, so the chrome adopts the preview's intent.

## Limitations (v1)

- `@PreviewParameter` previews surface a friendly error pointing at `compose-preview bundle render` instead — the viewer's reflective invocation can't enumerate provider values without the renderer's fan-out machinery.
- Bundle's recorded Maven coordinates are **not** downloaded. The viewer's bundled Compose graph supplies every API the app classes resolve against (relying on Compose's binary-compatibility story across point releases). Cross-major-version skew is a future resolver pass.
- Drop handler accepts a single file at a time; multi-file drops use the first.

## Verification

- `:bundle-viewer:check` passes (unit test exercises the bundle loader's happy path + the class-not-found error branch).
- **Headless smoke** under xvfb against `samples/cmp`'s `AppPreview` bundle: viewer process starts cleanly, `URLClassLoader` resolves the preview's enclosing class, Compose composition produces a non-trivial xvfb screenshot (~8 KB PNG). Cold-start ~3 s; live recomposition once open.

## Test plan

- [x] `./gradlew :bundle-viewer:check` passes
- [x] `./gradlew :bundle-viewer:installDist` produces `compose-preview-viewer` binary + 50-jar `lib/` (~37 MB)
- [x] `xvfb-run compose-preview-viewer samples/cmp/build/compose-previews/bundle.png` — viewer opens, composes the preview, captures a real screenshot
- [x] Drop-target wiring: `DropTarget` registered on `ComposeWindow`, cleared on `onDispose`
- [ ] Manual: drag/drop on macOS / Windows (no graphical CI runner available; smoke covers Linux+xvfb)

## Follow-ups (not in this PR)

- Maven coordinate resolution for bundles that reference deps outside the viewer's bundled Compose graph (Coil image loading, kotlinx.serialization, etc.).
- Preview switcher UI for multi-preview bundles (currently shows only the cover).
- `compose.desktop { application { ... } }` configuration for native installers (`.dmg`, `.msi`, `.deb`).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Y1vuwt2pQeeMjvqycNHNT)_