### PR TITLE
refactor: reduce log noise at normal level, improve filtering

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1181,6 +1181,9 @@ export async function activate(
                 if (!panel) {
                     return;
                 }
+                outputChannel.appendLine(
+                    `[panel] focus preview: ${functionName}`,
+                );
                 // Reveal the sidebar view. This is the stable command contributed
                 // by VS Code for any registered view (`<viewId>.focus`).
                 await vscode.commands.executeCommand(
@@ -4022,6 +4025,9 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             break;
         case "selectModule":
             selectedModule = msg.value || null;
+            moduleOutputChannel?.appendLine(
+                `[panel] module selected: ${selectedModule ?? "<none>"}`,
+            );
             sendModuleList();
             if (selectedModule) {
                 refresh(false);
@@ -4159,11 +4165,17 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             break;
         case "setA11yOverlay":
             if (earlyFeaturesEnabled()) {
+                moduleOutputChannel?.appendLine(
+                    `[panel] a11y overlay ${msg.enabled ? "enabled" : "disabled"} for ${msg.previewId}`,
+                );
                 void handleSetA11yOverlay(msg.previewId, msg.enabled);
             }
             break;
         case "setDataExtensionEnabled":
             if (earlyFeaturesEnabled()) {
+                moduleOutputChannel?.appendLine(
+                    `[panel] extension ${msg.kind} ${msg.enabled ? "enabled" : "disabled"} for ${msg.previewId}`,
+                );
                 void handleSetDataExtensionEnabled(
                     msg.previewId,
                     msg.kind,

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -1045,7 +1045,14 @@ export class GradleService {
                     // path, not a build failure. Log it differently and throw a
                     // typed error so callers can drop it silently.
                     if (CANCELLED_RE.test(message)) {
-                        this.logger.appendLine(`> ${task} cancelled`);
+                        const cancelledLine = `> ${task} cancelled`;
+                        if (
+                            this.logFilter.shouldEmitInformational(
+                                cancelledLine,
+                            )
+                        ) {
+                            this.logger.appendLine(cancelledLine);
+                        }
                         throw new TaskCancelledError(task);
                     }
                     detector.end();

--- a/vscode-extension/src/logFilter.ts
+++ b/vscode-extension/src/logFilter.ts
@@ -35,15 +35,30 @@ export function parseLogLevel(
     return fallback;
 }
 
-// Per-task status suffix that means "nothing happened" — the task body wasn't
-// re-executed. Drowning the user in twenty of these per refresh is what the
-// `normal` level exists to suppress.
-const NOOP_TASK_SUFFIX_RE = /\s(UP-TO-DATE|NO-SOURCE|SKIPPED|FROM-CACHE)\s*$/;
+// `> Task :module:taskname` headers — Gradle's per-task status line. Drowning
+// the user in dozens of these per refresh is what the `normal` level exists to
+// suppress. `FAILED` variants are caught by the failure-shaped branches above
+// before we get to this drop.
+const TASK_HEADER_RE = /^> Task :/;
 
 // Hides the full Gradle "1 actionable task: 1 up-to-date" / "9 actionable
 // tasks: 9 up-to-date" footer at normal+. The line is bookkeeping only —
 // `BUILD SUCCESSFUL/FAILED` (which we keep) already conveys the outcome.
 const ACTIONABLE_FOOTER_RE = /^\d+ actionable tasks?: /;
+
+// `Discovered N preview(s) in module '…':` + the indented bullet list that
+// follows it. Emitted by the gradle plugin's discoverPreviews task. Useful for
+// debugging the discovery pipeline, redundant for end users who already see
+// `[refresh] rendered N preview(s) for <file>`. The bullet continuation lines
+// start with two spaces, so we drop the header and any subsequent `  …` line
+// until a non-indented line.
+const DISCOVERED_HEADER_RE = /^Discovered \d+ preview\(s\) in module /;
+const DISCOVERED_BULLET_RE = /^ {2}\S/;
+
+// `BUILD SUCCESSFUL in 16s` is bookkeeping the user already infers from the
+// `[refresh] rendered N preview(s)` line that follows. `BUILD FAILED` is the
+// counterpart — we always keep that one (it's a failure).
+const BUILD_SUCCESSFUL_RE = /^BUILD SUCCESSFUL /;
 
 const CONFIG_CACHE_RE =
     /^(Reusing configuration cache\.|Configuration cache entry (reused|stored)\.|Calculating task graph .*)$/;
@@ -94,28 +109,62 @@ const ROBORAZZI_ACTIONBAR_FOLLOWUP_RE = new RegExp(
 
 const BUILD_SUCCESS_FAIL_RE = /^BUILD (SUCCESSFUL|FAILED) /;
 
-// Extension-side `[refresh]` / `[doctor]` / Gradle-task progress lines
-// emitted from `extension.ts` and `gradleService.ts`. These are useful at
-// normal but redundant at quiet — quiet keeps only error lines and the BUILD
-// outcome.
-const EXTENSION_INFO_PREFIXES = [
-    "[refresh] start ",
-    "[refresh] rendered ",
-    "[doctor] doctor diagnostics refreshed ",
+// Extension-side chatter that's high-volume but low-signal. At normal we keep
+// only the lines that answer "what's the panel doing right now" (focused file,
+// render outcome, panel actions, daemon readiness, failures); the rest drops
+// down to verbose. Quiet drops these too.
+//
+// Prefixes are deliberately *specific* — we don't blanket-drop `[doctor] ` or
+// `[refresh] ` because the same prefix carries failure messages (e.g.
+// `[doctor] :samples:cmp:composePreviewDoctor failed: ...`) that must survive.
+const NORMAL_CHATTER_PREFIXES = [
+    "[refresh] cache hit:",
+    "[refresh] cancelled — superseded ",
     "[daemon] spawning ",
-    "[daemon] ready for ",
+    "[daemon] webview ack ",
+    "[doctor] doctor diagnostics refreshed ",
     "[detect] ",
 ];
 
-// `> :module:task` and `> :module:task completed` are progress markers we
-// suppress at quiet. The `FAILED` / `cancelled` variants flow through their
-// own branches in GradleService and bypass [shouldEmitInformational].
-const TASK_PROGRESS_RE = /^> :[\w:.-]+( completed)?$/;
+// Lines that survive at normal (and verbose) but drop at quiet. The `[panel]`
+// prefix is reserved for user-initiated actions (preview selection, extension
+// toggle, focus); we always show those.
+const QUIET_CHATTER_PREFIXES = [
+    "[refresh] start ",
+    "[refresh] rendered ",
+    "[refresh] no module ",
+    "[refresh] done ",
+    "[refresh] auto-render: ",
+    "[startup] ",
+    "[daemon] ready for ",
+];
+
+// `> :module:task` / `> :module:task completed` / `> :module:task cancelled`
+// progress markers from gradleService.ts. The `FAILED` variant flows through a
+// separate branch in GradleService and bypasses [shouldEmitInformational].
+const TASK_PROGRESS_RE = /^> :[\w:.-]+( (completed|cancelled))?$/;
+
+// Daemon stderr — per-render phase / classloader / renderFinished chatter from
+// `RenderEngine.kt` and `UserClassLoaderHolder.kt`. Each render emits ~25 of
+// these lines (one per render phase × per data extension); a single refresh
+// can produce hundreds. Useful for daemon devs, useless for end users.
+//
+// Phase-failure lines (`phase=*.failed`) are kept — they're how a botched
+// render surfaces in the output channel without an exception stack.
+const DAEMON_RENDER_CHATTER_RE =
+    /^compose-ai-daemon: \[(render|renderFinished|classloader)\] /;
+const DAEMON_RENDER_FAILURE_RE =
+    /^compose-ai-daemon: \[render\] phase=[\w./]+\.failed\b/;
+const DAEMON_SANDBOX_POOL_RE = /^compose-ai-tools daemon: sandbox pool active /;
 
 export class LogFilter {
     private warnedOnce = new Set<string>();
     private inConfigureBlock = false;
     private inRoborazziBlock = false;
+    // Tracks the `Discovered N preview(s) in module …:` continuation — bullet
+    // lines starting with two spaces drop until a non-indented line ends the
+    // block. Persists across chunks like the configure-block flag.
+    private inDiscoveredBlock = false;
     // Tracks whether the last line we emitted from filterGradleChunk was blank,
     // so that dropping interstitial content between blanks doesn't accumulate
     // multiple consecutive blank lines in the output channel. Persists across
@@ -190,45 +239,71 @@ export class LogFilter {
             return "drop";
         }
 
+        // Discovered-preview block: header + indented bullet list. Drop the
+        // whole block at normal/quiet — it duplicates `[refresh] rendered N`.
+        if (this.inDiscoveredBlock) {
+            if (DISCOVERED_BULLET_RE.test(line)) {
+                return "drop";
+            }
+            this.inDiscoveredBlock = false;
+            // Fall through to classify this line normally.
+        }
+        if (DISCOVERED_HEADER_RE.test(line)) {
+            this.inDiscoveredBlock = true;
+            return "drop";
+        }
+
         const trimmed = line.trimEnd();
         if (trimmed.length === 0) {
             return "keep";
         }
 
+        // Failure-shaped lines survive at every non-verbose level.
+        if (/^FAILURE: /.test(trimmed)) {
+            return "keep";
+        }
+        if (/^\* What went wrong:/.test(trimmed)) {
+            return "keep";
+        }
+        if (/(^|\s)FAILED(\s|$)/.test(trimmed)) {
+            return "keep";
+        }
+        if (/^Caused by: /.test(trimmed)) {
+            return "keep";
+        }
+        if (/^[ \t]+at .+\(/.test(line)) {
+            return "keep";
+        }
+        if (/^e: /.test(trimmed)) {
+            return "keep";
+        } // kotlinc errors
+        if (/^w: /.test(trimmed)) {
+            return "keep";
+        } // kotlinc warnings
+
         if (this.level() === "quiet") {
-            // Quiet keeps only outcome lines and FAILED/error-shaped lines.
+            // Quiet keeps only outcome lines and the failure-shaped lines
+            // above. `BUILD SUCCESSFUL` survives so the user sees the outcome
+            // even when nothing went wrong.
             if (BUILD_SUCCESS_FAIL_RE.test(trimmed)) {
                 return "keep";
             }
-            if (/^FAILURE: /.test(trimmed)) {
-                return "keep";
-            }
-            if (/^\* What went wrong:/.test(trimmed)) {
-                return "keep";
-            }
-            if (/(^|\s)FAILED(\s|$)/.test(trimmed)) {
-                return "keep";
-            }
-            if (/^Caused by: /.test(trimmed)) {
-                return "keep";
-            }
-            if (/^[ \t]+at .+\(/.test(line)) {
-                return "keep";
-            }
-            if (/^e: /.test(trimmed)) {
-                return "keep";
-            } // kotlinc errors
-            if (/^w: /.test(trimmed)) {
-                return "keep";
-            } // kotlinc warnings
             return "drop";
         }
 
-        // normal level
-        if (
-            trimmed.startsWith("> Task ") &&
-            NOOP_TASK_SUFFIX_RE.test(trimmed)
-        ) {
+        // normal level — substantially less chatter than before. The
+        // per-task `> Task :module:task [STATUS]` headers, the
+        // discoverPreviews bullet list (handled above), and the bookkeeping
+        // tail (config cache, incubating, actionable footer) all drop.
+        // `BUILD SUCCESSFUL` also drops at normal — `[refresh] rendered N`
+        // already conveys success; `BUILD FAILED` survives via the
+        // failure-shaped branches above.
+        if (TASK_HEADER_RE.test(trimmed)) {
+            // Already handled by the `FAILED` branch above — drop everything
+            // else.
+            return "drop";
+        }
+        if (BUILD_SUCCESSFUL_RE.test(trimmed)) {
             return "drop";
         }
         if (CONFIG_CACHE_RE.test(trimmed)) {
@@ -311,19 +386,60 @@ export class LogFilter {
         if (DAEMON_TIMING_RE.test(line)) {
             return null;
         }
+        // Per-render phase / classloader / renderFinished chatter — hundreds
+        // of lines per refresh. Failure-shaped phase lines (`phase=*.failed`)
+        // survive so botched renders still surface.
+        if (DAEMON_RENDER_FAILURE_RE.test(line)) {
+            return line;
+        }
+        if (DAEMON_RENDER_CHATTER_RE.test(line)) {
+            return null;
+        }
+        if (DAEMON_SANDBOX_POOL_RE.test(line)) {
+            return null;
+        }
         return line;
     }
 
     /**
      * Used by extension-side `[refresh] ...` / `[doctor] ...` informational
-     * lines. Returns true at normal+ for non-error chatter, false at quiet.
-     * Errors and `FAILED` lines should bypass this and emit unconditionally.
+     * lines and gradle-task progress markers. At normal we keep only the
+     * lines that answer "what's the panel doing right now" — focused file,
+     * render outcome, panel actions, daemon readiness, failures. Quiet
+     * drops everything that isn't the [panel] action prefix or an
+     * unrecognised (likely error-shaped) line. Verbose emits unconditionally.
+     *
+     * Errors and `FAILED`-shaped lines should bypass this and emit through
+     * `outputChannel.appendLine` directly — both at quiet and normal.
      */
     shouldEmitInformational(line: string): boolean {
-        if (this.level() !== "quiet") {
+        const lvl = this.level();
+        if (lvl === "verbose") {
             return true;
         }
-        for (const prefix of EXTENSION_INFO_PREFIXES) {
+        // `[panel]` is user-initiated (preview selection, extension toggle).
+        // Always emit so the user sees what their click did.
+        if (line.startsWith("[panel] ")) {
+            return true;
+        }
+        if (lvl === "normal") {
+            for (const prefix of NORMAL_CHATTER_PREFIXES) {
+                if (line.startsWith(prefix)) {
+                    return false;
+                }
+            }
+            if (TASK_PROGRESS_RE.test(line)) {
+                return false;
+            }
+            return true;
+        }
+        // quiet
+        for (const prefix of QUIET_CHATTER_PREFIXES) {
+            if (line.startsWith(prefix)) {
+                return false;
+            }
+        }
+        for (const prefix of NORMAL_CHATTER_PREFIXES) {
             if (line.startsWith(prefix)) {
                 return false;
             }
@@ -344,6 +460,7 @@ export class LogFilter {
         this.warnedOnce.clear();
         this.inConfigureBlock = false;
         this.inRoborazziBlock = false;
+        this.inDiscoveredBlock = false;
         this.prevEmittedBlank = false;
     }
 }

--- a/vscode-extension/src/test/logFilter.test.ts
+++ b/vscode-extension/src/test/logFilter.test.ts
@@ -34,15 +34,24 @@ describe("LogFilter", () => {
             assert.strictEqual(out, "");
         });
 
-        it("keeps non-noop task headers", () => {
+        it("drops non-noop task headers too — all > Task : lines are noise at normal", () => {
             const f = withLevel("normal");
             const out = f.filterGradleChunk(
                 "> Task :samples:wear:compileDebugKotlin\n" +
                     "> Task :samples:wear:discoverPreviews\n",
             );
+            assert.strictEqual(out, "");
+        });
+
+        it("keeps task headers that FAILED", () => {
+            const f = withLevel("normal");
+            const out = f.filterGradleChunk(
+                "> Task :samples:wear:compileDebugKotlin\n" +
+                    "> Task :samples:wear:compileDebugKotlin FAILED\n",
+            );
             assert.strictEqual(
                 out,
-                "> Task :samples:wear:compileDebugKotlin\n> Task :samples:wear:discoverPreviews\n",
+                "> Task :samples:wear:compileDebugKotlin FAILED\n",
             );
         });
 
@@ -67,15 +76,12 @@ describe("LogFilter", () => {
             assert.strictEqual(out, "");
         });
 
-        it("keeps BUILD SUCCESSFUL / BUILD FAILED lines", () => {
+        it("drops BUILD SUCCESSFUL but keeps BUILD FAILED at normal", () => {
             const f = withLevel("normal");
             const out = f.filterGradleChunk(
                 "BUILD SUCCESSFUL in 16s\nBUILD FAILED in 1s\n",
             );
-            assert.strictEqual(
-                out,
-                "BUILD SUCCESSFUL in 16s\nBUILD FAILED in 1s\n",
-            );
+            assert.strictEqual(out, "BUILD FAILED in 1s\n");
         });
 
         it("drops the multi-line configure-project warning block", () => {
@@ -109,21 +115,31 @@ describe("LogFilter", () => {
                 "> Configure project :gradle-plugin\n" +
                     "WARNING: Unsupported Kotlin plugin version.\n" +
                     "\n" +
-                    "BUILD SUCCESSFUL in 1s\n",
+                    "BUILD FAILED in 1s\n",
             );
-            assert.strictEqual(out, "BUILD SUCCESSFUL in 1s\n");
+            assert.strictEqual(out, "BUILD FAILED in 1s\n");
         });
 
-        it("keeps the discoverPreviews bullet list at normal", () => {
+        it("drops the discoverPreviews bullet list at normal", () => {
             const f = withLevel("normal");
             const out = f.filterGradleChunk(
                 "Discovered 17 preview(s) in module 'wear':\n" +
-                    "  com.example.samplewear.PreviewsKt.ButtonPreview  [id:wearos_large_round]\n",
+                    "  com.example.samplewear.PreviewsKt.ButtonPreview  [id:wearos_large_round]\n" +
+                    "  com.example.samplewear.PreviewsKt.CardPreview  [id:wearos_large_round]\n",
+            );
+            assert.strictEqual(out, "");
+        });
+
+        it("ends the discovered block when a non-indented line appears", () => {
+            const f = withLevel("normal");
+            const out = f.filterGradleChunk(
+                "Discovered 17 preview(s) in module 'wear':\n" +
+                    "  com.example.samplewear.PreviewsKt.ButtonPreview  [id:wearos_large_round]\n" +
+                    "FAILURE: Build failed with an exception.\n",
             );
             assert.strictEqual(
                 out,
-                "Discovered 17 preview(s) in module 'wear':\n" +
-                    "  com.example.samplewear.PreviewsKt.ButtonPreview  [id:wearos_large_round]\n",
+                "FAILURE: Build failed with an exception.\n",
             );
         });
 
@@ -325,6 +341,45 @@ describe("LogFilter", () => {
                 null,
             );
         });
+
+        it("drops per-render phase / classloader / renderFinished chatter", () => {
+            const f = withLevel("normal");
+            const lines = [
+                "compose-ai-daemon: [classloader] allocate child loader parent=… loaderId=abc urls=[…]",
+                "compose-ai-daemon: [render] com.example.PreviewsKt#FooPreview loaderId=abc classFile=…",
+                "compose-ai-daemon: [render] mode=<default> effectiveRunAccessibility=false inspectionMode=true outputBaseName=Foo",
+                "compose-ai-daemon: [render] phase=evaluateRule.start outputBaseName=Foo",
+                "compose-ai-daemon: [render] phase=setContent.start outputBaseName=Foo",
+                "compose-ai-daemon: [render] phase=setContent.done outputBaseName=Foo",
+                "compose-ai-daemon: [render] phase=captureRoboImage.start outputBaseName=Foo",
+                "compose-ai-daemon: [render] phase=captureRoboImage.done outputBaseName=Foo",
+                "compose-ai-daemon: [render] phase=dataArtifact.fonts/used.start outputBaseName=Foo",
+                "compose-ai-daemon: [render] phase=dataArtifact.fonts/used.done outputBaseName=Foo tookMs=8",
+                "compose-ai-daemon: [render] phase=complete outputBaseName=Foo tookMs=900 pngPath=/tmp/foo.png",
+                "compose-ai-daemon: [renderFinished] previewId=Foo subscribedKinds=[] globalAttachKinds=[] attachments=[]",
+                "compose-ai-tools daemon: sandbox pool active (sandboxCount=5)",
+            ];
+            for (const line of lines) {
+                assert.strictEqual(
+                    f.filterDaemonStderrLine(line),
+                    null,
+                    `expected drop for: ${line}`,
+                );
+            }
+        });
+
+        it("keeps render phase failures and a11y completion lines", () => {
+            const f = withLevel("normal");
+            const failed =
+                "compose-ai-daemon: [render] phase=evaluateRule.failed outputBaseName=Foo error=RuntimeException: boom";
+            assert.strictEqual(f.filterDaemonStderrLine(failed), failed);
+            const a11yFailed =
+                "compose-ai-daemon: [render] phase=a11y.failed outputBaseName=Foo error=RuntimeException: boom";
+            assert.strictEqual(
+                f.filterDaemonStderrLine(a11yFailed),
+                a11yFailed,
+            );
+        });
     });
 
     describe("filterDaemonStderrLine at quiet", () => {
@@ -368,39 +423,127 @@ describe("LogFilter", () => {
     });
 
     describe("shouldEmitInformational", () => {
-        it("always emits at normal/verbose", () => {
-            for (const level of ["normal", "verbose"] as const) {
+        it("emits everything at verbose", () => {
+            const f = withLevel("verbose");
+            assert.strictEqual(
+                f.shouldEmitInformational("[refresh] start foo"),
+                true,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[doctor] anything"),
+                true,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[detect] anything"),
+                true,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("> :samples:wear:discoverPreviews"),
+                true,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[daemon] spawning anything"),
+                true,
+            );
+        });
+
+        it("emits the signal lines at normal", () => {
+            const f = withLevel("normal");
+            assert.strictEqual(
+                f.shouldEmitInformational("[refresh] start foo"),
+                true,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[refresh] rendered 13 preview(s)"),
+                true,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[refresh] no module — activeFile=foo",
+                ),
+                true,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[daemon] ready for samples/wear"),
+                true,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[startup] anything"),
+                true,
+            );
+        });
+
+        it("drops high-volume chatter at normal", () => {
+            const f = withLevel("normal");
+            assert.strictEqual(
+                f.shouldEmitInformational("[refresh] cache hit: foo"),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[refresh] cancelled — superseded by a newer refresh",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[daemon] spawning foo"),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[daemon] webview ack updateDataProducts foo",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[doctor] doctor diagnostics refreshed across 9",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[detect] something"),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("> :samples:wear:discoverPreviews"),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "> :samples:wear:discoverPreviews completed",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "> :samples:wear:discoverPreviews cancelled",
+                ),
+                false,
+            );
+
+            // Error / failure shaped lines pass through.
+            assert.strictEqual(
+                f.shouldEmitInformational("> :samples:wear:foo FAILED: ..."),
+                true,
+            );
+        });
+
+        it("always emits [panel] user-action lines at every level", () => {
+            for (const level of ["quiet", "normal", "verbose"] as const) {
                 const f = withLevel(level);
                 assert.strictEqual(
-                    f.shouldEmitInformational("[refresh] start foo"),
+                    f.shouldEmitInformational("[panel] module selected: foo"),
                     true,
                 );
                 assert.strictEqual(
                     f.shouldEmitInformational(
-                        "[doctor] doctor diagnostics refreshed across 9",
+                        "[panel] extension a11y/atf enabled for foo",
                     ),
                     true,
                 );
                 assert.strictEqual(
-                    f.shouldEmitInformational("[detect] something"),
-                    true,
-                );
-                assert.strictEqual(
-                    f.shouldEmitInformational(
-                        "> :samples:wear:discoverPreviews",
-                    ),
-                    true,
-                );
-                assert.strictEqual(
-                    f.shouldEmitInformational(
-                        "> :samples:wear:discoverPreviews completed",
-                    ),
-                    true,
-                );
-                assert.strictEqual(
-                    f.shouldEmitInformational(
-                        "[daemon] ready for samples/wear",
-                    ),
+                    f.shouldEmitInformational("[panel] focus preview: foo"),
                     true,
                 );
             }


### PR DESCRIPTION
Significantly reduces output channel noise at the "normal" log level by filtering out high-volume, low-signal chatter while preserving actionable information like failures and user-initiated actions.

## Summary

This change restructures the log filtering logic to be more selective at the "normal" level. Previously, normal mode kept most Gradle output except for noop task headers. Now it aggressively filters:
- All `> Task :module:task` headers (not just noop ones)
- `BUILD SUCCESSFUL` lines (redundant with `[refresh] rendered N` messages)
- Gradle discovery preview bullet lists
- Daemon render phase chatter and classloader logs
- High-volume extension chatter like cache hits and daemon spawning

Failure-shaped lines (`FAILED`, `FAILURE:`, exceptions, etc.) survive at all levels. User-initiated panel actions (`[panel]` prefix) always emit.

## Key Changes

- **Task header filtering**: Drop all `> Task :` lines at normal/quiet, not just ones with noop suffixes (UP-TO-DATE, SKIPPED, etc.)
- **BUILD SUCCESSFUL filtering**: Drop at normal since `[refresh] rendered N` already conveys success; keep `BUILD FAILED`
- **Discovery preview block**: Track and drop the `Discovered N preview(s)` header and its indented bullet list continuation
- **Daemon render chatter**: Filter per-render phase, classloader, and renderFinished lines; keep phase-failure lines
- **Extension chatter**: Separate high-volume prefixes (cache hits, daemon spawning, doctor diagnostics) that drop at normal from signal lines (render outcomes, daemon readiness, startup) that survive
- **Task progress markers**: Drop `> :module:task completed/cancelled` at normal; keep `FAILED` variants
- **Panel actions**: Add `[panel]` prefix to user-initiated actions (module selection, preview focus, a11y toggle) and always emit them
- **Informational filtering**: Restructure `shouldEmitInformational()` to explicitly list what drops at each level rather than what survives

## Implementation Details

- Added state tracking (`inDiscoveredBlock`) to handle multi-line discovery blocks across chunks
- Moved failure-shaped line checks before level-specific logic so they survive at all levels
- Separated "quiet chatter" (drops at quiet) from "normal chatter" (drops at normal) prefix lists
- Updated extension.ts and gradleService.ts to emit `[panel]` and `[refresh]` lines through the filter

https://claude.ai/code/session_01QTD64kzUgVg5qwUUrP8vxK