### PR TITLE
feat(release): ship the bundle viewer alongside the CLI and MCP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,10 +104,14 @@ jobs:
             publishAndReleaseToMavenCentral
 
   # Build the runnable applications shipped on each GitHub Release: the CLI
-  # (`compose-preview-*`) and the standalone MCP server (`compose-preview-mcp-*`).
-  # The CLI tarball already implementation-bundles `:mcp`, so the standalone
-  # MCP archive is for consumers who only want `compose-preview-mcp` on its
-  # own (e.g. wiring it into an MCP client without dragging the CLI in).
+  # (`compose-preview-*`), the standalone MCP server (`compose-preview-mcp-*`),
+  # and the desktop bundle viewer (`compose-preview-viewer-*`). The CLI tarball
+  # already implementation-bundles `:mcp`, so the standalone MCP archive is for
+  # consumers who only want `compose-preview-mcp` on its own (e.g. wiring it
+  # into an MCP client without dragging the CLI in). The viewer is a separate
+  # Compose Desktop application that opens a packed `.png` bundle and renders
+  # it live in a window; bigger than the CLI (ships its own Compose+Skiko
+  # runtime) so it's a separate download.
   #
   # Each dist is uploaded as its own artifact so `actions/upload-artifact`'s
   # lowest-common-ancestor logic collapses to the single `*/build/distributions/`
@@ -128,8 +132,12 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - name: Build CLI and MCP distributions
-        run: ./gradlew :cli:distZip :cli:distTar :mcp:distZip :mcp:distTar
+      - name: Build CLI, MCP, and viewer distributions
+        run: |
+          ./gradlew \
+            :cli:distZip :cli:distTar \
+            :mcp:distZip :mcp:distTar \
+            :bundle-viewer:distZip :bundle-viewer:distTar
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cli-dist
@@ -143,6 +151,16 @@ jobs:
           path: |
             mcp/build/distributions/compose-preview-mcp-*.zip
             mcp/build/distributions/compose-preview-mcp-*.tar.gz
+          retention-days: 1
+      # Viewer ships its full Compose Multiplatform Desktop + Skiko runtime in `lib/`, so the
+      # tarball is ~37 MB on Linux. Same single-artifact / single-parent path shape as the CLI
+      # and MCP uploads so the `release` job's flat `artifacts/*.{zip,tar.gz}` glob picks it up.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bundle-viewer-dist
+          path: |
+            bundle-viewer/build/distributions/compose-preview-viewer-*.zip
+            bundle-viewer/build/distributions/compose-preview-viewer-*.tar.gz
           retention-days: 1
 
   build-vscode-extension:

--- a/bundle-viewer/build.gradle.kts
+++ b/bundle-viewer/build.gradle.kts
@@ -9,6 +9,26 @@ plugins {
   application
 }
 
+// Version derivation mirrors `:cli/build.gradle.kts` — CI sets `PLUGIN_VERSION` from the git
+// tag (e.g. `0.10.15`), local builds compute the next-patch SNAPSHOT from
+// `.release-please-manifest.json`. Keeping the schemes aligned means the viewer's release
+// artefact ships at the same version as the CLI / plugin / MCP server, so `compose-preview
+// $X` and `compose-preview-viewer $X` always refer to mutually compatible builds.
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
+
+// `archivesName` drives the distZip / distTar file name (`<archivesName>-<version>.<ext>`) AND
+// the root directory inside the archive. Pinning here gives us `compose-preview-viewer-<ver>.zip`
+// / `compose-preview-viewer-<ver>.tar.gz` on disk and a matching root dir inside — same shape
+// the CLI uses and what the `gh release upload` glob in `.github/workflows/release.yml` expects.
+base { archivesName.set("compose-preview-viewer") }
+
 application {
   applicationName = "compose-preview-viewer"
   mainClass.set("ee.schimke.composeai.viewer.MainKt")
@@ -16,6 +36,15 @@ application {
   // would otherwise print a 4-line warning on every launch; pre-declaring native access for the
   // unnamed module silences it.
   applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")
+}
+
+// Match the CLI's archive-extension trick. `archiveExtension = "tar.gz"` lets Gradle compute
+// the file name as `<archivesName>-<version>.tar.gz` while keeping the extracted-archive root
+// dir at `<archivesName>-<version>/`. Setting `archiveFileName` directly would leak the
+// `.tar.gz` suffix into the extracted folder name — see the warning in `:cli/build.gradle.kts`.
+tasks.named<Tar>("distTar") {
+  archiveExtension.set("tar.gz")
+  compression = Compression.GZIP
 }
 
 dependencies {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -47,9 +47,12 @@ Both fallbacks share the same concurrency group as the primary path, so they can
    - **Data product connectors** — `ee.schimke.composeai:data-*-connector` artifacts used by daemon modules, including recomposition
 
    Maven Central is the only Maven coordinate source — we no longer mirror jars onto GitHub Packages. Consumers point Gradle at `mavenCentral()` and resolve every module from there.
-2. Builds the **CLI** and the standalone **MCP server** as `.zip` and `.tar.gz` distributions (`compose-preview-<ver>.{zip,tar.gz}` and `compose-preview-mcp-<ver>.{zip,tar.gz}`). The CLI tarball already implementation-bundles `:mcp`, so the MCP archive is for consumers who want to wire the server into an MCP client without dragging the CLI in.
+2. Builds the **CLI**, the standalone **MCP server**, and the **bundle viewer** as `.zip` and `.tar.gz` distributions:
+   - `compose-preview-<ver>.{zip,tar.gz}` — the CLI; tarball already implementation-bundles `:mcp` and the desktop renderer.
+   - `compose-preview-mcp-<ver>.{zip,tar.gz}` — the MCP server standalone for consumers who want to wire it into an MCP client without dragging the CLI in.
+   - `compose-preview-viewer-<ver>.{zip,tar.gz}` — single-window Compose Desktop app (`compose-preview-viewer <bundle.png>` or drag-and-drop) that opens a packed bundle and renders its `@Preview` composable live. Bigger than the CLI archive (~37 MB on Linux) because it ships its own Compose Multiplatform + Skiko runtime.
 3. Packages the **VS Code extension** as a `.vsix` file and publishes it to the **VS Code Marketplace** and **Open VSX** (runs alongside the Release upload, so a marketplace outage can't block the GitHub Release).
-4. Uploads the CLI, MCP, and VS Code extension artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).
+4. Uploads the CLI, MCP, viewer, and VS Code extension artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).
 
 Skill bundles (`compose-preview`, `compose-preview-review`) and the
 canonical bootstrap installer (`scripts/install.sh`) ship from a


### PR DESCRIPTION
## Summary

`compose-preview-viewer-<ver>.{zip,tar.gz}` now lands on every GitHub Release alongside the existing CLI and MCP archives. ~36 MB on Linux because the viewer ships its full Compose Multiplatform Desktop + Skiko runtime in `lib/` — consumers want it as a double-clickable app rather than a Maven dep.

Lets users do:

```bash
curl -L -o compose-preview-viewer.tar.gz \
  https://github.com/yschimke/compose-ai-tools/releases/latest/download/compose-preview-viewer-<ver>.tar.gz
tar xzf compose-preview-viewer.tar.gz
./compose-preview-viewer-<ver>/bin/compose-preview-viewer bundle.png
```

…or set the `.png` file association on macOS/Windows once and double-click bundles to open them.

## Build wiring

- **`bundle-viewer/build.gradle.kts`** adopts the same version-derivation pattern as `:cli` (env `PLUGIN_VERSION` in CI; next-patch SNAPSHOT from `.release-please-manifest.json` locally), pins `base.archivesName = "compose-preview-viewer"`, and renames the tar archive extension to `tar.gz` (matching the CLI's archive-name trick so the extracted root dir is `compose-preview-viewer-<ver>/`).
- **`.github/workflows/release.yml`**: the `build-applications` job now also runs `:bundle-viewer:distZip :bundle-viewer:distTar` and uploads a new `bundle-viewer-dist` artifact pointing at `bundle-viewer/build/distributions/compose-preview-viewer-*`. The existing flat `*.zip *.tar.gz` glob in the downstream `release` job's `gh release upload` picks the files up after `merge-multiple: true`.
- **`docs/RELEASING.md`** documents the new archive next to the CLI and MCP entries.

## Verified locally

`PLUGIN_VERSION=0.10.14 ./gradlew :bundle-viewer:distZip :bundle-viewer:distTar` produces:

```
bundle-viewer/build/distributions/
├── compose-preview-viewer-0.10.14.tar.gz   (36 MB)
└── compose-preview-viewer-0.10.14.zip      (36 MB)
```

Internal layout of the zip:

```
compose-preview-viewer-0.10.14/
├── bin/
│   ├── compose-preview-viewer
│   └── compose-preview-viewer.bat
└── lib/   (50 jars: bundle viewer + Compose Multiplatform + Skiko + kotlinx)
```

Same shape `gh release upload` expects from the existing CLI/MCP entries.

## Test plan

- [x] Local `:bundle-viewer:distZip :bundle-viewer:distTar` produces the expected archive names with the correct internal root dir.
- [x] `release.yml` artifact path globs match the archive names.
- [ ] Verified on first tagged release (will run automatically via `release-please` chain).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Y1vuwt2pQeeMjvqycNHNT)_