### PR TITLE
refactor: remove feature flags for auto-inject, cheap enable, and variant collapse

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -65,8 +65,9 @@ The plugin is on Maven Central, so no extra repository setup is needed when
 [project README](https://github.com/yschimke/compose-ai-tools#setup) for
 snapshot builds.
 
-To disable auto-inject and require an explicit plugin application, set
-`composePreview.autoInject.enabled` to `false`.
+The bundled init script always auto-applies the plugin to Android / Compose
+projects on every Gradle invocation, so no `build.gradle.kts` edit is
+required.
 
 ## Minimal mode
 
@@ -100,12 +101,11 @@ to full mode becomes possible.
 
 ### Settings
 
-| Setting                             | Default  | Description                                                                                                                                                                                                                                                                                                                                                                       |
-| ----------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `composePreview.mode`               | `auto`   | Backend mode: `auto` picks `full` only when the plugin is verifiably applied (via `applied.json` markers or a literal `id("ee.schimke.composeai.preview")`), else `minimal`. The post-Gradle-sync re-evaluation offers a one-click reload into full mode once auto-inject has applied the plugin. Force `full` or `minimal` to override. Requires a window reload to take effect. |
-| `composePreview.autoInject.enabled` | `true`   | Pass the bundled init script via `--init-script` so the plugin auto-applies to Android / Compose projects. Disable to keep Gradle invocations untouched and require manual `id("ee.schimke.composeai.preview")` setup.                                                                                                                                                            |
-| `composePreview.variant`            | `debug`  | Build variant to use for preview rendering (Android).                                                                                                                                                                                                                                                                                                                             |
-| `composePreview.logging.level`      | `normal` | Verbosity for the "Compose Preview" output channel. `quiet` shows only errors and the BUILD outcome; `normal` keeps active task headers and summary lines but drops UP-TO-DATE/SKIPPED noise, configuration-cache bookkeeping, and dedupes the repeated Roborazzi ActionBar warnings; `verbose` shows every line from Gradle and the daemon.                                      |
+| Setting                        | Default  | Description                                                                                                                                                                                                                                                                                                                                                                       |
+| ------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `composePreview.mode`          | `auto`   | Backend mode: `auto` picks `full` only when the plugin is verifiably applied (via `applied.json` markers or a literal `id("ee.schimke.composeai.preview")`), else `minimal`. The post-Gradle-sync re-evaluation offers a one-click reload into full mode once auto-inject has applied the plugin. Force `full` or `minimal` to override. Requires a window reload to take effect. |
+| `composePreview.variant`       | `debug`  | Build variant to use for preview rendering (Android).                                                                                                                                                                                                                                                                                                                             |
+| `composePreview.logging.level` | `normal` | Verbosity for the "Compose Preview" output channel. `quiet` shows only errors and the BUILD outcome; `normal` keeps active task headers and summary lines but drops UP-TO-DATE/SKIPPED noise, configuration-cache bookkeeping, and dedupes the repeated Roborazzi ActionBar warnings; `verbose` shows every line from Gradle and the daemon.                                      |
 
 ## Links
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -140,11 +140,6 @@
                         "Force full mode: daemon + data extensions + live previews."
                     ]
                 },
-                "composePreview.autoInject.enabled": {
-                    "type": "boolean",
-                    "default": true,
-                    "markdownDescription": "Pass a bundled Gradle init script via `--init-script` on every Gradle invocation. The script applies `ee.schimke.composeai.preview` to any project that applies `com.android.application`, `com.android.library`, or `org.jetbrains.compose`, so users don't have to edit `build.gradle.kts` to opt in.\n\nDisable to keep Gradle invocations untouched — the user must apply the plugin manually."
-                },
                 "composePreview.daemon.enabled": {
                     "type": "boolean",
                     "default": true,
@@ -155,16 +150,6 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Enable early, unstable preview features in the VS Code panel, including focus-mode diffs, focus inspector extension layers, a11y overlay controls, recording, and diff-all commands. Focus mode and live interactive previews remain available when this is off."
-                },
-                "composePreview.autoEnableCheap.enabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "When the focus-mode inspector suggests a data extension that's cheap to compute (theme tokens, fonts, strings, layout tree), auto-enable it on first sight per module. Expensive layers (recomposition heatmap, render trace, accessibility re-render) are never auto-enabled and stay click-to-toggle. Suggestions themselves don't depend on this setting; only whether the suggestion auto-applies."
-                },
-                "composePreview.collapseVariants.enabled": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Collapse @Preview variants (multi-preview, @PreviewParameter, font/uiMode/device combinations) so only one card per function is shown when no function or group filter is active. Picking a specific function or group from the filter toolbar expands all variants for that selection. Turn off to always show every variant."
                 },
                 "composePreview.logging.level": {
                     "type": "string",

--- a/vscode-extension/preview-harness/README.md
+++ b/vscode-extension/preview-harness/README.md
@@ -144,10 +144,7 @@ Drop `preview-harness/fixtures/<name>.json` with shape:
     "description": "What this scenario shows",
     "dataset": {
         "earlyFeatures": "false",
-        "autoEnableCheap": "false",
-        "collapseVariants": "false",
-        "minimalMode": "false",
-        "autoInject": "true"
+        "minimalMode": "false"
     },
     "messages": [
         { "command": "setPreviews", "moduleDir": "...", "previews": [...], "heavyStaleIds": [] },

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.json
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.json
@@ -3,10 +3,7 @@
   "description": "Focused card with three Accessibility Test Framework findings (one ERROR, two WARNINGs) overlaid on a stylised mobile mock. Drives focus mode and activates the Accessibility bundle so the chip bar, data tab, and on-image box-overlay all paint.",
   "dataset": {
     "earlyFeatures": "true",
-    "autoEnableCheap": "false",
-    "collapseVariants": "false",
-    "minimalMode": "false",
-    "autoInject": "true"
+    "minimalMode": "false"
   },
   "messages": [
     {

--- a/vscode-extension/preview-harness/fixtures/grid-default.json
+++ b/vscode-extension/preview-harness/fixtures/grid-default.json
@@ -3,10 +3,7 @@
   "description": "Four-card grid: three color variants plus a greeting, after setPreviews + per-card updateImage.",
   "dataset": {
     "earlyFeatures": "false",
-    "autoEnableCheap": "false",
-    "collapseVariants": "false",
-    "minimalMode": "false",
-    "autoInject": "true"
+    "minimalMode": "false"
   },
   "messages": [
     {

--- a/vscode-extension/preview-harness/fixtures/history-diff.json
+++ b/vscode-extension/preview-harness/fixtures/history-diff.json
@@ -3,10 +3,7 @@
   "description": "Focused card with realistic history/diff/regions payload (three regions, ~12% of pixels changed from baseline). Activates the History bundle so the diff overlay paints each region, the side legend lists them with pixel-count subtitles, and the tab body renders the diff table with the baseline header.",
   "dataset": {
     "earlyFeatures": "true",
-    "autoEnableCheap": "false",
-    "collapseVariants": "false",
-    "minimalMode": "false",
-    "autoInject": "true"
+    "minimalMode": "false"
   },
   "messages": [
     {

--- a/vscode-extension/preview-harness/fixtures/inspection-tree.json
+++ b/vscode-extension/preview-harness/fixtures/inspection-tree.json
@@ -3,10 +3,7 @@
   "description": "Focused card with realistic compose/semantics + layout/inspector payloads. Activates the Inspection bundle so the overlay layer paints over the header / primary CTA / secondary CTA / footer regions, the side legend populates with one entry per overlay box (label · role · testTag), and the inspection tab body renders the per-kind tree tables.",
   "dataset": {
     "earlyFeatures": "true",
-    "autoEnableCheap": "false",
-    "collapseVariants": "false",
-    "minimalMode": "false",
-    "autoInject": "true"
+    "minimalMode": "false"
   },
   "messages": [
     {

--- a/vscode-extension/preview-harness/fixtures/text-strings.json
+++ b/vscode-extension/preview-harness/fixtures/text-strings.json
@@ -3,10 +3,7 @@
   "description": "Focused card with realistic text/strings + fonts/used + i18n/translations payloads. Activates the Text / i18n bundle so the overflow/truncation overlay paints over the footer, the side legend lists each drawn-text entry, and the tab body renders the strings + fonts sub-tables.",
   "dataset": {
     "earlyFeatures": "true",
-    "autoEnableCheap": "false",
-    "collapseVariants": "false",
-    "minimalMode": "false",
-    "autoInject": "true"
+    "minimalMode": "false"
   },
   "messages": [
     {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -303,18 +303,6 @@ export function resolveMode(gradleService: {
 }
 
 /**
- * Whether the bundled `apply-compose-ai-preview.init.gradle.kts` is passed
- * to Gradle via `--init-script`. Off ⇒ the user must apply the preview
- * plugin themselves; on (default) ⇒ the script auto-applies it to any
- * Android / Compose project.
- */
-function autoInjectEnabled(): boolean {
-    return vscode.workspace
-        .getConfiguration("composePreview")
-        .get<boolean>("autoInject.enabled", true);
-}
-
-/**
  * True when the GradleOnly backend is wired up — i.e. we're in minimal mode.
  * Module-scope so auto-render call sites that live outside `activate()` (e.g.
  * [onDiagnosticsChanged], the stale-source kicker inside [refresh]) can gate
@@ -327,18 +315,6 @@ function autoInjectEnabled(): boolean {
  */
 function inMinimalMode(): boolean {
     return daemonGate?.spawnsDaemons === false;
-}
-
-function autoEnableCheapEnabled(): boolean {
-    return vscode.workspace
-        .getConfiguration("composePreview")
-        .get<boolean>("autoEnableCheap.enabled", false);
-}
-
-function collapseVariantsEnabled(): boolean {
-    return vscode.workspace
-        .getConfiguration("composePreview")
-        .get<boolean>("collapseVariants.enabled", true);
 }
 
 /**
@@ -664,20 +640,18 @@ export async function activate(
     // TypeScript and keep the rendered script in extension storage, which
     // survives extension updates without polluting `~/.gradle/init.d/`.
     let initScriptArgs: readonly string[] = [];
-    if (autoInjectEnabled()) {
-        try {
-            const initScriptPath = materializeInitScript(
-                context.globalStorageUri.fsPath,
-            );
-            initScriptArgs = ["--init-script", initScriptPath];
-            outputChannel.appendLine(
-                `[startup] auto-inject: --init-script ${initScriptPath} (plugin ${BUNDLED_PLUGIN_VERSION})`,
-            );
-        } catch (err) {
-            outputChannel.appendLine(
-                `[startup] auto-inject disabled: failed to materialise init script: ${(err as Error).message}`,
-            );
-        }
+    try {
+        const initScriptPath = materializeInitScript(
+            context.globalStorageUri.fsPath,
+        );
+        initScriptArgs = ["--init-script", initScriptPath];
+        outputChannel.appendLine(
+            `[startup] auto-inject: --init-script ${initScriptPath} (plugin ${BUNDLED_PLUGIN_VERSION})`,
+        );
+    } catch (err) {
+        outputChannel.appendLine(
+            `[startup] auto-inject disabled: failed to materialise init script: ${(err as Error).message}`,
+        );
     }
 
     gradleService = new GradleService(
@@ -1055,10 +1029,7 @@ export async function activate(
         onMessage,
         () => earlyFeaturesEnabled(),
         undefined,
-        () => autoEnableCheapEnabled(),
-        () => collapseVariantsEnabled(),
         () => inMinimalMode(),
-        () => autoInjectEnabled(),
     );
     if (isTestMode) {
         // Tap into every outgoing webview message so the test API can assert
@@ -1415,26 +1386,6 @@ export async function activate(
                 panel?.postMessage({
                     command: "setEarlyFeatures",
                     enabled: earlyFeaturesEnabled(),
-                });
-            }
-            if (
-                event.affectsConfiguration(
-                    "composePreview.autoEnableCheap.enabled",
-                )
-            ) {
-                panel?.postMessage({
-                    command: "setAutoEnableCheap",
-                    enabled: autoEnableCheapEnabled(),
-                });
-            }
-            if (
-                event.affectsConfiguration(
-                    "composePreview.collapseVariants.enabled",
-                )
-            ) {
-                panel?.postMessage({
-                    command: "setCollapseVariants",
-                    enabled: collapseVariantsEnabled(),
                 });
             }
         }),

--- a/vscode-extension/src/initScript.ts
+++ b/vscode-extension/src/initScript.ts
@@ -44,8 +44,7 @@ export function renderInitScript(
 // ee.schimke.composeai.preview (version pinned to ${pluginVersion}) to every
 // project that already applies com.android.application,
 // com.android.library, or org.jetbrains.compose — so consumers don't have
-// to edit their build files. Disable from settings via
-// composePreview.autoInject.enabled = false.
+// to edit their build files.
 //
 // Application uses pluginManager.withPlugin(...) (not afterEvaluate) so
 // AGP finalizeDsl / onVariants callbacks register before the DSL lock.

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -8,10 +8,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     private extensionUri: vscode.Uri;
     private onMessage: (msg: WebviewToExtension) => void;
     private earlyFeaturesEnabled: () => boolean;
-    private autoEnableCheapEnabled: () => boolean;
-    private collapseVariantsEnabled: () => boolean;
     private minimalModeEnabled: () => boolean;
-    private autoInjectEnabled: () => boolean;
     private shouldRestoreVisibility: () => boolean;
 
     constructor(
@@ -19,18 +16,12 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         onMessage: (msg: WebviewToExtension) => void,
         earlyFeaturesEnabled: () => boolean = () => false,
         shouldRestoreVisibility: () => boolean = () => false,
-        autoEnableCheapEnabled: () => boolean = () => false,
-        collapseVariantsEnabled: () => boolean = () => true,
         minimalModeEnabled: () => boolean = () => false,
-        autoInjectEnabled: () => boolean = () => true,
     ) {
         this.extensionUri = extensionUri;
         this.onMessage = onMessage;
         this.earlyFeaturesEnabled = earlyFeaturesEnabled;
-        this.autoEnableCheapEnabled = autoEnableCheapEnabled;
-        this.collapseVariantsEnabled = collapseVariantsEnabled;
         this.minimalModeEnabled = minimalModeEnabled;
-        this.autoInjectEnabled = autoInjectEnabled;
         this.shouldRestoreVisibility = shouldRestoreVisibility;
     }
 
@@ -63,10 +54,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     private getHtml(webview: vscode.Webview): string {
         const nonce = getNonce();
         const earlyFeaturesEnabled = this.earlyFeaturesEnabled();
-        const autoEnableCheapEnabled = this.autoEnableCheapEnabled();
-        const collapseVariantsEnabled = this.collapseVariantsEnabled();
         const minimalModeEnabled = this.minimalModeEnabled();
-        const autoInjectEnabled = this.autoInjectEnabled();
         const styleUri = webview.asWebviewUri(
             vscode.Uri.joinPath(this.extensionUri, "media", "preview.css"),
         );
@@ -95,10 +83,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 <body>
     <preview-app
         data-early-features="${earlyFeaturesEnabled ? "true" : "false"}"
-        data-auto-enable-cheap="${autoEnableCheapEnabled ? "true" : "false"}"
-        data-collapse-variants="${collapseVariantsEnabled ? "true" : "false"}"
         data-minimal-mode="${minimalModeEnabled ? "true" : "false"}"
-        data-auto-inject="${autoInjectEnabled ? "true" : "false"}"
     ></preview-app>
     <script nonce="${nonce}" src="${scriptUri}"></script>
 </body>

--- a/vscode-extension/src/test/variantCollapse.test.ts
+++ b/vscode-extension/src/test/variantCollapse.test.ts
@@ -10,20 +10,8 @@ const c = (id: string, functionKey: string): VariantCollapseCandidate => ({
 });
 
 describe("decideVariantCollapse", () => {
-    it("is inactive when the feature is disabled", () => {
-        const decision = decideVariantCollapse({
-            collapseVariants: false,
-            fnFilter: "all",
-            groupFilter: "all",
-            candidates: [c("a", "k1"), c("b", "k1"), c("d", "k2")],
-        });
-        assert.strictEqual(decision.active, false);
-        assert.strictEqual(decision.hidden.size, 0);
-    });
-
     it("is inactive when a function filter is narrowing", () => {
         const decision = decideVariantCollapse({
-            collapseVariants: true,
             fnFilter: "MyComposable",
             groupFilter: "all",
             candidates: [c("a", "k1"), c("b", "k1")],
@@ -34,7 +22,6 @@ describe("decideVariantCollapse", () => {
 
     it("is inactive when a group filter is narrowing", () => {
         const decision = decideVariantCollapse({
-            collapseVariants: true,
             fnFilter: "all",
             groupFilter: "dark",
             candidates: [c("a", "k1"), c("b", "k1")],
@@ -45,7 +32,6 @@ describe("decideVariantCollapse", () => {
 
     it("keeps the first variant per function key when active", () => {
         const decision = decideVariantCollapse({
-            collapseVariants: true,
             fnFilter: "all",
             groupFilter: "all",
             candidates: [
@@ -65,7 +51,6 @@ describe("decideVariantCollapse", () => {
 
     it("treats different className+functionName pairs as independent", () => {
         const decision = decideVariantCollapse({
-            collapseVariants: true,
             fnFilter: "all",
             groupFilter: "all",
             candidates: [
@@ -82,7 +67,6 @@ describe("decideVariantCollapse", () => {
 
     it("emits an empty hidden set when there are no candidates", () => {
         const decision = decideVariantCollapse({
-            collapseVariants: true,
             fnFilter: "all",
             groupFilter: "all",
             candidates: [],

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -615,25 +615,6 @@ export type ExtensionToWebview =
     | { command: "streamStopped"; previewId: string }
     | { command: "setEarlyFeatures"; enabled: boolean }
     /**
-     * Reflects `composePreview.autoEnableCheap.enabled` from settings.
-     * When `true` the focus inspector auto-flips on cheap, suggestion-
-     * matched data products (theme tokens, fonts, strings, layout tree)
-     * the first time it sees a preview in a given scope; expensive
-     * kinds (recomposition, render trace, a11y) stay click-to-enable.
-     * Sent at panel boot from `composePreview.autoEnableCheap.enabled`
-     * and again on settings change.
-     */
-    | { command: "setAutoEnableCheap"; enabled: boolean }
-    /**
-     * Reflects `composePreview.collapseVariants.enabled` from settings.
-     * When `true`, the preview grid shows only one card per function
-     * (`className + functionName`) while no function or group filter is
-     * active; picking a function or group from the toolbar expands all
-     * variants for that selection. Sent at panel boot and on settings
-     * change.
-     */
-    | { command: "setCollapseVariants"; enabled: boolean }
-    /**
      * Daemon capabilities for the active module — the kinds the daemon
      * can produce (`dataProducts`) and the data extensions registered
      * (`dataExtensions`). The focus inspector groups these into its

--- a/vscode-extension/src/webview/preview/components/PreviewGrid.ts
+++ b/vscode-extension/src/webview/preview/components/PreviewGrid.ts
@@ -36,15 +36,6 @@ export interface FilterValues {
     group: string;
 }
 
-export interface ApplyFiltersOptions {
-    /** When true, collapse variants of the same function (same
-     *  className+functionName) so only the first card survives. Only takes
-     *  effect when neither the function nor the group filter is narrower
-     *  than `"all"` — picking a function or group is treated as an
-     *  explicit "show all variants for this selection" signal. */
-    collapseVariants?: boolean;
-}
-
 export class PreviewGrid extends HTMLElement {
     private layoutMode: LayoutMode = "grid";
     private compileStale = false;
@@ -96,16 +87,12 @@ export class PreviewGrid extends HTMLElement {
      * picks and returns how many ended up visible — callers use that
      * count to decide whether to surface the "no matches" banner.
      *
-     * When `options.collapseVariants` is true and both filters are
-     * `"all"`, variants of the same function (matched on
-     * `data-class-name + data-function`) collapse to the first card —
-     * the rest pick up `filtered-out` (and an extra
+     * When both filters are `"all"`, variants of the same function
+     * (matched on `data-class-name + data-function`) collapse to the
+     * first card — the rest pick up `filtered-out` (and an extra
      * `collapsed-variant` class so callers can tell the two apart).
      */
-    applyFilters(
-        filters: FilterValues,
-        options: ApplyFiltersOptions = {},
-    ): number {
+    applyFilters(filters: FilterValues): number {
         const { fn, group } = filters;
         const cards = this.getCards();
         const filterEligible: HTMLElement[] = [];
@@ -120,7 +107,6 @@ export class PreviewGrid extends HTMLElement {
             if (show) filterEligible.push(card);
         }
         const decision = decideVariantCollapse({
-            collapseVariants: !!options.collapseVariants,
             fnFilter: fn,
             groupFilter: group,
             candidates: filterEligible.map((c) => ({

--- a/vscode-extension/src/webview/preview/filterController.ts
+++ b/vscode-extension/src/webview/preview/filterController.ts
@@ -40,10 +40,6 @@ export interface FilterControllerConfig {
     /** Re-apply layout after filter change — focus mode needs to
      *  recompute focusIndex bounds against the narrowed visible set. */
     applyLayout(): void;
-    /** Reflects `composePreview.collapseVariants.enabled`. When `true`,
-     *  the grid hides duplicate variants of the same function while no
-     *  function/group filter is narrowing the visible set. */
-    collapseVariants(): boolean;
 }
 
 export class FilterController {
@@ -75,13 +71,10 @@ export class FilterController {
      *  mode recomputes focusIndex bounds against the narrowed visible
      *  set). */
     apply(): void {
-        const visibleCount = this.config.grid.applyFilters(
-            {
-                fn: this.config.filterToolbar.getFunctionValue(),
-                group: this.config.filterToolbar.getGroupValue(),
-            },
-            { collapseVariants: this.config.collapseVariants() },
-        );
+        const visibleCount = this.config.grid.applyFilters({
+            fn: this.config.filterToolbar.getFunctionValue(),
+            group: this.config.filterToolbar.getGroupValue(),
+        });
 
         // Only own the message when we have a filter-specific thing to
         // say. When there are no previews at all, the extension owns

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -214,12 +214,6 @@ export class PreviewApp extends LitElement {
 
     protected render(): TemplateResult {
         const minimal = this.dataset.minimalMode === "true";
-        // When the bundled auto-inject init script handles the plugin, the
-        // "Apply plugin to project" link is misleading: the extension already
-        // applies it on every Gradle run, and the button's only effect is to
-        // open the build script. Hide it in that case so users aren't nudged
-        // toward an edit they don't need to make.
-        const autoInject = this.dataset.autoInject !== "false";
         return html`
             <progress-bar></progress-bar>
             <compile-errors-banner></compile-errors-banner>
@@ -262,19 +256,6 @@ export class PreviewApp extends LitElement {
                                   ></i>
                                   <span>Refresh previews</span>
                               </button>
-                              ${autoInject
-                                  ? ""
-                                  : html`
-                                        <button
-                                            type="button"
-                                            id="btn-minimal-apply-plugin"
-                                            class="minimal-apply-link"
-                                            title="Open this module's build script to apply the Compose Preview plugin"
-                                            aria-label="Apply Compose Preview plugin to project"
-                                        >
-                                            Apply plugin to project
-                                        </button>
-                                    `}
                           </div>
                       </div>
                   `
@@ -431,12 +412,6 @@ export class PreviewApp extends LitElement {
     protected firstUpdated(): void {
         const initialEarlyFeaturesEnabled =
             this.dataset.earlyFeatures === "true";
-        const initialAutoEnableCheap = this.dataset.autoEnableCheap === "true";
-        // Default true keeps the new collapse-by-default behaviour in
-        // ad-hoc test contexts (where the dataset attribute is missing);
-        // explicit `false` opts out.
-        const initialCollapseVariants =
-            this.dataset.collapseVariants !== "false";
         const minimalMode = this.dataset.minimalMode === "true";
         const vscode = getVsCodeApi<PersistedState>();
         // Listen for runtime mode flips from the extension (post-Gradle-sync
@@ -471,11 +446,6 @@ export class PreviewApp extends LitElement {
                 if (pending) pending.hidden = true;
                 vscode.postMessage({ command: "requestRefresh" });
             });
-            this.querySelector<HTMLButtonElement>(
-                "#btn-minimal-apply-plugin",
-            )?.addEventListener("click", () => {
-                vscode.postMessage({ command: "openModuleBuildFile" });
-            });
             // Toggle the "Saved changes pending" hint based on extension
             // signals. The extension fires `minimalSavePending` from the
             // save handler when it deliberately skips an auto-render so
@@ -502,8 +472,6 @@ export class PreviewApp extends LitElement {
         // terseness; writes go straight to `previewStore.setState`.
         previewStore.setState({
             earlyFeaturesEnabled: initialEarlyFeaturesEnabled,
-            autoEnableCheapEnabled: initialAutoEnableCheap,
-            collapseVariantsEnabled: initialCollapseVariants,
         });
         const earlyFeatures = (): boolean =>
             previewStore.getState().earlyFeaturesEnabled;
@@ -2183,8 +2151,6 @@ export class PreviewApp extends LitElement {
             messageBanner,
             getAllPreviews: () => previewStore.getState().allPreviews,
             applyLayout: () => focusController.applyLayout(),
-            collapseVariants: () =>
-                previewStore.getState().collapseVariantsEnabled,
         });
 
         const staleBadge = new StaleBadgeController(vscode);

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -231,17 +231,6 @@ export function handleExtensionMessage(
             return handlePreviewMainRefChanged(ctx);
         case "setEarlyFeatures":
             return handleSetEarlyFeatures(msg, ctx);
-        case "setAutoEnableCheap":
-            previewStore.setState({ autoEnableCheapEnabled: !!msg.enabled });
-            return;
-        case "setCollapseVariants":
-            previewStore.setState({
-                collapseVariantsEnabled: !!msg.enabled,
-            });
-            // Re-apply filters so the grid picks up the change without
-            // waiting for the user to touch the toolbar.
-            ctx.applyFilters();
-            return;
         case "setDaemonCapabilities":
             // The chip/bucket pipeline that consumed these descriptors
             // moved to the bundle shell (#1099); the slim focus

--- a/vscode-extension/src/webview/preview/previewStore.ts
+++ b/vscode-extension/src/webview/preview/previewStore.ts
@@ -41,26 +41,6 @@ export interface PreviewState {
     earlyFeaturesEnabled: boolean;
 
     /**
-     * Reflects `composePreview.autoEnableCheap.enabled`. When `true`,
-     * the focus inspector auto-enables cheap, suggestion-matched
-     * data products on first sight per scope. Default `false` — the
-     * feature is opt-in so users don't see toggles flip without their
-     * input. Updated at runtime by the `setAutoEnableCheap` extension
-     * message.
-     */
-    autoEnableCheapEnabled: boolean;
-
-    /**
-     * Reflects `composePreview.collapseVariants.enabled`. When `true`,
-     * `PreviewGrid.applyFilters` keeps only one card per function while
-     * neither the function nor the group filter is narrower than `"all"`
-     * — picking a function/group from the toolbar expands the variants
-     * for that selection. Updated at runtime by the
-     * `setCollapseVariants` extension message.
-     */
-    collapseVariantsEnabled: boolean;
-
-    /**
      * `previewId` of the card whose accessibility overlay subscription
      * is currently active, or `null` when no card is subscribed. Set by
      * `toggleA11yOverlay` and cleared on focus navigation, daemon
@@ -155,8 +135,6 @@ export interface PreviewState {
 
 const initialState: PreviewState = {
     earlyFeaturesEnabled: false,
-    autoEnableCheapEnabled: false,
-    collapseVariantsEnabled: true,
     a11yOverlayPreviewId: null,
     focusedPreviewId: null,
     allPreviews: [],

--- a/vscode-extension/src/webview/preview/variantCollapse.ts
+++ b/vscode-extension/src/webview/preview/variantCollapse.ts
@@ -24,7 +24,6 @@ export interface VariantCollapseDecision {
 }
 
 export interface VariantCollapseInput {
-    collapseVariants: boolean;
     /** Current function filter value — `"all"` means no narrowing. */
     fnFilter: string;
     /** Current group filter value — `"all"` means no narrowing. */
@@ -45,10 +44,7 @@ export interface VariantCollapseInput {
 export function decideVariantCollapse(
     input: VariantCollapseInput,
 ): VariantCollapseDecision {
-    const active =
-        input.collapseVariants &&
-        input.fnFilter === "all" &&
-        input.groupFilter === "all";
+    const active = input.fnFilter === "all" && input.groupFilter === "all";
     if (!active) {
         return { active: false, hidden: new Set() };
     }


### PR DESCRIPTION
Remove three configuration settings and their associated feature flag infrastructure:
- `composePreview.autoInject.enabled` — auto-inject is now always on
- `composePreview.autoEnableCheap.enabled` — cheap data products are no longer auto-enabled
- `composePreview.collapseVariants.enabled` — variant collapse is now always on

## Changes

**Extension core (`extension.ts`)**
- Remove `autoInjectEnabled()`, `autoEnableCheapEnabled()`, and `collapseVariantsEnabled()` helper functions
- Always materialize and pass the bundled init script to Gradle (remove conditional check)
- Remove configuration change listeners for the three removed settings
- Simplify `PreviewPanel` constructor by removing feature flag callbacks

**Webview (`main.ts`, `previewStore.ts`, `filterController.ts`)**
- Remove dataset attributes (`data-auto-inject`, `data-auto-enable-cheap`, `data-collapse-variants`) from preview app initialization
- Remove "Apply plugin to project" button that was only shown when auto-inject was disabled
- Remove `autoEnableCheapEnabled` and `collapseVariantsEnabled` from preview store state
- Remove `setAutoEnableCheap` and `setCollapseVariants` message handlers
- Simplify `FilterController` config by removing `collapseVariants()` callback
- Always pass `collapseVariants: true` behavior to `decideVariantCollapse()`

**Grid and variant collapse (`PreviewGrid.ts`, `variantCollapse.ts`)**
- Remove `ApplyFiltersOptions` interface and `collapseVariants` parameter from `applyFilters()`
- Simplify `decideVariantCollapse()` to always collapse variants when no function/group filter is active (remove the `collapseVariants` input flag)

**Configuration and types (`package.json`, `types.ts`)**
- Remove three settings from `package.json` configuration schema
- Remove `setAutoEnableCheap` and `setCollapseVariants` from `ExtensionToWebview` message union type
- Update README to clarify that auto-inject is always enabled

**Tests and fixtures**
- Remove test case for disabled variant collapse feature
- Update test harness fixtures to remove the three dataset attributes
- Update `variantCollapse.test.ts` to remove `collapseVariants` parameter from all test calls

The changes simplify the codebase by removing conditional logic around three features that are now always-on or always-off, reducing configuration surface area and maintenance burden.

https://claude.ai/code/session_0122WaanRijucBrKbDPkrbVm