### PR TITLE
fix: dedupe concurrent discoverPreviews and spare critical tasks from cancellation

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3524,7 +3524,16 @@ async function refresh(
         }
     }
     lastLoadedModules = modulePathList;
-    gradleService.cancel();
+    // Spare any in-flight `:<module>:discoverPreviews` for the module we're
+    // about to refresh. The silent reconcile path
+    // (`reconcilePreviewManifestAfterDaemonReady`) calls `discoverPreviews`
+    // directly, outside this coalesce gate; without the spare, every focus
+    // bounce that re-fires refresh() for the same file kills the reconcile
+    // mid-task. With the spare + the in-flight dedup in
+    // `GradleService.discoverPreviews`, the subsequent `discoverPreviews`
+    // call this refresh issues awaits the same Gradle run instead of
+    // starting a duplicate.
+    gradleService.cancel({ keepDiscoverFor: module.modulePath });
 
     // Forward progress-bar updates to the webview. Single tracker per refresh
     // — single instance feeds the Gradle phase signals (compile/discover/

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -278,6 +278,18 @@ export class GradleService {
         string,
         { manifest: PreviewManifest; timestamp: number }
     >();
+    /**
+     * Tracks in-flight `:<module>:discoverPreviews` runs so concurrent callers
+     * (refresh() + the silent reconciles from daemon `discoveryUpdated` and
+     * `refreshAfterDaemonReady`) share a single Gradle invocation instead of
+     * racing two against each other — where the second would normally hit
+     * `cancel()` and kill the first. Keyed by `modulePath`. Cleared in the
+     * `finally` of the runTask wrapper.
+     */
+    private inFlightDiscover = new Map<
+        string,
+        Promise<PreviewManifest | null>
+    >();
     private taskCounter = 0;
     private activeKeys = new Set<string>();
 
@@ -299,19 +311,30 @@ export class GradleService {
         module: ModuleInfo,
         opts?: TaskOptions,
     ): Promise<PreviewManifest | null> {
-        const cached = this.manifestCache.get(module.modulePath);
+        const key = module.modulePath;
+        const inFlight = this.inFlightDiscover.get(key);
+        if (inFlight) {
+            return inFlight;
+        }
+        const cached = this.manifestCache.get(key);
         if (cached && Date.now() - cached.timestamp < MANIFEST_CACHE_TTL_MS) {
             return cached.manifest;
         }
-        await this.runTask(`${module.modulePath}:discoverPreviews`, [], opts);
-        const manifest = this.readManifest(module);
-        if (manifest) {
-            this.manifestCache.set(module.modulePath, {
-                manifest,
-                timestamp: Date.now(),
-            });
-        }
-        return manifest;
+        const promise = (async (): Promise<PreviewManifest | null> => {
+            await this.runTask(`${key}:discoverPreviews`, [], opts);
+            const manifest = this.readManifest(module);
+            if (manifest) {
+                this.manifestCache.set(key, {
+                    manifest,
+                    timestamp: Date.now(),
+                });
+            }
+            return manifest;
+        })().finally(() => {
+            this.inFlightDiscover.delete(key);
+        });
+        this.inFlightDiscover.set(key, promise);
+        return promise;
     }
 
     /**
@@ -696,24 +719,49 @@ export class GradleService {
         }
     }
 
-    async cancel(): Promise<void> {
-        // `composePreviewDaemonStart` is intentionally excluded from the cancel
-        // pool. It's a one-shot, cheap, idempotent task that writes the launch
-        // descriptor every subsequent refresh needs; cancelling it mid-flight
-        // when the next refresh fires creates a permanent cycle where bootstrap
-        // is killed by the refresh it was supposed to enable, leaving
-        // "no launch descriptor" / "Build cancelled" forever.
+    async cancel(opts?: { keepDiscoverFor?: string }): Promise<void> {
+        // Three task families are intentionally excluded from the cancel pool:
         //
-        // Tradeoff: a refresh that arrives while the first-time bootstrap is
-        // still running now queues behind it on the Gradle daemon (the daemon
-        // serialises clients) instead of jumping the queue. That can add a few
-        // seconds on the very first refresh of a cold module, but only once
-        // per session — the descriptor is then UP-TO-DATE and bootstrap
-        // returns instantly. Steady-state is unaffected.
+        //   - `composePreviewDaemonStart`: a one-shot, cheap, idempotent task
+        //     that writes the launch descriptor every subsequent refresh
+        //     needs. Cancelling it mid-flight when the next refresh fires
+        //     creates a permanent cycle where bootstrap is killed by the
+        //     refresh it was supposed to enable, leaving "no launch
+        //     descriptor" / "Build cancelled" forever.
+        //
+        //   - `composePreviewApplied`: the activation-time marker bootstrap.
+        //     Cancelling it (e.g. when the activation `setTimeout` fires
+        //     while bootstrap is still running) breaks `findPreviewModules`
+        //     for the rest of the session — markers stay missing until the
+        //     user reloads.
+        //
+        //   - `:<module>:discoverPreviews` for [keepDiscoverFor]: the silent
+        //     reconcile path (`reconcilePreviewManifestAfterDaemonReady`)
+        //     calls `discoverPreviews` directly outside the refresh()
+        //     coalesce gate. Without this spare, a subsequent `refresh()`
+        //     for the same module would kill it and re-run an identical
+        //     task — the dedupe in [discoverPreviews] then lets that
+        //     subsequent call await the same in-flight promise.
+        //
+        // Tradeoff: a refresh that arrives while one of these is still
+        // running queues behind it on the Gradle daemon (the daemon
+        // serialises clients) instead of jumping the queue. For the
+        // first-time bootstrap that can add a few seconds on the very
+        // first refresh of a cold module, but only once per session —
+        // the bootstrap then becomes UP-TO-DATE and returns instantly.
+        // Steady-state is unaffected.
+        const keepDiscoverTask = opts?.keepDiscoverFor
+            ? `${opts.keepDiscoverFor}:discoverPreviews`
+            : null;
         const toCancel: string[] = [];
         const toKeep = new Set<string>();
         for (const key of this.activeKeys) {
-            if (taskFromKey(key).endsWith(":composePreviewDaemonStart")) {
+            const task = taskFromKey(key);
+            if (
+                task.endsWith(":composePreviewDaemonStart") ||
+                task === "composePreviewApplied" ||
+                (keepDiscoverTask !== null && task === keepDiscoverTask)
+            ) {
                 toKeep.add(key);
             } else {
                 toCancel.push(key);

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -868,6 +868,74 @@ describe("GradleService", () => {
         );
 
         it(
+            "dedupes concurrent calls into a single Gradle invocation",
+            withTempDir(async (dir) => {
+                // Two refresh paths (refresh() + the silent reconcile from
+                // refreshAfterDaemonReady) can hit discoverPreviews for the
+                // same module concurrently; without the dedupe they race two
+                // identical Gradle tasks, and the second's cancel() kills
+                // the first. The dedupe shares one promise.
+                const runCalls: string[] = [];
+                const resolvers: Array<() => void> = [];
+                const heldApi: GradleApi = {
+                    async runTask(opts) {
+                        runCalls.push(opts.taskName);
+                        await new Promise<void>((r) => {
+                            resolvers.push(r);
+                        });
+                    },
+                    async cancelRunTask() {},
+                };
+                fs.mkdirSync(path.join(dir, "mod"));
+                const manifestDir = path.join(
+                    dir,
+                    "mod",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.copyFileSync(
+                    path.join(
+                        __dirname,
+                        "..",
+                        "..",
+                        "src",
+                        "test",
+                        "fixtures",
+                        "previews.json",
+                    ),
+                    path.join(manifestDir, "previews.json"),
+                );
+
+                const service = new GradleService(dir, heldApi);
+                const first = service.discoverPreviews({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
+                const second = service.discoverPreviews({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
+
+                // Release the single in-flight runTask call.
+                await new Promise((resolve) => setImmediate(resolve));
+                assert.strictEqual(
+                    runCalls.length,
+                    1,
+                    `concurrent callers must share one Gradle run, got: ${runCalls.length}`,
+                );
+                for (const r of resolvers) r();
+
+                const [firstManifest, secondManifest] = await Promise.all([
+                    first,
+                    second,
+                ]);
+                assert.notStrictEqual(firstManifest, null);
+                assert.strictEqual(firstManifest, secondManifest);
+            }),
+        );
+
+        it(
             "uses cache for repeated calls within TTL",
             withTempDir(async (dir, api) => {
                 fs.mkdirSync(path.join(dir, "mod"));
@@ -1154,6 +1222,111 @@ describe("GradleService", () => {
                 // Release both held tasks so the test cleans up.
                 for (const r of resolvers) r();
                 await Promise.all([bootstrap, render]);
+            }),
+        );
+
+        it(
+            "skips composePreviewApplied so the activation refresh can't kill the marker bootstrap mid-flight",
+            withTempDir(async (dir, api) => {
+                const resolvers: Array<() => void> = [];
+                const heldApi: GradleApi = {
+                    async runTask(opts) {
+                        api.runCalls.push({
+                            taskName: opts.taskName,
+                            cancellationKey: opts.cancellationKey,
+                        });
+                        await new Promise<void>((r) => {
+                            resolvers.push(r);
+                        });
+                    },
+                    async cancelRunTask(opts) {
+                        api.cancelCalls.push({
+                            taskName: opts.taskName,
+                            cancellationKey: opts.cancellationKey,
+                        });
+                    },
+                };
+                const service = new GradleService(dir, heldApi);
+
+                const applied = service
+                    .bootstrapAppliedMarkers()
+                    .catch(() => {});
+                const render = service
+                    .discoverPreviews({ projectDir: "mod", modulePath: ":mod" })
+                    .catch(() => {});
+                await new Promise((resolve) => setImmediate(resolve));
+                await new Promise((resolve) => setImmediate(resolve));
+
+                await service.cancel();
+
+                const cancelledTasks = api.cancelCalls.map((c) => c.taskName);
+                assert.ok(
+                    !cancelledTasks.some((t) => t === "composePreviewApplied"),
+                    `composePreviewApplied must not be cancelled, got: ${cancelledTasks.join(", ")}`,
+                );
+                assert.ok(
+                    cancelledTasks.some((t) => t.endsWith(":discoverPreviews")),
+                    `other tasks must still be cancelled, got: ${cancelledTasks.join(", ")}`,
+                );
+
+                for (const r of resolvers) r();
+                await Promise.all([applied, render]);
+            }),
+        );
+
+        it(
+            "spares the in-flight :<module>:discoverPreviews when cancel({keepDiscoverFor}) names that module",
+            withTempDir(async (dir, api) => {
+                const resolvers: Array<() => void> = [];
+                const heldApi: GradleApi = {
+                    async runTask(opts) {
+                        api.runCalls.push({
+                            taskName: opts.taskName,
+                            cancellationKey: opts.cancellationKey,
+                        });
+                        await new Promise<void>((r) => {
+                            resolvers.push(r);
+                        });
+                    },
+                    async cancelRunTask(opts) {
+                        api.cancelCalls.push({
+                            taskName: opts.taskName,
+                            cancellationKey: opts.cancellationKey,
+                        });
+                    },
+                };
+                const service = new GradleService(dir, heldApi);
+
+                // Two in-flight discoverPreviews for different modules.
+                const keepRun = service
+                    .discoverPreviews({
+                        projectDir: "keep",
+                        modulePath: ":keep",
+                    })
+                    .catch(() => {});
+                const dropRun = service
+                    .discoverPreviews({
+                        projectDir: "drop",
+                        modulePath: ":drop",
+                    })
+                    .catch(() => {});
+                await new Promise((resolve) => setImmediate(resolve));
+                await new Promise((resolve) => setImmediate(resolve));
+
+                await service.cancel({ keepDiscoverFor: ":keep" });
+
+                const cancelledTasks = api.cancelCalls.map((c) => c.taskName);
+                assert.ok(
+                    !cancelledTasks.some((t) => t === ":keep:discoverPreviews"),
+                    `:keep:discoverPreviews must not be cancelled, got: ${cancelledTasks.join(", ")}`,
+                );
+                assert.ok(
+                    cancelledTasks.some((t) => t === ":drop:discoverPreviews"),
+                    `:drop:discoverPreviews must be cancelled, got: ${cancelledTasks.join(", ")}`,
+                );
+
+                for (const r of resolvers) r();
+                await Promise.all([keepRun, dropRun]);
             }),
         );
     });


### PR DESCRIPTION
## Summary

This change fixes race conditions in the Gradle preview discovery system by:
1. Deduplicating concurrent `discoverPreviews` calls for the same module into a single Gradle invocation
2. Protecting critical bootstrap tasks from cancellation
3. Allowing selective sparing of in-flight discovery tasks during refresh

## Key Changes

- **Deduplicate concurrent discovery calls**: Added `inFlightDiscover` map to `GradleService` to track in-flight `:<module>:discoverPreviews` tasks. When multiple callers request discovery for the same module concurrently, they now share a single Gradle invocation instead of racing two identical tasks.

- **Protect critical tasks from cancellation**: Extended the `cancel()` method to spare three task families:
  - `composePreviewDaemonStart`: one-shot bootstrap that writes the launch descriptor
  - `composePreviewApplied`: activation-time marker bootstrap
  - `:<module>:discoverPreviews` for a specified module: allows the silent reconcile path to complete without being killed by subsequent refresh calls

- **Selective task sparing in refresh**: Modified `refresh()` in `extension.ts` to call `cancel({ keepDiscoverFor: module.modulePath })`, sparing the in-flight discovery for the module being refreshed. This prevents the focus-bounce pattern from repeatedly killing the silent reconcile's discovery task.

## Implementation Details

The deduplication works by storing promises in `inFlightDiscover` keyed by module path. Concurrent callers check this map first before starting a new Gradle task. The promise is removed in a `finally` block after the task completes.

The cancellation logic now evaluates three conditions before marking a task for cancellation, with detailed comments explaining the tradeoffs: queuing behind protected tasks on the Gradle daemon adds latency only on first refresh of a cold module, but prevents permanent cycles where bootstrap is killed by the refresh it was supposed to enable.

Three new test cases validate:
1. Concurrent calls to `discoverPreviews` for the same module share one Gradle run
2. `composePreviewApplied` is never cancelled
3. `discoverPreviews` for a specified module is spared when `cancel({ keepDiscoverFor })` is used

https://claude.ai/code/session_01PYxbFHDrynNSKBDPbNdnc5