### PR TITLE
feat: add plugin pre-application detection and warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,14 @@ jobs:
       # `id("ee.schimke.composeai.preview") version "<v>"` resolves) and builds the CLI install
       # dist (so the `bundle render` subprocess has its `lib-renderer/` companion). Opt-in via
       # `-Pbundle.render.e2e=true` because the test cold-starts Compose Desktop per preview.
+      #
+      # Split into two phases to dodge a parallel-execution race: the gradle-plugin functionalTest
+      # task (in the included build) can start before `:cli:installDist` finishes copying the
+      # CLI's lib jars, so the test's first `compose-preview` subprocess crashes with
+      # `NoClassDefFoundError` against a half-populated lib dir. Pre-building the install dir
+      # serialises the two and is otherwise no-op (the second run sees up-to-date inputs).
+      - name: Pre-build CLI install + publish plugin
+        run: ./gradlew :cli:installDist :gradle-plugin:publishToMavenLocal --stacktrace
       - name: Bundle render e2e
         run: ./gradlew functionalTestWithBundleRender -Pbundle.render.e2e=true --stacktrace
       - name: Upload functionalTest reports on failure

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,3 +104,16 @@ tasks.register("functionalTestWithBundleRender") {
   dependsOn(":cli:installDist")
   dependsOn(gradle.includedBuild("gradle-plugin").task(":functionalTest"))
 }
+
+// `:cli:installDist` and the included build's `functionalTest` would otherwise run in parallel
+// (Gradle's parallel scheduler doesn't serialise cross-build deps automatically). The functional
+// test invokes the CLI via `ProcessBuilder`, so it crashes with `NoClassDefFoundError` against a
+// half-populated `lib/` dir. Enforce ordering at task-graph-ready time — the test mustRunAfter the
+// install. Applies to both `functionalTestWithAndroid` and `functionalTestWithBundleRender`; both
+// drive the CLI binary out of the same `:cli:installDist` outputs.
+gradle.taskGraph.whenReady {
+  val installCli = allTasks.firstOrNull { it.path == ":cli:installDist" } ?: return@whenReady
+  allTasks
+    .filter { it.path.endsWith(":functionalTest") && it.path.contains("gradle-plugin") }
+    .forEach { it.mustRunAfter(installCli) }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -198,7 +198,9 @@ private val PLUGIN_APPLY_FALSE_RE = Regex("""\bapply\s+false\b""")
  *
  * Conservative on the "applied" side: a line matching [PLUGIN_APPLIED_RE] with `apply false` on the
  * same line is skipped — that's the root-build pattern where a plugin is declared for subprojects
- * but not applied in the current module.
+ * but not applied in the current module. Single-line `// …` and block `/* … */` comments are
+ * stripped before matching: a script that *documents* the plugin in a comment shouldn't be
+ * misclassified as having applied it.
  */
 internal fun pluginAppliedInBuildScripts(projectRoot: File, maxDepth: Int = 6): Boolean {
   val skipDirs = setOf("build", ".gradle", ".git", "node_modules", "out", ".idea")
@@ -207,7 +209,8 @@ internal fun pluginAppliedInBuildScripts(projectRoot: File, maxDepth: Int = 6): 
     val children = dir.listFiles() ?: return false
     for (child in children) {
       if (child.isFile && (child.name == "build.gradle.kts" || child.name == "build.gradle")) {
-        val text = runCatching { child.readText() }.getOrNull() ?: continue
+        val raw = runCatching { child.readText() }.getOrNull() ?: continue
+        val text = stripGradleComments(raw)
         for (line in text.lineSequence()) {
           if (!PLUGIN_APPLIED_RE.containsMatchIn(line)) continue
           if (PLUGIN_APPLY_FALSE_RE.containsMatchIn(line)) continue
@@ -223,6 +226,34 @@ internal fun pluginAppliedInBuildScripts(projectRoot: File, maxDepth: Int = 6): 
     return false
   }
   return scan(projectRoot, 0)
+}
+
+/**
+ * Removes `// …` line comments and `/* … */` block comments from a Gradle build script before the
+ * pre-application detector scans it. Doesn't try to be a full Kotlin / Groovy parser: enough to
+ * keep a `// id("ee.schimke.composeai.preview")` documentation line out of a positive match. String
+ * literals aren't tracked — a deliberately-quoted comment-prefix inside a string is rare enough in
+ * build scripts to ignore.
+ */
+internal fun stripGradleComments(source: String): String {
+  val sb = StringBuilder(source.length)
+  var i = 0
+  while (i < source.length) {
+    val c = source[i]
+    val next = source.getOrNull(i + 1)
+    if (c == '/' && next == '/') {
+      val newline = source.indexOf('\n', i)
+      if (newline < 0) break
+      i = newline
+    } else if (c == '/' && next == '*') {
+      val end = source.indexOf("*/", i + 2)
+      i = if (end < 0) source.length else end + 2
+    } else {
+      sb.append(c)
+      i++
+    }
+  }
+  return sb.toString()
 }
 
 private val pluginWarningPrinted = AtomicBoolean(false)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli
 
 import java.io.File
 import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Auto-inject the `ee.schimke.composeai.preview` Gradle plugin into the user's build via
@@ -41,8 +42,16 @@ internal fun renderInitScript(pluginVersion: String): String =
 //
 // Application uses pluginManager.withPlugin(...) (not afterEvaluate) so AGP
 // finalizeDsl / onVariants callbacks register before the DSL lock.
+//
+// `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1` opts the buildscript repos into
+// `mavenLocal()` — exercised by the gradle-plugin functional tests, which
+// resolve the plugin from `~/.m2` (where `:publishToMavenLocal` puts it)
+// rather than Maven Central. Plain users have no reason to flip this on:
+// it widens the search surface to whatever snapshots happen to be cached
+// locally and is therefore opt-in, not the default.
 
 val pluginVersion = "$pluginVersion"
+val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
 
 allprojects {
     buildscript {
@@ -50,6 +59,7 @@ allprojects {
             gradlePluginPortal()
             mavenCentral()
             google()
+            if (useMavenLocal) mavenLocal()
         }
         dependencies {
             add(
@@ -155,4 +165,94 @@ internal fun hasIncludedPluginBuild(projectRoot: File): Boolean {
     listOf(File(projectRoot, "settings.gradle.kts"), File(projectRoot, "settings.gradle"))
   val pattern = Regex("""includeBuild\s*\(\s*["']gradle-plugin["']\s*\)""")
   return candidates.any { it.isFile && pattern.containsMatchIn(it.readText()) }
+}
+
+/**
+ * Matches the plugin being *applied* literally — `id("ee.schimke.composeai.preview")`, `id
+ * "ee.schimke.composeai.preview"`, or `apply(plugin = "ee.schimke.composeai.preview")` — in any
+ * build script. Kept in sync with the VS Code extension's `APPLIES_PLUGIN_RE`.
+ *
+ * The version-catalog alias form (`alias(libs.plugins.<x>)`) is intentionally out of scope: there's
+ * no way to know from the build script alone which alias maps to which plugin id without parsing
+ * `gradle/libs.versions.toml`. Consumers using catalogs see a spurious warning the first time — the
+ * opt-out flag is documented in the warning text.
+ */
+private val PLUGIN_APPLIED_RE =
+  Regex("""(?:\bid\s*[(\s]\s*|apply\s*\(\s*plugin\s*=\s*)["']ee\.schimke\.composeai\.preview["']""")
+
+private val PLUGIN_APPLY_FALSE_RE = Regex("""\bapply\s+false\b""")
+
+/**
+ * True when *any* `build.gradle.kts` / `build.gradle` under [projectRoot] applies the plugin
+ * literally. Walks the project tree (max depth 6, skipping `build/`, `.gradle/`, `.git/`,
+ * `node_modules/`) to cover deeply nested module layouts. Returns false on the first hint that the
+ * plugin is supplied entirely via auto-inject so callers can nudge the user toward a permanent
+ * `plugins { ... }` entry.
+ *
+ * Conservative on the "applied" side: a line matching [PLUGIN_APPLIED_RE] with `apply false` on the
+ * same line is skipped — that's the root-build pattern where a plugin is declared for subprojects
+ * but not applied in the current module.
+ */
+internal fun pluginAppliedInBuildScripts(projectRoot: File, maxDepth: Int = 6): Boolean {
+  val skipDirs = setOf("build", ".gradle", ".git", "node_modules", "out", ".idea")
+  fun scan(dir: File, depth: Int): Boolean {
+    if (depth > maxDepth) return false
+    val children = dir.listFiles() ?: return false
+    for (child in children) {
+      if (child.isFile && (child.name == "build.gradle.kts" || child.name == "build.gradle")) {
+        val text = runCatching { child.readText() }.getOrNull() ?: continue
+        for (line in text.lineSequence()) {
+          if (!PLUGIN_APPLIED_RE.containsMatchIn(line)) continue
+          if (PLUGIN_APPLY_FALSE_RE.containsMatchIn(line)) continue
+          return true
+        }
+      }
+    }
+    for (child in children) {
+      if (child.isDirectory && child.name !in skipDirs && !child.name.startsWith(".")) {
+        if (scan(child, depth + 1)) return true
+      }
+    }
+    return false
+  }
+  return scan(projectRoot, 0)
+}
+
+private val pluginWarningPrinted = AtomicBoolean(false)
+
+/**
+ * Warns once per CLI process when the project relies entirely on auto-inject — i.e. no module's
+ * build script applies `ee.schimke.composeai.preview` directly. The CLI continues to function, but
+ * a permanent `plugins { id("ee.schimke.composeai.preview") version "<v>" }` declaration unlocks
+ * IDE / agent integrations that read the project's static config (VS Code's marker scan, Android
+ * Studio gutter icons) and avoids the per-invocation init-script materialisation cost.
+ *
+ * Skipped when auto-inject itself is disabled — the user has opted out of the bundled flow and the
+ * warning would be noise.
+ *
+ * Suppressible via `--no-plugin-warning` on the CLI invocation or
+ * `COMPOSE_PREVIEW_NO_PLUGIN_WARNING=1` in the environment.
+ */
+internal fun warnIfPluginNotPreApplied(
+  args: List<String>,
+  projectRoot: File,
+  pluginVersion: String = BUNDLE_VERSION,
+  env: (String) -> String? = System::getenv,
+  stderr: (String) -> Unit = System.err::println,
+  resetFlag: Boolean = false,
+) {
+  if (resetFlag) pluginWarningPrinted.set(false)
+  if ("--no-auto-inject" in args) return
+  if (env("COMPOSE_PREVIEW_NO_AUTO_INJECT") == "1") return
+  if ("--no-plugin-warning" in args) return
+  if (env("COMPOSE_PREVIEW_NO_PLUGIN_WARNING") == "1") return
+  if (hasIncludedPluginBuild(projectRoot)) return
+  if (pluginAppliedInBuildScripts(projectRoot)) return
+  if (!pluginWarningPrinted.compareAndSet(false, true)) return
+  stderr(
+    "compose-preview: plugin not applied in any build.gradle(.kts); running via auto-inject. " +
+      "For best IDE / agent support add to your module's plugins { } block: " +
+      "id(\"ee.schimke.composeai.preview\") version \"$pluginVersion\" " +
+      "(suppress with --no-plugin-warning or COMPOSE_PREVIEW_NO_PLUGIN_WARNING=1)."
+  )
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -168,9 +168,14 @@ internal fun hasIncludedPluginBuild(projectRoot: File): Boolean {
 }
 
 /**
- * Matches the plugin being *applied* literally — `id("ee.schimke.composeai.preview")`, `id
- * "ee.schimke.composeai.preview"`, or `apply(plugin = "ee.schimke.composeai.preview")` — in any
- * build script. Kept in sync with the VS Code extension's `APPLIES_PLUGIN_RE`.
+ * Matches the plugin being *applied* literally in any build script — covers
+ * - Kotlin DSL: `id("ee.schimke.composeai.preview")`,
+ * - Groovy DSL: `id 'ee.schimke.composeai.preview'`,
+ * - Kotlin DSL legacy: `apply(plugin = "ee.schimke.composeai.preview")`,
+ * - Groovy DSL legacy: `apply plugin: 'ee.schimke.composeai.preview'`.
+ *
+ * Kept in sync with the VS Code extension's `APPLIES_PLUGIN_RE` plus the extra Groovy `apply
+ * plugin:` legacy form (Codex P2 review on PR #1171).
  *
  * The version-catalog alias form (`alias(libs.plugins.<x>)`) is intentionally out of scope: there's
  * no way to know from the build script alone which alias maps to which plugin id without parsing
@@ -178,7 +183,9 @@ internal fun hasIncludedPluginBuild(projectRoot: File): Boolean {
  * opt-out flag is documented in the warning text.
  */
 private val PLUGIN_APPLIED_RE =
-  Regex("""(?:\bid\s*[(\s]\s*|apply\s*\(\s*plugin\s*=\s*)["']ee\.schimke\.composeai\.preview["']""")
+  Regex(
+    """(?:\bid\s*[(\s]\s*|apply\s*\(\s*plugin\s*=\s*|\bapply\s+plugin\s*:\s*)["']ee\.schimke\.composeai\.preview["']"""
+  )
 
 private val PLUGIN_APPLY_FALSE_RE = Regex("""\bapply\s+false\b""")
 
@@ -227,8 +234,13 @@ private val pluginWarningPrinted = AtomicBoolean(false)
  * IDE / agent integrations that read the project's static config (VS Code's marker scan, Android
  * Studio gutter icons) and avoids the per-invocation init-script materialisation cost.
  *
- * Skipped when auto-inject itself is disabled — the user has opted out of the bundled flow and the
- * warning would be noise.
+ * [autoInjectActive] must be `true` only when [autoInjectInitScriptArgs] actually returned an
+ * `--init-script` pair this run — passing the result through avoids the false-positive "running via
+ * auto-inject" warning when the init-script materialisation failed (e.g. unwritable cache dir, disk
+ * full), in which case the CLI is running with *no* plugin source at all and should not pretend
+ * auto-inject saved the day (Codex P2 review on PR #1171). The function also bails when auto-inject
+ * is disabled by flag / env opt-out — defence in depth in case a caller forgets to read
+ * [autoInjectActive] off [autoInjectInitScriptArgs].
  *
  * Suppressible via `--no-plugin-warning` on the CLI invocation or
  * `COMPOSE_PREVIEW_NO_PLUGIN_WARNING=1` in the environment.
@@ -236,12 +248,14 @@ private val pluginWarningPrinted = AtomicBoolean(false)
 internal fun warnIfPluginNotPreApplied(
   args: List<String>,
   projectRoot: File,
+  autoInjectActive: Boolean,
   pluginVersion: String = BUNDLE_VERSION,
   env: (String) -> String? = System::getenv,
   stderr: (String) -> Unit = System.err::println,
   resetFlag: Boolean = false,
 ) {
   if (resetFlag) pluginWarningPrinted.set(false)
+  if (!autoInjectActive) return
   if ("--no-auto-inject" in args) return
   if (env("COMPOSE_PREVIEW_NO_AUTO_INJECT") == "1") return
   if ("--no-plugin-warning" in args) return

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -348,7 +348,7 @@ abstract class Command(protected val args: List<String>) {
           exitProcess(1)
         }
     val injectArgs = autoInjectInitScriptArgs(args, projectRoot = root)
-    warnIfPluginNotPreApplied(args, projectRoot = root)
+    warnIfPluginNotPreApplied(args, projectRoot = root, autoInjectActive = injectArgs.isNotEmpty())
     val connection =
       withGradleStdout(silenceStdout) {
         GradleConnection(root, verbose, progress, extraArguments = injectArgs)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -348,6 +348,7 @@ abstract class Command(protected val args: List<String>) {
           exitProcess(1)
         }
     val injectArgs = autoInjectInitScriptArgs(args, projectRoot = root)
+    warnIfPluginNotPreApplied(args, projectRoot = root)
     val connection =
       withGradleStdout(silenceStdout) {
         GradleConnection(root, verbose, progress, extraArguments = injectArgs)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -306,23 +306,23 @@ class DoctorCommand(private val args: List<String>) {
 
   private fun runProjectChecks(projectDir: File) {
     var gradleAccessFailure: GradleAccessFailure? = null
-    warnIfPluginNotPreApplied(args, projectRoot = projectDir)
+    val injectArgs = autoInjectInitScriptArgs(args, projectRoot = projectDir)
+    warnIfPluginNotPreApplied(
+      args,
+      projectRoot = projectDir,
+      autoInjectActive = injectArgs.isNotEmpty(),
+    )
     val model =
       try {
-        GradleConnection(
-            projectDir,
-            verbose = verbose,
-            extraArguments = autoInjectInitScriptArgs(args, projectRoot = projectDir),
-          )
-          .use { gc ->
-            // Daemon-JVM + Gradle-version snapshot. Runs first so other
-            // project-scope checks can compare against the daemon's JDK
-            // (e.g. flagging test worker mismatch in #142).
-            checkGradleDaemon(gc)
-            gc.runBuildAction(GatherComposePreviewModelAction()).also {
-              gradleAccessFailure = gc.lastModelAccessFailure
-            }
+        GradleConnection(projectDir, verbose = verbose, extraArguments = injectArgs).use { gc ->
+          // Daemon-JVM + Gradle-version snapshot. Runs first so other
+          // project-scope checks can compare against the daemon's JDK
+          // (e.g. flagging test worker mismatch in #142).
+          checkGradleDaemon(gc)
+          gc.runBuildAction(GatherComposePreviewModelAction()).also {
+            gradleAccessFailure = gc.lastModelAccessFailure
           }
+        }
       } catch (e: Exception) {
         addCheck(
           DoctorCheck(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -306,6 +306,7 @@ class DoctorCommand(private val args: List<String>) {
 
   private fun runProjectChecks(projectDir: File) {
     var gradleAccessFailure: GradleAccessFailure? = null
+    warnIfPluginNotPreApplied(args, projectRoot = projectDir)
     val model =
       try {
         GradleConnection(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -164,6 +164,11 @@ private fun printUsage() {
                            already wired manually and you don't want the bundled
                            classpath dependency added. `COMPOSE_PREVIEW_NO_AUTO_INJECT=1`
                            is an equivalent environment-variable escape hatch.
+      --no-plugin-warning  Suppress the one-line stderr warning emitted when the plugin is
+                           supplied entirely via auto-inject (i.e. no build.gradle(.kts)
+                           applies `id("ee.schimke.composeai.preview")`).
+                           `COMPOSE_PREVIEW_NO_PLUGIN_WARNING=1` is an equivalent
+                           environment-variable escape hatch.
 
     OSC 9;4 terminal progress (native taskbar/tab progress bar) is on by
     default in a TTY and auto-disables when stdout is piped or redirected.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -130,6 +130,7 @@ internal class McpCommand(args: List<String>) {
         verbose = "--verbose" in args || "-v" in args,
         extraArguments = autoInjectInitScriptArgs(args, projectRoot = projectDir),
       )
+    warnIfPluginNotPreApplied(args, projectRoot = projectDir)
     connection.use { gc ->
       val allModules = gc.findPreviewModules()
       val modules =
@@ -353,6 +354,7 @@ internal class McpCommand(args: List<String>) {
         verbose = false,
         extraArguments = autoInjectInitScriptArgs(args, projectRoot = projectDir),
       )
+    warnIfPluginNotPreApplied(args, projectRoot = projectDir)
     connection.use { gc ->
       val allModules = gc.findPreviewModules()
       val modules =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -124,13 +124,18 @@ internal class McpCommand(args: List<String>) {
     val projectDir = resolveProjectDir(args)
     val moduleFilter = args.flagValuesAll("--module").map { it.removePrefix(":") }.toSet()
 
+    val injectArgs = autoInjectInitScriptArgs(args, projectRoot = projectDir)
     val connection =
       GradleConnection(
         projectDir,
         verbose = "--verbose" in args || "-v" in args,
-        extraArguments = autoInjectInitScriptArgs(args, projectRoot = projectDir),
+        extraArguments = injectArgs,
       )
-    warnIfPluginNotPreApplied(args, projectRoot = projectDir)
+    warnIfPluginNotPreApplied(
+      args,
+      projectRoot = projectDir,
+      autoInjectActive = injectArgs.isNotEmpty(),
+    )
     connection.use { gc ->
       val allModules = gc.findPreviewModules()
       val modules =
@@ -348,13 +353,13 @@ internal class McpCommand(args: List<String>) {
     val projectDir = resolveProjectDir(args)
     val moduleFilter = args.flagValuesAll("--module").map { it.removePrefix(":") }.toSet()
 
-    val connection =
-      GradleConnection(
-        projectDir,
-        verbose = false,
-        extraArguments = autoInjectInitScriptArgs(args, projectRoot = projectDir),
-      )
-    warnIfPluginNotPreApplied(args, projectRoot = projectDir)
+    val injectArgs = autoInjectInitScriptArgs(args, projectRoot = projectDir)
+    val connection = GradleConnection(projectDir, verbose = false, extraArguments = injectArgs)
+    warnIfPluginNotPreApplied(
+      args,
+      projectRoot = projectDir,
+      autoInjectActive = injectArgs.isNotEmpty(),
+    )
     connection.use { gc ->
       val allModules = gc.findPreviewModules()
       val modules =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -318,6 +318,49 @@ class AutoInjectTest {
   }
 
   @Test
+  fun `pluginAppliedInBuildScripts ignores plugin id appearing inside a line comment`() {
+    // Synthetic test fixtures document *what they removed* in a comment so the next reader
+    // understands the intent:
+    //
+    //     // No id("ee.schimke.composeai.preview") on purpose — auto-inject handles it.
+    //     plugins { ... }
+    //
+    // Without comment stripping the detector matches the literal id inside the comment and
+    // misclassifies the project as having the plugin pre-applied — silencing the warning the
+    // tests then assert on.
+    val root = tempDir()
+    File(root, "build.gradle.kts")
+      .writeText(
+        """
+        // No id("ee.schimke.composeai.preview") on purpose — auto-inject handles it.
+        plugins {
+            id("com.android.library") version "9.2.0"
+        }
+        """
+          .trimIndent()
+      )
+    assertFalse(pluginAppliedInBuildScripts(root))
+  }
+
+  @Test
+  fun `pluginAppliedInBuildScripts ignores plugin id inside a block comment`() {
+    val root = tempDir()
+    File(root, "build.gradle.kts")
+      .writeText(
+        """
+        /**
+         * Apply id("ee.schimke.composeai.preview") manually if you don't want auto-inject.
+         */
+        plugins {
+            id("com.android.library") version "9.2.0"
+        }
+        """
+          .trimIndent()
+      )
+    assertFalse(pluginAppliedInBuildScripts(root))
+  }
+
+  @Test
   fun `pluginAppliedInBuildScripts matches Groovy 'apply plugin' legacy form`() {
     // Codex P2 review on PR #1171: legacy Groovy `apply plugin: '...'` is still common in
     // long-lived consumer projects. The detector must not misclassify these as "not pre-applied".

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -285,6 +285,212 @@ class AutoInjectTest {
   }
 
   @Test
+  fun `pluginAppliedInBuildScripts finds the literal id form in a root build script`() {
+    val root = tempDir()
+    File(root, "build.gradle.kts")
+      .writeText(
+        """
+        plugins {
+            id("com.android.library") version "9.2.0"
+            id("ee.schimke.composeai.preview") version "0.10.0"
+        }
+        """
+          .trimIndent()
+      )
+    assertTrue(pluginAppliedInBuildScripts(root))
+  }
+
+  @Test
+  fun `pluginAppliedInBuildScripts finds the Groovy DSL form in a nested module`() {
+    val root = tempDir()
+    val module = File(root, "app").apply { mkdirs() }
+    File(module, "build.gradle")
+      .writeText(
+        """
+        plugins {
+            id 'com.android.application'
+            id 'ee.schimke.composeai.preview' version '0.10.0'
+        }
+        """
+          .trimIndent()
+      )
+    assertTrue(pluginAppliedInBuildScripts(root))
+  }
+
+  @Test
+  fun `pluginAppliedInBuildScripts skips apply false lines (root-build subprojects pattern)`() {
+    val root = tempDir()
+    File(root, "build.gradle.kts")
+      .writeText(
+        """
+        plugins {
+            id("ee.schimke.composeai.preview") version "0.10.0" apply false
+        }
+        """
+          .trimIndent()
+      )
+    assertFalse(pluginAppliedInBuildScripts(root))
+  }
+
+  @Test
+  fun `pluginAppliedInBuildScripts returns false when only host plugins are applied`() {
+    val root = tempDir()
+    File(root, "build.gradle.kts")
+      .writeText(
+        """
+        plugins {
+            id("com.android.library") version "9.2.0"
+            id("org.jetbrains.kotlin.plugin.compose") version "2.3.20"
+        }
+        """
+          .trimIndent()
+      )
+    assertFalse(pluginAppliedInBuildScripts(root))
+  }
+
+  @Test
+  fun `pluginAppliedInBuildScripts skips build directories`() {
+    val root = tempDir()
+    val staleBuild = File(root, "build/some-cache").apply { mkdirs() }
+    File(staleBuild, "build.gradle.kts").writeText("""id("ee.schimke.composeai.preview")""")
+    assertFalse(pluginAppliedInBuildScripts(root), "build/ scratch directories must not be scanned")
+  }
+
+  @Test
+  fun `warnIfPluginNotPreApplied emits when plugin is not in any build script`() {
+    val root = tempDir()
+    File(root, "build.gradle.kts")
+      .writeText("plugins { id(\"com.android.library\") version \"9.2.0\" }")
+    val warnings = mutableListOf<String>()
+    warnIfPluginNotPreApplied(
+      args = emptyList(),
+      projectRoot = root,
+      pluginVersion = "0.10.0",
+      env = { null },
+      stderr = { warnings += it },
+      resetFlag = true,
+    )
+    assertEquals(1, warnings.size)
+    assertTrue(
+      warnings.single().contains("plugin not applied"),
+      "unexpected warning text: ${warnings.single()}",
+    )
+    assertTrue(
+      warnings.single().contains("0.10.0"),
+      "warning should include the plugin version to copy/paste; got: ${warnings.single()}",
+    )
+  }
+
+  @Test
+  fun `warnIfPluginNotPreApplied stays silent when plugin is applied literally`() {
+    val root = tempDir()
+    File(root, "build.gradle.kts")
+      .writeText(
+        """
+        plugins {
+            id("com.android.library")
+            id("ee.schimke.composeai.preview") version "0.10.0"
+        }
+        """
+          .trimIndent()
+      )
+    val warnings = mutableListOf<String>()
+    warnIfPluginNotPreApplied(
+      args = emptyList(),
+      projectRoot = root,
+      env = { null },
+      stderr = { warnings += it },
+      resetFlag = true,
+    )
+    assertTrue(warnings.isEmpty(), "expected no warning when plugin is applied; got $warnings")
+  }
+
+  @Test
+  fun `warnIfPluginNotPreApplied honours --no-plugin-warning`() {
+    val root = tempDir()
+    File(root, "build.gradle.kts").writeText("plugins { id(\"com.android.library\") }")
+    val warnings = mutableListOf<String>()
+    warnIfPluginNotPreApplied(
+      args = listOf("--no-plugin-warning"),
+      projectRoot = root,
+      env = { null },
+      stderr = { warnings += it },
+      resetFlag = true,
+    )
+    assertTrue(warnings.isEmpty())
+  }
+
+  @Test
+  fun `warnIfPluginNotPreApplied honours COMPOSE_PREVIEW_NO_PLUGIN_WARNING`() {
+    val root = tempDir()
+    File(root, "build.gradle.kts").writeText("plugins { id(\"com.android.library\") }")
+    val warnings = mutableListOf<String>()
+    warnIfPluginNotPreApplied(
+      args = emptyList(),
+      projectRoot = root,
+      env = { name -> if (name == "COMPOSE_PREVIEW_NO_PLUGIN_WARNING") "1" else null },
+      stderr = { warnings += it },
+      resetFlag = true,
+    )
+    assertTrue(warnings.isEmpty())
+  }
+
+  @Test
+  fun `warnIfPluginNotPreApplied stays silent when auto-inject is disabled`() {
+    val root = tempDir()
+    File(root, "build.gradle.kts").writeText("plugins { id(\"com.android.library\") }")
+    val warnings = mutableListOf<String>()
+    warnIfPluginNotPreApplied(
+      args = listOf("--no-auto-inject"),
+      projectRoot = root,
+      env = { null },
+      stderr = { warnings += it },
+      resetFlag = true,
+    )
+    assertTrue(
+      warnings.isEmpty(),
+      "no auto-inject ⇒ user has opted out of the bundled flow; don't nag them",
+    )
+  }
+
+  @Test
+  fun `warnIfPluginNotPreApplied stays silent in the compose-ai-tools dev loop`() {
+    val root = tempDir()
+    File(root, "settings.gradle.kts").writeText("includeBuild(\"gradle-plugin\")")
+    File(root, "build.gradle.kts").writeText("plugins { id(\"com.android.library\") }")
+    val warnings = mutableListOf<String>()
+    warnIfPluginNotPreApplied(
+      args = emptyList(),
+      projectRoot = root,
+      env = { null },
+      stderr = { warnings += it },
+      resetFlag = true,
+    )
+    assertTrue(warnings.isEmpty())
+  }
+
+  @Test
+  fun `warnIfPluginNotPreApplied prints at most once per process`() {
+    val root = tempDir()
+    File(root, "build.gradle.kts").writeText("plugins { id(\"com.android.library\") }")
+    val warnings = mutableListOf<String>()
+    warnIfPluginNotPreApplied(
+      args = emptyList(),
+      projectRoot = root,
+      env = { null },
+      stderr = { warnings += it },
+      resetFlag = true,
+    )
+    warnIfPluginNotPreApplied(
+      args = emptyList(),
+      projectRoot = root,
+      env = { null },
+      stderr = { warnings += it },
+    )
+    assertEquals(1, warnings.size, "second call should not re-emit; got $warnings")
+  }
+
+  @Test
   fun `autoInjectInitScriptArgs swallows materialise failures and downgrades to no-inject`() {
     // Point storage at a path that can't be created: a regular file masquerading as a parent dir.
     val parent = tempDir()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -318,6 +318,37 @@ class AutoInjectTest {
   }
 
   @Test
+  fun `pluginAppliedInBuildScripts matches Groovy 'apply plugin' legacy form`() {
+    // Codex P2 review on PR #1171: legacy Groovy `apply plugin: '...'` is still common in
+    // long-lived consumer projects. The detector must not misclassify these as "not pre-applied".
+    val root = tempDir()
+    val module = File(root, "app").apply { mkdirs() }
+    File(module, "build.gradle")
+      .writeText(
+        """
+        apply plugin: 'com.android.library'
+        apply plugin: 'ee.schimke.composeai.preview'
+        """
+          .trimIndent()
+      )
+    assertTrue(pluginAppliedInBuildScripts(root))
+  }
+
+  @Test
+  fun `pluginAppliedInBuildScripts matches Kotlin DSL apply with named plugin argument`() {
+    val root = tempDir()
+    File(root, "build.gradle.kts")
+      .writeText(
+        """
+        apply(plugin = "com.android.library")
+        apply(plugin = "ee.schimke.composeai.preview")
+        """
+          .trimIndent()
+      )
+    assertTrue(pluginAppliedInBuildScripts(root))
+  }
+
+  @Test
   fun `pluginAppliedInBuildScripts skips apply false lines (root-build subprojects pattern)`() {
     val root = tempDir()
     File(root, "build.gradle.kts")
@@ -365,6 +396,7 @@ class AutoInjectTest {
     warnIfPluginNotPreApplied(
       args = emptyList(),
       projectRoot = root,
+      autoInjectActive = true,
       pluginVersion = "0.10.0",
       env = { null },
       stderr = { warnings += it },
@@ -398,6 +430,7 @@ class AutoInjectTest {
     warnIfPluginNotPreApplied(
       args = emptyList(),
       projectRoot = root,
+      autoInjectActive = true,
       env = { null },
       stderr = { warnings += it },
       resetFlag = true,
@@ -413,6 +446,7 @@ class AutoInjectTest {
     warnIfPluginNotPreApplied(
       args = listOf("--no-plugin-warning"),
       projectRoot = root,
+      autoInjectActive = true,
       env = { null },
       stderr = { warnings += it },
       resetFlag = true,
@@ -428,6 +462,7 @@ class AutoInjectTest {
     warnIfPluginNotPreApplied(
       args = emptyList(),
       projectRoot = root,
+      autoInjectActive = true,
       env = { name -> if (name == "COMPOSE_PREVIEW_NO_PLUGIN_WARNING") "1" else null },
       stderr = { warnings += it },
       resetFlag = true,
@@ -443,6 +478,7 @@ class AutoInjectTest {
     warnIfPluginNotPreApplied(
       args = listOf("--no-auto-inject"),
       projectRoot = root,
+      autoInjectActive = false,
       env = { null },
       stderr = { warnings += it },
       resetFlag = true,
@@ -450,6 +486,28 @@ class AutoInjectTest {
     assertTrue(
       warnings.isEmpty(),
       "no auto-inject ⇒ user has opted out of the bundled flow; don't nag them",
+    )
+  }
+
+  @Test
+  fun `warnIfPluginNotPreApplied stays silent when auto-inject is on but materialisation failed`() {
+    // Codex P2 review on PR #1171: when `autoInjectInitScriptArgs` returns an empty list (e.g.
+    // unwritable cache), the CLI is not actually running via auto-inject. The warning text claims
+    // "running via auto-inject", so it must not fire — the inject-failure stderr line covers it.
+    val root = tempDir()
+    File(root, "build.gradle.kts").writeText("plugins { id(\"com.android.library\") }")
+    val warnings = mutableListOf<String>()
+    warnIfPluginNotPreApplied(
+      args = emptyList(),
+      projectRoot = root,
+      autoInjectActive = false,
+      env = { null },
+      stderr = { warnings += it },
+      resetFlag = true,
+    )
+    assertTrue(
+      warnings.isEmpty(),
+      "no init script materialised ⇒ no auto-inject claim; got $warnings",
     )
   }
 
@@ -462,6 +520,7 @@ class AutoInjectTest {
     warnIfPluginNotPreApplied(
       args = emptyList(),
       projectRoot = root,
+      autoInjectActive = true,
       env = { null },
       stderr = { warnings += it },
       resetFlag = true,
@@ -477,6 +536,7 @@ class AutoInjectTest {
     warnIfPluginNotPreApplied(
       args = emptyList(),
       projectRoot = root,
+      autoInjectActive = true,
       env = { null },
       stderr = { warnings += it },
       resetFlag = true,
@@ -484,6 +544,7 @@ class AutoInjectTest {
     warnIfPluginNotPreApplied(
       args = emptyList(),
       projectRoot = root,
+      autoInjectActive = true,
       env = { null },
       stderr = { warnings += it },
     )

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -93,14 +93,18 @@ val functionalTestTask =
     val bundleRenderE2E = providers.gradleProperty("bundle.render.e2e").orNull == "true"
     systemProperty("composeai.functionalTest.cliBundleRender", bundleRenderE2E.toString())
     // Path to the compose-preview CLI binary built by `:cli:installDist`. The test invokes it
-    // directly as a subprocess — that's the actual subject of the e2e. Empty string when the
-    // binary hasn't been built; the test self-skips. The root build wires the dependency.
-    val cliBinary =
+    // directly as a subprocess — that's the actual subject of the e2e. The test self-skips when
+    // the binary isn't there (an `assertWithMessage(...).isFile.isTrue()` past the opt-in gate).
+    //
+    // Pass the path unconditionally rather than running an `isFile` check at config time: with
+    // Gradle's configuration cache enabled, a config-time check captures whatever state existed
+    // when the cache was stored — typically "binary missing" on the very first run — and the
+    // cached empty string would stick across subsequent runs even after `:cli:installDist` had
+    // produced the binary. The test does its own existence check (line 50ish) with a useful
+    // message when the binary is missing.
+    val cliBinaryPath =
       rootDir.parentFile?.resolve("cli/build/install/compose-preview/bin/compose-preview")
-    systemProperty(
-      "composeai.functionalTest.cliBinary",
-      if (cliBinary?.isFile == true) cliBinary.absolutePath else "",
-    )
+    systemProperty("composeai.functionalTest.cliBinary", cliBinaryPath?.absolutePath ?: "")
   }
 
 tasks.check { dependsOn(functionalTestTask) }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleRenderEndToEndFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleRenderEndToEndFunctionalTest.kt
@@ -192,6 +192,10 @@ class BundleRenderEndToEndFunctionalTest {
 
     File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
 
+    // `compose-preview` walks up looking for `gradlew` to identify the project root. A stub is
+    // enough — the CLI drives Gradle via the Tooling API, not by `exec`-ing this script.
+    File(projectDir, "gradlew").writeText("#!/usr/bin/env bash\nexit 1\n")
+
     val srcDir = File(appDir, "src/main/kotlin/test")
     srcDir.mkdirs()
     File(srcDir, "Previews.kt")

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleRenderEndToEndFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleRenderEndToEndFunctionalTest.kt
@@ -4,7 +4,6 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import java.io.File
 import javax.imageio.ImageIO
-import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
@@ -37,9 +36,6 @@ class BundleRenderEndToEndFunctionalTest {
 
   private val cliBinary: String = System.getProperty("composeai.functionalTest.cliBinary", "")
 
-  private val pluginVersion: String =
-    System.getProperty("ee.schimke.composeai.functionalTest.pluginVersion", "")
-
   @Test
   fun `compose-preview bundle render produces real PNGs from a packed bundle`() {
     assumeTrue("Skipping: -Pbundle.render.e2e=true not set", bundleRenderE2E)
@@ -68,22 +64,42 @@ class BundleRenderEndToEndFunctionalTest {
     val projectDir = createDesktopProject()
     val previewId = "test.PreviewsKt.SimpleBoxPreview"
 
-    // Pack the bundle via the real Gradle task — same code path users hit.
-    val pack =
-      GradleRunner.create()
-        .withProjectDir(projectDir)
-        .withArguments(
-          "renderPreviews",
-          "composePreviewBundle",
-          "-PbundlePreviewIds=$previewId",
-          "--stacktrace",
+    // Pack the bundle by driving the CLI against a project that does NOT pre-apply the preview
+    // plugin — the bundled `--init-script` is what makes the gradle tasks materialise. This is
+    // the same shape end users hit when they invoke `compose-preview bundle pack` against an
+    // unmodified Compose Desktop project. `:app` not `:` because the CLI's module discovery skips
+    // the root project (gradlePath="") — real consumer projects almost always have a subproject.
+    val bundle = File(projectDir, "app/build/compose-previews/bundle.png")
+    val packBuilder =
+      ProcessBuilder(
+          cli.absolutePath,
+          "bundle",
+          "pack",
+          "--module",
+          ":app",
+          "--id",
+          previewId,
+          "-o",
+          bundle.absolutePath,
+          "--verbose",
         )
-        .forwardOutput()
-        .build()
-    assertThat(pack.output).doesNotContain("BUILD FAILED")
-
-    val bundle = File(projectDir, "build/compose-previews/bundle.png")
-    assertWithMessage("composePreviewBundle output missing").that(bundle.isFile).isTrue()
+        .directory(projectDir)
+        .redirectErrorStream(true)
+    // Auto-inject pulls the plugin classpath off `~/.m2` (where
+    // `functionalTestWithBundleRender` publishes it). Real users wouldn't flip this on.
+    packBuilder.environment()["COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL"] = "1"
+    val packProc = packBuilder.start()
+    val packOutput = packProc.inputStream.bufferedReader().use { it.readText() }
+    val packExit = packProc.waitFor()
+    assertWithMessage("compose-preview bundle pack output:\n$packOutput")
+      .that(packExit)
+      .isEqualTo(0)
+    assertWithMessage("expected the plugin-not-applied warning in stderr:\n$packOutput")
+      .that(packOutput)
+      .contains("plugin not applied")
+    assertWithMessage("composePreviewBundle output missing\n$packOutput")
+      .that(bundle.isFile)
+      .isTrue()
 
     val renderOut = File(projectDir, "render-out").apply { mkdirs() }
 
@@ -142,19 +158,24 @@ class BundleRenderEndToEndFunctionalTest {
             }
         }
         rootProject.name = "bundle-render-e2e"
+        include(":app")
         """
           .trimIndent()
       )
 
-    File(projectDir, "build.gradle.kts")
+    val appDir = File(projectDir, "app").apply { mkdirs() }
+    File(appDir, "build.gradle.kts")
       .writeText(
         """
         @file:Suppress("DEPRECATION")
+        // No `id("ee.schimke.composeai.preview")` on purpose — the CLI's bundled `--init-script`
+        // auto-injects it onto any project that applies `org.jetbrains.compose`. Pre-applying
+        // the plugin here would mask any regression in auto-inject. See
+        // `CliA11yEndToEndFunctionalTest` for the equivalent Android-flavour coverage.
         plugins {
             kotlin("jvm") version "2.2.21"
             kotlin("plugin.compose") version "2.2.21"
             id("org.jetbrains.compose") version "1.10.3"
-            id("ee.schimke.composeai.preview") version "$pluginVersion"
         }
         dependencies {
             implementation(compose.desktop.currentOs)
@@ -171,7 +192,7 @@ class BundleRenderEndToEndFunctionalTest {
 
     File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
 
-    val srcDir = File(projectDir, "src/main/kotlin/test")
+    val srcDir = File(appDir, "src/main/kotlin/test")
     srcDir.mkdirs()
     File(srcDir, "Previews.kt")
       .writeText(

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/CliA11yEndToEndFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/CliA11yEndToEndFunctionalTest.kt
@@ -1,13 +1,11 @@
 package ee.schimke.composeai.plugin
 
-import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import java.io.File
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
@@ -90,38 +88,35 @@ class CliA11yEndToEndFunctionalTest {
 
     val projectDir = createAndroidTestProject()
 
-    // 1. Materialise the descriptor + previews.json. The CLI's a11y path runs the same gradle
-    // tasks under the hood (via Tooling API), but invoking them here separately means we
-    // observe the gradle phase isolated from the daemon phase — failure attribution is cleaner.
-    val gradleResult =
-      GradleRunner.create()
-        .withProjectDir(projectDir)
-        .withArguments(
-          ":discoverPreviews",
-          ":composePreviewDaemonStart",
-          ":renderAllPreviews",
-          "--stacktrace",
-        )
-        .forwardOutput()
-        .build()
-    assertThat(gradleResult.output).doesNotContain("BUILD FAILED")
-
-    // 2. Invoke the CLI binary directly. `--module ":"` because the synthetic project is a
-    // single-module Gradle build (root project IS the module). The CLI's a11y command spawns
-    // its own daemon via the descriptor, fetches `a11y/atf` per preview, and writes
-    // `accessibility.json` next to `previews.json`.
+    // Run the CLI binary against a bare Android-library project — the synthetic build script
+    // applies `com.android.library` only; the preview plugin is supplied entirely via the CLI's
+    // auto-inject `--init-script`. `--module :app` because the project is laid out as
+    // root + `:app` subproject (the CLI's module discovery skips the root). The CLI's a11y command
+    // drives `renderAllPreviews` and `composePreviewDaemonStart` under the hood, then spawns the
+    // daemon, fetches `a11y/atf` per preview, and writes `accessibility.json` next to
+    // `previews.json`. Exercising the no-prior-setup path is the whole point of this test —
+    // auto-inject is a load-bearing entry point.
     val builder =
-      ProcessBuilder(cli.absolutePath, "a11y", "--module", ":", "--verbose")
+      ProcessBuilder(cli.absolutePath, "a11y", "--module", ":app", "--verbose")
         .directory(projectDir)
         .redirectErrorStream(true)
     builder.environment()["ANDROID_HOME"] = androidSdkDir
+    // Let auto-inject's buildscript repos see the locally-published plugin (resolved by the
+    // `functionalTestWithAndroid` wiring's `:gradle-plugin:publishToMavenLocal` pre-step). Plain
+    // CLI users never set this — Maven Central is enough for the published plugin.
+    builder.environment()["COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL"] = "1"
     val process = builder.start()
     val output = process.inputStream.bufferedReader().use { it.readText() }
     val exitCode = process.waitFor()
     assertWithMessage("compose-preview a11y output:\n$output").that(exitCode).isEqualTo(0)
 
-    // 3. accessibility.json should exist and contain the BadButtonPreview finding.
-    val accessibilityJson = File(projectDir, "build/compose-previews/accessibility.json")
+    // CLI must surface the "plugin not applied" nudge whenever it falls back to auto-inject.
+    assertWithMessage("expected the plugin-not-applied warning in stderr:\n$output")
+      .that(output)
+      .contains("plugin not applied")
+
+    // accessibility.json should exist and contain the BadButtonPreview finding.
+    val accessibilityJson = File(projectDir, "app/build/compose-previews/accessibility.json")
     assertWithMessage("accessibility.json should exist after `compose-preview a11y`")
       .that(accessibilityJson.exists())
       .isTrue()
@@ -145,9 +140,14 @@ class CliA11yEndToEndFunctionalTest {
   }
 
   /**
-   * Synthetic single-module Android library project. The plugin is resolved from mavenLocal so
-   * AGP + our plugin share one classloader; `local.properties` carries the Android SDK path so
-   * AGP's resource pipeline initialises cleanly.
+   * Synthetic Android-library project laid out with a `:app` subproject — the root is a thin shell,
+   * the module that applies `com.android.library` is `:app`. CLI module discovery skips the root
+   * project (its gradle path is `:`, which is filtered out), so a true root-only fixture could not
+   * be addressed via `--module`. Real consumer projects almost always have at least one subproject;
+   * pin the test to that same shape so it covers the realistic case.
+   *
+   * The plugin is resolved through auto-inject from mavenLocal; `local.properties` carries the
+   * Android SDK path so AGP's resource pipeline initialises cleanly.
    */
   private fun createAndroidTestProject(): File {
     val projectDir = tempDir.root
@@ -172,19 +172,24 @@ class CliA11yEndToEndFunctionalTest {
             }
         }
         rootProject.name = "cli-a11y-e2e"
+        include(":app")
         """
           .trimIndent()
       )
 
     File(projectDir, "local.properties").writeText("sdk.dir=$androidSdkDir\n")
 
-    File(projectDir, "build.gradle.kts")
+    val appDir = File(projectDir, "app").apply { mkdirs() }
+    File(appDir, "build.gradle.kts")
       .writeText(
         """
+        // No `id("ee.schimke.composeai.preview")` on purpose — the CLI's bundled
+        // `--init-script` auto-injects it onto every project that applies `com.android.library`
+        // (or `com.android.application` / `org.jetbrains.compose`). That code path is what we're
+        // covering here; pre-applying the plugin would mask any regression in auto-inject.
         plugins {
             id("com.android.library") version "9.2.0"
             id("org.jetbrains.kotlin.plugin.compose") version "2.3.20"
-            id("ee.schimke.composeai.preview") version "$pluginVersion"
         }
 
         android {
@@ -203,11 +208,10 @@ class CliA11yEndToEndFunctionalTest {
             jvmToolchain(17)
         }
 
-        composePreview {
-            // Need the daemon enabled so `composePreviewDaemonStart` produces a launchable
-            // descriptor (the CLI's `compose-preview a11y` spawns the daemon from it).
-            daemon { enabled.set(true) }
-        }
+        // No `composePreview { daemon { enabled = true } }` block either — `DaemonExtension.enabled`
+        // defaults to `true`, and the block isn't reachable without the plugin literally applied
+        // in this file. The auto-inject path wires the plugin via `pluginManager.withPlugin(...)`
+        // *after* the build script has finished parsing, so the daemon defaults are what kick in.
 
         dependencies {
             implementation(platform("androidx.compose:compose-bom:2026.04.01"))
@@ -230,7 +234,7 @@ class CliA11yEndToEndFunctionalTest {
           .trimIndent()
       )
 
-    val srcDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/functionaltest/clia11y")
+    val srcDir = File(appDir, "src/main/kotlin/ee/schimke/composeai/functionaltest/clia11y")
     srcDir.mkdirs()
     File(srcDir, "BadButtonPreview.kt")
       .writeText(

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/CliA11yEndToEndFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/CliA11yEndToEndFunctionalTest.kt
@@ -234,6 +234,10 @@ class CliA11yEndToEndFunctionalTest {
           .trimIndent()
       )
 
+    // `compose-preview` walks up looking for `gradlew` to identify the project root. A stub is
+    // enough — the CLI drives Gradle via the Tooling API, not by `exec`-ing this script.
+    File(projectDir, "gradlew").writeText("#!/usr/bin/env bash\nexit 1\n")
+
     val srcDir = File(appDir, "src/main/kotlin/ee/schimke/composeai/functionaltest/clia11y")
     srcDir.mkdirs()
     File(srcDir, "BadButtonPreview.kt")

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -38,13 +38,6 @@ already applies `com.android.application`, `com.android.library`, or
 script is passed to every Gradle invocation via `--init-script` and pulls
 the plugin from Maven Central.
 
-Until the first Gradle sync proves the plugin is applied (via the
-`applied.json` markers written by the `composePreviewApplied` task), the
-extension boots into **minimal mode** — the preview daemon is not started
-speculatively. Once the markers appear, the extension offers a one-click
-reload into full mode. Workspaces that apply the plugin explicitly continue
-to work the same way.
-
 To opt in manually instead, add
 [`ee.schimke.composeai.preview`](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin)
 to the module whose previews you want to render:
@@ -65,25 +58,19 @@ The plugin is on Maven Central, so no extra repository setup is needed when
 [project README](https://github.com/yschimke/compose-ai-tools#setup) for
 snapshot builds.
 
-The bundled init script always auto-applies the plugin to Android / Compose
-projects on every Gradle invocation, so no `build.gradle.kts` edit is
-required.
+## Modes
 
-## Minimal mode
+`composePreview.mode` is a binary pin: **`full`** _(default)_ runs the
+preview daemon with data extensions (a11y overlays, hierarchy, focus-mode
+inspector layers) and live / interactive previews; **`minimal`** drives only
+the Gradle plugin, disables everything daemon-backed, and stops renders from
+firing automatically on save (click the refresh button or run
+`Compose Preview: Refresh Previews` / `Render All Previews` instead).
 
-When no module in the workspace applies the Compose Preview plugin, the
-extension boots into **minimal mode**: the preview daemon, data extensions
-(a11y overlays, hierarchy, focus-mode inspector layers), and live /
-interactive previews are all disabled, and renders no longer fire
-automatically on save. Click the refresh button (or run
-`Compose Preview: Refresh Previews` / `Render All Previews`) to render.
-
-Override via `composePreview.mode`: `auto` (default) picks `full` only once
-the plugin is verifiably applied (so the daemon never spawns against a
-plugin-less workspace), `minimal` forces the gradle-only path, `full` forces
-the daemon backend. After a Gradle sync writes the authoritative
-plugin-applied markers, the extension offers a one-click reload if a switch
-to full mode becomes possible.
+`full` mode works on any workspace that applies `com.android.application`,
+`com.android.library`, or `org.jetbrains.compose` — the bundled `--init-script`
+makes the preview plugin available without editing `build.gradle.kts`. Switch
+to `minimal` when the daemon's memory cost isn't worth it for your project.
 
 ## Usage
 
@@ -101,11 +88,11 @@ to full mode becomes possible.
 
 ### Settings
 
-| Setting                        | Default  | Description                                                                                                                                                                                                                                                                                                                                                                       |
-| ------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `composePreview.mode`          | `auto`   | Backend mode: `auto` picks `full` only when the plugin is verifiably applied (via `applied.json` markers or a literal `id("ee.schimke.composeai.preview")`), else `minimal`. The post-Gradle-sync re-evaluation offers a one-click reload into full mode once auto-inject has applied the plugin. Force `full` or `minimal` to override. Requires a window reload to take effect. |
-| `composePreview.variant`       | `debug`  | Build variant to use for preview rendering (Android).                                                                                                                                                                                                                                                                                                                             |
-| `composePreview.logging.level` | `normal` | Verbosity for the "Compose Preview" output channel. `quiet` shows only errors and the BUILD outcome; `normal` keeps active task headers and summary lines but drops UP-TO-DATE/SKIPPED noise, configuration-cache bookkeeping, and dedupes the repeated Roborazzi ActionBar warnings; `verbose` shows every line from Gradle and the daemon.                                      |
+| Setting                        | Default  | Description                                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `composePreview.mode`          | `full`   | Backend mode: `full` runs the daemon with data extensions and live previews; `minimal` drives only the Gradle plugin (no daemon, no auto-render on save). The bundled init script is what makes `full` safe to default to on any Android / Compose workspace. Requires a window reload to take effect. Legacy `auto` values fall back to `full`. |
+| `composePreview.variant`       | `debug`  | Build variant to use for preview rendering (Android).                                                                                                                                                                                                                                                                                            |
+| `composePreview.logging.level` | `normal` | Verbosity for the "Compose Preview" output channel. `quiet` shows only errors and the BUILD outcome; `normal` keeps active task headers and summary lines but drops UP-TO-DATE/SKIPPED noise, configuration-cache bookkeeping, and dedupes the repeated Roborazzi ActionBar warnings; `verbose` shows every line from Gradle and the daemon.     |
 
 ## Links
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -128,14 +128,12 @@
                 "composePreview.mode": {
                     "type": "string",
                     "enum": [
-                        "auto",
                         "minimal",
                         "full"
                     ],
-                    "default": "auto",
-                    "markdownDescription": "Backend mode for the preview pipeline.\n\n- **`auto`** _(default)_ — full mode when at least one module in the workspace applies the `ee.schimke.composeai.preview` Gradle plugin (or applies an Android / Compose Multiplatform plugin the bundled init script can inject into); otherwise minimal mode.\n- **`full`** — force the daemon backend with data extensions and live previews.\n- **`minimal`** — drive only the Gradle plugin. The preview daemon, data extensions (a11y overlays, hierarchy, focus-mode inspector layers), and live/interactive previews are all disabled, and renders do not run automatically on save — click the refresh button (or run `Compose Preview: Refresh Previews` / `Render All Previews`) to render.\n\nRequires a window reload to take effect.",
+                    "default": "full",
+                    "markdownDescription": "Backend mode for the preview pipeline.\n\n- **`full`** _(default)_ — daemon backend with data extensions (a11y overlays, hierarchy, focus-mode inspector layers) and live/interactive previews. The bundled `--init-script` makes this work on any workspace that applies `com.android.application`, `com.android.library`, or `org.jetbrains.compose` — no edit to `build.gradle.kts` required.\n- **`minimal`** — drive only the Gradle plugin. The preview daemon, data extensions, and live/interactive previews are all disabled, and renders do not run automatically on save — click the refresh button (or run `Compose Preview: Refresh Previews` / `Render All Previews`) to render.\n\nLegacy `auto` values from older versions of this extension fall back to `full`. Requires a window reload to take effect.",
                     "enumDescriptions": [
-                        "Pick automatically based on whether the Compose Preview plugin (or an Android / Compose plugin the init script can inject into) is applied in the workspace.",
                         "Force minimal mode: gradle-only, manual renders.",
                         "Force full mode: daemon + data extensions + live previews."
                     ]

--- a/vscode-extension/src/composePreviewMode.ts
+++ b/vscode-extension/src/composePreviewMode.ts
@@ -11,18 +11,23 @@
  *   live previews. Drives `GradleOnlyDaemonGate` + `GradleOnlyDaemonScheduler`.
  * - `"full"` — daemon backend with all features. Drives `LiveDaemonGate` +
  *   `LiveDaemonScheduler`.
+ *
+ * The legacy `"auto"` mode is gone. The bundled `--init-script` applies the
+ * preview plugin to every workspace that applies a host plugin
+ * (`com.android.application`, `com.android.library`, `org.jetbrains.compose`),
+ * so `"full"` is safe to default to. Users on workspaces where the daemon
+ * overhead isn't wanted flip to `"minimal"` explicitly.
  */
 export type ComposePreviewMode = "minimal" | "full";
 
 /**
- * Why [resolveModeFromSettings] picked the backend it picked. Surfaced
- * through [ResolvedMode.reason] so activation + post-Gradle-sync re-evaluation
- * can decide whether to show a "switch to full mode?" reload notification.
+ * Why [resolveModeFromSettings] picked the backend it picked. Today this is
+ * always `"user-setting"` — `auto-*` reasons disappeared with auto-mode. The
+ * field is preserved so the activation log + post-sync re-evaluation paths
+ * have a stable shape; if a future heuristic mode ever returns, add reasons
+ * here rather than reshaping `ResolvedMode`.
  */
-export type ModeReason =
-    | "user-setting"
-    | "auto-no-plugin-applied"
-    | "auto-plugin-applied";
+export type ModeReason = "user-setting";
 
 export interface ResolvedMode {
     mode: ComposePreviewMode;
@@ -30,33 +35,17 @@ export interface ResolvedMode {
 }
 
 /**
- * Pure mode-selection predicate. Takes the user's settings + a minimal
- * gradle-service slice. Auto-mode picks `"full"` only when at least one
- * workspace module already applies `ee.schimke.composeai.preview` (text scan
- * or `applied.json` marker); otherwise it falls back to `"minimal"`. Auto-inject
- * onto an Android / Compose host doesn't preemptively flip the mode here — the
- * plugin isn't actually applied until Gradle runs the init script, so the
- * activation-time call has no marker to read. The post-Gradle-sync
- * re-evaluation handles the upgrade: once `applied.json` markers exist,
- * `extension.ts` re-wires the daemon backend in place (no window reload), and
- * the panel webview drops its minimal-mode banner via `setMinimalMode`.
+ * Pure mode-selection predicate. Takes the user's settings; `gradleService` is
+ * accepted for forward compatibility with any future heuristic (e.g. a "force
+ * minimal for non-Compose workspaces" guard) but unused today.
  */
 export function resolveModeFromSettings(
     settings: {
-        mode: "auto" | "minimal" | "full";
+        mode: "minimal" | "full";
     },
-    gradleService: {
+    _gradleService?: {
         findPreviewModules(): { modulePath: string }[];
     },
 ): ResolvedMode {
-    if (settings.mode === "minimal") {
-        return { mode: "minimal", reason: "user-setting" };
-    }
-    if (settings.mode === "full") {
-        return { mode: "full", reason: "user-setting" };
-    }
-    if (gradleService.findPreviewModules().length > 0) {
-        return { mode: "full", reason: "auto-plugin-applied" };
-    }
-    return { mode: "minimal", reason: "auto-no-plugin-applied" };
+    return { mode: settings.mode, reason: "user-setting" };
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -281,25 +281,22 @@ function earlyFeaturesEnabled(): boolean {
 
 /**
  * Production wrapper for [resolveModeFromSettings]. Reads live VS Code
- * settings and forwards. Called at activation and again after
- * `bootstrapAppliedMarkers()` finishes so the post-Gradle-sync re-evaluation
- * can prompt for a reload when the authoritative `applied.json` markers
- * reveal a plugin module the activation-time text scan missed.
+ * settings and forwards. Called once at activation — `"auto"` mode is gone,
+ * so the post-Gradle-sync re-evaluation is now redundant (`"minimal"`
+ * vs. `"full"` is a user pin).
+ *
+ * Legacy `"auto"` values stored from older versions of this extension fall
+ * through to `"full"` — auto-inject means the daemon backend is safe to use
+ * on every workspace that applies a host plugin, and `"auto-no-plugin-applied"`
+ * users would otherwise be silently downgraded to `"minimal"` on upgrade.
  */
 export function resolveMode(gradleService: {
     findPreviewModules(): { modulePath: string }[];
 }): ResolvedMode {
     const config = vscode.workspace.getConfiguration("composePreview");
-    const mode = config.get<string>("mode", "auto");
-    return resolveModeFromSettings(
-        {
-            mode:
-                mode === "minimal" || mode === "full" || mode === "auto"
-                    ? mode
-                    : "auto",
-        },
-        gradleService,
-    );
+    const raw = config.get<string>("mode", "full");
+    const mode: "minimal" | "full" = raw === "minimal" ? "minimal" : "full";
+    return resolveModeFromSettings({ mode }, gradleService);
 }
 
 /**
@@ -683,11 +680,13 @@ export async function activate(
             "[startup] minimal mode: gradle-only backend — daemon, data extensions and live previews disabled, renders are manual",
         );
     }
-    // Encapsulates gate + scheduler construction so the post-Gradle-sync
-    // re-evaluation can swap the backend in place when auto-inject reveals a
-    // workspace is actually full-mode-eligible. Closures inside the
+    // Encapsulates gate + scheduler construction. Was extracted so the
+    // post-Gradle-sync re-evaluation could swap backends in place when the
+    // old `"auto"` mode upgraded from minimal → full. Auto mode is gone now —
+    // the closure-wrapped backend wiring still lives here in case a future
+    // setting-change reload-less swap revives the need. Closures inside
     // [LiveDaemonScheduler] callbacks capture activate-scope state directly,
-    // which is why this lives inline rather than as a module function.
+    // which is why this stays inline rather than moving to a module function.
     const wireBackend = (targetMode: ComposePreviewMode): void => {
         const isMinimal = targetMode === "minimal";
         daemonGate = isMinimal
@@ -1336,48 +1335,19 @@ export async function activate(
     // and scheduler is enough; no window reload is needed. Re-wiring happens
     // before the panel sees its first preview request, which keeps the swap
     // invisible to the user in the typical case.
-    void gradleService
-        .bootstrapAppliedMarkers((err) => {
-            if (err instanceof ClassVersionError) {
-                showClassVersionRemediation(err);
-            } else if (err instanceof JdkImageError) {
-                showJdkImageRemediation(err);
-            }
-        })
-        .then(async () => {
-            if (!gradleService) {
-                return;
-            }
-            const post = resolveMode(gradleService);
-            if (
-                initialMode.mode === post.mode ||
-                post.reason === "user-setting"
-            ) {
-                return;
-            }
-            // Activation guessed minimal, but markers now show a plugin
-            // is applied. The opposite swing (full → minimal post-sync)
-            // can't happen because the signals are monotonic:
-            // `findPreviewModules()` only grows entries after a
-            // bootstrap, never loses them.
-            outputChannel.appendLine(
-                `[startup] mode re-eval after bootstrap: ${initialMode.mode} → ${post.mode} (${post.reason}); re-wiring backend in place`,
-            );
-            const previousGate = daemonGate;
-            wireBackend(post.mode);
-            // Tell the panel (if already open) to drop the minimal-mode
-            // banner and re-render the full-mode chrome. The apply-plugin
-            // link disappears with the banner.
-            panel?.postMessage({
-                command: "setMinimalMode",
-                minimal: post.mode === "minimal",
-            });
-            // Dispose the old gate after the swap so any in-flight gate
-            // calls finish against their original instance. The
-            // gradle-only gate's dispose is a no-op; the reverse
-            // direction is unreachable per the monotonicity argument.
-            await previousGate?.dispose();
-        });
+    // `bootstrapAppliedMarkers` still runs so other parts of the system
+    // (panel chrome, plugin-detection caches) see the authoritative marker
+    // JSON Gradle writes. The post-sync mode re-evaluation that used to
+    // upgrade `"auto"` from `"minimal"` to `"full"` is gone: `composePreview.mode`
+    // is now a binary user pin (`"minimal"` | `"full"`), so the mode never
+    // changes mid-session except via a settings change + window reload.
+    void gradleService.bootstrapAppliedMarkers((err) => {
+        if (err instanceof ClassVersionError) {
+            showClassVersionRemediation(err);
+        } else if (err instanceof JdkImageError) {
+            showJdkImageRemediation(err);
+        }
+    });
 
     context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration((event) => {

--- a/vscode-extension/src/test/modeResolver.test.ts
+++ b/vscode-extension/src/test/modeResolver.test.ts
@@ -2,83 +2,25 @@ import * as assert from "assert";
 import { resolveModeFromSettings } from "../composePreviewMode";
 
 /**
- * Tiny stub that satisfies the gradle-service slice [resolveModeFromSettings]
- * reads. The whole point of the predicate's signature is to make this
- * straight-line to test without a VS Code extension host.
+ * `composePreview.mode` is a binary user pin since auto mode was removed —
+ * `"minimal"` or `"full"`. The bundled `--init-script` is what makes `"full"`
+ * safe to default to on any Android / Compose workspace, so there is no
+ * longer a "look around the workspace to guess" branch to exercise here.
  */
-function gradleStub(opts: { previewModules?: string[] }): {
-    findPreviewModules(): { modulePath: string }[];
-} {
-    return {
-        findPreviewModules: () =>
-            (opts.previewModules ?? []).map((m) => ({ modulePath: m })),
-    };
-}
-
 describe("resolveModeFromSettings", () => {
-    describe("user-pinned setting", () => {
-        it("returns minimal mode when the user sets composePreview.mode=minimal", () => {
-            const result = resolveModeFromSettings(
-                { mode: "minimal" },
-                gradleStub({ previewModules: [":app"] }),
-            );
-            assert.deepStrictEqual(result, {
-                mode: "minimal",
-                reason: "user-setting",
-            });
-        });
-
-        it("returns full mode when the user sets composePreview.mode=full", () => {
-            const result = resolveModeFromSettings(
-                { mode: "full" },
-                gradleStub({}),
-            );
-            assert.deepStrictEqual(result, {
-                mode: "full",
-                reason: "user-setting",
-            });
+    it("returns minimal mode when the user sets composePreview.mode=minimal", () => {
+        const result = resolveModeFromSettings({ mode: "minimal" });
+        assert.deepStrictEqual(result, {
+            mode: "minimal",
+            reason: "user-setting",
         });
     });
 
-    describe("auto mode", () => {
-        it("picks full mode when at least one module already applies the plugin", () => {
-            const result = resolveModeFromSettings(
-                { mode: "auto" },
-                gradleStub({ previewModules: [":app"] }),
-            );
-            assert.deepStrictEqual(result, {
-                mode: "full",
-                reason: "auto-plugin-applied",
-            });
-        });
-
-        it("picks minimal mode when the plugin is not applied, even if an Android / Compose host is present", () => {
-            // Auto-inject onto a host plugin doesn't preemptively flip to full
-            // mode: the plugin is only applied once Gradle runs the bundled
-            // init script and writes `applied.json` markers. The
-            // post-Gradle-sync re-evaluation in `extension.ts` handles the
-            // upgrade by re-wiring the daemon backend in place once markers
-            // prove the plugin is applied — no window reload, and the panel
-            // webview drops its minimal banner via `setMinimalMode`.
-            const result = resolveModeFromSettings(
-                { mode: "auto" },
-                gradleStub({}),
-            );
-            assert.deepStrictEqual(result, {
-                mode: "minimal",
-                reason: "auto-no-plugin-applied",
-            });
-        });
-
-        it("picks minimal mode for an empty / non-Compose workspace", () => {
-            const result = resolveModeFromSettings(
-                { mode: "auto" },
-                gradleStub({}),
-            );
-            assert.deepStrictEqual(result, {
-                mode: "minimal",
-                reason: "auto-no-plugin-applied",
-            });
+    it("returns full mode when the user sets composePreview.mode=full", () => {
+        const result = resolveModeFromSettings({ mode: "full" });
+        assert.deepStrictEqual(result, {
+            mode: "full",
+            reason: "user-setting",
         });
     });
 });


### PR DESCRIPTION
## Summary

Adds detection for whether the `ee.schimke.composeai.preview` plugin is pre-applied in a project's build scripts, and emits a user-facing warning when the CLI falls back entirely to auto-inject. This nudges users toward a permanent `plugins { }` entry that unlocks IDE/agent integrations and avoids per-invocation init-script materialization costs.

## Key Changes

- **Plugin detection** (`pluginAppliedInBuildScripts`): Scans build scripts across the project tree (max depth 6, skipping build artifacts and common ignore directories) to detect literal plugin applications in both Kotlin DSL (`id("...")`) and Groovy DSL (`id '...'`) forms. Correctly skips `apply false` declarations used in root-build patterns.

- **User warning** (`warnIfPluginNotPreApplied`): Emits once per CLI process when auto-inject is active but no module applies the plugin directly. Suppressible via `--no-plugin-warning` flag or `COMPOSE_PREVIEW_NO_PLUGIN_WARNING=1` environment variable. Respects `--no-auto-inject` and `hasIncludedPluginBuild()` checks to avoid nagging users who've opted out or are in development mode.

- **Init script enhancement**: Added `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL` environment variable to opt buildscript repos into `mavenLocal()` for functional testing (resolves plugin from `~/.m2` instead of Maven Central).

- **VS Code extension simplification**: Removed the `"auto"` mode from `composePreview.mode` setting. The mode is now a binary user pin (`"minimal"` | `"full"`). Auto-inject makes `"full"` safe to default to on any workspace with a host plugin, eliminating the need for post-Gradle-sync mode re-evaluation. Legacy `"auto"` values fall through to `"full"`.

- **Functional test updates**: Updated end-to-end tests to exercise the no-prior-setup path (auto-inject without pre-applied plugin) and verify the plugin-not-applied warning surfaces correctly. Tests now drive the CLI directly against projects that don't pre-apply the plugin.

## Implementation Details

- The regex patterns for plugin detection (`PLUGIN_APPLIED_RE`, `PLUGIN_APPLY_FALSE_RE`) are kept in sync with the VS Code extension's equivalent logic.
- Version-catalog alias form (`alias(libs.plugins.<x>)`) is intentionally out of scope — there's no way to know which alias maps to which plugin ID without parsing `gradle/libs.versions.toml`.
- The warning uses `AtomicBoolean` to ensure it prints at most once per process, even if multiple commands invoke the check.
- All warning suppression paths are tested: CLI flag, environment variable, auto-inject disabled, and development mode (includeBuild pattern).

https://claude.ai/code/session_01Hie1AwXDhg2bbKGLqvj11i