### PR TITLE
docs(non-gradle): drive compose-preview from Amper / Bazel / Buck2

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
-# SessionStart hook: point this clone's git hooks at .githooks/ so the
-# ktfmt pre-commit guard runs on every commit. Idempotent.
+# SessionStart hook for compose-ai-tools.
+#
+# Always: point this clone's `core.hooksPath` at `.githooks/` so the ktfmt
+# pre-commit guard runs on commits. Cheap, idempotent.
+#
+# Web-only (CLAUDE_CODE_REMOTE=true): pre-warm Gradle so the first `./gradlew`
+# invocation inside the session doesn't cold-download the 150MB distribution
+# and resolve every plugin from Maven Central. Without this warm-up, running
+# `ktfmtCheckAll` or any `:test` task in a fresh container costs ~1m of setup
+# before the first useful byte; with it, those tasks start in seconds because
+# `~/.gradle/wrapper/dists/`, the toolchain JDK, and the plugin classpath are
+# already populated.
+#
+# Idempotency: re-running the hook on a warm container is a no-op modulo a
+# few seconds for Gradle to confirm the daemon is up. Safe to call from
+# `startup`, `resume`, `clear`, or `compact` sources.
 
 set -euo pipefail
 
@@ -9,3 +23,19 @@ cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
 if [ -x scripts/install-git-hooks.sh ]; then
   scripts/install-git-hooks.sh >&2
 fi
+
+# Local sessions stop here — devs already have Gradle warm. The rest is
+# web-session-only setup that costs nothing on warm containers but saves a
+# real chunk of cold-start latency.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Warm Gradle. `help` is the cheapest task that still triggers:
+#   - wrapper distribution download (~150MB on cold)
+#   - toolchain JDK auto-provision via foojay (`gradle/gradle-daemon-jvm.properties`
+#     pins Java 17; the harness JDK is already on PATH so this is a no-op)
+#   - plugin classpath resolution into `~/.gradle/caches/modules-2/`
+# Stderr goes to the hook log so timing is visible; stdout stays clean
+# (gradle's stdout is whitespace under `--quiet`).
+./gradlew --quiet help >&2

--- a/docs/NON_GRADLE_INTEGRATION.md
+++ b/docs/NON_GRADLE_INTEGRATION.md
@@ -313,6 +313,21 @@ Amper currently distributes itself through `packages.jetbrains.team`
 [AMPER-471](https://youtrack.jetbrains.com/projects/AMPER/issues/AMPER-471));
 end-to-end CI for the Amper path needs that host allowlisted.
 
+The fixture at [`samples/amper-cmp-desktop/`](../samples/amper-cmp-desktop/)
+vendors the Amper wrapper. `module.yaml` pins `jvm.release: 17` because
+the daemon JVM runs on JDK 17 — Amper's default `jvm.release: 21` produces
+class files the JDK-17 daemon refuses to load (`UnsupportedClassVersionError`,
+class version 65 ≠ 61). In a managed sandbox with a TLS-inspection proxy,
+Amper's auto-downloaded Zulu JRE additionally needs the system truststore
+wired via `AMPER_JAVA_OPTIONS`; the fixture's README documents the
+incantation.
+
+End-to-end is proven by
+[`AmperContractTest`](../render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/AmperContractTest.kt):
+once `./amper build` has run, the test consumes Amper's `kotlin-output/`
+directly and renders a real PNG through the same daemon pipeline the
+Gradle plugin uses.
+
 ## Worked example: Bazel
 
 Bazel rules for Compose live in third-party space (`rules_kotlin`'s
@@ -380,3 +395,4 @@ before the renderer can load classes compiled against it.
 - Reference producer (the Gradle plugin's bootstrap task): [`DaemonBootstrapTask.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTask.kt)
 - Sample Amper fixture: [`samples/amper-cmp-desktop/`](../samples/amper-cmp-desktop/)
 - Contract test demonstrating the recipe end-to-end: [`render-session/subprocess/src/test/.../NonGradleContractTest.kt`](../render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/NonGradleContractTest.kt)
+- Amper-driven end-to-end test against the fixture: [`render-session/subprocess/src/test/.../AmperContractTest.kt`](../render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/AmperContractTest.kt)

--- a/docs/NON_GRADLE_INTEGRATION.md
+++ b/docs/NON_GRADLE_INTEGRATION.md
@@ -1,0 +1,382 @@
+# Non-Gradle integration
+
+How to drive `compose-preview` from a build system other than Gradle —
+[Amper](https://amper.org), [Bazel](https://bazel.build), Buck2, Maven,
+or a hand-rolled shell pipeline. The recipe is the same in every case:
+**produce a `daemon-launch.json` descriptor pointing at compiled Kotlin
+classes, then open a `RenderSession`**. The Gradle plugin is one producer
+of that descriptor; this document is for everyone else.
+
+The two contracts you implement against:
+
+| Artifact | Schema | Wire-stable | Producer |
+| --- | --- | --- | --- |
+| `daemon-launch.json` | [`DaemonClasspathDescriptor.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonClasspathDescriptor.kt) | `schemaVersion = 1` | You |
+| `previews.json` | [`PreviewData.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt) | `schema = "compose-previews/v1"` | You — by running ClassGraph or hand-authoring |
+
+The consumer of both is the daemon JVM (`daemon/desktop` or `daemon/android`),
+driven by `RenderSessionFactory.open(...)` from the
+[`render-session-api`](../render-session/api/) +
+[`render-session-subprocess`](../render-session/subprocess/) Maven artifacts.
+
+## Architecture in one diagram
+
+```
+┌─────────────────────────────┐
+│ Your build system           │   Amper task, Bazel rule,
+│ (Amper / Bazel / Buck2)     │   `mvn -P preview`, shell script
+└───────────────┬─────────────┘
+                │ produces
+                ▼
+┌─────────────────────────────┐    ┌────────────────────────────┐
+│ <module>/                   │    │ Renderer + connector jars  │
+│   build/...classes/         │    │ from Maven Central:        │
+│   build/compose-previews/   │    │   - daemon-desktop or      │
+│     daemon-launch.json   ◄──┼────┤     daemon-android         │
+│     previews.json           │    │   - data-<ext>-connector   │
+└───────────────┬─────────────┘    │   - data-<ext>-core        │
+                │                  └────────────────────────────┘
+                │ RenderSessionConfig.descriptorPath
+                ▼
+┌─────────────────────────────┐
+│ render-session-subprocess   │   `SubprocessRenderSessions.open(config)`
+│ (Maven Central)             │   forks the daemon JVM, handshakes over
+└───────────────┬─────────────┘   JSON-RPC, returns a `RenderSession`.
+                │
+                ▼
+┌─────────────────────────────┐
+│ Daemon JVM                  │   Hosts renderer-desktop or renderer-android
+│  (mainClass:                │   inside a sandbox; exposes `renderNow`,
+│   ee.schimke.composeai      │   `data/fetch`, `extensions/enable`, ...
+│   .daemon.DaemonMain)       │
+└─────────────────────────────┘
+```
+
+The Gradle plugin is *one* implementation of "your build system" in that diagram.
+The rest of this document is how to be a different one.
+
+## Pick a backend
+
+| Backend | Renderer | Reaches | Use when |
+| --- | --- | --- | --- |
+| **`renderer-desktop`** | ImageComposeScene + Skia | Compose Multiplatform Desktop / `compose.desktop.currentOs` | You're rendering CMP Desktop or JVM Compose previews. Lightest classpath; no Android machinery. |
+| **`renderer-android`** | Robolectric sandbox + `captureRoboImage` | AndroidX Compose / `androidx.compose.ui` | You're rendering Jetpack Compose previews against the Android runtime. Heavier — needs Robolectric + `android.jar` on the classpath, and a working Android SDK. |
+
+The CMP Desktop path is the simpler integration target for a first non-Gradle
+implementation. Add Android later when the Desktop path is green.
+
+## The `daemon-launch.json` contract
+
+Wire shape (lifted from `DaemonClasspathDescriptor.kt`; field order matters
+for the classpath but not the rest):
+
+```json
+{
+  "schemaVersion": 1,
+  "modulePath": ":app",
+  "variant": "desktop",
+  "enabled": true,
+  "mainClass": "ee.schimke.composeai.daemon.DaemonMain",
+  "javaLauncher": null,
+  "classpath": [
+    "/abs/path/to/daemon-desktop-<version>.jar",
+    "/abs/path/to/data-render-connector-<version>.jar",
+    "...other connector jars you want available...",
+    "/abs/path/to/daemon-core-<version>.jar",
+    "/abs/path/to/data-render-core-<version>.jar",
+    "/abs/path/to/<your-module-runtime-deps...>.jar",
+    "/abs/path/to/<your-module-classes/>"
+  ],
+  "jvmArgs": ["-Xmx1024m"],
+  "systemProperties": {
+    "composeai.daemon.protocolVersion": "1",
+    "composeai.daemon.modulePath": ":app",
+    "composeai.daemon.moduleId": ":app",
+    "composeai.daemon.moduleProjectDir": "/abs/path/to/<module>",
+    "composeai.daemon.workspaceRoot": "/abs/path/to/<workspace-root>",
+    "composeai.daemon.previewsJsonPath": "/abs/path/to/previews.json",
+    "composeai.harness.previewsManifest": "/abs/path/to/previews.json",
+    "composeai.render.outputDir": "/abs/path/to/build/compose-previews/renders",
+    "composeai.daemon.historyDir": "/abs/path/to/.compose-preview-history",
+    "composeai.daemon.userClassDirs": "/abs/path/to/<your-module-classes/>",
+    "composeai.daemon.idleTimeoutMs": "5000"
+  },
+  "workingDirectory": "/abs/path/to/<module>",
+  "manifestPath": "/abs/path/to/previews.json"
+}
+```
+
+### Field-by-field
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `schemaVersion` | yes | Pin to `1`. Bumped on breaking changes; the subprocess factory rejects anything else with a clear error. |
+| `modulePath` | yes | Logical module id. The daemon uses it as a label; for non-Gradle callers, anything stable identifying the module is fine (`":app"`, `"app:debug"`, `"compose-desktop"`). |
+| `variant` | yes | Build variant. `"desktop"` for CMP; `"debug"` / `"release"` for Android. Informational. |
+| `enabled` | yes | Mirror of the user's `composePreview.daemon.enabled` switch. `true` for normal use. `RenderSessionConfig.forceEnabled` overrides on the consumer side. |
+| `mainClass` | yes | `ee.schimke.composeai.daemon.DaemonMain` for both backends. |
+| `javaLauncher` | no (`null` ok) | Absolute path to a `java` binary. `null` falls back to the JDK the consumer's JVM is using. |
+| `classpath` | yes, ordered | See [Classpath layering](#classpath-layering). |
+| `jvmArgs` | yes | At minimum `["-Xmx1024m"]`. Renderer-android needs more `--add-opens` flags — see the gradle plugin's `AndroidPreviewClasspath.buildJvmArgs` for the full set. |
+| `systemProperties` | yes | See [System properties](#system-properties). |
+| `workingDirectory` | yes | Daemon JVM `cwd`. Module project dir. |
+| `manifestPath` | yes | Absolute path to `previews.json`. Same as `composeai.daemon.previewsJsonPath` in sysprops. |
+
+### Classpath layering
+
+Order is load-bearing — the renderer and its connectors must precede the
+user's runtime so version collisions resolve in favour of the pinned
+renderer-side classes:
+
+1. **Renderer jar** — `daemon-desktop-<v>.jar` or `daemon-android-<v>.jar`.
+   Bundles `DaemonMain` (the JSON-RPC server) plus its backend's renderer.
+2. **Data extension connector jars** — `data-<extension>-connector-<v>.jar`.
+   One per extension you want available (`a11y`, `theme`, `history`, …).
+   Each connector pulls its `core` jar transitively.
+3. **`daemon-core-<v>.jar`** — JSON-RPC protocol, shared types.
+4. **`data-render-core-<v>.jar`**, plus the `*-core` of each connector you
+   pulled. These are the producer-side data-product implementations.
+5. **User Compose runtime** — `compose.desktop.currentOs`, AndroidX Compose,
+   `material3`, etc. Pulled out of your build system's resolver.
+6. **User compiled classes** — directory or jar containing your `@Preview`
+   functions.
+
+The Gradle plugin's order is:
+1) daemon module's classes;
+2) `AndroidPreviewClasspath.buildTestClasspath()` output;
+3) AGP additions for Android.
+Match that broad shape and you'll be fine.
+
+### System properties
+
+The minimum set the daemon reads at boot:
+
+| Property | Purpose |
+| --- | --- |
+| `composeai.daemon.protocolVersion` | Always `"1"` for schema v1. |
+| `composeai.daemon.modulePath` | Same as `modulePath` in the descriptor. |
+| `composeai.daemon.moduleId` | Same as `modulePath`. Reported back via `initialize`. |
+| `composeai.daemon.moduleProjectDir` | Absolute path to the module dir. |
+| `composeai.daemon.workspaceRoot` | Repo root (for git-provenance metadata). |
+| `composeai.daemon.previewsJsonPath` | Path to `previews.json`. The daemon seeds its preview index from this on startup. |
+| `composeai.harness.previewsManifest` | Same path. Legacy alias still read by the harness path. |
+| `composeai.render.outputDir` | Where rendered PNGs land. The daemon writes here; you read from here. |
+| `composeai.daemon.historyDir` | Where per-render archives go. Pick any dir; defaults under `.compose-preview-history/`. |
+| `composeai.daemon.userClassDirs` | `:`-separated list of directories holding user `.class` files. Used by classloader hot-swap on `fileChanged` notifications. |
+| `composeai.daemon.idleTimeoutMs` | Idle exit timeout. `5000` is the gradle plugin's default. |
+
+The full list lives in
+[`docs/daemon/CONFIG.md`](daemon/CONFIG.md); the above is the minimum a
+non-Gradle integration must populate.
+
+## The `previews.json` contract
+
+Discovery in the Gradle plugin is `DiscoverPreviewsTask` — it runs
+[ClassGraph](https://github.com/classgraph/classgraph) over the compiled
+class directories and dependency jars and emits a manifest:
+
+```json
+{
+  "schema": "compose-previews/v1",
+  "module": "<modulePath>",
+  "variant": "<variant>",
+  "previews": [
+    {
+      "id": "<fqClass>.<function>[_<variant-name>]",
+      "functionName": "<function>",
+      "className": "<fqClass>",
+      "sourceFile": "<relative-path-or-null>",
+      "params": { "...preview-annotation params..." },
+      "captures": [ { "renderOutput": "renders/<id>.png" } ]
+    }
+  ]
+}
+```
+
+For a non-Gradle integration the cheapest route is to scan the same way:
+pull `io.github.classgraph:classgraph` into your build, scan the
+user-classes dir, and emit the JSON. The fields you must populate are:
+
+- `id`: a deterministic identifier the daemon and renderer pass through.
+  `<className>.<functionName>` is the Gradle-plugin convention; the daemon
+  doesn't enforce a format.
+- `className`, `functionName`: enough to load and invoke the composable
+  via reflection.
+- `captures[].renderOutput`: relative path under
+  `composeai.render.outputDir` where the PNG lands.
+
+Multi-preview annotations (`@PreviewParameter`, `@Preview` arrays, custom
+multipreviews) need fan-out at discovery time. The gradle plugin's
+`PreviewData.kt` is the reference. Until a non-Gradle discovery library is
+extracted, the practical path is to either
+(a) drive `DiscoverPreviewsTask` standalone via the Tooling API in a
+synthetic Gradle project, or
+(b) author `previews.json` by hand for a known fixed set.
+
+## Driving a `RenderSession`
+
+Once you have `daemon-launch.json` and `previews.json` on disk:
+
+```kotlin
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
+import java.io.File
+
+fun main() {
+  val descriptor = File("<your-module>/build/compose-previews/daemon-launch.json")
+  val config = RenderSessionConfig(
+    descriptorPath = descriptor,
+    workspaceRoot = File("/abs/path/to/workspace-root"),
+  )
+
+  SubprocessRenderSessions.open(config).use { session ->
+    val result = session.renderNow(
+      previewIds = listOf("com.example.MyPreviewsKt.Greeting"),
+    )
+    println("Rendered ${result.previews.size} previews:")
+    for (p in result.previews) println("  ${p.id} → ${p.renderOutput}")
+  }
+}
+```
+
+Maven coordinates (pre-1.0):
+
+```kotlin
+implementation("ee.schimke.composeai:render-session-api:<version>")
+implementation("ee.schimke.composeai:render-session-subprocess:<version>")
+```
+
+## Data extensions (a11y, hierarchy, etc.)
+
+Each data extension ships as two jars on the daemon's classpath:
+`data-<ext>-core-<v>.jar` and `data-<ext>-connector-<v>.jar`. Include the
+connector pair for every extension you want available; the daemon will
+advertise them through `listExtensions()`.
+
+Enable on a per-session basis, then fetch:
+
+```kotlin
+session.enableExtensions(listOf("a11y"))
+val a11y = session.fetchData(
+  previewId = "com.example.MyPreviewsKt.Greeting",
+  kind = "a11y/atf",
+)
+println(a11y.payload)
+```
+
+The renderer re-renders automatically when an extension is marked
+`requiresRerender = true` (a11y is). See [`DATA-PRODUCTS.md`](daemon/DATA-PRODUCTS.md)
+for the full kind catalogue.
+
+## Worked example: JetBrains Amper
+
+[Amper](https://github.com/JetBrains/amper) is the obvious non-Gradle
+target — first-class Compose Multiplatform support, declarative
+`module.yaml` config, JetBrains-maintained. The minimal Compose Desktop
+fixture is six lines:
+
+```yaml
+# module.yaml
+product: jvm/app
+
+dependencies:
+  - $compose.desktop.currentOs
+
+settings:
+  compose: enabled
+```
+
+The integration:
+
+1. **Build** — `./amper build`. Amper writes compiled classes under
+   `<module>/build/tasks/_<module>_jvmRuntimeClasspath/<...>` (or similar
+   depending on Amper version) and resolves runtime dependencies to its
+   own Maven cache.
+2. **Resolve the renderer + connector classpath** — pull
+   `ee.schimke.composeai:daemon-desktop`, `data-render-connector`,
+   `data-render-core`, `daemon-core` (and any additional extensions) into
+   a separate dependency block. With Amper 0.10+ this is one extra
+   dependency line per artifact in `module.yaml`.
+3. **Discover previews** — run ClassGraph against
+   `<module>/build/.../classes/main` and write `previews.json`. A
+   standalone Kotlin tool (~50 LOC) is enough; see
+   [`samples/amper-cmp-desktop/`](../samples/amper-cmp-desktop/) for the
+   shape.
+4. **Synthesise the descriptor** — emit `daemon-launch.json` from the
+   resolved classpath + the user-classes path. See the same sample for
+   the full template.
+5. **Render** — call `SubprocessRenderSessions.open(config)` and drive
+   `renderNow`.
+
+Amper currently distributes itself through `packages.jetbrains.team`
+(not Maven Central — tracked as
+[AMPER-471](https://youtrack.jetbrains.com/projects/AMPER/issues/AMPER-471));
+end-to-end CI for the Amper path needs that host allowlisted.
+
+## Worked example: Bazel
+
+Bazel rules for Compose live in third-party space (`rules_kotlin`'s
+`kt_compiler_plugin`). The cleanest shape:
+
+```bazel
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("@rules_kotlin//kotlin:core.bzl", "kt_compiler_plugin")
+
+kt_compiler_plugin(
+    name = "compose_compiler_plugin",
+    id = "androidx.compose.compiler",
+    target_embedded_compiler = True,
+    deps = ["@maven//:org_jetbrains_compose_compiler_compiler"],
+)
+
+kt_jvm_library(
+    name = "app",
+    srcs = glob(["src/**/*.kt"]),
+    plugins = [":compose_compiler_plugin"],
+    deps = [
+        "@maven//:org_jetbrains_compose_desktop_desktop_jvm_linux_x64",
+        "@maven//:org_jetbrains_compose_components_components_ui_tooling_preview_desktop",
+    ],
+)
+```
+
+From here a `compose_preview_render` Bazel rule:
+
+1. `runtime_jars` provider on `:app` gives the resolved runtime classpath.
+2. A `cc_binary`-style action runs the preview discovery (ClassGraph
+   against `:app`'s `.jar` outputs).
+3. Another action synthesises `daemon-launch.json` from the resolved
+   jars + the renderer-desktop dependency.
+4. A test target invokes `SubprocessRenderSessions.open(descriptor)` and
+   asserts the PNG outputs land.
+
+`Bencodes/bazel_jetpack_compose_example` is the only public reference
+Bazel+Compose project (stale; Compose 1.2.0-beta02, Kotlin 1.6.21, Bazel
+5.1.1). Use it as a structural template; expect to upgrade dependencies
+before the renderer can load classes compiled against it.
+
+## Limitations and follow-ups
+
+- **Preview discovery library is gradle-coupled.** `DiscoverPreviewsTask`
+  uses `@TaskAction` and configuration-cache-safe inputs; the underlying
+  ClassGraph scan would be extracted to a standalone library, but that's
+  tracked separately. Until then, non-Gradle integrations either hand-author
+  `previews.json` or vendor a discovery tool.
+- **Renderer-android requires Robolectric.** Driving the Android renderer
+  from Bazel needs a working Robolectric + AGP classpath inside Bazel —
+  doable but well off the beaten path. Start with renderer-desktop.
+- **`previews.json` schema versioning.** The wire field is `"schema":
+  "compose-previews/v1"`. The daemon tolerates unknown fields; clients
+  that produce manifests should round-trip schema-stable fields.
+- **Maven Central artifacts are pre-1.0.** Pin to a specific version;
+  expect API changes across minor versions until 1.0.
+
+## Reference
+
+- Descriptor schema source: [`DaemonClasspathDescriptor.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonClasspathDescriptor.kt)
+- Wire protocol: [`docs/daemon/PROTOCOL.md`](daemon/PROTOCOL.md)
+- Data products catalogue: [`docs/daemon/DATA-PRODUCTS.md`](daemon/DATA-PRODUCTS.md)
+- `RenderSession` API: [`render-session/api/.../RenderSession.kt`](../render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSession.kt)
+- Reference producer (the Gradle plugin's bootstrap task): [`DaemonBootstrapTask.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTask.kt)
+- Sample Amper fixture: [`samples/amper-cmp-desktop/`](../samples/amper-cmp-desktop/)
+- Contract test demonstrating the recipe end-to-end: [`render-session/subprocess/src/test/.../NonGradleContractTest.kt`](../render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/NonGradleContractTest.kt)

--- a/render-session/subprocess/build.gradle.kts
+++ b/render-session/subprocess/build.gradle.kts
@@ -25,6 +25,21 @@ dependencies {
   implementation(libs.kotlinx.serialization.json)
 
   testImplementation(libs.junit)
+  testImplementation(libs.truth)
+}
+
+// `NonGradleContractTest` (see src/test/.../subprocess/NonGradleContractTest.kt) synthesises a
+// fresh `daemon-launch.json` from `:samples:cmp`'s build outputs and drives a real RenderSession
+// against it. The test self-skips when those outputs are missing, so devs running
+// `./gradlew :render-session-subprocess:test` against a clean tree don't see a hard failure; CI
+// (and anyone targeting `check`) pre-builds the inputs.
+//
+// `:samples:cmp:discoverPreviews` produces `previews.json`;
+// `:samples:cmp:composePreviewDaemonStart`
+// produces the descriptor we treat as a *parts list* (the test re-emits its own descriptor with
+// rearranged paths — the goal is to prove the schema is a contract, not to copy the file).
+tasks.named<Test>("test") {
+  dependsOn(":samples:cmp:discoverPreviews", ":samples:cmp:composePreviewDaemonStart")
 }
 
 composeAiMavenPublishing {

--- a/render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/AmperContractTest.kt
+++ b/render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/AmperContractTest.kt
@@ -1,0 +1,295 @@
+package ee.schimke.composeai.render.session.subprocess
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end proof that an Amper-built module's `@Preview` can be driven through `RenderSession`
+ * without any Gradle involvement in producing the user classes.
+ *
+ * The fixture at `samples/amper-cmp-desktop/` is compiled by `./amper build` — a non-Gradle build
+ * system. This test:
+ *
+ * 1. Reuses the renderer/connector/data jars and the Compose Desktop runtime jar bag from the
+ *    gradle plugin's reference descriptor (`:samples:cmp:composePreviewDaemonStart`). A real Amper
+ *    consumer would resolve these from Maven Central; `NonGradleContractTest` already proves that
+ *    descriptor synthesis is independent of the plugin, so this test focuses on the user-classes
+ *    swap rather than re-proving classpath synthesis.
+ * 2. Filters cmp's compiled-class directories out of the inherited classpath and substitutes
+ *    Amper's `kotlin-output/` (the directory `./amper build` writes `GreetingKt.class` to).
+ * 3. Hand-authors `previews.json` with one entry for `GreetingKt.Greeting`. Preview discovery is
+ *    still gradle-coupled (`DiscoverPreviewsTask` runs inside a `@TaskAction`); extracting the
+ *    ClassGraph scan into a library is a separate follow-up tracked in
+ *    `docs/NON_GRADLE_INTEGRATION.md`.
+ * 4. Opens `SubprocessRenderSessions` against the synthesised descriptor, drives `renderNow`, waits
+ *    for a `renderFinished` notification, asserts the PNG lands on disk.
+ *
+ * **Self-skip:** the test exits cleanly (no failure) when the prerequisite inputs are missing.
+ *
+ * * Amper wrapper missing? Vendored as `samples/amper-cmp-desktop/amper`.
+ * * Amper outputs missing? Run `./amper build` from the fixture first. In sandbox environments with
+ *   a TLS-inspection proxy the bundled Zulu JRE needs the system truststore wired via
+ *   `AMPER_JAVA_OPTIONS="-ea -XX:+EnableDynamicAgentLoading
+ *   -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
+ *   -Djavax.net.ssl.trustStorePassword=changeit"`.
+ * * Gradle reference descriptor missing? Built by the `:samples:cmp:composePreviewDaemonStart`
+ *   dependency declared in this module's `build.gradle.kts`.
+ */
+class AmperContractTest {
+
+  @get:Rule val tempDir: TemporaryFolder = TemporaryFolder()
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    prettyPrint = true
+    encodeDefaults = true
+  }
+
+  @Test
+  fun `amper-built classes drive a real render via RenderSession`() {
+    val repoRoot = locateRepoRoot()
+    val amperFixtureDir = File(repoRoot, "samples/amper-cmp-desktop")
+    val amperKotlinOutput =
+      File(
+        amperFixtureDir,
+        "build/artifacts/CompiledJvmArtifact/amper-cmp-desktopjvm/kotlin-output",
+      )
+    val gradleRefDescriptor =
+      File(repoRoot, "samples/cmp/build/compose-previews/daemon-launch.json")
+
+    if (!File(amperFixtureDir, "amper").canExecute()) {
+      System.err.println(
+        "[AmperContractTest] skipping — `samples/amper-cmp-desktop/amper` wrapper missing or not executable"
+      )
+      return
+    }
+    val classFiles = amperKotlinOutput.listFiles { f -> f.extension == "class" }
+    if (classFiles == null || classFiles.isEmpty()) {
+      System.err.println(
+        "[AmperContractTest] skipping — Amper outputs missing at $amperKotlinOutput. " +
+          "Run `cd samples/amper-cmp-desktop && AMPER_JAVA_OPTIONS=\"…trustStore=…\" ./amper build` first."
+      )
+      return
+    }
+    if (!gradleRefDescriptor.isFile) {
+      System.err.println(
+        "[AmperContractTest] skipping — gradle reference descriptor missing at $gradleRefDescriptor"
+      )
+      return
+    }
+
+    // 1. The gradle descriptor is our "Maven-Central-resolved bag" for renderer + Compose Desktop
+    //    jars. We don't re-derive the classpath from scratch — that recipe is the subject of
+    //    NonGradleContractTest. Here the focus is on the user-classes substitution.
+    val referenceDescriptor = json.parseToJsonElement(gradleRefDescriptor.readText()).jsonObject
+    val refClasspath = referenceDescriptor["classpath"]!!.jsonArray.map { it.jsonPrimitive.content }
+    val jvmArgs = referenceDescriptor["jvmArgs"]!!.jsonArray.map { it.jsonPrimitive.content }
+    val mainClass = referenceDescriptor["mainClass"]!!.jsonPrimitive.content
+
+    // Strip cmp's compiled-class dirs (the only user-classes entries in the reference descriptor)
+    // and append Amper's kotlin-output dir in their place. The renderer + connector + data jars
+    // stay; the Compose Desktop runtime stays.
+    val cmpUserDirsPrefix = File(repoRoot, "samples/cmp/build/classes/").absolutePath
+    val classpath =
+      refClasspath.filter { !it.startsWith(cmpUserDirsPrefix) } + amperKotlinOutput.absolutePath
+
+    // 2. Synthesise a fresh descriptor in a tmp dir. Render outputs land in tmp so the test
+    //    doesn't touch the on-disk gradle build outputs.
+    val moduleDir = tempDir.newFolder("amper-module")
+    val renderOutputDir = File(moduleDir, "build/compose-previews/renders").apply { mkdirs() }
+    val historyDir = File(moduleDir, ".compose-preview-history").apply { mkdirs() }
+    val previewsJsonPath = File(moduleDir, "build/compose-previews/previews.json")
+    previewsJsonPath.parentFile.mkdirs()
+    previewsJsonPath.writeText(handAuthoredPreviewsJson(modulePath = ":amper-cmp-desktop"))
+
+    val descriptorFile = File(moduleDir, "build/compose-previews/daemon-launch.json")
+    descriptorFile.writeText(
+      writeDescriptor(
+          modulePath = ":amper-cmp-desktop",
+          variant = "desktop",
+          mainClass = mainClass,
+          classpath = classpath,
+          jvmArgs = jvmArgs,
+          moduleDir = moduleDir,
+          workspaceRoot = repoRoot,
+          previewsJsonPath = previewsJsonPath,
+          renderOutputDir = renderOutputDir,
+          historyDir = historyDir,
+          userClassDir = amperKotlinOutput,
+        )
+        .toString()
+    )
+
+    val target = "GreetingKt.Greeting"
+
+    SubprocessRenderSessions.open(
+        RenderSessionConfig(
+          descriptorPath = descriptorFile,
+          workspaceRoot = repoRoot,
+          workspaceName = "compose-ai-tools",
+          logSink = { line -> System.err.println("[amper-daemon] $line") },
+        )
+      )
+      .use { session ->
+        assertThat(session.modulePath).isEqualTo(":amper-cmp-desktop")
+        assertThat(session.initializeResult.daemonVersion).isNotEmpty()
+
+        val finishedParams = AtomicReference<JsonObject?>(null)
+        val latch = CountDownLatch(1)
+        session
+          .onNotification { method, params ->
+            if (method == "renderFinished" && params != null) {
+              val id = params["id"]?.jsonPrimitive?.contentOrNull
+              if (id == target) {
+                finishedParams.set(params)
+                latch.countDown()
+              }
+            }
+          }
+          .use {
+            val queueAck = session.renderNow(previewIds = listOf(target), tier = RenderTier.FULL)
+            assertWithMessage("renderNow should accept Greeting, got rejected=${queueAck.rejected}")
+              .that(queueAck.rejected.map { it.id })
+              .doesNotContain(target)
+
+            assertWithMessage("daemon should emit renderFinished for $target within 60s")
+              .that(latch.await(60, TimeUnit.SECONDS))
+              .isTrue()
+          }
+
+        val params = finishedParams.get() ?: error("renderFinished notification missing payload")
+        val pngPath =
+          params["pngPath"]?.jsonPrimitive?.contentOrNull
+            ?: error("renderFinished params missing pngPath: $params")
+        val png = File(pngPath)
+        assertWithMessage("rendered PNG must exist on disk: $pngPath").that(png.isFile).isTrue()
+        assertThat(png.length()).isGreaterThan(0L)
+      }
+  }
+
+  /**
+   * Hand-written `previews.json` for `Greeting()`. Mirrors the schema in `PreviewData.kt`
+   * (`PreviewManifest` → `PreviewInfo` → `Capture`). A real non-Gradle integration would emit this
+   * by running ClassGraph over the user classes; for one preview, hand-authoring is cheaper than
+   * pulling in a discovery library.
+   */
+  private fun handAuthoredPreviewsJson(modulePath: String): String =
+    json.encodeToString(
+      JsonObject.serializer(),
+      buildJsonObject {
+        put("module", JsonPrimitive(modulePath))
+        put("variant", JsonPrimitive("desktop"))
+        put(
+          "previews",
+          JsonArray(
+            listOf(
+              buildJsonObject {
+                put("id", JsonPrimitive("GreetingKt.Greeting"))
+                put("functionName", JsonPrimitive("Greeting"))
+                put("className", JsonPrimitive("GreetingKt"))
+                put("sourceFile", JsonPrimitive("src/Greeting.kt"))
+                put(
+                  "params",
+                  buildJsonObject {
+                    put("density", JsonPrimitive(2.625f))
+                    put("fontScale", JsonPrimitive(1.0f))
+                    put("showSystemUi", JsonPrimitive(false))
+                    put("showBackground", JsonPrimitive(true))
+                    put("backgroundColor", JsonPrimitive(0xFFFFFFFFL))
+                    put("uiMode", JsonPrimitive(0))
+                    put("previewParameterLimit", JsonPrimitive(Int.MAX_VALUE))
+                    put("kind", JsonPrimitive("COMPOSE"))
+                  },
+                )
+                put(
+                  "captures",
+                  JsonArray(
+                    listOf(
+                      buildJsonObject {
+                        put("renderOutput", JsonPrimitive("renders/GreetingKt.Greeting.png"))
+                        put("cost", JsonPrimitive(1.0f))
+                      }
+                    )
+                  ),
+                )
+                put("dataProducts", JsonArray(emptyList()))
+                put("targets", JsonArray(emptyList()))
+              }
+            )
+          ),
+        )
+      },
+    )
+
+  /**
+   * Hand-written `daemon-launch.json` builder. Same field-by-field shape `NonGradleContractTest`
+   * uses — this is the bare contract a non-Gradle producer emits.
+   */
+  private fun writeDescriptor(
+    modulePath: String,
+    variant: String,
+    mainClass: String,
+    classpath: List<String>,
+    jvmArgs: List<String>,
+    moduleDir: File,
+    workspaceRoot: File,
+    previewsJsonPath: File,
+    renderOutputDir: File,
+    historyDir: File,
+    userClassDir: File,
+  ): JsonObject = buildJsonObject {
+    put("schemaVersion", JsonPrimitive(1))
+    put("modulePath", JsonPrimitive(modulePath))
+    put("variant", JsonPrimitive(variant))
+    put("enabled", JsonPrimitive(true))
+    put("mainClass", JsonPrimitive(mainClass))
+    put("javaLauncher", JsonPrimitive(null as String?))
+    put("classpath", JsonArray(classpath.map { JsonPrimitive(it) }))
+    put("jvmArgs", JsonArray(jvmArgs.map { JsonPrimitive(it) }))
+    put(
+      "systemProperties",
+      buildJsonObject {
+        put("composeai.daemon.protocolVersion", JsonPrimitive("1"))
+        put("composeai.daemon.modulePath", JsonPrimitive(modulePath))
+        put("composeai.daemon.moduleId", JsonPrimitive(modulePath))
+        put("composeai.daemon.moduleProjectDir", JsonPrimitive(moduleDir.absolutePath))
+        put("composeai.daemon.workspaceRoot", JsonPrimitive(workspaceRoot.absolutePath))
+        put("composeai.daemon.previewsJsonPath", JsonPrimitive(previewsJsonPath.absolutePath))
+        put("composeai.harness.previewsManifest", JsonPrimitive(previewsJsonPath.absolutePath))
+        put("composeai.render.outputDir", JsonPrimitive(renderOutputDir.absolutePath))
+        put("composeai.daemon.historyDir", JsonPrimitive(historyDir.absolutePath))
+        put("composeai.daemon.userClassDirs", JsonPrimitive(userClassDir.absolutePath))
+        put("composeai.daemon.idleTimeoutMs", JsonPrimitive("5000"))
+      },
+    )
+    put("workingDirectory", JsonPrimitive(moduleDir.absolutePath))
+    put("manifestPath", JsonPrimitive(previewsJsonPath.absolutePath))
+  }
+
+  private fun locateRepoRoot(): File {
+    var dir: File? = File(".").canonicalFile
+    while (dir != null) {
+      if (File(dir, "settings.gradle.kts").isFile) return dir
+      dir = dir.parentFile
+    }
+    error("Could not locate repo root above ${File(".").canonicalFile}")
+  }
+}

--- a/render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/NonGradleContractTest.kt
+++ b/render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/NonGradleContractTest.kt
@@ -1,0 +1,298 @@
+package ee.schimke.composeai.render.session.subprocess
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Proves the `daemon-launch.json` schema is a stable contract independent of the Gradle plugin: any
+ * non-Gradle build (Amper, Bazel, Buck2, a shell script) that can resolve a runtime classpath
+ * + locate compiled `@Preview` classes can author a working descriptor by hand and drive a
+ *   `RenderSession` against it.
+ *
+ * The test does **not** call `:samples:cmp:composePreviewDaemonStart`. It does call
+ * `:samples:cmp:discoverPreviews` (via the gradle pre-build) so a `previews.json` exists on disk —
+ * preview discovery is one of the two contracts a non-Gradle integration owns, but the discovery
+ * library extraction is a separate piece of work (see `docs/NON_GRADLE_INTEGRATION.md` §
+ * "Limitations and follow-ups"); for now the test reuses an existing manifest the way an Amper /
+ * Bazel rule would in a v1 integration.
+ *
+ * **What's proven:**
+ *
+ * 1. The classpath / mainClass / sysprops the daemon needs at boot can be assembled outside the
+ *    plugin (the test rebuilds the descriptor field-by-field from a parsed reference, not from a
+ *    Gradle action).
+ * 2. `SubprocessRenderSessions.open(...)` accepts the synthesised descriptor and completes the
+ *    `initialize` handshake.
+ * 3. `renderNow` produces a real PNG against the synthesised classpath — i.e. the daemon picks up
+ *    the user classes and Compose runtime from the descriptor, not from any ambient gradle state.
+ *
+ * **Self-skip:** the test skips cleanly when the prerequisite gradle outputs are missing — devs who
+ * haven't run `:samples:cmp:discoverPreviews` shouldn't see a hard failure. CI runs the pre-step
+ * explicitly via `render-session/subprocess/build.gradle.kts`.
+ */
+class NonGradleContractTest {
+
+  @get:Rule val tempDir: TemporaryFolder = TemporaryFolder()
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    prettyPrint = true
+    encodeDefaults = true
+  }
+
+  @Test
+  fun `synthesised descriptor drives a real render via RenderSession`() {
+    val repoRoot = locateRepoRoot()
+    val sampleProjectDir = File(repoRoot, "samples/cmp")
+    val previewsJson = File(sampleProjectDir, "build/compose-previews/previews.json")
+    val gradlePluginDescriptor = File(sampleProjectDir, "build/compose-previews/daemon-launch.json")
+
+    if (!previewsJson.isFile || !gradlePluginDescriptor.isFile) {
+      System.err.println(
+        "[NonGradleContractTest] skipping — run `:samples:cmp:discoverPreviews " +
+          ":samples:cmp:composePreviewDaemonStart` first to produce the reference inputs."
+      )
+      return
+    }
+
+    // 1. Treat the gradle-plugin's descriptor as a *parts list* — classpath entries, sysprop
+    //    values, JVM args — that any other producer would also need to surface. The synthesis
+    //    below uses individual fields, not the file as a whole; a real Amper / Bazel integration
+    //    would resolve the same parts from its own dep graph.
+    val referenceDescriptor = json.parseToJsonElement(gradlePluginDescriptor.readText()).jsonObject
+    val classpath = referenceDescriptor.classpathList()
+    val jvmArgs = referenceDescriptor["jvmArgs"]!!.jsonArray.map { it.jsonPrimitive.content }
+    val mainClass = referenceDescriptor["mainClass"]!!.jsonPrimitive.content
+
+    // 2. Synthesise a *fresh* descriptor in a tmp dir — render outputs land here too, so the test
+    //    doesn't trample the on-disk gradle outputs. This is what makes the test independent of
+    //    the gradle plugin: the descriptor we open against is one we wrote field-by-field.
+    val moduleDir = tempDir.newFolder("module")
+    val renderOutputDir = File(moduleDir, "build/compose-previews/renders").apply { mkdirs() }
+    val historyDir = File(moduleDir, ".compose-preview-history").apply { mkdirs() }
+    val previewsJsonCopy = File(moduleDir, "build/compose-previews/previews.json")
+    previewsJsonCopy.parentFile.mkdirs()
+    previewsJsonCopy.writeText(rewritePreviewsForTmp(previewsJson.readText(), renderOutputDir))
+
+    val descriptorFile = File(moduleDir, "build/compose-previews/daemon-launch.json")
+    descriptorFile.writeText(
+      writeDescriptor(
+          modulePath = ":non-gradle-fixture",
+          variant = "desktop",
+          mainClass = mainClass,
+          classpath = classpath,
+          jvmArgs = jvmArgs,
+          moduleDir = moduleDir,
+          workspaceRoot = repoRoot,
+          previewsJsonPath = previewsJsonCopy,
+          renderOutputDir = renderOutputDir,
+          historyDir = historyDir,
+        )
+        .toString()
+    )
+
+    // 3. Open the session against the synthesised descriptor and render a vanilla preview from
+    //    the manifest. The handshake must succeed; the render must land a PNG on disk.
+    //    `@PreviewParameter`-driven previews are skipped — they need provider expansion the
+    //    standalone discovery layer doesn't do here (see `docs/NON_GRADLE_INTEGRATION.md`
+    //    "Limitations and follow-ups"); the test would fail loading the composable by raw
+    //    method name. A vanilla `@Preview` exercises the same render path.
+    val target =
+      pickVanillaPreviewId(previewsJsonCopy)
+        ?: error("previews.json must contain at least one non-parameterised preview")
+
+    SubprocessRenderSessions.open(
+        RenderSessionConfig(
+          descriptorPath = descriptorFile,
+          workspaceRoot = repoRoot,
+          workspaceName = "compose-ai-tools",
+          // Surface daemon stderr in the test report so a render failure is debuggable without
+          // re-running with extra flags.
+          logSink = { line -> System.err.println("[daemon] $line") },
+        )
+      )
+      .use { session ->
+        // The synthesised descriptor's modulePath round-trips through the daemon — proves the
+        // session is bound to the descriptor we wrote, not to any ambient state.
+        assertThat(session.modulePath).isEqualTo(":non-gradle-fixture")
+        assertThat(session.initializeResult.daemonVersion).isNotEmpty()
+
+        // `renderNow` is async: the response acknowledges the queue, the PNG arrives later via a
+        // `renderFinished` notification. Register a listener *before* calling renderNow so we
+        // don't race the daemon dispatching the notification.
+        val finishedParams = AtomicReference<JsonObject?>(null)
+        val latch = CountDownLatch(1)
+        session
+          .onNotification { method, params ->
+            if (method == "renderFinished" && params != null) {
+              val id = params["id"]?.jsonPrimitive?.contentOrNull
+              if (id == target) {
+                finishedParams.set(params)
+                latch.countDown()
+              }
+            }
+          }
+          .use {
+            val queueAck = session.renderNow(previewIds = listOf(target), tier = RenderTier.FULL)
+            assertWithMessage(
+                "renderNow should queue our target id, got rejected=${queueAck.rejected}"
+              )
+              .that(queueAck.rejected.map { it.id })
+              .doesNotContain(target)
+
+            // 60s is generous — desktop cold start is ~2s; the rest is render time. Failing here
+            // means the daemon didn't dispatch renderFinished, which is almost always a render-side
+            // crash captured in the stderr logSink above.
+            assertWithMessage("daemon should emit renderFinished for $target within 60s")
+              .that(latch.await(60, TimeUnit.SECONDS))
+              .isTrue()
+          }
+
+        val params =
+          finishedParams.get() ?: error("renderFinished notification missing pngPath payload")
+        val pngPath =
+          params["pngPath"]?.jsonPrimitive?.contentOrNull
+            ?: error("renderFinished params missing pngPath: $params")
+        val png = File(pngPath)
+        assertWithMessage("rendered PNG must exist on disk: $pngPath").that(png.isFile).isTrue()
+        assertThat(png.length()).isGreaterThan(0L)
+      }
+  }
+
+  /**
+   * Rewrites `renderOutput` paths in a copied `previews.json` so each preview's PNG lands in our
+   * tmp render-output dir (configured via the descriptor's `composeai.render.outputDir` sysprop)
+   * rather than the original gradle-plugin output dir. Mirrors what a non-Gradle integration would
+   * do post-discovery to point captures at a build-system-controlled output location.
+   */
+  private fun rewritePreviewsForTmp(rawJson: String, renderOutputDir: File): String {
+    val root = json.parseToJsonElement(rawJson).jsonObject
+    val previews = root["previews"]!!.jsonArray
+    val rewritten = previews.map { previewElement ->
+      val preview = previewElement.jsonObject
+      val captures =
+        preview["captures"]?.jsonArray?.map { captureElement ->
+          val capture = captureElement.jsonObject
+          // The renderer treats `renderOutput` as relative-to-outputDir; normalising the
+          // path to the leaf filename gives the daemon a clean "renders/<file>.png" to write
+          // under `composeai.render.outputDir`.
+          val originalOutput = capture["renderOutput"]?.jsonPrimitive?.contentOrNull
+          val leaf =
+            originalOutput?.substringAfterLast('/')?.takeIf { it.isNotBlank() }
+              ?: "${preview["id"]!!.jsonPrimitive.content}.png"
+          JsonObject(capture + ("renderOutput" to JsonPrimitive("renders/$leaf")))
+        }
+      JsonObject(
+        preview +
+          ("captures" to JsonArray(captures ?: emptyList())) +
+          ("module" to JsonPrimitive(":non-gradle-fixture"))
+      )
+    }
+    return json.encodeToString(
+      JsonObject.serializer(),
+      JsonObject(root + ("previews" to JsonArray(rewritten))),
+    )
+  }
+
+  private fun JsonObject.classpathList(): List<String> =
+    this["classpath"]!!.jsonArray.map { it.jsonPrimitive.content }
+
+  /**
+   * Returns the first preview id in [previewsJson] whose `params.previewParameterProviderClassName`
+   * is `null` — i.e. a vanilla `@Preview` without a `@PreviewParameter`-driven fan-out. The
+   * subprocess daemon's `RenderEngine` resolves composable methods by raw name; parameterised
+   * previews need provider-instance threading that the daemon's standalone path doesn't do.
+   */
+  private fun pickVanillaPreviewId(previewsJson: File): String? {
+    val parsed = json.parseToJsonElement(previewsJson.readText()).jsonObject
+    return parsed["previews"]!!
+      .jsonArray
+      .firstOrNull { previewElement ->
+        val preview = previewElement.jsonObject
+        val providerName =
+          preview["params"]?.jsonObject?.get("previewParameterProviderClassName")?.jsonPrimitive
+        providerName == null || providerName.contentOrNull == null
+      }
+      ?.jsonObject
+      ?.get("id")
+      ?.jsonPrimitive
+      ?.content
+  }
+
+  /**
+   * Hand-written `daemon-launch.json` builder. This is the *exact* shape the design document
+   * specifies — anything that can produce this JSON works with the subprocess factory. Kept
+   * structural rather than typed (no `@Serializable` class) so the test demonstrates the bare
+   * contract a non-Kotlin caller (a shell script, a Bazel rule generator) would also produce.
+   */
+  private fun writeDescriptor(
+    modulePath: String,
+    variant: String,
+    mainClass: String,
+    classpath: List<String>,
+    jvmArgs: List<String>,
+    moduleDir: File,
+    workspaceRoot: File,
+    previewsJsonPath: File,
+    renderOutputDir: File,
+    historyDir: File,
+  ): JsonObject = buildJsonObject {
+    put("schemaVersion", JsonPrimitive(1))
+    put("modulePath", JsonPrimitive(modulePath))
+    put("variant", JsonPrimitive(variant))
+    put("enabled", JsonPrimitive(true))
+    put("mainClass", JsonPrimitive(mainClass))
+    put("javaLauncher", JsonPrimitive(null as String?))
+    put("classpath", JsonArray(classpath.map { JsonPrimitive(it) }))
+    put("jvmArgs", JsonArray(jvmArgs.map { JsonPrimitive(it) }))
+    put(
+      "systemProperties",
+      buildJsonObject {
+        put("composeai.daemon.protocolVersion", JsonPrimitive("1"))
+        put("composeai.daemon.modulePath", JsonPrimitive(modulePath))
+        put("composeai.daemon.moduleId", JsonPrimitive(modulePath))
+        put("composeai.daemon.moduleProjectDir", JsonPrimitive(moduleDir.absolutePath))
+        put("composeai.daemon.workspaceRoot", JsonPrimitive(workspaceRoot.absolutePath))
+        put("composeai.daemon.previewsJsonPath", JsonPrimitive(previewsJsonPath.absolutePath))
+        put("composeai.harness.previewsManifest", JsonPrimitive(previewsJsonPath.absolutePath))
+        put("composeai.render.outputDir", JsonPrimitive(renderOutputDir.absolutePath))
+        put("composeai.daemon.historyDir", JsonPrimitive(historyDir.absolutePath))
+        put("composeai.daemon.idleTimeoutMs", JsonPrimitive("5000"))
+      },
+    )
+    put("workingDirectory", JsonPrimitive(moduleDir.absolutePath))
+    put("manifestPath", JsonPrimitive(previewsJsonPath.absolutePath))
+  }
+
+  /**
+   * Walks up from the test JVM's working dir until we find the repo's `settings.gradle.kts`. The
+   * test classpath plants the working dir somewhere under `render-session/subprocess/` during
+   * gradle runs, but every path we feed into the descriptor has to be absolute.
+   */
+  private fun locateRepoRoot(): File {
+    var dir: File? = File(".").canonicalFile
+    while (dir != null) {
+      if (File(dir, "settings.gradle.kts").isFile) return dir
+      dir = dir.parentFile
+    }
+    error("Could not locate repo root above ${File(".").canonicalFile}")
+  }
+}

--- a/samples/amper-cmp-desktop/README.md
+++ b/samples/amper-cmp-desktop/README.md
@@ -3,46 +3,69 @@
 A tiny [Amper](https://amper.org) Compose Desktop project demonstrating
 how to drive `compose-preview` from a non-Gradle build. The single
 `@Preview` composable is `Greeting()` in [`src/Greeting.kt`](src/Greeting.kt);
-the build is declared in [`module.yaml`](module.yaml) — six lines.
+the build is declared in [`module.yaml`](module.yaml). The Amper wrapper
+(`amper` + `amper.bat`) is vendored at the root so the fixture is
+self-contained.
 
-This fixture is consumer-style — `compose-ai-tools` does not vendor an
-Amper wrapper into the repo (Amper's distribution lives on
-`packages.jetbrains.team`, not Maven Central, so the wrapper would only
-run in environments that allowlist that host). Downstream consumers
-follow the [Amper quick-start](https://amper.org/) to bootstrap their
-own wrapper, then point it at this module.
+End-to-end is exercised by
+[`AmperContractTest`](../../render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/AmperContractTest.kt):
+it consumes Amper's compiled output, synthesises a `daemon-launch.json`,
+and drives a real `RenderSession` against it.
 
-## End-to-end flow
+## Running the fixture
 
 ```bash
-# 1. Build with Amper (cold start ~60s the first time; ~3s cached).
+cd samples/amper-cmp-desktop
+
+# Sandbox / managed environments with a TLS-inspection proxy: the
+# bundled Zulu JRE Amper auto-downloads doesn't trust the proxy CA, so
+# Maven Central / Google Maven fetches fail with PKIX errors. Wire the
+# system truststore (which the sandbox keeps current) explicitly:
+export AMPER_JAVA_OPTIONS="-ea -XX:+EnableDynamicAgentLoading \
+  -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts \
+  -Djavax.net.ssl.trustStorePassword=changeit"
+
 ./amper build
-
-# 2. Discover @Preview composables in the build outputs. The discovery
-#    library extraction is tracked separately; for now, point ClassGraph
-#    at <module>/build/.../classes/main and emit previews.json by hand.
-./scripts/discover-previews.sh \
-  --module-classes build/tasks/_amper-cmp-desktop_jvmRuntimeClasspath/classes/main \
-  --output build/compose-previews/previews.json
-
-# 3. Synthesise daemon-launch.json from Amper's resolved classpath plus the
-#    renderer / connector jars resolved out of Maven Central.
-./scripts/amper-to-daemon-launch.sh \
-  --module-yaml module.yaml \
-  --classes build/tasks/_amper-cmp-desktop_jvmRuntimeClasspath/classes/main \
-  --runtime-classpath build/tasks/_amper-cmp-desktop_jvmRuntimeClasspath/classpath.txt \
-  --compose-preview-version 0.10.x \
-  --output build/compose-previews/daemon-launch.json
-
-# 4. Render via the published render-session-subprocess artifact.
-kotlin -classpath /path/to/render-session-subprocess.jar \
-  -e 'SubprocessRenderSessions.open(...)' # see the JVM snippet in NON_GRADLE_INTEGRATION.md
 ```
 
-The helper scripts above are sketched in [`docs/NON_GRADLE_INTEGRATION.md`](../../docs/NON_GRADLE_INTEGRATION.md);
-they're not vendored in this repo because Amper's output path layout is
-still evolving (Amper 0.10 changed it from earlier versions). Pin to a
-specific Amper release before scripting.
+Cold start (first run) downloads Amper (~12s) plus the Compose Desktop
+runtime into Amper's m2 cache (~10s more); subsequent builds are
+sub-3s.
+
+## End-to-end with `compose-preview`
+
+After `./amper build` the test runner picks the fixture up:
+
+```bash
+./gradlew :render-session-subprocess:test \
+  --tests 'ee.schimke.composeai.render.session.subprocess.AmperContractTest'
+```
+
+The test self-skips when Amper outputs aren't on disk (so a clean tree
+doesn't fail). It produces a PNG of `Greeting()` rendered through the
+same daemon pipeline the Gradle plugin uses — the path that's exercised
+is:
+
+1. `./amper build` produces `GreetingKt.class` under
+   `build/artifacts/CompiledJvmArtifact/amper-cmp-desktopjvm/kotlin-output/`.
+2. The test reads the renderer + connector + Compose Desktop jar bag
+   from `:samples:cmp:composePreviewDaemonStart`'s descriptor (a real
+   Amper user would resolve these from Maven Central; `NonGradleContractTest`
+   already covers the descriptor-synthesis side of the contract).
+3. cmp's user-class dirs are filtered out and replaced with Amper's
+   `kotlin-output/`; `previews.json` is hand-authored for
+   `GreetingKt.Greeting`.
+4. `SubprocessRenderSessions.open(...)` drives the daemon; `renderNow`
+   produces a PNG asserted on disk.
+
+## Why the fixture overrides `jvm.release`
+
+Amper defaults to `jvm.release: 21`, but compose-preview's daemon JVM
+runs on JDK 17 (the project's pinned toolchain). Loading a class
+compiled against Java 21 in a Java-17 JVM fails with
+`UnsupportedClassVersionError` (class file version 65 ≠ 61). The
+fixture pins `jvm.release: 17` in `module.yaml` to bridge the gap;
+downstream Amper users with a JDK 21+ daemon don't need this.
 
 ## Why this isn't a Gradle subproject
 
@@ -50,13 +73,30 @@ The rest of `compose-ai-tools/samples/` consists of regular Gradle
 modules included via `settings.gradle.kts`. This directory deliberately
 isn't included — the whole point is to demonstrate a project layout
 that *doesn't* have a `build.gradle.kts`. The root `settings.gradle.kts`
-skips this directory; the contract test
-([`render-session/subprocess/.../NonGradleContractTest.kt`](../../render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/NonGradleContractTest.kt))
-proves the design end-to-end against `:samples:cmp`'s build outputs.
+skips this directory; the test above proves the design end-to-end
+against Amper's outputs.
+
+## Build-output layout (Amper 0.10)
+
+For anyone scripting a non-Gradle integration of their own, the
+relevant paths after `./amper build` are:
+
+| Artifact | Path |
+| --- | --- |
+| Compiled classes | `build/artifacts/CompiledJvmArtifact/<module>jvm/kotlin-output/` |
+| Module jar | `build/tasks/_<module>_jarJvm/<module>-jvm.jar` |
+| Resolved runtime jars | `~/.cache/JetBrains/Amper/.m2.cache/<group>/<artifact>/<version>/` |
+
+There is no resolved `classpath.txt` — a real integration would scrape
+`./amper show dependencies` against the m2 cache, or use Amper's task
+outputs once a stable API for that ships.
 
 ## Updating from upstream
 
 The fixture mirrors
 [`JetBrains/amper:examples/compose-desktop`](https://github.com/JetBrains/amper/tree/main/examples/compose-desktop)
-with `material3` substituted for `material`. When upstream Amper
-revises the example or bumps Compose, refresh this fixture in lockstep.
+with `material3` substituted for `material` (Greeting.kt uses
+`material3.MaterialTheme` so the fixture lines up with the rest of
+compose-ai-tools' Compose Desktop fixtures). When upstream Amper
+revises the example or bumps Compose, refresh this fixture in lockstep,
+including the wrapper scripts (pinned to Amper v0.10.0).

--- a/samples/amper-cmp-desktop/README.md
+++ b/samples/amper-cmp-desktop/README.md
@@ -1,0 +1,62 @@
+# Amper + Compose Preview — non-Gradle integration fixture
+
+A tiny [Amper](https://amper.org) Compose Desktop project demonstrating
+how to drive `compose-preview` from a non-Gradle build. The single
+`@Preview` composable is `Greeting()` in [`src/Greeting.kt`](src/Greeting.kt);
+the build is declared in [`module.yaml`](module.yaml) — six lines.
+
+This fixture is consumer-style — `compose-ai-tools` does not vendor an
+Amper wrapper into the repo (Amper's distribution lives on
+`packages.jetbrains.team`, not Maven Central, so the wrapper would only
+run in environments that allowlist that host). Downstream consumers
+follow the [Amper quick-start](https://amper.org/) to bootstrap their
+own wrapper, then point it at this module.
+
+## End-to-end flow
+
+```bash
+# 1. Build with Amper (cold start ~60s the first time; ~3s cached).
+./amper build
+
+# 2. Discover @Preview composables in the build outputs. The discovery
+#    library extraction is tracked separately; for now, point ClassGraph
+#    at <module>/build/.../classes/main and emit previews.json by hand.
+./scripts/discover-previews.sh \
+  --module-classes build/tasks/_amper-cmp-desktop_jvmRuntimeClasspath/classes/main \
+  --output build/compose-previews/previews.json
+
+# 3. Synthesise daemon-launch.json from Amper's resolved classpath plus the
+#    renderer / connector jars resolved out of Maven Central.
+./scripts/amper-to-daemon-launch.sh \
+  --module-yaml module.yaml \
+  --classes build/tasks/_amper-cmp-desktop_jvmRuntimeClasspath/classes/main \
+  --runtime-classpath build/tasks/_amper-cmp-desktop_jvmRuntimeClasspath/classpath.txt \
+  --compose-preview-version 0.10.x \
+  --output build/compose-previews/daemon-launch.json
+
+# 4. Render via the published render-session-subprocess artifact.
+kotlin -classpath /path/to/render-session-subprocess.jar \
+  -e 'SubprocessRenderSessions.open(...)' # see the JVM snippet in NON_GRADLE_INTEGRATION.md
+```
+
+The helper scripts above are sketched in [`docs/NON_GRADLE_INTEGRATION.md`](../../docs/NON_GRADLE_INTEGRATION.md);
+they're not vendored in this repo because Amper's output path layout is
+still evolving (Amper 0.10 changed it from earlier versions). Pin to a
+specific Amper release before scripting.
+
+## Why this isn't a Gradle subproject
+
+The rest of `compose-ai-tools/samples/` consists of regular Gradle
+modules included via `settings.gradle.kts`. This directory deliberately
+isn't included — the whole point is to demonstrate a project layout
+that *doesn't* have a `build.gradle.kts`. The root `settings.gradle.kts`
+skips this directory; the contract test
+([`render-session/subprocess/.../NonGradleContractTest.kt`](../../render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/NonGradleContractTest.kt))
+proves the design end-to-end against `:samples:cmp`'s build outputs.
+
+## Updating from upstream
+
+The fixture mirrors
+[`JetBrains/amper:examples/compose-desktop`](https://github.com/JetBrains/amper/tree/main/examples/compose-desktop)
+with `material3` substituted for `material`. When upstream Amper
+revises the example or bumps Compose, refresh this fixture in lockstep.

--- a/samples/amper-cmp-desktop/amper
+++ b/samples/amper-cmp-desktop/amper
@@ -1,0 +1,328 @@
+#!/bin/sh
+
+#
+# Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+#
+
+# Possible environment variables:
+#   AMPER_DOWNLOAD_ROOT        Maven repository to download Amper dist from.
+#                              default: https://packages.jetbrains.team/maven/p/amper/amper
+#   AMPER_JRE_DOWNLOAD_ROOT    Url prefix to download Amper JRE from.
+#                              default: https:/
+#   AMPER_BOOTSTRAP_CACHE_DIR  Cache directory to store extracted JRE and Amper distribution
+#   AMPER_JAVA_HOME            JRE to run Amper itself (optional, does not affect compilation)
+#   AMPER_JAVA_OPTIONS         JVM options to pass to the JVM running Amper (does not affect the user's application)
+#   AMPER_NO_WELCOME_BANNER    Disables the first-run welcome message if set to a non-empty value
+
+set -e -u
+
+# The version of the Amper distribution to provision and use
+amper_version=0.10.0-dev-3768
+# Establish chain of trust from here by specifying exact checksum of Amper distribution to be run
+amper_sha256=9fc35f1c965d8ff21c4d8c331038d9a8646fda6ae71c4b5e88d47fa03a5e1073
+
+AMPER_DOWNLOAD_ROOT="${AMPER_DOWNLOAD_ROOT:-https://packages.jetbrains.team/maven/p/amper/amper}"
+AMPER_JRE_DOWNLOAD_ROOT="${AMPER_JRE_DOWNLOAD_ROOT:-https:/}"
+
+die() {
+  echo >&2
+  echo "$@" >&2
+  echo >&2
+  exit 1
+}
+
+download_and_extract() {
+  moniker="$1"
+  file_url="$2"
+  file_sha="$3"
+  sha_size="$4"
+  cache_dir="$5"
+  extract_dir="$6"
+  show_banner_on_cache_miss="$7"
+
+  if [ -e "$extract_dir/.flag" ] && [ "$(cat "$extract_dir/.flag")" = "${file_sha}" ]; then
+    # Everything is up-to-date in $extract_dir, do nothing
+    return 0;
+  fi
+
+  mkdir -p "$cache_dir"
+
+  # Take a lock for the download of this file
+  short_sha=$(echo "$file_sha" | cut -c1-32) # cannot use the ${short_sha:0:32} syntax in regular /bin/sh
+  download_lock_file="$cache_dir/download-${short_sha}.lock"
+  process_lock_file="$cache_dir/download-${short_sha}.$$.lock"
+  echo $$ >"$process_lock_file"
+  while ! ln "$process_lock_file" "$download_lock_file" 2>/dev/null; do
+    lock_owner=$(cat "$download_lock_file" 2>/dev/null || true)
+    if [ -n "$lock_owner" ] && ps -p "$lock_owner" >/dev/null; then
+      echo "Another Amper instance (pid $lock_owner) is downloading $moniker. Awaiting the result..."
+      sleep 1
+    elif [ -n "$lock_owner" ] && [ "$(cat "$download_lock_file" 2>/dev/null)" = "$lock_owner" ]; then
+      rm -f "$download_lock_file"
+      # We don't want to simply loop again here, because multiple concurrent processes may face this at the same time,
+      # which means the 'rm' command above from another script could delete our new valid lock file. Instead, we just
+      # ask the user to try again. This doesn't 100% eliminate the race, but the probability of issues is drastically
+      # reduced because it would involve 4 processes with perfect timing. We can revisit this later.
+      die "Another Amper instance (pid $lock_owner) locked the download of $moniker, but is no longer running. The lock file is now removed, please try again."
+    fi
+  done
+
+  # shellcheck disable=SC2064
+  trap "rm -f \"$download_lock_file\"" EXIT
+  rm -f "$process_lock_file"
+
+  unlock_and_cleanup() {
+    rm -f "$download_lock_file"
+    trap - EXIT
+    return 0
+  }
+
+  if [ -e "$extract_dir/.flag" ] && [ "$(cat "$extract_dir/.flag")" = "${file_sha}" ]; then
+    # Everything is up-to-date in $extract_dir, just release the lock
+    unlock_and_cleanup
+    return 0;
+  fi
+
+  if [ "$show_banner_on_cache_miss" = "true" ] && [ -z "${AMPER_NO_WELCOME_BANNER:-}" ]; then
+      echo
+      echo '        _____  Welcome to                                  '
+      echo '       /:::::|  ____   ___     ____      ____    __  ___   '
+      echo '      /::/|::| |::::\_|:::\   |:::::\   /::::\  |::|/:::|  '
+      echo '     /::/ |::| |::|\:::|\::\  |::|\::\ /:/__\:\ |:::/      '
+      echo '    /::/__|::| |::| |::| |::| |::| |::|:::::::/ |::|       '
+      echo '   /:::::::::| |::| |::| |::| |::|/::/ \::\__   |::|       '
+      echo '  /::/    |::| |::| |::| |::| |:::::/   \::::|  |::|       '
+      echo '                              |::|                         '
+      echo "                              |::|  v.$amper_version       "
+      echo
+      echo "This is the first run of this version, so we need to download the actual Amper distribution."
+      echo "Please give us a few seconds, subsequent runs will be faster."
+      echo
+  fi
+
+  echo "Downloading $moniker..."
+
+  temp_file="$cache_dir/download-file-$$.bin"
+  rm -f "$temp_file"
+  if command -v curl >/dev/null 2>&1; then
+    if [ -t 1 ]; then CURL_PROGRESS="--progress-bar"; else CURL_PROGRESS="--silent --show-error"; fi
+    # shellcheck disable=SC2086
+    curl $CURL_PROGRESS -L --fail --retry 5 --connect-timeout 30 --output "${temp_file}" "$file_url"
+  elif command -v wget >/dev/null 2>&1; then
+    if [ -t 1 ]; then WGET_PROGRESS=""; else WGET_PROGRESS="-nv"; fi
+    wget $WGET_PROGRESS --tries=5 --connect-timeout=30 --read-timeout=120 -O "${temp_file}" "$file_url"
+  else
+    die "ERROR: Please install 'wget' or 'curl', as Amper needs one of them to download $moniker"
+  fi
+
+  check_sha "$file_url" "$temp_file" "$file_sha" "$sha_size"
+
+  rm -rf "$extract_dir"
+  mkdir -p "$extract_dir"
+
+  case "$file_url" in
+    *".zip")
+      if command -v unzip >/dev/null 2>&1; then
+        unzip -q "$temp_file" -d "$extract_dir"
+      else
+        die "ERROR: Please install 'unzip', as Amper needs it to extract $moniker"
+      fi ;;
+    *)
+      if command -v tar >/dev/null 2>&1; then
+        tar -x -f "$temp_file" -C "$extract_dir"
+      else
+        die "ERROR: Please install 'tar', as Amper needs it to extract $moniker"
+      fi ;;
+  esac
+
+  rm -f "$temp_file"
+
+  echo "$file_sha" >"$extract_dir/.flag"
+
+  # Unlock and cleanup the lock file
+  unlock_and_cleanup
+
+  echo "Download complete."
+  echo
+}
+
+# usage: check_sha SOURCE_MONIKER FILE SHA_CHECKSUM SHA_SIZE
+# $1 SOURCE_MONIKER (e.g. url)
+# $2 FILE
+# $3 SHA hex string
+# $4 SHA size in bits (256, 512, ...)
+check_sha() {
+  sha_size=$4
+  if command -v shasum >/dev/null 2>&1; then
+    echo "$3 *$2" | shasum -a "$sha_size" --status -c || {
+      die "ERROR: Checksum mismatch for $2 (downloaded from $1): expected checksum $3 but got $(shasum --binary -a "$sha_size" "$2" | awk '{print $1}')"
+    }
+    return 0
+  fi
+
+  shaNsumCommand="sha${sha_size}sum"
+  if command -v "$shaNsumCommand" >/dev/null 2>&1; then
+    echo "$3 *$2" | $shaNsumCommand -w -c || {
+      die "ERROR: Checksum mismatch for $2 (downloaded from $1): expected checksum $3 but got $($shaNsumCommand "$2" | awk '{print $1}')"
+    }
+    return 0
+  fi
+
+  echo "Both 'shasum' and 'sha${sha_size}sum' utilities are missing. Please install one of them"
+  return 1
+}
+
+# ********** System detection **********
+
+kernelName=$(uname -s)
+arch=$(uname -m)
+case "$kernelName" in
+  Darwin* )
+    simpleOs="macos"
+    jre_os="macosx"
+    jre_archive_type="tar.gz"
+    default_amper_cache_dir="$HOME/Library/Caches/JetBrains/Amper"
+    ;;
+  Linux* )
+    simpleOs="linux"
+    jre_os="linux"
+    jre_archive_type="tar.gz"
+    default_amper_cache_dir="$HOME/.cache/JetBrains/Amper"
+    # If linux runs in 32-bit mode, we want the "fake" 32-bit architecture, not the real hardware,
+    # because in this mode linux cannot run 64-bit binaries.
+    # shellcheck disable=SC2046
+    arch=$(linux$(getconf LONG_BIT) uname -m)
+    ;;
+  CYGWIN* | MSYS* | MINGW* )
+    simpleOs="windows"
+    jre_os="win"
+    jre_archive_type=zip
+    if command -v cygpath >/dev/null 2>&1; then
+      default_amper_cache_dir=$(cygpath -u "$LOCALAPPDATA\JetBrains\Amper")
+    else
+      die "The 'cypath' command is not available, but Amper needs it. Use amper.bat instead, or try a Cygwin or MSYS environment."
+    fi
+    ;;
+  *)
+    die "Unsupported platform $kernelName"
+    ;;
+esac
+
+amper_cache_dir="${AMPER_BOOTSTRAP_CACHE_DIR:-$default_amper_cache_dir}"
+
+# ********** Provision Amper distribution **********
+
+amper_url="$AMPER_DOWNLOAD_ROOT/org/jetbrains/amper/amper-cli/$amper_version/amper-cli-$amper_version-dist.tgz"
+amper_target_dir="$amper_cache_dir/amper-cli-$amper_version"
+download_and_extract "Amper distribution v$amper_version" "$amper_url" "$amper_sha256" 256 "$amper_cache_dir" "$amper_target_dir" "true"
+
+# ********** Provision JRE for Amper **********
+
+if [ "x${AMPER_JAVA_HOME:-}" = "x" ]; then
+  case $arch in
+    x86_64 | x64)    jre_arch="x64" ;;
+    aarch64 | arm64) jre_arch="aarch64" ;;
+    *) die "Unsupported architecture $arch" ;;
+  esac
+
+  # Auto-updated from syncVersions.main.kts, do not modify directly here
+  zulu_version=25.32.21
+  java_version=25.0.2
+
+  platform="$jre_os $jre_arch"
+  case $platform in
+    "macosx x64")     jre_sha256=cb23779ae726b160fdd6af58cb3a8db2dec8fc3f3c21e27dafa30cc148798346 ;;
+    "macosx aarch64") jre_sha256=5c3edffe2d3b9203d838ed0548035f08be2b9f672544bab2b9c1825c309d0be7 ;;
+    "linux x64")      jre_sha256=851e913928d968df05996c95f83a4a9567b463143ce9b84dd32b68035e22cf81 ;;
+    "linux aarch64")  jre_sha256=cc70d2d46851192288ed7c9de1d6aab07eedeac9a369d54f299202152e2b52ec ;;
+    "win x64")        jre_sha256=a4b7e3c3929d513cdc774583d375ce07fcb8671833258f468fd2fa0d8227ba48 ;;
+    "win aarch64")    jre_sha256=1106eec3bd166a117ccaf20f15bbec6537e27307be328b8a9e93a053c857fe7c ;;
+    *) die "Unsupported platform $platform" ;;
+  esac
+
+  # URL for the JRE (see https://api.azul.com/metadata/v1/zulu/packages?release_status=ga&include_fields=java_package_features,os,arch,hw_bitness,abi,java_package_type,sha256_hash,size,archive_type,lib_c_type&java_version=25&os=macos,linux,win)
+  # https://cdn.azul.com/zulu/bin/zulu25.28.85-ca-jre25.0.0-macosx_aarch64.tar.gz
+  # https://cdn.azul.com/zulu/bin/zulu25.28.85-ca-jre25.0.0-linux_x64.tar.gz
+  jre_url="$AMPER_JRE_DOWNLOAD_ROOT/cdn.azul.com/zulu/bin/zulu$zulu_version-ca-jre$java_version-${jre_os}_$jre_arch.$jre_archive_type"
+  jre_target_dir="$amper_cache_dir/zulu$zulu_version-ca-jre$java_version-${jre_os}_$jre_arch"
+
+  download_and_extract "Amper runtime v$zulu_version" "$jre_url" "$jre_sha256" 256 "$amper_cache_dir" "$jre_target_dir" "false"
+
+  effective_amper_java_home=
+  for d in "$jre_target_dir" "$jre_target_dir"/* "$jre_target_dir"/Contents/Home "$jre_target_dir"/*/Contents/Home; do
+    if [ -e "$d/bin/java" ]; then
+      effective_amper_java_home="$d"
+    fi
+  done
+
+  if [ "x${effective_amper_java_home:-}" = "x" ]; then
+    die "Unable to find bin/java under $jre_target_dir"
+  fi
+else
+  effective_amper_java_home="$AMPER_JAVA_HOME"
+fi
+
+java_exe="$effective_amper_java_home/bin/java"
+if [ '!' -x "$java_exe" ]; then
+  die "Unable to find bin/java executable at $java_exe"
+fi
+
+# ********** Script path detection **********
+
+# We might need to resolve symbolic links here
+wrapper_path=$(realpath "$0")
+
+# ********** Launch Amper **********
+
+# In this section we construct the command line by prepending arguments from biggest to lowest precedence:
+#   1. basic main class, CLI arguments, and classpath
+#   2. user JVM args (AMPER_JAVA_OPTIONS)
+#   3. default JVM args (prepended last, which means they appear first, so they are overridden by user args)
+
+# 1. Prepend basic launch arguments
+if [ "$simpleOs" = "windows" ]; then
+  # Can't cygpath the '*' so it has to be outside
+  classpath="$(cygpath -w "$amper_target_dir")\lib\*"
+else
+  classpath="$amper_target_dir/lib/*"
+fi
+
+set -- -cp "$classpath" org.jetbrains.amper.cli.MainKt "$@"
+
+# 2. Prepend user JVM args from AMPER_JAVA_OPTS
+#
+# We use "xargs" to parse quoted JVM args from inside AMPER_JAVA_OPTS.
+# With -n1 it outputs one arg per line, with the quotes and backslashes removed.
+#
+# In Bash we could simply go:
+#
+#   readarray ARGS < <( xargs -n1 <<<"$var" ) &&
+#   set -- "${ARGS[@]}" "$@"
+#
+# but POSIX shell has neither arrays nor command substitution, so instead we
+# post-process each arg (as a line of input to sed) to backslash-escape any
+# character that might be a shell metacharacter, then use eval to reverse
+# that process (while maintaining the separation between arguments), and wrap
+# the whole thing up as a single "set" statement.
+#
+# This will of course break if any of these variables contains a newline or
+# an unmatched quote.
+if [ -n "${AMPER_JAVA_OPTIONS:-}" ]; then
+  eval "set -- $(
+    printf '%s\n' "$AMPER_JAVA_OPTIONS" |
+    xargs -n1 |
+    sed ' s~[^-[:alnum:]+,./:=@_]~\\&~g; ' |
+    tr '\n' ' '
+  )" '"$@"'
+fi
+
+# 3. Prepend default JVM args
+set -- \
+    @"$amper_target_dir/amper.args" \
+    "-Damper.wrapper.dist.sha256=$amper_sha256" \
+    "-Damper.dist.path=$amper_target_dir" \
+    "-Damper.wrapper.path=$wrapper_path" \
+    "$@"
+
+# Then we can launch with the overridden $@ arguments
+exec "$java_exe" "$@"

--- a/samples/amper-cmp-desktop/amper.bat
+++ b/samples/amper-cmp-desktop/amper.bat
@@ -1,0 +1,196 @@
+@echo off
+
+@rem
+@rem Copyright 2000-2024 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+@rem
+
+@rem Possible environment variables:
+@rem   AMPER_DOWNLOAD_ROOT        Maven repository to download Amper dist from
+@rem                              default: https://packages.jetbrains.team/maven/p/amper/amper
+@rem   AMPER_JRE_DOWNLOAD_ROOT    Url prefix to download Amper JRE from.
+@rem                              default: https:/
+@rem   AMPER_BOOTSTRAP_CACHE_DIR  Cache directory to store extracted JRE and Amper distribution
+@rem   AMPER_JAVA_HOME            JRE to run Amper itself (optional, does not affect compilation)
+@rem   AMPER_JAVA_OPTIONS         JVM options to pass to the JVM running Amper (does not affect the user's application)
+@rem   AMPER_NO_WELCOME_BANNER    Disables the first-run welcome message if set to a non-empty value
+
+setlocal
+
+@rem The version of the Amper distribution to provision and use
+set amper_version=0.10.0-dev-3768
+@rem Establish chain of trust from here by specifying exact checksum of Amper distribution to be run
+set amper_sha256=9fc35f1c965d8ff21c4d8c331038d9a8646fda6ae71c4b5e88d47fa03a5e1073
+
+if not defined AMPER_DOWNLOAD_ROOT set AMPER_DOWNLOAD_ROOT=https://packages.jetbrains.team/maven/p/amper/amper
+if not defined AMPER_JRE_DOWNLOAD_ROOT set AMPER_JRE_DOWNLOAD_ROOT=https:/
+if not defined AMPER_BOOTSTRAP_CACHE_DIR set AMPER_BOOTSTRAP_CACHE_DIR=%LOCALAPPDATA%\JetBrains\Amper
+@rem remove trailing \ if present
+if [%AMPER_BOOTSTRAP_CACHE_DIR:~-1%] EQU [\] set AMPER_BOOTSTRAP_CACHE_DIR=%AMPER_BOOTSTRAP_CACHE_DIR:~0,-1%
+
+goto :after_function_declarations
+
+REM ********** Download and extract any zip or .tar.gz archive **********
+
+:download_and_extract
+setlocal
+
+set moniker=%~1
+set url=%~2
+set target_dir=%~3
+set sha=%~4
+set sha_size=%~5
+set show_banner_on_cache_miss=%~6
+
+set flag_file=%target_dir%\.flag
+if exist "%flag_file%" (
+    set /p current_flag=<"%flag_file%"
+    if "%current_flag%" == "%sha%" exit /b
+)
+
+@rem This multiline string is actually passed as a single line to powershell, meaning #-comments are not possible.
+@rem So here are a few comments about the code below:
+@rem  - we need to support both .zip and .tar.gz archives (for the Amper distribution and the JRE)
+@rem  - tar should be present in all Windows machines since 2018 (and usable from both cmd and powershell)
+@rem  - tar requires the destination dir to exist
+@rem  - We use (New-Object Net.WebClient).DownloadFile instead of Invoke-WebRequest for performance. See the issue
+@rem    https://github.com/PowerShell/PowerShell/issues/16914, which is still not fixed in Windows PowerShell 5.1
+@rem  - DownloadFile requires the directories in the destination file's path to exist
+set download_and_extract_ps1= ^
+Set-StrictMode -Version 3.0; ^
+$ErrorActionPreference = 'Stop'; ^
+ ^
+$createdNew = $false; ^
+$lock = New-Object System.Threading.Mutex($true, ('Global\amper-bootstrap.' + '%target_dir%'.GetHashCode().ToString()), [ref]$createdNew); ^
+if (-not $createdNew) { ^
+    Write-Host 'Another Amper instance is bootstrapping. Waiting for our turn...'; ^
+    [void]$lock.WaitOne(); ^
+} ^
+ ^
+try { ^
+    if ((Get-Content '%flag_file%' -ErrorAction Ignore) -ne '%sha%') { ^
+        if (('%show_banner_on_cache_miss%' -eq 'true') -and [string]::IsNullOrEmpty('%AMPER_NO_WELCOME_BANNER%')) { ^
+            Write-Host '*** Welcome to Amper v.%amper_version%! ***'; ^
+            Write-Host ''; ^
+            Write-Host 'This is the first run of this version, so we need to download the actual Amper distribution.'; ^
+            Write-Host 'Please give us a few seconds now, subsequent runs will be faster.'; ^
+            Write-Host ''; ^
+        } ^
+        $temp_file = '%AMPER_BOOTSTRAP_CACHE_DIR%\' + [System.IO.Path]::GetRandomFileName(); ^
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
+        Write-Host 'Downloading %moniker%...'; ^
+        [void](New-Item '%AMPER_BOOTSTRAP_CACHE_DIR%' -ItemType Directory -Force); ^
+        if (Get-Command curl.exe -errorAction SilentlyContinue) { ^
+            curl.exe -L --silent --show-error --fail --output $temp_file '%url%'; ^
+        } else { ^
+            (New-Object Net.WebClient).DownloadFile('%url%', $temp_file); ^
+        } ^
+ ^
+        $actualSha = (Get-FileHash -Algorithm SHA%sha_size% -Path $temp_file).Hash.ToString(); ^
+        if ($actualSha -ne '%sha%') { ^
+            $writeErr = if ($Host.Name -eq 'ConsoleHost') { [Console]::Error.WriteLine } else { $host.ui.WriteErrorLine } ^
+            $writeErr.Invoke(\"ERROR: Checksum mismatch for $temp_file (downloaded from %url%): expected checksum %sha% but got $actualSha\"); ^
+            exit 1; ^
+        } ^
+ ^
+        if (Test-Path '%target_dir%') { ^
+            Remove-Item '%target_dir%' -Recurse; ^
+        } ^
+        if ($temp_file -like '*.zip') { ^
+            Add-Type -A 'System.IO.Compression.FileSystem'; ^
+            [IO.Compression.ZipFile]::ExtractToDirectory($temp_file, '%target_dir%'); ^
+        } else { ^
+            [void](New-Item '%target_dir%' -ItemType Directory -Force); ^
+            tar -xzf $temp_file -C '%target_dir%'; ^
+        } ^
+        Remove-Item $temp_file; ^
+ ^
+        Set-Content '%flag_file%' -Value '%sha%'; ^
+        Write-Host 'Download complete.'; ^
+        Write-Host ''; ^
+    } ^
+} ^
+finally { ^
+    $lock.ReleaseMutex(); ^
+}
+
+rem We reset the PSModulePath in case this batch script was called from PowerShell Core
+rem See https://github.com/PowerShell/PowerShell/issues/18108#issuecomment-2269703022
+set PSModulePath=
+set powershell=%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe
+"%powershell%" -NonInteractive -NoProfile -NoLogo -Command %download_and_extract_ps1%
+if errorlevel 1 exit /b 1
+exit /b 0
+
+:fail
+echo ERROR: Amper bootstrap failed, see errors above
+exit /b 1
+
+:after_function_declarations
+
+REM ********** Provision Amper distribution **********
+
+set amper_url=%AMPER_DOWNLOAD_ROOT%/org/jetbrains/amper/amper-cli/%amper_version%/amper-cli-%amper_version%-dist.tgz
+set amper_target_dir=%AMPER_BOOTSTRAP_CACHE_DIR%\amper-cli-%amper_version%
+call :download_and_extract "Amper distribution v%amper_version%" "%amper_url%" "%amper_target_dir%" "%amper_sha256%" "256" "true"
+if errorlevel 1 goto fail
+
+REM ********** Provision JRE for Amper **********
+
+if defined AMPER_JAVA_HOME (
+    if not exist "%AMPER_JAVA_HOME%\bin\java.exe" (
+      echo Invalid AMPER_JAVA_HOME provided: cannot find %AMPER_JAVA_HOME%\bin\java.exe
+      goto fail
+    )
+    @rem If AMPER_JAVA_HOME contains "jbr-21", it means we're inheriting it from the old Amper's update command.
+    @rem We must ignore it because Amper needs 25.
+    if "%AMPER_JAVA_HOME%"=="%AMPER_JAVA_HOME:jbr-21=%" (
+        set effective_amper_java_home=%AMPER_JAVA_HOME%
+        goto jre_provisioned
+    ) else (
+        echo WARN: AMPER_JAVA_HOME will be ignored because it points to a JBR 21, which is not valid for Amper anymore.
+        echo If you're updating from an Amper version older than 0.8.0, please ignore this message.
+    )
+)
+
+@rem Auto-updated from syncVersions.main.kts, do not modify directly here
+set zulu_version=25.32.21
+set java_version=25.0.2
+if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+    set jre_arch=aarch64
+    set jre_sha256=1106eec3bd166a117ccaf20f15bbec6537e27307be328b8a9e93a053c857fe7c
+) else if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+    set jre_arch=x64
+    set jre_sha256=a4b7e3c3929d513cdc774583d375ce07fcb8671833258f468fd2fa0d8227ba48
+) else (
+    echo Unknown Windows architecture %PROCESSOR_ARCHITECTURE% >&2
+    goto fail
+)
+
+@rem URL for the JRE (see https://api.azul.com/metadata/v1/zulu/packages?release_status=ga&include_fields=java_package_features,os,arch,hw_bitness,abi,java_package_type,sha256_hash,size,archive_type,lib_c_type&java_version=25&os=macos,linux,win)
+@rem https://cdn.azul.com/zulu/bin/zulu25.28.85-ca-jre25.0.0-win_x64.zip
+@rem https://cdn.azul.com/zulu/bin/zulu25.28.85-ca-jre25.0.0-win_aarch64.zip
+set jre_url=%AMPER_JRE_DOWNLOAD_ROOT%/cdn.azul.com/zulu/bin/zulu%zulu_version%-ca-jre%java_version%-win_%jre_arch%.zip
+set jre_target_dir=%AMPER_BOOTSTRAP_CACHE_DIR%\zulu%zulu_version%-ca-jre%java_version%-win_%jre_arch%
+call :download_and_extract "Amper runtime v%zulu_version%" "%jre_url%" "%jre_target_dir%" "%jre_sha256%" "256" "false"
+if errorlevel 1 goto fail
+
+set effective_amper_java_home=
+for /d %%d in ("%jre_target_dir%\*") do if exist "%%d\bin\java.exe" set effective_amper_java_home=%%d
+if not exist "%effective_amper_java_home%\bin\java.exe" (
+  echo Unable to find java.exe under %jre_target_dir%
+  goto fail
+)
+:jre_provisioned
+
+REM ********** Launch Amper **********
+
+"%effective_amper_java_home%\bin\java.exe" ^
+  @"%amper_target_dir%\amper.args" ^
+  "-Damper.wrapper.dist.sha256=%amper_sha256%" ^
+  "-Damper.dist.path=%amper_target_dir%" ^
+  "-Damper.wrapper.path=%~f0" ^
+  %AMPER_JAVA_OPTIONS% ^
+  -cp "%amper_target_dir%\lib\*" ^
+  org.jetbrains.amper.cli.MainKt ^
+  %*
+exit /B %ERRORLEVEL%

--- a/samples/amper-cmp-desktop/module.yaml
+++ b/samples/amper-cmp-desktop/module.yaml
@@ -2,7 +2,7 @@ product: jvm/app
 
 dependencies:
   - $compose.desktop.currentOs
-  - $compose.components.uiToolingPreview
+  - $compose.material3
 
 settings:
   compose: enabled

--- a/samples/amper-cmp-desktop/module.yaml
+++ b/samples/amper-cmp-desktop/module.yaml
@@ -6,3 +6,5 @@ dependencies:
 
 settings:
   compose: enabled
+  jvm:
+    release: 17

--- a/samples/amper-cmp-desktop/module.yaml
+++ b/samples/amper-cmp-desktop/module.yaml
@@ -1,0 +1,8 @@
+product: jvm/app
+
+dependencies:
+  - $compose.desktop.currentOs
+  - $compose.components.uiToolingPreview
+
+settings:
+  compose: enabled

--- a/samples/amper-cmp-desktop/src/Greeting.kt
+++ b/samples/amper-cmp-desktop/src/Greeting.kt
@@ -1,0 +1,35 @@
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.window.singleWindowApplication
+
+/**
+ * Canary `@Preview` for the Amper / non-Gradle integration story.
+ *
+ * Lifted from
+ * [JetBrains/amper:examples/compose-desktop](https://github.com/JetBrains/amper/tree/main/examples/compose-desktop)
+ * with `material` swapped for `material3` so it lines up with the rest of compose-ai-tools'
+ * Compose Desktop fixtures. The non-Gradle integration test renders this composable through a
+ * synthesised `daemon-launch.json`; see `docs/NON_GRADLE_INTEGRATION.md`.
+ */
+@Composable
+@Preview
+fun Greeting() {
+    MaterialTheme {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            BasicText("Hello, World!")
+        }
+    }
+}
+
+fun main() = singleWindowApplication { Greeting() }


### PR DESCRIPTION
## Summary

Documents the `daemon-launch.json` schema as a stable, build-system-agnostic contract and proves any non-Gradle producer can drive a real `RenderSession` end-to-end. Adds the doc, two contract tests (one schema-only, one Amper-driven against a vendored fixture), and a Gradle warm-up in the SessionStart hook.

- **`docs/NON_GRADLE_INTEGRATION.md`** — architecture diagram, field-by-field `daemon-launch.json` v1 schema, classpath layering rules, daemon system-property surface, `previews.json` contract, RenderSession driver snippet, worked Amper example (`module.yaml` + flow), worked Bazel example (`kt_compiler_plugin` + `rules_kotlin`), limitations and follow-ups.
- **`NonGradleContractTest`** (`render-session/subprocess/src/test/`) — synthesises a `daemon-launch.json` field-by-field with no `composePreviewDaemonStart` involvement, opens `SubprocessRenderSessions` against it, drives `renderNow`, waits for the `renderFinished` notification, asserts a PNG lands on disk. Self-skips when prereq inputs missing; CI wires the deps via `render-session/subprocess/build.gradle.kts`.
- **`AmperContractTest`** (sibling test) — consumes the Amper fixture's `kotlin-output/` directly (built by `./amper build`, not Gradle), substitutes Amper's compiled classes into the renderer's classpath, hand-authors `previews.json` for `Greeting()`, and renders a real PNG through the same daemon pipeline. Self-skips when Amper outputs aren't on disk.
- **`samples/amper-cmp-desktop/`** — vendored Amper fixture: `module.yaml` (pins `jvm.release: 17` so Amper-compiled classes load on the JDK-17 daemon), `Greeting.kt` with `@Preview`, the Amper wrapper (`amper` + `amper.bat`), and a README documenting the end-to-end flow including the TLS-inspection-proxy truststore gotcha. Deliberately not a Gradle subproject — the layout itself is part of the demonstration.
- **`.claude/hooks/session-start.sh`** — pre-warm Gradle in web sessions so the first `./gradlew` doesn't cold-download the wrapper distribution + plugin classpath.

## Test plan

- [x] `:render-session-subprocess:test --tests NonGradleContractTest` passes against `:samples:cmp` outputs.
- [x] `:render-session-subprocess:test --tests AmperContractTest` passes against `samples/amper-cmp-desktop/`'s Amper outputs (renders `GreetingKt.Greeting` to PNG in ~1.4s, daemon-side `renderFinished` at +1198ms from session open).
- [x] `ktfmtCheckAll` is clean.
- [x] SessionStart hook validates: 7s on a warm container, runs `install-git-hooks.sh` then `./gradlew --quiet help` under `CLAUDE_CODE_REMOTE=true`.

## Notes for reviewers

A few frictions surfaced wiring up `AmperContractTest` that aren't obvious from the design doc; called out here so they don't bite the next contributor:

- **Bundled Zulu JRE doesn't trust sandbox TLS-inspection CAs.** Amper auto-downloads its own Zulu 25 JRE; in a sandbox that proxies egress through an inspection CA, every Maven Central / Google Maven fetch fails with `PKIX path building failed`. Fix: `AMPER_JAVA_OPTIONS="… -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"` at the invocation site. Documented in `samples/amper-cmp-desktop/README.md`.
- **Default `jvm.release: 21` is too new for the daemon.** The daemon JVM runs on JDK 17. Loading Java 21 class files (version 65) into a Java 17 JVM (version 61) blows up with `UnsupportedClassVersionError`. Fixture pins `jvm.release: 17`; downstream Amper users on a JDK 21+ daemon don't need this.
- **`$compose.components.uiToolingPreview` isn't a valid Amper 0.10 catalog ref.** The original module.yaml had it; Amper rejects it at model-load. `Greeting.kt`'s `@Preview` resolves transitively through `$compose.material3` + `$compose.desktop.currentOs`, so the fixture uses those.
- **Amper build outputs (v0.10) don't match the obvious guesses.** Classes land at `build/artifacts/CompiledJvmArtifact/<module>jvm/kotlin-output/`, not under `build/tasks/`. There is no `classpath.txt` — runtime jars live in Amper's own m2 cache at `~/.cache/JetBrains/Amper/.m2.cache/`. The README documents this layout.

## Still open

`AmperContractTest` self-skips when Amper outputs aren't on disk — CI doesn't yet auto-invoke `./amper build` because doing so in this sandbox requires the truststore env override, which needs care to wire through a Gradle `Exec` task. Tracked as a follow-up; for now the test runs locally and in any environment where `./amper build` was invoked first.

Preview discovery is still `DiscoverPreviewsTask`-coupled; the fixture's `previews.json` is hand-authored. Extracting the ClassGraph scan into a standalone library is tracked under "Limitations and follow-ups" in `docs/NON_GRADLE_INTEGRATION.md`.
