### PR TITLE
fix: treat missing `merged` field as true in accessibility nodes

### DIFF
--- a/vscode-extension/src/test/a11yBundlePresenter.test.ts
+++ b/vscode-extension/src/test/a11yBundlePresenter.test.ts
@@ -282,6 +282,34 @@ describe("computeA11yBundleData", () => {
         assert.strictEqual(data.overlay.length, 1);
     });
 
+    it("treats a missing `merged` field as merged=true (daemon JSON omits the default)", () => {
+        // `AccessibilityDataProducer` writes `a11y-hierarchy.json` with
+        // `encodeDefaults = false`, so `merged: true` (the Kotlin
+        // default) is omitted from the wire JSON. The presenter must
+        // accept the missing field as the default-true case, otherwise
+        // every TalkBack stop on the wire gets dropped by `mergedOnly`
+        // and the bundle renders "0 elements / No rows" even when the
+        // daemon delivered 12 merged nodes.
+        const wireNodes: readonly AccessibilityNode[] = [
+            {
+                label: "Today",
+                role: "header",
+                states: ["focusable"],
+                boundsInScreen: "0,0,100,40",
+            } as unknown as AccessibilityNode,
+            {
+                label: "Morning run",
+                role: "text",
+                states: [],
+                boundsInScreen: "0,40,100,80",
+            } as unknown as AccessibilityNode,
+        ];
+        const data = computeA11yBundleData(wireNodes, []);
+        assert.strictEqual(data.rows.length, 2);
+        assert.ok(data.rows.every((r) => r.merged));
+        assert.ok(data.rows.every((r) => r.depth === 0));
+    });
+
     it("does not surface a finding on an unmerged child as an orphan when the bounds match", () => {
         // The finding lives on the inner Text node's bounds, which
         // also matches the merged Button (same bounds). When we

--- a/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
@@ -110,6 +110,14 @@ export function computeA11yBundleData(
     const consumedTargets = new Set<AccessibilityTouchTarget>();
 
     nodes.forEach((node, idx) => {
+        // The daemon serializes `AccessibilityNode` with
+        // `encodeDefaults = false`, so `merged: true` (the Kotlin
+        // default) is omitted from the wire JSON and lands here as
+        // `undefined`. Treat anything other than an explicit `false`
+        // as merged — otherwise the `mergedOnly` filter below drops
+        // every TalkBack stop on the wire, leaving the bundle empty
+        // even when a hierarchy with 12 nodes arrived.
+        const isMerged = node.merged !== false;
         // Index-stable id so the `mergedOnly` filter below doesn't
         // renumber ids across renders — the row's overlay box, the
         // data-table row, and the legend entry all share the index-
@@ -117,7 +125,7 @@ export function computeA11yBundleData(
         // findings runs unconditionally further down, so skipping
         // here doesn't cause a finding on an unmerged child to leak
         // out as an orphan row.
-        if (mergedOnly && !node.merged) return;
+        if (mergedOnly && !isMerged) return;
         const id = "a11y-" + idx;
         const bounds = parseBounds(node.boundsInScreen);
         const matchingFindings = bounds
@@ -135,7 +143,7 @@ export function computeA11yBundleData(
             label: node.label || "(unlabelled)",
             role: node.role ?? "",
             states: node.states?.join(", ") ?? "",
-            merged: node.merged,
+            merged: isMerged,
             findingCount: matchingFindings.length + targetFindingCount,
             topFindingLevel: top,
             boundsInScreen: node.boundsInScreen,
@@ -144,7 +152,7 @@ export function computeA11yBundleData(
             // Unmerged nodes sit under the nearest preceding merged
             // ancestor in emission order; render them indented so
             // the structure is visible without inventing parent ids.
-            depth: node.merged ? 0 : 1,
+            depth: isMerged ? 0 : 1,
         };
         rows.push(row);
         if (bounds) {

--- a/vscode-extension/src/webview/preview/focusPresentation.ts
+++ b/vscode-extension/src/webview/preview/focusPresentation.ts
@@ -204,7 +204,10 @@ function a11yHierarchyPresenter(
         const box = document.createElement("div");
         box.className = "focus-overlay-box";
         box.dataset.overlayId = "node-" + idx;
-        box.dataset.level = node.merged ? "warning" : "info";
+        // Daemon writes `AccessibilityNode` with `encodeDefaults = false`,
+        // so `merged: true` (the Kotlin default) is omitted from JSON;
+        // only an explicit `false` means unmerged.
+        box.dataset.level = node.merged === false ? "info" : "warning";
         // Bounds are in source-bitmap pixels; the overlay layer sizes
         // to the image's intrinsic size so % positioning lines up
         // without a resize handler.
@@ -221,7 +224,7 @@ function a11yHierarchyPresenter(
         detail:
             (node.role ? node.role : "") +
             (node.states.length > 0 ? " · " + node.states.join(", ") : ""),
-        level: node.merged ? "warning" : "info",
+        level: node.merged === false ? "info" : "warning",
     }));
 
     const reportBody = document.createElement("ol");


### PR DESCRIPTION
## Summary

The daemon serializes `AccessibilityNode` with `encodeDefaults = false`, which omits the `merged: true` default value from the wire JSON. This caused the presenter to incorrectly treat missing `merged` fields as falsy, resulting in all TalkBack stops being filtered out and bundles rendering as empty even when the daemon delivered nodes.

## Changes

- **a11yBundlePresenter.ts**: Updated `computeA11yBundleData` to treat `node.merged !== false` as the merged state, so `undefined` values are interpreted as merged (the Kotlin default). This ensures the `mergedOnly` filter doesn't drop all nodes from the wire.

- **focusPresentation.ts**: Updated `a11yHierarchyPresenter` to check `node.merged === false` explicitly when determining overlay styling and detail level, ensuring nodes without an explicit `false` value are treated as merged.

- **a11yBundlePresenter.test.ts**: Added test case verifying that nodes without a `merged` field are correctly treated as merged, preventing the "0 elements / No rows" rendering issue.

## Implementation Details

The fix introduces an `isMerged` variable that captures the correct interpretation (`node.merged !== false`) and uses it consistently throughout the presenter logic. This approach maintains backward compatibility while correctly handling the wire format where the default value is omitted.

https://claude.ai/code/session_01QwSnA69DnMCGNbMorZjjZ8