### PR TITLE
feat: anchor bundle chip bar to panel footer

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -26,6 +26,19 @@ body {
     color: var(--text-primary);
 }
 
+/* Anchor the bundle chip bar (the "extension bar" along the bottom) to
+   the bottom of the viewport — the strip should feel like a panel
+   footer no matter how tall or short the preview content is. The chip
+   bar element is the LAST child in `<preview-app>`'s template (after
+   focus-inspector); `margin-top: auto` inside a flex column with a
+   viewport-tall minimum height pushes it to the bottom regardless of
+   how much space the preview, tabs, and inspector consume above it. */
+preview-app {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
 /* -- Top progress strip ------------------------------------------------
  * A slim two-row strip permanently pinned to the very top of the panel:
  * phase-label row on top (≈13px text), 2px progress bar beneath.
@@ -2017,6 +2030,14 @@ body {
     gap: 2px;
     padding: 4px 6px;
     border-top: 1px solid var(--vscode-panel-border, transparent);
+    background: var(--vscode-editor-background, transparent);
+}
+/* Anchor the chip bar to the bottom of `preview-app`'s flex column —
+   the empty space above it grows until the panel content (preview,
+   tabs, inspector) is reached, so the bar feels docked to the panel
+   footer even when there's no scrollable content above. */
+bundle-chip-bar {
+    margin-top: auto;
 }
 .bundle-chip {
     display: inline-flex;

--- a/vscode-extension/src/webview/preview/components/BundleChipBar.ts
+++ b/vscode-extension/src/webview/preview/components/BundleChipBar.ts
@@ -23,13 +23,26 @@ export interface BundleToggledDetail {
 export class BundleChipBar extends LitElement {
     @state() private bundles: readonly BundleDescriptor[] = [];
     @state() private activeBundles: readonly BundleId[] = [];
+    /** Bundle ids the user is allowed to toggle in the current panel
+     *  configuration. When `null`, every bundle in `bundles` is shown
+     *  (the early-features-on default). When a set, only those bundles
+     *  paint chips — the rest are hidden so a basic-mode panel surfaces
+     *  just the graduated extensions (e.g. a11y) without leaking the
+     *  in-progress ones. */
+    @state() private availableBundles: ReadonlySet<BundleId> | null = null;
 
     setState(snapshot: {
         bundles: readonly BundleDescriptor[];
         activeBundles: readonly BundleId[];
+        availableBundles?: readonly BundleId[] | null;
     }): void {
         this.bundles = snapshot.bundles;
         this.activeBundles = snapshot.activeBundles;
+        this.availableBundles =
+            snapshot.availableBundles === undefined ||
+            snapshot.availableBundles === null
+                ? null
+                : new Set(snapshot.availableBundles);
     }
 
     protected createRenderRoot(): HTMLElement {
@@ -37,13 +50,18 @@ export class BundleChipBar extends LitElement {
     }
 
     protected render(): TemplateResult {
+        const visible = this.bundles.filter(
+            (b) =>
+                this.availableBundles === null ||
+                this.availableBundles.has(b.id),
+        );
         return html`
             <div
                 class="bundle-chip-bar"
                 role="toolbar"
                 aria-label="Data extensions"
             >
-                ${this.bundles.map((b) => this.renderChip(b))}
+                ${visible.map((b) => this.renderChip(b))}
             </div>
         `;
     }

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -192,15 +192,18 @@ export class FocusController {
         const mode = this.config.filterToolbar.getLayoutValue();
         this.config.grid.setLayoutMode(mode);
         this.config.focusControls.hidden = mode !== "focus";
-        // The data-extension chip bar + tab row are an early-features
-        // surface — gating them here so the strip never paints below
-        // the preview when the setting is off. When the user toggles
-        // early features mid-session, `handleSetEarlyFeatures` calls
-        // `applyLayout` again, so visibility tracks the flag without a
-        // panel reload.
-        const showBundleUi = mode === "focus" && this.config.earlyFeatures();
-        this.config.bundleChipBar.hidden = !showBundleUi;
-        this.config.dataTabs.hidden = !showBundleUi;
+        // The chip bar is now always visible (anchored to the bottom of
+        // the panel). Minimal mode hides it via CSS (`preview-app[data-
+        // minimal-mode="true"] bundle-chip-bar`), so this controller
+        // just keeps the element non-hidden — the chip bar itself
+        // filters which bundle chips render based on the early-features
+        // snapshot it receives from `reflectBundleState` in `main.ts`.
+        // The tab strip stays hidden until at least one bundle is
+        // active; DataTabs.render() returns empty when no active
+        // bundles, but unhiding it lets the host show tab bodies as
+        // soon as the user toggles a chip on, regardless of layout.
+        this.config.bundleChipBar.hidden = false;
+        this.config.dataTabs.hidden = false;
 
         if (mode === "focus") {
             const visible = this.getVisibleCards();

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -398,7 +398,6 @@ export class PreviewApp extends LitElement {
                     hidden
                 ></bundle-legend>
             </div>
-            <bundle-chip-bar hidden></bundle-chip-bar>
             <data-tabs hidden></data-tabs>
             <div
                 id="focus-inspector"
@@ -406,6 +405,7 @@ export class PreviewApp extends LitElement {
                 hidden
                 aria-label="Focused preview data"
             ></div>
+            <bundle-chip-bar></bundle-chip-bar>
         `;
     }
 
@@ -1935,9 +1935,16 @@ export class PreviewApp extends LitElement {
         };
         const reflectBundleState = (): void => {
             const s = bundleController.state();
+            // Without early features only the graduated bundles (a11y for
+            // now) show their chip — the rest are still in-progress and
+            // shouldn't surface from the always-visible chip bar.
+            const availableBundles: BundleId[] = earlyFeatures()
+                ? s.bundles.map((b) => b.id)
+                : ["a11y"];
             bundleChipBar.setState({
                 bundles: s.bundles,
                 activeBundles: s.activeBundles,
+                availableBundles,
             });
             dataTabs.setState({
                 bundles: s.bundles,
@@ -2530,6 +2537,7 @@ export class PreviewApp extends LitElement {
             },
             focusOnCard,
             deactivateAllBundles: () => bundleController.deactivateAll(),
+            refreshBundleState: () => reflectBundleState(),
         };
         window.addEventListener("message", (event) => {
             handleExtensionMessage(event.data, messageContext);

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -126,6 +126,15 @@ export interface PreviewMessageContext {
      * along with the rest of the early-features surface.
      */
     deactivateAllBundles(): void;
+    /**
+     * Re-render the bundle chip bar / tab row from the controller's
+     * current state. The chip bar filters which bundle chips paint
+     * based on the early-features snapshot, so the host runs this
+     * after `setEarlyFeatures` flips the flag to surface (or hide)
+     * the in-progress bundles without waiting for a state-changing
+     * controller event.
+     */
+    refreshBundleState(): void;
 }
 
 /** Methods the dispatcher needs from `<filter-toolbar>`. The component
@@ -598,6 +607,9 @@ function handleSetEarlyFeatures(
         ctx.liveState.handleEarlyFeaturesDisabled();
         ctx.deactivateAllBundles();
     }
+    // Refresh the chip-bar filter so newly graduated or hidden bundles
+    // paint correctly without the user having to nudge anything else.
+    ctx.refreshBundleState();
     ctx.applyLayout();
 }
 


### PR DESCRIPTION
## Summary

Refactor the bundle chip bar to always be visible and anchored to the bottom of the preview panel, rather than being conditionally hidden based on layout mode. The chip bar now filters which bundles display based on the early-features setting, allowing it to remain docked to the panel footer regardless of preview content height.

## Key Changes

- **CSS layout**: Added flexbox layout to `preview-app` with `min-height: 100vh` and `margin-top: auto` to `bundle-chip-bar`, anchoring it to the viewport bottom
- **DOM reordering**: Moved `bundle-chip-bar` to the end of the template (after `focus-inspector`) so it appears last in the flex column
- **Visibility logic**: Changed `bundleChipBar.hidden` from being controlled by layout mode to always `false`, delegating filtering to the component itself
- **Bundle filtering**: Added `availableBundles` state to `BundleChipBar` to filter which bundle chips render — shows all bundles when early features are enabled, otherwise only shows graduated bundles (currently "a11y")
- **State refresh**: Added `refreshBundleState()` method to re-render the chip bar when early-features setting changes, ensuring the filtered bundle list updates without requiring other state changes
- **Styling**: Added background color to the chip bar to match the editor background

## Implementation Details

The chip bar now acts as a persistent panel footer that stays visible and docked regardless of preview content height. When early features are disabled, the component still renders but only displays graduated bundles, preventing in-progress extensions from leaking into basic-mode panels. The `availableBundles` filtering happens at render time in the component, keeping the visibility logic encapsulated and allowing the controller to simply keep the element non-hidden.

https://claude.ai/code/session_01RUsdnMv4XkT2fCTMRG7MSc