### PR TITLE
feat: batch data extension subscriptions to fix partial bundle data

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -404,7 +404,7 @@ export interface ComposePreviewTestApi {
      */
     triggerSetDataExtensionEnabled(
         previewId: string,
-        kind: string,
+        kinds: readonly string[],
         enabled: boolean,
     ): Promise<void>;
     /**
@@ -1604,10 +1604,10 @@ export async function activate(
             },
             triggerSetDataExtensionEnabled(
                 previewId: string,
-                kind: string,
+                kinds: readonly string[],
                 enabled: boolean,
             ): Promise<void> {
-                return handleSetDataExtensionEnabled(previewId, kind, enabled);
+                return handleSetDataExtensionEnabled(previewId, kinds, enabled);
             },
             triggerWarmDaemon(filePath: string): Promise<boolean> {
                 return warmDaemonForFile(filePath);
@@ -4104,11 +4104,11 @@ function handleWebviewMessage(msg: WebviewToExtension) {
         case "setDataExtensionEnabled":
             if (earlyFeaturesEnabled()) {
                 moduleOutputChannel?.appendLine(
-                    `[panel] extension ${msg.kind} ${msg.enabled ? "enabled" : "disabled"} for ${msg.previewId}`,
+                    `[panel] extension ${msg.kinds.join(",")} ${msg.enabled ? "enabled" : "disabled"} for ${msg.previewId}`,
                 );
                 void handleSetDataExtensionEnabled(
                     msg.previewId,
-                    msg.kind,
+                    msg.kinds,
                     msg.enabled,
                 );
             }
@@ -4243,12 +4243,15 @@ function updateModuleA11ySubscription(
 }
 
 /**
- * Focus-inspector data-extension toggle. Routes a `(previewId, kind)`
- * subscription through the daemon scheduler so the daemon attaches (or
- * stops attaching) the payload on the next render. The webview already
- * paints a "Loading…" placeholder synchronously on toggle; the next
- * render swap (fed back through the existing data-product
- * notifications) replaces it with the real contribution.
+ * Bundle / focus-inspector data-extension toggle. Routes one or more
+ * `(previewId, kind)` subscriptions through the daemon scheduler in a
+ * single call so `data/subscribe` per kind is followed by exactly one
+ * `renderNow`. Issuing one wire round-trip per kind raced the daemon's
+ * subscription-driven render mode: the first subscribe arrived,
+ * `renderNow` started, the in-flight render's data-product set got
+ * frozen, and the second kind's product (e.g. `a11y/atf`) silently
+ * missed it — bundle showed only `a11y/hierarchy` even though the
+ * chip subscribed to both.
  *
  * For `a11y/*` kinds, also tracks the module-level subscription so the
  * panel can detect first-on / last-off transitions and trigger a panel
@@ -4265,26 +4268,44 @@ function updateModuleA11ySubscription(
  */
 async function handleSetDataExtensionEnabled(
     previewId: string,
-    kind: string,
+    kinds: readonly string[],
     enabled: boolean,
 ): Promise<void> {
     if (!daemonScheduler) {
+        return;
+    }
+    if (kinds.length === 0) {
         return;
     }
     const moduleId = previewModuleMap.get(previewId);
     if (!moduleId) {
         return;
     }
-    const a11yTransition = updateModuleA11ySubscription(
-        moduleId.modulePath,
-        previewId,
-        kind,
-        enabled,
-    );
+    // Update the module's a11y tracker per-kind, but the
+    // first-on / last-off transition is what gates the follow-up
+    // refresh — collapse the per-kind verdicts into one. A bundle
+    // activation enables every a11y kind at once, so only the first
+    // kind in the batch can trip the transition; the rest stay
+    // "unchanged" and must not override that.
+    let a11yTransition: "enabled" | "disabled" | "unchanged" = "unchanged";
+    for (const kind of kinds) {
+        const t = updateModuleA11ySubscription(
+            moduleId.modulePath,
+            previewId,
+            kind,
+            enabled,
+        );
+        if (t !== "unchanged") a11yTransition = t;
+    }
+    // Single subscription call so the wire sees `data/subscribe` per
+    // kind followed by exactly one `renderNow`. Per-kind dispatch
+    // would interleave with the daemon's mode-lock-on-first-
+    // subscribe and the second kind's data product (e.g. `a11y/atf`)
+    // would silently miss the in-flight render.
     await daemonScheduler.setDataProductSubscription(
         moduleId,
         previewId,
-        [kind],
+        kinds,
         enabled,
     );
     if (a11yTransition !== "unchanged") {
@@ -4294,23 +4315,27 @@ async function handleSetDataExtensionEnabled(
         // just kicks the panel to repaint with the freshly-arrived data products.
         void refresh(true, undefined, "fast");
     }
-    if (!enabled && (kind === "a11y/atf" || kind === "a11y/hierarchy")) {
+    if (!enabled) {
         // Mirror the toolbar A11y button's teardown — once the chip is unchecked, tear
         // down the cached overlay/legend immediately so the visual layer clears without
         // waiting on the next render. Empty arrays are the agreed signal: applyA11yUpdate
         // drops the corresponding cached entries and removes the layers from the DOM.
         // Other kinds (touchTargets, overlay) don't currently drive a webview overlay
         // independent of these two, so leaving them out keeps the message minimal.
-        const update: {
-            previewId: string;
-            findings?: never[];
-            nodes?: never[];
-        } = {
-            previewId,
-        };
-        if (kind === "a11y/atf") update.findings = [];
-        if (kind === "a11y/hierarchy") update.nodes = [];
-        panel?.postMessage({ command: "updateA11y", ...update });
+        const hasAtf = kinds.includes("a11y/atf");
+        const hasHierarchy = kinds.includes("a11y/hierarchy");
+        if (hasAtf || hasHierarchy) {
+            const update: {
+                previewId: string;
+                findings?: never[];
+                nodes?: never[];
+            } = {
+                previewId,
+            };
+            if (hasAtf) update.findings = [];
+            if (hasHierarchy) update.nodes = [];
+            panel?.postMessage({ command: "updateA11y", ...update });
+        }
     }
 }
 

--- a/vscode-extension/src/test/bundleController.test.ts
+++ b/vscode-extension/src/test/bundleController.test.ts
@@ -16,21 +16,36 @@ interface CapturedToggle {
     enabled: boolean;
 }
 
+interface CapturedBatch {
+    kinds: readonly string[];
+    enabled: boolean;
+}
+
 function build(initial?: BundleSnapshot): {
     controller: BundleController;
     toggles: CapturedToggle[];
+    batches: CapturedBatch[];
     persisted: BundleSnapshot[];
 } {
     const toggles: CapturedToggle[] = [];
+    const batches: CapturedBatch[] = [];
     const persisted: BundleSnapshot[] = [];
     const controller = new BundleController(
         {
-            setKindEnabled: (kind, enabled) => toggles.push({ kind, enabled }),
+            setKindsEnabled: (kinds, enabled) => {
+                // Capture both the per-kind unrolled view (the original
+                // test surface — most assertions look at individual
+                // kinds without caring how they were batched) and the
+                // batched view used by the "single call per activate"
+                // regression test below.
+                batches.push({ kinds: [...kinds], enabled });
+                for (const kind of kinds) toggles.push({ kind, enabled });
+            },
             persist: (snap) => persisted.push(snap),
         },
         initial,
     );
-    return { controller, toggles, persisted };
+    return { controller, toggles, batches, persisted };
 }
 
 describe("BundleController", () => {
@@ -45,6 +60,46 @@ describe("BundleController", () => {
         );
         assert.deepStrictEqual(controller.state().activeBundles, ["a11y"]);
         assert.strictEqual(controller.state().activeTab, "a11y");
+    });
+
+    it("activate posts a single batched host call carrying every default-ON kind", () => {
+        // Regression: one wire message per kind raced the daemon's
+        // subscription-driven render mode — the first subscribe locked
+        // the in-flight render's data-product set, the second arrived
+        // too late, and bundles with multiple default-ON kinds (a11y,
+        // text/i18n) silently delivered partial data products. The
+        // controller must batch into one host call so the extension
+        // host issues a single `data/subscribe` sequence + one
+        // `renderNow` against the daemon.
+        const { controller, batches } = build();
+        controller.toggleBundle("a11y");
+        const activates = batches.filter((b) => b.enabled);
+        assert.strictEqual(
+            activates.length,
+            1,
+            `activate must post exactly one batched host call, got ${activates.length}`,
+        );
+        assert.deepStrictEqual(
+            [...activates[0].kinds].sort(),
+            [...defaultOnKindsFor("a11y")].sort(),
+        );
+    });
+
+    it("deactivate posts a single batched host call carrying every active kind", () => {
+        const { controller, batches } = build();
+        controller.toggleBundle("a11y");
+        batches.length = 0;
+        controller.toggleBundle("a11y");
+        const deactivates = batches.filter((b) => !b.enabled);
+        assert.strictEqual(
+            deactivates.length,
+            1,
+            `deactivate must post exactly one batched host call, got ${deactivates.length}`,
+        );
+        assert.deepStrictEqual(
+            [...deactivates[0].kinds].sort(),
+            [...defaultOnKindsFor("a11y")].sort(),
+        );
     });
 
     it("chip re-press dismisses the bundle and unsubscribes", () => {

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -800,6 +800,52 @@ describe("DaemonScheduler", () => {
             assert.deepStrictEqual(kinds, ["a11y/atf", "a11y/hierarchy"]);
         });
 
+        it("setDataProductSubscription(true) emits exactly one renderNow per call regardless of kind count", async () => {
+            // Regression for the cluster of bugs where a bundle's
+            // chip enable produced an `a11y/hierarchy` attachment but
+            // no `a11y/atf`: per-kind dispatch resulted in
+            // `dataSubscribe(a11y/hierarchy)` → `renderNow` →
+            // `dataSubscribe(a11y/atf)`, and the daemon froze the
+            // in-flight render's data-product set after the first
+            // subscribe arrived. Batched dispatch must collapse to a
+            // single trailing `renderNow` so all subscriptions land
+            // first, then one render.
+            const { gate, scheduler } = build();
+            await scheduler.setDataProductSubscription(
+                mod("mod"),
+                "a",
+                ["a11y/atf", "a11y/hierarchy", "a11y/touchTargets"],
+                true,
+            );
+            const subs = gate.client!.calls.filter(
+                (c) => c.method === "dataSubscribe",
+            );
+            const renders = gate.client!.calls.filter(
+                (c) => c.method === "renderNow",
+            );
+            assert.strictEqual(subs.length, 3, "one subscribe per kind");
+            assert.strictEqual(
+                renders.length,
+                1,
+                `batched subscribe must emit exactly one renderNow, got ${renders.length}`,
+            );
+            // And the renderNow must be ordered AFTER all subscribes —
+            // otherwise the daemon races the same way per-kind dispatch
+            // did.
+            const lastSubscribeIdx = gate
+                .client!.calls.map((c, i) => ({ c, i }))
+                .filter((p) => p.c.method === "dataSubscribe")
+                .map((p) => p.i)
+                .reduce((a, b) => Math.max(a, b), -1);
+            const renderIdx = gate.client!.calls.findIndex(
+                (c) => c.method === "renderNow",
+            );
+            assert.ok(
+                renderIdx > lastSubscribeIdx,
+                `renderNow at index ${renderIdx} must come after the last dataSubscribe at index ${lastSubscribeIdx}`,
+            );
+        });
+
         it("setDataProductSubscription(true) twice is idempotent", async () => {
             const { gate, scheduler } = build();
             await scheduler.setDataProductSubscription(

--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -262,7 +262,7 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
 
         await api.triggerSetDataExtensionEnabled(
             target.id,
-            "a11y/hierarchy",
+            ["a11y/hierarchy"],
             true,
         );
 
@@ -298,7 +298,7 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
         );
         api.resetMessages();
 
-        await api.triggerSetDataExtensionEnabled(target.id, "a11y/atf", true);
+        await api.triggerSetDataExtensionEnabled(target.id, ["a11y/atf"], true);
 
         const ack = await waitFor(
             `webviewA11yState with findings for ${target.id}`,
@@ -339,7 +339,7 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
 
         await api.triggerSetDataExtensionEnabled(
             target.id,
-            "a11y/hierarchy",
+            ["a11y/hierarchy"],
             true,
         );
         await waitFor(
@@ -358,7 +358,7 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
 
         await api.triggerSetDataExtensionEnabled(
             target.id,
-            "a11y/hierarchy",
+            ["a11y/hierarchy"],
             false,
         );
         const teardown = await waitFor(

--- a/vscode-extension/src/test/focusBundleSmoke.test.ts
+++ b/vscode-extension/src/test/focusBundleSmoke.test.ts
@@ -47,7 +47,7 @@ import type { BundleExpander } from "../webview/preview/components/BundleExpande
 
 interface CapturedPost {
     previewId: string;
-    kind: string;
+    kinds: readonly string[];
     enabled: boolean;
 }
 
@@ -67,8 +67,8 @@ function buildScenario(): Scenario {
     const posts: CapturedPost[] = [];
     const previewId = "preview-smoke-0";
     const controller = new BundleController({
-        setKindEnabled: (kind, enabled) => {
-            posts.push({ previewId, kind, enabled });
+        setKindsEnabled: (kinds, enabled) => {
+            posts.push({ previewId, kinds: [...kinds], enabled });
         },
         persist: () => {},
     });
@@ -163,7 +163,7 @@ describe("Focus view data-extension toggle smoke", () => {
                     posts[0],
                     {
                         previewId,
-                        kind: k.kind,
+                        kinds: [k.kind],
                         enabled: !wasEnabled,
                     },
                     `${bundle.id}/${k.kind} post payload mismatch`,
@@ -180,7 +180,7 @@ describe("Focus view data-extension toggle smoke", () => {
         // arrives later. Whether the host posts is unrelated to
         // the UI state of the input element.
         const controller = new BundleController({
-            setKindEnabled: () => {
+            setKindsEnabled: () => {
                 /* host black-hole */
             },
             persist: () => {},

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -902,7 +902,17 @@ export type WebviewToExtension =
     | {
           command: "setDataExtensionEnabled";
           previewId: string;
-          kind: string;
+          /**
+           * Kinds toggled atomically. `BundleController.activate` /
+           * `deactivate` pass every default-ON kind in one message so the
+           * extension issues a single `data/subscribe` sequence + one
+           * `renderNow` — if we posted one message per kind the daemon
+           * would lock the render mode after the first subscribe arrived
+           * and the second kind's data product would silently miss the
+           * in-flight render. Single-kind toggles from the Configure
+           * expander pass `[kind]`.
+           */
+          kinds: readonly string[];
           enabled: boolean;
       }
     /**

--- a/vscode-extension/src/webview/preview/bundleController.ts
+++ b/vscode-extension/src/webview/preview/bundleController.ts
@@ -27,8 +27,18 @@ import {
 } from "./bundleRegistry";
 
 export interface BundleControllerHost {
-    /** Send a `setDataExtensionEnabled` to the extension host. */
-    setKindEnabled(kind: string, enabled: boolean): void;
+    /**
+     * Send a `setDataExtensionEnabled` to the extension host for one
+     * or more kinds at once. Batching matters for chip activation:
+     * issuing one wire message per kind lets the daemon lock the
+     * render mode after the first subscribe arrives, so subsequent
+     * kinds' data products miss the in-flight render (e.g.
+     * `a11y/hierarchy` attaches but `a11y/atf` doesn't). The
+     * controller routes `activate` / `deactivate` (all default-ON
+     * kinds together) and Configure-expander row toggles (single
+     * kind) through this one entry point.
+     */
+    setKindsEnabled(kinds: readonly string[], enabled: boolean): void;
     /** Persist a snapshot for restore across panel reload. */
     persist(snapshot: BundleSnapshot): void;
 }
@@ -183,7 +193,7 @@ export class BundleController {
             return;
         }
         this.enabled.set(bundleId, current);
-        this.host.setKindEnabled(kind, enabled);
+        this.host.setKindsEnabled([kind], enabled);
         this.fire();
     }
 
@@ -228,15 +238,21 @@ export class BundleController {
         const previouslyEnabled = this.enabled.get(id);
         const kinds = previouslyEnabled ?? [...defaultOnKindsFor(id)];
         this.enabled.set(id, kinds);
-        for (const k of kinds) this.host.setKindEnabled(k, true);
+        // Batched on purpose — the extension host's
+        // `handleSetDataExtensionEnabled` ships a single `data/subscribe`
+        // sequence followed by one `renderNow`, so all subscriptions
+        // land before the daemon decides which data products to attach.
+        // Per-kind dispatch races the daemon's mode-lock-on-first-
+        // subscribe; the second kind's product (e.g. `a11y/atf`)
+        // misses the render and the bundle shows partial data.
+        if (kinds.length > 0) this.host.setKindsEnabled(kinds, true);
         this.tab = id;
         this.fire();
     }
 
     private deactivate(id: BundleId): void {
-        for (const k of this.enabledKindsFor(id)) {
-            this.host.setKindEnabled(k, false);
-        }
+        const kinds = this.enabledKindsFor(id);
+        if (kinds.length > 0) this.host.setKindsEnabled([...kinds], false);
         this.active = this.active.filter((x) => x !== id);
         // Preserve the per-kind enable set on the dropped bundle so
         // a re-press restores the user's last configuration rather

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -679,26 +679,27 @@ export class PreviewApp extends LitElement {
 
         // Bundle controller — owns the chip ↔ tab ↔ overlay state machine
         // for the new panel shell. Additive to the existing focus-inspector
-        // chrome; the two coexist during migration. The controller's
-        // `setKindEnabled` forwards through the same `setDataExtensionEnabled`
-        // wire message the inspector already uses, so subscriptions land in
-        // a single place.
+        // chrome; the two coexist during migration. The controller batches
+        // every kind in a chip activation into a single `setKindsEnabled`
+        // host call so the wire ships one `setDataExtensionEnabled`
+        // message — per-kind dispatch raced the daemon's mode-lock-on-
+        // first-subscribe and left bundles with partial data products.
         const bundleChipBar = this._bundleChipBar;
         const dataTabs = this._dataTabs;
         const bundleLegend = this._bundleLegend;
         const bundleController = new BundleController(
             {
-                setKindEnabled: (kind, enabled) => {
+                setKindsEnabled: (kinds, enabled) => {
                     // Subscriptions are per-preview at the wire layer; we
                     // forward against the focused preview when there is
                     // one, otherwise the first visible card (the default
                     // multi-preview scoping rule from the design doc).
                     const target = currentBundleTarget();
-                    if (!target) return;
+                    if (!target || kinds.length === 0) return;
                     vscode.postMessage({
                         command: "setDataExtensionEnabled",
                         previewId: target,
-                        kind,
+                        kinds: [...kinds],
                         enabled,
                     });
                 },


### PR DESCRIPTION
## Summary

Fix a race condition where bundle activation with multiple default-ON kinds (e.g., `a11y/hierarchy` and `a11y/atf`) would result in partial data products being delivered. The issue occurred because per-kind subscription messages were dispatched individually, allowing the daemon to lock the render mode after the first subscribe arrived, causing subsequent kinds' data products to miss the in-flight render.

## Changes

- **API signature change**: `setKindEnabled(kind, enabled)` → `setKindsEnabled(kinds: readonly string[], enabled)` across the extension host, webview controller, and test APIs
  - Single-kind toggles (Configure expander rows) now pass `[kind]`
  - Bundle activation/deactivation passes all default-ON kinds in one call

- **Extension host (`extension.ts`)**:
  - Updated `ComposePreviewTestApi.triggerSetDataExtensionEnabled()` to accept `kinds: readonly string[]`
  - Modified `handleSetDataExtensionEnabled()` to batch all kinds into a single `daemonScheduler.setDataProductSubscription()` call
  - Consolidated per-kind a11y transition tracking to collapse multiple "unchanged" verdicts into one transition decision
  - Updated a11y teardown logic to check if any of the disabled kinds are `a11y/atf` or `a11y/hierarchy` rather than checking a single kind

- **Webview controller (`bundleController.ts`)**:
  - Updated `BundleControllerHost` interface to use `setKindsEnabled(kinds, enabled)`
  - Modified `activate()` to batch all default-ON kinds into a single host call
  - Modified `deactivate()` to batch all active kinds into a single host call
  - Single-kind row toggles continue to pass `[kind]` for backward compatibility

- **Webview main (`main.ts`)**:
  - Updated `BundleController` instantiation to use `setKindsEnabled` and pass kinds as an array

- **Message types (`types.ts`)**:
  - Changed `WebviewToExtension.setDataExtensionEnabled` message to use `kinds: readonly string[]` instead of `kind: string`

- **Tests**:
  - Added regression tests in `daemonScheduler.test.ts` to verify exactly one `renderNow` is emitted per batched subscription call, regardless of kind count
  - Added regression tests in `bundleController.test.ts` to verify activate/deactivate post single batched host calls
  - Updated `focusBundleSmoke.test.ts` and `e2eA11y.test.ts` to use the new `kinds` array format

## Implementation Details

The core fix ensures that when a bundle is activated, all its default-ON kinds are subscribed in a single wire message sequence: `data/subscribe` for each kind followed by exactly one `renderNow`. This prevents the daemon from locking the render mode prematurely and ensures all data products are attached to the same render cycle.

The a11y transition tracking was refactored to handle multiple kinds: only the first kind that triggers a transition (enabled→disabled or vice versa) sets the transition state, while subsequent kinds remain "unchanged" to avoid overriding the decision.

https://claude.ai/code/session_01QwSnA69DnMCGNbMorZjjZ8