### PR TITLE
fix: use plain console output to prevent ANSI artifacts in logs

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -651,11 +651,21 @@ export async function activate(
         );
     }
 
+    // Force plain console output. The Tooling API defaults to Gradle's "rich"
+    // console, which uses ANSI cursor moves to overdraw per-task progress
+    // labels. vscode-gradle strips ANSI codes (`showOutputColors: false`) but
+    // not the visible status tokens those cursor moves were updating, so the
+    // labels leak through as ` SKIPPED FROM-CACHE UP-TO-DATE UP-TO-DATE…`
+    // smashed together into the output channel. Plain mode emits one
+    // `> Task :foo UP-TO-DATE\n` per task instead, which logFilter already
+    // drops at normal level.
+    const baseGradleArgs: readonly string[] = ["--console=plain"];
+
     gradleService = new GradleService(
         workspaceRoot,
         gradleApi,
         outputChannel,
-        () => [...initScriptArgs],
+        () => [...baseGradleArgs, ...initScriptArgs],
         logFilter,
     );
 


### PR DESCRIPTION
## Summary
Fixes garbled output in the Gradle extension's output channel by forcing plain console mode instead of Gradle's default rich console format.

## Problem
The Tooling API defaults to Gradle's "rich" console mode, which uses ANSI cursor movement codes to overdraw per-task progress labels. While vscode-gradle strips ANSI color codes via `showOutputColors: false`, it doesn't remove the visible status tokens that those cursor moves were updating. This causes task status labels like `SKIPPED`, `FROM-CACHE`, and `UP-TO-DATE` to leak through as garbled text smashed together in the output channel.

## Solution
- Added `--console=plain` to the base Gradle arguments passed to GradleService
- Plain mode emits one clean `> Task :foo UP-TO-DATE\n` per task instead of using cursor movement tricks
- The logFilter already drops these plain-mode task status lines at normal log level, so the output remains clean

## Changes
- Modified `activate()` function to define `baseGradleArgs` with `--console=plain`
- Updated GradleService instantiation to prepend `baseGradleArgs` to the init script arguments

https://claude.ai/code/session_01LkJ3ECPX2vX3Fhbn8Qjjyp