### PR TITLE
fix: align JSON export shape with daemon wire format

### DIFF
--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -1177,12 +1177,27 @@ export class PreviewApp extends LitElement {
             body.table.setOverlayId(
                 (row) => (row as { id: string }).id ?? "a11y-row",
             );
-            body.table.setJsonPayload(() => ({
-                previewId: target,
-                nodes: targetSrc.nodes,
-                findings: targetSrc.findings,
-                touchTargets,
-            }));
+            // Mirror the daemon's wire shape so Copy JSON yields the
+            // same bytes a CLI consumer would get from
+            // `dataProducts/get` for each enabled kind, rather than a
+            // UI-flattened projection. `a11y/hierarchy` and `a11y/atf`
+            // live in `previewStore` (routed via `applyA11yUpdate`)
+            // rather than the generic `dataProductsByPreview` cache, so
+            // we rewrap them into their native payload envelopes here;
+            // `a11y/touchTargets` and `a11y/overlay` come straight from
+            // the daemon payload cache. Missing kinds emit `null` so
+            // the output's shape is stable across subscription states.
+            body.table.setJsonPayload(() => {
+                const byKind = dataProductsByPreview.get(target);
+                return {
+                    previewId: target,
+                    "a11y/hierarchy": { nodes: targetSrc.nodes },
+                    "a11y/atf": { findings: targetSrc.findings },
+                    "a11y/touchTargets":
+                        byKind?.get("a11y/touchTargets") ?? null,
+                    "a11y/overlay": byKind?.get("a11y/overlay") ?? null,
+                };
+            });
             // Stash for the row-click listener installed in
             // `a11yBody()`. Drop any stale selection so the detail
             // panel doesn't point at row indices the new data may


### PR DESCRIPTION
## Summary
Updated the JSON payload exported via "Copy JSON" in the preview panel to match the daemon's native wire format, ensuring consistency with what CLI consumers receive from `dataProducts/get` endpoints.

## Changes
- Restructured the JSON payload to use kind-based keys (`a11y/hierarchy`, `a11y/atf`, `a11y/touchTargets`, `a11y/overlay`) instead of flattened field names
- Wrapped `nodes` and `findings` in their native payload envelopes (`{ nodes: ... }` and `{ findings: ... }`)
- Integrated data from both the preview store (for `a11y/hierarchy` and `a11y/atf`) and the generic `dataProductsByPreview` cache (for `a11y/touchTargets` and `a11y/overlay`)
- Added null values for missing kinds to maintain stable output shape across different subscription states

## Implementation Details
The change mirrors the daemon's data product structure by rewrapping UI-flattened projections back into their native payload envelopes. This ensures that users copying JSON from the preview panel get the same byte-for-byte output they would receive from direct daemon API calls, improving consistency and reducing confusion when comparing outputs across different interfaces.

https://claude.ai/code/session_011ZmCXGWFGr62H71iPMSC9f