### PR TITLE
refactor: simplify focus inspector to remove redundant tool buttons

### DIFF
--- a/vscode-extension/src/webview/preview/focusInspector.ts
+++ b/vscode-extension/src/webview/preview/focusInspector.ts
@@ -1,13 +1,20 @@
 // Focus-mode inspector — the slim side panel that appears when a single
 // preview is focused. After the chip / bucket / presenter pipeline moved
-// to the new bundle shell (#1099), this controller only owns three
-// sections, top to bottom:
+// to the new bundle shell (#1099), this controller owns two sections,
+// top to bottom:
 //
 //   1. **Error banner** — surfaces the per-card render error when one
 //      is present. Driven by the `local/render/error` presenter so the
 //      shape stays consistent with the bundle-shell renderer.
-//   2. **History** — diff buttons (HEAD / main).
-//   3. **Tools** — A11y / Device / Live / Record buttons.
+//   2. **History** — diff buttons (HEAD / main), only rendered when the
+//      History bundle chip is active. The chip is the gate; the panel
+//      stays out of the DOM otherwise so the focus area below the
+//      preview is empty until the user opts in.
+//
+// The A11y / Device / Live / Record buttons that used to live here
+// were dropped: A11y rides the bottom chip bar, and Device / Live /
+// Record sit in the focus toolbar above the preview, so a third copy
+// inside the inspector was redundant.
 //
 // Everything else (suggestion chips, bucket list, legends, reports,
 // overlay stacks, MRU plumbing) was deleted with the pipeline it served.
@@ -33,13 +40,12 @@ export interface FocusInspectorConfig {
     /** Look up the manifest entry for a preview, or `undefined` when
      *  the preview is unknown to this panel. */
     getPreview(previewId: string): PreviewInfo | undefined;
-    /** Click handlers shared with the focus toolbar. */
-    onToggleA11yOverlay(): void;
-    /** `shift = false` matches the toolbar Live button — single-target. */
-    onToggleInteractive(shift: boolean): void;
-    onToggleRecording(): void;
+    /** Whether the History bundle chip is currently pressed. The
+     *  inspector renders the HISTORY panel only when this returns
+     *  `true` — the chip is the gate. */
+    isHistoryActive(): boolean;
+    /** Click handler for the HISTORY panel's diff buttons. */
     onRequestFocusedDiff(against: "head" | "main"): void;
-    onRequestLaunchOnDevice(): void;
 }
 
 export class FocusInspectorController {
@@ -87,8 +93,9 @@ export class FocusInspectorController {
             this.collectErrorPresentationsOnly(card, preview),
         );
         if (errorBanner) el.appendChild(errorBanner);
-        el.appendChild(this.historyPanel());
-        el.appendChild(this.controlsPanel());
+        if (this.config.isHistoryActive()) {
+            el.appendChild(this.historyPanel());
+        }
     }
 
     /**
@@ -225,56 +232,6 @@ export class FocusInspectorController {
         history.appendChild(historyActions);
         return history;
     }
-
-    private controlsPanel(): HTMLElement {
-        const controls = document.createElement("section");
-        controls.className = "focus-panel focus-controls-panel";
-        controls.appendChild(sectionHeader("settings-gear", "Tools"));
-        const toolActions = document.createElement("div");
-        toolActions.className = "focus-actions";
-        toolActions.appendChild(
-            actionButton("eye", "A11y", "Toggle accessibility overlay", () =>
-                this.config.onToggleA11yOverlay(),
-            ),
-        );
-        toolActions.appendChild(
-            actionButton(
-                "device-mobile",
-                "Device",
-                "Launch on connected Android device",
-                () => this.config.onRequestLaunchOnDevice(),
-            ),
-        );
-        toolActions.appendChild(
-            actionButton(
-                "circle-large-outline",
-                "Live",
-                "Toggle live preview",
-                () => this.config.onToggleInteractive(false),
-            ),
-        );
-        toolActions.appendChild(
-            actionButton(
-                "record-keys",
-                "Record",
-                "Record focused preview",
-                () => this.config.onToggleRecording(),
-            ),
-        );
-        controls.appendChild(toolActions);
-        return controls;
-    }
-}
-
-function sectionHeader(icon: string, label: string): HTMLElement {
-    const header = document.createElement("div");
-    header.className = "focus-panel-header";
-    header.innerHTML =
-        '<i class="codicon codicon-' + icon + '" aria-hidden="true"></i>';
-    const span = document.createElement("span");
-    span.textContent = label;
-    header.appendChild(span);
-    return header;
 }
 
 function actionButton(

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -583,6 +583,7 @@ export class PreviewApp extends LitElement {
         let inspector!: FocusInspectorController;
         let liveState!: LiveStateController;
         let focusController!: FocusController;
+        let bundleController!: BundleController;
         const dataProductsByPreview = new Map<string, Map<string, unknown>>();
         // Panel-side cache for the Text/i18n bundle's data-URI font
         // preview path. Keyed by `(previewId, fontRowId)` because two
@@ -668,13 +669,10 @@ export class PreviewApp extends LitElement {
             earlyFeatures,
             getPreview: (id) =>
                 previewStore.getState().allPreviews.find((p) => p.id === id),
-            onToggleA11yOverlay: () => focusController.toggleA11yOverlay(),
-            onToggleInteractive: (shift) => liveState.toggleInteractive(shift),
-            onToggleRecording: () => liveState.toggleRecording(),
+            isHistoryActive: () =>
+                bundleController.state().activeBundles.includes("history"),
             onRequestFocusedDiff: (against) =>
                 focusController.requestFocusedDiff(against),
-            onRequestLaunchOnDevice: () =>
-                focusController.requestLaunchOnDevice(),
         });
 
         // Bundle controller — owns the chip ↔ tab ↔ overlay state machine
@@ -687,7 +685,7 @@ export class PreviewApp extends LitElement {
         const bundleChipBar = this._bundleChipBar;
         const dataTabs = this._dataTabs;
         const bundleLegend = this._bundleLegend;
-        const bundleController = new BundleController(
+        bundleController = new BundleController(
             {
                 setKindsEnabled: (kinds, enabled) => {
                     // Subscriptions are per-preview at the wire layer; we
@@ -2002,6 +2000,16 @@ export class PreviewApp extends LitElement {
                 }
             }
             reflectLegendActiveTab();
+            // The focus inspector's HISTORY panel is gated on the
+            // history chip — re-render it so the panel mounts /
+            // unmounts in lockstep with the chip state. Guarded
+            // because `focusController` is initialised later in this
+            // setup body and the initial `reflectBundleState()` call
+            // below runs before it lands; the post-init `onChange`
+            // path always finds it ready.
+            if (focusController) {
+                inspector.render(focusController.focusedCard());
+            }
         };
         bundleController.onChange(() => reflectBundleState());
         reflectBundleState();


### PR DESCRIPTION
## Summary

Simplifies the focus inspector panel by removing the Tools section (A11y, Device, Live, Record buttons) which are now redundant. These controls have been relocated to other parts of the UI: A11y to the bottom chip bar, and Device/Live/Record to the focus toolbar above the preview.

## Changes

- **Removed Tools panel** from focus inspector (`controlsPanel()` method and related config callbacks)
  - Deleted `onToggleA11yOverlay()`, `onToggleInteractive()`, `onToggleRecording()`, and `onRequestLaunchOnDevice()` from `FocusInspectorConfig`
  - Removed the entire `controlsPanel()` method and `sectionHeader()` helper function

- **Made History panel conditional** on the History bundle chip state
  - Added `isHistoryActive()` callback to `FocusInspectorConfig` to gate History panel rendering
  - History panel now only renders when the History chip is active, keeping the focus area below the preview empty until the user opts in
  - Updated render logic to conditionally append the history panel based on chip state

- **Updated main.ts integration**
  - Captured `bundleController` reference to enable checking active bundles
  - Replaced removed tool button callbacks with `isHistoryActive()` implementation
  - Added re-render trigger in `reflectBundleState()` to mount/unmount History panel in sync with chip state changes

## Implementation Details

The History panel gating uses the bundle controller's active bundles state as the source of truth. The focus inspector re-renders whenever bundle state changes, ensuring the panel mounts and unmounts in lockstep with the History chip. The initial render is guarded since `focusController` is initialized later in the setup sequence.

https://claude.ai/code/session_011f56r6KofMYLqfFVuALofU