### PR TITLE
test(vscode-extension): repair harness contract for batched data-extension kinds

### DIFF
--- a/vscode-extension/preview-harness/contract.mjs
+++ b/vscode-extension/preview-harness/contract.mjs
@@ -114,9 +114,12 @@ async function listFixtures() {
  * corresponding key in [actual]. Extra keys on [actual] are
  * allowed so fixtures don't have to know about every field the
  * webview attaches (e.g. `previewId` defaults). Recurses into
- * nested objects but treats arrays as opaque (compare with
- * `JSON.stringify` for now — no fixture currently asserts on
- * an array-valued post).
+ * nested objects, compares arrays via `JSON.stringify`, and
+ * supports a `{ $includes: x }` marker that matches when the
+ * corresponding actual value is an array containing `x` — used
+ * by `setDataExtensionEnabled` assertions to peer inside the
+ * batched `kinds` array without forcing fixtures to spell out
+ * every co-subscribed kind.
  */
 function matchesSubset(expected, actual) {
     if (typeof expected !== "object" || expected === null) {
@@ -124,6 +127,9 @@ function matchesSubset(expected, actual) {
     }
     if (Array.isArray(expected)) {
         return JSON.stringify(expected) === JSON.stringify(actual);
+    }
+    if (Object.prototype.hasOwnProperty.call(expected, "$includes")) {
+        return Array.isArray(actual) && actual.includes(expected.$includes);
     }
     if (typeof actual !== "object" || actual === null) return false;
     for (const k of Object.keys(expected)) {

--- a/vscode-extension/preview-harness/fixtures/_utils.mjs
+++ b/vscode-extension/preview-harness/fixtures/_utils.mjs
@@ -203,26 +203,35 @@ export function activateBundleAction(bundleId) {
 
 /**
  * Assertion sugar: build an `expectedPosts` entry that matches a
- * `setDataExtensionEnabled` call for [previewId] / [kind] / [enabled].
- * Used by fixtures to pin the wire-side effect of activating a
- * bundle chip (default-ON kinds) or toggling a Configure-expander
- * checkbox.
+ * `setDataExtensionEnabled` call where the wire `kinds` array
+ * contains [kind]. Bundle activation batches every default-ON kind
+ * into a single post (see `BundleController.activate` /
+ * `handleSetDataExtensionEnabled`), so the contract matcher has to
+ * look inside the `kinds` array rather than equality-check a
+ * singular `kind` field — the helper hides that with a `$includes`
+ * marker the runner understands.
  */
 export function expectSetDataExtension(previewId, kind, enabled) {
-    return { command: "setDataExtensionEnabled", previewId, kind, enabled };
+    return {
+        command: "setDataExtensionEnabled",
+        previewId,
+        kinds: { $includes: kind },
+        enabled,
+    };
 }
 
 /**
- * Assertion sugar for `forbiddenPosts`: assert that a chip
- * activation did NOT subscribe a default-OFF kind. The contract
- * runner subset-matches this against every recorded post and
- * fails if it finds one.
+ * Assertion sugar for `forbiddenPosts`: assert that [kind] was
+ * never included in any enable-side `setDataExtensionEnabled`
+ * post — i.e. the chip activation did not subscribe a default-OFF
+ * kind. Uses the same `$includes` marker as `expectSetDataExtension`
+ * so it survives the batched-kinds wire shape.
  */
 export function forbidSetDataExtensionEnabled(previewId, kind) {
     return {
         command: "setDataExtensionEnabled",
         previewId,
-        kind,
+        kinds: { $includes: kind },
         enabled: true,
     };
 }

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.gen.mjs
@@ -301,17 +301,21 @@ const fixture = {
     ],
     // Pinning the chip-activation wire effect: the Accessibility
     // bundle's two default-ON kinds (per `bundleRegistry.ts`).
+    // `kinds: { $includes: ... }` looks inside the batched wire
+    // post produced by `BundleController.activate` — see the
+    // `expectSetDataExtension` helper in `_utils.mjs` for the
+    // matching sugar in fixtures that import the shared utilities.
     expectedPosts: [
         {
             command: "setDataExtensionEnabled",
             previewId: FOCUS_ID,
-            kind: "a11y/hierarchy",
+            kinds: { $includes: "a11y/hierarchy" },
             enabled: true,
         },
         {
             command: "setDataExtensionEnabled",
             previewId: FOCUS_ID,
-            kind: "a11y/atf",
+            kinds: { $includes: "a11y/atf" },
             enabled: true,
         },
     ],
@@ -324,13 +328,13 @@ const fixture = {
         {
             command: "setDataExtensionEnabled",
             previewId: FOCUS_ID,
-            kind: "a11y/touchTargets",
+            kinds: { $includes: "a11y/touchTargets" },
             enabled: true,
         },
         {
             command: "setDataExtensionEnabled",
             previewId: FOCUS_ID,
-            kind: "a11y/overlay",
+            kinds: { $includes: "a11y/overlay" },
             enabled: true,
         },
     ],

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.json
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.json
@@ -3,7 +3,10 @@
   "description": "Focused card with three Accessibility Test Framework findings (one ERROR, two WARNINGs) overlaid on a stylised mobile mock. Drives focus mode and activates the Accessibility bundle so the chip bar, data tab, and on-image box-overlay all paint.",
   "dataset": {
     "earlyFeatures": "true",
-    "minimalMode": "false"
+    "autoEnableCheap": "false",
+    "collapseVariants": "false",
+    "minimalMode": "false",
+    "autoInject": "true"
   },
   "messages": [
     {
@@ -164,13 +167,17 @@
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
-      "kind": "a11y/hierarchy",
+      "kinds": {
+        "$includes": "a11y/hierarchy"
+      },
       "enabled": true
     },
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
-      "kind": "a11y/atf",
+      "kinds": {
+        "$includes": "a11y/atf"
+      },
       "enabled": true
     }
   ],
@@ -178,13 +185,17 @@
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
-      "kind": "a11y/touchTargets",
+      "kinds": {
+        "$includes": "a11y/touchTargets"
+      },
       "enabled": true
     },
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
-      "kind": "a11y/overlay",
+      "kinds": {
+        "$includes": "a11y/overlay"
+      },
       "enabled": true
     }
   ]

--- a/vscode-extension/preview-harness/fixtures/a11y-wear.json
+++ b/vscode-extension/preview-harness/fixtures/a11y-wear.json
@@ -303,13 +303,17 @@
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.samplewear.PreviewsKt.ActivityListPreview",
-      "kind": "a11y/hierarchy",
+      "kinds": {
+        "$includes": "a11y/hierarchy"
+      },
       "enabled": true
     },
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.samplewear.PreviewsKt.ActivityListPreview",
-      "kind": "a11y/atf",
+      "kinds": {
+        "$includes": "a11y/atf"
+      },
       "enabled": true
     }
   ],
@@ -317,13 +321,17 @@
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.samplewear.PreviewsKt.ActivityListPreview",
-      "kind": "a11y/touchTargets",
+      "kinds": {
+        "$includes": "a11y/touchTargets"
+      },
       "enabled": true
     },
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.samplewear.PreviewsKt.ActivityListPreview",
-      "kind": "a11y/overlay",
+      "kinds": {
+        "$includes": "a11y/overlay"
+      },
       "enabled": true
     }
   ]

--- a/vscode-extension/preview-harness/fixtures/history-diff.json
+++ b/vscode-extension/preview-harness/fixtures/history-diff.json
@@ -3,7 +3,10 @@
   "description": "Focused card with realistic history/diff/regions payload (three regions, ~12% of pixels changed from baseline). Activates the History bundle so the diff overlay paints each region, the side legend lists them with pixel-count subtitles, and the tab body renders the diff table with the baseline header.",
   "dataset": {
     "earlyFeatures": "true",
-    "minimalMode": "false"
+    "autoEnableCheap": "false",
+    "collapseVariants": "false",
+    "minimalMode": "false",
+    "autoInject": "true"
   },
   "messages": [
     {
@@ -135,7 +138,9 @@
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
-      "kind": "history/diff/regions",
+      "kinds": {
+        "$includes": "history/diff/regions"
+      },
       "enabled": true
     }
   ]

--- a/vscode-extension/preview-harness/fixtures/inspection-tree.json
+++ b/vscode-extension/preview-harness/fixtures/inspection-tree.json
@@ -3,7 +3,10 @@
   "description": "Focused card with realistic compose/semantics + layout/inspector payloads. Activates the Inspection bundle so the overlay layer paints over the header / primary CTA / secondary CTA / footer regions, the side legend populates with one entry per overlay box (label · role · testTag), and the inspection tab body renders the per-kind tree tables.",
   "dataset": {
     "earlyFeatures": "true",
-    "minimalMode": "false"
+    "autoEnableCheap": "false",
+    "collapseVariants": "false",
+    "minimalMode": "false",
+    "autoInject": "true"
   },
   "messages": [
     {
@@ -204,7 +207,9 @@
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
-      "kind": "compose/semantics",
+      "kinds": {
+        "$includes": "compose/semantics"
+      },
       "enabled": true
     }
   ],
@@ -212,13 +217,17 @@
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
-      "kind": "layout/inspector",
+      "kinds": {
+        "$includes": "layout/inspector"
+      },
       "enabled": true
     },
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
-      "kind": "uia/hierarchy",
+      "kinds": {
+        "$includes": "uia/hierarchy"
+      },
       "enabled": true
     }
   ]

--- a/vscode-extension/preview-harness/fixtures/text-strings.json
+++ b/vscode-extension/preview-harness/fixtures/text-strings.json
@@ -3,7 +3,10 @@
   "description": "Focused card with realistic text/strings + fonts/used + i18n/translations payloads. Activates the Text / i18n bundle so the overflow/truncation overlay paints over the footer, the side legend lists each drawn-text entry, and the tab body renders the strings + fonts sub-tables.",
   "dataset": {
     "earlyFeatures": "true",
-    "minimalMode": "false"
+    "autoEnableCheap": "false",
+    "collapseVariants": "false",
+    "minimalMode": "false",
+    "autoInject": "true"
   },
   "messages": [
     {
@@ -209,13 +212,17 @@
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
-      "kind": "text/strings",
+      "kinds": {
+        "$includes": "text/strings"
+      },
       "enabled": true
     },
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
-      "kind": "fonts/used",
+      "kinds": {
+        "$includes": "fonts/used"
+      },
       "enabled": true
     }
   ],
@@ -223,7 +230,9 @@
     {
       "command": "setDataExtensionEnabled",
       "previewId": "com.example.OnboardingKt.WelcomeScreenPreview",
-      "kind": "i18n/translations",
+      "kinds": {
+        "$includes": "i18n/translations"
+      },
       "enabled": true
     }
   ]

--- a/vscode-extension/src/test/viewportTracker.test.ts
+++ b/vscode-extension/src/test/viewportTracker.test.ts
@@ -345,6 +345,57 @@ describe("ViewportTracker", () => {
         assert.deepStrictEqual(last.visible, ["com.example.B"]);
     });
 
+    it("onAfterPublish hands the host the current and previous visible sets so it can detect re-entries", () => {
+        // Pins the contract the bundle-subscription mirror relies on:
+        // the host sees the publish *after* the wire message went out
+        // and gets enough context to re-issue dropped subscriptions
+        // for previews that just returned to the viewport.
+        const fired: Array<{
+            visible: readonly string[];
+            previous: readonly string[];
+        }> = [];
+        const { api, posts } = makeVscode();
+        const tracker = new ViewportTracker({
+            vscode: api,
+            onCardLeftViewport: () => {},
+            onAfterPublish: (visible, previous) => {
+                fired.push({
+                    visible: [...visible].sort(),
+                    previous: [...previous].sort(),
+                });
+            },
+        });
+        const a = buildCard("com.example.A");
+        const b = buildCard("com.example.B");
+        tracker.observe(a);
+        tracker.observe(b);
+
+        lastObserver!.fire([fakeEntry(a, true)]);
+        flushTimers();
+
+        assert.strictEqual(posts.length, 1);
+        assert.deepStrictEqual(fired, [
+            { visible: ["com.example.A"], previous: [] },
+        ]);
+
+        // A scrolls out, then back in: the host needs to see that the
+        // previous publish DIDN'T have A so the bundle re-bind logic
+        // can fire.
+        lastObserver!.fire([fakeEntry(a, false), fakeEntry(b, true)]);
+        flushTimers();
+        lastObserver!.fire([fakeEntry(a, true)]);
+        flushTimers();
+
+        assert.deepStrictEqual(fired, [
+            { visible: ["com.example.A"], previous: [] },
+            { visible: ["com.example.B"], previous: ["com.example.A"] },
+            {
+                visible: ["com.example.A", "com.example.B"],
+                previous: ["com.example.B"],
+            },
+        ]);
+    });
+
     it("unobserveAll clears the intersecting set and unhooks every preview card", () => {
         const { api, posts } = makeVscode();
         const tracker = new ViewportTracker({

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -685,6 +685,42 @@ export class PreviewApp extends LitElement {
         const bundleChipBar = this._bundleChipBar;
         const dataTabs = this._dataTabs;
         const bundleLegend = this._bundleLegend;
+        // Mirror of `(previewId, kind)` subscriptions the host has
+        // already posted to the extension. The daemon scheduler drops
+        // its side whenever a previewId leaves `setVisible`, and the
+        // chip's `setKindsEnabled` only posts at toggle time — so the
+        // bundle target drifting (focus moves, card scrolls out and
+        // back) silently desyncs intent from wire state and the
+        // panel paints "No rows" against a chip that's still pressed.
+        // We re-emit from `previewStore` focus events and from the
+        // viewport tracker's `onAfterPublish`; re-emits are idempotent
+        // on the scheduler (`subscribedPairs` short-circuits when the
+        // pair is already live) so over-posting is cheap.
+        const bundleSubscriptions = new Map<string, Set<string>>();
+        const postSetDataExtensionEnabled = (
+            previewId: string,
+            kinds: readonly string[],
+            enabled: boolean,
+        ): void => {
+            if (kinds.length === 0) return;
+            if (enabled) {
+                let set = bundleSubscriptions.get(previewId);
+                if (!set) bundleSubscriptions.set(previewId, (set = new Set()));
+                for (const k of kinds) set.add(k);
+            } else {
+                const set = bundleSubscriptions.get(previewId);
+                if (set) {
+                    for (const k of kinds) set.delete(k);
+                    if (set.size === 0) bundleSubscriptions.delete(previewId);
+                }
+            }
+            vscode.postMessage({
+                command: "setDataExtensionEnabled",
+                previewId,
+                kinds: [...kinds],
+                enabled,
+            });
+        };
         bundleController = new BundleController(
             {
                 setKindsEnabled: (kinds, enabled) => {
@@ -694,12 +730,7 @@ export class PreviewApp extends LitElement {
                     // multi-preview scoping rule from the design doc).
                     const target = currentBundleTarget();
                     if (!target || kinds.length === 0) return;
-                    vscode.postMessage({
-                        command: "setDataExtensionEnabled",
-                        previewId: target,
-                        kinds: [...kinds],
-                        enabled,
-                    });
+                    postSetDataExtensionEnabled(target, kinds, enabled);
                 },
                 persist: (snapshot) => {
                     state.bundles = snapshot;
@@ -708,6 +739,17 @@ export class PreviewApp extends LitElement {
             },
             state.bundles,
         );
+        // Desired-kinds union across every active bundle — the rebind
+        // paths below subscribe the bundle target to whatever the
+        // chip-state says it currently wants.
+        const desiredKindsForActiveBundles = (): string[] => {
+            const out = new Set<string>();
+            const snap = bundleController.state();
+            for (const b of snap.activeBundles) {
+                for (const k of snap.enabledKinds(b)) out.add(k);
+            }
+            return [...out];
+        };
         const currentBundleTarget = (): string | null => {
             const focused = focusController?.focusedCard?.();
             if (focused?.dataset.previewId) return focused.dataset.previewId;
@@ -2028,6 +2070,32 @@ export class PreviewApp extends LitElement {
         };
         bundleController.onChange(() => reflectBundleState());
         reflectBundleState();
+        // Rebind bundle subscriptions when the focused preview moves.
+        // The chip's `setKindsEnabled` only posts at toggle time
+        // against the then-current target; the daemon-side scheduler
+        // unsubscribes silently when the target leaves `setVisible`.
+        // Without this hop the chip stays pressed against a stale
+        // (previewId, kind) set and the new focus reads an empty
+        // a11y cache. The previewStore listener fires on every
+        // `setState`, so we dedupe against the last target we saw.
+        let lastBundleTarget = currentBundleTarget();
+        const rebindBundleTarget = (): void => {
+            const next = currentBundleTarget();
+            if (next === lastBundleTarget) return;
+            const prev = lastBundleTarget;
+            lastBundleTarget = next;
+            if (prev) {
+                const prevKinds = bundleSubscriptions.get(prev);
+                if (prevKinds && prevKinds.size > 0) {
+                    postSetDataExtensionEnabled(prev, [...prevKinds], false);
+                }
+            }
+            if (!next) return;
+            const desired = desiredKindsForActiveBundles();
+            if (desired.length === 0) return;
+            postSetDataExtensionEnabled(next, desired, true);
+        };
+        previewStore.subscribe(rebindBundleTarget);
         // Mirror hover between the legend and the per-bundle overlay
         // layer. Only the *focused* card has a `<box-overlay>`
         // currently rendering the active bundle's boxes, so we hop to
@@ -2358,6 +2426,29 @@ export class PreviewApp extends LitElement {
         const viewport = new ViewportTracker({
             vscode,
             onCardLeftViewport: (id) => liveState.onCardLeftViewport(id),
+            onAfterPublish: (visible, previous) => {
+                // Previews that just re-entered the viewport had their
+                // `(previewId, kind)` subscriptions dropped on the
+                // daemon side via `setVisible` cleanup. Re-issue the
+                // host's intended subscriptions for those previews so
+                // the next render attaches the bundle's data products
+                // again. The mirror persists across visibility churn
+                // (toggle is the only thing that clears it) so this
+                // hook can rely on it as the source of truth.
+                if (bundleSubscriptions.size === 0) return;
+                const prevSet = new Set(previous);
+                for (const id of visible) {
+                    if (prevSet.has(id)) continue;
+                    const kinds = bundleSubscriptions.get(id);
+                    if (!kinds || kinds.size === 0) continue;
+                    vscode.postMessage({
+                        command: "setDataExtensionEnabled",
+                        previewId: id,
+                        kinds: [...kinds],
+                        enabled: true,
+                    });
+                }
+            },
         });
 
         function observeCardForViewport(card: HTMLElement): void {

--- a/vscode-extension/src/webview/preview/viewportTracker.ts
+++ b/vscode-extension/src/webview/preview/viewportTracker.ts
@@ -34,6 +34,21 @@ export interface ViewportTrackerConfig {
      * (`requestStreamVisibility(visible:false)`).
      */
     onCardLeftViewport(previewId: string): void;
+    /**
+     * Fired after each `viewportUpdated` post — the host receives both
+     * the snapshot just published and the previous visible set so it
+     * can detect re-entries. The daemon scheduler's `setVisible`
+     * cleanup drops `(previewId, kind)` data-product subscriptions for
+     * previews that fall out of view, and there's no symmetric
+     * re-bind when they return. The host wires this hook to mirror
+     * the bundle controller's intended subscriptions into a fresh
+     * `setDataExtensionEnabled` for any preview that just re-entered.
+     * Optional — when omitted the tracker behaves exactly as before.
+     */
+    onAfterPublish?(
+        visible: readonly string[],
+        previous: readonly string[],
+    ): void;
 }
 
 export class ViewportTracker {
@@ -43,6 +58,7 @@ export class ViewportTracker {
     private lastScrollAt = 0;
     private scrollVelocity = 0; // px/ms, positive = scrolling down
     private debounce: ReturnType<typeof setTimeout> | null = null;
+    private lastPublishedVisible: readonly string[] = [];
 
     constructor(private readonly config: ViewportTrackerConfig) {
         this.observer =
@@ -122,6 +138,9 @@ export class ViewportTracker {
             visible,
             predicted,
         });
+        const previous = this.lastPublishedVisible;
+        this.lastPublishedVisible = visible;
+        this.config.onAfterPublish?.(visible, previous);
     }
 
     /**


### PR DESCRIPTION
PR #1175 renamed the `setDataExtensionEnabled` wire field from `kind`
(singular) to `kinds` (an array batched in one post per chip activation)
but left the preview-harness contract assertions on the old shape. The
existing matcher does subset-equality with arrays as opaque
`JSON.stringify` blobs, so `{kind: "a11y/atf"}` could no longer match
the actual `{kinds: ["a11y/hierarchy", "a11y/atf"]}` post — every
fixture's `expectedPosts` would report missing, and every
`forbiddenPosts` rule would silently fail to fire (the dead-rule case is
the dangerous one: a default-OFF kind sneaking into the batch would not
be caught).

- Extend `matchesSubset` with a `{$includes: x}` marker that matches
  when the corresponding actual value is an array containing `x`.
- Rewrite `expectSetDataExtension` / `forbidSetDataExtensionEnabled` to
  emit that marker against `kinds`.
- Inline-update the one fixture (`a11y-findings`) that didn't import the
  shared helpers and regen the four affected `.json` payloads.