### PR TITLE
fix(vscode-extension): teach harness contract matcher about batched setDataExtensionEnabled

### DIFF
--- a/vscode-extension/preview-harness/contract.mjs
+++ b/vscode-extension/preview-harness/contract.mjs
@@ -133,7 +133,27 @@ function matchesSubset(expected, actual) {
 }
 
 function findMatchingPost(log, expected) {
-    return log.find((post) => matchesSubset(expected, post));
+    return log.find((post) => {
+        if (matchesSubset(expected, post)) return true;
+        // `setDataExtensionEnabled` switched from one message per kind
+        // (`kind: "x"`) to a batched form (`kinds: ["x", "y"]`) so chip
+        // activation lands as a single `data/subscribe` sequence rather
+        // than racing the daemon's mode-lock-on-first-subscribe. Fixtures
+        // still assert one kind at a time; treat `kind: "x"` as a match
+        // for any logged post whose `kinds` array contains "x".
+        if (
+            post?.command === "setDataExtensionEnabled" &&
+            Array.isArray(post.kinds) &&
+            typeof expected?.kind === "string"
+        ) {
+            return post.kinds.some((k) => {
+                const synthetic = { ...post, kind: k };
+                delete synthetic.kinds;
+                return matchesSubset(expected, synthetic);
+            });
+        }
+        return false;
+    });
 }
 
 async function loadFixture(name) {


### PR DESCRIPTION
#1175 changed the wire format from one `setDataExtensionEnabled` message
per kind (`kind: "x"`) to a batched form (`kinds: ["x", "y"]`) so a
chip activation lands as a single `data/subscribe` sequence instead of
racing the daemon's mode-lock-on-first-subscribe. Existing fixtures
still assert per-kind via `expectedPosts` / `forbiddenPosts`, so the
contract runner started failing for every fixture that exercises the
Accessibility / Inspection / Text-strings bundle chips.

Match `kind: "x"` against any logged post whose `kinds` array contains
"x" — the contract intent is still "did the chip subscribe to this
kind?", regardless of whether it arrived alone or batched with siblings.