### PR TITLE
fix: filter bare-status progress noise from Gradle output

### DIFF
--- a/vscode-extension/src/logFilter.ts
+++ b/vscode-extension/src/logFilter.ts
@@ -60,6 +60,19 @@ const DISCOVERED_BULLET_RE = /^ {2}\S/;
 // counterpart — we always keep that one (it's a failure).
 const BUILD_SUCCESSFUL_RE = /^BUILD SUCCESSFUL /;
 
+// Bare-status progress noise emitted by Gradle's rich console (and/or
+// vscode-gradle's own progress reporter) after ANSI cursor moves have been
+// stripped. Each task's `> Task :…` header was rendered to a column the
+// daemon later overwrote with the visible status token; with ANSI stripped,
+// only the status tokens survive — often glued together without separators,
+// and sometimes glued onto a `BUILD SUCCESSFUL in …` trailer in the same
+// physical chunk. `--console=plain` is supposed to suppress this but the
+// Tooling API path doesn't always honour it. Matches a line that is
+// **entirely** status tokens (optionally trailed by BUILD SUCCESSFUL); a
+// `FAILED` token is deliberately excluded so failure signals always survive.
+const BARE_STATUS_NOISE_RE =
+    /^\s*((UP-TO-DATE|SKIPPED|FROM-CACHE|NO-SOURCE)\s*)+(BUILD SUCCESSFUL in [^\n]*)?\s*$/;
+
 const CONFIG_CACHE_RE =
     /^(Reusing configuration cache\.|Configuration cache entry (reused|stored)\.|Calculating task graph .*)$/;
 
@@ -301,6 +314,9 @@ export class LogFilter {
         if (TASK_HEADER_RE.test(trimmed)) {
             // Already handled by the `FAILED` branch above — drop everything
             // else.
+            return "drop";
+        }
+        if (BARE_STATUS_NOISE_RE.test(trimmed)) {
             return "drop";
         }
         if (BUILD_SUCCESSFUL_RE.test(trimmed)) {

--- a/vscode-extension/src/test/logFilter.test.ts
+++ b/vscode-extension/src/test/logFilter.test.ts
@@ -84,6 +84,38 @@ describe("LogFilter", () => {
             assert.strictEqual(out, "BUILD FAILED in 1s\n");
         });
 
+        it("drops bare-status progress noise from Gradle's rich console after ANSI stripping", () => {
+            const f = withLevel("normal");
+            // Single chunk, no internal newlines, no trailing newline — the
+            // exact shape that leaks through onOutput when vscode-gradle's
+            // progress reporter emits per-task status tokens that have lost
+            // their `> Task :…` headers to ANSI cursor moves.
+            const out = f.filterGradleChunk(
+                " UP-TO-DATE UP-TO-DATE UP-TO-DATE UP-TO-DATE SKIPPED FROM-CACHE NO-SOURCE UP-TO-DATE",
+            );
+            assert.strictEqual(out, "");
+        });
+
+        it("drops bare-status noise glued onto a BUILD SUCCESSFUL trailer", () => {
+            const f = withLevel("normal");
+            const out = f.filterGradleChunk(
+                " UP-TO-DATE UP-TO-DATE UP-TO-DATE UP-TO-DATEBUILD SUCCESSFUL in 6s",
+            );
+            assert.strictEqual(out, "");
+        });
+
+        it("keeps lines that contain FAILED even when surrounded by status tokens", () => {
+            const f = withLevel("normal");
+            // FAILED must never get swallowed by the bare-status drop.
+            const out = f.filterGradleChunk(
+                " UP-TO-DATE UP-TO-DATE FAILED UP-TO-DATE\n",
+            );
+            assert.strictEqual(
+                out,
+                " UP-TO-DATE UP-TO-DATE FAILED UP-TO-DATE\n",
+            );
+        });
+
         it("drops the multi-line configure-project warning block", () => {
             const f = withLevel("normal");
             const out = f.filterGradleChunk(


### PR DESCRIPTION
Gradle's rich console emits task status tokens (UP-TO-DATE, SKIPPED, FROM-CACHE, NO-SOURCE) that can appear as bare noise in the output after ANSI cursor moves are stripped. This is particularly problematic when these tokens are glued together without separators or concatenated with BUILD SUCCESSFUL trailers.

## Changes

- Added `BARE_STATUS_NOISE_RE` regex pattern to identify and filter lines consisting entirely of status tokens, optionally followed by a BUILD SUCCESSFUL trailer
- The pattern deliberately excludes FAILED tokens to ensure failure signals are never suppressed
- Integrated the new filter into the log filtering logic to drop matching lines during normal log level processing
- Added three test cases covering:
  - Bare status tokens with no other content
  - Status tokens glued to a BUILD SUCCESSFUL trailer
  - Preservation of lines containing FAILED even when surrounded by status tokens

## Implementation Details

The regex matches lines that are entirely composed of status tokens (UP-TO-DATE, SKIPPED, FROM-CACHE, NO-SOURCE) with optional whitespace, and optionally ending with a BUILD SUCCESSFUL trailer. This handles the case where `--console=plain` doesn't suppress the noise through the Tooling API path.

https://claude.ai/code/session_01LkJ3ECPX2vX3Fhbn8Qjjyp