### PR TITLE
fix(vscode-extension): close the a11y-only race where caches stayed empty

### DIFF
--- a/vscode-extension/src/test/applyA11yUpdate.test.ts
+++ b/vscode-extension/src/test/applyA11yUpdate.test.ts
@@ -136,21 +136,28 @@ describe("applyA11yUpdate", () => {
         assert.strictEqual(cache.nodes.size, 0);
     });
 
-    it("silent no-op when the previewId has no card in the DOM", () => {
+    it("populates the caches even when the previewId has no card mounted yet", () => {
+        // Pre-#1180 this branch was a silent no-op, but the daemon's
+        // render-with-data-products notification can land before
+        // `setPreviews` has mounted the matching card — the bundle
+        // refresh then read an empty cache against payloads sitting
+        // unused in `dataProductsByPreview`, and the A11y table
+        // painted "No rows" stubbornly. Cache writes now run
+        // unconditionally so the refresh path sees fresh data when
+        // the card eventually mounts.
         buildCard("com.example.OTHER");
+        const finding = buildFinding("ERROR", "x");
+        const node = buildNode("X");
         const { config, cache } = buildConfig({
             previews: [buildPreviewInfo("com.example.GHOST")],
         });
         assert.doesNotThrow(() =>
-            applyA11yUpdate(
-                "com.example.GHOST",
-                [buildFinding("ERROR", "x")],
-                [buildNode("X")],
-                config,
-            ),
+            applyA11yUpdate("com.example.GHOST", [finding], [node], config),
         );
-        assert.strictEqual(cache.findings.size, 0);
-        assert.strictEqual(cache.nodes.size, 0);
+        assert.deepStrictEqual(cache.findings.get("com.example.GHOST"), [
+            finding,
+        ]);
+        assert.deepStrictEqual(cache.nodes.get("com.example.GHOST"), [node]);
     });
 
     it("writes the findings cache and mutates the matching PreviewInfo when findings are present", () => {

--- a/vscode-extension/src/webview/preview/applyA11yUpdate.ts
+++ b/vscode-extension/src/webview/preview/applyA11yUpdate.ts
@@ -82,8 +82,13 @@ export function applyA11yUpdate(
     config: A11yUpdateConfig,
 ): void {
     if (!config.earlyFeatures()) return;
-    const card = document.getElementById("preview-" + sanitizeId(previewId));
-    if (!card) return;
+    // Cache updates run unconditionally so the A11y bundle's `refresh`
+    // path can read fresh findings/nodes even if this `updateA11y`
+    // landed before the preview card mounted — a race the daemon-
+    // attached render path can lose when the first
+    // render-with-data-products arrives ahead of `setPreviews`. The
+    // DOM-dependent side effects (inspector render) are guarded
+    // separately below.
     if (findings !== undefined) {
         if (findings && findings.length > 0) {
             // Mutate the manifest entry's findings so downstream surfaces
@@ -106,6 +111,8 @@ export function applyA11yUpdate(
             config.deleteCardA11yNodes(previewId);
         }
     }
+    const card = document.getElementById("preview-" + sanitizeId(previewId));
+    if (!card) return;
     if (config.inFocus() && config.focusedCard() === card) {
         config.inspector.render(card);
     }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -1174,10 +1174,35 @@ export class PreviewApp extends LitElement {
         } => {
             const store = previewStore.getState();
             const preview = store.allPreviews.find((p) => p.id === previewId);
+            // a11y data arrives over two parallel channels: a dedicated
+            // `updateA11y` post (consumed by `applyA11yUpdate`, which
+            // writes the `cardA11yNodes` / `cardA11yFindings` caches)
+            // and the generic `updateDataProducts` post that feeds
+            // `dataProductsByPreview` like every other bundle. The
+            // dedicated channel is gated on the preview card being in
+            // the DOM at receive time (`applyA11yUpdate.ts:85`); if a
+            // render-with-attachments lands before the card is mounted
+            // — or before `earlyFeatures()` flips on — the cache stays
+            // empty even though the payload is sitting in
+            // `dataProductsByPreview`. Fall back to the same generic
+            // cache the rest of the bundles drink from so the
+            // accessibility table doesn't paint "No rows" against a
+            // bundle whose data is already in memory.
+            const byKind = dataProductsByPreview.get(previewId);
+            const hierarchyPayload = byKind?.get("a11y/hierarchy") as
+                | { nodes?: readonly AccessibilityNode[] }
+                | undefined;
+            const atfPayload = byKind?.get("a11y/atf") as
+                | { findings?: readonly AccessibilityFinding[] }
+                | undefined;
             const nodes =
-                store.cardA11yNodes.get(previewId) ?? preview?.a11yNodes ?? [];
+                store.cardA11yNodes.get(previewId) ??
+                hierarchyPayload?.nodes ??
+                preview?.a11yNodes ??
+                [];
             const findings =
                 store.cardA11yFindings.get(previewId) ??
+                atfPayload?.findings ??
                 preview?.a11yFindings ??
                 [];
             return { nodes, findings };


### PR DESCRIPTION
## Summary

The a11y bundle was stubbornly painting "No rows" with the chip still pressed, while every other bundle (Text, Inspection, History, Watch…) populated normally. Root cause: a11y is the only bundle that reads from a dedicated `cardA11yNodes` / `cardA11yFindings` pair fed by `updateA11y` → `applyA11yUpdate`, and `applyA11yUpdate` short-circuited the whole function whenever the matching preview card wasn't already in the DOM. Every other bundle reads from `dataProductsByPreview`, which `updateDataProducts` populates synchronously and unconditionally.

The extension forwards the same `(findings, nodes)` payloads down **both** channels (`onDataProductsAttached` posts `updateA11y` *and* `updateDataProducts` for the same render). So when a `renderFinished` with attachments races `setPreviews` — easy on first chip activation or after a re-discovery rebuilds cards — `updateDataProducts` cached the payload while `updateA11y` silently dropped it. The chip stayed on, the other bundles painted, and the a11y table read an empty dedicated cache against payloads already sitting in memory.

Two changes:

- **`applyA11yUpdate.ts`** — moved the `document.getElementById` check below the cache writes. The lookup still guards the only DOM-dependent side effect (`inspector.render(card)`), which is the original reason the function ever needed the element. Cache writes now run unconditionally.
- **`main.ts` `a11yDataForCard`** — falls back to `dataProductsByPreview` when the dedicated cache hasn't been written yet. The `updateA11y` path remains authoritative (it carries the manifest mutation + inspector re-render side effects), but the bundle table reads live data from whichever channel arrived first.

The existing `applyA11yUpdate` "ghost previewId" test is rewritten to assert the new behaviour (cache populated when card isn't mounted) with the rationale inline.

## Test plan

- [x] `npm --prefix vscode-extension run compile` — clean
- [x] `npm --prefix vscode-extension test` — 1023 passing
- [ ] Manual repro: open a Compose project, focus a preview, press the Accessibility chip on first activation. Bundle table should populate rather than show "No rows".
- [ ] Verify the focus inspector still re-renders only when the focused card matches the incoming a11y update (DOM-side effect preserved).
- [ ] Confirm the other bundles still paint as before (no read-path regression).

---
_Generated by [Claude Code](https://claude.ai/code/session_018PDERhfhTtNjwtQv84V83D)_