### PR TITLE
fix(vscode-extension): snap chip activation back to default kinds when stored set is empty

### DIFF
--- a/vscode-extension/src/test/bundleController.test.ts
+++ b/vscode-extension/src/test/bundleController.test.ts
@@ -169,6 +169,57 @@ describe("BundleController", () => {
         );
     });
 
+    it("re-activating a bundle whose stored kinds drained to empty falls back to defaults", () => {
+        // Configure-expander all-off used to persist `{a11y: []}`; the
+        // next chip activation read that empty array, the
+        // `kinds.length > 0` guard skipped `setKindsEnabled`, and the
+        // chip lit up against a bundle that never subscribed to
+        // anything — no `setDataExtensionEnabled` ever reached the
+        // extension, no `[daemon] onDataProductsAttached` log. Pin
+        // the contract that pressing the chip always produces a wire
+        // post: empty-stored snaps back to defaults rather than
+        // honouring a zero-kind preference the chip UI can't surface.
+        const { controller, toggles } = build();
+        controller.toggleBundle("a11y");
+        for (const k of ["a11y/hierarchy", "a11y/atf"]) {
+            controller.setKindEnabled("a11y", k, false);
+        }
+        // Sanity: stored kinds list is now empty.
+        assert.deepStrictEqual(controller.state().enabledKinds("a11y"), []);
+        controller.closeTab("a11y");
+        toggles.length = 0;
+        controller.toggleBundle("a11y");
+        const reactivated = toggles
+            .filter((t) => t.enabled)
+            .map((t) => t.kind)
+            .sort();
+        assert.deepStrictEqual(
+            reactivated,
+            ["a11y/atf", "a11y/hierarchy"],
+            "empty-stored kinds must snap back to defaults on re-activate",
+        );
+    });
+
+    it("activating a snapshot whose kinds drained out (registry drift) falls back to defaults", () => {
+        // Same guard as above, exercised via the snapshot path: a
+        // bundle whose persisted kinds all disappeared from the
+        // registry filters down to `[]` in the constructor, and the
+        // first activation must still subscribe defaults rather than
+        // silently no-op.
+        const { controller, toggles } = build({
+            activeBundles: [],
+            enabledKindsByBundle: { a11y: [] },
+            activeTab: null,
+        });
+        assert.deepStrictEqual(controller.state().enabledKinds("a11y"), []);
+        controller.toggleBundle("a11y");
+        const subscribed = toggles
+            .filter((t) => t.enabled)
+            .map((t) => t.kind)
+            .sort();
+        assert.deepStrictEqual(subscribed, ["a11y/atf", "a11y/hierarchy"]);
+    });
+
     it("MRU promotes the just-pressed bundle to the front of activeBundles", () => {
         const { controller } = build();
         controller.toggleBundle("a11y");

--- a/vscode-extension/src/webview/preview/bundleController.ts
+++ b/vscode-extension/src/webview/preview/bundleController.ts
@@ -235,8 +235,21 @@ export class BundleController {
         // MRU: most-recently activated lives at index 0 so the chip
         // bar shows it first.
         this.active = [id, ...this.active.filter((x) => x !== id)];
+        // `??` falls back on null/undefined only, not on an empty
+        // list — so a snapshot that persisted `{a11y: []}` (the user
+        // turned every kind off via Configure, or a kind name drifted
+        // out of the registry and was filtered to nothing on load)
+        // would land here with `kinds = []`, skip the
+        // `setKindsEnabled` call below, and leave the chip pressed
+        // against a bundle that has no subscriptions and never paints
+        // anything. Treat empty-stored as "no preference" and snap
+        // back to the bundle's defaults — pressing the chip should
+        // always mean "I want this bundle's data."
         const previouslyEnabled = this.enabled.get(id);
-        const kinds = previouslyEnabled ?? [...defaultOnKindsFor(id)];
+        const kinds =
+            previouslyEnabled && previouslyEnabled.length > 0
+                ? previouslyEnabled
+                : [...defaultOnKindsFor(id)];
         this.enabled.set(id, kinds);
         // Batched on purpose — the extension host's
         // `handleSetDataExtensionEnabled` ships a single `data/subscribe`


### PR DESCRIPTION
## Summary

Diagnosing "the Accessibility chip is stuck on but nothing happens — no `[daemon]` log lines, no `onDataProductsAttached`" turned up a silent no-op in `BundleController.activate`:

```ts
const previouslyEnabled = this.enabled.get(id);
const kinds = previouslyEnabled ?? [...defaultOnKindsFor(id)];
this.enabled.set(id, kinds);
if (kinds.length > 0) this.host.setKindsEnabled(kinds, true);
```

Nullish coalescing only catches `null` / `undefined` — an empty `[]` sails through. Two paths land there:

1. The Configure-expander turns the last kind off (stores `{a11y: []}`), the panel reloads, the user re-presses the chip → `kinds = []`, host call skipped, chip lit, zero subscriptions ever posted.
2. The constructor's snapshot-load filters stored kind names against the live registry: a kind that drifted out (rename / removal) reduces the stored list to `[]`, same dead-end.

Either way, no `setDataExtensionEnabled` reaches the extension host, so the daemon never sees `data/subscribe`, never runs in `mode=a11y`, never writes the a11y artifacts, never attaches data products — and the bundle table paints "No rows" against the chip that's still pressed.

## Fix

Treat empty-stored as "no preference" and snap back to the bundle's defaults on activate. Pressing a chip is a user gesture meaning "I want this bundle's data" — there's no UI affordance for "active with zero kinds," so honouring that state left the user stuck.

```ts
const kinds =
    previouslyEnabled && previouslyEnabled.length > 0
        ? previouslyEnabled
        : [...defaultOnKindsFor(id)];
```

Two regression tests pin both entry points (Configure-all-off and snapshot drift).

## Test plan

- [x] `npm --prefix vscode-extension run compile` — clean
- [x] `npm --prefix vscode-extension test` — 1028 passing (2 new)
- [ ] Manual repro: with a persisted `{a11y: []}` snapshot (or after disabling all a11y kinds via Configure and reloading), press the Accessibility chip. Output channel should now log `[panel] extension a11y/hierarchy,a11y/atf enabled for …` followed by `[daemon] onDataProductsAttached … kinds=[a11y/hierarchy,a11y/atf]`, and the bundle table populates.
- [ ] Sanity: pre-existing "user disabled one kind, re-activate keeps it off" behaviour (`bundleController.test.ts:158`) still holds — partial disables aren't reset, only fully-drained sets are.

---
_Generated by [Claude Code](https://claude.ai/code/session_018PDERhfhTtNjwtQv84V83D)_