### PR TITLE
feat(daemon/android): advertise compose/recomposition kind via a stub registry

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -54,6 +54,11 @@ dependencies {
   // core module re-exposes kotlinx-serialization-json as `api`, so we don't
   // re-declare it here.
   implementation(project(":daemon:core"))
+  // `compose/recomposition` kind constants. The full connector module is desktop-only
+  // (it depends on Compose Multiplatform's compose.ui for the `ImageComposeScene` reflection
+  // path); the Android registry advertises the kind from a stub that returns NotAvailable
+  // until the in-sandbox observer install lands in a follow-up.
+  implementation(project(":data-recomposition-core"))
   implementation(project(":data-fonts-connector"))
   implementation(project(":data-render-connector"))
   implementation(project(":data-history-connector"))

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecompositionStubRegistry.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecompositionStubRegistry.kt
@@ -1,0 +1,64 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.recomposition.RecompositionProduct
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Android-side stub for the `compose/recomposition` kind.
+ *
+ * **Why a stub?** The real producer ([data-recomposition-connector]'s
+ * `RecompositionDataProductRegistry`) is desktop-only today — it installs a
+ * `CompositionObserver` reflectively against the held `ImageComposeScene`'s
+ * `Recomposer`, and the Compose Multiplatform `compose.ui` dep that brings in
+ * `ImageComposeScene` conflicts with the Android daemon's `androidx.compose.ui`
+ * graph. On Android the equivalent observer install needs to run **inside** the
+ * Robolectric sandbox classloader and bridge counters back to the host through
+ * a primitive-only seam — a substantial cross-cutting change to the
+ * `daemon.bridge` surface that we are staging separately.
+ *
+ * **What this stub does.** Advertises the same `compose/recomposition`
+ * capability the real producer does so:
+ *
+ * - `initialize.capabilities.dataProducts` includes the kind on Android.
+ * - `data/subscribe` no longer fails with `-32020 kind not advertised`.
+ * - The panel's Performance bundle stops surfacing the subscribe-failed log
+ *   line every time the user toggles the chip on a Wear / Android preview.
+ *
+ * Fetches resolve to [DataProductRegistry.Outcome.NotAvailable] and the
+ * attachments list is always empty: the panel sees an honest "advertised but
+ * no data yet" state until the in-sandbox observer lands. Snapshot mode does
+ * **not** trigger a re-render here (would be wasted work — the next render
+ * would attach nothing anyway), which is why `requiresRerender` is `false`
+ * for the stub even though the real producer advertises `true`.
+ */
+class AndroidRecompositionStubRegistry : DataProductRegistry {
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = RecompositionProduct.KIND,
+        schemaVersion = RecompositionProduct.SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+        displayName = "Recomposition counts (stub)",
+      )
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != RecompositionProduct.KIND) return DataProductRegistry.Outcome.Unknown
+    return DataProductRegistry.Outcome.NotAvailable
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> =
+    emptyList()
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -305,6 +305,17 @@ fun main(args: Array<String>) {
             dataProductRegistry = WallpaperDataProductRegistry(),
           )
         )
+        // Stub advertisement of `compose/recomposition` so the panel's Performance bundle stops
+        // tripping `-32020 kind not advertised` when toggled on Android previews. Returns
+        // NotAvailable until the in-sandbox observer-install bridge lands; see
+        // [AndroidRecompositionStubRegistry] for the rationale.
+        add(
+          Extension(
+            id = "data/recomposition",
+            displayName = "Recomposition counts (stub)",
+            dataProductRegistry = AndroidRecompositionStubRegistry(),
+          )
+        )
         add(
           Extension(
             id = "data/ambient",


### PR DESCRIPTION
The real `RecompositionDataProductRegistry` in `:data-recomposition-connector`
is desktop-only — it installs a `CompositionObserver` reflectively against
the held `ImageComposeScene`'s `Recomposer`, and the Compose Multiplatform
`compose.ui` dep that brings in `ImageComposeScene` conflicts with the
Android daemon's `androidx.compose.ui` graph. As a result, the Android
daemon never advertised the `compose/recomposition` kind, so toggling the
Performance bundle chip on a Wear / Android preview surfaced
`-32020 kind not advertised` on every subscribe attempt.

This stub registry, registered as the `data/recomposition` extension on
Android, advertises the same capability the real producer does so:

- `initialize.capabilities.dataProducts` includes the kind on Android.
- `data/subscribe` succeeds (advertised kind).
- Fetches resolve to `Outcome.NotAvailable` and the attachments list is
  always empty — the panel sees an honest "advertised but no data yet"
  state rather than a wire error.

The in-sandbox observer-install bridge — which would actually populate
counts on the Android backend — lands in a follow-up. That work needs to
run inside the Robolectric sandbox classloader and bridge counter
increments back through the `daemon.bridge` surface; tracking that as a
separate change keeps this PR contained to the user-visible "stop the
error" win.