### PR TITLE
fix: gate panel data/subscribe by daemon-advertised kinds, use displayfilter/variants

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4291,6 +4291,34 @@ async function handleSetDataExtensionEnabled(
     if (!moduleId) {
         return;
     }
+    // Gate against the daemon's advertised capability set so the panel
+    // doesn't fire `data/subscribe` for kinds the daemon never claimed.
+    // The bundle catalogue is static (every host sees the same one)
+    // while the advertised set is per-daemon: `compose/recomposition`
+    // is desktop-only; `render/composeAiTrace` is gated on a sysprop;
+    // `displayfilter/variants` only shows up when filters are configured.
+    // When the snapshot is null (daemon not yet up / disposed mid-flight)
+    // we pass kinds through unchanged so the schedulers' own retry path
+    // can handle the request once the daemon comes online — squelching
+    // here would silently drop every toggle during the warm-up window.
+    const snap = daemonGate?.getCapabilitiesSnapshot(moduleId.modulePath);
+    const advertised = snap
+        ? new Set(snap.dataProducts.map((p) => p.kind))
+        : null;
+    const filteredKinds: string[] = [];
+    const dropped: string[] = [];
+    for (const kind of kinds) {
+        if (advertised && !advertised.has(kind)) dropped.push(kind);
+        else filteredKinds.push(kind);
+    }
+    if (dropped.length > 0) {
+        moduleOutputChannel?.appendLine(
+            `[panel] dropped unadvertised kinds for ${previewId}: ${dropped.join(", ")}`,
+        );
+    }
+    if (filteredKinds.length === 0) {
+        return;
+    }
     // Update the module's a11y tracker per-kind, but the
     // first-on / last-off transition is what gates the follow-up
     // refresh — collapse the per-kind verdicts into one. A bundle
@@ -4298,7 +4326,7 @@ async function handleSetDataExtensionEnabled(
     // kind in the batch can trip the transition; the rest stay
     // "unchanged" and must not override that.
     let a11yTransition: "enabled" | "disabled" | "unchanged" = "unchanged";
-    for (const kind of kinds) {
+    for (const kind of filteredKinds) {
         const t = updateModuleA11ySubscription(
             moduleId.modulePath,
             previewId,
@@ -4315,7 +4343,7 @@ async function handleSetDataExtensionEnabled(
     await daemonScheduler.setDataProductSubscription(
         moduleId,
         previewId,
-        kinds,
+        filteredKinds,
         enabled,
     );
     if (a11yTransition !== "unchanged") {
@@ -4332,8 +4360,8 @@ async function handleSetDataExtensionEnabled(
         // drops the corresponding cached entries and removes the layers from the DOM.
         // Other kinds (touchTargets, overlay) don't currently drive a webview overlay
         // independent of these two, so leaving them out keeps the message minimal.
-        const hasAtf = kinds.includes("a11y/atf");
-        const hasHierarchy = kinds.includes("a11y/hierarchy");
+        const hasAtf = filteredKinds.includes("a11y/atf");
+        const hasHierarchy = filteredKinds.includes("a11y/hierarchy");
         if (hasAtf || hasHierarchy) {
             const update: {
                 previewId: string;

--- a/vscode-extension/src/test/displayFilterBundlePresenter.test.ts
+++ b/vscode-extension/src/test/displayFilterBundlePresenter.test.ts
@@ -1,54 +1,69 @@
 // Display-filter bundle presenter (#1061 Cluster H). Pins the
-// kind→row derivation; the table is decorative (filter swap on click
-// is out of scope for v1), so the assertions focus on the row id /
-// filterId / label round-trip and the empty-entries path.
+// manifest-payload → row derivation. The daemon's wire kind is
+// `displayfilter/variants` and its payload enumerates one entry per
+// enabled filter; the presenter turns each entry into one row.
 
 import * as assert from "assert";
 import {
     computeDisplayFilterBundleData,
-    type DisplayFilterEntry,
+    type DisplayFilterVariantsPayload,
 } from "../webview/preview/displayFilterBundlePresenter";
 
-function entry(kind: string, label: string): DisplayFilterEntry {
-    return { kind, label };
+function payload(
+    variants: readonly { filter: string; path?: string; label?: string }[],
+): DisplayFilterVariantsPayload {
+    return { variants };
 }
 
 describe("computeDisplayFilterBundleData", () => {
-    it("emits no rows for an empty entries list", () => {
-        const data = computeDisplayFilterBundleData([]);
-        assert.strictEqual(data.rows.length, 0);
+    it("emits no rows for a null or empty payload", () => {
+        assert.strictEqual(computeDisplayFilterBundleData(null).rows.length, 0);
+        assert.strictEqual(
+            computeDisplayFilterBundleData(undefined).rows.length,
+            0,
+        );
+        assert.strictEqual(computeDisplayFilterBundleData({}).rows.length, 0);
+        assert.strictEqual(
+            computeDisplayFilterBundleData(payload([])).rows.length,
+            0,
+        );
     });
 
-    it("derives filterId from the tail of the wire kind", () => {
-        const data = computeDisplayFilterBundleData([
-            entry("displayfilter/grayscale", "Grayscale"),
-            entry("displayfilter/invert", "Invert"),
-        ]);
+    it("emits one row per manifest variant", () => {
+        const data = computeDisplayFilterBundleData(
+            payload([{ filter: "grayscale" }, { filter: "invert" }]),
+        );
         assert.strictEqual(data.rows.length, 2);
         assert.strictEqual(data.rows[0].filterId, "grayscale");
         assert.strictEqual(data.rows[1].filterId, "invert");
     });
 
     it("uses a stable id prefix per row for overlay correlation", () => {
-        const data = computeDisplayFilterBundleData([
-            entry("displayfilter/grayscale", "Grayscale"),
-        ]);
+        const data = computeDisplayFilterBundleData(
+            payload([{ filter: "grayscale" }]),
+        );
         assert.ok(data.rows[0].id.startsWith("displayfilter-"));
         assert.strictEqual(data.rows[0].id, "displayfilter-grayscale");
     });
 
-    it("preserves the original kind on each row", () => {
-        const data = computeDisplayFilterBundleData([
-            entry("displayfilter/deuteranopia", "Deuteranopia"),
-        ]);
-        assert.strictEqual(data.rows[0].kind, "displayfilter/deuteranopia");
+    it("derives a human label from the filter id when none is supplied", () => {
+        const data = computeDisplayFilterBundleData(
+            payload([{ filter: "deuteranopia" }]),
+        );
         assert.strictEqual(data.rows[0].label, "Deuteranopia");
     });
 
-    it("falls back to the whole kind when there is no slash", () => {
-        const data = computeDisplayFilterBundleData([
-            entry("grayscale", "Grayscale"),
-        ]);
-        assert.strictEqual(data.rows[0].filterId, "grayscale");
+    it("prefers the manifest-supplied label when present", () => {
+        const data = computeDisplayFilterBundleData(
+            payload([{ filter: "grayscale", label: "Bedtime grayscale" }]),
+        );
+        assert.strictEqual(data.rows[0].label, "Bedtime grayscale");
+    });
+
+    it("carries the variant PNG path through to the row", () => {
+        const data = computeDisplayFilterBundleData(
+            payload([{ filter: "invert", path: "/tmp/data/p1/invert.png" }]),
+        );
+        assert.strictEqual(data.rows[0].path, "/tmp/data/p1/invert.png");
     });
 });

--- a/vscode-extension/src/webview/preview/bundleRegistry.ts
+++ b/vscode-extension/src/webview/preview/bundleRegistry.ts
@@ -143,16 +143,16 @@ export const BUNDLES: readonly BundleDescriptor[] = [
         id: "display",
         label: "Display",
         icon: "device-desktop",
+        // The daemon advertises a single `displayfilter/variants` kind
+        // whose payload enumerates every enabled filter PNG. The per-
+        // filter row UI ("Grayscale", "Invert", daltonizer sims) is
+        // derived from that payload in `displayFilterBundlePresenter`;
+        // they are not separate wire kinds.
         kinds: [
             {
-                kind: "displayfilter/grayscale",
-                label: "Grayscale",
-                defaultOn: false,
-            },
-            {
-                kind: "displayfilter/invert",
-                label: "Invert",
-                defaultOn: false,
+                kind: "displayfilter/variants",
+                label: "Filter variants",
+                defaultOn: true,
             },
         ],
     },

--- a/vscode-extension/src/webview/preview/displayFilterBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/displayFilterBundlePresenter.ts
@@ -1,13 +1,18 @@
 // Display-filter bundle presenter — fills the "Display" tab body with
 // one row per post-process colour-matrix variant the daemon emits.
-// `DisplayFilters.kt` declares the enum of filters; the bundle
-// registry's `displayfilter/*` kinds are placeholders for the per-
-// filter on/off toggles users pick from the Configure… expander.
 //
-// The presenter is **stateless** — given the set of subscribed filter
-// ids it returns the row shape `<data-table>` consumes. There is no
-// overlay layer because display filters are an image-level transform;
-// users pick a filter to swap the whole card image, not a region.
+// The daemon advertises a single wire kind, `displayfilter/variants`,
+// whose payload manifest enumerates every enabled filter:
+//
+//     { variants: [{ filter, path, mediaType }, ...] }
+//
+// (See `DisplayFilterDataProducer.VariantsManifest` and
+// `DisplayFilterDataProductRegistry.kt`.) The presenter walks the
+// manifest's `variants` array and produces one row per filter. It is
+// **stateless** — given the parsed payload it returns the row shape
+// `<data-table>` consumes. There is no overlay layer because display
+// filters are an image-level transform; users pick a filter to swap
+// the whole card image, not a region.
 //
 // Out of scope for v1: actually swapping the focused card's image
 // when a row is clicked. The daemon-side override plumbing isn't
@@ -20,43 +25,49 @@ import type { DataTableColumn } from "./components/DataTable";
 export interface DisplayFilterRow {
     /** Stable id for `<data-table>` row hover / overlay correlation. */
     id: string;
-    /** Wire kind, e.g. `displayfilter/grayscale`. */
-    kind: string;
-    /** Tail of the kind — the human-readable filter id. */
+    /** Filter id as it appears in the manifest (e.g. `grayscale`). */
     filterId: string;
-    /** Bundle label from the registry; used as the row's "name". */
+    /** Human-readable filter label (falls back to `filterId`). */
     label: string;
+    /** PNG path from the manifest, if present. */
+    path?: string;
 }
 
 export interface DisplayFilterBundleData {
     rows: readonly DisplayFilterRow[];
 }
 
-export interface DisplayFilterEntry {
-    kind: string;
-    label: string;
+/**
+ * Parsed shape of the `displayfilter/variants` payload — narrow to
+ * what the presenter reads. The daemon emits `mediaType` too; the
+ * presenter ignores it for now (everything is image/png) but the
+ * field is part of the wire contract.
+ */
+export interface DisplayFilterVariantEntry {
+    filter: string;
+    path?: string;
+    label?: string;
+}
+
+export interface DisplayFilterVariantsPayload {
+    variants?: readonly DisplayFilterVariantEntry[];
 }
 
 /**
- * Build one row per filter the bundle catalogue advertises. The
- * presenter does not subscribe to the daemon-side filter PNGs — the
- * point of the tab is the user-facing toggle UI, the actual filtered
- * image rendering is daemon-side once that plumbing lands (see file
- * header TODO).
+ * Build one row per entry in the manifest. Returns an empty list
+ * when the payload is missing or malformed; the bundle tab then
+ * renders its empty-state hint rather than a half-built table.
  */
 export function computeDisplayFilterBundleData(
-    entries: readonly DisplayFilterEntry[],
+    payload: DisplayFilterVariantsPayload | null | undefined,
 ): DisplayFilterBundleData {
-    const rows: DisplayFilterRow[] = entries.map((e) => {
-        const slash = e.kind.lastIndexOf("/");
-        const filterId = slash >= 0 ? e.kind.slice(slash + 1) : e.kind;
-        return {
-            id: "displayfilter-" + filterId,
-            kind: e.kind,
-            filterId,
-            label: e.label,
-        };
-    });
+    const variants = payload?.variants ?? [];
+    const rows: DisplayFilterRow[] = variants.map((v) => ({
+        id: "displayfilter-" + v.filter,
+        filterId: v.filter,
+        label: v.label ?? humanLabel(v.filter),
+        path: v.path,
+    }));
     return { rows };
 }
 
@@ -81,9 +92,9 @@ export function displayFilterTableColumns(): readonly DataTableColumn<DisplayFil
 
 function renderThumbnail(row: DisplayFilterRow): TemplateResult {
     // Placeholder swatch labelled with the first two chars of the
-    // filter id. Once the daemon-side display-filter producer emits
-    // a per-preview PNG path (see DisplayFilterDataProducer.kt), the
-    // swatch will swap for an actual thumbnail.
+    // filter id. Once the bundle wires the manifest's per-variant
+    // PNG path into an `<img>`, the swatch will swap for an actual
+    // thumbnail.
     return html`
         <span
             class="displayfilter-thumb"
@@ -92,4 +103,9 @@ function renderThumbnail(row: DisplayFilterRow): TemplateResult {
             >${row.filterId.slice(0, 2).toUpperCase()}</span
         >
     `;
+}
+
+function humanLabel(filterId: string): string {
+    if (filterId.length === 0) return filterId;
+    return filterId.charAt(0).toUpperCase() + filterId.slice(1);
 }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -95,6 +95,7 @@ import {
 import {
     computeDisplayFilterBundleData,
     displayFilterTableColumns,
+    type DisplayFilterVariantsPayload,
 } from "./displayFilterBundlePresenter";
 import {
     computeResourcesBundleData,
@@ -1434,22 +1435,16 @@ export class PreviewApp extends LitElement {
         const refreshDisplayBundle = (): void => {
             const target = currentBundleTarget();
             if (!target) return;
-            // Build rows from the currently-subscribed kinds, not the
-            // full bundle catalog — otherwise filters show as "active"
-            // when their checkbox is off, drifting the displayed
-            // (and Copy-JSON'd) state away from actual subscriptions.
-            const bundle = getBundle("display");
-            const enabledKinds = new Set(
-                bundleController.state().enabledKinds("display"),
-            );
-            const entries =
-                bundle?.kinds
-                    .filter((k) => enabledKinds.has(k.kind))
-                    .map((k) => ({
-                        kind: k.kind,
-                        label: k.label,
-                    })) ?? [];
-            const data = computeDisplayFilterBundleData(entries);
+            // The daemon advertises a single `displayfilter/variants`
+            // kind whose payload manifest enumerates every enabled
+            // filter. Build rows from the latest attached payload, not
+            // the bundle catalog or chip state — the on-disk manifest
+            // is the source of truth for which filters actually have
+            // PNGs to display.
+            const byKind = dataProductsByPreview.get(target);
+            const payload = (byKind?.get("displayfilter/variants") ??
+                null) as DisplayFilterVariantsPayload | null;
+            const data = computeDisplayFilterBundleData(payload);
             const body = displayBodyBuilt();
             const table = body.table;
             table.setRows(data.rows);
@@ -1462,7 +1457,11 @@ export class PreviewApp extends LitElement {
             );
             table.setJsonPayload(() => ({
                 previewId: target,
-                filters: entries,
+                variants: data.rows.map((r) => ({
+                    filter: r.filterId,
+                    label: r.label,
+                    path: r.path,
+                })),
             }));
             // TODO: when daemon-side per-filter override plumbing lands,
             // forward `row-selected` events to a `requestDisplayFilter`


### PR DESCRIPTION
## Summary

The bundle catalogue in `bundleRegistry.ts` listed kinds the daemon never advertises (per-filter `displayfilter/grayscale`, `displayfilter/invert`) and platform-conditional kinds (`compose/recomposition` is desktop-only; `render/composeAiTrace` needs the trace sysprop). Toggling any of them in the chip / Configure expander fired a `data/subscribe` that came back `-32020 kind not advertised`.

- `handleSetDataExtensionEnabled` now filters kinds against `daemonGate.getCapabilitiesSnapshot(moduleId).dataProducts` before calling the scheduler. Unadvertised kinds are logged once per batch. When the snapshot is null (daemon warming / disposed) the filter short-circuits so transient nulls don't squelch every toggle.
- The display bundle now advertises the actual wire kind, `displayfilter/variants`. The Display tab presenter derives one row per filter from that kind's manifest payload (`variants: [{filter, path, mediaType}]`) instead of from chip state, so the table reflects what's on disk rather than the user's checkbox choices.

## Test plan

- [ ] Toggle the Performance chip on an Android / Wear preview — no `-32020 kind not advertised` in the panel log.
- [ ] Toggle the Display chip — Display tab renders rows from the daemon's `displayfilter/variants` payload.
- [ ] Toggle the same chips with the daemon offline / warming — no errors, the gate short-circuits.
- [ ] `npm --prefix vscode-extension test` (extension unit tests).


---
_Generated by [Claude Code](https://claude.ai/code/session_015zgrqhwS4GqiQwUPp1zJkh)_