### PR TITLE
fix(vscode-extension): tighten quiet/normal log filtering

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -158,11 +158,6 @@ const moduleManifestCache = new Map<string, PreviewInfo[]>();
  */
 const heavyRefreshOptIns = new Map<string, Set<string>>();
 let panel: PreviewPanel | null = null;
-// Captured from `activate()` so module-scoped dispatch helpers
-// (`handleWebviewMessage` etc.) can write to the same Compose Preview
-// output channel without threading it through every call site. Null
-// before activation; helpers must null-check.
-let moduleOutputChannel: vscode.OutputChannel | null = null;
 let debounceTimer: NodeJS.Timeout | null = null;
 let selectedModule: string | null = null;
 let pendingRefresh: AbortController | null = null;
@@ -237,6 +232,12 @@ let extensionContext: vscode.ExtensionContext | null = null;
  *  bugs are hard to diagnose from logs unless we explicitly announce each
  *  message we send to the webview. */
 let logLine: (msg: string) => void = () => {
+    /* noop pre-activate */
+};
+/** Like {@link logLine} but emits the message without the `[refresh] ` prefix,
+ *  so daemon/panel informational lines flow through `shouldEmitInformational`
+ *  with their own bracket-prefix (`[daemon] …`, `[panel] …`) intact. */
+let logInfo: (msg: string) => void = () => {
     /* noop pre-activate */
 };
 /** Guard against firing the "plugin not applied" notification more than once
@@ -573,9 +574,6 @@ export async function activate(
     const workspaceRoot = workspaceFolders[0].uri.fsPath;
     const outputChannel = vscode.window.createOutputChannel("Compose Preview");
     context.subscriptions.push(outputChannel);
-    // Mirror to module scope so dispatch helpers (e.g. `handleWebviewMessage`)
-    // can write to the same channel without threading it through every call.
-    moduleOutputChannel = outputChannel;
     // `composePreview.logging.level` is read on every emit so a settings.json
     // edit takes effect immediately without a window reload.
     const logFilter = new LogFilter(() =>
@@ -589,6 +587,11 @@ export async function activate(
         const line = `[refresh] ${msg}`;
         if (logFilter.shouldEmitInformational(line)) {
             outputChannel.appendLine(line);
+        }
+    };
+    logInfo = (msg: string) => {
+        if (logFilter.shouldEmitInformational(msg)) {
+            outputChannel.appendLine(msg);
         }
     };
 
@@ -769,7 +772,7 @@ export async function activate(
                           // the diagnostics provider already listens to. The panel receives a targeted
                           // `updateA11y` post so its cached overlays repaint without re-emitting the entire
                           // preview list.
-                          outputChannel.appendLine(
+                          logInfo(
                               `[daemon] onDataProductsAttached ${previewId} kinds=[${dataProducts
                                   .map((dp) => dp.kind)
                                   .join(
@@ -787,7 +790,7 @@ export async function activate(
                               dataProducts,
                               outputChannel,
                           );
-                          outputChannel.appendLine(
+                          logInfo(
                               `[daemon] decoded a11y for ${previewId}: findings=${decoded?.findings?.length ?? "<none>"} nodes=${decoded?.nodes?.length ?? "<none>"}`,
                           );
                           if (decoded && panel) {
@@ -819,7 +822,7 @@ export async function activate(
                                   .filter((dp) => dp.payload !== undefined);
                               const dropped =
                                   dataProducts.length - payloads.length;
-                              outputChannel.appendLine(
+                              logInfo(
                                   `[daemon] updateDataProducts post for ${previewId}: ` +
                                       `forwarding=${payloads.length} dropped=${dropped} ` +
                                       `kinds=[${payloads.map((p) => p.kind).join(",")}]` +
@@ -848,7 +851,7 @@ export async function activate(
                                   });
                               }
                           } else {
-                              outputChannel.appendLine(
+                              logInfo(
                                   `[daemon] updateDataProducts skipped for ${previewId}: panel not yet wired`,
                               );
                           }
@@ -1161,9 +1164,7 @@ export async function activate(
                 if (!panel) {
                     return;
                 }
-                outputChannel.appendLine(
-                    `[panel] focus preview: ${functionName}`,
-                );
+                logInfo(`[panel] focus preview: ${functionName}`);
                 // Reveal the sidebar view. This is the stable command contributed
                 // by VS Code for any registered view (`<viewId>.focus`).
                 await vscode.commands.executeCommand(
@@ -3940,7 +3941,7 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             // the loop ("host posted → webview consumed") and pairs with
             // the test-API `getReceivedMessages()` snapshot the e2e
             // suite asserts on.
-            moduleOutputChannel?.appendLine(
+            logInfo(
                 `[daemon] webview ack updateA11y previewId=${msg.previewId} ` +
                     `findings=${msg.findingsCount ?? "<none>"} ` +
                     `nodes=${msg.nodesCount ?? "<none>"}`,
@@ -3955,7 +3956,7 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             // message rode the host-side bridge but didn't reach the
             // webview — the kind of regression `webviewPreviewsRendered`
             // catches for the grid path.
-            moduleOutputChannel?.appendLine(
+            logInfo(
                 `[daemon] webview ack updateDataProducts previewId=${msg.previewId} ` +
                     `kinds=[${msg.kinds.join(",")}]`,
             );
@@ -3965,9 +3966,7 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             break;
         case "selectModule":
             selectedModule = msg.value || null;
-            moduleOutputChannel?.appendLine(
-                `[panel] module selected: ${selectedModule ?? "<none>"}`,
-            );
+            logInfo(`[panel] module selected: ${selectedModule ?? "<none>"}`);
             sendModuleList();
             if (selectedModule) {
                 refresh(false);
@@ -4105,7 +4104,7 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             break;
         case "setA11yOverlay":
             if (earlyFeaturesEnabled()) {
-                moduleOutputChannel?.appendLine(
+                logInfo(
                     `[panel] a11y overlay ${msg.enabled ? "enabled" : "disabled"} for ${msg.previewId}`,
                 );
                 void handleSetA11yOverlay(msg.previewId, msg.enabled);
@@ -4113,7 +4112,7 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             break;
         case "setDataExtensionEnabled":
             if (earlyFeaturesEnabled()) {
-                moduleOutputChannel?.appendLine(
+                logInfo(
                     `[panel] extension ${msg.kinds.join(",")} ${msg.enabled ? "enabled" : "disabled"} for ${msg.previewId}`,
                 );
                 void handleSetDataExtensionEnabled(
@@ -4312,7 +4311,7 @@ async function handleSetDataExtensionEnabled(
         else filteredKinds.push(kind);
     }
     if (dropped.length > 0) {
-        moduleOutputChannel?.appendLine(
+        logInfo(
             `[panel] dropped unadvertised kinds for ${previewId}: ${dropped.join(", ")}`,
         );
     }

--- a/vscode-extension/src/logFilter.ts
+++ b/vscode-extension/src/logFilter.ts
@@ -130,27 +130,46 @@ const BUILD_SUCCESS_FAIL_RE = /^BUILD (SUCCESSFUL|FAILED) /;
 // Prefixes are deliberately *specific* — we don't blanket-drop `[doctor] ` or
 // `[refresh] ` because the same prefix carries failure messages (e.g.
 // `[doctor] :samples:cmp:composePreviewDoctor failed: ...`) that must survive.
+//
+// `[refresh] [interactive] ...` / `[refresh] [stream] ...` shapes come from
+// logLine() wrapping `[interactive] …` / `[stream] …` messages with the
+// `[refresh] ` prefix — interactive scroll/click events and stream
+// start/stop fire per user gesture and would otherwise drown the channel.
 const NORMAL_CHATTER_PREFIXES = [
     "[refresh] cache hit:",
     "[refresh] cancelled — superseded ",
+    "[refresh] [interactive] ",
+    "[refresh] [stream] ",
+    "[refresh] daemon: skip ",
+    "[interactive] ",
+    "[stream] started ",
+    "[stream] stopped ",
     "[daemon] spawning ",
     "[daemon] webview ack ",
+    "[daemon] onDataProductsAttached ",
+    "[daemon] decoded a11y ",
+    "[daemon] updateDataProducts ",
     "[doctor] doctor diagnostics refreshed ",
     "[detect] ",
 ];
 
 // Lines that survive at normal (and verbose) but drop at quiet. The `[panel]`
-// prefix is reserved for user-initiated actions (preview selection, extension
-// toggle, focus); we always show those.
+// prefix carries user-initiated actions (preview selection, extension toggle,
+// focus). They survive at normal but drop at quiet — quiet is reserved for
+// "loading, daemon running, errors" only.
 const QUIET_CHATTER_PREFIXES = [
     "[refresh] start ",
     "[refresh] rendered ",
     "[refresh] no module ",
     "[refresh] done ",
     "[refresh] auto-render: ",
-    "[startup] ",
-    "[daemon] ready for ",
+    "[panel] ",
 ];
+
+// Lines that survive at every level (including quiet) because they answer
+// "is the extension loaded and is the daemon up". Used by the quiet branch of
+// `shouldEmitInformational`.
+const QUIET_KEEP_PREFIXES = ["[startup] ", "[daemon] ready for "];
 
 // `> :module:task` / `> :module:task completed` / `> :module:task cancelled`
 // progress markers from gradleService.ts. The `FAILED` variant flows through a
@@ -339,15 +358,20 @@ export class LogFilter {
      * current level. The line is passed without the `[daemon stderr] ` prefix.
      */
     filterDaemonStderrLine(line: string): string | null {
-        if (this.level() === "verbose") {
+        const lvl = this.level();
+        if (lvl === "verbose") {
             return line;
         }
 
-        // Roborazzi ActionBar block — first line shows once, follow-ups are
-        // always suppressed at normal/quiet. The block is line-by-line so we
-        // track our way through it with a flag.
+        // Roborazzi ActionBar block — at normal the first line shows once and
+        // follow-ups are always suppressed; at quiet the entire block drops
+        // (it's neither loading, daemon-ready, nor an error). The block is
+        // line-by-line so we track our way through it with a flag.
         if (ROBORAZZI_ACTIONBAR_FIRST_LINE_RE.test(line)) {
             this.inRoborazziBlock = true;
+            if (lvl === "quiet") {
+                return null;
+            }
             if (this.warnedOnce.has("roborazzi-actionbar")) {
                 return null;
             }
@@ -375,7 +399,7 @@ export class LogFilter {
             return line;
         }
 
-        if (this.level() === "quiet") {
+        if (lvl === "quiet") {
             // Drop everything that isn't an exception or stack frame.
             if (
                 line.startsWith("Exception ") ||
@@ -433,12 +457,12 @@ export class LogFilter {
         if (lvl === "verbose") {
             return true;
         }
-        // `[panel]` is user-initiated (preview selection, extension toggle).
-        // Always emit so the user sees what their click did.
-        if (line.startsWith("[panel] ")) {
-            return true;
-        }
         if (lvl === "normal") {
+            // `[panel]` is user-initiated (preview selection, extension toggle).
+            // Always emit at normal so the user sees what their click did.
+            if (line.startsWith("[panel] ")) {
+                return true;
+            }
             for (const prefix of NORMAL_CHATTER_PREFIXES) {
                 if (line.startsWith(prefix)) {
                     return false;
@@ -449,7 +473,14 @@ export class LogFilter {
             }
             return true;
         }
-        // quiet
+        // quiet — "loading, daemon running, errors" only. Allow-list the few
+        // signals that always survive, then deny-list the known chatter, and
+        // keep anything else (unfamiliar lines are likely error-shaped).
+        for (const prefix of QUIET_KEEP_PREFIXES) {
+            if (line.startsWith(prefix)) {
+                return true;
+            }
+        }
         for (const prefix of QUIET_CHATTER_PREFIXES) {
             if (line.startsWith(prefix)) {
                 return false;

--- a/vscode-extension/src/test/logFilter.test.ts
+++ b/vscode-extension/src/test/logFilter.test.ts
@@ -561,8 +561,8 @@ describe("LogFilter", () => {
             );
         });
 
-        it("always emits [panel] user-action lines at every level", () => {
-            for (const level of ["quiet", "normal", "verbose"] as const) {
+        it("emits [panel] user-action lines at normal and verbose", () => {
+            for (const level of ["normal", "verbose"] as const) {
                 const f = withLevel(level);
                 assert.strictEqual(
                     f.shouldEmitInformational("[panel] module selected: foo"),
@@ -579,6 +579,92 @@ describe("LogFilter", () => {
                     true,
                 );
             }
+        });
+
+        it("drops [panel] lines at quiet — quiet is loading/daemon/errors only", () => {
+            const f = withLevel("quiet");
+            assert.strictEqual(
+                f.shouldEmitInformational("[panel] module selected: foo"),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[panel] extension a11y/atf enabled for foo",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[panel] focus preview: foo"),
+                false,
+            );
+        });
+
+        it("drops interactive/stream chatter at normal", () => {
+            const f = withLevel("normal");
+            // logLine() wraps `[interactive] …` and `[stream] …` with the
+            // `[refresh] ` prefix; both shapes must drop.
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[refresh] [interactive] rotaryScroll com.example.Preview px=235,312 image=454x454 deltaY=-30",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[refresh] [stream] started for com.example.Preview (module=:samples:wear, streamId=fstream-1, codec=png, heldSession=true)",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[refresh] [stream] stopped for com.example.Preview (streamId=fstream-1)",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[refresh] daemon: skip post-warm refresh for :samples:wear; refresh already active",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[daemon] onDataProductsAttached com.example.Preview kinds=[a11y/hierarchy] panel=live transports=[a11y/hierarchy:path]",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[daemon] decoded a11y for com.example.Preview: findings=0 nodes=12",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[daemon] updateDataProducts post for com.example.Preview: forwarding=2 dropped=0 kinds=[a11y/hierarchy,a11y/atf]",
+                ),
+                false,
+            );
+        });
+
+        it("keeps loading/daemon-ready signals at quiet", () => {
+            const f = withLevel("quiet");
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[startup] compose-preview v0.0.0 loaded from /path",
+                ),
+                true,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[startup] mode=full reason=auto"),
+                true,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[daemon] ready for :samples:wear (daemonVersion=1, previews=17)",
+                ),
+                true,
+            );
         });
 
         it("drops chatter at quiet but keeps unknown / error-shaped lines", () => {
@@ -611,9 +697,12 @@ describe("LogFilter", () => {
                 ),
                 false,
             );
+            // `[daemon] ready ` survives at quiet — the user explicitly
+            // asked for "loading, daemon running, errors". `[daemon] spawning`
+            // is still chatter.
             assert.strictEqual(
                 f.shouldEmitInformational("[daemon] ready for samples/wear"),
-                false,
+                true,
             );
             assert.strictEqual(
                 f.shouldEmitInformational("[daemon] spawning foo"),


### PR DESCRIPTION
Quiet level was leaking high-volume per-gesture chatter (rotaryScroll
events, stream start/stop, data-product attach/decode/post, panel
toggles, post-warm refresh skips) because:

  - Several `[daemon] ...` and `[panel] ...` informational lines were
    written via `outputChannel.appendLine` directly, bypassing the
    LogFilter entirely.
  - `[refresh] [interactive] ...` / `[refresh] [stream] ...` shapes
    (produced by `logLine()` wrapping `[interactive] …` / `[stream] …`
    messages) were not in any chatter prefix list.

Route the bypassed lines through a new module-scoped `logInfo()` helper
that runs them through `shouldEmitInformational` without the `[refresh] `
prefix. Add the missing chatter prefixes so they drop at normal too —
per the user's spec, normal should not show scroll events.

Quiet is now an allow-list ("loading, daemon running, errors"):
`[startup] ` and `[daemon] ready for ` survive, `[panel] ` and the
Roborazzi ActionBar block drop along with the existing chatter set.