### PR TITLE
feat(vscode): show merged child text in a11y legend, render table as merge-aware tree

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2265,6 +2265,32 @@ bundle-chip-bar {
     line-height: 1.2;
     user-select: none;
 }
+.a11y-tree-pip {
+    /* Filled bullet marks a merged node (TalkBack focusable / screen-
+     * reader stop). Sits in the same gutter as `↳` so merged rows and
+     * unmerged child rows align vertically in the tree column. */
+    color: var(--vscode-charts-blue, currentColor);
+    opacity: 0.85;
+    line-height: 1.2;
+    font-size: 9px;
+    user-select: none;
+    display: inline-flex;
+    align-items: center;
+    min-width: 10px;
+}
+.a11y-label-stack-merged .a11y-label-text strong {
+    font-weight: 600;
+}
+.a11y-label-stack-unmerged {
+    /* Unmerged children of a merged ancestor — visually subordinate
+     * to the focusable parent above them. The lighter italic style
+     * makes the merge boundary obvious at a glance. */
+    color: var(--vscode-descriptionForeground, inherit);
+}
+.a11y-label-unmerged-text {
+    font-style: italic;
+    font-weight: 400;
+}
 .a11y-label-text {
     display: flex;
     flex-direction: column;

--- a/vscode-extension/src/test/a11yBundlePresenter.test.ts
+++ b/vscode-extension/src/test/a11yBundlePresenter.test.ts
@@ -250,18 +250,13 @@ describe("computeA11yBundleData", () => {
                 }),
             ],
             [],
-            [],
-            // Depth-annotation contract only matters when unmerged
-            // children are surfaced; opt back into the full hierarchy
-            // since the default `mergedOnly` filter would drop them.
-            { mergedOnly: false },
         );
         assert.strictEqual(data.rows.length, 2);
         assert.strictEqual(data.rows[0].depth, 0, "merged ⇒ top-level");
         assert.strictEqual(data.rows[1].depth, 1, "unmerged ⇒ child of merged");
     });
 
-    it("filters unmerged nodes by default so the legend stays focused on TalkBack stops", () => {
+    it("keeps unmerged children in the table but skips their overlay box (parent covers them)", () => {
         const data = computeA11yBundleData(
             [
                 node({
@@ -277,9 +272,64 @@ describe("computeA11yBundleData", () => {
             ],
             [],
         );
-        assert.strictEqual(data.rows.length, 1);
-        assert.strictEqual(data.rows[0].label, "Button");
+        // Both rows appear in the table — the tree view needs the
+        // child to be visible to show the merge structure.
+        assert.strictEqual(data.rows.length, 2);
+        assert.strictEqual(data.rows[0].merged, true);
+        assert.strictEqual(data.rows[1].merged, false);
+        // But the overlay only paints the merged parent — the child
+        // sits inside the parent's bounds and would just stack a
+        // duplicate box on the preview.
         assert.strictEqual(data.overlay.length, 1);
+        assert.strictEqual(data.overlay[0].id, data.rows[0].id);
+    });
+
+    it("derives a merged node's displayLabel from its unmerged children when the daemon emitted no label", () => {
+        // Wear `ActivityListPreview` case: the `clickable` row has no
+        // label on the wire, only its inner Text children. The
+        // legend would show "(unlabelled)" if we used `label`
+        // verbatim — `displayLabel` joins the child texts so users
+        // see what TalkBack would announce.
+        const data = computeA11yBundleData(
+            [
+                node({
+                    label: "",
+                    role: "clickable",
+                    merged: true,
+                    boundsInScreen: "0,0,100,40",
+                }),
+                node({
+                    label: "Morning run",
+                    merged: false,
+                    boundsInScreen: "5,5,95,20",
+                }),
+                node({
+                    label: "5.2 km · 28 min",
+                    merged: false,
+                    boundsInScreen: "5,20,95,35",
+                }),
+                node({
+                    label: "Heart rate row",
+                    role: "clickable",
+                    merged: true,
+                    boundsInScreen: "0,40,100,80",
+                }),
+            ],
+            [],
+        );
+        const parent = data.rows.find(
+            (r) => r.role === "clickable" && r.merged,
+        )!;
+        assert.strictEqual(parent.label, "(unlabelled)");
+        assert.strictEqual(
+            parent.displayLabel,
+            "Morning run · 5.2 km · 28 min",
+        );
+        // A merged node that DOES have its own label keeps it — the
+        // child walk only kicks in when the daemon emitted an empty
+        // string, and it stops at the next merged node.
+        const sibling = data.rows.find((r) => r.label === "Heart rate row")!;
+        assert.strictEqual(sibling.displayLabel, "Heart rate row");
     });
 
     it("treats a missing `merged` field as merged=true (daemon JSON omits the default)", () => {
@@ -312,9 +362,10 @@ describe("computeA11yBundleData", () => {
 
     it("does not surface a finding on an unmerged child as an orphan when the bounds match", () => {
         // The finding lives on the inner Text node's bounds, which
-        // also matches the merged Button (same bounds). When we
-        // filter unmerged nodes out, the finding must still merge
-        // onto the Button row instead of looking like an orphan.
+        // also matches the merged Button (same bounds). The finding
+        // must merge onto the Button row instead of looking like an
+        // orphan, regardless of whether the unmerged child is also
+        // present in the table.
         const data = computeA11yBundleData(
             [
                 node({
@@ -336,9 +387,15 @@ describe("computeA11yBundleData", () => {
                 }),
             ],
         );
-        assert.strictEqual(data.rows.length, 1);
-        assert.strictEqual(data.rows[0].findingCount, 1);
-        assert.strictEqual(data.rows[0].topFindingLevel, "warning");
+        const parent = data.rows.find((r) => r.merged && r.label === "Button");
+        assert.ok(parent);
+        assert.strictEqual(parent!.findingCount, 1);
+        assert.strictEqual(parent!.topFindingLevel, "warning");
+        // No orphan row should have been synthesised — the finding
+        // attached to the matching merged ancestor.
+        assert.ok(
+            !data.rows.some((r) => r.id.startsWith("a11y-finding-orphan-")),
+        );
     });
 
     it("orphan finding rows render at depth 0 regardless of hierarchy", () => {

--- a/vscode-extension/src/test/a11yRowDetail.test.ts
+++ b/vscode-extension/src/test/a11yRowDetail.test.ts
@@ -14,9 +14,11 @@ import type {
 import type { AccessibilityFinding } from "../webview/shared/types";
 
 function row(over: Partial<A11yRow>): A11yRow {
+    const label = over.label ?? "Title";
     return {
         id: over.id ?? "a11y-0",
-        label: over.label ?? "Title",
+        label,
+        displayLabel: over.displayLabel ?? label,
         role: over.role ?? "Button",
         states: over.states ?? "",
         merged: over.merged ?? true,

--- a/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
@@ -38,6 +38,14 @@ export interface AccessibilityTouchTarget {
 export interface A11yRow {
     id: string;
     label: string;
+    /** Label as it should appear in the legend / overlay tooltip.
+     *  For merged nodes that the daemon emitted without a `label`
+     *  (e.g. a `clickable` row whose only content is inner `Text`
+     *  children) this is the concatenation of the immediately-
+     *  following unmerged children's labels — the TalkBack-style
+     *  merged announcement. Falls back to `label` otherwise, with
+     *  the `(unlabelled)` placeholder applied for empty strings. */
+    displayLabel: string;
     role: string;
     states: string;
     merged: boolean;
@@ -80,9 +88,11 @@ export interface A11yBundleOptions {
     /** Show only `merged: true` nodes — the focusable / screen-reader
      *  stops. Unmerged children (e.g. inner `Text` inside a `Button`)
      *  duplicate their merged ancestor's bounds and clutter the
-     *  overlay + legend without adding new information for most
-     *  reviews. Defaults to `true`; flip to `false` to surface the
-     *  full hierarchy when debugging a specific merge boundary. */
+     *  overlay without adding new information for most reviews, but
+     *  in the data-table they make the tree structure (which text
+     *  rolls up into which focusable container) visible. Defaults
+     *  to `false`; flip to `true` to drop unmerged rows from the
+     *  table (the legend filters them out either way). */
     mergedOnly?: boolean;
 }
 
@@ -92,11 +102,20 @@ export function computeA11yBundleData(
     touchTargets: readonly AccessibilityTouchTarget[] = [],
     options: A11yBundleOptions = {},
 ): A11yBundleData {
-    const mergedOnly = options.mergedOnly ?? true;
+    const mergedOnly = options.mergedOnly ?? false;
     const rows: A11yRow[] = [];
     const overlay: OverlayBox[] = [];
     const findingsByBoundsKey = groupFindingsByBoundsKey(findings);
     const matchedKeys = new Set<string>();
+    // Pre-compute the merged announcement label for each merged node
+    // by walking its run of immediately-following `merged: false`
+    // children and concatenating their text — the wire format is flat
+    // so emission order is our only handle on parent/child. This is
+    // what TalkBack would read aloud for the focusable, and it's what
+    // the legend wants in place of the daemon's empty `label` on
+    // containers like `clickable` rows whose own text lives in
+    // unmerged Text children.
+    const mergedChildLabels = collectMergedChildLabels(nodes);
     // Index touch targets by bounds string — the daemon emits both
     // the hierarchy and the targets keyed on the same source bounds,
     // so we can merge per-node without exposing the daemon-internal
@@ -138,9 +157,14 @@ export function computeA11yBundleData(
             topLevel(matchingFindings),
             targetFindingCount > 0 ? "warning" : null,
         );
+        const rawLabel = node.label ?? "";
+        const inheritedLabel =
+            isMerged && !rawLabel ? (mergedChildLabels.get(idx) ?? "") : "";
+        const displayLabel = rawLabel || inheritedLabel || "(unlabelled)";
         const row: A11yRow = {
             id,
-            label: node.label || "(unlabelled)",
+            label: rawLabel || "(unlabelled)",
+            displayLabel,
             role: node.role ?? "",
             states: node.states?.join(", ") ?? "",
             merged: isMerged,
@@ -155,7 +179,12 @@ export function computeA11yBundleData(
             depth: isMerged ? 0 : 1,
         };
         rows.push(row);
-        if (bounds) {
+        // Only merged nodes draw overlay boxes — unmerged children
+        // share (or sit inside) their merged ancestor's bounds, so
+        // adding their boxes just stacks duplicates on the preview
+        // and clutters the screen-reader focus map. They still show
+        // in the table so the tree structure is visible.
+        if (bounds && isMerged) {
             overlay.push({
                 id,
                 bounds,
@@ -183,9 +212,11 @@ export function computeA11yBundleData(
         const id = "a11y-finding-orphan-" + idx;
         const bounds = parseBounds(fBounds);
         const level = normLevel(f.level);
+        const orphanLabel = f.viewDescription || "(no element)";
         rows.push({
             id,
-            label: f.viewDescription || "(no element)",
+            label: orphanLabel,
+            displayLabel: orphanLabel,
             role: f.type,
             states: "",
             merged: true,
@@ -221,9 +252,13 @@ export function computeA11yBundleData(
         if (tKey && matchedKeys.has(tKey)) return;
         const id = "a11y-touchtarget-orphan-" + idx;
         const bounds = parseBounds(t.boundsInScreen ?? "");
+        const orphanTargetLabel = t.nodeId
+            ? "node " + t.nodeId
+            : "(touch target)";
         rows.push({
             id,
-            label: t.nodeId ? "node " + t.nodeId : "(touch target)",
+            label: orphanTargetLabel,
+            displayLabel: orphanTargetLabel,
             role: "TouchTarget",
             states: t.findings.join(", "),
             merged: true,
@@ -249,6 +284,24 @@ export function computeA11yBundleData(
     });
 
     return { rows, overlay };
+}
+
+function collectMergedChildLabels(
+    nodes: readonly AccessibilityNode[],
+): Map<number, string> {
+    const out = new Map<number, string>();
+    for (let i = 0; i < nodes.length; i++) {
+        const n = nodes[i];
+        if (n.merged === false) continue;
+        const childTexts: string[] = [];
+        for (let j = i + 1; j < nodes.length; j++) {
+            if (nodes[j].merged !== false) break;
+            const childLabel = nodes[j].label;
+            if (childLabel) childTexts.push(childLabel);
+        }
+        if (childTexts.length > 0) out.set(i, childTexts.join(" · "));
+    }
+    return out;
 }
 
 function mergeLevel(
@@ -282,28 +335,47 @@ export function a11yTableColumns(): readonly DataTableColumn<A11yRow>[] {
         {
             header: "Label",
             cellClass: "a11y-label-cell",
-            render: (row) => html`
-                <div
-                    class=${row.depth > 0
-                        ? "a11y-label-stack a11y-label-stack-indent"
-                        : "a11y-label-stack"}
-                    data-depth=${row.depth}
-                >
-                    ${row.depth > 0
-                        ? html`<span class="a11y-tree-arm" aria-hidden="true"
-                              >↳</span
-                          >`
-                        : ""}
-                    <div class="a11y-label-text">
-                        <strong>${row.label}</strong>
-                        ${row.role
-                            ? html`<span class="a11y-row-role"
-                                  >${row.role}</span
+            render: (row) => {
+                const stackClasses = ["a11y-label-stack"];
+                if (row.depth > 0) stackClasses.push("a11y-label-stack-indent");
+                stackClasses.push(
+                    row.merged
+                        ? "a11y-label-stack-merged"
+                        : "a11y-label-stack-unmerged",
+                );
+                return html`
+                    <div
+                        class=${stackClasses.join(" ")}
+                        data-depth=${row.depth}
+                        data-merged=${row.merged ? "true" : "false"}
+                    >
+                        ${row.depth > 0
+                            ? html`<span
+                                  class="a11y-tree-arm"
+                                  aria-hidden="true"
+                                  >↳</span
                               >`
-                            : ""}
+                            : html`<span
+                                  class="a11y-tree-pip"
+                                  aria-hidden="true"
+                                  title="Merged (focusable / screen-reader stop)"
+                                  >●</span
+                              >`}
+                        <div class="a11y-label-text">
+                            ${row.merged
+                                ? html`<strong>${row.label}</strong>`
+                                : html`<span class="a11y-label-unmerged-text"
+                                      >${row.label}</span
+                                  >`}
+                            ${row.role
+                                ? html`<span class="a11y-row-role"
+                                      >${row.role}</span
+                                  >`
+                                : ""}
+                        </div>
                     </div>
-                </div>
-            `,
+                `;
+            },
         },
         {
             header: "States",

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -1280,11 +1280,18 @@ export class PreviewApp extends LitElement {
             // boxes (inspection, history-diff) wire their entries
             // the same way; the legend swaps slices based on the
             // active tab.
+            // Legend lists the focusable / TalkBack stops only —
+            // merged nodes plus orphan finding / touch-target rows
+            // (which carry their own bounds and synthesize as
+            // merged=true). Unmerged children render in the data
+            // table beneath their merged parent to show the tree
+            // structure, but they share bounds with that parent and
+            // would duplicate swatches on the overlay.
             const legendEntries: BundleLegendEntry[] = data.rows
-                .filter((row) => row.bounds !== null)
+                .filter((row) => row.bounds !== null && row.merged)
                 .map((row, idx) => ({
                     id: row.id,
-                    label: row.label,
+                    label: row.displayLabel,
                     detail: a11yLegendDetail(row),
                     level: row.topFindingLevel ?? "info",
                     color:


### PR DESCRIPTION
The Accessibility legend used to print "(unlabelled)" verbatim for any
merged node whose own `label` came back empty from the daemon — e.g. a
Wear `clickable` row whose only text lives in inner unmerged `Text`
children. The legend now derives a `displayLabel` by joining the
immediately-following unmerged children's labels (TalkBack-style merge
announcement), so the same row reads "Morning run · 5.2 km · 28 min".

The Accessibility table flips its default from "merged-only" to the
full hierarchy and visually distinguishes the two kinds:

  - merged (TalkBack focus stop): bullet pip, bold label
  - unmerged (child of a merged ancestor): ↳ arm, italic, indented

The overlay still paints only merged boxes — unmerged children sit
inside their parent's bounds, so painting them would stack duplicates
on the preview without adding information. The legend still filters
to merged + orphan rows for the same reason.