### PR TITLE
fix(vscode-extension): drain pending data/subscribe before warm-up render

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2062,6 +2062,19 @@ bundle-chip-bar {
     border-color: var(--vscode-focusBorder, transparent);
     opacity: 1;
 }
+/* Chips disabled while the preview daemon hasn't finished spawning.
+   Subscriptions issued during that window race the warm-up render and
+   land too late for the daemon's subscriptionDrivenRenderMode lock,
+   producing an extension-less first frame. Greying surfaces the wait
+   directly to the user instead. */
+.bundle-chip.bundle-chip-disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+.bundle-chip.bundle-chip-disabled:hover {
+    background: transparent;
+    opacity: 0.4;
+}
 .bundle-chip-label {
     white-space: nowrap;
 }

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -149,6 +149,18 @@ export interface DaemonScheduler {
         kinds: readonly string[],
         enabled: boolean,
     ): Promise<void>;
+    /**
+     * Resolves once every in-flight `data/subscribe` for [moduleId] has been
+     * acknowledged by the daemon (or has settled — failures count as drained).
+     * Callers that issue a `renderNow` independently of
+     * [setDataProductSubscription] (e.g. the activation-time warm-up render)
+     * await this before sending so the daemon's
+     * `subscriptionDrivenRenderMode` lock has the panel-side subscriptions
+     * recorded by the time the render is dispatched. Without this barrier the
+     * first daemon render on a fresh spawn races the panel's chip-driven
+     * subscribe posts and the user sees an extension-less first frame.
+     */
+    awaitPendingSubscribes(moduleId: string): Promise<void>;
     renderNow(
         module: ModuleInfo,
         previewIds: string[],
@@ -188,6 +200,20 @@ export class LiveDaemonScheduler implements DaemonScheduler {
      * leaves `setVisible`, so we only need to dedup re-subscribes.
      */
     private readonly subscribedPairs = new Set<string>();
+    /**
+     * In-flight `data/subscribe` promises per moduleId. Tracked so an
+     * out-of-band caller (the activation warm-up render in
+     * `warmShownPreviewsForFile`) can drain them via
+     * [awaitPendingSubscribes] before issuing a `renderNow`. Without this
+     * drain, the warm-up render races the panel's chip-driven subscribes
+     * for the very first preview after a daemon spawn and the daemon's
+     * `subscriptionDrivenRenderMode` lock misses the in-flight render —
+     * extensions appear empty until the user re-navigates.
+     */
+    private readonly pendingSubscribes = new Map<
+        string,
+        Set<Promise<unknown>>
+    >();
     /** Cards we've already speculatively requested so scrolling back over
      *  them doesn't re-queue identical work. Keyed by `${moduleId}::${id}`. */
     private speculated = new Set<string>();
@@ -430,16 +456,19 @@ export class LiveDaemonScheduler implements DaemonScheduler {
             if (enabled) {
                 this.subscribedPairs.add(subKey);
                 subscribedAny = true;
-                client.dataSubscribe({ previewId, kind }).catch((err) => {
-                    // Pre-D2 daemons reject with DataProductUnknown for every kind; that's
-                    // expected, not noise — log to the daemon channel and roll back the
-                    // bookkeeping so a later daemon spawn re-issues.
-                    const msg = (err as Error)?.message ?? String(err);
-                    this.logger.appendLine(
-                        `[daemon] dataSubscribe(${previewId}, ${kind}) failed: ${msg}`,
-                    );
-                    this.subscribedPairs.delete(subKey);
-                });
+                const subPromise = client
+                    .dataSubscribe({ previewId, kind })
+                    .catch((err) => {
+                        // Pre-D2 daemons reject with DataProductUnknown for every kind; that's
+                        // expected, not noise — log to the daemon channel and roll back the
+                        // bookkeeping so a later daemon spawn re-issues.
+                        const msg = (err as Error)?.message ?? String(err);
+                        this.logger.appendLine(
+                            `[daemon] dataSubscribe(${previewId}, ${kind}) failed: ${msg}`,
+                        );
+                        this.subscribedPairs.delete(subKey);
+                    });
+                this.trackPendingSubscribe(module.modulePath, subPromise);
             } else {
                 this.subscribedPairs.delete(subKey);
                 client.dataUnsubscribe({ previewId, kind }).catch((err) => {
@@ -475,6 +504,41 @@ export class LiveDaemonScheduler implements DaemonScheduler {
                     );
                 });
         }
+    }
+
+    /**
+     * Stash the in-flight `data/subscribe` promise so a parallel `renderNow`
+     * caller can drain it before sending. The promise is removed from the
+     * pending set on settle (resolve or reject) so a long-lived module
+     * doesn't accumulate references.
+     */
+    private trackPendingSubscribe(
+        moduleId: string,
+        promise: Promise<unknown>,
+    ): void {
+        let bucket = this.pendingSubscribes.get(moduleId);
+        if (!bucket) {
+            bucket = new Set();
+            this.pendingSubscribes.set(moduleId, bucket);
+        }
+        bucket.add(promise);
+        const drop = () => {
+            const current = this.pendingSubscribes.get(moduleId);
+            if (!current) return;
+            current.delete(promise);
+            if (current.size === 0) this.pendingSubscribes.delete(moduleId);
+        };
+        promise.then(drop, drop);
+    }
+
+    awaitPendingSubscribes(moduleId: string): Promise<void> {
+        const bucket = this.pendingSubscribes.get(moduleId);
+        if (!bucket || bucket.size === 0) {
+            return Promise.resolve();
+        }
+        // Snapshot — settle the entries we know about now; subscribes
+        // issued later are the next caller's problem.
+        return Promise.allSettled([...bucket]).then(() => undefined);
     }
 
     /**
@@ -720,6 +784,10 @@ export class GradleOnlyDaemonScheduler implements DaemonScheduler {
         _enabled: boolean,
     ): Promise<void> {
         /* no-op: data extensions are disabled in minimal mode */
+    }
+
+    async awaitPendingSubscribes(_moduleId: string): Promise<void> {
+        /* no-op: minimal mode never issues data/subscribe */
     }
 
     async renderNow(

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2717,6 +2717,16 @@ async function warmShownPreviewsForFile(
     try {
         await daemonScheduler.setFocus(module, ids);
         await daemonScheduler.setVisible(module, ids, []);
+        // Yield once so any panel postMessages queued during refresh /
+        // daemon warm-up (chip activation, restored bundle state) reach
+        // handleSetDataExtensionEnabled before the warm-up render fires,
+        // then drain the data/subscribe traffic those handlers kicked
+        // off. Without this barrier the daemon's
+        // subscriptionDrivenRenderMode lock misses this first render and
+        // the user sees an extension-less first frame until they
+        // navigate away and back.
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        await daemonScheduler.awaitPendingSubscribes(module.modulePath);
         await daemonScheduler.renderNow(module, ids, "fast", reason);
     } catch (err) {
         daemonShownPreviewWarmScopes.delete(scopeKey);

--- a/vscode-extension/src/test/bundleChipBar.test.ts
+++ b/vscode-extension/src/test/bundleChipBar.test.ts
@@ -1,0 +1,213 @@
+// `<bundle-chip-bar>` — verifies the chip strip's render, daemon-ready
+// gate, and toggle event. The chip-driven subscription flow itself is
+// covered by `bundleController.test.ts`; this suite focuses on the
+// component's DOM contract.
+
+import * as assert from "assert";
+import { BUNDLES } from "../webview/preview/bundleRegistry";
+
+// Importing the component registers the custom element. Tests drive it
+// through `setState` + DOM, then assert on the rendered light DOM.
+import "../webview/preview/components/BundleChipBar";
+import type {
+    BundleChipBar,
+    BundleToggledDetail,
+} from "../webview/preview/components/BundleChipBar";
+
+function build(): BundleChipBar {
+    const el = document.createElement("bundle-chip-bar") as BundleChipBar;
+    document.body.appendChild(el);
+    return el;
+}
+
+describe("BundleChipBar", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("renders one chip per available bundle in registry order", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: [],
+            availableBundles: null,
+        });
+        await el.updateComplete;
+        const chips = Array.from(
+            el.querySelectorAll<HTMLButtonElement>(".bundle-chip"),
+        );
+        assert.strictEqual(chips.length, BUNDLES.length);
+        const ids = chips.map((c) => c.getAttribute("data-bundle"));
+        assert.deepStrictEqual(
+            ids,
+            BUNDLES.map((b) => b.id),
+        );
+    });
+
+    it("filters chips by availableBundles when supplied", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: [],
+            availableBundles: ["a11y"],
+        });
+        await el.updateComplete;
+        const ids = Array.from(
+            el.querySelectorAll<HTMLButtonElement>(".bundle-chip"),
+        ).map((c) => c.getAttribute("data-bundle"));
+        assert.deepStrictEqual(ids, ["a11y"]);
+    });
+
+    it("paints active chips with bundle-chip-on + aria-pressed=true", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: ["a11y"],
+            availableBundles: null,
+        });
+        await el.updateComplete;
+        const a11y = el.querySelector<HTMLButtonElement>(
+            '.bundle-chip[data-bundle="a11y"]',
+        )!;
+        assert.ok(a11y.classList.contains("bundle-chip-on"));
+        assert.strictEqual(a11y.getAttribute("aria-pressed"), "true");
+    });
+
+    it("dispatches bundle-toggled when an enabled chip is clicked", async () => {
+        const el = build();
+        el.setState({
+            bundles: BUNDLES,
+            activeBundles: [],
+            availableBundles: null,
+        });
+        await el.updateComplete;
+        const toggled: BundleToggledDetail[] = [];
+        el.addEventListener("bundle-toggled", (evt) => {
+            toggled.push((evt as CustomEvent<BundleToggledDetail>).detail);
+        });
+        const a11y = el.querySelector<HTMLButtonElement>(
+            '.bundle-chip[data-bundle="a11y"]',
+        )!;
+        a11y.click();
+        assert.deepStrictEqual(toggled, [{ id: "a11y" }]);
+    });
+
+    describe("daemonReady gate", () => {
+        // Regression for the "first preview never gets extensions" UX:
+        // until the daemon has spawned, chip clicks would queue
+        // subscriptions whose follow-up renderNow races the warm-up
+        // render and misses the daemon's subscriptionDrivenRenderMode
+        // lock. Greying the chip surfaces the wait instead of leaving
+        // the user staring at a clickable control that produces no data.
+
+        it("disables inactive chips when daemonReady is false", async () => {
+            const el = build();
+            el.setState({
+                bundles: BUNDLES,
+                activeBundles: [],
+                availableBundles: null,
+                daemonReady: false,
+            });
+            await el.updateComplete;
+            const chips = Array.from(
+                el.querySelectorAll<HTMLButtonElement>(".bundle-chip"),
+            );
+            for (const chip of chips) {
+                assert.ok(
+                    chip.disabled,
+                    `chip ${chip.getAttribute("data-bundle")} should be disabled while daemon spawns`,
+                );
+                assert.ok(
+                    chip.classList.contains("bundle-chip-disabled"),
+                    `chip ${chip.getAttribute("data-bundle")} should carry the disabled class`,
+                );
+                assert.strictEqual(chip.getAttribute("aria-disabled"), "true");
+            }
+        });
+
+        it("keeps active chips enabled while daemon is not ready so the user can still turn them off", async () => {
+            const el = build();
+            el.setState({
+                bundles: BUNDLES,
+                activeBundles: ["a11y"],
+                availableBundles: null,
+                daemonReady: false,
+            });
+            await el.updateComplete;
+            const a11y = el.querySelector<HTMLButtonElement>(
+                '.bundle-chip[data-bundle="a11y"]',
+            )!;
+            assert.strictEqual(a11y.disabled, false);
+            assert.ok(!a11y.classList.contains("bundle-chip-disabled"));
+        });
+
+        it("swallows click events on disabled chips — no bundle-toggled dispatched", async () => {
+            const el = build();
+            el.setState({
+                bundles: BUNDLES,
+                activeBundles: [],
+                availableBundles: null,
+                daemonReady: false,
+            });
+            await el.updateComplete;
+            const toggled: BundleToggledDetail[] = [];
+            el.addEventListener("bundle-toggled", (evt) => {
+                toggled.push((evt as CustomEvent<BundleToggledDetail>).detail);
+            });
+            const a11y = el.querySelector<HTMLButtonElement>(
+                '.bundle-chip[data-bundle="a11y"]',
+            )!;
+            // Dispatch a synthetic click — the browser would block this for
+            // a disabled button, but the test environment doesn't always
+            // enforce that. The component's own handler must also guard.
+            a11y.dispatchEvent(
+                new MouseEvent("click", { bubbles: true, cancelable: true }),
+            );
+            assert.deepStrictEqual(toggled, []);
+        });
+
+        it("re-enables chips when daemonReady flips to true on a subsequent setState", async () => {
+            const el = build();
+            el.setState({
+                bundles: BUNDLES,
+                activeBundles: [],
+                availableBundles: null,
+                daemonReady: false,
+            });
+            await el.updateComplete;
+            el.setState({
+                bundles: BUNDLES,
+                activeBundles: [],
+                availableBundles: null,
+                daemonReady: true,
+            });
+            await el.updateComplete;
+            const chips = Array.from(
+                el.querySelectorAll<HTMLButtonElement>(".bundle-chip"),
+            );
+            for (const chip of chips) {
+                assert.strictEqual(chip.disabled, false);
+                assert.ok(!chip.classList.contains("bundle-chip-disabled"));
+            }
+        });
+
+        it("defaults to enabled when daemonReady is omitted (legacy callers / fixtures)", async () => {
+            const el = build();
+            el.setState({
+                bundles: BUNDLES,
+                activeBundles: [],
+                availableBundles: null,
+            });
+            await el.updateComplete;
+            const chips = Array.from(
+                el.querySelectorAll<HTMLButtonElement>(".bundle-chip"),
+            );
+            for (const chip of chips) {
+                assert.strictEqual(chip.disabled, false);
+            }
+        });
+    });
+});

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -27,6 +27,15 @@ class FakeClient {
      * mimicking a pre-D2 daemon. Tests that don't set this get a successful resolution.
      */
     public dataSubscribeRejects = false;
+    /**
+     * When set, every `dataSubscribe` call returns a pending promise instead of
+     * resolving synchronously. Each call appends a `resolve` function to
+     * [pendingSubscribeResolvers] so the test can decide when to settle them —
+     * this is what lets `awaitPendingSubscribes` regression tests assert the
+     * drain barrier without time-based hacks.
+     */
+    public deferDataSubscribe = false;
+    public pendingSubscribeResolvers: (() => void)[] = [];
 
     fileChanged(args: unknown): void {
         this.calls.push({ method: "fileChanged", args });
@@ -45,6 +54,13 @@ class FakeClient {
         this.calls.push({ method: "dataSubscribe", args });
         if (this.dataSubscribeRejects) {
             return Promise.reject(new Error("-32020 DataProductUnknown"));
+        }
+        if (this.deferDataSubscribe) {
+            return new Promise<{ ok: true }>((resolve) => {
+                this.pendingSubscribeResolvers.push(() =>
+                    resolve({ ok: true }),
+                );
+            });
         }
         return Promise.resolve({ ok: true });
     }
@@ -1032,6 +1048,128 @@ describe("DaemonScheduler", () => {
                 (c) => c.method === "dataSubscribe",
             );
             assert.strictEqual(subsAfter.length, 2);
+        });
+
+        it("awaitPendingSubscribes resolves immediately when no subscribe is in flight", async () => {
+            const { scheduler } = build();
+            // No subscribes ever issued — drain should be cheap and synchronous.
+            await scheduler.awaitPendingSubscribes(":mod");
+        });
+
+        it("awaitPendingSubscribes blocks until in-flight dataSubscribe settles", async () => {
+            // Regression for the "first preview after daemon spawn never gets
+            // extensions" bug: the warm-up renderNow in
+            // `warmShownPreviewsForFile` raced the panel's chip-driven
+            // data/subscribe calls. The daemon's
+            // `subscriptionDrivenRenderMode` lock only injects mode tags on
+            // *subsequent* renders, so a renderNow that ran before
+            // subscribe was acknowledged came back without extension data
+            // products attached — fixed only when the user navigated away
+            // and back. `awaitPendingSubscribes` is the barrier the warm-up
+            // path uses to serialise subscribes-before-render.
+            const { gate, scheduler } = build();
+            gate.client!.deferDataSubscribe = true;
+            // Issue a subscribe but don't await it — mimic the panel's
+            // chip activation handler running concurrently with the
+            // warm-up render path.
+            void scheduler.setDataProductSubscription(
+                mod("mod"),
+                "a",
+                ["a11y/atf"],
+                true,
+            );
+            // Yield once so the scheduler's internal `client.dataSubscribe`
+            // call has actually been issued.
+            await new Promise<void>((resolve) => setImmediate(resolve));
+            // Drain must not resolve until the subscribe settles. Use a
+            // race with a resolved sentinel: if the drain wins, the test
+            // fails because we resolved before the subscribe was settled.
+            const drain = scheduler.awaitPendingSubscribes(":mod");
+            let drained = false;
+            void drain.then(() => {
+                drained = true;
+            });
+            // Yield a few times to give a buggy implementation a chance
+            // to resolve early.
+            for (let i = 0; i < 5; i++) {
+                await new Promise<void>((resolve) => setImmediate(resolve));
+            }
+            assert.strictEqual(
+                drained,
+                false,
+                "awaitPendingSubscribes resolved while dataSubscribe was still in flight",
+            );
+            // Settle the subscribe; drain should resolve now.
+            gate.client!.pendingSubscribeResolvers.splice(0).forEach((fn) =>
+                fn(),
+            );
+            await drain;
+            assert.strictEqual(drained, true);
+        });
+
+        it("awaitPendingSubscribes lets a parallel renderNow land after subscribe acknowledgement", async () => {
+            // End-to-end ordering check for the warm-up race fix: when
+            // `setDataProductSubscription` is in flight and a caller
+            // drains via `awaitPendingSubscribes` before issuing
+            // renderNow, the dataSubscribe must appear on the wire (and
+            // be acknowledged) before the warm-up renderNow.
+            const { gate, scheduler } = build();
+            gate.client!.deferDataSubscribe = true;
+            // Fire the panel-side chip activation: subscribe is queued
+            // but its promise is pending.
+            void scheduler.setDataProductSubscription(
+                mod("mod"),
+                "a",
+                ["a11y/atf"],
+                true,
+            );
+            await new Promise<void>((resolve) => setImmediate(resolve));
+            // Mimic the warm-up render path: drain pending subscribes
+            // before issuing renderNow.
+            const warmup = (async () => {
+                await scheduler.awaitPendingSubscribes(":mod");
+                await scheduler.renderNow(
+                    mod("mod"),
+                    ["a"],
+                    "fast",
+                    "view-open",
+                );
+            })();
+            // The warm-up renderNow must not have been dispatched yet
+            // because the subscribe is still in flight.
+            await new Promise<void>((resolve) => setImmediate(resolve));
+            const earlyRenderCalls = gate.client!.calls.filter(
+                (c) =>
+                    c.method === "renderNow" &&
+                    (c.args as { reason?: string }).reason === "view-open",
+            );
+            assert.strictEqual(
+                earlyRenderCalls.length,
+                0,
+                "warm-up renderNow leaked past the awaitPendingSubscribes barrier",
+            );
+            // Settle the subscribe; the warm-up renderNow can now go.
+            gate.client!.pendingSubscribeResolvers.splice(0).forEach((fn) =>
+                fn(),
+            );
+            await warmup;
+            // Final wire order: dataSubscribe, post-subscribe renderNow
+            // (from setDataProductSubscription), warm-up renderNow.
+            const wire = gate.client!.calls.map((c) => c.method);
+            const subIdx = wire.indexOf("dataSubscribe");
+            const warmRenderIdx = gate.client!.calls.findIndex(
+                (c) =>
+                    c.method === "renderNow" &&
+                    (c.args as { reason?: string }).reason === "view-open",
+            );
+            assert.ok(
+                subIdx !== -1 && warmRenderIdx !== -1,
+                `expected both dataSubscribe and warm-up renderNow on the wire; got ${wire.join(", ")}`,
+            );
+            assert.ok(
+                warmRenderIdx > subIdx,
+                `warm-up renderNow at ${warmRenderIdx} must come after dataSubscribe at ${subIdx}; wire was ${wire.join(", ")}`,
+            );
         });
     });
 });

--- a/vscode-extension/src/webview/preview/components/BundleChipBar.ts
+++ b/vscode-extension/src/webview/preview/components/BundleChipBar.ts
@@ -30,11 +30,24 @@ export class BundleChipBar extends LitElement {
      *  just the graduated extensions (e.g. a11y) without leaking the
      *  in-progress ones. */
     @state() private availableBundles: ReadonlySet<BundleId> | null = null;
+    /** Whether the daemon for the focused module is up. Until the
+     *  daemon is ready, none of the chip-driven subscriptions can
+     *  produce data products — so the chips paint disabled with an
+     *  explanatory tooltip rather than appearing clickable. Clicks
+     *  during that window would queue subscriptions whose follow-up
+     *  renderNow would race the warm-up render (the bug
+     *  `awaitPendingSubscribes` exists to mitigate); greying the chip
+     *  surfaces the wait directly to the user. Defaults to `true` so
+     *  test fixtures and any code path that hasn't piped through
+     *  `setInteractiveAvailability` yet keep the legacy "always
+     *  enabled" behaviour. */
+    @state() private daemonReady = true;
 
     setState(snapshot: {
         bundles: readonly BundleDescriptor[];
         activeBundles: readonly BundleId[];
         availableBundles?: readonly BundleId[] | null;
+        daemonReady?: boolean;
     }): void {
         this.bundles = snapshot.bundles;
         this.activeBundles = snapshot.activeBundles;
@@ -43,6 +56,9 @@ export class BundleChipBar extends LitElement {
             snapshot.availableBundles === null
                 ? null
                 : new Set(snapshot.availableBundles);
+        if (snapshot.daemonReady !== undefined) {
+            this.daemonReady = snapshot.daemonReady;
+        }
     }
 
     protected createRenderRoot(): HTMLElement {
@@ -68,14 +84,23 @@ export class BundleChipBar extends LitElement {
 
     private renderChip(b: BundleDescriptor): TemplateResult {
         const pressed = this.activeBundles.includes(b.id);
+        const disabled = !this.daemonReady && !pressed;
+        const classes = ["bundle-chip"];
+        if (pressed) classes.push("bundle-chip-on");
+        if (disabled) classes.push("bundle-chip-disabled");
+        const title = disabled
+            ? `${b.label} — waiting for preview daemon`
+            : b.label;
         return html`
             <button
                 type="button"
-                class=${pressed ? "bundle-chip bundle-chip-on" : "bundle-chip"}
+                class=${classes.join(" ")}
                 aria-pressed=${pressed ? "true" : "false"}
+                aria-disabled=${disabled ? "true" : "false"}
+                ?disabled=${disabled}
                 data-bundle=${b.id}
-                title=${b.label}
-                @click=${() => this.onClick(b.id)}
+                title=${title}
+                @click=${() => this.onClick(b.id, disabled)}
             >
                 <i class=${"codicon codicon-" + b.icon} aria-hidden="true"></i>
                 <span class="bundle-chip-label">${b.label}</span>
@@ -83,7 +108,8 @@ export class BundleChipBar extends LitElement {
         `;
     }
 
-    private onClick(id: BundleId): void {
+    private onClick(id: BundleId, disabled: boolean): void {
+        if (disabled) return;
         this.dispatchEvent(
             new CustomEvent<BundleToggledDetail>("bundle-toggled", {
                 detail: { id },

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -2021,10 +2021,22 @@ export class PreviewApp extends LitElement {
             const availableBundles: BundleId[] = earlyFeatures()
                 ? s.bundles.map((b) => b.id)
                 : ["a11y"];
+            // Grey out inactive chips while the preview daemon is still
+            // spawning. A click during that window queues subscriptions
+            // whose follow-up renderNow races the warm-up render and
+            // misses the daemon's subscriptionDrivenRenderMode lock —
+            // surfacing the wait directly is clearer than the dataless
+            // bundle body the user would otherwise see. Active chips
+            // stay enabled so the user can still turn an in-flight
+            // bundle off if they want.
+            const daemonReady = isFocusedModuleReady(
+                liveState.getModuleDaemonReady(),
+            );
             bundleChipBar.setState({
                 bundles: s.bundles,
                 activeBundles: s.activeBundles,
                 availableBundles,
+                daemonReady,
             });
             dataTabs.setState({
                 bundles: s.bundles,

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -552,6 +552,10 @@ function handleSetInteractiveAvailability(
         ctx.applyInteractiveButtonState();
         ctx.applyRecordingButtonState();
     }
+    // Repaint the chip bar so its daemon-ready gate flips along with
+    // the live-toolbar buttons. The chips ungrey on `ready=true` and
+    // grey again if the daemon channel closes mid-session.
+    ctx.refreshBundleState();
 }
 
 function handlePreviewMainRefChanged(ctx: PreviewMessageContext): void {


### PR DESCRIPTION
The first preview after a daemon spawn never picked up data extensions
(a11y overlays, theme tokens, etc.) — the user had to navigate away and
back for them to apply. Root cause: `warmShownPreviewsForFile` fired its
`renderNow` in parallel with the panel's chip-driven `data/subscribe`
posts. When the warm-up renderNow reached the daemon first, the daemon's
`subscriptionDrivenRenderMode` lock — which only injects mode tags on
*subsequent* renders — missed the in-flight render and no extension data
products attached. Subsequent navigations replayed the subscribes from
the warm daemon and worked correctly.

Add an `awaitPendingSubscribes(moduleId)` barrier on the scheduler that
tracks in-flight `dataSubscribe` promises per module, and have
`warmShownPreviewsForFile` yield once (to let queued panel postMessages
flush) plus await the drain before issuing renderNow. The panel's own
subscribe-then-renderNow path is unchanged; this only adds serialisation
on the warm-up path that previously had no view of the panel's traffic.

Regression tests assert the drain blocks while a `dataSubscribe` is
pending and that a parallel renderNow lands strictly after the
acknowledged subscribe.