### PR TITLE
fix(vscode-extension): make Theming swatches visible and previewable

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2693,6 +2693,30 @@ bundle-chip-bar {
 .theming-swatch[data-source="wallpaper"] {
     border-style: dashed;
 }
+/* Scaled-down 20x20 preview for shape tokens — the corner-radius
+ * geometry is the affordance, so a translucent fill with a subtle
+ * outline is enough. CSS clamps `border-radius` at 50% of the side
+ * which makes 28 dp on a 20 px swatch render as a full circle —
+ * intentional, that's the "fully rounded" visual the spec implies. */
+.theming-shape-preview {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background-color: currentColor;
+    opacity: 0.22;
+    border: 1px solid currentColor;
+    box-sizing: border-box;
+}
+/* Inline sample for typography rows — paints `Aa` in the resolved
+ * font (loaded from Google Fonts in the panel head). Lives in the
+ * same column as the colour swatch so the table stays scannable. */
+.theming-font-sample {
+    display: inline-block;
+    min-width: 22px;
+    font-size: 16px;
+    line-height: 1;
+    text-align: center;
+}
 .theming-name-cell {
     min-width: 120px;
 }

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2707,15 +2707,13 @@ bundle-chip-bar {
     border: 1px solid currentColor;
     box-sizing: border-box;
 }
-/* Inline sample for typography rows — paints `Aa` in the resolved
- * font (loaded from Google Fonts in the panel head). Lives in the
- * same column as the colour swatch so the table stays scannable. */
-.theming-font-sample {
-    display: inline-block;
-    min-width: 22px;
-    font-size: 16px;
-    line-height: 1;
-    text-align: center;
+/* Typography rows render the token name itself in the resolved font
+ * (loaded from Google Fonts in the panel head) so the user sees the
+ * typeface at a glance. Sized a touch larger than the row's body text
+ * to give glyph variation room to breathe. */
+.theming-typography-name {
+    font-size: 15px;
+    line-height: 1.1;
 }
 .theming-name-cell {
     min-width: 120px;

--- a/vscode-extension/preview-harness/fixtures/theming.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/theming.gen.mjs
@@ -1,0 +1,266 @@
+// Generator for `theming.json`. Run with:
+//   node preview-harness/fixtures/theming.gen.mjs > preview-harness/fixtures/theming.json
+//
+// Drives focus mode + the Theming bundle so the rendered tab body
+// shows:
+//   - Colors section with CSSOM-applied swatches (a regression test
+//     for the lit `style=` sanitisation bug — if swatches go back to
+//     the empty checkerboard, this fixture snapshots the change).
+//   - Typography section with the token name rendered in the resolved
+//     Google Fonts family / weight / style.
+//   - Shapes section with a 20×20 preview square whose border-radius
+//     is parsed from the RoundedCornerShape value string.
+//   - Wallpaper kind is preloaded but default-OFF, so the Configure
+//     expander has something to opt into.
+//
+// Payload shapes mirror `ThemePayload` (`data/theme/core/.../
+// Material3ThemeModels.kt`) and `WallpaperPayload`
+// (`data/wallpaper/core/.../WallpaperModels.kt`) — enough fields to
+// drive the bundle presenter without depending on the live recorder.
+
+import {
+    EARLY_FEATURES_DATASET,
+    activateBundleAction,
+    buildMobileMock,
+    buildPreviewPair,
+    expectSetDataExtension,
+    focusAction,
+    forbidSetDataExtensionEnabled,
+} from "./_utils.mjs";
+
+const mock = buildMobileMock();
+const { W, H, png } = mock;
+
+const focusId = "com.example.ThemeShowcaseKt.LightThemePreview";
+const { focused, sibling } = buildPreviewPair({
+    focusId,
+    width: W,
+    height: H,
+    fnName: "LightThemePreview",
+    file: "ThemeShowcase.kt",
+});
+
+// `compose/theme` — Material 3 baseline-ish light scheme (the values
+// the user's screenshot was showing). Mixing #AARRGGBB and #RRGGBB
+// inputs so the cssColor() ARGB-vs-RGB path is exercised.
+const themePayload = {
+    resolvedTokens: {
+        colorScheme: {
+            primary: "#FF6750A4",
+            onPrimary: "#FFFFFFFF",
+            primaryContainer: "#FFEADDFF",
+            onPrimaryContainer: "#FF21005D",
+            secondary: "#FF625B71",
+            onSecondary: "#FFFFFFFF",
+            secondaryContainer: "#FFE8DEF8",
+            onSecondaryContainer: "#FF1D192B",
+            tertiary: "#FF7D5260",
+            onTertiary: "#FFFFFFFF",
+            tertiaryContainer: "#FFFFD8E4",
+            onTertiaryContainer: "#FF31111D",
+            error: "#FFB3261E",
+            onError: "#FFFFFFFF",
+            errorContainer: "#FFF9DEDC",
+            onErrorContainer: "#FF410E0B",
+            background: "#FFFEF7FF",
+            onBackground: "#FF1D1B20",
+            surface: "#FFFEF7FF",
+            onSurface: "#FF1D1B20",
+            surfaceVariant: "#FFE7E0EC",
+            onSurfaceVariant: "#FF49454F",
+            outline: "#FF79747E",
+            outlineVariant: "#FFCAC4D0",
+            inverseSurface: "#FF322F35",
+            inverseOnSurface: "#FFF5EFF7",
+            inversePrimary: "#FFD0BCFF",
+            scrim: "#FF000000",
+            surfaceTint: "#FF6750A4",
+        },
+        typography: {
+            displayLarge: {
+                fontFamily: "FontFamily.SansSerif",
+                fontSize: 57,
+                fontSizeUnit: "sp",
+                fontWeight: "FontWeight(weight=400)",
+                fontStyle: "Normal",
+                lineHeight: 64,
+                lineHeightUnit: "sp",
+                letterSpacing: -0.25,
+                letterSpacingUnit: "sp",
+            },
+            displayMedium: {
+                fontFamily: "FontFamily.SansSerif",
+                fontSize: 45,
+                fontSizeUnit: "sp",
+                fontWeight: "FontWeight(weight=400)",
+                fontStyle: "Normal",
+                lineHeight: 52,
+                lineHeightUnit: "sp",
+                letterSpacing: 0,
+                letterSpacingUnit: "sp",
+            },
+            headlineLarge: {
+                fontFamily: "FontFamily.SansSerif",
+                fontSize: 32,
+                fontSizeUnit: "sp",
+                fontWeight: "FontWeight(weight=400)",
+                fontStyle: "Normal",
+                lineHeight: 40,
+                lineHeightUnit: "sp",
+                letterSpacing: 0,
+                letterSpacingUnit: "sp",
+            },
+            titleLarge: {
+                fontFamily: "FontFamily.SansSerif",
+                fontSize: 22,
+                fontSizeUnit: "sp",
+                fontWeight: "FontWeight(weight=500)",
+                fontStyle: "Normal",
+                lineHeight: 28,
+                lineHeightUnit: "sp",
+                letterSpacing: 0,
+                letterSpacingUnit: "sp",
+            },
+            bodyLarge: {
+                fontFamily: "FontFamily.SansSerif",
+                fontSize: 16,
+                fontSizeUnit: "sp",
+                fontWeight: "FontWeight(weight=400)",
+                fontStyle: "Normal",
+                lineHeight: 24,
+                lineHeightUnit: "sp",
+                letterSpacing: 0.5,
+                letterSpacingUnit: "sp",
+            },
+            labelSmall: {
+                fontFamily: "FontFamily.SansSerif",
+                fontSize: 11,
+                fontSizeUnit: "sp",
+                fontWeight: "FontWeight(weight=500)",
+                fontStyle: "Normal",
+                lineHeight: 16,
+                lineHeightUnit: "sp",
+                letterSpacing: 0.5,
+                letterSpacingUnit: "sp",
+            },
+            // Italicised serif so the Name column renders the typeface
+            // distinctly — exercises both the FontFamily.Serif → Google
+            // Fonts stack and the italic CSSOM application.
+            displayItalic: {
+                fontFamily: "FontFamily.Serif",
+                fontSize: 24,
+                fontSizeUnit: "sp",
+                fontWeight: "FontWeight(weight=700)",
+                fontStyle: "Italic",
+                lineHeight: 32,
+                lineHeightUnit: "sp",
+                letterSpacing: 0,
+                letterSpacingUnit: "sp",
+            },
+            // Cursive — the Caveat family in the loaded Google Fonts
+            // set. Useful for verifying the cursive branch of
+            // `cssFontFamily`.
+            displayCursive: {
+                fontFamily: "FontFamily.Cursive",
+                fontSize: 20,
+                fontSizeUnit: "sp",
+                fontWeight: "FontWeight(weight=400)",
+                fontStyle: "Normal",
+                lineHeight: 28,
+                lineHeightUnit: "sp",
+                letterSpacing: 0,
+                letterSpacingUnit: "sp",
+            },
+        },
+        shapes: {
+            extraSmall:
+                "RoundedCornerShape(topStart = CornerSize(size = 4.0.dp), topEnd = CornerSize(size = 4.0.dp), bottomEnd = CornerSize(size = 4.0.dp), bottomStart = CornerSize(size = 4.0.dp))",
+            small: "RoundedCornerShape(8.0.dp)",
+            medium: "RoundedCornerShape(12.0.dp)",
+            large: "RoundedCornerShape(16.0.dp)",
+            // Asymmetric — exercises the four-corner branch of the
+            // parser so the preview square's corners differ visibly.
+            asymmetric:
+                "RoundedCornerShape(topStart = CornerSize(size = 16.0.dp), topEnd = CornerSize(size = 4.0.dp), bottomEnd = CornerSize(size = 16.0.dp), bottomStart = CornerSize(size = 4.0.dp))",
+            extraLarge: "RoundedCornerShape(28.0.dp)",
+            // Fully rounded — percent form, parsed via the percent
+            // branch of `parseBorderRadius`.
+            full: "RoundedCornerShape(50)",
+        },
+    },
+    // A couple of consumers so the Consumers column shows a non-zero
+    // count for the tokens the mock UI references most.
+    consumers: [
+        {
+            nodeId: "header-container",
+            tokens: ["primary", "onPrimary", "titleLarge"],
+        },
+        {
+            nodeId: "primary-button",
+            tokens: ["primary", "onPrimary", "labelSmall", "small"],
+        },
+        {
+            nodeId: "body-text",
+            tokens: ["onSurface", "bodyLarge"],
+        },
+    ],
+};
+
+// `compose/wallpaper` — preloaded but the kind is default-OFF in the
+// Theming bundle's catalog, so the Configure expander has something
+// to opt into. Activating the chip alone must NOT subscribe this
+// kind — the `forbiddenPosts` assertion below pins that.
+const wallpaperPayload = {
+    seedColor: "#FF6750A4",
+    isDark: false,
+    paletteStyle: "TONAL_SPOT",
+    contrastLevel: 0,
+    derivedColorScheme: {
+        primary: "#FF6750A4",
+        onPrimary: "#FFFFFFFF",
+        secondary: "#FF625B71",
+        tertiary: "#FF7D5260",
+        background: "#FFFEF7FF",
+    },
+};
+
+const setPreviews = {
+    command: "setPreviews",
+    moduleDir: "/workspace/sample-android",
+    heavyStaleIds: [],
+    previews: [focused, sibling],
+};
+
+const updateImage = {
+    command: "updateImage",
+    previewId: focusId,
+    captureIndex: 0,
+    imageData: png,
+};
+
+const updateDataProducts = {
+    command: "updateDataProducts",
+    previewId: focusId,
+    dataProducts: [
+        { kind: "compose/theme", payload: themePayload },
+        { kind: "compose/wallpaper", payload: wallpaperPayload },
+    ],
+};
+
+const fixture = {
+    name: "theming",
+    description:
+        "Focused card with a baseline Material 3 light colour scheme, eight typography tokens (sans / serif-italic / cursive), and six shape tokens. Activates the Theming bundle so the Colors swatches paint via CSSOM, the Typography rows render their token names in the resolved Google Fonts family, and the Shapes column shows the 20×20 corner-radius preview square. Wallpaper payload is preloaded but its kind is default-OFF, so it stays available behind the Configure expander.",
+    dataset: EARLY_FEATURES_DATASET,
+    messages: [setPreviews, updateImage, updateDataProducts],
+    actions: [focusAction(focusId), activateBundleAction("theming")],
+    // The Theming bundle's only default-ON kind (per `bundleRegistry.ts`).
+    expectedPosts: [expectSetDataExtension(focusId, "compose/theme", true)],
+    // `compose/wallpaper` is default-OFF — chip activation must not
+    // subscribe it. The payload above is preloaded so the wallpaper
+    // section can render once the user opts in via the Configure
+    // expander.
+    forbiddenPosts: [forbidSetDataExtensionEnabled(focusId, "compose/wallpaper")],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/theming.json
+++ b/vscode-extension/preview-harness/fixtures/theming.json
@@ -1,0 +1,293 @@
+{
+  "name": "theming",
+  "description": "Focused card with a baseline Material 3 light colour scheme, eight typography tokens (sans / serif-italic / cursive), and six shape tokens. Activates the Theming bundle so the Colors swatches paint via CSSOM, the Typography rows render their token names in the resolved Google Fonts family, and the Shapes column shows the 20×20 corner-radius preview square. Wallpaper payload is preloaded but its kind is default-OFF, so it stays available behind the Configure expander.",
+  "dataset": {
+    "earlyFeatures": "true",
+    "autoEnableCheap": "false",
+    "collapseVariants": "false",
+    "minimalMode": "false",
+    "autoInject": "true"
+  },
+  "messages": [
+    {
+      "command": "setPreviews",
+      "moduleDir": "/workspace/sample-android",
+      "heavyStaleIds": [],
+      "previews": [
+        {
+          "id": "com.example.ThemeShowcaseKt.LightThemePreview",
+          "functionName": "LightThemePreview",
+          "className": "ThemeShowcaseKt",
+          "sourceFile": "ThemeShowcase.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.ThemeShowcaseKt.LightThemePreview.png",
+              "label": ""
+            }
+          ]
+        },
+        {
+          "id": "com.example.ThemeShowcaseKt.LightThemePreviewSibling",
+          "functionName": "LightThemePreviewSibling",
+          "className": "ThemeShowcaseKt",
+          "sourceFile": "ThemeShowcase.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.ThemeShowcaseKt.LightThemePreviewSibling.png",
+              "label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "command": "updateImage",
+      "previewId": "com.example.ThemeShowcaseKt.LightThemePreview",
+      "captureIndex": 0,
+      "imageData": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC"
+    },
+    {
+      "command": "updateDataProducts",
+      "previewId": "com.example.ThemeShowcaseKt.LightThemePreview",
+      "dataProducts": [
+        {
+          "kind": "compose/theme",
+          "payload": {
+            "resolvedTokens": {
+              "colorScheme": {
+                "primary": "#FF6750A4",
+                "onPrimary": "#FFFFFFFF",
+                "primaryContainer": "#FFEADDFF",
+                "onPrimaryContainer": "#FF21005D",
+                "secondary": "#FF625B71",
+                "onSecondary": "#FFFFFFFF",
+                "secondaryContainer": "#FFE8DEF8",
+                "onSecondaryContainer": "#FF1D192B",
+                "tertiary": "#FF7D5260",
+                "onTertiary": "#FFFFFFFF",
+                "tertiaryContainer": "#FFFFD8E4",
+                "onTertiaryContainer": "#FF31111D",
+                "error": "#FFB3261E",
+                "onError": "#FFFFFFFF",
+                "errorContainer": "#FFF9DEDC",
+                "onErrorContainer": "#FF410E0B",
+                "background": "#FFFEF7FF",
+                "onBackground": "#FF1D1B20",
+                "surface": "#FFFEF7FF",
+                "onSurface": "#FF1D1B20",
+                "surfaceVariant": "#FFE7E0EC",
+                "onSurfaceVariant": "#FF49454F",
+                "outline": "#FF79747E",
+                "outlineVariant": "#FFCAC4D0",
+                "inverseSurface": "#FF322F35",
+                "inverseOnSurface": "#FFF5EFF7",
+                "inversePrimary": "#FFD0BCFF",
+                "scrim": "#FF000000",
+                "surfaceTint": "#FF6750A4"
+              },
+              "typography": {
+                "displayLarge": {
+                  "fontFamily": "FontFamily.SansSerif",
+                  "fontSize": 57,
+                  "fontSizeUnit": "sp",
+                  "fontWeight": "FontWeight(weight=400)",
+                  "fontStyle": "Normal",
+                  "lineHeight": 64,
+                  "lineHeightUnit": "sp",
+                  "letterSpacing": -0.25,
+                  "letterSpacingUnit": "sp"
+                },
+                "displayMedium": {
+                  "fontFamily": "FontFamily.SansSerif",
+                  "fontSize": 45,
+                  "fontSizeUnit": "sp",
+                  "fontWeight": "FontWeight(weight=400)",
+                  "fontStyle": "Normal",
+                  "lineHeight": 52,
+                  "lineHeightUnit": "sp",
+                  "letterSpacing": 0,
+                  "letterSpacingUnit": "sp"
+                },
+                "headlineLarge": {
+                  "fontFamily": "FontFamily.SansSerif",
+                  "fontSize": 32,
+                  "fontSizeUnit": "sp",
+                  "fontWeight": "FontWeight(weight=400)",
+                  "fontStyle": "Normal",
+                  "lineHeight": 40,
+                  "lineHeightUnit": "sp",
+                  "letterSpacing": 0,
+                  "letterSpacingUnit": "sp"
+                },
+                "titleLarge": {
+                  "fontFamily": "FontFamily.SansSerif",
+                  "fontSize": 22,
+                  "fontSizeUnit": "sp",
+                  "fontWeight": "FontWeight(weight=500)",
+                  "fontStyle": "Normal",
+                  "lineHeight": 28,
+                  "lineHeightUnit": "sp",
+                  "letterSpacing": 0,
+                  "letterSpacingUnit": "sp"
+                },
+                "bodyLarge": {
+                  "fontFamily": "FontFamily.SansSerif",
+                  "fontSize": 16,
+                  "fontSizeUnit": "sp",
+                  "fontWeight": "FontWeight(weight=400)",
+                  "fontStyle": "Normal",
+                  "lineHeight": 24,
+                  "lineHeightUnit": "sp",
+                  "letterSpacing": 0.5,
+                  "letterSpacingUnit": "sp"
+                },
+                "labelSmall": {
+                  "fontFamily": "FontFamily.SansSerif",
+                  "fontSize": 11,
+                  "fontSizeUnit": "sp",
+                  "fontWeight": "FontWeight(weight=500)",
+                  "fontStyle": "Normal",
+                  "lineHeight": 16,
+                  "lineHeightUnit": "sp",
+                  "letterSpacing": 0.5,
+                  "letterSpacingUnit": "sp"
+                },
+                "displayItalic": {
+                  "fontFamily": "FontFamily.Serif",
+                  "fontSize": 24,
+                  "fontSizeUnit": "sp",
+                  "fontWeight": "FontWeight(weight=700)",
+                  "fontStyle": "Italic",
+                  "lineHeight": 32,
+                  "lineHeightUnit": "sp",
+                  "letterSpacing": 0,
+                  "letterSpacingUnit": "sp"
+                },
+                "displayCursive": {
+                  "fontFamily": "FontFamily.Cursive",
+                  "fontSize": 20,
+                  "fontSizeUnit": "sp",
+                  "fontWeight": "FontWeight(weight=400)",
+                  "fontStyle": "Normal",
+                  "lineHeight": 28,
+                  "lineHeightUnit": "sp",
+                  "letterSpacing": 0,
+                  "letterSpacingUnit": "sp"
+                }
+              },
+              "shapes": {
+                "extraSmall": "RoundedCornerShape(topStart = CornerSize(size = 4.0.dp), topEnd = CornerSize(size = 4.0.dp), bottomEnd = CornerSize(size = 4.0.dp), bottomStart = CornerSize(size = 4.0.dp))",
+                "small": "RoundedCornerShape(8.0.dp)",
+                "medium": "RoundedCornerShape(12.0.dp)",
+                "large": "RoundedCornerShape(16.0.dp)",
+                "asymmetric": "RoundedCornerShape(topStart = CornerSize(size = 16.0.dp), topEnd = CornerSize(size = 4.0.dp), bottomEnd = CornerSize(size = 16.0.dp), bottomStart = CornerSize(size = 4.0.dp))",
+                "extraLarge": "RoundedCornerShape(28.0.dp)",
+                "full": "RoundedCornerShape(50)"
+              }
+            },
+            "consumers": [
+              {
+                "nodeId": "header-container",
+                "tokens": [
+                  "primary",
+                  "onPrimary",
+                  "titleLarge"
+                ]
+              },
+              {
+                "nodeId": "primary-button",
+                "tokens": [
+                  "primary",
+                  "onPrimary",
+                  "labelSmall",
+                  "small"
+                ]
+              },
+              {
+                "nodeId": "body-text",
+                "tokens": [
+                  "onSurface",
+                  "bodyLarge"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "kind": "compose/wallpaper",
+          "payload": {
+            "seedColor": "#FF6750A4",
+            "isDark": false,
+            "paletteStyle": "TONAL_SPOT",
+            "contrastLevel": 0,
+            "derivedColorScheme": {
+              "primary": "#FF6750A4",
+              "onPrimary": "#FFFFFFFF",
+              "secondary": "#FF625B71",
+              "tertiary": "#FF7D5260",
+              "background": "#FFFEF7FF"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "click": ".preview-card[data-preview-id=\"com.example.ThemeShowcaseKt.LightThemePreview\"] .card-focus-btn"
+    },
+    {
+      "click": "bundle-chip-bar button[data-bundle=\"theming\"]"
+    }
+  ],
+  "expectedPosts": [
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.ThemeShowcaseKt.LightThemePreview",
+      "kinds": {
+        "$includes": "compose/theme"
+      },
+      "enabled": true
+    }
+  ],
+  "forbiddenPosts": [
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.ThemeShowcaseKt.LightThemePreview",
+      "kinds": {
+        "$includes": "compose/wallpaper"
+      },
+      "enabled": true
+    }
+  ]
+}

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -76,9 +76,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'none'; img-src data:; font-src ${webview.cspSource}; style-src ${webview.cspSource} 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
+          content="default-src 'none'; img-src data:; font-src ${webview.cspSource} https://fonts.gstatic.com; style-src ${webview.cspSource} https://fonts.googleapis.com 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
     <link href="${codiconUri}" rel="stylesheet">
     <link href="${styleUri}" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;1,400&family=Roboto+Serif:ital,wght@0,400;0,500;0,700;1,400&family=Roboto+Mono:ital,wght@0,400;0,500;0,700&family=Caveat:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
     <preview-app

--- a/vscode-extension/src/test/themingBundlePresenter.test.ts
+++ b/vscode-extension/src/test/themingBundlePresenter.test.ts
@@ -6,8 +6,12 @@
 import * as assert from "assert";
 import {
     computeThemingBundleData,
+    cssFontFamily,
+    parseFontWeight,
+    parseShapeBorderRadius,
     type ThemePayload,
     type ThemingColorRow,
+    type ThemingShapeRow,
     type ThemingTypographyRow,
     type ThemingSeedRow,
     type WallpaperPayload,
@@ -248,5 +252,110 @@ describe("computeThemingBundleData", () => {
             (r) => r.kind === "color" && r.source === "wallpaper",
         );
         assert.strictEqual(derived.length, 2);
+    });
+
+    it("derives CSS font + weight + style for typography rows", () => {
+        const data = computeThemingBundleData(
+            theme({
+                resolvedTokens: {
+                    colorScheme: {},
+                    typography: {
+                        displayLarge: {
+                            fontFamily: "FontFamily.SansSerif",
+                            fontWeight: "FontWeight(weight=500)",
+                            fontStyle: "Italic",
+                        },
+                    },
+                    shapes: {},
+                },
+            }),
+            null,
+        );
+        const typo = data.rows[0] as ThemingTypographyRow;
+        // Sans-serif maps to Roboto so the Google-Fonts-loaded family
+        // is the one the swatch paints with.
+        assert.ok(typo.cssFontFamily.includes("Roboto"));
+        assert.strictEqual(typo.cssFontWeight, 500);
+        assert.strictEqual(typo.cssFontStyle, "italic");
+    });
+
+    it("emits a CSS border-radius for shape rows when parseable", () => {
+        const data = computeThemingBundleData(
+            theme({
+                resolvedTokens: {
+                    colorScheme: {},
+                    typography: {},
+                    shapes: {
+                        large: "RoundedCornerShape(16.dp)",
+                        asymmetric:
+                            "RoundedCornerShape(topStart = CornerSize(size = 4.0.dp), topEnd = CornerSize(size = 12.0.dp), bottomEnd = CornerSize(size = 12.0.dp), bottomStart = CornerSize(size = 4.0.dp))",
+                    },
+                },
+            }),
+            null,
+        );
+        const byName = (n: string) =>
+            data.rows.find(
+                (r) => r.kind === "shape" && r.name === n,
+            ) as ThemingShapeRow;
+        assert.strictEqual(byName("large").previewBorderRadius, "16px");
+        assert.strictEqual(
+            byName("asymmetric").previewBorderRadius,
+            "4px 12px 12px 4px",
+        );
+    });
+});
+
+describe("cssFontFamily", () => {
+    it("maps generic Compose families onto Google-Fonts stacks", () => {
+        assert.ok(cssFontFamily("FontFamily.SansSerif").includes("Roboto"));
+        assert.ok(cssFontFamily("FontFamily.Serif").includes("Roboto Serif"));
+        assert.ok(
+            cssFontFamily("FontFamily.Monospace").includes("Roboto Mono"),
+        );
+        assert.ok(cssFontFamily("FontFamily.Cursive").includes("Caveat"));
+    });
+    it("falls back to the system font when the family is missing", () => {
+        assert.strictEqual(cssFontFamily(null), "var(--vscode-font-family)");
+    });
+});
+
+describe("parseFontWeight", () => {
+    it("extracts the numeric weight from `FontWeight(weight=N)`", () => {
+        assert.strictEqual(parseFontWeight("FontWeight(weight=400)"), 400);
+        assert.strictEqual(parseFontWeight("FontWeight(weight=700)"), 700);
+    });
+    it("maps named weights onto CSS numerics", () => {
+        assert.strictEqual(parseFontWeight("Bold"), 700);
+        assert.strictEqual(parseFontWeight("Medium"), 500);
+    });
+    it("returns null for unparseable input", () => {
+        assert.strictEqual(parseFontWeight("—"), null);
+        assert.strictEqual(parseFontWeight(null), null);
+    });
+});
+
+describe("parseShapeBorderRadius", () => {
+    it("handles the single-value `RoundedCornerShape(N.dp)` shape", () => {
+        assert.strictEqual(
+            parseShapeBorderRadius("RoundedCornerShape(8.dp)"),
+            "8px",
+        );
+    });
+    it("preserves CSS-percentage shorthand", () => {
+        assert.strictEqual(
+            parseShapeBorderRadius("RoundedCornerShape(50%)"),
+            "50%",
+        );
+    });
+    it("returns null for CutCornerShape (CSS can't bevel)", () => {
+        assert.strictEqual(
+            parseShapeBorderRadius("CutCornerShape(4.dp)"),
+            null,
+        );
+    });
+    it("returns null for shapes outside our parser's scope", () => {
+        assert.strictEqual(parseShapeBorderRadius("GenericShape(...)"), null);
+        assert.strictEqual(parseShapeBorderRadius(null), null);
     });
 });

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -1398,13 +1398,24 @@ export class PreviewApp extends LitElement {
             const target = currentBundleTarget();
             if (!target) return;
             const byKind = dataProductsByPreview.get(target);
-            const theme =
-                (byKind?.get("compose/theme") as ThemePayload | undefined) ??
-                null;
-            const wallpaper =
-                (byKind?.get("compose/wallpaper") as
-                    | WallpaperPayload
-                    | undefined) ?? null;
+            // The cached payload outlives a Configure-expander toggle:
+            // the daemon stops streaming new updates once we unsubscribe,
+            // but the last payload sits in `dataProductsByPreview`. If
+            // we feed it into the presenter unconditionally the checkbox
+            // looks broken — the rows persist even though the kind is
+            // off. Honour the enabled-kinds set so unchecking "Theme
+            // tokens" or "Wallpaper" actually clears the corresponding
+            // section.
+            const enabled = bundleController.state().enabledKinds("theming");
+            const theme = enabled.includes("compose/theme")
+                ? ((byKind?.get("compose/theme") as ThemePayload | undefined) ??
+                  null)
+                : null;
+            const wallpaper = enabled.includes("compose/wallpaper")
+                ? ((byKind?.get("compose/wallpaper") as
+                      | WallpaperPayload
+                      | undefined) ?? null)
+                : null;
             const data = computeThemingBundleData(theme, wallpaper, target);
             const body = themingBody();
             const table = body.table;

--- a/vscode-extension/src/webview/preview/themingBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/themingBundlePresenter.ts
@@ -355,24 +355,19 @@ function renderSwatch(row: ThemingRow): TemplateResult | string {
             title=${row.value}
         ></span>`;
     }
-    if (row.kind === "typography") {
-        const fam = row.cssFontFamily;
-        const weight = row.cssFontWeight;
-        const style = row.cssFontStyle;
-        const apply = (el: Element | undefined): void => {
-            if (!el) return;
-            const e = el as HTMLElement;
-            e.style.fontFamily = fam;
-            if (weight !== null) e.style.fontWeight = String(weight);
-            e.style.fontStyle = style;
-        };
-        // Short pangram-ish sample — gives the user a glyph (Aa) plus a
-        // numeral and a punctuation mark, the three places fonts diverge
-        // most. Width is bounded by `.theming-swatch-cell` so it lines up
-        // with the colour swatch column above.
-        return html`<span class="theming-font-sample" ${ref(apply)}>Aa</span>`;
-    }
     return "";
+}
+
+function applyTypographyFont(row: ThemingTypographyRow) {
+    return (el: Element | undefined): void => {
+        if (!el) return;
+        const e = el as HTMLElement;
+        e.style.fontFamily = row.cssFontFamily;
+        if (row.cssFontWeight !== null) {
+            e.style.fontWeight = String(row.cssFontWeight);
+        }
+        e.style.fontStyle = row.cssFontStyle;
+    };
 }
 
 function renderName(row: ThemingRow): TemplateResult {
@@ -393,6 +388,17 @@ function renderName(row: ThemingRow): TemplateResult {
                 ? html`<span class="theming-name-sub">from wallpaper</span>`
                 : ""}
         </div>`;
+    }
+    if (row.kind === "typography") {
+        // Paint the token name itself in the resolved font so the user
+        // sees the typeface at a glance. CSP blocks inline `style=` and
+        // lit's `styleMap`, so the font is applied via a CSSOM ref
+        // callback — same trick the swatch uses.
+        return html`<strong
+            class="theming-typography-name"
+            ${ref(applyTypographyFont(row))}
+            >${row.name}</strong
+        >`;
     }
     return html`<strong>${row.name}</strong>`;
 }

--- a/vscode-extension/src/webview/preview/themingBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/themingBundlePresenter.ts
@@ -15,6 +15,7 @@
 // id is enough to keep `setOverlayId` happy for the shared primitive.
 
 import { html, type TemplateResult } from "lit";
+import { ref } from "lit/directives/ref.js";
 import type { DataTableColumn } from "./components/DataTable";
 
 /** Wire shape for one Material 3 typography token. Mirrors
@@ -110,6 +111,16 @@ export interface ThemingTypographyRow {
     style: string;
     lineHeight: string;
     letterSpacing: string;
+    /** CSS `font-family` stack derived from the daemon's `FontFamily.X`
+     *  toString. Used by the inline sample so the user sees the actual
+     *  glyph shape rather than just the token name. */
+    cssFontFamily: string;
+    /** Numeric CSS `font-weight` extracted from `FontWeight(weight=N)`,
+     *  or null when the daemon couldn't resolve one. */
+    cssFontWeight: number | null;
+    /** `"italic"` when the resolved style was Italic; `"normal"`
+     *  otherwise. */
+    cssFontStyle: "italic" | "normal";
 }
 
 export interface ThemingShapeRow {
@@ -118,6 +129,10 @@ export interface ThemingShapeRow {
     kind: "shape";
     name: string;
     value: string;
+    /** CSS `border-radius` string derived from the shape value so the
+     *  preview swatch paints the actual corner geometry. `null` when
+     *  the shape couldn't be parsed (e.g. CutCornerShape, custom). */
+    previewBorderRadius: string | null;
 }
 
 /** Seed-color summary row prepended to Colors when wallpaper is
@@ -231,17 +246,26 @@ export function computeThemingBundleData(
                 tok.letterSpacing,
                 tok.letterSpacingUnit,
             ),
+            cssFontFamily: cssFontFamily(tok.fontFamily),
+            cssFontWeight: parseFontWeight(tok.fontWeight),
+            cssFontStyle:
+                typeof tok.fontStyle === "string" &&
+                /italic/i.test(tok.fontStyle)
+                    ? "italic"
+                    : "normal",
         });
     }
 
     const shapes = theme?.resolvedTokens?.shapes ?? {};
     for (const name of Object.keys(shapes).sort()) {
+        const value = shapes[name];
         rows.push({
             id: "theming-shape-" + name,
             section: "Shapes",
             kind: "shape",
             name,
-            value: shapes[name],
+            value,
+            previewBorderRadius: parseShapeBorderRadius(value),
         });
     }
 
@@ -299,14 +323,54 @@ function sectionLabel(row: ThemingRow): string {
 
 function renderSwatch(row: ThemingRow): TemplateResult | string {
     if (row.kind === "color" || row.kind === "seed") {
+        // VS Code's webview CSP rejects inline `style=` attributes —
+        // including the ones lit's `styleMap` directive emits — so the
+        // swatch colour has to land via the CSSOM in a ref callback
+        // instead. Same dance `BoxOverlay.renderBox` does for overlay
+        // boxes; see that file for the CSP rationale.
+        const css = row.swatchCss;
+        const apply = (el: Element | undefined): void => {
+            if (!el) return;
+            (el as HTMLElement).style.backgroundColor = css;
+        };
         return html`<span
             class="theming-swatch"
             data-source=${row.kind === "seed"
                 ? "seed"
                 : (row as ThemingColorRow).source}
-            style=${"background-color: " + row.swatchCss}
+            ${ref(apply)}
             title=${row.hex}
         ></span>`;
+    }
+    if (row.kind === "shape") {
+        const radius = row.previewBorderRadius;
+        if (radius === null) return "";
+        const apply = (el: Element | undefined): void => {
+            if (!el) return;
+            (el as HTMLElement).style.borderRadius = radius;
+        };
+        return html`<span
+            class="theming-shape-preview"
+            ${ref(apply)}
+            title=${row.value}
+        ></span>`;
+    }
+    if (row.kind === "typography") {
+        const fam = row.cssFontFamily;
+        const weight = row.cssFontWeight;
+        const style = row.cssFontStyle;
+        const apply = (el: Element | undefined): void => {
+            if (!el) return;
+            const e = el as HTMLElement;
+            e.style.fontFamily = fam;
+            if (weight !== null) e.style.fontWeight = String(weight);
+            e.style.fontStyle = style;
+        };
+        // Short pangram-ish sample — gives the user a glyph (Aa) plus a
+        // numeral and a punctuation mark, the three places fonts diverge
+        // most. Width is bounded by `.theming-swatch-cell` so it lines up
+        // with the colour swatch column above.
+        return html`<span class="theming-font-sample" ${ref(apply)}>Aa</span>`;
     }
     return "";
 }
@@ -388,6 +452,125 @@ function formatScalar(
 function formatContrast(level: number): string {
     if (Number.isInteger(level)) return level.toFixed(1);
     return level.toFixed(2);
+}
+
+/**
+ * Map the Kotlin `FontFamily.X.toString()` shapes the daemon emits to
+ * a CSS font-family stack. The webview head loads Roboto / Roboto
+ * Serif / Roboto Mono / Caveat from Google Fonts so these stacks
+ * resolve to a real glyph rather than the system fallback.
+ */
+export function cssFontFamily(name: string | null | undefined): string {
+    if (!name) return "var(--vscode-font-family)";
+    const s = name.trim();
+    if (/SansSerif/i.test(s)) return "'Roboto', sans-serif";
+    if (/Serif/i.test(s) && !/SansSerif/i.test(s))
+        return "'Roboto Serif', serif";
+    if (/Monospace/i.test(s)) return "'Roboto Mono', monospace";
+    if (/Cursive/i.test(s)) return "'Caveat', cursive";
+    // Fall back to whatever the daemon reported — quoted defensively so
+    // a custom family name with spaces still resolves.
+    return `'${s.replace(/'/g, "")}', var(--vscode-font-family)`;
+}
+
+/**
+ * Pull the numeric weight out of `FontWeight(weight=400)` (the
+ * canonical Compose toString). Returns null when the shape doesn't
+ * match — e.g. `Normal`, `Bold`, an em-dash placeholder.
+ */
+export function parseFontWeight(
+    weight: string | null | undefined,
+): number | null {
+    if (!weight) return null;
+    const m = weight.match(/weight\s*=\s*(\d{2,3})/);
+    if (m) {
+        const n = parseInt(m[1], 10);
+        if (n >= 100 && n <= 900) return n;
+    }
+    // Named weights — Compose may toString to `Bold` / `Normal` for
+    // some inputs. Surface the canonical CSS numeric so the sample
+    // renders at the expected weight even without `weight=…`.
+    const lookup: Record<string, number> = {
+        thin: 100,
+        extralight: 200,
+        light: 300,
+        normal: 400,
+        regular: 400,
+        medium: 500,
+        semibold: 600,
+        bold: 700,
+        extrabold: 800,
+        black: 900,
+    };
+    const key = weight.trim().toLowerCase();
+    return lookup[key] ?? null;
+}
+
+/**
+ * Best-effort parse of the Material 3 shape token's toString into a
+ * CSS `border-radius` value. Handles `RoundedCornerShape(size.dp)`,
+ * the four-corner form `RoundedCornerShape(topStart = CornerSize(size
+ * = 8.0.dp), …)`, and the percent variants. Returns null for shapes
+ * we can't safely visualise (CutCornerShape, custom polygons) — the
+ * caller suppresses the preview swatch in that case.
+ *
+ * Numbers are emitted as `px` directly: the swatch is a fixed 20×20px
+ * box in the webview, so 1 dp ≈ 1 px is the only sensible scale for a
+ * scaled-down preview. Percent values pass through unchanged.
+ */
+export function parseShapeBorderRadius(
+    value: string | null | undefined,
+): string | null {
+    if (!value || typeof value !== "string") return null;
+    // CutCornerShape would render as bevelled corners, which CSS
+    // border-radius can't express. Skip rather than mis-paint.
+    if (/CutCornerShape/i.test(value)) return null;
+    if (!/RoundedCornerShape/i.test(value)) return null;
+    const corners: Record<string, string | null> = {
+        topStart: null,
+        topEnd: null,
+        bottomEnd: null,
+        bottomStart: null,
+    };
+    let matchedAnyCorner = false;
+    for (const corner of Object.keys(corners)) {
+        const re = new RegExp(
+            corner +
+                "\\s*=\\s*CornerSize\\(size\\s*=\\s*([0-9.]+)(\\.dp|dp|%)?",
+            "i",
+        );
+        const m = value.match(re);
+        if (m) {
+            corners[corner] = formatCornerSize(m[1], m[2]);
+            matchedAnyCorner = true;
+        }
+    }
+    if (matchedAnyCorner) {
+        // CSS order: top-left top-right bottom-right bottom-left. The
+        // Compose corner names map onto LTR layout (start = left).
+        const tl = corners.topStart ?? "0";
+        const tr = corners.topEnd ?? "0";
+        const br = corners.bottomEnd ?? "0";
+        const bl = corners.bottomStart ?? "0";
+        return `${tl} ${tr} ${br} ${bl}`;
+    }
+    // Single-arg form: `RoundedCornerShape(16.dp)` or
+    // `RoundedCornerShape(50)` (percent shorthand).
+    const single = value.match(
+        /RoundedCornerShape\(\s*([0-9.]+)(\.dp|dp|%)?\s*\)/i,
+    );
+    if (single) return formatCornerSize(single[1], single[2]);
+    return null;
+}
+
+function formatCornerSize(num: string, unit: string | undefined): string {
+    const parsed = parseFloat(num);
+    if (!Number.isFinite(parsed)) return "0";
+    if (unit === "%") return parsed + "%";
+    // 1 dp → 1 px in the scaled preview. CSS clamps `border-radius` at
+    // 50% of the side anyway, so a 28 dp radius on a 20 px swatch just
+    // reads as "fully rounded" — the intended affordance.
+    return parsed + "px";
 }
 
 /**


### PR DESCRIPTION
- Swatch backgrounds, shape preview border-radius, and typography font
  sample now apply via the `ref` directive (CSSOM) — the webview CSP
  rejects inline `style=` attributes and lit's `styleMap`, which is why
  the colour swatches were rendering as the empty checkerboard.
- Honour the "Theme tokens" / "Wallpaper" Configure-expander toggles
  by gating `refreshThemingBundle` on `bundleController.enabledKinds`.
  Previously the cached payload outlived the unsubscribe and the rows
  kept showing after the checkbox was off.
- Render each shape token on a scaled-down 20x20 swatch with the
  parsed border-radius; supports the single-value `RoundedCornerShape(N
  .dp)` form, the four-corner form, and percent shorthand.
- Show an inline `Aa` sample for each typography row in the resolved
  font, weight, and style. Allowlist Google Fonts in the panel CSP and
  preload Roboto / Roboto Serif / Roboto Mono / Caveat so the generic
  Compose `FontFamily.X` tokens map onto real glyphs.