### PR TITLE
fix(vscode-preview): absorb harness AA jitter with pixelmatch

### DIFF
--- a/.github/actions/lib/test_vscode_preview_diff.py
+++ b/.github/actions/lib/test_vscode_preview_diff.py
@@ -154,6 +154,50 @@ class TestPerceptualFilter(unittest.TestCase):
                 img.putpixel((x, y), fn(x, y))
         img.save(path)
 
+    def test_generate_reuses_prior_bytes_when_perceptually_identical(self) -> None:
+        self._require_pixelmatch()
+        with tempfile.TemporaryDirectory() as td:
+            prior_in = Path(td) / "prior-in"
+            fresh_in = Path(td) / "fresh-in"
+            prior_out = Path(td) / "prior-out"
+            fresh_out = Path(td) / "fresh-out"
+            prior_in.mkdir()
+            fresh_in.mkdir()
+
+            def checkerboard(x: int, y: int) -> tuple[int, int, int]:
+                v = 80 if (x // 4 + y // 4) % 2 == 0 else 200
+                return (v, v, v)
+
+            self._png(prior_in / "grid-default.dark.png", checkerboard)
+            # One-pixel jitter at (0, 0), same shape as the real flake.
+            self._png(
+                fresh_in / "grid-default.dark.png",
+                lambda x, y: (
+                    checkerboard(x, y)[0] + (1 if (x, y) == (0, 0) else 0),
+                    checkerboard(x, y)[1] + (1 if (x, y) == (0, 0) else 0),
+                    checkerboard(x, y)[2] + (1 if (x, y) == (0, 0) else 0),
+                ),
+            )
+
+            class GenPrior:
+                input_dir = str(prior_in)
+                output_dir = str(prior_out)
+            mod.cmd_generate(GenPrior())
+
+            class GenFresh:
+                input_dir = str(fresh_in)
+                output_dir = str(fresh_out)
+                prior_renders = str(prior_out / "renders")
+            mod.cmd_generate(GenFresh())
+
+            prior_png = (prior_out / "renders" / "grid-default.dark.png").read_bytes()
+            fresh_png = (fresh_out / "renders" / "grid-default.dark.png").read_bytes()
+            self.assertEqual(
+                fresh_png, prior_png,
+                "perceptually-identical render must reuse prior bytes so "
+                "the staged tree stays bit-identical",
+            )
+
     def test_copy_changed_skips_perceptually_identical(self) -> None:
         self._require_pixelmatch()
         with tempfile.TemporaryDirectory() as td:

--- a/.github/actions/lib/test_vscode_preview_diff.py
+++ b/.github/actions/lib/test_vscode_preview_diff.py
@@ -128,6 +128,92 @@ class TestCopyChanged(unittest.TestCase):
             self.assertEqual(copied, ["grid-default.light.png", "newfix.dark.png"])
 
 
+class TestPerceptualFilter(unittest.TestCase):
+    """Cover the pixelmatch path that absorbs antialiased-edge jitter.
+
+    The headless Chromium harness emits ±1-channel differences on a small
+    number of antialiased pixels between runs even when nothing about the
+    fixture has changed (originally surfaced by `inspection-tree`
+    repeatedly flipping by 2 bytes on `vscode-preview/main`). Without the
+    perceptual filter those PNGs read as "changed" and ship a fake row in
+    the PR diff comment.
+    """
+
+    def _require_pixelmatch(self) -> None:
+        try:
+            from pixelmatch.contrib.PIL import pixelmatch  # noqa: F401
+            from PIL import Image  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest("pixelmatch/Pillow not installed")
+
+    def _png(self, path: Path, fn) -> None:
+        from PIL import Image
+        img = Image.new("RGB", (32, 32), (255, 255, 255))
+        for x in range(32):
+            for y in range(32):
+                img.putpixel((x, y), fn(x, y))
+        img.save(path)
+
+    def test_copy_changed_skips_perceptually_identical(self) -> None:
+        self._require_pixelmatch()
+        with tempfile.TemporaryDirectory() as td:
+            base_dir = Path(td) / "base"
+            head_dir = Path(td) / "head"
+            staging = Path(td) / "staging"
+            base_dir.mkdir()
+            head_dir.mkdir()
+
+            # Same content but written twice — PIL emits identical bytes,
+            # so to simulate the harness flake we flip one corner pixel
+            # by 1 on the "head" copy. That mimics the real jitter we
+            # measured on `inspection-tree.dark.png`.
+            def shape(x: int, y: int) -> tuple[int, int, int]:
+                v = 80 if (x // 4 + y // 4) % 2 == 0 else 200
+                return (v, v, v)
+
+            self._png(base_dir / "grid-default.dark.png", shape)
+            self._png(head_dir / "grid-default.dark.png",
+                      lambda x, y: (shape(x, y)[0] + (1 if (x, y) == (0, 0) else 0),
+                                    shape(x, y)[1] + (1 if (x, y) == (0, 0) else 0),
+                                    shape(x, y)[2] + (1 if (x, y) == (0, 0) else 0)))
+
+            class GenArgs:
+                input_dir = str(base_dir)
+                output_dir = str(Path(td) / "baseline-out")
+            mod.cmd_generate(GenArgs())
+
+            baseline_renders = str(Path(td) / "baseline-out" / "renders")
+
+            class CopyArgs:
+                input_dir = str(head_dir)
+                baselines = str(Path(td) / "baseline-out" / "baselines.json")
+                output_dir = str(staging)
+                baseline_renders = None  # strict bytes path
+
+            mod.cmd_copy_changed(CopyArgs())
+            strict = sorted(p.name for p in (staging / "renders").iterdir())
+            self.assertEqual(
+                strict, ["grid-default.dark.png"],
+                "without --baseline-renders, sha mismatch must still copy",
+            )
+
+            shutil.rmtree(staging)
+
+            class CopyArgsPerceptual:
+                input_dir = str(head_dir)
+                baselines = str(Path(td) / "baseline-out" / "baselines.json")
+                output_dir = str(staging)
+                baseline_renders = str(Path(td) / "baseline-out" / "renders")
+            mod.cmd_copy_changed(CopyArgsPerceptual())
+            perceptual = sorted(
+                p.name for p in (staging / "renders").iterdir()
+            ) if (staging / "renders").exists() else []
+            self.assertEqual(
+                perceptual, [],
+                "single-pixel jitter must be absorbed by pixelmatch",
+            )
+
+
 class TestCompare(unittest.TestCase):
     def _run(
         self,

--- a/.github/actions/lib/vscode-preview-diff.py
+++ b/.github/actions/lib/vscode-preview-diff.py
@@ -156,9 +156,36 @@ def cmd_generate(args: argparse.Namespace) -> int:
     renders = output_dir / "renders"
     renders.mkdir(parents=True, exist_ok=True)
 
+    raw_prior = getattr(args, "prior_renders", None)
+    prior_renders = Path(raw_prior) if raw_prior else None
+
     entries = _scan(input_dir)
-    for name in entries:
+    reused = 0
+    for name, meta in entries.items():
+        # When the freshly-rendered PNG is perceptually identical to the
+        # prior baseline copy, prefer the prior bytes. That way the staged
+        # tree stays bit-identical for noop renders and the action's
+        # `TREE == PARENT_TREE` skip suppresses the empty baseline
+        # commit. Without this every push to `main` adds a no-op commit
+        # to `vscode-preview/main` (Chromium AA jitter, see
+        # `_perceptually_changed`).
+        if prior_renders is not None:
+            prior_png = prior_renders / name
+            if prior_png.exists() and not _perceptually_changed(
+                prior_png, input_dir / name
+            ):
+                shutil.copy2(prior_png, renders / name)
+                meta["sha256"] = _sha256(renders / name)
+                meta["size"] = (renders / name).stat().st_size
+                reused += 1
+                continue
         shutil.copy2(input_dir / name, renders / name)
+    if prior_renders is not None:
+        print(
+            f"reused {reused}/{len(entries)} prior captures as "
+            f"perceptually-identical",
+            file=sys.stderr,
+        )
 
     baselines = {
         "schema": 1,
@@ -321,6 +348,12 @@ def main(argv: list[str]) -> int:
     g = sub.add_parser("generate", help="Build baselines.json + README.md from an out/ dir")
     g.add_argument("input_dir")
     g.add_argument("--output-dir", required=True)
+    # Optional. Path to the prior baseline `renders/` tree (typically
+    # extracted from `vscode-preview/main` via `git archive`). When
+    # supplied, any freshly-rendered PNG that's pixelmatch-clean against
+    # its prior copy is re-staged using the prior bytes, so AA jitter
+    # doesn't append a no-op commit to the baseline history.
+    g.add_argument("--prior-renders", default=None)
     g.set_defaults(func=cmd_generate)
 
     cp = sub.add_parser("copy-changed", help="Copy only new/changed PNGs into a staging dir")

--- a/.github/actions/lib/vscode-preview-diff.py
+++ b/.github/actions/lib/vscode-preview-diff.py
@@ -87,6 +87,65 @@ def _image_url(repo: str, ref: str, path: str) -> str:
     return f"https://raw.githubusercontent.com/{repo}/{ref}/{path}"
 
 
+# Pixel count above pixelmatch's per-pixel threshold that we still treat as
+# perceptually unchanged. Headless Chromium emits ±1-channel jitter on
+# antialiased edges between runs even when nothing about the fixture has
+# changed — `inspection-tree.dark.png` reproducibly flips between 2 pixel
+# values on a single column without any source change. Same tolerance as
+# the composable side (`compare-previews.py`).
+_PERCEPTUAL_PIXEL_TOLERANCE = 16
+
+
+def _perceptually_changed(prior_png: Path, current_png: Path) -> bool:
+    """Return True if the two PNGs differ by more than rounding noise.
+
+    Mirrors `compare-previews._perceptually_changed`: uses Mapbox's
+    pixelmatch with AA detection on, so a handful of antialiased edge
+    pixels around glyphs and rounded corners — which the harness produces
+    non-deterministically between runs — don't count as real differences.
+
+    Falls back to ``True`` (i.e. defer to sha-mismatch) when the library
+    isn't importable, either PNG can't be located, or decoding fails. The
+    fallback is strictly no more permissive than the previous sha-only
+    behaviour.
+    """
+    try:
+        from pixelmatch.contrib.PIL import pixelmatch
+        from PIL import Image
+    except ImportError:
+        return True
+    if not prior_png.exists() or not current_png.exists():
+        return True
+    try:
+        with Image.open(prior_png) as prior, Image.open(current_png) as current:
+            if prior.size != current.size:
+                return True
+            diff = pixelmatch(prior, current, threshold=0.1, includeAA=False)
+    except Exception:
+        return True
+    return diff > _PERCEPTUAL_PIXEL_TOLERANCE
+
+
+def _is_changed(
+    name: str,
+    cur_meta: dict,
+    prior_meta: dict,
+    baseline_renders: Path | None,
+    input_dir: Path,
+) -> bool:
+    """Decide whether ``cur_meta`` is a real change vs ``prior_meta``.
+
+    Fast path: shas match → unchanged. On mismatch, if we have a local
+    copy of the prior PNG, run the perceptual filter; otherwise fall back
+    to the strict sha behaviour.
+    """
+    if prior_meta.get("sha256") == cur_meta["sha256"]:
+        return False
+    if baseline_renders is None:
+        return True
+    return _perceptually_changed(baseline_renders / name, input_dir / name)
+
+
 # ---------------------------------------------------------------------------
 # generate
 # ---------------------------------------------------------------------------
@@ -143,13 +202,16 @@ def cmd_copy_changed(args: argparse.Namespace) -> int:
     baselines = _load_json(Path(args.baselines)).get("captures", {})
     current = _scan(input_dir)
 
+    raw_renders = getattr(args, "baseline_renders", None)
+    baseline_renders = Path(raw_renders) if raw_renders else None
+
     renders = output_dir / "renders"
     renders.mkdir(parents=True, exist_ok=True)
 
     copied = 0
     for name, meta in current.items():
-        prior = baselines.get(name)
-        if prior and prior.get("sha256") == meta["sha256"]:
+        prior = baselines.get(name) or {}
+        if not _is_changed(name, meta, prior, baseline_renders, input_dir):
             continue
         shutil.copy2(input_dir / name, renders / name)
         copied += 1
@@ -166,6 +228,9 @@ def cmd_compare(args: argparse.Namespace) -> int:
     baselines = _load_json(Path(args.baselines)).get("captures", {})
     current = _scan(input_dir)
 
+    raw_renders = getattr(args, "baseline_renders", None)
+    baseline_renders = Path(raw_renders) if raw_renders else None
+
     new: list[tuple[str, dict]] = []
     changed: list[tuple[str, dict, dict]] = []
     removed: list[tuple[str, dict]] = []
@@ -174,7 +239,7 @@ def cmd_compare(args: argparse.Namespace) -> int:
         prior = baselines.get(name)
         if prior is None:
             new.append((name, meta))
-        elif prior.get("sha256") != meta["sha256"]:
+        elif _is_changed(name, meta, prior, baseline_renders, input_dir):
             changed.append((name, prior, meta))
 
     for name, meta in sorted(baselines.items()):
@@ -262,6 +327,11 @@ def main(argv: list[str]) -> int:
     cp.add_argument("input_dir")
     cp.add_argument("--baselines", required=True)
     cp.add_argument("--output-dir", required=True)
+    # Optional. When supplied, sha-mismatched pairs run through pixelmatch
+    # before being copied — collapses the antialiased-edge jitter the
+    # headless Chromium harness emits between runs (see
+    # `_perceptually_changed`). Strict-bytes fallback when omitted.
+    cp.add_argument("--baseline-renders", default=None)
     cp.set_defaults(func=cmd_copy_changed)
 
     c = sub.add_parser("compare", help="Emit a markdown PR comment body")
@@ -271,6 +341,9 @@ def main(argv: list[str]) -> int:
     c.add_argument("--base-ref", required=True)
     c.add_argument("--head-ref", required=True)
     c.add_argument("--base-branch", required=True)
+    # Same as `copy-changed --baseline-renders` — pixelmatch path for the
+    # PR-comment diff so the two surfaces agree.
+    c.add_argument("--baseline-renders", default=None)
     c.set_defaults(func=cmd_compare)
 
     args = parser.parse_args(argv)

--- a/.github/actions/vscode-preview-baselines/action.yml
+++ b/.github/actions/vscode-preview-baselines/action.yml
@@ -55,6 +55,33 @@ runs:
       working-directory: vscode-extension
       run: npm run harness:contract
 
+    - name: Fetch prior baselines
+      shell: bash
+      env:
+        BASELINE_BRANCH: ${{ inputs.branch }}
+      run: |
+        # Pull the prior `renders/` tree from the baseline branch so the
+        # generate step can reuse pixelmatch-clean PNGs verbatim. Without
+        # this, every push lands a no-op baseline commit when Chromium AA
+        # jitter flips the bytes of an otherwise-unchanged capture. Absent
+        # branch (first-ever run) falls back to a strict regenerate.
+        mkdir -p _vscode_prior
+        if git ls-remote --exit-code origin "$BASELINE_BRANCH" >/dev/null 2>&1; then
+          git fetch --depth=1 --quiet origin "$BASELINE_BRANCH"
+          git archive FETCH_HEAD renders 2>/dev/null \
+            | tar -x -C _vscode_prior/ 2>/dev/null || true
+        fi
+
+    - name: Install perceptual-diff dependencies
+      shell: bash
+      run: |
+        # pixelmatch (Mapbox; AA-aware) collapses the antialiased-edge
+        # jitter the harness emits between runs. Install failure falls
+        # back to strict-bytes generate, which restores the previous
+        # noisy-history behaviour but doesn't break the workflow.
+        python3 -m pip install --quiet 'pixelmatch==0.4.0' 'Pillow>=10' \
+          || echo "pixelmatch install failed; falling back to strict-bytes generate" >&2
+
     - name: Stage baselines
       shell: bash
       env:
@@ -62,6 +89,7 @@ runs:
       run: |
         python3 "$ACTION_PATH/../lib/vscode-preview-diff.py" generate \
           vscode-extension/preview-harness/out \
+          --prior-renders _vscode_prior/renders \
           --output-dir _vscode_baselines
 
     - name: Push to baselines branch

--- a/.github/actions/vscode-preview-comment/action.yml
+++ b/.github/actions/vscode-preview-comment/action.yml
@@ -78,9 +78,30 @@ runs:
           git fetch origin "$BASE_BRANCH"
           git show "origin/${BASE_BRANCH}:baselines.json" \
             > _vscode_baselines/baselines.json 2>/dev/null || true
+          # Extract the baseline `renders/` tree alongside `baselines.json`
+          # so the pixelmatch-based perceptual filter in
+          # `vscode-preview-diff.py` has both PNGs to diff. Without this
+          # the harness's ±1-channel antialiased-edge jitter (Chromium
+          # rasterisation is not bitwise-deterministic between runs) trips
+          # the sha comparison and surfaces a fake "changed" row in every
+          # PR. `git archive` writes to stdout so the working tree is
+          # untouched; failures (e.g. baseline branch has no `renders/`
+          # tree yet) fall back to the strict-bytes path.
+          git archive "origin/${BASE_BRANCH}" renders 2>/dev/null \
+            | tar -x -C _vscode_baselines/ 2>/dev/null || true
         else
           echo "No $BASE_BRANCH branch yet — treating all captures as new."
         fi
+
+    - name: Install perceptual-diff dependencies
+      shell: bash
+      run: |
+        # pixelmatch (Mapbox; AA-aware) collapses the antialiased-edge
+        # jitter the harness emits between runs. If install fails, the
+        # script falls back to strict sha-only comparison — same shape
+        # as the composable preview-comment action.
+        python3 -m pip install --quiet 'pixelmatch==0.4.0' 'Pillow>=10' \
+          || echo "pixelmatch install failed; falling back to strict-bytes diff" >&2
 
     - name: Resolve Before ref
       shell: bash
@@ -109,6 +130,7 @@ runs:
         python3 "$ACTION_PATH/../lib/vscode-preview-diff.py" copy-changed \
           vscode-extension/preview-harness/out \
           --baselines _vscode_baselines/baselines.json \
+          --baseline-renders _vscode_baselines/renders \
           --output-dir _vscode_pr_renders
 
     - name: Push PR captures
@@ -188,6 +210,7 @@ runs:
         python3 "$ACTION_PATH/../lib/vscode-preview-diff.py" compare \
           vscode-extension/preview-harness/out \
           --baselines _vscode_baselines/baselines.json \
+          --baseline-renders _vscode_baselines/renders \
           --repo "$REPO" \
           --base-ref "$BASE_REF" \
           --head-ref "$HEAD_REF" \


### PR DESCRIPTION
The vscode-preview pipeline compared captures with raw sha256. Headless
Chromium emits non-deterministic +/-1-channel differences on a handful
of antialiased edge pixels between runs even when the fixture didn't
change, so every PR shipped a fake "changed" row and `vscode-preview/main`
flipped the same two-byte delta back and forth on unrelated commits
(e.g. inspection-tree.dark.png at 68399 <-> 68401).

Mirror the composable side: on sha mismatch, run Mapbox pixelmatch with
AA detection on and only treat a pair as changed once the diff exceeds
~16 pixels. Verified against three real flake pairs from the baseline
branch (inspection-tree, a11y-findings.light, grid-default.light) -
all three now read as unchanged.

- new --baseline-renders flag on copy-changed/compare
- preview-comment action extracts renders/ tree and installs pixelmatch
- new TestPerceptualFilter exercises the strict and perceptual paths