### PR TITLE
fix: guard daemon readiness check against uninitialized liveState

### DIFF
--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -2047,9 +2047,24 @@ export class PreviewApp extends LitElement {
             // bundle body the user would otherwise see. Active chips
             // stay enabled so the user can still turn an in-flight
             // bundle off if they want.
-            const daemonReady = isFocusedModuleReady(
-                liveState.getModuleDaemonReady(),
-            );
+            //
+            // `liveState` is late-bound via `let liveState!`, and the
+            // initial `reflectBundleState()` call below runs *before*
+            // the controller is constructed (bundle setup happens
+            // earlier in `firstUpdated`). Skip the readiness probe on
+            // that pre-init pass so the synchronous deref doesn't
+            // throw and torpedo the rest of `firstUpdated` — including
+            // the `webviewPreviewsRendered` ack the e2e suite waits
+            // for. Leaving `daemonReady` undefined keeps the
+            // `BundleChipBar`'s `true` default in effect for harness
+            // fixtures + code paths that never pipe through
+            // `setInteractiveAvailability`; subsequent `onChange`
+            // calls (always after liveState is constructed) supply
+            // the real value.
+            const daemonReady =
+                typeof liveState !== "undefined"
+                    ? isFocusedModuleReady(liveState.getModuleDaemonReady())
+                    : undefined;
             bundleChipBar.setState({
                 bundles: s.bundles,
                 activeBundles: s.activeBundles,


### PR DESCRIPTION
## Summary
Fixes a potential runtime error during the initial `reflectBundleState()` call in `firstUpdated()` by guarding the daemon readiness probe against accessing `liveState` before it's been constructed.

## Changes
- Added a type guard to check if `liveState` is defined before calling `isFocusedModuleReady(liveState.getModuleDaemonReady())`
- When `liveState` is undefined (during pre-initialization), `daemonReady` is set to `undefined` instead of attempting a synchronous dereference
- This allows the `BundleChipBar` to retain its default `true` state during initial setup while subsequent `onChange` calls supply the real value once the controller is constructed

## Implementation Details
The issue occurs because `liveState` is late-bound via `let liveState!`, and the initial `reflectBundleState()` call runs before the controller is constructed. Without this guard, the synchronous dereference would throw an error and interrupt the rest of `firstUpdated()`, including the `webviewPreviewsRendered` acknowledgment that the e2e test suite depends on.

https://claude.ai/code/session_016vY4tAEumE5mXkRy49qVug