### PR TITLE
feat: add early-feature preview bundle export

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewIds.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewIds.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.plugin
+
+/**
+ * Parser for the `-PbundlePreviewIds=…` Gradle property used by `composePreviewBundle`.
+ *
+ * The wire format is comma-separated preview ids with backslash escapes: `\,` decodes to a literal
+ * `,`, `\\` decodes to a literal `\`, and any other `\<x>` keeps both characters verbatim. Escapes
+ * are needed because preview ids carry the `@Preview(name = …)` suffix (e.g.
+ * `com.example.Foo.Bar_Phone, dark`) — `,` is not in the discovery-time sanitiser's strip set, so
+ * it does reach the bundle task. Whitespace around each entry is trimmed (so `id1, id2` and
+ * `id1,id2` are equivalent); empty entries are dropped.
+ *
+ * Encoders (callers building `-PbundlePreviewIds=…`) should use [encode] for each id and
+ * `joinToString(",")` for the list. The pairing keeps the CLI's `bundle pack --id` flow and the VS
+ * Code panel's per-preview export aligned on a single transport.
+ */
+internal object BundlePreviewIds {
+  fun parse(raw: String): List<String> {
+    val out = mutableListOf<String>()
+    val current = StringBuilder()
+    var i = 0
+    while (i < raw.length) {
+      val c = raw[i]
+      if (c == '\\' && i + 1 < raw.length) {
+        val next = raw[i + 1]
+        if (next == ',' || next == '\\') {
+          current.append(next)
+          i += 2
+          continue
+        }
+      }
+      if (c == ',') {
+        addTrimmed(out, current)
+        current.clear()
+      } else {
+        current.append(c)
+      }
+      i++
+    }
+    addTrimmed(out, current)
+    return out
+  }
+
+  fun encode(id: String): String {
+    val sb = StringBuilder(id.length)
+    for (c in id) {
+      when (c) {
+        '\\',
+        ',' -> sb.append('\\').append(c)
+        else -> sb.append(c)
+      }
+    }
+    return sb.toString()
+  }
+
+  private fun addTrimmed(out: MutableList<String>, buf: StringBuilder) {
+    val trimmed = buf.toString().trim()
+    if (trimmed.isNotEmpty()) out.add(trimmed)
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -191,7 +191,7 @@ internal object ComposePreviewTasks {
   ) {
     val previewIdsProperty: Provider<List<String>> =
       project.providers.gradleProperty("bundlePreviewIds").map { raw ->
-        raw.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+        BundlePreviewIds.parse(raw)
       }
     val outputProperty: Provider<String> = project.providers.gradleProperty("bundleOutput")
     val pluginVersionProperty = PluginVersion.value

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/BundlePreviewIdsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/BundlePreviewIdsTest.kt
@@ -1,0 +1,69 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BundlePreviewIdsTest {
+
+  @Test
+  fun `parses a single id`() {
+    assertThat(BundlePreviewIds.parse("com.example.Foo.Bar")).containsExactly("com.example.Foo.Bar")
+  }
+
+  @Test
+  fun `splits unescaped commas and trims whitespace`() {
+    assertThat(BundlePreviewIds.parse("id1, id2 ,id3"))
+      .containsExactly("id1", "id2", "id3")
+      .inOrder()
+  }
+
+  @Test
+  fun `drops empty entries`() {
+    assertThat(BundlePreviewIds.parse(",,id1,,")).containsExactly("id1")
+  }
+
+  @Test
+  fun `escaped comma stays literal in the parsed id`() {
+    // `@Preview(name = "Phone, dark")` → id `…_Phone, dark`. The wire form is `…_Phone\, dark`.
+    assertThat(BundlePreviewIds.parse("""com.example.Foo.Bar_Phone\, dark"""))
+      .containsExactly("com.example.Foo.Bar_Phone, dark")
+  }
+
+  @Test
+  fun `escaped backslash stays literal in the parsed id`() {
+    assertThat(BundlePreviewIds.parse("""a\\b""")).containsExactly("""a\b""")
+  }
+
+  @Test
+  fun `mixes escaped and unescaped commas across multiple ids`() {
+    assertThat(BundlePreviewIds.parse("""id_a\,b,id_c,id_d\,e"""))
+      .containsExactly("id_a,b", "id_c", "id_d,e")
+      .inOrder()
+  }
+
+  @Test
+  fun `unknown escape sequence keeps both characters verbatim`() {
+    // `\n` is not a recognised escape — the parser leaves the backslash in place rather than
+    // swallowing it, so future escape additions stay backwards compatible.
+    assertThat(BundlePreviewIds.parse("""a\nb""")).containsExactly("""a\nb""")
+  }
+
+  @Test
+  fun `trailing backslash is preserved verbatim`() {
+    assertThat(BundlePreviewIds.parse("""a\""")).containsExactly("""a\""")
+  }
+
+  @Test
+  fun `encode escapes commas and backslashes`() {
+    assertThat(BundlePreviewIds.encode("com.example.Foo.Bar_Phone, dark"))
+      .isEqualTo("""com.example.Foo.Bar_Phone\, dark""")
+    assertThat(BundlePreviewIds.encode("""a\b""")).isEqualTo("""a\\b""")
+  }
+
+  @Test
+  fun `encode then parse round-trips ids with commas and backslashes`() {
+    val ids = listOf("com.example.Foo.Bar_Phone, dark", """a\b""", "plain", "with, two, commas")
+    val wire = ids.joinToString(",") { BundlePreviewIds.encode(it) }
+    assertThat(BundlePreviewIds.parse(wire)).containsExactlyElementsIn(ids).inOrder()
+  }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4079,6 +4079,11 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 void launchOnDevice(msg.previewId);
             }
             break;
+        case "requestExportPreviewBundle":
+            if (earlyFeaturesEnabled()) {
+                void exportPreviewBundle(msg.previewId);
+            }
+            break;
         case "requestStreamStart":
             void handleRequestStreamStart(msg.previewId);
             break;
@@ -5136,6 +5141,86 @@ function formatRelativeShort(iso: string | undefined): string {
     }
     const d = Math.round(h / 24);
     return d + "d ago";
+}
+
+/**
+ * Early-feature: pack the focused preview into a portable PNG+ZIP polyglot
+ * bundle. Resolves the owning module from [previewId], prompts for a save
+ * location, then runs `:<module>:renderPreviews` + `:<module>:composePreviewBundle`
+ * with `-PbundlePreviewIds=<previewId>` and `-PbundleOutput=<file>`. Reports
+ * success / failure via toasts; the resulting `.png` is a valid image that
+ * also unzips to the bundle contents.
+ */
+async function exportPreviewBundle(previewId: string): Promise<void> {
+    if (!gradleService) {
+        vscode.window.showInformationMessage(
+            "Compose Preview is not ready yet.",
+        );
+        return;
+    }
+    const module = previewModuleMap.get(previewId);
+    if (!module) {
+        vscode.window.showWarningMessage(
+            "Compose Preview: could not resolve module for the focused preview.",
+        );
+        return;
+    }
+    const label = lookupPreviewLabel(previewId) ?? previewId;
+    const defaultName =
+        label.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "") ||
+        "preview";
+    const defaultDir = path.join(
+        gradleService.workspaceRoot,
+        module.projectDir,
+        "build",
+        "compose-previews",
+    );
+    const defaultUri = vscode.Uri.file(
+        path.join(defaultDir, `${defaultName}.bundle.png`),
+    );
+    const target = await vscode.window.showSaveDialog({
+        defaultUri,
+        filters: { "PNG+ZIP bundle": ["png"] },
+        saveLabel: "Export bundle",
+        title: `Export ${label} as PNG+ZIP bundle`,
+    });
+    if (!target) {
+        return;
+    }
+    const outputPath = target.fsPath;
+    try {
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: `Exporting ${label} bundle…`,
+            },
+            async () => {
+                await gradleService!.exportPreviewBundle(
+                    module,
+                    previewId,
+                    outputPath,
+                );
+            },
+        );
+    } catch (err) {
+        const message = (err as Error).message ?? String(err);
+        logLine(`exportPreviewBundle failed: ${message}`);
+        vscode.window.showErrorMessage(
+            `Compose Preview: bundle export failed — ${message}`,
+        );
+        return;
+    }
+    const open = "Reveal in OS";
+    const choice = await vscode.window.showInformationMessage(
+        `Compose preview bundle saved: ${path.basename(outputPath)}`,
+        open,
+    );
+    if (choice === open) {
+        void vscode.commands.executeCommand(
+            "revealFileInOS",
+            vscode.Uri.file(outputPath),
+        );
+    }
 }
 
 function lookupPreviewLabel(previewId: string): string | undefined {

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -417,6 +417,34 @@ export class GradleService {
     }
 
     /**
+     * Runs `:<module>:renderPreviews` then `:<module>:composePreviewBundle`
+     * with `-PbundlePreviewIds=<previewId>` and `-PbundleOutput=<outputPath>`.
+     * The render step keeps the bundle's cover PNG fresh; the bundle step
+     * produces a PNG+ZIP polyglot at [outputPath]. Throws on failure.
+     */
+    async exportPreviewBundle(
+        module: ModuleInfo,
+        previewId: string,
+        outputPath: string,
+        opts?: TaskOptions,
+    ): Promise<void> {
+        const extraArgs = [
+            `-PbundlePreviewIds=${previewId}`,
+            `-PbundleOutput=${outputPath}`,
+        ];
+        await this.runTask(
+            `${module.modulePath}:renderPreviews`,
+            extraArgs,
+            opts,
+        );
+        await this.runTask(
+            `${module.modulePath}:composePreviewBundle`,
+            extraArgs,
+            opts,
+        );
+    }
+
+    /**
      * Runs `:<module>:composePreviewDoctor` and returns the parsed sidecar
      * report. Same JSON schema as `compose-preview doctor --json`'s per-
      * module shape — see `ComposePreviewDoctorTask.kt` in `gradle-plugin`.

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -264,6 +264,19 @@ export interface GradleApi {
     }): Promise<void>;
 }
 
+/**
+ * Encodes a preview id for the `-PbundlePreviewIds=…` Gradle property used
+ * by `composePreviewBundle`. Escapes `\\` and `,` so the plugin's
+ * comma-split parser (with backslash escapes — see `BundlePreviewIds.kt`
+ * in `:gradle-plugin`) reconstructs the original id. Preview ids carry
+ * the `@Preview(name = …)` suffix verbatim and `,` is not in the
+ * sanitiser's strip set, so the unescaped form would mis-split for any
+ * preview whose name contains a comma.
+ */
+export function encodeBundlePreviewId(id: string): string {
+    return id.replace(/\\/g, "\\\\").replace(/,/g, "\\,");
+}
+
 export class GradleService {
     /** Absolute path to the workspace root. Read-only — exposed for callers that need to resolve
      *  module-relative artifact paths (e.g. the Android manifest CodeLens, which jumps to a
@@ -418,9 +431,14 @@ export class GradleService {
 
     /**
      * Runs `:<module>:renderPreviews` then `:<module>:composePreviewBundle`
-     * with `-PbundlePreviewIds=<previewId>` and `-PbundleOutput=<outputPath>`.
+     * with `-PbundlePreviewIds=<encoded id>` and `-PbundleOutput=<outputPath>`.
      * The render step keeps the bundle's cover PNG fresh; the bundle step
      * produces a PNG+ZIP polyglot at [outputPath]. Throws on failure.
+     *
+     * [previewId] is encoded via [encodeBundlePreviewId] before being
+     * joined into the property value — `@Preview(name = "Phone, dark")`
+     * produces an id whose name suffix carries a literal comma, which
+     * would otherwise be mis-split by the plugin's CSV-style parser.
      */
     async exportPreviewBundle(
         module: ModuleInfo,
@@ -429,7 +447,7 @@ export class GradleService {
         opts?: TaskOptions,
     ): Promise<void> {
         const extraArgs = [
-            `-PbundlePreviewIds=${previewId}`,
+            `-PbundlePreviewIds=${encodeBundlePreviewId(previewId)}`,
             `-PbundleOutput=${outputPath}`,
         ];
         await this.runTask(

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -2,7 +2,12 @@ import * as assert from "assert";
 import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
-import { GradleService, GradleApi, TaskCancelledError } from "../gradleService";
+import {
+    GradleService,
+    GradleApi,
+    TaskCancelledError,
+    encodeBundlePreviewId,
+} from "../gradleService";
 import { JdkImageError } from "../jdkImageErrorDetector";
 
 /** Stub GradleApi that records invocations and allows test control. */
@@ -1329,5 +1334,32 @@ describe("GradleService", () => {
                 await Promise.all([keepRun, dropRun]);
             }),
         );
+    });
+});
+
+describe("encodeBundlePreviewId", () => {
+    it("leaves comma-free ids untouched", () => {
+        assert.strictEqual(
+            encodeBundlePreviewId("com.example.Foo.Bar"),
+            "com.example.Foo.Bar",
+        );
+    });
+
+    it("escapes commas with a leading backslash", () => {
+        // `@Preview(name = "Phone, dark")` lands the comma verbatim in the
+        // preview id, so the wire form must mark it as a literal rather
+        // than a separator.
+        assert.strictEqual(
+            encodeBundlePreviewId("com.example.Foo.Bar_Phone, dark"),
+            "com.example.Foo.Bar_Phone\\, dark",
+        );
+    });
+
+    it("escapes backslashes ahead of commas so escapes nest cleanly", () => {
+        // A preview id containing a backslash must double it; otherwise the
+        // plugin parser would consume the `\` as the prefix of whatever
+        // came next (e.g. `\,` would lose the literal `\`).
+        assert.strictEqual(encodeBundlePreviewId("a\\b"), "a\\\\b");
+        assert.strictEqual(encodeBundlePreviewId("a\\,b"), "a\\\\\\,b");
     });
 });

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -827,6 +827,15 @@ export type WebviewToExtension =
      */
     | { command: "requestLaunchOnDevice"; previewId: string }
     /**
+     * Focus-mode "Export bundle" click — early-features gated. The host
+     * shows a save dialog, then runs `:<module>:renderPreviews` +
+     * `:<module>:composePreviewBundle` with `-PbundlePreviewIds=<id>` and
+     * `-PbundleOutput=<file>` so the produced PNG+ZIP polyglot lands at
+     * the user-picked location. The bundle is single-preview (cover =
+     * focused preview).
+     */
+    | { command: "requestExportPreviewBundle"; previewId: string }
+    /**
      * `composestream/1` — open a live frame stream for [previewId]. The
      * extension acquires a held interactive session and pumps `streamFrame`
      * notifications down to the webview, where the canvas painter consumes

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -394,4 +394,25 @@ export class FocusController {
             previewId,
         });
     }
+
+    /**
+     * Early-feature export: pack the focused preview into a portable
+     * PNG+ZIP polyglot via the consumer module's `composePreviewBundle`
+     * task. The host shows a save dialog and then runs the Gradle task
+     * with `-PbundlePreviewIds=<focused>` so the resulting file contains
+     * just this one preview (cover = its rendered image).
+     */
+    requestExportPreviewBundle(): void {
+        if (!this.config.earlyFeatures()) return;
+        if (!this.inFocus()) return;
+        const visible = this.getVisibleCards();
+        const card = visible[this.config.getFocusIndex()];
+        if (!card) return;
+        const previewId = card.dataset.previewId;
+        if (!previewId) return;
+        this.config.vscode.postMessage({
+            command: "requestExportPreviewBundle",
+            previewId,
+        });
+    }
 }

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -32,6 +32,7 @@ export interface FocusToolbarElements {
     btnInteractive: HTMLButtonElement;
     btnStopInteractive: HTMLButtonElement;
     btnRecording: HTMLButtonElement;
+    btnExportBundle: HTMLButtonElement;
     btnExitFocus: HTMLButtonElement;
     recordingFormat: HTMLSelectElement;
     focusInspector: HTMLElement;
@@ -89,6 +90,7 @@ export class FocusToolbarController {
         this.el.btnA11yOverlay.hidden = !s.earlyFeatures || !s.inFocus;
         this.el.btnRecording.hidden = !s.earlyFeatures || !s.inFocus;
         this.el.recordingFormat.hidden = !s.earlyFeatures || !s.inFocus;
+        this.el.btnExportBundle.hidden = !s.earlyFeatures || !s.inFocus;
         if (!s.earlyFeatures) {
             this.el.focusInspector.hidden = true;
         }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -210,6 +210,7 @@ export class PreviewApp extends LitElement {
     private _btnStopInteractive!: HTMLButtonElement;
     @query("#btn-recording") private _btnRecording!: HTMLButtonElement;
     @query("#recording-format") private _recordingFormat!: HTMLSelectElement;
+    @query("#btn-export-bundle") private _btnExportBundle!: HTMLButtonElement;
     @query("#btn-exit-focus") private _btnExitFocus!: HTMLButtonElement;
     @query("#focus-position") private _focusPosition!: HTMLElement;
 
@@ -380,6 +381,15 @@ export class PreviewApp extends LitElement {
                 </select>
                 <button
                     class="icon-button"
+                    id="btn-export-bundle"
+                    title="Export focused preview as a portable PNG+ZIP bundle"
+                    aria-label="Export preview bundle"
+                    hidden
+                >
+                    <i class="codicon codicon-package" aria-hidden="true"></i>
+                </button>
+                <button
+                    class="icon-button"
                     id="btn-exit-focus"
                     title="Exit focus mode"
                     aria-label="Exit focus mode"
@@ -507,6 +517,7 @@ export class PreviewApp extends LitElement {
         const btnStopInteractive = this._btnStopInteractive;
         const btnRecording = this._btnRecording;
         const recordingFormat = this._recordingFormat;
+        const btnExportBundle = this._btnExportBundle;
         const btnExitFocus = this._btnExitFocus;
         const focusToolbar = new FocusToolbarController({
             btnPrev,
@@ -518,6 +529,7 @@ export class PreviewApp extends LitElement {
             btnInteractive,
             btnStopInteractive,
             btnRecording,
+            btnExportBundle,
             btnExitFocus,
             recordingFormat,
             focusInspector,
@@ -2390,6 +2402,9 @@ export class PreviewApp extends LitElement {
         btnRecording.addEventListener("click", () =>
             liveState.toggleRecording(),
         );
+        btnExportBundle.addEventListener("click", () =>
+            requestExportPreviewBundle(),
+        );
         btnExitFocus.addEventListener("click", () => exitFocus());
 
         // Focus-mode orchestration (applyLayout, button-state hooks, focus
@@ -2420,6 +2435,9 @@ export class PreviewApp extends LitElement {
         }
         function requestLaunchOnDevice(): void {
             focusController.requestLaunchOnDevice();
+        }
+        function requestExportPreviewBundle(): void {
+            focusController.requestExportPreviewBundle();
         }
         function toggleA11yOverlay(): void {
             focusController.toggleA11yOverlay();


### PR DESCRIPTION
## Summary
Add support for exporting focused Compose previews as portable PNG+ZIP polyglot bundles. This feature is gated behind the early-features flag and integrates with the Gradle build system to render and package individual previews.

## Changes
- **Extension message handling**: Added `requestExportPreviewBundle` case to `handleWebviewMessage` that invokes the new `exportPreviewBundle` function when early features are enabled
- **Bundle export implementation**: New `exportPreviewBundle` function that:
  - Resolves the module for the focused preview
  - Prompts user for save location via file dialog
  - Runs `renderPreviews` and `composePreviewBundle` Gradle tasks with appropriate preview ID and output path parameters
  - Shows progress notification and success/error toasts
  - Offers to reveal the exported file in OS file explorer
- **Gradle service integration**: New `exportPreviewBundle` method in `GradleService` that orchestrates the two-step Gradle task execution with bundle-specific parameters
- **UI components**: 
  - Added "Export bundle" button to focus toolbar (package icon, hidden by default)
  - Wired button click handler to trigger the export flow
  - Updated focus toolbar controller and elements interface to include the new button
- **Type definitions**: Added `requestExportPreviewBundle` command type to `WebviewToExtension` union with documentation
- **Focus controller**: New `requestExportPreviewBundle` method that validates early-features flag and focused preview state before posting message to extension

## Implementation Details
- The exported file is a valid PNG image that also unzips to reveal bundle contents (PNG+ZIP polyglot format)
- Default save location is `<module>/build/compose-previews/<preview-name>.bundle.png`
- Preview label is sanitized for use as filename (non-alphanumeric characters replaced with underscores)
- Feature is only available when early features are enabled and a preview is in focus

https://claude.ai/code/session_018CmvWsnkYC9D2pmX62sMpX