### PR TITLE
feat: add data extension progress tracking and doctor report

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -85,6 +85,12 @@
                 "category": "Compose Preview"
             },
             {
+                "command": "composePreview.copyDoctorReport",
+                "title": "Copy Doctor Report (for bug reports)",
+                "category": "Compose Preview",
+                "icon": "$(report)"
+            },
+            {
                 "command": "composePreview.restartDaemon",
                 "title": "Restart Preview Daemon (pick up rebuilt JAR)",
                 "category": "Compose Preview"
@@ -114,6 +120,11 @@
                     "command": "composePreview.refresh",
                     "when": "view == composePreview.panel",
                     "group": "navigation@2"
+                },
+                {
+                    "command": "composePreview.copyDoctorReport",
+                    "when": "view == composePreview.panel",
+                    "group": "navigation@3"
                 }
             ]
         },

--- a/vscode-extension/src/dataExtensionProgress.ts
+++ b/vscode-extension/src/dataExtensionProgress.ts
@@ -1,0 +1,305 @@
+// Tracks the in-flight window between "user enables a data extension in the
+// focus inspector" and "the daemon attaches the first matching data product
+// on a render." Without a visible indicator, non-a11y extension toggles
+// (recomposition, AI trace, display filters) appear inert until the next save
+// triggers a refresh. The tracker drives:
+//
+//   - the slim progress bar at the top of the preview panel (an indeterminate
+//     ease-out curve while at least one kind is pending — only painted when no
+//     real refresh is driving the bar, since refresh progress carries richer
+//     phase information),
+//   - a VS Code status-bar item summarising activity across all panels, and
+//   - a safety timeout per preview that, when it expires, fires a diagnostic
+//     callback so the extension can dump daemon state into the output channel.
+//
+// All timer / clock dependencies are injected so the unit tests can drive the
+// tracker deterministically (see `test/dataExtensionProgress.test.ts`).
+
+export interface ProgressPost {
+    label: string;
+    percent: number;
+}
+
+export interface StatusSummary {
+    pendingPreviewCount: number;
+    pendingKindCount: number;
+    /** Distinct kinds across all pending entries (sorted, deduplicated). */
+    kinds: readonly string[];
+}
+
+export interface DataExtensionPendingDiagnostics {
+    previewId: string;
+    moduleId: string;
+    kinds: readonly string[];
+    elapsedMs: number;
+}
+
+export interface DataExtensionTrackerScheduler {
+    setTimeout: (cb: () => void, ms: number) => unknown;
+    clearTimeout: (handle: unknown) => void;
+    setInterval: (cb: () => void, ms: number) => unknown;
+    clearInterval: (handle: unknown) => void;
+}
+
+export interface DataExtensionTrackerOptions {
+    /** Safety window before we declare the subscribe stuck. Default 30_000 ms. */
+    timeoutMs?: number;
+    /** Ease-out span for the indeterminate progress. Default 6_000 ms. */
+    easeMs?: number;
+    /** Tick interval for the progress curve. Default 250 ms. */
+    tickIntervalMs?: number;
+    /** Called when the panel slim progress bar should update. The caller is
+     *  responsible for suppressing the post when a real refresh is mid-flight. */
+    onProgress: (post: ProgressPost) => void;
+    /** Called when the panel slim progress bar should clear (no pending work). */
+    onClear: () => void;
+    /** Called whenever the pending set changes. `null` means no active work. */
+    onStatus: (summary: StatusSummary | null) => void;
+    /** Fired exactly once per pending entry when its timeout expires. The
+     *  caller is responsible for assembling a richer diagnostic dump (daemon
+     *  state, capability snapshot, etc.). The tracker still clears the entry
+     *  after firing so a stuck subscribe doesn't pin the UI forever. */
+    onTimeout: (diag: DataExtensionPendingDiagnostics) => void;
+    now?: () => number;
+    scheduler?: DataExtensionTrackerScheduler;
+}
+
+interface PendingEntry {
+    previewId: string;
+    moduleId: string;
+    kinds: Set<string>;
+    startedAt: number;
+    timeout: unknown | null;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_EASE_MS = 6_000;
+const DEFAULT_TICK_INTERVAL_MS = 250;
+const START_PERCENT = 0.08;
+const MAX_PERCENT = 0.88;
+
+const defaultScheduler: DataExtensionTrackerScheduler = {
+    setTimeout: (cb, ms) => setTimeout(cb, ms),
+    clearTimeout: (h) => clearTimeout(h as ReturnType<typeof setTimeout>),
+    setInterval: (cb, ms) => setInterval(cb, ms),
+    clearInterval: (h) => clearInterval(h as ReturnType<typeof setInterval>),
+};
+
+export class DataExtensionProgressTracker {
+    private readonly pending = new Map<string, PendingEntry>();
+    private ticker: unknown | null = null;
+    private readonly timeoutMs: number;
+    private readonly easeMs: number;
+    private readonly tickIntervalMs: number;
+    private readonly now: () => number;
+    private readonly scheduler: DataExtensionTrackerScheduler;
+    private disposed = false;
+
+    constructor(private readonly opts: DataExtensionTrackerOptions) {
+        this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+        this.easeMs = opts.easeMs ?? DEFAULT_EASE_MS;
+        this.tickIntervalMs = opts.tickIntervalMs ?? DEFAULT_TICK_INTERVAL_MS;
+        this.now = opts.now ?? Date.now;
+        this.scheduler = opts.scheduler ?? defaultScheduler;
+    }
+
+    begin(previewId: string, moduleId: string, kinds: readonly string[]): void {
+        if (this.disposed) return;
+        const additions = kinds.filter((k) => k.length > 0);
+        if (additions.length === 0) return;
+        let entry = this.pending.get(previewId);
+        if (!entry) {
+            entry = {
+                previewId,
+                moduleId,
+                kinds: new Set(additions),
+                startedAt: this.now(),
+                timeout: null,
+            };
+            this.pending.set(previewId, entry);
+        } else {
+            for (const k of additions) entry.kinds.add(k);
+            // Reset the elapsed clock when fresh kinds are added so a slow
+            // second subscribe doesn't ride the first one's already-running
+            // timeout. Keeps the safety window honest per chip-toggle batch.
+            entry.startedAt = this.now();
+        }
+        this.armTimeout(entry);
+        this.startTicker();
+        this.emitStatus();
+        this.emitProgress();
+    }
+
+    resolve(previewId: string, kinds: readonly string[]): void {
+        if (this.disposed) return;
+        const entry = this.pending.get(previewId);
+        if (!entry) return;
+        for (const k of kinds) entry.kinds.delete(k);
+        if (entry.kinds.size === 0) {
+            this.dropEntry(previewId);
+        } else {
+            this.emitStatus();
+        }
+    }
+
+    clearAll(): void {
+        if (this.disposed) return;
+        const ids = [...this.pending.keys()];
+        for (const id of ids) this.dropEntry(id, { silent: true });
+        this.stopTicker();
+        this.opts.onStatus(null);
+        this.opts.onClear();
+    }
+
+    snapshot(): readonly DataExtensionPendingDiagnostics[] {
+        const at = this.now();
+        const out: DataExtensionPendingDiagnostics[] = [];
+        for (const e of this.pending.values()) {
+            out.push({
+                previewId: e.previewId,
+                moduleId: e.moduleId,
+                kinds: [...e.kinds].sort(),
+                elapsedMs: at - e.startedAt,
+            });
+        }
+        return out;
+    }
+
+    get size(): number {
+        return this.pending.size;
+    }
+
+    dispose(): void {
+        if (this.disposed) return;
+        this.disposed = true;
+        this.stopTicker();
+        for (const e of this.pending.values()) {
+            if (e.timeout) this.scheduler.clearTimeout(e.timeout);
+        }
+        this.pending.clear();
+    }
+
+    private armTimeout(entry: PendingEntry): void {
+        if (entry.timeout) this.scheduler.clearTimeout(entry.timeout);
+        entry.timeout = this.scheduler.setTimeout(() => {
+            const live = this.pending.get(entry.previewId);
+            if (!live || live !== entry) return;
+            const diag: DataExtensionPendingDiagnostics = {
+                previewId: entry.previewId,
+                moduleId: entry.moduleId,
+                kinds: [...entry.kinds].sort(),
+                elapsedMs: this.now() - entry.startedAt,
+            };
+            // Drop the entry first so the diagnostic callback sees a clean
+            // tracker state (snapshot() during onTimeout won't include the
+            // expiring entry — its data is in `diag` already).
+            this.dropEntry(entry.previewId, { silent: true });
+            this.opts.onTimeout(diag);
+            // Re-emit status / clear AFTER onTimeout so the callback can read
+            // tracker.size === 0 reliably if it wants to.
+            this.emitStatus();
+            if (this.pending.size === 0) {
+                this.stopTicker();
+                this.opts.onClear();
+            }
+        }, this.timeoutMs);
+    }
+
+    private dropEntry(previewId: string, opts?: { silent?: boolean }): void {
+        const entry = this.pending.get(previewId);
+        if (!entry) return;
+        if (entry.timeout) this.scheduler.clearTimeout(entry.timeout);
+        this.pending.delete(previewId);
+        if (opts?.silent) return;
+        if (this.pending.size === 0) {
+            this.stopTicker();
+            this.opts.onClear();
+            this.opts.onStatus(null);
+        } else {
+            this.emitStatus();
+        }
+    }
+
+    private startTicker(): void {
+        if (this.ticker !== null) return;
+        this.ticker = this.scheduler.setInterval(
+            () => this.emitProgress(),
+            this.tickIntervalMs,
+        );
+    }
+
+    private stopTicker(): void {
+        if (this.ticker === null) return;
+        this.scheduler.clearInterval(this.ticker);
+        this.ticker = null;
+    }
+
+    private emitProgress(): void {
+        if (this.pending.size === 0) return;
+        // Track the entry that's been waiting the longest — that's the one
+        // the user is most likely watching, and its elapsed time is the
+        // honest signal for the bar's fill.
+        let oldestAt = Number.POSITIVE_INFINITY;
+        let oldest: PendingEntry | null = null;
+        const allKinds = new Set<string>();
+        for (const e of this.pending.values()) {
+            if (e.startedAt < oldestAt) {
+                oldestAt = e.startedAt;
+                oldest = e;
+            }
+            for (const k of e.kinds) allKinds.add(k);
+        }
+        if (!oldest) return;
+        const elapsed = Math.max(0, this.now() - oldestAt);
+        const ratio = 1 - Math.exp(-elapsed / this.easeMs);
+        const percent = clamp01(
+            START_PERCENT + (MAX_PERCENT - START_PERCENT) * ratio,
+        );
+        const kinds = [...allKinds].sort();
+        const label = formatLabel(kinds, this.pending.size);
+        this.opts.onProgress({ label, percent });
+    }
+
+    private emitStatus(): void {
+        if (this.pending.size === 0) {
+            this.opts.onStatus(null);
+            return;
+        }
+        const allKinds = new Set<string>();
+        for (const e of this.pending.values()) {
+            for (const k of e.kinds) allKinds.add(k);
+        }
+        const kinds = [...allKinds].sort();
+        this.opts.onStatus({
+            pendingPreviewCount: this.pending.size,
+            pendingKindCount: kinds.length,
+            kinds,
+        });
+    }
+}
+
+export function formatLabel(
+    kinds: readonly string[],
+    previewCount: number,
+): string {
+    const display = kinds.slice(0, 2).map(displayKind);
+    if (kinds.length > 2) display.push(`+${kinds.length - 2} more`);
+    const subject = display.join(", ") || "data extension";
+    if (previewCount > 1) {
+        return `Loading ${subject} (${previewCount} previews)`;
+    }
+    return `Loading ${subject}`;
+}
+
+function displayKind(kind: string): string {
+    // Kinds use `category/name` slashes; the short tail is more recognisable
+    // in a compact label than the full `a11y/atf` token. Keeps "a11y" out of
+    // a label like "Loading atf, hierarchy" still useful because the chip
+    // group above the panel already shows the family.
+    const slash = kind.indexOf("/");
+    return slash >= 0 ? kind.slice(slash + 1) : kind;
+}
+
+function clamp01(n: number): number {
+    return Math.max(0, Math.min(1, n));
+}

--- a/vscode-extension/src/doctorReport.ts
+++ b/vscode-extension/src/doctorReport.ts
@@ -1,0 +1,184 @@
+// Assembles a Markdown "Doctor Report" that bundles the per-module doctor
+// findings (which are also surfaced as build-file diagnostics by
+// `PreviewDoctorDiagnostics`) with environment, daemon, and capability data
+// the user is otherwise unlikely to know to copy from settings. The output is
+// intended to be pasted directly into a GitHub issue — the goal is "less
+// back-and-forth on the bug tracker," not a structured machine artefact.
+
+import type { DoctorModuleReport } from "./types";
+
+export interface DoctorReportEnvironment {
+    extensionVersion: string;
+    extensionPath: string;
+    vscodeVersion: string;
+    platform: string;
+    osRelease: string;
+    nodeVersion: string;
+    arch: string;
+    workspaceRoot: string;
+    mode: string;
+    earlyFeaturesEnabled: boolean;
+    loggingLevel: string;
+}
+
+export interface DoctorReportModule {
+    modulePath: string;
+    projectDir: string;
+    pluginApplied: boolean;
+    daemonReady: boolean;
+    daemonInteractive: boolean;
+    dataProducts: { kind: string; transport: string; schemaVersion: number }[];
+    dataExtensions: { id: string; displayName?: string }[];
+    /** `null` means the doctor task isn't available for this module (older
+     *  plugin, or `enabled = false` in the daemon descriptor). */
+    doctor: DoctorModuleReport | null;
+    /** `null` means the call succeeded — otherwise the captured error message. */
+    doctorError: string | null;
+}
+
+export interface DoctorReportPendingExtension {
+    previewId: string;
+    moduleId: string;
+    kinds: readonly string[];
+    elapsedMs: number;
+}
+
+export interface DoctorReportInput {
+    generatedAt: Date;
+    environment: DoctorReportEnvironment;
+    modules: readonly DoctorReportModule[];
+    pendingDataExtensions: readonly DoctorReportPendingExtension[];
+    /** Free-form notes the host wants to attach (e.g. "doctor task skipped
+     *  because gradleService is offline"). One line each. */
+    notes?: readonly string[];
+}
+
+/** Render the report as GitHub-flavoured Markdown. */
+export function renderDoctorReport(input: DoctorReportInput): string {
+    const lines: string[] = [];
+    const env = input.environment;
+    lines.push("# Compose Preview — Doctor Report");
+    lines.push("");
+    lines.push(`Generated: ${input.generatedAt.toISOString()}`);
+    lines.push("");
+    lines.push("## Environment");
+    lines.push("");
+    lines.push(`- Extension version: \`${env.extensionVersion}\``);
+    lines.push(`- Extension path: \`${env.extensionPath}\``);
+    lines.push(`- VS Code version: \`${env.vscodeVersion}\``);
+    lines.push(
+        `- Platform: \`${env.platform}\` (${env.osRelease}, ${env.arch})`,
+    );
+    lines.push(`- Node: \`${env.nodeVersion}\``);
+    lines.push(`- Workspace: \`${env.workspaceRoot}\``);
+    lines.push(`- Mode: \`${env.mode}\``);
+    lines.push(`- Early features: \`${env.earlyFeaturesEnabled}\``);
+    lines.push(`- Logging level: \`${env.loggingLevel}\``);
+    lines.push("");
+
+    if (input.modules.length === 0) {
+        lines.push("## Modules");
+        lines.push("");
+        lines.push(
+            "_No preview-eligible modules were detected in this workspace._",
+        );
+        lines.push("");
+    } else {
+        lines.push(`## Modules (${input.modules.length})`);
+        lines.push("");
+        for (const m of input.modules) {
+            lines.push(`### \`${m.modulePath}\``);
+            lines.push("");
+            lines.push(`- Project dir: \`${m.projectDir}\``);
+            lines.push(`- Plugin applied: \`${m.pluginApplied}\``);
+            lines.push(`- Daemon ready: \`${m.daemonReady}\``);
+            lines.push(`- Daemon interactive: \`${m.daemonInteractive}\``);
+            if (m.dataProducts.length === 0) {
+                lines.push("- Data products: _(none advertised)_");
+            } else {
+                lines.push("- Data products:");
+                for (const p of m.dataProducts) {
+                    lines.push(
+                        `    - \`${p.kind}\` (transport=${p.transport}, schema=${p.schemaVersion})`,
+                    );
+                }
+            }
+            if (m.dataExtensions.length === 0) {
+                lines.push("- Data extensions: _(none advertised)_");
+            } else {
+                lines.push("- Data extensions:");
+                for (const e of m.dataExtensions) {
+                    const label = e.displayName
+                        ? `\`${e.id}\` — ${e.displayName}`
+                        : `\`${e.id}\``;
+                    lines.push(`    - ${label}`);
+                }
+            }
+            if (m.doctorError) {
+                lines.push(`- Doctor: ⚠️ failed — \`${m.doctorError}\``);
+            } else if (!m.doctor) {
+                lines.push("- Doctor: _(not available for this module)_");
+            } else if (m.doctor.findings.length === 0) {
+                lines.push("- Doctor: ✅ no findings");
+            } else {
+                lines.push(
+                    `- Doctor (variant \`${m.doctor.variant}\`, schema \`${m.doctor.schema}\`): ${m.doctor.findings.length} finding(s)`,
+                );
+                for (const f of m.doctor.findings) {
+                    const sev = severityIcon(f.severity);
+                    lines.push(`    - ${sev} **${f.id}** — ${f.message}`);
+                    if (f.detail) {
+                        lines.push(`        - ${oneLine(f.detail)}`);
+                    }
+                    if (f.remediationSummary) {
+                        lines.push(`        - → ${f.remediationSummary}`);
+                    }
+                    for (const cmd of f.remediationCommands ?? []) {
+                        lines.push(`            \`${cmd}\``);
+                    }
+                    if (f.docsUrl) {
+                        lines.push(`        - docs: ${f.docsUrl}`);
+                    }
+                }
+            }
+            lines.push("");
+        }
+    }
+
+    lines.push("## Pending data extensions");
+    lines.push("");
+    if (input.pendingDataExtensions.length === 0) {
+        lines.push("_None — no data extensions are awaiting first arrival._");
+    } else {
+        for (const p of input.pendingDataExtensions) {
+            lines.push(
+                `- \`${p.previewId}\` (\`${p.moduleId}\`, ${Math.round(p.elapsedMs / 100) / 10}s waiting): kinds=[${p.kinds.map((k) => `\`${k}\``).join(", ")}]`,
+            );
+        }
+    }
+    lines.push("");
+
+    if (input.notes && input.notes.length > 0) {
+        lines.push("## Notes");
+        lines.push("");
+        for (const n of input.notes) lines.push(`- ${oneLine(n)}`);
+        lines.push("");
+    }
+
+    lines.push("---");
+    lines.push(
+        "_Generated by the Compose Preview extension. Paste this into a GitHub issue at https://github.com/yschimke/compose-ai-tools/issues — redact any private paths or repository names you don't want to share._",
+    );
+    return lines.join("\n");
+}
+
+function severityIcon(severity: string): string {
+    if (severity === "error") return "❌";
+    if (severity === "warning") return "⚠️";
+    if (severity === "info") return "ℹ️";
+    return `\`${severity}\``;
+}
+
+function oneLine(s: string): string {
+    return s.replace(/\s+/g, " ").trim();
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3024,9 +3024,20 @@ async function assembleDoctorReport(
         const snap =
             daemonGate?.getCapabilitiesSnapshot(module.modulePath) ?? null;
         let doctor = null;
+        // `runDoctor` swallows task / parse failures and returns null — the
+        // production caller (`PreviewDoctorDiagnostics`) prefers a quiet
+        // skip. For the bug-report path we want the opposite: surface the
+        // failure message so the user sees "Doctor: ⚠️ failed — ..." rather
+        // than "_(not available for this module)_", which is the most useful
+        // debugging signal in a bug report. The onError callback is the
+        // explicit handoff for that case. `runTask` itself doesn't throw
+        // past `runDoctor`, but the try/catch stays as a defensive backstop
+        // in case the contract ever changes.
         let doctorError: string | null = null;
         try {
-            doctor = await gs.runDoctor(module);
+            doctor = await gs.runDoctor(module, (msg) => {
+                doctorError = msg;
+            });
         } catch (err) {
             doctorError = (err as Error)?.message ?? String(err);
         }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -67,6 +67,16 @@ import {
     PhaseDurations,
 } from "./buildProgress";
 import {
+    DataExtensionPendingDiagnostics,
+    DataExtensionProgressTracker,
+    StatusSummary as DataExtensionStatusSummary,
+} from "./dataExtensionProgress";
+import {
+    DoctorReportInput,
+    DoctorReportModule,
+    renderDoctorReport,
+} from "./doctorReport";
+import {
     CompileError,
     extractCompileErrors,
     DiagnosticLike,
@@ -110,6 +120,20 @@ let daemonScheduler: DaemonScheduler | null = null;
 let daemonStatusItem: vscode.StatusBarItem | null = null;
 let interactiveStatusItem: vscode.StatusBarItem | null = null;
 let daemonStatusClearTimer: NodeJS.Timeout | null = null;
+/** Indicator for "data extension subscribed, first payload not yet received."
+ *  Lives in the VS Code status bar so the signal is visible even when the
+ *  Compose Preview panel isn't focused. Hidden when no kinds are pending. */
+let dataExtensionStatusItem: vscode.StatusBarItem | null = null;
+/** Tracker for the in-flight `data/subscribe` → `onDataProductsAttached`
+ *  window. Constructed in activate() so the timer callbacks are bound to
+ *  the live `panel` / `outputChannel` references. See dataExtensionProgress.ts. */
+let dataExtensionTracker: DataExtensionProgressTracker | null = null;
+/** Unfiltered emitter onto the "Compose Preview" output channel. Used by
+ *  failure-data dumps (data-extension safety timeout, doctor report) that
+ *  must surface regardless of `composePreview.logging.level`. */
+let logForce: (msg: string) => void = () => {
+    /* noop pre-activate */
+};
 /** Owned by activate(); reused by the live panel's focus-mode diff handler. */
 let historySource: HistorySource | null = null;
 /**
@@ -594,6 +618,12 @@ export async function activate(
             outputChannel.appendLine(msg);
         }
     };
+    // Bypasses `composePreview.logging.level` so failure-data dumps survive
+    // even on `quiet`. Use sparingly — reserved for diagnostics the user is
+    // expected to copy when filing a bug.
+    logForce = (msg: string) => {
+        outputChannel.appendLine(msg);
+    };
 
     // Startup fingerprint — answers "is the build I think I installed
     // actually loaded?" when triaging a save-loop bug. The extension version
@@ -783,6 +813,17 @@ export async function activate(
                                           `${dp.kind}:${dp.payload !== undefined ? "inline" : dp.path ? "path" : "empty"}`,
                                   )
                                   .join(",")}]`,
+                          );
+                          // First payload for a just-enabled kind clears
+                          // the panel progress bar / status item that the
+                          // chip toggle armed. Resolving with the actual
+                          // attached kinds means a partial attach (some
+                          // kinds arrived, others haven't) keeps the
+                          // remaining ones in the pending set until they
+                          // arrive or the safety timeout fires.
+                          dataExtensionTracker?.resolve(
+                              previewId,
+                              dataProducts.map((dp) => dp.kind),
                           );
                           const decoded = applyDataProductsToRegistry(
                               registry,
@@ -1025,6 +1066,45 @@ export async function activate(
     );
     interactiveStatusItem.command = "workbench.action.output.toggleOutput";
     context.subscriptions.push(interactiveStatusItem);
+
+    // Visible only while at least one data extension is awaiting its first
+    // payload. Click opens the output channel — useful when the entry has
+    // since timed out and the user wants to see the diagnostic dump.
+    dataExtensionStatusItem = vscode.window.createStatusBarItem(
+        vscode.StatusBarAlignment.Left,
+        88,
+    );
+    dataExtensionStatusItem.command = "workbench.action.output.toggleOutput";
+    context.subscriptions.push(dataExtensionStatusItem);
+    dataExtensionTracker = new DataExtensionProgressTracker({
+        onProgress: (post) => {
+            // Don't fight a real refresh for the slim bar — its phase labels
+            // ("Compiling Kotlin", "Rendering previews") carry richer info
+            // than ours and are already calibrated against module history.
+            // The status-bar item still reflects the data-extension activity
+            // so the signal isn't lost.
+            if (refreshInFlight) return;
+            panel?.postMessage({
+                command: "setProgress",
+                phase: "dataExtension",
+                label: post.label,
+                percent: post.percent,
+                slow: false,
+            });
+        },
+        onClear: () => {
+            if (refreshInFlight) return;
+            panel?.postMessage({ command: "clearProgress" });
+        },
+        onStatus: (summary) => applyDataExtensionStatus(summary),
+        onTimeout: (diag) => emitDataExtensionTimeoutDiagnostics(diag),
+    });
+    context.subscriptions.push({
+        dispose: () => {
+            dataExtensionTracker?.dispose();
+            dataExtensionTracker = null;
+        },
+    });
 
     // In test mode we wrap the webview-message handler so the test API can
     // also assert on inbound traffic (e.g. `webviewPreviewsRendered`, which
@@ -1313,6 +1393,35 @@ export async function activate(
         }
         await doctorDiagnostics.refresh(gradleService.findPreviewModules());
     };
+    const buildAndShowDoctorReport = async () => {
+        if (!gradleService) {
+            void vscode.window.showWarningMessage(
+                "Compose Preview: Gradle service not ready yet — try again after activation finishes.",
+            );
+            return;
+        }
+        await refreshDoctor();
+        const report = await assembleDoctorReport(
+            gradleService,
+            extVersion,
+            extPath,
+            workspaceRoot,
+        );
+        logForce(report);
+        // Markdown untitled doc — VS Code's preview-on-the-side flow gives
+        // the user a one-click "open preview" and a fully selectable buffer
+        // for copying. Clipboard is also primed so a copy-paste into a
+        // GitHub issue works without scrolling.
+        await vscode.env.clipboard.writeText(report);
+        const doc = await vscode.workspace.openTextDocument({
+            content: report,
+            language: "markdown",
+        });
+        await vscode.window.showTextDocument(doc, { preview: false });
+        void vscode.window.showInformationMessage(
+            "Doctor report copied to clipboard and opened as a Markdown doc. Paste into a GitHub issue if you're filing one.",
+        );
+    };
     context.subscriptions.push(
         vscode.commands.registerCommand("composePreview.runDoctor", () => {
             void vscode.window.withProgress(
@@ -1323,6 +1432,18 @@ export async function activate(
                 refreshDoctor,
             );
         }),
+        vscode.commands.registerCommand(
+            "composePreview.copyDoctorReport",
+            () => {
+                void vscode.window.withProgress(
+                    {
+                        location: vscode.ProgressLocation.Window,
+                        title: "Building Compose Preview doctor report…",
+                    },
+                    buildAndShowDoctorReport,
+                );
+            },
+        ),
         vscode.commands.registerCommand("composePreview.diffAllVsMain", () =>
             diffAllVsMain(),
         ),
@@ -2814,6 +2935,156 @@ function updateDaemonStatus(module: ModuleInfo, state: WarmState): void {
             );
             break;
     }
+}
+
+function applyDataExtensionStatus(
+    summary: DataExtensionStatusSummary | null,
+): void {
+    const item = dataExtensionStatusItem;
+    if (!item) return;
+    if (!summary) {
+        item.hide();
+        return;
+    }
+    const subjectKinds = summary.kinds.slice(0, 3).join(", ");
+    const more =
+        summary.kinds.length > 3 ? ` +${summary.kinds.length - 3}` : "";
+    const previewSuffix =
+        summary.pendingPreviewCount > 1
+            ? ` × ${summary.pendingPreviewCount}`
+            : "";
+    item.text = `$(loading~spin) ${subjectKinds}${more}${previewSuffix}`;
+    item.tooltip =
+        "Compose Preview: waiting for data extension payloads. " +
+        `Pending kinds: ${summary.kinds.join(", ") || "(unknown)"}. ` +
+        "Click to open the Compose Preview output channel.";
+    item.show();
+}
+
+function emitDataExtensionTimeoutDiagnostics(
+    diag: DataExtensionPendingDiagnostics,
+): void {
+    const lines: string[] = [];
+    lines.push(
+        `[data-extension-timeout] previewId=${diag.previewId} module=${diag.moduleId} ` +
+            `elapsedMs=${diag.elapsedMs} kinds=[${diag.kinds.join(",")}]`,
+    );
+    const moduleReady = daemonGate?.isDaemonReady(diag.moduleId) ?? false;
+    lines.push(
+        `    daemonReady=${moduleReady} refreshInFlight=${refreshInFlight}`,
+    );
+    const snap = daemonGate?.getCapabilitiesSnapshot(diag.moduleId);
+    if (!snap) {
+        lines.push(
+            "    capabilities: <none — daemon not initialised for this module>",
+        );
+    } else {
+        const advertisedKinds = new Set(snap.dataProducts.map((p) => p.kind));
+        const unsupported = diag.kinds.filter((k) => !advertisedKinds.has(k));
+        lines.push(
+            `    advertisedDataProducts=[${snap.dataProducts
+                .map((p) => `${p.kind}(transport=${p.transport})`)
+                .join(",")}]`,
+        );
+        lines.push(
+            `    advertisedDataExtensions=[${snap.dataExtensions.map((e) => e.id).join(",")}]`,
+        );
+        if (unsupported.length > 0) {
+            lines.push(
+                `    ⚠ unsupported (kind not advertised by daemon): [${unsupported.join(",")}]`,
+            );
+        }
+    }
+    const moduleInfo = gradleService?.findModuleByPath(diag.moduleId) ?? null;
+    if (!moduleInfo) {
+        lines.push(
+            `    moduleInfo: <not resolved — gradleService.findModuleByPath('${diag.moduleId}') returned null>`,
+        );
+    } else {
+        lines.push(`    moduleInfo: projectDir=${moduleInfo.projectDir}`);
+    }
+    lines.push(
+        "    Run `Compose Preview: Copy Doctor Report` for a full snapshot you can paste into a bug report.",
+    );
+    for (const line of lines) logForce(line);
+}
+
+async function assembleDoctorReport(
+    gs: GradleService,
+    extensionVersion: string,
+    extensionPath: string,
+    workspaceRoot: string,
+): Promise<string> {
+    const os = await import("node:os");
+    const config = vscode.workspace.getConfiguration("composePreview");
+    const modules = gs.findPreviewModules();
+    const reportModules: DoctorReportModule[] = [];
+    const notes: string[] = [];
+    for (const module of modules) {
+        const snap =
+            daemonGate?.getCapabilitiesSnapshot(module.modulePath) ?? null;
+        let doctor = null;
+        let doctorError: string | null = null;
+        try {
+            doctor = await gs.runDoctor(module);
+        } catch (err) {
+            doctorError = (err as Error)?.message ?? String(err);
+        }
+        reportModules.push({
+            modulePath: module.modulePath,
+            projectDir: module.projectDir,
+            pluginApplied: true,
+            daemonReady: daemonGate?.isDaemonReady(module.modulePath) ?? false,
+            daemonInteractive:
+                daemonGate?.isInteractiveSupported(module.modulePath) ?? false,
+            dataProducts:
+                snap?.dataProducts.map((p) => ({
+                    kind: p.kind,
+                    transport: p.transport,
+                    schemaVersion: p.schemaVersion,
+                })) ?? [],
+            dataExtensions:
+                snap?.dataExtensions.map((e) => ({
+                    id: e.id,
+                    displayName: e.displayName,
+                })) ?? [],
+            doctor,
+            doctorError,
+        });
+    }
+    const pending =
+        dataExtensionTracker?.snapshot().map((p) => ({
+            previewId: p.previewId,
+            moduleId: p.moduleId,
+            kinds: p.kinds,
+            elapsedMs: p.elapsedMs,
+        })) ?? [];
+    if (modules.length === 0) {
+        notes.push(
+            "No preview-eligible modules were found — make sure the Compose Preview Gradle plugin is applied to at least one module.",
+        );
+    }
+    const input: DoctorReportInput = {
+        generatedAt: new Date(),
+        environment: {
+            extensionVersion,
+            extensionPath,
+            vscodeVersion: vscode.version,
+            platform: process.platform,
+            osRelease: os.release(),
+            nodeVersion: process.version,
+            arch: process.arch,
+            workspaceRoot,
+            mode: config.get<string>("mode") ?? "<unset>",
+            earlyFeaturesEnabled:
+                config.get<boolean>("earlyFeatures.enabled") ?? false,
+            loggingLevel: config.get<string>("logging.level") ?? "<unset>",
+        },
+        modules: reportModules,
+        pendingDataExtensions: pending,
+        notes,
+    };
+    return renderDoctorReport(input);
 }
 
 /** Per-extension-session memo so bootstrap runs once per module. */
@@ -4343,6 +4614,18 @@ async function handleSetDataExtensionEnabled(
             enabled,
         );
         if (t !== "unchanged") a11yTransition = t;
+    }
+    // Start the progress indicator BEFORE awaiting the subscribe call so
+    // the user sees feedback the instant they click. The tracker resolves
+    // on `onDataProductsAttached`, on disable, or on its own safety timeout.
+    if (enabled) {
+        dataExtensionTracker?.begin(
+            previewId,
+            moduleId.modulePath,
+            filteredKinds,
+        );
+    } else {
+        dataExtensionTracker?.resolve(previewId, filteredKinds);
     }
     // Single subscription call so the wire sees `data/subscribe` per
     // kind followed by exactly one `renderNow`. Per-kind dispatch

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -426,15 +426,20 @@ export class GradleService {
      * wasn't produced. Callers should treat null as "skip doctor
      * diagnostics for this module", not as an empty finding set.
      */
-    async runDoctor(module: ModuleInfo): Promise<DoctorModuleReport | null> {
+    async runDoctor(
+        module: ModuleInfo,
+        onError?: (message: string) => void,
+    ): Promise<DoctorModuleReport | null> {
         const task = `${module.modulePath}:composePreviewDoctor`;
+        const fail = (message: string): null => {
+            this.logger.appendLine(`[doctor] ${message}`);
+            onError?.(message);
+            return null;
+        };
         try {
             await this.runTask(task);
         } catch (e) {
-            this.logger.appendLine(
-                `[doctor] ${task} failed: ${(e as Error).message}`,
-            );
-            return null;
+            return fail(`${task} failed: ${(e as Error).message}`);
         }
         const reportPath = path.join(
             this.workspaceRoot,
@@ -444,25 +449,22 @@ export class GradleService {
             "doctor.json",
         );
         if (!fs.existsSync(reportPath)) {
-            this.logger.appendLine(`[doctor] ${reportPath} not produced`);
-            return null;
+            return fail(`${reportPath} not produced`);
         }
         try {
             const parsed = JSON.parse(
                 fs.readFileSync(reportPath, "utf-8"),
             ) as DoctorModuleReport;
             if (!parsed.schema?.startsWith("compose-preview-doctor/")) {
-                this.logger.appendLine(
-                    `[doctor] unexpected schema in ${reportPath}: ${parsed.schema}`,
+                return fail(
+                    `unexpected schema in ${reportPath}: ${parsed.schema}`,
                 );
-                return null;
             }
             return parsed;
         } catch (e) {
-            this.logger.appendLine(
-                `[doctor] parse failed for ${reportPath}: ${(e as Error).message}`,
+            return fail(
+                `parse failed for ${reportPath}: ${(e as Error).message}`,
             );
-            return null;
         }
     }
 

--- a/vscode-extension/src/test/dataExtensionProgress.test.ts
+++ b/vscode-extension/src/test/dataExtensionProgress.test.ts
@@ -1,0 +1,239 @@
+import * as assert from "assert";
+import {
+    DataExtensionPendingDiagnostics,
+    DataExtensionProgressTracker,
+    ProgressPost,
+    StatusSummary,
+    formatLabel,
+} from "../dataExtensionProgress";
+
+/** Deterministic clock + scheduler shared with the buildProgress test idea —
+ *  exposes `setTimeout` in addition to `setInterval` so we can fire safety
+ *  timeouts on demand. */
+class FakeClock {
+    private t = 0;
+    private intervals: { interval: number; nextAt: number; cb: () => void }[] =
+        [];
+    private timeouts: { firesAt: number; cb: () => void }[] = [];
+    now = (): number => this.t;
+    setInterval = (cb: () => void, ms: number): unknown => {
+        const handle = { interval: ms, nextAt: this.t + ms, cb };
+        this.intervals.push(handle);
+        return handle;
+    };
+    clearInterval = (handle: unknown): void => {
+        this.intervals = this.intervals.filter((h) => h !== handle);
+    };
+    setTimeout = (cb: () => void, ms: number): unknown => {
+        const handle = { firesAt: this.t + ms, cb };
+        this.timeouts.push(handle);
+        return handle;
+    };
+    clearTimeout = (handle: unknown): void => {
+        this.timeouts = this.timeouts.filter((h) => h !== handle);
+    };
+    advance(ms: number): void {
+        const target = this.t + ms;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            const nextInterval = this.intervals
+                .filter((h) => h.nextAt <= target)
+                .sort((a, b) => a.nextAt - b.nextAt)[0];
+            const nextTimeout = this.timeouts
+                .filter((h) => h.firesAt <= target)
+                .sort((a, b) => a.firesAt - b.firesAt)[0];
+            const interT = nextInterval?.nextAt ?? Number.POSITIVE_INFINITY;
+            const timeT = nextTimeout?.firesAt ?? Number.POSITIVE_INFINITY;
+            if (
+                interT === Number.POSITIVE_INFINITY &&
+                timeT === Number.POSITIVE_INFINITY
+            ) {
+                break;
+            }
+            if (timeT <= interT) {
+                this.t = nextTimeout!.firesAt;
+                const cb = nextTimeout!.cb;
+                this.timeouts = this.timeouts.filter((h) => h !== nextTimeout);
+                cb();
+            } else {
+                this.t = nextInterval!.nextAt;
+                nextInterval!.nextAt += nextInterval!.interval;
+                nextInterval!.cb();
+            }
+        }
+        this.t = target;
+    }
+}
+
+interface Capture {
+    progress: ProgressPost[];
+    clears: number;
+    statuses: (StatusSummary | null)[];
+    timeouts: DataExtensionPendingDiagnostics[];
+}
+
+function makeTracker(
+    clock: FakeClock,
+    overrides: { timeoutMs?: number; easeMs?: number } = {},
+): {
+    tracker: DataExtensionProgressTracker;
+    capture: Capture;
+} {
+    const capture: Capture = {
+        progress: [],
+        clears: 0,
+        statuses: [],
+        timeouts: [],
+    };
+    const tracker = new DataExtensionProgressTracker({
+        timeoutMs: overrides.timeoutMs ?? 5_000,
+        easeMs: overrides.easeMs ?? 1_000,
+        tickIntervalMs: 100,
+        onProgress: (p) => capture.progress.push({ ...p }),
+        onClear: () => {
+            capture.clears += 1;
+        },
+        onStatus: (s) =>
+            capture.statuses.push(s ? { ...s, kinds: [...s.kinds] } : null),
+        onTimeout: (d) => capture.timeouts.push(d),
+        now: clock.now,
+        scheduler: {
+            setInterval: clock.setInterval,
+            clearInterval: clock.clearInterval,
+            setTimeout: clock.setTimeout,
+            clearTimeout: clock.clearTimeout,
+        },
+    });
+    return { tracker, capture };
+}
+
+describe("DataExtensionProgressTracker", () => {
+    it("emits status and progress when a pending entry is registered", () => {
+        const clock = new FakeClock();
+        const { tracker, capture } = makeTracker(clock);
+        tracker.begin("Preview#one", ":samples:android", ["a11y/atf"]);
+        assert.strictEqual(tracker.size, 1);
+        assert.ok(capture.progress.length > 0, "initial progress emitted");
+        assert.strictEqual(capture.progress[0].label, "Loading atf");
+        assert.ok(capture.progress[0].percent > 0);
+        assert.deepStrictEqual(capture.statuses.at(-1), {
+            pendingPreviewCount: 1,
+            pendingKindCount: 1,
+            kinds: ["a11y/atf"],
+        });
+    });
+
+    it("clears the bar when the matching data product arrives", () => {
+        const clock = new FakeClock();
+        const { tracker, capture } = makeTracker(clock);
+        tracker.begin("Preview#one", ":samples:android", [
+            "a11y/atf",
+            "a11y/hierarchy",
+        ]);
+        tracker.resolve("Preview#one", ["a11y/atf"]);
+        assert.strictEqual(tracker.size, 1, "still pending the other kind");
+        assert.strictEqual(capture.clears, 0);
+        tracker.resolve("Preview#one", ["a11y/hierarchy"]);
+        assert.strictEqual(tracker.size, 0);
+        assert.strictEqual(capture.clears, 1);
+        assert.strictEqual(capture.statuses.at(-1), null);
+    });
+
+    it("advances the progress percent toward the cap as time passes", () => {
+        const clock = new FakeClock();
+        const { tracker, capture } = makeTracker(clock, { easeMs: 500 });
+        tracker.begin("Preview#one", ":m", ["compose/recomposition"]);
+        const initialPct = capture.progress.at(-1)!.percent;
+        clock.advance(2_000);
+        const laterPct = capture.progress.at(-1)!.percent;
+        assert.ok(
+            laterPct > initialPct,
+            `expected percent to grow: ${initialPct} -> ${laterPct}`,
+        );
+        assert.ok(laterPct < 1, `percent should remain bounded: ${laterPct}`);
+    });
+
+    it("fires the safety timeout and clears the entry", () => {
+        const clock = new FakeClock();
+        const { tracker, capture } = makeTracker(clock, { timeoutMs: 1_000 });
+        tracker.begin("Preview#stalled", ":m", ["a11y/atf"]);
+        clock.advance(1_001);
+        assert.strictEqual(capture.timeouts.length, 1);
+        assert.strictEqual(capture.timeouts[0].previewId, "Preview#stalled");
+        assert.deepStrictEqual(capture.timeouts[0].kinds, ["a11y/atf"]);
+        assert.ok(
+            capture.timeouts[0].elapsedMs >= 1_000,
+            "elapsedMs should reflect the wait",
+        );
+        assert.strictEqual(tracker.size, 0, "entry dropped after timeout");
+        assert.strictEqual(
+            capture.clears,
+            1,
+            "bar cleared once the last entry expires",
+        );
+    });
+
+    it("does not fire the safety timeout after a payload arrives", () => {
+        const clock = new FakeClock();
+        const { tracker, capture } = makeTracker(clock, { timeoutMs: 1_000 });
+        tracker.begin("Preview#fast", ":m", ["a11y/atf"]);
+        clock.advance(500);
+        tracker.resolve("Preview#fast", ["a11y/atf"]);
+        clock.advance(2_000);
+        assert.strictEqual(capture.timeouts.length, 0);
+    });
+
+    it("aggregates kinds and preview counts in the status summary", () => {
+        const clock = new FakeClock();
+        const { tracker, capture } = makeTracker(clock);
+        tracker.begin("Preview#one", ":m", ["a11y/atf"]);
+        tracker.begin("Preview#two", ":m", ["compose/recomposition"]);
+        const last = capture.statuses.at(-1)!;
+        assert.strictEqual(last.pendingPreviewCount, 2);
+        assert.deepStrictEqual(last.kinds, [
+            "a11y/atf",
+            "compose/recomposition",
+        ]);
+    });
+
+    it("resolve is a no-op when the previewId is unknown", () => {
+        const clock = new FakeClock();
+        const { tracker, capture } = makeTracker(clock);
+        tracker.resolve("Preview#never-began", ["a11y/atf"]);
+        assert.strictEqual(tracker.size, 0);
+        assert.strictEqual(capture.clears, 0);
+    });
+
+    it("snapshot exposes pending entries for diagnostic dumps", () => {
+        const clock = new FakeClock();
+        const { tracker } = makeTracker(clock);
+        tracker.begin("Preview#one", ":samples:android", [
+            "a11y/atf",
+            "a11y/hierarchy",
+        ]);
+        clock.advance(750);
+        const snap = tracker.snapshot();
+        assert.strictEqual(snap.length, 1);
+        assert.strictEqual(snap[0].previewId, "Preview#one");
+        assert.strictEqual(snap[0].moduleId, ":samples:android");
+        assert.deepStrictEqual(snap[0].kinds, ["a11y/atf", "a11y/hierarchy"]);
+        assert.ok(snap[0].elapsedMs >= 750);
+    });
+});
+
+describe("formatLabel", () => {
+    it("uses the kind tail and pluralises for multi-preview activity", () => {
+        assert.strictEqual(formatLabel(["a11y/atf"], 1), "Loading atf");
+        assert.strictEqual(
+            formatLabel(["a11y/atf", "a11y/hierarchy"], 3),
+            "Loading atf, hierarchy (3 previews)",
+        );
+    });
+
+    it("truncates long kind lists with a +N more suffix", () => {
+        assert.strictEqual(
+            formatLabel(["a/one", "b/two", "c/three", "d/four"], 1),
+            "Loading one, two, +2 more",
+        );
+    });
+});

--- a/vscode-extension/src/test/doctorReport.test.ts
+++ b/vscode-extension/src/test/doctorReport.test.ts
@@ -1,0 +1,128 @@
+import * as assert from "assert";
+import { renderDoctorReport, DoctorReportInput } from "../doctorReport";
+
+function baseInput(): DoctorReportInput {
+    return {
+        generatedAt: new Date("2024-01-01T12:00:00Z"),
+        environment: {
+            extensionVersion: "0.1.0",
+            extensionPath: "/tmp/ext",
+            vscodeVersion: "1.85.0",
+            platform: "linux",
+            osRelease: "6.18.5",
+            nodeVersion: "v20.10.0",
+            arch: "x64",
+            workspaceRoot: "/repo",
+            mode: "full",
+            earlyFeaturesEnabled: false,
+            loggingLevel: "normal",
+        },
+        modules: [],
+        pendingDataExtensions: [],
+        notes: [],
+    };
+}
+
+describe("renderDoctorReport", () => {
+    it("includes environment data so support requests carry the basics", () => {
+        const out = renderDoctorReport(baseInput());
+        assert.ok(out.includes("Compose Preview — Doctor Report"));
+        assert.ok(out.includes("Extension version: `0.1.0`"));
+        assert.ok(out.includes("VS Code version: `1.85.0`"));
+        assert.ok(out.includes("Mode: `full`"));
+        assert.ok(out.includes("Logging level: `normal`"));
+    });
+
+    it("reports an empty-modules placeholder when no plugin is applied", () => {
+        const out = renderDoctorReport(baseInput());
+        assert.ok(
+            out.includes("No preview-eligible modules were detected"),
+            "empty-modules placeholder missing",
+        );
+    });
+
+    it("formats per-module doctor findings with severity and remediation", () => {
+        const input = baseInput();
+        input.modules = [
+            {
+                modulePath: ":samples:android",
+                projectDir: "samples/android",
+                pluginApplied: true,
+                daemonReady: true,
+                daemonInteractive: false,
+                dataProducts: [
+                    {
+                        kind: "a11y/atf",
+                        transport: "inline",
+                        schemaVersion: 1,
+                    },
+                ],
+                dataExtensions: [{ id: "a11y", displayName: "Accessibility" }],
+                doctor: {
+                    schema: "doctor/v1",
+                    module: ":samples:android",
+                    variant: "debug",
+                    findings: [
+                        {
+                            id: "robolectric-jar-stale",
+                            severity: "warning",
+                            message:
+                                "Robolectric jar is from an older Compose version.",
+                            detail: "Detected jar: foo.jar",
+                            remediationSummary: "Bump the dependency.",
+                            remediationCommands: [
+                                "./gradlew :app:dependencies",
+                            ],
+                            docsUrl: "https://example.com/docs",
+                        },
+                    ],
+                },
+                doctorError: null,
+            },
+        ];
+        const out = renderDoctorReport(input);
+        assert.ok(out.includes(":samples:android"));
+        assert.ok(out.includes("`a11y/atf`"));
+        assert.ok(out.includes("Accessibility"));
+        assert.ok(out.includes("⚠️ **robolectric-jar-stale**"));
+        assert.ok(out.includes("→ Bump the dependency."));
+        assert.ok(out.includes("`./gradlew :app:dependencies`"));
+        assert.ok(out.includes("https://example.com/docs"));
+    });
+
+    it("marks the doctor section as failed when an error was captured", () => {
+        const input = baseInput();
+        input.modules = [
+            {
+                modulePath: ":m",
+                projectDir: "m",
+                pluginApplied: true,
+                daemonReady: false,
+                daemonInteractive: false,
+                dataProducts: [],
+                dataExtensions: [],
+                doctor: null,
+                doctorError: "Gradle task failed",
+            },
+        ];
+        const out = renderDoctorReport(input);
+        assert.ok(out.includes("Doctor: ⚠️ failed"));
+        assert.ok(out.includes("Gradle task failed"));
+    });
+
+    it("lists pending data extensions with elapsed time", () => {
+        const input = baseInput();
+        input.pendingDataExtensions = [
+            {
+                previewId: "Preview#one",
+                moduleId: ":m",
+                kinds: ["a11y/atf"],
+                elapsedMs: 1_500,
+            },
+        ];
+        const out = renderDoctorReport(input);
+        assert.ok(out.includes("Preview#one"));
+        assert.ok(out.includes("1.5s waiting"));
+        assert.ok(out.includes("`a11y/atf`"));
+    });
+});

--- a/vscode-extension/src/test/doctorReport.test.ts
+++ b/vscode-extension/src/test/doctorReport.test.ts
@@ -87,7 +87,7 @@ describe("renderDoctorReport", () => {
         assert.ok(out.includes("⚠️ **robolectric-jar-stale**"));
         assert.ok(out.includes("→ Bump the dependency."));
         assert.ok(out.includes("`./gradlew :app:dependencies`"));
-        assert.ok(out.includes("https://example.com/docs"));
+        assert.ok(out.includes("docs: https://example.com/docs"));
     });
 
     it("marks the doctor section as failed when an error was captured", () => {


### PR DESCRIPTION
## Summary

Adds comprehensive progress tracking for data extension subscriptions and a diagnostic doctor report feature to help users troubleshoot issues when data extensions fail to arrive.

## Key Changes

- **Data Extension Progress Tracker** (`dataExtensionProgress.ts`):
  - New `DataExtensionProgressTracker` class that monitors the window between "user enables a data extension" and "daemon attaches the first matching data product"
  - Drives a slim progress bar in the preview panel with an indeterminate ease-out curve
  - Maintains a VS Code status-bar item showing pending data extension activity across all panels
  - Implements a safety timeout (default 30s) per preview that fires a diagnostic callback when data extensions don't arrive
  - All timer/clock dependencies are injected for deterministic unit testing
  - Includes `formatLabel()` utility for human-readable progress labels

- **Doctor Report** (`doctorReport.ts`):
  - New `renderDoctorReport()` function that assembles a Markdown report bundling per-module doctor findings with environment, daemon, and capability data
  - Designed to be pasted directly into GitHub issues for better bug report context
  - Includes environment info (extension version, VS Code version, platform, workspace), per-module diagnostics (daemon state, data products, data extensions, doctor findings), and pending data extension status
  - Severity icons and remediation guidance for doctor findings

- **Extension Integration** (`extension.ts`):
  - Integrates `DataExtensionProgressTracker` into the main extension lifecycle
  - Calls `tracker.begin()` when data extensions are enabled via chip toggles
  - Calls `tracker.resolve()` when data products arrive, clearing the progress indicator
  - New `composePreview.copyDoctorReport` command that builds and displays a doctor report as a Markdown document with clipboard copy
  - New `logForce()` function that bypasses logging level filters for diagnostic output
  - Timeout diagnostics logged to output channel with daemon state snapshot and capability information
  - Status bar item shows pending kinds and preview count with spinner icon

- **Tests**:
  - Comprehensive unit tests for `DataExtensionProgressTracker` with deterministic `FakeClock` for timer control
  - Tests for progress bar advancement, timeout firing, entry resolution, and status aggregation
  - Unit tests for `renderDoctorReport()` covering environment data, module findings, and pending extensions

## Notable Implementation Details

- Progress bar only displays when no real refresh is in-flight (refresh progress carries richer phase information)
- Safety timeout resets when fresh kinds are added to prevent slow second subscribes from riding the first one's timeout
- Timeout callback fires before status/clear emissions so diagnostic handlers can read `tracker.size === 0` reliably
- Doctor report uses GitHub-flavored Markdown for easy pasting into issues
- All timer dependencies injected via `DataExtensionTrackerScheduler` interface for testability

https://claude.ai/code/session_01LcCsCDnH3tRv8K6t9sXRdV