### PR TITLE
feat(vscode-extension): pull current branch before F5 build

### DIFF
--- a/vscode-extension/.vscode/tasks.json
+++ b/vscode-extension/.vscode/tasks.json
@@ -127,9 +127,27 @@
             "problemMatcher": []
         },
         {
+            "label": "git: pull current branch",
+            "type": "shell",
+            "command": "git",
+            "args": [
+                "pull",
+                "--ff-only"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "problemMatcher": []
+        },
+        {
             "label": "build: F5 artifacts",
             "dependsOrder": "sequence",
             "dependsOn": [
+                "git: pull current branch",
                 "npm: compile",
                 "gradle: F5 publish + install",
                 "extension: prepare artifact folder",


### PR DESCRIPTION
## Summary
- Add a `git: pull current branch` task that runs `git pull --ff-only` in the workspace folder
- Chain it as the first step of `build: F5 artifacts` so F5 fast-forwards the current branch before compile/publish
- `--ff-only` so a divergent branch fails loudly instead of creating a merge commit

## Test plan
- [ ] F5 on a clean, up-to-date branch — pull is a no-op, build proceeds
- [ ] F5 when origin has new commits — branch fast-forwards, build proceeds
- [ ] F5 with diverged local commits — pull fails, build stops with a clear error