### PR TITLE
refactor: simplify focus mode toolbar and navigation

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -604,6 +604,14 @@ preview-app {
     max-height: 70vh;
     object-fit: contain;
 }
+/* Focus mode is single-variant: the carousel arrows and the "+N
+ * variants" badge belong to multi-mode browsing. Hide them so Focus
+ * stays the inspector view of exactly the variant the user clicked. */
+.preview-grid.layout-focus .preview-card .frame-controls,
+.preview-grid.layout-focus .preview-card .variant-badge,
+.preview-grid.layout-focus .preview-card .animation-icon {
+    display: none;
+}
 
 .preview-card.filtered-out {
     display: none !important;
@@ -619,13 +627,6 @@ preview-app {
 }
 .focus-controls[hidden] {
     display: none;
-}
-#focus-position {
-    font-size: calc(var(--vscode-font-size) - 1px);
-    color: var(--text-secondary);
-    min-width: 50px;
-    text-align: center;
-    font-variant-numeric: tabular-nums;
 }
 
 .focus-inspector {

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -284,19 +284,22 @@ export function populatePreviewCard(
     imgContainer.appendChild(skeleton);
     card.appendChild(imgContainer);
 
-    // Single-click on the image enters LIVE for this preview (in any
-    // layout — focus, grid, flow, column). The first click toggles
-    // interactive on; subsequent clicks while LIVE forward as pointer
-    // events to the daemon (handled by attachInteractiveInputHandlers
-    // attached via updateImage). The handler is on the container, not
-    // the <img>, so clicks land before the image renders too. Modifier-
-    // aware: Shift+click follows the multi-stream semantics from
+    // Multi-mode (grid/flow/column): clicking the image enters Focus
+    // mode on this card, preserving the carousel's current variant
+    // (`card.dataset.currentIndex`) because focus is the inspector
+    // mode and we want to land on the variant the user was looking at.
+    // Focus mode: clicking the image enters LIVE (interactive
+    // streaming) for this preview — the toolbar's `btn-interactive` is
+    // the canonical entry, but image-click is the casual shortcut and
+    // forwards subsequent clicks as pointer events to the daemon while
+    // live (via attachInteractiveInputHandlers attached on updateImage).
+    // Modifier-aware: Shift+click follows multi-stream semantics from
     // toggleInteractive().
     imgContainer.addEventListener("click", (evt) => {
         const previewId = card.dataset.previewId;
         if (!previewId) return;
-        // If we're already live for this preview, the per-image click
-        // handler routes to recordInteractiveInput. Check before the
+        // Already-live: image-click routes to recordInteractiveInput
+        // (handled via attachInteractiveInputHandlers); skip the
         // stale-card branch so interactive clicks do not also queue a
         // heavyweight refresh for stale captures.
         if (config.liveState.isLive(previewId)) return;
@@ -304,6 +307,12 @@ export function populatePreviewCard(
             evt.preventDefault();
             evt.stopPropagation();
             config.staleBadge.requestHeavyRefresh(card);
+            return;
+        }
+        if (!config.inFocus()) {
+            evt.preventDefault();
+            evt.stopPropagation();
+            config.enterFocus(card);
             return;
         }
         config.liveState.enterInteractiveOnCard(card, evt.shiftKey);

--- a/vscode-extension/src/webview/preview/components/FilterToolbar.ts
+++ b/vscode-extension/src/webview/preview/components/FilterToolbar.ts
@@ -187,7 +187,6 @@ export class FilterToolbar extends LitElement {
                         <option value="grid">Grid</option>
                         <option value="flow">Flow</option>
                         <option value="column">Column</option>
-                        <option value="focus">Focus</option>
                     </select>
                     <i
                         class="codicon codicon-chevron-down select-chevron"

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -1,7 +1,7 @@
 // Focus-mode orchestration for the live "Compose Preview" panel.
 //
 // Lifted verbatim from `behavior.ts`'s `applyLayout` / `publishScopedPreview`
-// / `navigateFocus` / `focusOnCard` / `exitFocus` / `requestFocusedDiff` /
+// / `focusOnCard` / `exitFocus` / `requestFocusedDiff` /
 // `requestLaunchOnDevice` / `toggleA11yOverlay` cluster, plus the four
 // `applyXxxButtonState` hooks that drive the focus-mode toolbar. After
 // this lift `behavior.ts` is mostly setup + message-event wiring; the
@@ -53,10 +53,6 @@ export interface FocusControllerConfig {
     /** `<data-tabs>` — active-bundle tab row, rendered below the chip
      *  strip. Same focus-only visibility rule as `bundleChipBar`. */
     dataTabs: HTMLElement;
-    /** `<div id="focus-position">` — the "N / M" position indicator. */
-    focusPosition: HTMLElement;
-    btnPrev: HTMLButtonElement;
-    btnNext: HTMLButtonElement;
     focusToolbar: FocusToolbarController;
     inspector: FocusInspectorController;
     liveState: LiveStateController;
@@ -190,25 +186,27 @@ export class FocusController {
 
     applyLayout(): void {
         const mode = this.config.filterToolbar.getLayoutValue();
+        const inFocus = mode === "focus";
         this.config.grid.setLayoutMode(mode);
-        this.config.focusControls.hidden = mode !== "focus";
-        // The chip bar is now always visible (anchored to the bottom of
-        // the panel). Minimal mode hides it via CSS (`preview-app[data-
-        // minimal-mode="true"] bundle-chip-bar`), so this controller
-        // just keeps the element non-hidden — the chip bar itself
-        // filters which bundle chips render based on the early-features
-        // snapshot it receives from `reflectBundleState` in `main.ts`.
-        // The tab strip stays hidden until at least one bundle is
-        // active; DataTabs.render() returns empty when no active
-        // bundles, but unhiding it lets the host show tab bodies as
-        // soon as the user toggles a chip on, regardless of layout.
-        this.config.bundleChipBar.hidden = false;
-        this.config.dataTabs.hidden = false;
+        // Focus is the inspector mode: it owns the focus toolbar, chip
+        // bar, data-extension tabs, and the focus inspector sidebar.
+        // Multi modes (grid/flow/column) are the browser modes: filter
+        // toolbar only, no extensions. The split keeps each mode
+        // single-purpose so the user is never looking at extension
+        // data for a preview that isn't the one they targeted.
+        this.config.focusControls.hidden = !inFocus;
+        this.config.bundleChipBar.hidden = !inFocus;
+        this.config.dataTabs.hidden = !inFocus;
+        // Filter dropdowns are a multi-mode concept (which previews to
+        // show in the grid); in focus mode the user has already picked.
+        // `<filter-toolbar>` and the focus-inspector sidebar are also
+        // managed elsewhere — the inspector toggles its own `hidden`
+        // through `inspector.render(card | null)` below.
+        this.config.filterToolbar.hidden = inFocus;
 
-        if (mode === "focus") {
+        if (inFocus) {
             const visible = this.getVisibleCards();
             if (visible.length === 0) {
-                this.config.focusPosition.textContent = "0 / 0";
                 this.config.inspector.render(null);
                 this.publishScopedPreview();
                 return;
@@ -223,10 +221,6 @@ export class FocusController {
                 this.config.setFocusIndex(0);
             }
             this.config.grid.applyFocusVisibility(visible[focusIndex]);
-            this.config.focusPosition.textContent =
-                focusIndex + 1 + " / " + visible.length;
-            this.config.btnPrev.disabled = focusIndex === 0;
-            this.config.btnNext.disabled = focusIndex === visible.length - 1;
             this.config.inspector.render(visible[focusIndex]);
         } else {
             this.config.grid.applyFocusVisibility(null);
@@ -304,16 +298,6 @@ export class FocusController {
             command: "previewScopeChanged",
             previewId,
         });
-    }
-
-    navigateFocus(delta: number): void {
-        const visible = this.getVisibleCards();
-        if (visible.length === 0) return;
-        const cur = this.config.getFocusIndex();
-        this.config.setFocusIndex(
-            Math.max(0, Math.min(visible.length - 1, cur + delta)),
-        );
-        this.applyLayout();
     }
 
     /**

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -23,8 +23,6 @@
 // site.
 
 export interface FocusToolbarElements {
-    btnPrev: HTMLButtonElement;
-    btnNext: HTMLButtonElement;
     btnDiffHead: HTMLButtonElement;
     btnDiffMain: HTMLButtonElement;
     btnLaunchDevice: HTMLButtonElement;

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -199,8 +199,6 @@ export class PreviewApp extends LitElement {
     @query("data-tabs") private _dataTabs!: DataTabs;
     @query("#bundle-legend") private _bundleLegend!: BundleLegend;
     @query("#focus-controls") private _focusControls!: HTMLElement;
-    @query("#btn-prev") private _btnPrev!: HTMLButtonElement;
-    @query("#btn-next") private _btnNext!: HTMLButtonElement;
     @query("#btn-diff-head") private _btnDiffHead!: HTMLButtonElement;
     @query("#btn-diff-main") private _btnDiffMain!: HTMLButtonElement;
     @query("#btn-launch-device") private _btnLaunchDevice!: HTMLButtonElement;
@@ -211,7 +209,6 @@ export class PreviewApp extends LitElement {
     @query("#btn-recording") private _btnRecording!: HTMLButtonElement;
     @query("#recording-format") private _recordingFormat!: HTMLSelectElement;
     @query("#btn-exit-focus") private _btnExitFocus!: HTMLButtonElement;
-    @query("#focus-position") private _focusPosition!: HTMLElement;
 
     protected render(): TemplateResult {
         const minimal = this.dataset.minimalMode === "true";
@@ -264,29 +261,6 @@ export class PreviewApp extends LitElement {
 
             <message-banner></message-banner>
             <div id="focus-controls" class="focus-controls" hidden>
-                <button
-                    class="icon-button"
-                    id="btn-prev"
-                    title="Previous preview"
-                    aria-label="Previous preview"
-                >
-                    <i
-                        class="codicon codicon-arrow-left"
-                        aria-hidden="true"
-                    ></i>
-                </button>
-                <span id="focus-position" aria-live="polite"></span>
-                <button
-                    class="icon-button"
-                    id="btn-next"
-                    title="Next preview"
-                    aria-label="Next preview"
-                >
-                    <i
-                        class="codicon codicon-arrow-right"
-                        aria-hidden="true"
-                    ></i>
-                </button>
                 <button
                     class="icon-button"
                     id="btn-diff-head"
@@ -497,8 +471,6 @@ export class PreviewApp extends LitElement {
         // focusOnCard / exitFocus / restoreFilterState.
         const filterToolbar = this._filterToolbar;
         const focusControls = this._focusControls;
-        const btnPrev = this._btnPrev;
-        const btnNext = this._btnNext;
         const btnDiffHead = this._btnDiffHead;
         const btnDiffMain = this._btnDiffMain;
         const btnLaunchDevice = this._btnLaunchDevice;
@@ -509,8 +481,6 @@ export class PreviewApp extends LitElement {
         const recordingFormat = this._recordingFormat;
         const btnExitFocus = this._btnExitFocus;
         const focusToolbar = new FocusToolbarController({
-            btnPrev,
-            btnNext,
             btnDiffHead,
             btnDiffMain,
             btnLaunchDevice,
@@ -543,7 +513,6 @@ export class PreviewApp extends LitElement {
         // `<preview-card>` Lit component can subscribe per-card without
         // going through this closure (see the versioned-counter notes in
         // `previewStore.ts`).
-        const focusPosition = this._focusPosition;
         // Progress bar is owned by `<progress-bar>` — see
         // `components/ProgressBar.ts`. It listens for `setProgress` /
         // `clearProgress` directly and owns its own deferred-paint timing.
@@ -2269,9 +2238,6 @@ export class PreviewApp extends LitElement {
             focusControls,
             bundleChipBar,
             dataTabs,
-            focusPosition,
-            btnPrev,
-            btnNext,
             focusToolbar,
             inspector,
             liveState,
@@ -2370,8 +2336,6 @@ export class PreviewApp extends LitElement {
             applyFilters();
         });
 
-        btnPrev.addEventListener("click", () => navigateFocus(-1));
-        btnNext.addEventListener("click", () => navigateFocus(1));
         btnDiffHead.addEventListener("click", () => requestFocusedDiff("head"));
         btnDiffMain.addEventListener("click", () => requestFocusedDiff("main"));
         btnLaunchDevice.addEventListener("click", () =>
@@ -2405,9 +2369,6 @@ export class PreviewApp extends LitElement {
         }
         function applyRecordingButtonState(): void {
             focusController.applyRecordingButtonState();
-        }
-        function navigateFocus(delta: number): void {
-            focusController.navigateFocus(delta);
         }
         function focusOnCard(card: HTMLElement): void {
             focusController.focusOnCard(card);


### PR DESCRIPTION
## Summary

Removes the focus-mode position indicator ("N / M") and prev/next navigation buttons from the toolbar, simplifying the focus inspector UI. Navigation between previews is now handled by clicking on cards in the grid to enter focus mode, rather than using dedicated toolbar buttons.

## Key Changes

- **Removed focus toolbar navigation**: Deleted `btnPrev`, `btnNext`, and the position indicator (`focusPosition`) from the focus-controls toolbar and their associated event listeners
- **Simplified FocusController**: Removed `navigateFocus()` method and related button state management (`applyFocusVisibility` for prev/next buttons)
- **Updated layout logic**: Refactored `applyLayout()` to use a cleaner `inFocus` variable and made the filter toolbar hidden in focus mode (since the user has already selected their preview)
- **Enhanced card interaction**: Modified image-click behavior in `cardBuilder.ts` so clicking a card image in multi-mode (grid/flow/column) enters focus mode on that card, while in focus mode it enters interactive streaming
- **Updated styling**: Added CSS rules to hide carousel controls (frame-controls, variant-badge, animation-icon) in focus mode, keeping it as a single-variant inspector view
- **Cleaned up component interfaces**: Removed `btnPrev` and `btnNext` from `FocusToolbarElements` interface

## Implementation Details

The refactoring consolidates focus-mode entry points: users now click a card to enter focus mode (instead of using prev/next buttons), and the focus inspector becomes a true single-variant view of the selected preview. The filter toolbar is hidden in focus mode since layout selection is a multi-mode concept. This keeps each mode single-purpose and prevents the user from viewing extension data for a preview they didn't explicitly target.

https://claude.ai/code/session_018z2yxbnrULECjUT4PS1xRV