### PR TITLE
feat(daemon-desktop): advertise fonts/used and displayfilter on desktop (#1201)

### DIFF
--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -62,6 +62,12 @@ dependencies {
   // pipeline and writes per-variant PNGs + the `displayfilter-variants.json` manifest after each
   // PNG capture. Same dep on the Android side; the producer is renderer-agnostic (BufferedImage).
   implementation(project(":data-displayfilter-connector"))
+  // Fonts connector — issue #1201 phase 1. Producer is currently Android-only
+  // (GoogleFontInterceptor / Typeface accounting); the registry side reads JSON artefacts from
+  // disk so it can be advertised on desktop unconditionally — `data/fetch` returns
+  // NotAvailable when no producer has written. This removes the "kind not advertised" symptom
+  // on the panel's Performance / Fonts chips for CMP-desktop sessions.
+  implementation(project(":data-fonts-connector"))
 
   // Compose runtime / foundation / ui — the B-desktop.1.4 RenderEngine body
   // imports `ImageComposeScene`, `@Composable`, `currentComposer`,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -215,120 +215,33 @@ fun runDaemon(
     )
   }
 
-  val composeTraceEnabled =
-    PerfettoTraceDataProducer.enabled() && System.getProperty(RenderEngine.OUTPUT_DIR_PROP) != null
+  // `dataRoot` follows the same layout as `:daemon:android` — `<renderOutputDir>/../data` when
+  // `composeai.render.outputDir` is set, else null. Producers that write to disk land their
+  // per-render JSON / PNG artefacts under `dataRoot/<previewId>/...`; the matching registries read
+  // back from the same location. Computed unconditionally so file-based registries (`fonts/used`,
+  // `displayfilter`, ...) can be advertised even when no producer has written yet — `data/fetch`
+  // returns `NotAvailable` instead of `-32020 kind not advertised`. See issue #1201.
+  val dataRoot: File? =
+    System.getProperty(RenderEngine.OUTPUT_DIR_PROP)?.let { renderOutputDir ->
+      File(renderOutputDir).parentFile?.resolve("data") ?: File(renderOutputDir)
+    }
+  val composeTraceEnabled = dataRoot != null && PerfettoTraceDataProducer.enabled()
 
   // ExtensionRegistry — every contribution the daemon can expose is registered here, all inactive
   // by default. Clients call `extensions/enable` to opt in (typically the MCP supervisor enables a
   // configured allowlist on connect). See docs/daemon/PROTOCOL.md § 3a.
-  val perfettoDataRoot =
-    if (composeTraceEnabled) {
-      System.getProperty(RenderEngine.OUTPUT_DIR_PROP)?.let { renderOutputDir ->
-        File(renderOutputDir).parentFile?.resolve("data") ?: File(renderOutputDir)
-      }
-    } else null
   val extensions =
     ExtensionRegistry(
-      buildList {
-        add(
-          Extension(
-            id = "device/clip",
-            displayName = "Device clip",
-            dataProductRegistry = DeviceClipDataProductRegistry(previewIndex = previewIndex),
-            previewExtensionDescriptors = listOf(RenderPreviewExtension.deviceClipDescriptor),
-          )
-        )
-        add(
-          Extension(
-            id = "device/background",
-            displayName = "Device background",
-            dataProductRegistry = DeviceBackgroundDataProductRegistry(previewIndex = previewIndex),
-            previewExtensionDescriptors = listOf(RenderPreviewExtension.deviceBackgroundDescriptor),
-          )
-        )
-        add(
-          Extension(
-            id = "render/trace",
-            displayName = "Render trace",
-            dataProductRegistry = RenderTraceDataProductRegistry(),
-            previewExtensionDescriptors = listOf(RenderPreviewExtension.renderTraceDescriptor),
-          )
-        )
-        add(
-          Extension(
-            id = "render/test-failure",
-            displayName = "Test failure",
-            dataProductRegistry = TestFailureDataProductRegistry(),
-          )
-        )
-        add(
-          Extension(
-            id = "render/overlay-legend",
-            displayName = "Render overlay legend",
-            previewExtensionDescriptors = listOf(RenderPreviewExtension.overlayLegendDescriptor),
-          )
-        )
-        add(
-          Extension(
-            id = "data/theme",
-            displayName = "Material 3 theme override",
-            dataProductRegistry = themeRegistry,
-            previewOverrideExtensions = listOf(Material3ThemePreviewOverrideExtension()),
-          )
-        )
-        add(
-          Extension(
-            id = "data/wallpaper",
-            displayName = "Wallpaper override",
-            dataProductRegistry = wallpaperRegistry,
-            previewOverrideExtensions = listOf(WallpaperPreviewOverrideExtension()),
-          )
-        )
-        add(
-          Extension(
-            id = "data/pseudolocale",
-            displayName = "Pseudolocale (desktop)",
-            previewOverrideExtensions = listOf(PseudolocalePreviewOverrideExtensionDesktop()),
-          )
-        )
-        add(
-          Extension(
-            id = "data/recomposition",
-            displayName = "Recomposition counters",
-            dataProductRegistry = recompositionRegistry,
-          )
-        )
-        if (composeTraceEnabled && perfettoDataRoot != null) {
-          add(
-            Extension(
-              id = "compose/trace",
-              displayName = "Compose Perfetto trace",
-              dataProductRegistry = PerfettoTraceDataProductRegistry(rootDir = perfettoDataRoot),
-              previewExtensionDescriptors = listOf(RenderPreviewExtension.composeTraceDescriptor),
-            )
-          )
-        }
-        if (historyManager != null) {
-          add(
-            Extension(
-              id = "history/diff-regions",
-              displayName = "History diff regions",
-              dataProductRegistry =
-                HistoryDiffRegionsDataProductRegistry(historyManager = historyManager),
-            )
-          )
-        }
-        // Recording-script extensions are descriptor-only on the daemon side — the host's session
-        // registry decides what's actually dispatchable. The roadmap descriptors are advertised so
-        // panels can grey out unimplemented actions.
-        add(
-          Extension(
-            id = "recording/script",
-            displayName = "Recording-script extensions",
-            dataExtensionDescriptors = RecordingScriptDataExtensions.roadmapDescriptors,
-          )
-        )
-      }
+      buildDesktopExtensions(
+        previewIndex = previewIndex,
+        recompositionRegistry = recompositionRegistry,
+        themeRegistry = themeRegistry,
+        wallpaperRegistry = wallpaperRegistry,
+        historyManager = historyManager,
+        dataRoot = dataRoot,
+        composeTraceEnabled = composeTraceEnabled,
+        displayFilterEnabled = DisplayFilterConfig.fromSystemProperties().isNotEmpty(),
+      )
     )
 
   // Render engine consumes the registry's live override aggregator so `extensions/enable` mid-
@@ -558,4 +471,151 @@ private fun installSigtermShutdownHook(host: RenderHost, originalStdin: java.io.
         "compose-ai-daemon-sigterm-hook",
       )
     )
+}
+
+/**
+ * Builds the extension list registered on the desktop daemon. Extracted from [runDaemon] so unit
+ * tests can assert the registered ids without spinning up a full JSON-RPC server.
+ *
+ * **Per-backend parity with `:daemon:android`'s `DaemonMain`** (issue #1201). The two backends
+ * register different subsets because some producers are Android-API-bound (`uiautomator`,
+ * Robolectric ATF a11y, `Resources.getValue` interception). The registries below are file-based and
+ * portable: when no producer has written, `data/fetch` returns `NotAvailable` rather than the wire
+ * `-32020 kind not advertised`, which is what the panel needs to gate its chips correctly.
+ *
+ * Kinds whose producer is genuinely Android-bound (`resources/used`, `i18n/translations`, `a11y`,
+ * `uiautomator`, `data/navigation`) are NOT registered here — see issue #1201 for the per-kind
+ * portability triage. They stay unadvertised on desktop; the panel should honour
+ * `ServerCapabilities.backend == "desktop"` to grey out the corresponding chips.
+ */
+internal fun buildDesktopExtensions(
+  previewIndex: PreviewIndex,
+  recompositionRegistry: RecompositionDataProductRegistry,
+  themeRegistry: ThemeDataProductRegistry,
+  wallpaperRegistry: WallpaperDataProductRegistry,
+  historyManager: HistoryManager?,
+  dataRoot: File?,
+  composeTraceEnabled: Boolean,
+  displayFilterEnabled: Boolean,
+): List<Extension> = buildList {
+  add(
+    Extension(
+      id = "device/clip",
+      displayName = "Device clip",
+      dataProductRegistry = DeviceClipDataProductRegistry(previewIndex = previewIndex),
+      previewExtensionDescriptors = listOf(RenderPreviewExtension.deviceClipDescriptor),
+    )
+  )
+  add(
+    Extension(
+      id = "device/background",
+      displayName = "Device background",
+      dataProductRegistry = DeviceBackgroundDataProductRegistry(previewIndex = previewIndex),
+      previewExtensionDescriptors = listOf(RenderPreviewExtension.deviceBackgroundDescriptor),
+    )
+  )
+  add(
+    Extension(
+      id = "render/trace",
+      displayName = "Render trace",
+      dataProductRegistry = RenderTraceDataProductRegistry(),
+      previewExtensionDescriptors = listOf(RenderPreviewExtension.renderTraceDescriptor),
+    )
+  )
+  add(
+    Extension(
+      id = "render/test-failure",
+      displayName = "Test failure",
+      dataProductRegistry = TestFailureDataProductRegistry(),
+    )
+  )
+  add(
+    Extension(
+      id = "render/overlay-legend",
+      displayName = "Render overlay legend",
+      previewExtensionDescriptors = listOf(RenderPreviewExtension.overlayLegendDescriptor),
+    )
+  )
+  add(
+    Extension(
+      id = "data/theme",
+      displayName = "Material 3 theme override",
+      dataProductRegistry = themeRegistry,
+      previewOverrideExtensions = listOf(Material3ThemePreviewOverrideExtension()),
+    )
+  )
+  add(
+    Extension(
+      id = "data/wallpaper",
+      displayName = "Wallpaper override",
+      dataProductRegistry = wallpaperRegistry,
+      previewOverrideExtensions = listOf(WallpaperPreviewOverrideExtension()),
+    )
+  )
+  add(
+    Extension(
+      id = "data/pseudolocale",
+      displayName = "Pseudolocale (desktop)",
+      previewOverrideExtensions = listOf(PseudolocalePreviewOverrideExtensionDesktop()),
+    )
+  )
+  add(
+    Extension(
+      id = "data/recomposition",
+      displayName = "Recomposition counters",
+      dataProductRegistry = recompositionRegistry,
+    )
+  )
+  if (dataRoot != null) {
+    // Issue #1201 — file-based registries that are portable to desktop. The producer side is
+    // currently Android-only for `fonts/used` (the GoogleFontInterceptor / Typeface accounting
+    // path); the registry returns NotAvailable on desktop until a Skia-side font producer lands.
+    // `displayfilter` is fully portable (BufferedImage post-capture) and gated on the same sysprop
+    // the Android side reads.
+    add(
+      Extension(
+        id = "fonts/used",
+        displayName = "Fonts used",
+        dataProductRegistry = FontsUsedDataProductRegistry(rootDir = dataRoot),
+      )
+    )
+    if (displayFilterEnabled) {
+      add(
+        Extension(
+          id = "displayfilter",
+          displayName = "Display filter variants",
+          dataProductRegistry = DisplayFilterDataProductRegistry(rootDir = dataRoot),
+        )
+      )
+    }
+    if (composeTraceEnabled) {
+      add(
+        Extension(
+          id = "compose/trace",
+          displayName = "Compose Perfetto trace",
+          dataProductRegistry = PerfettoTraceDataProductRegistry(rootDir = dataRoot),
+          previewExtensionDescriptors = listOf(RenderPreviewExtension.composeTraceDescriptor),
+        )
+      )
+    }
+  }
+  if (historyManager != null) {
+    add(
+      Extension(
+        id = "history/diff-regions",
+        displayName = "History diff regions",
+        dataProductRegistry = HistoryDiffRegionsDataProductRegistry(historyManager = historyManager),
+      )
+    )
+  }
+  // Recording-script extensions are descriptor-only on the daemon side — the host's session
+  // registry decides what's actually dispatchable. The roadmap descriptors are advertised so
+  // panels can grey out unimplemented actions.
+  add(
+    Extension(
+      id = "recording/script",
+      displayName = "Recording-script extensions",
+      dataExtensionDescriptors = RecordingScriptDataExtensions.roadmapDescriptors,
+    )
+  )
 }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/BuildDesktopExtensionsTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/BuildDesktopExtensionsTest.kt
@@ -1,0 +1,111 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Verifies the per-backend extension matrix asserted by issue #1201 — closing the chip-shows- "kind
+ * not advertised" gap on CMP-desktop sessions. The test exercises the registry-building helper
+ * directly rather than spinning up a full JSON-RPC server: the wire-level `extensions/list`
+ * round-trip is exercised by [JsonRpcDesktopIntegrationTest] elsewhere, what's specific to this PR
+ * is which `Extension` instances [buildDesktopExtensions] emits given a particular config.
+ *
+ * **What's still Android-only.** The negative assertions below pin the kinds the desktop daemon
+ * deliberately does NOT advertise yet because their producers are Android-API-bound (`uiautomator`,
+ * `a11y` ATF, `resources/used`, `i18n/translations`) or because the registry side still lives in
+ * `:daemon:android`'s sources (`data/navigation`). Issue #1201's per-row triage tracks the
+ * migration path; the panel should honour `ServerCapabilities.backend == "desktop"` and grey those
+ * chips out instead of relying on the daemon to advertise them.
+ */
+class BuildDesktopExtensionsTest {
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private fun build(
+    dataRoot: File? = null,
+    composeTraceEnabled: Boolean = false,
+    displayFilterEnabled: Boolean = false,
+    historyManager: ee.schimke.composeai.daemon.history.HistoryManager? = null,
+  ): Set<String> {
+    val ids =
+      buildDesktopExtensions(
+          previewIndex = PreviewIndex.empty(),
+          recompositionRegistry = RecompositionDataProductRegistry(),
+          themeRegistry = ThemeDataProductRegistry(),
+          wallpaperRegistry = WallpaperDataProductRegistry(),
+          historyManager = historyManager,
+          dataRoot = dataRoot,
+          composeTraceEnabled = composeTraceEnabled,
+          displayFilterEnabled = displayFilterEnabled,
+        )
+        .map { it.id }
+    return ids.toSet()
+  }
+
+  @Test
+  fun core_extensions_register_without_data_root() {
+    val ids = build(dataRoot = null)
+    assertTrue("device/clip" in ids)
+    assertTrue("device/background" in ids)
+    assertTrue("render/trace" in ids)
+    assertTrue("render/test-failure" in ids)
+    assertTrue("render/overlay-legend" in ids)
+    assertTrue("data/theme" in ids)
+    assertTrue("data/wallpaper" in ids)
+    assertTrue("data/pseudolocale" in ids)
+    assertTrue("data/recomposition" in ids)
+    assertTrue("recording/script" in ids)
+
+    // File-based registries gate on dataRoot — none should appear here.
+    assertFalse("fonts/used" in ids)
+    assertFalse("displayfilter" in ids)
+    assertFalse("compose/trace" in ids)
+  }
+
+  @Test
+  fun fonts_used_advertised_when_data_root_set() {
+    val dataRoot = tempFolder.newFolder("data")
+    val ids = build(dataRoot = dataRoot)
+    assertTrue(
+      "'fonts/used' missing — produces NotAvailable on desktop until a Skia font " +
+        "producer lands, but advertising it removes the wire-level 'kind not advertised' error",
+      "fonts/used" in ids,
+    )
+  }
+
+  @Test
+  fun displayfilter_gated_on_filters_sysprop_via_helper_flag() {
+    val dataRoot = tempFolder.newFolder("data")
+    assertFalse("displayfilter" in build(dataRoot = dataRoot, displayFilterEnabled = false))
+    assertTrue("displayfilter" in build(dataRoot = dataRoot, displayFilterEnabled = true))
+  }
+
+  @Test
+  fun compose_trace_still_gated_on_perfetto_flag() {
+    val dataRoot = tempFolder.newFolder("data")
+    assertFalse("compose/trace" in build(dataRoot = dataRoot, composeTraceEnabled = false))
+    assertTrue("compose/trace" in build(dataRoot = dataRoot, composeTraceEnabled = true))
+  }
+
+  @Test
+  fun android_only_kinds_stay_unadvertised_on_desktop() {
+    val dataRoot = tempFolder.newFolder("data")
+    val ids = build(dataRoot = dataRoot, composeTraceEnabled = true, displayFilterEnabled = true)
+    // Producers for these kinds are Android-API-bound — the panel should grey them out based on
+    // `ServerCapabilities.backend == "desktop"` rather than expecting the daemon to advertise.
+    // Tracking migration of each in issue #1201.
+    assertFalse("resources/used" in ids)
+    assertFalse("i18n/translations" in ids)
+    assertFalse("a11y" in ids)
+    assertFalse("uiautomator" in ids)
+    // Registries below still live in :daemon:android's sources and need to be extracted to a
+    // shared connector module before desktop can register them. Same #1201 triage.
+    assertFalse("compose/semantics" in ids)
+    assertFalse("layout/inspector" in ids)
+    assertFalse("text/strings" in ids)
+    assertFalse("data/navigation" in ids)
+  }
+}


### PR DESCRIPTION
Closes the first portable subset of the data-product parity gap between
:daemon:android and :daemon:desktop. Both registries are file-based and
return `NotAvailable` when no producer has written, so advertising them
removes the wire-level `-32020 kind not advertised` symptom on the
panel's Fonts and Display Filter chips for CMP-desktop sessions —
without needing the producers to be portable yet.

Mechanically:

- Compute `dataRoot` unconditionally (when `composeai.render.outputDir`
  is set) instead of gating it on `composeTraceEnabled`, mirroring the
  Android layout. This unlocks file-based registries that the trace gate
  shouldn't bound.
- Extract the inline `buildList { ... }` registration into
  `buildDesktopExtensions(...)` so a unit test can pin the per-backend
  matrix without spinning up a full JSON-RPC server.
- Register `fonts/used` whenever `dataRoot` is set, and `displayfilter`
  behind the same `DisplayFilterConfig.fromSystemProperties()` gate the
  Android side uses.

Deliberately deferred (see #1201 triage): `compose/semantics`,
`layout/inspector`, `text/strings`, `i18n/translations` need their
connector modules migrated from `android.library` to JVM / Compose
Multiplatform before `:daemon:desktop` can depend on them;
`data/navigation` registry lives in `:daemon:android`'s sources and
needs extraction to a connector; `resources/used`, `a11y` ATF, and
`uiautomator` are Android-API-bound and should be greyed out by the
panel on `ServerCapabilities.backend == "desktop"` rather than
advertised.