### PR TITLE
feat: add bundle viewer panel for preview bundles

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -60,6 +60,19 @@ val composePreviewRenderer =
     isCanBeConsumed = false
   }
 
+// Sidecar configuration carrying the desktop daemon module (`:daemon:desktop`) plus its
+// Compose Multiplatform runtime. Same isolation story as `composePreviewRenderer` above —
+// never on the CLI's own classpath; only loaded by the subprocess JVM that
+// `compose-preview bundle daemon` spawns.
+//
+// Resolved into `cli/build/install/compose-preview/lib-daemon-desktop/` and located at
+// runtime via `APP_HOME/lib-daemon-desktop/`.
+val composePreviewDaemonDesktop =
+  configurations.create("composePreviewDaemonDesktop") {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+  }
+
 dependencies {
   implementation(libs.kotlinx.serialization.json)
   implementation("org.gradle:gradle-tooling-api:9.3.1")
@@ -82,11 +95,22 @@ dependencies {
   // runtime in `lib-renderer/`. Subprocess only; never on the CLI's own classpath.
   add("composePreviewRenderer", project(":renderer-desktop"))
 
+  // `compose-preview bundle daemon` ships the desktop daemon in `lib-daemon-desktop/`. Same
+  // subprocess-only isolation. The Compose Multiplatform runtime (incl. Skiko) is *not*
+  // bundled here — the subprocess classpath joins `lib-daemon-desktop/*` + `lib-renderer/*`
+  // at launch time, and the renderer sidecar already carries the per-OS Compose stack.
+  add("composePreviewDaemonDesktop", project(":daemon:desktop"))
+
   testImplementation(kotlin("test"))
 }
 
 distributions {
-  named("main") { contents { into("lib-renderer") { from(composePreviewRenderer) } } }
+  named("main") {
+    contents {
+      into("lib-renderer") { from(composePreviewRenderer) }
+      into("lib-daemon-desktop") { from(composePreviewDaemonDesktop) }
+    }
+  }
 }
 
 tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -44,6 +44,7 @@ class BundleCommand(args: List<String>) : Command(args) {
       "inspect" -> InspectSubcommand(args.drop(args.indexOf(sub) + 1)).run()
       "extract" -> ExtractSubcommand(args.drop(args.indexOf(sub) + 1)).run()
       "render" -> RenderSubcommand(args.drop(args.indexOf(sub) + 1)).run()
+      "daemon" -> BundleDaemonCommand(args.drop(args.indexOf(sub) + 1)).run()
       null,
       "help",
       "--help",
@@ -69,6 +70,7 @@ class BundleCommand(args: List<String>) : Command(args) {
         compose-preview bundle inspect <bundle.png>
         compose-preview bundle extract <bundle.png> [-o <dir>]
         compose-preview bundle render  <bundle.png> [-o <dir>]   (v1: stub — prints what would render)
+        compose-preview bundle daemon  <bundle.png> [-v]         (spawn the desktop daemon over stdio)
 
       Pack flags:
         --id <preview-id>   Preview to include. Repeatable. First is the cover. Default: all.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -1,0 +1,294 @@
+package ee.schimke.composeai.cli
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipInputStream
+import kotlin.system.exitProcess
+
+/**
+ * `compose-preview bundle daemon <bundle.png>` — spawn the desktop daemon JVM bound to a packed
+ * preview bundle's classpath. Inherits stdio so the parent process (the VS Code extension's bundle
+ * viewer panel) can speak the daemon's JSON-RPC protocol directly, the same way the Gradle plugin's
+ * `composePreviewDaemonStart` works for in-workspace modules.
+ *
+ * # Layout
+ *
+ * The packed bundle is a PNG+ZIP polyglot whose zip portion contains `classes/app.jar` (consumer
+ * module + inlined project deps) plus `previews.json` (discovery output). We extract both to a temp
+ * working directory, then launch a Java subprocess whose classpath joins
+ * `$APP_HOME/lib-daemon-desktop/` (daemon + data-extension connectors) with
+ * `$APP_HOME/lib-renderer/` (Compose Multiplatform + Skiko). The consumer's bytecode is exposed to
+ * the daemon via `-Dcomposeai.daemon.userClassDirs=<extracted-jar>`, and the discovery manifest via
+ * `-Dcomposeai.daemon.previewsJsonPath=<extracted-previews-json>` — the same sysprops the Gradle
+ * daemon launch path uses.
+ *
+ * The subprocess inherits stdin/stdout/stderr so the parent owns the JSON-RPC channel without
+ * additional plumbing. We don't wait on it from this command — `daemon` is `exec`-style: we print
+ * one ready line on stderr and replace this process via `ProcessBuilder.inheritIO`.
+ *
+ * # Maven coordinates intentionally not resolved
+ *
+ * `bundle.json`'s `classpath[]` entries record Maven coordinates for every dependency that
+ * contributed reachable classes to the rendered previews. v1 ignores them — the renderer's bundled
+ * Compose stack supplies every API call the bundle's classes resolve against, and a full resolver
+ * pass (download Maven, hash-verify, layer-on) is its own milestone. Same trade-off `bundle render`
+ * makes.
+ */
+class BundleDaemonCommand(args: List<String>) : Command(args) {
+
+  override fun run() {
+    val sub = args.firstOrNull { !it.startsWith("-") }
+    if (sub == null || sub in setOf("help", "--help", "-h")) {
+      printHelp()
+      if (sub == null) exitProcess(64)
+      return
+    }
+    val file = File(sub)
+    if (!file.isFile) {
+      System.err.println("bundle daemon: not a file: ${file.path}")
+      exitProcess(1)
+    }
+    val verbose = "--verbose" in args || "-v" in args
+    val workDir = createTempWorkDir()
+    val classesDir = workDir.resolve("classes").apply { mkdirs() }
+    val previewsJson = workDir.resolve("previews.json")
+    val zipBytes = BundleReader.extractZipBytes(file)
+    expandAppJarAndManifest(zipBytes, classesDir, previewsJson, file)
+
+    val daemonJars = locateSidecarJars("lib-daemon-desktop")
+    if (daemonJars.isEmpty()) {
+      System.err.println(
+        "bundle daemon: no daemon jars found. Looked in `${sidecarSearchDescription("lib-daemon-desktop")}`; " +
+          "either build the CLI via `./gradlew :cli:installDist` or set " +
+          "`-Dcomposeai.cli.libDaemonDesktopDir=<install-root/lib-daemon-desktop>`."
+      )
+      exitProcess(1)
+    }
+    val rendererJars = locateSidecarJars("lib-renderer")
+    if (rendererJars.isEmpty()) {
+      System.err.println(
+        "bundle daemon: no renderer jars found. Looked in `${sidecarSearchDescription("lib-renderer")}`; " +
+          "either build the CLI via `./gradlew :cli:installDist` or set " +
+          "`-Dcomposeai.cli.libRendererDir=<install-root/lib-renderer>`."
+      )
+      exitProcess(1)
+    }
+
+    val classpath = (daemonJars + rendererJars).joinToString(File.pathSeparator) { it.absolutePath }
+    val javaBin = locateJava()
+    val command = buildList {
+      add(javaBin)
+      add("--enable-native-access=ALL-UNNAMED")
+      // PROTOCOL.md § 3a — the daemon advertises capabilities lazily; the client
+      // (BundleViewerPanel's DaemonClient) does the `initialize` round-trip on stdin.
+      add("-D${USER_CLASS_DIRS_PROP}=${classesDir.absolutePath}")
+      add("-D${PREVIEWS_JSON_PATH_PROP}=${previewsJson.absolutePath}")
+      // Tag the temp dir on the daemon so logs / debug dumps make it discoverable.
+      add("-Dcomposeai.daemon.bundleSource=${file.absolutePath}")
+      add("-cp")
+      add(classpath)
+      add("ee.schimke.composeai.daemon.DaemonMain")
+    }
+
+    if (verbose) {
+      System.err.println("[bundle-daemon] working dir: ${workDir.absolutePath}")
+      System.err.println("[bundle-daemon] classes dir: ${classesDir.absolutePath}")
+      System.err.println("[bundle-daemon] previews.json: ${previewsJson.absolutePath}")
+      System.err.println("[bundle-daemon] daemon jars: ${daemonJars.size}")
+      System.err.println("[bundle-daemon] renderer jars: ${rendererJars.size}")
+      System.err.println("[bundle-daemon] launching: ${command.joinToString(" ")}")
+    }
+
+    val pb = ProcessBuilder(command).inheritIO()
+    val proc = pb.start()
+    // Best-effort cleanup: if the parent goes away, kill the daemon and drop the temp dir.
+    Runtime.getRuntime()
+      .addShutdownHook(
+        Thread {
+          try {
+            proc.destroy()
+          } catch (_: Throwable) {
+            /* ignore */
+          }
+          try {
+            workDir.deleteRecursively()
+          } catch (_: Throwable) {
+            /* ignore */
+          }
+        }
+      )
+    val exitCode = proc.waitFor()
+    try {
+      workDir.deleteRecursively()
+    } catch (_: Throwable) {
+      /* ignore */
+    }
+    exitProcess(exitCode)
+  }
+
+  private fun printHelp() {
+    println(
+      """
+      compose-preview bundle daemon — start the desktop daemon against a packed bundle
+
+      Usage:
+        compose-preview bundle daemon <bundle.png> [-v]
+
+      Inherits stdio: the spawned daemon JVM speaks JSON-RPC over stdin/stdout and writes log
+      lines to stderr, the same protocol `composePreviewDaemonStart` uses in a Gradle module.
+      Intended for tools that drive the daemon directly (the VS Code extension's bundle
+      viewer panel is the v1 consumer).
+
+      Flags:
+        -v, --verbose   Print the resolved working dir + classpath sizes before launch.
+      """
+        .trimIndent()
+    )
+  }
+
+  /**
+   * Extract `classes/app.jar` into [classesDir] and `previews.json` into [previewsJson]. Throws if
+   * either entry is missing — both are required for the daemon to come up against a usable preview
+   * index.
+   */
+  private fun expandAppJarAndManifest(
+    zipBytes: ByteArray,
+    classesDir: File,
+    previewsJson: File,
+    bundleFile: File,
+  ) {
+    var sawAppJar = false
+    var sawPreviewsJson = false
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        when (entry.name) {
+          "previews.json" -> {
+            previewsJson.writeBytes(zin.readBytes())
+            sawPreviewsJson = true
+          }
+          "classes/app.jar" -> {
+            val appJarBytes = zin.readBytes()
+            expandJarBytesSafely(appJarBytes, classesDir)
+            sawAppJar = true
+          }
+        }
+        zin.closeEntry()
+      }
+    }
+    require(sawAppJar) {
+      "bundle daemon: classes/app.jar missing in ${bundleFile.path} — not a packed bundle"
+    }
+    require(sawPreviewsJson) {
+      "bundle daemon: previews.json missing in ${bundleFile.path} — not a packed bundle"
+    }
+  }
+
+  /**
+   * Unpack the bundled app jar, rejecting Zip Slip. Shared shape with `BundleRenderer`'s
+   * `expandJarBytes` — duplicated here to avoid widening that class's surface for a single caller;
+   * the helper is small enough that the duplication is cheaper than a refactor.
+   */
+  private fun expandJarBytesSafely(appJarBytes: ByteArray, targetDir: File) {
+    val canonicalTarget = targetDir.canonicalFile
+    ZipInputStream(ByteArrayInputStream(appJarBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        val candidate = File(targetDir, entry.name).canonicalFile
+        if (
+          candidate != canonicalTarget &&
+            !candidate.path.startsWith(canonicalTarget.path + File.separator)
+        ) {
+          throw SecurityException(
+            "bundle daemon: app jar entry escapes target dir: ${entry.name} → ${candidate.path}"
+          )
+        }
+        if (entry.isDirectory) {
+          candidate.mkdirs()
+        } else {
+          candidate.parentFile?.mkdirs()
+          candidate.outputStream().use { sink -> zin.copyTo(sink) }
+        }
+        zin.closeEntry()
+      }
+    }
+  }
+
+  private fun createTempWorkDir(): File {
+    val base = System.getProperty("java.io.tmpdir") ?: "/tmp"
+    return File(base, "compose-preview-bundle-daemon-${System.nanoTime()}").also { it.mkdirs() }
+  }
+
+  /**
+   * Locate a sidecar jar dir inside the CLI install. In order: explicit sysprop override
+   * (`composeai.cli.libDaemonDesktopDir` / `composeai.cli.libRendererDir`), `$APP_HOME/<name>`,
+   * `<jar-parent>/../<name>` (IDE / `JavaExec` runs).
+   */
+  private fun locateSidecarJars(sidecarName: String): List<File> {
+    val sysprop =
+      when (sidecarName) {
+        "lib-daemon-desktop" -> "composeai.cli.libDaemonDesktopDir"
+        "lib-renderer" -> "composeai.cli.libRendererDir"
+        else -> "composeai.cli.${sidecarName.replace('-', '.')}Dir"
+      }
+    val override = System.getProperty(sysprop)
+    val appHome = System.getProperty("composeai.cli.appHome") ?: System.getenv("APP_HOME")
+    val candidates =
+      listOfNotNull(
+          override?.let { File(it) },
+          appHome?.let { File(it, sidecarName) },
+          inferSidecarFromClasspath(sidecarName),
+        )
+        .distinct()
+    val firstExistingDir = candidates.firstOrNull { it.isDirectory } ?: return emptyList()
+    return firstExistingDir
+      .listFiles { f -> f.isFile && f.name.endsWith(".jar") }
+      ?.sortedBy { it.name }
+      .orEmpty()
+  }
+
+  private fun sidecarSearchDescription(sidecarName: String): String {
+    val sysprop =
+      when (sidecarName) {
+        "lib-daemon-desktop" -> "composeai.cli.libDaemonDesktopDir"
+        "lib-renderer" -> "composeai.cli.libRendererDir"
+        else -> "composeai.cli.${sidecarName.replace('-', '.')}Dir"
+      }
+    val override = System.getProperty(sysprop)
+    val appHome = System.getProperty("composeai.cli.appHome") ?: System.getenv("APP_HOME")
+    return listOfNotNull(
+        override?.let { "-D$sysprop=$it" },
+        appHome?.let { "$it/$sidecarName" },
+        "<classpath-parent>/../$sidecarName",
+      )
+      .joinToString(" or ")
+  }
+
+  private fun inferSidecarFromClasspath(sidecarName: String): File? {
+    val cp = System.getProperty("java.class.path") ?: return null
+    val firstEntry = cp.split(File.pathSeparator).firstOrNull { it.endsWith(".jar") } ?: return null
+    val libDir = File(firstEntry).parentFile ?: return null
+    val installRoot = libDir.parentFile ?: return null
+    val candidate = File(installRoot, sidecarName)
+    return candidate.takeIf { it.isDirectory }
+  }
+
+  private fun locateJava(): String {
+    System.getProperty("composeai.cli.javaBinary")?.let {
+      return it
+    }
+    val javaHome = System.getProperty("java.home") ?: error("java.home not set")
+    val bin = File(javaHome, "bin/java")
+    if (bin.isFile) return bin.absolutePath
+    val winBin = File(javaHome, "bin/java.exe")
+    if (winBin.isFile) return winBin.absolutePath
+    return bin.absolutePath // best-effort; the spawn will surface the failure
+  }
+
+  companion object {
+    // Same names the gradle daemon launch path uses — kept inline so this command doesn't
+    // need an extra :daemon:core dependency just for the constants.
+    private const val USER_CLASS_DIRS_PROP = "composeai.daemon.userClassDirs"
+    private const val PREVIEWS_JSON_PATH_PROP = "composeai.daemon.previewsJsonPath"
+  }
+}

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -3014,6 +3014,21 @@ preview-app[data-minimal-mode="true"] data-tabs {
     display: none !important;
 }
 
+/* Bundle viewer mode: hosted by `BundleViewerPanel`, the panel shows
+   re-rendered previews from a `composePreviewBundle` file with no Gradle
+   module behind them. Drop the filter toolbar (function/group/layout
+   selectors don't apply to a single bundle), the compile-errors banner,
+   the progress bar (the host already shows a notification), and the data
+   tabs (no daemon to supply data products yet). Focus mode is forced from
+   the boot path so the carousel-style chrome is the only one visible. */
+preview-app[data-bundle-mode="true"] filter-toolbar,
+preview-app[data-bundle-mode="true"] compile-errors-banner,
+preview-app[data-bundle-mode="true"] progress-bar,
+preview-app[data-bundle-mode="true"] data-tabs,
+preview-app[data-bundle-mode="true"] bundle-chip-bar {
+    display: none !important;
+}
+
 /* In-view minimal-mode banner — surfaces the manual refresh, explains why
    saves don't auto-render, and links to the build script so the user can
    apply the Compose Preview plugin (which enables full mode). */

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -107,6 +107,13 @@
                 "category": "Compose Preview",
                 "icon": "$(device-mobile)",
                 "enablement": "config.composePreview.earlyFeatures.enabled"
+            },
+            {
+                "command": "composePreview.openBundle",
+                "title": "Open Preview Bundle…",
+                "category": "Compose Preview",
+                "icon": "$(package)",
+                "enablement": "config.composePreview.earlyFeatures.enabled"
             }
         ],
         "menus": {
@@ -125,6 +132,19 @@
                     "command": "composePreview.copyDoctorReport",
                     "when": "view == composePreview.panel",
                     "group": "navigation@3"
+                }
+            ],
+            "explorer/context": [
+                {
+                    "command": "composePreview.openBundle",
+                    "when": "resourceExtname == .png && config.composePreview.earlyFeatures.enabled",
+                    "group": "navigation@10"
+                }
+            ],
+            "commandPalette": [
+                {
+                    "command": "composePreview.openBundle",
+                    "when": "config.composePreview.earlyFeatures.enabled"
                 }
             ]
         },
@@ -159,6 +179,12 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Enable early, unstable preview features in the VS Code panel, including focus-mode diffs, focus inspector extension layers, a11y overlay controls, recording, and diff-all commands. Focus mode and live interactive previews remain available when this is off."
+                },
+                "composePreview.bundleCliPath": {
+                    "type": "string",
+                    "default": "",
+                    "scope": "machine-overridable",
+                    "markdownDescription": "Absolute path to the `compose-preview` CLI launcher used by `Compose Preview: Open Preview Bundle…`. Empty (default) falls back to `$COMPOSE_PREVIEW_CLI` and then `compose-preview` on PATH (the install script's default landing spot is `~/.local/bin/compose-preview`)."
                 },
                 "composePreview.logging.level": {
                     "type": "string",

--- a/vscode-extension/src/bundleDaemonHost.ts
+++ b/vscode-extension/src/bundleDaemonHost.ts
@@ -1,0 +1,259 @@
+// Spawns `compose-preview bundle daemon <bundle.png>` as a subprocess and
+// wraps its stdio in a `DaemonClient`. Lets `BundleViewerPanel` reach the
+// same protocol surface the sidebar panel uses for in-workspace modules
+// (renderNow, data/subscribe, interactive/*, composestream/1, …) without
+// owning anything beyond "feed this preview id to the daemon, surface
+// what comes back."
+//
+// One host per bundle viewer panel. Initialised lazily on first use so
+// the bundle can be opened even when the CLI isn't installed — the
+// panel falls back to a "daemon unavailable" toolbar in that case.
+
+import { ChildProcess, spawn } from "child_process";
+import * as fs from "fs";
+import { DaemonClient, DaemonClientEvents } from "./daemon/daemonClient";
+import {
+    DataSubscribeParams,
+    InitializeResult,
+    RenderNowParams,
+} from "./daemon/daemonProtocol";
+
+export interface BundleDaemonOptions {
+    /** Absolute path to the bundle file to mount. */
+    bundlePath: string;
+    /** Absolute path to the `compose-preview` launcher (resolved via
+     *  `bundleRender.locateBundleCli` upstream). */
+    cliPath: string;
+    /** Forwarded into `DaemonClient` for stderr / RPC tracing. */
+    logger?: { appendLine(line: string): void };
+    /** Daemon-event callbacks. The panel populates this with handlers that
+     *  forward renderFinished / updateA11y / updateDataProducts straight
+     *  to its webview. */
+    events: DaemonClientEvents;
+    /** Initialize payload's `clientVersion` field. Mirrors the sidebar
+     *  panel's value so the daemon's compatibility check passes
+     *  identically. */
+    clientVersion: string;
+}
+
+export interface BundleDaemonHandle {
+    /** JSON-RPC surface for caller-side requests (renderNow, dataSubscribe,
+     *  …). The client is wired to the spawned process's stdio. */
+    client: DaemonClient;
+    /** Capabilities + advertised extensions, returned by `initialize`
+     *  + `extensions/enable`. The panel uses
+     *  `capabilities.dataExtensions` to decide which chips to surface. */
+    initializeResult: InitializeResult;
+    /** Resolves with the JVM's exit code once it terminates. */
+    exited: Promise<number | null>;
+    /** Drops the subprocess (SIGTERM, then SIGKILL after a grace period
+     *  if the daemon hangs on stdout flush). Idempotent. */
+    dispose(): void;
+}
+
+export class BundleDaemonSpawnError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "BundleDaemonSpawnError";
+    }
+}
+
+/**
+ * Spawns the CLI subcommand, opens a [DaemonClient] over its stdio, and
+ * runs `initialize` + `initialized` + `extensions/enable` (with every
+ * advertised extension id) so the panel can start subscribing to data
+ * products immediately. Throws [BundleDaemonSpawnError] when the
+ * launcher exits before `initialize` resolves.
+ */
+export async function spawnBundleDaemon(
+    opts: BundleDaemonOptions,
+): Promise<BundleDaemonHandle> {
+    if (!fs.existsSync(opts.cliPath)) {
+        throw new BundleDaemonSpawnError(
+            `compose-preview launcher missing: ${opts.cliPath}`,
+        );
+    }
+    const child = spawn(
+        opts.cliPath,
+        ["bundle", "daemon", opts.bundlePath, "-v"],
+        {
+            stdio: ["pipe", "pipe", "pipe"],
+            windowsHide: true,
+        },
+    );
+    if (!child.stdin || !child.stdout || !child.stderr) {
+        throw new BundleDaemonSpawnError(
+            "bundle daemon spawn produced no stdio streams",
+        );
+    }
+    // The CLI emits a leading `[bundle-daemon] launching: …` block on
+    // stderr before exec-ing the JVM; surface it (and subsequent daemon
+    // stderr) into the extension log so spawn failures are debuggable.
+    child.stderr.setEncoding("utf-8");
+    child.stderr.on("data", (chunk: string) => {
+        for (const line of chunk.split(/\r?\n/)) {
+            if (line.length === 0) continue;
+            opts.logger?.appendLine(`[bundle-daemon] ${line}`);
+        }
+    });
+
+    const exited = new Promise<number | null>((resolve) => {
+        child.on("exit", (code) => {
+            opts.logger?.appendLine(
+                `[bundle-daemon] process exited with code=${code}`,
+            );
+            resolve(code);
+        });
+    });
+
+    // Reject fast if the launcher dies before `initialize` returns —
+    // happens when the CLI can't find its sidecar jars or the bundle is
+    // malformed beyond the manifest-read pre-flight.
+    const earlyDeath = new Promise<never>((_, reject) => {
+        child.once("exit", (code) => {
+            reject(
+                new BundleDaemonSpawnError(
+                    `bundle daemon exited before initialize (code=${code})`,
+                ),
+            );
+        });
+    });
+
+    const client = new DaemonClient(
+        child.stdin,
+        child.stdout,
+        opts.events,
+        opts.logger,
+    );
+
+    let initializeResult: InitializeResult;
+    try {
+        initializeResult = await Promise.race([
+            client.initialize({
+                clientVersion: opts.clientVersion,
+                workspaceRoot: "",
+                moduleId: `bundle:${opts.bundlePath}`,
+                moduleProjectDir: "",
+                capabilities: { visibility: true, metrics: true },
+            }),
+            earlyDeath,
+        ]);
+    } catch (err) {
+        safeKill(child);
+        throw err;
+    }
+    client.initialized();
+
+    // Same transitional opt-in the sidebar daemon does — enable every
+    // extension the daemon advertises so the panel's chip bar has
+    // something to subscribe to without per-card lifecycle bookkeeping.
+    try {
+        const list = await client.extensionsList();
+        const ids = (list.extensions ?? []).map((info) => info.id);
+        if (ids.length > 0) {
+            const enabled = await client.extensionsEnable({ ids });
+            initializeResult = {
+                ...initializeResult,
+                capabilities: {
+                    ...initializeResult.capabilities,
+                    dataProducts:
+                        enabled.dataProducts ??
+                        initializeResult.capabilities.dataProducts,
+                    dataExtensions:
+                        enabled.dataExtensions ??
+                        initializeResult.capabilities.dataExtensions,
+                    previewExtensions:
+                        enabled.previewExtensions ??
+                        initializeResult.capabilities.previewExtensions,
+                },
+            };
+        }
+    } catch (err) {
+        opts.logger?.appendLine(
+            `[bundle-daemon] extensions/list+enable failed: ${(err as Error).message}`,
+        );
+    }
+
+    return {
+        client,
+        initializeResult,
+        exited,
+        dispose: () => safeKill(child),
+    };
+}
+
+function safeKill(child: ChildProcess): void {
+    if (child.killed || child.exitCode !== null) return;
+    try {
+        child.kill("SIGTERM");
+    } catch {
+        /* ignore */
+    }
+    // Hard-kill grace period — the daemon should drain stdin and exit
+    // within a second of SIGTERM; if it hangs (uncaught throwable in a
+    // background thread), force the issue so the user's tab close
+    // doesn't leave a zombie JVM.
+    setTimeout(() => {
+        if (child.exitCode === null && !child.killed) {
+            try {
+                child.kill("SIGKILL");
+            } catch {
+                /* ignore */
+            }
+        }
+    }, 1500);
+}
+
+/**
+ * Helpers around the daemon's data-extension surface — the bundle viewer
+ * panel's webview messages map onto a small subset of the protocol and
+ * we collect the mapping here so the panel stays a thin router.
+ */
+export const A11Y_DATA_KINDS = ["a11y/atf", "a11y/hierarchy"] as const;
+
+/**
+ * Subscribe / unsubscribe all kinds in [kinds] for [previewId] against
+ * the supplied client, returning once every individual call resolves.
+ * Failures are caught and reported via [onError]; the call set is
+ * "best-effort" because the daemon may advertise a kind in
+ * `extensions/list` but reject `data/subscribe` for it (depends on
+ * connector readiness). Mirrors the sidebar panel's call shape.
+ */
+export async function setKindsSubscribed(
+    client: DaemonClient,
+    previewId: string,
+    kinds: readonly string[],
+    subscribed: boolean,
+    onError?: (kind: string, err: Error) => void,
+): Promise<void> {
+    await Promise.all(
+        kinds.map(async (kind) => {
+            const params: DataSubscribeParams = { previewId, kind };
+            try {
+                if (subscribed) {
+                    await client.dataSubscribe(params);
+                } else {
+                    await client.dataUnsubscribe(params);
+                }
+            } catch (err) {
+                onError?.(kind, err as Error);
+            }
+        }),
+    );
+}
+
+/** Convenience for the initial-render fan-out: ask the daemon to
+ *  render every preview id in the bundle at full tier. */
+export function renderAll(
+    client: DaemonClient,
+    previewIds: string[],
+    reason = "bundle-open",
+): Promise<unknown> {
+    if (previewIds.length === 0) return Promise.resolve();
+    const params: RenderNowParams = {
+        previews: previewIds,
+        tier: "full",
+        reason,
+    };
+    return client.renderNow(params);
+}

--- a/vscode-extension/src/bundleFormat.ts
+++ b/vscode-extension/src/bundleFormat.ts
@@ -1,0 +1,303 @@
+// Minimal reader for the PNG+ZIP polyglot produced by `composePreviewBundle`.
+//
+// The bundle is a valid PNG (Finder, GitHub, Slack render the cover image)
+// whose trailing bytes are a standard zip archive — any tool that walks
+// the EOCD signature `PK\x05\x06` reads the inner files. We only need to:
+//
+// 1. Recognise the file as a bundle (PNG header + EOCD present).
+// 2. Pull out `bundle.json` + `previews.json` so the host can title the
+//    editor and verify the bundle's backend before spawning the renderer.
+//
+// The CLI's `BundleReader.kt` does the same job on the JVM side; we keep
+// this TypeScript reader scoped to just-enough to surface a useful editor
+// title before the heavy `bundle render` subprocess has finished.
+
+import * as fs from "fs";
+import * as path from "path";
+import * as zlib from "zlib";
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const EOCD_MAGIC = Buffer.from([0x50, 0x4b, 0x05, 0x06]);
+const LOCAL_FILE_HEADER_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+// Cap on bundle file size we'll try to read inline. Real bundles are
+// typically 1–20 MB (one classes/app.jar + one cover PNG + manifests);
+// 200 MB is a generous ceiling that still rejects "the user dropped a
+// 4 GB MP4".
+const MAX_BUNDLE_BYTES = 200 * 1024 * 1024;
+// EOCD record search window. Spec allows up to 65 535 bytes of comment;
+// in practice composePreviewBundle writes no comment and the EOCD is at
+// the very end.
+const EOCD_SEARCH_BYTES = 64 * 1024;
+
+export interface BundleManifest {
+    /** Plugin schema version recorded by `composePreviewBundle`. v1 today. */
+    schemaVersion?: number;
+    backend?: string;
+    previewIds?: string[];
+    coverPreviewId?: string | null;
+    modulePath?: string;
+    producedBy?: string;
+}
+
+export interface PreviewParamsLike {
+    name?: string | null;
+    group?: string | null;
+    widthDp?: number | null;
+    heightDp?: number | null;
+    backgroundColor?: number;
+    showBackground?: boolean;
+    locale?: string | null;
+    fontScale?: number;
+    uiMode?: number;
+    device?: string | null;
+}
+
+export interface BundlePreviewInfo {
+    id: string;
+    functionName: string;
+    className: string;
+    sourceFile?: string | null;
+    params: PreviewParamsLike;
+}
+
+export interface BundlePreviewsManifest {
+    module?: string;
+    variant?: string;
+    previews: BundlePreviewInfo[];
+}
+
+export interface BundleContents {
+    manifest: BundleManifest | null;
+    previews: BundlePreviewsManifest | null;
+}
+
+export class BundleFormatError extends Error {
+    constructor(
+        public readonly file: string,
+        message: string,
+    ) {
+        super(message);
+        this.name = "BundleFormatError";
+    }
+}
+
+/**
+ * Quick sniff: does [filePath] look like a `composePreviewBundle`
+ * output? Reads only the header bytes + a tail window, so it stays cheap
+ * for drag-and-drop hover paths.
+ */
+export async function isLikelyBundle(filePath: string): Promise<boolean> {
+    let fh: fs.promises.FileHandle | null = null;
+    try {
+        fh = await fs.promises.open(filePath, "r");
+        const stat = await fh.stat();
+        if (stat.size < PNG_MAGIC.length + EOCD_MAGIC.length) {
+            return false;
+        }
+        const header = Buffer.alloc(PNG_MAGIC.length);
+        await fh.read(header, 0, header.length, 0);
+        if (!header.equals(PNG_MAGIC)) {
+            return false;
+        }
+        return (await findEocdOffset(fh, stat.size)) !== null;
+    } catch {
+        return false;
+    } finally {
+        await fh?.close();
+    }
+}
+
+/**
+ * Reads [filePath] as a PNG+ZIP polyglot and returns the parsed
+ * `bundle.json` + `previews.json` entries. Throws [BundleFormatError]
+ * if the file isn't a valid bundle (missing PNG header, no EOCD, zip
+ * portion unreadable, manifest absent). Either return field may be
+ * `null` when the entry was present but unparseable — the caller treats
+ * that as "open with the bytes we did get and let the renderer
+ * complain", rather than refusing the drop outright.
+ */
+export async function readBundleContents(
+    filePath: string,
+): Promise<BundleContents> {
+    const stat = await fs.promises.stat(filePath);
+    if (stat.size > MAX_BUNDLE_BYTES) {
+        throw new BundleFormatError(
+            filePath,
+            `bundle is ${formatBytes(stat.size)}; refusing to read past ${formatBytes(MAX_BUNDLE_BYTES)}.`,
+        );
+    }
+    if (stat.size < PNG_MAGIC.length + EOCD_MAGIC.length) {
+        throw new BundleFormatError(
+            filePath,
+            "file is too small to be a bundle.",
+        );
+    }
+    let fh: fs.promises.FileHandle | null = null;
+    try {
+        fh = await fs.promises.open(filePath, "r");
+        const header = Buffer.alloc(PNG_MAGIC.length);
+        await fh.read(header, 0, header.length, 0);
+        if (!header.equals(PNG_MAGIC)) {
+            throw new BundleFormatError(
+                filePath,
+                "file is not a PNG (missing PNG header bytes).",
+            );
+        }
+        const eocdOffset = await findEocdOffset(fh, stat.size);
+        if (eocdOffset === null) {
+            throw new BundleFormatError(
+                filePath,
+                "file has a PNG header but no zip end-of-central-directory record — not a bundle.",
+            );
+        }
+        // Read the whole file. Bundles are small (capped at
+        // MAX_BUNDLE_BYTES above) and we need the bytes between the
+        // first PK\x03\x04 local file header and the EOCD anyway — the
+        // PNG portion is a few hundred bytes of header + cover image.
+        // `readZipEntries` scans for the local-file-header magic so the
+        // PNG prefix is skipped without us needing to compute the exact
+        // boundary.
+        const zipBytes = await readBytes(fh, 0, stat.size);
+        const entries = readZipEntries(zipBytes);
+        return {
+            manifest: parseJsonEntry<BundleManifest>(entries, "bundle.json"),
+            previews: parseJsonEntry<BundlePreviewsManifest>(
+                entries,
+                "previews.json",
+            ),
+        };
+    } finally {
+        await fh?.close();
+    }
+}
+
+function parseJsonEntry<T>(
+    entries: Map<string, Buffer>,
+    name: string,
+): T | null {
+    const raw = entries.get(name);
+    if (!raw) return null;
+    try {
+        return JSON.parse(raw.toString("utf-8")) as T;
+    } catch {
+        return null;
+    }
+}
+
+async function findEocdOffset(
+    fh: fs.promises.FileHandle,
+    fileSize: number,
+): Promise<number | null> {
+    const window = Math.min(EOCD_SEARCH_BYTES, fileSize);
+    const start = fileSize - window;
+    const buf = await readBytes(fh, start, window);
+    for (let i = buf.length - EOCD_MAGIC.length; i >= 0; i--) {
+        if (
+            buf[i] === EOCD_MAGIC[0] &&
+            buf[i + 1] === EOCD_MAGIC[1] &&
+            buf[i + 2] === EOCD_MAGIC[2] &&
+            buf[i + 3] === EOCD_MAGIC[3]
+        ) {
+            return start + i;
+        }
+    }
+    return null;
+}
+
+async function readBytes(
+    fh: fs.promises.FileHandle,
+    offset: number,
+    length: number,
+): Promise<Buffer> {
+    const buf = Buffer.alloc(length);
+    const { bytesRead } = await fh.read(buf, 0, length, offset);
+    return bytesRead === length ? buf : buf.subarray(0, bytesRead);
+}
+
+/**
+ * Minimal zip walker: scans for local file headers (`PK\x03\x04`) and
+ * inflates each entry. Skips entries whose compressed payload we can't
+ * read (zip64, encryption, unsupported compression methods) rather than
+ * throwing — the caller only needs `bundle.json` + `previews.json` and
+ * the rest of the archive (classes/app.jar, renders/*.png, etc.) is
+ * consumed by the JVM-side renderer.
+ */
+function readZipEntries(zipBytes: Buffer): Map<string, Buffer> {
+    const out = new Map<string, Buffer>();
+    // Locate the start of the zip portion by scanning for the first
+    // local-file-header magic. The polyglot file has PNG bytes before
+    // this point.
+    let cursor = findLocalFileHeaderStart(zipBytes);
+    if (cursor < 0) return out;
+    while (cursor + 30 <= zipBytes.length) {
+        if (zipBytes.readUInt32LE(cursor) !== 0x04034b50) {
+            break;
+        }
+        const compressionMethod = zipBytes.readUInt16LE(cursor + 8);
+        const compressedSize = zipBytes.readUInt32LE(cursor + 18);
+        const uncompressedSize = zipBytes.readUInt32LE(cursor + 22);
+        const nameLen = zipBytes.readUInt16LE(cursor + 26);
+        const extraLen = zipBytes.readUInt16LE(cursor + 28);
+        const nameStart = cursor + 30;
+        const dataStart = nameStart + nameLen + extraLen;
+        if (dataStart + compressedSize > zipBytes.length) break;
+        const name = zipBytes.toString("utf-8", nameStart, nameStart + nameLen);
+        const payload = zipBytes.subarray(
+            dataStart,
+            dataStart + compressedSize,
+        );
+        const inflated = inflate(compressionMethod, payload, uncompressedSize);
+        if (inflated) out.set(name, inflated);
+        cursor = dataStart + compressedSize;
+    }
+    return out;
+}
+
+function findLocalFileHeaderStart(buf: Buffer): number {
+    for (let i = 0; i + 4 <= buf.length; i++) {
+        if (
+            buf[i] === LOCAL_FILE_HEADER_MAGIC[0] &&
+            buf[i + 1] === LOCAL_FILE_HEADER_MAGIC[1] &&
+            buf[i + 2] === LOCAL_FILE_HEADER_MAGIC[2] &&
+            buf[i + 3] === LOCAL_FILE_HEADER_MAGIC[3]
+        ) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+function inflate(
+    method: number,
+    payload: Buffer,
+    uncompressedSize: number,
+): Buffer | null {
+    try {
+        if (method === 0) {
+            return payload.subarray(0, uncompressedSize);
+        }
+        if (method === 8) {
+            return zlib.inflateRawSync(payload);
+        }
+    } catch {
+        return null;
+    }
+    return null;
+}
+
+function formatBytes(n: number): string {
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+    if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MiB`;
+    return `${(n / 1024 / 1024 / 1024).toFixed(2)} GiB`;
+}
+
+/** Short label for a bundle file — the basename minus `.bundle.png` /
+ *  `.png` suffix. Used as the editor tab title. */
+export function bundleLabel(filePath: string): string {
+    const base = path.basename(filePath);
+    if (base.endsWith(".bundle.png"))
+        return base.slice(0, -".bundle.png".length);
+    if (base.endsWith(".png")) return base.slice(0, -".png".length);
+    return base;
+}

--- a/vscode-extension/src/bundleRender.ts
+++ b/vscode-extension/src/bundleRender.ts
@@ -1,0 +1,188 @@
+// Drives `compose-preview bundle render <bundle.png> -o <outDir>` from the
+// extension host — used by the bundle viewer panel to re-render a dropped
+// or command-opened bundle outside any Gradle workspace.
+//
+// The CLI's `BundleRenderer` already handles classpath resolution, the
+// per-preview subprocess fan-out, and the manifest parsing — we just need
+// to spawn the launcher, parse its summary lines, and surface progress to
+// VS Code's notification UI.
+
+import { spawn } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import { BundleRenderResult, parseRenderOutput } from "./bundleRenderOutput";
+
+export { BundleRenderResult, parseRenderOutput } from "./bundleRenderOutput";
+export type {
+    BundleFailedPreview,
+    BundleRenderedPreview,
+} from "./bundleRenderOutput";
+
+/** Stand-in for the CLI not being on PATH (or the config override
+ *  pointing at a non-executable file). Distinct from a launcher that
+ *  exited non-zero — that surfaces as a regular `Error`. */
+export class BundleCliNotFoundError extends Error {
+    constructor(public readonly searched: string[]) {
+        super(
+            `compose-preview CLI not found. Looked at: ${searched.join(", ")}. ` +
+                "Install the CLI via `scripts/install.sh` or set `composePreview.bundleCliPath`.",
+        );
+        this.name = "BundleCliNotFoundError";
+    }
+}
+
+export interface BundleRenderOptions {
+    bundlePath: string;
+    outputDir: string;
+    /** Resolved CLI launcher path. Use [locateBundleCli] to find one. */
+    cliPath: string;
+    /** Receives one decoded chunk of stdout/stderr per write. The host
+     *  uses this to surface live progress in the notification body. */
+    onOutput?: (chunk: string) => void;
+    /** Cancellation token from `vscode.window.withProgress`. When fired,
+     *  we SIGTERM the subprocess and reject. */
+    cancellation?: vscode.CancellationToken;
+}
+
+/**
+ * Spawns `compose-preview bundle render <bundlePath> -o <outputDir> -v`
+ * and returns the parsed result. Throws on launcher failure (non-zero
+ * exit, killed, or unparseable output); per-preview render failures are
+ * reported via [BundleRenderResult.failed] and don't reject the promise.
+ */
+export async function renderBundle(
+    opts: BundleRenderOptions,
+): Promise<BundleRenderResult> {
+    await fs.promises.mkdir(opts.outputDir, { recursive: true });
+    const args = [
+        "bundle",
+        "render",
+        opts.bundlePath,
+        "-o",
+        opts.outputDir,
+        "-v",
+    ];
+    return new Promise<BundleRenderResult>((resolve, reject) => {
+        const proc = spawn(opts.cliPath, args, {
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+        let cancelled = false;
+        const cancel = opts.cancellation?.onCancellationRequested(() => {
+            cancelled = true;
+            proc.kill("SIGTERM");
+        });
+        let stdout = "";
+        let stderr = "";
+        proc.stdout.on("data", (chunk: Buffer) => {
+            const text = chunk.toString("utf-8");
+            stdout += text;
+            opts.onOutput?.(text);
+        });
+        proc.stderr.on("data", (chunk: Buffer) => {
+            const text = chunk.toString("utf-8");
+            stderr += text;
+            opts.onOutput?.(text);
+        });
+        proc.on("error", (err) => {
+            cancel?.dispose();
+            reject(err);
+        });
+        proc.on("close", (code) => {
+            cancel?.dispose();
+            if (cancelled) {
+                reject(new Error("bundle render cancelled"));
+                return;
+            }
+            const result = parseRenderOutput(stdout, opts.outputDir);
+            if (result === null) {
+                reject(
+                    new Error(
+                        `compose-preview bundle render exited with code ${code} and no summary on stdout.\n` +
+                            tailLines(stderr || stdout, 20),
+                    ),
+                );
+                return;
+            }
+            if (code !== 0 && result.succeeded.length === 0) {
+                reject(
+                    new Error(
+                        `compose-preview bundle render exited with code ${code}.\n` +
+                            tailLines(stderr || stdout, 20),
+                    ),
+                );
+                return;
+            }
+            resolve(result);
+        });
+    });
+}
+
+function tailLines(text: string, count: number): string {
+    const lines = text.split(/\r?\n/);
+    return lines.slice(-count).join("\n");
+}
+
+/**
+ * Locate a `compose-preview` launcher to use for `bundle render`. In
+ * order:
+ *
+ * 1. `composePreview.bundleCliPath` setting — explicit user override.
+ * 2. `COMPOSE_PREVIEW_CLI` environment variable — same purpose, useful
+ *    for CI / dev shells that bake the path into a profile.
+ * 3. `compose-preview` on PATH — the install script's default landing
+ *    spot (`~/.local/bin/compose-preview`).
+ *
+ * Returns the absolute path of the first existing candidate, or throws
+ * [BundleCliNotFoundError] listing what was tried.
+ */
+export async function locateBundleCli(): Promise<string> {
+    const tried: string[] = [];
+    const configured = vscode.workspace
+        .getConfiguration("composePreview")
+        .get<string>("bundleCliPath");
+    if (configured && configured.trim().length > 0) {
+        tried.push(`composePreview.bundleCliPath=${configured}`);
+        if (await isExecutable(configured)) return configured;
+    }
+    const envCli = process.env.COMPOSE_PREVIEW_CLI;
+    if (envCli && envCli.trim().length > 0) {
+        tried.push(`COMPOSE_PREVIEW_CLI=${envCli}`);
+        if (await isExecutable(envCli)) return envCli;
+    }
+    const fromPath = await findOnPath("compose-preview");
+    if (fromPath) {
+        tried.push(`PATH=${fromPath}`);
+        return fromPath;
+    }
+    tried.push("PATH (no `compose-preview` entry)");
+    throw new BundleCliNotFoundError(tried);
+}
+
+async function isExecutable(filePath: string): Promise<boolean> {
+    try {
+        const stat = await fs.promises.stat(filePath);
+        if (!stat.isFile()) return false;
+        await fs.promises.access(filePath, fs.constants.X_OK);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function findOnPath(binary: string): Promise<string | null> {
+    const PATH = process.env.PATH ?? "";
+    const sep = process.platform === "win32" ? ";" : ":";
+    const exts =
+        process.platform === "win32"
+            ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT").split(";")
+            : [""];
+    for (const dir of PATH.split(sep)) {
+        if (!dir) continue;
+        for (const ext of exts) {
+            const candidate = path.join(dir, binary + ext.toLowerCase());
+            if (await isExecutable(candidate)) return candidate;
+        }
+    }
+    return null;
+}

--- a/vscode-extension/src/bundleRenderOutput.ts
+++ b/vscode-extension/src/bundleRenderOutput.ts
@@ -1,0 +1,72 @@
+// Pure parser for `compose-preview bundle render`'s summary block. Lives
+// in its own module (no `vscode` import) so it can be unit-tested under
+// the host mocha harness — `bundleRender.ts` pulls vscode in for the
+// `withProgress` integration and isn't loadable outside the editor.
+
+import * as path from "path";
+
+export interface BundleRenderedPreview {
+    /** Preview id as recorded in the bundle's `previews.json`. */
+    id: string;
+    /** Absolute path to the rendered PNG inside the output directory. */
+    outputFile: string;
+}
+
+export interface BundleFailedPreview {
+    id: string;
+    exitCode: number;
+}
+
+export interface BundleRenderResult {
+    previewCount: number;
+    succeeded: BundleRenderedPreview[];
+    failed: BundleFailedPreview[];
+}
+
+/**
+ * Parses the CLI's render summary block. Output shape from
+ * `cli/src/main/kotlin/.../BundleCommand.kt` (RenderSubcommand):
+ *
+ *     rendered N / M preview(s) → <outputDir>
+ *       ok    <id>  →  <basename.png>
+ *       FAIL  <id>  (exit=<code>)
+ *
+ * Returns `null` when no summary line was found — the caller treats that
+ * as launcher failure rather than "rendered 0 of 0".
+ */
+export function parseRenderOutput(
+    stdout: string,
+    outputDir: string,
+): BundleRenderResult | null {
+    const summaryMatch = stdout.match(
+        /rendered\s+(\d+)\s*\/\s*(\d+)\s+preview\(s\)/,
+    );
+    if (!summaryMatch) return null;
+    const succeeded: BundleRenderedPreview[] = [];
+    const failed: BundleFailedPreview[] = [];
+    const okRe = /^\s{2}ok\s+(\S+)\s+→\s+(.+?)\s*$/;
+    const failRe = /^\s{2}FAIL\s+(\S+)\s+\(exit=(-?\d+)\)/;
+    for (const line of stdout.split(/\r?\n/)) {
+        const ok = line.match(okRe);
+        if (ok) {
+            const id = ok[1];
+            const filename = ok[2];
+            succeeded.push({
+                id,
+                outputFile: path.isAbsolute(filename)
+                    ? filename
+                    : path.join(outputDir, filename),
+            });
+            continue;
+        }
+        const fail = line.match(failRe);
+        if (fail) {
+            failed.push({ id: fail[1], exitCode: parseInt(fail[2], 10) });
+        }
+    }
+    return {
+        previewCount: parseInt(summaryMatch[2], 10),
+        succeeded,
+        failed,
+    };
+}

--- a/vscode-extension/src/bundleViewerPanel.ts
+++ b/vscode-extension/src/bundleViewerPanel.ts
@@ -1,18 +1,20 @@
 // Editor-style webview panel for an opened preview bundle.
 //
 // The bundle is a `composePreviewBundle` polyglot file (PNG header
-// followed by a zip). We extract its manifest, re-render the contained
-// previews via `compose-preview bundle render`, then surface the
-// renders in a panel that reuses the existing `<preview-app>` Lit
-// element in `bundle-mode` — focus-mode chrome, no Gradle / daemon
-// coupling.
+// followed by a zip). We spawn the desktop daemon JVM bound to that
+// bundle's classpath via `compose-preview bundle daemon`, then surface
+// the daemon's renders + data extensions in a panel that reuses the
+// existing `<preview-app>` Lit element in `bundle-mode`. The daemon
+// stays resident for the lifetime of the tab so focus-mode features
+// (data-extension chips, a11y overlay, interactive, recording) work the
+// same way as in the sidebar panel — they're just sourced from a packed
+// bundle rather than a Gradle module.
 //
-// One panel per bundle path; opening the same bundle twice reveals the
-// existing tab rather than spawning a duplicate render.
+// One panel per absolute bundle path; opening the same bundle twice
+// reveals the existing tab rather than spawning a duplicate daemon.
 
 import * as crypto from "crypto";
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 import {
@@ -21,21 +23,53 @@ import {
     BundleFormatError,
     readBundleContents,
 } from "./bundleFormat";
+import { BundleCliNotFoundError, locateBundleCli } from "./bundleRender";
 import {
-    BundleCliNotFoundError,
-    BundleRenderResult,
-    locateBundleCli,
-    renderBundle,
-} from "./bundleRender";
+    A11Y_DATA_KINDS,
+    BundleDaemonHandle,
+    renderAll,
+    setKindsSubscribed,
+    spawnBundleDaemon,
+} from "./bundleDaemonHost";
+import { DaemonClient } from "./daemon/daemonClient";
+import {
+    DataProductAttachment,
+    RenderFailedParams,
+    RenderFinishedParams,
+} from "./daemon/daemonProtocol";
 import type { Capture, PreviewInfo, PreviewParams } from "./types";
 
 const CHANNEL = "[bundle-viewer]";
+const CLIENT_VERSION = "compose-preview-bundle-viewer/1";
 
 export interface BundleViewerHostDeps {
     extensionUri: vscode.Uri;
     earlyFeaturesEnabled: () => boolean;
     logLine: (message: string) => void;
 }
+
+/**
+ * Webview messages this panel reads from `<preview-app>`. Same wire
+ * shapes as the sidebar router, just scoped to the subset that makes
+ * sense for a bundle (no module-relative file opens, no Gradle refresh).
+ */
+type WebviewMessage =
+    | { command: "webviewReady" }
+    | { command: "openExternal"; url: string }
+    | { command: "setA11yOverlay"; previewId: string; enabled: boolean }
+    | {
+          command: "setDataExtensionEnabled";
+          previewId: string;
+          kinds: string[];
+          enabled: boolean;
+      }
+    | { command: "refreshHeavy"; previewId: string }
+    | { command: "previewScopeChanged"; previewId: string | null }
+    | {
+          command: "viewportUpdated";
+          visible: string[];
+          predicted: string[];
+      };
 
 export class BundleViewerPanel {
     /** Open panels keyed by absolute bundle path. */
@@ -92,8 +126,22 @@ export class BundleViewerPanel {
         return viewer;
     }
 
-    private renderRoot: string | null = null;
     private disposed = false;
+    private daemon: BundleDaemonHandle | null = null;
+    /** Webview signalled `webviewReady`; safe to push messages after this. */
+    private webviewReady = false;
+    /** Queued initial `setPreviews` until the webview is ready (the panel
+     *  can boot before its first `firstUpdated` if the user has the tab in
+     *  the background while VS Code restores window state). */
+    private pendingSetPreviews: PreviewInfo[] | null = null;
+    /** Active a11y-overlay subscriptions, used so `dispose` can unwind
+     *  the daemon-side state cleanly even when the panel closes
+     *  abruptly. */
+    private readonly a11yOverlays = new Set<string>();
+    /** `(previewId, kind)` subscriptions started via the data-extension
+     *  chip-bar. Mirrors the wire state so a chip toggle off (or panel
+     *  disposal) unsubscribes exactly what we subscribed to. */
+    private readonly dataSubscriptions = new Map<string, Set<string>>();
 
     private constructor(
         private readonly bundlePath: string,
@@ -103,32 +151,24 @@ export class BundleViewerPanel {
     ) {
         panel.webview.html = this.buildHtml();
         panel.onDidDispose(() => this.dispose());
-        panel.webview.onDidReceiveMessage(
-            (msg: { command?: string }) => void this.onWebviewMessage(msg),
-        );
+        panel.webview.onDidReceiveMessage((msg: WebviewMessage) => {
+            void this.onWebviewMessage(msg);
+        });
     }
 
     private dispose(): void {
         if (this.disposed) return;
         this.disposed = true;
         BundleViewerPanel.active.delete(this.bundlePath);
-        if (this.renderRoot) {
-            // Best-effort: drop the temp renders so we don't accumulate
-            // them across sessions. Ignore errors — the OS will clean up
-            // anything we leave behind on reboot.
-            fs.promises
-                .rm(this.renderRoot, { recursive: true, force: true })
-                .catch(() => {
-                    /* ignore */
-                });
-        }
+        this.daemon?.dispose();
+        this.daemon = null;
     }
 
     private start(): void {
-        void this.runRender();
+        void this.spawnDaemonAndSeed();
     }
 
-    private async runRender(): Promise<void> {
+    private async spawnDaemonAndSeed(): Promise<void> {
         let cliPath: string;
         try {
             cliPath = await locateBundleCli();
@@ -144,72 +184,165 @@ export class BundleViewerPanel {
             );
             return;
         }
-        const renderRoot = await fs.promises.mkdtemp(
-            path.join(os.tmpdir(), "compose-preview-bundle-"),
-        );
-        this.renderRoot = renderRoot;
-        let result: BundleRenderResult;
+        let daemon: BundleDaemonHandle;
         try {
-            result = await vscode.window.withProgress(
+            daemon = await vscode.window.withProgress(
                 {
                     location: vscode.ProgressLocation.Notification,
-                    title: `Rendering bundle ${bundleLabel(this.bundlePath)}…`,
-                    cancellable: true,
+                    title: `Starting preview daemon for ${bundleLabel(this.bundlePath)}…`,
+                    cancellable: false,
                 },
-                async (progress, token) => {
-                    return renderBundle({
+                () =>
+                    spawnBundleDaemon({
                         bundlePath: this.bundlePath,
-                        outputDir: renderRoot,
                         cliPath,
-                        cancellation: token,
-                        onOutput: (chunk) => {
-                            const line = chunk.split(/\r?\n/).at(-1)?.trim();
-                            if (line) progress.report({ message: line });
+                        logger: {
+                            appendLine: (line) => this.deps.logLine(line),
                         },
-                    });
-                },
+                        clientVersion: CLIENT_VERSION,
+                        events: {
+                            onRenderFinished: (params) =>
+                                void this.onRenderFinished(params),
+                            onRenderFailed: (params) =>
+                                this.onRenderFailed(params),
+                        },
+                    }),
             );
         } catch (err) {
             const message = (err as Error).message ?? String(err);
-            this.deps.logLine(`${CHANNEL} render failed: ${message}`);
-            this.postError("Bundle render failed", message);
+            this.deps.logLine(`${CHANNEL} daemon spawn failed: ${message}`);
+            this.postError("Bundle daemon failed to start", message);
             return;
         }
-        await this.publish(result);
+        this.daemon = daemon;
+        // If the JVM dies while the panel is still open, surface it once
+        // and dispose so a follow-up open spawns a fresh daemon rather
+        // than re-using the dead handle.
+        daemon.exited.then((code) => {
+            if (this.disposed || code === null || code === 0) return;
+            this.postError(
+                "Bundle daemon exited",
+                `JVM exit code ${code} — open the Compose Preview output channel for details.`,
+            );
+            this.dispose();
+        });
+
+        const previews = synthesisePreviews(this.contents);
+        this.pendingSetPreviews = previews;
+        if (this.webviewReady) this.flushPendingSetPreviews();
+
+        // Tell the daemon the panel cares about every preview in the
+        // bundle. `setVisible` ungates the scheduler and lets
+        // subsequent `renderNow` calls actually fan out.
+        const ids = previews.map((p) => p.id);
+        try {
+            daemon.client.setVisible({ ids });
+        } catch (err) {
+            this.deps.logLine(
+                `${CHANNEL} setVisible failed: ${(err as Error).message}`,
+            );
+        }
+        try {
+            await renderAll(daemon.client, ids, "bundle-open");
+        } catch (err) {
+            this.deps.logLine(
+                `${CHANNEL} initial renderNow failed: ${(err as Error).message}`,
+            );
+        }
     }
 
-    private async publish(result: BundleRenderResult): Promise<void> {
-        if (this.disposed) return;
-        const previews = synthesisePreviews(this.contents, result);
+    private flushPendingSetPreviews(): void {
+        const previews = this.pendingSetPreviews;
+        if (!previews) return;
+        this.pendingSetPreviews = null;
+        // Signal "daemon-backed mode is live" to the webview by writing a
+        // truthy moduleDir — `<preview-app>`'s bundle-mode toolbar gating
+        // unhides the daemon-driven buttons once it sees a non-empty
+        // module id. Bundle path serves as the synthetic id.
         this.panel.webview.postMessage({
             command: "setPreviews",
             previews,
-            moduleDir: this.renderRoot ?? "",
+            moduleDir: `bundle:${this.bundlePath}`,
             heavyStaleIds: [],
         });
-        await Promise.all(
-            result.succeeded.map(async (rendered) => {
-                try {
-                    const buf = await fs.promises.readFile(rendered.outputFile);
-                    if (this.disposed) return;
-                    this.panel.webview.postMessage({
-                        command: "updateImage",
-                        previewId: rendered.id,
-                        captureIndex: 0,
-                        imageData: buf.toString("base64"),
-                    });
-                } catch (err) {
-                    this.deps.logLine(
-                        `${CHANNEL} read render ${rendered.id} failed: ${(err as Error).message}`,
-                    );
-                }
-            }),
-        );
-        if (result.failed.length > 0) {
-            const ids = result.failed.map((f) => f.id).join(", ");
-            void vscode.window.showWarningMessage(
-                `Compose Preview — ${path.basename(this.bundlePath)}: ${result.failed.length} preview(s) failed to render (${ids}).`,
+        this.panel.webview.postMessage({
+            command: "bundleDaemonReady",
+            bundlePath: this.bundlePath,
+        });
+    }
+
+    private async onRenderFinished(
+        params: RenderFinishedParams,
+    ): Promise<void> {
+        if (this.disposed) return;
+        try {
+            const buf = await fs.promises.readFile(params.pngPath);
+            this.panel.webview.postMessage({
+                command: "updateImage",
+                previewId: params.id,
+                captureIndex: 0,
+                imageData: buf.toString("base64"),
+            });
+        } catch (err) {
+            this.deps.logLine(
+                `${CHANNEL} read renderFinished png ${params.pngPath}: ${(err as Error).message}`,
             );
+        }
+        // Forward subscribed data-product attachments to the webview.
+        // Same shape the sidebar's `updateA11y` / `updateDataProducts`
+        // uses; the bundle viewer's <preview-app> consumes them
+        // identically.
+        if (params.dataProducts?.length) {
+            this.forwardDataProducts(params.id, params.dataProducts);
+        }
+    }
+
+    private onRenderFailed(params: RenderFailedParams): void {
+        if (this.disposed) return;
+        this.panel.webview.postMessage({
+            command: "setImageError",
+            previewId: params.id,
+            captureIndex: 0,
+            message: params.error?.message ?? "Render failed",
+        });
+    }
+
+    /**
+     * Split [attachments] into the a11y bucket (which the webview
+     * consumes via `updateA11y` with structured findings + hierarchy
+     * nodes) and the generic bucket (`updateDataProducts`). Mirrors the
+     * sidebar's mapping at extension.ts:onRenderFinished.
+     */
+    private forwardDataProducts(
+        previewId: string,
+        attachments: DataProductAttachment[],
+    ): void {
+        let findings: unknown = undefined;
+        let nodes: unknown = undefined;
+        const others: { kind: string; payload: unknown }[] = [];
+        for (const att of attachments) {
+            if (att.kind === "a11y/atf") {
+                findings = att.payload ?? null;
+            } else if (att.kind === "a11y/hierarchy") {
+                nodes = att.payload ?? null;
+            } else {
+                others.push({ kind: att.kind, payload: att.payload });
+            }
+        }
+        if (findings !== undefined || nodes !== undefined) {
+            this.panel.webview.postMessage({
+                command: "updateA11y",
+                previewId,
+                findings,
+                nodes,
+            });
+        }
+        if (others.length > 0) {
+            this.panel.webview.postMessage({
+                command: "updateDataProducts",
+                previewId,
+                dataProducts: others,
+            });
         }
     }
 
@@ -219,15 +352,119 @@ export class BundleViewerPanel {
         );
     }
 
-    private async onWebviewMessage(msg: { command?: string }): Promise<void> {
-        // The bundle viewer only round-trips a handful of messages today.
-        // Most webview→host commands (refreshHeavy, requestStreamStart,
-        // …) assume a Gradle module; in bundle mode they no-op silently.
-        if (msg.command === "openExternal") {
-            const url = (msg as { url?: string }).url;
-            if (url && /^https?:\/\//i.test(url)) {
-                void vscode.env.openExternal(vscode.Uri.parse(url));
-            }
+    private async onWebviewMessage(msg: WebviewMessage): Promise<void> {
+        if (this.disposed) return;
+        switch (msg.command) {
+            case "webviewReady":
+                this.webviewReady = true;
+                if (this.pendingSetPreviews) this.flushPendingSetPreviews();
+                break;
+            case "openExternal":
+                if (msg.url && /^https?:\/\//i.test(msg.url)) {
+                    void vscode.env.openExternal(vscode.Uri.parse(msg.url));
+                }
+                break;
+            case "setA11yOverlay":
+                await this.handleA11yOverlay(msg.previewId, msg.enabled);
+                break;
+            case "setDataExtensionEnabled":
+                await this.handleDataExtensionToggle(
+                    msg.previewId,
+                    msg.kinds,
+                    msg.enabled,
+                );
+                break;
+            case "refreshHeavy":
+                await this.requestRender([msg.previewId], "refresh-heavy");
+                break;
+            case "previewScopeChanged":
+                // Informational — the bundle viewer ignores scope shifts
+                // because every preview in the bundle is "in scope".
+                break;
+            case "viewportUpdated":
+                this.daemon?.client.setVisible({ ids: msg.visible });
+                break;
+        }
+    }
+
+    private async handleA11yOverlay(
+        previewId: string,
+        enabled: boolean,
+    ): Promise<void> {
+        if (!this.daemon) return;
+        if (enabled) {
+            this.a11yOverlays.add(previewId);
+        } else {
+            this.a11yOverlays.delete(previewId);
+        }
+        await setKindsSubscribed(
+            this.daemon.client,
+            previewId,
+            A11Y_DATA_KINDS,
+            enabled,
+            (kind, err) =>
+                this.deps.logLine(
+                    `${CHANNEL} data/${enabled ? "subscribe" : "unsubscribe"} ${kind} ${previewId} failed: ${err.message}`,
+                ),
+        );
+        if (!enabled) {
+            // Tear down panel-side cache the same way the sidebar does —
+            // an empty `updateA11y` clears the overlay without waiting
+            // for a fresh renderFinished.
+            this.panel.webview.postMessage({
+                command: "updateA11y",
+                previewId,
+                findings: null,
+                nodes: null,
+            });
+        } else {
+            await this.requestRender([previewId], "a11y-overlay-on");
+        }
+    }
+
+    private async handleDataExtensionToggle(
+        previewId: string,
+        kinds: string[],
+        enabled: boolean,
+    ): Promise<void> {
+        if (!this.daemon) return;
+        const bucket =
+            this.dataSubscriptions.get(previewId) ?? new Set<string>();
+        for (const kind of kinds) {
+            if (enabled) bucket.add(kind);
+            else bucket.delete(kind);
+        }
+        if (bucket.size === 0) this.dataSubscriptions.delete(previewId);
+        else this.dataSubscriptions.set(previewId, bucket);
+        await setKindsSubscribed(
+            this.daemon.client,
+            previewId,
+            kinds,
+            enabled,
+            (kind, err) =>
+                this.deps.logLine(
+                    `${CHANNEL} data ${enabled ? "subscribe" : "unsubscribe"} ${kind} ${previewId}: ${err.message}`,
+                ),
+        );
+        if (enabled) {
+            // Trigger a render so the daemon attaches the newly-subscribed
+            // kinds; mirrors what the sidebar does after a chip toggle.
+            await this.requestRender([previewId], "extension-on");
+        }
+    }
+
+    private async requestRender(
+        previews: string[],
+        reason: string,
+    ): Promise<void> {
+        const client: DaemonClient | undefined = this.daemon?.client;
+        if (!client) return;
+        try {
+            await client.renderNow({ previews, tier: "full", reason });
+        } catch (err) {
+            this.deps.logLine(
+                `${CHANNEL} renderNow ${previews.join(",")} (${reason}) failed: ${(err as Error).message}`,
+            );
         }
     }
 
@@ -272,19 +509,13 @@ export class BundleViewerPanel {
 }
 
 /**
- * Map the bundle's discovery-time `previews.json` + the per-preview CLI
- * render outcomes into the `PreviewInfo` shape `<preview-app>` consumes
- * via `setPreviews`. The render-output filename is bundle-viewer-local
- * (`<renderRoot>/<safeFilename(id)>.png`), which we record as an absolute
- * path; the panel's `setPreviews` handler treats `moduleDir` + the
- * `renderOutput` field as an absolute path when the first segment is
- * already rooted.
+ * Map the bundle's discovery-time `previews.json` into the `PreviewInfo`
+ * shape `<preview-app>` consumes via `setPreviews`. Images arrive later
+ * via daemon `renderFinished` notifications → host `updateImage`
+ * postMessages, so the synthetic `Capture[]` here carries a placeholder
+ * `renderOutput` string that the panel only uses as a key.
  */
-function synthesisePreviews(
-    contents: BundleContents,
-    result: BundleRenderResult,
-): PreviewInfo[] {
-    const renderById = new Map(result.succeeded.map((r) => [r.id, r]));
+function synthesisePreviews(contents: BundleContents): PreviewInfo[] {
     return (contents.previews?.previews ?? []).map((entry) => {
         const params: PreviewParams = {
             name: entry.params.name ?? null,
@@ -299,12 +530,11 @@ function synthesisePreviews(
             locale: entry.params.locale ?? null,
             group: entry.params.group ?? null,
         };
-        const rendered = renderById.get(entry.id);
         const captures: Capture[] = [
             {
                 advanceTimeMillis: null,
                 scroll: null,
-                renderOutput: rendered ? rendered.outputFile : "",
+                renderOutput: `${entry.id}.png`,
             },
         ];
         return {

--- a/vscode-extension/src/bundleViewerPanel.ts
+++ b/vscode-extension/src/bundleViewerPanel.ts
@@ -1,0 +1,319 @@
+// Editor-style webview panel for an opened preview bundle.
+//
+// The bundle is a `composePreviewBundle` polyglot file (PNG header
+// followed by a zip). We extract its manifest, re-render the contained
+// previews via `compose-preview bundle render`, then surface the
+// renders in a panel that reuses the existing `<preview-app>` Lit
+// element in `bundle-mode` — focus-mode chrome, no Gradle / daemon
+// coupling.
+//
+// One panel per bundle path; opening the same bundle twice reveals the
+// existing tab rather than spawning a duplicate render.
+
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as vscode from "vscode";
+import {
+    BundleContents,
+    bundleLabel,
+    BundleFormatError,
+    readBundleContents,
+} from "./bundleFormat";
+import {
+    BundleCliNotFoundError,
+    BundleRenderResult,
+    locateBundleCli,
+    renderBundle,
+} from "./bundleRender";
+import type { Capture, PreviewInfo, PreviewParams } from "./types";
+
+const CHANNEL = "[bundle-viewer]";
+
+export interface BundleViewerHostDeps {
+    extensionUri: vscode.Uri;
+    earlyFeaturesEnabled: () => boolean;
+    logLine: (message: string) => void;
+}
+
+export class BundleViewerPanel {
+    /** Open panels keyed by absolute bundle path. */
+    private static readonly active = new Map<string, BundleViewerPanel>();
+
+    /**
+     * Open (or reveal) a viewer for [bundlePath]. The file is validated
+     * before the panel is created — non-bundle PNGs / unreadable files
+     * surface an error toast without creating a stray empty tab.
+     */
+    static async open(
+        bundlePath: string,
+        deps: BundleViewerHostDeps,
+    ): Promise<BundleViewerPanel | null> {
+        const absolute = path.resolve(bundlePath);
+        const existing = BundleViewerPanel.active.get(absolute);
+        if (existing) {
+            existing.panel.reveal(vscode.ViewColumn.Active);
+            return existing;
+        }
+        let contents: BundleContents;
+        try {
+            contents = await readBundleContents(absolute);
+        } catch (err) {
+            const message =
+                err instanceof BundleFormatError
+                    ? err.message
+                    : `Unable to read bundle: ${(err as Error).message}`;
+            void vscode.window.showErrorMessage(
+                `Compose Preview — ${path.basename(absolute)}: ${message}`,
+            );
+            deps.logLine(`${CHANNEL} reject ${absolute}: ${message}`);
+            return null;
+        }
+        if (!contents.previews || contents.previews.previews.length === 0) {
+            void vscode.window.showWarningMessage(
+                `Compose Preview — ${path.basename(absolute)}: bundle has no previews to render.`,
+            );
+            return null;
+        }
+        const panel = vscode.window.createWebviewPanel(
+            "composePreview.bundleViewer",
+            `Bundle: ${bundleLabel(absolute)}`,
+            vscode.ViewColumn.Active,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true,
+                localResourceRoots: [deps.extensionUri],
+            },
+        );
+        const viewer = new BundleViewerPanel(absolute, panel, deps, contents);
+        BundleViewerPanel.active.set(absolute, viewer);
+        viewer.start();
+        return viewer;
+    }
+
+    private renderRoot: string | null = null;
+    private disposed = false;
+
+    private constructor(
+        private readonly bundlePath: string,
+        private readonly panel: vscode.WebviewPanel,
+        private readonly deps: BundleViewerHostDeps,
+        private readonly contents: BundleContents,
+    ) {
+        panel.webview.html = this.buildHtml();
+        panel.onDidDispose(() => this.dispose());
+        panel.webview.onDidReceiveMessage(
+            (msg: { command?: string }) => void this.onWebviewMessage(msg),
+        );
+    }
+
+    private dispose(): void {
+        if (this.disposed) return;
+        this.disposed = true;
+        BundleViewerPanel.active.delete(this.bundlePath);
+        if (this.renderRoot) {
+            // Best-effort: drop the temp renders so we don't accumulate
+            // them across sessions. Ignore errors — the OS will clean up
+            // anything we leave behind on reboot.
+            fs.promises
+                .rm(this.renderRoot, { recursive: true, force: true })
+                .catch(() => {
+                    /* ignore */
+                });
+        }
+    }
+
+    private start(): void {
+        void this.runRender();
+    }
+
+    private async runRender(): Promise<void> {
+        let cliPath: string;
+        try {
+            cliPath = await locateBundleCli();
+        } catch (err) {
+            const message =
+                err instanceof BundleCliNotFoundError
+                    ? err.message
+                    : (err as Error).message;
+            this.deps.logLine(`${CHANNEL} ${message}`);
+            this.postError(
+                "compose-preview CLI not found",
+                "Install the CLI (scripts/install.sh) or set `composePreview.bundleCliPath`.",
+            );
+            return;
+        }
+        const renderRoot = await fs.promises.mkdtemp(
+            path.join(os.tmpdir(), "compose-preview-bundle-"),
+        );
+        this.renderRoot = renderRoot;
+        let result: BundleRenderResult;
+        try {
+            result = await vscode.window.withProgress(
+                {
+                    location: vscode.ProgressLocation.Notification,
+                    title: `Rendering bundle ${bundleLabel(this.bundlePath)}…`,
+                    cancellable: true,
+                },
+                async (progress, token) => {
+                    return renderBundle({
+                        bundlePath: this.bundlePath,
+                        outputDir: renderRoot,
+                        cliPath,
+                        cancellation: token,
+                        onOutput: (chunk) => {
+                            const line = chunk.split(/\r?\n/).at(-1)?.trim();
+                            if (line) progress.report({ message: line });
+                        },
+                    });
+                },
+            );
+        } catch (err) {
+            const message = (err as Error).message ?? String(err);
+            this.deps.logLine(`${CHANNEL} render failed: ${message}`);
+            this.postError("Bundle render failed", message);
+            return;
+        }
+        await this.publish(result);
+    }
+
+    private async publish(result: BundleRenderResult): Promise<void> {
+        if (this.disposed) return;
+        const previews = synthesisePreviews(this.contents, result);
+        this.panel.webview.postMessage({
+            command: "setPreviews",
+            previews,
+            moduleDir: this.renderRoot ?? "",
+            heavyStaleIds: [],
+        });
+        await Promise.all(
+            result.succeeded.map(async (rendered) => {
+                try {
+                    const buf = await fs.promises.readFile(rendered.outputFile);
+                    if (this.disposed) return;
+                    this.panel.webview.postMessage({
+                        command: "updateImage",
+                        previewId: rendered.id,
+                        captureIndex: 0,
+                        imageData: buf.toString("base64"),
+                    });
+                } catch (err) {
+                    this.deps.logLine(
+                        `${CHANNEL} read render ${rendered.id} failed: ${(err as Error).message}`,
+                    );
+                }
+            }),
+        );
+        if (result.failed.length > 0) {
+            const ids = result.failed.map((f) => f.id).join(", ");
+            void vscode.window.showWarningMessage(
+                `Compose Preview — ${path.basename(this.bundlePath)}: ${result.failed.length} preview(s) failed to render (${ids}).`,
+            );
+        }
+    }
+
+    private postError(title: string, detail: string): void {
+        void vscode.window.showErrorMessage(
+            `Compose Preview — ${path.basename(this.bundlePath)}: ${title}. ${detail}`,
+        );
+    }
+
+    private async onWebviewMessage(msg: { command?: string }): Promise<void> {
+        // The bundle viewer only round-trips a handful of messages today.
+        // Most webview→host commands (refreshHeavy, requestStreamStart,
+        // …) assume a Gradle module; in bundle mode they no-op silently.
+        if (msg.command === "openExternal") {
+            const url = (msg as { url?: string }).url;
+            if (url && /^https?:\/\//i.test(url)) {
+                void vscode.env.openExternal(vscode.Uri.parse(url));
+            }
+        }
+    }
+
+    private buildHtml(): string {
+        const webview = this.panel.webview;
+        const nonce = crypto.randomBytes(16).toString("hex");
+        const styleUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.deps.extensionUri, "media", "preview.css"),
+        );
+        const codiconUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this.deps.extensionUri, "media", "codicon.css"),
+        );
+        const scriptUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(
+                this.deps.extensionUri,
+                "media",
+                "webview",
+                "preview.js",
+            ),
+        );
+        const early = this.deps.earlyFeaturesEnabled() ? "true" : "false";
+        return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'none'; img-src data:; font-src ${webview.cspSource} https://fonts.gstatic.com; style-src ${webview.cspSource} https://fonts.googleapis.com 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
+    <link href="${codiconUri}" rel="stylesheet">
+    <link href="${styleUri}" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,500;0,700;1,400&family=Roboto+Serif:ital,wght@0,400;0,500;0,700;1,400&family=Roboto+Mono:ital,wght@0,400;0,500;0,700&family=Caveat:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <preview-app
+        data-early-features="${early}"
+        data-minimal-mode="false"
+        data-bundle-mode="true"
+    ></preview-app>
+    <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+    }
+}
+
+/**
+ * Map the bundle's discovery-time `previews.json` + the per-preview CLI
+ * render outcomes into the `PreviewInfo` shape `<preview-app>` consumes
+ * via `setPreviews`. The render-output filename is bundle-viewer-local
+ * (`<renderRoot>/<safeFilename(id)>.png`), which we record as an absolute
+ * path; the panel's `setPreviews` handler treats `moduleDir` + the
+ * `renderOutput` field as an absolute path when the first segment is
+ * already rooted.
+ */
+function synthesisePreviews(
+    contents: BundleContents,
+    result: BundleRenderResult,
+): PreviewInfo[] {
+    const renderById = new Map(result.succeeded.map((r) => [r.id, r]));
+    return (contents.previews?.previews ?? []).map((entry) => {
+        const params: PreviewParams = {
+            name: entry.params.name ?? null,
+            device: entry.params.device ?? null,
+            widthDp: entry.params.widthDp ?? null,
+            heightDp: entry.params.heightDp ?? null,
+            fontScale: entry.params.fontScale ?? 1,
+            showSystemUi: false,
+            showBackground: entry.params.showBackground ?? false,
+            backgroundColor: entry.params.backgroundColor ?? 0,
+            uiMode: entry.params.uiMode ?? 0,
+            locale: entry.params.locale ?? null,
+            group: entry.params.group ?? null,
+        };
+        const rendered = renderById.get(entry.id);
+        const captures: Capture[] = [
+            {
+                advanceTimeMillis: null,
+                scroll: null,
+                renderOutput: rendered ? rendered.outputFile : "",
+            },
+        ];
+        return {
+            id: entry.id,
+            functionName: entry.functionName,
+            className: entry.className,
+            sourceFile: entry.sourceFile ?? null,
+            params,
+            captures,
+        };
+    });
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -16,6 +16,8 @@ import {
     findPluginAppliedAncestor,
 } from "./pluginDetection";
 import { PreviewPanel } from "./previewPanel";
+import { BundleViewerPanel } from "./bundleViewerPanel";
+import { isLikelyBundle } from "./bundleFormat";
 import { PreviewRegistry } from "./previewRegistry";
 import { PreviewGutterDecorations } from "./previewGutterDecorations";
 import { PreviewHoverProvider } from "./previewHoverProvider";
@@ -1450,6 +1452,19 @@ export async function activate(
         vscode.commands.registerCommand(
             "composePreview.launchOnDevice",
             (previewId?: string) => launchOnDevice(previewId),
+        ),
+        vscode.commands.registerCommand(
+            "composePreview.openBundle",
+            (resource?: vscode.Uri) => {
+                if (!earlyFeaturesEnabled()) {
+                    void vscode.window.showInformationMessage(
+                        "Compose Preview: enable composePreview.earlyFeatures.enabled to open preview bundles.",
+                    );
+                    return;
+                }
+                const fsPath = resource?.fsPath ?? "";
+                void handleBundleDropped(fsPath, path.basename(fsPath) || "");
+            },
         ),
     );
     // Refresh applied-markers in the background so future module resolution can
@@ -4366,6 +4381,11 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 void exportPreviewBundle(msg.previewId);
             }
             break;
+        case "bundleDropped":
+            if (earlyFeaturesEnabled()) {
+                void handleBundleDropped(msg.fsPath, msg.fileName);
+            }
+            break;
         case "requestStreamStart":
             void handleRequestStreamStart(msg.previewId);
             break;
@@ -5515,6 +5535,52 @@ async function exportPreviewBundle(previewId: string): Promise<void> {
             vscode.Uri.file(outputPath),
         );
     }
+}
+
+/**
+ * Webview drop / `composePreview.openBundle` command entry. Resolves
+ * [fsPath] (or shows a quick-open if absent), validates that the file
+ * looks like a `composePreviewBundle` PNG+ZIP polyglot, and routes to
+ * [BundleViewerPanel] in a separate editor tab.
+ */
+async function handleBundleDropped(
+    fsPath: string,
+    fileName: string,
+): Promise<void> {
+    let resolved = fsPath;
+    if (!resolved || resolved.length === 0) {
+        const picked = await vscode.window.showOpenDialog({
+            canSelectMany: false,
+            openLabel: `Open bundle (${fileName})`,
+            filters: { "Bundle PNG": ["png"] },
+        });
+        if (!picked || picked.length === 0) return;
+        resolved = picked[0].fsPath;
+    }
+    if (!resolved.toLowerCase().endsWith(".png")) {
+        void vscode.window.showWarningMessage(
+            `Compose Preview: ${path.basename(resolved)} is not a .png file.`,
+        );
+        return;
+    }
+    if (!(await isLikelyBundle(resolved))) {
+        void vscode.window.showWarningMessage(
+            `Compose Preview: ${path.basename(resolved)} doesn't look like a preview bundle (no zip trailer).`,
+        );
+        return;
+    }
+    await BundleViewerPanel.open(resolved, {
+        extensionUri: getExtensionUri(),
+        earlyFeaturesEnabled,
+        logLine,
+    });
+}
+
+function getExtensionUri(): vscode.Uri {
+    if (!extensionContext) {
+        throw new Error("compose-preview extension is not activated");
+    }
+    return extensionContext.extensionUri;
 }
 
 function lookupPreviewLabel(previewId: string): string | undefined {

--- a/vscode-extension/src/test/bundleDaemonHost.test.ts
+++ b/vscode-extension/src/test/bundleDaemonHost.test.ts
@@ -1,0 +1,161 @@
+// Coverage for the pure helpers in `bundleDaemonHost` that don't need
+// VS Code or a live JVM. The `spawnBundleDaemon` entry point is exercised
+// end-to-end via the electron integration suite (it shells out to the
+// real CLI subcommand); here we pin the small wire-mapping helpers that
+// the panel relies on.
+
+import * as assert from "assert";
+import { Readable, Writable } from "stream";
+
+import {
+    A11Y_DATA_KINDS,
+    renderAll,
+    setKindsSubscribed,
+} from "../bundleDaemonHost";
+import { DaemonClient } from "../daemon/daemonClient";
+
+/** Build a `DaemonClient` whose request channel is captured to a list,
+ *  with canned per-method responses. Avoids reaching for jest-style
+ *  spies — we only need to assert call order + reject-recovery. */
+function buildClient(responses: Record<string, unknown[]>): {
+    client: DaemonClient;
+    requests: Array<{ method: string; params: unknown }>;
+} {
+    const requests: Array<{ method: string; params: unknown }> = [];
+    const pendingByMethod = new Map<string, unknown[]>();
+    for (const [method, queue] of Object.entries(responses)) {
+        pendingByMethod.set(method, [...queue]);
+    }
+    let nextId = 0;
+    const stdout = new Readable({ read() {} });
+    const stdin = new Writable({
+        write(chunk: Buffer, _enc, cb) {
+            // Strip LSP framing: split on `\r\n\r\n` once and decode the body
+            // as JSON.
+            const text = chunk.toString("utf-8");
+            const sep = text.indexOf("\r\n\r\n");
+            const body = sep >= 0 ? text.slice(sep + 4) : text;
+            let parsed: { id?: number; method?: string; params?: unknown };
+            try {
+                parsed = JSON.parse(body);
+            } catch {
+                cb();
+                return;
+            }
+            if (parsed.method) {
+                requests.push({
+                    method: parsed.method,
+                    params: parsed.params,
+                });
+                if (parsed.id !== undefined) {
+                    nextId = parsed.id;
+                    const queue = pendingByMethod.get(parsed.method) ?? [];
+                    const result = queue.shift();
+                    const payload =
+                        result instanceof Error
+                            ? {
+                                  jsonrpc: "2.0",
+                                  id: nextId,
+                                  error: {
+                                      code: -32000,
+                                      message: result.message,
+                                  },
+                              }
+                            : { jsonrpc: "2.0", id: nextId, result };
+                    const json = JSON.stringify(payload);
+                    const frame =
+                        `Content-Length: ${Buffer.byteLength(json)}\r\n\r\n` +
+                        json;
+                    queueMicrotask(() => stdout.push(frame));
+                }
+            }
+            cb();
+        },
+    });
+    const client = new DaemonClient(stdin, stdout, {});
+    return { client, requests };
+}
+
+describe("renderAll", () => {
+    it("issues a single renderNow with tier=full for every preview id", async () => {
+        const { client, requests } = buildClient({
+            renderNow: [{ queued: ["a", "b"], rejected: [] }],
+        });
+        await renderAll(client, ["a", "b"], "test");
+        assert.strictEqual(requests.length, 1);
+        assert.strictEqual(requests[0].method, "renderNow");
+        assert.deepStrictEqual(requests[0].params, {
+            previews: ["a", "b"],
+            tier: "full",
+            reason: "test",
+        });
+    });
+
+    it("no-ops on an empty preview list (no RPC traffic)", async () => {
+        const { client, requests } = buildClient({});
+        await renderAll(client, [], "test");
+        assert.strictEqual(requests.length, 0);
+    });
+});
+
+describe("setKindsSubscribed", () => {
+    it("subscribes each kind via data/subscribe in parallel", async () => {
+        const { client, requests } = buildClient({
+            "data/subscribe": [{ ok: true }, { ok: true }],
+        });
+        await setKindsSubscribed(
+            client,
+            "pv",
+            ["a11y/atf", "a11y/hierarchy"],
+            true,
+        );
+        assert.strictEqual(requests.length, 2);
+        for (const r of requests) {
+            assert.strictEqual(r.method, "data/subscribe");
+            assert.strictEqual(
+                (r.params as { previewId: string }).previewId,
+                "pv",
+            );
+        }
+        assert.deepStrictEqual(
+            requests.map((r) => (r.params as { kind: string }).kind).sort(),
+            ["a11y/atf", "a11y/hierarchy"],
+        );
+    });
+
+    it("unsubscribes via data/unsubscribe when enabled=false", async () => {
+        const { client, requests } = buildClient({
+            "data/unsubscribe": [{ ok: true }],
+        });
+        await setKindsSubscribed(client, "pv", ["theming/main"], false);
+        assert.strictEqual(requests[0].method, "data/unsubscribe");
+    });
+
+    it("surfaces per-kind rejections via the error callback without rejecting the whole call", async () => {
+        const errors: Array<[string, string]> = [];
+        const { client } = buildClient({
+            "data/subscribe": [new Error("DataProductUnknown"), { ok: true }],
+        });
+        await setKindsSubscribed(
+            client,
+            "pv",
+            ["unknown/kind", "a11y/atf"],
+            true,
+            (kind, err) => errors.push([kind, err.message]),
+        );
+        // Order of resolution races since we await Promise.all, but at
+        // least one error must surface and the call itself completes.
+        assert.strictEqual(errors.length, 1);
+        assert.match(errors[0][1], /DataProductUnknown/);
+    });
+});
+
+describe("A11Y_DATA_KINDS", () => {
+    it("covers the a11y/atf + a11y/hierarchy pair the focus overlay needs", () => {
+        // The sidebar's `setA11yOverlay` handler subscribes the same two
+        // kinds; this assertion pins the bundle viewer to the same set
+        // so a future split (e.g. introducing `a11y/atf/v2`) is
+        // explicit.
+        assert.deepStrictEqual(A11Y_DATA_KINDS, ["a11y/atf", "a11y/hierarchy"]);
+    });
+});

--- a/vscode-extension/src/test/bundleFormat.test.ts
+++ b/vscode-extension/src/test/bundleFormat.test.ts
@@ -1,0 +1,288 @@
+// Coverage for the minimal PNG+ZIP bundle reader.
+//
+// We don't have a fixture of a real `composePreviewBundle` output checked
+// into the test tree (they're large and tied to a Gradle module), so we
+// synthesise tiny polyglots in-memory: a stub PNG followed by a stored
+// (uncompressed) zip carrying `bundle.json` + `previews.json` entries.
+
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as zlib from "zlib";
+
+import {
+    bundleLabel,
+    isLikelyBundle,
+    readBundleContents,
+} from "../bundleFormat";
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** Build a minimal valid-looking PNG: header + IHDR + IDAT + IEND. The
+ *  reader only sniffs the magic, so the chunk content can be a stub. */
+function stubPng(): Buffer {
+    return Buffer.concat([
+        PNG_MAGIC,
+        chunk("IHDR", Buffer.alloc(13)),
+        chunk("IDAT", Buffer.alloc(8)),
+        chunk("IEND", Buffer.alloc(0)),
+    ]);
+}
+
+function chunk(type: string, data: Buffer): Buffer {
+    const length = Buffer.alloc(4);
+    length.writeUInt32BE(data.length, 0);
+    const typeAndData = Buffer.concat([Buffer.from(type, "ascii"), data]);
+    // CRC is not validated by the reader; zero-fill keeps the shape valid.
+    const crc = Buffer.alloc(4);
+    return Buffer.concat([length, typeAndData, crc]);
+}
+
+interface ZipEntry {
+    name: string;
+    content: Buffer;
+    /** 0 = stored, 8 = deflate. Defaults to 0. */
+    method?: 0 | 8;
+}
+
+/** Build a tiny zip archive with the supplied entries. Stored entries
+ *  let us assert on the parser's no-inflate path; deflate entries
+ *  exercise `zlib.inflateRawSync`. */
+function buildZip(entries: ZipEntry[]): Buffer {
+    const localParts: Buffer[] = [];
+    const centralParts: Buffer[] = [];
+    let offset = 0;
+    for (const entry of entries) {
+        const method = entry.method ?? 0;
+        const nameBytes = Buffer.from(entry.name, "utf-8");
+        const uncompressed = entry.content;
+        const payload =
+            method === 0 ? uncompressed : zlib.deflateRawSync(uncompressed);
+        const crc = crc32(uncompressed);
+        const lfh = Buffer.alloc(30);
+        lfh.writeUInt32LE(0x04034b50, 0);
+        lfh.writeUInt16LE(20, 4); // version
+        lfh.writeUInt16LE(0, 6); // flags
+        lfh.writeUInt16LE(method, 8);
+        lfh.writeUInt16LE(0, 10); // mtime
+        lfh.writeUInt16LE(0, 12); // mdate
+        lfh.writeUInt32LE(crc, 14);
+        lfh.writeUInt32LE(payload.length, 18);
+        lfh.writeUInt32LE(uncompressed.length, 22);
+        lfh.writeUInt16LE(nameBytes.length, 26);
+        lfh.writeUInt16LE(0, 28);
+        const localBlock = Buffer.concat([lfh, nameBytes, payload]);
+        localParts.push(localBlock);
+
+        const cdh = Buffer.alloc(46);
+        cdh.writeUInt32LE(0x02014b50, 0);
+        cdh.writeUInt16LE(20, 4);
+        cdh.writeUInt16LE(20, 6);
+        cdh.writeUInt16LE(0, 8);
+        cdh.writeUInt16LE(method, 10);
+        cdh.writeUInt16LE(0, 12);
+        cdh.writeUInt16LE(0, 14);
+        cdh.writeUInt32LE(crc, 16);
+        cdh.writeUInt32LE(payload.length, 20);
+        cdh.writeUInt32LE(uncompressed.length, 24);
+        cdh.writeUInt16LE(nameBytes.length, 28);
+        cdh.writeUInt16LE(0, 30); // extra
+        cdh.writeUInt16LE(0, 32); // comment
+        cdh.writeUInt16LE(0, 34); // disk
+        cdh.writeUInt16LE(0, 36); // internal attrs
+        cdh.writeUInt32LE(0, 38); // external attrs
+        cdh.writeUInt32LE(offset, 42); // local header offset
+        centralParts.push(Buffer.concat([cdh, nameBytes]));
+        offset += localBlock.length;
+    }
+    const localAll = Buffer.concat(localParts);
+    const centralAll = Buffer.concat(centralParts);
+    const eocd = Buffer.alloc(22);
+    eocd.writeUInt32LE(0x06054b50, 0);
+    eocd.writeUInt16LE(0, 4); // disk
+    eocd.writeUInt16LE(0, 6); // disk with cd
+    eocd.writeUInt16LE(entries.length, 8);
+    eocd.writeUInt16LE(entries.length, 10);
+    eocd.writeUInt32LE(centralAll.length, 12);
+    eocd.writeUInt32LE(localAll.length, 16);
+    eocd.writeUInt16LE(0, 20); // comment length
+    return Buffer.concat([localAll, centralAll, eocd]);
+}
+
+/** Plain CRC-32, IEEE polynomial. Each `buildZip` entry needs one. */
+function crc32(buf: Buffer): number {
+    let crc = 0xffffffff;
+    for (const byte of buf) {
+        crc = crc ^ byte;
+        for (let i = 0; i < 8; i++) {
+            crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+        }
+    }
+    return (crc ^ 0xffffffff) >>> 0;
+}
+
+function writeTempBundle(contents: Buffer, suffix = ".bundle.png"): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "compose-bundle-test-"));
+    const file = path.join(dir, "fixture" + suffix);
+    fs.writeFileSync(file, contents);
+    return file;
+}
+
+describe("isLikelyBundle", () => {
+    it("returns true for a PNG header followed by a zip EOCD", async () => {
+        const file = writeTempBundle(
+            Buffer.concat([
+                stubPng(),
+                buildZip([{ name: "bundle.json", content: Buffer.from("{}") }]),
+            ]),
+        );
+        assert.strictEqual(await isLikelyBundle(file), true);
+    });
+
+    it("returns false for a plain PNG (no zip trailer)", async () => {
+        const file = writeTempBundle(stubPng());
+        assert.strictEqual(await isLikelyBundle(file), false);
+    });
+
+    it("returns false for a non-PNG file with a zip trailer", async () => {
+        // Same zip body, but no PNG header up front — must not pass.
+        const file = writeTempBundle(
+            buildZip([{ name: "bundle.json", content: Buffer.from("{}") }]),
+        );
+        assert.strictEqual(await isLikelyBundle(file), false);
+    });
+
+    it("returns false for a file too small to even hold a header", async () => {
+        const file = writeTempBundle(Buffer.from([0x89, 0x50]));
+        assert.strictEqual(await isLikelyBundle(file), false);
+    });
+
+    it("returns false for a missing path", async () => {
+        assert.strictEqual(
+            await isLikelyBundle("/no/such/path/.bundle.png"),
+            false,
+        );
+    });
+});
+
+describe("readBundleContents", () => {
+    it("extracts bundle.json and previews.json from a stored-zip polyglot", async () => {
+        const manifest = {
+            schemaVersion: 1,
+            backend: "desktop",
+            previewIds: ["com.example.Foo.Bar"],
+            coverPreviewId: "com.example.Foo.Bar",
+            modulePath: ":sample",
+            producedBy: "compose-preview 0.10.0",
+        };
+        const previews = {
+            module: ":sample",
+            variant: "debug",
+            previews: [
+                {
+                    id: "com.example.Foo.Bar",
+                    functionName: "Bar",
+                    className: "com.example.Foo",
+                    sourceFile: null,
+                    params: { name: null },
+                },
+            ],
+        };
+        const file = writeTempBundle(
+            Buffer.concat([
+                stubPng(),
+                buildZip([
+                    {
+                        name: "bundle.json",
+                        content: Buffer.from(JSON.stringify(manifest)),
+                    },
+                    {
+                        name: "previews.json",
+                        content: Buffer.from(JSON.stringify(previews)),
+                    },
+                ]),
+            ]),
+        );
+        const out = await readBundleContents(file);
+        assert.deepStrictEqual(out.manifest, manifest);
+        assert.deepStrictEqual(out.previews, previews);
+    });
+
+    it("decompresses deflate entries (method=8)", async () => {
+        const file = writeTempBundle(
+            Buffer.concat([
+                stubPng(),
+                buildZip([
+                    {
+                        name: "bundle.json",
+                        content: Buffer.from(
+                            JSON.stringify({ schemaVersion: 1 }),
+                        ),
+                        method: 8,
+                    },
+                ]),
+            ]),
+        );
+        const out = await readBundleContents(file);
+        assert.deepStrictEqual(out.manifest, { schemaVersion: 1 });
+        assert.strictEqual(out.previews, null);
+    });
+
+    it("rejects a file that isn't a PNG even if it has a zip trailer", async () => {
+        const file = writeTempBundle(
+            buildZip([{ name: "bundle.json", content: Buffer.from("{}") }]),
+        );
+        await assert.rejects(() => readBundleContents(file), /not a PNG/i);
+    });
+
+    it("rejects a PNG with no zip EOCD trailer", async () => {
+        const file = writeTempBundle(stubPng());
+        await assert.rejects(
+            () => readBundleContents(file),
+            /end-of-central-directory/i,
+        );
+    });
+
+    it("returns null for a malformed JSON entry rather than throwing", async () => {
+        // The reader's contract is "best-effort": a corrupt bundle.json
+        // shouldn't block the host from still surfacing previews.json
+        // (or vice versa). Either side being null is the caller's signal
+        // to fall back to the renderer's own parser.
+        const file = writeTempBundle(
+            Buffer.concat([
+                stubPng(),
+                buildZip([
+                    {
+                        name: "bundle.json",
+                        content: Buffer.from("{not valid json"),
+                    },
+                    {
+                        name: "previews.json",
+                        content: Buffer.from(JSON.stringify({ previews: [] })),
+                    },
+                ]),
+            ]),
+        );
+        const out = await readBundleContents(file);
+        assert.strictEqual(out.manifest, null);
+        assert.deepStrictEqual(out.previews, { previews: [] });
+    });
+});
+
+describe("bundleLabel", () => {
+    it("strips .bundle.png to surface just the slug", () => {
+        assert.strictEqual(
+            bundleLabel("/tmp/MyPreview.bundle.png"),
+            "MyPreview",
+        );
+    });
+
+    it("strips .png for bundles named without the .bundle infix", () => {
+        assert.strictEqual(bundleLabel("/tmp/shared.png"), "shared");
+    });
+
+    it("leaves non-png basenames untouched", () => {
+        assert.strictEqual(bundleLabel("/tmp/odd.txt"), "odd.txt");
+    });
+});

--- a/vscode-extension/src/test/bundleRender.test.ts
+++ b/vscode-extension/src/test/bundleRender.test.ts
@@ -1,0 +1,82 @@
+// Coverage for `parseRenderOutput` — the CLI summary parser the
+// `BundleViewerPanel` relies on to surface per-preview render outcomes.
+// We don't drive the real CLI here (that's a JVM spawn); locating /
+// spawning the binary is covered by integration in the cloud env.
+
+import * as assert from "assert";
+import * as path from "path";
+import { parseRenderOutput } from "../bundleRenderOutput";
+
+describe("parseRenderOutput", () => {
+    it("parses a successful render summary with relative filenames", () => {
+        const stdout =
+            "rendered 2 / 2 preview(s) → /tmp/out\n" +
+            "  ok    com.example.Foo.Bar  →  com.example.Foo.Bar.png\n" +
+            "  ok    com.example.Foo.Baz  →  com.example.Foo.Baz.png\n";
+        const result = parseRenderOutput(stdout, "/tmp/out");
+        assert.ok(result);
+        assert.strictEqual(result!.previewCount, 2);
+        assert.deepStrictEqual(
+            result!.succeeded.map((s) => s.id),
+            ["com.example.Foo.Bar", "com.example.Foo.Baz"],
+        );
+        assert.strictEqual(
+            result!.succeeded[0].outputFile,
+            path.join("/tmp/out", "com.example.Foo.Bar.png"),
+        );
+        assert.strictEqual(result!.failed.length, 0);
+    });
+
+    it("records failed previews with their exit code", () => {
+        const stdout =
+            "rendered 1 / 2 preview(s) → /tmp/out\n" +
+            "  ok    com.example.Foo.Bar  →  com.example.Foo.Bar.png\n" +
+            "  FAIL  com.example.Foo.Baz  (exit=137)\n";
+        const result = parseRenderOutput(stdout, "/tmp/out");
+        assert.ok(result);
+        assert.strictEqual(result!.previewCount, 2);
+        assert.strictEqual(result!.succeeded.length, 1);
+        assert.deepStrictEqual(result!.failed, [
+            { id: "com.example.Foo.Baz", exitCode: 137 },
+        ]);
+    });
+
+    it("returns null when no summary line is present (launcher crashed before reporting)", () => {
+        const stdout = "compose-preview: failed to read bundle\n";
+        assert.strictEqual(parseRenderOutput(stdout, "/tmp/out"), null);
+    });
+
+    it("treats summary as 0/0 valid when previewCount is zero", () => {
+        const stdout = "rendered 0 / 0 preview(s) → /tmp/out\n";
+        const result = parseRenderOutput(stdout, "/tmp/out");
+        assert.ok(result);
+        assert.strictEqual(result!.previewCount, 0);
+        assert.strictEqual(result!.succeeded.length, 0);
+        assert.strictEqual(result!.failed.length, 0);
+    });
+
+    it("keeps absolute paths verbatim when the CLI emits them", () => {
+        // The CLI today emits basenames, but `BundleRenderer.kt` could
+        // grow to emit absolute paths; the parser shouldn't double-root
+        // those by re-joining with `outputDir`.
+        const stdout =
+            "rendered 1 / 1 preview(s) → /tmp/out\n" +
+            "  ok    com.example.Foo.Bar  →  /custom/path/foo.png\n";
+        const result = parseRenderOutput(stdout, "/tmp/out");
+        assert.strictEqual(
+            result!.succeeded[0].outputFile,
+            "/custom/path/foo.png",
+        );
+    });
+
+    it("ignores extra prose between summary and the listing", () => {
+        const stdout =
+            "compose-preview bundle render — desktop backend\n" +
+            "rendered 1 / 1 preview(s) → /tmp/out\n" +
+            "\n" +
+            "  ok    com.example.Foo.Bar  →  com.example.Foo.Bar.png\n" +
+            "Done in 4.2s\n";
+        const result = parseRenderOutput(stdout, "/tmp/out");
+        assert.strictEqual(result!.succeeded.length, 1);
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -489,6 +489,16 @@ export type ExtensionToWebview =
      */
     | { command: "setMinimalMode"; minimal: boolean }
     /**
+     * Bundle viewer panel: the desktop daemon spawned for [bundlePath]
+     * has finished `initialize` + `extensions/enable` and is ready to
+     * serve `renderNow` / `data/subscribe` / interactive requests. The
+     * panel flips bundle-mode toolbar gating to allow daemon-backed
+     * buttons (a11y overlay, focus inspector chips) the same way the
+     * sidebar does when its module's daemon transitions to `ready`.
+     * Sidebar panels never receive this.
+     */
+    | { command: "bundleDaemonReady"; bundlePath: string }
+    /**
      * Drives the slim progress bar at the top of the panel. `percent` is
      * monotonic within a refresh and clamped to [0, 1]; `label` is the
      * user-facing phase name ("Compiling Kotlin", "Rendering previews"…).

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -836,6 +836,18 @@ export type WebviewToExtension =
      */
     | { command: "requestExportPreviewBundle"; previewId: string }
     /**
+     * User dragged a file onto the sidebar preview panel. The host
+     * checks that [fsPath] is a `composePreviewBundle` polyglot
+     * (PNG+ZIP) and opens it in a `BundleViewerPanel`. Non-bundle
+     * files surface a warning toast.
+     *
+     * [fsPath] is the path the host OS provided to the webview's drop
+     * handler. Some platforms / VS Code builds expose only the file
+     * name, in which case [fsPath] is empty and the host falls back to
+     * showing a quick-pick rooted at the workspace folder.
+     */
+    | { command: "bundleDropped"; fsPath: string; fileName: string }
+    /**
      * `composestream/1` — open a live frame stream for [previewId]. The
      * extension acquires a held interactive session and pumps `streamFrame`
      * notifications down to the webview, where the canvas painter consumes

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -62,10 +62,14 @@ export interface FocusControllerConfig {
      *  layout transitions. */
     state: FocusControllerPersistedState;
     earlyFeatures(): boolean;
-    /** When true the panel is a bundle viewer with no daemon / Gradle
-     *  module behind it; toolbar buttons that depend on either are
-     *  forced hidden. Optional so non-bundle hosts can omit it. */
+    /** When true the panel is a bundle viewer. Daemon-driven buttons
+     *  gate on [bundleDaemonReady] instead of being forced hidden.
+     *  Module-only buttons (launch on device, diff vs HEAD/main) stay
+     *  hidden regardless. Optional so non-bundle hosts can omit it. */
     bundleMode?(): boolean;
+    /** True once `bundleDaemonReady` has been observed for this panel.
+     *  Only consulted when [bundleMode] returns true. */
+    bundleDaemonReady?(): boolean;
     getA11yOverlayId(): string | null;
     setA11yOverlayId(id: string | null): void;
     getFocusIndex(): number;
@@ -96,10 +100,16 @@ export class FocusController {
     }
 
     applyEarlyFeatureVisibility(): void {
+        const bundle = this.config.bundleMode?.() ?? false;
         this.config.focusToolbar.applyEarlyFeatureVisibility({
             earlyFeatures: this.config.earlyFeatures(),
             inFocus: this.inFocus(),
-            bundleMode: this.config.bundleMode?.() ?? false,
+            bundleMode: bundle,
+            // In non-bundle mode, daemon readiness is intentionally
+            // forced true — sidebar panels gate daemon-backed buttons
+            // per-button via the `applyXxxButtonState` hooks instead.
+            bundleDaemonReady:
+                !bundle || (this.config.bundleDaemonReady?.() ?? false),
         });
     }
 

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -62,6 +62,10 @@ export interface FocusControllerConfig {
      *  layout transitions. */
     state: FocusControllerPersistedState;
     earlyFeatures(): boolean;
+    /** When true the panel is a bundle viewer with no daemon / Gradle
+     *  module behind it; toolbar buttons that depend on either are
+     *  forced hidden. Optional so non-bundle hosts can omit it. */
+    bundleMode?(): boolean;
     getA11yOverlayId(): string | null;
     setA11yOverlayId(id: string | null): void;
     getFocusIndex(): number;
@@ -95,6 +99,7 @@ export class FocusController {
         this.config.focusToolbar.applyEarlyFeatureVisibility({
             earlyFeatures: this.config.earlyFeatures(),
             inFocus: this.inFocus(),
+            bundleMode: this.config.bundleMode?.() ?? false,
         });
     }
 

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -39,11 +39,17 @@ export interface FocusToolbarElements {
 export interface EarlyFeatureVisibilityState {
     earlyFeatures: boolean;
     inFocus: boolean;
-    /** Hosted by `BundleViewerPanel` — there's no Gradle module, no
-     *  daemon, and no history, so any button that depends on one
-     *  (launch on device, diff vs HEAD/main, recording, a11y overlay,
-     *  export bundle) is hidden. Only prev / next / exit-focus remain. */
+    /** Hosted by `BundleViewerPanel`. There's never a Gradle module nor
+     *  history behind a bundle, so launch-on-device + diff buttons stay
+     *  hidden regardless of daemon state. Daemon-driven buttons (a11y
+     *  overlay, recording, focus inspector chips) follow [bundleDaemonReady]
+     *  — they only surface once the per-bundle daemon JVM has
+     *  initialised. */
     bundleMode: boolean;
+    /** True once `bundleDaemonReady` has been observed (or always true in
+     *  non-bundle mode). Drives the daemon-backed toolbar buttons in
+     *  bundle viewer panels. */
+    bundleDaemonReady: boolean;
 }
 
 export interface InteractiveButtonState {
@@ -88,16 +94,24 @@ export class FocusToolbarController {
 
     applyEarlyFeatureVisibility(s: EarlyFeatureVisibilityState): void {
         const bundle = s.bundleMode;
+        // Buttons that intrinsically need a Gradle module — stay hidden
+        // in bundle mode regardless of daemon state.
         this.el.btnDiffHead.hidden = bundle || !s.earlyFeatures;
         this.el.btnDiffMain.hidden = bundle || !s.earlyFeatures;
         this.el.btnLaunchDevice.hidden = bundle || !s.earlyFeatures;
-        this.el.btnA11yOverlay.hidden =
-            bundle || !s.earlyFeatures || !s.inFocus;
-        this.el.btnRecording.hidden = bundle || !s.earlyFeatures || !s.inFocus;
-        this.el.recordingFormat.hidden =
-            bundle || !s.earlyFeatures || !s.inFocus;
         this.el.btnExportBundle.hidden =
             bundle || !s.earlyFeatures || !s.inFocus;
+        // Daemon-backed buttons — visible in either host once the
+        // backing daemon is ready (or, in non-bundle mode, always —
+        // sidebar panels gate daemon-readiness per-button via the
+        // individual `applyXxxButtonState` hooks).
+        const daemonHidden = bundle && !s.bundleDaemonReady;
+        this.el.btnA11yOverlay.hidden =
+            daemonHidden || !s.earlyFeatures || !s.inFocus;
+        this.el.btnRecording.hidden =
+            daemonHidden || !s.earlyFeatures || !s.inFocus;
+        this.el.recordingFormat.hidden =
+            daemonHidden || !s.earlyFeatures || !s.inFocus;
         if (!s.earlyFeatures) {
             this.el.focusInspector.hidden = true;
         }

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -39,6 +39,11 @@ export interface FocusToolbarElements {
 export interface EarlyFeatureVisibilityState {
     earlyFeatures: boolean;
     inFocus: boolean;
+    /** Hosted by `BundleViewerPanel` — there's no Gradle module, no
+     *  daemon, and no history, so any button that depends on one
+     *  (launch on device, diff vs HEAD/main, recording, a11y overlay,
+     *  export bundle) is hidden. Only prev / next / exit-focus remain. */
+    bundleMode: boolean;
 }
 
 export interface InteractiveButtonState {
@@ -82,13 +87,17 @@ export class FocusToolbarController {
     constructor(private readonly el: FocusToolbarElements) {}
 
     applyEarlyFeatureVisibility(s: EarlyFeatureVisibilityState): void {
-        this.el.btnDiffHead.hidden = !s.earlyFeatures;
-        this.el.btnDiffMain.hidden = !s.earlyFeatures;
-        this.el.btnLaunchDevice.hidden = !s.earlyFeatures;
-        this.el.btnA11yOverlay.hidden = !s.earlyFeatures || !s.inFocus;
-        this.el.btnRecording.hidden = !s.earlyFeatures || !s.inFocus;
-        this.el.recordingFormat.hidden = !s.earlyFeatures || !s.inFocus;
-        this.el.btnExportBundle.hidden = !s.earlyFeatures || !s.inFocus;
+        const bundle = s.bundleMode;
+        this.el.btnDiffHead.hidden = bundle || !s.earlyFeatures;
+        this.el.btnDiffMain.hidden = bundle || !s.earlyFeatures;
+        this.el.btnLaunchDevice.hidden = bundle || !s.earlyFeatures;
+        this.el.btnA11yOverlay.hidden =
+            bundle || !s.earlyFeatures || !s.inFocus;
+        this.el.btnRecording.hidden = bundle || !s.earlyFeatures || !s.inFocus;
+        this.el.recordingFormat.hidden =
+            bundle || !s.earlyFeatures || !s.inFocus;
+        this.el.btnExportBundle.hidden =
+            bundle || !s.earlyFeatures || !s.inFocus;
         if (!s.earlyFeatures) {
             this.el.focusInspector.hidden = true;
         }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -398,7 +398,51 @@ export class PreviewApp extends LitElement {
         const initialEarlyFeaturesEnabled =
             this.dataset.earlyFeatures === "true";
         const minimalMode = this.dataset.minimalMode === "true";
+        const bundleMode = this.dataset.bundleMode === "true";
         const vscode = getVsCodeApi<PersistedState>();
+        // Bundle mode: this <preview-app> is hosted by `BundleViewerPanel`
+        // showing previews re-rendered from a `composePreviewBundle` file.
+        // There's no daemon, no Gradle module, and no history — clamp the
+        // layout to focus mode and let the rest of the wiring degrade
+        // gracefully. Toolbar buttons that need a module
+        // (launch-on-device, diff, recording, export) hide themselves via
+        // their own gates; filter toolbar would otherwise let the user
+        // pick a layout that doesn't make sense for a single bundle.
+        if (bundleMode) {
+            this.classList.add("bundle-mode");
+        }
+        // Drag-and-drop entry point: dropping a bundle PNG onto the
+        // panel asks the host to open it in a new editor tab. Prevent
+        // default so the webview doesn't try to navigate to the file URL.
+        // Bundle-mode panels don't accept drops themselves — re-opening
+        // a bundle is a top-level action that belongs to the sidebar
+        // panel + command palette.
+        if (!bundleMode) {
+            this.addEventListener("dragover", (evt: DragEvent) => {
+                if (!hasFileTransfer(evt.dataTransfer)) return;
+                evt.preventDefault();
+                if (evt.dataTransfer) {
+                    evt.dataTransfer.dropEffect = "copy";
+                }
+            });
+            this.addEventListener("drop", (evt: DragEvent) => {
+                const files = evt.dataTransfer?.files;
+                if (!files || files.length === 0) return;
+                evt.preventDefault();
+                // VS Code's webview shim exposes `.path` on the File
+                // object for drops from the host OS; in environments
+                // where it's absent (older VS Code, web), fall back to
+                // the name and let the host warn that it can't resolve
+                // an absolute path.
+                const file = files[0] as File & { path?: string };
+                const fsPath = file.path ?? "";
+                vscode.postMessage({
+                    command: "bundleDropped",
+                    fsPath,
+                    fileName: file.name,
+                });
+            });
+        }
         // Listen for runtime mode flips from the extension (post-Gradle-sync
         // re-evaluation that upgrades minimal -> full once `applied.json`
         // markers prove the plugin is applied). Flip the dataset attribute and
@@ -2271,6 +2315,7 @@ export class PreviewApp extends LitElement {
             diffOverlayConfig,
             state,
             earlyFeatures,
+            bundleMode: () => bundleMode,
             getA11yOverlayId: a11yOverlay,
             setA11yOverlayId: setA11yOverlay,
             getFocusIndex: () => previewStore.getState().focusIndex,
@@ -2312,8 +2357,14 @@ export class PreviewApp extends LitElement {
             interactiveInputConfig,
         });
 
-        // Restore layout preference
-        if (
+        // Restore layout preference. Bundle-mode panels (hosted by
+        // `BundleViewerPanel`) clamp to focus mode — the filter toolbar
+        // is hidden and the persisted layout from the sidebar panel
+        // shouldn't carry over.
+        if (bundleMode) {
+            filterToolbar.setLayoutValue("focus");
+            state.layout = "focus";
+        } else if (
             state.layout &&
             ["grid", "flow", "column", "focus"].includes(state.layout)
         ) {
@@ -2713,4 +2764,15 @@ export class PreviewApp extends LitElement {
         // stateful messages so the grid isn't permanently empty.
         getVsCodeApi().postMessage({ command: "webviewReady" });
     }
+}
+
+/** Does this DataTransfer carry one or more files? Browser `dataTransfer.files`
+ *  is always defined but reports `length === 0` for non-file drags (e.g.
+ *  dragging selected text). The `.types` set is populated synchronously even
+ *  during `dragover`, where `.files` is masked until the actual drop.
+ */
+function hasFileTransfer(dt: DataTransfer | null): boolean {
+    if (!dt) return false;
+    if (dt.types && Array.from(dt.types).includes("Files")) return true;
+    return dt.files != null && dt.files.length > 0;
 }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -399,6 +399,12 @@ export class PreviewApp extends LitElement {
             this.dataset.earlyFeatures === "true";
         const minimalMode = this.dataset.minimalMode === "true";
         const bundleMode = this.dataset.bundleMode === "true";
+        // Bundle viewer panels gate daemon-driven focus-mode buttons
+        // (a11y overlay, recording, focus inspector chips) on this flag
+        // — it flips true when the host posts `bundleDaemonReady` after
+        // the per-bundle daemon JVM finishes `initialize`. Sidebar
+        // panels never see that message and ignore this flag entirely.
+        let bundleDaemonReady = false;
         const vscode = getVsCodeApi<PersistedState>();
         // Bundle mode: this <preview-app> is hosted by `BundleViewerPanel`
         // showing previews re-rendered from a `composePreviewBundle` file.
@@ -458,6 +464,28 @@ export class PreviewApp extends LitElement {
                 this.requestUpdate();
             }
         });
+        // Bundle-mode panels listen for the host's `bundleDaemonReady`
+        // signal; once seen, daemon-backed focus-mode buttons stop
+        // hiding. The flag is set before the focus controller is
+        // constructed, but the message may also arrive later (the
+        // daemon spawn is async); re-apply visibility on each event so
+        // the toolbar reflects readiness without a layout change.
+        if (bundleMode) {
+            window.addEventListener("message", (event: MessageEvent) => {
+                const data = event.data as { command?: string };
+                if (data?.command !== "bundleDaemonReady") return;
+                if (bundleDaemonReady) return;
+                bundleDaemonReady = true;
+                // `focusController` is initialised later in this
+                // function; the let-binding above closes over it.
+                // Guard against the message arriving before init.
+                try {
+                    focusController?.applyEarlyFeatureVisibility();
+                } catch {
+                    /* not yet constructed; first applyLayout will pick it up */
+                }
+            });
+        }
         if (minimalMode) {
             // Minimal mode hides the extension chrome (bundle chip bar +
             // data tabs) since data extensions are disabled — see CSS rule.
@@ -2316,6 +2344,7 @@ export class PreviewApp extends LitElement {
             state,
             earlyFeatures,
             bundleMode: () => bundleMode,
+            bundleDaemonReady: () => bundleDaemonReady,
             getA11yOverlayId: a11yOverlay,
             setA11yOverlayId: setA11yOverlay,
             getFocusIndex: () => previewStore.getState().focusIndex,

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -284,11 +284,12 @@ export function handleExtensionMessage(
         case "minimalSavePending":
         case "minimalSavePendingClear":
         case "setMinimalMode":
+        case "bundleDaemonReady":
             // Handled directly by Lit components (`<message-banner>`,
             // `<progress-bar>`, `<compile-errors-banner>`,
-            // `<preview-app>`'s minimal-mode banner) — they listen on
-            // `window` for these and the dispatcher does not duplicate
-            // the routing.
+            // `<preview-app>`'s minimal-mode banner / bundle-mode
+            // toolbar gate) — they listen on `window` for these and
+            // the dispatcher does not duplicate the routing.
             return;
         default:
             return assertNever(msg);


### PR DESCRIPTION
## Summary

Adds support for opening and viewing `composePreviewBundle` files (PNG+ZIP polyglots) directly in VS Code as editor tabs. Users can now drop bundle files onto the extension or use the "Open Preview Bundle…" command to spawn a dedicated daemon JVM and render previews in a focused panel, reusing the existing `<preview-app>` Lit element in a new "bundle mode."

## Key Changes

- **Bundle format reader** (`bundleFormat.ts`): Minimal PNG+ZIP polyglot parser that extracts `bundle.json` and `previews.json` manifests without inflating the entire archive. Validates file structure and surfaces user-friendly errors for invalid bundles.

- **Bundle viewer panel** (`bundleViewerPanel.ts`): New editor panel class that manages one daemon JVM per bundle file. Spawns `compose-preview bundle daemon` subprocess, wires its stdio to a `DaemonClient`, and surfaces renders + data extensions in the webview. Handles focus-mode features (a11y overlay, recording, data-extension chips) identically to the sidebar panel.

- **Bundle daemon host** (`bundleDaemonHost.ts`): Spawns the CLI subcommand and wraps its stdio in a `DaemonClient`. Runs `initialize` + `extensions/enable` handshake so the panel can immediately subscribe to data products. Provides helpers (`renderAll`, `setKindsSubscribed`) for common daemon operations.

- **Bundle render integration** (`bundleRender.ts`, `bundleRenderOutput.ts`): Drives `compose-preview bundle render` for re-rendering bundles outside Gradle workspaces. Parses CLI summary output to surface per-preview success/failure.

- **CLI daemon command** (`BundleDaemonCommand.kt`): New `compose-preview bundle daemon <bundle.png>` subcommand that extracts the bundle's classpath and spawns a desktop daemon JVM with the consumer's bytecode + discovery manifest exposed via sysprops. Inherits stdio for JSON-RPC protocol.

- **Webview integration**: Updated `<preview-app>` to support "bundle mode" — a layout variant that hides module-relative actions (launch-on-device, diff) and gates daemon-driven buttons (a11y, recording, chips) on `bundleDaemonReady` signal. Added drag-and-drop support for bundle files.

- **Extension commands**: Registered `composePreview.openBundle` command and wired bundle file drops to the viewer panel opener.

- **Test coverage**: Added unit tests for bundle format parsing, daemon host helpers, and render output parsing.

## Implementation Details

- One panel per absolute bundle path; opening the same bundle twice reveals the existing tab rather than spawning duplicate daemons.
- Bundle validation happens before panel creation — invalid files surface error toasts without creating stray tabs.
- The daemon stays resident for the tab's lifetime, enabling focus-mode features to work identically to sidebar panels (sourced from packed bundle rather than Gradle module).
- Bundle mode is gated behind `composePreview.earlyFeatures.enabled` config flag.

https://claude.ai/code/session_018CmvWsnkYC9D2pmX62sMpX