### PR TITLE
fix(daemon-android): plug recomposition bridge leaks on session shutdown

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecompositionDataProductRegistry.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecompositionDataProductRegistry.kt
@@ -225,13 +225,24 @@ open class AndroidRecompositionDataProductRegistry : DataProductRegistry {
         )
       }
       is RobolectricHost.InteractiveSessionLifecycle.Released -> {
-        liveSessions.remove(event.previewId)
+        // Scope cleanup to the released stream — a watchdog-driven close for an old session can
+        // race with a new acquire for the same previewId, so we must verify the streamId
+        // before nulling out subscription state. `AndroidInteractiveSession.close()` clears the
+        // active-stream ref before firing the close hook, which is what makes the race
+        // observable: by the time we see Released(A) the host may have already entered
+        // Acquired(B) for the same preview. Without this guard we'd wipe out B's
+        // sandboxStreamId and silently drop subsequent attachments.
+        liveSessions.compute(event.previewId) { _, current ->
+          if (current?.streamId == event.streamId) null else current
+        }
         val state = subscriptions[event.previewId] ?: return
-        // The held loop has already disposed every recomposition observer on Close — we just
-        // forget the sandbox stream id so attachmentsFor stops shipping payloads.
-        state.observerInstalled = false
-        state.sandboxStreamId = null
-        state.slot = null
+        if (state.sandboxStreamId == event.streamId) {
+          // The held loop has already disposed every recomposition observer on Close — we just
+          // forget the sandbox stream id so attachmentsFor stops shipping payloads.
+          state.observerInstalled = false
+          state.sandboxStreamId = null
+          state.slot = null
+        }
       }
     }
   }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -2098,14 +2098,26 @@ open class RobolectricHost(
                 }
                 is InteractiveCommand.Close -> {
                   // Issue #1204 — dispose every live recomposition observer for this session
-                  // before returning. Best-effort: a thrown dispose is swallowed so the close
-                  // path still completes (mirrors the desktop producer's dispose-best-effort
-                  // pattern).
-                  for ((_, dispose) in recompositionHandles) {
+                  // before returning, AND drop the bridge counter slot so a session that ended
+                  // without an explicit data/unsubscribe (idle-lease watchdog, interactive/stop
+                  // while still subscribed) doesn't leak per-(previewId, streamId) maps for the
+                  // life of the JVM. Best-effort: a thrown dispose / bridge close is swallowed
+                  // so the close path still completes (mirrors the desktop producer's
+                  // dispose-best-effort pattern).
+                  for ((previewIdKey, dispose) in recompositionHandles) {
                     try {
                       dispose()
                     } catch (_: Throwable) {
                       // Already going down; nothing to do.
+                    }
+                    try {
+                      ee.schimke.composeai.daemon.bridge.SandboxRecompositionBridge.close(
+                        previewIdKey,
+                        start.streamId,
+                      )
+                    } catch (_: Throwable) {
+                      // Bridge close is pure ConcurrentHashMap.remove — shouldn't throw, but
+                      // the catch keeps the held-loop teardown path defensive.
                     }
                   }
                   recompositionHandles.clear()


### PR DESCRIPTION
## Summary

Two follow-ups to the #1204 producer flagged by Codex review on #1211, which merged before these landed.

- **Close-path bridge cleanup** (`RobolectricHost.kt`): the held-loop `Close` handler now calls `SandboxRecompositionBridge.close(previewId, streamId)` for each disposed observer. Without this, a session that ends without an explicit `data/unsubscribe` (idle-lease watchdog, `interactive/stop` while still subscribed) leaked the per-`(previewId, streamId)` counter map for the JVM lifetime.
- **streamId-scoped Released cleanup** (`AndroidRecompositionDataProductRegistry.kt`): the `Released` handler now verifies the released `streamId` matches the currently tracked stream before nulling out subscription state. Without this, a watchdog-close-vs-fresh-acquire race for the same previewId could let a stale `Released(A)` wipe out the new `Acquired(B)`'s `sandboxStreamId` and silently drop subsequent attachments until the client re-subscribed.

## Test plan

- [x] `:daemon:android:ktfmtCheck`
- [x] `:daemon:android:testDebugUnitTest --tests "ee.schimke.composeai.daemon.AndroidRecompositionDataProductRegistryTest"` (all 5 pass; ~39s with the held-Robolectric integration test)
- [ ] CI on this branch

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXsMjCS7wFyQgnzE2Ygwnj)_