### PR TITLE
test: add keyboard input integration tests for issue #1203

### DIFF
--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
@@ -264,8 +264,168 @@ class DesktopInteractiveSessionTest {
     return matches.toDouble() / total.toDouble()
   }
 
+  /**
+   * Issue #1203 — end-to-end coverage for the desktop `KEY_DOWN` / `KEY_UP` wire shape into a held
+   * composition. Mirrors [click_input_flips_state_and_repaints]:
+   *
+   * 1. **Bootstrap render is red** — `KeyPressColorSquare` paints its `pressed = false` branch.
+   * 2. **`KEY_DOWN` with `keyCode = "29"` (Android `KEYCODE_A`) reaches the composition** — routed
+   *    through [DesktopInteractiveSession.dispatch] → `BaseComposeScene.sendKeyEvent` → the focused
+   *    node's `Modifier.onKeyEvent` lambda flips `pressed = true`.
+   * 3. **`remember` state survives across renders** — the second render paints green, which is only
+   *    true if the held scene persisted the mutation. Same load-bearing assertion as the click
+   *    test, applied to the keyboard surface.
+   *
+   * Counterpart to the harness scenario `SInteractiveKeyDispatch` from the issue's acceptance
+   * criteria, run in-process here so we exercise the Skiko `sendKeyEvent` translation table without
+   * paying the subprocess + baseline-PNG cost of real-mode harness tests.
+   */
+  @Test
+  fun key_down_input_flips_state_and_repaints() {
+    val outputDir = tempFolder.newFolder("interactive-key-renders")
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == KEY_PRESS_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "KeyPressColorSquare",
+              widthPx = 64,
+              heightPx = 64,
+              density = 1.0f,
+              outputBaseName = "key-press-color-square",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = KEY_PRESS_PREVIEW_ID,
+          classLoader =
+            DesktopInteractiveSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+        )
+      try {
+        // Bootstrap render — no key dispatched yet, `pressed = false` so the box is red.
+        val first = session.render(requestId = RenderHost.nextRequestId())
+        assertNotNull("first render must produce a pngPath", first.pngPath)
+        val firstImage = readPng(File(first.pngPath!!))
+        val redMatch = pixelMatchPct(firstImage, expectedRgb = 0xEF5350, perChannelTolerance = 8)
+        assertTrue(
+          "expected ≥ 95% red pixels on bootstrap render; got ${"%.2f".format(redMatch * 100)}%",
+          redMatch >= 0.95,
+        )
+
+        // Dispatch KEY_DOWN(KEYCODE_A) — wire format is the Android `KEYCODE_*` int as a
+        // decimal string; the desktop session translates through `androidKeycodeToComposeKey`
+        // to the Skiko `Key.A` constant. `KEYCODE_A == 29` per `InteractiveKeyCodes`.
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "test-stream-key-1",
+            kind = InteractiveInputKind.KEY_DOWN,
+            keyCode = "29",
+          )
+        )
+
+        // Re-render — `Modifier.onKeyEvent` should have flipped `pressed = true` and the box
+        // should paint green. Load-bearing for the issue #1203 contract: without the new
+        // dispatch wiring this would still be red (the old no-op branch).
+        val second = session.render(requestId = RenderHost.nextRequestId())
+        assertNotNull("second render must produce a pngPath", second.pngPath)
+        val secondImage = readPng(File(second.pngPath!!))
+        val greenMatch = pixelMatchPct(secondImage, expectedRgb = 0x66BB6A, perChannelTolerance = 8)
+        assertTrue(
+          "expected ≥ 95% green pixels after KEY_DOWN(KEYCODE_A); got " +
+            "${"%.2f".format(greenMatch * 100)}% — this is the load-bearing #1203 assertion " +
+            "(daemon side wire shape went from no-op to real Skiko sendKeyEvent).",
+          greenMatch >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+    assertFalse(
+      "render thread must not observe an InterruptedException",
+      host.renderThreadInterrupted,
+    )
+  }
+
+  /**
+   * Issue #1203 — unmapped keycodes drop silently. A forward-looking client that sends a key
+   * outside the translation table (e.g. `F13`) shouldn't crash the dispatch loop or flip the
+   * fixture state; the second render must still be red.
+   */
+  @Test
+  fun key_down_with_unmapped_keycode_is_a_silent_no_op() {
+    val outputDir = tempFolder.newFolder("interactive-key-unmapped-renders")
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == KEY_PRESS_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "KeyPressColorSquare",
+              widthPx = 64,
+              heightPx = 64,
+              density = 1.0f,
+              outputBaseName = "key-press-unmapped",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = KEY_PRESS_PREVIEW_ID,
+          classLoader =
+            DesktopInteractiveSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+        )
+      try {
+        // Bootstrap.
+        val first = session.render(requestId = RenderHost.nextRequestId())
+        assertNotNull(first.pngPath)
+
+        // Dispatch a wire keycode that the desktop translation table doesn't cover (Android
+        // `KEYCODE_F13 == 183`; intentionally outside `InteractiveKeyCodes`). Must NOT throw,
+        // must NOT mutate composition state.
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "test-stream-key-unmapped",
+            kind = InteractiveInputKind.KEY_DOWN,
+            keyCode = "183",
+          )
+        )
+
+        val second = session.render(requestId = RenderHost.nextRequestId())
+        assertNotNull(second.pngPath)
+        val secondImage = readPng(File(second.pngPath!!))
+        val redMatch = pixelMatchPct(secondImage, expectedRgb = 0xEF5350, perChannelTolerance = 8)
+        assertTrue(
+          "unmapped keycode must not flip state; expected ≥ 95% red; got " +
+            "${"%.2f".format(redMatch * 100)}%",
+          redMatch >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
   companion object {
     private const val FIXTURE_PREVIEW_ID = "click-toggle-square"
     private const val FRAME_CLOCK_PREVIEW_ID = "frame-clock-square"
+    private const val KEY_PRESS_PREVIEW_ID = "key-press-color-square"
   }
 }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus
 import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
@@ -736,9 +737,183 @@ class DesktopRecordingSessionTest {
     return matches.toDouble() / total.toDouble()
   }
 
+  /**
+   * Issue #1203 — scripted `input.keyDown` against the held composition. Mirrors the click test's
+   * contract for the new keyboard surface:
+   *
+   * 1. **Frame 0 paints green** — the `input.keyDown` event at `tMs = 0` drains before the first
+   *    render tick, flipping `KeyPressColorSquare.pressed = true` via the new
+   *    `keyHandler(KeyEventType.KeyDown)` registry entry.
+   * 2. **State holds across frames** — frame 5 (between event drain and stop) still paints green.
+   *    Without held-scene state the `mutableStateOf` would reset between renders.
+   * 3. **Script evidence reports APPLIED** — `RecordingScriptEvidence.status` for the
+   *    `input.keyDown` event comes back `APPLIED`, not `UNSUPPORTED`. This is the contract the
+   *    descriptor's `supported = true` advertises to clients — flipping it to `UNSUPPORTED` again
+   *    would be a regression on the `recording/script` wire shape.
+   *
+   * Counterpart to the harness scenario `SRecordingKeyDispatch` from the issue's acceptance
+   * criteria. Run in-process here so the test exercises both the script handler registry and the
+   * Skiko translation table without paying the harness's subprocess cost.
+   */
+  @Test
+  fun scripted_keyDown_flips_state_and_emits_applied_evidence() {
+    val outputDir = tempFolder.newFolder("recording-key-renders")
+    val recordingsRoot = tempFolder.newFolder("recordings-key-root")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == KEY_PRESS_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "KeyPressColorSquare",
+              widthPx = 64,
+              heightPx = 64,
+              density = 1.0f,
+              outputBaseName = "key-press-recording-square",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = KEY_PRESS_PREVIEW_ID,
+          recordingId = "test-rec-key-1",
+          classLoader =
+            DesktopRecordingSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 1.0f,
+          overrides = null,
+        )
+      try {
+        session.postScript(
+          listOf(
+            RecordingScriptEvent(
+              tMs = 0L,
+              kind = "input.keyDown",
+              keyCode = "29", // KEYCODE_A
+            )
+          )
+        )
+
+        val result = session.stop()
+        assertTrue("frame count must be ≥ 1", result.frameCount >= 1)
+
+        // Frame 0 — keyDown drained at tMs = 0, the fixture flipped to green.
+        val frame0 = readPng(File(result.framesDir, "frame-00000.png"))
+        val greenAt0 = pixelMatchPct(frame0, expectedRgb = 0x66BB6A, perChannelTolerance = 8)
+        assertTrue(
+          "frame 0 expected ≥ 95% green pixels (pressed = true after input.keyDown@0); got " +
+            "${"%.2f".format(greenAt0 * 100)}% — load-bearing for issue #1203's recording wire.",
+          greenAt0 >= 0.95,
+        )
+
+        // Script evidence — `RecordingScriptEvidence.status` for the keyDown event must be
+        // APPLIED, not the pre-#1203 UNSUPPORTED. This is the contract a recording client
+        // (panel, MCP) keys off when grading the playback.
+        val keyEvidence = result.scriptEvents.find { it.kind == "input.keyDown" }
+        assertNotNull(
+          "every scripted event must have an evidence entry; got: ${result.scriptEvents}",
+          keyEvidence,
+        )
+        assertEquals(
+          "input.keyDown evidence must be APPLIED on the desktop backend post-#1203",
+          RecordingScriptEventStatus.APPLIED,
+          keyEvidence!!.status,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
+   * Issue #1203 — recording counterpart to the interactive "unmapped keycode is a silent no-op". An
+   * unknown wire keycode should surface as `UNSUPPORTED` evidence with a clear reason rather than
+   * crashing the script playback or being silently dropped.
+   */
+  @Test
+  fun scripted_keyDown_with_unmapped_keycode_emits_unsupported_evidence() {
+    val outputDir = tempFolder.newFolder("recording-key-unmapped-renders")
+    val recordingsRoot = tempFolder.newFolder("recordings-key-unmapped-root")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == KEY_PRESS_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "KeyPressColorSquare",
+              widthPx = 64,
+              heightPx = 64,
+              density = 1.0f,
+              outputBaseName = "key-press-unmapped-recording",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = KEY_PRESS_PREVIEW_ID,
+          recordingId = "test-rec-key-unmapped",
+          classLoader =
+            DesktopRecordingSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 1.0f,
+          overrides = null,
+        )
+      try {
+        session.postScript(
+          listOf(
+            RecordingScriptEvent(
+              tMs = 0L,
+              kind = "input.keyDown",
+              keyCode = "183", // KEYCODE_F13 — outside the desktop translation table
+            )
+          )
+        )
+
+        val result = session.stop()
+        val keyEvidence = result.scriptEvents.find { it.kind == "input.keyDown" }
+        assertNotNull(keyEvidence)
+        assertEquals(
+          "unmapped keycode must surface UNSUPPORTED evidence so the agent learns which key " +
+            "didn't make it through",
+          RecordingScriptEventStatus.UNSUPPORTED,
+          keyEvidence!!.status,
+        )
+        assertNotNull(
+          "UNSUPPORTED evidence must carry a human-readable message",
+          keyEvidence.message,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
   companion object {
     private const val FIXTURE_PREVIEW_ID = "tristate-click-square"
     private const val FAILURE_PREVIEW_ID = "click-to-boom-square"
+    private const val KEY_PRESS_PREVIEW_ID = "key-press-color-square"
     // Component-preview-sized sandbox — a button-ish 120x60 surface, deliberately NOT phone-sized.
     private const val COMPONENT_WIDTH_PX = 120
     private const val COMPONENT_HEIGHT_PX = 60

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.daemon
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,7 +15,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
 
 /**
@@ -376,4 +384,39 @@ fun FontScaleAwareSquare() {
 @Composable
 fun WallpaperAwareSquare() {
   Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.primary))
+}
+
+/**
+ * Issue #1203 — fixture for the desktop keyboard-dispatch integration tests.
+ *
+ * Paints red on first composition; flips green when the `Key.A` key down event reaches the
+ * composition's focused node. The fixture installs a [FocusRequester] and requests focus inside a
+ * [LaunchedEffect] so the held scene's key-event pipeline has a target by the time the test
+ * dispatches its first `KEY_DOWN(KEYCODE_A)`. Without focus, `BaseComposeScene. sendKeyEvent` has
+ * nowhere to deliver the event and the assertion would fail spuriously.
+ *
+ * Used by `DesktopInteractiveSessionTest.key_down_input_flips_state_and_repaints` and
+ * `DesktopRecordingSessionTest.scripted_keyDown_flips_state_and_emits_applied_evidence`. Both
+ * backends share the fixture so a wire-level mix-up between interactive and recording paths would
+ * surface as the same colour transition test.
+ */
+@Composable
+fun KeyPressColorSquare() {
+  var pressed by remember { mutableStateOf(false) }
+  val color = if (pressed) Color(0xFF66BB6A) else Color(0xFFEF5350)
+  val focusRequester = remember { FocusRequester() }
+  LaunchedEffect(Unit) { focusRequester.requestFocus() }
+  Box(
+    modifier =
+      Modifier.fillMaxSize()
+        .background(color)
+        .focusRequester(focusRequester)
+        .focusable()
+        .onKeyEvent { event ->
+          if (event.type == KeyEventType.KeyDown && event.key == Key.A) {
+            pressed = true
+            true
+          } else false
+        }
+  )
 }


### PR DESCRIPTION
## Summary

Add comprehensive integration tests for keyboard input dispatch on the desktop backend, covering both interactive and recording sessions. These tests validate the new keyboard event handling wire shape introduced in issue #1203.

## Key Changes

- **Interactive session tests** (`DesktopInteractiveSessionTest`):
  - `key_down_input_flips_state_and_repaints()` — verifies that `KEY_DOWN` events with mapped keycodes (e.g., `KEYCODE_A`) are correctly translated through the Skiko layer and reach the composition's `onKeyEvent` handler, mutating held state across renders
  - `key_down_with_unmapped_keycode_is_a_silent_no_op()` — confirms that unmapped keycodes (e.g., `KEYCODE_F13`) drop silently without crashing or mutating state

- **Recording session tests** (`DesktopRecordingSessionTest`):
  - `scripted_keyDown_flips_state_and_emits_applied_evidence()` — validates that scripted `input.keyDown` events drain before the first render tick, flip composition state, and emit `APPLIED` evidence status
  - `scripted_keyDown_with_unmapped_keycode_emits_unsupported_evidence()` — ensures unmapped keycodes surface as `UNSUPPORTED` evidence with a human-readable message rather than crashing

- **Test fixture** (`RedFixturePreviews.kt`):
  - New `KeyPressColorSquare()` composable that paints red by default and green when `Key.A` is pressed
  - Installs a `FocusRequester` and requests focus in a `LaunchedEffect` to ensure the key-event pipeline has a target
  - Shared by both interactive and recording tests to validate the wire shape consistency across backends

## Implementation Details

- Tests use color-matching assertions (≥95% pixel match with 8-bit per-channel tolerance) to verify state mutations across render frames
- Both test suites mirror each other's contract to catch wire-level inconsistencies between interactive and recording paths
- Recording tests additionally validate `RecordingScriptEventStatus` enum values (`APPLIED` vs `UNSUPPORTED`) to ensure the wire contract advertised to clients is honored
- Unmapped keycode handling is tested in both paths to ensure graceful degradation without crashes or silent state corruption

https://claude.ai/code/session_011zyPv1X4fWCRz3SSKgmsEi