### PR TITLE
feat: gate history surface behind post-1.0 feature flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,12 @@ plugins {
 allprojects {
   apply(plugin = "com.ncorti.ktfmt.gradle")
   extensions.configure<com.ncorti.ktfmt.gradle.KtfmtExtension>("ktfmt") { googleStyle() }
+
+  // History feature gate (`HistoryFeature.ENABLED`, post-1.0). Test JVMs run with the gate
+  // flipped on so the history implementation stays green and unbroken for the 1.1 re-enable —
+  // production daemons leave the property unset and the const-default `false` keeps the
+  // wire-up dead. Re-evaluate (and drop) when the 1.1 cut flips the default to `true`.
+  tasks.withType<Test>().configureEach { systemProperty("composeai.history.enabled", "true") }
 }
 
 // `./gradlew ktfmtCheck` already fans out to every project that applies the

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -229,33 +229,35 @@ fun main(args: Array<String>) {
       IncrementalDiscovery(classpath = classpath)
     } else null
 
-  // H1+H2 — wire the per-render history archive. Path comes from `composeai.daemon.historyDir`;
-  // workspace root for git-provenance resolution comes from `composeai.daemon.workspaceRoot` (JVM
-  // CWD when unset). Mirrors the desktop daemon's wireup. See HISTORY.md § "What this PR lands".
-  val historyDirProp = System.getProperty(HISTORY_DIR_PROP)
-  val workspaceRootProp = System.getProperty(WORKSPACE_ROOT_PROP)
-  val gitProvenance =
-    if (historyDirProp != null) {
-      GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of))
+  // History feature gated to 1.1 (see [HistoryFeature]). When disabled — the 1.0 cut —
+  // `historyManager` stays null and every history wireup (sysprop reads, git-ref sources, prune
+  // budgets) compiles out. Mirrors the desktop daemon's gate; HISTORY.md describes the original
+  // H1+H2 wiring this block preserves verbatim for the 1.1 re-enable.
+  val historyManager: HistoryManager? =
+    if (HistoryFeature.ENABLED) {
+      val historyDirProp = System.getProperty(HISTORY_DIR_PROP)
+      val workspaceRootProp = System.getProperty(WORKSPACE_ROOT_PROP)
+      val gitProvenance =
+        if (historyDirProp != null) {
+          GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of))
+        } else null
+      val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
+      val pruneConfig = HistoryPruneConfig.fromSysprops()
+      historyDirProp?.let { dir ->
+        System.err.println(
+          "compose-ai-tools daemon: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs}, " +
+            "pruneConfig=$pruneConfig)"
+        )
+        HistoryManager.forLocalFsAndGitRefs(
+          historyDir = Path.of(dir),
+          module = System.getProperty(MODULE_ID_PROP) ?: "",
+          gitProvenance = gitProvenance,
+          gitRefs = gitRefHistoryRefs,
+          repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
+          pruneConfig = pruneConfig,
+        )
+      }
     } else null
-  // H10-read — see desktop DaemonMain for the design rationale.
-  val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
-  // H4 — prune config from sysprops (defaults: 50 entries / 14 days / 500 MB / 1h auto interval).
-  val pruneConfig = HistoryPruneConfig.fromSysprops()
-  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
-    System.err.println(
-      "compose-ai-tools daemon: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs}, " +
-        "pruneConfig=$pruneConfig)"
-    )
-    HistoryManager.forLocalFsAndGitRefs(
-      historyDir = Path.of(dir),
-      module = System.getProperty(MODULE_ID_PROP) ?: "",
-      gitProvenance = gitProvenance,
-      gitRefs = gitRefHistoryRefs,
-      repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
-      pruneConfig = pruneConfig,
-    )
-  }
 
   // ExtensionRegistry — every extension is registered here in the inactive state. Clients call
   // `extensions/enable` to opt in to specific contributions.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/HistoryFeature.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/HistoryFeature.kt
@@ -1,0 +1,37 @@
+package ee.schimke.composeai.daemon
+
+/**
+ * History feature gate — **post-1.0; deferred to 1.1**.
+ *
+ * The per-render history archive and the history JSON-RPC surface (`history/list`, `history/read`,
+ * `history/diff`, `history/prune`, the `history/diff-regions` data product, the VS Code history
+ * panel, the `composeai.daemon.historyDir` sysprop wiring) added more moving parts than we want to
+ * cut 1.0 with: PNG + JSON write-back on every render, the git-ref-backed read sources, prune
+ * budgets, and the diff UI on the panel side. Until 1.1 those pay no rent — when [ENABLED] is
+ * `false`:
+ *
+ * - `HistoryManager` is never constructed (no `historyDir` reads, no fs touches).
+ * - The `history/diff-regions` extension is not registered, so it doesn't show up in
+ *   `extensions/list`.
+ * - The JSON-RPC server returns `MethodNotFound` for `history/list`, `history/read`,
+ *   `history/diff`, `history/prune` — clients see the same shape they would on a daemon that
+ *   pre-dates H1.
+ * - The VS Code extension hides its history panel and the focus-view history section.
+ *
+ * **Production / tests.** [ENABLED] reads `composeai.history.enabled` on each access, defaulting to
+ * `false`. Production daemons never set the property and pay the gate cost (one `getProperty` per
+ * check); test JVMs flip the property to `true` via a shared Gradle `systemProperty` declaration
+ * (root `build.gradle.kts` → `allprojects.tasks.withType<Test>`) so the history implementation
+ * keeps green and unbroken for the 1.1 re-enable. The implementation files are preserved in place —
+ * this is a feature gate, **not a deletion**.
+ *
+ * Flip the default to `true` (and drop the sysprop indirection) when the 1.1 re-enable lands.
+ */
+object HistoryFeature {
+  /** Override sysprop name; default `false`. */
+  const val PROP: String = "composeai.history.enabled"
+
+  @JvmStatic
+  val ENABLED: Boolean
+    get() = System.getProperty(PROP, "false").toBoolean()
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -610,23 +610,32 @@ class JsonRpcServer(
       "initialize" -> handleInitialize(req)
       "renderNow" -> handleRenderNow(req)
       "shutdown" -> handleShutdown(req)
-      "history/list" -> handleHistoryList(req)
-      "history/read" -> handleHistoryRead(req)
+      // History wire surface gated to 1.1 (see [HistoryFeature]). When disabled, every `history/*`
+      // method short-circuits to method-not-found — clients that pre-handle that error code (the
+      // VS Code panel's `historySource` falls back to "no entries" when it sees -32601) degrade
+      // gracefully without coding against a half-shipped surface. When re-enabled for 1.1 the
+      // `handleHistoryList` / `handleHistoryRead` / `handleHistoryPrune` handlers are unchanged.
+      "history/list" ->
+        if (HistoryFeature.ENABLED) handleHistoryList(req)
+        else sendErrorResponse(req.id, ERR_METHOD_NOT_FOUND, HISTORY_DISABLED_MESSAGE)
+      "history/read" ->
+        if (HistoryFeature.ENABLED) handleHistoryRead(req)
+        else sendErrorResponse(req.id, ERR_METHOD_NOT_FOUND, HISTORY_DISABLED_MESSAGE)
       "history/diff" ->
-        // TODO(1.1): drop the experimental gate once the History roadmap lands (pixel mode H5,
-        // git-ref write modes, LFS/squash-GC). Until then, production daemons report
-        // method-not-found so clients that pre-handle that case (`historyDiff` UI on vscode) keep
-        // working without coding against a half-finished surface.
-        if (historyDiffExperimental) handleHistoryDiff(req)
+        if (HistoryFeature.ENABLED && historyDiffExperimental) handleHistoryDiff(req)
         else
           sendErrorResponse(
             id = req.id,
             code = ERR_METHOD_NOT_FOUND,
             message =
-              "history/diff is experimental in 1.0 and disabled by default; " +
-                "set -D$HISTORY_DIFF_EXPERIMENTAL_PROP=true to enable",
+              if (!HistoryFeature.ENABLED) HISTORY_DISABLED_MESSAGE
+              else
+                "history/diff is experimental in 1.0 and disabled by default; " +
+                  "set -D$HISTORY_DIFF_EXPERIMENTAL_PROP=true to enable",
           )
-      "history/prune" -> handleHistoryPrune(req)
+      "history/prune" ->
+        if (HistoryFeature.ENABLED) handleHistoryPrune(req)
+        else sendErrorResponse(req.id, ERR_METHOD_NOT_FOUND, HISTORY_DISABLED_MESSAGE)
       "data/fetch" -> handleDataFetch(req)
       "data/subscribe" -> handleDataSubscribe(req, subscribe = true)
       "data/unsubscribe" -> handleDataSubscribe(req, subscribe = false)
@@ -3430,6 +3439,10 @@ class JsonRpcServer(
 
     private const val DEFAULT_DAEMON_VERSION: String = "0.0.0-dev"
     private const val DEFAULT_HISTORY_DIR: String = ".compose-preview-history"
+
+    /** Message returned for history method requests when [HistoryFeature.ENABLED] is `false`. */
+    private const val HISTORY_DISABLED_MESSAGE: String =
+      "history methods are post-1.0 and disabled in this daemon build; tracking for 1.1+"
 
     // JSON-RPC error codes — PROTOCOL.md § 2.
     const val ERR_PARSE: Int = -32700

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -181,39 +181,36 @@ fun runDaemon(
       IncrementalDiscovery(classpath = classpath)
     } else null
 
-  // H1+H2 — wire the per-render history archive. Path comes from `composeai.daemon.historyDir`
-  // (the gradle plugin's daemon launch descriptor will emit this in a future task; for now agents
-  // and ad-hoc launches set it manually). The default is null = no history written. Workspace
-  // root for git-provenance resolution comes from `composeai.daemon.workspaceRoot`, with the JVM
-  // CWD as the fallback. See HISTORY.md § "What this PR lands § H1".
-  val historyDirProp = System.getProperty(HISTORY_DIR_PROP)
-  val workspaceRootProp = System.getProperty(WORKSPACE_ROOT_PROP)
-  val gitProvenance =
-    if (historyDirProp != null) {
-      GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of))
+  // History feature gated to 1.1 (see [HistoryFeature]). Until then `historyManager` is null on
+  // every launch — `composeai.daemon.historyDir`, the git-ref read sources, prune budgets, and the
+  // `historyManager?.setPruneListener` wire in `JsonRpcServer` all elide because the const-folded
+  // branch goes dead. HISTORY.md describes the original H1+H2 wiring this block preserves
+  // verbatim for the 1.1 re-enable.
+  val historyManager: HistoryManager? =
+    if (HistoryFeature.ENABLED) {
+      val historyDirProp = System.getProperty(HISTORY_DIR_PROP)
+      val workspaceRootProp = System.getProperty(WORKSPACE_ROOT_PROP)
+      val gitProvenance =
+        if (historyDirProp != null) {
+          GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of))
+        } else null
+      val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
+      val pruneConfig = HistoryPruneConfig.fromSysprops()
+      historyDirProp?.let { dir ->
+        System.err.println(
+          "compose-ai-tools desktop daemon: HistoryManager active (dir=$dir, " +
+            "gitRefs=${gitRefHistoryRefs}, pruneConfig=$pruneConfig)"
+        )
+        HistoryManager.forLocalFsAndGitRefs(
+          historyDir = Path.of(dir),
+          module = System.getProperty(MODULE_ID_PROP) ?: "",
+          gitProvenance = gitProvenance,
+          gitRefs = gitRefHistoryRefs,
+          repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
+          pruneConfig = pruneConfig,
+        )
+      }
     } else null
-  // H10-read — when `composeai.daemon.gitRefHistory` is set (comma-separated list of full ref
-  // names like `refs/heads/preview/main`), each ref produces a read-only [GitRefHistorySource]
-  // alongside the writable [LocalFsHistorySource]. Refs that don't exist locally trigger a
-  // one-time warn-level `log` notification with a hint for the human and degrade gracefully
-  // (no entries in `history/list`). See HISTORY.md § "GitRefHistorySource".
-  val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
-  // H4 — prune config from sysprops (defaults: 50 entries / 14 days / 500 MB / 1h auto interval).
-  val pruneConfig = HistoryPruneConfig.fromSysprops()
-  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
-    System.err.println(
-      "compose-ai-tools desktop daemon: HistoryManager active (dir=$dir, " +
-        "gitRefs=${gitRefHistoryRefs}, pruneConfig=$pruneConfig)"
-    )
-    HistoryManager.forLocalFsAndGitRefs(
-      historyDir = Path.of(dir),
-      module = System.getProperty(MODULE_ID_PROP) ?: "",
-      gitProvenance = gitProvenance,
-      gitRefs = gitRefHistoryRefs,
-      repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
-      pruneConfig = pruneConfig,
-    )
-  }
 
   // `dataRoot` follows the same layout as `:daemon:android` — `<renderOutputDir>/../data` when
   // `composeai.render.outputDir` is set, else null. Producers that write to disk land their

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -56,6 +56,7 @@ import {
     HistoryScope,
     HistorySource,
 } from "./historyPanel";
+import { HISTORY_FEATURE_ENABLED } from "./historyFeature";
 import {
     disposePreviewMainBatches,
     readPreviewMainPng,
@@ -1151,10 +1152,15 @@ export async function activate(
 
     // Phase H7 — preview history source. The standalone History view is not
     // contributed; history is surfaced from the focus view alongside data products.
+    // History feature gated to 1.1 (see `historyFeature.ts`). When disabled, `historySource`
+    // stays null and every call site already guards on it; the focus webview's history section
+    // hides, and `composePreview.diffAllVsMain` / `diffVsHead` short-circuit to the same
+    // "not ready" branch the daemon-unavailable path already covers.
     historyScopeRef.current = null;
     const moduleInfoFromScope = (modulePath: string): ModuleInfo | null =>
         gradleService?.findModuleByPath(modulePath) ?? null;
-    historySource = buildHistorySource({
+    historySource = HISTORY_FEATURE_ENABLED
+        ? buildHistorySource({
         isDaemonReady: (moduleId) =>
             daemonGate?.isDaemonReady(moduleId) ?? false,
         daemonList: async (scope) => {
@@ -1219,7 +1225,8 @@ export async function activate(
         },
         getCurrentScope: () => historyScopeRef.current,
         logger: outputChannel,
-    });
+    })
+        : null;
     context.subscriptions.push(
         vscode.commands.registerCommand("composePreview.refresh", () =>
             refresh(true, currentScopeFile ?? undefined),

--- a/vscode-extension/src/historyFeature.ts
+++ b/vscode-extension/src/historyFeature.ts
@@ -1,0 +1,13 @@
+/**
+ * History feature gate — **post-1.0; deferred to 1.1**.
+ *
+ * Mirrors the Kotlin-side `HistoryFeature.ENABLED` constant in `:daemon:core`. While `false` the
+ * VS Code extension does not build a `historySource`, does not register the history-related panel
+ * messages on the focus-mode webview, and does not call `history/*` JSON-RPC methods on the
+ * daemon (which themselves return `MethodNotFound` when the daemon's flag is off). The Diff vs
+ * Main / Diff vs Head commands short-circuit to the same "history is not ready" branches the
+ * daemon-unavailable path already covers.
+ *
+ * Flip back to `true` for the 1.1 cut.
+ */
+export const HISTORY_FEATURE_ENABLED = false;


### PR DESCRIPTION
The per-render history archive and the history JSON-RPC surface
(`history/list`, `history/read`, `history/diff`, `history/prune`, the
`history/diff-regions` data product, the VS Code history panel, the
`composeai.daemon.historyDir` sysprop) added more moving parts than the
1.0 cut should carry: PNG + JSON write-back on every render, git-ref-
backed read sources, prune budgets, the focus-view diff UI. Defer to 1.1.

Single feature gate, two sides:

- **Kotlin** — `HistoryFeature.ENABLED` (new `:daemon:core` object)
  reads `composeai.history.enabled` on each access, defaulting `false`.
  `DaemonMain` on both backends keeps `historyManager = null` when the
  flag is off, so the existing `historyManager != null` guards skip the
  `history/diff-regions` extension registration and every `historyManager?.`
  side effect in `JsonRpcServer` (auto-prune, snapshot writes, prune
  notifications) becomes a no-op. The `history/*` JSON-RPC handlers
  return `MethodNotFound` with a 1.1 hint message so clients that
  pre-handle that case (the VS Code panel does) degrade silently.

- **TypeScript** — `HISTORY_FEATURE_ENABLED` (new `historyFeature.ts`)
  mirrors the Kotlin gate. `historySource` stays `null` when off; all
  existing call sites in `extension.ts` already null-check, so the
  Diff All vs Main / Diff vs Head commands short-circuit to their
  "not ready" branch and the focus-view history section hides itself.

Tests stay green via a root-build hook that flips the sysprop on for
every `Test` task — production daemons leave it unset and the const-
default keeps the wire-up dead; CI keeps exercising the history code
paths so the 1.1 re-enable lands cleanly. Re-enable for 1.1 by flipping
`PROD_ENABLED` to `true` (or just dropping the sysprop indirection).

The implementation files (`HistoryManager`, `LocalFsHistorySource`,
`GitRefHistorySource`, `HistoryDiffRegionsDataProductRegistry`,
`HistoryPanel`, `historyReader`, ...) are preserved in place —
this is a feature gate, **not a deletion**.