### PR TITLE
test(daemon-harness): pin compose/recomposition wire shape on Android real-mode

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -139,9 +139,18 @@ fun main(args: Array<String>) {
       // production shape we must preserve the warm-spare pool and per-slot user classloaders;
       // otherwise the router silently downgrades the daemon to v1 interactive mode and scroll/click
       // inputs only trigger stateless re-renders. Standalone harness launchers have no preview
-      // index/user class dirs, so they keep the old single-sandbox route.
+      // index/user class dirs, so they default to the single-sandbox route — but an explicit
+      // `composeai.daemon.sandboxCount=N` sysprop wins so harness scenarios that need interactive
+      // sessions (issue #1204's `compose/recomposition` real-mode wire test) can opt into the
+      // pool without paying the warm-spare-default cost for every other harness scenario.
       val productionManifestRoute = previewIndex.size > 0 || hasUserClasses
-      val routerSandboxCount = if (productionManifestRoute) sandboxCount else 1
+      val explicitSandboxCount = System.getProperty(SANDBOX_COUNT_PROP)?.toIntOrNull() != null
+      val routerSandboxCount =
+        when {
+          productionManifestRoute -> sandboxCount
+          explicitSandboxCount -> sandboxCount
+          else -> 1
+        }
       val singletonHolder: UserClassLoaderHolder? =
         if (routerSandboxCount == 1)
           userClassloaderHolderFactory?.let { factory ->

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
@@ -2,6 +2,10 @@ package ee.schimke.composeai.daemon.harness
 
 import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.ClientCapabilities
+import ee.schimke.composeai.daemon.protocol.DataSubscribeParams
+import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableParams
+import ee.schimke.composeai.daemon.protocol.ExtensionsEnableResult
 import ee.schimke.composeai.daemon.protocol.FileChangedParams
 import ee.schimke.composeai.daemon.protocol.FileKind
 import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
@@ -15,6 +19,11 @@ import ee.schimke.composeai.daemon.protocol.HistoryReadParams
 import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
 import ee.schimke.composeai.daemon.protocol.InitializeParams
 import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import ee.schimke.composeai.daemon.protocol.InteractiveStartParams
+import ee.schimke.composeai.daemon.protocol.InteractiveStartResult
+import ee.schimke.composeai.daemon.protocol.InteractiveStopParams
 import ee.schimke.composeai.daemon.protocol.JsonRpcNotification
 import ee.schimke.composeai.daemon.protocol.JsonRpcRequest
 import ee.schimke.composeai.daemon.protocol.RenderNowParams
@@ -99,7 +108,7 @@ private constructor(
         method = "initialize",
         params = json.encodeToJsonElement(InitializeParams.serializer(), params),
       )
-    val response = sendAndPoll(id, request, 30.seconds)
+    val response = sendAndPoll(id, request, 120.seconds)
     val resultElem =
       response["result"]
         ?: error("initialize: no result in response — error=${response["error"]}, full=${response}")
@@ -251,6 +260,135 @@ private constructor(
         params = json.encodeToJsonElement(HistoryReadParams.serializer(), params),
       )
     return sendAndPoll(rpcId, request, 10.seconds)
+  }
+
+  /**
+   * Drives `extensions/enable` for the given extension ids; returns the daemon's
+   * [ExtensionsEnableResult] so tests can introspect newly-enabled / pulled-in / unknown ids.
+   * Extensions registered by the daemon are inactive by default — features like
+   * `compose/recomposition` only appear in `initialize.capabilities.dataProducts` once the client
+   * opts in.
+   */
+  fun extensionsEnable(ids: List<String>): ExtensionsEnableResult {
+    val rpcId = nextId.getAndIncrement()
+    val payload = ExtensionsEnableParams(ids = ids)
+    val request =
+      JsonRpcRequest(
+        id = rpcId,
+        method = "extensions/enable",
+        params = json.encodeToJsonElement(ExtensionsEnableParams.serializer(), payload),
+      )
+    val response = sendAndPoll(rpcId, request, 10.seconds)
+    val resultElem =
+      response["result"]
+        ?: error("extensions/enable: no result — error=${response["error"]}, full=$response")
+    return json.decodeFromJsonElement(ExtensionsEnableResult.serializer(), resultElem)
+  }
+
+  /**
+   * Issue #1204 — drives `data/subscribe` with a per-kind options bag. The [params] argument is the
+   * `params.params` sub-bag that producers like `compose/recomposition` read (`frameStreamId` /
+   * `mode`); pass `null` for kinds whose subscribe payload is empty.
+   */
+  fun dataSubscribe(
+    previewId: String,
+    kind: String,
+    params: JsonObject? = null,
+  ): DataSubscribeResult {
+    val rpcId = nextId.getAndIncrement()
+    val payload = DataSubscribeParams(previewId = previewId, kind = kind, params = params)
+    val request =
+      JsonRpcRequest(
+        id = rpcId,
+        method = "data/subscribe",
+        params = json.encodeToJsonElement(DataSubscribeParams.serializer(), payload),
+      )
+    val response = sendAndPoll(rpcId, request, 10.seconds)
+    val resultElem =
+      response["result"]
+        ?: error("data/subscribe: no result — error=${response["error"]}, full=$response")
+    return json.decodeFromJsonElement(DataSubscribeResult.serializer(), resultElem)
+  }
+
+  /** Issue #1204 — drives `data/unsubscribe`; pairs with [dataSubscribe]. */
+  fun dataUnsubscribe(previewId: String, kind: String): DataSubscribeResult {
+    val rpcId = nextId.getAndIncrement()
+    val payload = DataSubscribeParams(previewId = previewId, kind = kind, params = null)
+    val request =
+      JsonRpcRequest(
+        id = rpcId,
+        method = "data/unsubscribe",
+        params = json.encodeToJsonElement(DataSubscribeParams.serializer(), payload),
+      )
+    val response = sendAndPoll(rpcId, request, 10.seconds)
+    val resultElem =
+      response["result"]
+        ?: error("data/unsubscribe: no result — error=${response["error"]}, full=$response")
+    return json.decodeFromJsonElement(DataSubscribeResult.serializer(), resultElem)
+  }
+
+  /**
+   * Issue #1204 — drives `interactive/start` and returns the daemon's [InteractiveStartResult] so
+   * tests can branch on `heldSession` / capture the daemon-allocated `frameStreamId`. Generous
+   * timeout because the Android backend's first `interactive/start` triggers slot 1's first sandbox
+   * dispatch (`createAndroidComposeRule` + `setContent`), which can run into seconds on a cold
+   * cache.
+   */
+  fun interactiveStart(previewId: String, inspectionMode: Boolean? = null): InteractiveStartResult {
+    val rpcId = nextId.getAndIncrement()
+    val payload = InteractiveStartParams(previewId = previewId, inspectionMode = inspectionMode)
+    val request =
+      JsonRpcRequest(
+        id = rpcId,
+        method = "interactive/start",
+        params = json.encodeToJsonElement(InteractiveStartParams.serializer(), payload),
+      )
+    val response = sendAndPoll(rpcId, request, 180.seconds)
+    val resultElem =
+      response["result"]
+        ?: error("interactive/start: no result — error=${response["error"]}, full=$response")
+    return json.decodeFromJsonElement(InteractiveStartResult.serializer(), resultElem)
+  }
+
+  /**
+   * Issue #1204 — fires an `interactive/input` notification (no response expected). The daemon
+   * routes the input into the held session keyed by [frameStreamId] and emits a fresh
+   * `renderFinished` (poll for it via [pollRenderFinishedFor]).
+   */
+  fun interactiveInput(
+    frameStreamId: String,
+    kind: InteractiveInputKind,
+    pixelX: Int? = null,
+    pixelY: Int? = null,
+    scrollDeltaY: Float? = null,
+    keyCode: String? = null,
+  ) {
+    val payload =
+      InteractiveInputParams(
+        frameStreamId = frameStreamId,
+        kind = kind,
+        pixelX = pixelX,
+        pixelY = pixelY,
+        scrollDeltaY = scrollDeltaY,
+        keyCode = keyCode,
+      )
+    sendNotificationFrame(
+      "interactive/input",
+      json.encodeToJsonElement(InteractiveInputParams.serializer(), payload),
+    )
+  }
+
+  /** Issue #1204 — drives `interactive/stop` for the held session keyed by [frameStreamId]. */
+  fun interactiveStop(frameStreamId: String) {
+    val rpcId = nextId.getAndIncrement()
+    val payload = InteractiveStopParams(frameStreamId = frameStreamId)
+    val request =
+      JsonRpcRequest(
+        id = rpcId,
+        method = "interactive/stop",
+        params = json.encodeToJsonElement(InteractiveStopParams.serializer(), payload),
+      )
+    sendAndPoll(rpcId, request, 30.seconds)
   }
 
   /** Drives `renderNow` for the given preview ids at the given [tier]. */

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessTestSupport.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessTestSupport.kt
@@ -235,7 +235,11 @@ fun realModeScenario(name: String, previews: List<RealModePreview>): RealModeSce
  * `"real-android"` (vs `"real"` for desktop) so failure diagnostics in [HarnessClient]'s reader
  * threads make obvious which target produced the failure.
  */
-fun realAndroidModeScenario(name: String, previews: List<RealModePreview>): RealModeScenarioPaths {
+fun realAndroidModeScenario(
+  name: String,
+  previews: List<RealModePreview>,
+  extraJvmArgs: List<String> = emptyList(),
+): RealModeScenarioPaths {
   val (rendersDir, reportsDir, manifestFile, _) = prepareRealModeScenarioPaths(name, previews)
   // The Android daemon needs its runtime classpath resolved through AGP's variant model — the
   // harness's plain JVM `java.class.path` doesn't include AAR-derived JARs (e.g. roborazzi,
@@ -254,6 +258,7 @@ fun realAndroidModeScenario(name: String, previews: List<RealModePreview>): Real
       rendersDir = rendersDir,
       previewsManifest = manifestFile,
       classpath = androidClasspath,
+      extraJvmArgs = extraJvmArgs,
     )
   return RealModeScenarioPaths(
     name = name,

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/RecompositionAttachmentsAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/RecompositionAttachmentsAndroidRealModeTest.kt
@@ -1,0 +1,229 @@
+package ee.schimke.composeai.daemon.harness
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume
+import org.junit.Test
+
+/**
+ * Issue #1204 acceptance scenario — drives the Android daemon end-to-end through
+ * `extensions/enable` + `interactive/start` + `data/subscribe(compose/recomposition, mode=delta)`
+ * + `interactive/input` and pins the JSON-RPC wire contract for the `compose/recomposition` data
+ *   product on Android. Verifies a real client can:
+ *
+ * - See `compose/recomposition` advertised after enabling the `data/recomposition` extension.
+ * - Subscribe to it (no `-32020 kind not advertised`).
+ * - Observe a `compose/recomposition` attachment ride along on every `renderFinished` while the
+ *   subscription is live, with the correct schema version, mode (`delta`), and `sinceFrameStreamId`
+ *   echoing the subscribe-time id.
+ *
+ * **Cross-process click→delta assertion deferred.** The producer's behavioural invariant — "a click
+ * flips at least one scope and the next renderFinished carries a non-zero delta" — IS covered
+ * end-to-end against a real Robolectric sandbox + real Compose runtime + real held session by
+ * [ee.schimke.composeai.daemon.AndroidRecompositionDataProductRegistryTest]'s
+ * `delta_subscribe_then_click_attaches_non_empty_payload_and_resets_between_flushes`. In the
+ * cross-process harness the same in-sandbox observer install runs (DBG-confirmed: the observer is
+ * attached to the right [androidx.compose.runtime.Recomposer] + composition), but the post-click
+ * `onScopeExit` never fires — presumed to race against [JsonRpcServer.startInteractiveFrameLoop]'s
+ * continuous live-frame renders draining + clock-advancing the held composition between the
+ * observer install and the subsequent click. Reproducing that race in a stable cross-process
+ * assertion would require a way to quiesce the live-frame loop (or a `mode=delta` snapshot variant
+ * that doesn't depend on the rule's recomposer dispatch). Tracked as a follow-up; for now this
+ * scenario pins the wire shape so a future regression in `attachmentsFor` / `dataProducts` plumbing
+ * surfaces immediately, and the unit test continues to own the behavioural invariant.
+ *
+ * **Skipped under fake mode and under `-Pharness.target=desktop`.**
+ *
+ * **Cold-spawn cost.** Robolectric sandbox bootstrap dominates (~7-30s warm with the second sandbox
+ * slot, much longer on a cold cache); the test uses generous timeouts to absorb that without
+ * flapping.
+ */
+class RecompositionAttachmentsAndroidRealModeTest {
+
+  @Test
+  fun recomposition_attachments_ship_on_renderFinished_android_real_mode() {
+    Assume.assumeTrue(
+      "Skipping RecompositionAttachmentsAndroidRealModeTest — set -Pharness.host=real to enable.",
+      HarnessTestSupport.harnessHost() == "real",
+    )
+    Assume.assumeTrue(
+      "Skipping RecompositionAttachmentsAndroidRealModeTest — android variant; set " +
+        "-Pharness.target=android.",
+      HarnessTestSupport.harnessTarget() == "android",
+    )
+
+    val previewId = "interactive-clicktoggle"
+    val paths =
+      realAndroidModeScenario(
+        name = "recomposition-android",
+        previews =
+          listOf(
+            RealModePreview(
+              id = previewId,
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "ClickToggleSquare",
+              widthPx = 96,
+              heightPx = 96,
+            )
+          ),
+        // Issue #1204 — interactive sessions need slot 1 pinned; the harness manifest path
+        // defaults to a single sandbox, so we explicitly opt into a 2-sandbox pool.
+        extraJvmArgs = listOf("-Dcomposeai.daemon.sandboxCount=2"),
+      )
+
+    val client = HarnessClient.start(paths.launcher)
+    try {
+      val initResult = client.initialize()
+      assertEquals(2, initResult.protocolVersion)
+      client.sendInitialized()
+
+      // Extensions are inactive at registration — `compose/recomposition` only appears in the
+      // public capability set once an `extensions/enable` lands. Mirrors what the VS Code panel
+      // does when the user toggles the Performance bundle chip.
+      val enabled = client.extensionsEnable(listOf("data/recomposition"))
+      assertTrue(
+        "extensions/enable must surface compose/recomposition as a public capability " +
+          "(newlyEnabled=${enabled.newlyEnabled}, unknown=${enabled.unknown})",
+        enabled.dataProducts.any { it.kind == "compose/recomposition" },
+      )
+
+      // Pin the preview as visible so subscriptions stick (PROTOCOL.md § 5 —
+      // sticky-while-visible).
+      client.setVisible(listOf(previewId))
+
+      // interactive/start acquires slot 1 and runs setContent on ClickToggleSquare. After it
+      // returns, the JsonRpcServer's live-frame loop also begins driving renders at 250ms ticks.
+      val startResult = client.interactiveStart(previewId)
+      assertTrue(
+        "Android backend must allocate a held session for compose/recomposition delta mode to " +
+          "attach anything — fallbackReason=${startResult.fallbackReason}",
+        startResult.heldSession,
+      )
+      val frameStreamId = startResult.frameStreamId
+      assertTrue("frameStreamId must be non-blank", frameStreamId.isNotBlank())
+
+      // Subscribe to compose/recomposition with mode=delta. The held session is live, so the
+      // registry installs the in-sandbox observer immediately on this call.
+      client.dataSubscribe(
+        previewId = previewId,
+        kind = "compose/recomposition",
+        params =
+          buildJsonObject {
+            put("frameStreamId", JsonPrimitive(frameStreamId))
+            put("mode", JsonPrimitive("delta"))
+          },
+      )
+
+      // Send a click so the subsequent renderFinished frame would carry a non-zero delta if the
+      // observer fired. We don't assert on delta size (see KDoc): instead the loop below verifies
+      // the wire shape that's stable across the cross-process onScopeExit race.
+      client.interactiveInput(
+        frameStreamId = frameStreamId,
+        kind = InteractiveInputKind.CLICK,
+        pixelX = 48,
+        pixelY = 48,
+      )
+
+      // Verify wire shape on the next few renderFinished frames. Each frame while subscribed must
+      // carry exactly one compose/recomposition attachment with the right schemaVersion / mode /
+      // sinceFrameStreamId / monotonic inputSeq. inputSeq is verified to be strictly increasing
+      // across frames so a regression in the producer's per-flush counter shows up here.
+      var lastInputSeq: Long = 0L
+      for (i in 0 until FRAMES_TO_VERIFY) {
+        val finished = client.pollRenderFinishedFor(previewId, FRAME_POLL_TIMEOUT)
+        val params = finished["params"]?.jsonObject ?: error("renderFinished must carry params")
+        val attachments =
+          params["dataProducts"]?.jsonArray
+            ?: error(
+              "every renderFinished while subscribed must carry dataProducts; got params=$params, " +
+                "stderr=${client.dumpStderr()}"
+            )
+        val recomp =
+          attachments
+            .map { it.jsonObject }
+            .firstOrNull { it["kind"]?.jsonPrimitive?.contentOrNull == "compose/recomposition" }
+            ?: error(
+              "every renderFinished while subscribed must carry a compose/recomposition " +
+                "attachment; got kinds=" +
+                attachments.map { it.jsonObject["kind"]?.jsonPrimitive?.contentOrNull }
+            )
+        assertEquals(1, recomp["schemaVersion"]?.jsonPrimitive?.long?.toInt())
+        assertEquals(
+          "compose/recomposition is INLINE — path must be absent on the wire",
+          null,
+          recomp["path"],
+        )
+        val payload =
+          recomp["payload"]?.jsonObject
+            ?: error("compose/recomposition is INLINE — payload must be present, got $recomp")
+        assertEquals("delta", payload["mode"]?.jsonPrimitive?.contentOrNull)
+        assertEquals(
+          "sinceFrameStreamId must echo the subscribe-time frameStreamId",
+          frameStreamId,
+          payload["sinceFrameStreamId"]?.jsonPrimitive?.contentOrNull,
+        )
+        val inputSeq =
+          payload["inputSeq"]?.jsonPrimitive?.long
+            ?: error("inputSeq must be present on every delta payload, got $payload")
+        assertTrue(
+          "inputSeq must increment monotonically (lastInputSeq=$lastInputSeq, " +
+            "current=$inputSeq, frame=$i)",
+          inputSeq > lastInputSeq,
+        )
+        lastInputSeq = inputSeq
+        // nodes must be present (encodeDefaults=true) — whether non-empty is left to the unit
+        // test; see KDoc.
+        assertNotNull("payload.nodes must be present, got $payload", payload["nodes"])
+      }
+      assertTrue(
+        "must observe at least $FRAMES_TO_VERIFY frames with the wire-shape contract",
+        lastInputSeq >= FRAMES_TO_VERIFY.toLong(),
+      )
+
+      // Unsubscribe and stop session before shutdown so the registry's bridge cleanup runs
+      // through the explicit path the test pins.
+      client.dataUnsubscribe(previewId, "compose/recomposition")
+      client.interactiveStop(frameStreamId)
+
+      val exitCode = client.shutdownAndExit(timeout = 60.seconds)
+      assertEquals("daemon must exit cleanly. Stderr=\n${client.dumpStderr()}", 0, exitCode)
+    } catch (t: Throwable) {
+      System.err.println(
+        "RecompositionAttachmentsAndroidRealModeTest failed; stderr from daemon:\n" +
+          client.dumpStderr()
+      )
+      throw t
+    } finally {
+      try {
+        client.close()
+      } catch (_: Throwable) {}
+    }
+  }
+
+  companion object {
+    /**
+     * Number of renderFinished frames we'll consume to verify the wire-shape contract. Enough to
+     * cover the post-click window without dragging the scenario out — the live-frame loop emits at
+     * 250ms so this is ~1.5s of frames steady-state, dominated by sandbox cold-boot on the first
+     * frame.
+     */
+    private const val FRAMES_TO_VERIFY: Int = 6
+
+    /**
+     * Per-frame poll bound. The live loop emits at ~250ms steady-state, but the first frame after
+     * an Android cold-boot can take 5-30s (HardwareRenderer init + composition). Use 30s so the
+     * first iteration absorbs that cost without flapping.
+     */
+    private val FRAME_POLL_TIMEOUT = 30.seconds
+  }
+}


### PR DESCRIPTION
## Summary

Closes out issue #1204's third acceptance bullet — a harness scenario in `daemon/harness/` (Android real-mode) that drives the spawned `:daemon:android` daemon through the full `extensions/enable` + `interactive/start` + `data/subscribe(compose/recomposition, mode=delta)` + `interactive/input` flow and asserts the JSON-RPC wire contract for the `compose/recomposition` data product.

Each `renderFinished` while subscribed must carry a `compose/recomposition` attachment with the right schemaVersion, mode (`delta`), `sinceFrameStreamId` echoing the subscribe-time id, and a monotonic `inputSeq`.

## Supporting changes

- `DaemonMain` now honors an explicit `composeai.daemon.sandboxCount` sysprop even in harness manifest mode (was hardcoded to 1, which blocked interactive sessions).
- `HarnessClient` grows typed helpers for `extensions/enable`, `data/subscribe`, `data/unsubscribe`, `interactive/start`, `interactive/input`, `interactive/stop`. `initialize` timeout bumped to 120s to cover Android sandbox cold-boot.
- `realAndroidModeScenario` takes an `extraJvmArgs` parameter so scenarios can opt into the multi-sandbox pool without hard-coding it on the launcher.

## Caveat

The behavioural invariant — "post-click `renderFinished` carries a non-zero delta" — is **not** asserted in this cross-process test. It IS covered by `AndroidRecompositionDataProductRegistryTest.delta_subscribe_then_click_attaches_non_empty_payload_and_resets_between_flushes` (#1211), which exercises the same in-sandbox observer install + Compose runtime in-process. The cross-process path currently races against the `JsonRpcServer` live-frame loop — the observer install is confirmed (right Recomposer, right composition, observer attached), but `onScopeExit` doesn't fire post-click in subprocess mode. Inline KDoc on the test class documents the gap and points at the unit test as the authoritative behavioural coverage.

## Test plan

- [x] `./gradlew :daemon:harness:test --tests RecompositionAttachmentsAndroidRealModeTest -Pharness.host=real -Pharness.target=android` (passes; ~48s with Android cold-boot)
- [x] `./gradlew :daemon:android:testDebugUnitTest --tests AndroidRecompositionDataProductRegistryTest` (5/5 pass)
- [x] `./gradlew :daemon:android:ktfmtCheck :daemon:harness:ktfmtCheck`
- [ ] CI on this branch

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXsMjCS7wFyQgnzE2Ygwnj)_