### PR TITLE
fix(daemon-harness): propagate composeai.history.enabled to spawned daemons

### DIFF
--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -3,6 +3,19 @@ package ee.schimke.composeai.daemon.harness
 import java.io.File
 
 /**
+ * Propagates the `composeai.history.enabled` sysprop from the test JVM into a spawned daemon
+ * subprocess. Production daemons leave the property unset and the `HistoryFeature` default
+ * (`false`) keeps the history surface dead; the test JVM sets it `true` via the root build's
+ * `tasks.withType<Test>().configureEach { systemProperty("composeai.history.enabled", "true") }`
+ * hook so the history implementation stays exercised in CI. Without the explicit propagation here
+ * the spawned daemon JVM inherits nothing and the harness's history scenarios (S9 / S10 / S11) trip
+ * `MethodNotFound` for every history method call. Drop when 1.1 flips the default.
+ */
+private fun MutableList<String>.addHistoryFeatureSyspropIfSet() {
+  System.getProperty("composeai.history.enabled")?.let { add("-Dcomposeai.history.enabled=$it") }
+}
+
+/**
  * How the harness spawns the daemon JVM that [HarnessClient] talks to — see
  * [TEST-HARNESS § 8a + § 9](../../../docs/daemon/TEST-HARNESS.md#8a-the-fakehost-test-fixture).
  *
@@ -93,6 +106,7 @@ class FakeHarnessLauncher(
           add("-Dcomposeai.daemon.history.maxTotalSizeBytes=$pruneMaxTotalSizeBytes")
         if (pruneAutoIntervalMs != null)
           add("-Dcomposeai.daemon.history.autoPruneIntervalMs=$pruneAutoIntervalMs")
+        addHistoryFeatureSyspropIfSet()
         addAll(extraJvmArgs)
         add("-cp")
         add(cpString)
@@ -168,6 +182,7 @@ class RealDesktopHarnessLauncher(
         add("-Dcomposeai.daemon.idleTimeoutMs=2000")
         // Save-after-render ordering watchdog — same justification as `FakeHarnessLauncher` above.
         add("-Dcomposeai.daemon.discoveryWatchdogMs=500")
+        addHistoryFeatureSyspropIfSet()
         addAll(extraJvmArgs)
         add("-cp")
         add(cpString)
@@ -302,6 +317,7 @@ class RealAndroidHarnessLauncher(
         // can dominate the first render's wall-clock; tests should use a large *poll* timeout
         // (60-120s) rather than relying on this idle timeout to back-stop a hung daemon.
         add("-Dcomposeai.daemon.idleTimeoutMs=2000")
+        addHistoryFeatureSyspropIfSet()
         addAll(extraJvmArgs)
         add("-cp")
         add(cpString)


### PR DESCRIPTION
Follow-up to #1220. The history feature gate's test-mode sysprop only
landed on the Gradle test worker JVM via the root-build
`tasks.withType<Test>` hook — the harness spawns the daemon JVM through
`ProcessBuilder` with an explicit `-D…` arg list and was not forwarding
the property to the child. Spawned daemons therefore saw
`HistoryFeature.ENABLED = false` and tripped `MethodNotFound` for every
`history/list` / `history/read` / `history/prune` call, breaking the
S9 / S10 / S11 scenarios in both the desktop and android harness CI
jobs.

Propagate the property at each of the three `ProcessBuilder` command
sites — `FakeHarnessLauncher`, `RealDesktopHarnessLauncher`, the
android-flavour launcher — via a small `addHistoryFeatureSyspropIfSet`
helper. Production daemons (which never have the property set in their
parent JVM) are unaffected; the helper is a no-op when the property is
absent. Drop the helper outright when 1.1 flips the default and the
gate goes away.

Caught in code review by Codex bot on #1220
(`chatgpt-codex-connector` P1 comment) plus three failing harness
checks in the same PR; the merge went ahead with automerge enabled so
this restores main's harness CI on its own.