### PR TITLE
refactor: consolidate data product registry implementations

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FileBackedDataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FileBackedDataProductRegistry.kt
@@ -87,6 +87,18 @@ abstract class FileBackedDataProductRegistry(
     payload: JsonElement?,
   ): List<DataProductExtra>? = null
 
+  /**
+   * Whether [fetch] should honour `inline = true` for a `PATH`-transport [kind] by reading
+   * [readInlinePayload]. Default `true` — agents asking for inline get the JSON payload back
+   * inlined, even though the registry could also serve a path.
+   *
+   * Override to `false` for kinds whose on-disk artefact is **not** JSON: the a11y registry's
+   * overlay kind is a PNG, so an `inline = true` fetch must still return the path rather than
+   * trying to parse PNG bytes as JSON and emitting `FetchFailed`. `INLINE`-transport kinds are
+   * unaffected — they're always read regardless of the flag.
+   */
+  protected open fun allowInlineUpgrade(kind: String): Boolean = true
+
   override fun fetch(
     previewId: String,
     kind: String,
@@ -96,7 +108,8 @@ abstract class FileBackedDataProductRegistry(
     val cap = byKind[kind] ?: return DataProductRegistry.Outcome.Unknown
     val file = fileFor(previewId, kind) ?: return DataProductRegistry.Outcome.Unknown
     if (!file.exists()) return missingOutcome(previewId, kind)
-    val shouldInline = cap.transport == DataProductTransport.INLINE || inline
+    val shouldInline =
+      cap.transport == DataProductTransport.INLINE || (inline && allowInlineUpgrade(kind))
     return if (shouldInline) {
       val payload =
         try {

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FileBackedDataProductRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FileBackedDataProductRegistryTest.kt
@@ -228,4 +228,38 @@ class FileBackedDataProductRegistryTest {
     assertTrue(reg.isKnown("demo/path"))
     assertTrue(!reg.isKnown("nope"))
   }
+
+  private class BinaryPathRegistry(rootDir: File) :
+    FileBackedDataProductRegistry(
+      capabilities =
+        listOf(
+          DataProductCapability(
+            kind = "demo/binary",
+            schemaVersion = 1,
+            transport = DataProductTransport.PATH,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          )
+        )
+    ) {
+    private val root = rootDir
+
+    override fun fileFor(previewId: String, kind: String): File? =
+      if (kind == "demo/binary") root.resolve(previewId).resolve("payload.png") else null
+
+    override fun allowInlineUpgrade(kind: String): Boolean = false
+  }
+
+  @Test
+  fun fetch_path_returns_path_when_inline_upgrade_disallowed() {
+    val reg = BinaryPathRegistry(tempFolder.root)
+    val written = writeFile(tempFolder.root, "p", "payload.png", "not json — these are PNG bytes")
+    val outcome = reg.fetch("p", "demo/binary", params = null, inline = true)
+    val ok = outcome as DataProductRegistry.Outcome.Ok
+    // The disabled upgrade keeps the response on the path branch — without it the JSON parse
+    // of binary bytes would explode and we'd return FetchFailed.
+    assertEquals(written.absolutePath, ok.result.path)
+    assertNull(ok.result.payload)
+  }
 }

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
@@ -1,7 +1,5 @@
 package ee.schimke.composeai.daemon
 
-import ee.schimke.composeai.daemon.protocol.DataFetchResult
-import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductExtra
 import ee.schimke.composeai.daemon.protocol.DataProductFacet
@@ -167,9 +165,61 @@ object AccessibilityDataProducer {
  * `rootDir` mirrors `RenderEngine`'s `dataDir` (defaults to `<outputDir.parent>/data`). Wired by
  * [DaemonMain].
  */
-class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductRegistry {
-
-  private val json = Json { ignoreUnknownKeys = true }
+class AccessibilityDataProductRegistry(private val rootDir: File) :
+  FileBackedDataProductRegistry(
+    capabilities =
+      listOf(
+        DataProductCapability(
+          kind = AccessibilityDataProducer.KIND_ATF,
+          schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+          transport = DataProductTransport.INLINE,
+          attachable = true,
+          fetchable = true,
+          requiresRerender = true,
+          displayName = "Accessibility findings",
+          facets =
+            listOf(DataProductFacet.STRUCTURED, DataProductFacet.CHECK, DataProductFacet.DIAGNOSTIC),
+          sampling = SamplingPolicy.End,
+        ),
+        DataProductCapability(
+          kind = AccessibilityDataProducer.KIND_HIERARCHY,
+          schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+          transport = DataProductTransport.PATH,
+          attachable = true,
+          fetchable = true,
+          requiresRerender = true,
+          displayName = "Accessibility hierarchy",
+          facets = listOf(DataProductFacet.STRUCTURED),
+          mediaTypes = listOf("application/json"),
+          sampling = SamplingPolicy.End,
+        ),
+        DataProductCapability(
+          kind = AccessibilityDataProducer.KIND_TOUCH_TARGETS,
+          schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+          transport = DataProductTransport.INLINE,
+          attachable = true,
+          fetchable = true,
+          requiresRerender = true,
+          displayName = "Touch target findings",
+          facets =
+            listOf(DataProductFacet.STRUCTURED, DataProductFacet.CHECK, DataProductFacet.DIAGNOSTIC),
+          sampling = SamplingPolicy.End,
+        ),
+        DataProductCapability(
+          kind = AccessibilityDataProducer.KIND_OVERLAY,
+          schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+          transport = DataProductTransport.PATH,
+          attachable = true,
+          fetchable = true,
+          requiresRerender = true,
+          displayName = "Accessibility overlay",
+          facets =
+            listOf(DataProductFacet.ARTIFACT, DataProductFacet.IMAGE, DataProductFacet.OVERLAY),
+          mediaTypes = listOf("image/png"),
+          sampling = SamplingPolicy.End,
+        ),
+      )
+  ) {
 
   /**
    * D2.2 — set of `(previewId, kind)` pairs the dispatcher has reported subscribed via
@@ -182,153 +232,45 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
    * hook); the bookkeeping is structural and idempotent so adding the read site is the only
    * remaining step.
    */
-  private val subscribedPairs: MutableSet<Pair<String, String>> =
-    ConcurrentHashMap.newKeySet()
+  private val subscribedPairs: MutableSet<Pair<String, String>> = ConcurrentHashMap.newKeySet()
 
-  override val capabilities: List<DataProductCapability> =
-    listOf(
-      DataProductCapability(
-        kind = AccessibilityDataProducer.KIND_ATF,
-        schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
-        transport = DataProductTransport.INLINE,
-        attachable = true,
-        fetchable = true,
-        requiresRerender = true,
-        displayName = "Accessibility findings",
-        facets = listOf(DataProductFacet.STRUCTURED, DataProductFacet.CHECK, DataProductFacet.DIAGNOSTIC),
-        sampling = SamplingPolicy.End,
-      ),
-      DataProductCapability(
-        kind = AccessibilityDataProducer.KIND_HIERARCHY,
-        schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
-        transport = DataProductTransport.PATH,
-        attachable = true,
-        fetchable = true,
-        requiresRerender = true,
-        displayName = "Accessibility hierarchy",
-        facets = listOf(DataProductFacet.STRUCTURED),
-        mediaTypes = listOf("application/json"),
-        sampling = SamplingPolicy.End,
-      ),
-      DataProductCapability(
-        kind = AccessibilityDataProducer.KIND_TOUCH_TARGETS,
-        schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
-        transport = DataProductTransport.INLINE,
-        attachable = true,
-        fetchable = true,
-        requiresRerender = true,
-        displayName = "Touch target findings",
-        facets = listOf(DataProductFacet.STRUCTURED, DataProductFacet.CHECK, DataProductFacet.DIAGNOSTIC),
-        sampling = SamplingPolicy.End,
-      ),
-      DataProductCapability(
-        kind = AccessibilityDataProducer.KIND_OVERLAY,
-        schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
-        transport = DataProductTransport.PATH,
-        attachable = true,
-        fetchable = true,
-        requiresRerender = true,
-        displayName = "Accessibility overlay",
-        facets = listOf(DataProductFacet.ARTIFACT, DataProductFacet.IMAGE, DataProductFacet.OVERLAY),
-        mediaTypes = listOf("image/png"),
-        sampling = SamplingPolicy.End,
-      ),
-    )
-
-  override fun fetch(
-    previewId: String,
-    kind: String,
-    params: JsonElement?,
-    inline: Boolean,
-  ): DataProductRegistry.Outcome {
-    val (file, transport) =
+  override fun fileFor(previewId: String, kind: String): File? {
+    val fileName =
       when (kind) {
-        AccessibilityDataProducer.KIND_ATF ->
-          fileFor(previewId, AccessibilityDataProducer.FILE_ATF) to DataProductTransport.INLINE
-        AccessibilityDataProducer.KIND_HIERARCHY ->
-          fileFor(previewId, AccessibilityDataProducer.FILE_HIERARCHY) to
-            DataProductTransport.PATH
-        AccessibilityDataProducer.KIND_TOUCH_TARGETS ->
-          fileFor(previewId, AccessibilityDataProducer.FILE_TOUCH_TARGETS) to
-            DataProductTransport.INLINE
-        AccessibilityDataProducer.KIND_OVERLAY ->
-          fileFor(previewId, AccessibilityDataProducer.FILE_OVERLAY) to DataProductTransport.PATH
-        else -> return DataProductRegistry.Outcome.Unknown
+        AccessibilityDataProducer.KIND_ATF -> AccessibilityDataProducer.FILE_ATF
+        AccessibilityDataProducer.KIND_HIERARCHY -> AccessibilityDataProducer.FILE_HIERARCHY
+        AccessibilityDataProducer.KIND_TOUCH_TARGETS -> AccessibilityDataProducer.FILE_TOUCH_TARGETS
+        AccessibilityDataProducer.KIND_OVERLAY -> AccessibilityDataProducer.FILE_OVERLAY
+        else -> return null
       }
-    // D2.2 — every a11y kind is `requiresRerender = true`. A missing artefact means the latest
-    // render didn't run in a11y mode (the producer's writeArtifacts is gated on
-    // `effectiveRunAccessibility`); the dispatcher reacts by queueing a re-render with
-    // `mode=a11y` and re-invoking fetch, which then finds the freshly-written file. See
-    // [DataProductRegistry.Outcome.RequiresRerender] for the dispatch contract.
-    if (!file.exists()) return DataProductRegistry.Outcome.RequiresRerender("a11y")
-    val extras = extrasFor(previewId, kind)
-    // The overlay kind is binary (PNG); never parse it as JSON. Path-only.
-    if (kind == AccessibilityDataProducer.KIND_OVERLAY) {
-      return DataProductRegistry.Outcome.Ok(
-        DataFetchResult(
-          kind = kind,
-          schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
-          path = file.absolutePath,
-          extras = extras.takeIf { it.isNotEmpty() },
-        )
-      )
-    }
-    val payloadElement: JsonElement? =
-      try {
-        json.parseToJsonElement(file.readText())
-      } catch (t: Throwable) {
-        return DataProductRegistry.Outcome.FetchFailed(
-          message = "could not parse $kind for $previewId: ${t.message}"
-        )
-      }
-    val result =
-      when {
-        inline ->
-          DataFetchResult(
-            kind = kind,
-            schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
-            payload = payloadElement,
-            extras = extras.takeIf { it.isNotEmpty() },
-          )
-        transport == DataProductTransport.INLINE ->
-          // Even when the caller didn't ask for inline, the `inline` transport kind has no
-          // separate `path` representation. Returning the parsed payload keeps the API
-          // self-consistent: `transport='inline'` ⇒ payload always set.
-          DataFetchResult(
-            kind = kind,
-            schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
-            payload = payloadElement,
-            extras = extras.takeIf { it.isNotEmpty() },
-          )
-        else ->
-          DataFetchResult(
-            kind = kind,
-            schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
-            path = file.absolutePath,
-            extras = extras.takeIf { it.isNotEmpty() },
-          )
-      }
-    return DataProductRegistry.Outcome.Ok(result)
+    return rootDir.resolve(previewId).resolve(fileName)
   }
 
   /**
-   * Builds the [DataProductExtra] list for [kind] by scanning [previewId]'s data dir for
-   * known sibling outputs. Today the only extra is the a11y overlay PNG, attached to all
-   * three a11y kinds. Returns an empty list when no extras are available — the caller wraps
-   * the result in `takeIf { it.isNotEmpty() }` so the wire field stays absent in that case.
+   * D2.2 — every a11y kind is `requiresRerender = true`. A missing artefact means the latest
+   * render didn't run in a11y mode (the producer's writeArtifacts is gated on
+   * `effectiveRunAccessibility`); the dispatcher reacts by queueing a re-render with `mode=a11y`
+   * and re-invoking fetch, which then finds the freshly-written file.
    */
-  private fun extrasFor(previewId: String, kind: String): List<DataProductExtra> {
-    val attaches =
-      when (kind) {
-        AccessibilityDataProducer.KIND_ATF,
-        AccessibilityDataProducer.KIND_HIERARCHY,
-        AccessibilityDataProducer.KIND_TOUCH_TARGETS,
-        AccessibilityDataProducer.KIND_OVERLAY -> true
-        else -> false
-      }
-    if (!attaches) return emptyList()
-    val overlay = fileFor(previewId, AccessibilityDataProducer.FILE_OVERLAY)
-    if (!overlay.exists()) return emptyList()
+  override fun missingOutcome(previewId: String, kind: String): DataProductRegistry.Outcome =
+    DataProductRegistry.Outcome.RequiresRerender("a11y")
+
+  /** The overlay kind is a PNG — never parse it as JSON, even on `inline = true`. */
+  override fun allowInlineUpgrade(kind: String): Boolean =
+    kind != AccessibilityDataProducer.KIND_OVERLAY
+
+  /**
+   * The overlay PNG rides as an `extras` entry on every a11y kind so a panel that subscribed to
+   * any of them gets the picture handy without a follow-up `data/fetch`. Skips when the overlay
+   * file isn't on disk for [previewId].
+   */
+  override fun extras(
+    previewId: String,
+    kind: String,
+    payload: JsonElement?,
+  ): List<DataProductExtra>? {
+    val overlay = rootDir.resolve(previewId).resolve(AccessibilityDataProducer.FILE_OVERLAY)
+    if (!overlay.exists()) return null
     return listOf(
       DataProductExtra(
         name = AccessibilityDataProducer.OVERLAY_EXTRA_NAME,
@@ -339,88 +281,6 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
     )
   }
 
-  override fun attachmentsFor(
-    previewId: String,
-    kinds: Set<String>,
-  ): List<DataProductAttachment> {
-    val out = mutableListOf<DataProductAttachment>()
-    for (kind in kinds) {
-      val extras = extrasFor(previewId, kind).takeIf { it.isNotEmpty() }
-      when (kind) {
-        AccessibilityDataProducer.KIND_ATF -> {
-          val file = fileFor(previewId, AccessibilityDataProducer.FILE_ATF)
-          if (!file.exists()) continue
-          val parsed =
-            try {
-              json.parseToJsonElement(file.readText())
-            } catch (t: Throwable) {
-              System.err.println(
-                "AccessibilityDataProductRegistry: parse $kind failed for $previewId: ${t.message}"
-              )
-              continue
-            }
-          out.add(
-            DataProductAttachment(
-              kind = kind,
-              schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
-              payload = parsed,
-              extras = extras,
-            )
-          )
-        }
-        AccessibilityDataProducer.KIND_HIERARCHY -> {
-          val file = fileFor(previewId, AccessibilityDataProducer.FILE_HIERARCHY)
-          if (!file.exists()) continue
-          out.add(
-            DataProductAttachment(
-              kind = kind,
-              schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
-              path = file.absolutePath,
-              extras = extras,
-            )
-          )
-        }
-        AccessibilityDataProducer.KIND_TOUCH_TARGETS -> {
-          val file = fileFor(previewId, AccessibilityDataProducer.FILE_TOUCH_TARGETS)
-          if (!file.exists()) continue
-          val parsed =
-            try {
-              json.parseToJsonElement(file.readText())
-            } catch (t: Throwable) {
-              System.err.println(
-                "AccessibilityDataProductRegistry: parse $kind failed for $previewId: ${t.message}"
-              )
-              continue
-            }
-          out.add(
-            DataProductAttachment(
-              kind = kind,
-              schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
-              payload = parsed,
-              extras = extras,
-            )
-          )
-        }
-        AccessibilityDataProducer.KIND_OVERLAY -> {
-          val file = fileFor(previewId, AccessibilityDataProducer.FILE_OVERLAY)
-          if (!file.exists()) continue
-          out.add(
-            DataProductAttachment(
-              kind = kind,
-              schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
-              path = file.absolutePath,
-              extras = extras,
-            )
-          )
-        }
-      // Unknown kinds drop out silently — the dispatcher already filtered against
-      // `capabilities` before calling this; an unrecognised kind here means the
-      // dispatcher's filtering drifted and we'd rather skip than emit garbage.
-      }
-    }
-    return out
-  }
-
   /**
    * D2.2 — record `(previewId, kind)` so the next render of [previewId] can run in a11y mode.
    * Idempotent across re-subscribes (the [Set] de-duplicates). Only the four advertised a11y
@@ -428,7 +288,7 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
    * matching, but this is defensive) is ignored.
    */
   override fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {
-    if (!isAccessibilityKind(kind)) return
+    if (!isKnown(kind)) return
     subscribedPairs.add(previewId to kind)
   }
 
@@ -438,26 +298,17 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
    * runs, [isPreviewSubscribed] reflects the new state synchronously.
    */
   override fun onUnsubscribe(previewId: String, kind: String) {
-    if (!isAccessibilityKind(kind)) return
+    if (!isKnown(kind)) return
     subscribedPairs.remove(previewId to kind)
   }
 
   /**
    * D2.2 — `true` iff at least one a11y kind has a live subscription for [previewId]. Designed for
-   * the host's render dispatcher: when this returns `true` the next `host.submit(...)` payload
-   * for [previewId] should carry `mode=a11y` so the renderer flips `LocalInspectionMode` and
-   * writes the ATF/hierarchy artefacts the subscribed kinds will read off disk on the next
+   * the host's render dispatcher: when this returns `true` the next `host.submit(...)` payload for
+   * [previewId] should carry `mode=a11y` so the renderer flips `LocalInspectionMode` and writes
+   * the ATF/hierarchy artefacts the subscribed kinds will read off disk on the next
    * `attachmentsFor` pass.
    */
   fun isPreviewSubscribed(previewId: String): Boolean =
     subscribedPairs.any { (id, _) -> id == previewId }
-
-  private fun isAccessibilityKind(kind: String): Boolean =
-    kind == AccessibilityDataProducer.KIND_ATF ||
-      kind == AccessibilityDataProducer.KIND_HIERARCHY ||
-      kind == AccessibilityDataProducer.KIND_TOUCH_TARGETS ||
-      kind == AccessibilityDataProducer.KIND_OVERLAY
-
-  private fun fileFor(previewId: String, fileName: String): File =
-    rootDir.resolve(previewId).resolve(fileName)
 }

--- a/data/displayfilter/connector/src/main/kotlin/ee/schimke/composeai/daemon/DisplayFilterDataProductRegistry.kt
+++ b/data/displayfilter/connector/src/main/kotlin/ee/schimke/composeai/daemon/DisplayFilterDataProductRegistry.kt
@@ -1,14 +1,11 @@
 package ee.schimke.composeai.daemon
 
-import ee.schimke.composeai.daemon.protocol.DataFetchResult
-import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductExtra
 import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import java.io.File
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -21,83 +18,40 @@ import kotlinx.serialization.json.jsonPrimitive
  * listed paths to fetch each filtered image.
  *
  * `attachable: true` so the manifest rides `renderFinished.dataProducts`; `fetchable: true` for
- * pull-on-demand. Variant PNGs ride along as `extras` so a panel that subscribed to the manifest
- * still has every PNG path handy without a follow-up `data/fetch`.
+ * pull-on-demand. Variant PNGs ride along as `extras` (the [extras] override below) so a panel that
+ * subscribed to the manifest still has every PNG path handy without a follow-up `data/fetch`.
  *
  * `rootDir` mirrors `RenderEngine`'s `dataDir` (defaults to `<outputDir.parent>/data`). Wired by
  * [DaemonMain].
  */
-class DisplayFilterDataProductRegistry(private val rootDir: File) : DataProductRegistry {
-
-  private val json = Json { ignoreUnknownKeys = true }
-
-  override val capabilities: List<DataProductCapability> =
-    listOf(
-      DataProductCapability(
-        kind = DisplayFilterDataProducer.KIND_VARIANTS,
-        schemaVersion = DisplayFilterDataProducer.SCHEMA_VERSION,
-        transport = DataProductTransport.INLINE,
-        attachable = true,
-        fetchable = true,
-        requiresRerender = false,
-        displayName = "Display filter variants",
-        facets = listOf(DataProductFacet.STRUCTURED, DataProductFacet.IMAGE),
-        mediaTypes = listOf("application/json"),
-        sampling = SamplingPolicy.End,
+class DisplayFilterDataProductRegistry(private val rootDir: File) :
+  FileBackedDataProductRegistry(
+    capabilities =
+      listOf(
+        DataProductCapability(
+          kind = DisplayFilterDataProducer.KIND_VARIANTS,
+          schemaVersion = DisplayFilterDataProducer.SCHEMA_VERSION,
+          transport = DataProductTransport.INLINE,
+          attachable = true,
+          fetchable = true,
+          requiresRerender = false,
+          displayName = "Display filter variants",
+          facets = listOf(DataProductFacet.STRUCTURED, DataProductFacet.IMAGE),
+          mediaTypes = listOf("application/json"),
+          sampling = SamplingPolicy.End,
+        )
       )
-    )
+  ) {
+  override fun fileFor(previewId: String, kind: String): File? =
+    if (kind == DisplayFilterDataProducer.KIND_VARIANTS)
+      rootDir.resolve(previewId).resolve(DisplayFilterDataProducer.FILE_VARIANTS)
+    else null
 
-  override fun fetch(
+  override fun extras(
     previewId: String,
     kind: String,
-    params: JsonElement?,
-    inline: Boolean,
-  ): DataProductRegistry.Outcome {
-    if (kind != DisplayFilterDataProducer.KIND_VARIANTS) return DataProductRegistry.Outcome.Unknown
-    val file = manifestFile(previewId)
-    if (!file.exists()) return DataProductRegistry.Outcome.NotAvailable
-    val payload =
-      try {
-        json.parseToJsonElement(file.readText())
-      } catch (t: Throwable) {
-        return DataProductRegistry.Outcome.FetchFailed(
-          message = "could not parse $kind for $previewId: ${t.message}"
-        )
-      }
-    val extras = variantExtras(payload).takeIf { it.isNotEmpty() }
-    return DataProductRegistry.Outcome.Ok(
-      DataFetchResult(
-        kind = kind,
-        schemaVersion = DisplayFilterDataProducer.SCHEMA_VERSION,
-        payload = payload,
-        extras = extras,
-      )
-    )
-  }
-
-  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
-    if (DisplayFilterDataProducer.KIND_VARIANTS !in kinds) return emptyList()
-    val file = manifestFile(previewId)
-    if (!file.exists()) return emptyList()
-    val payload =
-      try {
-        json.parseToJsonElement(file.readText())
-      } catch (t: Throwable) {
-        System.err.println(
-          "DisplayFilterDataProductRegistry: parse manifest failed for $previewId: ${t.message}"
-        )
-        return emptyList()
-      }
-    val extras = variantExtras(payload).takeIf { it.isNotEmpty() }
-    return listOf(
-      DataProductAttachment(
-        kind = DisplayFilterDataProducer.KIND_VARIANTS,
-        schemaVersion = DisplayFilterDataProducer.SCHEMA_VERSION,
-        payload = payload,
-        extras = extras,
-      )
-    )
-  }
+    payload: JsonElement?,
+  ): List<DataProductExtra>? = payload?.let(::variantExtras)?.takeIf { it.isNotEmpty() }
 
   /**
    * Maps each `variants[]` entry in the parsed manifest to a [DataProductExtra]. Reading the
@@ -122,7 +76,4 @@ class DisplayFilterDataProductRegistry(private val rootDir: File) : DataProductR
       )
     }
   }
-
-  private fun manifestFile(previewId: String): File =
-    rootDir.resolve(previewId).resolve(DisplayFilterDataProducer.FILE_VARIANTS)
 }

--- a/data/resources/connector/src/main/kotlin/ee/schimke/composeai/daemon/ResourcesUsedDataProduct.kt
+++ b/data/resources/connector/src/main/kotlin/ee/schimke/composeai/daemon/ResourcesUsedDataProduct.kt
@@ -269,70 +269,23 @@ private object ResourceSourceIndex {
   private val FILE_RESOURCE_TYPES = setOf("drawable", "layout")
 }
 
-/** Registry side for `resources/used`; reads the latest JSON artefact from disk. */
-class ResourcesUsedDataProductRegistry(private val rootDir: File) : DataProductRegistry {
-  private val json = Json { ignoreUnknownKeys = true }
-
-  override val capabilities: List<DataProductCapability> =
-    listOf(
-      DataProductCapability(
-        kind = ResourcesUsedDataProducer.KIND,
-        schemaVersion = ResourcesUsedDataProducer.SCHEMA_VERSION,
-        transport = DataProductTransport.PATH,
-        attachable = true,
-        fetchable = true,
-        requiresRerender = false,
-      )
-    )
-
-  override fun fetch(
-    previewId: String,
-    kind: String,
-    params: JsonElement?,
-    inline: Boolean,
-  ): DataProductRegistry.Outcome {
-    if (kind != ResourcesUsedDataProducer.KIND) return DataProductRegistry.Outcome.Unknown
-    val file = fileFor(previewId)
-    if (!file.exists()) return DataProductRegistry.Outcome.NotAvailable
-    if (!inline) {
-      return DataProductRegistry.Outcome.Ok(
-        DataFetchResult(
-          kind = kind,
+/** Registry for `resources/used`. PATH transport; base class supplies the inline-upgrade path. */
+class ResourcesUsedDataProductRegistry(private val rootDir: File) :
+  FileBackedDataProductRegistry(
+    capabilities =
+      listOf(
+        DataProductCapability(
+          kind = ResourcesUsedDataProducer.KIND,
           schemaVersion = ResourcesUsedDataProducer.SCHEMA_VERSION,
-          path = file.absolutePath,
+          transport = DataProductTransport.PATH,
+          attachable = true,
+          fetchable = true,
+          requiresRerender = false,
         )
       )
-    }
-    val payload: JsonObject =
-      try {
-        json.parseToJsonElement(file.readText()) as JsonObject
-      } catch (t: Throwable) {
-        return DataProductRegistry.Outcome.FetchFailed(
-          message = "could not parse $kind for $previewId: ${t.message}"
-        )
-      }
-    return DataProductRegistry.Outcome.Ok(
-      DataFetchResult(
-        kind = kind,
-        schemaVersion = ResourcesUsedDataProducer.SCHEMA_VERSION,
-        payload = payload,
-      )
-    )
-  }
-
-  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
-    if (ResourcesUsedDataProducer.KIND !in kinds) return emptyList()
-    val file = fileFor(previewId)
-    if (!file.exists()) return emptyList()
-    return listOf(
-      DataProductAttachment(
-        kind = ResourcesUsedDataProducer.KIND,
-        schemaVersion = ResourcesUsedDataProducer.SCHEMA_VERSION,
-        path = file.absolutePath,
-      )
-    )
-  }
-
-  private fun fileFor(previewId: String): File =
-    rootDir.resolve(previewId).resolve(ResourcesUsedDataProducer.FILE)
+  ) {
+  override fun fileFor(previewId: String, kind: String): File? =
+    if (kind == ResourcesUsedDataProducer.KIND)
+      rootDir.resolve(previewId).resolve(ResourcesUsedDataProducer.FILE)
+    else null
 }

--- a/data/uiautomator/connector/src/main/kotlin/ee/schimke/composeai/daemon/UiAutomatorDataProducer.kt
+++ b/data/uiautomator/connector/src/main/kotlin/ee/schimke/composeai/daemon/UiAutomatorDataProducer.kt
@@ -1,7 +1,5 @@
 package ee.schimke.composeai.daemon
 
-import ee.schimke.composeai.daemon.protocol.DataFetchResult
-import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
@@ -10,7 +8,6 @@ import ee.schimke.composeai.renderer.uiautomator.UiAutomatorDataProducts
 import ee.schimke.composeai.renderer.uiautomator.UiAutomatorHierarchyPayload
 import java.io.File
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
 
 /**
  * D2 — writes the per-render UIAutomator hierarchy artefact the data-product registry surfaces
@@ -69,91 +66,26 @@ object UiAutomatorDataProducer {
  *
  * `rootDir` mirrors `RenderEngine`'s `dataDir`. Wired by [DaemonMain].
  */
-class UiAutomatorDataProductRegistry(private val rootDir: File) : DataProductRegistry {
-
-  private val json = Json { ignoreUnknownKeys = true }
-
-  override val capabilities: List<DataProductCapability> =
-    listOf(
-      DataProductCapability(
-        kind = UiAutomatorDataProducer.KIND_HIERARCHY,
-        schemaVersion = UiAutomatorDataProducer.SCHEMA_VERSION,
-        transport = DataProductTransport.PATH,
-        attachable = true,
-        fetchable = true,
-        requiresRerender = false,
-        displayName = "UIAutomator hierarchy",
-        facets = listOf(DataProductFacet.STRUCTURED),
-        mediaTypes = listOf("application/json"),
-        sampling = SamplingPolicy.End,
-      )
-    )
-
-  override fun fetch(
-    previewId: String,
-    kind: String,
-    params: JsonElement?,
-    inline: Boolean,
-  ): DataProductRegistry.Outcome {
-    val file =
-      when (kind) {
-        UiAutomatorDataProducer.KIND_HIERARCHY ->
-          fileFor(previewId, UiAutomatorDataProducer.FILE_HIERARCHY)
-        else -> return DataProductRegistry.Outcome.Unknown
-      }
-    if (!file.exists()) return DataProductRegistry.Outcome.NotAvailable
-    if (inline) {
-      val payloadElement: JsonElement =
-        try {
-          json.parseToJsonElement(file.readText())
-        } catch (t: Throwable) {
-          return DataProductRegistry.Outcome.FetchFailed(
-            message = "could not parse $kind for $previewId: ${t.message}"
-          )
-        }
-      return DataProductRegistry.Outcome.Ok(
-        DataFetchResult(
-          kind = kind,
+class UiAutomatorDataProductRegistry(private val rootDir: File) :
+  FileBackedDataProductRegistry(
+    capabilities =
+      listOf(
+        DataProductCapability(
+          kind = UiAutomatorDataProducer.KIND_HIERARCHY,
           schemaVersion = UiAutomatorDataProducer.SCHEMA_VERSION,
-          payload = payloadElement,
+          transport = DataProductTransport.PATH,
+          attachable = true,
+          fetchable = true,
+          requiresRerender = false,
+          displayName = "UIAutomator hierarchy",
+          facets = listOf(DataProductFacet.STRUCTURED),
+          mediaTypes = listOf("application/json"),
+          sampling = SamplingPolicy.End,
         )
       )
-    }
-    return DataProductRegistry.Outcome.Ok(
-      DataFetchResult(
-        kind = kind,
-        schemaVersion = UiAutomatorDataProducer.SCHEMA_VERSION,
-        path = file.absolutePath,
-      )
-    )
-  }
-
-  override fun attachmentsFor(
-    previewId: String,
-    kinds: Set<String>,
-  ): List<DataProductAttachment> {
-    val out = mutableListOf<DataProductAttachment>()
-    for (kind in kinds) {
-      when (kind) {
-        UiAutomatorDataProducer.KIND_HIERARCHY -> {
-          val file = fileFor(previewId, UiAutomatorDataProducer.FILE_HIERARCHY)
-          if (!file.exists()) continue
-          out.add(
-            DataProductAttachment(
-              kind = kind,
-              schemaVersion = UiAutomatorDataProducer.SCHEMA_VERSION,
-              path = file.absolutePath,
-            )
-          )
-        }
-      // Unknown kinds drop out silently — the dispatcher already filtered against
-      // `capabilities` before calling this; an unrecognised kind here means the
-      // dispatcher's filtering drifted and we'd rather skip than emit garbage.
-      }
-    }
-    return out
-  }
-
-  private fun fileFor(previewId: String, fileName: String): File =
-    rootDir.resolve(previewId).resolve(fileName)
+  ) {
+  override fun fileFor(previewId: String, kind: String): File? =
+    if (kind == UiAutomatorDataProducer.KIND_HIERARCHY)
+      rootDir.resolve(previewId).resolve(UiAutomatorDataProducer.FILE_HIERARCHY)
+    else null
 }


### PR DESCRIPTION
Extract common fetch/attachment logic into a reusable `FileBackedDataProductRegistry` base class, eliminating duplication across four registry implementations.

## Summary

This refactor introduces `FileBackedDataProductRegistry`, an abstract base class that handles the boilerplate logic for file-based data product registries. Four concrete implementations (AccessibilityDataProductRegistry, UiAutomatorDataProductRegistry, DisplayFilterDataProductRegistry, ResourcesUsedDataProductRegistry) now inherit from this base and only override the minimal required methods.

## Key Changes

- **New `FileBackedDataProductRegistry` base class** that implements:
  - `fetch()` with support for both inline and path-based transport
  - `attachmentsFor()` with automatic extras attachment
  - JSON parsing with error handling
  - Inline upgrade logic for PATH-transport kinds (with override hook)
  - Extras attachment via overridable `extras()` method

- **Subclass simplifications**:
  - AccessibilityDataProductRegistry: Moved capabilities to constructor, implemented `fileFor()`, `extras()`, and `allowInlineUpgrade()` overrides
  - UiAutomatorDataProductRegistry: Reduced to single `fileFor()` override
  - DisplayFilterDataProductRegistry: Reduced to `fileFor()` and `extras()` overrides
  - ResourcesUsedDataProductRegistry: Reduced to single `fileFor()` override

- **New `allowInlineUpgrade()` hook**: Allows registries to opt out of inline JSON parsing for binary formats (e.g., PNG overlays in a11y registry)

- **Test coverage**: Added test case verifying that binary PATH-transport kinds respect the `allowInlineUpgrade = false` setting

## Implementation Details

The base class centralizes:
- File existence checks and missing-file handling
- JSON parsing with exception-to-FetchFailed conversion
- Transport-aware response building (inline vs. path)
- Extras attachment logic
- Subscription tracking (via abstract `onSubscribe`/`onUnsubscribe`)

Subclasses implement only:
- `fileFor(previewId, kind)`: Maps kind to file path
- `extras()` (optional): Computes extras for a given kind/payload
- `allowInlineUpgrade()` (optional): Controls inline JSON parsing for PATH transport

This reduces ~400 lines of duplicated boilerplate while maintaining identical behavior.

https://claude.ai/code/session_01BDrfiX9wQs8Ei7RWHUnEUq