### PR TITLE
docs(daemon): per-backend data-product matrix in DATA-PRODUCTS.md

### DIFF
--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -289,28 +289,34 @@ A `data/fetch` that needs a re-render:
 
 ## Per-backend support matrix (issue #1201)
 
-Which kinds each backend's `extensions/list` advertises and serves through `data/fetch` / `data/subscribe`. Read this together with `initialize.capabilities.dataProducts`: the daemon never lies about what it can advertise, so a kind that shows up in `extensions/list` will round-trip through `data/fetch` (possibly returning `NotAvailable` when no producer has written yet, but **never** `-32020 DataProductUnknown`).
+Which `kind` strings each backend's `extensions/list` advertises and serves through `data/fetch` / `data/subscribe`. The first column is the wire-level `kind` the client passes — **not** the daemon-side `Extension.id` (those differ: e.g. the extension registered as `data/theme` exposes the kind `compose/theme`). Read this together with `initialize.capabilities.dataProducts`: the daemon never lies about what it can advertise, so a kind that shows up in the capability list will round-trip through `data/fetch` (possibly returning `NotAvailable` when no producer has written yet, but **never** `-32020 DataProductUnknown`).
 
-| Kind | Android | Desktop (CMP) | Notes |
+| `kind` | Android | Desktop (CMP) | Notes |
 |---|---|---|---|
-| `device/clip` / `device/background` | ✅ | ✅ | Renderer-agnostic device-bound previewer. |
-| `render/trace` / `render/test-failure` / `render/overlay-legend` | ✅ | ✅ | Renderer-agnostic. |
-| `data/theme` / `data/wallpaper` / `data/pseudolocale` | ✅ | ✅ | Override-extension shapes. Pseudolocale has separate Android / Desktop planner modules — see `:data-pseudolocale-connector{-desktop}`. |
-| `data/recomposition` | ✅ stub | ✅ producer | The Compose-runtime observer install lands on desktop; Android exposes a `NotAvailable`-only stub until the in-sandbox install ships. |
-| `compose/trace` | ✅ | ✅ | Both backends, gated on `composeai.perfetto.enabled` + `composeai.render.outputDir`. |
-| `displayfilter` | ✅ | ✅ | Both backends, gated on `composeai.displayfilter.filters`. Producer is pure `BufferedImage` post-capture. |
+| `render/deviceClip` / `render/deviceBackground` | ✅ | ✅ | Renderer-agnostic device-bound previewer. |
+| `render/trace` | ✅ | ✅ | Phase breakdown from render metrics. |
+| `render/composeAiTrace` | ✅ | ✅ | Both backends, gated on `composeai.perfetto.enabled` + `composeai.render.outputDir`. |
+| `test/failure` | ✅ | ✅ | Postmortem bundle on `renderFailed`. Renderer-agnostic. |
+| `compose/theme` | ✅ | ✅ | Material 3 theme tokens. Override-extension shape. |
+| `compose/wallpaper` | ✅ | ✅ | Wallpaper override shape. |
+| `compose/recomposition` | ✅ stub | ✅ producer | The Compose-runtime observer install lands on desktop; Android exposes a `NotAvailable`-only stub until the in-sandbox install ships. |
+| `displayfilter/variants` | ✅ | ✅ | Both backends, gated on `composeai.displayfilter.filters`. Producer is pure `BufferedImage` post-capture. |
 | `fonts/used` | ✅ producer | 📁 registry-only | Android: `GoogleFontInterceptor` + Typeface accounting. Desktop: registry returns `NotAvailable` until a Skia-side font producer ports. |
 | `compose/semantics` / `layout/inspector` | ✅ producer | 📁 registry-only | Android producer reads the Robolectric semantics tree. Desktop registry serves the file once a CMP-portable producer driving `LocalView` / `SemanticsOwner` lands. |
 | `text/strings` | ✅ producer | 📁 registry-only | Synthesised from `compose/semantics`; ports along with that kind. |
 | `i18n/translations` | ✅ producer | 📁 registry-only | Reads `values*/strings.xml`. Desktop equivalent reads `org.jetbrains.compose.resources.ResourceEnvironment` once that producer ports. |
 | `data/navigation` | ✅ producer | 📁 registry-only | Android producer reads `Activity.intent` + `OnBackPressedDispatcher`. Desktop equivalent watches `NavController`; same registry file shape. |
 | `history/diff/regions` + history JSON-RPC | 🔒 1.1 | 🔒 1.1 | Both backends gated behind `HistoryFeature.ENABLED` (post-1.0). See `daemon/core/.../HistoryFeature.kt`. |
-| `a11y/atf` + `a11y/hierarchy` + `a11y/touchTargets` + `a11y/overlay` | ✅ | ❌ Android-only | Producer depends on ATF + Robolectric `AccessibilityNodeInfo` walks. CMP-portable subset (geometric touch-target + contrast against `SemanticsNode`) is a future track; not blocked on registry. |
+| `a11y/atf` / `a11y/hierarchy` / `a11y/touchTargets` / `a11y/overlay` | ✅ | ❌ Android-only | Producer depends on ATF + Robolectric `AccessibilityNodeInfo` walks. CMP-portable subset (geometric touch-target + contrast against `SemanticsNode`) is a future track; not blocked on registry. |
 | `resources/used` | ✅ | ❌ Android-only | Producer intercepts `Resources.getValue`; no Compose-Multiplatform analogue ships. |
-| `uia/hierarchy` (uiautomator) | ✅ | ❌ Android-only | UIAutomator is Android-API surface; CMP-desktop panel chips should grey out on `serverCapabilities.backend == "desktop"`. |
-| `data/ambient` | ✅ Wear-only | ❌ | Robolectric shadow of `AmbientLifecycleObserver` — Wear OS only. |
+| `uia/hierarchy` | ✅ | ❌ Android-only | UIAutomator is Android-API surface; CMP-desktop panel chips should grey out on `serverCapabilities.backend == "desktop"`. |
+| `compose/ambient` | ✅ Wear-only | ❌ | Robolectric shadow of `AmbientLifecycleObserver` — Wear OS only. |
 
 Legend: ✅ producer = backend writes the artefact each render. 📁 registry-only = backend advertises the kind and serves `data/fetch` against the file when present; producer has not ported yet, so the kind returns `NotAvailable` until either a port lands or an Android render writes into the same `dataRoot` (which only happens if Android and Desktop daemons share an output dir — an unusual deployment). ❌ = not advertised; panel should grey out on `serverCapabilities.backend == "desktop"`. 🔒 = gated behind a feature flag.
+
+> The CMP-desktop panel additionally surfaces several override extensions that don't ship a `kind` and therefore aren't `data/fetch`-able: `data/pseudolocale` (locale override + `LayoutDirection.Rtl`) and `render/overlay-legend` (preview overlay only). They appear in `extensions/list` but their `dataProducts` capability set is empty by design.
+
+
 
 ## Worked example: `a11y/hierarchy`
 

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -287,6 +287,31 @@ A `data/fetch` that needs a re-render:
 | `history/diff/regions` | default | low | Per-pixel bbox of changed regions vs. another history entry. |
 | `test/failure` | failed render | low | Postmortem bundle: phase, error type/message/stack, fallback fields for what's not yet captured. Fetch-only after `renderFailed`. |
 
+## Per-backend support matrix (issue #1201)
+
+Which kinds each backend's `extensions/list` advertises and serves through `data/fetch` / `data/subscribe`. Read this together with `initialize.capabilities.dataProducts`: the daemon never lies about what it can advertise, so a kind that shows up in `extensions/list` will round-trip through `data/fetch` (possibly returning `NotAvailable` when no producer has written yet, but **never** `-32020 DataProductUnknown`).
+
+| Kind | Android | Desktop (CMP) | Notes |
+|---|---|---|---|
+| `device/clip` / `device/background` | ✅ | ✅ | Renderer-agnostic device-bound previewer. |
+| `render/trace` / `render/test-failure` / `render/overlay-legend` | ✅ | ✅ | Renderer-agnostic. |
+| `data/theme` / `data/wallpaper` / `data/pseudolocale` | ✅ | ✅ | Override-extension shapes. Pseudolocale has separate Android / Desktop planner modules — see `:data-pseudolocale-connector{-desktop}`. |
+| `data/recomposition` | ✅ stub | ✅ producer | The Compose-runtime observer install lands on desktop; Android exposes a `NotAvailable`-only stub until the in-sandbox install ships. |
+| `compose/trace` | ✅ | ✅ | Both backends, gated on `composeai.perfetto.enabled` + `composeai.render.outputDir`. |
+| `displayfilter` | ✅ | ✅ | Both backends, gated on `composeai.displayfilter.filters`. Producer is pure `BufferedImage` post-capture. |
+| `fonts/used` | ✅ producer | 📁 registry-only | Android: `GoogleFontInterceptor` + Typeface accounting. Desktop: registry returns `NotAvailable` until a Skia-side font producer ports. |
+| `compose/semantics` / `layout/inspector` | ✅ producer | 📁 registry-only | Android producer reads the Robolectric semantics tree. Desktop registry serves the file once a CMP-portable producer driving `LocalView` / `SemanticsOwner` lands. |
+| `text/strings` | ✅ producer | 📁 registry-only | Synthesised from `compose/semantics`; ports along with that kind. |
+| `i18n/translations` | ✅ producer | 📁 registry-only | Reads `values*/strings.xml`. Desktop equivalent reads `org.jetbrains.compose.resources.ResourceEnvironment` once that producer ports. |
+| `data/navigation` | ✅ producer | 📁 registry-only | Android producer reads `Activity.intent` + `OnBackPressedDispatcher`. Desktop equivalent watches `NavController`; same registry file shape. |
+| `history/diff/regions` + history JSON-RPC | 🔒 1.1 | 🔒 1.1 | Both backends gated behind `HistoryFeature.ENABLED` (post-1.0). See `daemon/core/.../HistoryFeature.kt`. |
+| `a11y/atf` + `a11y/hierarchy` + `a11y/touchTargets` + `a11y/overlay` | ✅ | ❌ Android-only | Producer depends on ATF + Robolectric `AccessibilityNodeInfo` walks. CMP-portable subset (geometric touch-target + contrast against `SemanticsNode`) is a future track; not blocked on registry. |
+| `resources/used` | ✅ | ❌ Android-only | Producer intercepts `Resources.getValue`; no Compose-Multiplatform analogue ships. |
+| `uia/hierarchy` (uiautomator) | ✅ | ❌ Android-only | UIAutomator is Android-API surface; CMP-desktop panel chips should grey out on `serverCapabilities.backend == "desktop"`. |
+| `data/ambient` | ✅ Wear-only | ❌ | Robolectric shadow of `AmbientLifecycleObserver` — Wear OS only. |
+
+Legend: ✅ producer = backend writes the artefact each render. 📁 registry-only = backend advertises the kind and serves `data/fetch` against the file when present; producer has not ported yet, so the kind returns `NotAvailable` until either a port lands or an Android render writes into the same `dataRoot` (which only happens if Android and Desktop daemons share an output dir — an unusual deployment). ❌ = not advertised; panel should grey out on `serverCapabilities.backend == "desktop"`. 🔒 = gated behind a feature flag.
+
 ## Worked example: `a11y/hierarchy`
 
 The first kind to ship; mirrors the renderer-side type:

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -153,6 +153,12 @@ Result:
   // androidSdk — fixed Android SDK level the backend renders against. Populated by the
   // Robolectric backend from its pinned @Config(sdk = ...) value; absent/null on Desktop and
   // other non-Android backends.
+  //
+  // Per-backend data-product matrix: the set of kinds each backend advertises in
+  // `extensions/list` / `data/fetch` differs because some producers are Android-API-bound
+  // (`a11y/*`, `resources/used`, `uiautomator`, `data/ambient`). Clients render the panel chips
+  // off `backend` plus the live `extensions/list` snapshot — see DATA-PRODUCTS.md §
+  // "Per-backend support matrix" for the full table.
   classpathFingerprint: string;      // SHA-256 hex of the resolved test classpath
   manifest: {
     path: string;                    // absolute path to the daemon's working previews.json


### PR DESCRIPTION
Adds the per-backend data-product matrix #1201 calls for. After phase 4 lands, this rebases onto `main` automatically.

## Summary

#1201's third acceptance criterion was:

> Update protocol docs at `docs/daemon/PROTOCOL.md` and `docs/daemon/DATA-PRODUCTS.md` to list the per-backend matrix — today the only signal is reading the source.

This adds a table to `DATA-PRODUCTS.md` right after the open-set catalogue: one row per kind, columns for Android and Desktop, with a legend distinguishing:

- ✅ **producer ships and writes** the artefact each render
- 📁 **registry-only** — kind is advertised but returns `NotAvailable` until a producer ports (the steady state for `fonts/used`, `compose/semantics`, `layout/inspector`, `text/strings`, `i18n/translations`, `data/navigation` on desktop)
- ❌ **Android-only**, panel should grey out on `serverCapabilities.backend == "desktop"` (`a11y/*`, `resources/used`, `uia/hierarchy`, `data/ambient`)
- 🔒 **post-1.0 feature flag** (`history/*` behind `HistoryFeature.ENABLED`)

`PROTOCOL.md` gets a small forward-reference next to `serverCapabilities.backend` so clients reading the wire docs know where to find the per-backend kind list.

## Test plan

- [x] Pure docs change — no code touched
- [x] Branched off `agent/pick-up-1201-phase4` so the matrix accurately reflects the post-merge state of `data/navigation`'s registry-only support on desktop

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDrfiX9wQs8Ei7RWHUnEUq)_