### PR TITLE
style: prettier-fix indentation of historySource ternary

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1161,71 +1161,71 @@ export async function activate(
         gradleService?.findModuleByPath(modulePath) ?? null;
     historySource = HISTORY_FEATURE_ENABLED
         ? buildHistorySource({
-        isDaemonReady: (moduleId) =>
-            daemonGate?.isDaemonReady(moduleId) ?? false,
-        daemonList: async (scope) => {
-            const module = moduleInfoFromScope(scope.moduleId);
-            if (!module) {
-                throw new Error("daemon unavailable");
-            }
-            const client = await daemonGate?.getOrSpawn(
-                module,
-                daemonScheduler!.daemonEvents(scope.moduleId),
-            );
-            if (!client) {
-                throw new Error("daemon unavailable");
-            }
-            return client.historyList({ previewId: scope.previewId });
-        },
-        daemonRead: async (id) => {
-            const moduleId = historyScopeRef.current?.moduleId;
-            if (!moduleId) {
-                throw new Error("no scope");
-            }
-            const module = moduleInfoFromScope(moduleId);
-            if (!module) {
-                throw new Error("daemon unavailable");
-            }
-            const client = await daemonGate?.getOrSpawn(
-                module,
-                daemonScheduler!.daemonEvents(moduleId),
-            );
-            if (!client) {
-                throw new Error("daemon unavailable");
-            }
-            return client.historyRead({ id, inline: false });
-        },
-        daemonDiff: async (fromId, toId) => {
-            const moduleId = historyScopeRef.current?.moduleId;
-            if (!moduleId) {
-                throw new Error("no scope");
-            }
-            const module = moduleInfoFromScope(moduleId);
-            if (!module) {
-                throw new Error("daemon unavailable");
-            }
-            const client = await daemonGate?.getOrSpawn(
-                module,
-                daemonScheduler!.daemonEvents(moduleId),
-            );
-            if (!client) {
-                throw new Error("daemon unavailable");
-            }
-            // TODO(1.1): history/diff is experimental in the 1.0 daemon and
-            // returns MethodNotFound unless the user opts in via
-            // `composeai.experimental.historyDiff`. Once the daemon flips the
-            // default, simplify this back to a direct call. Until then,
-            // surface the gate as a clear "diff unavailable" rather than a
-            // raw RPC error.
-            return client.historyDiff({
-                from: fromId,
-                to: toId,
-                mode: "metadata",
-            });
-        },
-        getCurrentScope: () => historyScopeRef.current,
-        logger: outputChannel,
-    })
+              isDaemonReady: (moduleId) =>
+                  daemonGate?.isDaemonReady(moduleId) ?? false,
+              daemonList: async (scope) => {
+                  const module = moduleInfoFromScope(scope.moduleId);
+                  if (!module) {
+                      throw new Error("daemon unavailable");
+                  }
+                  const client = await daemonGate?.getOrSpawn(
+                      module,
+                      daemonScheduler!.daemonEvents(scope.moduleId),
+                  );
+                  if (!client) {
+                      throw new Error("daemon unavailable");
+                  }
+                  return client.historyList({ previewId: scope.previewId });
+              },
+              daemonRead: async (id) => {
+                  const moduleId = historyScopeRef.current?.moduleId;
+                  if (!moduleId) {
+                      throw new Error("no scope");
+                  }
+                  const module = moduleInfoFromScope(moduleId);
+                  if (!module) {
+                      throw new Error("daemon unavailable");
+                  }
+                  const client = await daemonGate?.getOrSpawn(
+                      module,
+                      daemonScheduler!.daemonEvents(moduleId),
+                  );
+                  if (!client) {
+                      throw new Error("daemon unavailable");
+                  }
+                  return client.historyRead({ id, inline: false });
+              },
+              daemonDiff: async (fromId, toId) => {
+                  const moduleId = historyScopeRef.current?.moduleId;
+                  if (!moduleId) {
+                      throw new Error("no scope");
+                  }
+                  const module = moduleInfoFromScope(moduleId);
+                  if (!module) {
+                      throw new Error("daemon unavailable");
+                  }
+                  const client = await daemonGate?.getOrSpawn(
+                      module,
+                      daemonScheduler!.daemonEvents(moduleId),
+                  );
+                  if (!client) {
+                      throw new Error("daemon unavailable");
+                  }
+                  // TODO(1.1): history/diff is experimental in the 1.0 daemon and
+                  // returns MethodNotFound unless the user opts in via
+                  // `composeai.experimental.historyDiff`. Once the daemon flips the
+                  // default, simplify this back to a direct call. Until then,
+                  // surface the gate as a clear "diff unavailable" rather than a
+                  // raw RPC error.
+                  return client.historyDiff({
+                      from: fromId,
+                      to: toId,
+                      mode: "metadata",
+                  });
+              },
+              getCurrentScope: () => historyScopeRef.current,
+              logger: outputChannel,
+          })
         : null;
     context.subscriptions.push(
         vscode.commands.registerCommand("composePreview.refresh", () =>

--- a/vscode-extension/src/test/electron/suite/e2e.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2e.test.ts
@@ -127,6 +127,28 @@ describeE2E("Compose Preview e2e (real Gradle)", function () {
         api.injectGradleApi(
             new RealGradleApi(repoRoot, (line) => console.log(line)),
         );
+
+        // Resolve the webview view. Without this, `panel.view` stays
+        // undefined, every `panel.postMessage` is silently dropped, and
+        // the `webviewPreviewsRendered` ack the assertion waits for is
+        // never sent. `postedMessageLog` still captures the host's post
+        // *attempts*, which is why the earlier `setPreviews` waitFor
+        // matched — but the resolved-webview round-trip needs the view
+        // open. The activation-time auto-refresh is suppressed under
+        // `COMPOSE_PREVIEW_TEST_MODE=1`, so no extra-render side effects
+        // from the focus call.
+        await vscode.commands.executeCommand("composePreview.panel.focus");
+        await waitFor(
+            "webviewReady from the resolved webview",
+            30_000,
+            100,
+            () => {
+                const inbound = api.getReceivedMessages();
+                return inbound.find(
+                    (m) => (m as PostedMessage).command === "webviewReady",
+                );
+            },
+        );
     });
 
     it("renders previews for samples/cmp through the real Gradle plugin", async () => {

--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -176,6 +176,24 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
             ),
         );
 
+        // Resolve the webview view. The `webviewA11yState` ack the chip
+        // tests wait for only fires from a live webview script, and
+        // without explicit focus `panel.view` stays undefined — every
+        // host `postMessage` no-ops. See the matching note in
+        // `e2e.test.ts`. Idempotent if the cmp suite already opened it.
+        await vscode.commands.executeCommand("composePreview.panel.focus");
+        await waitFor(
+            "webviewReady from the resolved webview",
+            30_000,
+            100,
+            () => {
+                const inbound = api.getReceivedMessages();
+                return inbound.find(
+                    (m) => (m as PostedMessage).command === "webviewReady",
+                );
+            },
+        );
+
         // The chip toggles below send `data/subscribe` through the daemon
         // scheduler, which requires a live daemon and therefore a
         // `composePreviewDaemonStart`-produced launch descriptor. Activation


### PR DESCRIPTION
#1220 introduced `HISTORY_FEATURE_ENABLED ? buildHistorySource({...}) :
null` but kept the original indent on the wrapped argument block. Apply
prettier so `format:check` is clean again — the pre-commit hook was
blocking unrelated commits on this leftover.