### PR TITLE
chore: pin material-kolor to 4.0.x line

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,6 +47,17 @@
       "allowedVersions": "/^2025\\.11\\./"
     },
     {
+      "description": "material-kolor: pin to the 4.0.x line. `:data-wallpaper-connector` is published against the renderer-android Compose floor (`compose-bom-compat`, Compose 1.9.5); 4.1.0 rebuilt against Compose Multiplatform 1.10.0 + Kotlin 2.3.0 and migrated to a Multiplatform Android library, raising the transitive floor above our published surface. See gradle/libs.versions.toml for the full rationale — bumping the floor is a manual decision.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchDepNames": [
+        "com.materialkolor:material-kolor"
+      ],
+      "matchCurrentValue": "/^4\\.0\\./",
+      "allowedVersions": "/^4\\.0\\./"
+    },
+    {
       "description": "VS Code API floor declarations — bumping these drops support for older editors, must be a manual decision.",
       "matchFileNames": [
         "vscode-extension/package.json"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -109,6 +109,15 @@ checker-qual = "4.1.0"
 # extension's seed → ColorScheme derivation (HCT tonal palettes, palette
 # styles, contrast level) so the result matches what Android's wallpaper-
 # derived dynamic theming actually produces.
+# Pinned to the 4.0.x line: `:data-wallpaper-connector` is a published
+# module and its consumers live on the renderer-android Compose floor
+# (`compose-bom-compat`, Compose 1.9.5). 4.1.0 rebuilt against Compose
+# Multiplatform 1.10.0 + Kotlin 2.3.0 and switched from an Android library
+# to a "Multiplatform Android library" — both move the transitive floor
+# above what our published surface targets. Renovate is constrained to
+# 4.0.x in `.github/renovate.json`; bumping the supported floor is a
+# manual decision (re-check `:data-wallpaper-connector:compileKotlin`
+# against `compose-bom-compat` when raising it).
 material-kolor = "4.0.5"
 
 [libraries]


### PR DESCRIPTION
Constrains `material-kolor` dependency to the 4.0.x release line to maintain compatibility with the renderer-android Compose floor.

## Summary

The `:data-wallpaper-connector` module is published and consumed by external projects that target the renderer-android Compose floor (`compose-bom-compat`, Compose 1.9.5). Version 4.1.0 of material-kolor was rebuilt against Compose Multiplatform 1.10.0 + Kotlin 2.3.0 and migrated to a Multiplatform Android library, both of which raise the transitive dependency floor above our published surface.

## Changes

- Added Renovate constraint in `.github/renovate.json` to pin material-kolor to `^4.0.x`
- Updated `gradle/libs.versions.toml` with detailed rationale explaining the pin and conditions for future upgrades
- Bumping the supported floor requires manual decision and re-validation of `:data-wallpaper-connector:compileKotlin` against `compose-bom-compat`

https://claude.ai/code/session_016WznfzhZnEPRAyfNJxrqZM