### PR TITLE
fix(vscode-extension): buffer daemon stderr across pipe chunk boundaries

### DIFF
--- a/vscode-extension/src/daemon/daemonProcess.ts
+++ b/vscode-extension/src/daemon/daemonProcess.ts
@@ -54,6 +54,45 @@ export function readLaunchDescriptor(
     }
 }
 
+/**
+ * Splits a stream of arbitrary text chunks into newline-delimited lines, holding
+ * the trailing fragment of the last chunk until the next chunk (or `flush`)
+ * completes it. Node's `Readable.on("data", ...)` flushes when the writer flushes
+ * — not on line boundaries — so a naive `chunk.split(/\r?\n/)` treats a partial
+ * line as complete and emits the prefix on its own. For the daemon's stderr that
+ * silently corrupts uncaught-exception output: the JVM writes
+ * `Exception in thread "main" ` *then* invokes `printStackTrace`, and any pipe
+ * boundary between those two writes emits the prefix alone, while the
+ * `java.lang.X: msg` continuation arrives in the next chunk and gets dropped by
+ * the quiet-level allow-list filter.
+ */
+export class ChunkLineSplitter {
+    private buffer = "";
+
+    /** Append `chunk` and return every complete line it produced. */
+    feed(chunk: string): string[] {
+        this.buffer += chunk;
+        const lines: string[] = [];
+        let newlineIndex: number;
+        while ((newlineIndex = this.buffer.search(/\r?\n/)) !== -1) {
+            lines.push(this.buffer.slice(0, newlineIndex));
+            const matchLength = this.buffer[newlineIndex] === "\r" ? 2 : 1;
+            this.buffer = this.buffer.slice(newlineIndex + matchLength);
+        }
+        return lines;
+    }
+
+    /** Return any pending fragment (no trailing newline) and clear the buffer. */
+    flush(): string | null {
+        if (this.buffer.length === 0) {
+            return null;
+        }
+        const tail = this.buffer;
+        this.buffer = "";
+        return tail;
+    }
+}
+
 export interface SpawnedDaemon {
     client: DaemonClient;
     process: ChildProcess;
@@ -138,17 +177,39 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
     // logger so daemon `System.err.println` lands in the user's output panel.
     // The filter dedupes the Roborazzi ActionBar banner and drops the boot
     // diagnostics at normal level; verbose passes everything through.
+    //
+    // Buffer carry-over across chunk boundaries: pipes flush whenever the
+    // writer happens to flush, not on line boundaries. Java's uncaught-exception
+    // handler writes `Exception in thread "main" ` and then calls
+    // `printStackTrace`, and the pipe can land its boundary between those two
+    // writes — splitting on `\r?\n` per chunk would treat the partial prefix
+    // as a complete line and emit `Exception in thread "main" ` with no class
+    // name. The quiet-level filter (allow-listed to `^Exception ` / `^Caused
+    // by: ` / `^\s+at`) would then drop the `java.lang.X: ...` continuation
+    // line that arrives in the next chunk because it doesn't start with one
+    // of those prefixes, making every link/initialiser failure look like the
+    // exception had no message.
     child.stderr.setEncoding("utf-8");
+    const emitStderrLine = (line: string): void => {
+        if (line.length === 0) {
+            return;
+        }
+        const filtered = logFilter.filterDaemonStderrLine(line);
+        if (filtered === null) {
+            return;
+        }
+        logger?.appendLine(`[daemon stderr] ${filtered}`);
+    };
+    const stderrSplitter = new ChunkLineSplitter();
     child.stderr.on("data", (chunk: string) => {
-        for (const line of chunk.split(/\r?\n/)) {
-            if (line.length === 0) {
-                continue;
-            }
-            const filtered = logFilter.filterDaemonStderrLine(line);
-            if (filtered === null) {
-                continue;
-            }
-            logger?.appendLine(`[daemon stderr] ${filtered}`);
+        for (const line of stderrSplitter.feed(chunk)) {
+            emitStderrLine(line);
+        }
+    });
+    child.stderr.on("end", () => {
+        const tail = stderrSplitter.flush();
+        if (tail !== null) {
+            emitStderrLine(tail);
         }
     });
 

--- a/vscode-extension/src/test/daemonProcess.test.ts
+++ b/vscode-extension/src/test/daemonProcess.test.ts
@@ -2,7 +2,10 @@ import * as assert from "assert";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { readLaunchDescriptor } from "../daemon/daemonProcess";
+import {
+    ChunkLineSplitter,
+    readLaunchDescriptor,
+} from "../daemon/daemonProcess";
 import {
     DAEMON_DESCRIPTOR_SCHEMA_VERSION,
     DaemonLaunchDescriptor,
@@ -157,4 +160,74 @@ describe("readLaunchDescriptor", () => {
             assert.strictEqual(result?.javaLauncher, null);
         }),
     );
+});
+
+describe("ChunkLineSplitter", () => {
+    it("emits whole lines from a single chunk", () => {
+        const s = new ChunkLineSplitter();
+        assert.deepStrictEqual(s.feed("alpha\nbeta\ngamma\n"), [
+            "alpha",
+            "beta",
+            "gamma",
+        ]);
+        assert.strictEqual(s.flush(), null);
+    });
+
+    it("holds a trailing fragment until the next chunk completes it", () => {
+        // Reproduces the JVM uncaught-exception bug: the JVM does
+        // `System.err.print("Exception in thread \"main\" ")` and *then* calls
+        // `printStackTrace`. When a pipe boundary lands between those two writes
+        // the prefix arrived without `\n`; the previous naive splitter emitted
+        // it as a complete line, and the quiet-level filter dropped the
+        // `java.lang.IllegalArgumentException: ...` continuation that arrived
+        // in the next chunk.
+        const s = new ChunkLineSplitter();
+        assert.deepStrictEqual(s.feed('Exception in thread "main" '), []);
+        assert.deepStrictEqual(
+            s.feed(
+                "java.lang.IllegalArgumentException: PreviewManifestRouter: " +
+                    "manifest '/x' does not exist\n\tat A.b(File.kt:1)\n",
+            ),
+            [
+                'Exception in thread "main" java.lang.IllegalArgumentException: ' +
+                    "PreviewManifestRouter: manifest '/x' does not exist",
+                "\tat A.b(File.kt:1)",
+            ],
+        );
+        assert.strictEqual(s.flush(), null);
+    });
+
+    it("handles CRLF and bare LF line endings", () => {
+        const s = new ChunkLineSplitter();
+        assert.deepStrictEqual(s.feed("a\r\nb\nc\r\n"), ["a", "b", "c"]);
+        assert.strictEqual(s.flush(), null);
+    });
+
+    it("splits across arbitrary mid-line chunk boundaries", () => {
+        const s = new ChunkLineSplitter();
+        const full = "alpha\nbeta\ngamma";
+        const all: string[] = [];
+        for (const char of full) {
+            for (const line of s.feed(char)) {
+                all.push(line);
+            }
+        }
+        const tail = s.flush();
+        if (tail !== null) {
+            all.push(tail);
+        }
+        assert.deepStrictEqual(all, ["alpha", "beta", "gamma"]);
+    });
+
+    it("emits empty lines between blank-line separated paragraphs", () => {
+        const s = new ChunkLineSplitter();
+        assert.deepStrictEqual(s.feed("a\n\nb\n"), ["a", "", "b"]);
+    });
+
+    it("flushes a final fragment with no trailing newline", () => {
+        const s = new ChunkLineSplitter();
+        assert.deepStrictEqual(s.feed("partial"), []);
+        assert.strictEqual(s.flush(), "partial");
+        assert.strictEqual(s.flush(), null);
+    });
 });


### PR DESCRIPTION
Node's `Readable.on("data", ...)` flushes when the writer flushes — not on line
boundaries — so splitting each chunk on `\r?\n` treats a partial trailing
fragment as a complete line. The JVM's uncaught-exception handler does
`System.err.print("Exception in thread \"main\" ")` and *then* invokes
`printStackTrace`; if the pipe lands a boundary between those two writes, the
splitter emitted the prefix alone and the continuation arrived in the next
chunk as `java.lang.X: msg` — which the quiet-level log filter
(`^Exception ` / `^Caused by: ` / `^\s+at`) drops because it doesn't start with
an allowed prefix. The user saw `[daemon stderr] Exception in thread "main" `
with no class or message and a stack pointing at an unrelated initialiser,
when the real cause was a `previews.json`-missing `IllegalArgumentException`
from `PreviewManifestRouter`.

Extracted the line splitting into a `ChunkLineSplitter` that holds the
trailing fragment until a newline arrives (or the stream ends), and added unit
coverage for the exception-prefix split case plus CRLF / per-char chunking /
final-fragment-on-flush.