### PR TITLE
fix(vscode): only restore focus mode on boot when the focused preview is still present

### DIFF
--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -36,6 +36,16 @@ export interface FocusControllerPersistedState {
     layout?: "grid" | "flow" | "column" | "focus";
     diffMode?: DiffMode;
     filters?: { fn?: string; group?: string };
+    /** Previously focused previewId — written on every focus navigation
+     *  so a webview reload can verify the focused preview still belongs
+     *  to the currently active file before re-entering focus mode.
+     *  See the deferred restore at boot in `main.ts`. */
+    focusedPreviewId?: string | null;
+    /** Layout to fall back to when exiting focus. Persisted (not just
+     *  held in `previewStore`) so the cold-boot "drop out of focus if
+     *  the focused preview isn't in the current file" path can restore
+     *  the prior dropdown choice. */
+    previousLayout?: "grid" | "flow" | "column";
 }
 
 export interface FocusControllerConfig {
@@ -309,6 +319,13 @@ export class FocusController {
         // re-walking the DOM. Same value goes upstream to the extension
         // so the History panel can re-scope.
         previewStore.setState({ focusedPreviewId: previewId });
+        // Also persist so the next webview boot can verify the focused
+        // preview is still in the active file's manifest before re-
+        // entering focus mode.
+        if (this.config.state.focusedPreviewId !== previewId) {
+            this.config.state.focusedPreviewId = previewId;
+            this.config.vscode.setState(this.config.state);
+        }
         this.config.vscode.postMessage({
             command: "previewScopeChanged",
             previewId,

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -159,6 +159,21 @@ interface PersistedState {
     layout?: "grid" | "flow" | "column" | "focus";
     diffMode?: DiffMode;
     /**
+     * `previewId` of the focused preview at unload time. Used at boot to
+     * verify the focused preview still belongs to the currently active
+     * file before re-entering focus mode — see the deferred restore in
+     * `firstUpdated` and the `applyPendingFocusRestore` callback. Stays
+     * `null` when not in focus mode.
+     */
+    focusedPreviewId?: string | null;
+    /**
+     * Layout to fall back to when exiting focus mode. Persisted (not just
+     * held in `previewStore.previousLayout`) so a cold boot from
+     * `layout === "focus"` can land on the prior dropdown choice when the
+     * focused preview isn't in the active file's manifest anymore.
+     */
+    previousLayout?: "grid" | "flow" | "column";
+    /**
      * Per-scope MRU of focus-inspector data-product `kind` strings —
      * scope is the active module dir today (see `getScope` in
      * `FocusInspectorConfig`). Most-recent-first within each list,
@@ -615,9 +630,10 @@ export class PreviewApp extends LitElement {
         // the persisted layout so initial subscribers see the right value.
         previewStore.setState({
             previousLayout:
-                state.layout && state.layout !== "focus"
+                state.previousLayout ??
+                (state.layout && state.layout !== "focus"
                     ? state.layout
-                    : "grid",
+                    : "grid"),
         });
         let filterDebounce: ReturnType<typeof setTimeout> | null = null;
 
@@ -2359,8 +2375,12 @@ export class PreviewApp extends LitElement {
             setFocusIndex: (next) =>
                 previewStore.setState({ focusIndex: next }),
             getPreviousLayout: () => previewStore.getState().previousLayout,
-            setPreviousLayout: (next) =>
-                previewStore.setState({ previousLayout: next }),
+            setPreviousLayout: (next) => {
+                previewStore.setState({ previousLayout: next });
+                state.previousLayout = next;
+                // `focusOnCard` calls `vscode.setState(state)` itself
+                // after this returns, so no separate persist call here.
+            },
             getLastScopedPreviewId: () =>
                 previewStore.getState().lastScopedPreviewId,
             setLastScopedPreviewId: (next) =>
@@ -2398,12 +2418,32 @@ export class PreviewApp extends LitElement {
         // `BundleViewerPanel`) clamp to focus mode — the filter toolbar
         // is hidden and the persisted layout from the sidebar panel
         // shouldn't carry over.
+        //
+        // Focus mode is restored lazily: cold boots don't enter focus
+        // until `setPreviews` arrives and confirms the previously focused
+        // preview is in the active file's manifest. Otherwise reopening
+        // the panel against a different file (or no open file) leaves
+        // the user staring at an empty focus stage with the filter
+        // toolbar hidden. `pendingFocusRestoreId` carries the previously
+        // focused previewId across to the first `setPreviews` handler.
+        let pendingFocusRestoreId: string | null = null;
         if (bundleMode) {
             filterToolbar.setLayoutValue("focus");
             state.layout = "focus";
+        } else if (state.layout === "focus") {
+            pendingFocusRestoreId = state.focusedPreviewId ?? null;
+            const fallback = state.previousLayout ?? "grid";
+            filterToolbar.setLayoutValue(fallback);
+            state.layout = fallback;
+            // Clear the persisted focused-preview marker until we
+            // confirm the focused preview reappears. If `setPreviews`
+            // re-enters focus mode, `publishScopedPreview` will write
+            // it back; otherwise we stay out of focus.
+            state.focusedPreviewId = null;
+            vscode.setState(state);
         } else if (
             state.layout &&
-            ["grid", "flow", "column", "focus"].includes(state.layout)
+            ["grid", "flow", "column"].includes(state.layout)
         ) {
             filterToolbar.setLayoutValue(state.layout);
         }
@@ -2416,11 +2456,15 @@ export class PreviewApp extends LitElement {
 
         filterToolbar.addEventListener("layout-changed", () => {
             const next = filterToolbar.getLayoutValue();
+            // User took control of the layout — drop any deferred
+            // focus-restore from the previous session so a late-arriving
+            // `setPreviews` doesn't yank them back into focus mode.
+            pendingFocusRestoreId = null;
             if (next === "focus" && state.layout !== "focus") {
                 // state.layout is now narrowed to "grid"|"flow"|"column"|undefined.
-                previewStore.setState({
-                    previousLayout: state.layout ?? "grid",
-                });
+                const prev = state.layout ?? "grid";
+                previewStore.setState({ previousLayout: prev });
+                state.previousLayout = prev;
             }
             state.layout = next;
             vscode.setState(state);
@@ -2618,6 +2662,18 @@ export class PreviewApp extends LitElement {
             applyRelativeSizing,
             applyFilters,
             applyLayout,
+            applyPendingFocusRestore: () => {
+                if (!pendingFocusRestoreId) return;
+                const target = pendingFocusRestoreId;
+                // One-shot — clear before acting so a focusOnCard call
+                // that re-runs applyLayout (and therefore setPreviews
+                // handlers, in pathological re-entrancy) doesn't loop.
+                pendingFocusRestoreId = null;
+                const card = grid
+                    .getVisibleCards()
+                    .find((c) => c.dataset.previewId === target);
+                if (card) focusController.focusOnCard(card);
+            },
             applyInteractiveButtonState,
             applyRecordingButtonState,
             saveFilterState,

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -92,6 +92,14 @@ export interface PreviewMessageContext {
     applyRelativeSizing(previews: PreviewInfo[]): void;
     applyFilters(): void;
     applyLayout(): void;
+    /**
+     * One-shot focus restoration triggered by the first `setPreviews`
+     * after a webview boot. If the panel was in focus mode at unload,
+     * the boot defers re-entering focus until this call verifies the
+     * previously focused preview is in the new manifest. No-op after
+     * it's consumed once or when there's no pending focus to restore.
+     */
+    applyPendingFocusRestore(): void;
     applyInteractiveButtonState(): void;
     applyRecordingButtonState(): void;
     saveFilterState(): void;
@@ -338,6 +346,10 @@ function handleSetPreviews(
     ctx.restoreFilterState();
     ctx.applyFilters();
     ctx.applyLayout();
+    // Lazy focus-mode restore — re-enters focus only if the previously
+    // focused preview survived the new manifest. See the deferred-restore
+    // note on `pendingFocusRestoreId` in `main.ts`.
+    ctx.applyPendingFocusRestore();
     // setPreviews can rebuild the focused card from scratch; re-stamp the live
     // badge so the LIVE chip reattaches to the right card(s). Drop any live
     // previewIds that are gone from the new manifest — silent cleanup; the


### PR DESCRIPTION
When the panel was unloaded in focus mode and the webview later rebooted
against a different (or no) active file, the layout snapped into an
empty focus stage with the filter toolbar hidden. Persist the focused
previewId and the prior dropdown layout, then on boot fall back to the
previous layout and only re-enter focus once `setPreviews` confirms the
previously focused preview is in the new manifest. Subsequent user
layout changes drop the pending restore so a late `setPreviews` cannot
yank the panel back into focus.