### PR TITLE
fix: scroll long/gif preview cards no longer show static base capture

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -846,6 +846,14 @@ abstract class RobolectricRenderTestBase(
                     // [handleLongCapture].
                     val outputFile = job.outputFile
                     outputFile.parentFile?.mkdirs()
+                    // Clean any stale .error.json from this slot before
+                    // attempting a fresh render. Today's success must not
+                    // leave yesterday's failure haunting the panel; today's
+                    // failure must overwrite yesterday's anyway. The
+                    // capture-zero sidecar is already cleaned earlier in
+                    // renderDefault — this covers every other capture and
+                    // every data product.
+                    RenderErrorSidecar.deleteStale(outputFile)
 
                     val scroll = job.scroll
                     val longHandled = scroll != null &&
@@ -930,7 +938,32 @@ abstract class RobolectricRenderTestBase(
                             }
                         }
 
-                    if (!longHandled && !gifHandled && !animationHandled && !focusGifHandled) {
+                    // `handleLongCapture` / `handleGifCapture` returned false
+                    // (e.g. `NoScrollable` — no scrollable on the requested
+                    // axis): for a LONG/GIF *data product* job we must NOT
+                    // fall through to a single `captureRoboImage`. That
+                    // would write PNG bytes into a `.gif`-named file (no
+                    // animation in the panel) or stamp the unscrolled first
+                    // viewport into the long-scroll PNG path (the panel
+                    // would show what looks like the static base capture
+                    // under a "scroll long" / "scroll gif" label).
+                    // Write a structured error sidecar instead so the panel
+                    // surfaces the real failure.
+                    val productFellThrough =
+                        job is ProductRenderJob &&
+                            !longHandled && !gifHandled
+                    if (productFellThrough) {
+                        val modeName = scroll?.mode?.name ?: "?"
+                        val axisName = scroll?.axis?.name ?: "VERTICAL"
+                        RenderErrorSidecar.write(
+                            outputFile,
+                            IllegalStateException(
+                                "@ScrollingPreview($modeName) on '${preview.id}': no scrollable " +
+                                    "composable found on axis $axisName — refusing to write a " +
+                                    "single-frame capture into the data product path."
+                            ),
+                        )
+                    } else if (!longHandled && !gifHandled && !animationHandled && !focusGifHandled) {
                         // TOP mode is the unscrolled initial frame — no
                         // drive, just a capture. END mode drives the first
                         // scrollable on the requested axis to its content
@@ -960,7 +993,8 @@ abstract class RobolectricRenderTestBase(
                     // output, and @FocusedPreview(gif=true) GIF output —
                     // those files' dimensions are the full scrollable
                     // extent / frame size, not the composable's intrinsic box.
-                    if (!longHandled && !gifHandled && !animationHandled && !focusGifHandled &&
+                    if (!productFellThrough &&
+                        !longHandled && !gifHandled && !animationHandled && !focusGifHandled &&
                         (wrapWidth || wrapHeight) && measured != null) {
                         cropPngTopLeft(
                             file = outputFile,

--- a/vscode-extension/src/test/cardMetadata.test.ts
+++ b/vscode-extension/src/test/cardMetadata.test.ts
@@ -199,6 +199,77 @@ describe("refreshCardMetadata", () => {
         assert.strictEqual(merged![1]!.imageData, "BYTES-1");
     });
 
+    it("drops imageData when the renderOutput at an index changes", () => {
+        // Regression for the "scroll gif / scroll long shows the static
+        // base-capture image" symptom. When @ScrollingPreview produces
+        // an image data product, `withDataProductCaptures` drops the
+        // (no-scroll, no-time) base capture and folds the LONG/GIF
+        // product into the captures array. The slot at index 0 shifts
+        // from `renders/<id>.png` (static) to
+        // `data/render-scroll-{long,gif}/<id>.{png,gif}` (data product),
+        // and the old static bytes must NOT carry across to the new
+        // slot.
+        const p0 = preview("preview:1", {
+            captures: [capture("renders/X.png", "")],
+        });
+        const card = buildCard(p0);
+        setCardCaptures("preview:1", [
+            {
+                renderOutput: "renders/X.png",
+                label: "",
+                imageData: "STATIC-BYTES",
+                errorMessage: null,
+                renderError: null,
+            },
+        ]);
+
+        const p1 = preview("preview:1", {
+            captures: [capture("data/render-scroll-long/X.png", "scroll long")],
+        });
+        const { config } = buildConfig();
+        refreshCardMetadata(card, p1, config);
+
+        const merged = previewStore.getState().cardCaptures.get("preview:1");
+        assert.ok(merged);
+        assert.strictEqual(merged!.length, 1);
+        assert.strictEqual(
+            merged![0]!.renderOutput,
+            "data/render-scroll-long/X.png",
+        );
+        assert.strictEqual(merged![0]!.label, "scroll long");
+        // The wrong-slot static bytes must NOT carry into the LONG slot.
+        assert.strictEqual(merged![0]!.imageData, null);
+    });
+
+    it("drops carry-over errorMessage when renderOutput at an index changes", () => {
+        // Companion to the imageData case above: a prior error left
+        // against the static slot must not bleed into the data product
+        // slot when the captures array shifts shape.
+        const p0 = preview("preview:1", {
+            captures: [capture("renders/X.png", "")],
+        });
+        const card = buildCard(p0);
+        setCardCaptures("preview:1", [
+            {
+                renderOutput: "renders/X.png",
+                label: "",
+                imageData: null,
+                errorMessage: "Render failed",
+                renderError: null,
+            },
+        ]);
+
+        const p1 = preview("preview:1", {
+            captures: [capture("data/render-scroll-gif/X.gif", "scroll gif")],
+        });
+        const { config } = buildConfig();
+        refreshCardMetadata(card, p1, config);
+
+        const merged = previewStore.getState().cardCaptures.get("preview:1");
+        assert.ok(merged);
+        assert.strictEqual(merged![0]!.errorMessage, null);
+    });
+
     it("clamps dataset.currentIndex when the new capture count is shorter", () => {
         const p0 = preview("preview:1", {
             captures: [capture("a.png"), capture("b.png"), capture("c.png")],

--- a/vscode-extension/src/webview/preview/cardMetadata.ts
+++ b/vscode-extension/src/webview/preview/cardMetadata.ts
@@ -70,26 +70,34 @@ export function refreshCardMetadata(
             p.functionName + (p.params.name ? " — " + p.params.name : "");
         title.title = buildTooltip(p);
     }
-    // Refresh capture labels in place. If the capture count changed
-    // (e.g. user edited @RoboComposePreviewOptions) we preserve
-    // already-received imageData for renderOutputs that carry over.
+    // Refresh capture labels in place. Preserve already-received
+    // imageData / errorMessage only when the slot at this index addresses
+    // the same renderOutput as before — otherwise we'd paint the previous
+    // capture's bytes into a different file's slot. That's how a static
+    // base capture's PNG bytes ended up showing under a "scroll long" /
+    // "scroll gif" label when @ScrollingPreview data products fold in
+    // (the static capture is dropped from the array, the LONG/GIF slot
+    // shifts down to index 0, and the cached static bytes get carried
+    // across to the wrong slot). When the renderOutput changes we reset
+    // to null-image and let the next render's updateImage fill it in.
     const newCaps = p.captures.map((c) => ({
         renderOutput: c.renderOutput,
         label: c.label || "",
     }));
     const prior = previewStore.getState().cardCaptures.get(p.id) ?? [];
-    // Match by index rather than renderOutput since filenames may
-    // legitimately change (e.g. a preview gains a @RoboComposePreviewOptions
-    // annotation). Mismatched positions just reset to null-image.
-    const mergedCaps = newCaps.map(
-        (nc, i): CapturePresentation => ({
+    const mergedCaps = newCaps.map((nc, i): CapturePresentation => {
+        const carry =
+            prior[i] && prior[i].renderOutput === nc.renderOutput
+                ? prior[i]
+                : null;
+        return {
             label: nc.label,
             renderOutput: nc.renderOutput || "",
-            imageData: prior[i]?.imageData ?? null,
-            errorMessage: prior[i]?.errorMessage ?? null,
-            renderError: prior[i]?.renderError ?? null,
-        }),
-    );
+            imageData: carry?.imageData ?? null,
+            errorMessage: carry?.errorMessage ?? null,
+            renderError: carry?.renderError ?? null,
+        };
+    });
     setCardCaptures(p.id, mergedCaps);
     const curIdx = parseInt(card.dataset.currentIndex || "0", 10);
     if (curIdx >= mergedCaps.length) {


### PR DESCRIPTION
Two independent bugs collaborated to surface the unscrolled top frame
under "1 / 1 · scroll long" / "1 / 1 · scroll gif" labels in the VS Code
panel:

- Renderer: when handleLongCapture / handleGifCapture returned false
  (e.g. NoScrollable — no scrollable on the requested axis), the caller
  fell through to a single captureRoboImage into the data-product
  output path. That stamped PNG bytes into a `.gif`-named file (panel
  can't animate) or a single-viewport PNG into the long-scroll PNG
  path (panel shows what looks like the static capture under a "scroll
  long" label). Product jobs that fall through now write an error
  sidecar instead, so the panel surfaces the real failure rather than
  silently displaying a misleading image. Also clear any stale
  .error.json next to every per-job output (not just capture-zero)
  before re-rendering.

- Panel cache: refreshCardMetadata carried imageData over by raw index.
  When `withDataProductCaptures` dropped the static base capture and
  folded a LONG/GIF data product into the array, the slot at index 0
  shifted from `renders/<id>.png` to
  `data/render-scroll-{long,gif}/<id>.{png,gif}`, but the previously
  cached static bytes carried across. Gate the carry-over on
  renderOutput matching the prior slot; on mismatch reset to
  null-image and let the next updateImage fill it in.