### PR TITLE
fix(gradle-plugin): harden renderPreviews against missing android.jar (#1243)

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.plugin
 
+import java.io.File
+import java.util.zip.ZipFile
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
@@ -48,6 +50,7 @@ internal object AndroidPreviewClasspath {
   fun buildTestClasspath(
     project: Project,
     bootClasspath: Provider<List<RegularFile>>,
+    bootClasspathFallback: Provider<List<File>>,
     rendererConfig: Configuration,
     rendererClassDirs: FileCollection,
     sourceClassDirs: FileCollection,
@@ -100,9 +103,102 @@ internal object AndroidPreviewClasspath {
       // shadows applied). The outer stub does NOT shadow the sandboxed PixelCopy.
       //
       // Sourced from AGP's SdkComponents so we don't have to parse local.properties
-      // or read rootProject.file(...).
+      // or read rootProject.file(...). When AGP's bootClasspath resolves empty (rare
+      // — e.g. compileSdk left at its DSL default on a freshly-applied AGP variant,
+      // or a module type that doesn't bind sdkComponents), the fallback derived from
+      // `local.properties` / `ANDROID_HOME` rescues the load. See issue #1243 — when
+      // neither path supplies android.jar, Robolectric's own `Config.<clinit>` fails
+      // with `NoClassDefFoundError: android/app/Application` before the test runs.
       from(project.files(bootClasspath))
+      from(project.files(bootClasspathFallback))
     }
+
+  /**
+   * Lazy fallback for `android.jar`, used when AGP's `sdkComponents.bootClasspath` provider returns
+   * an empty list (issue #1243). Reads `sdk.dir` from `local.properties` first, falls back to the
+   * `ANDROID_HOME` / `ANDROID_SDK_ROOT` env vars, then picks the highest-versioned `platforms/
+   * android-N/android.jar` under that SDK root. Any version is acceptable for outer-classpath
+   * resolution of `android.app.Application` — Robolectric still drives the in-sandbox framework
+   * from its own `android-all` artifact, gated by `sdk=…` in the generated
+   * `robolectric.properties`.
+   *
+   * Returns an empty list when no SDK can be located on disk; in that case
+   * [validateApplicationOnClasspath] surfaces a clear error before the test JVM forks.
+   */
+  fun buildBootClasspathFallback(project: Project): Provider<List<File>> {
+    val localProperties =
+      project.rootProject.layout.projectDirectory.file("local.properties").asFile
+    val androidHomeEnv = project.providers.environmentVariable("ANDROID_HOME")
+    val androidSdkRootEnv = project.providers.environmentVariable("ANDROID_SDK_ROOT")
+    return project.providers.provider {
+      val sdkDir =
+        sdkDirFromLocalProperties(localProperties)
+          ?: androidHomeEnv.orNull?.takeIf { it.isNotBlank() }
+          ?: androidSdkRootEnv.orNull?.takeIf { it.isNotBlank() }
+          ?: return@provider emptyList<File>()
+      val androidJar = highestPlatformAndroidJar(File(sdkDir))
+      if (androidJar != null && androidJar.isFile) listOf(androidJar) else emptyList()
+    }
+  }
+
+  /**
+   * Throws a Gradle-friendly `IllegalStateException` describing how to fix the situation when the
+   * resolved test classpath has no entry that defines `android/app/Application.class`. Intended for
+   * a `doFirst {}` on the `renderPreviews` `Test` task so the user sees a precise error rather than
+   * the `NoClassDefFoundError` in Robolectric's `Config.<clinit>` (issue #1243).
+   */
+  fun validateApplicationOnClasspath(classpath: Iterable<File>) {
+    val scanned = classpath.filter { it.isFile && it.name.endsWith(".jar") }
+    val found = scanned.any { jar -> jarContainsEntry(jar, "android/app/Application.class") }
+    if (found) return
+    val sample = scanned.take(10).joinToString("\n") { " - ${it.absolutePath}" }
+    val more = if (scanned.size > 10) "\n - (+${scanned.size - 10} more)" else ""
+    throw IllegalStateException(
+      """
+        |compose-preview: android.jar is not on the renderPreviews test classpath, so
+        |Robolectric's Config.<clinit> will fail with NoClassDefFoundError: android/app/Application
+        |before any preview renders. (issue #1243)
+        |
+        |Common causes:
+        | * `compileSdk` is unset in the module's `android { }` block (AGP's sdkComponents
+        |   .bootClasspath then resolves empty).
+        | * `sdk.dir` is missing from `local.properties` AND `ANDROID_HOME` / `ANDROID_SDK_ROOT`
+        |   are unset, so the plugin's fallback couldn't locate the SDK either.
+        | * No `platforms/android-*/android.jar` is installed at the resolved SDK root.
+        |
+        |Classpath JARs scanned (none contained android/app/Application.class):
+        |$sample$more
+        """
+        .trimMargin()
+    )
+  }
+
+  private fun sdkDirFromLocalProperties(localProperties: File): String? {
+    if (!localProperties.isFile) return null
+    return runCatching {
+        val props = java.util.Properties()
+        localProperties.inputStream().use { props.load(it) }
+        props.getProperty("sdk.dir")?.takeIf { it.isNotBlank() }
+      }
+      .getOrNull()
+  }
+
+  private fun highestPlatformAndroidJar(sdkRoot: File): File? {
+    val platforms = File(sdkRoot, "platforms")
+    if (!platforms.isDirectory) return null
+    return platforms
+      .listFiles { f -> f.isDirectory && f.name.startsWith("android-") }
+      .orEmpty()
+      .mapNotNull { dir ->
+        val jar = File(dir, "android.jar")
+        if (jar.isFile) dir.name.removePrefix("android-").toIntOrNull()?.let { it to jar } else null
+      }
+      .maxByOrNull { it.first }
+      ?.second
+  }
+
+  private fun jarContainsEntry(jar: File, entryPath: String): Boolean =
+    runCatching { ZipFile(jar).use { it.getEntry(entryPath) != null } }.getOrDefault(false)
 
   /**
    * Static JVM open flags that the renderPreviews test JVM needs. Pure data — no Gradle DSL

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1105,10 +1105,12 @@ internal object AndroidPreviewSupport {
     // classes / classpath additions are still composed in the Test lambda below
     // (they need `findByName("test${capVariant}UnitTest")` which only resolves
     // late).
+    val bootClasspathFallback = AndroidPreviewClasspath.buildBootClasspathFallback(project)
     val resolvedClasspath =
       AndroidPreviewClasspath.buildTestClasspath(
         project = project,
         bootClasspath = bootClasspath,
+        bootClasspathFallback = bootClasspathFallback,
         rendererConfig = rendererConfig,
         rendererClassDirs = rendererClassDirs,
         sourceClassDirs = sourceClassDirs,
@@ -1314,6 +1316,15 @@ internal object AndroidPreviewSupport {
         // dataProducts.
         outputs.dir(dataProductsDirectory).withPropertyName("dataProductsDir")
 
+        // Fail fast with a clear, fixable error if android.jar isn't actually
+        // on the resolved classpath — otherwise the user sees Robolectric's
+        // own `Config.<clinit>` -> `NoClassDefFoundError: android/app/Application`
+        // (issue #1243), which doesn't hint at the root cause (missing
+        // compileSdk / unresolved SDK location). doFirst runs in the Gradle
+        // process at task-execution time, so `classpath.files` is fully
+        // resolved by the time we inspect it.
+        doFirst { AndroidPreviewClasspath.validateApplicationOnClasspath(classpath.files) }
+
         dependsOn(discoverTask)
         dependsOn(generateRobolectricPropertiesTask)
         if (useLocalRenderer) {
@@ -1385,6 +1396,11 @@ internal object AndroidPreviewSupport {
         systemProperty("composeai.resources.outputDir", resourcesRendersOutputDir.get())
 
         outputs.dir(resourcesRendersSubtree).withPropertyName("resourcesRendersDir")
+
+        // Same #1243 guard as renderPreviews above — the resource render task
+        // boots Robolectric through the identical classpath and hits the same
+        // `Config.<clinit>` -> `Application.class` resolution at runner init.
+        doFirst { AndroidPreviewClasspath.validateApplicationOnClasspath(classpath.files) }
 
         dependsOn("discoverAndroidResources")
         dependsOn(generateRobolectricPropertiesTask)

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspathTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspathTest.kt
@@ -1,0 +1,107 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the issue #1243 guards on the renderer test classpath:
+ * * `buildBootClasspathFallback` recovers `android.jar` from `local.properties` / `ANDROID_HOME`
+ *   when AGP's `sdkComponents.bootClasspath` is empty.
+ * * `validateApplicationOnClasspath` surfaces a precise error when no entry on the resolved
+ *   classpath defines `android/app/Application.class`, replacing the opaque Robolectric
+ *   `Config.<clinit>` `NoClassDefFoundError` the user otherwise sees.
+ */
+class AndroidPreviewClasspathTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  @Test
+  fun `fallback reads sdk dir from local properties and returns highest platform android jar`() {
+    val sdkRoot = tmp.newFolder("sdk")
+    writeAndroidJar(File(sdkRoot, "platforms/android-30/android.jar"))
+    writeAndroidJar(File(sdkRoot, "platforms/android-35/android.jar"))
+    writeAndroidJar(File(sdkRoot, "platforms/android-33/android.jar"))
+
+    val rootDir = tmp.newFolder("project")
+    File(rootDir, "local.properties").writeText("sdk.dir=${sdkRoot.absolutePath}\n")
+    val project = ProjectBuilder.builder().withProjectDir(rootDir).build()
+
+    val resolved = AndroidPreviewClasspath.buildBootClasspathFallback(project).get()
+
+    assertThat(resolved.map { it.absolutePath })
+      .containsExactly(File(sdkRoot, "platforms/android-35/android.jar").absolutePath)
+  }
+
+  @Test
+  fun `fallback returns empty when no sdk location is configured`() {
+    val rootDir = tmp.newFolder("project-no-sdk")
+    val project = ProjectBuilder.builder().withProjectDir(rootDir).build()
+
+    // No local.properties, and we can't set env vars from a unit test — relying on the test
+    // process's ANDROID_HOME not pointing at a valid platforms tree. This is true for the
+    // gradle-plugin test JVM in this repo (uses JDK toolchain, no Android SDK env).
+    val resolved = AndroidPreviewClasspath.buildBootClasspathFallback(project).get()
+
+    // Either truly empty, or — on hosts where ANDROID_HOME points at a real SDK — a single jar.
+    // Asserting the type/shape (not the exact value) keeps the test stable on developer machines
+    // and CI alike. The exact-local-properties path is asserted by the previous test.
+    resolved.forEach {
+      assertThat(it.name).isEqualTo("android.jar")
+      assertThat(it.isFile).isTrue()
+    }
+  }
+
+  @Test
+  fun `validate throws when no jar on classpath defines android Application`() {
+    val noisy = tmp.newFile("noise.jar")
+    writeJar(noisy, mapOf("some/other/Class.class" to ByteArray(8)))
+
+    val thrown =
+      runCatching { AndroidPreviewClasspath.validateApplicationOnClasspath(listOf(noisy)) }
+        .exceptionOrNull()
+
+    assertThat(thrown).isInstanceOf(IllegalStateException::class.java)
+    assertThat(thrown!!.message).contains("issue #1243")
+    assertThat(thrown.message).contains("android.jar is not on the renderPreviews test classpath")
+    assertThat(thrown.message).contains("compileSdk")
+  }
+
+  @Test
+  fun `validate succeeds when a classpath jar carries android Application`() {
+    val androidJar = tmp.newFile("android.jar")
+    writeAndroidJar(androidJar)
+
+    AndroidPreviewClasspath.validateApplicationOnClasspath(listOf(androidJar))
+  }
+
+  @Test
+  fun `validate ignores directories and non-jar files`() {
+    val dir = tmp.newFolder("classes")
+    val notAJar = tmp.newFile("notes.txt").apply { writeText("ignore me") }
+    val androidJar = tmp.newFile("android.jar")
+    writeAndroidJar(androidJar)
+
+    AndroidPreviewClasspath.validateApplicationOnClasspath(listOf(dir, notAJar, androidJar))
+  }
+
+  private fun writeAndroidJar(file: File) {
+    writeJar(file, mapOf("android/app/Application.class" to ByteArray(16)))
+  }
+
+  private fun writeJar(file: File, entries: Map<String, ByteArray>) {
+    file.parentFile?.mkdirs()
+    JarOutputStream(file.outputStream()).use { out ->
+      for ((path, bytes) in entries) {
+        out.putNextEntry(JarEntry(path))
+        out.write(bytes)
+        out.closeEntry()
+      }
+    }
+  }
+}


### PR DESCRIPTION
Robolectric's own `Config.<clinit>` references `Application.class` and
fails with `NoClassDefFoundError: android/app/Application` when the
renderer test JVM's outer classpath has no `android.jar` — observed in
Material 3 samples where AGP's `sdkComponents.bootClasspath` resolved
empty. The user-visible failure is opaque: an `initializationError` on
`RobolectricRenderTest` before any preview runs, with no hint at the
root cause.

Two-layer defence:

1. `AndroidPreviewClasspath.buildBootClasspathFallback` derives
   `android.jar` from `local.properties` (`sdk.dir`) or
   `ANDROID_HOME` / `ANDROID_SDK_ROOT` when AGP's bootClasspath
   provider returns nothing, picking the highest installed
   `platforms/android-*/android.jar`. Added to the renderer test
   classpath alongside the AGP-supplied value — harmless duplicate
   on the common path, recovery on the edge case.

2. `renderPreviews` and `renderAndroidResources` now `doFirst {}`
   validate that the resolved classpath actually contains a JAR
   that defines `android/app/Application.class`. When neither path
   supplied one, the user sees a precise error pointing at the
   likely fixes (set `compileSdk`, populate `local.properties`,
   install a platforms-N package) instead of Robolectric's
   `Config.<clinit>` stack.