### PR TITLE
fix(daemon): use className= in ShadowAmbientLifecycleObserver @Implements

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
@@ -87,18 +87,23 @@ class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(testClas
   }
 
   /**
-   * Conditionally registers [ShadowAmbientLifecycleObserver]. The shadow's
-   * `@Implements(AmbientLifecycleObserver::class)` value forces Robolectric's
-   * [org.robolectric.internal.bytecode.ShadowMap.obtainShadowInfo] to resolve
-   * `androidx.wear.ambient.AmbientLifecycleObserver` via reflection during sandbox bootstrap; on
-   * non-Wear consumers (e.g. `:samples:android`, plain Android apps) that class isn't on the
-   * runtime classpath and the resolution throws `TypeNotPresentException`, killing the daemon
-   * before any render runs (issue: PR #891 regression hit by run-agent-audit-samples.py).
+   * Conditionally registers [ShadowAmbientLifecycleObserver].
    *
-   * Returning the shadow only when wear-ambient is loadable keeps the existing wear path intact
-   * while leaving non-wear consumers untouched. The same gate is mirrored on the engine side in
-   * [ee.schimke.composeai.daemon.RobolectricHost] for `AmbientPreviewOverrideExtension` /
-   * `AmbientInputDispatchObserver` instantiation.
+   * Two interlocking precautions keep non-Wear consumers safe (issue #1244, PR #891 regression hit
+   * by `run-agent-audit-samples.py`):
+   * 1. **The shadow uses `@Implements(className = …)` instead of the `value = …` class-literal
+   *    form**, so Robolectric's [org.robolectric.internal.bytecode.ShadowMap.obtainShadowInfo]
+   *    reads the FQN as a `String` rather than dereferencing a deferred `Class<?>` proxy that the
+   *    JVM annotation parser would resolve via the shadow's defining loader. That deferred
+   *    resolution was the path that threw `TypeNotPresentException` mid-sandbox-bootstrap on Wear
+   *    sample classpaths shipping the shadow next to a stale/mismatched wear AAR.
+   * 2. **This gate still hides the shadow when wear-ambient isn't loadable**, so the shadow class
+   *    — which references `AmbientLifecycleObserver` in field and method-parameter types — is
+   *    only ever returned to Robolectric on classpaths where its symbolic links can be resolved.
+   *
+   * The same gate is mirrored on the engine side in [ee.schimke.composeai.daemon.RobolectricHost]
+   * for `AmbientPreviewOverrideExtension` / `AmbientInputDispatchObserver` instantiation —
+   * those concrete classes call into `AmbientStateController` which directly imports wear API.
    */
   override fun getExtraShadows(method: FrameworkMethod): Array<Class<*>> =
     if (isWearAmbientAvailable(javaClass.classLoader)) {

--- a/data/ambient/connector/src/main/kotlin/ee/schimke/composeai/daemon/ShadowAmbientLifecycleObserver.kt
+++ b/data/ambient/connector/src/main/kotlin/ee/schimke/composeai/daemon/ShadowAmbientLifecycleObserver.kt
@@ -24,8 +24,22 @@ import org.robolectric.annotation.RealObject
  * (`onCreate` / `onResume` / `onPause` / `onDestroy`) are no-ops — the controller drives the
  * ambient transitions directly, and the AOSP impl's lifecycle plumbing (which would have
  * registered with `WearableActivityController`) is intentionally bypassed.
+ *
+ * **Issue #1244 — `@Implements(className = …)` instead of `@Implements(value = …)`.** Robolectric's
+ * `ShadowMap.obtainShadowInfo` reads the shadow's `@Implements` annotation via
+ * `clazz.getAnnotation(Implements.class)`, then queries `className()` first and only dereferences
+ * `value()` when `className()` is empty. The class-literal form (`AmbientLifecycleObserver::class`)
+ * stores a deferred `Class<?>` ref in the annotation proxy; calling `.value()` forces the JVM's
+ * `AnnotationInvocationHandler` to resolve `androidx.wear.ambient.AmbientLifecycleObserver`
+ * against the shadow class's defining loader. On Wear-sample daemon classpaths that ship the
+ * shadow but mismatched-runtime-or-stale wear AAR coordinates this throws
+ * `TypeNotPresentException` mid-sandbox-bootstrap — which the `getExtraShadows` gate in
+ * `SandboxHoldingRunner` can't intercept because the failure is deep inside Robolectric's
+ * iteration loop. Using the FQN string keeps the annotation parseable on any classpath; the
+ * shadow itself is only ever loaded when the wear AAR is present (the
+ * [SandboxHoldingRunner.getExtraShadows] gate is preserved as defence in depth).
  */
-@Implements(AmbientLifecycleObserver::class)
+@Implements(className = "androidx.wear.ambient.AmbientLifecycleObserver")
 class ShadowAmbientLifecycleObserver {
 
   @RealObject @Suppress("unused") private lateinit var realObserver: AmbientLifecycleObserver

--- a/data/ambient/connector/src/test/kotlin/ee/schimke/composeai/daemon/ShadowAmbientLifecycleObserverAnnotationTest.kt
+++ b/data/ambient/connector/src/test/kotlin/ee/schimke/composeai/daemon/ShadowAmbientLifecycleObserverAnnotationTest.kt
@@ -1,0 +1,47 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.robolectric.annotation.Implements
+
+/**
+ * Pins the `@Implements` annotation form on [ShadowAmbientLifecycleObserver] (issue #1244).
+ *
+ * The shadow must declare `@Implements(className = "androidx.wear.ambient.AmbientLifecycleObserver")`
+ * rather than `@Implements(value = AmbientLifecycleObserver::class)`. Robolectric's
+ * `ShadowMap.obtainShadowInfo` reads `className()` first and only falls back to `value().getName()`
+ * when `className` is empty; the class-literal form stores a deferred `Class<?>` reference in the
+ * annotation proxy, and calling `.value()` forces the JVM's `AnnotationInvocationHandler` to
+ * resolve `androidx.wear.ambient.AmbientLifecycleObserver` against the shadow's defining loader.
+ * On daemon classpaths that ship the shadow next to a mismatched / stale wear AAR (the bug report
+ * in issue #1244 surfaced this against the wear sample) that resolution throws
+ * `TypeNotPresentException` deep inside Robolectric's `createClassLoaderConfig` loop — before
+ * `SandboxHoldingRunner.getExtraShadows`'s gate has a chance to intercept the next sandbox.
+ *
+ * Touching `value()` here makes the regression noisy: if anyone reverts the annotation to the
+ * class-literal form, the deferred proxy resolution kicks in inside this test instead of mid-render
+ * in a daemon's stderr.
+ */
+class ShadowAmbientLifecycleObserverAnnotationTest {
+
+  @Test
+  fun `shadow declares className not value`() {
+    val annotation =
+      ShadowAmbientLifecycleObserver::class.java.getAnnotation(Implements::class.java)
+    assertNotNull("ShadowAmbientLifecycleObserver must carry @Implements", annotation)
+    assertEquals(
+      "ShadowAmbientLifecycleObserver must target AmbientLifecycleObserver by className",
+      "androidx.wear.ambient.AmbientLifecycleObserver",
+      annotation!!.className,
+    )
+    // `value()` must default to `void.class` so the annotation proxy never has to resolve a
+    // deferred Class<?> reference. If the class-literal form sneaks back in, this line throws
+    // `TypeNotPresentException` on any loader without the wear AAR.
+    assertEquals(
+      "@Implements.value() must default to void.class so no deferred class resolution runs",
+      Void.TYPE,
+      annotation.value.java,
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- Switch the Wear ambient Robolectric shadow from `@Implements(AmbientLifecycleObserver::class)` to `@Implements(className = "androidx.wear.ambient.AmbientLifecycleObserver")` so Robolectric's `ShadowMap.obtainShadowInfo` never has to dereference the annotation's deferred `Class<?>` proxy during sandbox bootstrap.
- Keep `SandboxHoldingRunner.getExtraShadows`'s wear-ambient gate as defence in depth — the shadow class still has `AmbientLifecycleObserver` types in its field/parameter signatures, so the gate keeps it off Robolectric's iteration when the wear AAR isn't loadable.
- Add a regression test (`ShadowAmbientLifecycleObserverAnnotationTest`) that pins the annotation contract: `className` must be the FQN and `value` must default to `Void.TYPE`. If anyone reverts to the class-literal form, the test fails noisily instead of the regression resurfacing in a daemon's stderr mid-render.

## Why

Robolectric reads `className()` first and only falls back to `value().getName()` when `className` is empty. The class-literal form (`AmbientLifecycleObserver::class`) stores a deferred `Class<?>` ref in the annotation proxy, and `.value()` forces the JVM's `AnnotationInvocationHandler` to resolve `androidx.wear.ambient.AmbientLifecycleObserver` against the shadow's defining loader. On Wear-sample daemon classpaths the resolution can throw `TypeNotPresentException` deep inside Robolectric's `createClassLoaderConfig` iteration — before `getExtraShadows`'s gate has a chance to skip the next sandbox (the throw lands inside the loop body, not at the gate). The FQN string form keeps the annotation parseable on any classpath.

Fixes #1244.

## Test plan

- [x] `./gradlew :data-ambient-connector:testDebugUnitTest` — new `ShadowAmbientLifecycleObserverAnnotationTest` + existing `AmbientStateControllerTest` / `AmbientDataProductTest` pass.
- [x] `./gradlew :daemon:android:testDebugUnitTest --tests "ee.schimke.composeai.daemon.AmbientClasspathDetectionTest"` — pre-existing classpath-detection regression test still passes.
- [x] `./gradlew :samples:wear:renderAllPreviews` — wear sample still renders all 21 previews.
- [x] `./gradlew :data-ambient-connector:ktfmtCheck :daemon:android:ktfmtCheck` — formatter clean.
- [x] Spawn the daemon for `:samples:wear` and `:samples:android` directly — both bootstrap all 5 sandboxes without hitting the `TypeNotPresentException` path; wear sample sees the shadow registered, plain-android sample sees the gate skip it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXrWaMmJdqymS6zQG3dGnk)_