### PR TITLE
feat: add notification preview support

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -199,14 +199,18 @@ class RenderEngine(
     val themeFallbackCapture = MaterialThemeFallbackCapture()
 
     val isTile = spec.kind.equals(TILE_KIND, ignoreCase = true)
+    val isNotification = spec.kind.equals(NOTIFICATION_KIND, ignoreCase = true)
+    val nonComposable = isTile || isNotification
     val clazz = trace.section("classloader:loadPreviewClass") { Class.forName(spec.className, true, classLoader) }
-    // Tile previews are non-composable top-level functions returning
-    // `TilePreviewData`; routing them through `getDeclaredComposableMethod` would throw
-    // `NoSuchMethodException` (the Compose-method lookup expects `(Composer, Int, …)` trailing
-    // params). The tile path skips composable resolution entirely and paints the inflated tile
-    // View through [renderer.TilePreviewComposable] in the setContent body below.
+    // Tile / notification previews are non-composable top-level functions returning
+    // `TilePreviewData` / `android.app.Notification`; routing them through
+    // `getDeclaredComposableMethod` would throw `NoSuchMethodException` (the Compose-method
+    // lookup expects `(Composer, Int, …)` trailing params). The non-composable paths skip
+    // composable resolution entirely and paint the inflated View through
+    // [renderer.TilePreviewComposable] / [renderer.NotificationPreviewComposable] in the
+    // setContent body below.
     val composableMethod: ComposableMethod? =
-      if (isTile) null
+      if (nonComposable) null
       else trace.section("compose:resolveComposable") { clazz.getDeclaredComposableMethod(spec.functionName) }
 
     // Self-diagnostic — surfaces in the VS Code extension's output channel as `[daemon stderr] …`.
@@ -328,6 +332,16 @@ class RenderEngine(
                             // `findTilePreviewMethod` would `Class.forName` against the parent
                             // loader and either miss user classes (under isolation) or render
                             // stale bytecode after an edit.
+                            classLoader = classLoader,
+                          )
+                        } else if (isNotification) {
+                          // Non-composable `@NotificationPreview` — mirrors the standalone
+                          // renderer's `NotificationPreviewStrategy`. The inflated RemoteViews
+                          // lands inside the `Box` via `AndroidView`, same Compose-tree shape as
+                          // the tile path so captureRoboImage downstream is unchanged.
+                          ee.schimke.composeai.renderer.NotificationPreviewComposable(
+                            className = spec.className,
+                            functionName = spec.functionName,
                             classLoader = classLoader,
                           )
                         } else {
@@ -790,6 +804,13 @@ class RenderEngine(
      * unchanged through the daemon's render path.
      */
     const val TILE_KIND: String = "TILE"
+
+    /**
+     * `RenderSpec.kind` value flagging a notification preview (non-composable function returning
+     * `android.app.Notification`). Mirrors `ee.schimke.composeai.plugin.PreviewKind.NOTIFICATION`
+     * so a manifest-emitted value round-trips unchanged through the daemon's render path.
+     */
+    const val NOTIFICATION_KIND: String = "NOTIFICATION"
 
     /**
      * Virtual time to advance before capture in the paused-`mainClock` path, in milliseconds.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -72,6 +72,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         "androidx.compose.ui.tooling.preview.Preview",
         "androidx.compose.desktop.ui.tooling.preview.Preview",
         TILE_PREVIEW_FQN,
+        NOTIFICATION_PREVIEW_FQN,
       )
     private val CONTAINER_FQNS =
       setOf(
@@ -105,6 +106,11 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     private const val COMPOSER_FQN = "androidx.compose.runtime.Composer"
 
     internal const val TILE_PREVIEW_FQN = "androidx.wear.tiles.tooling.preview.Preview"
+
+    // Our own opt-in for Android notification previews. Function signature is
+    // `(android.content.Context) -> android.app.Notification`; same FQN-match
+    // policy as the other annotations we own. See `NotificationPreview.kt`.
+    internal const val NOTIFICATION_PREVIEW_FQN = "ee.schimke.composeai.preview.NotificationPreview"
 
     // failOnEmpty diagnostics: cap the JAR + annotation FQN sample sizes
     // so the lifecycle log stays readable on projects with huge classpaths.
@@ -557,8 +563,11 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     // @Preview drove the fan-out.
     val previewParameter = extractPreviewParameter(method)
     val isTilePreview = isAnyTilePreviewAnnotation(annotations, scanResult)
+    val isNotificationPreview = isAnyNotificationPreviewAnnotation(annotations, scanResult)
     val hasUnsupportedParameters =
-      !isTilePreview && hasUnsupportedPreviewParameters(method, previewParameter)
+      !isTilePreview &&
+        !isNotificationPreview &&
+        hasUnsupportedPreviewParameters(method, previewParameter)
     if (hasUnsupportedParameters) {
       logger.warn(
         "composePreview: skipping @Preview '${classInfo.name}.${method.name}' — " +
@@ -651,6 +660,25 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     return false
   }
 
+  /**
+   * Notification previews (`NOTIFICATION_PREVIEW_FQN`) take a single `(Context)` argument supplied
+   * by the renderer at run time — same shape as a `(Context)` tile preview, so
+   * the @PreviewParameter contract that gates Compose previews doesn't apply. Walk direct
+   * annotations + multi-preview meta-annotations so a notification preview reached through a future
+   * multi-preview alias is exempted too.
+   */
+  private fun isAnyNotificationPreviewAnnotation(
+    annotations: List<AnnotationInfo>,
+    scanResult: ScanResult,
+  ): Boolean {
+    if (collectDirectPreviews(annotations).any { it.name == NOTIFICATION_PREVIEW_FQN }) return true
+    for (ann in annotations) {
+      val resolved = resolveMultiPreview(ann, scanResult, mutableSetOf())
+      if (resolved.any { it.name == NOTIFICATION_PREVIEW_FQN }) return true
+    }
+    return false
+  }
+
   private fun hasUnsupportedPreviewParameters(
     method: MethodInfo,
     previewParameter: Pair<String, Int>?,
@@ -724,21 +752,25 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     timings: List<Long>,
   ): PreviewOutputPlan {
     val isTile = ann.name == TILE_PREVIEW_FQN
-    val effectiveTimings = if (isTile) emptyList() else timings
-    val effectiveScrolls = if (isTile) emptyList() else scrolls
-    // Tile previews don't go through `mainClock` either — `TileRenderer`
-    // inflates a static View and there's no animation surface to drive.
-    val effectiveAnimation = if (isTile) null else animation
-    // `@FocusedPreview` only applies to Compose previews (the focus owner
-    // is a Compose construct); tile previews ignore it. `gif = true` swaps
-    // the per-step PNG fan-out for a single GIF capture, so skip the
-    // per-step PNG path entirely when a GIF spec is set.
-    val effectiveFocusGif = if (isTile) null else focusGif
-    val effectiveFocuses = if (isTile || effectiveFocusGif != null) emptyList() else focuses
-    // `@AmbientPreview` is Wear-Compose-only — it drives `LocalAmbientModeManager`. Tile previews
-    // render through `TileRenderer` and never enter the Compose composition where the local lives,
-    // so the override is a no-op there.
-    val effectiveAmbient = if (isTile) null else ambient
+    // Notification previews aren't composable either — no `mainClock`, no scrollables, no focus
+    // owner. Treat them the same as tiles for every dimensional fan-out so the single-capture
+    // path runs unmodified.
+    val isNotification = ann.name == NOTIFICATION_PREVIEW_FQN
+    val nonComposable = isTile || isNotification
+    val effectiveTimings = if (nonComposable) emptyList() else timings
+    val effectiveScrolls = if (nonComposable) emptyList() else scrolls
+    // Tile / notification previews don't go through `mainClock` — there's no animation surface to
+    // drive.
+    val effectiveAnimation = if (nonComposable) null else animation
+    // `@FocusedPreview` only applies to Compose previews (the focus owner is a Compose construct).
+    // `gif = true` swaps the per-step PNG fan-out for a single GIF capture, so skip the per-step
+    // PNG path entirely when a GIF spec is set.
+    val effectiveFocusGif = if (nonComposable) null else focusGif
+    val effectiveFocuses = if (nonComposable || effectiveFocusGif != null) emptyList() else focuses
+    // `@AmbientPreview` is Wear-Compose-only — it drives `LocalAmbientModeManager`. Non-composable
+    // previews render outside the Compose composition where the local lives, so the override is a
+    // no-op there.
+    val effectiveAmbient = if (nonComposable) null else ambient
 
     // @AnimatedPreview and @FocusedPreview(gif = true) both produce a `.gif` output for the
     // function. When one is paired with anything else on the same function — scroll/time
@@ -1211,10 +1243,12 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     val id = fqn + suffix
     val outputPlan =
       buildOutputPlan(ann, id, scrolls, animation, focuses, focusGif, ambient, timings)
-    // Tile previews don't go through @Composable invocations — they return a `TilePreviewData`
-    // and the renderer reflects them directly. Skipping the lazy means the bytecode walk never
-    // runs for tile-only methods.
-    val targets = if (params.kind == PreviewKind.TILE) emptyList() else inferredTargets.value
+    // Tile / notification previews don't go through @Composable invocations — they return a
+    // `TilePreviewData` / `Notification` and the renderer reflects them directly. Skipping the
+    // lazy means the bytecode walk never runs for these methods.
+    val targets =
+      if (params.kind == PreviewKind.TILE || params.kind == PreviewKind.NOTIFICATION) emptyList()
+      else inferredTargets.value
     return PreviewInfo(
       id = id,
       functionName = method.name,
@@ -1284,6 +1318,14 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     wrapperClassName: String?,
     previewParameter: Pair<String, Int>?,
   ): PreviewParams {
+    // `@NotificationPreview` has no parameters, so the rest of this function — which
+    // dereferences `device` / `widthDp` / `fontScale` / etc. from `ann.parameterValues` — would
+    // throw `NoSuchElementException`. Return a minimal params object up-front; the renderer
+    // applies its own default qualifiers when rendering RemoteViews. Width/height parameters
+    // will be added when the variants matrix from #1249 lands.
+    if (ann.name == NOTIFICATION_PREVIEW_FQN) {
+      return PreviewParams(kind = PreviewKind.NOTIFICATION)
+    }
     val pv = ann.parameterValues
     val kind = if (ann.name == TILE_PREVIEW_FQN) PreviewKind.TILE else PreviewKind.COMPOSE
     val device = (pv.getValue("device") as? String)?.ifBlank { null }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -6,11 +6,14 @@ import kotlinx.serialization.Serializable
  * Which @Preview flavour the entry came from. Drives renderer selection — [COMPOSE] previews are
  * `@Composable` functions invoked through the normal Compose machinery; [TILE] previews are plain
  * functions returning `androidx.wear.tiles.tooling.preview.TilePreviewData` that need to be
- * inflated via `androidx.wear.tiles.renderer.TileRenderer`.
+ * inflated via `androidx.wear.tiles.renderer.TileRenderer`; [NOTIFICATION] previews are plain
+ * functions taking a `Context` and returning `android.app.Notification`, inflated via
+ * `Notification.Builder.recoverBuilder` + `RemoteViews.apply` (see issue #1249).
  */
 enum class PreviewKind {
   COMPOSE,
   TILE,
+  NOTIFICATION,
 }
 
 /**

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/NotificationPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/NotificationPreview.kt
@@ -1,0 +1,19 @@
+package ee.schimke.composeai.preview
+
+/**
+ * Marks a function `(android.content.Context) -> android.app.Notification` as a renderable preview
+ * of an Android notification. Discovered by the compose-preview Gradle plugin by FQN — consumers
+ * that want to use the annotation in their own code depend on
+ * `ee.schimke.composeai:preview-annotations`.
+ *
+ * The render path inflates the notification's expanded `bigContentView` (or the standard
+ * `contentView` when no `setStyle(...)` was applied) via [`Notification.Builder.recoverBuilder`]
+ * and draws the resulting `RemoteViews` to a PNG under `renders/`. This is the AOSP visual, not the
+ * Pixel / OEM-skinned visual — OEM chrome (rounded corners, brand tint) is drawn by SystemUI
+ * on-device and isn't reproducible inside Robolectric. See issue #1249 for the design and the
+ * variants matrix planned in follow-up PRs.
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+@MustBeDocumented
+annotation class NotificationPreview

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/NotificationPreviewRenderer.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/NotificationPreviewRenderer.kt
@@ -1,0 +1,137 @@
+package ee.schimke.composeai.renderer
+
+import android.app.Notification
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import java.lang.reflect.Method
+
+/**
+ * Renders a `@NotificationPreview` function — `(Context) -> Notification` — into the surrounding
+ * Compose tree via an [AndroidView] hosting the inflated `RemoteViews`. Mirrors the structure of
+ * [TilePreviewComposable]: reflect the user's function, invoke it, hand the result to a platform
+ * inflater, host the resulting View.
+ *
+ * Inflation path uses `Notification.Builder.recoverBuilder(context, notification)` to get back a
+ * platform builder, then asks it for `createBigContentView()` (expanded heads-up / shade content)
+ * and falls back to `createContentView()` for collapsed-only notifications. This is the AOSP
+ * visual — the SystemUI chrome a Pixel / OEM device draws on top is not reproducible inside
+ * Robolectric. See issue #1249 for the full design.
+ */
+@Composable
+fun NotificationPreviewComposable(
+    className: String,
+    functionName: String,
+    /**
+     * Classloader used to resolve [className]. `null` defers to the caller-thread context
+     * classloader (the standalone renderer path's user classes share the test classpath). Same
+     * shape as [TilePreviewComposable] for the daemon path's per-render child loader.
+     */
+    classLoader: ClassLoader? = null,
+) {
+    val context = LocalContext.current
+    AndroidView(
+        modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+        factory = { ctx ->
+            val parent = FrameLayout(ctx).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                )
+            }
+            renderNotificationInto(context, className, functionName, classLoader, parent)
+            parent
+        },
+    )
+}
+
+private fun renderNotificationInto(
+    context: Context,
+    className: String,
+    functionName: String,
+    classLoader: ClassLoader?,
+    parent: FrameLayout,
+) {
+    val notification = invokeNotificationPreviewFunction(context, className, functionName, classLoader)
+    val view = inflateNotificationView(context, notification, parent)
+        ?: error("NotificationPreview '$functionName' produced no inflatable RemoteViews")
+    parent.addView(
+        view,
+        FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+        ),
+    )
+}
+
+/**
+ * Resolves the user's notification factory and returns its result. Prefers a `(Context)` overload;
+ * the no-arg overload is accepted too for functions that build a notification from a singleton
+ * context (rare, but the symmetry with [TilePreviewComposable] keeps the contract predictable).
+ */
+private fun invokeNotificationPreviewFunction(
+    context: Context,
+    className: String,
+    functionName: String,
+    classLoader: ClassLoader?,
+): Notification {
+    val method = findNotificationPreviewMethod(className, functionName, classLoader)
+    method.isAccessible = true
+    val result = when (method.parameterTypes.size) {
+        0 -> method.invoke(null)
+        1 -> method.invoke(null, context)
+        else -> error(
+            "NotificationPreview '$functionName' has unsupported signature; " +
+                "expected 0 or 1 (Context) parameters, found ${method.parameterTypes.size}",
+        )
+    }
+    return result as? Notification
+        ?: error("NotificationPreview '$functionName' did not return android.app.Notification")
+}
+
+private fun findNotificationPreviewMethod(
+    className: String,
+    functionName: String,
+    classLoader: ClassLoader?,
+): Method {
+    val cls = if (classLoader != null) Class.forName(className, true, classLoader) else Class.forName(className)
+    val candidates = cls.declaredMethods.filter { it.name == functionName }
+    if (candidates.isEmpty()) {
+        error("No method '$functionName' on '$className'")
+    }
+    return candidates.firstOrNull {
+        it.parameterTypes.size == 1 && it.parameterTypes[0] == Context::class.java
+    }
+        ?: candidates.firstOrNull { it.parameterTypes.isEmpty() }
+        ?: error(
+            "NotificationPreview '$functionName' on '$className' has no supported overload " +
+                "(expected no-arg or single Context parameter)",
+        )
+}
+
+/**
+ * Builds the expanded notification View. Tries `createBigContentView()` (the heads-up / expanded
+ * layout used when the notification carries a `setStyle(...)`), falling back to the standard
+ * `createContentView()` for collapsed-only notifications. Returns `null` if neither path
+ * produces a `RemoteViews` — caller treats that as a render error.
+ */
+@Suppress("DEPRECATION")
+private fun inflateNotificationView(
+    context: Context,
+    notification: Notification,
+    parent: ViewGroup,
+): View? {
+    // `createBigContentView` / `createContentView` are marked deprecated for production
+    // posting paths (where the system inflates them for you) but there's no non-deprecated
+    // alternative when you specifically want the RemoteViews tree for offline rendering.
+    val builder = Notification.Builder.recoverBuilder(context, notification)
+    val remoteViews = builder.createBigContentView() ?: builder.createContentView() ?: return null
+    return remoteViews.apply(context, parent)
+}

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -21,6 +21,7 @@ internal interface PreviewRenderStrategy {
 private val STRATEGIES: Map<PreviewKind, PreviewRenderStrategy> = mapOf(
     PreviewKind.COMPOSE to ComposePreviewStrategy,
     PreviewKind.TILE to TilePreviewStrategy,
+    PreviewKind.NOTIFICATION to NotificationPreviewStrategy,
 )
 
 internal fun strategyFor(kind: PreviewKind): PreviewRenderStrategy =
@@ -157,6 +158,21 @@ internal fun resolvePreviewReceiver(clazz: Class<*>): Any? {
         ctor.isAccessible = true
         ctor.newInstance()
     }.getOrNull()
+}
+
+/**
+ * Notifications strategy: invoke the non-composable `(Context) -> Notification` function and
+ * inflate the resulting `RemoteViews` through an `AndroidView`. See
+ * [NotificationPreviewComposable] for the heavy lifting.
+ */
+private object NotificationPreviewStrategy : PreviewRenderStrategy {
+    @Composable
+    override fun Render(preview: RenderPreviewEntry, widthDp: Int, heightDp: Int, previewArgs: List<Any?>) {
+        NotificationPreviewComposable(
+            className = preview.className,
+            functionName = preview.functionName,
+        )
+    }
 }
 
 /**

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 enum class PreviewKind {
     COMPOSE,
     TILE,
+    NOTIFICATION,
 }
 
 /**

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationPreviews.kt
@@ -1,0 +1,50 @@
+package com.example.sampleandroid
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import ee.schimke.composeai.preview.NotificationPreview
+
+private const val CHANNEL_ID = "sample"
+
+private fun ensureChannel(context: Context) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (nm.getNotificationChannel(CHANNEL_ID) == null) {
+            nm.createNotificationChannel(
+                NotificationChannel(CHANNEL_ID, "Sample", NotificationManager.IMPORTANCE_DEFAULT),
+            )
+        }
+    }
+}
+
+@NotificationPreview
+fun simpleNotificationPreview(context: Context): Notification {
+    ensureChannel(context)
+    return NotificationCompat.Builder(context, CHANNEL_ID)
+        .setSmallIcon(android.R.drawable.ic_dialog_info)
+        .setContentTitle("New message")
+        .setContentText("Hello from compose-preview")
+        .build()
+}
+
+@NotificationPreview
+fun bigTextNotificationPreview(context: Context): Notification {
+    ensureChannel(context)
+    return NotificationCompat.Builder(context, CHANNEL_ID)
+        .setSmallIcon(android.R.drawable.ic_dialog_email)
+        .setContentTitle("Long-form update")
+        .setContentText("Tap to read")
+        .setStyle(
+            NotificationCompat.BigTextStyle()
+                .bigText(
+                    "Notification previews now render through the same Robolectric pipeline " +
+                        "Compose @Preview uses. This is the BigTextStyle variant — the expanded " +
+                        "shade layout, drawn at AOSP fidelity (no Pixel / OEM chrome).",
+                ),
+        )
+        .build()
+}


### PR DESCRIPTION
Add support for rendering Android notification previews through the compose-preview pipeline, enabling developers to preview notifications at AOSP fidelity without device chrome.

## Summary

This change introduces a new `@NotificationPreview` annotation and rendering infrastructure that allows developers to preview `(Context) -> Notification` functions. Notifications are rendered by inflating their `RemoteViews` through Robolectric, producing AOSP-standard visuals (without OEM-specific chrome like rounded corners or brand tints).

## Key Changes

- **New annotation**: `@NotificationPreview` in `preview-annotations` module marks notification preview functions
- **Gradle plugin discovery**: Extended `DiscoverPreviewsTask` to recognize `@NotificationPreview` annotations and treat them as non-composable previews (like tiles)
  - Notification previews skip parameter validation, animation/scroll/focus/ambient overrides, and bytecode target inference
  - Added `isAnyNotificationPreviewAnnotation()` to handle direct and multi-preview meta-annotations
- **Renderer implementation**: New `NotificationPreviewComposable` in `renderer-android` that:
  - Reflects and invokes the user's notification factory function (supporting both `(Context)` and no-arg signatures)
  - Uses `Notification.Builder.recoverBuilder()` to extract the notification's `RemoteViews`
  - Prefers expanded `bigContentView` (for styled notifications) with fallback to `contentView`
  - Hosts the inflated view in an `AndroidView` within the Compose tree
- **Strategy registration**: Added `NotificationPreviewStrategy` to the renderer's strategy map
- **Data model**: Added `NOTIFICATION` variant to `PreviewKind` enum
- **Sample previews**: Added `NotificationPreviews.kt` demonstrating simple and `BigTextStyle` notification previews

## Implementation Details

- Notification previews are treated identically to tile previews for dimensional fan-out (single capture, no animation/scroll/focus/ambient overrides)
- The renderer uses reflection to locate and invoke preview functions, matching the pattern used for tile previews
- Deprecated `createBigContentView()` / `createContentView()` APIs are used intentionally — there's no non-deprecated alternative for offline `RemoteViews` rendering
- The AOSP visual produced is the baseline; OEM chrome (Pixel-specific styling) is drawn by SystemUI on-device and cannot be reproduced in Robolectric (see issue #1249)

https://claude.ai/code/session_017q11eXtZk1AyNtKsnYMuLM