### PR TITLE
feat(ci): add SDK compatibility matrix workflow + docs

### DIFF
--- a/.github/workflows/sdk-matrix.yml
+++ b/.github/workflows/sdk-matrix.yml
@@ -1,0 +1,207 @@
+name: SDK Compatibility Matrix
+
+# Nightly sweep over (JDK × compileSdk × targetSdk × minSdk × sdkVersion override) for the
+# synthetic `:samples:sdk-matrix` module. Documents which SDK combinations render cleanly under
+# auto-detection, which need the `composePreview.sdkVersion` override knob, and which are
+# expected-to-fail (e.g. JDK 17 cannot render at Robolectric SDK 36). Drives
+# `docs/SDK_COMPATIBILITY.md`.
+#
+# Matrix scope and filtering rationale (see also docs/SDK_COMPATIBILITY.md):
+# - compileSdk ∈ {35, 36, 37}. Below 35 is non-sensical for any active app (Play Store new-app
+#   floor since Aug 2025); above 37 isn't shipping today.
+# - targetSdk ≤ compileSdk (AGP rule).
+# - minSdk ∈ {24, 36}. Issue #1248's `PackageParser: Requires newer sdk version` is gated by
+#   minSdk; the matrix spans low-floor (typical) and tightly-targeting consumers.
+# - JDK ∈ {17, 21}. Robolectric SDK 36 requires JDK 21+
+#   (`DefaultSdkProvider.verifySupportedSdk`); the matrix's whole reason to sweep two JDKs is
+#   to surface that constraint.
+# - sdkVersion override ∈ {auto, 35}. `auto` exercises the plugin's auto-detect path; `35` is
+#   the rescue override consumers on JDK 17 reach for when their compileSdk is 36+.
+
+on:
+  schedule:
+    # 04:17 UTC daily — offset from the other crons in this repo to avoid
+    # piling onto the same runner pool.
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: sdk-matrix-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    name: ${{ matrix.label }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # ----- JDK 17, auto-detect -----
+          # Baseline: compileSdk=35 lands within Robolectric's JDK 17 ceiling, renders cleanly.
+          - { label: "jdk17 / compileSdk=35 / target=35 / min=24 / auto", jdk: "17", compileSdk: 35, targetSdk: 35, minSdk: 24, sdkVersion: "", expect: pass }
+          # JDK 17 + compileSdk≥36 fails at sandbox bootstrap: Robolectric refuses SDK 36
+          # without JDK 21. The minSdk axis is moot here; this is purely a JDK constraint.
+          - { label: "jdk17 / compileSdk=36 / target=36 / min=24 / auto", jdk: "17", compileSdk: 36, targetSdk: 36, minSdk: 24, sdkVersion: "", expect: fail }
+          # Above-ceiling clamps to 36 — same JDK refusal afterward.
+          - { label: "jdk17 / compileSdk=37 / target=37 / min=24 / auto (clamp)", jdk: "17", compileSdk: 37, targetSdk: 37, minSdk: 24, sdkVersion: "", expect: fail }
+          # ----- JDK 17, sdkVersion=35 override -----
+          # The rescue path consumers on JDK 17 + compileSdk=36 take. APK's minSdk=24 parses
+          # cleanly against the SDK 35 framework Robolectric synthesizes.
+          - { label: "jdk17 / compileSdk=36 / target=36 / min=24 / override=35", jdk: "17", compileSdk: 36, targetSdk: 36, minSdk: 24, sdkVersion: "35", expect: pass }
+          # The original #1248 shape: override pins Robolectric to SDK 35, but the APK's
+          # `<uses-sdk minSdkVersion="36">` is newer than the runtime framework, so
+          # PackageParser refuses. Documented failure, not a regression.
+          - { label: "jdk17 / compileSdk=36 / target=36 / min=36 / override=35", jdk: "17", compileSdk: 36, targetSdk: 36, minSdk: 36, sdkVersion: "35", expect: fail }
+          # ----- JDK 21, auto-detect -----
+          # Parity sanity check at the bottom of the range.
+          - { label: "jdk21 / compileSdk=35 / target=35 / min=24 / auto", jdk: "21", compileSdk: 35, targetSdk: 35, minSdk: 24, sdkVersion: "", expect: pass }
+          # JDK 21 unlocks Robolectric SDK 36 — auto-detect picks sdk=36 and renders.
+          - { label: "jdk21 / compileSdk=36 / target=36 / min=24 / auto", jdk: "21", compileSdk: 36, targetSdk: 36, minSdk: 24, sdkVersion: "", expect: pass }
+          # The #1248 case JDK 21 fixes outright: minSdk=36 matches the runtime framework.
+          - { label: "jdk21 / compileSdk=36 / target=36 / min=36 / auto", jdk: "21", compileSdk: 36, targetSdk: 36, minSdk: 36, sdkVersion: "", expect: pass }
+          # Above-ceiling clamp; minSdk=24 trivially parses against SDK 36.
+          - { label: "jdk21 / compileSdk=37 / target=37 / min=24 / auto (clamp)", jdk: "21", compileSdk: 37, targetSdk: 37, minSdk: 24, sdkVersion: "", expect: pass }
+          # Above-ceiling clamp with minSdk=36 — clamp lands at exactly the right level.
+          - { label: "jdk21 / compileSdk=37 / target=37 / min=36 / auto (clamp)", jdk: "21", compileSdk: 37, targetSdk: 37, minSdk: 36, sdkVersion: "", expect: pass }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.jdk }}
+
+      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-provider: basic
+          cache-read-only: true
+
+      - name: Render :samples:sdk-matrix
+        id: render
+        env:
+          GRADLE_OPTS: -Xmx4g -Dfile.encoding=UTF-8
+        run: |
+          set +e
+          sdk_version_arg=""
+          if [ -n "${{ matrix.sdkVersion }}" ]; then
+            sdk_version_arg="-Pcomposeai.matrix.sdkVersion=${{ matrix.sdkVersion }}"
+          fi
+          ./gradlew :samples:sdk-matrix:renderAllPreviews \
+            -Pcomposeai.matrix.compileSdk=${{ matrix.compileSdk }} \
+            -Pcomposeai.matrix.targetSdk=${{ matrix.targetSdk }} \
+            -Pcomposeai.matrix.minSdk=${{ matrix.minSdk }} \
+            $sdk_version_arg \
+            --stacktrace 2>&1 | tee build.log
+          exit_code=${PIPESTATUS[0]}
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          if [ "$exit_code" -eq 0 ]; then
+            echo "outcome=pass" >> "$GITHUB_OUTPUT"
+          else
+            echo "outcome=fail" >> "$GITHUB_OUTPUT"
+          fi
+          # The step itself exits 0 so the aggregator sees every cell. Pass/fail is recorded
+          # in the cell JSON; the aggregator flags rows where `outcome != expected`.
+          exit 0
+
+      - name: Record cell result
+        env:
+          LABEL: ${{ matrix.label }}
+          JDK: ${{ matrix.jdk }}
+          COMPILE_SDK: ${{ matrix.compileSdk }}
+          TARGET_SDK: ${{ matrix.targetSdk }}
+          MIN_SDK: ${{ matrix.minSdk }}
+          SDK_VERSION: ${{ matrix.sdkVersion }}
+          EXPECT: ${{ matrix.expect }}
+          OUTCOME: ${{ steps.render.outputs.outcome }}
+          EXIT_CODE: ${{ steps.render.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          mkdir -p cell-results
+          slug=$(printf '%s' "$LABEL" | tr -c '[:alnum:]' '-' | tr -s '-' | sed 's/^-//;s/-$//')
+          python3 - "$slug" <<'PY'
+          import json, os, sys
+          slug = sys.argv[1]
+          row = {
+            "label": os.environ["LABEL"],
+            "jdk": os.environ["JDK"],
+            "compileSdk": int(os.environ["COMPILE_SDK"]),
+            "targetSdk": int(os.environ["TARGET_SDK"]),
+            "minSdk": int(os.environ["MIN_SDK"]),
+            "sdkVersion": os.environ["SDK_VERSION"] or None,
+            "expected": os.environ["EXPECT"],
+            "outcome": os.environ["OUTCOME"],
+            "exitCode": int(os.environ["EXIT_CODE"]),
+          }
+          with open(f"cell-results/{slug}.json", "w") as f:
+            json.dump(row, f)
+          PY
+
+      - name: Upload cell result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sdk-matrix-cell-${{ strategy.job-index }}
+          path: |
+            cell-results/*.json
+            samples/sdk-matrix/build/compose-previews/renders/*.png
+            samples/sdk-matrix/build/generated/composeai/robolectric/**/robolectric.properties
+            build.log
+
+  aggregate:
+    name: Aggregate matrix results
+    runs-on: ubuntu-latest
+    needs: matrix
+    if: always()
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download cell results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: cell-results
+          pattern: sdk-matrix-cell-*
+          merge-multiple: true
+
+      - name: Render results table
+        id: report
+        run: |
+          set -euo pipefail
+          python3 scripts/sdk_matrix_report.py \
+            --cells cell-results \
+            --out matrix-report.md
+          echo "## SDK Compatibility Matrix (run $(date -u +%FT%TZ))" >> "$GITHUB_STEP_SUMMARY"
+          cat matrix-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if any cell drifted from expectations
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, sys
+          from pathlib import Path
+          drift = []
+          for p in sorted(Path("cell-results").rglob("*.json")):
+            row = json.load(open(p))
+            if row["outcome"] != row["expected"]:
+              drift.append(row["label"])
+          if drift:
+            print("Drift detected:", file=sys.stderr)
+            for d in drift:
+              print(f" - {d}", file=sys.stderr)
+            sys.exit(1)
+          print("All cells matched expectations.")
+          PY
+
+      - name: Upload aggregated report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sdk-matrix-report
+          path: matrix-report.md

--- a/docs/SDK_COMPATIBILITY.md
+++ b/docs/SDK_COMPATIBILITY.md
@@ -1,0 +1,115 @@
+# SDK compatibility matrix
+
+This page documents which `(JDK × compileSdk × targetSdk × minSdk × composePreview.sdkVersion)`
+combinations the renderer supports, which need the `composePreview.sdkVersion` override knob,
+and which are expected-to-fail with the reason each one fails.
+
+A nightly workflow ([`.github/workflows/sdk-matrix.yml`](../.github/workflows/sdk-matrix.yml))
+exercises every cell listed below against the synthetic
+[`:samples:sdk-matrix`](../samples/sdk-matrix) module — a single `@Preview` composable that
+renders the runtime-observed `Build.VERSION.SDK_INT`, `Build.VERSION.RELEASE`, and
+`applicationInfo.targetSdkVersion` so each cell's captured PNG is self-documenting. The
+workflow's job summary surfaces a pass/fail table; the aggregator job fails if any cell's
+outcome drifts from the expectation below.
+
+## How the two known failure modes interact
+
+Two separate constraints can break a Robolectric preview render. Distinguishing them is the
+whole point of this matrix:
+
+1. **Robolectric × JDK constraint.** Robolectric 4.16.x refuses to bootstrap an Android SDK 36
+   sandbox unless the test JVM is JDK 21+ (`DefaultSdkProvider.verifySupportedSdk`). On JDK 17,
+   any cell that resolves Robolectric's `sdk=` to 36 fails *at sandbox boot* with
+   `Android SDK 36 requires Java 21 (have Java 17)` — before any preview body runs and
+   independent of `minSdk` / `targetSdk` / the consumer's manifest. The fix is to bump the test
+   toolchain to JDK 21, or to pin `composePreview.sdkVersion = 35` so Robolectric stays inside
+   JDK 17's window.
+2. **PackageParser × minSdk constraint** (the original [issue #1248](https://github.com/yschimke/compose-ai-tools/issues/1248)).
+   Once Robolectric *does* bootstrap, it parses the consumer's `apk-for-local-test.ap_` through
+   Android's `PackageParser`. If the manifest's `<uses-sdk android:minSdkVersion="N">` is
+   *newer* than the framework Robolectric synthesized, parsing fails with
+   `Requires newer sdk version #N (current version is #M)`. The fix is to either lower
+   `minSdk`, or pin `composePreview.sdkVersion` to a level that satisfies it (which then
+   re-introduces constraint #1 if you bump too high on JDK 17).
+
+The matrix exercises both, with cells deliberately crossing each constraint's threshold.
+
+## Matrix axes
+
+| Axis | Values | Why |
+| --- | --- | --- |
+| **JDK** | 17, 21 | Constraint #1 above. The project itself runs on JDK 17 (per [`docs/AGENTS.md`](AGENTS.md)), but consumers can be on either. |
+| **compileSdk** | 35, 36, 37 | 35 is the Play Store new-app target floor since Aug 2025; below that is non-sensical for any active app. 36 is the current AGP default. 37 covers consumers pulled forward by transitive `minCompileSdk` requirements (e.g. `wear-tiles-renderer`, `compose-remote` alpha). |
+| **targetSdk** | 35, 36, 37 (subset) | Constrained to `targetSdk ≤ compileSdk` per AGP. The matrix doesn't include combinations like `targetSdk = 24, compileSdk = 36` — implausible for any active app. |
+| **minSdk** | 24, 36 | The PackageParser check is gated by `minSdk`. The matrix spans low-floor (`24`, typical consumer default) and tightly-targeting (`36`, an app explicitly requiring the latest framework). |
+| **`composePreview.sdkVersion`** | unset (auto-detect), `35` | The override knob added by [#1254](https://github.com/yschimke/compose-ai-tools/pull/1254). `unset` exercises the auto-detect path (`compileSdk` → `sdk=N` in `robolectric.properties`); `35` is the rescue value JDK 17 consumers reach for. |
+
+## Expectation table
+
+`expected: pass` cells render cleanly. `expected: fail` cells document an intentional
+limitation; the nightly workflow fails the aggregator job if any outcome drifts from these
+expectations.
+
+| JDK | compileSdk | targetSdk | minSdk | sdkVersion | Expected | Why |
+|---:|---:|---:|---:|---|---|---|
+| 17 | 35 | 35 | 24 | auto | ✅ pass | Baseline: auto-detect resolves to `sdk=35`, inside JDK 17's window, manifest minSdk is below the runtime framework. |
+| 17 | 36 | 36 | 24 | auto | ❌ fail | **Constraint #1.** Auto-detect resolves to `sdk=36`; Robolectric refuses to bootstrap on JDK 17. Fix: bump toolchain to JDK 21, OR set `composePreview.sdkVersion = 35`. |
+| 17 | 37 | 37 | 24 | auto | ❌ fail | Above-ceiling clamp lands at `sdk=36`; same JDK refusal as the row above. The clamp warning fires regardless. |
+| 17 | 36 | 36 | 24 | 35 | ✅ pass | Rescue path: override pins Robolectric to SDK 35, which JDK 17 supports. Manifest `minSdk=24` ≤ 35, so PackageParser is happy. |
+| 17 | 36 | 36 | 36 | 35 | ❌ fail | **Constraint #2 — the original #1248 shape.** Override pins Robolectric to SDK 35 (JDK 17 safe), but the manifest's `<uses-sdk minSdkVersion="36">` requires runtime ≥ 36, so PackageParser refuses. Only fix on JDK 17 is to lower `minSdk`. To stay on `minSdk=36`, the consumer needs JDK 21 + auto-detect. |
+| 21 | 35 | 35 | 24 | auto | ✅ pass | Parity sanity check at the bottom of the range. |
+| 21 | 36 | 36 | 24 | auto | ✅ pass | JDK 21 unlocks SDK 36; auto-detect picks `sdk=36` and renders. |
+| 21 | 36 | 36 | 36 | auto | ✅ pass | **The #1248 case JDK 21 fixes outright.** Runtime SDK matches manifest `minSdk`, PackageParser passes, no override needed. |
+| 21 | 37 | 37 | 24 | auto | ⚠️ pass (clamp) | Above-ceiling clamp lands at `sdk=36`; warning fires. `minSdk=24` ≤ 36 so PackageParser is happy. |
+| 21 | 37 | 37 | 36 | auto | ⚠️ pass (clamp) | Same clamp behaviour; `minSdk=36` ≤ 36 so PackageParser is still happy. |
+
+## Combinations the matrix deliberately does not cover
+
+| Excluded combo | Why |
+| --- | --- |
+| `targetSdk < 35` | Play Store policy: new apps must target SDK 35+ since Aug 2025 and updates since Nov 2025. Any active project has `targetSdk ≥ 35`. |
+| `compileSdk < 35` | AGP requires `compileSdk ≥ targetSdk`, and the previous row pins `targetSdk ≥ 35`. |
+| `minSdk > targetSdk` | AGP rejects this at configuration time. |
+| `compileSdk > 37` | Out of Robolectric 4.16.1's range; the plugin's `MAX_SUPPORTED_SDK = 36` clamp covers everything ≥ 36 identically. Worth a dedicated cell only when Robolectric ships API 37+. |
+| Cross-product of every `sdkVersion` override with every cell | Once the override has been shown to rescue / preserve the constraint #2 fail on JDK 17, repeating it on JDK 21 adds no signal — the plugin's resolver is unit-tested in `GenerateRobolectricPropertiesTaskTest`. |
+
+## How to use the override knob
+
+When a cell in your project lands in the ❌ row, your options are:
+
+1. **Bump the test toolchain to JDK 21.** Required if you need `minSdk ≥ 36` — only JDK 21
+   lets Robolectric synthesize a SDK 36 framework. Add to your module's `build.gradle.kts`:
+
+   ```kotlin
+   kotlin { jvmToolchain(21) }
+   tasks.withType<Test>().configureEach {
+     javaLauncher.set(
+       javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
+     )
+   }
+   ```
+
+2. **Pin Robolectric to a lower SDK explicitly:**
+
+   ```kotlin
+   composePreview { sdkVersion.set(35) }
+   ```
+
+   Use when you can't bump the JDK; previews render against the SDK 35 framework. Note that
+   if your APK's manifest claims `minSdk ≥ 36`, PackageParser will still refuse (row 5 above)
+   — only JDK 21 + auto-detect resolves that combination.
+
+3. **Wait for Robolectric to ship API 37+** if you're already on `compileSdk = 37` and want
+   the rendered framework to match exactly.
+
+## Updating this doc
+
+When the matrix expectations shift (e.g. Robolectric adds API 37, or the project's toolchain
+moves to JDK 21), update both:
+
+1. The `expect:` field in [`.github/workflows/sdk-matrix.yml`](../.github/workflows/sdk-matrix.yml)
+   (per-cell).
+2. The "Expectation table" above so the doc stays the contract.
+
+The nightly job's aggregator step fails outright if any cell's outcome drifts from the
+`expect:` field — that's the signal to revisit this page.

--- a/samples/sdk-matrix/build.gradle.kts
+++ b/samples/sdk-matrix/build.gradle.kts
@@ -1,0 +1,72 @@
+// Synthetic single-`@Preview` module driven by `composeai.matrix.*` Gradle properties so the
+// nightly `sdk-matrix.yml` workflow can sweep (compileSdk × targetSdk × minSdk) without forking a
+// fresh sample per cell. Deliberately does NOT apply `composeai.android-conventions` — that plugin
+// pins `compileSdk = 36`, which would defeat the whole point.
+//
+// `com.android.application` rather than `com.android.library` because AGP 9.x removes `targetSdk`
+// from `LibraryDefaultConfig` (library modules aren't supposed to pin a target), and `targetSdk`
+// is one of the axes the matrix needs to sweep.
+//
+// Run locally:
+//   ./gradlew :samples:sdk-matrix:renderAllPreviews \
+//     -Pcomposeai.matrix.compileSdk=36 \
+//     -Pcomposeai.matrix.targetSdk=36 \
+//     -Pcomposeai.matrix.minSdk=24
+//
+// See `docs/SDK_COMPATIBILITY.md` for the full cell matrix and the documented outcomes.
+import org.gradle.api.JavaVersion
+
+plugins {
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.compose.compiler)
+  id("ee.schimke.composeai.preview")
+}
+
+val matrixCompileSdk: Int =
+  providers.gradleProperty("composeai.matrix.compileSdk").orNull?.toIntOrNull() ?: 36
+val matrixTargetSdk: Int =
+  providers.gradleProperty("composeai.matrix.targetSdk").orNull?.toIntOrNull() ?: 36
+val matrixMinSdk: Int =
+  providers.gradleProperty("composeai.matrix.minSdk").orNull?.toIntOrNull() ?: 24
+val matrixSdkOverride: Int? =
+  providers.gradleProperty("composeai.matrix.sdkVersion").orNull?.toIntOrNull()
+
+composePreview {
+  // `composeai.matrix.sdkVersion` is unset by default (auto-detect path); set it from the
+  // workflow when a cell is documenting the override branch.
+  matrixSdkOverride?.let { sdkVersion.set(it) }
+}
+
+android {
+  namespace = "com.example.sdkmatrix"
+  compileSdk = matrixCompileSdk
+
+  defaultConfig {
+    applicationId = "com.example.sdkmatrix"
+    minSdk = matrixMinSdk
+    @Suppress("ExpiringTargetSdkVersion")
+    targetSdk = matrixTargetSdk
+    versionCode = 1
+    versionName = "1.0"
+  }
+
+  buildFeatures { compose = true }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+
+  testOptions { unitTests { isIncludeAndroidResources = true } }
+}
+
+kotlin { jvmToolchain(17) }
+
+dependencies {
+  implementation(platform(libs.compose.bom.stable))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.ui.tooling.preview)
+  implementation(libs.compose.foundation)
+  debugImplementation("androidx.compose.ui:ui-tooling")
+}

--- a/samples/sdk-matrix/src/main/AndroidManifest.xml
+++ b/samples/sdk-matrix/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/samples/sdk-matrix/src/main/kotlin/com/example/sdkmatrix/MatrixPreview.kt
+++ b/samples/sdk-matrix/src/main/kotlin/com/example/sdkmatrix/MatrixPreview.kt
@@ -1,0 +1,56 @@
+package com.example.sdkmatrix
+
+import android.os.Build
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * The single `@Preview` the SDK-compatibility matrix workflow exercises. The preview body reads
+ * what Robolectric and AGP actually surface at render time — `Build.VERSION.SDK_INT` (the
+ * synthesized framework level, driven by `sdk=N` in the generated `robolectric.properties`),
+ * `Build.VERSION.RELEASE` (the matching Android release codename), and
+ * `applicationInfo.targetSdkVersion` (what AGP stamped into the manifest from
+ * `composeai.matrix.targetSdk`) — and renders them as text. The captured PNG is therefore
+ * self-documenting: each matrix cell's artifact literally shows the observed values for that
+ * cell. The nightly aggregator just reads the cells' pass/fail state and surfaces the PNGs.
+ */
+@Preview(name = "SdkMatrixPreview", widthDp = 280, heightDp = 160)
+@Composable
+fun SdkMatrixPreview() {
+  val context = LocalContext.current
+  val observedTarget = context.applicationInfo.targetSdkVersion
+  Column(
+    modifier = Modifier.size(280.dp, 160.dp).background(Color(0xFF1B1B1F)).padding(12.dp),
+    verticalArrangement = Arrangement.spacedBy(4.dp),
+  ) {
+    Text(
+      text = "sdk-matrix",
+      color = Color(0xFFCFBCFF),
+      fontSize = 14.sp,
+      style = MaterialTheme.typography.titleSmall,
+    )
+    Text(
+      text = "Build.VERSION.SDK_INT = ${Build.VERSION.SDK_INT}",
+      color = Color.White,
+      fontSize = 12.sp,
+    )
+    Text(
+      text = "Build.VERSION.RELEASE = ${Build.VERSION.RELEASE}",
+      color = Color.White,
+      fontSize = 12.sp,
+    )
+    Text(text = "targetSdkVersion = $observedTarget", color = Color.White, fontSize = 12.sp)
+  }
+}

--- a/scripts/sdk_matrix_report.py
+++ b/scripts/sdk_matrix_report.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Aggregate per-cell JSON results from `.github/workflows/sdk-matrix.yml` into a Markdown
+table for the workflow job summary (and, eventually, `docs/SDK_COMPATIBILITY.md`).
+
+Each cell JSON has the shape:
+
+    {
+      "label": "jdk17 / compileSdk=35 / target=35 / min=24",
+      "jdk": "17",
+      "compileSdk": 35,
+      "targetSdk": 35,
+      "minSdk": 24,
+      "expected": "pass",
+      "outcome": "pass",
+      "exitCode": 0
+    }
+
+The table sorts by (JDK, compileSdk, targetSdk, minSdk) so the doc reads top-down from "newest
+consumer on newest JDK" to "older consumer on older JDK". A trailing summary line counts
+unexpected outcomes (where `outcome != expected`) — that's the value worth alerting on.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class Cell:
+    label: str
+    jdk: str
+    compile_sdk: int
+    target_sdk: int
+    min_sdk: int
+    expected: str
+    outcome: str
+    exit_code: int
+
+    @classmethod
+    def from_json(cls, payload: dict) -> "Cell":
+        return cls(
+            label=payload["label"],
+            jdk=payload["jdk"],
+            compile_sdk=payload["compileSdk"],
+            target_sdk=payload["targetSdk"],
+            min_sdk=payload["minSdk"],
+            expected=payload["expected"],
+            outcome=payload["outcome"],
+            exit_code=payload["exitCode"],
+        )
+
+    @property
+    def matches_expectation(self) -> bool:
+        return self.outcome == self.expected
+
+
+def status_glyph(cell: Cell) -> str:
+    if cell.outcome == "pass" and cell.expected == "pass":
+        return "✅ pass"
+    if cell.outcome == "fail" and cell.expected == "fail":
+        return "❌ fail (expected)"
+    if cell.outcome == "pass" and cell.expected == "fail":
+        return "❓ pass (expected fail — investigate)"
+    return "💥 fail (unexpected)"
+
+
+def render(cells: list[Cell]) -> str:
+    cells_sorted = sorted(
+        cells, key=lambda c: (c.jdk, c.compile_sdk, c.target_sdk, c.min_sdk)
+    )
+    lines: list[str] = [
+        "| JDK | compileSdk | targetSdk | minSdk | Expected | Outcome |",
+        "|---:|---:|---:|---:|---|---|",
+    ]
+    for c in cells_sorted:
+        lines.append(
+            f"| {c.jdk} | {c.compile_sdk} | {c.target_sdk} | {c.min_sdk} | "
+            f"{c.expected} | {status_glyph(c)} |"
+        )
+    unexpected = [c for c in cells if not c.matches_expectation]
+    lines.append("")
+    if unexpected:
+        lines.append(f"**{len(unexpected)} cell(s) drifted from expectations:**")
+        for c in unexpected:
+            lines.append(f"- `{c.label}` — expected {c.expected}, got {c.outcome}")
+    else:
+        lines.append("All cells matched their documented expectations.")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cells", required=True, type=Path,
+                        help="Directory containing per-cell JSON files.")
+    parser.add_argument("--out", required=True, type=Path,
+                        help="Markdown table output path.")
+    args = parser.parse_args(argv)
+
+    cells: list[Cell] = []
+    for path in sorted(args.cells.rglob("*.json")):
+        with path.open() as f:
+            cells.append(Cell.from_json(json.load(f)))
+    if not cells:
+        print(f"No cell JSON files found under {args.cells}", file=sys.stderr)
+        return 1
+    args.out.write_text(render(cells))
+    print(f"Wrote {args.out} ({len(cells)} cells)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,8 @@ include(":samples:android-screenshot-test")
 
 include(":samples:android-daemon-bench")
 
+include(":samples:sdk-matrix")
+
 include(":samples:wear")
 
 include(":samples:cmp")


### PR DESCRIPTION
## Summary

Nightly matrix workflow + docs page that sweep `(JDK × compileSdk × targetSdk × minSdk × composePreview.sdkVersion)` for a synthetic single-`@Preview` module. Surfaces both known failure modes of the renderer:

1. **Robolectric × JDK** — Robolectric 4.16.x refuses SDK 36 without JDK 21 (`DefaultSdkProvider.verifySupportedSdk`).
2. **PackageParser × minSdk** — the original [#1248](https://github.com/yschimke/compose-ai-tools/issues/1248) `Requires newer sdk version` shape.

The matrix expectations are the documented contract: the aggregator job fails the workflow if any cell drifts from its `expect:` field.

- `samples/sdk-matrix/` — synthetic preview module driven by `-Pcomposeai.matrix.*` flags. The preview body reads runtime-observed `Build.VERSION.SDK_INT`, `Build.VERSION.RELEASE`, and `applicationInfo.targetSdkVersion` so each cell's captured PNG is self-documenting.
- `.github/workflows/sdk-matrix.yml` — daily cron + `workflow_dispatch`, `fail-fast: false`, ~11 filtered cells (no nonsense combinations: `minSdk ≤ targetSdk ≤ compileSdk`, `targetSdk ≥ 35` for Play Store policy, `compileSdk ≤ 37`).
- `scripts/sdk_matrix_report.py` — pure-Python aggregator that renders the Markdown table for the job summary.
- `docs/SDK_COMPATIBILITY.md` — full expectation table, rationale per axis, what the matrix doesn't cover and why, and consumer-facing instructions for the `composePreview.sdkVersion` override.

## Test plan

Verified each JDK 17 prediction locally:

- [x] `compileSdk=35, target=35, min=24, auto` → ✅ renders, PNG shows `SDK_INT=35`.
- [x] `compileSdk=36, target=36, min=24, auto` → ❌ fails with `Android SDK 36 requires Java 21` at sandbox bootstrap (constraint #1).
- [x] `compileSdk=36, target=36, min=24, sdkVersion=35` → ✅ rescue path renders.
- [x] `compileSdk=36, target=36, min=36, sdkVersion=35` → ❌ original #1248 shape: `PackageParser: Requires newer sdk version #36 (current version is #35)` (constraint #2).

JDK 21 predictions rely on the unit-tested `resolveSdk` chain and the published Robolectric 4.16.1 SDK 36 support; they'll run in the first nightly. The workflow is gated to nightly + manual only — does not block PRs.

## Notes

- Module deliberately does **not** apply `composeai.android-conventions` so `compileSdk` can vary.
- Module is `com.android.application` (not library) because AGP 9.x removed `targetSdk` from `LibraryDefaultConfig`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W99ZfhRGDnF53N8as5F5X9)_