### PR TITLE
feat: add notification preview composable and CI workflow

### DIFF
--- a/.github/workflows/notification-previews.yml
+++ b/.github/workflows/notification-previews.yml
@@ -1,0 +1,78 @@
+name: Notification Previews
+
+# Renders the Android sample's `@NotificationPreview` + composable-helper notification previews
+# and uploads the resulting PNGs as a workflow artifact. Kept as a dedicated workflow — separate
+# from compose `Preview Baselines`, `A11y Report`, and the resource-baseline path inside
+# `preview-baselines` — so notification-rendering churn doesn't block the pixel-diff hot path,
+# and so adding the baseline-branch + PR-comment machinery later (mirroring `a11y-report.yml`)
+# is an additive change to this file rather than a refactor of the others.
+#
+# Variant matrix demonstrated: `BigTextVariantsPreview` fans out across Light / Dark / Arabic /
+# German / Japanese / Large font through stacked `@Preview` (see `NotificationVariants.kt`); the
+# FQN-discovered `@NotificationPreview` path renders `simpleNotificationPreview` and
+# `bigTextNotificationPreview` from the same module. Both kinds of preview land in
+# `samples/android/build/compose-previews/renders/` and get filtered into the artifact below.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: notification-previews-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  render:
+    name: Render notification previews
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Render samples:android previews
+        run: ./gradlew :samples:android:renderAllPreviews --no-daemon
+      - name: Stage notification PNGs
+        run: |
+          set -euo pipefail
+          mkdir -p _notification_renders
+          # Both annotation paths land here:
+          #   - `NotificationPreviewsKt.*` from `@NotificationPreview` (FQN-discovered)
+          #   - `NotificationVariantPreviewsKt.*` from `@Preview` + composable helper
+          # Glob captures both. Empty result is a hard failure — if nothing matched, either
+          # the sample lost its notification previews or the discovery path silently dropped
+          # them, and the artifact-upload step below would happily upload nothing.
+          shopt -s nullglob
+          files=(samples/android/build/compose-previews/renders/*Notification*.png)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No notification preview PNGs were rendered." >&2
+            ls samples/android/build/compose-previews/renders/ >&2 || true
+            exit 1
+          fi
+          cp "${files[@]}" _notification_renders/
+          echo "Rendered ${#files[@]} notification preview(s):"
+          ls -la _notification_renders/
+      - name: Upload notification renders artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: notification-previews
+          path: _notification_renders/
+          if-no-files-found: error
+          retention-days: 14
+      - name: Upload renderPreviews reports on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: renderPreviews-reports
+          path: |
+            samples/android/build/reports/tests/renderPreviews/
+            samples/android/build/test-results/renderPreviews/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/samples/android/src/main/AndroidManifest.xml
+++ b/samples/android/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="Sample Android"
+        android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round">
         <activity

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationContent.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationContent.kt
@@ -1,0 +1,73 @@
+package com.example.sampleandroid
+
+import android.app.Notification
+import android.content.Context
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+
+/**
+ * Composable helper that inflates a notification factory into the surrounding Compose tree.
+ *
+ * Pairs with stacked `@Preview` (multi-preview meta-annotations) to fan out variants of the same
+ * notification across the existing knobs `@Preview` already owns — `uiMode`, `locale`, `widthDp`,
+ * `fontScale`. The fan-out is driven by Compose tooling: discovery + the renderer's COMPOSE path
+ * pick each `@Preview` up as a separate entry, so no notification-specific plumbing is required.
+ *
+ * Inflation path mirrors the renderer-side `NotificationPreviewComposable`:
+ * `Notification.Builder.recoverBuilder(context, notification)` → `createBigContentView()` (with
+ * `createContentView()` as the collapsed fallback) → `RemoteViews.apply(...)`. This is the AOSP
+ * visual; OEM chrome (Pixel rounded corners, Samsung tinting) is drawn by SystemUI on-device and
+ * isn't reproducible under Robolectric.
+ *
+ * Sample-local for now — promotion to a published `:notification-preview-runtime` artifact is the
+ * next slice after #1249.
+ */
+@Composable
+fun NotificationContent(factory: (Context) -> Notification) {
+  val context = LocalContext.current
+  AndroidView(
+    modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+    factory = { ctx ->
+      val parent =
+        FrameLayout(ctx).apply {
+          layoutParams =
+            ViewGroup.LayoutParams(
+              ViewGroup.LayoutParams.MATCH_PARENT,
+              ViewGroup.LayoutParams.WRAP_CONTENT,
+            )
+        }
+      val notification = factory(context)
+      val view =
+        inflateNotificationView(context, notification, parent)
+          ?: error("NotificationContent produced no inflatable RemoteViews")
+      parent.addView(
+        view,
+        FrameLayout.LayoutParams(
+          ViewGroup.LayoutParams.MATCH_PARENT,
+          ViewGroup.LayoutParams.WRAP_CONTENT,
+        ),
+      )
+      parent
+    },
+  )
+}
+
+@Suppress("DEPRECATION")
+private fun inflateNotificationView(
+  context: Context,
+  notification: Notification,
+  parent: ViewGroup,
+): android.view.View? {
+  // `createBigContentView` / `createContentView` are marked deprecated for production posting
+  // paths (where the system inflates them for you) but there's no non-deprecated alternative when
+  // you specifically want the RemoteViews tree for offline rendering.
+  val builder = Notification.Builder.recoverBuilder(context, notification)
+  val remoteViews = builder.createBigContentView() ?: builder.createContentView() ?: return null
+  return remoteViews.apply(context, parent)
+}

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationContent.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationContent.kt
@@ -2,6 +2,7 @@ package com.example.sampleandroid
 
 import android.app.Notification
 import android.content.Context
+import android.content.res.Configuration
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -41,6 +42,13 @@ fun NotificationContent(factory: (Context) -> Notification) {
               ViewGroup.LayoutParams.MATCH_PARENT,
               ViewGroup.LayoutParams.WRAP_CONTENT,
             )
+          // RemoteViews title rows resolve `?attr/textColorPrimary` against the activity theme,
+          // which is near-white under `uiMode = NIGHT_YES`. Without a matching dark surface
+          // behind the inflated tree, the title text renders white-on-white. SystemUI on-device
+          // paints the dark notification surface for us; here we have to do it ourselves. Read
+          // `android.R.attr.colorBackground` from the theme so the colour tracks the active
+          // night-mode configuration without us hard-coding light / dark values.
+          setBackgroundColor(resolveBackgroundColor(ctx))
         }
       val notification = factory(context)
       val view =
@@ -56,6 +64,24 @@ fun NotificationContent(factory: (Context) -> Notification) {
       parent
     },
   )
+}
+
+/**
+ * AOSP-derived notification surface colours, picked off the active `Configuration.uiMode`. We
+ * deliberately don't read `?android:attr/colorBackground` from the activity theme: the renderer's
+ * sandbox activity uses a generic theme that resolves the same lavender for both day and night
+ * modes, so the title row's `?attr/textColorPrimary` (near-white under NIGHT_YES) renders
+ * white-on-white. Hard-coding the two surface values keeps each variant's contrast correct.
+ *
+ * Values approximate `Theme.DeviceDefault.Notification` / `…Notification.Dark` (≈ `#FFFFFF`
+ * day, `#1F1F1F` night) — close enough to AOSP that the rendered PNG reads like the shade
+ * surface a stock device would draw.
+ */
+private fun resolveBackgroundColor(context: Context): Int {
+  val night =
+    (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+      Configuration.UI_MODE_NIGHT_YES
+  return if (night) 0xFF1F1F1F.toInt() else 0xFFFFFFFF.toInt()
 }
 
 @Suppress("DEPRECATION")

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationVariantPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationVariantPreviews.kt
@@ -1,0 +1,51 @@
+package com.example.sampleandroid
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.compose.runtime.Composable
+import androidx.core.app.NotificationCompat
+
+private const val VARIANTS_CHANNEL_ID = "variants"
+
+private fun ensureVariantsChannel(context: Context) {
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+    val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    if (nm.getNotificationChannel(VARIANTS_CHANNEL_ID) == null) {
+      nm.createNotificationChannel(
+        NotificationChannel(
+          VARIANTS_CHANNEL_ID,
+          "Variants",
+          NotificationManager.IMPORTANCE_DEFAULT,
+        )
+      )
+    }
+  }
+}
+
+/**
+ * `BigTextStyle` notification rendered across the matrix declared by [NotificationVariants].
+ *
+ * One source function fans out into six PNGs — Light / Dark / Arabic / German / Japanese / Large
+ * font — via the existing COMPOSE discovery path. No `@NotificationPreview` annotation involved;
+ * the helper composable + stacked `@Preview` is what carries the variant matrix. Notification
+ * strings come from `notification_strings.xml` (default + `values-ar/`, `values-de/`,
+ * `values-ja/`) so the locale axis shows translated content, not just a layout-direction flip.
+ */
+@NotificationVariants
+@Composable
+fun BigTextVariantsPreview() {
+  NotificationContent { ctx ->
+    ensureVariantsChannel(ctx)
+    NotificationCompat.Builder(ctx, VARIANTS_CHANNEL_ID)
+      .setSmallIcon(android.R.drawable.ic_dialog_email)
+      .setContentTitle(ctx.getString(R.string.notif_variant_title))
+      .setContentText(ctx.getString(R.string.notif_variant_text))
+      .setStyle(
+        NotificationCompat.BigTextStyle()
+          .bigText(ctx.getString(R.string.notif_variant_big_text))
+      )
+      .build()
+  }
+}

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationVariants.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationVariants.kt
@@ -1,0 +1,27 @@
+package com.example.sampleandroid
+
+import android.content.res.Configuration
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * Multi-preview meta-annotation for a notification rendered under several environment axes.
+ * Compose tooling fans this out into one preview entry per `@Preview` below, identically in
+ * Android Studio's preview pane and in this project's Robolectric pipeline.
+ *
+ * The axes are deliberately the ones `@Preview` already owns — theme (`uiMode`), locale, and
+ * `fontScale`. Style / content axes (BigText vs Messaging vs Inbox, long-title vs no-icon, ...)
+ * are separate factory functions, mirroring how Compose component previews work:
+ * `ButtonDefault` vs `ButtonDisabled` are separate `@Preview`s, not a fan-out from one.
+ *
+ * Locale fan-out resolves real translated strings via `values-<lang>/notification_strings.xml`
+ * — `ar` flips layout direction *and* loads the Arabic body, `de` / `ja` pick up their language
+ * resources, `en` is the default-qualifier `values/`. Demonstrates the variants-via-multi-preview
+ * approach discussed on issue #1249.
+ */
+@Preview(name = "Light", uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "Arabic", locale = "ar")
+@Preview(name = "German", locale = "de")
+@Preview(name = "Japanese", locale = "ja")
+@Preview(name = "Large font", fontScale = 1.5f)
+annotation class NotificationVariants

--- a/samples/android/src/main/res/values-ar/notification_strings.xml
+++ b/samples/android/src/main/res/values-ar/notification_strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="notif_variant_title">تحديث معاينة Compose</string>
+  <string name="notif_variant_text">انقر للقراءة</string>
+  <string name="notif_variant_big_text">تنتشر الإشعارات الآن عبر محاور بيئة Preview@ — المظهر واللغة ومقياس الخط — من خلال آلية المعاينة المتعددة الموجودة في Compose. مصنع واحد، متغيرات معروضة متعددة.</string>
+</resources>

--- a/samples/android/src/main/res/values-ar/notification_strings.xml
+++ b/samples/android/src/main/res/values-ar/notification_strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <string name="app_name">عينة Android</string>
   <string name="notif_variant_title">تحديث معاينة Compose</string>
   <string name="notif_variant_text">انقر للقراءة</string>
   <string name="notif_variant_big_text">تنتشر الإشعارات الآن عبر محاور بيئة Preview@ — المظهر واللغة ومقياس الخط — من خلال آلية المعاينة المتعددة الموجودة في Compose. مصنع واحد، متغيرات معروضة متعددة.</string>

--- a/samples/android/src/main/res/values-de/notification_strings.xml
+++ b/samples/android/src/main/res/values-de/notification_strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <string name="app_name">Android-Beispiel</string>
   <string name="notif_variant_title">Compose-Vorschau aktualisiert</string>
   <string name="notif_variant_text">Tippen zum Lesen</string>
   <string name="notif_variant_big_text">Benachrichtigungen fächern sich nun über die Umgebungsachsen von @Preview auf — Theme, Sprache, Schriftskalierung — durch den vorhandenen Multi-Preview-Mechanismus von Compose. Eine Factory, viele gerenderte Varianten.</string>

--- a/samples/android/src/main/res/values-de/notification_strings.xml
+++ b/samples/android/src/main/res/values-de/notification_strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="notif_variant_title">Compose-Vorschau aktualisiert</string>
+  <string name="notif_variant_text">Tippen zum Lesen</string>
+  <string name="notif_variant_big_text">Benachrichtigungen fächern sich nun über die Umgebungsachsen von @Preview auf — Theme, Sprache, Schriftskalierung — durch den vorhandenen Multi-Preview-Mechanismus von Compose. Eine Factory, viele gerenderte Varianten.</string>
+</resources>

--- a/samples/android/src/main/res/values-ja/notification_strings.xml
+++ b/samples/android/src/main/res/values-ja/notification_strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <string name="app_name">サンプル Android</string>
   <string name="notif_variant_title">Compose プレビュー更新</string>
   <string name="notif_variant_text">タップして読む</string>
   <string name="notif_variant_big_text">通知は、Compose の既存のマルチプレビュー機構を通じて、@Preview の環境軸（テーマ、ロケール、フォントスケール）に展開されるようになりました。1 つのファクトリーから複数のバリアントがレンダリングされます。</string>

--- a/samples/android/src/main/res/values-ja/notification_strings.xml
+++ b/samples/android/src/main/res/values-ja/notification_strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="notif_variant_title">Compose プレビュー更新</string>
+  <string name="notif_variant_text">タップして読む</string>
+  <string name="notif_variant_big_text">通知は、Compose の既存のマルチプレビュー機構を通じて、@Preview の環境軸（テーマ、ロケール、フォントスケール）に展開されるようになりました。1 つのファクトリーから複数のバリアントがレンダリングされます。</string>
+</resources>

--- a/samples/android/src/main/res/values/notification_strings.xml
+++ b/samples/android/src/main/res/values/notification_strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Notification strings for `NotificationVariantPreviews`. Localised across
+  `values/`, `values-ar/`, `values-de/`, `values-ja/` so the `@NotificationVariants`
+  matrix exercises Compose tooling's `locale` knob with real translated content
+  (not just a layout-direction flip). Strings are deliberately notification-shaped:
+  one-line title, two-line body.
+-->
+<resources>
+  <string name="notif_variant_title">Compose preview update</string>
+  <string name="notif_variant_text">Tap to read</string>
+  <string name="notif_variant_big_text">Notifications now fan out across @Preview environment axes — theme, locale, font scale — through Compose\'s existing multi-preview machinery. One factory, many rendered variants.</string>
+</resources>

--- a/samples/android/src/main/res/values/notification_strings.xml
+++ b/samples/android/src/main/res/values/notification_strings.xml
@@ -7,6 +7,7 @@
   one-line title, two-line body.
 -->
 <resources>
+  <string name="app_name">Sample Android</string>
   <string name="notif_variant_title">Compose preview update</string>
   <string name="notif_variant_text">Tap to read</string>
   <string name="notif_variant_big_text">Notifications now fan out across @Preview environment axes — theme, locale, font scale — through Compose\'s existing multi-preview machinery. One factory, many rendered variants.</string>


### PR DESCRIPTION
Add support for rendering Android notifications in Compose previews with multi-variant support across theme, locale, and font scale axes.

## Summary

This change introduces a composable helper (`NotificationContent`) that inflates Android notifications into the Compose preview tree, enabling offline rendering of notification layouts. It pairs with a multi-preview meta-annotation (`@NotificationVariants`) to fan out a single notification factory across multiple environment configurations (Light/Dark theme, Arabic/German/Japanese locales, and large font scale).

## Key changes

- **`NotificationContent` composable**: Inflates `Notification` objects via `RemoteViews` into a Compose `AndroidView`. Handles theme-aware background color resolution to ensure proper contrast in both light and dark modes, mirroring SystemUI's notification surface rendering.

- **`@NotificationVariants` meta-annotation**: Stacked `@Preview` annotation that declares six preview variants (Light, Dark, Arabic, German, Japanese, Large font) for use with the composable helper. Leverages Compose tooling's existing discovery and rendering machinery without notification-specific plumbing.

- **`BigTextVariantsPreview` sample**: Demonstrates the pattern with a `BigTextStyle` notification that fans out across all six variants defined by `@NotificationVariants`.

- **Localized notification strings**: Added `notification_strings.xml` across `values/`, `values-ar/`, `values-de/`, and `values-ja/` to provide real translated content for locale variants, not just layout-direction flips.

- **`notification-previews.yml` CI workflow**: Dedicated GitHub Actions workflow that renders notification previews via `renderAllPreviews` Gradle task and uploads the resulting PNGs as a workflow artifact. Includes validation to ensure previews are actually generated and failure diagnostics.

## Implementation details

- The `NotificationContent` composable uses `Notification.Builder.recoverBuilder()` to extract `RemoteViews` from a built notification, then inflates them into a `FrameLayout` parent. This mirrors the AOSP rendering path without requiring SystemUI.
- Background color resolution reads `Configuration.uiMode` to apply appropriate light (`#FFFFFF`) or dark (`#1F1F1F`) surface colors, ensuring title text contrast matches the active theme.
- The CI workflow validates that notification PNGs are produced and fails explicitly if the glob matches no files, preventing silent artifact upload of empty results.

https://claude.ai/code/session_017q11eXtZk1AyNtKsnYMuLM