### PR TITLE
fix: restore default plugin repos when seeding mavenLocal

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -151,8 +151,22 @@ gradle.settingsEvaluated {
     // path that survives. pluginManagement.repositories.mavenLocal() covers the catalog-alias /
     // literal-`id(...) version "..."` case where resolution goes through the plugins DSL instead
     // of our buildscript classpath injection.
+    //
+    // `gradle.settingsEvaluated` fires for every build, including composite-included builds
+    // (e.g. androidchka's `build-logic`). Gradle only auto-adds the default Plugin Portal when
+    // `pluginManagement.repositories` is empty after settings evaluation — once we explicitly add
+    // `mavenLocal()` the list is non-empty and the default is suppressed, so a `build-logic`
+    // module that relies on the implicit default for `kotlin-dsl` (resolved via plugin marker
+    // from the Gradle Plugin Portal) fails. Restore those defaults explicitly when the build
+    // didn't declare any plugin repos of its own.
     if (useMavenLocal) {
+        val seedPluginDefaults = pluginManagement.repositories.isEmpty()
         pluginManagement.repositories.mavenLocal()
+        if (seedPluginDefaults) {
+            pluginManagement.repositories.gradlePluginPortal()
+            pluginManagement.repositories.mavenCentral()
+            pluginManagement.repositories.google()
+        }
         dependencyResolutionManagement.repositories.mavenLocal()
     }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -578,6 +578,27 @@ class AutoInjectTest {
   }
 
   @Test
+  fun `init script restores default plugin repositories when seeding mavenLocal into an empty pluginManagement`() {
+    // `gradle.settingsEvaluated` fires for every included build, including composite `build-logic`
+    // modules (e.g. androidchka's). Gradle only auto-applies its `gradlePluginPortal()` default
+    // when `pluginManagement.repositories` is empty after settings evaluation — so blindly
+    // appending `mavenLocal()` from the init script turns a build that relied on the implicit
+    // default into a build with mavenLocal as the *only* plugin repo, breaking resolution of
+    // `kotlin-dsl` (whose plugin marker lives on the Gradle Plugin Portal). The integration
+    // matrix's `androidchka (compose:material3 samples)` job exposed this. Restore the defaults
+    // explicitly when the consumer didn't declare any of its own.
+    val script = renderInitScript("0.1.0-SNAPSHOT")
+    assertTrue(
+      script.contains("pluginManagement.repositories.isEmpty()"),
+      "expected the script to detect an empty pluginManagement repo list before seeding defaults",
+    )
+    assertTrue(
+      script.contains("pluginManagement.repositories.gradlePluginPortal()"),
+      "expected the script to restore gradlePluginPortal when seeding into empty repos",
+    )
+  }
+
+  @Test
   fun `init script strips comments before matching plugin declarations`() {
     // Codex P2 review on PR #1183: a documentation line like
     //   // id("ee.schimke.composeai.preview") version "..."


### PR DESCRIPTION
## Summary
Fixes an issue where adding `mavenLocal()` to an empty `pluginManagement.repositories` list suppresses Gradle's implicit default repositories, breaking plugin resolution in composite builds that rely on the Gradle Plugin Portal (e.g., for `kotlin-dsl`).

## Changes
- **AutoInject.kt**: Modified the init script to detect when `pluginManagement.repositories` is empty before seeding `mavenLocal()`, and explicitly restore the default repositories (`gradlePluginPortal()`, `mavenCentral()`, `google()`) in that case
- **AutoInjectTest.kt**: Added test case to verify the init script correctly detects empty plugin repositories and restores defaults

## Implementation Details
The issue manifested in composite builds (like androidchka's `build-logic` modules) where `gradle.settingsEvaluated` fires for each included build. When the init script blindly appended `mavenLocal()` to an empty repository list, Gradle's automatic default repository injection was suppressed, causing plugin marker resolution failures.

The fix checks if the repository list is empty before modification and conditionally restores the three default repositories that Gradle would normally add implicitly.

https://claude.ai/code/session_018hrEUCcNxptCu3uBqbsBNB