### PR TITLE
test: add persistent latch for webview ready signal

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -454,6 +454,16 @@ export interface ComposePreviewTestApi {
     getReceivedMessages(): unknown[];
     /** Drop both message buffers (posted + received). */
     resetMessages(): void;
+    /**
+     * `true` once the resolved webview has signalled `webviewReady` at
+     * least once this session. Survives [resetMessages] so a later test
+     * suite can confirm the webview is alive without depending on a
+     * `webviewReady` still sitting in the received buffer — the first
+     * `resetMessages()` after the initial ready signal would otherwise
+     * leave subsequent suites waiting forever for a one-shot message
+     * that the webview never re-emits.
+     */
+    isWebviewReady(): boolean;
 }
 
 /** Captured messages for [ComposePreviewTestApi.getPostedMessages]. Only
@@ -463,6 +473,14 @@ const postedMessageLog: unknown[] = [];
 /** Captured messages for [ComposePreviewTestApi.getReceivedMessages]. Only
  *  populated when running under `COMPOSE_PREVIEW_TEST_MODE=1`. */
 const receivedMessageLog: unknown[] = [];
+
+/** Persistent latch for [ComposePreviewTestApi.isWebviewReady]. Unlike
+ *  `receivedMessageLog` this is *not* cleared by `resetMessages()`, so a
+ *  later e2e suite can verify the webview is alive even after a prior
+ *  suite drained the inbound buffer. The webview emits `webviewReady`
+ *  exactly once per resolved view, so once-latched-forever matches the
+ *  underlying signal. */
+let webviewEverReady = false;
 
 /**
  * D2 — routes daemon-attached `a11y/atf` + `a11y/hierarchy` data products into the
@@ -1116,6 +1134,9 @@ export async function activate(
     const onMessage = isTestMode
         ? (msg: WebviewToExtension) => {
               receivedMessageLog.push(msg);
+              if (msg.command === "webviewReady") {
+                  webviewEverReady = true;
+              }
               handleWebviewMessage(msg);
           }
         : handleWebviewMessage;
@@ -1775,6 +1796,9 @@ export async function activate(
             resetMessages(): void {
                 postedMessageLog.length = 0;
                 receivedMessageLog.length = 0;
+            },
+            isWebviewReady(): boolean {
+                return webviewEverReady;
             },
         };
         return testApi;

--- a/vscode-extension/src/test/electron/suite/e2e.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2e.test.ts
@@ -138,11 +138,17 @@ describeE2E("Compose Preview e2e (real Gradle)", function () {
         // `COMPOSE_PREVIEW_TEST_MODE=1`, so no extra-render side effects
         // from the focus call.
         await vscode.commands.executeCommand("composePreview.panel.focus");
+        // `webviewReady` is one-shot — the webview emits it once on
+        // resolve. `resetMessages()` in a sibling suite would otherwise
+        // make `getReceivedMessages()` scans loop forever. Prefer the
+        // persistent latch; the inbound scan covers the first-suite
+        // case where the latch hasn't flipped yet.
         await waitFor(
             "webviewReady from the resolved webview",
             30_000,
             100,
             () => {
+                if (api.isWebviewReady()) return true;
                 const inbound = api.getReceivedMessages();
                 return inbound.find(
                     (m) => (m as PostedMessage).command === "webviewReady",

--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -182,11 +182,20 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
         // host `postMessage` no-ops. See the matching note in
         // `e2e.test.ts`. Idempotent if the cmp suite already opened it.
         await vscode.commands.executeCommand("composePreview.panel.focus");
+        // `webviewReady` is a one-shot signal: the webview emits it once
+        // on resolve and never again. When the cmp suite ran first it
+        // already drove that signal, and `resetMessages()` inside the
+        // cmp `it()` cleared the inbound buffer — so scanning
+        // `getReceivedMessages()` for `webviewReady` here would loop
+        // forever. Use the persistent latch instead; fall back to the
+        // inbound scan only when the wear suite is the first to focus
+        // the panel (e.g. `e2e*.test.js` runs in isolation).
         await waitFor(
             "webviewReady from the resolved webview",
             30_000,
             100,
             () => {
+                if (api.isWebviewReady()) return true;
                 const inbound = api.getReceivedMessages();
                 return inbound.find(
                     (m) => (m as PostedMessage).command === "webviewReady",


### PR DESCRIPTION
## Summary

Add a persistent latch to track whether the webview has signalled `webviewReady` at least once, allowing test suites to verify webview readiness without depending on the one-shot message remaining in the received buffer.

## Changes

- **Extension API**: Add `isWebviewReady(): boolean` method to `ComposePreviewTestApi` interface that returns the persistent latch state
- **Message tracking**: Introduce `webviewEverReady` module-level variable that latches to `true` when a `webviewReady` command is received, and is *not* cleared by `resetMessages()`
- **Message handler**: Update test mode message handler to set the latch when `webviewReady` is received
- **Test API implementation**: Implement `isWebviewReady()` to return the latch value
- **E2E tests**: Update both `e2e.test.ts` and `e2eA11y.test.ts` to check the persistent latch first before scanning the received message buffer

## Implementation Details

The `webviewReady` signal is emitted exactly once per resolved webview view. When test suites call `resetMessages()` to clear the inbound buffer between tests, this one-shot message is lost. The persistent latch survives `resetMessages()`, allowing subsequent test suites (e.g., the wear suite running after the compose suite) to confirm the webview is alive without waiting forever for a message that will never be re-emitted.

The implementation maintains backward compatibility by falling back to the inbound message scan when the latch hasn't been set yet (e.g., when a test suite runs in isolation).

https://claude.ai/code/session_01NLeYDbefMYLgyGW8GWHb1f