### PR TITLE
fix(ci): wire SDK matrix JDK axis through toolchain + surface per-cell failure reasons

### DIFF
--- a/.github/workflows/sdk-matrix.yml
+++ b/.github/workflows/sdk-matrix.yml
@@ -117,6 +117,7 @@ jobs:
             -Pcomposeai.matrix.compileSdk=${{ matrix.compileSdk }} \
             -Pcomposeai.matrix.targetSdk=${{ matrix.targetSdk }} \
             -Pcomposeai.matrix.minSdk=${{ matrix.minSdk }} \
+            -Pcomposeai.matrix.jvmToolchain=${{ matrix.jdk }} \
             $sdk_version_arg \
             $robolectric_arg \
             $max_supported_arg \
@@ -125,8 +126,28 @@ jobs:
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
           if [ "$exit_code" -eq 0 ]; then
             echo "outcome=pass" >> "$GITHUB_OUTPUT"
+            echo "reason=" >> "$GITHUB_OUTPUT"
           else
             echo "outcome=fail" >> "$GITHUB_OUTPUT"
+            # Pull the most useful one-liner out of the build log so the aggregated report can
+            # explain each red cell without forcing the reader to download artifacts. Priority
+            # order: a Robolectric/PackageParser/Java-version line beats a generic
+            # `Execution failed` line, which beats falling back to "see build.log". The pattern
+            # set covers the four documented failure shapes (#1248 PackageParser, JDK 21
+            # requirement, missing SDK jar, plus a generic Gradle exception fallback).
+            reason=$(grep -m1 -E \
+              "Requires newer sdk version|Android SDK [0-9]+ requires Java|API level [0-9]+ is not available|UnsupportedOperationException|Could not resolve all files|composeai.matrix" \
+              build.log | head -c 400 || true)
+            if [ -z "$reason" ]; then
+              reason=$(grep -m1 -E "^.*[Ff]ailed|FAILURE: " build.log | head -c 400 || true)
+            fi
+            if [ -z "$reason" ]; then
+              reason="see build.log artifact"
+            fi
+            # `$GITHUB_OUTPUT` is line-delimited; escape any newlines / pipes in the matched
+            # message so it survives a single `output=` line.
+            reason_one_line=$(printf '%s' "$reason" | tr '\n' ' ' | tr -s ' ' | sed 's/|/\\|/g')
+            echo "reason=$reason_one_line" >> "$GITHUB_OUTPUT"
           fi
           # The step itself exits 0 so the aggregator sees every cell. Pass/fail is recorded
           # in the cell JSON; the aggregator flags rows where `outcome != expected`.
@@ -145,6 +166,7 @@ jobs:
           EXPECT: ${{ matrix.expect }}
           OUTCOME: ${{ steps.render.outputs.outcome }}
           EXIT_CODE: ${{ steps.render.outputs.exit_code }}
+          REASON: ${{ steps.render.outputs.reason }}
         run: |
           set -euo pipefail
           mkdir -p cell-results
@@ -164,6 +186,7 @@ jobs:
             "expected": os.environ["EXPECT"],
             "outcome": os.environ["OUTCOME"],
             "exitCode": int(os.environ["EXIT_CODE"]),
+            "reason": os.environ.get("REASON") or None,
           }
           with open(f"cell-results/{slug}.json", "w") as f:
             json.dump(row, f)

--- a/samples/sdk-matrix/build.gradle.kts
+++ b/samples/sdk-matrix/build.gradle.kts
@@ -15,6 +15,9 @@
 //
 // See `docs/SDK_COMPATIBILITY.md` for the full cell matrix and the documented outcomes.
 import org.gradle.api.JavaVersion
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
 
 plugins {
   alias(libs.plugins.android.application)
@@ -44,6 +47,13 @@ val matrixRobolectricVersion: String? =
 // without the task's validator throwing.
 val matrixMaxSupportedSdk: Int? =
   providers.gradleProperty("composeai.matrix.maxSupportedSdk").orNull?.toIntOrNull()
+// JDK toolchain the Kotlin compile + Test workers fork into. Driven by the workflow's matrix
+// `jdk` axis. Defaults to JDK 17 (the project's baseline), but bumps to 21 for cells that
+// exercise Robolectric SDK 36+: Robolectric's `DefaultSdkProvider.verifySupportedSdk` refuses
+// SDK 36 unless the test JVM is JDK 21+, so the matrix's whole JDK axis only does its job if the
+// Test task actually forks into the matrix-selected JDK rather than the project default.
+val matrixJvmToolchain: Int =
+  providers.gradleProperty("composeai.matrix.jvmToolchain").orNull?.toIntOrNull() ?: 17
 
 composePreview {
   // `composeai.matrix.sdkVersion` is unset by default (auto-detect path); set it from the
@@ -91,7 +101,19 @@ android {
   testOptions { unitTests { isIncludeAndroidResources = true } }
 }
 
-kotlin { jvmToolchain(17) }
+kotlin { jvmToolchain(matrixJvmToolchain) }
+
+// Belt-and-braces: the Test task's `javaLauncher` is what actually decides which JDK the test
+// JVM forks into. `kotlin { jvmToolchain(N) }` sets it on the AGP-created Test tasks, but a
+// fresh `Test` task created later wouldn't inherit. Pin it explicitly so every Test task — now
+// and future — honours the matrix's JDK axis.
+val javaToolchains = extensions.getByType(JavaToolchainService::class.java)
+
+tasks.withType(Test::class.java).configureEach {
+  javaLauncher.set(
+    javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(matrixJvmToolchain)) }
+  )
+}
 
 dependencies {
   implementation(platform(libs.compose.bom.stable))

--- a/scripts/sdk_matrix_report.py
+++ b/scripts/sdk_matrix_report.py
@@ -41,6 +41,7 @@ class Cell:
     expected: str
     outcome: str
     exit_code: int
+    reason: str | None
 
     @classmethod
     def from_json(cls, payload: dict) -> "Cell":
@@ -55,6 +56,7 @@ class Cell:
             expected=payload["expected"],
             outcome=payload["outcome"],
             exit_code=payload["exitCode"],
+            reason=payload.get("reason"),
         )
 
     @property
@@ -72,22 +74,44 @@ def status_glyph(cell: Cell) -> str:
     return "💥 fail (unexpected)"
 
 
+def _short_reason(reason: str | None, char_limit: int = 140) -> str:
+    """Trim a captured failure line for the inline table column. The full text shows up below
+    the table for each cell that failed; this trim just keeps the table readable."""
+    if not reason:
+        return ""
+    cleaned = reason.strip()
+    if len(cleaned) <= char_limit:
+        return cleaned
+    return cleaned[: char_limit - 1].rstrip() + "…"
+
+
+def _escape_table_cell(text: str) -> str:
+    return text.replace("|", "\\|").replace("\n", " ").strip()
+
+
 def render(cells: list[Cell]) -> str:
     cells_sorted = sorted(
         cells, key=lambda c: (c.jdk, c.compile_sdk, c.target_sdk, c.min_sdk)
     )
     lines: list[str] = [
-        "| JDK | compileSdk | targetSdk | minSdk | sdkVersion | Robolectric | Expected | Outcome |",
-        "|---:|---:|---:|---:|---|---|---|---|",
+        "| JDK | compileSdk | targetSdk | minSdk | sdkVersion | Robolectric | Expected | Outcome | Reason |",
+        "|---:|---:|---:|---:|---|---|---|---|---|",
     ]
     for c in cells_sorted:
         sdk_override = c.sdk_version or "auto"
         robolectric = c.robolectric or "stable"
+        # Inline reason only when the cell actually failed — passes don't need a reason column
+        # entry. Keep it short; the full text lands under the table.
+        reason_cell = ""
+        if c.outcome == "fail":
+            reason_cell = _escape_table_cell(_short_reason(c.reason))
         lines.append(
             f"| {c.jdk} | {c.compile_sdk} | {c.target_sdk} | {c.min_sdk} | "
-            f"{sdk_override} | {robolectric} | {c.expected} | {status_glyph(c)} |"
+            f"{sdk_override} | {robolectric} | {c.expected} | {status_glyph(c)} | "
+            f"{reason_cell} |"
         )
     unexpected = [c for c in cells if not c.matches_expectation]
+    failed = [c for c in cells if c.outcome == "fail"]
     lines.append("")
     if unexpected:
         lines.append(f"**{len(unexpected)} cell(s) drifted from expectations:**")
@@ -95,6 +119,17 @@ def render(cells: list[Cell]) -> str:
             lines.append(f"- `{c.label}` — expected {c.expected}, got {c.outcome}")
     else:
         lines.append("All cells matched their documented expectations.")
+    # Always print full per-cell failure reasons under the table — the most actionable info for
+    # someone reading the workflow summary. Includes expected fails so the doc keeps "why" right
+    # next to each ❌ row; drift cells get an extra bold marker.
+    if failed:
+        lines.append("")
+        lines.append("### Failure reasons")
+        lines.append("")
+        for c in sorted(failed, key=lambda x: (x.jdk, x.compile_sdk, x.target_sdk, x.min_sdk)):
+            tag = " **(unexpected)**" if not c.matches_expectation else ""
+            reason = c.reason or "(no message captured — see build.log artifact)"
+            lines.append(f"- `{c.label}`{tag}: {reason}")
     return "\n".join(lines) + "\n"
 
 


### PR DESCRIPTION
## Summary

Fixes the first nightly's drift report (all JDK 21 + `compileSdk ≥ 36` cells red) **and** surfaces a per-cell failure reason in the aggregator output (requested while the fix was in flight).

### Why every JDK 21 cell drifted

`samples/sdk-matrix/build.gradle.kts` hardcoded `kotlin { jvmToolchain(17) }`. `actions/setup-java` installed the matrix's `jdk` JDK but Gradle's Kotlin toolchain ignored it and forked Test workers into JDK 17 anyway. Robolectric SDK 36 then refused on JDK 17 (`Android SDK 36 requires Java 21`), the snapshot cells inherited the same failure, and the aggregator drift-check turned red.

Fix: thread the matrix's `jdk` axis through a `composeai.matrix.jvmToolchain` Gradle property; the sample applies it via both `kotlin { jvmToolchain(N) }` and `tasks.withType<Test> { javaLauncher = … }` belt-and-braces. Workflow render step passes `-Pcomposeai.matrix.jvmToolchain=${{ matrix.jdk }}`.

### Failure-reason capture

Render step now greps the build log for the most actionable one-liner — covers the documented failure shapes (PackageParser, JDK 21 requirement, missing SDK jar, snapshot resolution failures, Gradle config exceptions). The aggregator surfaces it both inline in the table (`Reason` column) and as a longer "Failure reasons" list underneath the table. Unexpected drift cells get a **(unexpected)** tag so the actionable rows are visible at a glance.

## Test plan

- [x] `:samples:sdk-matrix:renderAllPreviews` with `-Pcomposeai.matrix.compileSdk=36 -Pcomposeai.matrix.minSdk=36 -Pcomposeai.matrix.jvmToolchain=21` — green, PNG shows `SDK_INT = 36`, `RELEASE = 16`. This is the exact drift cell from the failing nightly.
- [x] Aggregator smoke test with a mixed pass / expected-fail / unexpected-fail set renders both the inline `Reason` column and the trailing reason list.
- [x] `:gradle-plugin:test` green; YAML + ktfmt clean.

The first nightly after this lands should show all JDK 21 cells flipping back to green; if any stay red, the `Reason` column will explain why without needing to download the per-cell artifacts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W99ZfhRGDnF53N8as5F5X9)_