### PR TITLE
fix(ci): point SDK matrix snapshot probe at the new Sonatype Central URL

### DIFF
--- a/docs/SDK_COMPATIBILITY.md
+++ b/docs/SDK_COMPATIBILITY.md
@@ -112,7 +112,7 @@ When a cell in your project lands in the ❌ row, your options are:
    // settings.gradle.kts — add the snapshots repo:
    dependencyResolutionManagement {
      repositories {
-       maven("https://oss.sonatype.org/content/repositories/snapshots/") {
+       maven("https://central.sonatype.com/repository/maven-snapshots/") {
          content { includeGroup("org.robolectric") }
        }
      }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,10 +8,14 @@ pluginManagement {
 }
 
 // Snapshot probe for the SDK compatibility matrix's snapshot cells. Pulls Robolectric
-// snapshots (which carry API 37 fixes ahead of the next stable release) from the OSS Sonatype
-// snapshots repo so `:samples:sdk-matrix` can render at SDK 37. Repo is added only when the
-// property is set; default builds aren't slowed by an extra snapshot lookup. Scoped to
-// `org.robolectric` so a stray snapshot artifact in some other group can't leak in.
+// snapshots (which carry API 37 fixes ahead of the next stable release) from the new Sonatype
+// Central Maven snapshots endpoint so `:samples:sdk-matrix` can render at SDK 37. The legacy
+// `oss.sonatype.org` host is still reachable but stopped accepting new snapshots during
+// Sonatype's 2024–2025 migration to `central.sonatype.com`. Both endpoints are added so a
+// future-published snapshot that lands on the old host still resolves; in practice the new one
+// wins. Scoped to `org.robolectric` so a stray snapshot artifact in some other group can't leak
+// in. Repos are added only when the property is set; default builds aren't slowed by extra
+// snapshot lookups.
 val matrixRobolectricVersion: String? =
   providers.gradleProperty("composeai.matrix.robolectricVersion").orNull
 
@@ -22,8 +26,12 @@ dependencyResolutionManagement {
     mavenCentral()
     maven("https://repo.gradle.org/gradle/libs-releases")
     if (matrixRobolectricVersion?.endsWith("-SNAPSHOT") == true) {
+      maven("https://central.sonatype.com/repository/maven-snapshots/") {
+        name = "robolectric-snapshots-central"
+        content { includeGroup("org.robolectric") }
+      }
       maven("https://oss.sonatype.org/content/repositories/snapshots/") {
-        name = "robolectric-snapshots"
+        name = "robolectric-snapshots-oss"
         content { includeGroup("org.robolectric") }
       }
     }


### PR DESCRIPTION
## Summary

The nightly's `Could not find org.robolectric:robolectric:4.17-SNAPSHOT` failure (in the two snapshot probe cells, post-JDK-toolchain fix) is because `oss.sonatype.org/content/repositories/snapshots/` stopped accepting new snapshots during Sonatype's 2024–2025 migration. Robolectric's master branch now publishes to `central.sonatype.com/repository/maven-snapshots/`.

- `settings.gradle.kts` adds the new Central snapshots endpoint ahead of the legacy host; both stay scoped to `org.robolectric` and gated on `composeai.matrix.robolectricVersion`.
- Consumer-facing snippet in `docs/SDK_COMPATIBILITY.md` updated to match.

## Test plan

- [x] `settings.gradle.kts` configures cleanly with the snapshot property set.
- [ ] CI is the real probe — sandbox blocks both Sonatype endpoints, so local resolution can't fetch.

The next nightly should flip both `robolectric=4.17-SNAPSHOT` cells to ✅ pass; if they still fail the new `Reason` column will show why directly in the workflow summary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W99ZfhRGDnF53N8as5F5X9)_