### PR TITLE
feat(vscode-extension): add per-card Controls toggle for interactive …

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1411,6 +1411,50 @@ preview-app {
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.28);
 }
 
+/* Issue #1203 — per-card "Controls" toggle. Sits on the top-left of the
+ * image container so it doesn't overlap the live-stop button (top-right).
+ * Visible only when the daemon advertises an interactive-only data extension
+ * (e.g. `input.keyboard`); the helper in `liveCardControls.ts` injects /
+ * removes the element rather than relying on CSS `display:none`. The pressed
+ * state uses the focus / accent foreground to mirror VS Code's own toggle
+ * buttons. */
+.card-controls-toggle-btn {
+    position: absolute;
+    top: 6px;
+    left: 6px;
+    z-index: 4;
+    color: var(--vscode-foreground);
+    background: color-mix(
+        in srgb,
+        var(--vscode-editor-background) 82%,
+        transparent
+    );
+    border-color: color-mix(in srgb, var(--vscode-foreground) 30%, transparent);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.28);
+}
+
+.card-controls-toggle-btn[aria-pressed="true"] {
+    color: var(--vscode-button-foreground, #fff);
+    background: var(--vscode-focusBorder, #007fd4);
+    border-color: var(--vscode-focusBorder, #007fd4);
+}
+
+.card-controls-toggle-btn:hover:not(:disabled) {
+    background: color-mix(
+        in srgb,
+        var(--vscode-focusBorder, #007fd4) 22%,
+        var(--vscode-editor-background)
+    );
+}
+
+.card-controls-toggle-btn[aria-pressed="true"]:hover:not(:disabled) {
+    background: color-mix(
+        in srgb,
+        var(--vscode-focusBorder, #007fd4) 85%,
+        var(--vscode-editor-background)
+    );
+}
+
 .card-live-stop-btn:hover:not(:disabled) {
     background: color-mix(
         in srgb,

--- a/vscode-extension/src/test/liveCardControls.test.ts
+++ b/vscode-extension/src/test/liveCardControls.test.ts
@@ -17,7 +17,11 @@
 //     stray button stamped onto the card root).
 
 import * as assert from "assert";
-import { ensureLiveCardControls } from "../webview/preview/liveCardControls";
+import {
+    ensureControlsToggleButton,
+    ensureLiveCardControls,
+    removeControlsToggleButton,
+} from "../webview/preview/liveCardControls";
 
 /** Build a `<div class="preview-card">` with an `.image-container`
  *  child (the place the per-card stop button gets appended to) and
@@ -183,5 +187,146 @@ describe("ensureLiveCardControls", () => {
         assert.strictEqual(card.children.length, 0);
         // The callback isn't invoked just by ensureing controls.
         assert.strictEqual(invoked, 0);
+    });
+});
+
+describe("ensureControlsToggleButton (issue #1203)", () => {
+    beforeEach(() => {
+        document.body.innerHTML = "";
+    });
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("stamps a .card-controls-toggle-btn with the right shape + pressed state", () => {
+        const card = buildCard();
+        ensureControlsToggleButton(card, {
+            enabled: false,
+            onToggle: () => {},
+        });
+        const btn = card.querySelector(
+            ".card-controls-toggle-btn",
+        ) as HTMLButtonElement | null;
+        assert.ok(btn, "controls toggle should appear in image-container");
+        assert.strictEqual(btn!.type, "button");
+        assert.strictEqual(btn!.classList.contains("icon-button"), true);
+        assert.strictEqual(btn!.getAttribute("aria-pressed"), "false");
+        assert.ok(
+            /Turn on/.test(btn!.title),
+            "off-state title should say 'Turn on'",
+        );
+        assert.ok(btn!.querySelector("i.codicon.codicon-keyboard"));
+    });
+
+    it("reflects the enabled state via aria-pressed + title", () => {
+        const card = buildCard();
+        ensureControlsToggleButton(card, { enabled: true, onToggle: () => {} });
+        const btn = card.querySelector(
+            ".card-controls-toggle-btn",
+        ) as HTMLButtonElement;
+        assert.strictEqual(btn.getAttribute("aria-pressed"), "true");
+        assert.ok(
+            /Turn off/.test(btn.title),
+            "on-state title should say 'Turn off'",
+        );
+    });
+
+    it("is idempotent — repeat calls don't duplicate the button or restack handlers", () => {
+        const card = buildCard();
+        let calls: boolean[] = [];
+        ensureControlsToggleButton(card, {
+            enabled: false,
+            onToggle: (_c, next) => calls.push(next),
+        });
+        // A second call with a different onToggle must not stack a new handler.
+        ensureControlsToggleButton(card, {
+            enabled: false,
+            onToggle: () => calls.push(true),
+        });
+        assert.strictEqual(
+            card.querySelectorAll(".card-controls-toggle-btn").length,
+            1,
+            "duplicate calls must not stamp a second button",
+        );
+        const btn = card.querySelector(
+            ".card-controls-toggle-btn",
+        ) as HTMLButtonElement;
+        btn.click();
+        assert.deepStrictEqual(
+            calls,
+            [true],
+            "the FIRST call's onToggle is bound; second-call onToggle stays disconnected",
+        );
+    });
+
+    it("click toggles between aria-pressed = false → true by invoking onToggle with !current", () => {
+        const card = buildCard();
+        const seen: boolean[] = [];
+        ensureControlsToggleButton(card, {
+            enabled: false,
+            onToggle: (_c, next) => seen.push(next),
+        });
+        const btn = card.querySelector(
+            ".card-controls-toggle-btn",
+        ) as HTMLButtonElement;
+        btn.click(); // aria-pressed = "false" → onToggle(true)
+        // Simulate the controller updating state.
+        ensureControlsToggleButton(card, { enabled: true, onToggle: () => {} });
+        // Re-bind onToggle to capture the next call (handler stays original — so use
+        // the first onToggle by leaving binding alone). Note this verifies that the
+        // pressed state reflects the latest enabled flag passed to ensure().
+        assert.strictEqual(btn.getAttribute("aria-pressed"), "true");
+        assert.deepStrictEqual(seen, [true]);
+        // Toggle off — handler was bound on the first call, so seen should grow.
+        btn.click(); // aria-pressed = "true" → onToggle(false)
+        assert.deepStrictEqual(seen, [true, false]);
+    });
+
+    it("click suppresses default and stops propagation", () => {
+        const card = buildCard();
+        let bubbled = 0;
+        card.addEventListener("click", () => bubbled++);
+        ensureControlsToggleButton(card, {
+            enabled: false,
+            onToggle: () => {},
+        });
+        const btn = card.querySelector(
+            ".card-controls-toggle-btn",
+        ) as HTMLButtonElement;
+        const evt = new Event("click", { bubbles: true, cancelable: true });
+        btn.dispatchEvent(evt);
+        assert.strictEqual(evt.defaultPrevented, true);
+        assert.strictEqual(bubbled, 0);
+    });
+
+    it("is a silent no-op when .image-container is missing", () => {
+        const card = buildBareCard();
+        assert.doesNotThrow(() =>
+            ensureControlsToggleButton(card, {
+                enabled: false,
+                onToggle: () => {},
+            }),
+        );
+        assert.strictEqual(
+            card.querySelector(".card-controls-toggle-btn"),
+            null,
+        );
+        assert.strictEqual(card.children.length, 0);
+    });
+
+    it("removeControlsToggleButton drops the button and is idempotent on a button-less card", () => {
+        const card = buildCard();
+        ensureControlsToggleButton(card, {
+            enabled: false,
+            onToggle: () => {},
+        });
+        assert.ok(card.querySelector(".card-controls-toggle-btn"));
+        removeControlsToggleButton(card);
+        assert.strictEqual(
+            card.querySelector(".card-controls-toggle-btn"),
+            null,
+        );
+        // Second call is a no-op.
+        assert.doesNotThrow(() => removeControlsToggleButton(card));
     });
 });

--- a/vscode-extension/src/webview/preview/interactiveInput.ts
+++ b/vscode-extension/src/webview/preview/interactiveInput.ts
@@ -112,8 +112,9 @@ export interface InteractiveInputConfig {
      * event so toggling controls off mid-session immediately stops forwarding; the listener
      * itself stays attached (cheaper than rebinding on every toggle).
      *
-     * Defaulted to "always false" so a config that doesn't wire it through keeps the
-     * pre-toggle behaviour of swallowing every keystroke that lands on a live card.
+     * Omitted entirely → the gate is bypassed (every keystroke that passes the `isLive`
+     * check is forwarded), matching the pre-toggle behaviour. When supplied, returning
+     * `false` drops the keystroke before the wire post.
      */
     isControlsEnabled?(previewId: string): boolean;
     vscode: VsCodeApi<unknown>;

--- a/vscode-extension/src/webview/preview/interactiveInput.ts
+++ b/vscode-extension/src/webview/preview/interactiveInput.ts
@@ -106,6 +106,16 @@ export interface InteractiveInputConfig {
      * keep the pre-#1203 behaviour (no keyboard listener attached).
      */
     supportsControl?(kind: string): boolean;
+    /**
+     * Issue #1203 — predicate keyed on `data-preview-id`. Returns true when the user has
+     * flipped the per-card "Controls" toggle on for this preview. Called on every keyboard
+     * event so toggling controls off mid-session immediately stops forwarding; the listener
+     * itself stays attached (cheaper than rebinding on every toggle).
+     *
+     * Defaulted to "always false" so a config that doesn't wire it through keeps the
+     * pre-toggle behaviour of swallowing every keystroke that lands on a live card.
+     */
+    isControlsEnabled?(previewId: string): boolean;
     vscode: VsCodeApi<unknown>;
 }
 
@@ -175,6 +185,12 @@ export function attachInteractiveInputHandlers(
         const onKey = (evt: KeyboardEvent, kind: "keyDown" | "keyUp"): void => {
             const id = card.dataset.previewId;
             if (!id || !config.isLive(id)) return;
+            // Per-card "Controls" toggle gate (issue #1203). Without an explicit
+            // opt-in, a card in live mode for click / drag interaction would
+            // silently swallow every key the user pressed.
+            if (config.isControlsEnabled && !config.isControlsEnabled(id)) {
+                return;
+            }
             const keyCode = domCodeToAndroidKeycode(evt.code);
             if (keyCode == null) return;
             config.vscode.postMessage({

--- a/vscode-extension/src/webview/preview/liveCardControls.ts
+++ b/vscode-extension/src/webview/preview/liveCardControls.ts
@@ -44,3 +44,62 @@ export function ensureLiveCardControls(
     });
     container.appendChild(btn);
 }
+
+/**
+ * Idempotently inject a `.card-controls-toggle-btn` overlay into [card]'s
+ * `.image-container`. This is the per-card entry point for issue #1203
+ * interactive-only data extensions (canonical case: `input.keyboard`).
+ *
+ * Clicking the button toggles the panel-side "controls" flag for the
+ * preview. When that flag flips on, [onToggle] is responsible for both
+ * (a) entering live mode for the card (interactive dispatch can't land
+ * outside a held composition — see `LiveStateController.extensionRequiresInteractive`)
+ * and (b) attaching the keyboard listener.
+ *
+ * The button stays in the DOM across capability / live-state changes;
+ * [enabled] only controls the pressed visual state. Visibility is driven
+ * by adding / removing the element rather than re-creating it, so the
+ * click handler is bound exactly once per card.
+ */
+export function ensureControlsToggleButton(
+    card: HTMLElement,
+    opts: {
+        enabled: boolean;
+        onToggle: (card: HTMLElement, next: boolean) => void;
+    },
+): void {
+    const container = card.querySelector(".image-container");
+    if (!container) return;
+    let btn = container.querySelector<HTMLButtonElement>(
+        ".card-controls-toggle-btn",
+    );
+    if (!btn) {
+        btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "icon-button card-controls-toggle-btn";
+        btn.innerHTML =
+            '<i class="codicon codicon-keyboard" aria-hidden="true"></i>';
+        btn.addEventListener("click", (evt) => {
+            evt.preventDefault();
+            evt.stopPropagation();
+            const wasEnabled = btn!.getAttribute("aria-pressed") === "true";
+            opts.onToggle(card, !wasEnabled);
+        });
+        container.appendChild(btn);
+    }
+    btn.setAttribute("aria-pressed", opts.enabled ? "true" : "false");
+    btn.title = opts.enabled
+        ? "Turn off interactive controls (keyboard input)"
+        : "Turn on interactive controls (keyboard input). Enters live mode.";
+    btn.setAttribute("aria-label", btn.title);
+}
+
+/**
+ * Remove the controls-toggle button from [card] when the daemon stops
+ * advertising any interactive-only extension. Idempotent: no-op when the
+ * button isn't present.
+ */
+export function removeControlsToggleButton(card: HTMLElement): void {
+    const btn = card.querySelector(".card-controls-toggle-btn");
+    if (btn) btn.remove();
+}

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -45,7 +45,11 @@ import { planFollowFocusTeardown } from "./followFocus";
 import { attachInteractiveInputHandlers } from "./interactiveInput";
 import type { InteractiveInputConfig } from "./interactiveInput";
 import { stampLiveBadgesOnGrid } from "./liveBadge";
-import { ensureLiveCardControls } from "./liveCardControls";
+import {
+    ensureControlsToggleButton,
+    ensureLiveCardControls,
+    removeControlsToggleButton,
+} from "./liveCardControls";
 import { planLiveToggle, planRecordingToggle } from "./liveTransitions";
 import { throttleLiveOnViewportLeave } from "./liveViewportThrottle";
 import type { VsCodeApi } from "../shared/vscode";
@@ -83,6 +87,13 @@ export class LiveStateController {
     // etc.) call `.clear()` / `.delete()` directly.
     private interactivePreviewIds: Set<string> = new Set<string>();
     private recordingPreviewIds: Set<string> = new Set<string>();
+    // Issue #1203 — per-preview "controls" toggle state. A card with controls
+    // enabled is in interactive mode AND has the keyboard listener attached;
+    // toggling controls off detaches the listener but leaves live mode alone.
+    // Cleared when the card stops live mode (the listener is unreachable
+    // without an active session anyway, and re-entering live should not silently
+    // re-attach keyboard interception).
+    private controlsEnabledPreviewIds: Set<string> = new Set<string>();
 
     // Per-module availability — written from `setInteractiveAvailability`
     // via `setAvailability`, read by the focus toolbar predicates through
@@ -216,6 +227,69 @@ export class LiveStateController {
     }
 
     /**
+     * Issue #1203 — true when the user has enabled the per-card "controls" toggle for
+     * [previewId]. Consumed by the keyboard listener's `supportsControl` gate (via
+     * `interactiveInputConfig.isControlsEnabled`) so a card without the toggle on stays
+     * pointer-only even when the daemon advertises keyboard dispatch.
+     */
+    isControlsEnabled(previewId: string): boolean {
+        return this.controlsEnabledPreviewIds.has(previewId);
+    }
+
+    /**
+     * Issue #1203 — per-card "Controls" button click. Toggling on auto-enters live
+     * mode (interactive dispatch only lands against a held composition) and attaches
+     * the keyboard listener; toggling off detaches the listener but leaves live mode
+     * intact — the user may still want to click / drag the preview.
+     *
+     * Idempotent: re-enabling a card that's already on (e.g. via a duplicate event) is
+     * a no-op; disabling a card that's already off is a no-op.
+     */
+    toggleControlsForCard(card: HTMLElement, enabled: boolean): void {
+        const previewId = card.dataset.previewId;
+        if (!previewId) return;
+        if (enabled) {
+            if (this.controlsEnabledPreviewIds.has(previewId)) return;
+            this.controlsEnabledPreviewIds.add(previewId);
+            this.enterLiveModeForExtension(card);
+            attachInteractiveInputHandlers(
+                card,
+                this.cfg.interactiveInputConfig,
+            );
+        } else {
+            if (!this.controlsEnabledPreviewIds.has(previewId)) return;
+            this.controlsEnabledPreviewIds.delete(previewId);
+        }
+        this.applyControlsToggleButtons();
+    }
+
+    /**
+     * Issue #1203 — re-stamp the per-card "Controls" button across the grid based on
+     * the current daemon capability snapshot. Called after `setDaemonCapabilities` and
+     * after each per-card toggle so the button appears / disappears in lock-step with
+     * the daemon's `requiresInteractive` extension set.
+     *
+     * Buttons appear on every card when at least one interactive-only extension is
+     * advertised; their pressed visual state reflects `isControlsEnabled(previewId)`.
+     */
+    applyControlsToggleButtons(): void {
+        const advertised = this.moduleInteractiveOnlyExtensions.size > 0;
+        const cards = document.querySelectorAll<HTMLElement>(".preview-card");
+        for (const card of cards) {
+            if (!advertised) {
+                removeControlsToggleButton(card);
+                continue;
+            }
+            const previewId = card.dataset.previewId;
+            if (!previewId) continue;
+            ensureControlsToggleButton(card, {
+                enabled: this.controlsEnabledPreviewIds.has(previewId),
+                onToggle: (c, next) => this.toggleControlsForCard(c, next),
+            });
+        }
+    }
+
+    /**
      * Posts the live-mode wire command for [previewId] — routes through
      * [liveToggleCommand] which always picks `requestStreamStart` /
      * `requestStreamStop` now that streaming is the only live path.
@@ -263,9 +337,11 @@ export class LiveStateController {
         const ids = Array.from(this.interactivePreviewIds);
         this.interactivePreviewIds.clear();
         ids.forEach((previewId) => {
+            this.controlsEnabledPreviewIds.delete(previewId);
             this.postLiveCommand(previewId, false);
         });
         this.applyLiveBadge();
+        this.applyControlsToggleButtons();
         this.cfg.applyInteractiveButtonState();
     }
 
@@ -274,8 +350,14 @@ export class LiveStateController {
         const previewId = card.dataset.previewId;
         if (!previewId || !this.interactivePreviewIds.has(previewId)) return;
         this.interactivePreviewIds.delete(previewId);
+        // Issue #1203 — keyboard listener is gated on isControlsEnabled, but
+        // leaving the flag set across a live-mode bounce would silently
+        // re-attach interception the next time the user enters live mode for
+        // unrelated reasons. Clear it so the toggle stays explicit.
+        this.controlsEnabledPreviewIds.delete(previewId);
         this.postLiveCommand(previewId, false);
         this.applyLiveBadge();
+        this.applyControlsToggleButtons();
         this.cfg.applyInteractiveButtonState();
     }
 
@@ -412,6 +494,13 @@ export class LiveStateController {
         this.interactivePreviewIds.forEach((id) => {
             if (!stillExists(id)) this.interactivePreviewIds.delete(id);
         });
+        // Issue #1203 — keep the per-card "Controls" set in sync. A preview
+        // that no longer exists for the daemon to dispatch into shouldn't
+        // keep a panel-side flag that would re-attach interception on a
+        // future preview that happens to reuse the id.
+        this.controlsEnabledPreviewIds.forEach((id) => {
+            if (!stillExists(id)) this.controlsEnabledPreviewIds.delete(id);
+        });
     }
 
     /** Daemon-not-ready — drop UI bookkeeping silently. */
@@ -423,6 +512,10 @@ export class LiveStateController {
         if (this.recordingPreviewIds.size > 0) {
             this.recordingPreviewIds.clear();
         }
+        // Issue #1203 — controls-enabled flag must also drop when the daemon
+        // disappears; the listener wouldn't reach a daemon anyway.
+        this.controlsEnabledPreviewIds.clear();
+        this.applyControlsToggleButtons();
         this.cfg.applyInteractiveButtonState();
         this.cfg.applyRecordingButtonState();
     }

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -521,15 +521,22 @@ export class LiveStateController {
     }
 
     /** Extension-driven `clearInteractive` — silent, the extension already
-     *  stopped the streams server-side. */
+     *  stopped the streams server-side. Also drop the per-card "Controls"
+     *  flag (#1203) so a future live-mode re-entry doesn't silently re-attach
+     *  keyboard interception, matching `stopInteractiveForCard` /
+     *  `stopAllInteractive`. */
     handleExtensionClearInteractive(previewId: string | null): void {
         if (previewId) {
             this.interactivePreviewIds.delete(previewId);
+            this.controlsEnabledPreviewIds.delete(previewId);
             this.applyLiveBadge();
+            this.applyControlsToggleButtons();
             this.cfg.applyInteractiveButtonState();
         } else if (this.interactivePreviewIds.size > 0) {
             this.interactivePreviewIds.clear();
+            this.controlsEnabledPreviewIds.clear();
             this.applyLiveBadge();
+            this.applyControlsToggleButtons();
             this.cfg.applyInteractiveButtonState();
         }
     }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -2322,6 +2322,10 @@ export class PreviewApp extends LitElement {
             // which `updateImage` already drives on every live render.
             supportsControl: (kind: string) =>
                 liveState.supportsInteractiveControl(kind),
+            // Issue #1203 — per-card "Controls" toggle gate. The listener stays
+            // attached across toggles; this predicate is consulted on every
+            // keystroke so flipping the toggle off immediately stops forwarding.
+            isControlsEnabled: (id: string) => liveState.isControlsEnabled(id),
             vscode,
         };
 

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -267,6 +267,9 @@ export function handleExtensionMessage(
                     .filter((e) => e.requiresInteractive === true)
                     .map((e) => e.id),
             );
+            // Restamp the per-card "Controls" buttons so they appear /
+            // disappear in lock-step with the daemon-advertised set.
+            ctx.liveState.applyControlsToggleButtons();
             return;
         case "streamStarted": {
             const card = document.getElementById(
@@ -357,6 +360,10 @@ function handleSetPreviews(
     const newIds = new Set(msg.previews.map((p) => p.id));
     ctx.liveState.pruneLive((id) => newIds.has(id));
     ctx.liveState.applyLiveBadge();
+    // Restamp the per-card "Controls" buttons (#1203). Cards that just landed
+    // in the grid need the button injected when the daemon advertises an
+    // interactive-only extension; cards that were dropped won't be visited.
+    ctx.liveState.applyControlsToggleButtons();
     ctx.applyInteractiveButtonState();
     // Tell the extension the cards reached the grid. Powers the e2e test's
     // "real webview consumed setPreviews" assertion — `postedMessageLog`


### PR DESCRIPTION
…extensions

Hooks the issue #1203 `requiresInteractive` flag into a real UI surface: a per-card "Controls" button (keyboard codicon, top-left of the `.image-container`) that appears on every preview card when the daemon advertises at least one interactive-only data extension. Toggling it on auto-enters live mode via the existing `enterLiveModeForExtension` seam and gates the keyboard listener through a new `isControlsEnabled` predicate; toggling off detaches keyboard interception but leaves live mode intact so click / drag still work.

Wiring:

- `liveCardControls.ts` grows `ensureControlsToggleButton` / `removeControlsToggleButton` next to the existing stop-button helper. Click handler is bound exactly once per card; `aria-pressed` + title reflect the latest enabled flag on every call.
- `LiveStateController` tracks a `controlsEnabledPreviewIds: Set<string>`, exposes `isControlsEnabled`, `toggleControlsForCard`, and an `applyControlsToggleButtons()` grid stamper. Stamping fires after `setDaemonCapabilities`, `setPreviews`, per-card toggle, and on daemon-lost so the button stays in lock-step with the advertised set.
- `interactiveInput.ts` consults `isControlsEnabled` on every keystroke rather than at attach time — flipping the toggle off stops forwarding immediately without rebinding the listener.
- Pruning paths (`stopAllInteractive`, `stopInteractiveForCard`, `pruneLive`, `handleDaemonLost`) clear the flag so it never carries silently across a live-mode bounce or a preview id being reused.

Adds 7 happy-dom tests pinning the button shape, idempotency, click toggling, suppress-default-and-propagation, missing-container no-op, and `removeControlsToggleButton` symmetry.

CSS uses the focus-border accent for the pressed state so it visually matches VS Code's own toggle buttons.