### PR TITLE
ci(integration): mark androidchka cell non-blocking on PRs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -117,6 +117,13 @@ jobs:
     name: ${{ matrix.name }}
     needs: build-plugin
     runs-on: ubuntu-latest
+    # `continue-on-error: true` on a matrix entry makes that entry's failures
+    # surface as warnings rather than blocking required-status checks on PRs.
+    # Used by the `androidchka` cell — it pairs against a live `androidx-main`
+    # checkout and is intentionally a daily *signal* of upstream drift, not a
+    # gate on PR merges. Other cells default to `false` (blocking) when the
+    # field is absent.
+    continue-on-error: ${{ matrix.continue_on_error == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -219,6 +226,12 @@ jobs:
             repo: yschimke/androidchka
             ref: main
             workdir: .
+            # Non-blocking on PRs: this entry pairs with a live `androidx-main`
+            # checkout, so a failure here means *upstream* AndroidX shipped a
+            # break — not that the PR did anything wrong. The daily cron is
+            # still what surfaces the drift; we just don't want it gating
+            # unrelated PR merges.
+            continue_on_error: true
             # Daily drift sentinel against upstream androidx. androidchka
             # is a Gradle workspace that selectively builds a handful of
             # androidx modules from a sibling `androidx/androidx` checkout


### PR DESCRIPTION
## Summary

The `androidchka (compose:material3 samples)` matrix entry in the `Integration` workflow pairs against a live `androidx/androidx@androidx-main` checkout. When that cell fails it means **upstream AndroidX shipped a break** — not that the PR under test did anything wrong. But because it's treated as a required status check, every coincident PR ends up gated behind upstream drift the PR can't fix.

This change marks just that cell as `continue-on-error: true` so its failures surface as warnings rather than hard gates. The daily cron run still records the failure conclusion for drift tracking; PR merges aren't blocked by it.

## Change

Adds a `continue_on_error: true` flag to the `androidchka (compose:material3 samples)` matrix entry, plumbed through to a job-level `continue-on-error: ${{ matrix.continue_on_error == true }}` expression. Every other matrix entry defaults to `false` (blocking) when the field is absent — `agp8-min`, `androidify`, `wear-os-samples`, etc. stay strict.

## Test plan

- [x] YAML parses cleanly (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- [ ] Next PR that runs against an `androidx-main` break shows the cell as a warning ("Some checks were not successful") rather than blocking auto-merge.
- [ ] Daily scheduled run still records the failure conclusion on the workflow page so drift stays visible.
- [ ] Other cells continue to block on real failures (verify by checking that `agp8-min` etc. still gate when intentionally broken — not exercised in this PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_017q11eXtZk1AyNtKsnYMuLM)_