### PR TITLE
docs: tidy stale a11y-model relocation breadcrumbs

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -121,16 +121,6 @@ data class RenderManifest(
     val dataExtensionReports: Map<String, String> = emptyMap(),
 )
 
-// ---------------------------------------------------------------------------
-// Accessibility models (`AccessibilityReport`, `AccessibilityEntry`,
-// `AccessibilityNode`, `AccessibilityFinding`) used to live here. They moved
-// to `:data-a11y-core` (`AccessibilityModels.kt`) under the same package as
-// part of the D2.2 split — see `data/a11y/core/.../AccessibilityModels.kt`.
-// Renderer-android keeps them on its API surface via `api(project(":data-a11y-core"))`,
-// so existing imports of `ee.schimke.composeai.renderer.AccessibilityFinding` etc.
-// resolve unchanged.
-// ---------------------------------------------------------------------------
-
 @Serializable
 data class RenderPreviewEntry(
     val id: String,

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -174,7 +174,7 @@ export interface PreviewTarget {
 
 /**
  * Per-node entry in the `a11y/hierarchy` data product. Mirrors the renderer-side
- * `AccessibilityNode` (in `renderer-android/.../RenderManifest.kt`).
+ * `AccessibilityNode` (in `data/a11y/core/.../AccessibilityModels.kt`).
  */
 export interface AccessibilityNode {
     label: string;


### PR DESCRIPTION
## Summary

Two stale relocation breadcrumbs left over from when the accessibility model types moved out of `:renderer-android` into `:data-a11y-core`:

- `renderer-android/.../RenderManifest.kt:125-132` — a tombstone comment saying "the a11y types used to live here, they're at `:data-a11y-core/AccessibilityModels.kt` now." The types haven't lived here in a while and this file isn't a relevant landmark for them anymore. Dropped.
- `vscode-extension/src/types.ts:177` — the TypeScript `AccessibilityNode` mirror still documented its Kotlin counterpart as `renderer-android/.../RenderManifest.kt`. Repointed at `data/a11y/core/.../AccessibilityModels.kt`.

No code changes — comments only.

## Test plan

- [x] `./gradlew :renderer-android:compileDebugKotlin` clean locally.
- [x] `npm --prefix vscode-extension run format:check` clean.
- [ ] CI green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lc94k8Hka1CbgMX3B7wAHy)_