### PR TITLE
feat(daemon-desktop): honor orientation override via widthPx/heightPx swap

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -180,9 +180,13 @@ open class DesktopHost(
    * `device` (resolved by `DeviceDimensions`). `localeTag` is advertised only when the Compose UI
    * runtime on the classpath exposes its providable locale list; older Compose Desktop runtimes
    * keep treating it as unsupported rather than falling back to JVM-wide `Locale.setDefault(...)`.
-   * `orientation` is no-op because `ImageComposeScene` has no rotation concept. `inspectionMode`
-   * flows into `LocalInspectionMode` on the one-shot render path; interactive and recording
-   * sessions keep their runtime-like `false` default.
+   * `orientation` is modelled as a `widthPx ↔ heightPx` swap before `ImageComposeScene`
+   * construction (issue #1208) — `ImageComposeScene` has no display-rotation concept, but
+   * `LANDSCAPE` is observably just the dimension swap (plus a `LocalConfiguration.orientation` flip
+   * on Android, which desktop's `RenderEngine` doesn't compose today). Explicit `widthPx` /
+   * `heightPx` overrides on the same call win — orientation is a hint that only fires when neither
+   * dimension was set. `inspectionMode` flows into `LocalInspectionMode` on the one-shot render
+   * path; interactive and recording sessions keep their runtime-like `false` default.
    */
   override val supportedOverrides: Set<String> = buildSet {
     add("widthPx")
@@ -191,6 +195,7 @@ open class DesktopHost(
     if (RenderEngine.supportsLocaleTagOverride()) add("localeTag")
     add("fontScale")
     add("uiMode")
+    add("orientation")
     add("device")
     add("inspectionMode")
     add("material3Theme")
@@ -437,15 +442,22 @@ open class DesktopHost(
    * go through the host's render-queue payload string.
    *
    * Explicit `widthPx` / `heightPx` / `density` overrides win over `device`-resolved values.
-   * `outputBaseName` is rewritten to `recording-<recordingId>` so a stray engine fast-path encode
-   * (only used by the one-shot `engine.render` wrapper, not by the recording flow) wouldn't collide
-   * with another preview's PNG. The recording flow itself never reads it.
+   * Issue #1208 — `orientation = LANDSCAPE` swaps the resolved `widthPx`/`heightPx` only when
+   * neither an explicit pixel dimension nor a `device` token was supplied; otherwise the explicit
+   * sizing wins (orientation is a hint, not a forced rotation). `outputBaseName` is rewritten to
+   * `recording-<recordingId>` so a stray engine fast-path encode (only used by the one-shot
+   * `engine.render` wrapper, not by the recording flow) wouldn't collide with another preview's
+   * PNG. The recording flow itself never reads it.
    */
   private fun applyOverrides(
     base: RenderSpec,
     overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides?,
     recordingId: String,
   ): RenderSpec {
+    val explicitDimensionSupplied =
+      overrides?.widthPx != null ||
+        overrides?.heightPx != null ||
+        overrides?.device?.takeIf { it.isNotBlank() } != null
     val merged =
       mergePreviewOverrides(
         base =
@@ -490,9 +502,13 @@ open class DesktopHost(
           RenderSpec.SpecOrientation.LANDSCAPE
         null -> null
       }
+    val shouldSwap =
+      orientation == RenderSpec.SpecOrientation.LANDSCAPE && !explicitDimensionSupplied
+    val effectiveWidthPx = if (shouldSwap) merged.heightPx else merged.widthPx
+    val effectiveHeightPx = if (shouldSwap) merged.widthPx else merged.heightPx
     return base.copy(
-      widthPx = merged.widthPx,
-      heightPx = merged.heightPx,
+      widthPx = effectiveWidthPx,
+      heightPx = effectiveHeightPx,
       density = merged.density,
       device = merged.device,
       localeTag = merged.localeTag,
@@ -606,11 +622,31 @@ open class DesktopHost(
     val previewId = map["previewId"]?.takeIf { it.isNotBlank() } ?: return null
     val resolver = previewSpecResolver ?: return null
     val base = resolver(previewId) ?: return null
+    val widthOverride = map["widthPx"]?.toIntOrNull()
+    val heightOverride = map["heightPx"]?.toIntOrNull()
+    val orientation =
+      when (map["orientation"]?.lowercase()) {
+        "portrait" -> RenderSpec.SpecOrientation.PORTRAIT
+        "landscape" -> RenderSpec.SpecOrientation.LANDSCAPE
+        else -> base.orientation
+      }
+    // Issue #1208 — desktop has no display rotation, but `LANDSCAPE` reduces to a `widthPx ↔
+    // heightPx` swap. Explicit pixel overrides (or device-derived dims emitted by
+    // `JsonRpcServer.encodeRenderPayload`) win over the hint, so we only swap when neither
+    // dimension was supplied on the wire. `PreviewManifestRouter` always emits widthPx/heightPx
+    // from its manifest defaults, so the swap there fires on the router side instead — see
+    // [PreviewManifestRouter.submit].
+    val baseWidthPx = widthOverride ?: base.widthPx
+    val baseHeightPx = heightOverride ?: base.heightPx
+    val shouldSwap =
+      orientation == RenderSpec.SpecOrientation.LANDSCAPE &&
+        widthOverride == null &&
+        heightOverride == null
     return base.copy(
       previewId = previewId,
       renderMode = map["mode"]?.takeIf { it.isNotBlank() },
-      widthPx = map["widthPx"]?.toIntOrNull() ?: base.widthPx,
-      heightPx = map["heightPx"]?.toIntOrNull() ?: base.heightPx,
+      widthPx = if (shouldSwap) baseHeightPx else baseWidthPx,
+      heightPx = if (shouldSwap) baseWidthPx else baseHeightPx,
       density = map["density"]?.toFloatOrNull() ?: base.density,
       localeTag = map["localeTag"]?.takeIf { it.isNotBlank() } ?: base.localeTag,
       fontScale = map["fontScale"]?.toFloatOrNull() ?: base.fontScale,
@@ -620,12 +656,7 @@ open class DesktopHost(
           "dark" -> RenderSpec.SpecUiMode.DARK
           else -> base.uiMode
         },
-      orientation =
-        when (map["orientation"]?.lowercase()) {
-          "portrait" -> RenderSpec.SpecOrientation.PORTRAIT
-          "landscape" -> RenderSpec.SpecOrientation.LANDSCAPE
-          else -> base.orientation
-        },
+      orientation = orientation,
       inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull() ?: base.inspectionMode,
     )
   }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -80,6 +80,18 @@ class PreviewManifestRouter(
     val baseHeightPx = deviceSpec?.let { (it.heightDp * it.density).toInt() } ?: resolved.heightPx
     val baseDensity = deviceSpec?.density ?: resolved.density
     val effectiveDevice = deviceOverride ?: resolved.device
+    // Issue #1208 — `orientation = landscape` on desktop is a `widthPx ↔ heightPx` swap; explicit
+    // pixel overrides (or device-derived dims) win over the hint. We apply the swap here, before
+    // the rewritten payload reaches `DesktopHost`, because the router unconditionally emits
+    // widthPx/heightPx tokens which would otherwise hide the "no explicit dims" signal from the
+    // downstream `DesktopHost.specFromPreviewIdPayload` swap branch.
+    val shouldSwapOrientation =
+      inbound["orientation"]?.lowercase() == "landscape" &&
+        inbound["widthPx"] == null &&
+        inbound["heightPx"] == null &&
+        deviceOverride == null
+    val effectiveBaseWidthPx = if (shouldSwapOrientation) baseHeightPx else baseWidthPx
+    val effectiveBaseHeightPx = if (shouldSwapOrientation) baseWidthPx else baseHeightPx
     val routed =
       RenderRequest.Render(
         id = typed.id,
@@ -91,8 +103,8 @@ class PreviewManifestRouter(
             append("functionName=").append(entry.functionName).append(';')
             // Inbound explicit override wins over both the device-derived value and the
             // per-preview manifest default.
-            append("widthPx=").append(inbound["widthPx"] ?: baseWidthPx).append(';')
-            append("heightPx=").append(inbound["heightPx"] ?: baseHeightPx).append(';')
+            append("widthPx=").append(inbound["widthPx"] ?: effectiveBaseWidthPx).append(';')
+            append("heightPx=").append(inbound["heightPx"] ?: effectiveBaseHeightPx).append(';')
             append("density=").append(inbound["density"] ?: baseDensity).append(';')
             append("showBackground=").append(resolved.showBackground).append(';')
             if (resolved.backgroundColor != 0L) {
@@ -102,9 +114,9 @@ class PreviewManifestRouter(
               ?.takeIf { it.isNotBlank() }
               ?.let { append("device=").append(it).append(';') }
             // PROTOCOL.md § 5 (`renderNow.overrides`) — locale / fontScale / uiMode / orientation
-            // pass straight through. Desktop's `RenderEngine` ignores everything except size /
-            // density today (see RenderEngine.kt), but the fields ride along for parity with the
-            // android router so a single payload string drives both backends.
+            // pass straight through. `orientation = landscape` is applied above as a swap of the
+            // forwarded widthPx/heightPx; the token still rides along so downstream consumers see
+            // the resolved orientation. Other fields are honoured by `RenderEngine` directly.
             inbound["localeTag"]?.let { append("localeTag=").append(it).append(';') }
             inbound["fontScale"]?.let { append("fontScale=").append(it).append(';') }
             inbound["uiMode"]?.let { append("uiMode=").append(it).append(';') }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -549,9 +549,12 @@ data class RenderSpec(
    */
   val uiMode: SpecUiMode? = null,
   /**
-   * Portrait/landscape override. **No-op on desktop** — there's no display rotation concept for an
-   * `ImageComposeScene`. The size override (`widthPx`/`heightPx`) is the natural lever; the field
-   * is carried so a single payload string drives both backends.
+   * Portrait/landscape override. Desktop has no display-rotation concept on `ImageComposeScene`,
+   * but issue #1208 reduces `LANDSCAPE` to a `widthPx ↔ heightPx` swap applied by [DesktopHost]
+   * before the spec reaches the engine. Explicit `widthPx`/`heightPx` overrides on the same call
+   * win over the hint — `RenderEngine` reads the resolved dimensions straight from this spec
+   * without re-interpreting the orientation field, so any swap must already be baked in by the
+   * caller.
    */
   val orientation: SpecOrientation? = null,
   /**

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
@@ -93,6 +93,9 @@ class DesktopHostTest {
     val supported = DesktopHost().supportedOverrides
 
     assertEquals(RenderEngine.supportsLocaleTagOverride(), "localeTag" in supported)
+    // Issue #1208 — desktop now models `orientation = landscape` as a `widthPx ↔ heightPx` swap
+    // before scene construction, so the capability is advertised on both backends.
+    assertTrue("orientation should be advertised on desktop", "orientation" in supported)
   }
 
   /**

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -19,10 +19,12 @@ import org.junit.rules.TemporaryFolder
 /**
  * Desktop counterpart of `:daemon:android`'s `OverrideIntegrationTest`. Drives
  * [PreviewManifestRouter] directly with override-bearing payloads to prove the desktop renderer
- * actually applies `widthPx`, `uiMode`, and `fontScale` (PROTOCOL.md § 5, INTERACTIVE.md § 8a).
+ * actually applies `widthPx`, `uiMode`, `fontScale`, and `orientation` (PROTOCOL.md § 5,
+ * INTERACTIVE.md § 8a).
  *
  * `localeTag` is applied only when the Compose UI runtime exposes a providable locale list;
- * `orientation` is a no-op on desktop (`ImageComposeScene` has no rotation concept).
+ * `orientation = landscape` reduces to a `widthPx ↔ heightPx` swap before `ImageComposeScene`
+ * construction since issue #1208 — see [orientationOverrideSwapsDimensions].
  */
 class OverrideIntegrationTest {
 
@@ -56,6 +58,100 @@ class OverrideIntegrationTest {
       val large = renderAndDecode(host, "previewId=red-square;widthPx=128;heightPx=128", "large")
       assertEquals("widthPx override should reach the RenderSpec", 128, large.width)
       assertEquals("heightPx override should reach the RenderSpec", 128, large.height)
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
+   * Issue #1208 — `orientation = landscape` reduces to a `widthPx ↔ heightPx` swap on the desktop
+   * backend because `ImageComposeScene` has no display-rotation concept. The test exercises the
+   * swap on a manifest whose base shape is taller-than-wide; landscape should flip the rendered PNG
+   * to wider-than-tall, and explicit `widthPx`/`heightPx` overrides on the same call should win
+   * over the hint (orientation is a hint, not a forced rotation).
+   */
+  @Test
+  fun orientationOverrideSwapsDimensions() {
+    val outputDir = tempFolder.newFolder("renders-orientation")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "portrait-rect",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "RedSquare",
+              widthPx = 60,
+              heightPx = 120,
+              density = 1.0f,
+              outputBaseName = "portrait-rect",
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      val portrait = renderAndDecode(host, "previewId=portrait-rect", "portrait-default")
+      assertEquals("manifest default width should be honoured", 60, portrait.width)
+      assertEquals("manifest default height should be honoured", 120, portrait.height)
+      assertTrue(
+        "default orientation should be taller-than-wide; got ${portrait.width}x${portrait.height}",
+        portrait.height > portrait.width,
+      )
+
+      val landscape =
+        renderAndDecode(host, "previewId=portrait-rect;orientation=landscape", "landscape")
+      assertEquals("orientation=landscape should swap widthPx", 120, landscape.width)
+      assertEquals("orientation=landscape should swap heightPx", 60, landscape.height)
+      assertTrue(
+        "orientation=landscape should produce wider-than-tall; got ${landscape.width}x${landscape.height}",
+        landscape.width > landscape.height,
+      )
+
+      // Re-asserting portrait keeps the spec at base dims — a no-op swap.
+      val explicitPortrait =
+        renderAndDecode(host, "previewId=portrait-rect;orientation=portrait", "portrait-explicit")
+      assertEquals("orientation=portrait should leave widthPx alone", 60, explicitPortrait.width)
+      assertEquals("orientation=portrait should leave heightPx alone", 120, explicitPortrait.height)
+
+      // Precedence: explicit widthPx/heightPx win over the orientation hint. The caller asked
+      // for 200x80 AND landscape; the explicit dims are taken as-is.
+      val explicitLandscape =
+        renderAndDecode(
+          host,
+          "previewId=portrait-rect;widthPx=200;heightPx=80;orientation=landscape",
+          "explicit-landscape",
+        )
+      assertEquals(
+        "explicit widthPx should win over orientation hint",
+        200,
+        explicitLandscape.width,
+      )
+      assertEquals(
+        "explicit heightPx should win over orientation hint",
+        80,
+        explicitLandscape.height,
+      )
+
+      // Precedence in the opposite direction: explicit taller-than-wide pixels with
+      // orientation=landscape — the explicit dims still win, no swap fires.
+      val explicitTaller =
+        renderAndDecode(
+          host,
+          "previewId=portrait-rect;widthPx=40;heightPx=100;orientation=landscape",
+          "explicit-taller",
+        )
+      assertEquals(
+        "explicit widthPx should win over orientation hint even when taller-than-wide",
+        40,
+        explicitTaller.width,
+      )
+      assertEquals(
+        "explicit heightPx should win over orientation hint even when taller-than-wide",
+        100,
+        explicitTaller.height,
+      )
     } finally {
       host.shutdown()
     }

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -146,9 +146,9 @@ Result:
   // unsupported sliders.
   // Empty list = pre-feature daemon;
   // treat absent and `[]` identically and assume any field might be ignored.
-  // Today: Robolectric advertises every field; Desktop omits "orientation" (no rotation concept
-  // on `ImageComposeScene`), Android-only timing knobs, and "localeTag" unless the Compose UI
-  // runtime exposes a providable locale list.
+  // Today: Robolectric advertises every field; Desktop advertises `orientation` (modelled as a
+  // `widthPx ↔ heightPx` swap on `ImageComposeScene` since #1208) but omits Android-only timing
+  // knobs, and "localeTag" unless the Compose UI runtime exposes a providable locale list.
   //
   // androidSdk — fixed Android SDK level the backend renders against. Populated by the
   // Robolectric backend from its pinned @Config(sdk = ...) value; absent/null on Desktop and
@@ -321,7 +321,9 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
   localeTag?: string;                // BCP-47 (e.g. "en-US", "fr", "ja-JP").
   fontScale?: number;                // 1.0 = system default
   uiMode?: "light" | "dark";         // Android-only today.
-  orientation?: "portrait" | "landscape";  // Android-only today.
+  orientation?: "portrait" | "landscape";  // Android: full rotation. Desktop: `landscape` swaps
+                                     // the resolved widthPx/heightPx before scene construction
+                                     // when neither dimension was set explicitly (issue #1208).
   device?: string;                   // "id:pixel_5", "id:wearos_small_round", "spec:width=400dp,height=800dp,dpi=320".
                                      // Resolved by the daemon's catalog into widthPx/heightPx/density;
                                      // explicit widthPx/heightPx/density above take precedence.
@@ -351,7 +353,7 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
 
 The result resolves as soon as the request is queued, **not** when rendering completes. Per-render progress arrives as `renderStarted` / `renderFinished` / `renderFailed` notifications keyed by ID.
 
-`overrides` are merged onto the discovery-time `RenderSpec` per-call. A subsequent `renderNow` for the same preview **without** `overrides` reverts to the discovery-time defaults — overrides are not sticky across calls. Backends that don't model a particular field ignore it (e.g. desktop has no display rotation concept, so `orientation` is a no-op on the desktop render path today; desktop `localeTag` requires a Compose UI runtime that exposes a providable locale list). `inspectionMode` controls the `LocalInspectionMode` value for this one-shot render; absent/null preserves preview behaviour (`true`). `material3Theme` is applied in the renderer's normal Compose tree as a `MaterialTheme(...) { preview() }` wrapper, so it affects components that read Material 3 locals without requiring the preview source to declare its own theme.
+`overrides` are merged onto the discovery-time `RenderSpec` per-call. A subsequent `renderNow` for the same preview **without** `overrides` reverts to the discovery-time defaults — overrides are not sticky across calls. Backends that don't model a particular field ignore it (e.g. desktop `localeTag` requires a Compose UI runtime that exposes a providable locale list). `orientation` is supported on both backends: Android performs a full rotation via the resource qualifier; desktop reduces `landscape` to a `widthPx ↔ heightPx` swap before `ImageComposeScene` construction (issue #1208). Explicit pixel/`device` overrides on the same call win over the orientation hint on desktop — pass `orientation` alone for the swap to fire. `inspectionMode` controls the `LocalInspectionMode` value for this one-shot render; absent/null preserves preview behaviour (`true`). `material3Theme` is applied in the renderer's normal Compose tree as a `MaterialTheme(...) { preview() }` wrapper, so it affects components that read Material 3 locals without requiring the preview source to declare its own theme.
 
 **Coalescing.** When `overrides` is non-null and a prior override-bearing render is still in-flight for the same `previewId`, the new request is rejected with `reason = "coalesced: …"` rather than queued. The client (panel, MCP, etc.) is responsible for resubmitting on the next `renderFinished` if the latest override values still differ from what was rendered. Plain (no-overrides) `renderNow` is unaffected — the existing save-debounce loop continues to coalesce upstream.
 


### PR DESCRIPTION
## Summary
- Swap effective `widthPx`/`heightPx` on the desktop host when `overrides.orientation == LANDSCAPE`, with explicit dimensions winning over the orientation hint.
- Add `orientation` to `DesktopHost.supportedOverrides` and refresh the KDoc + `docs/daemon/PROTOCOL.md` §3/§5 to describe desktop swap semantics + precedence.
- Apply the swap on both `applyOverrides` (recording) and `specFromPreviewIdPayload` (renderNow) paths, plus `PreviewManifestRouter` harness path which unconditionally emits width/height tokens.

Closes #1208.

## Test plan
- [x] `:daemon:desktop:test --tests OverrideIntegrationTest` (new `orientationOverrideSwapsDimensions` + existing 4)
- [x] `:daemon:desktop:test --tests DesktopHostTest` (extended `supportedOverridesReflectRuntimeLocaleCapability`)
- [x] `:daemon:desktop:test --tests JsonRpcDesktopIntegrationTest DesktopRecordingSessionTest DesktopInteractiveSessionTest`
- [x] `:daemon:desktop:ktfmtCheck`
- [ ] Pre-existing `RecompositionDataProductRegistryTest.observer_install_failure_degrades_to_advertise_but_useless` failure reproduces on clean `origin/main` — unrelated, flagged separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sderu4ai7SkoMgvV33BGeA)_