### PR TITLE
feat(data-focus): add desktop connector + wire focus override into desktop daemon

### DIFF
--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -57,6 +57,12 @@ dependencies {
   // `localeTag` → `PseudolocaleOverrideExtensionDesktop`. The locale-list rewrite
   // (`en-XA` → `en`, `ar-XB` → `ar`) lives in `RenderEngine.localeProviders`.
   implementation(project(":data-pseudolocale-connector-desktop"))
+  // Focus (desktop): the around-composable that flips `LocalInputModeManager` to keyboard mode and
+  // drives `FocusManager.moveFocus(...)` from `renderNow.overrides.focus`. Issue #1205 — Android
+  // wires `FocusPreviewOverrideExtension` from `:data-focus-connector`; CMP Desktop uses this
+  // platform-portable mirror. The Android-only `FocusOverlay` (Android-View focus-owner reflection)
+  // is not shipped on desktop.
+  implementation(project(":data-focus-connector-desktop"))
   implementation(project(":data-recomposition-connector"))
   // Display-filter connector — `DisplayFilterDataProducer.writeArtifacts` runs the post-capture
   // pipeline and writes per-variant PNGs + the `displayfilter-variants.json` manifest after each

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -549,6 +549,20 @@ internal fun buildDesktopExtensions(
       previewOverrideExtensions = listOf(WallpaperPreviewOverrideExtension()),
     )
   }
+  tryAdd("data/focus") {
+    // Issue #1205 — focus / keyboard-traversal override. The planner reads
+    // `renderNow.overrides.focus` and emits the around-composable that flips
+    // `LocalInputModeManager` to keyboard mode and drives `FocusManager.moveFocus(...)`.
+    // Android wires the same planner from `:data-focus-connector` directly into the
+    // RenderEngine's `previewOverrideExtensions` list (see RobolectricHost); the desktop
+    // backend instead routes through the extension registry so `extensions/list` reports
+    // `data/focus` and the override only fires when the extension is active.
+    Extension(
+      id = "data/focus",
+      displayName = "Focus override",
+      previewOverrideExtensions = listOf(FocusPreviewOverrideExtension()),
+    )
+  }
   tryAdd("data/pseudolocale") {
     Extension(
       id = "data/pseudolocale",

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -195,6 +195,10 @@ open class DesktopHost(
     add("inspectionMode")
     add("material3Theme")
     add("wallpaper")
+    // Issue #1205 — `renderNow.overrides.focus` is honoured by the planner registered in
+    // `data/focus` (`FocusPreviewOverrideExtension`), which installs the around-composable that
+    // flips `LocalInputModeManager` to keyboard mode and drives `FocusManager.moveFocus(...)`.
+    add("focus")
   }
 
   /** PROTOCOL.md § 3 — desktop backend identifier surfaced via `capabilities.backend`. */

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/BuildDesktopExtensionsTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/BuildDesktopExtensionsTest.kt
@@ -55,6 +55,9 @@ class BuildDesktopExtensionsTest {
     assertTrue("data/theme" in ids)
     assertTrue("data/wallpaper" in ids)
     assertTrue("data/pseudolocale" in ids)
+    // Issue #1205 — `data/focus` registers the focus / keyboard-traversal override planner so
+    // `renderNow.overrides.focus` is no longer silently ignored on the desktop backend.
+    assertTrue("data/focus" in ids)
     assertTrue("data/recomposition" in ids)
     assertTrue("recording/script" in ids)
 

--- a/data/focus/connector-desktop/build.gradle.kts
+++ b/data/focus/connector-desktop/build.gradle.kts
@@ -1,0 +1,52 @@
+@file:Suppress("DEPRECATION")
+
+// `:data-focus-connector-desktop` is the JVM-side counterpart to `:data-focus-connector` (Android).
+// Both planners read `renderNow.overrides.focus` and emit a `PreviewOverrideExtension` that wraps
+// the
+// content in an `AroundComposable` driving `LocalInputModeManager` / `FocusManager.moveFocus(...)`.
+//
+// **Why a separate source set?** `:data-focus-connector` is an `android.library` module, so its
+// outputs can't be consumed from `:daemon:desktop`'s JVM classpath. The around-composable plumbing
+// itself only depends on `androidx.compose.runtime` + `androidx.compose.ui` (`LocalFocusManager`,
+// `LocalInputModeManager`, `FocusManager.moveFocus`) — fully Compose Multiplatform portable. The
+// Android module additionally ships `FocusOverlay` (a `BufferedImage` overlay sourced from
+// `AndroidComposeView.focusOwner` via reflection); that's Android-only and stays on the Android
+// side.
+//
+// Mirrors `:data-pseudolocale-connector-desktop`'s layout — see the comment header there for the
+// platform-split rationale.
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.compiler)
+}
+
+dependencies {
+  // Wire-shape (`FocusOverride` / `FocusDirection`) — re-exported so consumers (`:daemon:desktop`)
+  // can refer to the model types without a second project dep.
+  api(project(":data-focus-core"))
+
+  // DataExtension / AroundComposableExtension / DataExtensionId / DataExtensionPhase. Re-exported
+  // so
+  // the planner / extension classes can be referenced from `DesktopHost`'s
+  // `previewOverrideExtensions` list without a second project dep on the consumer.
+  api(project(":daemon:core"))
+  api(project(":data-render-compose"))
+
+  implementation(compose.runtime)
+  implementation(compose.ui)
+
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-focus-connector-desktop",
+    displayName = "Compose Preview - Focus Data Product Connector (Desktop)",
+    description =
+      "Daemon-side focus / keyboard-traversal data-product connector for Compose Multiplatform Desktop: drives the around-composable that lets `renderNow.overrides.focus` render under a synthetic keyboard input mode. Mirrors :data-focus-connector — see that module for the Android-only `FocusOverlay`.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/focus/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/FocusControllerDesktop.kt
+++ b/data/focus/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/FocusControllerDesktop.kt
@@ -1,0 +1,68 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.focus.FocusDirection as ComposeFocusDirection
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.input.InputModeManager
+import ee.schimke.composeai.daemon.protocol.FocusDirection
+import ee.schimke.composeai.daemon.protocol.FocusOverride
+
+/**
+ * Process-static state holder for the active focus override.
+ *
+ * Desktop counterpart of `:data-focus-connector`'s [FocusController]. The wire-shape, settle
+ * window, and the snapshot-state semantics match — see the Android module for the full rationale
+ * (the `LaunchedEffect`-vs-outer-loop comment, why 250ms covers the ripple crossfade, etc.).
+ * Desktop's daemon path only seeds the controller from [FocusOverrideExtension]'s constructor;
+ * there is no per-capture `@FocusedPreview` plugin loop on CMP Desktop today, so the renderer-side
+ * `applyFocusOverride(...)` helper isn't shipped here.
+ */
+object FocusController {
+
+  private val state: MutableState<FocusOverride?> = mutableStateOf(null)
+
+  val activeFocus: State<FocusOverride?>
+    get() = state
+
+  /** Per-capture settle window in ms — matches the Android connector for parity. */
+  const val SETTLE_MS: Long = 250L
+
+  /** Replace the active override. `null` clears the state and disables focus driving. */
+  fun set(override: FocusOverride?) {
+    state.value = override
+  }
+
+  fun current(): FocusOverride? = state.value
+
+  /** Cleanup hook for per-session reset. */
+  fun resetForNewSession() {
+    state.value = null
+  }
+}
+
+/**
+ * [InputModeManager] that always reports [InputMode.Keyboard] — provided via
+ * `androidx.compose.ui.platform.LocalInputModeManager` so previews that call
+ * `FocusRequester.requestFocus()` actually receive focus. Compose Multiplatform Desktop's default
+ * host treats focus much like Robolectric: `Modifier.clickable` registers its focusable with
+ * `Focusability.SystemDefined`, which refuses focus while the input mode is `InputMode.Touch`.
+ * Forcing keyboard mode for the duration of any focus-driven render unblocks the focus walk.
+ */
+object KeyboardInputModeManager : InputModeManager {
+  override val inputMode: InputMode = InputMode.Keyboard
+
+  override fun requestInputMode(inputMode: InputMode): Boolean = false
+}
+
+/** Maps the wire-shape [FocusDirection] enum onto Compose's `FocusDirection` value class. */
+fun FocusDirection.toCompose(): ComposeFocusDirection =
+  when (this) {
+    FocusDirection.Next -> ComposeFocusDirection.Next
+    FocusDirection.Previous -> ComposeFocusDirection.Previous
+    FocusDirection.Up -> ComposeFocusDirection.Up
+    FocusDirection.Down -> ComposeFocusDirection.Down
+    FocusDirection.Left -> ComposeFocusDirection.Left
+    FocusDirection.Right -> ComposeFocusDirection.Right
+  }

--- a/data/focus/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProductDesktop.kt
+++ b/data/focus/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProductDesktop.kt
@@ -1,0 +1,104 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.focus.FocusDirection as ComposeFocusDirection
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalInputModeManager
+import ee.schimke.composeai.daemon.protocol.FocusOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.focus.Material3FocusProduct
+import ee.schimke.composeai.data.render.extensions.DataExtension
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+
+/**
+ * `AroundComposable` extension that owns the focus / keyboard-traversal around-composable concerns
+ * on Compose Multiplatform Desktop. Desktop counterpart of `:data-focus-connector`'s
+ * [FocusOverrideExtension]: installs `LocalInputModeManager provides KeyboardInputModeManager` and
+ * a `LaunchedEffect`-driven focus walk that observes [FocusController.activeFocus] and dispatches
+ * `FocusManager.moveFocus(...)` on every transition.
+ *
+ * Only the daemon path (`renderNow.overrides.focus`) wires through here today — CMP Desktop doesn't
+ * have a per-capture `@FocusedPreview` plugin path (issue #1205). The constructor seeds the
+ * controller via a `DisposableEffect` so a single-frame render driven by the daemon picks up the
+ * requested focus target.
+ *
+ * Runs in the [DataExtensionPhase.OuterEnvironment] phase so the input-mode flip happens before the
+ * user-environment phase reaches preview content.
+ */
+class FocusOverrideExtension(private val seed: FocusOverride? = null) :
+  AroundComposableExtension(
+    id = ID,
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.OuterEnvironment,
+        provides = setOf(DataExtensionCapability(Material3FocusProduct.KIND)),
+      ),
+  ) {
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    if (seed != null) {
+      DisposableEffect(seed) {
+        FocusController.set(seed)
+        onDispose { FocusController.set(null) }
+      }
+    }
+    CompositionLocalProvider(LocalInputModeManager provides KeyboardInputModeManager) {
+      val focusManager = LocalFocusManager.current
+      val active by FocusController.activeFocus
+      val lastIndex = remember { mutableIntStateOf(-1) }
+      val entered = remember { mutableStateOf(false) }
+      LaunchedEffect(active) {
+        val cap = active ?: return@LaunchedEffect
+        val direction = cap.direction
+        val tabIndex = cap.tabIndex
+        if (direction != null) {
+          if (!entered.value) {
+            focusManager.moveFocus(ComposeFocusDirection.Enter)
+            entered.value = true
+          }
+          focusManager.moveFocus(direction.toCompose())
+        } else if (tabIndex != null) {
+          // `moveFocus(Enter)` lands the owner on an internal root that sits *before* the first
+          // focusable, so the first walk needs `tabIndex + 1` Next steps to land on button
+          // `tabIndex`. Subsequent calls walk only the delta.
+          val from = lastIndex.value
+          if (from < 0) {
+            focusManager.moveFocus(ComposeFocusDirection.Enter)
+            repeat(tabIndex + 1) { focusManager.moveFocus(ComposeFocusDirection.Next) }
+          } else if (tabIndex > from) {
+            repeat(tabIndex - from) { focusManager.moveFocus(ComposeFocusDirection.Next) }
+          }
+          lastIndex.value = tabIndex
+        }
+      }
+      content()
+    }
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId(Material3FocusProduct.KIND)
+  }
+}
+
+/**
+ * Planner that maps `renderNow.overrides.focus` to a [FocusOverrideExtension]. No-op when the field
+ * is null — matches the wallpaper / theme / pseudolocale-desktop planners.
+ */
+class FocusPreviewOverrideExtension : DataExtension<PreviewOverrides> {
+  override val id: DataExtensionId = FocusOverrideExtension.ID
+
+  override fun plan(request: PreviewOverrides): PlannedDataExtension? =
+    request.focus?.let(::FocusOverrideExtension)
+}

--- a/data/focus/connector-desktop/src/test/kotlin/ee/schimke/composeai/daemon/FocusDataProductDesktopTest.kt
+++ b/data/focus/connector-desktop/src/test/kotlin/ee/schimke/composeai/daemon/FocusDataProductDesktopTest.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.AmbientOverride
+import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
+import ee.schimke.composeai.daemon.protocol.FocusDirection
+import ee.schimke.composeai.daemon.protocol.FocusOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.focus.Material3FocusProduct
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the contract of `:data-focus-connector-desktop`'s extension surface. Mirrors
+ * `FocusDataProductTest` in `:data-focus-connector` (Android) — issue #1205.
+ */
+class FocusDataProductDesktopTest {
+
+  @After fun tearDown() = FocusController.resetForNewSession()
+
+  @Test
+  fun `focus override extension declares around-composable hook in OuterEnvironment phase`() {
+    val extension = FocusOverrideExtension(FocusOverride(tabIndex = 0))
+    val hook: AroundComposableHook = extension
+
+    assertEquals(DataExtensionId(Material3FocusProduct.KIND), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.AroundComposable), extension.hooks)
+    assertEquals(DataExtensionPhase.OuterEnvironment, extension.constraints.phase)
+    assertTrue(extension.hasAroundComposableHook)
+    assertEquals(extension, hook)
+  }
+
+  @Test
+  fun `planner returns extension when focus override present`() {
+    val planner = FocusPreviewOverrideExtension()
+    val planned =
+      planner.plan(PreviewOverrides(focus = FocusOverride(direction = FocusDirection.Next)))
+    assertTrue("expected planner to produce a hook", planned is AroundComposableHook)
+    assertEquals(DataExtensionId(Material3FocusProduct.KIND), planned!!.id)
+  }
+
+  @Test
+  fun `planner abstains when focus override absent`() {
+    val planner = FocusPreviewOverrideExtension()
+    assertNull(planner.plan(PreviewOverrides()))
+    assertNull(planner.plan(PreviewOverrides(widthPx = 320)))
+    // Sibling overrides (e.g. ambient) shouldn't trigger the focus planner.
+    assertNull(
+      planner.plan(
+        PreviewOverrides(ambient = AmbientOverride(state = AmbientStateOverride.AMBIENT))
+      )
+    )
+  }
+
+  @Test
+  fun `controller starts inactive`() {
+    FocusController.resetForNewSession()
+    assertNull(FocusController.current())
+  }
+
+  @Test
+  fun `controller set propagates state and clear resets it`() {
+    FocusController.set(FocusOverride(tabIndex = 2, overlay = true))
+    assertEquals(FocusOverride(tabIndex = 2, overlay = true), FocusController.current())
+
+    FocusController.set(null)
+    assertNull(FocusController.current())
+  }
+
+  @Test
+  fun `controller settle window matches the Android connector for parity`() {
+    // Sentinel: the Android connector exposes the same constant for the renderer's per-capture
+    // clock advance. Bump in lockstep to keep behaviour aligned across backends.
+    assertEquals(250L, FocusController.SETTLE_MS)
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -196,6 +196,10 @@ include(":data-focus-connector")
 
 project(":data-focus-connector").projectDir = file("data/focus/connector")
 
+include(":data-focus-connector-desktop")
+
+project(":data-focus-connector-desktop").projectDir = file("data/focus/connector-desktop")
+
 include(":data-pseudolocale-core")
 
 project(":data-pseudolocale-core").projectDir = file("data/pseudolocale/core")


### PR DESCRIPTION
## Summary
- New `data/focus/connector-desktop/` module mirroring `data/pseudolocale/connector-desktop/` — needed because the original `:data-focus-connector` applies AGP's `android.library` plugin so its outputs aren't consumable from `:daemon:desktop`'s JVM classpath.
- Port the platform-portable bits: `FocusOverrideExtension`, `FocusPreviewOverrideExtension`, `FocusController`, `KeyboardInputModeManager`, `FocusDirection.toCompose()`. The Android-only `FocusOverlay.kt` (uses `android.view.View` and reflects into `AndroidComposeView.focusOwner`) was intentionally left out.
- Wire the extension into the desktop daemon (`DaemonMain.kt`) and add `"focus"` to `DesktopHost.supportedOverrides`.

Closes #1205.

## Test plan
- [x] `:data-focus-connector-desktop:test` (6 new tests)
- [x] `:daemon:desktop:test --tests BuildDesktopExtensionsTest --tests DesktopHostTest`
- [x] `:data-focus-connector:test` (Android — no regression on the original module)
- [x] `:data-focus-connector-desktop:ktfmtCheck :daemon:desktop:ktfmtCheckMain :daemon:desktop:ktfmtCheckTest`
- [ ] Pre-existing `RecompositionDataProductRegistryTest.observer_install_failure_degrades_to_advertise_but_useless` failure reproduces on clean `origin/main` — unrelated, flagged separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sderu4ai7SkoMgvV33BGeA)_