### PR TITLE
ci: restore agp8-min to JDK 17 via composePreview.sdkVersion = 35

### DIFF
--- a/.github/ci/fixtures/agp8-min/app/build.gradle.kts
+++ b/.github/ci/fixtures/agp8-min/app/build.gradle.kts
@@ -33,6 +33,25 @@ android {
   buildFeatures { compose = true }
 }
 
+// The compose-preview plugin is applied by the CI-bundled init script after
+// AGP, so the `composePreview` extension is registered on the project but
+// its Kotlin type isn't on this script's buildscript classpath — we can't
+// reference it directly in the typed DSL. Configure `sdkVersion = 35`
+// reflectively so Robolectric synthesizes a SDK 35 framework instead of
+// auto-detecting SDK 36 from `compileSdk = 36`. That keeps the agp8-min
+// job on JDK 17 (the realistic toolchain for AGP 8.x consumers): JDK 17 +
+// SDK 36 trips `DefaultSdkProvider.verifySupportedSdk`, but JDK 17 + SDK
+// 35 + manifest `minSdk = 24` is the documented "rescue path" row in
+// docs/SDK_COMPATIBILITY.md. Production consumers can set this via the
+// typed DSL: `composePreview { sdkVersion.set(35) }`.
+afterEvaluate {
+  val ext = project.extensions.findByName("composePreview") ?: return@afterEvaluate
+  @Suppress("UNCHECKED_CAST")
+  val sdk = ext.javaClass.getMethod("getSdkVersion").invoke(ext)
+      as org.gradle.api.provider.Property<Int>
+  sdk.set(35)
+}
+
 dependencies {
   // compose-bom 2025.11.01 pins compose-ui / compose-runtime to 1.9.5 —
   // matches `compose-bom-compat` in `gradle/libs.versions.toml`, which is

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -618,17 +618,16 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          # JDK 21 (not 17) because the fixture's `compileSdk = 36` forces
-          # Robolectric 4.16.1 to synthesize a SDK 36 sandbox, and
-          # `DefaultSdkProvider.verifySupportedSdk` rejects SDK 36 on JDK 17
-          # at sandbox boot (see docs/SDK_COMPATIBILITY.md, row 2 — the
-          # `compileSdk = 36 × JDK 17 × auto` cell is documented as ❌ fail).
-          # The fixture's `compileSdk` can't drop below 36 either:
-          # renderer-android publishes with `minCompileSdk = 36`, so AGP
-          # would reject the AAR at metadata-merge time. JDK 21 here matches
-          # what consumers on the AGP 8.x floor with `compileSdk = 36` need
-          # to run renderPreviews against this version of renderer-android.
-          java-version: 21
+          # JDK 17 — the realistic toolchain for an AGP 8.x consumer. The
+          # fixture's `compileSdk = 36` would normally trip Robolectric
+          # 4.16.1's `DefaultSdkProvider.verifySupportedSdk` (it refuses to
+          # synthesize a SDK 36 sandbox on JDK 17 — see
+          # docs/SDK_COMPATIBILITY.md row 2). The fixture works around that
+          # by pinning `composePreview.sdkVersion = 35` (the documented
+          # JDK-17 rescue path, row 4), so Robolectric stays inside JDK
+          # 17's window while AGP still gets the `compileSdk = 36` that
+          # renderer-android's `minCompileSdk` requires.
+          java-version: 17
 
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:


### PR DESCRIPTION
## Summary

#1291 left the `agp8-min` integration job on JDK 21 to side-step Robolectric 4.16.1's refusal to synthesize a SDK 36 sandbox on JDK 17 (the `compileSdk = 36 × JDK 17 × auto` ❌ cell — `docs/SDK_COMPATIBILITY.md` row 2). But the fixture's whole job is to represent a realistic AGP 8.x consumer, and AGP 8.x apps overwhelmingly build on JDK 17. Demanding JDK 21 for the renderer to work is the wrong contract.

This PR restores JDK 17 and uses the documented "rescue path" (row 4) instead: pin `composePreview.sdkVersion = 35` so Robolectric synthesizes a SDK 35 framework — inside JDK 17's window — while AGP still gets the `compileSdk = 36` that renderer-android's `minCompileSdk` requires. The fixture's `minSdk = 24 ≤ 35`, so PackageParser is happy too.

Side effect: this also fixes the Phase 3 render failure on `main` (`Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (17) and 'compileDebugKotlin' (21)`). With JDK 17 back as the toolchain, both Kotlin and Java compile tasks emit Java 17 bytecode and AGP's consistency check is satisfied.

The `sdkVersion` override is wired reflectively in the fixture's `build.gradle.kts` because the plugin is injected by the CI init script — its extension type isn't on the buildscript classpath, so the typed DSL (`composePreview { sdkVersion.set(35) }`) won't compile here. Production consumers don't need reflection; they apply the plugin in their `plugins { }` block and use the typed DSL directly. An inline comment documents this.

## Test plan

- [ ] `agp8-min` job's Phase 1 step "renderPreviews must FAIL on the too-old BOM" still exits non-zero.
- [ ] Phase 2 step "doctor must surface env.compose-bom-version" still asserts the check.
- [ ] Phase 3 step "renderPreviews must PASS at renderer floor" now exits zero on JDK 17 (was failing with the JVM-target inconsistency).
- [ ] `renders-agp8-min` artifact contains at least one PNG.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDgSjkaFt77R3aFUn4hD2C)_