### PR TITLE
fix(daemon-desktop): make orientation-override swap idempotent

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -182,11 +182,14 @@ open class DesktopHost(
    * keep treating it as unsupported rather than falling back to JVM-wide `Locale.setDefault(...)`.
    * `orientation` is modelled as a `widthPx ↔ heightPx` swap before `ImageComposeScene`
    * construction (issue #1208) — `ImageComposeScene` has no display-rotation concept, but
-   * `LANDSCAPE` is observably just the dimension swap (plus a `LocalConfiguration.orientation` flip
-   * on Android, which desktop's `RenderEngine` doesn't compose today). Explicit `widthPx` /
-   * `heightPx` overrides on the same call win — orientation is a hint that only fires when neither
-   * dimension was set. `inspectionMode` flows into `LocalInspectionMode` on the one-shot render
-   * path; interactive and recording sessions keep their runtime-like `false` default.
+   * `LANDSCAPE` / `PORTRAIT` are observably just the dimension swap (plus a
+   * `LocalConfiguration.orientation` flip on Android, which desktop's `RenderEngine` doesn't
+   * compose today). The hint is **idempotent**: it only fires when the requested orientation
+   * conflicts with the current aspect ratio (so a landscape-shaped base + `LANDSCAPE` is a no-op).
+   * Explicit `widthPx` / `heightPx` overrides on the same call still win — orientation is a hint
+   * that only fires when no dimensions were set. `inspectionMode` flows into `LocalInspectionMode`
+   * on the one-shot render path; interactive and recording sessions keep their runtime-like `false`
+   * default.
    */
   override val supportedOverrides: Set<String> = buildSet {
     add("widthPx")
@@ -446,10 +449,11 @@ open class DesktopHost(
    * go through the host's render-queue payload string.
    *
    * Explicit `widthPx` / `heightPx` / `density` overrides win over `device`-resolved values.
-   * Issue #1208 — `orientation = LANDSCAPE` swaps the resolved `widthPx`/`heightPx` only when
-   * neither an explicit pixel dimension nor a `device` token was supplied; otherwise the explicit
-   * sizing wins (orientation is a hint, not a forced rotation). `outputBaseName` is rewritten to
-   * `recording-<recordingId>` so a stray engine fast-path encode (only used by the one-shot
+   * Issue #1208 — `orientation` swaps the resolved `widthPx`/`heightPx` only when neither an
+   * explicit pixel dimension nor a `device` token was supplied AND the requested orientation
+   * conflicts with the current aspect ratio. Otherwise the explicit sizing wins or the swap is a
+   * no-op (orientation is an idempotent hint, not a forced rotation). `outputBaseName` is rewritten
+   * to `recording-<recordingId>` so a stray engine fast-path encode (only used by the one-shot
    * `engine.render` wrapper, not by the recording flow) wouldn't collide with another preview's
    * PNG. The recording flow itself never reads it.
    */
@@ -506,8 +510,19 @@ open class DesktopHost(
           RenderSpec.SpecOrientation.LANDSCAPE
         null -> null
       }
+    // Issue #1208 — orientation is an idempotent hint meaning "make it look like X", not a forced
+    // rotation: only swap when the requested orientation conflicts with the current aspect ratio.
+    // A base whose shape already matches the request (e.g. landscape 120×60 + LANDSCAPE) stays
+    // put, otherwise repeated calls would flip back and forth. Explicit `widthPx` / `heightPx` /
+    // `device` overrides still win over the hint, so the swap only fires when no dimensions were
+    // set on the wire.
     val shouldSwap =
-      orientation == RenderSpec.SpecOrientation.LANDSCAPE && !explicitDimensionSupplied
+      !explicitDimensionSupplied &&
+        when (orientation) {
+          RenderSpec.SpecOrientation.LANDSCAPE -> merged.heightPx > merged.widthPx
+          RenderSpec.SpecOrientation.PORTRAIT -> merged.widthPx > merged.heightPx
+          null -> false
+        }
     val effectiveWidthPx = if (shouldSwap) merged.heightPx else merged.widthPx
     val effectiveHeightPx = if (shouldSwap) merged.widthPx else merged.heightPx
     return base.copy(
@@ -634,18 +649,23 @@ open class DesktopHost(
         "landscape" -> RenderSpec.SpecOrientation.LANDSCAPE
         else -> base.orientation
       }
-    // Issue #1208 — desktop has no display rotation, but `LANDSCAPE` reduces to a `widthPx ↔
-    // heightPx` swap. Explicit pixel overrides (or device-derived dims emitted by
-    // `JsonRpcServer.encodeRenderPayload`) win over the hint, so we only swap when neither
-    // dimension was supplied on the wire. `PreviewManifestRouter` always emits widthPx/heightPx
-    // from its manifest defaults, so the swap there fires on the router side instead — see
-    // [PreviewManifestRouter.submit].
+    // Issue #1208 — desktop has no display rotation, but `LANDSCAPE` / `PORTRAIT` reduce to a
+    // `widthPx ↔ heightPx` swap. The hint is idempotent: only swap when the requested orientation
+    // conflicts with the current aspect ratio (e.g. landscape-base + LANDSCAPE = no-op). Explicit
+    // pixel overrides (or device-derived dims emitted by `JsonRpcServer.encodeRenderPayload`) win
+    // over the hint, so we only swap when neither dimension was supplied on the wire.
+    // `PreviewManifestRouter` always emits widthPx/heightPx from its manifest defaults, so the
+    // swap there fires on the router side instead — see [PreviewManifestRouter.submit].
     val baseWidthPx = widthOverride ?: base.widthPx
     val baseHeightPx = heightOverride ?: base.heightPx
     val shouldSwap =
-      orientation == RenderSpec.SpecOrientation.LANDSCAPE &&
-        widthOverride == null &&
-        heightOverride == null
+      widthOverride == null &&
+        heightOverride == null &&
+        when (orientation) {
+          RenderSpec.SpecOrientation.LANDSCAPE -> baseHeightPx > baseWidthPx
+          RenderSpec.SpecOrientation.PORTRAIT -> baseWidthPx > baseHeightPx
+          null -> false
+        }
     return base.copy(
       previewId = previewId,
       renderMode = map["mode"]?.takeIf { it.isNotBlank() },

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -80,16 +80,23 @@ class PreviewManifestRouter(
     val baseHeightPx = deviceSpec?.let { (it.heightDp * it.density).toInt() } ?: resolved.heightPx
     val baseDensity = deviceSpec?.density ?: resolved.density
     val effectiveDevice = deviceOverride ?: resolved.device
-    // Issue #1208 — `orientation = landscape` on desktop is a `widthPx ↔ heightPx` swap; explicit
-    // pixel overrides (or device-derived dims) win over the hint. We apply the swap here, before
+    // Issue #1208 — `orientation` on desktop is a `widthPx ↔ heightPx` swap; explicit pixel
+    // overrides (or device-derived dims) win over the hint. The hint is idempotent: only swap
+    // when the requested orientation conflicts with the current aspect ratio (e.g. a base that
+    // is already landscape + `orientation=landscape` stays put). We apply the swap here, before
     // the rewritten payload reaches `DesktopHost`, because the router unconditionally emits
     // widthPx/heightPx tokens which would otherwise hide the "no explicit dims" signal from the
     // downstream `DesktopHost.specFromPreviewIdPayload` swap branch.
+    val requestedOrientation = inbound["orientation"]?.lowercase()
+    val orientationCanSwap =
+      inbound["widthPx"] == null && inbound["heightPx"] == null && deviceOverride == null
     val shouldSwapOrientation =
-      inbound["orientation"]?.lowercase() == "landscape" &&
-        inbound["widthPx"] == null &&
-        inbound["heightPx"] == null &&
-        deviceOverride == null
+      orientationCanSwap &&
+        when (requestedOrientation) {
+          "landscape" -> baseHeightPx > baseWidthPx
+          "portrait" -> baseWidthPx > baseHeightPx
+          else -> false
+        }
     val effectiveBaseWidthPx = if (shouldSwapOrientation) baseHeightPx else baseWidthPx
     val effectiveBaseHeightPx = if (shouldSwapOrientation) baseWidthPx else baseHeightPx
     val routed =

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -157,6 +157,108 @@ class OverrideIntegrationTest {
     }
   }
 
+  /**
+   * Issue #1208 — the orientation hint must be idempotent: a request that already matches the base
+   * aspect ratio should be a no-op, never a blind swap. Otherwise a landscape-shaped base (e.g.
+   * 120×60) plus `orientation = landscape` would flip to portrait (60×120), and the same payload
+   * sent twice would oscillate. Mirrors the LANDSCAPE → LANDSCAPE branch in `applyOverrides`,
+   * `specFromPreviewIdPayload`, and `PreviewManifestRouter.submit`.
+   */
+  @Test
+  fun orientationOverrideIsIdempotentForMatchingBase() {
+    val outputDir = tempFolder.newFolder("renders-orientation-idempotent")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "landscape-rect",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "RedSquare",
+              widthPx = 120,
+              heightPx = 60,
+              density = 1.0f,
+              outputBaseName = "landscape-rect",
+            ),
+            PreviewManifestEntry(
+              id = "portrait-rect",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "RedSquare",
+              widthPx = 60,
+              heightPx = 120,
+              density = 1.0f,
+              outputBaseName = "portrait-rect",
+            ),
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      // Landscape base + orientation=landscape => no swap, stays 120×60.
+      val landscapeNoOp =
+        renderAndDecode(host, "previewId=landscape-rect;orientation=landscape", "landscape-noop")
+      assertEquals(
+        "orientation=landscape on landscape base should not swap widthPx",
+        120,
+        landscapeNoOp.width,
+      )
+      assertEquals(
+        "orientation=landscape on landscape base should not swap heightPx",
+        60,
+        landscapeNoOp.height,
+      )
+
+      // Sending the same payload again must produce identical dims (idempotent).
+      val landscapeRepeat =
+        renderAndDecode(host, "previewId=landscape-rect;orientation=landscape", "landscape-repeat")
+      assertEquals(
+        "repeated orientation=landscape must be idempotent on width",
+        120,
+        landscapeRepeat.width,
+      )
+      assertEquals(
+        "repeated orientation=landscape must be idempotent on height",
+        60,
+        landscapeRepeat.height,
+      )
+
+      // Portrait base + orientation=portrait => no swap, stays 60×120 (symmetric branch).
+      val portraitNoOp =
+        renderAndDecode(host, "previewId=portrait-rect;orientation=portrait", "portrait-noop")
+      assertEquals(
+        "orientation=portrait on portrait base should not swap widthPx",
+        60,
+        portraitNoOp.width,
+      )
+      assertEquals(
+        "orientation=portrait on portrait base should not swap heightPx",
+        120,
+        portraitNoOp.height,
+      )
+
+      // Landscape base + orientation=portrait => swap to 60×120 (PORTRAIT branch).
+      val landscapeToPortrait =
+        renderAndDecode(
+          host,
+          "previewId=landscape-rect;orientation=portrait",
+          "landscape-to-portrait",
+        )
+      assertEquals(
+        "orientation=portrait on landscape base should swap widthPx",
+        60,
+        landscapeToPortrait.width,
+      )
+      assertEquals(
+        "orientation=portrait on landscape base should swap heightPx",
+        120,
+        landscapeToPortrait.height,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
   @Test
   fun uiModeOverrideFlipsDarkAwareComposable() {
     val outputDir = tempFolder.newFolder("renders-uimode")

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -146,9 +146,10 @@ Result:
   // unsupported sliders.
   // Empty list = pre-feature daemon;
   // treat absent and `[]` identically and assume any field might be ignored.
-  // Today: Robolectric advertises every field; Desktop advertises `orientation` (modelled as a
-  // `widthPx ↔ heightPx` swap on `ImageComposeScene` since #1208) but omits Android-only timing
-  // knobs, and "localeTag" unless the Compose UI runtime exposes a providable locale list.
+  // Today: Robolectric advertises every field; Desktop advertises `orientation` (modelled as an
+  // idempotent `widthPx ↔ heightPx` swap on `ImageComposeScene` since #1208 — only fires when the
+  // request conflicts with the current aspect ratio) but omits Android-only timing knobs, and
+  // "localeTag" unless the Compose UI runtime exposes a providable locale list.
   //
   // androidSdk — fixed Android SDK level the backend renders against. Populated by the
   // Robolectric backend from its pinned @Config(sdk = ...) value; absent/null on Desktop and
@@ -321,9 +322,11 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
   localeTag?: string;                // BCP-47 (e.g. "en-US", "fr", "ja-JP").
   fontScale?: number;                // 1.0 = system default
   uiMode?: "light" | "dark";         // Android-only today.
-  orientation?: "portrait" | "landscape";  // Android: full rotation. Desktop: `landscape` swaps
-                                     // the resolved widthPx/heightPx before scene construction
-                                     // when neither dimension was set explicitly (issue #1208).
+  orientation?: "portrait" | "landscape";  // Android: full rotation. Desktop: idempotent hint
+                                     // that swaps the resolved widthPx/heightPx before scene
+                                     // construction when neither dimension was set explicitly AND
+                                     // the request conflicts with the current aspect ratio
+                                     // (issue #1208). Repeated calls are stable.
   device?: string;                   // "id:pixel_5", "id:wearos_small_round", "spec:width=400dp,height=800dp,dpi=320".
                                      // Resolved by the daemon's catalog into widthPx/heightPx/density;
                                      // explicit widthPx/heightPx/density above take precedence.
@@ -353,7 +356,7 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
 
 The result resolves as soon as the request is queued, **not** when rendering completes. Per-render progress arrives as `renderStarted` / `renderFinished` / `renderFailed` notifications keyed by ID.
 
-`overrides` are merged onto the discovery-time `RenderSpec` per-call. A subsequent `renderNow` for the same preview **without** `overrides` reverts to the discovery-time defaults — overrides are not sticky across calls. Backends that don't model a particular field ignore it (e.g. desktop `localeTag` requires a Compose UI runtime that exposes a providable locale list). `orientation` is supported on both backends: Android performs a full rotation via the resource qualifier; desktop reduces `landscape` to a `widthPx ↔ heightPx` swap before `ImageComposeScene` construction (issue #1208). Explicit pixel/`device` overrides on the same call win over the orientation hint on desktop — pass `orientation` alone for the swap to fire. `inspectionMode` controls the `LocalInspectionMode` value for this one-shot render; absent/null preserves preview behaviour (`true`). `material3Theme` is applied in the renderer's normal Compose tree as a `MaterialTheme(...) { preview() }` wrapper, so it affects components that read Material 3 locals without requiring the preview source to declare its own theme.
+`overrides` are merged onto the discovery-time `RenderSpec` per-call. A subsequent `renderNow` for the same preview **without** `overrides` reverts to the discovery-time defaults — overrides are not sticky across calls. Backends that don't model a particular field ignore it (e.g. desktop `localeTag` requires a Compose UI runtime that exposes a providable locale list). `orientation` is supported on both backends: Android performs a full rotation via the resource qualifier; desktop reduces `landscape`/`portrait` to a `widthPx ↔ heightPx` swap before `ImageComposeScene` construction (issue #1208). The desktop hint is **idempotent** — it means "make it look like X", not "always flip": the swap only fires when the requested orientation conflicts with the current aspect ratio, so a landscape-shaped base plus `orientation = landscape` is a no-op (repeated calls stay stable). Explicit pixel/`device` overrides on the same call win over the orientation hint on desktop — pass `orientation` alone for the swap to fire. `inspectionMode` controls the `LocalInspectionMode` value for this one-shot render; absent/null preserves preview behaviour (`true`). `material3Theme` is applied in the renderer's normal Compose tree as a `MaterialTheme(...) { preview() }` wrapper, so it affects components that read Material 3 locals without requiring the preview source to declare its own theme.
 
 **Coalescing.** When `overrides` is non-null and a prior override-bearing render is still in-flight for the same `previewId`, the new request is rejected with `reason = "coalesced: …"` rather than queued. The client (panel, MCP, etc.) is responsible for resubmitting on the next `renderFinished` if the latest override values still differ from what was rendered. Plain (no-overrides) `renderNow` is unaffected — the existing save-debounce loop continues to coalesce upstream.
 


### PR DESCRIPTION
## Summary
Follow-up to #1288 (review feedback). The orientation-override swap introduced there was non-idempotent: a preview whose base dimensions were already landscape (e.g. 120×60) got flipped to portrait when the caller explicitly asked for `LANDSCAPE`. Same hazard for PORTRAIT against an already-portrait base.

The three swap sites in `DesktopHost.applyOverrides`, `DesktopHost.specFromPreviewIdPayload`, and `PreviewManifestRouter.submit` now decide swap via:

```kotlin
when (orientation) {
  LANDSCAPE -> heightPx > widthPx
  PORTRAIT  -> widthPx > heightPx
  null      -> false
}
```

gated on no explicit `widthPx`/`heightPx` (and no `device`/`deviceOverride`). The PORTRAIT branch is also new — was absent before. Treats `orientation` as a hint meaning "make it look like X".

## Test plan
- [x] `:daemon:desktop:test --tests OverrideIntegrationTest` (new `orientationOverrideIsIdempotentForMatchingBase` + existing 4)
- [x] `:daemon:desktop:test --tests DesktopHostTest`
- [x] `:daemon:desktop:ktfmtCheck`

New test covers: landscape base + LANDSCAPE = no swap (and re-applying stays no-op); portrait base + PORTRAIT = no swap; landscape base + PORTRAIT = swap (the previously-missing branch). Existing `orientationOverrideSwapsDimensions` still passes unchanged.