### PR TITLE
fix(interactive): map NumpadComma to KEYCODE_NUMPAD_COMMA (159)

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveKeyCodes.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveKeyCodes.kt
@@ -117,6 +117,7 @@ object InteractiveKeyCodes {
   const val NUMPAD_SUBTRACT: Int = 156
   const val NUMPAD_ADD: Int = 157
   const val NUMPAD_DOT: Int = 158
+  const val NUMPAD_COMMA: Int = 159
   const val NUMPAD_ENTER: Int = 160
   const val NUMPAD_EQUALS: Int = 161
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopKeyDispatch.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopKeyDispatch.kt
@@ -113,6 +113,7 @@ private val ANDROID_KEYCODE_TO_COMPOSE_KEY: Map<Int, Key> = buildMap {
   put(InteractiveKeyCodes.NUMPAD_SUBTRACT, Key.NumPadSubtract)
   put(InteractiveKeyCodes.NUMPAD_ADD, Key.NumPadAdd)
   put(InteractiveKeyCodes.NUMPAD_DOT, Key.NumPadDot)
+  put(InteractiveKeyCodes.NUMPAD_COMMA, Key.NumPadComma)
   put(InteractiveKeyCodes.NUMPAD_ENTER, Key.NumPadEnter)
   put(InteractiveKeyCodes.NUMPAD_EQUALS, Key.NumPadEquals)
   // Punctuation.

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopKeyDispatchTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopKeyDispatchTest.kt
@@ -37,6 +37,7 @@ class DesktopKeyDispatchTest {
     assertEquals(Key.NumPadSubtract, androidKeycodeToComposeKey("156"))
     assertEquals(Key.NumPadAdd, androidKeycodeToComposeKey("157"))
     assertEquals(Key.NumPadDot, androidKeycodeToComposeKey("158"))
+    assertEquals(Key.NumPadComma, androidKeycodeToComposeKey("159"))
     assertEquals(Key.NumPadEnter, androidKeycodeToComposeKey("160"))
     assertEquals(Key.NumPadEquals, androidKeycodeToComposeKey("161"))
   }

--- a/vscode-extension/src/test/interactiveInput.test.ts
+++ b/vscode-extension/src/test/interactiveInput.test.ts
@@ -666,6 +666,7 @@ describe("domCodeToAndroidKeycode (issue #1203)", () => {
         assert.strictEqual(domCodeToAndroidKeycode("NumpadSubtract"), 156);
         assert.strictEqual(domCodeToAndroidKeycode("NumpadAdd"), 157);
         assert.strictEqual(domCodeToAndroidKeycode("NumpadDecimal"), 158);
+        assert.strictEqual(domCodeToAndroidKeycode("NumpadComma"), 159);
         assert.strictEqual(domCodeToAndroidKeycode("NumpadEnter"), 160);
         assert.strictEqual(domCodeToAndroidKeycode("NumpadEqual"), 161);
         // Punctuation.

--- a/vscode-extension/src/webview/preview/interactiveInput.ts
+++ b/vscode-extension/src/webview/preview/interactiveInput.ts
@@ -562,6 +562,7 @@ const DOM_CODE_TO_ANDROID_KEYCODE: ReadonlyMap<string, number> = new Map([
     ["NumpadSubtract", 156],
     ["NumpadAdd", 157],
     ["NumpadDecimal", 158],
+    ["NumpadComma", 159],
     ["NumpadEnter", 160],
     ["NumpadEqual", 161],
     // Punctuation.


### PR DESCRIPTION
## Summary
Follow-up to #1290 (review feedback). The numpad expansion omitted `KeyboardEvent.code === "NumpadComma"` → `KEYCODE_NUMPAD_COMMA` (Android keycode 159, sits between 158 `NUMPAD_DOT` and 160 `NUMPAD_ENTER` in AOSP). EU keyboard layouts emit `NumpadComma` instead of `NumpadDecimal` for the decimal key, so events were silently dropped.

Three sides updated, mirroring the surrounding entries:
- `InteractiveKeyCodes.NUMPAD_COMMA = 159` (daemon-core).
- `DesktopKeyDispatch` maps it to `Key.NumPadComma` (verified present in Compose UI desktop 1.10.3 — the pinned version).
- `DOM_CODE_TO_ANDROID_KEYCODE["NumpadComma"] = 159` (panel).

## Test plan
- [x] `:daemon:desktop:test --tests DesktopKeyDispatchTest`
- [x] `:daemon:desktop:compileKotlin`
- [x] `vscode-extension` `npm test` — 1124 passing
- [x] `:daemon:core:ktfmtCheckMain :daemon:desktop:ktfmtCheckMain :daemon:desktop:ktfmtCheckTest`