### PR TITLE
ci: agp8-min uses a material3 1.4 API to demonstrate the BOM floor honestly

### DIFF
--- a/.github/ci/fixtures/agp8-min/app/build.gradle.kts
+++ b/.github/ci/fixtures/agp8-min/app/build.gradle.kts
@@ -33,6 +33,25 @@ android {
   buildFeatures { compose = true }
 }
 
+// The compose-preview plugin is applied by the CI-bundled init script after
+// AGP, so the `composePreview` extension is registered on the project but
+// its Kotlin type isn't on this script's buildscript classpath — we can't
+// reference it directly in the typed DSL. Configure `sdkVersion = 35`
+// reflectively so Robolectric synthesizes a SDK 35 framework instead of
+// auto-detecting SDK 36 from `compileSdk = 36`. That keeps the agp8-min
+// job on JDK 17 (the realistic toolchain for AGP 8.x consumers): JDK 17 +
+// SDK 36 trips `DefaultSdkProvider.verifySupportedSdk`, but JDK 17 + SDK
+// 35 + manifest `minSdk = 24` is the documented "rescue path" row in
+// docs/SDK_COMPATIBILITY.md. Production consumers can set this via the
+// typed DSL: `composePreview { sdkVersion.set(35) }`.
+afterEvaluate {
+  val ext = project.extensions.findByName("composePreview") ?: return@afterEvaluate
+  @Suppress("UNCHECKED_CAST")
+  val sdk = ext.javaClass.getMethod("getSdkVersion").invoke(ext)
+      as org.gradle.api.provider.Property<Int>
+  sdk.set(35)
+}
+
 dependencies {
   // compose-bom 2025.11.01 pins compose-ui / compose-runtime to 1.9.5 —
   // matches `compose-bom-compat` in `gradle/libs.versions.toml`, which is

--- a/.github/ci/fixtures/agp8-min/app/build.gradle.kts
+++ b/.github/ci/fixtures/agp8-min/app/build.gradle.kts
@@ -53,19 +53,19 @@ afterEvaluate {
 }
 
 dependencies {
-  // compose-bom 2025.11.01 pins compose-ui / compose-runtime to 1.9.5 —
-  // matches `compose-bom-compat` in `gradle/libs.versions.toml`, which is
-  // the version renderer-android compiles its public API against. Below
-  // this BOM the renderer's bytecode references method signatures (e.g.
-  // `ComposeUiNode.setCompositeKeyHash`, first shipped in compose-ui 1.9)
-  // that the consumer's runtime doesn't have, and `renderPreviews` fails
-  // with `NoSuchMethodError` at render time. The agp8-min CI job
-  // deliberately downgrades this BOM to 2024.12.01 (Compose 1.7.6) to
-  // demonstrate that failure mode and confirm `compose-preview doctor`
-  // surfaces the `env.compose-bom-version` finding, then bumps it back to
-  // exercise the success path. See `.github/workflows/integration.yml`,
-  // the `agp8-min` job.
-  val composeBom = platform("androidx.compose:compose-bom:2025.11.01")
+  // compose-bom 2026.05.00 — `compose-bom-stable` in the project's own
+  // version catalog, what `:samples:android` and the rest of the codebase
+  // build against. Ships material3 1.4+ (which is what `Previews.kt`'s
+  // `LoadingIndicator` requires; the M3 1.3.x line in
+  // compose-bom 2024.12.01 doesn't have that composable). The agp8-min
+  // CI job downgrades this to 2024.12.01 in Phase 1 so the consumer's
+  // own preview source fails to compile against the older material3 —
+  // the same failure shape a real consumer hits when they pull a new
+  // Compose API ahead of their BOM. `compose-preview doctor` warns about
+  // the too-old BOM through its `env.compose-bom-version` pre-flight
+  // check (grep-based against `build.gradle.kts`, runs before Gradle).
+  // Phase 3 restores 2026.05.00 and asserts render then succeeds.
+  val composeBom = platform("androidx.compose:compose-bom:2026.05.00")
   implementation(composeBom)
   implementation("androidx.compose.ui:ui")
   implementation("androidx.compose.ui:ui-tooling-preview")

--- a/.github/ci/fixtures/agp8-min/app/src/main/kotlin/com/example/agp8min/Previews.kt
+++ b/.github/ci/fixtures/agp8-min/app/src/main/kotlin/com/example/agp8min/Previews.kt
@@ -1,16 +1,31 @@
 package com.example.agp8min
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 
-// One @Preview is enough — the integration job only verifies that
-// `discoverPreviews` finds it and writes `previews.json`. Adding a second
-// preview just to "cover edge cases" is wasted CI time; the in-repo
-// sample-android module exercises every renderer feature already.
+// `LoadingIndicator` is a material3 1.4+ composable (added in the
+// "Material You expressive" wave). compose-bom 2026.05.00 — what the
+// fixture pins above and what `:samples:android` uses too — ships M3 1.4,
+// so this preview compiles cleanly there. compose-bom 2024.12.01, which
+// the agp8-min CI job downgrades to in Phase 1, ships M3 1.3.x without
+// this composable; the import then fails to resolve and `compileDebugKotlin`
+// errors out before `renderPreviews` can even start. That's the same
+// failure shape a real consumer hits when they reach for a new Compose API
+// ahead of their BOM, and it's what `compose-preview doctor`'s
+// `env.compose-bom-version` pre-flight warns about.
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Preview
 @Composable
 fun GreetingPreview() {
-  Surface { Text(text = "agp8-min fixture") }
+  Surface {
+    Column {
+      Text(text = "agp8-min fixture")
+      LoadingIndicator()
+    }
+  }
 }

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -618,17 +618,16 @@ jobs:
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          # JDK 21 (not 17) because the fixture's `compileSdk = 36` forces
-          # Robolectric 4.16.1 to synthesize a SDK 36 sandbox, and
-          # `DefaultSdkProvider.verifySupportedSdk` rejects SDK 36 on JDK 17
-          # at sandbox boot (see docs/SDK_COMPATIBILITY.md, row 2 — the
-          # `compileSdk = 36 × JDK 17 × auto` cell is documented as ❌ fail).
-          # The fixture's `compileSdk` can't drop below 36 either:
-          # renderer-android publishes with `minCompileSdk = 36`, so AGP
-          # would reject the AAR at metadata-merge time. JDK 21 here matches
-          # what consumers on the AGP 8.x floor with `compileSdk = 36` need
-          # to run renderPreviews against this version of renderer-android.
-          java-version: 21
+          # JDK 17 — the realistic toolchain for an AGP 8.x consumer. The
+          # fixture's `compileSdk = 36` would normally trip Robolectric
+          # 4.16.1's `DefaultSdkProvider.verifySupportedSdk` (it refuses to
+          # synthesize a SDK 36 sandbox on JDK 17 — see
+          # docs/SDK_COMPATIBILITY.md row 2). The fixture works around that
+          # by pinning `composePreview.sdkVersion = 35` (the documented
+          # JDK-17 rescue path, row 4), so Robolectric stays inside JDK
+          # 17's window while AGP still gets the `compileSdk = 36` that
+          # renderer-android's `minCompileSdk` requires.
+          java-version: 17
 
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -667,22 +667,27 @@ jobs:
           cp -R .github/ci/fixtures/agp8-min/. "$RUNNER_TEMP/fixture/"
           chmod +x "$RUNNER_TEMP/fixture/gradlew"
 
-      # ── Three-phase floor test ─────────────────────────────────────────
-      # The committed fixture pins compose-bom to 2025.11.01 (Compose 1.9.5),
-      # which matches the renderer's `compose-bom-compat` floor. To prove the
-      # floor is real AND that `compose-preview doctor` explains it, we:
-      #   1. Downgrade the staged fixture's BOM to 2024.12.01 (Compose 1.7.6).
-      #   2. Run `renderPreviews` and assert it FAILS at render time
-      #      (renderer-android calls `ComposeUiNode.setCompositeKeyHash`, a
-      #      compose-ui 1.9+ method that 1.7.6 doesn't have).
-      #   3. Run `compose-preview doctor --json` and assert the
-      #      `env.compose-bom-version` check fires as `warning` — that's the
-      #      user-facing diagnostic for this exact failure mode.
-      #   4. Bump the staged BOM back to 2025.11.01, clear stale outputs,
-      #      and re-run `renderPreviews` — this time expecting a clean PNG.
-      # Any drift in either direction (renderer floor moves, or doctor stops
-      # surfacing the check) flips this job red.
-      - name: Phase 1 — downgrade staged fixture BOM below renderer floor
+      # ── Three-phase BOM-floor test ────────────────────────────────────
+      # The committed fixture pins `compose-bom` to 2026.05.00 (matches
+      # `compose-bom-stable` in `gradle/libs.versions.toml` — what
+      # `:samples:android` uses) and the preview source references
+      # `androidx.compose.material3.LoadingIndicator`, a material3 1.4+
+      # composable. To prove the BOM floor is real AND that
+      # `compose-preview doctor` explains it, we:
+      #   1. Downgrade the staged fixture's BOM to 2024.12.01 (material3
+      #      1.3.1, no `LoadingIndicator`).
+      #   2. Run `renderPreviews` and assert it FAILS — `compileDebugKotlin`
+      #      errors out on the unresolved `LoadingIndicator` import. This
+      #      is the same failure shape a real consumer hits when their
+      #      source reaches for a new Compose API ahead of their BOM.
+      #   3. Run `compose-preview doctor --json` and assert
+      #      `env.compose-bom-version` fires as `warning` — the doctor's
+      #      pre-flight catches the too-old BOM before any compile attempt.
+      #   4. Bump the staged BOM back to 2026.05.00, clear stale outputs,
+      #      re-run `renderPreviews`. Expect a clean PNG.
+      # Any drift in either direction (BOM floor moves, M3 1.4 features
+      # land elsewhere, or doctor stops surfacing the check) flips red.
+      - name: Phase 1 — downgrade staged fixture BOM below the material3 1.4 line
         env:
           OLD_BOM: "2024.12.01"
         run: |
@@ -707,7 +712,7 @@ jobs:
           rc=$?
           set -e
           if [ "$rc" -eq 0 ]; then
-            echo "::error::renderPreviews unexpectedly succeeded against compose-bom 2024.12.01 (Compose 1.7.6). The renderer-android floor is documented as Compose 1.9.5 in renderer-android/build.gradle.kts — either the floor changed (update this fixture + the doc) or the failure mode regressed."
+            echo "::error::renderPreviews unexpectedly succeeded against compose-bom 2024.12.01. Previews.kt imports androidx.compose.material3.LoadingIndicator (material3 1.4+); 2024.12.01 ships material3 1.3.1 without it, so compileDebugKotlin should fail. Either the BOM mapping changed (move the Phase 1 pin lower) or the preview no longer references a post-1.3 API (pick a fresher one)."
             exit 1
           fi
           echo "renderPreviews failed as expected (exit code $rc); proceeding to doctor."
@@ -760,9 +765,9 @@ jobs:
                   print(f"  fix:     {cmd}")
           PY
 
-      - name: Phase 3 — bump staged fixture BOM back to renderer floor
+      - name: Phase 3 — bump staged fixture BOM back to the committed pin
         env:
-          NEW_BOM: "2025.11.01"
+          NEW_BOM: "2026.05.00"
         run: |
           set -euo pipefail
           fixture_build="$RUNNER_TEMP/fixture/app/build.gradle.kts"
@@ -783,7 +788,7 @@ jobs:
           # call covers both the discovery path and the renderer-android AAR
           # resolution from the mavenLocal snapshot seeded earlier. This is
           # the "oldest AGP × Kotlin together" floor-coverage cell (Gradle
-          # 8.13 + AGP 8.13.0 + Kotlin 2.0.21 + compose-bom 2025.11.01).
+          # 8.13 + AGP 8.13.0 + Kotlin 2.0.21 + JDK 17 + compose-bom 2026.05.00).
           ./gradlew --init-script "$COMPOSE_AI_INIT_SCRIPT" renderPreviews \
             --no-configuration-cache --stacktrace
 


### PR DESCRIPTION
## Summary

The previous shape of the `agp8-min` three-phase floor test was passing the "render must fail" assertion *for the wrong reason* — earlier rounds tripped the JVM-target consistency check (JDK 21 toolchain → Kotlin 21 / Java 17 mismatch), not the Compose floor. With JDK 17 properly restored in #1293, compose-bom 2024.12.01 turns out to render the trivial `Surface { Text(...) }` fixture just fine: the renderer is *deliberately* engineered to stay compatible with old BOMs (see `renderer-android/src/main/kotlin/.../RobolectricRenderTest.kt:605` — it avoids emitting `setCompositeKeyHash` so its bytecode loads against compose-ui 1.6+).

This PR reframes the test to prove what it claims. The agp8-min job now demonstrates the BOM floor as users actually hit it — *their own preview source* references an API that needs a newer BOM:

- Bump the committed fixture BOM to `2026.05.00` (matches `compose-bom-stable` in `gradle/libs.versions.toml`; what `:samples:android` uses).
- `Previews.kt` now references `androidx.compose.material3.LoadingIndicator`, a material3 1.4+ composable.
- **Phase 1**: downgrade staged BOM to `2024.12.01` (material3 1.3.x, no `LoadingIndicator`). `compileDebugKotlin` errors on the unresolved import; `renderPreviews` exits non-zero. Assertion holds.
- **Phase 2**: `compose-preview doctor --json` is grep-based and runs before Gradle; `env.compose-bom-version` still fires as `warning` against the 2024.12.01 BOM (anything below 2025.01.00 trips it). Same assertion as before.
- **Phase 3**: bump staged BOM back to `2026.05.00`, re-run `renderPreviews`. Expect a clean PNG.

The failure mode is now the same shape a real consumer hits when they reach for a new Compose API ahead of their BOM — and `compose-preview doctor` catches it.

## Test plan

- [ ] Phase 1 step "renderPreviews must FAIL on the too-old BOM" exits non-zero with an unresolved-`LoadingIndicator` Kotlin compile error.
- [ ] Phase 2 step "doctor must surface env.compose-bom-version" passes — the printed message names version `2024.12.01`.
- [ ] Phase 3 step "renderPreviews must PASS" exits zero on compose-bom 2026.05.00.
- [ ] `renders-agp8-min` artifact contains at least one PNG.
- [ ] `doctor-agp8-min` artifact contains the parsed JSON.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDgSjkaFt77R3aFUn4hD2C)_