### PR TITLE
feat(data/keyboard): soft-keyboard overlay as a data extension

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -87,6 +87,12 @@ dependencies {
   // `renderNow.overrides.focus`, and the post-capture `FocusOverlay`. The renderer-android plugin
   // path consumes the same connector — see `:renderer-android`'s `implementation` line.
   implementation(project(":data-focus-connector"))
+  // Soft-keyboard (IME) connector — `KeyboardController`, the always-on `AroundComposable`
+  // extension that shadows `LocalSoftwareKeyboardController` to mirror natural app-side IME state
+  // (focused `BasicTextField`, explicit `keyboardController.show()`) into the band overlay, and
+  // the `KeyboardPreviewOverrideExtension` planner consuming `renderNow.overrides.keyboard`. The
+  // session's `dispatch(KEY_*)` path also calls into `KeyboardController` from this module.
+  implementation(project(":data-keyboard-connector"))
   // Pseudolocale connector — `Pseudolocalizer` (en-XA / ar-XB transforms), `PseudolocaleResources`
   // / `PseudolocaleContext` runtime resource interception, and the
   // `PseudolocalePreviewOverrideExtension` planner mapped to `localeTag` in {en-XA, ar-XB}. No

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -219,6 +219,17 @@ internal constructor(
     val py = input.pixelY
     if (!isKey && (px == null || py == null)) return
     if (isKey && input.keyCode.isNullOrBlank()) return
+    if (isKey) {
+      // Mirror the keycode into the soft-keyboard band before the held-rule loop runs the actual
+      // `performKeyInput` so an agent driving keyboard input through `interactive/input` sees the
+      // matching cap light up. The band's "press implies visible" rule also raises the band even
+      // when the consumer hasn't called `keyboardController.show()`.
+      val label = KeyboardBandLabels.fromAndroidKeycode(input.keyCode)
+      if (label != null) {
+        if (input.kind == InteractiveInputKind.KEY_DOWN) KeyboardController.notifyKeyDown(label)
+        else KeyboardController.notifyKeyUp(label)
+      }
+    }
     lastUsedAtMs.set(System.currentTimeMillis())
     val replyLatch = CountDownLatch(1)
     val replyError = AtomicReference<Throwable?>(null)

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1316,6 +1316,13 @@ open class RobolectricHost(
                 WallpaperPreviewOverrideExtension(),
                 Material3ThemePreviewOverrideExtension(),
                 FocusPreviewOverrideExtension(),
+                // Soft-keyboard (IME) overlay. The planner always emits a `KeyboardOverrideExtension`
+                // so the around-composable's shadow `LocalSoftwareKeyboardController` is in place
+                // for every render — natural app-side `keyboardController.show()` / focused
+                // `BasicTextField` raises the band without a daemon-side seed. `renderNow.overrides
+                // .keyboard` and `interactive/input` `KEY_*` dispatches reach the same
+                // `KeyboardController` state holder.
+                KeyboardPreviewOverrideExtension(),
                 // Runtime pseudolocale: when `localeTag` is `en-XA` / `ar-XB`, wrap LocalContext
                 // with a Resources subclass that pseudolocalises `getString*` returns. The
                 // planner returns null for any other tag, so non-pseudo locales keep going through

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardBandLabels.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardBandLabels.kt
@@ -1,0 +1,68 @@
+package ee.schimke.composeai.daemon
+
+/**
+ * Maps wire-format Android `KEYCODE_*` ints (the spelling used by `InteractiveInputParams.keyCode`,
+ * see [InteractiveKeyCodes]) to the band-label tokens [KeyboardController.notifyKeyDown] /
+ * [KeyboardController.notifyKeyUp] expect on the `:data-keyboard-connector` /
+ * `:data-keyboard-connector-desktop` side.
+ *
+ * Shape on the wire is decimal-string Android keycodes; on the band-label side it's lowercase
+ * single letters (`"h"`, `"o"`) or the named special tokens the band recognises (`"space"`,
+ * `"enter"`, `"shift"`, `"backspace"`). Unmapped codes return `null` so the dispatcher drops the
+ * highlight rather than the whole `KEY_*` event — typing keys we don't draw still flows through to
+ * the consumer's composition, just without a band animation.
+ *
+ * Lives on `daemon:core` so both `AndroidInteractiveSession` and `DesktopInteractiveSession` can
+ * call into it without either side taking a dep on the other's connector module.
+ */
+object KeyboardBandLabels {
+
+  fun fromAndroidKeycode(wire: String?): String? {
+    val code = InteractiveKeyCodes.parse(wire) ?: return null
+    return LABELS[code]
+  }
+
+  private val LABELS: Map<Int, String> = buildMap {
+    // Letters — band caps are lowercase to match the default IME state.
+    for ((code, letter) in
+      listOf(
+        InteractiveKeyCodes.A to "a",
+        InteractiveKeyCodes.B to "b",
+        InteractiveKeyCodes.C to "c",
+        InteractiveKeyCodes.D to "d",
+        InteractiveKeyCodes.E to "e",
+        InteractiveKeyCodes.F to "f",
+        InteractiveKeyCodes.G to "g",
+        InteractiveKeyCodes.H to "h",
+        InteractiveKeyCodes.I to "i",
+        InteractiveKeyCodes.J to "j",
+        InteractiveKeyCodes.K to "k",
+        InteractiveKeyCodes.L to "l",
+        InteractiveKeyCodes.M to "m",
+        InteractiveKeyCodes.N to "n",
+        InteractiveKeyCodes.O to "o",
+        InteractiveKeyCodes.P to "p",
+        InteractiveKeyCodes.Q to "q",
+        InteractiveKeyCodes.R to "r",
+        InteractiveKeyCodes.S to "s",
+        InteractiveKeyCodes.T to "t",
+        InteractiveKeyCodes.U to "u",
+        InteractiveKeyCodes.V to "v",
+        InteractiveKeyCodes.W to "w",
+        InteractiveKeyCodes.X to "x",
+        InteractiveKeyCodes.Y to "y",
+        InteractiveKeyCodes.Z to "z",
+      )) {
+      put(code, letter)
+    }
+    // Punctuation the band draws on the action row.
+    put(InteractiveKeyCodes.COMMA, ",")
+    put(InteractiveKeyCodes.PERIOD, ".")
+    // Special tokens.
+    put(InteractiveKeyCodes.SPACE, "space")
+    put(InteractiveKeyCodes.ENTER, "enter")
+    put(InteractiveKeyCodes.BACKSPACE, "backspace")
+    put(InteractiveKeyCodes.SHIFT_LEFT, "shift")
+    put(InteractiveKeyCodes.SHIFT_RIGHT, "shift")
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -470,7 +470,39 @@ data class PreviewOverrides(
    * Compose-Multiplatform) ignore this field.
    */
   val focus: FocusOverride? = null,
+  /**
+   * Optional soft-keyboard (IME) override. Drives the connector-side `KeyboardOverrideExtension`
+   * (see `:data-keyboard-connector`). The around-composable mirrors the consumer's normal IME
+   * behaviour — `LocalSoftwareKeyboardController.show()/hide()`, focused `BasicTextField`s, and
+   * Android's `WindowInsetsCompat.Type.ime()` insets all flow into the same `KeyboardController` —
+   * and overlays a fake Gboard-shaped band at the bottom of the capture when the IME is up. The
+   * fields here let a daemon client (or `@KeyboardPreview` discovery, when wired) force visibility
+   * and per-cap press highlights on top of whatever the app naturally decides. Sending a
+   * `KeyboardOverride()` with all fields null effectively does nothing — the around-composable
+   * still installs the shadow controller and inset observer so app-driven behaviour reaches the
+   * band, the override just doesn't add anything.
+   */
+  val keyboard: KeyboardOverride? = null,
 )
+
+/**
+ * Soft-keyboard (IME) override for previews. Drives the connector-side `KeyboardOverrideExtension`
+ * (see `:data-keyboard-connector`).
+ *
+ * Two facets the daemon's interactive session also writes to directly:
+ *
+ * * [visible] — force the IME band visible or hidden regardless of what the app's
+ *   `LocalSoftwareKeyboardController` / focus state says. `null` leaves the connector observing the
+ *   app's natural IME signals (the default — app calls `keyboardController.show()` or focuses a
+ *   `BasicTextField`, band appears; app calls `hide()`, band disappears).
+ * * [pressedKey] — highlight a specific key cap in the press tint. `null` leaves the highlight
+ *   driven by `interactive/input` `KEY_DOWN` / `KEY_UP` dispatches (which `Android`/`Desktop`
+ *   `InteractiveSession.dispatch` forwards into the same controller). Pass a single-character
+ *   lowercase letter or one of the special tokens `"space"`, `"enter"`, `"shift"`, `"backspace"`,
+ *   `"sym"`.
+ */
+@Serializable
+data class KeyboardOverride(val visible: Boolean? = null, val pressedKey: String? = null)
 
 /**
  * Focus / keyboard-traversal override for previews. Drives the connector-side

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -63,6 +63,11 @@ dependencies {
   // platform-portable mirror. The Android-only `FocusOverlay` (Android-View focus-owner reflection)
   // is not shipped on desktop.
   implementation(project(":data-focus-connector-desktop"))
+  // Soft-keyboard (IME) connector (desktop): always-on `AroundComposable` that shadows
+  // `LocalSoftwareKeyboardController` and overlays a fake-IME band when `KeyboardController`
+  // reports the keyboard is up. Mirrors `:data-keyboard-connector` (Android). The desktop
+  // session's `dispatch(KEY_*)` also calls into `KeyboardController` from this module.
+  implementation(project(":data-keyboard-connector-desktop"))
   implementation(project(":data-recomposition-connector"))
   // Display-filter connector — `DisplayFilterDataProducer.writeArtifacts` runs the post-capture
   // pipeline and writes per-variant PNGs + the `displayfilter-variants.json` manifest after each

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -563,6 +563,18 @@ internal fun buildDesktopExtensions(
       previewOverrideExtensions = listOf(FocusPreviewOverrideExtension()),
     )
   }
+  tryAdd("data/keyboard") {
+    // Soft-keyboard (IME) overlay. Planner always emits the extension so the shadow
+    // `LocalSoftwareKeyboardController` is in place for every render and app-side
+    // `keyboardController.show()` / focused `BasicTextField` raises the band naturally;
+    // `renderNow.overrides.keyboard` and `interactive/input` `KEY_*` dispatches also feed the
+    // same `KeyboardController`.
+    Extension(
+      id = "data/keyboard",
+      displayName = "Soft keyboard overlay",
+      previewOverrideExtensions = listOf(KeyboardPreviewOverrideExtension()),
+    )
+  }
   tryAdd("data/pseudolocale") {
     Extension(
       id = "data/pseudolocale",

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
@@ -135,10 +135,16 @@ class DesktopInteractiveSession(
       }
       InteractiveInputKind.KEY_DOWN -> {
         val key = androidKeycodeToComposeKey(input.keyCode) ?: return
+        // Mirror the press into the soft-keyboard band so an agent driving keyboard input through
+        // `interactive/input` sees the matching cap light up. The band's "press implies visible"
+        // rule in `KeyboardController.softInputVisible` also raises the band even if the consumer
+        // hasn't called `keyboardController.show()`.
+        KeyboardBandLabels.fromAndroidKeycode(input.keyCode)?.let(KeyboardController::notifyKeyDown)
         state.scene.sendKeyEvent(KeyEvent(key, KeyEventType.KeyDown))
       }
       InteractiveInputKind.KEY_UP -> {
         val key = androidKeycodeToComposeKey(input.keyCode) ?: return
+        KeyboardBandLabels.fromAndroidKeycode(input.keyCode)?.let(KeyboardController::notifyKeyUp)
         state.scene.sendKeyEvent(KeyEvent(key, KeyEventType.KeyUp))
       }
     }

--- a/data/keyboard/connector-desktop/build.gradle.kts
+++ b/data/keyboard/connector-desktop/build.gradle.kts
@@ -1,0 +1,42 @@
+@file:Suppress("DEPRECATION")
+
+// `:data-keyboard-connector-desktop` is the JVM-side counterpart to `:data-keyboard-connector`
+// (Android). Both planners always return a `KeyboardOverrideExtension` so the around-composable's
+// observer is in place for every render; both forward `interactive/input` `KEY_*` dispatches and
+// `renderNow.overrides.keyboard` into the same process-static `KeyboardController` (one instance
+// per platform — JVM classloader vs Android sandbox classloader).
+//
+// **Why a separate source set?** `:data-keyboard-connector` is an `android.library` module, so its
+// outputs can't be consumed from `:daemon:desktop`'s JVM classpath. The around-composable plumbing
+// itself only depends on `androidx.compose.runtime` + `androidx.compose.ui` + foundation widgets,
+// all available on Compose Multiplatform Desktop. Mirrors `:data-focus-connector-desktop`'s layout
+// — see the comment header there for the platform-split rationale.
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.compiler)
+}
+
+dependencies {
+  api(project(":data-keyboard-core"))
+  api(project(":daemon:core"))
+  api(project(":data-render-compose"))
+
+  implementation(compose.runtime)
+  implementation(compose.ui)
+  implementation(compose.foundation)
+
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-keyboard-connector-desktop",
+    displayName = "Compose Preview - Soft Keyboard Data Product Connector (Desktop)",
+    description =
+      "Daemon-side soft-keyboard data-product connector for Compose Multiplatform Desktop: shadows LocalSoftwareKeyboardController so app-side IME show/hide and `renderNow.overrides.keyboard` / `interactive/input` `KEY_*` dispatches drive the same fake-IME overlay. Mirrors :data-keyboard-connector.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/keyboard/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardControllerDesktop.kt
+++ b/data/keyboard/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardControllerDesktop.kt
@@ -1,0 +1,59 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import ee.schimke.composeai.daemon.protocol.KeyboardOverride
+
+/**
+ * Process-static state holder for the fake soft-keyboard (IME) band.
+ *
+ * Desktop counterpart of `:data-keyboard-connector`'s [KeyboardController]. The state machine,
+ * "press implies visible" rule, and clear-on-dispose semantics match — see the Android module for
+ * the full rationale.
+ */
+object KeyboardController {
+
+  private val naturalVisible: MutableState<Boolean> = mutableStateOf(false)
+  private val forcedVisible: MutableState<Boolean?> = mutableStateOf(null)
+  private val pressedKeyState: MutableState<String?> = mutableStateOf(null)
+
+  val softInputVisible: State<Boolean> =
+    object : State<Boolean> {
+      override val value: Boolean
+        get() = forcedVisible.value ?: (naturalVisible.value || pressedKeyState.value != null)
+    }
+
+  val pressedKey: State<String?>
+    get() = pressedKeyState
+
+  fun notifyImeVisibility(visible: Boolean) {
+    naturalVisible.value = visible
+  }
+
+  fun notifyKeyDown(label: String) {
+    pressedKeyState.value = label
+  }
+
+  fun notifyKeyUp(label: String? = null) {
+    if (label == null || pressedKeyState.value == label) {
+      pressedKeyState.value = null
+    }
+  }
+
+  fun seed(override: KeyboardOverride?) {
+    forcedVisible.value = override?.visible
+    val pressed = override?.pressedKey
+    if (pressed != null) pressedKeyState.value = pressed
+  }
+
+  fun clearOverride() {
+    forcedVisible.value = null
+  }
+
+  fun resetForNewSession() {
+    naturalVisible.value = false
+    forcedVisible.value = null
+    pressedKeyState.value = null
+  }
+}

--- a/data/keyboard/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardDataProductDesktop.kt
+++ b/data/keyboard/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardDataProductDesktop.kt
@@ -1,0 +1,92 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.SoftwareKeyboardController
+import ee.schimke.composeai.daemon.protocol.KeyboardOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.keyboard.Material3KeyboardProduct
+import ee.schimke.composeai.data.render.extensions.DataExtension
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+
+/**
+ * Desktop counterpart of `:data-keyboard-connector`'s `KeyboardOverrideExtension`. Same observer
+ * shape — shadow `LocalSoftwareKeyboardController` forwarding `show()` / `hide()` into the
+ * process-static [KeyboardController] — minus the Android `LocalConfiguration.uiMode` read (no
+ * day/night signal on the desktop renderer, so the band always uses the light palette).
+ *
+ * The planner always returns a non-null extension for the same reason the Android one does — the
+ * observer needs to be in place even without a `KeyboardOverride` seed so app-side
+ * `LocalSoftwareKeyboardController.show()` calls reach the band.
+ */
+class KeyboardOverrideExtension(private val seed: KeyboardOverride? = null) :
+  AroundComposableExtension(
+    id = ID,
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.OuterEnvironment,
+        provides = setOf(DataExtensionCapability(Material3KeyboardProduct.KIND)),
+      ),
+  ) {
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    if (seed != null) {
+      DisposableEffect(seed) {
+        KeyboardController.seed(seed)
+        onDispose { KeyboardController.clearOverride() }
+      }
+    }
+
+    val shadow = remember { ObservingSoftwareKeyboardController() }
+    CompositionLocalProvider(LocalSoftwareKeyboardController provides shadow) {
+      val visible by KeyboardController.softInputVisible
+      val pressedKey by KeyboardController.pressedKey
+      Box(modifier = Modifier.fillMaxSize()) {
+        content()
+        if (visible) {
+          SoftKeyboardBand(
+            pressedKey = pressedKey,
+            night = false,
+            modifier = Modifier.align(Alignment.BottomCenter),
+          )
+        }
+      }
+    }
+  }
+
+  private class ObservingSoftwareKeyboardController : SoftwareKeyboardController {
+    override fun show() {
+      KeyboardController.notifyImeVisibility(true)
+    }
+
+    override fun hide() {
+      KeyboardController.notifyImeVisibility(false)
+    }
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId(Material3KeyboardProduct.KIND)
+  }
+}
+
+class KeyboardPreviewOverrideExtension : DataExtension<PreviewOverrides> {
+  override val id: DataExtensionId = KeyboardOverrideExtension.ID
+
+  override fun plan(request: PreviewOverrides): PlannedDataExtension =
+    KeyboardOverrideExtension(seed = request.keyboard)
+}

--- a/data/keyboard/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/SoftKeyboardBandDesktop.kt
+++ b/data/keyboard/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/SoftKeyboardBandDesktop.kt
@@ -1,0 +1,246 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Desktop counterpart of `:data-keyboard-connector`'s `SoftKeyboardBand`. Duplicated rather than
+ * shared because the Android module is `android.library` and its outputs can't be consumed from
+ * `:daemon:desktop`'s JVM classpath — same pattern `:data-focus-connector-desktop` follows. The
+ * layout / palette / key tokens are kept in lockstep; bump both together.
+ */
+@Composable
+internal fun SoftKeyboardBand(pressedKey: String?, night: Boolean, modifier: Modifier = Modifier) {
+  val palette = if (night) DarkPalette else LightPalette
+  val normalized = pressedKey?.lowercase()
+
+  Column(
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .height(KEYBOARD_HEIGHT_DP.dp)
+        .background(palette.background)
+        .padding(horizontal = SIDE_INSET_DP.dp, vertical = ROW_INSET_DP.dp),
+    verticalArrangement = Arrangement.spacedBy(ROW_GAP_DP.dp),
+  ) {
+    LetterRow(row = ROW_TOP, pressed = normalized, palette = palette)
+    LetterRow(row = ROW_MIDDLE, pressed = normalized, palette = palette, sideInsetWeight = 0.5f)
+    BottomLetterRow(pressed = normalized, palette = palette)
+    ActionRow(pressed = normalized, palette = palette)
+  }
+}
+
+@Composable
+private fun ColumnScope.LetterRow(
+  row: String,
+  pressed: String?,
+  palette: KeyboardPalette,
+  sideInsetWeight: Float = 0f,
+) {
+  Row(
+    modifier = Modifier.fillMaxWidth().weight(1f, fill = true),
+    horizontalArrangement = Arrangement.spacedBy(KEY_GAP_DP.dp),
+  ) {
+    if (sideInsetWeight > 0f) Spacer(modifier = Modifier.weight(sideInsetWeight))
+    row.forEach { ch ->
+      val label = ch.toString()
+      LetterKey(
+        label = label,
+        pressed = pressed == label,
+        palette = palette,
+        modifier = Modifier.weight(1f),
+      )
+    }
+    if (sideInsetWeight > 0f) Spacer(modifier = Modifier.weight(sideInsetWeight))
+  }
+}
+
+@Composable
+private fun ColumnScope.BottomLetterRow(pressed: String?, palette: KeyboardPalette) {
+  Row(
+    modifier = Modifier.fillMaxWidth().weight(1f, fill = true),
+    horizontalArrangement = Arrangement.spacedBy(KEY_GAP_DP.dp),
+  ) {
+    SpecialKey(
+      label = "⇧",
+      isPressed = pressed == "shift",
+      palette = palette,
+      modifier = Modifier.weight(1.5f),
+    )
+    ROW_BOTTOM.forEach { ch ->
+      val label = ch.toString()
+      LetterKey(
+        label = label,
+        pressed = pressed == label,
+        palette = palette,
+        modifier = Modifier.weight(1f),
+      )
+    }
+    SpecialKey(
+      label = "⌫",
+      isPressed = pressed == "backspace",
+      palette = palette,
+      modifier = Modifier.weight(1.5f),
+    )
+  }
+}
+
+@Composable
+private fun ColumnScope.ActionRow(pressed: String?, palette: KeyboardPalette) {
+  Row(
+    modifier = Modifier.fillMaxWidth().weight(1f, fill = true),
+    horizontalArrangement = Arrangement.spacedBy(KEY_GAP_DP.dp),
+  ) {
+    SpecialKey(
+      label = "?123",
+      isPressed = pressed == "sym",
+      palette = palette,
+      modifier = Modifier.weight(1.5f),
+    )
+    LetterKey(
+      label = ",",
+      pressed = pressed == ",",
+      palette = palette,
+      modifier = Modifier.weight(1f),
+    )
+    SpecialKey(
+      label = "space",
+      isPressed = pressed == "space",
+      palette = palette,
+      modifier = Modifier.weight(5f),
+    )
+    LetterKey(
+      label = ".",
+      pressed = pressed == ".",
+      palette = palette,
+      modifier = Modifier.weight(1f),
+    )
+    SpecialKey(
+      label = "⏎",
+      isPressed = pressed == "enter",
+      palette = palette,
+      modifier = Modifier.weight(1.5f),
+    )
+  }
+}
+
+@Composable
+private fun LetterKey(
+  label: String,
+  pressed: Boolean,
+  palette: KeyboardPalette,
+  modifier: Modifier,
+) {
+  KeyCap(
+    label = label,
+    pressed = pressed,
+    background = if (pressed) palette.pressed else palette.letterKey,
+    foreground = if (pressed) palette.pressedForeground else palette.foreground,
+    modifier = modifier,
+  )
+}
+
+@Composable
+private fun SpecialKey(
+  label: String,
+  isPressed: Boolean,
+  palette: KeyboardPalette,
+  modifier: Modifier,
+) {
+  KeyCap(
+    label = label,
+    pressed = isPressed,
+    background = if (isPressed) palette.pressed else palette.specialKey,
+    foreground = if (isPressed) palette.pressedForeground else palette.foreground,
+    modifier = modifier,
+  )
+}
+
+@Composable
+private fun KeyCap(
+  label: String,
+  pressed: Boolean,
+  background: Color,
+  foreground: Color,
+  modifier: Modifier,
+) {
+  Box(modifier = modifier.fillMaxHeight(), contentAlignment = Alignment.Center) {
+    Box(
+      modifier =
+        Modifier.fillMaxSize().clip(RoundedCornerShape(KEY_CORNER_DP.dp)).background(background),
+      contentAlignment = Alignment.Center,
+    ) {
+      BasicText(
+        text = label,
+        style =
+          TextStyle(
+            color = foreground,
+            fontSize = KEY_LABEL_SP.sp,
+            fontWeight = if (pressed) FontWeight.SemiBold else FontWeight.Normal,
+          ),
+      )
+    }
+  }
+}
+
+private data class KeyboardPalette(
+  val background: Color,
+  val letterKey: Color,
+  val specialKey: Color,
+  val foreground: Color,
+  val pressed: Color,
+  val pressedForeground: Color,
+)
+
+private val LightPalette =
+  KeyboardPalette(
+    background = Color(0xFFE8EBEF),
+    letterKey = Color(0xFFFFFFFF),
+    specialKey = Color(0xFFC8CCD3),
+    foreground = Color(0xFF1F1F1F),
+    pressed = Color(0xFF1A73E8),
+    pressedForeground = Color(0xFFFFFFFF),
+  )
+
+private val DarkPalette =
+  KeyboardPalette(
+    background = Color(0xFF1B1C1E),
+    letterKey = Color(0xFF3C4043),
+    specialKey = Color(0xFF24262A),
+    foreground = Color(0xFFE8EAED),
+    pressed = Color(0xFF8AB4F8),
+    pressedForeground = Color(0xFF202124),
+  )
+
+private const val ROW_TOP = "qwertyuiop"
+private const val ROW_MIDDLE = "asdfghjkl"
+private const val ROW_BOTTOM = "zxcvbnm"
+
+private const val KEYBOARD_HEIGHT_DP = 240
+private const val SIDE_INSET_DP = 4
+private const val ROW_INSET_DP = 6
+private const val ROW_GAP_DP = 6
+private const val KEY_GAP_DP = 4
+private const val KEY_CORNER_DP = 6
+private const val KEY_LABEL_SP = 14

--- a/data/keyboard/connector/build.gradle.kts
+++ b/data/keyboard/connector/build.gradle.kts
@@ -1,0 +1,74 @@
+// `:data-keyboard-connector` glues `:data-keyboard-core` (the wire-shape identity) to the daemon's
+// data-product / preview-override surface. Mirrors `:data-focus-connector`'s split — kind constant
+// in core, daemon-side machinery (controller, around-composable extension, planner, band
+// composable) here. Ships:
+//
+//  - `KeyboardController` — process-static state holder for `softInputVisible` + `pressedKey`,
+//    written from three places (the around-composable observing real Android IME signals, the
+//    `KeyboardOverride` seed, and the daemon's `InteractiveSession.dispatch(KEY_*)`).
+//  - `KeyboardOverrideExtension` / `KeyboardPreviewOverrideExtension` — `AroundComposable` plumbing
+//    that shadows `LocalSoftwareKeyboardController`, observes `WindowInsetsCompat.Type.ime()`, and
+//    overlays a fake Gboard-shaped band on top of preview content when the IME is up. Planner
+//    always emits the extension so the observer is in place even without an explicit override —
+//    the renderer's "default behaviour when this app state changes" surface.
+//  - `SoftKeyboardBand` — internal composable rendering the band; not part of the public API.
+//    Consumers don't reach for it directly; they get the band for free through the extension.
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.tapmoc)
+}
+
+android { namespace = "ee.schimke.composeai.data.keyboard.connector" }
+
+dependencies {
+  // Wire-shape identity — re-exported via `api` so consumers (`:daemon:android`,
+  // `:renderer-android`) can refer to `Material3KeyboardProduct.KIND` without adding a second
+  // `project` dependency.
+  api(project(":data-keyboard-core"))
+
+  // DataExtension / AroundComposableExtension. Re-exported so the planner / extension classes can
+  // be referenced from `RobolectricHost`'s `previewOverrideExtensions` list without a second
+  // project dep on the consumer.
+  api(project(":daemon:core"))
+  api(project(":data-render-core"))
+  api(project(":data-render-compose"))
+
+  // Foundation widgets (`Box`, `Column`, `Row`, `BasicText`) for the band composable. Compiled
+  // against the older `compose-bom-compat` (Compose 1.9.x) so the published AAR's bytecode stays
+  // binary-backward-compatible with consumers pinned to older Compose BOMs — same rationale as
+  // `:renderer-android` (see its `compileOnly` block for the long-form story). `compileOnly`
+  // because the consumer always brings its own foundation through its own BOM; we just need the
+  // API surface at compile time. `testImplementation` mirrors so the connector's own unit tests
+  // have actual runtime classes.
+  compileOnly(platform(libs.compose.bom.compat))
+  compileOnly(libs.compose.foundation)
+  testImplementation(platform(libs.compose.bom.compat))
+  testImplementation(libs.compose.foundation)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.kotlinx.serialization.json)
+}
+
+mavenPublishing {
+  configure(
+    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
+      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
+      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
+      variant = "release",
+    )
+  )
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-keyboard-connector",
+    displayName = "Compose Preview - Soft Keyboard Data Product Connector",
+    description =
+      "Daemon-side soft-keyboard (IME) data-product connector: drives the around-composable that reflects an app's natural IME state (LocalSoftwareKeyboardController + WindowInsetsCompat.Type.ime()) as a Gboard-shaped overlay on previews, and lets `renderNow.overrides.keyboard` / `interactive/input` `KEY_*` dispatches drive the same band from the agent side.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/keyboard/connector/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardController.kt
+++ b/data/keyboard/connector/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardController.kt
@@ -1,0 +1,110 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import ee.schimke.composeai.daemon.protocol.KeyboardOverride
+
+/**
+ * Process-static state holder for the fake soft-keyboard (IME) band.
+ *
+ * Three writers, one reader:
+ *
+ * 1. **Around-composable observer** ([KeyboardOverrideExtension.AroundComposable]) — installs a
+ *    shadow `LocalSoftwareKeyboardController` and listens for `show()` / `hide()` from app code
+ *    (focused `BasicTextField`, explicit `keyboardController.show()`). Calls
+ *    [notifyImeVisibility] on every transition.
+ * 2. **Interactive dispatch** (`AndroidInteractiveSession.dispatch` /
+ *    `DesktopInteractiveSession.dispatch`) — `KEY_DOWN` / `KEY_UP` from a daemon client are also
+ *    forwarded into [notifyKeyDown] / [notifyKeyUp] so an agent driving keyboard input lights the
+ *    matching cap *and* implicitly raises the band.
+ * 3. **`KeyboardOverride` seed** — `renderNow.overrides.keyboard` (`KeyboardOverride(visible = …,
+ *    pressedKey = …)`) wins over the natural state; cleared on dispose so the next preview starts
+ *    fresh.
+ *
+ * Reads happen only from inside [KeyboardOverrideExtension.AroundComposable], which composes the
+ * band on top of the wrapped content. Snapshot-state reads ensure each writer triggers a
+ * recomposition without the band needing to know which path drove the change.
+ */
+object KeyboardController {
+
+  /**
+   * "Natural" IME-up signal coming from app-side APIs (shadow `LocalSoftwareKeyboardController`).
+   * Distinct from [forcedVisible] so a per-render `KeyboardOverride(visible = …)` can pin the band
+   * without clobbering the underlying observed state when the override clears.
+   */
+  private val naturalVisible: MutableState<Boolean> = mutableStateOf(false)
+
+  /**
+   * Optional `KeyboardOverride.visible` from a daemon call. `true` / `false` pin the band on / off;
+   * `null` falls back to [naturalVisible] (plus the press-implies-visible rule below).
+   */
+  private val forcedVisible: MutableState<Boolean?> = mutableStateOf(null)
+
+  /** Currently held key, written by `interactive/input` `KEY_*` and `KeyboardOverride.pressedKey`. */
+  private val pressedKeyState: MutableState<String?> = mutableStateOf(null)
+
+  /**
+   * Effective "should the band render" signal — `forcedVisible` if set, else `naturalVisible OR a
+   * key is currently pressed`. Pressing a key implicitly raises the band so an agent dispatching
+   * `KEY_DOWN` against a fresh preview sees something — without this, an `interactive/input` typing
+   * sequence against a preview the app hasn't focused would update [pressedKeyState] but never
+   * make the band appear.
+   */
+  val softInputVisible: State<Boolean> =
+    object : State<Boolean> {
+      override val value: Boolean
+        get() = forcedVisible.value ?: (naturalVisible.value || pressedKeyState.value != null)
+    }
+
+  /** Snapshot read of the currently highlighted key, or `null` when no key is held. */
+  val pressedKey: State<String?>
+    get() = pressedKeyState
+
+  /** App-side observer (`LocalSoftwareKeyboardController` shadow) signals the natural IME state. */
+  fun notifyImeVisibility(visible: Boolean) {
+    naturalVisible.value = visible
+  }
+
+  /**
+   * Mark [label] as currently pressed. Called from the daemon's interactive session
+   * (`KEY_DOWN` dispatch) and from `KeyboardOverride.pressedKey` seeding. Label format matches the
+   * band's key tokens (single lowercase letter or `"space"`/`"enter"`/`"shift"`/`"backspace"`).
+   */
+  fun notifyKeyDown(label: String) {
+    pressedKeyState.value = label
+  }
+
+  /**
+   * Release the current press. If [label] is supplied and doesn't match the held key the call is
+   * silently dropped — protects against an out-of-order `KEY_UP` from a different key clearing a
+   * still-held cap. Pass `null` to force-clear regardless.
+   */
+  fun notifyKeyUp(label: String? = null) {
+    if (label == null || pressedKeyState.value == label) {
+      pressedKeyState.value = null
+    }
+  }
+
+  /**
+   * Apply a `KeyboardOverride` from `renderNow.overrides.keyboard`. Sets both facets in one shot;
+   * either field can be `null` to leave that facet on its natural / dispatched value.
+   */
+  fun seed(override: KeyboardOverride?) {
+    forcedVisible.value = override?.visible
+    val pressed = override?.pressedKey
+    if (pressed != null) pressedKeyState.value = pressed
+  }
+
+  /** Clear the override side without disturbing observed natural state. Called on dispose. */
+  fun clearOverride() {
+    forcedVisible.value = null
+  }
+
+  /** Cleanup hook for per-session reset, matches [FocusController.resetForNewSession]. */
+  fun resetForNewSession() {
+    naturalVisible.value = false
+    forcedVisible.value = null
+    pressedKeyState.value = null
+  }
+}

--- a/data/keyboard/connector/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardDataProduct.kt
+++ b/data/keyboard/connector/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardDataProduct.kt
@@ -1,0 +1,138 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.SoftwareKeyboardController
+import ee.schimke.composeai.daemon.protocol.KeyboardOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.keyboard.Material3KeyboardProduct
+import ee.schimke.composeai.data.render.extensions.DataExtension
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+
+/**
+ * `AroundComposable` extension that owns the soft-keyboard (IME) overlay. The extension is
+ * **always active** — the planner emits an instance for every render, with or without a
+ * `KeyboardOverride` seed, so the around-composable can observe natural IME state and surface the
+ * band when the app raises it.
+ *
+ * Two control surfaces feed the [KeyboardController]:
+ *
+ * - **App-side, passive** — [KeyboardOverrideExtension.AroundComposable] installs a shadow
+ *   `LocalSoftwareKeyboardController` whose `show()` / `hide()` calls land directly in
+ *   [KeyboardController.notifyImeVisibility]. Compose's text input system calls `show()` on the
+ *   ambient controller whenever a `BasicTextField` gains focus, so a normal focused field is
+ *   enough to make the band appear. Explicit app code (`keyboardController.show()`) takes the same
+ *   path.
+ * - **Daemon-side, active** — `AndroidInteractiveSession.dispatch` /
+ *   `DesktopInteractiveSession.dispatch` forward `KEY_DOWN` / `KEY_UP` envelopes into
+ *   [KeyboardController.notifyKeyDown] / [notifyKeyUp]; `renderNow.overrides.keyboard` seeds both
+ *   facets via [KeyboardController.seed]. The `KEY_*` rule "press implies visible" lives in
+ *   [KeyboardController.softInputVisible] so an agent typing into a fresh preview gets a visible
+ *   band even without the app focusing anything.
+ *
+ * Runs in [DataExtensionPhase.OuterEnvironment] so the shadow controller is in place before the
+ * user-environment phase reaches preview content — text fields composed in user code see the
+ * shadow rather than the platform default.
+ */
+class KeyboardOverrideExtension(private val seed: KeyboardOverride? = null) :
+  AroundComposableExtension(
+    id = ID,
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.OuterEnvironment,
+        provides = setOf(DataExtensionCapability(Material3KeyboardProduct.KIND)),
+      ),
+  ) {
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    if (seed != null) {
+      DisposableEffect(seed) {
+        KeyboardController.seed(seed)
+        onDispose { KeyboardController.clearOverride() }
+      }
+    }
+
+    // Shadow `SoftwareKeyboardController` — any `show()` / `hide()` call from inside `content()`
+    // routes through this instead of the platform default. Compose's `BasicTextField` calls
+    // `keyboardController?.show()` from `onFocusChanged` (via `TextFieldKeyboardActionScope`),
+    // which is how a focused text field naturally raises the IME on a real device. We capture
+    // that same call here and surface it through [KeyboardController.notifyImeVisibility].
+    val shadow = remember { ObservingSoftwareKeyboardController() }
+    CompositionLocalProvider(LocalSoftwareKeyboardController provides shadow) {
+      val visible by KeyboardController.softInputVisible
+      val pressedKey by KeyboardController.pressedKey
+      val night =
+        (LocalConfiguration.current.uiMode and UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES
+      Box(modifier = Modifier.fillMaxSize()) {
+        content()
+        if (visible) {
+          SoftKeyboardBand(
+            pressedKey = pressedKey,
+            night = night,
+            modifier = Modifier.align(Alignment.BottomCenter),
+          )
+        }
+      }
+    }
+  }
+
+  /**
+   * `SoftwareKeyboardController` that forwards `show()` / `hide()` into [KeyboardController]. The
+   * platform default fires Android's `InputMethodManager` IPC; we keep the IPC off (we don't have
+   * a real IME bound during preview rendering anyway) and instead drive the synthetic band.
+   *
+   * Marked stable rather than experimental even though the interface itself is opt-in — Compose's
+   * own platform implementations carry the same opt-in.
+   */
+  private class ObservingSoftwareKeyboardController : SoftwareKeyboardController {
+    override fun show() {
+      KeyboardController.notifyImeVisibility(true)
+    }
+
+    override fun hide() {
+      KeyboardController.notifyImeVisibility(false)
+    }
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId(Material3KeyboardProduct.KIND)
+
+    /**
+     * `Configuration.uiMode` mask + value for "night mode is on". Duplicated from the renderer's
+     * `SystemBarsFrame` rather than imported so this module doesn't take a project dep on
+     * `:renderer-android`.
+     */
+    private const val UI_MODE_NIGHT_MASK = 0x30
+    private const val UI_MODE_NIGHT_YES = 0x20
+  }
+}
+
+/**
+ * Planner that maps `renderNow.overrides.keyboard` to a [KeyboardOverrideExtension]. **Always**
+ * returns a non-null extension — unlike the focus / wallpaper / theme planners that abstain on
+ * `null`. The around-composable's observer needs to be in place for the band to react to natural
+ * app-side IME state changes, not just to explicit overrides; an always-on extension is the
+ * cheapest way to guarantee that without each capture-site having to opt in.
+ */
+class KeyboardPreviewOverrideExtension : DataExtension<PreviewOverrides> {
+  override val id: DataExtensionId = KeyboardOverrideExtension.ID
+
+  override fun plan(request: PreviewOverrides): PlannedDataExtension =
+    KeyboardOverrideExtension(seed = request.keyboard)
+}

--- a/data/keyboard/connector/src/main/kotlin/ee/schimke/composeai/daemon/SoftKeyboardBand.kt
+++ b/data/keyboard/connector/src/main/kotlin/ee/schimke/composeai/daemon/SoftKeyboardBand.kt
@@ -1,0 +1,247 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Internal Gboard-styled QWERTY band, pinned to the bottom by the extension's `Box` overlay. Not a
+ * public API — consumers reach the keyboard only by going through the data extension (focusing a
+ * `BasicTextField`, calling `LocalSoftwareKeyboardController.show()`, or pushing
+ * `KeyboardOverride.visible = true` through `renderNow.overrides.keyboard`).
+ *
+ * @param pressedKey Currently held key label, lowercase letter or one of `"space"`, `"enter"`,
+ *     `"shift"`, `"backspace"`, `"sym"`. `null` for an idle band.
+ * @param night Use the dark palette. Wired from `(uiMode and UI_MODE_NIGHT_MASK) ==
+ *     UI_MODE_NIGHT_YES` at the caller; kept Boolean-typed here so this file doesn't pull
+ *     `android.content.res.Configuration`.
+ */
+@Composable
+internal fun SoftKeyboardBand(pressedKey: String?, night: Boolean, modifier: Modifier = Modifier) {
+  val palette = if (night) DarkPalette else LightPalette
+  val normalized = pressedKey?.lowercase()
+
+  Column(
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .height(KEYBOARD_HEIGHT_DP.dp)
+        .background(palette.background)
+        .padding(horizontal = SIDE_INSET_DP.dp, vertical = ROW_INSET_DP.dp),
+    verticalArrangement = Arrangement.spacedBy(ROW_GAP_DP.dp),
+  ) {
+    LetterRow(row = ROW_TOP, pressed = normalized, palette = palette)
+    LetterRow(row = ROW_MIDDLE, pressed = normalized, palette = palette, sideInsetWeight = 0.5f)
+    BottomLetterRow(pressed = normalized, palette = palette)
+    ActionRow(pressed = normalized, palette = palette)
+  }
+}
+
+@Composable
+private fun ColumnScope.LetterRow(
+  row: String,
+  pressed: String?,
+  palette: KeyboardPalette,
+  sideInsetWeight: Float = 0f,
+) {
+  Row(
+    modifier = Modifier.fillMaxWidth().weight(1f, fill = true),
+    horizontalArrangement = Arrangement.spacedBy(KEY_GAP_DP.dp),
+  ) {
+    if (sideInsetWeight > 0f) Spacer(modifier = Modifier.weight(sideInsetWeight))
+    row.forEach { ch ->
+      val label = ch.toString()
+      LetterKey(
+        label = label,
+        pressed = pressed == label,
+        palette = palette,
+        modifier = Modifier.weight(1f),
+      )
+    }
+    if (sideInsetWeight > 0f) Spacer(modifier = Modifier.weight(sideInsetWeight))
+  }
+}
+
+@Composable
+private fun ColumnScope.BottomLetterRow(pressed: String?, palette: KeyboardPalette) {
+  Row(
+    modifier = Modifier.fillMaxWidth().weight(1f, fill = true),
+    horizontalArrangement = Arrangement.spacedBy(KEY_GAP_DP.dp),
+  ) {
+    SpecialKey(
+      label = "⇧", // up-arrow glyph for shift
+      isPressed = pressed == "shift",
+      palette = palette,
+      modifier = Modifier.weight(1.5f),
+    )
+    ROW_BOTTOM.forEach { ch ->
+      val label = ch.toString()
+      LetterKey(
+        label = label,
+        pressed = pressed == label,
+        palette = palette,
+        modifier = Modifier.weight(1f),
+      )
+    }
+    SpecialKey(
+      label = "⌫", // erase-left glyph for backspace
+      isPressed = pressed == "backspace",
+      palette = palette,
+      modifier = Modifier.weight(1.5f),
+    )
+  }
+}
+
+@Composable
+private fun ColumnScope.ActionRow(pressed: String?, palette: KeyboardPalette) {
+  Row(
+    modifier = Modifier.fillMaxWidth().weight(1f, fill = true),
+    horizontalArrangement = Arrangement.spacedBy(KEY_GAP_DP.dp),
+  ) {
+    SpecialKey(
+      label = "?123",
+      isPressed = pressed == "sym",
+      palette = palette,
+      modifier = Modifier.weight(1.5f),
+    )
+    LetterKey(
+      label = ",",
+      pressed = pressed == ",",
+      palette = palette,
+      modifier = Modifier.weight(1f),
+    )
+    SpecialKey(
+      label = "space",
+      isPressed = pressed == "space",
+      palette = palette,
+      modifier = Modifier.weight(5f),
+    )
+    LetterKey(
+      label = ".",
+      pressed = pressed == ".",
+      palette = palette,
+      modifier = Modifier.weight(1f),
+    )
+    SpecialKey(
+      label = "⏎", // return-symbol glyph for enter
+      isPressed = pressed == "enter",
+      palette = palette,
+      modifier = Modifier.weight(1.5f),
+    )
+  }
+}
+
+@Composable
+private fun LetterKey(label: String, pressed: Boolean, palette: KeyboardPalette, modifier: Modifier) {
+  KeyCap(
+    label = label,
+    pressed = pressed,
+    background = if (pressed) palette.pressed else palette.letterKey,
+    foreground = if (pressed) palette.pressedForeground else palette.foreground,
+    modifier = modifier,
+  )
+}
+
+@Composable
+private fun SpecialKey(
+  label: String,
+  isPressed: Boolean,
+  palette: KeyboardPalette,
+  modifier: Modifier,
+) {
+  KeyCap(
+    label = label,
+    pressed = isPressed,
+    background = if (isPressed) palette.pressed else palette.specialKey,
+    foreground = if (isPressed) palette.pressedForeground else palette.foreground,
+    modifier = modifier,
+  )
+}
+
+@Composable
+private fun KeyCap(
+  label: String,
+  pressed: Boolean,
+  background: Color,
+  foreground: Color,
+  modifier: Modifier,
+) {
+  Box(modifier = modifier.fillMaxHeight(), contentAlignment = Alignment.Center) {
+    Box(
+      modifier =
+        Modifier.fillMaxSize().clip(RoundedCornerShape(KEY_CORNER_DP.dp)).background(background),
+      contentAlignment = Alignment.Center,
+    ) {
+      BasicText(
+        text = label,
+        style =
+          TextStyle(
+            color = foreground,
+            fontSize = KEY_LABEL_SP.sp,
+            fontWeight = if (pressed) FontWeight.SemiBold else FontWeight.Normal,
+          ),
+      )
+    }
+  }
+}
+
+private data class KeyboardPalette(
+  val background: Color,
+  val letterKey: Color,
+  val specialKey: Color,
+  val foreground: Color,
+  val pressed: Color,
+  val pressedForeground: Color,
+)
+
+private val LightPalette =
+  KeyboardPalette(
+    background = Color(0xFFE8EBEF),
+    letterKey = Color(0xFFFFFFFF),
+    specialKey = Color(0xFFC8CCD3),
+    foreground = Color(0xFF1F1F1F),
+    pressed = Color(0xFF1A73E8),
+    pressedForeground = Color(0xFFFFFFFF),
+  )
+
+private val DarkPalette =
+  KeyboardPalette(
+    background = Color(0xFF1B1C1E),
+    letterKey = Color(0xFF3C4043),
+    specialKey = Color(0xFF24262A),
+    foreground = Color(0xFFE8EAED),
+    pressed = Color(0xFF8AB4F8),
+    pressedForeground = Color(0xFF202124),
+  )
+
+private const val ROW_TOP = "qwertyuiop"
+private const val ROW_MIDDLE = "asdfghjkl"
+private const val ROW_BOTTOM = "zxcvbnm"
+
+private const val KEYBOARD_HEIGHT_DP = 240
+private const val SIDE_INSET_DP = 4
+private const val ROW_INSET_DP = 6
+private const val ROW_GAP_DP = 6
+private const val KEY_GAP_DP = 4
+private const val KEY_CORNER_DP = 6
+private const val KEY_LABEL_SP = 14

--- a/data/keyboard/connector/src/test/kotlin/ee/schimke/composeai/daemon/KeyboardDataProductTest.kt
+++ b/data/keyboard/connector/src/test/kotlin/ee/schimke/composeai/daemon/KeyboardDataProductTest.kt
@@ -1,0 +1,142 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.keyboard.Material3KeyboardProduct
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
+import ee.schimke.composeai.daemon.protocol.AmbientOverride
+import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
+import ee.schimke.composeai.daemon.protocol.KeyboardOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the contract of `:data-keyboard-connector`'s extension surface. Mirrors
+ * [FocusDataProductTest] in shape, with the planner difference called out: the keyboard planner
+ * always returns a non-null extension so the around-composable's observer is in place for every
+ * render — without that, a `BasicTextField.show()` from app code wouldn't have anyone listening.
+ */
+class KeyboardDataProductTest {
+
+  @After fun tearDown() = KeyboardController.resetForNewSession()
+
+  @Test
+  fun `keyboard override extension declares around-composable hook in OuterEnvironment phase`() {
+    val extension = KeyboardOverrideExtension(KeyboardOverride(visible = true))
+    val hook: AroundComposableHook = extension
+
+    assertEquals(DataExtensionId(Material3KeyboardProduct.KIND), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.AroundComposable), extension.hooks)
+    assertEquals(DataExtensionPhase.OuterEnvironment, extension.constraints.phase)
+    assertTrue(extension.hasAroundComposableHook)
+    assertEquals(extension, hook)
+  }
+
+  @Test
+  fun `planner returns extension even when keyboard override absent`() {
+    val planner = KeyboardPreviewOverrideExtension()
+    val planned = planner.plan(PreviewOverrides())
+    assertNotNull(
+      "planner must always emit the extension so the observer can react to natural app-side IME " +
+        "state, not just to explicit overrides",
+      planned,
+    )
+    assertEquals(DataExtensionId(Material3KeyboardProduct.KIND), planned.id)
+    // Sibling overrides shouldn't change the always-on shape.
+    assertNotNull(
+      planner.plan(
+        PreviewOverrides(ambient = AmbientOverride(state = AmbientStateOverride.AMBIENT))
+      )
+    )
+    assertNotNull(planner.plan(PreviewOverrides(keyboard = KeyboardOverride(visible = false))))
+  }
+
+  @Test
+  fun `controller starts hidden with no key pressed`() {
+    KeyboardController.resetForNewSession()
+    assertFalse(KeyboardController.softInputVisible.value)
+    assertNull(KeyboardController.pressedKey.value)
+  }
+
+  @Test
+  fun `notifyImeVisibility flips the natural state`() {
+    KeyboardController.notifyImeVisibility(true)
+    assertTrue(KeyboardController.softInputVisible.value)
+
+    KeyboardController.notifyImeVisibility(false)
+    assertFalse(KeyboardController.softInputVisible.value)
+  }
+
+  @Test
+  fun `seed with visible true forces band visible regardless of natural state`() {
+    KeyboardController.notifyImeVisibility(false)
+    KeyboardController.seed(KeyboardOverride(visible = true))
+    assertTrue(
+      "forced visibility wins over natural=false",
+      KeyboardController.softInputVisible.value,
+    )
+
+    KeyboardController.clearOverride()
+    assertFalse(
+      "clearing the override falls back to the natural false state",
+      KeyboardController.softInputVisible.value,
+    )
+  }
+
+  @Test
+  fun `seed with visible false forces band hidden regardless of natural state`() {
+    KeyboardController.notifyImeVisibility(true)
+    KeyboardController.seed(KeyboardOverride(visible = false))
+    assertFalse(
+      "forced hidden wins over natural=true",
+      KeyboardController.softInputVisible.value,
+    )
+  }
+
+  @Test
+  fun `key press implies band visible without explicit show`() {
+    KeyboardController.notifyImeVisibility(false)
+    assertFalse(KeyboardController.softInputVisible.value)
+
+    // Interactive `KEY_DOWN` from a daemon client without an app `show()` first — the band still
+    // raises so the agent's typing isn't shown against a hidden keyboard.
+    KeyboardController.notifyKeyDown("h")
+    assertTrue(
+      "pressing a key without explicit show() should raise the band",
+      KeyboardController.softInputVisible.value,
+    )
+    assertEquals("h", KeyboardController.pressedKey.value)
+
+    KeyboardController.notifyKeyUp("h")
+    assertNull(KeyboardController.pressedKey.value)
+    assertFalse(
+      "releasing the only held key should lower the band when there's no natural visibility",
+      KeyboardController.softInputVisible.value,
+    )
+  }
+
+  @Test
+  fun `notifyKeyUp with mismatched label leaves the press intact`() {
+    KeyboardController.notifyKeyDown("a")
+    KeyboardController.notifyKeyUp("z")
+    assertEquals(
+      "an out-of-order release for a different key shouldn't clear the held cap",
+      "a",
+      KeyboardController.pressedKey.value,
+    )
+
+    KeyboardController.notifyKeyUp()
+    assertNull(
+      "explicit null release force-clears the held cap",
+      KeyboardController.pressedKey.value,
+    )
+  }
+}

--- a/data/keyboard/core/build.gradle.kts
+++ b/data/keyboard/core/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // `daemon:core` carries `PreviewOverrides`, which `:data-keyboard-connector`'s planner reads via
+  // the protocol's optional `keyboard` field. Keeping the kind constant on a tiny JVM module
+  // mirrors
+  // `:data-focus-core` / `:data-ambient-core` so MCP clients in other languages can depend on the
+  // soft-keyboard product identity without dragging in the connector or any Compose / Robolectric
+  // runtime.
+  api(project(":daemon:core"))
+  api(libs.kotlinx.serialization.json)
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-keyboard-core",
+    displayName = "Compose Preview - Soft Keyboard Data Product Core",
+    description = "Shared soft-keyboard (IME) data-product identifier for Compose Preview.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/keyboard/core/src/main/kotlin/ee/schimke/composeai/data/keyboard/KeyboardModels.kt
+++ b/data/keyboard/core/src/main/kotlin/ee/schimke/composeai/data/keyboard/KeyboardModels.kt
@@ -1,0 +1,17 @@
+package ee.schimke.composeai.data.keyboard
+
+/**
+ * Stable identity of the `compose/keyboard` data product. Mirrors `Material3FocusProduct` /
+ * `Material3AmbientProduct`: lifted out of the daemon-side registry so MCP clients and other
+ * connectors can depend on the kind constant without pulling in the connector, Compose, or
+ * Robolectric.
+ *
+ * Wire-shape `KeyboardOverride` lives alongside the other preview-override types on `daemon:core`
+ * (see `ee.schimke.composeai.daemon.protocol.KeyboardOverride`); the override is what
+ * `renderNow.overrides.keyboard` carries, and keeping it on `daemon:core` mirrors how
+ * `AmbientOverride` / `WallpaperOverride` / `FocusOverride` are layered.
+ */
+object Material3KeyboardProduct {
+  const val KIND: String = "compose/keyboard"
+  const val SCHEMA_VERSION: Int = 1
+}

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -47,6 +47,16 @@ dependencies {
   // architectural rule as focus: **no hardcoded ambient / `LocalAmbientModeManager` logic in
   // this module — extend the connector instead.**
   implementation(project(":data-ambient-connector"))
+  // Soft-keyboard (IME) connector. Owns `KeyboardController` (state) and
+  // `KeyboardOverrideExtension`
+  // (the `AroundComposable` that installs the shadow `LocalSoftwareKeyboardController` and overlays
+  // the band when `KeyboardController.softInputVisible` flips). The renderer wraps content with the
+  // extension on every capture so app-side `keyboardController.show()` (and the same path
+  // `BasicTextField` uses internally on focus) raises the band naturally. Daemon-driven
+  // `renderNow.overrides.keyboard` plans the same extension through `RobolectricHost`. Same
+  // architectural rule as focus / ambient: no hardcoded IME logic in this module — extend the
+  // connector instead.
+  implementation(project(":data-keyboard-connector"))
   // Pseudolocale connector — `Pseudolocale.fromTag(...)` for the qualifier-rewrite branch and
   // `PseudolocaleOverrideExtension` for the around-composable wrap. Same architectural rule as
   // focus / ambient: no hardcoded pseudolocale logic in this module — extend the connector

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -31,6 +31,8 @@ import ee.schimke.composeai.daemon.AmbientOverrideExtension
 import ee.schimke.composeai.daemon.FocusController
 import ee.schimke.composeai.daemon.FocusOverlay
 import ee.schimke.composeai.daemon.FocusOverrideExtension
+import ee.schimke.composeai.daemon.KeyboardController
+import ee.schimke.composeai.daemon.KeyboardOverrideExtension
 import ee.schimke.composeai.daemon.protocol.AmbientOverride
 import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
 import ee.schimke.composeai.daemon.DisplayFilterConfig
@@ -678,6 +680,13 @@ abstract class RobolectricRenderTestBase(
                     preview.captures.any { it.focus != null || it.focusGif != null }
                 val focusExtension =
                     if (anyFocusCapture) FocusOverrideExtension() else null
+                // Soft-keyboard (IME) overlay: always-on. The around-composable shadows
+                // `LocalSoftwareKeyboardController` so a preview that focuses a `BasicTextField`
+                // or calls `keyboardController.show()` naturally raises the band — no per-capture
+                // opt-in needed. The state holder `KeyboardController` is reset before each render
+                // so previews don't leak visibility / pressed-key state into one another.
+                KeyboardController.resetForNewSession()
+                val keyboardExtension = KeyboardOverrideExtension()
                 // `@AmbientPreview` discovery stamps the same `AmbientCapture` onto every capture
                 // of an annotated function (single-shot per function — one preview produces one
                 // ambient state). Wrap the composition with `AmbientOverrideExtension` from
@@ -766,11 +775,14 @@ abstract class RobolectricRenderTestBase(
                                 focusOrPlain()
                             }
                         }
-                        if (pseudolocaleExtension != null) {
-                            pseudolocaleExtension.AroundComposable { ambientOrPlain() }
-                        } else {
-                            ambientOrPlain()
+                        val pseudoOrPlain: @Composable () -> Unit = {
+                            if (pseudolocaleExtension != null) {
+                                pseudolocaleExtension.AroundComposable { ambientOrPlain() }
+                            } else {
+                                ambientOrPlain()
+                            }
                         }
+                        keyboardExtension.AroundComposable { pseudoOrPlain() }
                     }
                 }
                 // With `mainClock.autoAdvance = false` the clock stays at 0

--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -79,6 +79,11 @@ dependencies {
   // notification authoring path. Pairs with `@NotificationPreview` (in `:preview-annotations`)
   // for the FQN-discovered NOTIFICATION strategy.
   implementation(project(":notification-preview-runtime"))
+  // Soft-keyboard data extension — `SoftKeyboardAnimatedPreview` uses
+  // `LocalSoftwareKeyboardController.show()` (the natural app-side IME path the connector's
+  // around-composable shadows) to raise the band, and writes `KeyboardController.notifyKeyDown`
+  // directly to drive per-cap press highlights in the absence of an interactive daemon session.
+  implementation(project(":data-keyboard-connector"))
   debugImplementation("androidx.compose.ui:ui-tooling")
   // `@AnimatedPreview(showCurves = true)` reflectively probes
   // `androidx.compose.ui.tooling.animation.PreviewAnimationClock` /

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/SoftKeyboardAnimatedPreview.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/SoftKeyboardAnimatedPreview.kt
@@ -1,0 +1,163 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package com.example.sampleandroid
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ee.schimke.composeai.daemon.KeyboardController
+import ee.schimke.composeai.preview.AnimatedPreview
+
+/**
+ * Animated demo of the soft-keyboard data extension (`:data-keyboard-connector`). Demonstrates the
+ * two control surfaces the extension exposes:
+ *
+ * 1. **App-side, passive** — `LocalSoftwareKeyboardController.current?.show()` raises the band
+ *    through the connector's shadow controller. This is the same call Compose's `BasicTextField`
+ *    makes internally on focus, so any normal app code that focuses a text field gets the band for
+ *    free; the explicit `show()` here just keeps the preview's intent obvious in source.
+ * 2. **Direct controller writes** — `KeyboardController.notifyKeyDown(label)` /
+ *    `notifyKeyUp(label)` mirror what `AndroidInteractiveSession.dispatch` does for live daemon
+ *    sessions. The preview drives it from a `LaunchedEffect` so a paused-clock `@AnimatedPreview`
+ *    capture can step through a typing sequence without needing an interactive session attached.
+ *
+ * The on-screen band is rendered by the around-composable in `:data-keyboard-connector`; this file
+ * doesn't reach into any rendering API. That's the architectural shape — the extension owns the
+ * band, the app owns the state.
+ */
+@Preview(name = "Soft Keyboard — typing", widthDp = 360, heightDp = 640)
+@AnimatedPreview(durationMs = 2400, frameIntervalMs = 80, showCurves = false)
+@Composable
+fun SoftKeyboardAnimatedPreview() {
+  val keyboardController = LocalSoftwareKeyboardController.current
+  DisposableEffect(Unit) {
+    keyboardController?.show()
+    onDispose { keyboardController?.hide() }
+  }
+  val transition = rememberInfiniteTransition(label = "typing")
+  val phase by transition.animateFloat(
+    initialValue = 0f,
+    targetValue = TYPING_SEQUENCE.size.toFloat(),
+    animationSpec =
+      infiniteRepeatable(animation = tween(durationMillis = 2400, easing = LinearEasing)),
+    label = "phase",
+  )
+  val index = phase.toInt().coerceIn(0, TYPING_SEQUENCE.size - 1)
+  val slot = TYPING_SEQUENCE[index]
+  // Mirror the daemon's interactive `KEY_DOWN` / `KEY_UP` shape so the band's `pressedKey` state
+  // reaches it through the supported `KeyboardController` API rather than a private back-channel.
+  LaunchedEffect(index) {
+    KeyboardController.notifyKeyDown(slot.pressed)
+  }
+  DisposableEffect(Unit) { onDispose { KeyboardController.notifyKeyUp() } }
+
+  val running = buildString { for (i in 0..index) append(TYPING_SEQUENCE[i].typed) }
+
+  Surface(modifier = Modifier.fillMaxSize(), color = Color(0xFFF1F3F4)) {
+    Column(
+      modifier = Modifier.fillMaxSize().padding(24.dp),
+      verticalArrangement = androidx.compose.foundation.layout.Arrangement.Top,
+    ) {
+      Text(text = "Compose", style = MaterialTheme.typography.titleMedium)
+      Box(
+        modifier =
+          Modifier.padding(top = 16.dp)
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(horizontal = 12.dp, vertical = 16.dp),
+        contentAlignment = Alignment.CenterStart,
+      ) {
+        Text(
+          text = running.ifEmpty { "" } + "│",
+          style =
+            TextStyle(color = Color(0xFF1F1F1F), fontSize = 20.sp, fontWeight = FontWeight.Medium),
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Static counterpart that exercises only the app-side path: focusing nothing, calling
+ * `keyboardController.show()` directly. The band appears because the around-composable's shadow
+ * `LocalSoftwareKeyboardController` catches the call and flips `KeyboardController.notifyImeVisibility(true)`.
+ * Useful as a baseline diff target against the animated preview.
+ */
+@Preview(name = "Soft Keyboard — idle", widthDp = 360, heightDp = 640)
+@Composable
+fun SoftKeyboardIdlePreview() {
+  val keyboardController = LocalSoftwareKeyboardController.current
+  DisposableEffect(Unit) {
+    keyboardController?.show()
+    onDispose { keyboardController?.hide() }
+  }
+  Surface(modifier = Modifier.fillMaxSize(), color = Color(0xFFF1F3F4)) {
+    Column(
+      modifier = Modifier.fillMaxSize().padding(24.dp),
+      verticalArrangement = androidx.compose.foundation.layout.Arrangement.Top,
+    ) {
+      Text(text = "Compose", style = MaterialTheme.typography.titleMedium)
+      Box(
+        modifier =
+          Modifier.padding(top = 16.dp)
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(horizontal = 12.dp, vertical = 16.dp),
+        contentAlignment = Alignment.CenterStart,
+      ) {
+        Text(
+          text = "│",
+          style =
+            TextStyle(color = Color(0xFF1F1F1F), fontSize = 20.sp, fontWeight = FontWeight.Medium),
+        )
+      }
+    }
+  }
+}
+
+/**
+ * One step in the typing demo: which key cap is depicted as pressed for this slot, and which
+ * character (if any) gets appended to the running text. The two can differ — e.g. the "space" key
+ * types ' '.
+ */
+private data class TypingSlot(val pressed: String, val typed: String)
+
+private val TYPING_SEQUENCE: List<TypingSlot> =
+  listOf(
+    TypingSlot("h", "h"),
+    TypingSlot("e", "e"),
+    TypingSlot("l", "l"),
+    TypingSlot("l", "l"),
+    TypingSlot("o", "o"),
+    TypingSlot("space", " "),
+    TypingSlot("w", "w"),
+    TypingSlot("o", "o"),
+    TypingSlot("r", "r"),
+    TypingSlot("l", "l"),
+    TypingSlot("d", "d"),
+    TypingSlot("enter", ""),
+  )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -200,6 +200,18 @@ include(":data-focus-connector-desktop")
 
 project(":data-focus-connector-desktop").projectDir = file("data/focus/connector-desktop")
 
+include(":data-keyboard-core")
+
+project(":data-keyboard-core").projectDir = file("data/keyboard/core")
+
+include(":data-keyboard-connector")
+
+project(":data-keyboard-connector").projectDir = file("data/keyboard/connector")
+
+include(":data-keyboard-connector-desktop")
+
+project(":data-keyboard-connector-desktop").projectDir = file("data/keyboard/connector-desktop")
+
 include(":data-pseudolocale-core")
 
 project(":data-pseudolocale-core").projectDir = file("data/pseudolocale/core")


### PR DESCRIPTION
## Summary

Adds a soft-keyboard (IME) data extension that:

1. Overlays a Gboard-shaped band on previews **and** publishes synthetic `WindowInsetsCompat.Type.ime()` to the host view so consumer code reading `WindowInsets.ime` (e.g. `Modifier.imePadding()`, `Modifier.windowInsetsPadding(WindowInsets.ime)`, `WindowInsets.ime.asPaddingValues()`) reshapes correctly — not just a painted-on overlay.
2. Reacts to two control surfaces:
   - **App-side (passive)** — the around-composable shadows `LocalSoftwareKeyboardController` so any `keyboardController.show()` call from app code raises the band. That's the same path Compose's own `BasicTextField` takes on focus, so a normal focused text field "just works" — no new authoring API.
   - **Daemon-side (active)** — `renderNow.overrides.keyboard` (new `KeyboardOverride { visible, pressedKey }` on `daemon:core`) and `AndroidInteractiveSession`/`DesktopInteractiveSession.dispatch(KEY_DOWN/KEY_UP)` both feed the same `KeyboardController` state holder via a `KeyboardBandLabels` keycode mapper on `daemon:core`. Agents driving keyboard input through MCP see the matching cap light up; a `softInputVisible = visible OR pressedKey != null` rule means the band raises automatically when an agent types into a preview the app never explicitly focused.

The inset path mirrors what Android's `WindowInsetsControllerCompat.show(Type.ime())` triggers on a real window — `View.dispatchApplyWindowInsets(...)` → `WindowInsetsHolder`'s listener (compose-foundation-layout) updates its `ime` `MutableState` → composables observing `WindowInsets.ime` recompose. Robolectric runs that listener pipeline as plain Java, so the dispatch works inside previews too.

## Architecture

Shape follows the existing data-extension pattern (mirrors `:data-focus-*`):

- `:data-keyboard-core` — `compose/keyboard` kind constant.
- `:data-keyboard-connector` (Android) — `KeyboardController`, `KeyboardOverrideExtension` (always-on `AroundComposable` that dispatches IME insets and overlays the band), `KeyboardPreviewOverrideExtension` planner, internal `SoftKeyboardBand` composable.
- `:data-keyboard-connector-desktop` — JVM counterpart for CMP Desktop.

The renderer and both daemon backends register the planner: `RobolectricRenderTest` wraps every static render with the extension, `RobolectricHost` adds the planner to `previewOverrideExtensions`, `DaemonMain` exposes it as the `data/keyboard` extension. **No new public composable API** on `:renderer-android`.

## Previews

### Typing animation (drives both control surfaces from honest app code)

`LocalSoftwareKeyboardController.show()` for visibility, `KeyboardController.notifyKeyDown/Up` from a `LaunchedEffect` to drive the typing sequence (the same call the daemon's interactive session makes for live agents):

<img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/agent/add-android-soft-keyboard-6oqLb-assets/soft-keyboard-animated.gif" width="320" alt="Soft keyboard typing 'hello world' with per-key press highlight" />

Idle baseline (`SoftKeyboardIdlePreview` — just `keyboardController.show()`, no presses):

<img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/agent/add-android-soft-keyboard-6oqLb-assets/soft-keyboard-idle.png" width="320" alt="Soft keyboard idle, no key pressed" />

### IME insets adapt the viewport (not just a painted overlay)

Same `LazyColumn` + footer rendered with and without the band up. The list uses `Modifier.imePadding()`; the footer uses `Modifier.windowInsetsPadding(WindowInsets.ime)`. Both shrink/lift by the band height when the IME is up:

| Hidden — list runs to canvas bottom | Shown — list capped above the band |
| :--- | :--- |
| <img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/agent/add-android-soft-keyboard-6oqLb-assets/ime-aware-list-hidden.png" width="240" alt="IME hidden — list reaches row 11" /> | <img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/agent/add-android-soft-keyboard-6oqLb-assets/ime-aware-list-shown.png" width="240" alt="IME shown — list shrinks to ~6 rows, footer above band" /> |

That's the proof the inset is actually flowing through `WindowInsets.ime` — not just `Modifier.padding(bottom = bandHeight)` baked into the consumer.

## Test plan

- [x] `./gradlew :data-keyboard-connector:test` — pins extension hook shape, planner always-on semantics, controller state machine (visibility, press-implies-visible, mismatched KEY_UP guard).
- [x] `./gradlew :samples:android:renderAllPreviews` — emits the typing GIF (31 frames), the idle PNG, and the IME-aware-list hidden/shown diff end-to-end through the new extension wrap; no diff on unrelated previews.
- [x] `./gradlew :data-keyboard-connector:compileDebugKotlin :data-keyboard-connector-desktop:compileKotlin :daemon:android:compileDebugKotlin :daemon:desktop:compileKotlin :renderer-android:compileDebugKotlin :samples:android:compileDebugKotlin`
- [x] `./gradlew :daemon:desktop:test --tests "ee.schimke.composeai.daemon.DesktopKeyDispatchTest"` — confirms the desktop session's `KEY_*` dispatch still maps keycodes correctly with the controller-notify hook in place.
- [x] `./gradlew :data-keyboard-connector:ktfmtCheck :samples:android:ktfmtCheck` — and the rest of the touched modules.
