### PR TITLE
ci: agp8-min uses VerticalDragHandle (material3 1.4.0) for the floor demo

### DIFF
--- a/.github/ci/fixtures/agp8-min/app/build.gradle.kts
+++ b/.github/ci/fixtures/agp8-min/app/build.gradle.kts
@@ -55,16 +55,16 @@ afterEvaluate {
 dependencies {
   // compose-bom 2026.05.00 — `compose-bom-stable` in the project's own
   // version catalog, what `:samples:android` and the rest of the codebase
-  // build against. Ships material3 1.4+ (which is what `Previews.kt`'s
-  // `LoadingIndicator` requires; the M3 1.3.x line in
-  // compose-bom 2024.12.01 doesn't have that composable). The agp8-min
-  // CI job downgrades this to 2024.12.01 in Phase 1 so the consumer's
-  // own preview source fails to compile against the older material3 —
-  // the same failure shape a real consumer hits when they pull a new
-  // Compose API ahead of their BOM. `compose-preview doctor` warns about
-  // the too-old BOM through its `env.compose-bom-version` pre-flight
-  // check (grep-based against `build.gradle.kts`, runs before Gradle).
-  // Phase 3 restores 2026.05.00 and asserts render then succeeds.
+  // build against. Ships material3 1.4.0 (which is what `Previews.kt`'s
+  // `VerticalDragHandle` requires; the M3 1.3.1 line in compose-bom
+  // 2024.12.01 doesn't have that composable). The agp8-min CI job
+  // downgrades this to 2024.12.01 in Phase 1 so the consumer's own
+  // preview source fails to compile against the older material3 — the
+  // same failure shape a real consumer hits when they pull a new Compose
+  // API ahead of their BOM. `compose-preview doctor` warns about the
+  // too-old BOM through its `env.compose-bom-version` pre-flight check
+  // (grep-based against `build.gradle.kts`, runs before Gradle). Phase 3
+  // restores 2026.05.00 and asserts render then succeeds.
   val composeBom = platform("androidx.compose:compose-bom:2026.05.00")
   implementation(composeBom)
   implementation("androidx.compose.ui:ui")

--- a/.github/ci/fixtures/agp8-min/app/src/main/kotlin/com/example/agp8min/Previews.kt
+++ b/.github/ci/fixtures/agp8-min/app/src/main/kotlin/com/example/agp8min/Previews.kt
@@ -1,31 +1,30 @@
 package com.example.agp8min
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDragHandle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 
-// `LoadingIndicator` is a material3 1.4+ composable (added in the
-// "Material You expressive" wave). compose-bom 2026.05.00 — what the
-// fixture pins above and what `:samples:android` uses too — ships M3 1.4,
-// so this preview compiles cleanly there. compose-bom 2024.12.01, which
-// the agp8-min CI job downgrades to in Phase 1, ships M3 1.3.x without
-// this composable; the import then fails to resolve and `compileDebugKotlin`
-// errors out before `renderPreviews` can even start. That's the same
-// failure shape a real consumer hits when they reach for a new Compose API
+// `VerticalDragHandle` is a material3 1.4 composable (added with the
+// expressive drag-handle component family, stable in 1.4.0 — no opt-in
+// needed). compose-bom 2026.05.00 — what the fixture pins above and what
+// `:samples:android` uses too — ships M3 1.4.0, so this preview compiles
+// cleanly there. compose-bom 2024.12.01, which the agp8-min CI job
+// downgrades to in Phase 1, ships M3 1.3.1 without this composable; the
+// import then fails to resolve and `compileDebugKotlin` errors out
+// before `renderPreviews` can even start. That's the same failure shape
+// a real consumer hits when their source reaches for a new Compose API
 // ahead of their BOM, and it's what `compose-preview doctor`'s
 // `env.compose-bom-version` pre-flight warns about.
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Preview
 @Composable
 fun GreetingPreview() {
   Surface {
     Column {
       Text(text = "agp8-min fixture")
-      LoadingIndicator()
+      VerticalDragHandle()
     }
   }
 }

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -684,15 +684,15 @@ jobs:
       # The committed fixture pins `compose-bom` to 2026.05.00 (matches
       # `compose-bom-stable` in `gradle/libs.versions.toml` — what
       # `:samples:android` uses) and the preview source references
-      # `androidx.compose.material3.LoadingIndicator`, a material3 1.4+
+      # `androidx.compose.material3.VerticalDragHandle`, a material3 1.4.0
       # composable. To prove the BOM floor is real AND that
       # `compose-preview doctor` explains it, we:
       #   1. Downgrade the staged fixture's BOM to 2024.12.01 (material3
-      #      1.3.1, no `LoadingIndicator`).
+      #      1.3.1, no `VerticalDragHandle`).
       #   2. Run `renderPreviews` and assert it FAILS — `compileDebugKotlin`
-      #      errors out on the unresolved `LoadingIndicator` import. This
-      #      is the same failure shape a real consumer hits when their
-      #      source reaches for a new Compose API ahead of their BOM.
+      #      errors out on the unresolved `VerticalDragHandle` import.
+      #      Same failure shape a real consumer hits when their source
+      #      reaches for a new Compose API ahead of their BOM.
       #   3. Run `compose-preview doctor --json` and assert
       #      `env.compose-bom-version` fires as `warning` — the doctor's
       #      pre-flight catches the too-old BOM before any compile attempt.
@@ -725,7 +725,7 @@ jobs:
           rc=$?
           set -e
           if [ "$rc" -eq 0 ]; then
-            echo "::error::renderPreviews unexpectedly succeeded against compose-bom 2024.12.01. Previews.kt imports androidx.compose.material3.LoadingIndicator (material3 1.4+); 2024.12.01 ships material3 1.3.1 without it, so compileDebugKotlin should fail. Either the BOM mapping changed (move the Phase 1 pin lower) or the preview no longer references a post-1.3 API (pick a fresher one)."
+            echo "::error::renderPreviews unexpectedly succeeded against compose-bom 2024.12.01. Previews.kt imports androidx.compose.material3.VerticalDragHandle (material3 1.4.0); 2024.12.01 ships material3 1.3.1 without it, so compileDebugKotlin should fail. Either the BOM mapping changed (move the Phase 1 pin lower) or the preview no longer references a post-1.3 API (pick a fresher one)."
             exit 1
           fi
           echo "renderPreviews failed as expected (exit code $rc); proceeding to doctor."


### PR DESCRIPTION
## Summary

Phase 3 of the `agp8-min` job has been failing on `main` since #1297 because the API I picked (`LoadingIndicator`) only ships its design tokens in material3 1.4.0 — the public composable wasn't stabilized in that release, so `import androidx.compose.material3.LoadingIndicator` unresolves even against the bumped BOM. Phase 1 ("fail on too-old BOM") was still passing for the right reason; Phase 3 ("succeed at the floor") wasn't.

This round I verified the BOM contents empirically by pulling the POMs and AAR class lists from Google Maven, instead of guessing:

| BOM | material3 | `VerticalDragHandle` present? |
|---|---|---|
| `2024.12.01` (Phase 1 downgrade) | 1.3.1 | ❌ no `DragHandleKt`, no top-level class |
| `2026.05.00` (Phase 3 restore) | 1.4.0 | ✅ `DragHandleKt.class` + `VerticalDragHandleDefaults.class` |

`androidx.compose.material3.VerticalDragHandle` is a **stable** public composable in material3 1.4.0 — no `@OptIn` annotation needed, default parameters all the way through. Switching the demonstrator over should flip Phase 3 from red → green without touching Phases 1 and 2 (downgrade still trips the same import-resolve failure, doctor still surfaces `env.compose-bom-version`).

## Test plan

- [ ] Phase 1 step "renderPreviews must FAIL on the too-old BOM" still exits non-zero with "Unresolved reference: VerticalDragHandle".
- [ ] Phase 2 step "doctor must surface env.compose-bom-version" still passes.
- [ ] Phase 3 step "renderPreviews must PASS at renderer floor" now exits zero on compose-bom 2026.05.00.
- [ ] `renders-agp8-min` artifact contains at least one PNG.
- [ ] `doctor-agp8-min` artifact contains the parsed JSON.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDgSjkaFt77R3aFUn4hD2C)_