### PR TITLE
feat(data/keyboard): publish WindowInsets.ime so layouts adapt to the band

### DIFF
--- a/data/keyboard/connector/build.gradle.kts
+++ b/data/keyboard/connector/build.gradle.kts
@@ -46,8 +46,20 @@ dependencies {
   // have actual runtime classes.
   compileOnly(platform(libs.compose.bom.compat))
   compileOnly(libs.compose.foundation)
+  // `androidx.core` for `WindowInsetsCompat` / `ViewCompat.dispatchApplyWindowInsets(view, insets)`
+  // — the connector publishes synthetic `WindowInsetsCompat.Type.ime()` insets to the host view so
+  // consumer code reading `WindowInsets.ime` (`Modifier.imePadding()`,
+  // `Modifier.windowInsetsPadding(WindowInsets.ime)`,
+  // `WindowInsets.ime.asPaddingValues()`) sees the band's height and reshapes accordingly.
+  // `compileOnly` because the consumer always brings its own `androidx.core` (transitively, via
+  // `androidx.compose.ui:ui`); we just need the API surface at compile time. Pinned to the
+  // matching compat floor (1.13.0) so the published AAR's bytecode stays binary-backward-
+  // compatible with consumers on older `androidx.core` lines — same rationale as
+  // `compose-foundation`.
+  compileOnly("androidx.core:core:1.13.0")
   testImplementation(platform(libs.compose.bom.compat))
   testImplementation(libs.compose.foundation)
+  testImplementation("androidx.core:core:1.13.0")
 
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.serialization.json)

--- a/data/keyboard/connector/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardDataProduct.kt
+++ b/data/keyboard/connector/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardDataProduct.kt
@@ -12,8 +12,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.SoftwareKeyboardController
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import ee.schimke.composeai.daemon.protocol.KeyboardOverride
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.keyboard.Material3KeyboardProduct
@@ -79,6 +85,34 @@ class KeyboardOverrideExtension(private val seed: KeyboardOverride? = null) :
       val pressedKey by KeyboardController.pressedKey
       val night =
         (LocalConfiguration.current.uiMode and UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES
+
+      // Publish synthetic `WindowInsetsCompat.Type.ime()` insets on the host view so consumer code
+      // reading `WindowInsets.ime` (e.g. `Modifier.imePadding()`,
+      // `Modifier.windowInsetsPadding(WindowInsets.ime)`, or
+      // `WindowInsets.ime.asPaddingValues()` passed to a `LazyColumn`'s `contentPadding`) sees the
+      // band's height as a bottom inset — the same shape Compose's foundation-layout reads on a
+      // real device when the platform IME is up. Without this dispatch the band would just paint
+      // on top of preview content and a list's last row would render under the keys; with it, the
+      // viewport shrinks naturally and the consumer's inset-aware layout adapts.
+      //
+      // The path mirrors what Android's `WindowInsetsControllerCompat.show(Type.ime())` triggers
+      // on a real window — the platform calls `View.dispatchApplyWindowInsets(...)`, the listener
+      // installed by `WindowInsetsHolder` (compose-foundation-layout) updates its `ime`
+      // MutableState, and any composable observing `WindowInsets.ime` recomposes. Robolectric's
+      // `View` runs the listener pipeline as plain Java, so the dispatch works there too.
+      val view = LocalView.current
+      val density = LocalDensity.current
+      val imeBottomPx = with(density) { KEYBOARD_HEIGHT_DP.dp.roundToPx() }
+      DisposableEffect(visible, imeBottomPx, view) {
+        val insets = if (visible) Insets.of(0, 0, 0, imeBottomPx) else Insets.NONE
+        val compat =
+          WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.ime(), insets)
+            .build()
+        ViewCompat.dispatchApplyWindowInsets(view, compat)
+        onDispose {}
+      }
+
       Box(modifier = Modifier.fillMaxSize()) {
         content()
         if (visible) {

--- a/data/keyboard/connector/src/main/kotlin/ee/schimke/composeai/daemon/SoftKeyboardBand.kt
+++ b/data/keyboard/connector/src/main/kotlin/ee/schimke/composeai/daemon/SoftKeyboardBand.kt
@@ -238,7 +238,7 @@ private const val ROW_TOP = "qwertyuiop"
 private const val ROW_MIDDLE = "asdfghjkl"
 private const val ROW_BOTTOM = "zxcvbnm"
 
-private const val KEYBOARD_HEIGHT_DP = 240
+internal const val KEYBOARD_HEIGHT_DP = 240
 private const val SIDE_INSET_DP = 4
 private const val ROW_INSET_DP = 6
 private const val ROW_GAP_DP = 6

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/SoftKeyboardImeInsetsPreview.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/SoftKeyboardImeInsetsPreview.kt
@@ -1,0 +1,142 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package com.example.sampleandroid
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+/**
+ * Confirms the soft-keyboard data extension publishes real `WindowInsetsCompat.Type.ime()` insets
+ * — not just a painted-on overlay. A `LazyColumn` with `Modifier.imePadding()` should shrink so its
+ * last row sits **above** the band, not behind it. Pair-rendered against [ImeAwareListHiddenPreview]
+ * as a same-content/different-IME-state diff: both show a 30-row list under the same heading; only
+ * this one raises the IME (and thus shrinks the list to the band-relative viewport).
+ *
+ * Compose's IME inset story:
+ *
+ * - `WindowInsetsCompat.Type.ime()` is the canonical Android IME inset type.
+ * - Compose's `WindowInsets.ime` (in `androidx.compose.foundation.layout`) surfaces that type to
+ *   composable code via `WindowInsetsHolder`, which subscribes to the host view's
+ *   `dispatchApplyWindowInsets` callback.
+ * - `Modifier.imePadding()` is shorthand for `Modifier.windowInsetsPadding(WindowInsets.ime)`;
+ *   `Modifier.consumeWindowInsets(WindowInsets.ime)` lets a parent that already padded for the IME
+ *   tell its children to ignore it. `WindowInsets.ime.asPaddingValues()` plugs the inset into a
+ *   `LazyColumn`'s `contentPadding` instead of stealing layout space.
+ *
+ * The connector dispatches synthetic `WindowInsetsCompat.Type.ime()` to the renderer's host view
+ * whenever `KeyboardController.softInputVisible` flips, so all three of those code paths "just
+ * work" inside the preview — same as on a real Android device with a real IME up.
+ */
+@Preview(name = "IME-aware list — keyboard up", widthDp = 360, heightDp = 640)
+@Composable
+fun ImeAwareListShownPreview() {
+  val keyboardController = LocalSoftwareKeyboardController.current
+  DisposableEffect(Unit) {
+    keyboardController?.show()
+    onDispose { keyboardController?.hide() }
+  }
+  ImeAwareList(showLabel = "keyboard up — list capped above the band")
+}
+
+/**
+ * Companion preview with the IME hidden. Same list, same scroll state, no `keyboardController.show()`
+ * — the band stays down and the list runs to the bottom of the canvas. Diffing this against
+ * [ImeAwareListShownPreview] makes the inset-driven viewport adaptation visible at a glance.
+ */
+@Preview(name = "IME-aware list — keyboard hidden", widthDp = 360, heightDp = 640)
+@Composable
+fun ImeAwareListHiddenPreview() {
+  ImeAwareList(showLabel = "keyboard hidden — list fills the canvas")
+}
+
+@Composable
+private fun ImeAwareList(showLabel: String) {
+  Surface(modifier = Modifier.fillMaxSize(), color = Color(0xFFF1F3F4)) {
+    Box(modifier = Modifier.fillMaxSize()) {
+      LazyColumn(
+        modifier =
+          Modifier.fillMaxSize()
+            // `WindowInsets.ime` is what the connector publishes on visibility. `imePadding()`
+            // applies it as a bottom padding so the LazyColumn's viewport shrinks to fit above
+            // the band — the canonical Compose pattern for adjustResize-style behaviour.
+            .imePadding(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+      ) {
+        item {
+          Text(
+            text = showLabel,
+            style =
+              MaterialTheme.typography.labelMedium.copy(
+                color = Color(0xFF5F6368),
+                fontWeight = FontWeight.SemiBold,
+              ),
+            modifier = Modifier.padding(bottom = 8.dp),
+          )
+        }
+        items(LIST_ROWS) { row ->
+          ListRow(row)
+          HorizontalDivider(color = Color(0xFFE0E0E0))
+        }
+      }
+      // Footer pinned just above the band via `WindowInsets.ime`, demonstrating
+      // `Modifier.windowInsetsPadding(WindowInsets.ime)` working alongside `imePadding()` on the
+      // list — same inset, two consumers.
+      Text(
+        text = "ime-aware footer",
+        style =
+          MaterialTheme.typography.labelSmall.copy(
+            color = Color(0xFF5F6368),
+            fontWeight = FontWeight.Medium,
+          ),
+        modifier =
+          Modifier.align(Alignment.BottomCenter)
+            .windowInsetsPadding(WindowInsets.ime)
+            .padding(8.dp),
+      )
+    }
+  }
+}
+
+@Composable
+private fun ListRow(row: ListEntry) {
+  Box(modifier = Modifier.fillMaxWidth().height(56.dp), contentAlignment = Alignment.CenterStart) {
+    Text(
+      text = "${row.index}. ${row.title}",
+      style = MaterialTheme.typography.bodyMedium.copy(color = Color(0xFF1F1F1F)),
+    )
+  }
+}
+
+private data class ListEntry(val index: Int, val title: String)
+
+/**
+ * 30 rows. The hidden-keyboard preview runs the canvas full-bleed so the last visible row hits
+ * around row 12-14 (depending on font metrics); the keyboard-up preview shrinks the viewport by
+ * the band's 240dp, which knocks the visible window down by ~4-5 rows. The diff is the proof the
+ * inset is actually flowing through `WindowInsets.ime` and not just a painted-on overlay.
+ */
+private val LIST_ROWS: List<ListEntry> =
+  (1..30).map { ListEntry(index = it, title = "Item $it") }


### PR DESCRIPTION
Follow-up to #1298 (already merged). That PR shipped the soft-keyboard data extension with the band painted on top of preview content; this PR makes the connector publish `WindowInsetsCompat.Type.ime()` so composables that respect `WindowInsets.ime` reshape their viewports instead of letting the band sit on top of their content.

## Summary

- `KeyboardOverrideExtension.AroundComposable` (Android) now dispatches a synthetic `WindowInsetsCompat` carrying `Type.ime()` insets of `(0, 0, 0, bandHeightPx)` to `LocalView.current` via `ViewCompat.dispatchApplyWindowInsets(...)` whenever `KeyboardController.softInputVisible` flips. Compose's `WindowInsetsHolder` (foundation-layout) listens to the View's `setOnApplyWindowInsetsListener` callback and updates its `ime` `MutableState`, so consumer code reading `WindowInsets.ime` (`Modifier.imePadding()`, `Modifier.windowInsetsPadding(WindowInsets.ime)`, `WindowInsets.ime.asPaddingValues()`) recomposes / re-lays-out — same shape `WindowInsetsControllerCompat.show(Type.ime())` triggers on a real Android window.
- `KEYBOARD_HEIGHT_DP` promoted from `private` to `internal` so the extension converts the band height to px through `LocalDensity` without duplicating the constant.
- `androidx.core:core:1.13.0` added as `compileOnly` on `:data-keyboard-connector` (consumer always brings runtime transitively via `androidx.compose.ui:ui`). Pinned to the compat floor so the published AAR's bytecode stays binary-backward-compatible with consumers on older `androidx.core` lines — matches the `compose-foundation` posture.
- New `SoftKeyboardImeInsetsPreview` sample with a `LazyColumn` + footer pair using `Modifier.imePadding()` and `Modifier.windowInsetsPadding(WindowInsets.ime)`. The hidden/shown render diff makes the inset adaptation visible.

## Render diff

| Hidden — list runs to canvas bottom | Shown — list capped above the band |
| :--- | :--- |
| <img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/agent/add-android-soft-keyboard-6oqLb-assets/ime-aware-list-hidden.png" width="240" alt="IME hidden — list reaches row 11" /> | <img src="https://raw.githubusercontent.com/yschimke/compose-ai-tools/agent/add-android-soft-keyboard-6oqLb-assets/ime-aware-list-shown.png" width="240" alt="IME shown — list shrinks to ~6 rows, footer above band" /> |

That's the proof the inset is flowing through `WindowInsets.ime` instead of being faked via `Modifier.padding(bottom = bandHeight)` baked into the consumer — the same `LazyColumn` shrinks from ~11 visible rows to ~6 when the band is up, and the ime-aware footer lifts to sit above the band.

## Test plan

- [x] `./gradlew :data-keyboard-connector:compileDebugKotlin :data-keyboard-connector:test` — connector tests stay green (`KeyboardDataProductTest` already covers the controller state machine; the inset dispatch is exercised end-to-end by the sample render).
- [x] `./gradlew :samples:android:renderAllPreviews` — emits the new hidden/shown PNGs from a clean checkout off `origin/main`; no diff on unrelated previews.
- [x] `./gradlew :data-keyboard-connector:ktfmtCheck :samples:android:ktfmtCheck`

## Process note

The previous follow-up commit `fef6c20` was stacked onto the already-merged branch of #1298. This PR cherry-picks that commit onto a fresh branch from `origin/main` per `CLAUDE.md`'s "if the PR has merged, create a fresh branch from origin/main for follow-up work instead of stacking commits onto the merged branch" rule. No content difference vs the stacked commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_011pyAK77C88m6JwKPq7kXVo)_