### PR TITLE
refactor(preview-discovery): rename package to ee.schimke.composeai.discovery

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.plugin
+package ee.schimke.composeai.discovery
 
 import kotlinx.serialization.Serializable
 

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDataTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDataTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.plugin
+package ee.schimke.composeai.discovery
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.serialization.encodeToString

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AccessibilityFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AccessibilityFunctionalTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.*
 import java.io.File
 import kotlinx.serialization.json.Json
 import org.gradle.testkit.runner.GradleRunner

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.*
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.zip.ZipInputStream

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/CliA11yInputsFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/CliA11yInputsFunctionalTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.*
 import java.io.File
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ColorValidationTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ColorValidationTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.*
 import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.*
 import java.io.File
 import kotlinx.serialization.json.Json
 import org.gradle.testkit.runner.GradleRunner

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.*
 import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -4,6 +4,7 @@ import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.Variant
+import ee.schimke.composeai.discovery.*
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.attributes.Attribute

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.discovery.*
 import io.github.classgraph.ClassGraph
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.discovery.*
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverAndroidResourcesTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverAndroidResourcesTask.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.discovery.*
 import java.io.File
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.discovery.*
 import io.github.classgraph.AnnotationClassRef
 import io.github.classgraph.AnnotationEnumValue
 import io.github.classgraph.AnnotationInfo

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRenderShardsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRenderShardsTask.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.discovery.*
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ManifestReferenceExtractor.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ManifestReferenceExtractor.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.discovery.*
 import java.io.File
 import java.io.InputStream
 import javax.xml.stream.XMLInputFactory

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.discovery.*
 import ee.schimke.composeai.plugin.daemon.DaemonExtension
 import javax.inject.Inject
 import org.gradle.api.Action

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewTargetInference.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewTargetInference.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.discovery.*
 import io.github.classgraph.ClassInfo
 import io.github.classgraph.MethodInfo
 import io.github.classgraph.ScanResult

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.discovery.*
 import javax.inject.Inject
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ResourceDiscovery.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ResourceDiscovery.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.discovery.*
 import java.io.File
 
 /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ResourceXmlClassifier.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ResourceXmlClassifier.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.discovery.*
 import java.io.File
 import java.io.InputStream
 import javax.xml.stream.XMLInputFactory

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.*
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.*
 import org.junit.Test
 
 class DeviceDimensionsTest {

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ManifestReferenceExtractorTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ManifestReferenceExtractorTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.*
 import org.junit.Test
 
 class ManifestReferenceExtractorTest {

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewTargetInferenceTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewTargetInferenceTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.*
 import org.junit.Test
 
 class PreviewTargetInferenceTest {

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResourceDiscoveryTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResourceDiscoveryTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.*
 import java.io.File
 import org.junit.Rule
 import org.junit.Test

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResourceXmlClassifierTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResourceXmlClassifierTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.*
 import org.junit.Test
 
 class ResourceXmlClassifierTest {


### PR DESCRIPTION
## Summary

Phase A2a of the contrib refactor: renames the `:preview-discovery` module's package from `ee.schimke.composeai.plugin` (deferred in #1300 to limit import churn) to `ee.schimke.composeai.discovery` so the package matches the module name and the seam between the gradle plugin and the new pure-JVM library is visible at the source level.

24 importers across `:gradle-plugin` pick up `import ee.schimke.composeai.discovery.*` — star-form because the discovery types are a tightly-coupled domain (the `previews.json` schema) and enumerating 30+ explicit imports per file would make the diff harder to read than it solves. The next two PRs in the series (A2b: extract `DiscoverPreviewsTask`'s ClassGraph scan into a library function; A2c: add the `java -jar` CLI main) land their new code in the same `ee.schimke.composeai.discovery` package alongside the data types.

## Test plan

- [x] `./gradlew :gradle-plugin:compileKotlin :gradle-plugin:compileTestKotlin :gradle-plugin:compileFunctionalTestKotlin` — all sources resolve discovery types via the new import path
- [x] `./gradlew :gradle-plugin:test :gradle-plugin:preview-discovery:test` — unit tests for the schema (`PreviewDataTest`) and the rest of the plugin stay green
- [x] `./gradlew ktfmtCheckAll`
- [x] `./gradlew :gradle-plugin:publishToMavenLocal` — produces both `ee.schimke.composeai:compose-preview-plugin` and `ee.schimke.composeai:preview-discovery` from a single call (publish-transitivity wired in #1300)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fea3X5qLi4qZfX12fYFKuS)_