### PR TITLE
feat(preview-discovery): add java -jar CLI entry point

### DIFF
--- a/gradle-plugin/preview-discovery/build.gradle.kts
+++ b/gradle-plugin/preview-discovery/build.gradle.kts
@@ -53,3 +53,16 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2026")
 }
+
+// CLI entry point (`PreviewDiscoveryCli`) is what Bazel rules and Amper tasks shell out to —
+// stamping the `Main-Class` attribute lets a build system invoke the artifact via
+// `java -cp <classpath> ee.schimke.composeai.discovery.PreviewDiscoveryCli ...` or
+// `java -jar preview-discovery-<v>.jar ...` (the latter only when all transitive jars sit
+// next to the artifact, which is the shape a Bazel `runtime_jars` provider produces). The
+// transitive deps (classgraph, asm, kotlinx-serialization) are `api` so consumers resolving
+// the pom get the full classpath without extra work.
+tasks.named<Jar>("jar").configure {
+  manifest {
+    attributes("Main-Class" to "ee.schimke.composeai.discovery.PreviewDiscoveryCli")
+  }
+}

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
@@ -1,0 +1,165 @@
+package ee.schimke.composeai.discovery
+
+import java.io.File
+import kotlin.system.exitProcess
+import kotlinx.serialization.json.Json
+
+/**
+ * `java -jar preview-discovery-<version>.jar` entry point. Thin CLI wrapper over
+ * [PreviewDiscovery.discover] for non-Gradle build systems — a Bazel `genrule` or an Amper
+ * task can shell out here without buying into a Gradle Tooling-API client.
+ *
+ * Usage:
+ * ```
+ * java -jar preview-discovery.jar \
+ *   --classes <dir>[:<dir>...] \
+ *   --dependency-jars <jar>[:<jar>...] \
+ *   --source-files <file>[:<file>...] \
+ *   --module <name> \
+ *   --variant <name> \
+ *   --project-directory <dir> \
+ *   [--fail-on-empty] \
+ *   --out <path>
+ * ```
+ *
+ * `--classes`, `--dependency-jars`, `--source-files` accept a `File.pathSeparator`-separated
+ * list (matching how `java -cp` already encodes classpaths on the consumer's platform) and can
+ * be repeated to concatenate. Empty entries are skipped, so passing an empty value through is
+ * harmless when a build rule's input list happens to be empty.
+ *
+ * Exit codes: `0` on success (manifest written), `1` on discovery failure (e.g. zero previews
+ * + `--fail-on-empty`), `2` on argument parsing failure.
+ */
+public object PreviewDiscoveryCli {
+
+  @JvmStatic
+  public fun main(args: Array<String>) {
+    val parsed =
+      try {
+        parse(args)
+      } catch (e: ArgError) {
+        System.err.println("preview-discovery: ${e.message}")
+        printUsage(System.err)
+        exitProcess(2)
+      }
+
+    val outcome = PreviewDiscovery.discover(parsed.input)
+    when (outcome) {
+      is PreviewDiscovery.Outcome.Success -> {
+        outcome.warnings.forEach { System.err.println("WARN: $it") }
+        parsed.outFile.parentFile?.mkdirs()
+        parsed.outFile.writeText(JSON.encodeToString(outcome.manifest))
+        outcome.infoMessages.forEach { System.err.println(it) }
+        exitProcess(0)
+      }
+      is PreviewDiscovery.Outcome.Failure -> {
+        outcome.diagnostics.forEach { System.err.println(it) }
+        System.err.println("preview-discovery: ${outcome.reason}")
+        exitProcess(1)
+      }
+    }
+  }
+
+  private val JSON = Json {
+    prettyPrint = true
+    encodeDefaults = true
+  }
+
+  internal data class ParsedArgs(val input: PreviewDiscovery.Input, val outFile: File)
+
+  internal class ArgError(message: String) : RuntimeException(message)
+
+  internal fun parse(args: Array<String>): ParsedArgs {
+    val classDirs = mutableListOf<File>()
+    val dependencyJars = mutableListOf<File>()
+    val sourceFiles = mutableListOf<File>()
+    var moduleName: String? = null
+    var variantName: String? = null
+    var projectDirectory: File? = null
+    var failOnEmpty = false
+    var outPath: File? = null
+
+    var i = 0
+    while (i < args.size) {
+      val arg = args[i]
+      when (arg) {
+        "--classes" -> classDirs += splitPathList(requireValue(args, i)).map { File(it) }
+        "--dependency-jars" ->
+          dependencyJars += splitPathList(requireValue(args, i)).map { File(it) }
+        "--source-files" ->
+          sourceFiles += splitPathList(requireValue(args, i)).map { File(it) }
+        "--module" -> moduleName = requireValue(args, i)
+        "--variant" -> variantName = requireValue(args, i)
+        "--project-directory" -> projectDirectory = File(requireValue(args, i))
+        "--out" -> outPath = File(requireValue(args, i))
+        "--fail-on-empty" -> {
+          failOnEmpty = true
+          i++
+          continue
+        }
+        "-h",
+        "--help" -> {
+          printUsage(System.out)
+          exitProcess(0)
+        }
+        else -> throw ArgError("unknown argument: $arg")
+      }
+      i += 2
+    }
+
+    val module = moduleName ?: throw ArgError("--module is required")
+    val variant = variantName ?: throw ArgError("--variant is required")
+    val projectDir = projectDirectory ?: throw ArgError("--project-directory is required")
+    val out = outPath ?: throw ArgError("--out is required")
+
+    return ParsedArgs(
+      input =
+        PreviewDiscovery.Input(
+          classDirs = classDirs,
+          dependencyJars = dependencyJars,
+          sourceFiles = sourceFiles,
+          moduleName = module,
+          variantName = variant,
+          projectDirectory = projectDir,
+          failOnEmpty = failOnEmpty,
+        ),
+      outFile = out,
+    )
+  }
+
+  private fun requireValue(args: Array<String>, i: Int): String {
+    if (i + 1 >= args.size) throw ArgError("${args[i]} requires a value")
+    return args[i + 1]
+  }
+
+  private fun splitPathList(raw: String): List<String> =
+    raw.split(File.pathSeparatorChar).filter { it.isNotEmpty() }
+
+  private fun printUsage(out: java.io.PrintStream) {
+    out.println(
+      """
+      Usage: java -jar preview-discovery.jar [options]
+
+      Required:
+        --module <name>             Logical module name; surfaces as PreviewManifest.module.
+        --variant <name>            Build variant ("debug" / "release" / "desktop");
+                                    surfaces as PreviewManifest.variant.
+        --project-directory <dir>   Module root; PreviewInfo.sourceFile paths are rendered
+                                    relative to this.
+        --out <path>                Destination path for the emitted previews.json.
+
+      Inputs (path-separator-delimited, repeatable):
+        --classes <dir>[:<dir>...]            Compiled .class directories belonging to the module.
+        --dependency-jars <jar>[:<jar>...]    Dependency JARs to merge onto the scan classpath.
+        --source-files <file>[:<file>...]     Source files used to resolve module-relative paths.
+
+      Flags:
+        --fail-on-empty   Exit non-zero with diagnostics when zero previews are discovered.
+        --help, -h        Print this message.
+
+      Exit codes: 0 = success, 1 = discovery failure, 2 = argument parsing failure.
+      """
+        .trimIndent()
+    )
+  }
+}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCliTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCliTest.kt
@@ -1,0 +1,136 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class PreviewDiscoveryCliTest {
+
+  @Test
+  fun `parse fills every Input field from the canonical arg shape`() {
+    val parsed =
+      PreviewDiscoveryCli.parse(
+        arrayOf(
+          "--classes",
+          "/tmp/a${File.pathSeparator}/tmp/b",
+          "--dependency-jars",
+          "/tmp/c.jar",
+          "--source-files",
+          "/tmp/x.kt${File.pathSeparator}/tmp/y.kt",
+          "--module",
+          ":app",
+          "--variant",
+          "debug",
+          "--project-directory",
+          "/tmp/project",
+          "--fail-on-empty",
+          "--out",
+          "/tmp/previews.json",
+        )
+      )
+
+    assertThat(parsed.input.classDirs.map { it.path }).containsExactly("/tmp/a", "/tmp/b").inOrder()
+    assertThat(parsed.input.dependencyJars.map { it.path }).containsExactly("/tmp/c.jar")
+    assertThat(parsed.input.sourceFiles.map { it.path })
+      .containsExactly("/tmp/x.kt", "/tmp/y.kt")
+      .inOrder()
+    assertThat(parsed.input.moduleName).isEqualTo(":app")
+    assertThat(parsed.input.variantName).isEqualTo("debug")
+    assertThat(parsed.input.projectDirectory.path).isEqualTo("/tmp/project")
+    assertThat(parsed.input.failOnEmpty).isTrue()
+    assertThat(parsed.outFile.path).isEqualTo("/tmp/previews.json")
+  }
+
+  @Test
+  fun `repeated --classes accumulates`() {
+    val parsed =
+      PreviewDiscoveryCli.parse(
+        arrayOf(
+          "--classes",
+          "/a",
+          "--classes",
+          "/b",
+          "--module",
+          "m",
+          "--variant",
+          "v",
+          "--project-directory",
+          "/proj",
+          "--out",
+          "/out",
+        )
+      )
+
+    assertThat(parsed.input.classDirs.map { it.path }).containsExactly("/a", "/b").inOrder()
+  }
+
+  @Test
+  fun `--fail-on-empty defaults to false when absent`() {
+    val parsed =
+      PreviewDiscoveryCli.parse(
+        arrayOf(
+          "--module",
+          "m",
+          "--variant",
+          "v",
+          "--project-directory",
+          "/proj",
+          "--out",
+          "/out",
+        )
+      )
+    assertThat(parsed.input.failOnEmpty).isFalse()
+  }
+
+  @Test
+  fun `missing --module errors with a clear message`() {
+    val error =
+      assertThrows(PreviewDiscoveryCli.ArgError::class.java) {
+        PreviewDiscoveryCli.parse(
+          arrayOf("--variant", "v", "--project-directory", "/p", "--out", "/o")
+        )
+      }
+    assertThat(error.message).contains("--module is required")
+  }
+
+  @Test
+  fun `unknown argument errors`() {
+    val error =
+      assertThrows(PreviewDiscoveryCli.ArgError::class.java) {
+        PreviewDiscoveryCli.parse(arrayOf("--bogus", "v"))
+      }
+    assertThat(error.message).contains("--bogus")
+  }
+
+  @Test
+  fun `flag without value errors`() {
+    val error =
+      assertThrows(PreviewDiscoveryCli.ArgError::class.java) {
+        PreviewDiscoveryCli.parse(arrayOf("--module"))
+      }
+    assertThat(error.message).contains("--module requires a value")
+  }
+
+  @Test
+  fun `splitPathList drops empties so build-system-passed empty inputs are harmless`() {
+    val parsed =
+      PreviewDiscoveryCli.parse(
+        arrayOf(
+          // Bazel `$(locations …)` substitutions can produce an empty leading segment when the
+          // input set is empty — the CLI must tolerate that without spurious File("") entries.
+          "--classes",
+          "${File.pathSeparator}/a${File.pathSeparator}${File.pathSeparator}/b",
+          "--module",
+          "m",
+          "--variant",
+          "v",
+          "--project-directory",
+          "/p",
+          "--out",
+          "/o",
+        )
+      )
+    assertThat(parsed.input.classDirs.map { it.path }).containsExactly("/a", "/b").inOrder()
+  }
+}


### PR DESCRIPTION
## Summary

Phase A2c of the contrib refactor (final piece of Phase A). New `PreviewDiscoveryCli` wraps `PreviewDiscovery.discover(...)` with a `@JvmStatic main` + arg parser so Bazel rules and Amper tasks can shell out to discovery without buying into a Gradle Tooling-API client.

```
java -cp <classpath> ee.schimke.composeai.discovery.PreviewDiscoveryCli \
  --classes <dir>[:<dir>...] \
  --dependency-jars <jar>[:<jar>...] \
  --source-files <file>[:<file>...] \
  --module <name> --variant <name> \
  --project-directory <dir> \
  [--fail-on-empty] \
  --out <path>
```

The jar's `Main-Class` manifest attribute points at the CLI, so `java -jar preview-discovery-<v>.jar ...` also works when all transitive jars (classgraph, asm, kotlinx-serialization) sit next to the artifact — the shape a Bazel `runtime_jars` provider produces. Multi-value flags accept a `File.pathSeparator`-delimited list and can be repeated; empty segments are dropped so a build rule passing through an empty `$(locations …)` substitution stays harmless.

**Exit codes:** `0` = success, `1` = discovery failure (e.g. zero previews + `--fail-on-empty`), `2` = argument parsing failure. Warnings go to stderr, the emitted JSON goes to `--out`.

This closes **Phase A** of the contrib refactor (`contrib/README.md`). Next: Phase B — bootstrap `yschimke/compose-ai-contrib` consuming `ee.schimke.composeai:preview-discovery` from Maven Central.

## Test plan

- [x] `./gradlew :gradle-plugin:preview-discovery:test` — new `PreviewDiscoveryCliTest` covers arg-parsing edges (missing required, unknown flag, flag without value, repeated `--classes`, empty segments)
- [x] `./gradlew :gradle-plugin:preview-discovery:jar` — `META-INF/MANIFEST.MF` carries `Main-Class: ee.schimke.composeai.discovery.PreviewDiscoveryCli`
- [x] Verified end-to-end: `java -cp <classpath> ...PreviewDiscoveryCli --help` prints the usage block
- [x] `./gradlew ktfmtCheckAll`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fea3X5qLi4qZfX12fYFKuS)_