### PR TITLE
feat(render-cli): new :render-cli library — java -jar over render-session-subprocess

### DIFF
--- a/render-cli/build.gradle.kts
+++ b/render-cli/build.gradle.kts
@@ -1,0 +1,50 @@
+// Thin CLI over `render-session-subprocess` for non-Gradle build systems. Lives in the outer
+// build (not in the gradle-plugin includeBuild) because it depends on `:render-session-subprocess`
+// and `:render-session-api`, both outer-build modules.
+//
+// Phase A of the contrib refactor (see `contrib/README.md`): contrib repo Bazel rules and
+// Amper tasks shell out to `java -jar render-cli.jar --descriptor X --previews Foo,Bar` to
+// drive a render, rather than re-implementing the JSON-RPC subprocess dance from scratch.
+// The library API surface lives in `:render-session-api`; this module is purely a CLI
+// adapter.
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // Public `RenderSession` contract surfaced in the CLI's behaviour — the args map directly
+  // onto `renderNow(previewIds, tier, reason, ...)` and the printed result onto the
+  // `renderFinished` notification payload.
+  api(project(":render-session-api"))
+  // Subprocess backend is the only implementation today; the CLI is therefore subprocess-only.
+  // If an in-process backend lands later, the CLI's `--mode embedded` flag would route here.
+  implementation(project(":render-session-subprocess"))
+  implementation(libs.kotlinx.serialization.json)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "render-cli",
+    displayName = "Compose Preview — Render CLI",
+    description =
+      "`java -jar` CLI over the render-session-subprocess library. Lets non-Gradle build " +
+        "systems (Bazel rules, Amper tasks) drive a render against an existing " +
+        "`daemon-launch.json` without buying into a Kotlin/JVM client.",
+  )
+  inceptionYear.set("2026")
+}
+
+// `Main-Class` stamp lets a build system invoke the artifact via `java -jar render-cli.jar ...`
+// when all transitive jars (render-session-subprocess, render-session-api, daemon-core, mcp,
+// kotlinx-serialization) sit alongside, or via `java -cp <classpath> ...RenderCli ...` when
+// the build system resolves the classpath itself. Same pattern as `:preview-discovery`
+// and `:daemon-launch-builder`.
+tasks.named<Jar>("jar").configure {
+  manifest { attributes("Main-Class" to "ee.schimke.composeai.render.cli.RenderCli") }
+}

--- a/render-cli/src/main/kotlin/ee/schimke/composeai/render/cli/RenderCli.kt
+++ b/render-cli/src/main/kotlin/ee/schimke/composeai/render/cli/RenderCli.kt
@@ -1,0 +1,216 @@
+package ee.schimke.composeai.render.cli
+
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.system.exitProcess
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `java -jar render-cli-<version>.jar` entry point. Thin CLI wrapper over
+ * [SubprocessRenderSessions.open] for non-Gradle build systems. A Bazel `genrule` or an Amper task
+ * can shell out here to drive a render against an existing `daemon-launch.json` without buying into
+ * a Kotlin/JVM client.
+ *
+ * Usage:
+ * ```
+ * java -jar render-cli.jar \
+ *   --descriptor <daemon-launch.json> \
+ *   --workspace-root <dir> \
+ *   --previews <id>[,<id>...] \
+ *   [--tier FULL|FAST] \
+ *   [--reason <text>] \
+ *   [--timeout-seconds 60] \
+ *   [--workspace-name <name>]
+ * ```
+ *
+ * `--previews` accepts a comma-separated list and can be repeated. The CLI waits for one
+ * `renderFinished` notification per requested preview id, prints the resulting PNG path to stdout
+ * (`<id>\t<pngPath>`), and exits 0 on success.
+ *
+ * Exit codes: `0` = all renders succeeded, `1` = at least one render rejected, failed, or timed
+ * out, `2` = argument parsing failure.
+ */
+public object RenderCli {
+
+  @JvmStatic
+  public fun main(args: Array<String>) {
+    val parsed =
+      try {
+        parse(args)
+      } catch (e: ArgError) {
+        System.err.println("render-cli: ${e.message}")
+        printUsage(System.err)
+        exitProcess(2)
+      }
+
+    exitProcess(run(parsed))
+  }
+
+  /** Returns the process exit code. Extracted for testability. */
+  internal fun run(parsed: ParsedArgs): Int {
+    val pending = ConcurrentHashMap.newKeySet<String>().apply { addAll(parsed.previewIds) }
+    val results = ConcurrentHashMap<String, String>()
+    val latch = CountDownLatch(parsed.previewIds.size)
+
+    SubprocessRenderSessions.open(
+        RenderSessionConfig(
+          descriptorPath = parsed.descriptor,
+          workspaceRoot = parsed.workspaceRoot,
+          workspaceName = parsed.workspaceName,
+          logSink = { line -> System.err.println("[daemon] $line") },
+        )
+      )
+      .use { session ->
+        session
+          .onNotification { method, params ->
+            if (method != "renderFinished" || params == null) return@onNotification
+            val id = params["id"]?.jsonPrimitive?.contentOrNull ?: return@onNotification
+            val pngPath = params["pngPath"]?.jsonPrimitive?.contentOrNull
+            if (id in pending && pngPath != null) {
+              results[id] = pngPath
+              pending.remove(id)
+              latch.countDown()
+            }
+          }
+          .use {
+            val ack =
+              session.renderNow(
+                previewIds = parsed.previewIds,
+                tier = parsed.tier,
+                reason = parsed.reason,
+              )
+            if (ack.rejected.isNotEmpty()) {
+              for (rejected in ack.rejected) {
+                System.err.println("render-cli: rejected ${rejected.id}: ${rejected.reason}")
+              }
+              return 1
+            }
+
+            val finished = latch.await(parsed.timeoutSeconds, TimeUnit.SECONDS)
+            if (!finished) {
+              System.err.println(
+                "render-cli: timed out after ${parsed.timeoutSeconds}s waiting for: " +
+                  pending.joinToString(",")
+              )
+              return 1
+            }
+
+            for (id in parsed.previewIds) {
+              println("$id\t${results.getValue(id)}")
+            }
+            return 0
+          }
+      }
+  }
+
+  internal data class ParsedArgs(
+    val descriptor: File,
+    val workspaceRoot: File,
+    val workspaceName: String,
+    val previewIds: List<String>,
+    val tier: RenderTier,
+    val reason: String?,
+    val timeoutSeconds: Long,
+  )
+
+  internal class ArgError(message: String) : RuntimeException(message)
+
+  internal fun parse(args: Array<String>): ParsedArgs {
+    var descriptor: File? = null
+    var workspaceRoot: File? = null
+    var workspaceName: String? = null
+    val previewIds = mutableListOf<String>()
+    var tier = RenderTier.FULL
+    var reason: String? = null
+    var timeoutSeconds = 60L
+
+    var i = 0
+    while (i < args.size) {
+      val arg = args[i]
+      when (arg) {
+        "--descriptor" -> descriptor = File(requireValue(args, i))
+        "--workspace-root" -> workspaceRoot = File(requireValue(args, i))
+        "--workspace-name" -> workspaceName = requireValue(args, i)
+        "--previews" -> previewIds += requireValue(args, i).split(',').filter { it.isNotEmpty() }
+        "--tier" ->
+          tier =
+            try {
+              RenderTier.valueOf(requireValue(args, i))
+            } catch (_: IllegalArgumentException) {
+              throw ArgError("--tier must be one of ${RenderTier.values().joinToString(",")}")
+            }
+        "--reason" -> reason = requireValue(args, i)
+        "--timeout-seconds" ->
+          timeoutSeconds =
+            requireValue(args, i).toLongOrNull()?.takeIf { it > 0 }
+              ?: throw ArgError("--timeout-seconds must be a positive integer")
+        "-h",
+        "--help" -> {
+          printUsage(System.out)
+          exitProcess(0)
+        }
+        else -> throw ArgError("unknown argument: $arg")
+      }
+      i += 2
+    }
+
+    val descriptorFile = descriptor ?: throw ArgError("--descriptor is required")
+    val root = workspaceRoot ?: throw ArgError("--workspace-root is required")
+    // Default workspace name to the root dir's basename — matches the convention
+    // `SubprocessRenderSessions`
+    // uses when callers leave the field blank. Override with `--workspace-name` only when the
+    // build system has a stable identifier worth surfacing in daemon logs.
+    val name = workspaceName ?: root.name
+    if (previewIds.isEmpty()) throw ArgError("--previews requires at least one id")
+
+    return ParsedArgs(
+      descriptor = descriptorFile,
+      workspaceRoot = root,
+      workspaceName = name,
+      previewIds = previewIds,
+      tier = tier,
+      reason = reason,
+      timeoutSeconds = timeoutSeconds,
+    )
+  }
+
+  private fun requireValue(args: Array<String>, i: Int): String {
+    if (i + 1 >= args.size) throw ArgError("${args[i]} requires a value")
+    return args[i + 1]
+  }
+
+  private fun printUsage(out: java.io.PrintStream) {
+    out.println(
+      """
+      Usage: java -jar render-cli.jar [options]
+
+      Required:
+        --descriptor <path>         Absolute path to daemon-launch.json.
+        --workspace-root <dir>      Workspace root (the repo root containing the module).
+        --previews <id>[,<id>...]   Comma-separated preview ids to render. Repeatable.
+
+      Optional:
+        --workspace-name <name>     Stable workspace identifier; defaults to the basename of
+                                    --workspace-root.
+        --tier FULL|FAST            Render tier; defaults to FULL.
+        --reason <text>             Free-form reason surfaced in daemon logs.
+        --timeout-seconds <n>       Wait at most this long for every requested render to
+                                    emit `renderFinished`; defaults to 60.
+        --help, -h                  Print this message.
+
+      Output:
+        One `<id>\t<pngPath>` line per successful render on stdout.
+        Daemon stderr is mirrored to render-cli's stderr.
+
+      Exit codes: 0 = success, 1 = any render rejected/failed/timed out, 2 = arg error.
+      """
+        .trimIndent()
+    )
+  }
+}

--- a/render-cli/src/test/kotlin/ee/schimke/composeai/render/cli/RenderCliTest.kt
+++ b/render-cli/src/test/kotlin/ee/schimke/composeai/render/cli/RenderCliTest.kt
@@ -1,0 +1,122 @@
+package ee.schimke.composeai.render.cli
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class RenderCliTest {
+
+  @Test
+  fun `parse fills every required field`() {
+    val parsed =
+      RenderCli.parse(
+        arrayOf(
+          "--descriptor",
+          "/abs/build/daemon-launch.json",
+          "--workspace-root",
+          "/abs/repo",
+          "--previews",
+          "Foo.Greeting,Bar.Welcome",
+        )
+      )
+
+    assertThat(parsed.descriptor.path).isEqualTo("/abs/build/daemon-launch.json")
+    assertThat(parsed.workspaceRoot.path).isEqualTo("/abs/repo")
+    assertThat(parsed.workspaceName).isEqualTo("repo")
+    assertThat(parsed.previewIds).containsExactly("Foo.Greeting", "Bar.Welcome").inOrder()
+    assertThat(parsed.tier).isEqualTo(RenderTier.FULL)
+    assertThat(parsed.reason).isNull()
+    assertThat(parsed.timeoutSeconds).isEqualTo(60L)
+  }
+
+  @Test
+  fun `repeated --previews concatenates`() {
+    val parsed =
+      RenderCli.parse(
+        arrayOf(
+          "--descriptor",
+          "/d",
+          "--workspace-root",
+          "/r",
+          "--previews",
+          "a,b",
+          "--previews",
+          "c",
+        )
+      )
+    assertThat(parsed.previewIds).containsExactly("a", "b", "c").inOrder()
+  }
+
+  @Test
+  fun `--workspace-name overrides default`() {
+    val parsed =
+      RenderCli.parse(
+        arrayOf(
+          "--descriptor",
+          "/d",
+          "--workspace-root",
+          "/some/repo",
+          "--workspace-name",
+          "my-workspace",
+          "--previews",
+          "a",
+        )
+      )
+    assertThat(parsed.workspaceName).isEqualTo("my-workspace")
+  }
+
+  @Test
+  fun `--tier accepts FULL and FAST and rejects nonsense`() {
+    val full = RenderCli.parse(base() + arrayOf("--tier", "FULL"))
+    assertThat(full.tier).isEqualTo(RenderTier.FULL)
+
+    val fast = RenderCli.parse(base() + arrayOf("--tier", "FAST"))
+    assertThat(fast.tier).isEqualTo(RenderTier.FAST)
+
+    val error =
+      assertThrows(RenderCli.ArgError::class.java) {
+        RenderCli.parse(base() + arrayOf("--tier", "EXTRA_CRISPY"))
+      }
+    assertThat(error.message).contains("--tier must be one of")
+  }
+
+  @Test
+  fun `--timeout-seconds requires a positive integer`() {
+    val parsed = RenderCli.parse(base() + arrayOf("--timeout-seconds", "120"))
+    assertThat(parsed.timeoutSeconds).isEqualTo(120L)
+
+    val negative =
+      assertThrows(RenderCli.ArgError::class.java) {
+        RenderCli.parse(base() + arrayOf("--timeout-seconds", "-1"))
+      }
+    assertThat(negative.message).contains("positive integer")
+
+    val notANumber =
+      assertThrows(RenderCli.ArgError::class.java) {
+        RenderCli.parse(base() + arrayOf("--timeout-seconds", "soon"))
+      }
+    assertThat(notANumber.message).contains("positive integer")
+  }
+
+  @Test
+  fun `missing --descriptor errors`() {
+    val error =
+      assertThrows(RenderCli.ArgError::class.java) {
+        RenderCli.parse(arrayOf("--workspace-root", "/r", "--previews", "a"))
+      }
+    assertThat(error.message).contains("--descriptor is required")
+  }
+
+  @Test
+  fun `empty --previews errors`() {
+    val error =
+      assertThrows(RenderCli.ArgError::class.java) {
+        RenderCli.parse(arrayOf("--descriptor", "/d", "--workspace-root", "/r", "--previews", ""))
+      }
+    assertThat(error.message).contains("--previews requires at least one id")
+  }
+
+  private fun base(): Array<String> =
+    arrayOf("--descriptor", "/d", "--workspace-root", "/r", "--previews", "a")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -285,3 +285,7 @@ project(":render-session-subprocess").projectDir = file("render-session/subproce
 include(":render-session-embedded-desktop")
 
 project(":render-session-embedded-desktop").projectDir = file("render-session/embedded-desktop")
+
+// Thin `java -jar` CLI over `:render-session-subprocess` for non-Gradle build systems
+// (Bazel rules, Amper tasks in `yschimke/compose-ai-contrib`). See `contrib/README.md`.
+include(":render-cli")


### PR DESCRIPTION
## Summary

Third and final hook of **Phase A** in the contrib refactor (see `contrib/README.md`), after `:preview-discovery` (#1300 / #1305 / #1306 / #1307) and `:daemon-launch-builder` (#1309). `:render-cli` is a thin `java -jar` wrapper over `SubprocessRenderSessions.open(...).renderNow(...)` so Bazel rules and Amper tasks in `yschimke/compose-ai-contrib` can drive a render against an existing `daemon-launch.json` without buying into a Kotlin/JVM client:

```
java -jar render-cli.jar \
  --descriptor /abs/build/daemon-launch.json \
  --workspace-root /abs/repo \
  --previews Foo.Greeting,Bar.Welcome \
  [--tier FULL|FAST] \
  [--reason "ad-hoc"] \
  [--timeout-seconds 60] \
  [--workspace-name <stable-id>]
```

## CLI semantics

- Opens a `SubprocessRenderSessions` against the descriptor, registers a `renderFinished` notification listener, queues `renderNow`, waits on a `CountDownLatch` for one notification per requested id.
- Per-preview success prints `<id>\t<pngPath>` to stdout; daemon stderr is mirrored to the CLI's stderr through `RenderSessionConfig.logSink`.
- Exit codes: `0` = all renders succeeded, `1` = any render rejected / failed / timed out, `2` = argument parsing failure.

## Location & wiring

Lives in the outer build (not in `:gradle-plugin`'s composite) because its deps — `:render-session-api` + `:render-session-subprocess` — are outer-build modules. Stamps `Main-Class` on the jar so `java -jar` works when transitive jars sit alongside, plus the `java -cp <classpath> ee.schimke.composeai.render.cli.RenderCli ...` shape Bazel `runtime_jars` produces.

## Test plan

- [x] `./gradlew :render-cli:test` — `RenderCliTest` covers arg-parsing edges (missing required, malformed `--tier` / `--timeout-seconds`, repeated `--previews`, empty `--previews`, `--workspace-name` default)
- [x] `./gradlew :render-cli:publishToMavenLocal` puts `ee.schimke.composeai:render-cli` into `~/.m2/` with the `Main-Class` manifest stamped
- [x] `./gradlew ktfmtCheckAll` clean

The end-to-end `renderNow` round-trip through a real daemon is already covered by `NonGradleContractTest` in `:render-session-subprocess`; this CLI is a thin adapter over the same library and doesn't warrant a second subprocess-driven test.

**Closes Phase A.** Phase B (bootstrap `yschimke/compose-ai-contrib` consuming all three artifacts from Maven Central) is the next concrete step, but lives outside this repo.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fea3X5qLi4qZfX12fYFKuS)_