### PR TITLE
docs(contrib): Phase B blueprint for yschimke/compose-ai-contrib

### DIFF
--- a/contrib/.github/workflows/amper-android.yml
+++ b/contrib/.github/workflows/amper-android.yml
@@ -1,0 +1,68 @@
+name: Amper Android sample
+
+# Opt-in workflow for the Amper Android sample
+# (amper-android/). Triggers on PRs that touch the sample or
+# this workflow file, plus manual dispatch. Not part of the default
+# `check` matrix because Amper's first run downloads the Android SDK
+# image into its cache (~tens of seconds) which is wasted wall-clock
+# for PRs that don't touch the sample.
+#
+# Lifted from yschimke/compose-ai-tools as part of Phase B of the
+# contrib refactor — see compose-ai-tools/contrib/README.md for the
+# migration history.
+
+on:
+  pull_request:
+    paths:
+      - "amper-android/**"
+      - ".github/workflows/amper-android.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  amper-build:
+    name: ./amper build (amper-android)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: amper-android
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+        with:
+          packages: "platforms;android-35 build-tools;35.0.0"
+      - name: Build
+        env:
+          # Mirrors amper-cmp-desktop/README.md — the bundled
+          # Zulu JRE Amper auto-downloads doesn't trust the sandbox /
+          # runner CA for some setups. Wiring the system truststore
+          # explicitly is harmless on a stock runner and necessary on
+          # TLS-inspecting environments.
+          AMPER_JAVA_OPTIONS: >-
+            -ea -XX:+EnableDynamicAgentLoading
+            -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
+            -Djavax.net.ssl.trustStorePassword=changeit
+        run: ./amper build
+      - name: Assert APK exists
+        run: |
+          apk="$(find build -name '*.apk' -print -quit)"
+          if [ -z "$apk" ]; then
+            echo "No APK produced under build/." >&2
+            find build -maxdepth 4 -type f >&2
+            exit 1
+          fi
+          echo "Built: $apk"

--- a/contrib/.github/workflows/bazel.yml
+++ b/contrib/.github/workflows/bazel.yml
@@ -1,0 +1,88 @@
+name: Bazel sample
+
+# Opt-in workflow for the Bazel demos. Two jobs:
+#   - bazel-build runs the resources-only sample (bazel/).
+#   - bazel-build-apk runs the Compose APK sample (bazel-apk/),
+#     `continue-on-error: true` because it's known-fragile while
+#     bazelbuild/rules_kotlin#1388 is open.
+# Not part of the default `check` matrix because the Bazel toolchain
+# install adds wall-clock to every PR — see issue #1253 for the wider
+# rollout plan.
+#
+# Lifted from yschimke/compose-ai-tools as part of Phase B of the
+# contrib refactor — see compose-ai-tools/contrib/README.md for the
+# migration history.
+
+on:
+  pull_request:
+    paths:
+      - "bazel/**"
+      - "bazel-apk/**"
+      - ".github/workflows/bazel.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bazel-build:
+    name: bazel build //:app_resources
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bazel
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Bazel version
+        # Bazelisk is pre-installed on the ubuntu-latest runner image
+        # as `/usr/bin/bazel`. Avoids a third-party setup action and
+        # a writable-prefix curl install.
+        run: bazel version
+      - name: Build resources manifest
+        run: bazel build //:app_resources
+      - name: Inspect output
+        run: |
+          out="$(bazel cquery --output=files //:app_resources)"
+          echo "--- resources.json ---"
+          cat "$out"
+          echo "--- validating JSON ---"
+          python3 -c "import json,sys; d=json.load(open('$out')); \
+            assert d['resources'], 'no resources discovered'; \
+            print(f'{len(d[\"resources\"])} resources')"
+
+  bazel-build-apk:
+    # Opt-in second job: Bazel + Compose APK target. Marked
+    # `continue-on-error: true` because the rules_kotlin + Compose
+    # compiler combination is broken on Kotlin 2.x
+    # (bazelbuild/rules_kotlin#1388) and we're tracking the path back
+    # to green from outside this workflow. Don't block PR merges on
+    # this; do let it run so we can see when upstream fixes it.
+    name: bazel build //:bazel_sample_apk (known fragile)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: bazel-apk
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+        with:
+          packages: "platforms;android-34 build-tools;34.0.0"
+      - name: Bazel version
+        run: bazel version
+      - name: Build APK
+        run: bazel build //:bazel_sample_apk

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,239 +1,108 @@
-# `contrib/` — staging area for `yschimke/compose-ai-contrib`
+# Lifting `contrib/` to `yschimke/compose-ai-contrib`
 
-This directory tracks the upcoming split of all Amper and Bazel
-integration code out of `compose-ai-tools` into a new dedicated repo,
-[`yschimke/compose-ai-contrib`](https://github.com/yschimke/compose-ai-contrib)
-(does not exist yet).
+This directory is the staging area for [`yschimke/compose-ai-contrib`](https://github.com/yschimke/compose-ai-contrib)
+— the planned dedicated repo for non-Gradle integrations of
+`compose-preview`. **Phase A (extracting the publishable hooks) is
+complete on `yschimke/compose-ai-tools:main`.** This file is the
+shopping list for **Phase B**: create the new repo and drop in
+everything from `contrib/`.
 
-The contrib repo consumes `compose-ai-tools` **only through published
-Maven Central artifacts**. No path-based deps, no `includeBuild`. This
-file is the migration plan; once the new repo is bootstrapped most of
-its contents move out and only a stub link remains here.
+## Status
 
-## Why split
+| Phase | What | State |
+| --- | --- | --- |
+| A1 | `:preview-discovery` (schema + scan + CLI) | **done** — `ee.schimke.composeai:preview-discovery` on Maven Central |
+| A2 | `:daemon-launch-builder` (descriptor + builder + CLI) | **done** — `ee.schimke.composeai:daemon-launch-builder` |
+| A3 | `:render-cli` (CLI over render-session-subprocess) | **done** — `ee.schimke.composeai:render-cli` |
+| B  | Bootstrap `yschimke/compose-ai-contrib` consuming the artifacts above | **this file — pending repo creation** |
+| C  | Delete `contrib/`, lifted workflows, and worked-example sub-sections from this repo | **waiting on B** |
 
-- The Amper/Bazel surface is fixture-shaped (samples + worked-example
-  docs + opt-in CI), not core. Keeping it in the tools repo dilutes the
-  "this is the published toolchain" message and slows PRs that don't
-  touch it.
-- The CLI (`cli/`) is Gradle-specific by design — its `GradleConnection`
-  is the Tooling-API client and `AutoInject` wires the plugin via
-  `--init-script`. Replicating that shape for Amper/Bazel would mean
-  forking the CLI per build system, which we want to avoid.
-- The daemon (`daemon/core` + `daemon/desktop` + `daemon/android`) and
-  MCP server (`mcp/`) are already build-system-agnostic — they consume
-  `daemon-launch.json` + `previews.json` on disk. Any build system that
-  can produce those files can drive them.
+## What to lift
 
-## Architectural cut
+When `yschimke/compose-ai-contrib` is created, copy these files
+verbatim — the new repo's tree mirrors this directory exactly:
 
 ```
-┌──────────────────── compose-ai-tools (this repo) ────────────────────┐
-│                                                                       │
-│  PUBLISHED ARTIFACTS (Maven Central — ee.schimke.composeai:…)         │
-│    daemon-core, daemon-desktop, daemon-android                        │
-│    renderer-desktop, renderer-android                                 │
-│    data-*-core, data-*-connector  (a11y, theme, history, …)          │
-│    render-session-api, render-session-subprocess                      │
-│    render-session-embedded-desktop                                    │
-│    preview-annotations                                                │
-│    gradle-plugin   (Gradle-only consumers)                            │
-│                                                                       │
-│  NEW HOOKS NEEDED (extracted from gradle-plugin internals):           │
-│    preview-discovery        ← ClassGraph scan, currently 1392 LOC     │
-│                               inside DiscoverPreviewsTask             │
-│    daemon-launch-builder    ← typed builder for daemon-launch.json,   │
-│                               currently DaemonClasspathDescriptor     │
-│                               (internal) + AndroidPreviewClasspath    │
-│                               helpers in the gradle plugin            │
-│    render-cli               ← ~30 LOC main wrapping                   │
-│                               SubprocessRenderSessions.open(...)      │
-│                                                                       │
-│  CLI (Gradle-only, stays here):                                       │
-│    compose-preview  ← GradleConnection / AutoInject / Tooling API     │
-│                                                                       │
-└───────────────────────────────────────────────────────────────────────┘
-
-┌──────────────── yschimke/compose-ai-contrib (future) ─────────────────┐
-│                                                                       │
-│  NO CLI of its own. Just build-system-native glue invoking the        │
-│  published hooks via `java -jar`:                                     │
-│                                                                       │
-│  bazel/                                                               │
-│    rules/                                                             │
-│      compose_preview.bzl       ← discover_previews,                   │
-│                                  build_daemon_descriptor,             │
-│                                  render_previews rules                │
-│    samples/                                                           │
-│      resources/                ← ex-samples/bazel                     │
-│      apk/                      ← ex-samples/bazel-apk                 │
-│                                                                       │
-│  amper/                                                               │
-│    rules/                      ← (TBD — Amper's extension model is    │
-│                                  still maturing; may be a separate    │
-│                                  helper jar invoked from module.yaml) │
-│    samples/                                                           │
-│      android/                  ← ex-samples/amper-android             │
-│      cmp-desktop/              ← ex-samples/amper-cmp-desktop         │
-│                                                                       │
-│  contract-tests/                                                      │
-│    AmperContractTest           ← moved from                           │
-│                                  :render-session-subprocess:test      │
-│                                  (consumes published artifacts only)  │
-│                                                                       │
-│  docs/                                                                │
-│    amper.md                    ← lifted from                          │
-│    bazel.md                       NON_GRADLE_INTEGRATION.md           │
-│                                  worked-example sections              │
-│                                                                       │
-│  .github/workflows/                                                   │
-│    amper-android.yml           ← lifted verbatim                      │
-│    bazel.yml                   ← lifted verbatim                      │
-│                                                                       │
-└───────────────────────────────────────────────────────────────────────┘
+contrib/                      compose-ai-contrib/
+├── amper-android/        ─►  amper-android/
+├── amper-cmp-desktop/    ─►  amper-cmp-desktop/
+├── bazel/                ─►  bazel/
+├── bazel-apk/            ─►  bazel-apk/
+├── docs/                 ─►  docs/
+│   ├── amper.md          ─►    amper.md
+│   └── bazel.md          ─►    bazel.md
+├── .github/              ─►  .github/
+│   └── workflows/        ─►    workflows/
+│       ├── amper-android.yml  amper-android.yml
+│       └── bazel.yml          bazel.yml
+└── SETUP.md              ─►  README.md  (or merge into project README)
 ```
 
-## Three-phase plan
+Then create the repo's Gradle root from [`SETUP.md`](SETUP.md) — the
+file documents the exact `settings.gradle.kts` / `build.gradle.kts` /
+`gradle/libs.versions.toml` to drop in.
 
-### Phase A — Extract the hooks (in `compose-ai-tools`, blocking)
+## Phase A — what got extracted
 
-These extractions are **prerequisites** for compose-ai-contrib to consume
-the toolchain via published artifacts without re-implementing internals.
+The three published artifacts a non-Gradle build system needs:
 
-- [ ] **`:preview-discovery`** — new module. Pure JVM library wrapping
-      ClassGraph; lifts the scan from `DiscoverPreviewsTask` (1392 LOC,
-      `gradle-plugin/src/main/kotlin/.../DiscoverPreviewsTask.kt`).
-      Provides a programmatic API and a `java -jar` main class:
-      ```
-      java -jar preview-discovery.jar \
-        --classes <dir> [--classes <dir>...] \
-        --dependency-jars <jar>:<jar>:... \
-        --module <name> --variant <name> \
-        --out previews.json
-      ```
-      `DiscoverPreviewsTask` becomes a thin Gradle adapter around the
-      same library. Published as `ee.schimke.composeai:preview-discovery`.
+| Artifact | Coords | What it does |
+| --- | --- | --- |
+| `preview-discovery` | `ee.schimke.composeai:preview-discovery:<v>` | ClassGraph scan over compiled classes; writes `previews.json`. Has both a Kotlin API and a `java -jar` CLI (`ee.schimke.composeai.discovery.PreviewDiscoveryCli`). |
+| `daemon-launch-builder` | `ee.schimke.composeai:daemon-launch-builder:<v>` | Typed builder + serializer for `daemon-launch.json`. Kotlin API + CLI (`ee.schimke.composeai.daemonlaunch.DaemonLaunchBuilderCli`). |
+| `render-cli` | `ee.schimke.composeai:render-cli:<v>` | Thin CLI over `SubprocessRenderSessions` — drives the daemon JVM and prints rendered PNG paths. Main class `ee.schimke.composeai.render.cli.RenderCli`. |
 
-- [ ] **`:daemon-launch-builder`** — new module. Promotes
-      `DaemonClasspathDescriptor` from `internal` to a public typed
-      builder; lifts the classpath/JVM-args/sysprop assembly from
-      `gradle-plugin/.../daemon/DaemonBootstrapTask.kt` +
-      `gradle-plugin/.../AndroidPreviewClasspath.kt` into pure-JVM code.
-      Programmatic API + `java -jar` main:
-      ```
-      java -jar daemon-launch-builder.jar \
-        --module <path> --variant <desktop|debug|release> \
-        --renderer-classpath <jar>:<jar>:... \
-        --user-classpath <jar>:<dir>:... \
-        --previews-json <path> \
-        --render-output-dir <dir> \
-        --out daemon-launch.json
-      ```
-      Published as `ee.schimke.composeai:daemon-launch-builder`.
-      **Bonus:** the duplicated `writeDescriptor` helper in
-      `NonGradleContractTest` + `AmperContractTest` goes away.
+A Bazel rule or Amper task chains these three jars:
 
-- [ ] **`:render-cli`** — new module. ~30 LOC main wrapping
-      `SubprocessRenderSessions.open(config).renderNow(...)`:
-      ```
-      java -jar render-cli.jar \
-        --descriptor daemon-launch.json \
-        --workspace-root <dir> \
-        --previews Foo.Greeting,Bar.Welcome
-      ```
-      Published as `ee.schimke.composeai:render-cli`.
+```
+discover → previews.json   (preview-discovery)
+build descriptor → daemon-launch.json   (daemon-launch-builder, takes resolved jars + sysprops)
+render → PNGs   (render-cli, reads both files above)
+```
 
-Each new module wires `composeai.maven-publishing` and rides the existing
-`release-please` flow.
+No Gradle. No AGP. Just three published Maven artifacts and a JDK.
 
-### Phase B — Bootstrap `yschimke/compose-ai-contrib`
+## Phase B checklist (do once the repo exists)
 
-- [ ] Create the repo with the layout shown above.
-- [ ] All deps via Maven Central; nothing path-based.
-- [ ] Lift the four sample dirs and the two CI workflows from
-      `compose-ai-tools`.
-- [ ] Rewrite `AmperContractTest` to depend on
-      `ee.schimke.composeai:render-cli` + `:render-session-subprocess`
-      from Maven Central instead of `project(":render-session-subprocess")`.
-- [ ] Lift the "Worked example: JetBrains Amper" + "Worked example:
-      Bazel" sections out of `docs/NON_GRADLE_INTEGRATION.md`.
+- [ ] Create `yschimke/compose-ai-contrib` (public, empty).
+- [ ] `cp -r contrib/* <new-repo>/` (everything except this file —
+      `contrib/README.md` is the migration plan, not consumer docs).
+- [ ] Apply the Gradle scaffolding from [`SETUP.md`](SETUP.md).
+- [ ] Bootstrap CI: enable Actions, the lifted `amper-android.yml` /
+      `bazel.yml` start running on push automatically.
+- [ ] Open a PR back into this repo doing Phase C (delete the staged
+      content here once compose-ai-contrib is operational).
 
-### Phase C — Cut over from this repo
+## Phase C — what gets deleted from this repo
 
-- [ ] Delete `samples/{amper-android,amper-cmp-desktop,bazel,bazel-apk}/`.
-- [ ] Delete
-      `render-session/subprocess/src/test/.../AmperContractTest.kt`.
-- [ ] Delete `.github/workflows/{amper-android,bazel}.yml`.
-- [ ] Slim `docs/NON_GRADLE_INTEGRATION.md` to just the contract
-      sections (daemon-launch.json schema, previews.json schema,
-      classpath layering, sysprops). Add a one-line link to
-      compose-ai-contrib's worked-example docs.
-- [ ] Replace this `contrib/` directory with a stub `contrib/README.md`
-      that points at the new repo.
+After Phase B succeeds:
 
-## What stays in `compose-ai-tools`
+- `contrib/amper-android/` / `amper-cmp-desktop/` / `bazel/` / `bazel-apk/`
+- `.github/workflows/amper-android.yml` / `bazel.yml`
+- `render-session/subprocess/src/test/.../AmperContractTest.kt`
+  (replaced by a Maven-Central-consuming equivalent in compose-ai-contrib)
+- The "Worked example: JetBrains Amper" and "Worked example: Bazel"
+  sub-sections of [`docs/NON_GRADLE_INTEGRATION.md`](../docs/NON_GRADLE_INTEGRATION.md);
+  replace with a one-line link to compose-ai-contrib's `docs/`.
 
-- All published artifacts (the toolchain itself).
-- `docs/NON_GRADLE_INTEGRATION.md` minus the worked-example sub-sections
-  — the contract is the published interface and belongs here.
-- `render-session/subprocess/src/test/.../NonGradleContractTest.kt` —
-  proves the contract is portable without naming any specific build
-  system.
-- Doc-comment mentions of Bazel/Amper as illustrative non-Gradle
-  consumers in `notification-preview-runtime/` and `renderer-android/`.
+The contract sections of `NON_GRADLE_INTEGRATION.md` (the
+`daemon-launch.json` schema spec, classpath layering, sysprops) stay
+here — those are the published interface and belong with the published
+artifacts.
 
-## Simplifications this move enables
+## Decisions locked in earlier
 
-Independently valuable, listed here for visibility:
+These were captured in this file's first draft (Phase A1 era) and
+remain in force:
 
-- **Plugin slims down.** `DiscoverPreviewsTask` shrinks from 1392 LOC
-  (Gradle wiring + ClassGraph scanning + multi-preview fan-out) to a
-  thin `@TaskAction` over the new library.
-- **Descriptor builder stops being duplicated.** Today the gradle plugin
-  has the canonical builder (`internal`), and the two contract tests
-  each re-implement the same `writeDescriptor(...)` helper. Phase A
-  collapses three implementations into one.
-- **`:render-session-subprocess:test` becomes generically "JSON-RPC
-  contract verified."** Today it has one build-system-agnostic test
-  (`NonGradleContractTest`) and one Amper-specific test
-  (`AmperContractTest`). After Phase C the module's test suite has no
-  build-system bias.
-- **Sample tree gets less misleading.** Four of `samples/`'s 17
-  directories are non-Gradle fixtures excluded from `settings.gradle.kts`
-  by convention only. Moving them out makes the "every dir under
-  `samples/` is a Gradle subproject" rule a real rule.
-- **CI sheet trims.** `.github/workflows/{amper-android,bazel}.yml` are
-  path-filtered opt-in jobs that almost never trigger on tools-repo PRs.
-
-## Decisions
-
-These were open in earlier drafts; locked in here so Phase A can start.
-
-1. **`:preview-discovery` ships a library + a CLI main.** The library
-   is what Gradle's `DiscoverPreviewsTask` calls into; the CLI is what
-   Bazel rules `java -jar` from a `genrule`. Same build, two consumers.
-2. **`:daemon-launch-builder` is generic — "assemble a descriptor"
-   only.** The Android-specific classpath layering
-   (`AndroidPreviewClasspath`: AGP `artifactView` resolution, R.jar
-   appending, `--add-opens` set) stays in the gradle plugin. The new
-   library's API is "given these resolved jar lists + sysprops + JVM
-   args, emit a valid `daemon-launch.json`." Non-Gradle consumers
-   resolve their classpath through their own dep system (Bazel
-   `rules_jvm_external`, Amper m2 cache scrape) and hand it to the
-   builder.
+1. **`preview-discovery` ships library + CLI main.**
+2. **`daemon-launch-builder` is generic — "assemble a descriptor" only.**
+   Android-specific classpath layering (`AndroidPreviewClasspath`'s AGP
+   `artifactView` resolution, R.jar appending, the
+   Robolectric-on-JDK-17 `--add-opens` set) stays in `:gradle-plugin`.
 3. **Amper integration is shell-scripts-invoking-`java -jar`, not
    plugins.** Amper 0.10's extension model isn't there yet
    ([AMPER-471](https://youtrack.jetbrains.com/projects/AMPER/issues/AMPER-471))
-   and waiting for it blocks adoption. The pragmatic shape is a small
-   shell wrapper that runs after `./amper build` and pipes Amper's
-   `build/artifacts/.../kotlin-output/` through the three published
-   jars. Revisit when Amper ships first-class plugins.
+   and waiting for it blocks adoption.
 4. **Separate `:render-cli`, not `DaemonMain --render-once`.** Keeps
-   the daemon JSON-RPC-only — no CLI parsing concern leaks into a
-   wire-protocol server. The extra published artifact is ~30 LOC and
-   is what Bazel/Amper rules actually shell out to.
-
-## Current state
-
-This `contrib/` directory now holds the four moved fixtures. Phase A
-(the three library extractions) is the next concrete step.
+   the daemon JSON-RPC-only.

--- a/contrib/SETUP.md
+++ b/contrib/SETUP.md
@@ -1,0 +1,206 @@
+# Setting up `yschimke/compose-ai-contrib`
+
+This is the Gradle scaffolding to drop into `yschimke/compose-ai-contrib`
+after lifting the rest of `contrib/`. The new repo has two real Gradle
+needs: (1) drive the lifted CI workflows, (2) host a contract test
+that exercises the published `compose-preview` artifacts end-to-end
+against the lifted Amper fixture. Everything else (the Amper / Bazel
+fixtures themselves) is build-system-native and doesn't touch Gradle.
+
+## Layout
+
+```
+compose-ai-contrib/
+├── amper-android/                # lifted from compose-ai-tools/contrib/
+├── amper-cmp-desktop/            # lifted
+├── bazel/                        # lifted
+├── bazel-apk/                    # lifted
+├── docs/                         # lifted (amper.md, bazel.md)
+│   ├── amper.md
+│   └── bazel.md
+├── contract-tests/
+│   └── amper-cmp-desktop/        # NEW — Maven-Central-consuming version of
+│       ├── build.gradle.kts      # render-session-subprocess's AmperContractTest
+│       └── src/test/kotlin/...
+├── .github/
+│   └── workflows/
+│       ├── amper-android.yml     # lifted; paths already point at amper-android/
+│       ├── bazel.yml             # lifted; paths already point at bazel/ + bazel-apk/
+│       └── contract-tests.yml    # NEW — runs :contract-tests:amper-cmp-desktop:test
+├── settings.gradle.kts           # NEW — see below
+├── build.gradle.kts              # NEW — empty root, conventions in :contract-tests
+├── gradle/
+│   ├── libs.versions.toml        # NEW — pin the ee.schimke.composeai versions
+│   └── wrapper/                  # standard Gradle wrapper
+├── gradlew                       # standard wrapper script
+├── gradlew.bat
+└── README.md                     # consumer-facing intro (not the migration plan)
+```
+
+## `settings.gradle.kts`
+
+```kotlin
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    mavenCentral()
+  }
+}
+
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    mavenCentral()
+    // Optional: snapshots from Sonatype Central. Pin to a release version in
+    // libs.versions.toml unless you're testing against an unreleased commit.
+    maven("https://central.sonatype.com/repository/maven-snapshots/") {
+      name = "ossSnapshots"
+      content { includeGroup("ee.schimke.composeai") }
+    }
+  }
+}
+
+rootProject.name = "compose-ai-contrib"
+
+include(":contract-tests:amper-cmp-desktop")
+project(":contract-tests:amper-cmp-desktop").projectDir =
+  file("contract-tests/amper-cmp-desktop")
+```
+
+## `gradle/libs.versions.toml`
+
+```toml
+[versions]
+# Pin to a release tag from yschimke/compose-ai-tools. Bump in lockstep with
+# upstream releases (release-please cuts a new tag for each merge, so the
+# version line moves in `compose-ai-tools/.release-please-manifest.json`).
+composeai = "0.11.0"
+kotlin = "2.3.21"
+junit = "4.13.2"
+truth = "1.4.5"
+
+[libraries]
+composeai-preview-discovery = { module = "ee.schimke.composeai:preview-discovery", version.ref = "composeai" }
+composeai-daemon-launch-builder = { module = "ee.schimke.composeai:daemon-launch-builder", version.ref = "composeai" }
+composeai-render-cli = { module = "ee.schimke.composeai:render-cli", version.ref = "composeai" }
+composeai-render-session-api = { module = "ee.schimke.composeai:render-session-api", version.ref = "composeai" }
+composeai-render-session-subprocess = { module = "ee.schimke.composeai:render-session-subprocess", version.ref = "composeai" }
+composeai-daemon-desktop = { module = "ee.schimke.composeai:daemon-desktop", version.ref = "composeai" }
+composeai-daemon-core = { module = "ee.schimke.composeai:daemon-core", version.ref = "composeai" }
+composeai-data-render-connector = { module = "ee.schimke.composeai:data-render-connector", version.ref = "composeai" }
+composeai-data-render-core = { module = "ee.schimke.composeai:data-render-core", version.ref = "composeai" }
+junit = { module = "junit:junit", version.ref = "junit" }
+truth = { module = "com.google.common.truth:truth", version.ref = "truth" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+```
+
+## `contract-tests/amper-cmp-desktop/build.gradle.kts`
+
+```kotlin
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // Builder + serializer for daemon-launch.json. The contract test assembles
+  // a descriptor from the resolved render-side classpath plus the lifted
+  // Amper fixture's `kotlin-output/`.
+  testImplementation(libs.composeai.daemon.launch.builder)
+  testImplementation(libs.composeai.render.session.subprocess)
+  testImplementation(libs.composeai.render.session.api)
+
+  // The render-side classpath the descriptor will reference. Surfaced into
+  // the test JVM as a system property so the test can substitute the
+  // user-classes path without re-resolving anything.
+  rendererRuntime(libs.composeai.daemon.desktop)
+  rendererRuntime(libs.composeai.daemon.core)
+  rendererRuntime(libs.composeai.data.render.connector)
+  rendererRuntime(libs.composeai.data.render.core)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+}
+
+val rendererRuntime by configurations.creating
+
+tasks.test {
+  // The renderer-side classpath in a single sysprop so the contract test
+  // doesn't have to know about Gradle's configurations API at runtime.
+  systemProperty(
+    "contrib.rendererClasspath",
+    rendererRuntime.asPath,
+  )
+  // Lifted Amper fixture lives at the repo root.
+  systemProperty(
+    "contrib.amperFixtureDir",
+    rootProject.layout.projectDirectory.dir("amper-cmp-desktop").asFile.absolutePath,
+  )
+}
+```
+
+## `contract-tests/amper-cmp-desktop/src/test/kotlin/.../AmperContractTest.kt` — sketch
+
+Lift from
+[`render-session/subprocess/src/test/.../AmperContractTest.kt`](https://github.com/yschimke/compose-ai-tools/blob/main/render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/AmperContractTest.kt)
+with three changes:
+
+1. Replace the `:samples:cmp:composePreviewDaemonStart`-derived classpath
+   discovery with `System.getProperty("contrib.rendererClasspath").split(":")`.
+2. Replace the hand-rolled `writeDescriptor(...)` JSON builder with
+   `DaemonLaunchBuilder.build(...)` + `DaemonLaunchBuilder.encode(descriptor)`.
+3. Read the fixture from `System.getProperty("contrib.amperFixtureDir")`
+   instead of walking up to a Gradle workspace root.
+
+The self-skip behaviour (no Amper outputs on disk → exit cleanly)
+stays — Amper outputs are produced by `./amper build` in the fixture
+dir, which CI runs via `.github/workflows/amper-android.yml`'s
+sibling.
+
+## `.github/workflows/contract-tests.yml` — sketch
+
+```yaml
+name: contract tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  amper-cmp-desktop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<sha>
+      - uses: actions/setup-java@<sha>
+        with: { distribution: temurin, java-version: 17 }
+
+      - name: Amper build (produces kotlin-output/ for the contract test)
+        working-directory: amper-cmp-desktop
+        env:
+          AMPER_JAVA_OPTIONS: >-
+            -ea -XX:+EnableDynamicAgentLoading
+            -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts
+            -Djavax.net.ssl.trustStorePassword=changeit
+        run: ./amper build
+
+      - name: Contract test
+        run: ./gradlew :contract-tests:amper-cmp-desktop:test --stacktrace
+```
+
+## Notes
+
+- **No `includeBuild`.** All deps via Maven Central. This is what makes
+  compose-ai-contrib a real "downstream consumer" — anything that
+  works here also works for a third-party adopter.
+- **Single-version pinning.** `composeai = "0.11.0"` in
+  `libs.versions.toml` is the only place to bump when consuming a
+  newer release. The renderer side and the library side are versioned
+  together.
+- **No render-cli dep in the contract test.** The test drives
+  `SubprocessRenderSessions` directly because that's the most direct
+  proof the published artifacts work end-to-end. A separate test (or
+  a `bazel build`-only smoke target) can exercise `render-cli`'s
+  `java -jar` path.

--- a/contrib/docs/amper.md
+++ b/contrib/docs/amper.md
@@ -1,0 +1,162 @@
+# Driving `compose-preview` from Amper
+
+[Amper](https://github.com/JetBrains/amper) — JetBrains' declarative
+build system with first-class Compose Multiplatform support — is the
+shortest non-Gradle path to rendering `@Preview` composables. The
+recipe below uses the three published `compose-preview` artifacts
+(extracted in Phase A — see
+[`ee.schimke.composeai:preview-discovery`](https://central.sonatype.com/artifact/ee.schimke.composeai/preview-discovery),
+[`:daemon-launch-builder`](https://central.sonatype.com/artifact/ee.schimke.composeai/daemon-launch-builder),
+[`:render-cli`](https://central.sonatype.com/artifact/ee.schimke.composeai/render-cli))
+plus a shell wrapper around `./amper build`. No Gradle, no AGP.
+
+## Minimal Compose Desktop fixture
+
+The Amper module itself is six lines —
+[`amper-cmp-desktop/module.yaml`](../amper-cmp-desktop/module.yaml)
+in this repo is the canonical example, cribbed from JetBrains' upstream:
+
+```yaml
+# module.yaml
+product: jvm/app
+
+dependencies:
+  - $compose.desktop.currentOs
+
+settings:
+  compose: enabled
+  jvm:
+    release: 17
+```
+
+`jvm.release: 17` is load-bearing — the `compose-preview` daemon runs
+on JDK 17 and refuses class files compiled against newer JDKs with
+`UnsupportedClassVersionError` (class version 65 ≠ 61). Amper's
+default is `jvm.release: 21`.
+
+`./amper build` produces:
+
+| Artifact | Path |
+| --- | --- |
+| Compiled classes | `build/artifacts/CompiledJvmArtifact/<module>jvm/kotlin-output/` |
+| Module jar | `build/tasks/_<module>_jarJvm/<module>-jvm.jar` |
+| Resolved runtime jars | `~/.cache/JetBrains/Amper/.m2.cache/<group>/<artifact>/<version>/` |
+
+## Three-step rendering pipeline
+
+```
+./amper build                              ← Amper produces compiled classes
+  ↓
+java -jar preview-discovery.jar            ← Phase A artifact #1
+  → previews.json
+  ↓
+java -jar daemon-launch-builder.jar        ← Phase A artifact #2
+  → daemon-launch.json
+  ↓
+java -jar render-cli.jar                   ← Phase A artifact #3
+  → PNGs on disk
+```
+
+### 1. Discover previews
+
+The published `ee.schimke.composeai:preview-discovery` jar scans
+Amper's compiled output and writes a conforming `previews.json`:
+
+```bash
+java -cp <preview-discovery-and-deps> \
+  ee.schimke.composeai.discovery.PreviewDiscoveryCli \
+  --classes build/artifacts/CompiledJvmArtifact/<module>jvm/kotlin-output \
+  --module <module> \
+  --variant desktop \
+  --project-directory . \
+  --out build/compose-previews/previews.json
+```
+
+`<preview-discovery-and-deps>` is the resolved classpath for the jar
+plus its transitives (`classgraph`, `asm`, `kotlinx-serialization`).
+A wrapper script that calls Coursier (or any other Maven resolver) to
+materialise that bag is the typical shape.
+
+### 2. Synthesise the daemon descriptor
+
+`daemon-launch-builder` takes the renderer-side classpath (resolved
+via Amper's m2 cache or a separate Coursier call) and emits
+`daemon-launch.json`:
+
+```bash
+java -cp <daemon-launch-builder-and-deps> \
+  ee.schimke.composeai.daemonlaunch.DaemonLaunchBuilderCli \
+  --module-path :amper-cmp-desktop \
+  --variant desktop \
+  --main-class ee.schimke.composeai.daemon.DaemonMain \
+  --classpath <renderer-jar>:<connector-jars>:<compose-desktop-runtime>:<user-classes> \
+  --jvm-arg -Xmx1024m \
+  --system-property composeai.daemon.protocolVersion=1 \
+  --system-property composeai.daemon.modulePath=:amper-cmp-desktop \
+  --system-property composeai.daemon.workspaceRoot=$(pwd) \
+  --system-property composeai.daemon.previewsJsonPath=$(pwd)/build/compose-previews/previews.json \
+  --system-property composeai.render.outputDir=$(pwd)/build/compose-previews/renders \
+  --working-directory $(pwd) \
+  --manifest-path $(pwd)/build/compose-previews/previews.json \
+  --out build/compose-previews/daemon-launch.json
+```
+
+The renderer-side jars are:
+
+- `ee.schimke.composeai:daemon-desktop:<v>` (or `daemon-android` for
+  Compose Android — needs Robolectric machinery; start with desktop).
+- `ee.schimke.composeai:data-render-connector:<v>` and `-core` per
+  data extension you want available.
+- `ee.schimke.composeai:daemon-core:<v>`.
+- The Compose runtime jars Amper already resolved.
+
+Classpath order is load-bearing: the renderer jar leads so its
+pinned-version classes win over consumer transitives.
+
+### 3. Render
+
+```bash
+java -cp <render-cli-and-deps> \
+  ee.schimke.composeai.render.cli.RenderCli \
+  --descriptor build/compose-previews/daemon-launch.json \
+  --workspace-root $(pwd) \
+  --previews GreetingKt.Greeting \
+  --timeout-seconds 60
+```
+
+Output on stdout: `GreetingKt.Greeting<TAB>/abs/path/Greeting.png`.
+
+## Sandbox / TLS-inspection environments
+
+In managed sandboxes with a TLS-inspection proxy, Amper's bundled Zulu
+JRE doesn't trust the proxy CA and Maven Central / Google Maven fetches
+fail with PKIX errors. Wire the system truststore explicitly:
+
+```bash
+export AMPER_JAVA_OPTIONS="-ea -XX:+EnableDynamicAgentLoading \
+  -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts \
+  -Djavax.net.ssl.trustStorePassword=changeit"
+```
+
+Harmless on a stock runner; necessary in TLS-inspecting environments.
+
+## Limitations
+
+- **Amper distribution.** Amper itself ships through
+  `packages.jetbrains.team` (not Maven Central — tracked as
+  [AMPER-471](https://youtrack.jetbrains.com/projects/AMPER/issues/AMPER-471));
+  CI needs that host allowlisted.
+- **Plugin model.** Amper 0.10 doesn't have first-class plugin support
+  yet. The shape above is "shell scripts invoking `java -jar`
+  between Amper task runs", not real Amper plugins. Revisit when
+  Amper ships plugins.
+- **Android rendering** needs the Android backend (`daemon-android`)
+  + Robolectric on the classpath — heavier; not covered here. Start
+  with Compose Desktop.
+
+## See also
+
+- The Amper Compose Desktop fixture: [`amper-cmp-desktop/`](../amper-cmp-desktop/)
+- The Amper Android fixture: [`amper-android/`](../amper-android/)
+- Contract spec (`daemon-launch.json` schema, classpath layering,
+  sysprops): [`yschimke/compose-ai-tools/docs/NON_GRADLE_INTEGRATION.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/NON_GRADLE_INTEGRATION.md)

--- a/contrib/docs/bazel.md
+++ b/contrib/docs/bazel.md
@@ -1,0 +1,210 @@
+# Driving `compose-preview` from Bazel
+
+Bazel rules for Compose live in third-party space (`rules_kotlin`'s
+`kt_compiler_plugin`). The recipe below uses the three published
+`compose-preview` artifacts (extracted in Phase A — see
+[`ee.schimke.composeai:preview-discovery`](https://central.sonatype.com/artifact/ee.schimke.composeai/preview-discovery),
+[`:daemon-launch-builder`](https://central.sonatype.com/artifact/ee.schimke.composeai/daemon-launch-builder),
+[`:render-cli`](https://central.sonatype.com/artifact/ee.schimke.composeai/render-cli))
+through `rules_jvm_external` and a small set of `genrule`s that chain
+the three `java -jar` invocations.
+
+## Two fixtures shipped here
+
+- [`bazel/`](../bazel/) — resources-only sample. Demonstrates the
+  `discover_resources` rule shape against an Android `res/` tree
+  cribbed from `compose-ai-tools/samples/android/`. No SDK toolchain
+  needed; runs on every Bazel CI runner.
+- [`bazel-apk/`](../bazel-apk/) — Compose APK target via `rules_kotlin`
+  + `rules_android` + `rules_jvm_external`. Known-fragile while
+  [`bazelbuild/rules_kotlin#1388`](https://github.com/bazelbuild/rules_kotlin/issues/1388)
+  is open; treat as scaffolding for when the toolchain unblocks.
+
+## Building the Compose target
+
+The structural shape that compiles cleanly today (Kotlin 2.x via
+`rules_kotlin` 2.x + the bundled `org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable`):
+
+```bazel
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("@rules_kotlin//kotlin:core.bzl", "kt_compiler_plugin")
+
+kt_compiler_plugin(
+    name = "compose_compiler_plugin",
+    id = "androidx.compose.compiler",
+    target_embedded_compiler = True,
+    deps = ["@maven//:org_jetbrains_kotlin_kotlin_compose_compiler_plugin_embeddable"],
+)
+
+kt_jvm_library(
+    name = "app",
+    srcs = glob(["src/**/*.kt"]),
+    plugins = [":compose_compiler_plugin"],
+    deps = [
+        "@maven//:org_jetbrains_compose_desktop_desktop_jvm_linux_x64",
+        "@maven//:org_jetbrains_compose_components_components_ui_tooling_preview_desktop",
+    ],
+)
+```
+
+`bazel-apk/` lays this out for the Android target; the Compose Desktop
+target is structurally identical minus the AGP machinery.
+
+## Three-step rendering pipeline
+
+```
+bazel build //:app                              ← rules_kotlin produces .jar
+  ↓
+genrule + java -jar preview-discovery.jar       ← Phase A artifact #1
+  → previews.json
+  ↓
+genrule + java -jar daemon-launch-builder.jar   ← Phase A artifact #2
+  → daemon-launch.json
+  ↓
+sh_test + java -jar render-cli.jar              ← Phase A artifact #3
+  → PNGs on disk
+```
+
+### 1. `MODULE.bazel` deps
+
+```bazel
+bazel_dep(name = "rules_jvm_external", version = "<latest>")
+bazel_dep(name = "rules_kotlin", version = "<latest>")
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.install(
+    artifacts = [
+        "ee.schimke.composeai:preview-discovery:<v>",
+        "ee.schimke.composeai:daemon-launch-builder:<v>",
+        "ee.schimke.composeai:render-cli:<v>",
+
+        # Renderer-side closure for the daemon descriptor's classpath:
+        "ee.schimke.composeai:daemon-desktop:<v>",
+        "ee.schimke.composeai:daemon-core:<v>",
+        "ee.schimke.composeai:data-render-connector:<v>",
+        "ee.schimke.composeai:data-render-core:<v>",
+        # ...other data extensions you want available
+    ],
+    repositories = ["https://repo1.maven.org/maven2"],
+)
+use_repo(maven, "maven")
+```
+
+### 2. `discover_previews` rule
+
+A `genrule` that invokes `PreviewDiscoveryCli` against `:app`'s
+compiled output:
+
+```bazel
+genrule(
+    name = "discover_previews",
+    srcs = [":app"],
+    outs = ["previews.json"],
+    tools = ["@maven//:ee_schimke_composeai_preview_discovery"],
+    cmd = """
+        java -cp $(rootpath @maven//:ee_schimke_composeai_preview_discovery):$$(echo $(rlocationpaths @maven//:ee_schimke_composeai_preview_discovery) | tr ' ' ':') \\
+            ee.schimke.composeai.discovery.PreviewDiscoveryCli \\
+            --classes $(rootpath :app) \\
+            --module //$(package_name):app \\
+            --variant desktop \\
+            --project-directory $(BINDIR) \\
+            --out $@
+    """,
+)
+```
+
+The exact classpath construction depends on how `rules_jvm_external`
+exposes transitives in your bazel version — the `@maven//:artifact`
+label resolves to all transitives by default; older versions need
+`exclude_transitive` flipping.
+
+### 3. `build_daemon_descriptor` rule
+
+```bazel
+genrule(
+    name = "daemon_descriptor",
+    srcs = [
+        ":app",
+        ":discover_previews",
+    ],
+    outs = ["daemon-launch.json"],
+    tools = ["@maven//:ee_schimke_composeai_daemon_launch_builder"],
+    cmd = """
+        # Renderer-side classpath: daemon-desktop + connectors + data-* cores,
+        # then the Compose Desktop runtime jars rules_kotlin pulled in for :app.
+        RENDERER_CP="$$(echo $(rlocationpaths @maven//:ee_schimke_composeai_daemon_desktop \\
+            @maven//:ee_schimke_composeai_daemon_core \\
+            @maven//:ee_schimke_composeai_data_render_connector \\
+            @maven//:ee_schimke_composeai_data_render_core) | tr ' ' ':')"
+        USER_CP="$(rootpath :app)"
+
+        java -cp $(rootpath @maven//:ee_schimke_composeai_daemon_launch_builder) \\
+            ee.schimke.composeai.daemonlaunch.DaemonLaunchBuilderCli \\
+            --module-path //$(package_name):app \\
+            --variant desktop \\
+            --main-class ee.schimke.composeai.daemon.DaemonMain \\
+            --classpath $$RENDERER_CP:$$USER_CP \\
+            --jvm-arg -Xmx1024m \\
+            --system-property composeai.daemon.protocolVersion=1 \\
+            --system-property composeai.daemon.modulePath=//$(package_name):app \\
+            --system-property composeai.daemon.previewsJsonPath=$(rootpath :discover_previews) \\
+            --system-property composeai.render.outputDir=$(@D)/renders \\
+            --working-directory $$(pwd) \\
+            --manifest-path $(rootpath :discover_previews) \\
+            --out $@
+    """,
+)
+```
+
+### 4. `render_previews` test
+
+A `sh_test` (or a custom rule) that invokes `RenderCli` and asserts
+each requested PNG exists:
+
+```bazel
+sh_test(
+    name = "render_previews_test",
+    srcs = ["render_previews_test.sh"],
+    data = [
+        ":daemon_descriptor",
+        ":discover_previews",
+        "@maven//:ee_schimke_composeai_render_cli",
+        # ... renderer-side closure that daemon-launch.json's classpath refers to
+    ],
+    args = ["$(rootpath :daemon_descriptor)"],
+)
+```
+
+Where `render_previews_test.sh` does:
+
+```bash
+java -cp $(<the classpath from your rules_jvm_external manifest>) \
+    ee.schimke.composeai.render.cli.RenderCli \
+    --descriptor "$1" \
+    --workspace-root "$PWD" \
+    --previews $PREVIEWS \
+    --timeout-seconds 60
+```
+
+## Limitations
+
+- **`rules_kotlin` + Compose compiler.** Kotlin 2.x via the bundled
+  `kotlin-compose-compiler-plugin-embeddable` works; the standalone
+  `androidx.compose.compiler:compiler` jar is broken on K2
+  ([`rules_kotlin#1388`](https://github.com/bazelbuild/rules_kotlin/issues/1388)).
+- **Android rendering.** The Android backend (`daemon-android`)
+  requires Robolectric + a working AGP-equivalent classpath. Driving
+  that from Bazel is doable but well off the beaten path. Start with
+  Compose Desktop above.
+- **Reference projects.** `Bencodes/bazel_jetpack_compose_example`
+  was the only public reference (now stale — Compose 1.2.0-beta02,
+  Kotlin 1.6.21, Bazel 5.1.1). Use it as a structural template;
+  expect to upgrade deps before the renderer can load classes
+  compiled against it.
+
+## See also
+
+- The Bazel resources sample: [`bazel/`](../bazel/)
+- The Bazel Compose APK sample: [`bazel-apk/`](../bazel-apk/)
+- Contract spec (`daemon-launch.json` schema, classpath layering,
+  sysprops): [`yschimke/compose-ai-tools/docs/NON_GRADLE_INTEGRATION.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/NON_GRADLE_INTEGRATION.md)

--- a/docs/NON_GRADLE_INTEGRATION.md
+++ b/docs/NON_GRADLE_INTEGRATION.md
@@ -11,8 +11,8 @@ The two contracts you implement against:
 
 | Artifact | Schema | Wire-stable | Producer |
 | --- | --- | --- | --- |
-| `daemon-launch.json` | [`DaemonClasspathDescriptor.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonClasspathDescriptor.kt) | `schemaVersion = 1` | You |
-| `previews.json` | [`PreviewData.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt) | `schema = "compose-previews/v1"` | You — by running ClassGraph or hand-authoring |
+| `daemon-launch.json` | [`DaemonClasspathDescriptor.kt`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonClasspathDescriptor.kt) (published as `ee.schimke.composeai:daemon-launch-builder`) | `schemaVersion = 1` | You — or [`DaemonLaunchBuilder`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilder.kt) / its `java -jar` CLI |
+| `previews.json` | [`PreviewData.kt`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt) (published as `ee.schimke.composeai:preview-discovery`) | `schema = "compose-previews/v1"` | You — or [`PreviewDiscovery`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt) / its `java -jar` CLI |
 
 The consumer of both is the daemon JVM (`daemon/desktop` or `daemon/android`),
 driven by `RenderSessionFactory.open(...)` from the
@@ -372,11 +372,6 @@ before the renderer can load classes compiled against it.
 
 ## Limitations and follow-ups
 
-- **Preview discovery library is gradle-coupled.** `DiscoverPreviewsTask`
-  uses `@TaskAction` and configuration-cache-safe inputs; the underlying
-  ClassGraph scan would be extracted to a standalone library, but that's
-  tracked separately. Until then, non-Gradle integrations either hand-author
-  `previews.json` or vendor a discovery tool.
 - **Renderer-android requires Robolectric.** Driving the Android renderer
   from Bazel needs a working Robolectric + AGP classpath inside Bazel —
   doable but well off the beaten path. Start with renderer-desktop.
@@ -388,11 +383,14 @@ before the renderer can load classes compiled against it.
 
 ## Reference
 
-- Descriptor schema source: [`DaemonClasspathDescriptor.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonClasspathDescriptor.kt)
+- Descriptor schema source: [`DaemonClasspathDescriptor.kt`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonClasspathDescriptor.kt) (published as `ee.schimke.composeai:daemon-launch-builder`)
 - Wire protocol: [`docs/daemon/PROTOCOL.md`](daemon/PROTOCOL.md)
 - Data products catalogue: [`docs/daemon/DATA-PRODUCTS.md`](daemon/DATA-PRODUCTS.md)
 - `RenderSession` API: [`render-session/api/.../RenderSession.kt`](../render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSession.kt)
-- Reference producer (the Gradle plugin's bootstrap task): [`DaemonBootstrapTask.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTask.kt)
+- Reference producer (the Gradle plugin's bootstrap task): [`DaemonBootstrapTask.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTask.kt) — now a thin adapter over `DaemonLaunchBuilder`
+- Standalone preview-discovery library + CLI: [`PreviewDiscovery.kt`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt) + [`PreviewDiscoveryCli.kt`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt)
+- Standalone daemon-launch-builder library + CLI: [`DaemonLaunchBuilder.kt`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilder.kt) + [`DaemonLaunchBuilderCli.kt`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilderCli.kt)
+- Render CLI driving `SubprocessRenderSessions`: [`RenderCli.kt`](../render-cli/src/main/kotlin/ee/schimke/composeai/render/cli/RenderCli.kt)
 - Sample Amper fixture: [`contrib/amper-cmp-desktop/`](../contrib/amper-cmp-desktop/)
 - Contract test demonstrating the recipe end-to-end: [`render-session/subprocess/src/test/.../NonGradleContractTest.kt`](../render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/NonGradleContractTest.kt)
 - Amper-driven end-to-end test against the fixture: [`render-session/subprocess/src/test/.../AmperContractTest.kt`](../render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/AmperContractTest.kt)


### PR DESCRIPTION
## Summary

Phase A of the contrib refactor is complete on main (#1299 / #1300 / #1305 / #1306 / #1307 / #1309 / #1310). This PR prepares **Phase B**: populate `contrib/` with everything the new `yschimke/compose-ai-contrib` repo needs so a single `cp -r contrib/* <new-repo>/` plus the Gradle scaffolding in `SETUP.md` gives a working setup.

### Added

- **`contrib/SETUP.md`** — concrete `settings.gradle.kts`, `gradle/libs.versions.toml`, and `contract-tests/amper-cmp-desktop/build.gradle.kts` to drop into the new repo. Also sketches the rewrite of `AmperContractTest` against Maven-Central-resolved artifacts (replacing the current `:samples:cmp`-coupled version).
- **`contrib/docs/amper.md`** + **`contrib/docs/bazel.md`** — worked examples updated to drive the Phase A artifacts (`preview-discovery`, `daemon-launch-builder`, `render-cli`) via `java -jar` rather than the previous "hand-author `previews.json`" guidance. Supersede the corresponding sub-sections of `docs/NON_GRADLE_INTEGRATION.md` (which will be slimmed in Phase C).
- **`contrib/.github/workflows/{amper-android.yml,bazel.yml}`** — copies with paths rewritten so they work in the new repo (`amper-android/` instead of `contrib/amper-android/`).

### Rewrote

- **`contrib/README.md`** from "first draft of the plan" to "Phase B shopping list" — Phase A status table, file-by-file lift map, and a concrete Phase B checklist for when the new repo gets created.

### Touched up in this repo as Phase A drift fixes

- **`docs/NON_GRADLE_INTEGRATION.md`** — descriptor table now points at the new `:daemon-launch-builder` module location + the published artifact. The "Limitations and follow-ups" section drops the "Preview discovery library is gradle-coupled" bullet now that `:preview-discovery` exists. Reference section adds links to the three new CLIs.

## What's deliberately NOT in this PR

- **No file moves out of compose-ai-tools.** Phase C (deleting `contrib/amper-*` / `bazel*` / lifted workflows / `AmperContractTest` + slimming `NON_GRADLE_INTEGRATION.md`) waits on compose-ai-contrib being operational; jumping to Phase C now would break the existing `amper-cmp-desktop` CI job and `AmperContractTest`'s fixture path.
- **No code in `contrib/contract-tests/`.** The rewrite is sketched in `SETUP.md` but the buildable version belongs in the new repo where it can actually test against Maven Central artifacts. Authoring speculatively here risks divergence from whatever shape the new repo's settings end up taking.

## Harness scope note

This session can only push to `yschimke/compose-ai-tools`. Creating `yschimke/compose-ai-contrib` and the actual `cp -r` step needs an out-of-session action by the human (or a session with broader repo scope).

## Test plan

- [x] `git diff --stat` shows only docs/blueprint additions; no source code, no Gradle config changes for the outer build
- [x] No interference with the outer build — `contrib/SETUP.md` describes a Gradle setup for the new repo, but no `settings.gradle.kts` / `build.gradle.kts` files in `contrib/` itself
- [x] Lifted workflow YAML files compile syntactically (same shape as `.github/workflows/*.yml` originals minus path rewrites)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fea3X5qLi4qZfX12fYFKuS)_