### PR TITLE
feat(daemon-desktop): advertise touch-overlay + keyboard-band data-extension descriptors

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
 import ee.schimke.composeai.daemon.history.HistoryPruneConfig
 import ee.schimke.composeai.data.render.RenderPreviewExtension
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import java.io.File
 import java.io.InputStream
@@ -569,10 +570,22 @@ internal fun buildDesktopExtensions(
     // `keyboardController.show()` / focused `BasicTextField` raises the band naturally;
     // `renderNow.overrides.keyboard` and `interactive/input` `KEY_*` dispatches also feed the
     // same `KeyboardController`.
+    //
+    // [dataExtensionDescriptors] advertises the connector's `KeyboardOverrideExtension.ID` so the
+    // panel / MCP can discover it via `initialize.capabilities.dataExtensions` and gate the
+    // per-card "force soft-keyboard band" toggle on the daemon actually shipping the extension —
+    // rather than the current broad "any interactive backend" gate.
     Extension(
       id = "data/keyboard",
       displayName = "Soft keyboard overlay",
       previewOverrideExtensions = listOf(KeyboardPreviewOverrideExtension()),
+      dataExtensionDescriptors =
+        listOf(
+          DataExtensionDescriptor(
+            id = KeyboardOverrideExtension.ID,
+            displayName = "Soft keyboard overlay",
+          )
+        ),
     )
   }
   tryAdd("data/pseudolocale") {
@@ -594,10 +607,21 @@ internal fun buildDesktopExtensions(
     // unchanged. Lives in `:daemon:desktop` for now since this is the first backend with live
     // mode; a future `data/touch-overlay/connector/` module will host the planner so Android picks
     // it up automatically when live mode lands on Robolectric.
+    //
+    // [dataExtensionDescriptors] advertises `TouchOverlayExtension.ID` so the panel / MCP can
+    // discover the extension via `initialize.capabilities.dataExtensions` and gate the per-card
+    // "touch overlay" toggle on the daemon actually shipping it (today: desktop only).
     Extension(
       id = "data/touch-overlay",
       displayName = "Touch event overlay",
       previewOverrideExtensions = listOf(TouchOverlayPreviewOverrideExtension()),
+      dataExtensionDescriptors =
+        listOf(
+          DataExtensionDescriptor(
+            id = TouchOverlayExtension.ID,
+            displayName = "Touch event overlay",
+          )
+        ),
     )
   }
   tryAdd("data/recomposition") {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/BuildDesktopExtensionsTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/BuildDesktopExtensionsTest.kt
@@ -116,6 +116,40 @@ class BuildDesktopExtensionsTest {
   }
 
   @Test
+  fun touch_overlay_and_keyboard_band_advertise_data_extension_descriptors() {
+    // The override-driven extensions (`data/touch-overlay` + `data/keyboard`) carry a
+    // `DataExtensionDescriptor` so GUI clients (panel, MCP) can discover them via
+    // `initialize.capabilities.dataExtensions` and gate per-card toggle UI on the daemon
+    // actually shipping the matching planner. Without descriptors the capability list is empty
+    // and clients fall back to hardcoded knowledge of the field names.
+    val extensions =
+      buildDesktopExtensions(
+        previewIndex = PreviewIndex.empty(),
+        recompositionRegistry = RecompositionDataProductRegistry(),
+        themeRegistry = ThemeDataProductRegistry(),
+        wallpaperRegistry = WallpaperDataProductRegistry(),
+        historyManager = null,
+        dataRoot = null,
+        composeTraceEnabled = false,
+        displayFilterEnabled = false,
+      )
+    val touch = extensions.single { it.id == "data/touch-overlay" }
+    val touchDescriptorIds = touch.dataExtensionDescriptors.map { it.id.value }
+    assertTrue(
+      "data/touch-overlay must advertise its DataExtensionDescriptor so the panel can " +
+        "discover the toggle; got $touchDescriptorIds",
+      TouchOverlayExtension.ID.value in touchDescriptorIds,
+    )
+    val keyboard = extensions.single { it.id == "data/keyboard" }
+    val keyboardDescriptorIds = keyboard.dataExtensionDescriptors.map { it.id.value }
+    assertTrue(
+      "data/keyboard must advertise its DataExtensionDescriptor so the panel can " +
+        "discover the toggle; got $keyboardDescriptorIds",
+      KeyboardOverrideExtension.ID.value in keyboardDescriptorIds,
+    )
+  }
+
+  @Test
   fun android_only_kinds_stay_unadvertised_on_desktop() {
     val dataRoot = tempFolder.newFolder("data")
     val ids = build(dataRoot = dataRoot, composeTraceEnabled = true, displayFilterEnabled = true)


### PR DESCRIPTION
## Summary

- `data/touch-overlay` and `data/keyboard` ship preview-override extensions but were registered in `DaemonMain.kt` without `DataExtensionDescriptor` entries — `initialize.capabilities.dataExtensions` was empty for both, forcing GUI clients (the per-card toggle buttons in #1308, MCP, future tools) to hardcode field names instead of discovering them through the capability surface.
- Adds minimal descriptors keyed off the canonical planner ids (`TouchOverlayExtension.ID` = `touch-overlay`, `KeyboardOverrideExtension.ID` = `compose/keyboard`). `recordingScriptEvents` stays empty and `requiresInteractive = false` — both extensions work in recording and live mode so the panel needn't auto-enter live on toggle.
- Unblocks tightening the per-card toggle visibility in the panel — buttons can now gate on the matching id being in the daemon's `dataExtensions` set instead of the current broad "any interactive backend" check.

## Test plan

- [x] New `BuildDesktopExtensionsTest.touch_overlay_and_keyboard_band_advertise_data_extension_descriptors` asserts both descriptors flow through `buildDesktopExtensions`.
- [x] `:daemon:desktop:test` passes (the unrelated `RecompositionDataProductRegistryTest` flake reproduces on a pristine `origin/main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HargtVaPJDmRRTfPdaEw3a)_