### PR TITLE
feat(daemon-android): route PreviewOverrides through interactive acquire

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -810,9 +810,6 @@ open class RobolectricHost(
     onSessionClosed: (() -> Unit)?,
     overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides?,
   ): InteractiveSession {
-    // overrides ignored — Android host doesn't route PreviewOverrides through interactive setup
-    // today. Accepting the param keeps the interface contract honoured and leaves a single-line
-    // change point for when the Android-side touch-overlay extension lands.
     if (sandboxCount < 2) {
       throw UnsupportedOperationException(
         "RobolectricHost: interactive sessions require sandboxCount >= 2 " +
@@ -826,15 +823,23 @@ open class RobolectricHost(
           "RobolectricHost has no previewSpecResolver; pass one at construction time to enable " +
             "v3 interactive sessions"
         )
-    val spec =
+    val baseSpec =
       resolver(previewId)
         ?: throw UnsupportedOperationException(
           "RobolectricHost.previewSpecResolver returned null for previewId='$previewId'; " +
             "interactive session not allocated"
         )
+    // Apply the same override-merge pass recording uses (PR #1304 lit the symmetric path on
+    // desktop, #1313 brought the data/touch-overlay planner to Robolectric, this completes the
+    // story for Android). `touchOverlay = true` here installs the `TouchOverlayExtension`
+    // `AroundComposable` against the held composition so an external panel driving multi-touch
+    // via `interactive/input` sees the visualization rings on streamed frames. `outputBaseName`
+    // is a recording-only field but `applyOverrides` reuses the same merge path; tagging it
+    // `interactive-$previewId` keeps the trace-friendly naming without affecting behaviour.
+    val effectiveSpec = applyOverrides(baseSpec, overrides, "interactive-$previewId")
     return acquireInteractiveSession(
       previewId = previewId,
-      spec = spec,
+      spec = effectiveSpec,
       inspectionMode = inspectionMode,
       onSessionClosed = onSessionClosed,
     )
@@ -1025,7 +1030,7 @@ open class RobolectricHost(
           "RobolectricHost.previewSpecResolver returned null for previewId='$previewId'; " +
             "recording session not allocated"
         )
-    val effectiveSpec = applyRecordingOverrides(baseSpec, overrides, recordingId)
+    val effectiveSpec = applyOverrides(baseSpec, overrides, recordingId)
     val interactive =
       acquireInteractiveSession(
         previewId = previewId,
@@ -1059,10 +1064,21 @@ open class RobolectricHost(
     )
   }
 
-  private fun applyRecordingOverrides(
+  /**
+   * Merge [overrides] over [base]'s preview-spec fields, producing the effective `RenderSpec` that
+   * `engine.setUp` (and the interactive bridge) consume. Mirrors `DesktopHost.applyOverrides` —
+   * called from both [acquireRecordingSession] and [acquireInteractiveSession] (#1304/#1313/this
+   * PR brought the call sites into symmetry).
+   *
+   * [sessionId] tags the output base name. Recording sessions pass the recording id (used by the
+   * recording surface to scope frame paths); interactive sessions pass `"interactive-$previewId"`
+   * — the field is recording-only on the wire but reusing the same merge path keeps the override
+   * application byte-identical between the two acquire paths.
+   */
+  private fun applyOverrides(
     base: RenderSpec,
     overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides?,
-    recordingId: String,
+    sessionId: String,
   ): RenderSpec {
     val merged =
       mergePreviewOverrides(
@@ -1120,7 +1136,10 @@ open class RobolectricHost(
         },
       inspectionMode = merged.inspectionMode,
       overrides = merged.toExtensionOverrides(),
-      outputBaseName = "recording-$recordingId",
+      // Recording sessions consume this on disk (`recordings/<recordingId>/...`); interactive
+      // sessions pass `"interactive-$previewId"` and never read the field. The `recording-`
+      // prefix is preserved for byte-compat with existing recording-test expectations.
+      outputBaseName = "recording-$sessionId",
     )
   }
 


### PR DESCRIPTION
## Summary

- `RobolectricHost.acquireInteractiveSession` has accepted an `overrides` parameter since #1304 but silently ignored it — the inline comment even spelled that out. With #1313 having brought `TouchOverlayPreviewOverrideExtension` into Robolectric's `previewOverrideExtensions` list, the planner was wired but the override flag never reached it on the interactive path; only recording sessions (via `applyRecordingOverrides`) actually flipped the touch overlay on.
- An external panel calling `interactive/start` against the Android backend with `overrides.touchOverlay = true` would get standard frames back with no visualization, despite the toggle being exposed in the panel UI (#1308) and the Android backend advertising the descriptor (#1313).

## Change

- Rename the existing private `applyRecordingOverrides` → `applyOverrides` (call sites in both `acquireRecordingSession` and the public `acquireInteractiveSession`).
- The renamed function takes the session id as a generic parameter — recording passes the recording id (used by the recording surface to scope on-disk frame paths); interactive passes `"interactive-$previewId"` (`outputBaseName` is unused on the interactive path but reusing the same merge keeps the call sites symmetric).
- Mirrors `DesktopHost`'s shape, which has worked this way since #1304.
- Recording's `outputBaseName = "recording-$sessionId"` prefix is preserved so existing recording test expectations don't drift.

## Test plan

- [x] `AndroidRecordingSessionTest` — 27 tests, 0 failures (the recording path that previously called `applyRecordingOverrides` still works).
- [x] `:daemon:android:compileDebugUnitTestKotlin` clean.
- [ ] End-to-end cyan-pixel verification on interactive Android (mirroring desktop's `InteractiveTouchOverlayTest`) is **deferred**. The held-rule loop's `pointerDown` case at `RobolectricHost.kt:2394-2396` performs `performTouchInput { down(position) }` without advancing `mainClock` — only the `click` case advances, between its synthesised down/move/up. The press is therefore queued but not flushed before the externally-rendered frame captures, so the touch overlay observer doesn't see the down in time to paint the cyan ring. Fix is a separate concern from the override plumbing; tracking as a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HargtVaPJDmRRTfPdaEw3a)_