### PR TITLE
docs(contrib): finish Phase C cutover — slim README + NON_GRADLE_INTEGRATION

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,108 +1,20 @@
-# Lifting `contrib/` to `yschimke/compose-ai-contrib`
+# `contrib/` — moved to [`yschimke/compose-ai-contrib`](https://github.com/yschimke/compose-ai-contrib)
 
-This directory is the staging area for [`yschimke/compose-ai-contrib`](https://github.com/yschimke/compose-ai-contrib)
-— the planned dedicated repo for non-Gradle integrations of
-`compose-preview`. **Phase A (extracting the publishable hooks) is
-complete on `yschimke/compose-ai-tools:main`.** This file is the
-shopping list for **Phase B**: create the new repo and drop in
-everything from `contrib/`.
+All non-Gradle integration code (Amper / Bazel fixtures, worked-example
+docs, opt-in CI) lives in the dedicated
+[`yschimke/compose-ai-contrib`](https://github.com/yschimke/compose-ai-contrib)
+repo. The toolchain itself stays here — `compose-ai-contrib` consumes
+the published Maven Central artifacts:
 
-## Status
+- `ee.schimke.composeai:preview-discovery` — ClassGraph scan + `previews.json` builder. Has a `java -jar` CLI ([`PreviewDiscoveryCli`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt)).
+- `ee.schimke.composeai:daemon-launch-builder` — typed `daemon-launch.json` builder + CLI ([`DaemonLaunchBuilderCli`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilderCli.kt)).
+- `ee.schimke.composeai:render-cli` — thin CLI over [`SubprocessRenderSessions`](../render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt).
 
-| Phase | What | State |
-| --- | --- | --- |
-| A1 | `:preview-discovery` (schema + scan + CLI) | **done** — `ee.schimke.composeai:preview-discovery` on Maven Central |
-| A2 | `:daemon-launch-builder` (descriptor + builder + CLI) | **done** — `ee.schimke.composeai:daemon-launch-builder` |
-| A3 | `:render-cli` (CLI over render-session-subprocess) | **done** — `ee.schimke.composeai:render-cli` |
-| B  | Bootstrap `yschimke/compose-ai-contrib` consuming the artifacts above | **this file — pending repo creation** |
-| C  | Delete `contrib/`, lifted workflows, and worked-example sub-sections from this repo | **waiting on B** |
+The wire-stable contract (`daemon-launch.json` + `previews.json`
+schemas, classpath layering, system properties) is documented in
+[`docs/NON_GRADLE_INTEGRATION.md`](../docs/NON_GRADLE_INTEGRATION.md).
+That file stays here — it's the published interface and belongs with
+the published artifacts.
 
-## What to lift
-
-When `yschimke/compose-ai-contrib` is created, copy these files
-verbatim — the new repo's tree mirrors this directory exactly:
-
-```
-contrib/                      compose-ai-contrib/
-├── amper-android/        ─►  amper-android/
-├── amper-cmp-desktop/    ─►  amper-cmp-desktop/
-├── bazel/                ─►  bazel/
-├── bazel-apk/            ─►  bazel-apk/
-├── docs/                 ─►  docs/
-│   ├── amper.md          ─►    amper.md
-│   └── bazel.md          ─►    bazel.md
-├── .github/              ─►  .github/
-│   └── workflows/        ─►    workflows/
-│       ├── amper-android.yml  amper-android.yml
-│       └── bazel.yml          bazel.yml
-└── SETUP.md              ─►  README.md  (or merge into project README)
-```
-
-Then create the repo's Gradle root from [`SETUP.md`](SETUP.md) — the
-file documents the exact `settings.gradle.kts` / `build.gradle.kts` /
-`gradle/libs.versions.toml` to drop in.
-
-## Phase A — what got extracted
-
-The three published artifacts a non-Gradle build system needs:
-
-| Artifact | Coords | What it does |
-| --- | --- | --- |
-| `preview-discovery` | `ee.schimke.composeai:preview-discovery:<v>` | ClassGraph scan over compiled classes; writes `previews.json`. Has both a Kotlin API and a `java -jar` CLI (`ee.schimke.composeai.discovery.PreviewDiscoveryCli`). |
-| `daemon-launch-builder` | `ee.schimke.composeai:daemon-launch-builder:<v>` | Typed builder + serializer for `daemon-launch.json`. Kotlin API + CLI (`ee.schimke.composeai.daemonlaunch.DaemonLaunchBuilderCli`). |
-| `render-cli` | `ee.schimke.composeai:render-cli:<v>` | Thin CLI over `SubprocessRenderSessions` — drives the daemon JVM and prints rendered PNG paths. Main class `ee.schimke.composeai.render.cli.RenderCli`. |
-
-A Bazel rule or Amper task chains these three jars:
-
-```
-discover → previews.json   (preview-discovery)
-build descriptor → daemon-launch.json   (daemon-launch-builder, takes resolved jars + sysprops)
-render → PNGs   (render-cli, reads both files above)
-```
-
-No Gradle. No AGP. Just three published Maven artifacts and a JDK.
-
-## Phase B checklist (do once the repo exists)
-
-- [ ] Create `yschimke/compose-ai-contrib` (public, empty).
-- [ ] `cp -r contrib/* <new-repo>/` (everything except this file —
-      `contrib/README.md` is the migration plan, not consumer docs).
-- [ ] Apply the Gradle scaffolding from [`SETUP.md`](SETUP.md).
-- [ ] Bootstrap CI: enable Actions, the lifted `amper-android.yml` /
-      `bazel.yml` start running on push automatically.
-- [ ] Open a PR back into this repo doing Phase C (delete the staged
-      content here once compose-ai-contrib is operational).
-
-## Phase C — what gets deleted from this repo
-
-After Phase B succeeds:
-
-- `contrib/amper-android/` / `amper-cmp-desktop/` / `bazel/` / `bazel-apk/`
-- `.github/workflows/amper-android.yml` / `bazel.yml`
-- `render-session/subprocess/src/test/.../AmperContractTest.kt`
-  (replaced by a Maven-Central-consuming equivalent in compose-ai-contrib)
-- The "Worked example: JetBrains Amper" and "Worked example: Bazel"
-  sub-sections of [`docs/NON_GRADLE_INTEGRATION.md`](../docs/NON_GRADLE_INTEGRATION.md);
-  replace with a one-line link to compose-ai-contrib's `docs/`.
-
-The contract sections of `NON_GRADLE_INTEGRATION.md` (the
-`daemon-launch.json` schema spec, classpath layering, sysprops) stay
-here — those are the published interface and belong with the published
-artifacts.
-
-## Decisions locked in earlier
-
-These were captured in this file's first draft (Phase A1 era) and
-remain in force:
-
-1. **`preview-discovery` ships library + CLI main.**
-2. **`daemon-launch-builder` is generic — "assemble a descriptor" only.**
-   Android-specific classpath layering (`AndroidPreviewClasspath`'s AGP
-   `artifactView` resolution, R.jar appending, the
-   Robolectric-on-JDK-17 `--add-opens` set) stays in `:gradle-plugin`.
-3. **Amper integration is shell-scripts-invoking-`java -jar`, not
-   plugins.** Amper 0.10's extension model isn't there yet
-   ([AMPER-471](https://youtrack.jetbrains.com/projects/AMPER/issues/AMPER-471))
-   and waiting for it blocks adoption.
-4. **Separate `:render-cli`, not `DaemonMain --render-once`.** Keeps
-   the daemon JSON-RPC-only.
+The migration history (Phase A extraction PRs, Phase B blueprint,
+Phase C cutover) is recoverable from `git log -- contrib/`.

--- a/docs/NON_GRADLE_INTEGRATION.md
+++ b/docs/NON_GRADLE_INTEGRATION.md
@@ -268,107 +268,15 @@ The renderer re-renders automatically when an extension is marked
 `requiresRerender = true` (a11y is). See [`DATA-PRODUCTS.md`](daemon/DATA-PRODUCTS.md)
 for the full kind catalogue.
 
-## Worked example: JetBrains Amper
+## Worked examples
 
-[Amper](https://github.com/JetBrains/amper) is the obvious non-Gradle
-target — first-class Compose Multiplatform support, declarative
-`module.yaml` config, JetBrains-maintained. The minimal Compose Desktop
-fixture is six lines:
-
-```yaml
-# module.yaml
-product: jvm/app
-
-dependencies:
-  - $compose.desktop.currentOs
-
-settings:
-  compose: enabled
-```
-
-The integration:
-
-1. **Build** — `./amper build`. Amper writes compiled classes under
-   `<module>/build/tasks/_<module>_jvmRuntimeClasspath/<...>` (or similar
-   depending on Amper version) and resolves runtime dependencies to its
-   own Maven cache.
-2. **Resolve the renderer + connector classpath** — pull
-   `ee.schimke.composeai:daemon-desktop`, `data-render-connector`,
-   `data-render-core`, `daemon-core` (and any additional extensions) into
-   a separate dependency block. With Amper 0.10+ this is one extra
-   dependency line per artifact in `module.yaml`.
-3. **Discover previews** — run ClassGraph against
-   `<module>/build/.../classes/main` and write `previews.json`. A
-   standalone Kotlin tool (~50 LOC) is enough; see
-   [`contrib/amper-cmp-desktop/`](../contrib/amper-cmp-desktop/) for the
-   shape.
-4. **Synthesise the descriptor** — emit `daemon-launch.json` from the
-   resolved classpath + the user-classes path. See the same sample for
-   the full template.
-5. **Render** — call `SubprocessRenderSessions.open(config)` and drive
-   `renderNow`.
-
-Amper currently distributes itself through `packages.jetbrains.team`
-(not Maven Central — tracked as
-[AMPER-471](https://youtrack.jetbrains.com/projects/AMPER/issues/AMPER-471));
-end-to-end CI for the Amper path needs that host allowlisted.
-
-The fixture at [`contrib/amper-cmp-desktop/`](../contrib/amper-cmp-desktop/)
-vendors the Amper wrapper. `module.yaml` pins `jvm.release: 17` because
-the daemon JVM runs on JDK 17 — Amper's default `jvm.release: 21` produces
-class files the JDK-17 daemon refuses to load (`UnsupportedClassVersionError`,
-class version 65 ≠ 61). In a managed sandbox with a TLS-inspection proxy,
-Amper's auto-downloaded Zulu JRE additionally needs the system truststore
-wired via `AMPER_JAVA_OPTIONS`; the fixture's README documents the
-incantation.
-
-End-to-end is proven by
-[`AmperContractTest`](../render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/AmperContractTest.kt):
-once `./amper build` has run, the test consumes Amper's `kotlin-output/`
-directly and renders a real PNG through the same daemon pipeline the
-Gradle plugin uses.
-
-## Worked example: Bazel
-
-Bazel rules for Compose live in third-party space (`rules_kotlin`'s
-`kt_compiler_plugin`). The cleanest shape:
-
-```bazel
-load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
-load("@rules_kotlin//kotlin:core.bzl", "kt_compiler_plugin")
-
-kt_compiler_plugin(
-    name = "compose_compiler_plugin",
-    id = "androidx.compose.compiler",
-    target_embedded_compiler = True,
-    deps = ["@maven//:org_jetbrains_compose_compiler_compiler"],
-)
-
-kt_jvm_library(
-    name = "app",
-    srcs = glob(["src/**/*.kt"]),
-    plugins = [":compose_compiler_plugin"],
-    deps = [
-        "@maven//:org_jetbrains_compose_desktop_desktop_jvm_linux_x64",
-        "@maven//:org_jetbrains_compose_components_components_ui_tooling_preview_desktop",
-    ],
-)
-```
-
-From here a `compose_preview_render` Bazel rule:
-
-1. `runtime_jars` provider on `:app` gives the resolved runtime classpath.
-2. A `cc_binary`-style action runs the preview discovery (ClassGraph
-   against `:app`'s `.jar` outputs).
-3. Another action synthesises `daemon-launch.json` from the resolved
-   jars + the renderer-desktop dependency.
-4. A test target invokes `SubprocessRenderSessions.open(descriptor)` and
-   asserts the PNG outputs land.
-
-`Bencodes/bazel_jetpack_compose_example` is the only public reference
-Bazel+Compose project (stale; Compose 1.2.0-beta02, Kotlin 1.6.21, Bazel
-5.1.1). Use it as a structural template; expect to upgrade dependencies
-before the renderer can load classes compiled against it.
+Build-system-specific recipes (JetBrains Amper, Bazel) live in
+[`yschimke/compose-ai-contrib`](https://github.com/yschimke/compose-ai-contrib),
+the dedicated repo for non-Gradle integrations. The recipes there
+drive the published `ee.schimke.composeai:preview-discovery` +
+`:daemon-launch-builder` + `:render-cli` artifacts through
+`java -jar` from a build-system-native rule. This document is the
+contract spec the recipes implement against.
 
 ## Limitations and follow-ups
 
@@ -391,6 +299,5 @@ before the renderer can load classes compiled against it.
 - Standalone preview-discovery library + CLI: [`PreviewDiscovery.kt`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt) + [`PreviewDiscoveryCli.kt`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt)
 - Standalone daemon-launch-builder library + CLI: [`DaemonLaunchBuilder.kt`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilder.kt) + [`DaemonLaunchBuilderCli.kt`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilderCli.kt)
 - Render CLI driving `SubprocessRenderSessions`: [`RenderCli.kt`](../render-cli/src/main/kotlin/ee/schimke/composeai/render/cli/RenderCli.kt)
-- Sample Amper fixture: [`contrib/amper-cmp-desktop/`](../contrib/amper-cmp-desktop/)
 - Contract test demonstrating the recipe end-to-end: [`render-session/subprocess/src/test/.../NonGradleContractTest.kt`](../render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/NonGradleContractTest.kt)
-- Amper-driven end-to-end test against the fixture: [`render-session/subprocess/src/test/.../AmperContractTest.kt`](../render-session/subprocess/src/test/kotlin/ee/schimke/composeai/render/session/subprocess/AmperContractTest.kt)
+- Build-system-specific fixtures + end-to-end tests: [`yschimke/compose-ai-contrib`](https://github.com/yschimke/compose-ai-contrib)


### PR DESCRIPTION
## Summary

Finishes Phase C — #1318 shipped the file deletes (sample dirs, workflows, `AmperContractTest`) but skipped two textual rewrites because they were `Write`/`Edit`-staged in the working tree rather than `git add`-ed before the `git commit` call. The PR went out with the deletes only and left `contrib/README.md` + `docs/NON_GRADLE_INTEGRATION.md` at their stale Phase B blueprint content on main.

Catching it up:

- **`contrib/README.md`** — replaced the Phase B blueprint (108 lines: status table, lift map, Phase B checklist, Phase C plan, decisions index) with a 21-line pointer at `yschimke/compose-ai-contrib`. The migration history stays recoverable via `git log -- contrib/`.
- **`docs/NON_GRADLE_INTEGRATION.md`** — dropped the two ~50-line "Worked example: JetBrains Amper" + "Worked example: Bazel" sub-sections; replaced with a four-sentence "Worked examples" pointer to compose-ai-contrib. Also dropped the now-dangling `AmperContractTest` reference and the staged `contrib/amper-cmp-desktop/` fixture link from the Reference section.

The contract spec (`daemon-launch.json` schema, classpath layering, sysprops) stays — that's the published interface and belongs with the published artifacts.

## Test plan

- [x] `git status --short` clean after the commit
- [x] `grep -n "AmperContractTest\|contrib/amper\|contrib/bazel" docs/NON_GRADLE_INTEGRATION.md` returns nothing
- [x] Net delta: 2 files changed, +29 / −210 lines


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fea3X5qLi4qZfX12fYFKuS)_