### PR TITLE
fix(daemon-android): wrap held composition with previewOverrideExtensions chain

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -121,7 +121,12 @@ class RenderEngine(
    * registered planner inspects the merged [PreviewOverrides] and contributes its own
    * `AroundComposable` (or other) hook when its override applies.
    */
-  private val previewOverrideExtensions: PreviewOverrideExtensions =
+  // `internal` so `RobolectricHost.SandboxRunner.runHeldInteractiveSession` (same module) can
+  // read it when wrapping `InvokeHeldComposable` with the planner output — interactive sessions
+  // bypass the public `render(...)` path that the non-held / recording paths use, but still need
+  // the same `AroundComposable` chain (canonical case: touch-overlay rings). Stays effectively
+  // private outside `:daemon:android`.
+  internal val previewOverrideExtensions: PreviewOverrideExtensions =
     PreviewOverrideExtensions.Empty,
   /**
    * Always-on data extensions (fonts, resources, i18n) that own their recorder + post-capture

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -20,6 +20,8 @@ import ee.schimke.composeai.data.render.PreviewDeviceContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
 import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
+import ee.schimke.composeai.data.render.extensions.compose.ComposeDataExtensionPipeline
+import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionCompositionSink
 import ee.schimke.composeai.data.theme.ResolvedThemeTokens
 import ee.schimke.composeai.data.theme.ThemePayload
 import ee.schimke.composeai.data.theme.TypographyToken
@@ -902,6 +904,12 @@ open class RobolectricHost(
             null -> null
           },
         inspectionMode = inspectionMode,
+        // Decomposed `spec.overrides.touchOverlay` so the held-rule loop can wrap
+        // `InvokeHeldComposable` with the touch-overlay planner output. Other override fields
+        // stay on the host side; only the ones planners actually read on the interactive path
+        // get threaded across the sandbox boundary (see the field's doc on
+        // `InteractiveCommand.Start`).
+        touchOverlay = spec.overrides?.touchOverlay,
       )
     )
     if (!replyLatch.await(INTERACTIVE_START_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
@@ -1845,7 +1853,33 @@ open class RobolectricHost(
                       androidx.compose.foundation.layout.Box(
                         modifier = androidx.compose.ui.Modifier.fillMaxSize()
                       ) {
-                        InvokeHeldComposable(composableMethod)
+                        // Wrap with the same `previewOverrideExtensions` chain the non-held
+                        // render path uses (see `RenderEngine.kt:302-309`) so interactive
+                        // sessions get `TouchOverlayExtension` + any other AroundComposable
+                        // override extensions whose planner emits. Without this wrap, the
+                        // extensions registered on the engine never reach the held composition
+                        // — they're consulted only inside `RenderEngine.render`'s composition
+                        // setup, which the held-rule `setContent` bypasses.
+                        //
+                        // The reconstructed `PreviewOverrides(touchOverlay = …)` carries only
+                        // the fields whose planners are exercised on the interactive path
+                        // today; other override-driven planners ride along because their
+                        // `plan(request)` returns an extension regardless of input (e.g. the
+                        // always-active keyboard band). See `InteractiveCommand.Start.touchOverlay`
+                        // for the cross-boundary-threading rationale.
+                        val syntheticOverrides =
+                          ee.schimke.composeai.daemon.protocol.PreviewOverrides(
+                            touchOverlay = start.touchOverlay
+                          )
+                        ComposeDataExtensionPipeline.Apply(
+                          extensions =
+                            engine.previewOverrideExtensions.plan(syntheticOverrides),
+                          previewId = null,
+                          renderMode = null,
+                          sink = RecordingExtensionCompositionSink(),
+                        ) {
+                          InvokeHeldComposable(composableMethod)
+                        }
                       }
                     }
                   }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -406,6 +406,17 @@ sealed interface InteractiveCommand {
     val orientation: String? = null,
     /** Held-session `LocalInspectionMode`; `null` preserves the runtime-like default (`false`). */
     val inspectionMode: Boolean? = null,
+    /**
+     * Decomposed `spec.overrides.touchOverlay`. When `true`, the held-rule loop wraps
+     * `InvokeHeldComposable` with the planner output that includes `TouchOverlayExtension`, so a
+     * panel-driven `interactive/input` with multi-touch dispatch paints the visualization rings
+     * on the streamed frames. Threaded as a primitive (not the full `PreviewOverrides` bag)
+     * because the protocol's nested types live in the instrumented daemon package and don't
+     * cross the sandbox classloader boundary cleanly — same decomposition pattern the other
+     * `spec.*` qualifier fields above use. Other planner-relevant fields (keyboard,
+     * material3Theme, …) can be added the same way when their interactive use cases need them.
+     */
+    val touchOverlay: Boolean? = null,
   ) : InteractiveCommand
 
   /**

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveTouchOverlayTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveTouchOverlayTest.kt
@@ -1,0 +1,147 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.io.ByteArrayInputStream
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end touch-overlay verification on Robolectric — the Android counterpart of
+ * `:daemon:desktop`'s `InteractiveTouchOverlayTest`.
+ *
+ * Pins the structural fix from this PR: the held-rule `setContent` now wraps
+ * `InvokeHeldComposable` with `ComposeDataExtensionPipeline.Apply(extensions =
+ * engine.previewOverrideExtensions.plan(...))`, so `TouchOverlayExtension`'s `AroundComposable`
+ * actually paints the visualization rings on the held composition. Pre-fix, the extension was
+ * registered on the engine and the override propagated correctly through #1317's plumbing, but
+ * the held-rule `setContent` bypassed the extension chain entirely and the rings never appeared.
+ *
+ * The single-pointer `pointerDown` (no matching `pointerUp`) keeps `activePointers` non-empty so
+ * the overlay paints a ring at the press point. The dispatch loop's existing 100 ms `mainClock`
+ * advance after every dispatch (`RobolectricHost.kt:1882`) is what flushes the press through
+ * Compose's pointer pipeline before the next render captures.
+ */
+class AndroidInteractiveTouchOverlayTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun overlay_enabled_session_paints_cyan_ring_on_press() {
+    val outputDir = tempFolder.newFolder("interactive-overlay-renders")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+
+    val host = RobolectricHost(sandboxCount = 2, previewSpecResolver = previewSpecResolver())
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = OVERLAY_PREVIEW_ID,
+          classLoader = AndroidInteractiveTouchOverlayTest::class.java.classLoader!!,
+          overrides = PreviewOverrides(touchOverlay = true),
+        )
+      try {
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "android-overlay-test-stream",
+            kind = InteractiveInputKind.POINTER_DOWN,
+            pixelX = INTERACTIVE_WIDTH_PX / 2,
+            pixelY = INTERACTIVE_HEIGHT_PX / 2,
+            pointerId = 1,
+          )
+        )
+        val pressed = session.render(requestId = RenderHost.nextRequestId())
+        assertNotNull("pressed render must produce a PNG path", pressed.pngPath)
+        val pressedImg = decode(File(pressed.pngPath!!))
+        val cyanMatch =
+          pixelMatchPct(pressedImg, expectedRgb = 0x00BCD4, perChannelTolerance = 60)
+        assertTrue(
+          "pressed frame must contain cyan overlay-ring pixels (interactive overlay enabled); " +
+            "got ${"%.4f".format(cyanMatch * 100)}% — if 0, either the override didn't reach " +
+            "the held composition (this PR's `ComposeDataExtensionPipeline.Apply` wrap) or the " +
+            "press wasn't observed by `Modifier.pointerInput` on the Initial pass",
+          cyanMatch > 0.0005,
+        )
+
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "android-overlay-test-stream",
+            kind = InteractiveInputKind.POINTER_UP,
+            pixelX = INTERACTIVE_WIDTH_PX / 2,
+            pixelY = INTERACTIVE_HEIGHT_PX / 2,
+            pointerId = 1,
+          )
+        )
+        session.render(requestId = RenderHost.nextRequestId())
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  private fun previewSpecResolver(): (String) -> RenderSpec? = { previewId ->
+    when (previewId) {
+      OVERLAY_PREVIEW_ID ->
+        RenderSpec(
+          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+          functionName = "ClickToggleSquare",
+          widthPx = INTERACTIVE_WIDTH_PX,
+          heightPx = INTERACTIVE_HEIGHT_PX,
+          density = 1.0f,
+          showBackground = true,
+          outputBaseName = "interactive-touch-overlay",
+        )
+      else -> null
+    }
+  }
+
+  private fun decode(file: File): java.awt.image.BufferedImage {
+    require(file.exists()) { "expected capture at ${file.absolutePath}" }
+    val bytes = file.readBytes()
+    require(bytes.isNotEmpty()) { "capture is empty: ${file.absolutePath}" }
+    return ByteArrayInputStream(bytes).use { ImageIO.read(it) }
+      ?: error("ImageIO refused to decode capture: ${file.absolutePath}")
+  }
+
+  private fun pixelMatchPct(
+    img: java.awt.image.BufferedImage,
+    expectedRgb: Int,
+    perChannelTolerance: Int,
+  ): Double {
+    val expR = (expectedRgb shr 16) and 0xFF
+    val expG = (expectedRgb shr 8) and 0xFF
+    val expB = expectedRgb and 0xFF
+    var matches = 0L
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val rgb = img.getRGB(x, y)
+        val r = (rgb shr 16) and 0xFF
+        val g = (rgb shr 8) and 0xFF
+        val b = rgb and 0xFF
+        if (
+          abs(r - expR) <= perChannelTolerance &&
+            abs(g - expG) <= perChannelTolerance &&
+            abs(b - expB) <= perChannelTolerance
+        ) {
+          matches++
+        }
+      }
+    }
+    return matches.toDouble() / (img.width.toLong() * img.height.toLong()).toDouble()
+  }
+
+  companion object {
+    private const val OVERLAY_PREVIEW_ID = "android-touch-overlay-interactive"
+    private const val INTERACTIVE_WIDTH_PX = 96
+    private const val INTERACTIVE_HEIGHT_PX = 96
+  }
+}


### PR DESCRIPTION
## Summary

PR #1317 plumbed `PreviewOverrides.touchOverlay` through `RobolectricHost.acquireInteractiveSession`. The override reached the merged `RenderSpec` but the held-rule `setContent` at `RobolectricHost.kt:1823-1854` invoked `InvokeHeldComposable(composableMethod)` directly — with no `AroundComposable` wrap — so the `TouchOverlayExtension` registered on the engine's `previewOverrideExtensions` list never reached the held composition. Recording inherited the same gap (recording wraps an interactive session via `acquireInteractiveSession`), but no Android-side test caught it.

Fix mirrors the non-held render path (`RenderEngine.kt:302-309`): wrap `InvokeHeldComposable` with `ComposeDataExtensionPipeline.Apply(extensions = engine.previewOverrideExtensions.plan(syntheticOverrides), ...)`.

## Plumbing

- `InteractiveCommand.Start` carries a new `touchOverlay: Boolean?` field — decomposed from `spec.overrides.touchOverlay` so it crosses the sandbox classloader boundary as a primitive (the nested protocol types don't cross safely; same decomposition pattern `localeTag` / `fontScale` / `uiMode` use).
- `RobolectricHost.acquireInteractiveSession` passes `touchOverlay = spec.overrides?.touchOverlay` when constructing `InteractiveCommand.Start`.
- `RenderEngine.previewOverrideExtensions` flips from `private` to `internal` so `SandboxRunner.runHeldInteractiveSession` (same module) can call `.plan(...)` on it.
- Held `setContent` reconstructs a minimal `PreviewOverrides(touchOverlay = start.touchOverlay)` and wraps `InvokeHeldComposable` with `ComposeDataExtensionPipeline.Apply`. Other planner-relevant override fields can be added the same way; today only the keyboard planner runs on the interactive path, and it's always-active so it doesn't read the override bag.

## Bonus

Recording on Android gets the touch overlay for free because the recording session wraps an interactive session and both share the held-rule path. Pre-fix, recording's `overrides.touchOverlay = true` propagated through `applyOverrides` but the held composition skipped the chain just like interactive.

## Test plan

- [x] New `AndroidInteractiveTouchOverlayTest` — dispatches a held `POINTER_DOWN` against `ClickToggleSquare` with `overrides.touchOverlay = true`, renders, asserts the captured frame contains cyan ring pixels. **Passes** (previously would have hit 0%).
- [x] `AndroidRecordingSessionTest` — 27/27 pass.
- [x] `AndroidInteractiveSessionTest` — 15/16 pass (the 1 failure is the unrelated pre-existing `UiAutomatorUnsupportedReason` classloader-cast flake that reproduces on a pristine `origin/main` worktree).
- [x] `:daemon:android:compileDebugKotlin` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HargtVaPJDmRRTfPdaEw3a)_