### PR TITLE
fix(samples): default sdk-matrix to compileSdk=35 so JDK 17 baselines render

### DIFF
--- a/samples/sdk-matrix/build.gradle.kts
+++ b/samples/sdk-matrix/build.gradle.kts
@@ -25,10 +25,15 @@ plugins {
   id("ee.schimke.composeai.preview")
 }
 
+// Defaults pinned to SDK 35 (not 36) so the no-override path renders cleanly under the project's
+// default JDK 17 toolchain — Robolectric refuses to bootstrap an SDK 36 sandbox without JDK 21+
+// (`DefaultSdkProvider.verifySupportedSdk`), which would fail every regular `preview-baselines`
+// run that doesn't set the matrix `-P` overrides. The nightly `sdk-matrix.yml` workflow always
+// passes explicit cell values, so it sweeps the full {35, 36, 37} range regardless of the default.
 val matrixCompileSdk: Int =
-  providers.gradleProperty("composeai.matrix.compileSdk").orNull?.toIntOrNull() ?: 36
+  providers.gradleProperty("composeai.matrix.compileSdk").orNull?.toIntOrNull() ?: 35
 val matrixTargetSdk: Int =
-  providers.gradleProperty("composeai.matrix.targetSdk").orNull?.toIntOrNull() ?: 36
+  providers.gradleProperty("composeai.matrix.targetSdk").orNull?.toIntOrNull() ?: 35
 val matrixMinSdk: Int =
   providers.gradleProperty("composeai.matrix.minSdk").orNull?.toIntOrNull() ?: 24
 val matrixSdkOverride: Int? =


### PR DESCRIPTION
The synthetic `:samples:sdk-matrix` module defaulted compileSdk/targetSdk
to 36, so when `preview-baselines.yml` (which uses the project's default
JDK 17 toolchain) ran `compose-preview show` it tripped Robolectric's
`DefaultSdkProvider.verifySupportedSdk` refusal: "Android SDK 36 requires
Java 21 (have Java 17)". The nightly `sdk-matrix.yml` workflow always
passes explicit `-Pcomposeai.matrix.*` overrides, so its cell coverage is
unchanged — only the no-override fallback moves to a JDK-17-safe level.

Fixes #1325