### PR TITLE
feat(vscode): spike continuous-compile worker behind opt-in flag

### DIFF
--- a/docs/daemon/CONTINUOUS-COMPILE.md
+++ b/docs/daemon/CONTINUOUS-COMPILE.md
@@ -1,0 +1,132 @@
+# Continuous-compile worker — spike
+
+**Status:** opt-in spike behind `composePreview.daemon.continuousCompile`.
+Default is off. This document describes the design, what we expect to
+measure, and the exit criteria for either landing it as the default or
+abandoning it for a stage-2 attempt that hosts the Kotlin Build Tools
+API inside the daemon JVM directly.
+
+## Why
+
+[`baseline-latency.csv`](baseline-latency.csv) ("warm-after-1-line-edit")
+shows roughly **2 s of Gradle plumbing per save** before the daemon even
+sees the change — config + compile + discovery walls add up to that even
+when `compileDebugKotlin` itself is producing only a handful of bytes of
+new bytecode. The daemon save loop already pays this on every keystroke
+through `gradleService.compileOnly()` → `:<module>:composePreviewCompile`
+([gradleService.ts:366](../../vscode-extension/src/gradleService.ts)).
+
+`gradle --continuous` keeps a single Gradle invocation resident, with
+configuration cached, the task graph wired, and the Kotlin compiler
+warm. On each source change Gradle's file watcher fires another build
+incrementally. The configuration + tooling-API overhead per save drops
+from ~500 ms to one watcher notification.
+
+This is the architectural choice JetBrains made for **Compose Hot
+Reload** ([JetBrains/compose-hot-reload](https://github.com/JetBrains/compose-hot-reload),
+[blog post](https://blog.jetbrains.com/kotlin/2026/01/the-journey-to-compose-hot-reload-1-0-0/));
+their `Recompiler` module launches a continuous Gradle daemon and
+broadcasts changed class files over a socket. We're not copying their
+hot-swap path (the daemon already has the parent/child classloader
+split for that — see [CLASSLOADER.md](CLASSLOADER.md)) — just borrowing
+the Gradle-as-long-running-compiler idea.
+
+DESIGN.md § 1 still lists "hot kotlinc / compile-daemon integration"
+as a non-goal; this is the first explicit exception. The flag remains
+opt-in until the spike is either promoted or retired.
+
+## How
+
+```
+                                       ┌─────────────────────────────────┐
+   onDidSaveTextDocument               │ gradle --continuous             │
+       │                               │   :<module>:composePreviewCompile│
+       ▼                               │                                  │
+   gradleService.compileOnly(module) ──┤ ChunkLineSplitter ◀─── stdout    │
+       │ (worker registered?)          │   ↳ parses                       │
+       ▼                               │     Change detected, …           │
+   worker.waitForNextBuild() ───┐      │     BUILD SUCCESSFUL in 420ms    │
+                                │      └─────────────────────────────────┘
+              ┌─ ok=true ───────┴─ resolves with the build's outcome
+              │
+       (existing) fileChanged({kind:"source"}) → daemon
+              ↓
+       (existing) renderNow → PNG
+```
+
+`ContinuousCompileWorker`
+([continuousCompileWorker.ts](../../vscode-extension/src/daemon/continuousCompileWorker.ts))
+owns the subprocess. State machine:
+
+| State    | Transition trigger                                   | Effect                                                              |
+| -------- | ---------------------------------------------------- | ------------------------------------------------------------------- |
+| idle     | "Change detected, executing build…" line             | Records `buildStartedAtMs`, emits `buildStarted`                    |
+| running  | "BUILD SUCCESSFUL in N(ms\|s)" / "BUILD FAILED in …" | Emits `buildFinished({ok, durationMs, errors})`, returns to idle    |
+
+`waitForNextBuild()` resolves on the next outcome whose trigger landed
+after the caller's clock, or on an in-flight build whose `Change
+detected` is fresher than `IN_FLIGHT_ACCEPT_WINDOW_MS` (500 ms — see
+the constant's comment). Stale in-flight builds, the warm-up build,
+and subprocess exits all resolve as null; callers (the gradle service)
+fall back to a one-shot `composePreviewCompile` invocation in that
+case so the save loop never gets stuck.
+
+`ContinuousCompileManager`
+([continuousCompileManager.ts](../../vscode-extension/src/daemon/continuousCompileManager.ts))
+holds one worker per module, started at daemon warm and stopped on
+deactivate / `composePreview.restartDaemon`. The `GradleService` looks
+the worker up at save time and delegates if one is registered.
+
+## What we expect to measure
+
+Hypothesis: a single Gradle invocation amortises the ~500 ms
+configuration wall across every save, leaving only the kotlinc work
+itself. On a 1-line edit that should compress the **2 s →
+sub-500 ms** for the compile leg of the save loop. Combined with the
+existing daemon (which eliminates the ~1.7 s `forkAndInit` line in
+[`baseline-latency.csv`](baseline-latency.csv)), save → pixels should
+land under 1 s on desktop and inside the 3 s budget on Android.
+
+Open questions the spike is meant to answer:
+
+1. **Does Gradle's file watcher pick up VS Code's saves reliably?**
+   `WatchService` semantics on Linux/macOS/Windows + WSL/Docker have
+   been historically uneven. Spike log line on every detected change
+   so we can see when the watcher misses one.
+2. **Does Gradle's `--continuous` debounce (~250 ms quiet period)
+   conflict with rapid resaves?** The in-flight acceptance window in
+   the worker is calibrated for the common case; race tests in
+   [`continuousCompileWorker.test.ts`](../../vscode-extension/src/test/continuousCompileWorker.test.ts)
+   cover the stale-in-flight case explicitly.
+3. **Memory footprint.** A Gradle daemon held resident per module is
+   real RAM. Worth instrumenting against a typical workspace
+   (3 – 5 module project) before promoting the default.
+4. **Compose plugin classpath rebuilds.** If the user touches
+   `libs.versions.toml` or a `build.gradle.kts` the continuous build
+   may need to reconfigure. Confirm it self-recovers, or tear down +
+   respawn on the existing Tier-1 classpath-dirty signal.
+
+## Exit criteria
+
+**Promote to default** when:
+
+- A 1-line edit save loop, measured under the harness flow used by
+  [`baseline-latency.csv`](baseline-latency.csv), lands **< 1 s on
+  desktop**, **< 2 s on Android**, on the reference machine.
+- The `samples/android-daemon-bench` and `samples/desktop-daemon-bench`
+  scenarios run for 10 minutes without the worker getting wedged.
+- Memory delta vs the off path is acceptable on the same fixture
+  workspace (rough budget: < 500 MB extra resident per module).
+
+**Abandon, escalate to stage 2 (BTA in-daemon)** when:
+
+- Gradle's watcher misses saves or debounces them in ways that produce
+  wrong-frame renders we can't paper over.
+- The per-save win on desktop is < 200 ms (i.e. the Gradle daemon's
+  round-trip cost on `gradle --continuous` is itself the floor).
+- The Compose plugin path can't survive a long-running daemon for
+  long enough (Gradle's per-build memory growth is a known issue).
+
+Either way, the spike is contained: dropping the flag back to `false`
+removes the worker entirely from the save loop. No production code
+path off the flag changes.

--- a/docs/daemon/DESIGN.md
+++ b/docs/daemon/DESIGN.md
@@ -18,7 +18,11 @@
 - The `compose-preview` CLI binary keeps using the Gradle task. (MCP
   daemon mode is shipped separately as `:mcp` — see [MCP.md](MCP.md).)
 - Replacing `composePreviewRender` — daemon fronts it for the editor loop only.
-- Hot kotlinc / compile-daemon integration.
+- Hot kotlinc / compile-daemon integration. (Stage-1 spike behind
+  `composePreview.daemon.continuousCompile` — long-running `gradle
+  --continuous` worker per module — landed for measurement. See
+  [CONTINUOUS-COMPILE.md](CONTINUOUS-COMPILE.md). Stage-2 in-daemon Kotlin
+  Build Tools API integration is gated on that spike's exit criteria.)
 - Tier-3 dependency-graph reachability index — v1 uses a conservative
   "module-changed = all previews stale, filtered by visibility" rule.
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -175,6 +175,11 @@
                     "description": "Deprecated. The preview daemon is always on; this setting is ignored. Opt out at the build level via `composePreview { daemon { enabled = false } }`.",
                     "markdownDeprecationMessage": "This setting has no effect. The preview daemon is always on; opt out at the build level via `composePreview { daemon { enabled = false } }`."
                 },
+                "composePreview.daemon.continuousCompile": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "**Experimental.** Replace the per-save Gradle compile round-trip with a long-running `gradle --continuous :<module>:composePreviewCompile` worker per daemon-warmed module. On a 1-line edit this shaves the ~500 ms Gradle configuration + tooling-API overhead off every save; the cost is one extra Gradle daemon's worth of memory held resident per module. Off by default; see [docs/daemon/CONTINUOUS-COMPILE.md](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/CONTINUOUS-COMPILE.md) for the spike. Requires a window reload to take effect."
+                },
                 "composePreview.earlyFeatures.enabled": {
                     "type": "boolean",
                     "default": false,

--- a/vscode-extension/src/daemon/continuousCompileManager.ts
+++ b/vscode-extension/src/daemon/continuousCompileManager.ts
@@ -1,0 +1,84 @@
+import type { spawn } from "child_process";
+import {
+    ContinuousCompileWorker,
+    ContinuousCompileWorkerLogger,
+} from "./continuousCompileWorker";
+import { GradleService, ModuleInfo } from "../gradleService";
+
+/**
+ * Owns the per-module [ContinuousCompileWorker] processes spawned under
+ * the `composePreview.daemon.continuousCompile` opt-in flag.
+ *
+ * Activation lifecycle:
+ *   - The extension instantiates one manager when the flag is enabled.
+ *   - `ensureWorker(module)` is called after the daemon has warmed for
+ *     that module (the same seam `daemonBootstrappedModules` uses) — by
+ *     then we know the daemon-launch descriptor is valid, so the same
+ *     classpath assumptions hold for the long-running gradle process.
+ *   - `disposeAll()` runs in `deactivate()` so the subprocess gets a
+ *     chance to shut down cleanly via EOF-to-stdin before VS Code
+ *     reclaims the window.
+ *
+ * Workers are registered on the [GradleService] via
+ * [GradleService.setContinuousCompileWorker]; `compileOnly()` looks them
+ * up there at save time. The manager keeps the lookup map authoritative
+ * so a failed startup (subprocess exits immediately) cleanly unregisters
+ * the worker and the next save falls back to the one-shot Gradle path.
+ */
+export class ContinuousCompileManager {
+    private readonly workers = new Map<string, ContinuousCompileWorker>();
+
+    constructor(
+        private readonly workspaceRoot: string,
+        private readonly gradleService: GradleService,
+        private readonly logger: ContinuousCompileWorkerLogger,
+        private readonly extraArgs: ReadonlyArray<string> = [],
+        /** Test seam — defaults to node's `child_process.spawn`. */
+        private readonly spawnFn?: typeof spawn,
+    ) {}
+
+    /** Idempotent — second call for the same module is a no-op. */
+    ensureWorker(module: ModuleInfo): void {
+        const key = module.modulePath;
+        if (this.workers.has(key)) {
+            return;
+        }
+        const worker = new ContinuousCompileWorker({
+            workspaceRoot: this.workspaceRoot,
+            taskPath: `${key}:composePreviewCompile`,
+            extraArgs: this.extraArgs,
+            logger: this.logger,
+            spawnFn: this.spawnFn,
+        });
+        try {
+            worker.start();
+        } catch (err) {
+            this.logger.appendLine(
+                `[continuous] failed to start worker for ${key}: ${(err as Error).message}`,
+            );
+            return;
+        }
+        this.workers.set(key, worker);
+        this.gradleService.setContinuousCompileWorker(key, worker);
+    }
+
+    async disposeWorker(modulePath: string): Promise<void> {
+        const worker = this.workers.get(modulePath);
+        if (!worker) {
+            return;
+        }
+        this.workers.delete(modulePath);
+        this.gradleService.setContinuousCompileWorker(modulePath, null);
+        await worker.stop();
+    }
+
+    async disposeAll(): Promise<void> {
+        const keys = [...this.workers.keys()];
+        await Promise.all(keys.map((k) => this.disposeWorker(k)));
+    }
+
+    /** Module paths with an active worker. Test/diagnostic surface. */
+    activeModules(): readonly string[] {
+        return [...this.workers.keys()];
+    }
+}

--- a/vscode-extension/src/daemon/continuousCompileWorker.ts
+++ b/vscode-extension/src/daemon/continuousCompileWorker.ts
@@ -1,0 +1,313 @@
+import { ChildProcess, spawn } from "child_process";
+import { EventEmitter } from "events";
+import * as path from "path";
+import { ChunkLineSplitter } from "./daemonProcess";
+import { KotlinCompileErrorDetector } from "../kotlinCompileErrorDetector";
+import { CompileError } from "../compileErrors";
+
+/**
+ * Long-running `gradle --continuous :<module>:composePreviewCompile` worker.
+ *
+ * Spike behind `composePreview.daemon.continuousCompile`
+ * ([docs/daemon/CONTINUOUS-COMPILE.md](../../../docs/daemon/CONTINUOUS-COMPILE.md)).
+ * Removes the per-save Gradle configuration + Tooling-API round-trip from
+ * the daemon save loop: a single Gradle invocation stays resident,
+ * re-running `composePreviewCompile` whenever Gradle's continuous-mode
+ * file watcher detects a source change.
+ *
+ * Production extension code normally reaches Gradle through the official
+ * `vscjava.vscode-gradle` API (see `src/test/electron/realGradleApi.ts`
+ * comment). This worker is the explicit exception — the vscode-gradle
+ * gRPC layer doesn't surface clean EOF-to-stdin shutdown for continuous
+ * mode, and cancellation semantics for a build that's meant to never
+ * resolve are awkward. We own the subprocess directly here, gated behind
+ * an experimental config flag so the regular code path is unchanged when
+ * the flag is off.
+ *
+ * State machine, driven by Gradle's `--console=plain` output:
+ *
+ *   idle ──"Change detected, executing build…"──▶ running
+ *   running ──"BUILD SUCCESSFUL in N(ms|s)" / "BUILD FAILED…"──▶ idle
+ *
+ * The very first build that runs at worker start (the warm-up, usually
+ * `UP-TO-DATE`) is intentionally NOT flagged as a `buildStarted` event —
+ * only `Change detected` triggers count. That way `waitForNextBuild()`
+ * resolves only on a build that was kicked off by an actual source change
+ * after the caller's `now()`, not on the warm-up.
+ */
+
+export interface BuildOutcome {
+    ok: boolean;
+    /** Wall-clock ms when the BUILD SUCCESSFUL/FAILED line was observed. */
+    finishedAtMs: number;
+    /** Reported by Gradle (`"in 480ms"` → 480, `"in 1.2s"` → 1200). null if
+     *  the trailer didn't parse — keep the outcome but treat duration as
+     *  unknown for metrics. */
+    durationMs: number | null;
+    /** Empty when ok=true. Populated from KotlinCompileErrorDetector on failure. */
+    errors: CompileError[];
+}
+
+export interface ContinuousCompileWorkerLogger {
+    appendLine(line: string): void;
+}
+
+export interface ContinuousCompileWorkerOptions {
+    /** Repo root — the directory containing `gradlew`. */
+    workspaceRoot: string;
+    /** Fully-qualified gradle task path, e.g. `:samples:android:composePreviewCompile`. */
+    taskPath: string;
+    /** Extra args appended to the invocation (project properties etc.). */
+    extraArgs?: ReadonlyArray<string>;
+    logger?: ContinuousCompileWorkerLogger;
+    /** Injection point for tests. Defaults to node's `child_process.spawn`. */
+    spawnFn?: typeof spawn;
+    /** Injection point for tests. Defaults to `Date.now`. */
+    nowFn?: () => number;
+    /** Default 60_000 ms. */
+    buildTimeoutMs?: number;
+}
+
+/**
+ * Matches Gradle's BUILD outcome trailer. Groups: 1=SUCCESSFUL|FAILED, 2=ms, 3=seconds.
+ * Examples we've observed across Gradle 8/9:
+ *   "BUILD SUCCESSFUL in 480ms"
+ *   "BUILD SUCCESSFUL in 1s"
+ *   "BUILD SUCCESSFUL in 1.4s"
+ *   "BUILD FAILED in 2s"
+ */
+const BUILD_OUTCOME_RE =
+    /^BUILD (SUCCESSFUL|FAILED) in (?:(\d+)\s*ms|(\d+(?:\.\d+)?)\s*s)\b/;
+const CHANGE_DETECTED_RE = /^Change detected, executing build/;
+
+/**
+ * If a build is already in flight when `waitForNextBuild()` is called and its
+ * `Change detected` line landed within this many ms before the call, we
+ * accept that build as the caller's — Gradle's watcher commonly notices a
+ * file save before VS Code's event loop dispatches the next microtask, so
+ * the in-flight build IS the one triggered by the caller's save. Beyond
+ * this window the build is treated as stale: we wait for the next one
+ * instead, even though it costs an extra round-trip. Tuned higher than
+ * Gradle's quiet-period debounce (~250 ms) and below a "rapid resave"
+ * interval; a stale build that races a long-running cold compile would
+ * otherwise mis-attribute its outcome to a later save and produce a render
+ * that lags the source.
+ */
+const IN_FLIGHT_ACCEPT_WINDOW_MS = 500;
+
+export class ContinuousCompileWorker {
+    private child: ChildProcess | null = null;
+    private readonly stdoutSplitter = new ChunkLineSplitter();
+    private readonly stderrSplitter = new ChunkLineSplitter();
+    private errorDetector = new KotlinCompileErrorDetector();
+    private readonly events = new EventEmitter();
+    /** null while idle; timestamp ms set on "Change detected", cleared on BUILD outcome. */
+    private buildStartedAtMs: number | null = null;
+    private stopped = false;
+    private exitPromise: Promise<number | null> = Promise.resolve(null);
+    private readonly logger: ContinuousCompileWorkerLogger;
+    private readonly now: () => number;
+    private readonly defaultTimeoutMs: number;
+
+    constructor(private readonly opts: ContinuousCompileWorkerOptions) {
+        this.logger = opts.logger ?? { appendLine() {} };
+        this.now = opts.nowFn ?? Date.now;
+        this.defaultTimeoutMs = opts.buildTimeoutMs ?? 60_000;
+    }
+
+    /** True between `start()` returning and `stop()` (or the subprocess exiting). */
+    get running(): boolean {
+        return this.child !== null && !this.stopped;
+    }
+
+    /** Spawn the long-running gradle process. Resolves once the child has been spawned;
+     *  does NOT wait for the warm-up build to finish. */
+    start(): void {
+        if (this.child) {
+            throw new Error("ContinuousCompileWorker.start() called twice");
+        }
+        const gradlewPath = path.join(
+            this.opts.workspaceRoot,
+            process.platform === "win32" ? "gradlew.bat" : "gradlew",
+        );
+        const args = [
+            this.opts.taskPath,
+            "--continuous",
+            "--console=plain",
+            ...(this.opts.extraArgs ?? []),
+        ];
+        this.logger.appendLine(
+            `[continuous] spawn ${gradlewPath} ${args.join(" ")} (cwd=${this.opts.workspaceRoot})`,
+        );
+        const spawnFn = this.opts.spawnFn ?? spawn;
+        const child = spawnFn(gradlewPath, args, {
+            cwd: this.opts.workspaceRoot,
+            env: { ...process.env },
+            stdio: ["pipe", "pipe", "pipe"],
+        });
+        if (!child.stdout || !child.stderr) {
+            throw new Error(
+                "ContinuousCompileWorker: spawn produced no stdio streams",
+            );
+        }
+        this.child = child;
+        child.stdout.on("data", (chunk: Buffer) =>
+            this.consumeStdout(chunk.toString("utf-8")),
+        );
+        child.stderr.on("data", (chunk: Buffer) =>
+            this.consumeStderr(chunk.toString("utf-8")),
+        );
+        this.exitPromise = new Promise<number | null>((resolve) => {
+            child.once("exit", (code) => {
+                this.stopped = true;
+                this.logger.appendLine(
+                    `[continuous] gradle --continuous exited (code=${code})`,
+                );
+                this.events.emit("exit", code);
+                resolve(code);
+            });
+            child.once("error", (err) => {
+                this.stopped = true;
+                this.logger.appendLine(
+                    `[continuous] gradle --continuous error: ${err.message}`,
+                );
+                this.events.emit("exit", null);
+                resolve(null);
+            });
+        });
+    }
+
+    /**
+     * Resolves with the outcome of the build triggered by the caller's
+     * save. Two acceptance paths:
+     *
+     *   - **In-flight, fresh:** a build is currently running and its
+     *     `Change detected` landed within [IN_FLIGHT_ACCEPT_WINDOW_MS] of
+     *     this call. We treat that build as the caller's and resolve on
+     *     its `BUILD SUCCESSFUL/FAILED`.
+     *   - **Idle (or stale in-flight):** wait for the next `Change
+     *     detected` to fire after this call, then resolve on the
+     *     subsequent BUILD outcome.
+     *
+     * Returns `null` on timeout, on subprocess exit, or if the worker is
+     * already stopped. Callers should treat `null` the same as a compile
+     * failure for save-loop purposes — defer to the Gradle fallback path.
+     */
+    waitForNextBuild(timeoutMs?: number): Promise<BuildOutcome | null> {
+        if (this.stopped) {
+            return Promise.resolve(null);
+        }
+        const callTimeMs = this.now();
+        const timeout = timeoutMs ?? this.defaultTimeoutMs;
+        return new Promise<BuildOutcome | null>((resolve) => {
+            let settled = false;
+            let observedTriggerAfterCall =
+                this.buildStartedAtMs !== null &&
+                callTimeMs - this.buildStartedAtMs < IN_FLIGHT_ACCEPT_WINDOW_MS;
+
+            const onBuildStarted = (at: number) => {
+                if (at >= callTimeMs) {
+                    observedTriggerAfterCall = true;
+                }
+            };
+            const onBuildFinished = (outcome: BuildOutcome) => {
+                if (observedTriggerAfterCall) {
+                    settle(outcome);
+                }
+            };
+            const onExit = () => settle(null);
+            const timer = setTimeout(() => settle(null), timeout);
+
+            const settle = (v: BuildOutcome | null) => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                this.events.off("buildStarted", onBuildStarted);
+                this.events.off("buildFinished", onBuildFinished);
+                this.events.off("exit", onExit);
+                clearTimeout(timer);
+                resolve(v);
+            };
+
+            this.events.on("buildStarted", onBuildStarted);
+            this.events.on("buildFinished", onBuildFinished);
+            this.events.on("exit", onExit);
+        });
+    }
+
+    /**
+     * Gracefully stop the subprocess. Sends EOF on stdin (the canonical
+     * "stop continuous build" signal from Gradle's user manual), then
+     * falls back to SIGTERM after a 5s grace window.
+     */
+    async stop(): Promise<void> {
+        if (!this.child || this.stopped) {
+            return;
+        }
+        try {
+            this.child.stdin?.end();
+        } catch {
+            /* ignore */
+        }
+        const fallback = new Promise<void>((resolve) =>
+            setTimeout(() => {
+                try {
+                    this.child?.kill("SIGTERM");
+                } catch {
+                    /* ignore */
+                }
+                resolve();
+            }, 5_000),
+        );
+        await Promise.race([this.exitPromise.then(() => undefined), fallback]);
+        this.stopped = true;
+        this.child = null;
+    }
+
+    private consumeStdout(chunk: string): void {
+        this.errorDetector.consume(chunk);
+        for (const line of this.stdoutSplitter.feed(chunk)) {
+            this.scanLine(line);
+        }
+    }
+
+    private consumeStderr(chunk: string): void {
+        // Kotlin error lines (`e: file://...`) sometimes land on stderr depending
+        // on Gradle/Kotlin version + console-mode interactions. Feed both.
+        this.errorDetector.consume(chunk);
+        for (const line of this.stderrSplitter.feed(chunk)) {
+            this.scanLine(line);
+        }
+    }
+
+    private scanLine(line: string): void {
+        if (CHANGE_DETECTED_RE.test(line)) {
+            this.buildStartedAtMs = this.now();
+            this.events.emit("buildStarted", this.buildStartedAtMs);
+            return;
+        }
+        const m = BUILD_OUTCOME_RE.exec(line);
+        if (!m) {
+            return;
+        }
+        this.errorDetector.end();
+        const ok = m[1] === "SUCCESSFUL";
+        const ms = m[2]
+            ? parseInt(m[2], 10)
+            : m[3]
+              ? Math.round(parseFloat(m[3]) * 1000)
+              : null;
+        const errors = ok ? [] : this.errorDetector.getErrors();
+        const outcome: BuildOutcome = {
+            ok,
+            finishedAtMs: this.now(),
+            durationMs: ms,
+            errors,
+        };
+        this.buildStartedAtMs = null;
+        // Reset the detector so the next build's errors are scoped to that build.
+        this.errorDetector = new KotlinCompileErrorDetector();
+        this.events.emit("buildFinished", outcome);
+    }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -51,6 +51,7 @@ import {
     LiveDaemonScheduler,
     WarmState,
 } from "./daemon/daemonScheduler";
+import { ContinuousCompileManager } from "./daemon/continuousCompileManager";
 import {
     buildHistorySource,
     HistoryScope,
@@ -120,6 +121,9 @@ const DAEMON_SPAWN_PROGRESS_MS = 7_000;
 let gradleService: GradleService | null = null;
 let daemonGate: DaemonGate | null = null;
 let daemonScheduler: DaemonScheduler | null = null;
+/** Non-null only when `composePreview.daemon.continuousCompile` is set. Spike —
+ *  see [docs/daemon/CONTINUOUS-COMPILE.md]. */
+let continuousCompileManager: ContinuousCompileManager | null = null;
 let daemonStatusItem: vscode.StatusBarItem | null = null;
 let interactiveStatusItem: vscode.StatusBarItem | null = null;
 let daemonStatusClearTimer: NodeJS.Timeout | null = null;
@@ -1070,6 +1074,27 @@ export async function activate(
     };
     wireBackend(initialMode.mode);
 
+    // Continuous-compile worker manager (spike, opt-in via
+    // `composePreview.daemon.continuousCompile`). Replaces the per-save
+    // Gradle round-trip with a long-running `gradle --continuous` process
+    // per module. Off by default. See docs/daemon/CONTINUOUS-COMPILE.md.
+    if (
+        initialMode.mode !== "minimal" &&
+        vscode.workspace
+            .getConfiguration("composePreview")
+            .get<boolean>("daemon.continuousCompile", false)
+    ) {
+        continuousCompileManager = new ContinuousCompileManager(
+            workspaceRoot,
+            gradleService,
+            outputChannel,
+            initScriptArgs,
+        );
+        outputChannel.appendLine(
+            "[continuous] composePreview.daemon.continuousCompile = true; per-module workers will start on first daemon warm-up",
+        );
+    }
+
     // Status-bar slot for daemon lifecycle. Hidden when the daemon flag is
     // off or no module is currently warming. Surfacing the cold-bootstrap
     // pause (typically 2-4 s on first scope-in) avoids the "panel is stuck"
@@ -1323,6 +1348,12 @@ export async function activate(
                 // clearing this the spawn would skip the bootstrap and the
                 // descriptor on disk could still reference the previous build.
                 daemonBootstrappedModules.clear();
+                // Tear down the continuous-compile workers in lockstep — they
+                // pin the Gradle daemon's classpath snapshot at spawn time, and
+                // a daemon restart often follows a renderer-JAR rebuild that
+                // would otherwise leave the worker holding stale state. The
+                // next warm will re-create them via `ensureWorker`.
+                await continuousCompileManager?.disposeAll();
                 // Hide the status-bar item — its text references a specific module
                 // that's no longer relevant; the next warmModule call will repopulate
                 // it through its progress callback.
@@ -1836,6 +1867,10 @@ export function deactivate() {
     // processes after a window close. Fire-and-forget — VS Code won't wait
     // for an async deactivate beyond a few seconds anyway.
     void daemonGate?.dispose();
+    // Same shape for the continuous-compile workers (spike). Sends EOF on
+    // stdin to each worker's `gradle --continuous` subprocess; falls back
+    // to SIGTERM after a grace window if Gradle is wedged.
+    void continuousCompileManager?.disposeAll();
     disposePreviewMainBatches();
 }
 
@@ -2165,6 +2200,7 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
                     ? "disabled"
                     : "failed";
             }
+            continuousCompileManager?.ensureWorker(module);
         } catch (err) {
             daemonBootstrappedModules.delete(moduleKey);
             logLine(`daemon: ${String((err as Error).message ?? err)}`);
@@ -2481,6 +2517,7 @@ async function warmDaemonForFile(
                 : `warm returned false for ${moduleKey} after bootstrap (ensureModule could not spawn daemon — check daemon-launch.json + daemon channel logs)`;
         } else {
             lastWarmDaemonError = null;
+            continuousCompileManager?.ensureWorker(module);
         }
         finishDaemonStartupProgress(module, filePath, warmed);
         if (warmed && opts.refreshAfterReady) {

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -21,6 +21,7 @@ import {
     KotlinCompileErrorDetector,
 } from "./kotlinCompileErrorDetector";
 import { LogFilter } from "./logFilter";
+import { ContinuousCompileWorker } from "./daemon/continuousCompileWorker";
 
 /**
  * Expands a parameterized preview's single template capture into N captures
@@ -305,6 +306,15 @@ export class GradleService {
     >();
     private taskCounter = 0;
     private activeKeys = new Set<string>();
+    /**
+     * Per-module continuous-compile workers, registered by the daemon
+     * scheduler when `composePreview.daemon.continuousCompile` is enabled.
+     * When a module has a worker, [compileOnly] awaits the worker's next
+     * BUILD outcome instead of running a one-shot `composePreviewCompile`
+     * task. Spike behind opt-in flag — see
+     * [docs/daemon/CONTINUOUS-COMPILE.md].
+     */
+    private continuousWorkers = new Map<string, ContinuousCompileWorker>();
 
     constructor(
         workspaceRoot: string,
@@ -365,11 +375,55 @@ export class GradleService {
      */
     async compileOnly(module: ModuleInfo, opts?: TaskOptions): Promise<void> {
         this.manifestCache.delete(module.modulePath);
+        const worker = this.continuousWorkers.get(module.modulePath);
+        if (worker && worker.running) {
+            const start = Date.now();
+            const outcome = await worker.waitForNextBuild();
+            const elapsed = Date.now() - start;
+            if (!outcome) {
+                this.logger.appendLine(
+                    `[continuous] ${module.modulePath} compileOnly fell through after ${elapsed}ms — falling back to Gradle`,
+                );
+                // Fall through to the one-shot Gradle path so the caller still
+                // sees a fresh .class output even when the worker timed out
+                // or exited unexpectedly.
+            } else {
+                this.logger.appendLine(
+                    `[continuous] ${module.modulePath} compileOnly ok=${outcome.ok} durationMs=${outcome.durationMs} waitMs=${elapsed}`,
+                );
+                if (!outcome.ok) {
+                    throw new KotlinCompileError(
+                        outcome.errors,
+                        `${module.modulePath}:composePreviewCompile`,
+                    );
+                }
+                return;
+            }
+        }
         await this.runTask(
             `${module.modulePath}:composePreviewCompile`,
             [],
             opts,
         );
+    }
+
+    /**
+     * Register (or clear with `null`) a continuous-compile worker for a
+     * module. Called by the daemon scheduler when the
+     * `composePreview.daemon.continuousCompile` flag is set. The scheduler
+     * owns the worker's lifecycle (start / stop); this map is just the
+     * lookup path `compileOnly` uses to short-circuit per-save Gradle
+     * invocations.
+     */
+    setContinuousCompileWorker(
+        modulePath: string,
+        worker: ContinuousCompileWorker | null,
+    ): void {
+        if (worker) {
+            this.continuousWorkers.set(modulePath, worker);
+        } else {
+            this.continuousWorkers.delete(modulePath);
+        }
     }
 
     /**

--- a/vscode-extension/src/test/continuousCompileManager.test.ts
+++ b/vscode-extension/src/test/continuousCompileManager.test.ts
@@ -1,0 +1,144 @@
+import * as assert from "assert";
+import { EventEmitter, Readable, Writable } from "stream";
+import { ChildProcess, SpawnOptions } from "child_process";
+import { ContinuousCompileManager } from "../daemon/continuousCompileManager";
+import { ContinuousCompileWorker } from "../daemon/continuousCompileWorker";
+import { GradleService, ModuleInfo } from "../gradleService";
+
+class FakeChild extends EventEmitter {
+    stdout = new Readable({ read() {} });
+    stderr = new Readable({ read() {} });
+    stdin = new Writable({
+        write(_c, _e, cb) {
+            cb();
+        },
+    });
+    pushStdout(s: string): void {
+        this.stdout.push(s);
+    }
+    kill(): boolean {
+        return true;
+    }
+}
+
+function fakeSpawnRecorder(): {
+    spawnFn: typeof import("child_process").spawn;
+    calls: { command: string; args: readonly string[] }[];
+    children: FakeChild[];
+} {
+    const calls: { command: string; args: readonly string[] }[] = [];
+    const children: FakeChild[] = [];
+    const spawnFn = ((
+        command: string,
+        args: readonly string[],
+        _options?: SpawnOptions,
+    ): ChildProcess => {
+        calls.push({ command, args });
+        const child = new FakeChild();
+        children.push(child);
+        return child as unknown as ChildProcess;
+    }) as unknown as typeof import("child_process").spawn;
+    return { spawnFn, calls, children };
+}
+
+function makeModule(modulePath: string): ModuleInfo {
+    return {
+        modulePath,
+        projectDir: modulePath.replace(/^:/, "").replace(/:/g, "/"),
+        plugins: ["com.android.application"],
+        variant: "debug",
+    } as ModuleInfo;
+}
+
+/**
+ * Minimal GradleService double — captures `setContinuousCompileWorker` calls
+ * so the manager test can assert the registration handshake without dragging
+ * in the full GradleService dependency stack.
+ */
+class FakeGradleService {
+    public readonly registered = new Map<
+        string,
+        ContinuousCompileWorker | null
+    >();
+    setContinuousCompileWorker(
+        modulePath: string,
+        worker: ContinuousCompileWorker | null,
+    ): void {
+        this.registered.set(modulePath, worker);
+    }
+}
+
+function makeManager(): {
+    manager: ContinuousCompileManager;
+    gradleService: FakeGradleService;
+    calls: { command: string; args: readonly string[] }[];
+    children: FakeChild[];
+} {
+    const gradleService = new FakeGradleService();
+    const { spawnFn, calls, children } = fakeSpawnRecorder();
+    const manager = new ContinuousCompileManager(
+        "/repo",
+        gradleService as unknown as GradleService,
+        { appendLine() {} },
+        [],
+        spawnFn,
+    );
+    return { manager, gradleService, calls, children };
+}
+
+describe("ContinuousCompileManager", () => {
+    it("ensureWorker spawns gradlew once and registers the worker", () => {
+        const { manager, gradleService, calls } = makeManager();
+        manager.ensureWorker(makeModule(":samples:cmp"));
+        assert.strictEqual(calls.length, 1);
+        assert.deepStrictEqual(calls[0].args, [
+            ":samples:cmp:composePreviewCompile",
+            "--continuous",
+            "--console=plain",
+        ]);
+        assert.deepStrictEqual(manager.activeModules(), [":samples:cmp"]);
+        assert.notStrictEqual(
+            gradleService.registered.get(":samples:cmp"),
+            null,
+        );
+    });
+
+    it("ensureWorker is idempotent", () => {
+        const { manager, gradleService, calls } = makeManager();
+        const module = makeModule(":samples:cmp");
+        manager.ensureWorker(module);
+        const first = gradleService.registered.get(":samples:cmp");
+        manager.ensureWorker(module);
+        const second = gradleService.registered.get(":samples:cmp");
+        assert.strictEqual(first, second);
+        assert.strictEqual(calls.length, 1);
+        assert.deepStrictEqual(manager.activeModules(), [":samples:cmp"]);
+    });
+
+    it("disposeWorker unregisters and signals stdin EOF", async () => {
+        const { manager, gradleService, children } = makeManager();
+        manager.ensureWorker(makeModule(":samples:cmp"));
+        // Fire-and-forget — `stop()` waits up to 5s for exit, so simulate one.
+        const stopping = manager.disposeWorker(":samples:cmp");
+        setTimeout(() => children[0].emit("exit", 0), 5);
+        await stopping;
+        assert.deepStrictEqual(manager.activeModules(), []);
+        assert.strictEqual(gradleService.registered.get(":samples:cmp"), null);
+    });
+
+    it("disposeAll tears down every worker in parallel", async () => {
+        const { manager, gradleService, children } = makeManager();
+        manager.ensureWorker(makeModule(":samples:android"));
+        manager.ensureWorker(makeModule(":samples:cmp"));
+        assert.strictEqual(manager.activeModules().length, 2);
+        const disposing = manager.disposeAll();
+        setTimeout(() => children.forEach((c) => c.emit("exit", 0)), 5);
+        await disposing;
+        assert.strictEqual(manager.activeModules().length, 0);
+        assert.strictEqual(
+            gradleService.registered.get(":samples:android"),
+            null,
+        );
+        assert.strictEqual(gradleService.registered.get(":samples:cmp"), null);
+    });
+});

--- a/vscode-extension/src/test/continuousCompileWorker.test.ts
+++ b/vscode-extension/src/test/continuousCompileWorker.test.ts
@@ -1,0 +1,326 @@
+import * as assert from "assert";
+import { EventEmitter, Readable, Writable } from "stream";
+import { ChildProcess, SpawnOptions } from "child_process";
+import {
+    BuildOutcome,
+    ContinuousCompileWorker,
+} from "../daemon/continuousCompileWorker";
+
+/**
+ * Test double for the subset of `ChildProcess` the worker reads. We push
+ * canned stdout chunks through `pushStdout` (and `pushStderr`) to drive
+ * the worker's parser the way real Gradle output would.
+ */
+class FakeChild extends EventEmitter {
+    stdout = new Readable({ read() {} });
+    stderr = new Readable({ read() {} });
+    stdin: Writable & { ended: boolean };
+    stdinEnded = false;
+    killed: NodeJS.Signals | null = null;
+
+    constructor() {
+        super();
+        const self = this;
+        this.stdin = Object.assign(
+            new Writable({
+                write(_chunk, _enc, cb) {
+                    cb();
+                },
+                final(cb) {
+                    self.stdinEnded = true;
+                    cb();
+                },
+            }),
+            { ended: false },
+        );
+    }
+
+    pushStdout(chunk: string): void {
+        this.stdout.push(chunk);
+    }
+
+    pushStderr(chunk: string): void {
+        this.stderr.push(chunk);
+    }
+
+    exit(code: number | null = 0): void {
+        this.emit("exit", code);
+    }
+
+    kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+        this.killed = signal;
+        return true;
+    }
+}
+
+interface SpawnCall {
+    command: string;
+    args: readonly string[];
+    options: SpawnOptions;
+}
+
+function fakeSpawn(onSpawn: (call: SpawnCall) => FakeChild): {
+    spawnFn: (
+        command: string,
+        args: readonly string[],
+        options: SpawnOptions,
+    ) => ChildProcess;
+    calls: SpawnCall[];
+    children: FakeChild[];
+} {
+    const calls: SpawnCall[] = [];
+    const children: FakeChild[] = [];
+    const spawnFn = (
+        command: string,
+        args: readonly string[],
+        options: SpawnOptions,
+    ): ChildProcess => {
+        const call: SpawnCall = { command, args, options };
+        calls.push(call);
+        const child = onSpawn(call);
+        children.push(child);
+        return child as unknown as ChildProcess;
+    };
+    return { spawnFn, calls, children };
+}
+
+class FakeClock {
+    t = 0;
+    now = (): number => this.t;
+    advance(ms: number): void {
+        this.t += ms;
+    }
+}
+
+function makeWorker(
+    clock: FakeClock,
+    spawnFn: ReturnType<typeof fakeSpawn>["spawnFn"],
+    logger?: { appendLine(line: string): void },
+): ContinuousCompileWorker {
+    return new ContinuousCompileWorker({
+        workspaceRoot: "/repo",
+        taskPath: ":samples:android:composePreviewCompile",
+        spawnFn: spawnFn as unknown as typeof import("child_process").spawn,
+        nowFn: clock.now,
+        logger,
+        buildTimeoutMs: 1_000,
+    });
+}
+
+/** Flush the microtask queue so EventEmitter-routed Promises settle. */
+function tick(): Promise<void> {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("ContinuousCompileWorker", () => {
+    it("spawns gradlew with --continuous and the requested task", () => {
+        const clock = new FakeClock();
+        const { spawnFn, calls, children } = fakeSpawn(() => new FakeChild());
+        const worker = makeWorker(clock, spawnFn);
+        worker.start();
+        assert.strictEqual(calls.length, 1);
+        assert.match(calls[0].command, /gradlew(\.bat)?$/);
+        assert.deepStrictEqual(calls[0].args, [
+            ":samples:android:composePreviewCompile",
+            "--continuous",
+            "--console=plain",
+        ]);
+        assert.strictEqual(calls[0].options.cwd, "/repo");
+        // Spawned child is tracked for subsequent assertions.
+        assert.strictEqual(children.length, 1);
+        // running is true after start.
+        assert.strictEqual(worker.running, true);
+    });
+
+    it("ignores the warm-up BUILD SUCCESSFUL (no Change detected before it)", async () => {
+        const clock = new FakeClock();
+        const { spawnFn, children } = fakeSpawn(() => new FakeChild());
+        const worker = makeWorker(clock, spawnFn);
+        worker.start();
+        const child = children[0];
+
+        // Warm-up build runs immediately at worker start — no "Change detected".
+        clock.advance(100);
+        child.pushStdout(
+            "> Task :samples:android:composePreviewCompile UP-TO-DATE\n",
+        );
+        child.pushStdout("BUILD SUCCESSFUL in 480ms\n");
+        await tick();
+
+        // Now the caller fires waitForNextBuild — must NOT see the warm-up.
+        clock.advance(50);
+        const pending = worker.waitForNextBuild(500);
+        // Drive a real source-change build through.
+        clock.advance(20);
+        child.pushStdout("Change detected, executing build...\n");
+        clock.advance(420);
+        child.pushStdout("BUILD SUCCESSFUL in 420ms\n");
+        const outcome = await pending;
+        assert.notStrictEqual(outcome, null);
+        assert.strictEqual(outcome!.ok, true);
+        assert.strictEqual(outcome!.durationMs, 420);
+    });
+
+    it("resolves with BUILD SUCCESSFUL after Change detected", async () => {
+        const clock = new FakeClock();
+        const { spawnFn, children } = fakeSpawn(() => new FakeChild());
+        const worker = makeWorker(clock, spawnFn);
+        worker.start();
+        const child = children[0];
+
+        clock.advance(50);
+        const pending = worker.waitForNextBuild();
+        clock.advance(10);
+        child.pushStdout("Change detected, executing build...\n");
+        clock.advance(900);
+        child.pushStdout("BUILD SUCCESSFUL in 900ms\n");
+        const outcome = await pending;
+        assert.deepStrictEqual(outcome, {
+            ok: true,
+            finishedAtMs: 960,
+            durationMs: 900,
+            errors: [],
+        } satisfies BuildOutcome);
+    });
+
+    it("captures Kotlin compile errors on BUILD FAILED", async () => {
+        const clock = new FakeClock();
+        const { spawnFn, children } = fakeSpawn(() => new FakeChild());
+        const worker = makeWorker(clock, spawnFn);
+        worker.start();
+        const child = children[0];
+
+        const pending = worker.waitForNextBuild();
+        child.pushStdout("Change detected, executing build...\n");
+        child.pushStdout(
+            "e: file:///repo/samples/android/src/main/kotlin/Foo.kt:12:5 Unresolved reference: bar\n",
+        );
+        child.pushStdout("BUILD FAILED in 2s\n");
+        const outcome = await pending;
+        assert.notStrictEqual(outcome, null);
+        assert.strictEqual(outcome!.ok, false);
+        assert.strictEqual(outcome!.durationMs, 2000);
+        assert.strictEqual(outcome!.errors.length, 1);
+        assert.strictEqual(outcome!.errors[0].line, 12);
+        assert.match(outcome!.errors[0].file, /Foo\.kt$/);
+    });
+
+    it("times out cleanly when no build follows", async () => {
+        const clock = new FakeClock();
+        const { spawnFn } = fakeSpawn(() => new FakeChild());
+        const worker = makeWorker(clock, spawnFn);
+        worker.start();
+        const outcome = await worker.waitForNextBuild(20);
+        assert.strictEqual(outcome, null);
+    });
+
+    it("returns null when the subprocess exits mid-wait", async () => {
+        const clock = new FakeClock();
+        const { spawnFn, children } = fakeSpawn(() => new FakeChild());
+        const worker = makeWorker(clock, spawnFn);
+        worker.start();
+        const child = children[0];
+        const pending = worker.waitForNextBuild(5_000);
+        child.exit(1);
+        const outcome = await pending;
+        assert.strictEqual(outcome, null);
+        assert.strictEqual(worker.running, false);
+    });
+
+    it("returns null immediately when called on a stopped worker", async () => {
+        const clock = new FakeClock();
+        const { spawnFn, children } = fakeSpawn(() => new FakeChild());
+        const worker = makeWorker(clock, spawnFn);
+        worker.start();
+        children[0].exit(0);
+        await tick();
+        const outcome = await worker.waitForNextBuild(5_000);
+        assert.strictEqual(outcome, null);
+    });
+
+    it("treats an in-flight Change-detected build as the caller's build", async () => {
+        // Race: Gradle's watcher fires before our save event delivers a
+        // waitForNextBuild() call. The build's Change-detected timestamp is
+        // after the caller's clock, so we should still observe its outcome.
+        const clock = new FakeClock();
+        const { spawnFn, children } = fakeSpawn(() => new FakeChild());
+        const worker = makeWorker(clock, spawnFn);
+        worker.start();
+        const child = children[0];
+        clock.advance(100);
+        // Change detected at t=100ms (after our t=0 baseline).
+        child.pushStdout("Change detected, executing build...\n");
+        await tick();
+        clock.advance(50);
+        // Caller fires at t=150ms — build started at t=100ms is still in flight.
+        const pending = worker.waitForNextBuild(5_000);
+        clock.advance(400);
+        child.pushStdout("BUILD SUCCESSFUL in 450ms\n");
+        const outcome = await pending;
+        assert.notStrictEqual(outcome, null);
+        assert.strictEqual(outcome!.ok, true);
+    });
+
+    it("ignores an in-flight build older than the accept window", async () => {
+        // A build that started long before this call is treated as stale —
+        // it almost certainly doesn't include the caller's freshly-saved
+        // edits, so waiting for it would produce a render that lags the
+        // source. We wait for the NEXT build instead, even though it costs
+        // an extra round-trip.
+        const clock = new FakeClock();
+        const { spawnFn, children } = fakeSpawn(() => new FakeChild());
+        const worker = makeWorker(clock, spawnFn);
+        worker.start();
+        const child = children[0];
+        // Build started at t=0 (long before the caller).
+        child.pushStdout("Change detected, executing build...\n");
+        await tick();
+        // Caller fires at t=1500ms — delta=1500 > IN_FLIGHT_ACCEPT_WINDOW_MS (500).
+        clock.advance(1_500);
+        const pending = worker.waitForNextBuild(50);
+        // The stale build completes but its outcome must NOT satisfy us.
+        clock.advance(100);
+        child.pushStdout("BUILD SUCCESSFUL in 1600ms\n");
+        const outcome = await pending;
+        assert.strictEqual(outcome, null);
+    });
+
+    it("parses duration trailers in ms, s, and fractional seconds", async () => {
+        const cases: Array<[string, number]> = [
+            ["BUILD SUCCESSFUL in 480ms\n", 480],
+            ["BUILD SUCCESSFUL in 1s\n", 1000],
+            ["BUILD SUCCESSFUL in 1.4s\n", 1400],
+            ["BUILD SUCCESSFUL in 12s\n", 12000],
+        ];
+        for (const [line, expected] of cases) {
+            const clock = new FakeClock();
+            const { spawnFn, children } = fakeSpawn(() => new FakeChild());
+            const worker = makeWorker(clock, spawnFn);
+            worker.start();
+            const child = children[0];
+            const pending = worker.waitForNextBuild();
+            child.pushStdout("Change detected, executing build...\n");
+            child.pushStdout(line);
+            const outcome = await pending;
+            assert.strictEqual(
+                outcome?.durationMs,
+                expected,
+                `parse failure for ${JSON.stringify(line)}`,
+            );
+        }
+    });
+
+    it("stop() sends EOF on stdin and resolves once the child exits", async () => {
+        const clock = new FakeClock();
+        const { spawnFn, children } = fakeSpawn(() => new FakeChild());
+        const worker = makeWorker(clock, spawnFn);
+        worker.start();
+        const child = children[0];
+        const stopping = worker.stop();
+        // Simulate gradle reacting to EOF.
+        setTimeout(() => child.exit(0), 5);
+        await stopping;
+        assert.strictEqual(child.stdinEnded, true);
+        assert.strictEqual(worker.running, false);
+    });
+});


### PR DESCRIPTION
## Summary

Stage-1 of the kotlinc-in-daemon investigation. Adds an opt-in
`composePreview.daemon.continuousCompile` VS Code setting; when enabled,
a long-running `gradle --continuous :<module>:composePreviewCompile`
worker is started per daemon-warmed module and
`gradleService.compileOnly()` delegates to it instead of running a
one-shot Gradle task per save. The per-save Gradle configuration +
tooling-API round-trip (~500 ms on a warm 1-line edit, per
`docs/daemon/baseline-latency.csv`) drops out of the save loop; only
the kotlinc work itself remains.

Off by default. With the flag off, no code path changes.

### Architecture

- `ContinuousCompileWorker` owns the subprocess and parses Gradle's
  `--console=plain` stream into a tiny state machine (`Change detected
  …` → running; `BUILD SUCCESSFUL/FAILED in N(ms|s)` → idle). Captures
  Kotlin compile errors through the existing
  `KotlinCompileErrorDetector`.
- `ContinuousCompileManager` holds one worker per module, started on
  daemon warm and stopped on `composePreview.restartDaemon` /
  deactivate.
- `GradleService.compileOnly()` short-circuits to the worker when one
  is registered; null outcomes (timeout, subprocess exit, stale
  in-flight build outside the 500 ms acceptance window) fall back to
  the one-shot `composePreviewCompile` task path so the save loop
  never gets stuck.
- The flag is exposed in VS Code settings under
  **Compose Preview › Daemon: Continuous Compile**. Requires a window
  reload to take effect.

### Why `gradle --continuous` and not the Kotlin Build Tools API directly

This is the architecture JetBrains shipped for Compose Hot Reload 1.0
(their `Recompiler` module spawns a continuous Gradle daemon and
broadcasts changed classes). It keeps Gradle's source-set + variant +
KSP/KAPT wiring intact and avoids the unknowns around loading the
Compose compiler plugin through the still-experimental BTA. Stage 2
(BTA hosted inside `:daemon:core`) is gated on this spike's measured
outcome — see `docs/daemon/CONTINUOUS-COMPILE.md` for the exit
criteria.

This is the first explicit exception to the DESIGN.md non-goal "Hot
kotlinc / compile-daemon integration"; that line has been updated to
point at the spike doc.

## Test plan

- [ ] `npm test` in `vscode-extension/` — full suite green (1150
  passing locally, including the 11 worker + 4 manager tests added
  here).
- [ ] Manual: open the repo in the dev host with the flag **off**,
  edit a `.kt` in `:samples:cmp`, capture save → pixel timing as
  baseline.
- [ ] Manual: flip `composePreview.daemon.continuousCompile = true`
  in VS Code settings, reload window, repeat the edit. Confirm a
  `[continuous] spawn` line appears in the Compose Preview output
  channel on daemon warm, and one `[continuous] :samples:cmp
  compileOnly ok=true durationMs=… waitMs=…` line per save thereafter.
- [ ] Same on `:samples:android` — watch for Gradle build-directory
  lock contention with `composePreviewRender` (renderer task runs
  through a separate Gradle path).
- [ ] Break a `.kt` deliberately; confirm `BUILD FAILED` flows through
  as a `KotlinCompileError` with the same banner the Gradle path
  surfaces today.
- [ ] Hit `composePreview.restartDaemon`; confirm the workers are
  torn down + respawned on the next save.

The four open questions and the promote/abandon thresholds are
spelled out in `docs/daemon/CONTINUOUS-COMPILE.md`.