### PR TITLE
test(vscode-extension): surface warm-daemon failure cause in e2eA11y assertion

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -443,6 +443,14 @@ export interface ComposePreviewTestApi {
      * Gradle-task render path and never touches the daemon gate.
      */
     triggerWarmDaemon(filePath: string): Promise<boolean>;
+    /**
+     * Most recent failure reason recorded by `warmDaemonForFile`, or `null`
+     * if the last call succeeded (or none was made yet). Exposed so the
+     * wear a11y `before()` hook can surface the underlying cause when the
+     * warm returns `false` — otherwise the assertion just says "warm
+     * failed" with no actionable detail in CI output.
+     */
+    getLastWarmDaemonError(): string | null;
     /** Snapshot of every panel message posted since [resetMessages]. */
     getPostedMessages(): unknown[];
     /**
@@ -1787,6 +1795,9 @@ export async function activate(
             triggerWarmDaemon(filePath: string): Promise<boolean> {
                 return warmDaemonForFile(filePath);
             },
+            getLastWarmDaemonError(): string | null {
+                return lastWarmDaemonError;
+            },
             getPostedMessages(): unknown[] {
                 return [...postedMessageLog];
             },
@@ -2430,10 +2441,14 @@ async function warmDaemonForFile(
     opts: { refreshAfterReady?: boolean } = {},
 ): Promise<boolean> {
     if (!daemonGate || !daemonScheduler || !gradleService) {
+        lastWarmDaemonError =
+            "warm aborted: backend not wired " +
+            `(daemonGate=${!!daemonGate}, daemonScheduler=${!!daemonScheduler}, gradleService=${!!gradleService})`;
         return false;
     }
     const module = gradleService.resolveModule(filePath);
     if (!module) {
+        lastWarmDaemonError = `warm aborted: resolveModule returned null for ${filePath} (no applied.json marker and no plugin id in build.gradle.kts)`;
         return false;
     }
     const moduleKey = module.modulePath;
@@ -2441,7 +2456,13 @@ async function warmDaemonForFile(
         if (daemonGate.isDaemonReady(moduleKey) && opts.refreshAfterReady) {
             await refreshAfterDaemonReady(filePath, "view-open");
         }
-        return daemonGate.isDaemonReady(moduleKey);
+        const ready = daemonGate.isDaemonReady(moduleKey);
+        if (!ready) {
+            lastWarmDaemonError = `warm aborted: ${moduleKey} already bootstrapped this session but daemon is not ready (prior spawn failed without resetting the memo)`;
+        } else {
+            lastWarmDaemonError = null;
+        }
+        return ready;
     }
     daemonBootstrappedModules.add(moduleKey);
     try {
@@ -2455,6 +2476,11 @@ async function warmDaemonForFile(
         );
         if (!warmed) {
             daemonBootstrappedModules.delete(moduleKey);
+            lastWarmDaemonError = daemonGate.isBuildDisabled(module)
+                ? `warm returned false for ${moduleKey}: descriptor has enabled=false (composePreview { daemon { enabled = ... } })`
+                : `warm returned false for ${moduleKey} after bootstrap (ensureModule could not spawn daemon — check daemon-launch.json + daemon channel logs)`;
+        } else {
+            lastWarmDaemonError = null;
         }
         finishDaemonStartupProgress(module, filePath, warmed);
         if (warmed && opts.refreshAfterReady) {
@@ -2465,9 +2491,9 @@ async function warmDaemonForFile(
         daemonBootstrappedModules.delete(moduleKey);
         stopDaemonStartupProgress(module);
         panel?.postMessage({ command: "clearProgress" });
-        logLine(
-            `daemon: warm failed for ${moduleKey}: ${String((err as Error).message ?? err)}`,
-        );
+        const reason = String((err as Error).message ?? err);
+        lastWarmDaemonError = `warm threw for ${moduleKey}: ${reason}`;
+        logLine(`daemon: warm failed for ${moduleKey}: ${reason}`);
         vscode.window.showErrorMessage(
             "Compose Preview daemon failed to start. Preview saves will not render until the daemon is fixed.",
         );
@@ -3146,6 +3172,16 @@ async function assembleDoctorReport(
 
 /** Per-extension-session memo so bootstrap runs once per module. */
 const daemonBootstrappedModules = new Set<string>();
+
+/**
+ * Most recent reason `warmDaemonForFile` returned `false`. `null` when the
+ * last call succeeded (or no call has been made). Exposed through the test
+ * API so the wear a11y `before()` hook can include the underlying cause in
+ * its assertion message — production warm failures already surface through
+ * `outputChannel` + the user-facing error dialog, so this is captured for
+ * test diagnostics only.
+ */
+let lastWarmDaemonError: string | null = null;
 
 /**
  * Read Error-severity diagnostics for `filePath` from whichever language

--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -211,7 +211,13 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
         // an explicit warm here the first `triggerSetDataExtensionEnabled`
         // throws `[daemon] no launch descriptor for :samples:wear`.
         const warmed = await api.triggerWarmDaemon(wearKotlinFile);
-        assert.ok(warmed, "wear daemon must warm before chip subscriptions");
+        assert.ok(
+            warmed,
+            "wear daemon must warm before chip subscriptions" +
+                (warmed
+                    ? ""
+                    : `; cause: ${api.getLastWarmDaemonError() ?? "<unknown>"}`),
+        );
 
         // One refresh bootstraps every `it`: the wear composePreviewRenderAll
         // cold path is the slowest piece of the suite, so paying for it


### PR DESCRIPTION
`triggerWarmDaemon` returns `boolean`, so when the wear `before()` hook's
`assert.ok(warmed, ...)` fires in CI the developer sees "wear daemon must
warm before chip subscriptions" and nothing else — `warmDaemonForFile`'s
real failure mode (no module resolved, descriptor enabled=false, bootstrap
task crashed, JVM spawn threw, ...) is lost to the outputChannel that no
one harvests. Issue #1326 was filed against exactly this opaque failure.

Capture the failure reason in a module-level `lastWarmDaemonError` and
expose it on `ComposePreviewTestApi.getLastWarmDaemonError()`. Each of
the four warm exit paths writes a distinct message:

  - backend not wired (gate/scheduler/gradleService still null)
  - resolveModule returned null (workspace layout / marker drift)
  - already-bootstrapped memo says yes but daemon is not ready
  - warmModule returned false (split: build-disabled vs spawn failed)
  - warmModule threw (forwards the underlying message)

The e2eA11y `before()` hook reads it on failure and appends `; cause: ...`
to the assertion message, so the next CI run on #1326 carries an
actionable diagnosis in the test output instead of a bare boolean miss.