### PR TITLE
fix(gradle-plugin): open jdk.internal.access for Robolectric on JDK 25+

### DIFF
--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -295,6 +295,9 @@ class RealAndroidHarnessLauncher(
         add("--add-opens=java.base/java.lang=ALL-UNNAMED")
         add("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED")
         add("--add-opens=java.base/java.nio=ALL-UNNAMED")
+        // SDK 36 + JDK 25/26: Robolectric's `FileDescriptorInterceptor.setInt`
+        // reflects through `jdk.internal.access.SharedSecrets` (see #1328).
+        add("--add-opens=java.base/jdk.internal.access=ALL-UNNAMED")
         // Render output directory.
         add("-Dcomposeai.render.outputDir=${rendersDir.absolutePath}")
         // Wire the manifest router (same as desktop).

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
@@ -215,6 +215,19 @@ internal object AndroidPreviewClasspath {
       // opens. Reached via `PathIterator` — triggered here by Wear Compose's
       // curved text renderer.
       "--add-opens=java.base/java.nio=ALL-UNNAMED",
+      // Robolectric's `FileDescriptorInterceptor.setInt` reflects into
+      // `jdk.internal.access.SharedSecrets#getJavaIOFileDescriptorAccess()`
+      // to mutate `FileDescriptor.fd` (the older `Field.setInt` path was
+      // replaced in 4.13+). On SDK 36 sandboxes the framework's
+      // `com.android.internal.os.ApplicationSharedMemory.create()` runs
+      // during `AndroidTestEnvironment.setUpApplicationState`, hits the
+      // interceptor, and without this opens the JDK raises
+      // `IllegalAccessException: class … cannot access class
+      // jdk.internal.access.SharedSecrets (in module java.base) because
+      // module java.base does not export jdk.internal.access` — wrapped by
+      // Robolectric as `Failed to interact with raw FileDescriptor
+      // internals; perhaps JRE has changed?`. Issue #1328.
+      "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
     )
 
   /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1439,12 +1439,7 @@ internal object AndroidPreviewSupport {
         useJUnit()
 
         jvmArgs(agpTestTask?.jvmArgs ?: emptyList<String>())
-        jvmArgs(
-          "--add-opens=java.base/java.io=ALL-UNNAMED",
-          "--add-opens=java.base/java.lang=ALL-UNNAMED",
-          "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
-          "--add-opens=java.base/java.nio=ALL-UNNAMED",
-        )
+        jvmArgs(AndroidPreviewClasspath.buildJvmArgs())
         agpTestTask?.javaLauncher?.orNull?.let { javaLauncher.set(it) }
 
         systemProperty("robolectric.graphicsMode", "NATIVE")

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspathTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspathTest.kt
@@ -91,6 +91,18 @@ class AndroidPreviewClasspathTest {
     AndroidPreviewClasspath.validateApplicationOnClasspath(listOf(dir, notAJar, androidJar))
   }
 
+  @Test
+  fun `buildJvmArgs opens jdk_internal_access for FileDescriptorInterceptor`() {
+    // Regression for issue #1328: Robolectric 4.16's `FileDescriptorInterceptor.setInt`
+    // reflects into `jdk.internal.access.SharedSecrets`, which the JDK refuses to expose to
+    // an unnamed module without `--add-opens=java.base/jdk.internal.access=ALL-UNNAMED`. On
+    // SDK 36 sandboxes `ApplicationSharedMemory.create()` runs during Robolectric setup and
+    // hits that interceptor, surfacing as `Failed to interact with raw FileDescriptor
+    // internals; perhaps JRE has changed?`.
+    assertThat(AndroidPreviewClasspath.buildJvmArgs())
+      .contains("--add-opens=java.base/jdk.internal.access=ALL-UNNAMED")
+  }
+
   private fun writeAndroidJar(file: File) {
     writeJar(file, mapOf("android/app/Application.class" to ByteArray(16)))
   }


### PR DESCRIPTION
Robolectric 4.16's `FileDescriptorInterceptor.setInt` reflects into
`jdk.internal.access.SharedSecrets#getJavaIOFileDescriptorAccess()`
to mutate `FileDescriptor.fd`. On SDK 36 sandboxes the framework's
`ApplicationSharedMemory.create()` runs during
`AndroidTestEnvironment.setUpApplicationState` and hits that
interceptor; under JDKs that strictly enforce module integrity this
raises `IllegalAccessException` because `java.base` does not export
`jdk.internal.access` to the unnamed module, which Robolectric
wraps as "Failed to interact with raw FileDescriptor internals;
perhaps JRE has changed?".

Add `--add-opens=java.base/jdk.internal.access=ALL-UNNAMED` to the
shared JVM-args list (consumed by `composePreviewRender`, the
resource render task, and the daemon harness). Also fold the
hand-rolled list in `AndroidPreviewSupport` for the resource task
into `AndroidPreviewClasspath.buildJvmArgs()` so the two paths
stay in sync.

Fixes #1328.