### PR TITLE
fix(vscode): skip auto-inject when settings.gradle includes :gradle-plugin

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -95,7 +95,11 @@ import {
     hasFreshRenderStamp,
     writeRenderFreshnessStamp,
 } from "./renderFreshness";
-import { BUNDLED_PLUGIN_VERSION, materializeInitScript } from "./initScript";
+import {
+    BUNDLED_PLUGIN_VERSION,
+    hasIncludedPluginBuild,
+    materializeInitScript,
+} from "./initScript";
 import {
     ComposePreviewMode,
     ResolvedMode,
@@ -698,19 +702,31 @@ export async function activate(
     // a static media path) lets us version-pin the plugin coordinate in
     // TypeScript and keep the rendered script in extension storage, which
     // survives extension updates without polluting `~/.gradle/init.d/`.
+    //
+    // Skipped when the workspace is the compose-ai-tools repo itself
+    // (`includeBuild("gradle-plugin")` in settings.gradle[.kts]) — the
+    // included build already provides the plugin and a Maven-resolved
+    // classpath dep on top would pin the build-script compilation against
+    // the extension's bundled version. Mirrors the CLI's `AutoInject.kt`.
     let initScriptArgs: readonly string[] = [];
-    try {
-        const initScriptPath = materializeInitScript(
-            context.globalStorageUri.fsPath,
-        );
-        initScriptArgs = ["--init-script", initScriptPath];
+    if (hasIncludedPluginBuild(workspaceRoot)) {
         outputChannel.appendLine(
-            `[startup] auto-inject: --init-script ${initScriptPath} (plugin ${BUNDLED_PLUGIN_VERSION})`,
+            `[startup] auto-inject disabled: settings.gradle[.kts] includes :gradle-plugin (compose-ai-tools dev loop)`,
         );
-    } catch (err) {
-        outputChannel.appendLine(
-            `[startup] auto-inject disabled: failed to materialise init script: ${(err as Error).message}`,
-        );
+    } else {
+        try {
+            const initScriptPath = materializeInitScript(
+                context.globalStorageUri.fsPath,
+            );
+            initScriptArgs = ["--init-script", initScriptPath];
+            outputChannel.appendLine(
+                `[startup] auto-inject: --init-script ${initScriptPath} (plugin ${BUNDLED_PLUGIN_VERSION})`,
+            );
+        } catch (err) {
+            outputChannel.appendLine(
+                `[startup] auto-inject disabled: failed to materialise init script: ${(err as Error).message}`,
+            );
+        }
     }
 
     // Force plain console output. The Tooling API defaults to Gradle's "rich"
@@ -4210,11 +4226,7 @@ async function refresh(
             pickRefreshMode(activeFile) === "daemon" &&
             daemonGate !== null &&
             !daemonGate.isBuildDisabled(module);
-        if (
-            sourceIsStale &&
-            !inMinimalMode() &&
-            !daemonWillRender
-        ) {
+        if (sourceIsStale && !inMinimalMode() && !daemonWillRender) {
             logLine(
                 `auto-render: ${path.basename(activeFile)} newer than rendered PNGs — kicking fresh render`,
             );

--- a/vscode-extension/src/initScript.ts
+++ b/vscode-extension/src/initScript.ts
@@ -243,3 +243,34 @@ export function initScriptDigest(
         .digest("hex")
         .slice(0, 16);
 }
+
+/**
+ * True when [workspaceRoot]'s `settings.gradle[.kts]` declares
+ * `includeBuild("gradle-plugin")` — the compose-ai-tools repo's own dev-loop
+ * layout. Stacking a Maven-resolved classpath dep (auto-inject) on top of an
+ * included build that already provides `ee.schimke.composeai.preview` makes
+ * Gradle compile the consumer's build script against the published version
+ * baked into the extension, while the included build's local source provides
+ * a different (potentially newer) shape — so a build file that references a
+ * property added since that published version fails with "Unresolved
+ * reference". Skipping auto-inject in this case lets the included build win.
+ *
+ * Mirrors the CLI's `hasIncludedPluginBuild` in `cli/.../AutoInject.kt`.
+ */
+export function hasIncludedPluginBuild(workspaceRoot: string): boolean {
+    const candidates = [
+        path.join(workspaceRoot, "settings.gradle.kts"),
+        path.join(workspaceRoot, "settings.gradle"),
+    ];
+    const pattern = /includeBuild\s*\(\s*["']gradle-plugin["']\s*\)/;
+    for (const file of candidates) {
+        let text: string;
+        try {
+            text = fs.readFileSync(file, "utf-8");
+        } catch {
+            continue;
+        }
+        if (pattern.test(text)) return true;
+    }
+    return false;
+}

--- a/vscode-extension/src/test/initScript.test.ts
+++ b/vscode-extension/src/test/initScript.test.ts
@@ -5,6 +5,7 @@ import * as path from "path";
 import {
     BUNDLED_PLUGIN_VERSION,
     INIT_SCRIPT_FILENAME,
+    hasIncludedPluginBuild,
     initScriptDigest,
     materializeInitScript,
     renderInitScript,
@@ -251,6 +252,59 @@ describe("materializeInitScript", () => {
             const onDisk = fs.readFileSync(target, "utf-8");
             assert.match(onDisk, /val pluginVersion = "2\.0\.0"/);
             assert.ok(!onDisk.includes('val pluginVersion = "1.0.0"'));
+        }),
+    );
+});
+
+describe("hasIncludedPluginBuild", () => {
+    it(
+        'returns true for settings.gradle.kts declaring includeBuild("gradle-plugin")',
+        withTempDir((dir) => {
+            fs.writeFileSync(
+                path.join(dir, "settings.gradle.kts"),
+                'rootProject.name = "demo"\nincludeBuild("gradle-plugin")\n',
+            );
+            assert.strictEqual(hasIncludedPluginBuild(dir), true);
+        }),
+    );
+
+    it(
+        "returns true for Groovy settings.gradle with single quotes and parens",
+        withTempDir((dir) => {
+            fs.writeFileSync(
+                path.join(dir, "settings.gradle"),
+                "rootProject.name = 'demo'\nincludeBuild('gradle-plugin')\n",
+            );
+            assert.strictEqual(hasIncludedPluginBuild(dir), true);
+        }),
+    );
+
+    it(
+        "returns true when includeBuild() has extra whitespace",
+        withTempDir((dir) => {
+            fs.writeFileSync(
+                path.join(dir, "settings.gradle.kts"),
+                'includeBuild( "gradle-plugin" )\n',
+            );
+            assert.strictEqual(hasIncludedPluginBuild(dir), true);
+        }),
+    );
+
+    it(
+        "returns false when no settings file exists",
+        withTempDir((dir) => {
+            assert.strictEqual(hasIncludedPluginBuild(dir), false);
+        }),
+    );
+
+    it(
+        "returns false when settings.gradle.kts includes a different build",
+        withTempDir((dir) => {
+            fs.writeFileSync(
+                path.join(dir, "settings.gradle.kts"),
+                'includeBuild("build-logic")\n',
+            );
+            assert.strictEqual(hasIncludedPluginBuild(dir), false);
         }),
     );
 });


### PR DESCRIPTION
Mirror the CLI's `hasIncludedPluginBuild` short-circuit so the VS Code
extension stops layering an init-script-injected
`ee.schimke.composeai.preview` classpath dep on top of the included build
when the workspace IS the compose-ai-tools repo. The two together pin
build-script compilation against the extension's bundled (potentially
older) plugin coordinate, so a reference to a property added since that
version — e.g. `:samples:sdk-matrix`'s
`maxSupportedSdkOverride.set(...)` — fails with "Unresolved reference".

The CLI already does this in `AutoInject.kt::hasIncludedPluginBuild`;
the extension was missing the equivalent gate, so VS Code sessions
against this repo hit the conflict on every Gradle invocation.

Fixes #1336.