### PR TITLE
feat(data/pseudolocale): pseudolocalise stringResource on CMP Desktop

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,8 +1,11 @@
 import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskAction
 
 plugins {
@@ -104,11 +107,41 @@ dependencies {
   testImplementation(kotlin("test"))
 }
 
+// Multiple JetBrains Compose Multiplatform `components-*-desktop` artifacts ship as
+// `library-desktop-<version>.jar` (e.g. `components-resources-desktop` and
+// `components-ui-tooling-preview-desktop`), so a flat copy into `lib-daemon-desktop/` collides on
+// filename. Stage the resolved artifacts to a build directory first, disambiguating colliding
+// filenames by Maven `module-version.jar`, so both end up on the daemon's classpath at runtime.
+val stageDaemonDesktopLibs =
+  tasks.register<Sync>("stageDaemonDesktopLibs") {
+    description = "Stages :daemon:desktop runtime artifacts, renaming filename collisions."
+    destinationDir = layout.buildDirectory.dir("staged-daemon-desktop-libs").get().asFile
+    val artifactsProvider = composePreviewDaemonDesktop.incoming.artifacts.resolvedArtifacts
+    from(artifactsProvider.map { it.map(ResolvedArtifactResult::getFile) })
+    val nameByPath = artifactsProvider.map { resolved ->
+      val counts = resolved.groupingBy { it.file.name }.eachCount()
+      resolved.associate { artifact ->
+        val original = artifact.file.name
+        val mapped =
+          if (counts.getValue(original) > 1) {
+            val id = artifact.id.componentIdentifier
+            if (id is ModuleComponentIdentifier) "${id.module}-${id.version}.jar" else original
+          } else original
+        artifact.file.absolutePath to mapped
+      }
+    }
+    inputs.property("nameByPath", nameByPath)
+    eachFile {
+      val mapped = nameByPath.get()[file.absolutePath]
+      if (mapped != null) name = mapped
+    }
+  }
+
 distributions {
   named("main") {
     contents {
       into("lib-renderer") { from(composePreviewRenderer) }
-      into("lib-daemon-desktop") { from(composePreviewDaemonDesktop) }
+      into("lib-daemon-desktop") { from(stageDaemonDesktopLibs) }
     }
   }
 }

--- a/data/pseudolocale/connector-desktop/build.gradle.kts
+++ b/data/pseudolocale/connector-desktop/build.gradle.kts
@@ -3,12 +3,15 @@
 // `:data-pseudolocale-connector-desktop` is the JVM-side counterpart to
 // `:data-pseudolocale-connector`
 // (Android). Both planners read `renderNow.overrides.localeTag` and emit a
-// `PreviewOverrideExtension`, but the desktop variant has a narrower contract: CMP Desktop's
-// string-resource path (`org.jetbrains.compose.resources`) doesn't go through
-// `LocalContext.resources`,
-// so we don't pseudolocalise text content here. What we *do* provide:
+// `PreviewOverrideExtension`. What this connector contributes:
 //
 // - `LayoutDirection.Rtl` for `ar-XB` so RTL bugs surface in the rendered PNG.
+// - A wrapped `LocalResourceReader` so every `org.jetbrains.compose.resources.stringResource(...)`
+//   lookup returns the pseudolocalised accent / bidi text. CMP Desktop's `stringResource` doesn't
+//   walk `LocalContext.resources`, so we intercept at the byte-level reader instead of swapping a
+//   `Resources` subclass like Android does. The `LocalComposeEnvironment` env-swap path the issue
+//   originally suggested is unreachable — both the env interface and its CompositionLocal are
+//   declared `internal` to `org.jetbrains.compose.resources` at CMP 1.10.x.
 // - A rewritten `LocaleList` (en-XA → en, ar-XB → ar) so locale-sensitive Compose text rendering
 //   resolves against a real BCP-47 locale instead of a tag the JVM doesn't know.
 //
@@ -30,6 +33,11 @@ dependencies {
   api(project(":data-render-compose"))
   implementation(compose.runtime)
   implementation(compose.ui)
+  // `org.jetbrains.compose.resources.LocalResourceReader` — the byte-level interceptor we wrap so
+  // every `stringResource(...)` lookup on desktop returns the pseudolocalised form. The `internal`
+  // env-swap path (`LocalComposeEnvironment` / `ComposeEnvironment`) isn't reachable from outside
+  // the resources module at CMP 1.10.x, so this is the published handle that actually works.
+  implementation(compose.components.resources)
 
   testImplementation(libs.junit)
 }
@@ -39,7 +47,7 @@ composeAiMavenPublishing {
     artifactId = "data-pseudolocale-connector-desktop",
     displayName = "Compose Preview - Pseudolocale Data Product Connector (Desktop)",
     description =
-      "Daemon-side pseudolocale data-product connector for Compose Multiplatform Desktop: provides LayoutDirection.Rtl for ar-XB and a rewritten LocaleList for en-XA / ar-XB. Text-content pseudolocalization is Android-only — see :data-pseudolocale-connector.",
+      "Daemon-side pseudolocale data-product connector for Compose Multiplatform Desktop: wraps LocalResourceReader so stringResource(...) returns the pseudolocalised accent / bidi form, provides LayoutDirection.Rtl for ar-XB, and emits a rewritten LocaleList for en-XA / ar-XB.",
   )
   inceptionYear.set("2026")
 }

--- a/data/pseudolocale/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleOverrideExtensionDesktop.kt
+++ b/data/pseudolocale/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleOverrideExtensionDesktop.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
@@ -12,16 +13,29 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
 import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.LocalResourceReader
 
 /**
  * Desktop counterpart to the Android `PseudolocaleOverrideExtension`.
  *
- * **Scope.** Only the layout-direction half of pseudolocale support runs here — for `ar-XB` we
- * provide `LocalLayoutDirection = Rtl` so the captured PNG flips. The text-content
- * pseudolocalisation (the `[Ĥêļļö ···]` accent / RLO-PDF bidi wrap on string-resource lookups)
- * lives in the Android connector because it intercepts `Resources.getText`. CMP Desktop's
- * `org.jetbrains.compose.resources.stringResource` doesn't walk `LocalContext.resources`, so the
- * Android trick doesn't apply — see `site/reference/pseudolocale.md`'s "platform support" section.
+ * **Scope.** Two halves of pseudolocale support run here:
+ * - `LocalLayoutDirection = Rtl` for `ar-XB` so the captured PNG flips. Same as Android.
+ * - `LocalResourceReader` wrapped with [PseudolocalizingResourceReader] so every
+ *   `org.jetbrains.compose.resources.stringResource(...)` lookup returns the pseudolocalised accent
+ *   / RLO-PDF bidi form. CMP Desktop's `stringResource` doesn't walk `LocalContext.resources`, so
+ *   the Android `Resources.getText` interception trick doesn't apply — instead we intercept at the
+ *   byte-level `ResourceReader` that the resource-loading machinery ultimately calls. See
+ *   [PseudolocalizingResourceReader] for the record-format details.
+ *
+ * **Why not the env swap.** The issue spec preferred a `ComposeEnvironment` / `ResourceEnvironment`
+ * swap. At Compose Multiplatform 1.10.3 both `ComposeEnvironment` (interface) and
+ * `LocalComposeEnvironment` (`StaticCompositionLocalOf`) are declared `internal`, and the
+ * `ResourceEnvironment` constructor itself is internal — none of the three are reachable from
+ * outside `org.jetbrains.compose.resources`. The env also only selects which qualifier-keyed
+ * resource bundle to read; it doesn't transform output. `LocalResourceReader` is public (marked
+ * `@ExperimentalResourceApi`) and is the one published handle that can change what
+ * `stringResource(...)` returns.
  *
  * **Locale-list rewrite.** The `en-XA` / `ar-XB` BCP-47 tag isn't a real locale to the JVM, so the
  * desktop renderer rewrites it to the base tag (`en` / `ar`) before threading through the
@@ -29,6 +43,7 @@ import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExten
  * rewrite there (not here) keeps the around-composable focused on Compose-side providers and leaves
  * the renderer in charge of pre-composition state.
  */
+@OptIn(ExperimentalResourceApi::class)
 class PseudolocaleOverrideExtensionDesktop(private val mode: Pseudolocale) :
   AroundComposableExtension(
     id = ID,
@@ -36,10 +51,18 @@ class PseudolocaleOverrideExtensionDesktop(private val mode: Pseudolocale) :
   ) {
   @Composable
   override fun AroundComposable(content: @Composable () -> Unit) {
+    val baseReader = LocalResourceReader.current
+    val wrappedReader =
+      remember(baseReader, mode) { PseudolocalizingResourceReader(baseReader, mode) }
     if (mode.isRtl) {
-      CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) { content() }
+      CompositionLocalProvider(
+        LocalLayoutDirection provides LayoutDirection.Rtl,
+        LocalResourceReader provides wrappedReader,
+      ) {
+        content()
+      }
     } else {
-      content()
+      CompositionLocalProvider(LocalResourceReader provides wrappedReader) { content() }
     }
   }
 

--- a/data/pseudolocale/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocalizingResourceReader.kt
+++ b/data/pseudolocale/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocalizingResourceReader.kt
@@ -1,0 +1,104 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.pseudolocale.Pseudolocale
+import ee.schimke.composeai.data.pseudolocale.Pseudolocalizer
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.ResourceReader
+
+/**
+ * [ResourceReader] decorator that pseudolocalises every string-shaped record on its way out of the
+ * binary resource store.
+ *
+ * **Why we wrap the reader and not the env.** Compose Multiplatform Resources 1.10.x keeps
+ * `ComposeEnvironment` and `LocalComposeEnvironment` `internal`, so the swap-friendly path the
+ * `androidx.compose.ui.res.stringResource` Android trick uses is not reachable from outside the
+ * library module. The `ResourceEnvironment` itself only chooses which qualifier-keyed resource
+ * bytes to load — it doesn't transform output. The byte-level interceptor `LocalResourceReader`
+ * (public, marked `@ExperimentalResourceApi`) is the one swap point that actually changes what
+ * `stringResource(...)` returns.
+ *
+ * **Record format.** `getStringItem` in `StringResourcesUtils.kt` reads bytes from `readPart(...)`,
+ * decodes UTF-8, splits on `|`, takes `recordItems.first()` as the type (`string`, `string-array`,
+ * `plurals`) and `recordItems.last()` as the data. Data layouts:
+ * - `string` — single Base64-encoded UTF-8 payload.
+ * - `string-array` — comma-separated Base64 payloads.
+ * - `plurals` — comma-separated `<category>:<Base64>` pairs.
+ *
+ * We decode each Base64 chunk, run [Pseudolocalizer.transform] over the UTF-8 text, and re-encode
+ * with the original `<type>|...|` prefix preserved. Any record that isn't recognised as one of the
+ * three string-shaped types — fonts, drawables, raw bytes — passes through untouched.
+ *
+ * **Cache caveat.** Compose Resources keeps a process-wide `stringItemsCache` keyed by
+ * `path/offset-size`, populated by the *first* reader to answer a given key. Mixing pseudo and
+ * non-pseudo renders inside one JVM (or two different pseudolocale modes back-to-back) will see the
+ * earlier render's cached value on the second pass. The renderer doesn't fork per render, so
+ * callers that need clean state between modes should restart the JVM — same caveat the renderer
+ * notes for other process-wide Compose state.
+ */
+@OptIn(ExperimentalResourceApi::class, ExperimentalEncodingApi::class)
+internal class PseudolocalizingResourceReader(
+  private val delegate: ResourceReader,
+  private val mode: Pseudolocale,
+) : ResourceReader {
+
+  override suspend fun read(path: String): ByteArray = delegate.read(path)
+
+  override suspend fun readPart(path: String, offset: Long, size: Long): ByteArray {
+    val raw = delegate.readPart(path, offset, size)
+    val record = raw.decodeToString()
+    val pipe = record.indexOf('|')
+    // No `|` means this isn't a string record (e.g. raw image bytes). Pass through unchanged.
+    if (pipe < 0) return raw
+    val type = record.substring(0, pipe)
+    val lastPipe = record.lastIndexOf('|')
+    val prefix = record.substring(0, lastPipe + 1)
+    val data = record.substring(lastPipe + 1)
+    val transformedData =
+      when (type) {
+        "plurals" -> transformPlurals(data)
+        "string-array" -> transformArray(data)
+        // Any other type — `string` or unrecognised — is treated as a single Base64 chunk.
+        else -> transformSingle(data)
+      } ?: return raw
+    return (prefix + transformedData).encodeToByteArray()
+  }
+
+  override fun getUri(path: String): String = delegate.getUri(path)
+
+  private fun transformSingle(data: String): String? {
+    val decoded = decodeOrNull(data) ?: return null
+    return Base64.encode(Pseudolocalizer.transform(decoded, mode).encodeToByteArray())
+  }
+
+  private fun transformArray(data: String): String? {
+    val parts = data.split(",")
+    val encoded = parts.map { item ->
+      val decoded = decodeOrNull(item) ?: return null
+      Base64.encode(Pseudolocalizer.transform(decoded, mode).encodeToByteArray())
+    }
+    return encoded.joinToString(",")
+  }
+
+  private fun transformPlurals(data: String): String? {
+    val parts = data.split(",")
+    val encoded = parts.map { item ->
+      val colon = item.indexOf(':')
+      if (colon < 0) return null
+      val category = item.substring(0, colon)
+      val payload = item.substring(colon + 1)
+      val decoded = decodeOrNull(payload) ?: return null
+      val pseudo = Pseudolocalizer.transform(decoded, mode)
+      "$category:${Base64.encode(pseudo.encodeToByteArray())}"
+    }
+    return encoded.joinToString(",")
+  }
+
+  private fun decodeOrNull(base64: String): String? =
+    try {
+      Base64.decode(base64).decodeToString()
+    } catch (_: IllegalArgumentException) {
+      null
+    }
+}

--- a/data/pseudolocale/connector-desktop/src/test/kotlin/ee/schimke/composeai/daemon/PseudolocalizingResourceReaderTest.kt
+++ b/data/pseudolocale/connector-desktop/src/test/kotlin/ee/schimke/composeai/daemon/PseudolocalizingResourceReaderTest.kt
@@ -1,0 +1,210 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.pseudolocale.Pseudolocale
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.ResourceReader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies the desktop connector pseudolocalises strings at the
+ * `org.jetbrains.compose.resources.ResourceReader` byte level — parallels
+ * `PseudolocaleResourcesSpanPreservationTest` on Android, which covers the same contract through
+ * the `Resources.getText` interception path.
+ *
+ * The Compose Resources record format the test pokes at is `getStringItem` in
+ * `StringResourcesUtils.kt`: UTF-8 bytes split on `|`, last segment is the data:
+ * - `string` — single Base64 of the UTF-8 text.
+ * - `string-array` — comma-separated Base64 chunks.
+ * - `plurals` — comma-separated `<category>:<Base64>` pairs.
+ */
+@OptIn(ExperimentalResourceApi::class, ExperimentalEncodingApi::class)
+class PseudolocalizingResourceReaderTest {
+
+  @Test
+  fun `string records get the accent and bracket wrap`() {
+    val (path, offset, size, raw) = stringRecord("string", "Hello")
+    val reader = PseudolocalizingResourceReader(stubReader(path, raw), Pseudolocale.ACCENT)
+
+    val out = runBlocking { reader.readPart(path, offset, size) }
+    val decoded = decodeStringRecord(out)
+
+    assertTrue("accented output should start with '[': $decoded", decoded.startsWith("["))
+    assertTrue("accented output should end with ']': $decoded", decoded.endsWith("]"))
+    assertTrue(
+      "accented output should contain the accent form of Hello: $decoded",
+      decoded.contains("Ĥêļļö"),
+    )
+  }
+
+  @Test
+  fun `string records get the per-word RLO PDF wrap in bidi mode`() {
+    val (path, offset, size, raw) = stringRecord("string", "Hello world")
+    val reader = PseudolocalizingResourceReader(stubReader(path, raw), Pseudolocale.BIDI)
+
+    val out = runBlocking { reader.readPart(path, offset, size) }
+    val decoded = decodeStringRecord(out)
+
+    // RLO `‮` then characters then PDF `‬` for each whitespace-separated word.
+    val rlo = '‮'
+    val pdf = '‬'
+    assertTrue(
+      "bidi output should wrap 'Hello' in RLO/PDF: $decoded",
+      decoded.contains("${rlo}Hello${pdf}"),
+    )
+    assertTrue(
+      "bidi output should wrap 'world' in RLO/PDF: $decoded",
+      decoded.contains("${rlo}world${pdf}"),
+    )
+  }
+
+  @Test
+  fun `format placeholders survive the transform untouched`() {
+    val (path, offset, size, raw) = stringRecord("string", "Hello %1\$s, you have %2\$d items")
+    val reader = PseudolocalizingResourceReader(stubReader(path, raw), Pseudolocale.ACCENT)
+
+    val out = runBlocking { reader.readPart(path, offset, size) }
+    val decoded = decodeStringRecord(out)
+
+    assertTrue("placeholder %1\$s should survive: $decoded", decoded.contains("%1\$s"))
+    assertTrue("placeholder %2\$d should survive: $decoded", decoded.contains("%2\$d"))
+  }
+
+  @Test
+  fun `string-array records pseudolocalise each entry`() {
+    val items = listOf("Save", "Cancel", "Retry")
+    val (path, offset, size, raw) = arrayRecord(items)
+    val reader = PseudolocalizingResourceReader(stubReader(path, raw), Pseudolocale.ACCENT)
+
+    val out = runBlocking { reader.readPart(path, offset, size) }
+    val record = out.decodeToString()
+    val parts = record.removePrefix("string-array|").split(",")
+
+    assertEquals(items.size, parts.size)
+    val decodedItems = parts.map { Base64.decode(it).decodeToString() }
+    assertTrue("first entry accented: ${decodedItems[0]}", decodedItems[0].contains("Šàʌê"))
+    assertTrue("second entry accented: ${decodedItems[1]}", decodedItems[1].contains("Çàñçêļ"))
+    assertTrue("third entry accented: ${decodedItems[2]}", decodedItems[2].contains("Ŕêţŕý"))
+  }
+
+  @Test
+  fun `plural records pseudolocalise each category`() {
+    val plurals = mapOf("one" to "%1\$d item", "other" to "%1\$d items")
+    val (path, offset, size, raw) = pluralRecord(plurals)
+    val reader = PseudolocalizingResourceReader(stubReader(path, raw), Pseudolocale.ACCENT)
+
+    val out = runBlocking { reader.readPart(path, offset, size) }
+    val record = out.decodeToString()
+    val data = record.removePrefix("plurals|")
+    val decoded =
+      data.split(",").associate { entry ->
+        val cat = entry.substringBefore(':')
+        val pseudo = Base64.decode(entry.substringAfter(':')).decodeToString()
+        cat to pseudo
+      }
+
+    assertEquals(setOf("one", "other"), decoded.keys)
+    assertTrue("one form pseudolocalised: ${decoded["one"]}", decoded["one"]!!.contains("îţêɱ"))
+    assertTrue(
+      "other form pseudolocalised: ${decoded["other"]}",
+      decoded["other"]!!.contains("îţêɱš"),
+    )
+    assertTrue(
+      "placeholder preserved in one: ${decoded["one"]}",
+      decoded["one"]!!.contains("%1\$d"),
+    )
+  }
+
+  @Test
+  fun `non-string records pass through untouched`() {
+    // A record with no `|` separator — emulates an image / raw-bytes resource. The reader must
+    // return the bytes unchanged, byte-for-byte.
+    val raw = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+    val reader = PseudolocalizingResourceReader(stubReader("img.png", raw), Pseudolocale.ACCENT)
+
+    val out = runBlocking { reader.readPart("img.png", 0, raw.size.toLong()) }
+
+    assertArrayEqualsBytes(raw, out)
+  }
+
+  @Test
+  fun `read and getUri delegate unchanged`() {
+    val raw = "delegated-bytes".encodeToByteArray()
+    val delegate = stubReader("any", raw, uri = "file:///fake/any")
+    val reader = PseudolocalizingResourceReader(delegate, Pseudolocale.ACCENT)
+
+    val read = runBlocking { reader.read("any") }
+    assertArrayEqualsBytes(raw, read)
+    assertSame("file:///fake/any", reader.getUri("any"))
+  }
+
+  // -- helpers --------------------------------------------------------------
+
+  private data class Record(
+    val path: String,
+    val offset: Long,
+    val size: Long,
+    val bytes: ByteArray,
+  )
+
+  private fun stringRecord(type: String, text: String): Record {
+    val bytes = "$type|${Base64.encode(text.encodeToByteArray())}".encodeToByteArray()
+    return Record("strings.cvr", 0, bytes.size.toLong(), bytes)
+  }
+
+  private fun arrayRecord(items: List<String>): Record {
+    val joined = items.joinToString(",") { Base64.encode(it.encodeToByteArray()) }
+    val bytes = "string-array|$joined".encodeToByteArray()
+    return Record("strings.cvr", 0, bytes.size.toLong(), bytes)
+  }
+
+  private fun pluralRecord(items: Map<String, String>): Record {
+    val joined =
+      items.entries.joinToString(",") { (k, v) -> "$k:${Base64.encode(v.encodeToByteArray())}" }
+    val bytes = "plurals|$joined".encodeToByteArray()
+    return Record("strings.cvr", 0, bytes.size.toLong(), bytes)
+  }
+
+  private fun decodeStringRecord(bytes: ByteArray): String {
+    val record = bytes.decodeToString()
+    val data = record.substringAfterLast('|')
+    return Base64.decode(data).decodeToString()
+  }
+
+  private fun stubReader(
+    path: String,
+    bytes: ByteArray,
+    uri: String = "file:///fake/$path",
+  ): ResourceReader {
+    val expectedPath = path
+    val resolvedUri = uri
+    return object : ResourceReader {
+      override suspend fun read(path: String): ByteArray {
+        check(path == expectedPath) { "unexpected path $path" }
+        return bytes
+      }
+
+      override suspend fun readPart(path: String, offset: Long, size: Long): ByteArray {
+        check(path == expectedPath) { "unexpected path $path" }
+        return bytes.copyOfRange(offset.toInt(), (offset + size).toInt())
+      }
+
+      override fun getUri(path: String): String {
+        check(path == expectedPath) { "unexpected path $path" }
+        return resolvedUri
+      }
+    }
+  }
+
+  private fun assertArrayEqualsBytes(expected: ByteArray, actual: ByteArray) {
+    assertEquals("byte length", expected.size, actual.size)
+    for (i in expected.indices) {
+      assertEquals("byte at $i", expected[i], actual[i])
+    }
+  }
+}

--- a/site/reference/pseudolocale.md
+++ b/site/reference/pseudolocale.md
@@ -24,7 +24,7 @@ pseudolocalises every `stringResource(...)` lookup on the fly.
 | Cost | low |
 | Token usage | n/a — visual-only effect, no JSON payload. |
 | Transport | n/a |
-| Platforms | Android (full) · CMP Desktop (layout-direction only) |
+| Platforms | Android (full) · CMP Desktop (full) |
 
 ## What it answers
 
@@ -35,7 +35,6 @@ pseudolocalises every `stringResource(...)` lookup on the fly.
 ## What it does NOT answer
 
 - It does not pseudolocalise hard-coded Kotlin string literals (`Text("Hi")`) — same limitation Android Studio's pseudolocale dropdown has. Use the gap as a checklist of strings that need extracting to `strings.xml`.
-- It does not pseudolocalise text content on CMP Desktop. `org.jetbrains.compose.resources.stringResource(Res.string.foo)` doesn't walk `LocalContext.resources`, so the Android Resources-subclass interception doesn't apply there. The desktop path supplies the layout-direction half (`ar-XB` flips `LocalLayoutDirection` to RTL); `en-XA` is a visual no-op on desktop.
 - It does not score copy expansion against a per-language budget. Pair with the `text/strings` data product's `didOverflowWidth` / `truncated` fields if you want a CI gate.
 
 ## Use cases
@@ -91,8 +90,11 @@ to be restarted between locales.
   compare the three PNGs in `samples/android/build/compose-previews/renders/`.
 - **CMP Desktop** — [`samples/cmp/.../PseudolocalePreviews.kt`](https://github.com/yschimke/compose-ai-tools/blob/main/samples/cmp/src/main/kotlin/com/example/samplecmp/PseudolocalePreviews.kt)
   ships `default` and `bidi` previews. Run `./gradlew :samples:cmp:composePreviewRenderAll`
-  and compare — the `bidi` PNG flips the row layout, but text content stays
-  the same.
+  and compare — the `bidi` PNG flips the row layout. Text resolved through
+  `org.jetbrains.compose.resources.stringResource(Res.string.foo)` is also
+  pseudolocalised: the connector wraps `LocalResourceReader`, so byte-level
+  reads of the binary Compose Resources records get accent / RLO-PDF wrapped
+  before they reach the composable.
 
 ## How it works
 
@@ -126,9 +128,18 @@ Android, one piece on Desktop:
      callsite picks up the wrapped path automatically. Also provides
      `LocalLayoutDirection = Rtl` for `ar-XB`.
    - **Desktop** ([`:data-pseudolocale-connector-desktop`](https://github.com/yschimke/compose-ai-tools/tree/main/data/pseudolocale/connector-desktop))
-     — provides `LocalLayoutDirection = Rtl` for `ar-XB`. Doesn't
-     intercept resources because CMP's `stringResource` path doesn't
-     go through `LocalContext`.
+     — wraps `LocalResourceReader` (the `@ExperimentalResourceApi`
+     interceptor from `org.jetbrains.compose.resources`) with a
+     decorator that pseudolocalises every string-shaped record
+     coming out of `readPart(...)`. Strings, string-arrays and
+     plurals are decoded from the `<type>|...|<base64>` binary
+     record format, run through `Pseudolocalizer.transform(...)` and
+     re-encoded. Other resource types (drawables, fonts) pass
+     through unchanged. The intended `ComposeEnvironment` swap path
+     isn't reachable at CMP 1.10.x — both the interface and its
+     `LocalComposeEnvironment` are `internal` to
+     `org.jetbrains.compose.resources`. Also provides
+     `LocalLayoutDirection = Rtl` for `ar-XB`.
 
 Pure transform code (`Pseudolocalizer.accent`, `Pseudolocalizer.bidi`)
 lives in `:data-pseudolocale-core` with no Android or Compose
@@ -143,8 +154,8 @@ preservation (`%1$s`, `{name}`, `<b>…</b>`).
 |---|---|---|
 | `localeTag` rewrite to base locale | ✅ | ✅ |
 | `LayoutDirection.Rtl` for `ar-XB` | ✅ | ✅ |
-| `[Ĥêļļö ···]` accent transform of `stringResource(...)` | ✅ | ❌ |
-| RLO / PDF bidi wrap of `stringResource(...)` | ✅ | ❌ |
+| `[Ĥêļļö ···]` accent transform of `stringResource(...)` | ✅ | ✅ |
+| RLO / PDF bidi wrap of `stringResource(...)` | ✅ | ✅ |
 | Hard-coded literal strings (`Text("Hi")`) | n/a — never pseudolocalised | n/a |
 
 ## Comparison to AGP `pseudoLocalesEnabled`


### PR DESCRIPTION
## Summary

The desktop pseudolocale override previously only flipped layout direction for `ar-XB`; `en-XA` was a visual no-op because CMP Desktop's `org.jetbrains.compose.resources.stringResource` doesn't walk `LocalContext.resources`, so the Android `Resources` subclass trick didn't apply.

Wraps `LocalResourceReader` (public, `@ExperimentalResourceApi`) with a decorator that pseudolocalises every string-shaped record coming out of `readPart`: strings, string-arrays and plurals are decoded from the `<type>|...|<base64>` binary format, run through `Pseudolocalizer.transform`, and re-encoded. Other resource types pass through untouched.

### Why `LocalResourceReader`, not the issue's suggested env swap

#1206 suggested `LocalComposeEnvironment` / `ResourceEnvironment`. Both are declared `internal` to `org.jetbrains.compose.resources` at CMP 1.10.x, and the env itself only selects qualifier-keyed bundles — it doesn't transform output. `LocalResourceReader` is the one published handle that actually changes what `stringResource` returns.

### Known caveat (documented in code)

Compose Resources keeps a process-wide `stringItemsCache` keyed by `path/offset-size`. Mixing pseudo and non-pseudo renders inside one JVM will see the first render's cached value on subsequent passes; `ResourceCaches.clear()` is `internal suspend` and unreachable without reflection. Documented inline.

Closes #1206

## Test plan

- [x] `./gradlew :data-pseudolocale-connector-desktop:test` — all 7 new + 2 existing pass
- [x] Verified new tests fail on a stubbed pass-through reader (4 of 7 fail as expected)
- [x] `./gradlew :data-pseudolocale-connector-desktop:build` clean
- [x] `./gradlew :daemon:desktop:compileKotlin :daemon:desktop:compileTestKotlin` clean
- [x] `ktfmtFormat` run
- [ ] End-to-end: render a CMP sample using `stringResource(...)` with `localeTag = "en-XA"` and confirm `[Ĥêļļö ···]`-style accenting (not exercised in CI — manual smoke for reviewer)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4kjjFi8Tz4kBHzLah2BjA)_