### PR TITLE
fix(vscode-extension): include JVM exit code + stderr tail when daemon spawn fails

### DIFF
--- a/vscode-extension/src/daemon/daemonProcess.ts
+++ b/vscode-extension/src/daemon/daemonProcess.ts
@@ -101,6 +101,41 @@ export interface SpawnedDaemon {
     exited: Promise<number | null>;
 }
 
+/**
+ * Issue #1326 — recent-stderr tail size carried into spawn-failure messages.
+ * Sized for the typical Robolectric / Compose boot crash: the JVM prints
+ * `Exception in thread "main" ...` plus a stack trace that fits comfortably
+ * under 50 lines, and a fresh sandbox bootstrap prints ~20 informational
+ * lines before that, so 50 lines is enough to anchor the crash in its
+ * surrounding context without making test failures unscannable.
+ */
+const RECENT_STDERR_LIMIT = 50;
+
+/**
+ * Issue #1326 — build a spawn-failure message that includes the JVM exit code
+ * (when known) and the tail of the daemon's stderr, so callers that only see
+ * the rejected promise — most importantly the e2e test runner — can see why
+ * the JVM died instead of a bare `Daemon channel closed`. Exported for unit
+ * coverage; callers go through [spawnDaemon].
+ */
+export function formatDaemonSpawnFailure(opts: {
+    cause: string;
+    modulePath: string;
+    exitCode: number | null;
+    recentStderr: readonly string[];
+}): string {
+    const exitSuffix =
+        opts.exitCode !== null ? ` (JVM exit code=${opts.exitCode})` : "";
+    const head = `${opts.cause}${exitSuffix}`;
+    if (opts.recentStderr.length === 0) {
+        return head;
+    }
+    const tail = opts.recentStderr.slice(-RECENT_STDERR_LIMIT);
+    return [head, `[daemon stderr tail for ${opts.modulePath}]`, ...tail].join(
+        "\n",
+    );
+}
+
 export interface SpawnOptions {
     workspaceRoot: string;
     descriptor: DaemonLaunchDescriptor;
@@ -190,6 +225,18 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
     // of those prefixes, making every link/initialiser failure look like the
     // exception had no message.
     child.stderr.setEncoding("utf-8");
+    // Issue #1326 — keep the raw (unfiltered) tail so a spawn-time crash can
+    // surface its stderr through the rejected promise, not just the output
+    // channel. The display path below still applies the user's log-level
+    // filter; the diagnostic buffer is independent so the dropped Roborazzi
+    // banner doesn't hide the exception that landed on the next line.
+    const recentStderr: string[] = [];
+    const captureStderrLine = (line: string): void => {
+        recentStderr.push(line);
+        if (recentStderr.length > RECENT_STDERR_LIMIT * 2) {
+            recentStderr.splice(0, recentStderr.length - RECENT_STDERR_LIMIT);
+        }
+    };
     const emitStderrLine = (line: string): void => {
         if (line.length === 0) {
             return;
@@ -203,18 +250,22 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
     const stderrSplitter = new ChunkLineSplitter();
     child.stderr.on("data", (chunk: string) => {
         for (const line of stderrSplitter.feed(chunk)) {
+            captureStderrLine(line);
             emitStderrLine(line);
         }
     });
     child.stderr.on("end", () => {
         const tail = stderrSplitter.flush();
         if (tail !== null) {
+            captureStderrLine(tail);
             emitStderrLine(tail);
         }
     });
 
+    let exitCode: number | null = null;
     const exited = new Promise<number | null>((resolve) => {
         child.on("exit", (code) => {
+            exitCode = code;
             // Exit messages always print — the JVM exiting unexpectedly is
             // never noise. The successful exit case (code=0 on user-driven
             // shutdown) is rare enough that it's still useful at quiet.
@@ -243,7 +294,25 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
         } catch {
             /* ignore */
         }
-        throw err;
+        // Issue #1326 — channel-closed rejections race the process exit
+        // event, and the stderr stream typically still has bytes buffered
+        // when initialize rejects. Wait a short grace period so the exit
+        // code and the final stderr lines are in hand before we build the
+        // failure message; cap at 500ms so a wedged JVM doesn't hang the
+        // warm path.
+        await Promise.race([
+            exited,
+            new Promise<void>((resolve) => setTimeout(resolve, 500)),
+        ]);
+        const cause = (err as Error)?.message ?? String(err);
+        throw new Error(
+            formatDaemonSpawnFailure({
+                cause,
+                modulePath: descriptor.modulePath,
+                exitCode,
+                recentStderr,
+            }),
+        );
     }
 
     // PROTOCOL.md § 3 — `initialized` MUST land before any further request, otherwise the

--- a/vscode-extension/src/test/daemonProcess.test.ts
+++ b/vscode-extension/src/test/daemonProcess.test.ts
@@ -4,7 +4,9 @@ import * as os from "os";
 import * as path from "path";
 import {
     ChunkLineSplitter,
+    formatDaemonSpawnFailure,
     readLaunchDescriptor,
+    spawnDaemon,
 } from "../daemon/daemonProcess";
 import {
     DAEMON_DESCRIPTOR_SCHEMA_VERSION,
@@ -229,5 +231,145 @@ describe("ChunkLineSplitter", () => {
         assert.deepStrictEqual(s.feed("partial"), []);
         assert.strictEqual(s.flush(), "partial");
         assert.strictEqual(s.flush(), null);
+    });
+});
+
+describe("formatDaemonSpawnFailure (issue #1326)", () => {
+    it("returns just the cause when stderr and exit code are absent", () => {
+        // Channel close before the JVM exit event fires and with no stderr
+        // chunks buffered: degrade gracefully to the bare cause so the message
+        // matches the legacy shape the rest of the gate-error wrapping
+        // assumes.
+        assert.strictEqual(
+            formatDaemonSpawnFailure({
+                cause: "Daemon channel closed",
+                modulePath: ":samples:wear",
+                exitCode: null,
+                recentStderr: [],
+            }),
+            "Daemon channel closed",
+        );
+    });
+
+    it("appends the exit code when the JVM exit event has fired", () => {
+        assert.strictEqual(
+            formatDaemonSpawnFailure({
+                cause: "Daemon channel closed",
+                modulePath: ":samples:wear",
+                exitCode: 1,
+                recentStderr: [],
+            }),
+            "Daemon channel closed (JVM exit code=1)",
+        );
+    });
+
+    it("appends the stderr tail and a module-scoped header", () => {
+        const out = formatDaemonSpawnFailure({
+            cause: "Daemon channel closed",
+            modulePath: ":samples:wear",
+            exitCode: 1,
+            recentStderr: [
+                'Exception in thread "main" java.lang.NoClassDefFoundError: Foo',
+                "\tat ee.schimke.composeai.daemon.DaemonMain.main(DaemonMain.kt:42)",
+            ],
+        });
+        assert.deepStrictEqual(out.split("\n"), [
+            "Daemon channel closed (JVM exit code=1)",
+            "[daemon stderr tail for :samples:wear]",
+            'Exception in thread "main" java.lang.NoClassDefFoundError: Foo',
+            "\tat ee.schimke.composeai.daemon.DaemonMain.main(DaemonMain.kt:42)",
+        ]);
+    });
+
+    it("surfaces stderr + exit code through spawnDaemon when the JVM dies before initialize", async () => {
+        // End-to-end check that the diagnostic actually reaches the rejected
+        // promise. Stand in a tiny Node script for the daemon JVM: it
+        // simulates a JVM that prints a Robolectric / Compose-style boot
+        // crash to stderr and exits before answering `initialize`. The fix
+        // for issue #1326 must wrap the resulting "Daemon channel closed"
+        // with the stderr tail and exit code; without the wrapping the test
+        // runner would see only the bare phrase, hiding the actual cause.
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "daemon-spawn-"));
+        try {
+            const scriptPath = path.join(dir, "fake-daemon.mjs");
+            fs.writeFileSync(
+                scriptPath,
+                [
+                    "process.stderr.write(",
+                    "  'Exception in thread \"main\" java.lang.IllegalStateException: boom\\n'",
+                    ");",
+                    "process.stderr.write(",
+                    "  '\\tat ee.schimke.composeai.daemon.DaemonMain.main(DaemonMain.kt:42)\\n'",
+                    ");",
+                    "process.exit(2);",
+                ].join("\n"),
+            );
+            const descriptor: DaemonLaunchDescriptor = {
+                schemaVersion: DAEMON_DESCRIPTOR_SCHEMA_VERSION,
+                modulePath: ":samples:wear",
+                variant: "debug",
+                enabled: true,
+                mainClass: "ignored",
+                // Borrow the active Node binary as the fake JVM and pass the
+                // script via systemProperties → -D entries, which `spawnDaemon`
+                // forwards verbatim. Node ignores -D flags, so we instead use
+                // jvmArgs to inject the script path before -cp, which Node
+                // accepts as its own first positional arg.
+                javaLauncher: process.execPath,
+                classpath: ["ignored"],
+                jvmArgs: [scriptPath],
+                systemProperties: {},
+                workingDirectory: dir,
+                manifestPath: path.join(dir, "previews.json"),
+            };
+            let err: Error | null = null;
+            try {
+                await spawnDaemon({
+                    workspaceRoot: dir,
+                    descriptor,
+                    clientVersion: "test",
+                    events: {},
+                });
+            } catch (e) {
+                err = e as Error;
+            }
+            assert.ok(err, "spawnDaemon must reject when the JVM dies early");
+            const message = err!.message;
+            assert.ok(
+                message.includes("[daemon stderr tail for :samples:wear]"),
+                `expected stderr-tail header in message, got: ${message}`,
+            );
+            assert.ok(
+                message.includes("java.lang.IllegalStateException: boom"),
+                `expected JVM exception text in message, got: ${message}`,
+            );
+            assert.ok(
+                message.includes("JVM exit code=2"),
+                `expected exit-code suffix in message, got: ${message}`,
+            );
+        } finally {
+            fs.rmSync(dir, { recursive: true });
+        }
+    });
+
+    it("caps the stderr tail at the documented limit", () => {
+        // A real Robolectric bootstrap can dump hundreds of informational
+        // lines before the crash; only the last ~50 carry signal. Pin the
+        // cap so a regression that prints every line back to the test runner
+        // is loud.
+        const lines = Array.from({ length: 200 }, (_, i) => `line-${i}`);
+        const out = formatDaemonSpawnFailure({
+            cause: "boom",
+            modulePath: ":samples:wear",
+            exitCode: null,
+            recentStderr: lines,
+        });
+        const split = out.split("\n");
+        // 1 cause line + 1 header line + 50 tail lines = 52
+        assert.strictEqual(split.length, 52);
+        assert.strictEqual(split[0], "boom");
+        assert.strictEqual(split[1], "[daemon stderr tail for :samples:wear]");
+        assert.strictEqual(split[2], "line-150");
+        assert.strictEqual(split[51], "line-199");
     });
 });


### PR DESCRIPTION
The wear e2e test was failing with the bare phrase "Daemon channel
closed" — accurate but useless. The real cause (an uncaught JVM
exception, a missing class, a Robolectric bootstrap failure) was on
the daemon's stderr, but stderr only flowed to the VS Code output
channel, which the test runner never sees. CI logs therefore showed
the daemon dying without a diagnosis, and the assertion message
collapsed to "spawn failed: Daemon channel closed".

spawnDaemon now keeps an unfiltered rolling tail of the daemon's
stderr (capped at the documented limit), tracks the JVM exit code,
and — when initialize rejects — waits a short grace period for the
exit event to land before throwing an enriched Error that carries the
exit code and the stderr tail. The reject propagates through
LiveDaemonGate.spawn → warmDaemonForFile → the e2eA11y assertion, so
the same diagnostic now reaches the test runner output.

Verified with a new spawnDaemon end-to-end test that stands in a tiny
Node script for the JVM, prints a stack trace to stderr, exits 2, and
asserts the resulting Error carries both. Unit tests cover the
message-formatting helper, including the tail cap.

Refs #1326