### PR TITLE
chore(vscode-extension): drop vestigial autoEnableCheap from harness fixtures

### DIFF
--- a/vscode-extension/preview-harness/fixtures/_utils.mjs
+++ b/vscode-extension/preview-harness/fixtures/_utils.mjs
@@ -176,7 +176,6 @@ export function buildPreviewPair({ focusId, width, height, fnName, file }) {
  */
 export const EARLY_FEATURES_DATASET = {
     earlyFeatures: "true",
-    autoEnableCheap: "false",
     collapseVariants: "false",
     minimalMode: "false",
     autoInject: "true",

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.gen.mjs
@@ -260,7 +260,6 @@ const fixture = {
     dataset: {
         // `earlyFeatures` is the gate for the chip bar + data tabs.
         earlyFeatures: "true",
-        autoEnableCheap: "false",
         collapseVariants: "false",
         minimalMode: "false",
         autoInject: "true",

--- a/vscode-extension/preview-harness/fixtures/a11y-findings.json
+++ b/vscode-extension/preview-harness/fixtures/a11y-findings.json
@@ -3,7 +3,6 @@
   "description": "Focused card with three Accessibility Test Framework findings (one ERROR, two WARNINGs) overlaid on a stylised mobile mock. Drives focus mode and activates the Accessibility bundle so the chip bar, data tab, and on-image box-overlay all paint.",
   "dataset": {
     "earlyFeatures": "true",
-    "autoEnableCheap": "false",
     "collapseVariants": "false",
     "minimalMode": "false",
     "autoInject": "true"

--- a/vscode-extension/preview-harness/fixtures/a11y-wear.json
+++ b/vscode-extension/preview-harness/fixtures/a11y-wear.json
@@ -3,7 +3,6 @@
   "description": "Wear OS ActivityListPreview (small-round, 384×384 capture of the real composePreviewRenderAll output) focused with the Accessibility bundle active. Two clickable activity cards trip ERROR-level missing-contentDescription findings, the status icon trips a WARNING-level touch-target rule, and the low-contrast time text trips a contrast WARNING. Drives the slim legend column treatment against a size-constrained preview and the merged-hierarchy default (four unmerged inner Text nodes are emitted on the wire but the default `mergedOnly` filter drops them from the legend and the on-image overlay).",
   "dataset": {
     "earlyFeatures": "true",
-    "autoEnableCheap": "false",
     "collapseVariants": "false",
     "minimalMode": "false",
     "autoInject": "true"

--- a/vscode-extension/preview-harness/fixtures/grid-default.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/grid-default.gen.mjs
@@ -148,7 +148,6 @@ const fixture = {
         "Four-card grid: three color variants plus a greeting, after setPreviews + per-card updateImage.",
     dataset: {
         earlyFeatures: "false",
-        autoEnableCheap: "false",
         collapseVariants: "false",
         minimalMode: "false",
         autoInject: "true",

--- a/vscode-extension/preview-harness/fixtures/history-diff.json
+++ b/vscode-extension/preview-harness/fixtures/history-diff.json
@@ -3,7 +3,6 @@
   "description": "Focused card with realistic history/diff/regions payload (three regions, ~12% of pixels changed from baseline). Activates the History bundle so the diff overlay paints each region, the side legend lists them with pixel-count subtitles, and the tab body renders the diff table with the baseline header.",
   "dataset": {
     "earlyFeatures": "true",
-    "autoEnableCheap": "false",
     "collapseVariants": "false",
     "minimalMode": "false",
     "autoInject": "true"

--- a/vscode-extension/preview-harness/fixtures/inspection-tree.json
+++ b/vscode-extension/preview-harness/fixtures/inspection-tree.json
@@ -3,7 +3,6 @@
   "description": "Focused card with realistic compose/semantics + layout/inspector payloads. Activates the Inspection bundle so the overlay layer paints over the header / primary CTA / secondary CTA / footer regions, the side legend populates with one entry per overlay box (label · role · testTag), and the inspection tab body renders the per-kind tree tables.",
   "dataset": {
     "earlyFeatures": "true",
-    "autoEnableCheap": "false",
     "collapseVariants": "false",
     "minimalMode": "false",
     "autoInject": "true"

--- a/vscode-extension/preview-harness/fixtures/text-strings.json
+++ b/vscode-extension/preview-harness/fixtures/text-strings.json
@@ -3,7 +3,6 @@
   "description": "Focused card with realistic text/strings + fonts/used + i18n/translations payloads. Activates the Text / i18n bundle so the overflow/truncation overlay paints over the footer, the side legend lists each drawn-text entry, and the tab body renders the strings + fonts sub-tables.",
   "dataset": {
     "earlyFeatures": "true",
-    "autoEnableCheap": "false",
     "collapseVariants": "false",
     "minimalMode": "false",
     "autoInject": "true"

--- a/vscode-extension/preview-harness/fixtures/theming.json
+++ b/vscode-extension/preview-harness/fixtures/theming.json
@@ -3,7 +3,6 @@
   "description": "Focused card with a baseline Material 3 light colour scheme, eight typography tokens (sans / serif-italic / cursive), and six shape tokens. Activates the Theming bundle so the Colors swatches paint via CSSOM, the Typography rows render their token names in the resolved Google Fonts family, and the Shapes column shows the 20×20 corner-radius preview square. Wallpaper payload is preloaded but its kind is default-OFF, so it stays available behind the Configure expander.",
   "dataset": {
     "earlyFeatures": "true",
-    "autoEnableCheap": "false",
     "collapseVariants": "false",
     "minimalMode": "false",
     "autoInject": "true"


### PR DESCRIPTION
The runtime consumer for the cheap-render auto-enable suggestion was
removed in #1099/#1103, and the package.json contribution / previewStore
field / setAutoEnableCheap message handler were already retired. The
only stragglers were `autoEnableCheap: "false"` entries in the
preview-harness fixture datasets; nothing reads them. Removes the key
from `_utils.mjs`, the two `*.gen.mjs` files that inline their own
dataset, and the six checked-in `.json` fixtures.

Refs #1104.