### PR TITLE
fix(daemon-desktop): pin held-scene operations to a single-thread executor (#1229)

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -4,6 +4,8 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
@@ -312,70 +314,74 @@ open class DesktopHost(
     // interactive path doesn't write per-frame PNGs — keeps the spec shape symmetric and avoids a
     // null branch in `applyOverrides`.
     val spec = applyOverrides(baseSpec, overrides, recordingId = "interactive-$previewId")
-    val state = engine.setUp(spec, classLoader, inspectionMode = inspectionMode ?: false)
-    val session =
-      DesktopInteractiveSession(
-        previewId = previewId,
-        engine = engine,
-        state = state,
-        sandboxStats = sandboxStats,
-        onCloseHook = onSessionClosed,
-      )
-    val listener = interactiveSessionListener
-    if (listener == null) {
-      return session
+    // Allocate a single-thread executor up-front and run setUp on it. Every subsequent scene
+    // touch — dispatch, render, the listener's observer install / dispose, and close — is also
+    // pinned to this thread by [DesktopInteractiveSession]. That serialises the Compose
+    // recomposer (and its `Dispatchers.Unconfined`-dispatched `LaunchedEffect` coroutines) onto
+    // one thread so an `interactive/stop` can't race a still-running effect body, which is what
+    // trips `Detected multithreaded access to SnapshotStateObserver` and the follow-on Skiko
+    // SIGABRT in issue #1229. The session takes ownership of the executor and shuts it down on
+    // [InteractiveSession.close]; on a setUp failure we shut it down here.
+    val sceneExecutor = Executors.newSingleThreadExecutor { r ->
+      Thread(r, "compose-ai-daemon-interactive-scene-$previewId").apply { isDaemon = true }
     }
-    // D5 — fire onSessionLifecycle(previewId, scene) so the recomposition producer can install
-    // its CompositionObserver against the live scene. Wrap the session so that close() also
-    // fires onSessionLifecycle(previewId, null) — without the wrapper the producer would leak
-    // the observer handle past `interactive/stop`.
-    try {
-      listener.onSessionLifecycle(previewId, state.scene)
-    } catch (t: Throwable) {
-      System.err.println(
-        "compose-ai-daemon: DesktopHost: interactiveSessionListener.acquire threw " +
-          "(${t.javaClass.simpleName}: ${t.message}); continuing with session"
-      )
-    }
-    return ListenerNotifyingSession(delegate = session, listener = listener, previewId = previewId)
-  }
-
-  /**
-   * Thin [InteractiveSession] wrapper that fires [interactiveSessionListener]'s "released"
-   * notification on [close]. All other calls forward to the wrapped [DesktopInteractiveSession].
-   * Idempotent: a second [close] is a no-op (matches the [DesktopInteractiveSession.close]
-   * contract).
-   */
-  private class ListenerNotifyingSession(
-    private val delegate: InteractiveSession,
-    private val listener: InteractiveSessionListener,
-    override val previewId: String,
-  ) : InteractiveSession {
-
-    @Volatile private var closed = false
-
-    override val isClosed: Boolean
-      get() = closed || delegate.isClosed
-
-    override fun dispatch(input: ee.schimke.composeai.daemon.protocol.InteractiveInputParams) =
-      delegate.dispatch(input)
-
-    override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult =
-      delegate.render(requestId, advanceTimeMs)
-
-    override fun close() {
-      if (closed) return
-      closed = true
+    val state =
       try {
-        listener.onSessionLifecycle(previewId, null)
-      } catch (t: Throwable) {
-        System.err.println(
-          "compose-ai-daemon: DesktopHost: interactiveSessionListener.release threw " +
-            "(${t.javaClass.simpleName}: ${t.message}); continuing with session.close()"
-        )
+        sceneExecutor
+          .submit<RenderEngine.SceneState> {
+            engine.setUp(spec, classLoader, inspectionMode = inspectionMode ?: false)
+          }
+          .get()
+      } catch (e: ExecutionException) {
+        sceneExecutor.shutdownNow()
+        throw e.cause ?: e
+      } catch (e: Throwable) {
+        sceneExecutor.shutdownNow()
+        throw e
       }
-      delegate.close()
-    }
+    // D5 — fire onSessionLifecycle(previewId, scene) on the scene executor so the recomposition
+    // producer's `CompositionObserver` install lands on the same thread that will later drive
+    // every recomposition, dispatch, and tear-down. The matching released-side hook
+    // (`onSessionLifecycle(_, null)`) is plumbed in as the session's `onSceneClose` so it also
+    // runs on the executor — pre-#1229, the released call ran on the JSON-RPC read thread which
+    // is exactly the cross-thread teardown the issue tracked.
+    val listener = interactiveSessionListener
+    val onSceneClose: (() -> Unit)? =
+      if (listener != null) {
+        try {
+          sceneExecutor.submit { listener.onSessionLifecycle(previewId, state.scene) }.get()
+        } catch (e: ExecutionException) {
+          System.err.println(
+            "compose-ai-daemon: DesktopHost: interactiveSessionListener.acquire threw " +
+              "(${e.cause?.javaClass?.simpleName ?: e.javaClass.simpleName}: " +
+              "${e.cause?.message ?: e.message}); continuing with session"
+          )
+        } catch (t: Throwable) {
+          System.err.println(
+            "compose-ai-daemon: DesktopHost: interactiveSessionListener.acquire threw " +
+              "(${t.javaClass.simpleName}: ${t.message}); continuing with session"
+          )
+        }
+        {
+          try {
+            listener.onSessionLifecycle(previewId, null)
+          } catch (t: Throwable) {
+            System.err.println(
+              "compose-ai-daemon: DesktopHost: interactiveSessionListener.release threw " +
+                "(${t.javaClass.simpleName}: ${t.message}); continuing with session.close()"
+            )
+          }
+        }
+      } else null
+    return DesktopInteractiveSession(
+      previewId = previewId,
+      engine = engine,
+      state = state,
+      sandboxStats = sandboxStats,
+      sceneExecutor = sceneExecutor,
+      onSceneClose = onSceneClose,
+      onCloseHook = onSessionClosed,
+    )
   }
 
   /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
@@ -16,6 +16,10 @@ import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.scene.ComposeScenePointer
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
 
 /**
  * Desktop concrete [InteractiveSession] holding a long-lived
@@ -43,9 +47,16 @@ import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
  * takes scene-px which equals natural pixels at density 1.0; we divide by the held density before
  * dispatch. Null coords (e.g. for keyboard events, which we no-op anyway) skip the dispatch.
  *
- * **Threading.** Per the [InteractiveSession] contract, `JsonRpcServer` serialises calls to one
- * instance — dispatch and render run on the same fire-and-forget worker thread per input. Skiko
- * isn't thread-safe, so the contract matches the underlying constraint.
+ * **Threading.** Every scene touch — `setUp` (run by [DesktopHost] before construction), every
+ * `dispatch`, every `render`, the optional [onSceneClose] hook, and the final `tearDown` — is
+ * pinned to [sceneExecutor], a single-thread executor that this session owns and disposes on
+ * [close]. That confines the recomposer's `LaunchedEffect` coroutines (which inherit the scene's
+ * default `Dispatchers.Unconfined` and therefore resume on whatever thread last drove
+ * recomposition) and the global `SnapshotStateObserver`'s registration to a single thread. Without
+ * that pin, an `interactive/stop` running on the JSON-RPC read thread can race a `LaunchedEffect`
+ * body still executing on a render worker thread — the cross-thread snapshot touch is what trips
+ * `Detected multithreaded access to SnapshotStateObserver` (issue #1229) and, on Linux/Skiko, can
+ * escalate to a SIGABRT inside the native scene-close path.
  */
 class DesktopInteractiveSession(
   override val previewId: String,
@@ -53,13 +64,24 @@ class DesktopInteractiveSession(
   private val state: RenderEngine.SceneState,
   private val sandboxStats: SandboxLifecycleStats,
   /**
-   * Fired exactly once after [close] flips `closed = true` and tears down the held scene. Mirrors
-   * [AndroidInteractiveSession.onCloseHook] so the same JsonRpcServer-side cleanup wiring works
-   * across both backends. DesktopHost has no idle-lease watchdog today (only explicit close + the
-   * D5 listener wrapper drive close), so on desktop the hook is effectively the same as
-   * `interactiveSessionListener.onSessionLifecycle(_, scene = null)` — but routing it through the
-   * same shape as Android keeps the host-shared API uniform and gives the desktop daemon a free
-   * hook point for any future async-close path.
+   * Single-thread executor owned by this session — every scene touch runs here. The caller
+   * ([DesktopHost.acquireInteractiveSession]) is responsible for already having executed
+   * [RenderEngine.setUp] on this executor before passing [state] in, so the scene is allocated on
+   * the same thread that will later render / dispatch / tear it down.
+   */
+  private val sceneExecutor: ExecutorService,
+  /**
+   * Optional hook fired on [sceneExecutor] right before [RenderEngine.tearDown] during [close].
+   * Used by [DesktopHost] to drive `InteractiveSessionListener.onSessionLifecycle(_, null)` — the
+   * recomposition producer's observer-dispose — on the same thread the observer was installed on.
+   * Failures are logged and swallowed; the scene tear-down proceeds either way.
+   */
+  private val onSceneClose: (() -> Unit)? = null,
+  /**
+   * Fired exactly once after [close] flips `closed = true`, the scene tear-down completes, and the
+   * executor shuts down. Pure server-side cleanup — doesn't touch the scene, so it runs on whatever
+   * thread called [close]. Mirrors [AndroidInteractiveSession.onCloseHook] so the same
+   * `JsonRpcServer`-side cleanup wiring works across both backends.
    */
   private val onCloseHook: (() -> Unit)? = null,
 ) : InteractiveSession {
@@ -74,8 +96,8 @@ class DesktopInteractiveSession(
    * playback so an external panel sending two simultaneous `pointerDown`s actually gets a
    * `Modifier.transformable {}` zoom callback (the gating signal is ≥ 2 pointers in one event).
    *
-   * Per the [InteractiveSession] contract, JsonRpcServer serialises calls into one session, so a
-   * plain `MutableMap` is safe — no `ConcurrentHashMap` needed.
+   * Read and written only from [sceneExecutor]'s thread, so a plain `MutableMap` is safe — no
+   * `ConcurrentHashMap` needed.
    */
   private val activePointers: MutableMap<Int, Offset> = mutableMapOf()
 
@@ -84,6 +106,13 @@ class DesktopInteractiveSession(
 
   override fun dispatch(input: InteractiveInputParams) {
     if (closed) return
+    runOnSceneThread {
+      if (closed) return@runOnSceneThread
+      dispatchOnSceneThread(input)
+    }
+  }
+
+  private fun dispatchOnSceneThread(input: InteractiveInputParams) {
     val px = input.pixelX
     val py = input.pixelY
     when (input.kind) {
@@ -162,27 +191,85 @@ class DesktopInteractiveSession(
 
   override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {
     check(!closed) { "DesktopInteractiveSession.render() called after close()" }
-    return engine.renderOnce(
-      state,
-      requestId,
-      sandboxStats = sandboxStats,
-      useWallClockFrameTime = true,
-    )
+    return runOnSceneThreadForResult {
+      check(!closed) { "DesktopInteractiveSession.render() called after close()" }
+      engine.renderOnce(state, requestId, sandboxStats = sandboxStats, useWallClockFrameTime = true)
+    }
   }
 
   override fun close() {
     if (closed) return
     closed = true
-    engine.tearDown(state)
-    if (onCloseHook != null) {
-      try {
-        onCloseHook.invoke()
-      } catch (t: Throwable) {
-        System.err.println(
-          "compose-ai-daemon: DesktopInteractiveSession: onCloseHook threw " +
-            "(${t.javaClass.simpleName}: ${t.message}); continuing"
-        )
+    try {
+      runOnSceneThread {
+        if (onSceneClose != null) {
+          try {
+            onSceneClose.invoke()
+          } catch (t: Throwable) {
+            System.err.println(
+              "compose-ai-daemon: DesktopInteractiveSession: onSceneClose threw " +
+                "(${t.javaClass.simpleName}: ${t.message}); continuing with tearDown"
+            )
+          }
+        }
+        engine.tearDown(state)
       }
+    } finally {
+      sceneExecutor.shutdown()
+      try {
+        if (!sceneExecutor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+          System.err.println(
+            "compose-ai-daemon: DesktopInteractiveSession($previewId): sceneExecutor did not " +
+              "terminate within ${EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS}s; continuing"
+          )
+        }
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+      }
+      if (onCloseHook != null) {
+        try {
+          onCloseHook.invoke()
+        } catch (t: Throwable) {
+          System.err.println(
+            "compose-ai-daemon: DesktopInteractiveSession: onCloseHook threw " +
+              "(${t.javaClass.simpleName}: ${t.message}); continuing"
+          )
+        }
+      }
+    }
+  }
+
+  /**
+   * Submit [block] to [sceneExecutor] and wait. Rejected submissions (executor already shut down
+   * because a concurrent [close] won the race) are silently dropped — matches the "stale call after
+   * stop" contract documented on [InteractiveSession]. Exceptions thrown inside [block] are
+   * unwrapped from [ExecutionException] so callers see the original cause.
+   */
+  private inline fun runOnSceneThread(crossinline block: () -> Unit) {
+    val future =
+      try {
+        sceneExecutor.submit { block() }
+      } catch (_: RejectedExecutionException) {
+        return
+      }
+    try {
+      future.get()
+    } catch (e: ExecutionException) {
+      throw e.cause ?: e
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+    }
+  }
+
+  private inline fun <T> runOnSceneThreadForResult(crossinline block: () -> T): T {
+    val future = sceneExecutor.submit<T> { block() }
+    return try {
+      future.get()
+    } catch (e: ExecutionException) {
+      throw e.cause ?: e
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+      throw e
     }
   }
 
@@ -261,5 +348,13 @@ class DesktopInteractiveSession(
      * instant to the human.
      */
     private const val CLICK_HOLD_MS: Long = 100L
+
+    /**
+     * Bound on how long [close] waits for [sceneExecutor] to drain. Generous — a single tear-down
+     * is normally sub-second, but a recompose stuck behind a slow `LaunchedEffect` could
+     * conceivably take longer. Logging-then-continuing past the bound is better than hanging the
+     * JSON-RPC read thread indefinitely.
+     */
+    private const val EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS: Long = 5L
   }
 }

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/SInteractiveKeyDispatchRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/SInteractiveKeyDispatchRealModeTest.kt
@@ -138,18 +138,16 @@ class SInteractiveKeyDispatchRealModeTest {
         keyCode = "29",
       )
 
-      // 4. Shutdown — the daemon tears down the held session as part of shutdown sequencing.
-      // We deliberately don't drive an explicit `interactive/stop` notification here: the
-      // `LaunchedEffect { requestFocus() }` in `KeyPressColorSquare` triggers a known
-      // Compose `SnapshotStateObserver` multithread warning when the host's idle thread
-      // races the close path's render-thread teardown. The warning is benign (the close
-      // path catches it and continues), but the same race trips a SIGABRT in Skiko native
-      // code on this sandbox when the test drives the explicit stop before shutdown.
-      // Letting `shutdown` drive teardown serialises everything onto the daemon's shutdown
-      // sequencer and sidesteps the race. The wire-shape contract this scenario pins
-      // (`interactive/start` returns a held session, `interactive/input` notifications
-      // round-trip without serialisation faults) is already proven by the time we reach
-      // this point.
+      // 4. Explicit `interactive/stop` — the daemon tears down the held session synchronously.
+      // Issue #1229: pre-fix, this raced the `LaunchedEffect { requestFocus() }` in
+      // `KeyPressColorSquare`, tripping a Compose `SnapshotStateObserver` multithread warning
+      // (and a follow-on Skiko SIGABRT). The fix pins every scene touch — setUp, dispatch,
+      // render, the listener's observer install/dispose, and tearDown — to a single
+      // per-session executor thread inside `DesktopInteractiveSession`, so an explicit stop
+      // here is wire-equivalent to letting shutdown drive the teardown.
+      client.interactiveStop(frameStreamId = startResult.frameStreamId)
+
+      // 5. Shutdown — daemon exits cleanly.
       val exitCode = client.shutdownAndExit(timeout = 30.seconds)
       assertEquals("daemon must exit cleanly. Stderr=\n${client.dumpStderr()}", 0, exitCode)
 
@@ -160,6 +158,17 @@ class SInteractiveKeyDispatchRealModeTest {
           "round-trip; got:\n$stderr",
         stderr.contains("SerializationException") ||
           stderr.contains("at ee.schimke.composeai.daemon.JsonRpcServer.tryDecode"),
+      )
+      // Issue #1229 regression guard — pre-fix, the explicit `interactive/stop` above raced the
+      // `LaunchedEffect { requestFocus() }` in `KeyPressColorSquare` and tripped Compose's
+      // multithread-access warning on the global `SnapshotStateObserver`. The per-session
+      // scene executor pins every recomposer/effect/teardown step to one thread; if a future
+      // change regresses that and the warning starts firing again, fail loudly here instead of
+      // letting the follow-on Skiko SIGABRT take down the subprocess silently.
+      assertFalse(
+        "daemon stderr must not contain a SnapshotStateObserver multithread-access warning " +
+          "(issue #1229 regression); got:\n$stderr",
+        stderr.contains("Detected multithreaded access to SnapshotStateObserver"),
       )
     } catch (t: Throwable) {
       System.err.println(


### PR DESCRIPTION
Fixes #1229.

Every scene touch — setUp, dispatch, render, the recomposition listener's
observer install/dispose, and tearDown — now runs on a per-session
single-thread executor owned by `DesktopInteractiveSession`. The Compose
recomposer launches `LaunchedEffect` coroutines on `Dispatchers.Unconfined`,
which means they resume on whatever thread drove the last recomposition;
pre-fix that was the JSON-RPC render worker, while `interactive/stop` ran
`session.close()` on the read thread. The cross-thread close-during-effect
window is what tripped `Detected multithreaded access to
SnapshotStateObserver` (and the follow-on Skiko SIGABRT) against
`KeyPressColorSquare`'s `LaunchedEffect { requestFocus() }`.

`SInteractiveKeyDispatchRealModeTest` now drives the explicit
`interactive/stop` it used to deliberately skip, and asserts that no
SnapshotStateObserver warning appears in daemon stderr so a future
regression of the executor confinement fails loudly instead of going
silent until SIGABRT.

`ListenerNotifyingSession` is absorbed into `DesktopInteractiveSession`
via an `onSceneClose` hook so the listener's release-side
`onSessionLifecycle(_, null)` also runs on the executor — matching the
acquire side and removing one more cross-thread teardown step.

## Test plan

- [x] `:daemon:desktop:test --tests "*DesktopInteractiveSession*" "*DesktopKeyDispatch*" "*RecompositionAudit*" "*InteractiveTouchOverlay*"` — all pass
- [x] `:daemon:harness:test --tests "*SInteractiveKeyDispatchRealModeTest" -Pharness.host=real -Ptarget=desktop` — passes, 5× consecutive runs all green, stderr clean
- [x] `ktfmtCheck` on the touched modules
- [x] Full `:daemon:desktop:test` — only pre-existing failure is `RecompositionDataProductRegistryTest.observer_install_failure_degrades_to_advertise_but_useless`, which fails identically on `bf26bd8` (the branch base) and is unrelated to this change