### PR TITLE
ci(renovate): pin androidx.core and compose-multiplatform floors

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,6 +58,29 @@
       "allowedVersions": "/^4\\.0\\./"
     },
     {
+      "description": "androidx.core:core: pin to the 1.13.x line. `:data-keyboard-connector` declares this as a `compileOnly` compat floor so the published AAR's bytecode stays binary-backward-compatible with consumers on older `androidx.core` lines (same rationale as `compose-foundation` via `compose-bom-compat`). Raising the floor is a manual decision.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchDepNames": [
+        "androidx.core:core"
+      ],
+      "matchCurrentValue": "/^1\\.13\\./",
+      "allowedVersions": "/^1\\.13\\./"
+    },
+    {
+      "description": "compose-multiplatform: pin to the 1.10.x line. `:data-render-compose` exposes `org.jetbrains.compose.{runtime,ui}` as `api` on a published artifact, so the Compose Multiplatform version is part of the supported-minimum floor for consumers. 1.11.0 ships ABI-breaking changes (non-Android `Shader` becomes a Compose wrapper type, `NativePaint`/`NativeCanvas` typealiases deprecated, `Paint.asFrameworkPaint`/`Canvas.nativeCanvas` replaced) and bumps the required Kotlin language/API to 2.2 — raising the floor is a manual decision. Keep `samples/cmp-shared`'s explicit `ui-tooling-preview` coord in lockstep so the plugin's compose-runtime compatibility check stays happy.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchPackageNames": [
+        "org.jetbrains.compose",
+        "org.jetbrains.compose{/,}**"
+      ],
+      "matchCurrentValue": "/^1\\.10\\./",
+      "allowedVersions": "/^1\\.10\\./"
+    },
+    {
       "description": "VS Code API floor declarations — bumping these drops support for older editors, must be a manual decision.",
       "matchFileNames": [
         "vscode-extension/package.json"


### PR DESCRIPTION
#1342 surfaced two bumps that would have raised the published-API
floor for consumers:

- androidx.core:core 1.13.0 → 1.18.0 in :data-keyboard-connector,
  declared as a compileOnly compat floor matching :renderer-android's
  compose-bom-compat rationale.
- compose-multiplatform 1.10.3 → 1.11.0, whose org.jetbrains.compose.{
  runtime,ui} libraries are re-exposed as api by the published
  :data-render-compose. 1.11.0 ships ABI-breaking Shader/Paint changes
  and requires Kotlin 2.2 language/API.

Add packageRules that constrain both to their current minor lines so
Renovate stops proposing these bumps. The asm 9.10 patch from the same
PR is test-only (daemon harness) and remains free to update.