### PR TITLE
ci: skip GITHUB_TOKEN on cross-org public checkouts in integration

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -280,6 +280,15 @@ jobs:
           ref: ${{ matrix.ref }}
           path: external
           persist-credentials: false
+          # Use anonymous HTTPS for cross-org public checkouts. The default
+          # GITHUB_TOKEN is scoped to this repo; when actions/checkout sets it
+          # as the Authorization header against `android/wear-os-samples`,
+          # github.com rejects it (401) and git falls back to an interactive
+          # askpass prompt that does not exist on the runner — surfacing as
+          # `fatal: could not read Username for 'https://github.com': terminal
+          # prompts disabled`. Passing an empty token tells the action to
+          # skip auth header setup; anonymous HTTPS works for any public repo.
+          token: ""
 
       - name: Checkout ${{ matrix.secondary_repo }} (secondary)
         if: matrix.secondary_repo != ''
@@ -290,6 +299,8 @@ jobs:
           path: ${{ matrix.secondary_path }}
           filter: ${{ matrix.secondary_filter }}
           persist-credentials: false
+          # See note on the primary checkout above — same reasoning.
+          token: ""
 
       - name: Wire androidx symlink in androidchka workspace
         if: matrix.wire_androidx_symlink


### PR DESCRIPTION
## Summary

The `Integration / wear-os-samples (ComposeStarter)` job's external checkout step has been failing with:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

across all three of actions/checkout's built-in retries.

Root cause: `actions/checkout@v6` always sets the workflow's `${{ github.token }}` as the `Authorization: Basic` header for the fetch unless `token` is explicitly empty. This workflow's permissions block is:

```yaml
permissions:
  contents: read
```

That token is scoped to `yschimke/compose-ai-tools` only. When the action attempts to clone `android/wear-os-samples` (or any other cross-org matrix entry), github.com rejects the header (401), git falls back to the credential helper, and the runner has no interactive terminal — surfacing as the askpass error above.

Setting `token: ""` skips the auth-header setup so the fetch goes out as anonymous HTTPS, which is sufficient for any public repo. Applied to both the primary matrix checkout and the (currently unused) secondary checkout for consistency.

## Test plan

- [ ] `Integration / wear-os-samples (ComposeStarter)` checkout step succeeds and the rest of the job runs end-to-end (discover → render → daemon round-trip).
- [ ] `Integration / wear-os-samples (WearTilesKotlin)` checkout step succeeds and the tile-render verification still passes.
- [ ] `Integration / androidify` checkout step succeeds and discovery still runs.
- [ ] `agp8-min` job — unaffected (uses the in-repo fixture, no external checkout).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy9J74TMDzZQ3azwkFU6FM)_