### PR TITLE
feat(notification-preview-runtime): surface axis + content edge-case gallery

### DIFF
--- a/notification-preview-runtime/src/main/kotlin/ee/schimke/composeai/preview/notification/NotificationContent.kt
+++ b/notification-preview-runtime/src/main/kotlin/ee/schimke/composeai/preview/notification/NotificationContent.kt
@@ -25,10 +25,10 @@ import java.io.File
  * pick each `@Preview` up as a separate entry, so no notification-specific plumbing is required.
  *
  * Inflation path mirrors the renderer-side `NotificationPreviewComposable`:
- * `Notification.Builder.recoverBuilder(context, notification)` → `createBigContentView()` (with
- * `createContentView()` as the collapsed fallback) → `RemoteViews.apply(...)`. This is the AOSP
- * visual; OEM chrome (Pixel rounded corners, Samsung tinting) is drawn by SystemUI on-device and
- * isn't reproducible under Robolectric.
+ * `Notification.Builder.recoverBuilder(context, notification)` → [surface]'s matching
+ * `createXxxContentView()` (with `createContentView()` as the collapsed fallback) →
+ * `RemoteViews.apply(...)`. This is the AOSP visual; OEM chrome (Pixel rounded corners, Samsung
+ * tinting) is drawn by SystemUI on-device and isn't reproducible under Robolectric.
  *
  * Pass [previewId] to opt into the structured-fields JSON sidecar — when the renderer's
  * `composeai.render.outputDir` system property is set (i.e. running under the
@@ -37,12 +37,25 @@ import java.io.File
  * FQN-discovered `@NotificationPreview` strategy in `:renderer-android`. Helper-based call sites
  * that don't know their preview id at compile time can leave it `null`; sidecar emission is opt-in.
  *
+ * Pass [surface] to render a specific notification surface: [NotificationSurface.EXPANDED]
+ * (default, the shade-expanded `createBigContentView()` layout — the most informative variant and
+ * what the rest of the gallery uses), [NotificationSurface.COLLAPSED]
+ * (`createContentView()` — the one-line shade row), or [NotificationSurface.HEADS_UP]
+ * (`createHeadsUpContentView()` — the popup variant shown for high-importance channels). On AOSP
+ * heads-up returns the same `RemoteViews` as the expanded layout for most styles; the parameter
+ * is still distinct in the API so multi-preview meta-annotations can author 3-way surface
+ * fan-outs.
+ *
  * [previewId] is the first parameter so [factory] stays the trailing-lambda slot — `NotificationContent
  * { ctx -> ... }` is the common shape and shouldn't require named arguments. Pass `previewId` only
  * when you actually want the sidecar: `NotificationContent(previewId = "Foo") { ctx -> ... }`.
  */
 @Composable
-fun NotificationContent(previewId: String? = null, factory: (Context) -> Notification) {
+fun NotificationContent(
+  previewId: String? = null,
+  surface: NotificationSurface = NotificationSurface.EXPANDED,
+  factory: (Context) -> Notification,
+) {
   val context = LocalContext.current
   AndroidView(
     modifier = Modifier.fillMaxWidth().wrapContentHeight(),
@@ -67,7 +80,7 @@ fun NotificationContent(previewId: String? = null, factory: (Context) -> Notific
         NotificationSidecar.write(previewId, notification, context)
       }
       val view =
-        inflateNotificationView(context, notification, parent)
+        inflateNotificationView(context, notification, parent, surface)
           ?: error("NotificationContent produced no inflatable RemoteViews")
       parent.addView(
         view,
@@ -79,6 +92,26 @@ fun NotificationContent(previewId: String? = null, factory: (Context) -> Notific
       parent
     },
   )
+}
+
+/**
+ * Notification surface the [NotificationContent] helper inflates. The three values map to the
+ * three `Notification.Builder.createXxxContentView()` entry points SystemUI uses on-device:
+ *
+ *  - [COLLAPSED] → `createContentView()`, the one-line row that appears when the shade lists
+ *    the notification alongside others. Wide-and-short.
+ *  - [EXPANDED] → `createBigContentView()`, the layout shown when the user taps to expand. Most
+ *    style classes (`BigTextStyle`, `MessagingStyle`, `InboxStyle`, …) only differ from
+ *    collapsed in this layout, so it's the most informative variant and the default.
+ *  - [HEADS_UP] → `createHeadsUpContentView()`, the popup variant shown for high-importance
+ *    channels (or `setPriority(PRIORITY_HIGH)` pre-O). On stock AOSP this returns the same
+ *    `RemoteViews` tree as the expanded layout for most styles — we still surface it as a
+ *    distinct value because OEM skins (and the platform's `MediaStyle`) do diverge.
+ */
+enum class NotificationSurface {
+  COLLAPSED,
+  EXPANDED,
+  HEADS_UP,
 }
 
 /**
@@ -104,12 +137,23 @@ private fun inflateNotificationView(
   context: Context,
   notification: Notification,
   parent: ViewGroup,
+  surface: NotificationSurface,
 ): android.view.View? {
-  // `createBigContentView` / `createContentView` are marked deprecated for production posting
-  // paths (where the system inflates them for you) but there's no non-deprecated alternative when
-  // you specifically want the RemoteViews tree for offline rendering.
+  // `createBigContentView` / `createContentView` / `createHeadsUpContentView` are marked
+  // deprecated for production posting paths (where the system inflates them for you) but there's
+  // no non-deprecated alternative when you specifically want the RemoteViews tree for offline
+  // rendering. Each surface falls back to `createContentView()` so notifications without a
+  // `setStyle(...)` (which produce no big / heads-up layout) still render at least the collapsed
+  // row instead of erroring out.
   val builder = Notification.Builder.recoverBuilder(context, notification)
-  val remoteViews = builder.createBigContentView() ?: builder.createContentView() ?: return null
+  val remoteViews =
+    when (surface) {
+      NotificationSurface.COLLAPSED -> builder.createContentView()
+      NotificationSurface.EXPANDED ->
+        builder.createBigContentView() ?: builder.createContentView()
+      NotificationSurface.HEADS_UP ->
+        builder.createHeadsUpContentView() ?: builder.createContentView()
+    } ?: return null
   return remoteViews.apply(context, parent)
 }
 

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationStyleGallery.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationStyleGallery.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.app.NotificationCompat
 import androidx.core.app.Person
 import ee.schimke.composeai.preview.notification.NotificationContent
+import ee.schimke.composeai.preview.notification.NotificationSurface
 
 /**
  * Gallery of additional `NotificationCompat` styles routed through the `NotificationContent`
@@ -28,7 +29,10 @@ import ee.schimke.composeai.preview.notification.NotificationContent
  * Covers the surfaces real apps mostly ship: Messaging (Signal / WhatsApp / Discord),
  * Inbox-summary (Gmail), `BigPictureStyle` (camera / share notifications), actions
  * (reply / dismiss button row), `MediaStyle` (now-playing card), and
- * `DecoratedCustomViewStyle` (custom progress body under default chrome).
+ * `DecoratedCustomViewStyle` (custom progress body under default chrome). Below the style
+ * gallery are two additional sections: a surface-axis fan-out (collapsed / expanded / heads-up
+ * of the same notification through `NotificationSurface`) and a content-edge-case set
+ * (long-title truncation, no-text, no-large-icon, action overflow, grouped summary).
  */
 private const val GALLERY_CHANNEL_ID = "gallery"
 
@@ -215,6 +219,181 @@ fun DecoratedCustomViewPreview() {
       .setCustomContentView(body)
       .setCustomBigContentView(body)
       .setStyle(NotificationCompat.DecoratedCustomViewStyle())
+      .build()
+  }
+}
+
+// --- Surface axis (collapsed / expanded / heads-up) -------------------------------------------
+//
+// The three previews below render the *same* notification through the three `NotificationSurface`
+// values, so the rendered PNGs document how each `createXxxContentView()` path differs. Authors
+// who only care about one surface keep using the default (`EXPANDED`) on `NotificationContent`;
+// the surface parameter is opt-in.
+
+private fun surfaceAxisNotification(ctx: Context) =
+  NotificationCompat.Builder(ctx, GALLERY_CHANNEL_ID)
+    .setSmallIcon(android.R.drawable.ic_dialog_email)
+    .setContentTitle("Compose preview")
+    .setContentText("Tap to read the update")
+    .setStyle(
+      NotificationCompat.BigTextStyle()
+        .bigText(
+          "Notification previews now expose the three SystemUI surfaces — collapsed shade row, " +
+            "expanded body, and heads-up popup — through the `NotificationSurface` enum on the " +
+            "`NotificationContent` helper."
+        )
+    )
+    .build()
+
+@Preview(name = "Surface — collapsed")
+@Composable
+fun CollapsedSurfacePreview() {
+  NotificationContent(surface = NotificationSurface.COLLAPSED) { ctx ->
+    ensureGalleryChannel(ctx)
+    surfaceAxisNotification(ctx)
+  }
+}
+
+@Preview(name = "Surface — expanded")
+@Composable
+fun ExpandedSurfacePreview() {
+  NotificationContent(surface = NotificationSurface.EXPANDED) { ctx ->
+    ensureGalleryChannel(ctx)
+    surfaceAxisNotification(ctx)
+  }
+}
+
+@Preview(name = "Surface — heads-up")
+@Composable
+fun HeadsUpSurfacePreview() {
+  NotificationContent(surface = NotificationSurface.HEADS_UP) { ctx ->
+    ensureGalleryChannel(ctx)
+    surfaceAxisNotification(ctx)
+  }
+}
+
+// --- Content edge cases -----------------------------------------------------------------------
+//
+// One preview per edge case from issue #1249's "Content edge cases" row of the variants matrix.
+// These exist so the rendered PNGs document how the AOSP layout degrades — long-string truncation,
+// missing optional fields, action overflow, group-summary chrome.
+
+/**
+ * Very long title — exercises the AOSP layout's collapsed truncation behaviour. SystemUI clips
+ * the title to one line on collapsed surfaces; the expanded layout (rendered here) lets the title
+ * wrap to two lines and then ellipsises.
+ */
+@Preview(name = "Edge — long title")
+@Composable
+fun LongTitlePreview() {
+  NotificationContent { ctx ->
+    ensureGalleryChannel(ctx)
+    NotificationCompat.Builder(ctx, GALLERY_CHANNEL_ID)
+      .setSmallIcon(android.R.drawable.ic_dialog_info)
+      .setContentTitle(
+        "A notification title that goes on far past the width of any reasonable phone shade " +
+          "to exercise the AOSP layout's title-row ellipsisation"
+      )
+      .setContentText("Tap to open")
+      .build()
+  }
+}
+
+/**
+ * Title only — no `setContentText`, no `setStyle`. Demonstrates the minimum-viable layout the
+ * AOSP renderer falls back to when the builder doesn't carry a body. The text row collapses to
+ * nothing; the small-icon header still draws.
+ */
+@Preview(name = "Edge — no text")
+@Composable
+fun NoTextPreview() {
+  NotificationContent { ctx ->
+    ensureGalleryChannel(ctx)
+    NotificationCompat.Builder(ctx, GALLERY_CHANNEL_ID)
+      .setSmallIcon(android.R.drawable.ic_dialog_info)
+      .setContentTitle("Sync complete")
+      .build()
+  }
+}
+
+/**
+ * `MessagingStyle` *without* `Person` icons — `setIcon(...)` omitted on both senders. The
+ * inflated layout drops the avatar column and the name rows reflow to the left edge. Mirrors how
+ * the gallery's main [MessagingStylePreview] would degrade for apps that haven't wired up
+ * per-contact avatars yet.
+ */
+@Preview(name = "Edge — no large icon")
+@Composable
+fun NoLargeIconPreview() {
+  NotificationContent { ctx ->
+    ensureGalleryChannel(ctx)
+    val you = Person.Builder().setName("You").build()
+    val alice = Person.Builder().setName("Alice").build()
+    val now = System.currentTimeMillis()
+    NotificationCompat.Builder(ctx, GALLERY_CHANNEL_ID)
+      .setSmallIcon(android.R.drawable.sym_action_chat)
+      .setStyle(
+        NotificationCompat.MessagingStyle(you)
+          .setConversationTitle("Alice")
+          .addMessage("No avatars on this one", now - 120_000, alice)
+          .addMessage("Just the small icon row", now - 60_000, you)
+      )
+      .build()
+  }
+}
+
+/**
+ * Six actions — SystemUI silently caps the visible action row at three on most layouts, so the
+ * later three never paint. The rendered PNG documents the truncation point.
+ */
+@Preview(name = "Edge — many actions")
+@Composable
+fun ManyActionsPreview() {
+  NotificationContent { ctx ->
+    ensureGalleryChannel(ctx)
+    val noopIntent =
+      PendingIntent.getActivity(
+        ctx,
+        0,
+        Intent("com.example.sampleandroid.NOOP"),
+        PendingIntent.FLAG_IMMUTABLE,
+      )
+    val builder =
+      NotificationCompat.Builder(ctx, GALLERY_CHANNEL_ID)
+        .setSmallIcon(android.R.drawable.ic_dialog_alert)
+        .setContentTitle("Action overflow")
+        .setContentText("System truncates beyond three")
+    listOf("Reply", "Archive", "Snooze", "Mute", "Delete", "Star").forEach { label ->
+      builder.addAction(android.R.drawable.ic_menu_more, label, noopIntent)
+    }
+    builder.build()
+  }
+}
+
+/**
+ * Group summary notification — `setGroupSummary(true)` + the same `setGroup(...)` key the
+ * children carry. SystemUI shows the summary as a single collapsed row with a counter; the
+ * rendered PNG here uses the standard `setContentTitle` / `setContentText` fields the summary
+ * inflater falls back to when no `InboxStyle` is attached.
+ */
+@Preview(name = "Edge — grouped summary")
+@Composable
+fun GroupedSummaryPreview() {
+  NotificationContent { ctx ->
+    ensureGalleryChannel(ctx)
+    NotificationCompat.Builder(ctx, GALLERY_CHANNEL_ID)
+      .setSmallIcon(android.R.drawable.ic_dialog_email)
+      .setContentTitle("3 new messages")
+      .setContentText("From Alice, Bob, Carol")
+      .setGroup("messages")
+      .setGroupSummary(true)
+      .setStyle(
+        NotificationCompat.InboxStyle()
+          .setSummaryText("project-updates@")
+          .addLine("Alice  Did the previews land?")
+          .addLine("Bob  Reviewed the PR, ship it")
+          .addLine("Carol  Question about MessagingStyle")
+      )
       .build()
   }
 }


### PR DESCRIPTION
## Summary
- `NotificationContent` now takes a `surface: NotificationSurface` parameter (`COLLAPSED` / `EXPANDED` / `HEADS_UP`) that routes to the matching `Notification.Builder.createXxxContentView()` method, with `createContentView()` as the fallback when a style doesn't define a heads-up or big layout. Default stays `EXPANDED` so existing call sites are unchanged.
- Six new entries on `NotificationStyleGallery`:
  - Surface axis: collapsed / expanded / heads-up of the same `BigTextStyle` notification, demonstrating the three SystemUI inflate paths side-by-side.
  - Content edge cases (from the variants matrix in #1249): long-title truncation, no body text, `MessagingStyle` without per-`Person` icons, six-action overflow (SystemUI silently caps at three), and a grouped summary row.

Wraps up the last two unfilled axes from the planning issue.

Closes #1249.

## Test plan
- [x] `./gradlew :notification-preview-runtime:compileDebugKotlin` (default-parameter API change is source-compatible)
- [x] `./gradlew :renderer-android:test`
- [x] `./gradlew :samples:android:composePreviewRenderAll` — all 8 new captures land under `renders/` and visually distinct (e.g. collapsed surface shows the one-line layout; many-actions surface only paints the first three button labels)
- [x] `./gradlew :samples:android:ktfmtCheck` :notification-preview-runtime:ktfmtCheck

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPixzzuya1nNmRQDxH1Zb7)_