### PR TITLE
test(vscode-extension): drive e2e against joreilly/Confetti (published-plugin path)

### DIFF
--- a/.github/workflows/vscode-extension-e2e-external.yml
+++ b/.github/workflows/vscode-extension-e2e-external.yml
@@ -1,0 +1,121 @@
+name: VS Code Extension E2E (external consumer)
+
+# Companion to `vscode-extension-e2e.yml`. That workflow drives the
+# extension against `:samples:cmp` / `:samples:wear`, both wired via
+# `includeBuild("gradle-plugin")` — the dev-loop path. This workflow drives
+# the extension against `joreilly/Confetti` (pinned SHA), with the plugin
+# resolved through the consumer's `gradle/libs.versions.toml` against the
+# local SNAPSHOT just `publishToMavenLocal`'d. That closes the published-
+# plugin-coordinate gap: the in-repo suite can't catch regressions where the
+# plugin works fine via `includeBuild` but fails as a published artifact
+# against a real KMP/AGP/Compose classpath.
+#
+# Cost: a cold run is multi-tens of minutes (Confetti's Apollo codegen and
+# KMP target setup alone take 2-5 min before any compose-preview task
+# runs). Not on PRs. Not on every push to main. Manual + weekly.
+#
+# Triggers:
+#   workflow_dispatch — manual one-off runs (any branch). Bump the
+#                       Confetti SHA or the plugin version here when
+#                       investigating a regression.
+#   schedule          — weekly, Sundays 06:00 UTC. Picks up drift in
+#                       Confetti's transitive deps + our own renderer
+#                       compat with the latest published consumer code.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confetti_ref:
+        description: "Confetti git SHA / branch / tag (defaults to the pin in setup-external-e2e.sh)"
+        required: false
+        type: string
+  schedule:
+    - cron: "0 6 * * 0"
+
+permissions:
+  contents: read
+
+concurrency:
+  # Manual dispatches get their own slot via run_id; scheduled runs
+  # collapse onto a single in-flight per cron tick.
+  group: vscode-extension-e2e-external-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  e2e-external:
+    name: VS Code Extension E2E (Confetti, published plugin)
+    runs-on: ubuntu-latest
+    # 90 minutes ceiling — Confetti's cold configuration alone can be
+    # 5-10 min on a fresh CI runner before any compose-preview task
+    # touches the daemon. The mocha suite's own per-`it` ceiling
+    # (`this.timeout(30 * 60_000)`) trips first on a wedge.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+
+      # Same caches as vscode-extension-e2e.yml — the VS Code download is
+      # the larger of the two, and on a cron-driven schedule the cache key
+      # is usually a hit since the OS doesn't change.
+      - name: Cache VS Code download
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: vscode-extension/.vscode-test
+          key: vscode-test-electron-${{ runner.os }}
+
+      # Publish the plugin + every supporting module to mavenLocal so
+      # the consumer's catalog resolves to *this* commit, not the
+      # already-released coordinate Maven Central serves. `publishToMavenLocal`
+      # without a project filter fans out to every module the
+      # `composeai.maven-publishing` convention plugin applies to.
+      - name: Publish plugin to mavenLocal
+        run: ./gradlew publishToMavenLocal --no-daemon
+
+      - name: Install extension dependencies
+        working-directory: vscode-extension
+        run: npm ci
+
+      - name: Compile extension
+        working-directory: vscode-extension
+        run: npm run compile
+
+      # Prepare the external workspace: clone Confetti at the pinned SHA
+      # (or the workflow_dispatch override), rewrite its catalog to
+      # point at the SNAPSHOT we just published, seed local.properties
+      # with the runner's Android SDK path. Stdout is the prepared
+      # workspace path — capture it and forward to the test runner.
+      - name: Prepare external workspace (Confetti)
+        id: prepare
+        env:
+          EXTERNAL_REPO_REF: ${{ inputs.confetti_ref }}
+        run: |
+          workspace=$(vscode-extension/scripts/setup-external-e2e.sh \
+            "${RUNNER_TEMP}/compose-preview-external-e2e")
+          echo "workspace=$workspace" >> "$GITHUB_OUTPUT"
+          echo "[workflow] prepared external workspace at $workspace"
+
+      - name: Run external-consumer e2e under xvfb
+        working-directory: vscode-extension
+        env:
+          COMPOSE_PREVIEW_E2E_WORKSPACE: ${{ steps.prepare.outputs.workspace }}
+        run: xvfb-run -a npm run test:e2e-external
+
+      - name: Upload renders + daemon logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-external-renders
+          path: |
+            ${{ steps.prepare.outputs.workspace }}/androidApp/build/compose-previews/
+            ${{ steps.prepare.outputs.workspace }}/shared/build/compose-previews/
+            ${{ steps.prepare.outputs.workspace }}/wearApp/build/compose-previews/
+            vscode-extension/.vscode-test/user-data/logs/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -221,6 +221,7 @@
         "test": "npm run compile && mocha --exit out/test/runMocha.js",
         "test:electron": "npm run compile && node ./out/test/electron/runTest.js",
         "test:e2e": "npm run compile && COMPOSE_PREVIEW_E2E=1 node ./out/test/electron/runTest.js",
+        "test:e2e-external": "npm run compile && COMPOSE_PREVIEW_E2E_EXTERNAL=1 COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1 node ./out/test/electron/runTest.js",
         "lint": "eslint src --ext ts",
         "package": "npm run compile && vsce package --no-dependencies",
         "harness:snapshot": "node esbuild.webview.mjs && node preview-harness/snapshot.mjs",

--- a/vscode-extension/scripts/setup-external-e2e.sh
+++ b/vscode-extension/scripts/setup-external-e2e.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Prepares an external (third-party) Gradle/Kotlin project as the workspace
+# for the VS Code extension e2e suite at `e2eExternal.test.ts`. Built around
+# joreilly/Confetti by default — a real-world Compose Multiplatform + Wear OS
+# consumer that already declares `alias(libs.plugins.composeai.preview)` —
+# but the same shape works for any repo whose `gradle/libs.versions.toml`
+# pins our plugin version through `composeai-preview`.
+#
+# Why a separate suite: the in-repo `:samples:*` e2e wires the plugin via
+# `includeBuild("gradle-plugin")`, which is the perfectly-aligned dev-loop
+# path. Real consumers resolve the plugin from Maven Central and hit a much
+# harsher classpath (Apollo, KMP wasmJs+iOS, KMM Bridge, Firebase, ...).
+# Failures that only surface against a real consumer — stale daemon-launch
+# descriptors, classpath fingerprint mismatches, AGP/AndroidX alignment
+# drift — go unseen until a user files an issue. This script + the matching
+# suite close that gap by driving the published-coordinate path against a
+# fixed third-party SHA.
+#
+# Usage:
+#   scripts/setup-external-e2e.sh [TARGET_DIR]
+#
+# Env (override defaults):
+#   EXTERNAL_REPO_URL   git URL (default: https://github.com/joreilly/Confetti.git)
+#   EXTERNAL_REPO_REF   commit SHA / tag / branch (default: pinned SHA below)
+#   PLUGIN_VERSION      plugin coordinate to inject (default: read from
+#                       `.release-please-manifest.json` and bump to
+#                       next-patch -SNAPSHOT, matching what
+#                       `publishToMavenLocal` produced)
+#   ANDROID_SDK_DIR     absolute path written into `local.properties`
+#                       (default: ANDROID_HOME or /opt/android-sdk)
+#
+# Output: prints the absolute path to the prepared workspace on stdout.
+
+set -euo pipefail
+
+DEFAULT_REPO_URL="https://github.com/joreilly/Confetti.git"
+# Pinned to the commit that bumped composeai-preview to 0.9.1 (PR #1689).
+# Picked because it's the most recent point where the catalog declares our
+# plugin id, so future Confetti reshuffles can't silently break the suite.
+# Bump when we want to test against newer downstream code.
+DEFAULT_REPO_REF="2044dcc7efe90773b71eecf84ebc318327837984"
+
+target_dir="${1:-/tmp/compose-preview-external-e2e}"
+repo_url="${EXTERNAL_REPO_URL:-$DEFAULT_REPO_URL}"
+repo_ref="${EXTERNAL_REPO_REF:-$DEFAULT_REPO_REF}"
+
+# Resolve PLUGIN_VERSION the same way `scripts/generate-version.mjs` does so
+# the catalog rewrite matches the extension's `BUNDLED_PLUGIN_VERSION`. The
+# Node helper is the single source of truth — duplicating the bump logic in
+# bash would drift.
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+plugin_version="${PLUGIN_VERSION:-}"
+if [[ -z "$plugin_version" ]]; then
+  plugin_version="$(node -e '
+    const { readFileSync } = require("node:fs");
+    const { resolve } = require("node:path");
+    const env = process.env.PLUGIN_VERSION;
+    if (env) { process.stdout.write(env); process.exit(0); }
+    const m = JSON.parse(readFileSync(resolve("'"$script_dir"'", "../../.release-please-manifest.json"), "utf8"));
+    const [major, minor, patch] = String(m["."]).split(".").map((p) => parseInt(p, 10));
+    process.stdout.write(`${major}.${minor}.${patch + 1}-SNAPSHOT`);
+  ')"
+fi
+
+android_sdk_dir="${ANDROID_SDK_DIR:-${ANDROID_HOME:-/opt/android-sdk}}"
+
+echo "[setup-external-e2e] target=$target_dir" >&2
+echo "[setup-external-e2e] repo=$repo_url@$repo_ref" >&2
+echo "[setup-external-e2e] plugin_version=$plugin_version" >&2
+echo "[setup-external-e2e] android_sdk_dir=$android_sdk_dir" >&2
+
+if [[ ! -d "$target_dir/.git" ]]; then
+  rm -rf "$target_dir"
+  # Shallow init + fetch-by-SHA — the default branch may not contain the
+  # pinned SHA (after a force-push) and `git clone --branch <sha>` doesn't
+  # work. init+fetch is the GitHub-recommended pattern for SHA-pinned
+  # fixtures.
+  git init -q "$target_dir"
+  (
+    cd "$target_dir"
+    git remote add origin "$repo_url"
+    git fetch --depth 1 origin "$repo_ref"
+    git checkout -q FETCH_HEAD
+  )
+else
+  (
+    cd "$target_dir"
+    current="$(git rev-parse HEAD)"
+    if [[ "$current" != "$repo_ref"* ]]; then
+      git fetch --depth 1 origin "$repo_ref"
+      git checkout -q FETCH_HEAD
+    fi
+  )
+fi
+
+# Rewrite the catalog so the plugin resolves to our SNAPSHOT instead of the
+# stale published version Confetti currently pins. The pre-applied detector
+# in the extension's init-script keys off `alias(libs.plugins.<x>)`, so
+# Gradle still applies it via the catalog — we just point the catalog at a
+# different version. Idempotent: running twice produces the same file.
+catalog="$target_dir/gradle/libs.versions.toml"
+if [[ ! -f "$catalog" ]]; then
+  echo "[setup-external-e2e] expected $catalog — repo layout changed?" >&2
+  exit 1
+fi
+python3 - "$catalog" "$plugin_version" <<'PY'
+import re
+import sys
+
+path, version = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as fh:
+    text = fh.read()
+new = re.sub(
+    r'^(\s*composeai-preview\s*=\s*)"[^"]+"',
+    rf'\g<1>"{version}"',
+    text,
+    count=1,
+    flags=re.MULTILINE,
+)
+if new == text:
+    sys.exit("composeai-preview entry not found in catalog; refusing to proceed")
+with open(path, "w", encoding="utf-8") as fh:
+    fh.write(new)
+PY
+
+# Android SDK path — Confetti and most Android consumers fail Gradle
+# configuration without one of `local.properties:sdk.dir`, `ANDROID_HOME`,
+# or `ANDROID_SDK_ROOT`. Writing the file is the most reliable signal
+# across Gradle / AGP versions.
+echo "sdk.dir=$android_sdk_dir" > "$target_dir/local.properties"
+
+echo "$target_dir"

--- a/vscode-extension/src/test/electron/runTest.ts
+++ b/vscode-extension/src/test/electron/runTest.ts
@@ -32,10 +32,31 @@ async function main(): Promise<void> {
     // into the local plugin via `includeBuild("gradle-plugin")`, without
     // duplicating fixture build files. The fast suite keeps its tiny
     // pre-baked workspace.
+    //
+    // External-consumer e2e (COMPOSE_PREVIEW_E2E_EXTERNAL=1, set by `npm
+    // run test:e2e-external` and the matching CI workflow) opens whatever
+    // path COMPOSE_PREVIEW_E2E_WORKSPACE points at — typically a
+    // setup-external-e2e.sh checkout of joreilly/Confetti. Exercises the
+    // *published* plugin coordinate path against a real third-party
+    // build, complementing the in-repo `includeBuild` suite.
     const e2eMode = process.env.COMPOSE_PREVIEW_E2E === "1";
-    const workspacePath = e2eMode
-        ? path.resolve(extensionDevelopmentPath, "..")
-        : path.join(fixturesRoot, "workspace");
+    const e2eExternal = process.env.COMPOSE_PREVIEW_E2E_EXTERNAL === "1";
+    let workspacePath: string;
+    if (e2eExternal) {
+        const external = process.env.COMPOSE_PREVIEW_E2E_WORKSPACE;
+        if (!external) {
+            throw new Error(
+                "COMPOSE_PREVIEW_E2E_EXTERNAL=1 requires COMPOSE_PREVIEW_E2E_WORKSPACE " +
+                    "(absolute path to the prepared external-consumer Gradle workspace; " +
+                    "see vscode-extension/scripts/setup-external-e2e.sh)",
+            );
+        }
+        workspacePath = external;
+    } else if (e2eMode) {
+        workspacePath = path.resolve(extensionDevelopmentPath, "..");
+    } else {
+        workspacePath = path.join(fixturesRoot, "workspace");
+    }
     const fakeGradleExtensionPath = path.join(
         fixturesRoot,
         "fake-vscode-gradle",
@@ -86,6 +107,31 @@ async function main(): Promise<void> {
             ELECTRON_RUN_AS_NODE: undefined,
             COMPOSE_PREVIEW_TEST_MODE: "1",
             ...(e2eMode ? { COMPOSE_PREVIEW_E2E: "1" } : {}),
+            // Forward the external-consumer flag (and the workspace
+            // path, for diagnostic logs) into the extension host so the
+            // gated `describeExternal(...)` actually runs. The
+            // `runTest.ts` parent only inspects the bare flag, but the
+            // host needs the path so e2eExternal.test.ts can sanity-check
+            // the workspace layout in `before()`.
+            ...(e2eExternal
+                ? {
+                      COMPOSE_PREVIEW_E2E_EXTERNAL: "1",
+                      COMPOSE_PREVIEW_E2E_WORKSPACE: workspacePath,
+                  }
+                : {}),
+            // Pulled through so the renderer-resolving init script (see
+            // initScript.ts → `useMavenLocal`) seeds mavenLocal into the
+            // plugin classpath. Tests don't toggle this themselves —
+            // the workflow + `npm run test:e2e-external` set it from
+            // the outside, and forwarding it here keeps the contract
+            // explicit instead of relying on environment inheritance
+            // semantics of @vscode/test-electron.
+            ...(process.env.COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL
+                ? {
+                      COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL:
+                          process.env.COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL,
+                  }
+                : {}),
         },
     });
     console.log(`[runTest] tests complete`);

--- a/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
@@ -1,0 +1,306 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import type { ComposePreviewTestApi } from "../../../extension";
+import { RealGradleApi } from "../realGradleApi";
+
+/**
+ * External-consumer end-to-end test. Drives the VS Code extension against a
+ * third-party Gradle project that resolves the Compose Preview plugin from
+ * Maven Central via a version-catalog alias — the *published* coordinate
+ * path, not the `includeBuild("gradle-plugin")` dev-loop the existing
+ * `:samples:cmp` / `:samples:wear` e2e exercises.
+ *
+ * Why a separate suite: the in-repo e2e is a fast feedback loop, but it
+ * misses every regression that hinges on the plugin being resolved as a
+ * published artifact against a real consumer's classpath. Issues this
+ * suite is positioned to catch (none of which `:samples:*` will surface):
+ *
+ *   - **Stale `daemon-launch.json`** after a plugin upgrade — the
+ *     extension reuses the cached descriptor, the JVM spawns against a
+ *     mismatched JAR, `initialize` throws.
+ *   - **Classpath fingerprint mismatch** (`classpathDirty` notification)
+ *     when AGP/Kotlin/Compose drift between renderer and consumer.
+ *   - **First-spawn failure** memo eviction
+ *     (`daemonBootstrappedModules.delete(moduleKey)`) — the "already
+ *     bootstrapped this session but daemon is not ready" branch in
+ *     `warmDaemonForFile`.
+ *   - **Catalog-alias detection** — Confetti's modules apply the plugin
+ *     via `alias(libs.plugins.composeai.preview)`. The literal
+ *     `appliesPlugin` regex doesn't match catalog aliases, so the panel
+ *     relies entirely on the `applied.json` marker the
+ *     `composePreviewApplied` task writes during the first Gradle run.
+ *     Verifies that path works end-to-end on a project that has never
+ *     written the marker before.
+ *
+ * Gated on `COMPOSE_PREVIEW_E2E_EXTERNAL=1` (set by `npm run
+ * test:e2e-external` and the matching CI workflow). Skipped silently
+ * everywhere else; cold cost on a fresh CI runner is multi-tens of
+ * minutes because the consumer brings its own KMP + Apollo + Firebase
+ * configuration phase before any Compose Preview task runs.
+ *
+ * Workspace shape: `runTest.ts` opens the path from
+ * `COMPOSE_PREVIEW_E2E_WORKSPACE` as the VS Code workspace. The matching
+ * CI workflow materialises that path via `setup-external-e2e.sh`, which
+ * clones Confetti at a pinned SHA, rewrites its catalog to point at the
+ * local SNAPSHOT, and seeds `local.properties`. The Confetti pin is
+ * intentional — bumping it is a deliberate "we want to test against
+ * newer downstream code" decision, not an automatic update.
+ *
+ * Module under test: `:androidApp`. Picked because it's the simplest
+ * plugin-applied module in Confetti (no KMP shared sources, no Wear OS
+ * Robolectric SDK gymnastics). The `:shared` and `:wearApp` modules are
+ * deliberately out of scope for the first cut — they widen the failure
+ * surface to KMP commonMain visibility and Wear/Robolectric SDK
+ * alignment, both of which deserve their own follow-up suite.
+ */
+
+const E2E_EXTERNAL = process.env.COMPOSE_PREVIEW_E2E_EXTERNAL === "1";
+const describeExternal = E2E_EXTERNAL ? describe : describe.skip;
+
+interface PostedMessage {
+    command: string;
+    [key: string]: unknown;
+}
+
+async function waitFor<T>(
+    description: string,
+    timeoutMs: number,
+    pollMs: number,
+    probe: () => T | undefined,
+): Promise<T> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const value = probe();
+        if (value !== undefined) {
+            return value;
+        }
+        await new Promise((r) => setTimeout(r, pollMs));
+    }
+    throw new Error(
+        `Timed out after ${timeoutMs}ms waiting for: ${description}`,
+    );
+}
+
+describeExternal(
+    "Compose Preview external-consumer e2e (real Gradle, published plugin)",
+    function () {
+        // Confetti's first cold configuration alone takes 2-5 min (Apollo
+        // codegen, KMP target setup, Firebase plugin), and the daemon's
+        // first render adds another few. 30 minutes is the same ceiling
+        // CI sets for the workflow timeout; the hook below trips first
+        // on a real wedge.
+        this.timeout(30 * 60_000);
+
+        let api: ComposePreviewTestApi;
+        let kotlinFile: string;
+        let workspaceRoot: string;
+        let renderDir: string;
+
+        before(async function () {
+            this.timeout(30 * 60_000);
+
+            const folders = vscode.workspace.workspaceFolders;
+            assert.ok(
+                folders && folders.length > 0,
+                "external workspace must be open — runTest.ts should have " +
+                    "passed COMPOSE_PREVIEW_E2E_WORKSPACE through to VS Code",
+            );
+            workspaceRoot = folders[0].uri.fsPath;
+
+            // Sanity-check the workspace shape so a misconfigured runner
+            // fails loud at `before` rather than with an opaque
+            // `resolveModule returned null` later. `androidApp/` and the
+            // catalog entry are the two markers we keyed the suite to;
+            // changing them needs to be a conscious decision.
+            kotlinFile = path.join(
+                workspaceRoot,
+                "androidApp",
+                "src",
+                "main",
+                "java",
+                "dev",
+                "johnoreilly",
+                "confetti",
+                "ui",
+                "component",
+                "Background.kt",
+            );
+            assert.ok(
+                fs.existsSync(kotlinFile),
+                `expected external workspace fixture file at ${kotlinFile} — ` +
+                    "did setup-external-e2e.sh run against the pinned SHA?",
+            );
+
+            const catalogPath = path.join(
+                workspaceRoot,
+                "gradle",
+                "libs.versions.toml",
+            );
+            const catalogText = fs.readFileSync(catalogPath, "utf-8");
+            assert.match(
+                catalogText,
+                /^composeai-preview\s*=\s*"[^"]+"/m,
+                `expected composeai-preview catalog entry in ${catalogPath} ` +
+                    "(the catalog rewrite in setup-external-e2e.sh is the wiring " +
+                    "for COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL to pick up the local SNAPSHOT)",
+            );
+
+            renderDir = path.join(
+                workspaceRoot,
+                "androidApp",
+                "build",
+                "compose-previews",
+                "renders",
+            );
+            // Clean any prior renders so the assertion below proves this
+            // run produced PNGs, not a stale artifact from a developer's
+            // last local build of the same workspace path.
+            if (fs.existsSync(renderDir)) {
+                for (const entry of fs.readdirSync(renderDir)) {
+                    fs.rmSync(path.join(renderDir, entry), {
+                        recursive: true,
+                        force: true,
+                    });
+                }
+            }
+
+            const ext = vscode.extensions.getExtension<ComposePreviewTestApi>(
+                "yuri-schimke.compose-preview",
+            );
+            assert.ok(ext, "compose-preview extension must be present");
+            const exported = await ext.activate();
+            assert.ok(
+                exported,
+                "activate() must return ComposePreviewTestApi under COMPOSE_PREVIEW_TEST_MODE=1",
+            );
+            api = exported;
+            api.injectGradleApi(
+                new RealGradleApi(
+                    workspaceRoot,
+                    (line) => console.log(line),
+                    // Opt the init-script into mavenLocal so the local
+                    // SNAPSHOT the workflow published is the plugin
+                    // Gradle resolves. Without this the catalog entry
+                    // routes to Maven Central, which has the *previously
+                    // released* version — defeating the point of
+                    // exercising HEAD against a real consumer.
+                    [],
+                ),
+            );
+
+            await vscode.commands.executeCommand("composePreview.panel.focus");
+            await waitFor(
+                "webviewReady from the resolved webview",
+                30_000,
+                100,
+                () => {
+                    if (api.isWebviewReady()) return true;
+                    const inbound = api.getReceivedMessages();
+                    return inbound.find(
+                        (m) => (m as PostedMessage).command === "webviewReady",
+                    );
+                },
+            );
+        });
+
+        it("warms the daemon for :androidApp and renders at least one preview", async function () {
+            api.resetMessages();
+
+            // Drive the same activation-time path the user hits: warm
+            // the daemon (composePreviewDaemonStart → JVM spawn →
+            // initialize → extensions/list+enable) and then refresh.
+            // Surfacing the warm result separately keeps the failure
+            // message actionable when initialize fails — the daemon
+            // stderr tail is already in the channel log thanks to
+            // issue #1326's wrapping (`formatDaemonSpawnFailure`).
+            const warmed = await api.triggerWarmDaemon(kotlinFile);
+            assert.ok(
+                warmed,
+                "warm aborted — see daemon channel log for the spawn-failure " +
+                    `tail. lastWarmDaemonError=${api.getLastWarmDaemonError() ?? "<null>"}`,
+            );
+
+            await api.triggerRefresh(kotlinFile, /* force */ true, "full");
+
+            const previewsMessage = await waitFor(
+                "non-empty setPreviews from external composePreviewRenderAll",
+                this.timeout(),
+                500,
+                () => {
+                    const msgs = api.getPostedMessages();
+                    // Scan in reverse so the suite latches onto the
+                    // populated payload, not the initial empty one the
+                    // refresh flow emits before Gradle finishes.
+                    for (let i = msgs.length - 1; i >= 0; i--) {
+                        const m = msgs[i] as PostedMessage;
+                        if (m.command !== "setPreviews") continue;
+                        const previews = m.previews as
+                            | Array<unknown>
+                            | undefined;
+                        if (previews && previews.length > 0) return m;
+                    }
+                    return undefined;
+                },
+            );
+
+            const previews = previewsMessage.previews as Array<{
+                id: string;
+            }>;
+            console.log(
+                `[e2e-external] received ${previews.length} previews: ` +
+                    previews
+                        .map((p) => p.id)
+                        .slice(0, 10)
+                        .join(", ") +
+                    (previews.length > 10 ? ", ..." : ""),
+            );
+
+            // The bar is intentionally low — `>= 1` proves the chain is
+            // intact end-to-end. Pinning a higher number couples the
+            // suite to Confetti's preview count, which drifts when
+            // upstream adds or removes `@Preview`s. The smoke is "did
+            // anything render through the published-plugin path."
+            assert.ok(
+                previews.length >= 1,
+                `expected at least 1 preview from :androidApp, got ${previews.length}`,
+            );
+
+            const pngs = fs.existsSync(renderDir)
+                ? fs.readdirSync(renderDir).filter((n) => n.endsWith(".png"))
+                : [];
+            assert.ok(
+                pngs.length >= 1,
+                `expected at least 1 rendered PNG in ${renderDir}, found ${pngs.length}`,
+            );
+
+            // Wait for the webview ack so a regression that posts into
+            // an unresolved view (the bug e2e.test.ts already
+            // regression-locks against `:samples:cmp`) also fires here
+            // against the published plugin path. The matching
+            // assertion shape there is what to mirror — same comment
+            // applies about postedMessageLog being insufficient on its
+            // own.
+            const renderedSignal = await waitFor(
+                "webviewPreviewsRendered from the live webview",
+                this.timeout(),
+                500,
+                () => {
+                    const inbound = api.getReceivedMessages();
+                    const m = inbound.find(
+                        (raw) =>
+                            (raw as PostedMessage).command ===
+                            "webviewPreviewsRendered",
+                    ) as { command: string; count: number } | undefined;
+                    if (!m || m.count <= 0) return undefined;
+                    return m;
+                },
+            );
+            assert.ok(
+                renderedSignal.count >= 1,
+                `webview rendered ${renderedSignal.count} cards but ${previews.length} previews were sent`,
+            );
+        });
+    },
+);

--- a/vscode-extension/src/test/electron/suite/index.ts
+++ b/vscode-extension/src/test/electron/suite/index.ts
@@ -30,12 +30,32 @@ export async function run(): Promise<void> {
     // `npm run test:e2e`) runs only the slow real-Gradle suite; the fast
     // suite excludes it. Pattern selection here so each mode's run output
     // doesn't list "skipped" entries for the other mode's tests.
+    //
+    // External-consumer mode (COMPOSE_PREVIEW_E2E_EXTERNAL=1) is a third
+    // bucket: runs *only* `e2eExternal*.test.js` so the in-repo
+    // `:samples:*` suites don't pay the external workspace's
+    // configuration tax (they'd skip anyway because the file paths point
+    // at `samples/cmp/…`, but mocha still loads the modules and the
+    // `describe.skip` noise is unhelpful).
     const e2eMode = process.env.COMPOSE_PREVIEW_E2E === "1";
-    // Match every `e2e*.test.js` so the slow suite can be split across
-    // files (`e2e.test.js`, `e2eA11y.test.js`, …) without having to
-    // restate file names here.
-    const pattern = e2eMode ? "**/e2e*.test.js" : "**/*.test.js";
-    const ignore = e2eMode ? [] : ["**/e2e*.test.js"];
+    const e2eExternalMode = process.env.COMPOSE_PREVIEW_E2E_EXTERNAL === "1";
+    let pattern: string;
+    let ignore: string[];
+    if (e2eExternalMode) {
+        pattern = "**/e2eExternal*.test.js";
+        ignore = [];
+    } else if (e2eMode) {
+        // Match every `e2e*.test.js` so the slow suite can be split across
+        // files (`e2e.test.js`, `e2eA11y.test.js`, …) without having to
+        // restate file names here. Exclude the external-consumer suite
+        // explicitly — it shares the `e2e*` prefix but belongs to a
+        // different workspace.
+        pattern = "**/e2e*.test.js";
+        ignore = ["**/e2eExternal*.test.js"];
+    } else {
+        pattern = "**/*.test.js";
+        ignore = ["**/e2e*.test.js"];
+    }
     // Sort so execution order is deterministic across runners — glob's
     // filesystem-order traversal otherwise puts `e2eA11y.test.js` ahead of
     // `e2e.test.js` on the GitHub-hosted Linux image, which left the cmp
@@ -43,7 +63,8 @@ export async function run(): Promise<void> {
     // budget. Plain lexical order runs the lighter cmp suite first.
     const files = (await glob(pattern, { cwd: testsRoot, ignore })).sort();
     console.log(
-        `[suite] discovered ${files.length} test file(s) in ${testsRoot} (e2e=${e2eMode})`,
+        `[suite] discovered ${files.length} test file(s) in ${testsRoot} ` +
+            `(e2e=${e2eMode} external=${e2eExternalMode})`,
     );
     for (const f of files) {
         const abs = path.resolve(testsRoot, f);


### PR DESCRIPTION
Closes the published-plugin-coordinate gap in the e2e suite. The existing
`vscode-extension-e2e.yml` runs `:samples:cmp` and `:samples:wear` through
`includeBuild("gradle-plugin")` — the dev-loop path. That misses every
regression that hinges on the plugin resolving as a *published* artifact
against a real consumer classpath: stale `daemon-launch.json` after a
plugin upgrade, classpath fingerprint mismatches when AGP/Kotlin/Compose
drift between renderer and consumer, the `daemonBootstrappedModules`
memo-eviction branch after a failed warm, and catalog-alias detection
through `applied.json` (the in-repo samples bake those markers in).

This wires:

* `scripts/setup-external-e2e.sh` — clones joreilly/Confetti at a pinned
  SHA, rewrites its `gradle/libs.versions.toml` `composeai-preview`
  entry to the local SNAPSHOT, seeds `local.properties` with the
  runner's Android SDK path.
* `e2eExternal.test.ts` — opens that prepared workspace, warms the
  daemon for `:androidApp`, drives `composePreviewRenderAll`, asserts
  the populated `setPreviews` lands and the webview acks
  `webviewPreviewsRendered`. Gated on `COMPOSE_PREVIEW_E2E_EXTERNAL=1`.
* `runTest.ts` + `suite/index.ts` — third bucket alongside the fast and
  e2e suites; forwards `COMPOSE_PREVIEW_E2E_WORKSPACE` and
  `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL` into the extension host.
* `package.json` — `test:e2e-external` script.
* `.github/workflows/vscode-extension-e2e-external.yml` — manual +
  weekly cron. Publishes the plugin to mavenLocal, runs the setup
  script, drives the suite under xvfb, uploads renders + daemon logs
  on failure.

Confetti is intentional: it already declares
`alias(libs.plugins.composeai.preview)` against three modules
(`:androidApp`, `:shared`, `:wearApp`), brings a non-trivial classpath
(Apollo, KMP wasmJs+iOS, Firebase, Decompose), and is maintained
upstream — so drift between the renderer and a real consumer surfaces
in this suite before it surfaces in a user bug report. Only
`:androidApp` is in scope for the first cut; `:shared` and `:wearApp`
deserve their own follow-up suites.

Cost: the workflow is not on PRs and not on every push — manual +
weekly schedule (Sundays 06:00 UTC), 90-minute ceiling.