### PR TITLE
feat(vscode-extension): wire 'Copy as selector' row action on uia/hierarchy rows

### DIFF
--- a/vscode-extension/src/test/inspectionPresenters.test.ts
+++ b/vscode-extension/src/test/inspectionPresenters.test.ts
@@ -6,6 +6,7 @@ import {
     computeInspectionBundleData,
     type InspectionKind,
 } from "../webview/preview/inspectionPresenters";
+import { flushMicrotasks, stubClipboard } from "./helpers/clipboard";
 
 describe("computeInspectionBundleData (cardBundleOverlay path)", () => {
     afterEach(() => {
@@ -172,5 +173,44 @@ describe("computeInspectionBundleData (cardBundleOverlay path)", () => {
         );
         assert.strictEqual(data.overlay.length, 0);
         assert.strictEqual(data.sections.length, 0);
+    });
+
+    it("wires a 'Copy as selector' row action on uia/hierarchy rows", async () => {
+        const payload = {
+            nodes: [
+                {
+                    text: "Submit",
+                    testTag: "submit",
+                    boundsInScreen: "0,0,100,40",
+                    actions: ["click"],
+                },
+                {
+                    text: "Cancel",
+                    testTag: "cancel",
+                    boundsInScreen: "0,40,100,80",
+                    actions: ["click"],
+                },
+            ],
+        };
+        const captured = stubClipboard();
+        try {
+            const data = computeInspectionBundleData(
+                (kind) => (kind === "uia/hierarchy" ? payload : undefined),
+                new Set<InspectionKind>(["uia/hierarchy"]),
+            );
+            const rows = data.sections[0].data.body.querySelectorAll(
+                "tbody tr[data-legend-id]",
+            );
+            assert.strictEqual(rows.length, 2);
+            const actBtn = rows[0].querySelector<HTMLButtonElement>(
+                ".inspection-tree-action-btn",
+            );
+            assert.ok(actBtn, "row action button missing");
+            actBtn!.click();
+            await flushMicrotasks();
+            assert.strictEqual(captured.text, 'By.testTag("submit")');
+        } finally {
+            captured.restore();
+        }
     });
 });

--- a/vscode-extension/src/webview/preview/inspectionPresenters.ts
+++ b/vscode-extension/src/webview/preview/inspectionPresenters.ts
@@ -17,11 +17,13 @@
 
 import {
     buildInspectionTreeTable,
+    copyToClipboard,
     type TreeColumn,
     type TreeTableNode,
 } from "./inspectionTreeTable";
 import type { OverlayBox } from "./components/BoxOverlay";
 import { parseBounds as parseCardBounds } from "./cardData";
+import { buildSelectorSnippet } from "./uiaSelector";
 
 // ---- compose/semantics --------------------------------------------------
 
@@ -448,6 +450,15 @@ function computeUiaHierarchyBundleData(
         rows,
         hasOverlayFor: (n) => parseCardBounds(n.boundsInScreen) !== null,
         jsonForCopy: () => payload,
+        rowAction: {
+            icon: "copy",
+            label: "Selector",
+            title: "Copy as By.testTag(...) selector",
+            onClick: (n) => {
+                const snippet = buildSelectorSnippet(n, nodes);
+                if (snippet) void copyToClipboard(snippet);
+            },
+        },
     });
     return { body, summary, overlay };
 }

--- a/vscode-extension/src/webview/preview/inspectionTreeTable.ts
+++ b/vscode-extension/src/webview/preview/inspectionTreeTable.ts
@@ -288,7 +288,7 @@ function setExpanded(
  * unavailable (older webviews / non-secure contexts). Failures swallow
  * silently — the button has no visible result anyway.
  */
-async function copyToClipboard(text: string): Promise<void> {
+export async function copyToClipboard(text: string): Promise<void> {
     try {
         const nav = (globalThis as { navigator?: Navigator }).navigator;
         if (nav?.clipboard?.writeText) {


### PR DESCRIPTION
## Summary

The framework-coupled `uiaHierarchyPresenter` carried a `rowAction` that called `buildSelectorSnippet` and copied the snippet to the clipboard. When the presenter framework was retired in #1349, the bundle-data path (`computeUiaHierarchyBundleData`) had no `rowAction`, so the affordance disappeared from the Inspection tab.

This PR re-wires it on the bundle-data path so each row in the UI Automator hierarchy table carries the "Copy selector" button again.

- `buildSelectorSnippet` (in `webview/preview/uiaSelector.ts`) was already in the tree, mirrored from the Kotlin `HierarchySelectorBuilder`.
- `copyToClipboard` (in `webview/preview/inspectionTreeTable.ts`) was already in the tree, but private — exported it so `inspectionPresenters.ts` can share the same fallback chain (`navigator.clipboard.writeText` → hidden `<textarea>` + `execCommand`).
- Added a unit test pinning the wiring: click row 0 → clipboard receives `By.testTag("submit")`.

## Test plan

- [ ] `npm run compile` clean
- [ ] `npm test` — 1114 passing locally, including the new "wires a 'Copy as selector' row action on uia/hierarchy rows" case
- [ ] `npm run format:check` clean

Refs #1104, #1059.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9fK6gvrwKxV8ZpGdDiBZR)_