### PR TITLE
feat(vscode-extension): paint compose/semantics mergeDescendants nodes with warning palette

### DIFF
--- a/vscode-extension/src/test/inspectionPresenters.test.ts
+++ b/vscode-extension/src/test/inspectionPresenters.test.ts
@@ -157,6 +157,40 @@ describe("computeInspectionBundleData (cardBundleOverlay path)", () => {
         });
     });
 
+    it("flags compose/semantics mergeDescendants nodes with the warning palette", () => {
+        // mergeDescendants → child semantics get absorbed into the
+        // parent, so the parent's overlay box represents merged
+        // information. `clearAndSet` and the default (null) stay on
+        // info — only the mergeDescendants case warrants the warning
+        // accent.
+        const payload = {
+            root: {
+                nodeId: "1",
+                boundsInRoot: "0,0,100,100",
+                mergeMode: "mergeDescendants",
+                children: [
+                    {
+                        nodeId: "2",
+                        boundsInRoot: "10,10,40,40",
+                        mergeMode: "clearAndSet",
+                    },
+                    {
+                        nodeId: "3",
+                        boundsInRoot: "50,10,90,40",
+                    },
+                ],
+            },
+        };
+        const data = computeInspectionBundleData(
+            (kind) => (kind === "compose/semantics" ? payload : undefined),
+            new Set<InspectionKind>(["compose/semantics"]),
+        );
+        const byId = new Map(data.overlay.map((b) => [b.id, b]));
+        assert.strictEqual(byId.get("semantics-1")?.level, "warning");
+        assert.strictEqual(byId.get("semantics-2")?.level, "info");
+        assert.strictEqual(byId.get("semantics-3")?.level, "info");
+    });
+
     it("ignores kinds the user has not enabled", () => {
         const payload = {
             root: {

--- a/vscode-extension/src/webview/preview/inspectionPresenters.ts
+++ b/vscode-extension/src/webview/preview/inspectionPresenters.ts
@@ -311,10 +311,20 @@ function computeComposeSemanticsBundleData(
         nodeById.set(id, { kind: "compose/semantics", node: entry.node });
         const bounds = parseCardBounds(entry.node.boundsInRoot);
         if (!bounds) continue;
+        // `mergeDescendants` nodes absorb their children's semantics into
+        // the parent, so the box stands in for multiple nodes' worth of
+        // a11y data — worth visually distinguishing on the overlay so a
+        // reviewer can spot where the merge boundary sits. (`clearAndSet`
+        // stays on `info`: it drops descendants rather than absorbing
+        // them, and is rare enough that surfacing it competes with the
+        // more useful merge-boundary signal.)
         overlay.push({
             id,
             bounds,
-            level: "info",
+            level:
+                entry.node.mergeMode === "mergeDescendants"
+                    ? "warning"
+                    : "info",
             tooltip: semanticsTooltip(entry.node),
         });
     }


### PR DESCRIPTION
## Summary

The inspection bundle's `compose/semantics` overlay was painting every node with `level: "info"`, hiding the merge-boundary signal the legacy `applyHierarchyOverlay` used to surface.

Restores it on the bundle compute path:

- `mergeMode === "mergeDescendants"` → `warning` accent. These nodes absorb their descendants' semantics into the parent, so the parent's overlay box stands in for multiple nodes' worth of a11y data — worth visually distinguishing on the overlay so a reviewer can spot where the merge boundary sits.
- `mergeMode === "clearAndSet"` and the default `null` → `info` (unchanged). `clearAndSet` drops descendants rather than absorbing them, and is rare enough that surfacing it would compete with the more useful merge-boundary signal.

The daemon emits `mergeMode` as one of `"mergeDescendants"` / `"clearAndSet"` / `null` (see `ComposeSemanticsDataProduct.kt:73`).

## Test plan

- [ ] `npm run compile` clean
- [ ] `npm test` — 1114 passing locally, including the new "flags compose/semantics mergeDescendants nodes with the warning palette" case
- [ ] `npm run format:check` clean

Refs #1104.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9fK6gvrwKxV8ZpGdDiBZR)_