### PR TITLE
feat(vscode-extension): surface a11y/touchTargets overlap count as a Size-cell badge

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -2431,6 +2431,23 @@ bundle-chip-bar {
     --overlay-color: #1976d2;
 }
 
+/* Inline badge appended to the Size cell when an `a11y/touchTargets`
+   entry reports overlap with other targets. Sits next to the dp size
+   so the reviewer doesn't have to read the Findings cell to spot an
+   overlap collision. */
+.a11y-overlap-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 6px;
+    padding: 0 5px;
+    border-radius: 9px;
+    background: #f57c00;
+    color: white;
+    font-size: 11px;
+    font-weight: 700;
+}
+
 /* "Configure…" expander inside a bundle tab body. Default closed —
  * the chip already turned on the bundle's default-ON kinds, the
  * expander is for power users who want to add a default-OFF kind or

--- a/vscode-extension/src/test/a11yBundlePresenter.test.ts
+++ b/vscode-extension/src/test/a11yBundlePresenter.test.ts
@@ -162,6 +162,50 @@ describe("computeA11yBundleData", () => {
         assert.strictEqual(data.rows[0].findingCount, 1);
     });
 
+    it("counts overlapping touch targets on the row's overlap badge field", () => {
+        const data = computeA11yBundleData(
+            [
+                node({ label: "PrimaryBtn", boundsInScreen: "0,0,100,40" }),
+                node({ label: "SecondaryBtn", boundsInScreen: "50,0,150,40" }),
+            ],
+            [],
+            [
+                touchTarget({
+                    nodeId: "primary",
+                    boundsInScreen: "0,0,100,40",
+                    findings: ["overlapping"],
+                    overlappingNodeIds: ["secondary"],
+                }),
+                touchTarget({
+                    nodeId: "secondary",
+                    boundsInScreen: "50,0,150,40",
+                    findings: ["overlapping"],
+                    overlappingNodeIds: ["primary"],
+                }),
+            ],
+        );
+        assert.strictEqual(data.rows.length, 2);
+        // Each row picks up the matching target's overlap count.
+        assert.strictEqual(data.rows[0].touchTargetOverlapCount, 1);
+        assert.strictEqual(data.rows[1].touchTargetOverlapCount, 1);
+    });
+
+    it("leaves touchTargetOverlapCount at 0 when no overlap data is attached", () => {
+        const data = computeA11yBundleData(
+            [node({ boundsInScreen: "0,0,10,10" })],
+            [],
+            [
+                touchTarget({
+                    boundsInScreen: "0,0,10,10",
+                    widthDp: 48,
+                    heightDp: 48,
+                    findings: [],
+                }),
+            ],
+        );
+        assert.strictEqual(data.rows[0].touchTargetOverlapCount, 0);
+    });
+
     it("does not downgrade an ATF error when a touch target also applies", () => {
         const data = computeA11yBundleData(
             [node({ boundsInScreen: "0,0,10,10" })],

--- a/vscode-extension/src/test/a11yRowDetail.test.ts
+++ b/vscode-extension/src/test/a11yRowDetail.test.ts
@@ -27,6 +27,7 @@ function row(over: Partial<A11yRow>): A11yRow {
         boundsInScreen: over.boundsInScreen ?? "0,0,10,10",
         bounds: over.bounds ?? { left: 0, top: 0, right: 10, bottom: 10 },
         touchTargetSizeDp: over.touchTargetSizeDp ?? null,
+        touchTargetOverlapCount: over.touchTargetOverlapCount ?? 0,
         depth: over.depth ?? 0,
     };
 }

--- a/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/a11yBundlePresenter.ts
@@ -57,6 +57,11 @@ export interface A11yRow {
      *  a corresponding `a11y/touchTargets` entry. `null` otherwise —
      *  the "Size" column renders a dash. */
     touchTargetSizeDp: string | null;
+    /** Number of other targets this row's touch target overlaps with,
+     *  per `AccessibilityTouchTarget.overlappingNodeIds`. `0` when the
+     *  target has no overlap data or no other-target hits — the "Size"
+     *  cell renders no overlap badge in that case. */
+    touchTargetOverlapCount: number;
     /** Visual indent depth (`0` for top-level / merged nodes, `1`
      *  for unmerged children of the nearest preceding merged
      *  ancestor in emission order). The wire format
@@ -173,6 +178,7 @@ export function computeA11yBundleData(
             boundsInScreen: node.boundsInScreen,
             bounds,
             touchTargetSizeDp: target ? formatTargetSize(target) : null,
+            touchTargetOverlapCount: target?.overlappingNodeIds?.length ?? 0,
             // Unmerged nodes sit under the nearest preceding merged
             // ancestor in emission order; render them indented so
             // the structure is visible without inventing parent ids.
@@ -225,6 +231,7 @@ export function computeA11yBundleData(
             boundsInScreen: fBounds,
             bounds,
             touchTargetSizeDp: null,
+            touchTargetOverlapCount: 0,
             depth: 0,
         });
         if (bounds) {
@@ -267,6 +274,7 @@ export function computeA11yBundleData(
             boundsInScreen: t.boundsInScreen ?? "",
             bounds,
             touchTargetSizeDp: formatTargetSize(t),
+            touchTargetOverlapCount: t.overlappingNodeIds?.length ?? 0,
             depth: 0,
         });
         if (bounds) {
@@ -384,7 +392,25 @@ export function a11yTableColumns(): readonly DataTableColumn<A11yRow>[] {
         {
             header: "Size",
             cellClass: "a11y-size-cell",
-            render: (row) => row.touchTargetSizeDp ?? "—",
+            render: (row) => {
+                if (!row.touchTargetSizeDp) return "—";
+                if (row.touchTargetOverlapCount === 0) {
+                    return row.touchTargetSizeDp;
+                }
+                const overlapTitle =
+                    row.touchTargetOverlapCount === 1
+                        ? "Overlaps 1 other touch target"
+                        : `Overlaps ${row.touchTargetOverlapCount} other touch targets`;
+                return html`
+                    ${row.touchTargetSizeDp}
+                    <span
+                        class="a11y-overlap-badge"
+                        title=${overlapTitle}
+                        data-overlap-count=${row.touchTargetOverlapCount}
+                        >↔${row.touchTargetOverlapCount}</span
+                    >
+                `;
+            },
         },
         {
             header: "Findings",


### PR DESCRIPTION
## Summary

The Accessibility bundle's table already rendered the per-target `widthDp×heightDp dp` value in the "Size" column (shipped in #1087), but `AccessibilityTouchTarget.overlappingNodeIds` was not surfaced anywhere visible. Only the `"overlapping"` finding string in the Findings cell hinted at a collision, and that count is the total of all WCAG findings, not specifically overlap collisions.

Adds an `↔N` overlap badge inline next to the size when the target reports overlap with N other targets.

- New `touchTargetOverlapCount: number` field on `A11yRow`, populated on both the hierarchy-merge path and the orphan-touch-target path.
- `a11yTableColumns()` Size cell renders the badge when count > 0, with a tooltip ("Overlaps N other touch targets").
- New `.a11y-overlap-badge` CSS rule (warning-orange, matches the existing `a11y-findings-badge[data-level="warning"]` palette).

Two new unit tests pin the per-target overlap count assignment (1 overlap reported / 0 by default).

## Test plan

- [ ] `npm run compile` clean (host + webview)
- [ ] `npm test` — 1115 passing locally, including the two new "counts overlapping touch targets…" / "leaves touchTargetOverlapCount at 0…" cases
- [ ] `npm run format:check` clean
- [ ] Visual: focus a preview whose `a11y/touchTargets` payload reports overlap; confirm the Size cell shows the `↔1` badge alongside the dp size, with the tooltip on hover

Refs #1104.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9fK6gvrwKxV8ZpGdDiBZR)_