### PR TITLE
feat(vscode-extension): auto-light Errors chip on renderFailed via dispatcher

### DIFF
--- a/vscode-extension/src/test/handleErrorMessagePromote.test.ts
+++ b/vscode-extension/src/test/handleErrorMessagePromote.test.ts
@@ -1,0 +1,132 @@
+// Auto-light contract for the Errors bundle chip — verifies that
+// `setImageError` / `setError` calls `ctx.promoteErrorsBundle()` so
+// the panel surfaces the chip as soon as a render fails, without
+// waiting for the daemon's `test/failure` payload to arrive (the old
+// `updateDataProducts`-driven path only fired when the chip was
+// already on — see the comment removed from main.ts).
+
+import * as assert from "assert";
+import {
+    handleExtensionMessage,
+    type PreviewMessageContext,
+} from "../webview/preview/messageHandlers";
+import { sanitizeId } from "../webview/preview/cardData";
+import type { ExtensionToWebview } from "../types";
+
+function buildCard(previewId: string): HTMLElement {
+    const card = document.createElement("div");
+    card.id = "preview-" + sanitizeId(previewId);
+    card.dataset.currentIndex = "0";
+    const container = document.createElement("div");
+    container.className = "image-container";
+    card.appendChild(container);
+    return card;
+}
+
+interface ContextWithSpy {
+    ctx: PreviewMessageContext;
+    promoteCalls(): number;
+}
+
+function buildContextStub(): ContextWithSpy {
+    const calls = { promote: 0 };
+    const noop = () => {};
+    const ctx: PreviewMessageContext = {
+        vscode: {
+            postMessage: noop,
+            getState: () => undefined,
+            setState: noop,
+        } as PreviewMessageContext["vscode"],
+        grid: {} as PreviewMessageContext["grid"],
+        filterToolbar: {
+            setFunctionOptions: noop,
+            setGroupOptions: noop,
+            setFunctionValue: noop,
+        } as PreviewMessageContext["filterToolbar"],
+        liveState: {} as PreviewMessageContext["liveState"],
+        staleBadge: {} as PreviewMessageContext["staleBadge"],
+        loadingOverlay: {} as PreviewMessageContext["loadingOverlay"],
+        diffOverlayConfig: {} as PreviewMessageContext["diffOverlayConfig"],
+        streamingPainter: {} as PreviewMessageContext["streamingPainter"],
+        earlyFeatures: () => true,
+        getA11yOverlayId: () => null,
+        setA11yOverlayId: noop,
+        setAllPreviews: noop,
+        setModuleDir: noop,
+        setLastScopedPreviewId: noop,
+        renderPreviews: noop,
+        applyRelativeSizing: noop,
+        applyFilters: noop,
+        applyLayout: noop,
+        applyPendingFocusRestore: noop,
+        applyInteractiveButtonState: noop,
+        applyRecordingButtonState: noop,
+        saveFilterState: noop,
+        restoreFilterState: noop,
+        ensureNotBlank: noop,
+        applyA11yUpdate: noop,
+        updateDataProducts: noop,
+        applyFontPreviewBytes: noop,
+        focusOnCard: noop,
+        deactivateAllBundles: noop,
+        refreshBundleState: noop,
+        promoteErrorsBundle: () => {
+            calls.promote += 1;
+        },
+    };
+    return { ctx, promoteCalls: () => calls.promote };
+}
+
+describe("handleErrorMessage promoteErrorsBundle", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("calls promoteErrorsBundle on setImageError", () => {
+        const card = buildCard("preview-A");
+        document.body.appendChild(card);
+        const { ctx, promoteCalls } = buildContextStub();
+        const msg: ExtensionToWebview = {
+            command: "setImageError",
+            previewId: "preview-A",
+            captureIndex: 0,
+            message: "Render failed",
+        };
+        handleExtensionMessage(msg, ctx);
+        assert.strictEqual(promoteCalls(), 1);
+        assert.ok(
+            card.classList.contains("has-error"),
+            "card should be flagged with has-error",
+        );
+        assert.strictEqual(card.dataset.renderError, "Render failed");
+    });
+
+    it("calls promoteErrorsBundle on setError (preview-wide)", () => {
+        const card = buildCard("preview-B");
+        document.body.appendChild(card);
+        const { ctx, promoteCalls } = buildContextStub();
+        const msg: ExtensionToWebview = {
+            command: "setError",
+            previewId: "preview-B",
+            message: "Daemon crashed",
+        };
+        handleExtensionMessage(msg, ctx);
+        assert.strictEqual(promoteCalls(), 1);
+    });
+
+    it("does not call promoteErrorsBundle when the previewId has no card", () => {
+        // No DOM card present — the handler short-circuits before
+        // building the error panel, so the promote callback also
+        // doesn't fire. (No card = no preview to flag, and we'd
+        // rather not light the bundle for a phantom failure.)
+        const { ctx, promoteCalls } = buildContextStub();
+        const msg: ExtensionToWebview = {
+            command: "setImageError",
+            previewId: "preview-missing",
+            captureIndex: 0,
+            message: "Render failed",
+        };
+        handleExtensionMessage(msg, ctx);
+        assert.strictEqual(promoteCalls(), 0);
+    });
+});

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -2750,20 +2750,6 @@ export class PreviewApp extends LitElement {
                 ) {
                     refreshErrorsBundle();
                 }
-                // Auto-light the Errors chip when a test/failure
-                // payload arrives. Hooked here rather than on the
-                // daemon-side renderFailed because by the time
-                // test/failure is fetched the panel already has the
-                // payload via updateDataProducts; routing through the
-                // dispatcher would need a new PreviewMessageContext
-                // callback. Re-pressing the chip later still toggles
-                // it off.
-                if (dataProducts.some((dp) => dp.kind === "test/failure")) {
-                    bundleController.handleExternalKindToggle(
-                        "test/failure",
-                        true,
-                    );
-                }
                 if (
                     matchesTarget &&
                     activeBundles.includes("performance") &&
@@ -2851,6 +2837,8 @@ export class PreviewApp extends LitElement {
             focusOnCard,
             deactivateAllBundles: () => bundleController.deactivateAll(),
             refreshBundleState: () => reflectBundleState(),
+            promoteErrorsBundle: () =>
+                bundleController.handleExternalKindToggle("test/failure", true),
         };
         window.addEventListener("message", (event) => {
             handleExtensionMessage(event.data, messageContext);

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -141,6 +141,18 @@ export interface PreviewMessageContext {
      * controller event.
      */
     refreshBundleState(): void;
+    /**
+     * Auto-light the Errors bundle chip when a render failure
+     * arrives via `setError` / `setImageError`. Routes through the
+     * same `BundleController.handleExternalKindToggle("test/failure", true)`
+     * call the legacy `updateDataProducts`-side promotion used,
+     * but fires immediately on `renderFailed` rather than waiting
+     * for the daemon's `test/failure` data product to land — that
+     * payload only ships when the Errors chip is already enabled,
+     * so the old path couldn't auto-light the chip on a cold render
+     * failure.
+     */
+    promoteErrorsBundle(): void;
 }
 
 /** Methods the dispatcher needs from `<filter-toolbar>`. The component
@@ -508,6 +520,13 @@ function handleErrorMessage(
             errCard.dataset.className ?? "",
         ),
     );
+    // Auto-light the Errors bundle chip — the bundle's `test/failure`
+    // kind is the postmortem fetch and starts subscribing the moment
+    // the chip is active. Doing this here (rather than waiting for a
+    // `test/failure` data product to arrive) means a first-time render
+    // failure surfaces the chip even though the user hadn't pre-
+    // subscribed.
+    ctx.promoteErrorsBundle();
 }
 
 function handlePreviewDiffReady(


### PR DESCRIPTION
## Summary

The Errors chip was auto-lighting inside `updateDataProducts` only when a `test/failure` data product arrived — but `test/failure` is `defaultOn: false`, so the daemon only fetches it once the chip is already active. That made the auto-light path a no-op on a cold render failure: the user had to manually click the Errors chip first, then see the postmortem.

Reroute the promotion through the panel dispatcher's `setError` / `setImageError` handler (which is the panel-side echo of the daemon's `renderFailed` notification), so the chip lights up on every render failure, regardless of subscription state.

- New `PreviewMessageContext.promoteErrorsBundle()` callback (this is the "new dispatcher callback" the comment removed from `main.ts` was waiting for).
- `handleErrorMessage` calls it after stamping the per-card error.
- `main.ts` wires the callback to `bundleController.handleExternalKindToggle("test/failure", true)`.
- The old `updateDataProducts`-side block (with its self-documented "would need a new PreviewMessageContext callback" caveat) is removed.

Adds a unit test covering both error-message variants (`setError` / `setImageError`) and the no-card short-circuit case.

## Test plan

- [ ] `npm run compile` clean (host + webview)
- [ ] `npm test` — 1118 passing locally, including three new "promoteErrorsBundle" cases
- [ ] `npm run format:check` clean
- [ ] Manual: trigger a render failure with the Errors chip OFF; confirm the chip lights up automatically and the postmortem subscribes (would not have happened with the old code path)

Refs #1104.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9fK6gvrwKxV8ZpGdDiBZR)_