### PR TITLE
fix(vscode-extension): close recent codex robustness findings (#1362)

### DIFF
--- a/vscode-extension/src/daemon/continuousCompileManager.ts
+++ b/vscode-extension/src/daemon/continuousCompileManager.ts
@@ -24,6 +24,13 @@ import { GradleService, ModuleInfo } from "../gradleService";
  * up there at save time. The manager keeps the lookup map authoritative
  * so a failed startup (subprocess exits immediately) cleanly unregisters
  * the worker and the next save falls back to the one-shot Gradle path.
+ *
+ * Crash handling: once a worker's subprocess emits `exit`, the manager
+ * drops it from [workers] and the GradleService registration. A later
+ * [ensureWorker] call for the same module will spawn a fresh worker —
+ * without this, a Gradle-daemon crash or immediate task failure would
+ * leave the entry stuck in the map and the early-return in `ensureWorker`
+ * would silently degrade `compileOnly()` to the one-shot fallback forever.
  */
 export class ContinuousCompileManager {
     private readonly workers = new Map<string, ContinuousCompileWorker>();
@@ -37,7 +44,13 @@ export class ContinuousCompileManager {
         private readonly spawnFn?: typeof spawn,
     ) {}
 
-    /** Idempotent — second call for the same module is a no-op. */
+    /**
+     * Idempotent — a second call for the same module while a worker is
+     * still live is a no-op. If the previous worker's subprocess exited
+     * (Gradle daemon crash, immediate task failure, etc.) the stale entry
+     * has already been cleared by the `exit` listener, so this call
+     * spawns a replacement instead of early-returning.
+     */
     ensureWorker(module: ModuleInfo): void {
         const key = module.modulePath;
         if (this.workers.has(key)) {
@@ -60,6 +73,17 @@ export class ContinuousCompileManager {
         }
         this.workers.set(key, worker);
         this.gradleService.setContinuousCompileWorker(key, worker);
+        // Clear the slot on subprocess exit so a subsequent `ensureWorker`
+        // call can spawn a fresh subprocess instead of returning the
+        // already-dead one. `disposeWorker` removes the entry before
+        // calling `stop()`, so the guard against double-clearing keeps
+        // the orderly-shutdown path a no-op here.
+        worker.onceExit(() => {
+            if (this.workers.get(key) === worker) {
+                this.workers.delete(key);
+                this.gradleService.setContinuousCompileWorker(key, null);
+            }
+        });
     }
 
     async disposeWorker(modulePath: string): Promise<void> {

--- a/vscode-extension/src/daemon/continuousCompileWorker.ts
+++ b/vscode-extension/src/daemon/continuousCompileWorker.ts
@@ -120,6 +120,16 @@ export class ContinuousCompileWorker {
         return this.child !== null && !this.stopped;
     }
 
+    /**
+     * Fires once when the underlying subprocess exits (either spawn error
+     * or normal `exit`), regardless of whether the exit was caller-driven
+     * via [stop] or a crash. Lets the manager clear stale entries from
+     * its lookup map so a subsequent `ensureWorker` call can respawn.
+     */
+    onceExit(listener: () => void): void {
+        this.events.once("exit", listener);
+    }
+
     /** Spawn the long-running gradle process. Resolves once the child has been spawned;
      *  does NOT wait for the warm-up build to finish. */
     start(): void {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -452,6 +452,24 @@ export interface ComposePreviewTestApi {
      */
     triggerWarmDaemon(filePath: string): Promise<boolean>;
     /**
+     * Drive `composePreviewApplied` against the currently-wired
+     * `gradleService` and await completion, so subsequent
+     * `resolveModule()`/`findPreviewModules()` calls see the authoritative
+     * `applied.json` markers.
+     *
+     * Background: production activation fires `bootstrapAppliedMarkers`
+     * fire-and-forget *before* tests can `injectGradleApi(...)`, and the
+     * injection replaces the GradleService instance — so the in-flight
+     * activation bootstrap is targeted at the original (now-orphaned)
+     * service. Tests that depend on marker-driven module discovery
+     * (catalog-alias modules like Confetti's `:androidApp`, which
+     * `appliesPlugin` text-scan can't resolve) must drive the bootstrap
+     * explicitly on the injected service before warming the daemon, or
+     * they race the async marker write and intermittently see
+     * `resolveModule returned null`.
+     */
+    triggerBootstrapAppliedMarkers(): Promise<void>;
+    /**
      * Most recent failure reason recorded by `warmDaemonForFile`, or `null`
      * if the last call succeeded (or none was made yet). Exposed so the
      * wear a11y `before()` hook can surface the underlying cause when the
@@ -1841,6 +1859,12 @@ export async function activate(
             },
             triggerWarmDaemon(filePath: string): Promise<boolean> {
                 return warmDaemonForFile(filePath);
+            },
+            async triggerBootstrapAppliedMarkers(): Promise<void> {
+                if (!gradleService) {
+                    return;
+                }
+                await gradleService.bootstrapAppliedMarkers();
             },
             getLastWarmDaemonError(): string | null {
                 return lastWarmDaemonError;

--- a/vscode-extension/src/initScript.ts
+++ b/vscode-extension/src/initScript.ts
@@ -246,7 +246,8 @@ export function initScriptDigest(
 
 /**
  * True when [workspaceRoot]'s `settings.gradle[.kts]` declares
- * `includeBuild("gradle-plugin")` — the compose-ai-tools repo's own dev-loop
+ * `includeBuild("gradle-plugin")` AND that included build actually publishes
+ * `ee.schimke.composeai.preview` — the compose-ai-tools repo's own dev-loop
  * layout. Stacking a Maven-resolved classpath dep (auto-inject) on top of an
  * included build that already provides `ee.schimke.composeai.preview` makes
  * Gradle compile the consumer's build script against the published version
@@ -254,6 +255,16 @@ export function initScriptDigest(
  * a different (potentially newer) shape — so a build file that references a
  * property added since that published version fails with "Unresolved
  * reference". Skipping auto-inject in this case lets the included build win.
+ *
+ * The sentinel check (looking for the plugin id inside
+ * `gradle-plugin/build.gradle.kts`) is the issue #1362 narrowing: previously
+ * any workspace that happened to nest a local build-logic module under the
+ * conventional name `gradle-plugin` matched this guard and the extension
+ * silently dropped `--init-script`, regressing preview rendering for users
+ * who don't manually apply the plugin. The compose-ai-tools repo is the only
+ * shape that pairs that include name with the compose-preview plugin id, so
+ * requiring both keeps the dev-loop carve-out without false-positiving on
+ * unrelated workspaces.
  *
  * Mirrors the CLI's `hasIncludedPluginBuild` in `cli/.../AutoInject.kt`.
  */
@@ -263,6 +274,7 @@ export function hasIncludedPluginBuild(workspaceRoot: string): boolean {
         path.join(workspaceRoot, "settings.gradle"),
     ];
     const pattern = /includeBuild\s*\(\s*["']gradle-plugin["']\s*\)/;
+    let includedBuildDeclared = false;
     for (const file of candidates) {
         let text: string;
         try {
@@ -270,7 +282,30 @@ export function hasIncludedPluginBuild(workspaceRoot: string): boolean {
         } catch {
             continue;
         }
-        if (pattern.test(text)) return true;
+        if (pattern.test(text)) {
+            includedBuildDeclared = true;
+            break;
+        }
+    }
+    if (!includedBuildDeclared) return false;
+
+    // Sentinel: the included build must actually publish the compose-preview
+    // plugin id. Look at both build-script flavours so a Groovy-DSL
+    // gradle-plugin module is still recognised. Reading is best-effort — a
+    // missing/unreadable build script means it's not the compose-ai-tools
+    // shape, so auto-inject should stay on.
+    const sentinelCandidates = [
+        path.join(workspaceRoot, "gradle-plugin", "build.gradle.kts"),
+        path.join(workspaceRoot, "gradle-plugin", "build.gradle"),
+    ];
+    for (const file of sentinelCandidates) {
+        let text: string;
+        try {
+            text = fs.readFileSync(file, "utf-8");
+        } catch {
+            continue;
+        }
+        if (text.includes("ee.schimke.composeai.preview")) return true;
     }
     return false;
 }

--- a/vscode-extension/src/test/continuousCompileManager.test.ts
+++ b/vscode-extension/src/test/continuousCompileManager.test.ts
@@ -141,4 +141,73 @@ describe("ContinuousCompileManager", () => {
         );
         assert.strictEqual(gradleService.registered.get(":samples:cmp"), null);
     });
+
+    it("respawns after the worker subprocess crashes", () => {
+        // Regression for #1362: a continuous worker whose subprocess exits
+        // after `start()` returns (Gradle daemon crash, immediate task
+        // failure, etc.) used to stay in the `workers` map forever, so
+        // every subsequent `ensureWorker` early-returned and
+        // `compileOnly()` silently degraded to the one-shot fallback for
+        // the rest of the session.
+        const { manager, gradleService, calls, children } = makeManager();
+        const module = makeModule(":samples:cmp");
+        manager.ensureWorker(module);
+        assert.strictEqual(calls.length, 1);
+        assert.deepStrictEqual(manager.activeModules(), [":samples:cmp"]);
+
+        // Simulate a crash — Gradle daemon died, or the task threw before
+        // continuous mode latched. The manager's `exit` listener should
+        // remove the entry and clear the GradleService registration.
+        children[0].emit("exit", 1);
+        assert.deepStrictEqual(manager.activeModules(), []);
+        assert.strictEqual(gradleService.registered.get(":samples:cmp"), null);
+
+        // A subsequent `ensureWorker` for the same module should produce a
+        // fresh subprocess instead of being silently swallowed by the
+        // idempotency early-return.
+        manager.ensureWorker(module);
+        assert.strictEqual(calls.length, 2);
+        assert.deepStrictEqual(manager.activeModules(), [":samples:cmp"]);
+        assert.notStrictEqual(
+            gradleService.registered.get(":samples:cmp"),
+            null,
+        );
+    });
+
+    it("respawn keeps registration consistent across the crash/restart cycle", () => {
+        // Extra coverage: the GradleService should observe the dead
+        // worker being unregistered (so `compileOnly` falls back to the
+        // one-shot path between crash and respawn) and then re-registered
+        // with the new worker. Asserts both setContinuousCompileWorker
+        // calls happened in order.
+        const gradleService = new FakeGradleService();
+        const writes: (ContinuousCompileWorker | null)[] = [];
+        const orig =
+            gradleService.setContinuousCompileWorker.bind(gradleService);
+        gradleService.setContinuousCompileWorker = (
+            modulePath: string,
+            worker: ContinuousCompileWorker | null,
+        ): void => {
+            writes.push(worker);
+            orig(modulePath, worker);
+        };
+        const { spawnFn, children } = fakeSpawnRecorder();
+        const manager = new ContinuousCompileManager(
+            "/repo",
+            gradleService as unknown as GradleService,
+            { appendLine() {} },
+            [],
+            spawnFn,
+        );
+        const module = makeModule(":samples:cmp");
+        manager.ensureWorker(module);
+        children[0].emit("exit", 137);
+        manager.ensureWorker(module);
+
+        assert.strictEqual(writes.length, 3);
+        assert.notStrictEqual(writes[0], null);
+        assert.strictEqual(writes[1], null);
+        assert.notStrictEqual(writes[2], null);
+        assert.notStrictEqual(writes[0], writes[2]);
+    });
 });

--- a/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
@@ -208,6 +208,18 @@ describeExternal(
         it("warms the daemon for :androidApp and renders at least one preview", async function () {
             api.resetMessages();
 
+            // Confetti's `:androidApp` applies the compose-preview plugin
+            // via `alias(libs.plugins.composeai.preview)` — the literal
+            // `id(...)` text-scan in `appliesPlugin` doesn't match catalog
+            // aliases, so `resolveModule` stays null until Gradle writes
+            // `applied.json` for the module. The activation-time
+            // `bootstrapAppliedMarkers` call is fire-and-forget AND
+            // targets the original GradleService (the one `injectGradleApi`
+            // above replaced), so without an explicit await the warm below
+            // races the marker write and intermittently fails on cold
+            // workspaces. Regression for #1362.
+            await api.triggerBootstrapAppliedMarkers();
+
             // Drive the same activation-time path the user hits: warm
             // the daemon (composePreviewDaemonStart → JVM spawn →
             // initialize → extensions/list+enable) and then refresh.

--- a/vscode-extension/src/test/initScript.test.ts
+++ b/vscode-extension/src/test/initScript.test.ts
@@ -257,13 +257,31 @@ describe("materializeInitScript", () => {
 });
 
 describe("hasIncludedPluginBuild", () => {
+    /**
+     * Seeds the included build's `build.gradle.kts` with the compose-preview
+     * plugin id so the sentinel check (#1362) passes. Callers that want to
+     * verify the *negative* path can skip this helper.
+     */
+    function writeComposePreviewGradlePlugin(dir: string): void {
+        const pluginDir = path.join(dir, "gradle-plugin");
+        fs.mkdirSync(pluginDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(pluginDir, "build.gradle.kts"),
+            "plugins { `java-gradle-plugin` }\n" +
+                "gradlePlugin {\n" +
+                '  plugins { create("composePreview") { id = "ee.schimke.composeai.preview" } }\n' +
+                "}\n",
+        );
+    }
+
     it(
-        'returns true for settings.gradle.kts declaring includeBuild("gradle-plugin")',
+        'returns true for settings.gradle.kts declaring includeBuild("gradle-plugin") when the included build publishes the compose-preview plugin',
         withTempDir((dir) => {
             fs.writeFileSync(
                 path.join(dir, "settings.gradle.kts"),
                 'rootProject.name = "demo"\nincludeBuild("gradle-plugin")\n',
             );
+            writeComposePreviewGradlePlugin(dir);
             assert.strictEqual(hasIncludedPluginBuild(dir), true);
         }),
     );
@@ -275,6 +293,7 @@ describe("hasIncludedPluginBuild", () => {
                 path.join(dir, "settings.gradle"),
                 "rootProject.name = 'demo'\nincludeBuild('gradle-plugin')\n",
             );
+            writeComposePreviewGradlePlugin(dir);
             assert.strictEqual(hasIncludedPluginBuild(dir), true);
         }),
     );
@@ -285,6 +304,25 @@ describe("hasIncludedPluginBuild", () => {
             fs.writeFileSync(
                 path.join(dir, "settings.gradle.kts"),
                 'includeBuild( "gradle-plugin" )\n',
+            );
+            writeComposePreviewGradlePlugin(dir);
+            assert.strictEqual(hasIncludedPluginBuild(dir), true);
+        }),
+    );
+
+    it(
+        "accepts a Groovy-DSL sentinel build script too",
+        withTempDir((dir) => {
+            fs.writeFileSync(
+                path.join(dir, "settings.gradle.kts"),
+                'includeBuild("gradle-plugin")\n',
+            );
+            const pluginDir = path.join(dir, "gradle-plugin");
+            fs.mkdirSync(pluginDir, { recursive: true });
+            fs.writeFileSync(
+                path.join(pluginDir, "build.gradle"),
+                "// Groovy DSL\n" +
+                    'gradlePlugin { plugins { composePreview { id = "ee.schimke.composeai.preview" } } }\n',
             );
             assert.strictEqual(hasIncludedPluginBuild(dir), true);
         }),
@@ -304,6 +342,45 @@ describe("hasIncludedPluginBuild", () => {
                 path.join(dir, "settings.gradle.kts"),
                 'includeBuild("build-logic")\n',
             );
+            assert.strictEqual(hasIncludedPluginBuild(dir), false);
+        }),
+    );
+
+    it(
+        'returns false when includeBuild("gradle-plugin") matches but the included build is an unrelated local build-logic project (issue #1362)',
+        withTempDir((dir) => {
+            // A common convention in unrelated workspaces: a local
+            // `gradle-plugin/` included build that publishes convention
+            // plugins under a different id. Auto-inject must stay enabled
+            // there — the workspace doesn't have a local source of truth
+            // for `ee.schimke.composeai.preview`, so dropping
+            // `--init-script` regresses preview rendering.
+            fs.writeFileSync(
+                path.join(dir, "settings.gradle.kts"),
+                'rootProject.name = "demo"\nincludeBuild("gradle-plugin")\n',
+            );
+            const pluginDir = path.join(dir, "gradle-plugin");
+            fs.mkdirSync(pluginDir, { recursive: true });
+            fs.writeFileSync(
+                path.join(pluginDir, "build.gradle.kts"),
+                "plugins { `java-gradle-plugin` }\n" +
+                    "gradlePlugin {\n" +
+                    '  plugins { create("conventions") { id = "com.example.conventions" } }\n' +
+                    "}\n",
+            );
+            assert.strictEqual(hasIncludedPluginBuild(dir), false);
+        }),
+    );
+
+    it(
+        'returns false when includeBuild("gradle-plugin") matches but the included build has no build script at all',
+        withTempDir((dir) => {
+            fs.writeFileSync(
+                path.join(dir, "settings.gradle.kts"),
+                'includeBuild("gradle-plugin")\n',
+            );
+            // No gradle-plugin/build.gradle{.kts} on disk — the sentinel
+            // can't confirm the dev-loop shape, so auto-inject stays on.
             assert.strictEqual(hasIncludedPluginBuild(dir), false);
         }),
     );


### PR DESCRIPTION
## Summary

Closes the three codex findings tracked in #1362 — all vscode-extension scope, all small.

### 1. `continuousCompileManager` respawns after a worker crash (P2)

Adds a `ContinuousCompileWorker.onceExit(...)` hook and uses it in the manager to drop the lookup-map entry (and clear the `GradleService` registration) when the subprocess exits. Previously a Gradle-daemon crash or an immediate task failure left a dead worker pinned in the map, so the idempotency early-return in `ensureWorker` made every later call a no-op and `compileOnly()` silently degraded to the one-shot fallback for the rest of the session. New unit tests cover the crash/respawn cycle and the GradleService registration sequence.

### 2. `hasIncludedPluginBuild` sentinel (P2)

`hasIncludedPluginBuild` now requires both `includeBuild("gradle-plugin")` in settings AND the literal plugin id `ee.schimke.composeai.preview` inside the included build's `build.gradle{.kts}` (Kotlin or Groovy). The previous text-only match collided with workspaces that use `gradle-plugin/` as a conventional name for local build-logic projects — auto-inject silently disabled itself there and the extension stopped passing `--init-script`, regressing preview rendering. The compose-ai-tools repo is the only shape that pairs both markers, so requiring them keeps the dev-loop carve-out without false-positiving on unrelated workspaces. Tests updated to seed the sentinel for the positive cases and add explicit negative coverage for the issue-1362 scenario.

**Out of scope — host-side mirror needed:** the CLI carries the identical text-only guard at `cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt::hasIncludedPluginBuild` and should get the same sentinel narrowing in a follow-up. Kept out of this PR per the issue's "vscode-extension only" scope rule.

### 3. `e2eExternal` bootstrap race (P1)

Adds a `ComposePreviewTestApi.triggerBootstrapAppliedMarkers()` seam and uses it in the external-consumer e2e to await `composePreviewApplied` before warming the daemon. The previous shape kicked `triggerWarmDaemon(kotlinFile)` immediately after activation, racing the fire-and-forget `bootstrapAppliedMarkers` run. On catalog-alias modules like Confetti's `:androidApp` the literal `appliesPlugin` text-scan can't resolve the module — `resolveModule` stays null until Gradle writes `applied.json`, and the warm intermittently failed on cold cron runs. The new seam also handles the fact that the test's `injectGradleApi(...)` replaces the activation-time `GradleService` instance, so the original bootstrap was targeting an orphaned service anyway.

## Test plan

- [x] `cd vscode-extension && npm run compile` — clean
- [x] `cd vscode-extension && npm test` — 1122 passing, including the new `ContinuousCompileManager` crash/respawn and `hasIncludedPluginBuild` sentinel tests
- [x] `cd vscode-extension && npm run format:check` — clean
- [ ] Full external e2e (`npm run test:e2e-external`) — requires Gradle + xvfb, not run from this change; the fix is verified by reading the new bootstrap-then-warm order against the activation flow. Will manifest in the weekly external-suite cron.

Closes #1362

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrokMktYqb8RkaWf9FKLgP)_