### PR TITLE
refactor(vscode-extension): extract createBundleExpander helper

### DIFF
--- a/vscode-extension/src/test/bundleExpanderWiring.test.ts
+++ b/vscode-extension/src/test/bundleExpanderWiring.test.ts
@@ -1,0 +1,76 @@
+// Coverage for `createBundleExpander` — the helper that the per-
+// bundle body builders in `main.ts` use to construct + wire each
+// `<bundle-expander>`. Pins the post-construction state so a future
+// refactor (e.g. lifting the expander slot into `<data-tabs>`)
+// can't drop the `data-bundle` attribute or the controller wiring
+// without a test noticing.
+
+import * as assert from "assert";
+import { BundleController } from "../webview/preview/bundleController";
+import { createBundleExpander } from "../webview/preview/bundleExpanderWiring";
+import {
+    defaultOnKindsFor,
+    getBundle,
+} from "../webview/preview/bundleRegistry";
+import "../webview/preview/components/BundleExpander";
+
+interface CapturedPost {
+    kinds: readonly string[];
+    enabled: boolean;
+}
+
+function buildController(): {
+    controller: BundleController;
+    posts: CapturedPost[];
+} {
+    const posts: CapturedPost[] = [];
+    const controller = new BundleController({
+        setKindsEnabled: (kinds, enabled) => {
+            posts.push({ kinds: [...kinds], enabled });
+        },
+        persist: () => {},
+    });
+    return { controller, posts };
+}
+
+describe("createBundleExpander", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("stamps data-bundle and constructs a bundle-expander element", () => {
+        const { controller } = buildController();
+        const el = createBundleExpander("a11y", controller);
+        assert.strictEqual(el.tagName.toLowerCase(), "bundle-expander");
+        assert.strictEqual(el.dataset.bundle, "a11y");
+    });
+
+    it("forwards user kind toggles into the controller", async () => {
+        const { controller, posts } = buildController();
+        const expander = createBundleExpander("a11y", controller);
+        document.body.appendChild(expander);
+        // Activate the bundle so the controller has a target.
+        controller.toggleBundle("a11y");
+        const bundle = getBundle("a11y")!;
+        expander.setOpened(true);
+        expander.setState({
+            bundleId: "a11y",
+            kinds: bundle.kinds,
+            enabledKinds: defaultOnKindsFor("a11y"),
+        });
+        await expander.updateComplete;
+        // The default-OFF touchTargets checkbox is the cheapest gesture
+        // to fake — flip it on and assert one capture with the matching
+        // kind. Drops here mean the helper forgot the wiring call.
+        posts.length = 0;
+        const box = expander.querySelector<HTMLInputElement>(
+            'input[data-kind="a11y/touchTargets"]',
+        );
+        assert.ok(box, "touchTargets checkbox missing");
+        box!.checked = true;
+        box!.dispatchEvent(new Event("change", { bubbles: true }));
+        assert.strictEqual(posts.length, 1);
+        assert.deepStrictEqual(posts[0].kinds, ["a11y/touchTargets"]);
+        assert.strictEqual(posts[0].enabled, true);
+    });
+});

--- a/vscode-extension/src/webview/preview/bundleExpanderWiring.ts
+++ b/vscode-extension/src/webview/preview/bundleExpanderWiring.ts
@@ -21,6 +21,7 @@
 // `src/test/eventBusContract.test.ts` also covers the
 // producer/consumer pairing for `kind-toggled`.
 
+import type { BundleId } from "./bundleRegistry";
 import type { BundleController } from "./bundleController";
 import type { BundleExpander } from "./components/BundleExpander";
 import { on } from "../shared/eventBus";
@@ -39,4 +40,25 @@ export function wireExpanderToController(
     return on(expander, "kind-toggled", (det) => {
         controller.setKindEnabled(det.bundleId, det.kind, det.enabled);
     });
+}
+
+/**
+ * Create + wire a `<bundle-expander>` for [bundleId]. Each per-bundle
+ * tab body builder in `main.ts` previously inlined the same three-
+ * line construct (createElement + cast + `wireExpanderToController`);
+ * the helper keeps the wiring contract in one place so a future
+ * refactor can change the expander shape without sweeping every body
+ * builder. The element's `data-bundle` attribute is stamped so the
+ * DOM inspector can tell expanders apart at a glance.
+ */
+export function createBundleExpander(
+    bundleId: BundleId,
+    controller: BundleController,
+): BundleExpander {
+    const expander = document.createElement(
+        "bundle-expander",
+    ) as BundleExpander;
+    expander.dataset.bundle = bundleId;
+    wireExpanderToController(expander, controller);
+    return expander;
 }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -61,7 +61,7 @@ import {
 import type { OverlayBox } from "./components/BoxOverlay";
 import { BundleController, type BundleSnapshot } from "./bundleController";
 import { getBundle, type BundleId } from "./bundleRegistry";
-import { wireExpanderToController } from "./bundleExpanderWiring";
+import { createBundleExpander } from "./bundleExpanderWiring";
 import { a11yTableColumns, computeA11yBundleData } from "./a11yBundlePresenter";
 import { buildA11yRowDetail } from "./a11yRowDetail";
 import {
@@ -883,10 +883,7 @@ export class PreviewApp extends LitElement {
             const wrapper = document.createElement("div");
             wrapper.className = "bundle-tab-body";
             wrapper.dataset.bundle = id;
-            const expander = document.createElement(
-                "bundle-expander",
-            ) as BundleExpander;
-            wireExpanderToController(expander, bundleController);
+            const expander = createBundleExpander(id, bundleController);
             const table = document.createElement(
                 "data-table",
             ) as DataTable<unknown>;
@@ -955,10 +952,10 @@ export class PreviewApp extends LitElement {
             const wrapper = document.createElement("div");
             wrapper.className = "bundle-tab-body";
             wrapper.dataset.bundle = "performance";
-            const expander = document.createElement(
-                "bundle-expander",
-            ) as BundleExpander;
-            wireExpanderToController(expander, bundleController);
+            const expander = createBundleExpander(
+                "performance",
+                bundleController,
+            );
             // Recomposition uses the shared `<data-table>` so row hover
             // and copy-JSON parity with the other bundles is automatic.
             // Render trace + Perfetto don't fit the row model, so they
@@ -1002,10 +999,7 @@ export class PreviewApp extends LitElement {
             const wrapper = document.createElement("div");
             wrapper.className = "bundle-tab-body text-bundle-body";
             wrapper.dataset.bundle = "text";
-            const expander = document.createElement(
-                "bundle-expander",
-            ) as BundleExpander;
-            wireExpanderToController(expander, bundleController);
+            const expander = createBundleExpander("text", bundleController);
             const stringsTable = document.createElement(
                 "data-table",
             ) as DataTable<DrawnTextRow>;
@@ -1915,10 +1909,10 @@ export class PreviewApp extends LitElement {
             const wrapper = document.createElement("div");
             wrapper.className = "bundle-tab-body inspection-bundle-body";
             wrapper.dataset.bundle = "inspection";
-            const expander = document.createElement(
-                "bundle-expander",
-            ) as BundleExpander;
-            wireExpanderToController(expander, bundleController);
+            const expander = createBundleExpander(
+                "inspection",
+                bundleController,
+            );
             const host = document.createElement("section");
             host.className = "inspection-bundle-host";
             const rowDetail = document.createElement(


### PR DESCRIPTION
## Summary

Each of the four per-bundle tab body builders in `main.ts` (`buildBundleBody`, `performanceBody`, `textBody`, `inspectionBody`) inlined the same three-line `<bundle-expander>` construct — `createElement` + cast + `wireExpanderToController`. Lift it into a shared `createBundleExpander(bundleId, controller)` helper alongside the existing `wireExpanderToController` plumbing.

Side benefit: the helper stamps `data-bundle` on the expander element, so the four expanders are distinguishable in the DOM inspector without re-reading the bundle id off the wrapper.

The bigger architectural lift suggested in #1104 (move the slot into `<data-tabs>` itself) is left for later — this helper extraction is a no-op compared to that, but it gives a single edit point for whoever picks up the bigger lift.

Adds two unit tests covering the construction shape (`data-bundle` stamp + tag name) and the post-construction controller wiring (kind-toggle event flows into `setKindEnabled`).

## Test plan

- [ ] `npm run compile` clean (host + webview)
- [ ] `npm test` — 1119 passing locally, including the two new `createBundleExpander` cases
- [ ] `npm run format:check` clean
- [ ] The existing `focusBundleSmoke.test.ts` keeps importing `wireExpanderToController` directly (unchanged) and still passes — both helpers are exported

Refs #1104.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9fK6gvrwKxV8ZpGdDiBZR)_