### PR TITLE
feat(data-permissions): add runtime-permissions data extension

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -93,6 +93,15 @@ dependencies {
   // the `KeyboardPreviewOverrideExtension` planner consuming `renderNow.overrides.keyboard`. The
   // session's `dispatch(KEY_*)` path also calls into `KeyboardController` from this module.
   implementation(project(":data-keyboard-connector"))
+  // Runtime-permissions connector — `PermissionsController` (process-static grant + queried-set
+  // state), the always-on `AroundComposable` extension that installs `LocalPermissionsHost` and
+  // pushes `renderNow.overrides.permissions` into Robolectric's `ShadowApplication` grant state,
+  // the `PermissionsPreviewOverrideExtension` planner, the `PermissionsDataProductRegistry`
+  // serving the captured payload, and `ShadowContextWrapperPermissionTracker` (Robolectric shadow
+  // that records every `ContextCompat.checkSelfPermission(...)` call). Registered on the engine
+  // via `RobolectricHost.previewOverrideExtensions` and via the daemon's `ExtensionRegistry`
+  // below.
+  implementation(project(":data-permissions-connector"))
   // Touch-event visualization connector — same module `:daemon:desktop` consumes. The
   // `TouchOverlayExtension` `AroundComposable` is pure Compose foundation/runtime so the single
   // shared JVM module works on both backends (no Android/desktop fork needed, unlike

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -349,6 +349,28 @@ fun main(args: Array<String>) {
             dataProductRegistry = AmbientDataProductRegistry(),
           )
         }
+        tryAdd("data/permissions") {
+          // Runtime-permissions override + query tracker. Registry serves the
+          // `compose/permissions` payload (effective grant map + permissions the screen has
+          // queried). The actual planner lives in `RobolectricHost`'s
+          // `previewOverrideExtensions` list — same wiring shape as keyboard / focus — so the
+          // around-composable's `LocalPermissionsHost` is in place even when no client has
+          // explicitly enabled this extension. `dataExtensionDescriptors` advertises the planner
+          // so panel / MCP clients can gate their permission-override UI on the daemon actually
+          // shipping it.
+          Extension(
+            id = "data/permissions",
+            displayName = "Runtime permissions override",
+            dataProductRegistry = PermissionsDataProductRegistry(),
+            dataExtensionDescriptors =
+              listOf(
+                DataExtensionDescriptor(
+                  id = PermissionsOverrideExtension.ID,
+                  displayName = "Runtime permissions override",
+                )
+              ),
+          )
+        }
         tryAdd("data/touch-overlay") {
           // Touch-event visualization overlay (`AroundComposableHook` from
           // `:data-touch-overlay-connector`) — paints a translucent ring at every active pointer

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1354,6 +1354,13 @@ open class RobolectricHost(
                 // .keyboard` and `interactive/input` `KEY_*` dispatches reach the same
                 // `KeyboardController` state holder.
                 KeyboardPreviewOverrideExtension(),
+                // Runtime-permissions override + tracker. Planner always emits the extension so
+                // `LocalPermissionsHost` is in scope on every render and screens consulting it
+                // (or whose `ContextCompat.checkSelfPermission(...)` calls land in
+                // `ShadowContextWrapperPermissionTracker`) reach the controller's recordQuery
+                // path. `renderNow.overrides.permissions.grants` flips the effective
+                // `ShadowApplication` grant state and the `LocalPermissionsHost` snapshot map.
+                PermissionsPreviewOverrideExtension(),
                 // Touch-event visualization overlay. Mirrors `DesktopHost`'s registration — same
                 // `TouchOverlayPreviewOverrideExtension` planner from the shared
                 // `:data-touch-overlay-connector` module. Plans an extension only when

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
@@ -105,12 +105,20 @@ class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(testClas
    * for `AmbientPreviewOverrideExtension` / `AmbientInputDispatchObserver` instantiation —
    * those concrete classes call into `AmbientStateController` which directly imports wear API.
    */
-  override fun getExtraShadows(method: FrameworkMethod): Array<Class<*>> =
+  override fun getExtraShadows(method: FrameworkMethod): Array<Class<*>> {
+    val shadows = mutableListOf<Class<*>>()
+    // Wear ambient shadow — only when the wear AAR is on the classpath (issue #1244).
     if (isWearAmbientAvailable(javaClass.classLoader)) {
-      arrayOf(ShadowAmbientLifecycleObserver::class.java)
-    } else {
-      emptyArray()
+      shadows += ShadowAmbientLifecycleObserver::class.java
     }
+    // Runtime-permissions tracker shadow. Always registered — `android.content.ContextWrapper`
+    // is core Android, present on every consumer classpath, so the symbolic links the shadow
+    // declares always resolve. The shadow forwards `checkPermission(...)` to the real
+    // implementation and records the query in `PermissionsController` for the
+    // `compose/permissions` data product.
+    shadows += ShadowContextWrapperPermissionTracker::class.java
+    return shadows.toTypedArray()
+  }
 }
 
 /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.daemon.protocol.AmbientOverride
 import ee.schimke.composeai.daemon.protocol.FocusOverride
 import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
 import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.PermissionsOverride
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.daemon.protocol.WallpaperOverride
@@ -31,6 +32,7 @@ data class PreviewOverrideBaseSpec(
   val ambient: AmbientOverride? = null,
   val focus: FocusOverride? = null,
   val touchOverlay: Boolean? = null,
+  val permissions: PermissionsOverride? = null,
 )
 
 data class MergedPreviewOverrides(
@@ -48,6 +50,7 @@ data class MergedPreviewOverrides(
   val ambient: AmbientOverride?,
   val focus: FocusOverride?,
   val touchOverlay: Boolean?,
+  val permissions: PermissionsOverride?,
 ) {
   /**
    * Project the merged overrides down to a [PreviewOverrides] bag that only carries fields
@@ -70,6 +73,7 @@ data class MergedPreviewOverrides(
         ambient == null &&
         focus == null &&
         touchOverlay != true &&
+        permissions == null &&
         !isPseudolocale
     ) {
       return null
@@ -81,6 +85,7 @@ data class MergedPreviewOverrides(
       focus = focus,
       localeTag = if (isPseudolocale) localeTag else null,
       touchOverlay = touchOverlay,
+      permissions = permissions,
     )
   }
 }
@@ -125,6 +130,7 @@ fun mergePreviewOverrides(
       ambient = base.ambient,
       focus = base.focus,
       touchOverlay = base.touchOverlay,
+      permissions = base.permissions,
     )
   }
   val deviceOverride = overrides.device?.takeIf { it.isNotBlank() }
@@ -151,5 +157,6 @@ fun mergePreviewOverrides(
     ambient = overrides.ambient ?: base.ambient,
     focus = overrides.focus ?: base.focus,
     touchOverlay = overrides.touchOverlay ?: base.touchOverlay,
+    permissions = overrides.permissions ?: base.permissions,
   )
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -495,7 +495,42 @@ data class PreviewOverrides(
    * band, the override just doesn't add anything.
    */
   val keyboard: KeyboardOverride? = null,
+  /**
+   * Optional Android runtime-permissions override. Drives the connector-side
+   * `PermissionsOverrideExtension` (see `:data-permissions-connector`). The around-composable seeds
+   * Robolectric's `ShadowApplication` grant state from [PermissionsOverride.grants] so consumer
+   * code reading `ContextCompat.checkSelfPermission(...)` sees the requested value, *and* installs
+   * a `LocalPermissionsHost` composition local so a screen consulting it observes live updates the
+   * panel pushes via subsequent `renderNow.overrides.permissions` calls without a fresh render.
+   * Permission names are the `Manifest.permission.*` constant strings (e.g.
+   * `"android.permission.CAMERA"`). Android-only — the desktop backend ignores this field.
+   */
+  val permissions: PermissionsOverride? = null,
 )
+
+/**
+ * Android runtime-permissions override for previews. Drives the connector-side
+ * `PermissionsOverrideExtension` (see `:data-permissions-connector`).
+ *
+ * Sending a fresh `permissions` on a subsequent `renderNow` re-renders the held preview with the
+ * new grants; the connector also accepts live updates without a fresh render via
+ * `PermissionsController.set(...)` so an open interactive session can flip a grant and observe the
+ * screen react. Permissions not listed in [grants] keep whatever state Robolectric started them
+ * with — by default everything is denied except those baked into the manifest the consumer's
+ * preview JAR carries.
+ */
+@Serializable
+data class PermissionsOverride(
+  /** Permission name -> grant state. Keys are `Manifest.permission.*` constant strings. */
+  val grants: Map<String, PermissionGrantStateOverride> = emptyMap()
+)
+
+/** Wire spelling for [PermissionsOverride.grants] values. */
+@Serializable
+enum class PermissionGrantStateOverride {
+  @SerialName("granted") GRANTED,
+  @SerialName("denied") DENIED,
+}
 
 /**
  * Soft-keyboard (IME) override for previews. Drives the connector-side `KeyboardOverrideExtension`

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
@@ -3,6 +3,8 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.protocol.FocusDirection
 import ee.schimke.composeai.daemon.protocol.FocusOverride
 import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
+import ee.schimke.composeai.daemon.protocol.PermissionsOverride
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.UiMode
 import org.junit.Assert.assertEquals
@@ -109,6 +111,31 @@ class PreviewOverrideMergeTest {
 
     val empty = mergePreviewOverrides(base, PreviewOverrides()).toExtensionOverrides()
     assertNull("merged extension bag should be null when no extension fields are set", empty)
+  }
+
+  @Test
+  fun `permissions override merges into the bag and flows through toExtensionOverrides`() {
+    val base =
+      PreviewOverrideBaseSpec(
+        widthPx = 320,
+        heightPx = 480,
+        density = 2.0f,
+        device = null,
+        localeTag = null,
+        fontScale = null,
+        uiMode = null,
+        orientation = null,
+        inspectionMode = null,
+      )
+
+    val override =
+      PermissionsOverride(
+        grants = mapOf("android.permission.CAMERA" to PermissionGrantStateOverride.GRANTED)
+      )
+    val merged = mergePreviewOverrides(base, PreviewOverrides(permissions = override))
+
+    assertEquals(override, merged.permissions)
+    assertEquals(override, merged.toExtensionOverrides()?.permissions)
   }
 
   @Test

--- a/data/permissions/connector/build.gradle.kts
+++ b/data/permissions/connector/build.gradle.kts
@@ -1,0 +1,78 @@
+// `:data-permissions-connector` glues `:data-permissions-core` (the wire-shape) to the daemon's
+// data-product / preview-override surface. Mirrors `:data-ambient-connector`'s split — payload in
+// the core module, daemon-side machinery (controller, around-composable extension, planner,
+// Robolectric shadow for tracking queries) here. Ships:
+//
+//  - `PermissionsController` — process-static state holder for the current grant map and the set
+//    of permissions the screen has queried during the active render / interactive session.
+//  - `PermissionsOverrideExtension` / `PermissionsPreviewOverrideExtension` — `AroundComposable`
+//    plumbing that seeds Robolectric's `ShadowApplication.grantPermissions/denyPermissions` from
+//    the override and installs `LocalPermissionsHost` so consumer code can read the live grant
+//    state and recompose when the controller flips. Planner is always-on (like
+//    `KeyboardPreviewOverrideExtension`) so the controller's CompositionLocal is in place on every
+//    render — the panel still sees an empty `queried` list when no permission was checked.
+//  - `ShadowContextWrapperPermissionTracker` — Robolectric shadow that intercepts
+//    `ContextWrapper.checkPermission(String, int, int)` so `ContextCompat.checkSelfPermission(...)`
+//    calls land in `PermissionsController.recordQuery`. The shadow forwards to the real
+//    implementation so Robolectric's own grant tracking still wins; we're purely observing.
+//  - `PermissionsDataProductRegistry` — `compose/permissions` registry serving the captured
+//    payload (effective grant map + queried permission list).
+//
+// Android-library because the wire-up uses `android.Manifest`, `android.content.pm.PackageManager`,
+// and Robolectric shadows on `android.content.ContextWrapper`. The desktop daemon doesn't register
+// this connector — permissions are an Android platform concept and the wallpaper / theme override
+// already covers the cross-backend "themed preview" need.
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.tapmoc)
+}
+
+android { namespace = "ee.schimke.composeai.data.permissions.connector" }
+
+dependencies {
+  // Wire-shape + product-kind constants. Re-exported via `api` so consumers (`:daemon:android`)
+  // can refer to `PermissionsPayload` / `Material3PermissionsProduct.KIND` without adding a second
+  // `project` dependency.
+  api(project(":data-permissions-core"))
+
+  // DataProductRegistry interface, DataExtension, AroundComposableExtension. Re-exported via
+  // `api` so the connector's planner / extension classes can be referenced from
+  // `RobolectricHost`'s `previewOverrideExtensions` list.
+  api(project(":daemon:core"))
+  api(project(":data-render-core"))
+  api(project(":data-render-compose"))
+
+  // Robolectric — the shadow on `ContextWrapper.checkPermission` uses `@Implements` /
+  // `@Implementation` annotations + `@RealObject`. `compileOnly` because the shadow only runs
+  // inside a Robolectric sandbox; non-test consumers never instantiate it directly. Daemon's
+  // runtime classpath already includes Robolectric.
+  compileOnly(libs.robolectric)
+  testImplementation(libs.robolectric)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.kotlinx.serialization.json)
+}
+
+mavenPublishing {
+  configure(
+    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
+      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
+      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
+      variant = "release",
+    )
+  )
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-permissions-connector",
+    displayName = "Compose Preview - Permissions Data Product Connector",
+    description =
+      "Daemon-side Android runtime-permissions data-product connector: lets `renderNow.overrides.permissions` flip a preview's grant state and records which permissions the screen queries.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsController.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsController.kt
@@ -1,0 +1,159 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
+import ee.schimke.composeai.daemon.protocol.PermissionsOverride
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Process-static state holder for the Android runtime-permissions connector.
+ *
+ * Three responsibilities:
+ *
+ * 1. **Grant map** — the effective permission -> grant-state mapping the around-composable applies
+ *    for the current render. Snapshot-state so a screen reading `LocalPermissionsHost.check(perm)`
+ *    inside a `@Composable` recomposes when [set] flips a grant.
+ * 2. **Query tracker** — the set of permissions the screen has asked about so far in the render /
+ *    interactive session, in insertion order. Written by either the Robolectric shadow on
+ *    `ContextWrapper.checkPermission(...)` (covering `ContextCompat.checkSelfPermission(...)`) or
+ *    the explicit `LocalPermissionsHost.check(...)` opt-in helper.
+ * 3. **Robolectric grant sync** — when the override is applied the controller calls into
+ *    `ShadowApplication.grantPermissions(...)` / `denyPermissions(...)` via reflection so consumer
+ *    code reading the permission through the platform path also sees the requested state without
+ *    the connector forking a custom shadow on `Application.checkPermission`.
+ *
+ * **Threading.** [set], [recordQuery], [resetForNewSession] are guarded by a single mutex.
+ * Snapshot-state writes happen on whatever thread fires the override (the daemon's render thread
+ * for `renderNow.overrides.permissions`); reads are by definition on the composition thread and
+ * Compose's snapshot machinery handles the cross-thread propagation.
+ */
+object PermissionsController {
+
+  private val lock = Any()
+
+  /** Effective grant map. Persisted across renders so a session that flips a grant mid-flight is observable. */
+  private val grantsState: MutableState<Map<String, PermissionGrantStateOverride>> =
+    mutableStateOf(emptyMap())
+
+  /** Insertion-ordered tracking of which permissions the screen has queried. */
+  private val queriedSet: MutableState<List<String>> = mutableStateOf(emptyList())
+
+  /** Hooks notified on grant-map changes — populated by the around-composable's `DisposableEffect`. */
+  private val listeners: MutableList<() -> Unit> = CopyOnWriteArrayList()
+
+  /** Cache of unique queried permissions for O(1) duplicate suppression in [recordQuery]. */
+  private val queriedSeen: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+  val grants: State<Map<String, PermissionGrantStateOverride>>
+    get() = grantsState
+
+  val queried: State<List<String>>
+    get() = queriedSet
+
+  /**
+   * Apply a fresh override. Replaces the entire grant map — a follow-up `renderNow.overrides
+   * .permissions` with `grants = mapOf("CAMERA" to GRANTED)` revokes anything previously granted
+   * that isn't in the new map. Matches `KeyboardController.seed` semantics. `null` clears the
+   * override (empty map).
+   *
+   * Also pushes the grant state into Robolectric's `ShadowApplication` so the platform permission
+   * path (`ContextCompat.checkSelfPermission`, `Activity.checkSelfPermission`,
+   * `PackageManager.checkPermission`) returns the requested value without a fresh shadow on
+   * `Application.checkPermission`. Reflection-driven to avoid a hard compile-time dep on
+   * Robolectric in the connector's public surface — the daemon's runtime classpath always carries
+   * Robolectric.
+   */
+  fun set(override: PermissionsOverride?) {
+    val newGrants = override?.grants ?: emptyMap()
+    synchronized(lock) {
+      grantsState.value = newGrants
+      syncRobolectricGrants(newGrants)
+    }
+    listeners.toList().forEach { it() }
+  }
+
+  /** Read the current grant for [permission]. `null` means "no override applied" — caller defaults. */
+  fun grantFor(permission: String): PermissionGrantStateOverride? = grantsState.value[permission]
+
+  /**
+   * Record a query against [permission]. Idempotent — duplicate queries don't re-append. The
+   * insertion-ordered list is what the data-product payload surfaces, so the panel can display
+   * queries in roughly the sequence the composition issued them.
+   */
+  fun recordQuery(permission: String) {
+    if (queriedSeen.add(permission)) {
+      synchronized(lock) { queriedSet.value = queriedSet.value + permission }
+    }
+  }
+
+  /** Register a callback fired on every [set] transition. Returns an unregister handle. */
+  fun addChangeListener(listener: () -> Unit): () -> Unit {
+    listeners.add(listener)
+    return { listeners.remove(listener) }
+  }
+
+  /**
+   * Cleanup hook for per-session reset (interactive close, recording stop, sandbox recycle). Drops
+   * the grant map and the queried list so the next preview starts fresh. Mirrors
+   * `KeyboardController.resetForNewSession` / `AmbientStateController.resetForNewSession`.
+   */
+  fun resetForNewSession() {
+    synchronized(lock) {
+      grantsState.value = emptyMap()
+      queriedSet.value = emptyList()
+      queriedSeen.clear()
+      syncRobolectricGrants(emptyMap())
+    }
+  }
+
+  /**
+   * Push the grant map into Robolectric's `ShadowApplication`. We reach into the
+   * `org.robolectric.Shadows.shadowOf(application)` API reflectively so a non-Robolectric
+   * classpath (impossible today, but defensive) doesn't link-error on the controller class itself.
+   * The shadow's `grantPermissions(vararg String)` / `denyPermissions(vararg String)` are the
+   * supported public API for seeding the platform permission path; everything `ContextCompat
+   * .checkSelfPermission` reaches eventually consults the same data structure.
+   *
+   * Permissions present in the override are granted or denied per their wire state. Permissions
+   * NOT present in the override are explicitly denied so a re-render with a shrunk grant map
+   * doesn't leak the previous render's grants.
+   */
+  private fun syncRobolectricGrants(grants: Map<String, PermissionGrantStateOverride>) {
+    try {
+      val rEnvCls =
+        Class.forName("org.robolectric.RuntimeEnvironment", true, javaClass.classLoader)
+      val app = rEnvCls.getMethod("getApplication").invoke(null) ?: return
+      val shadowsCls = Class.forName("org.robolectric.Shadows", true, javaClass.classLoader)
+      val shadowOf =
+        shadowsCls.getMethod("shadowOf", Class.forName("android.app.Application"))
+      val shadowApp = shadowOf.invoke(null, app) ?: return
+      val granted =
+        grants.filterValues { it == PermissionGrantStateOverride.GRANTED }.keys.toTypedArray()
+      val denied =
+        grants.filterValues { it == PermissionGrantStateOverride.DENIED }.keys.toTypedArray()
+      val shadowAppCls = shadowApp.javaClass
+      // Clear the previously-granted set first by denying everything in the override; then grant
+      // the explicit grants. Permissions outside the override stay at their post-deny default
+      // (denied), which is what we want for "absent from map = revoke".
+      shadowAppCls.getMethod("denyPermissions", Array<String>::class.java)
+        .invoke(shadowApp, denied + granted)
+      if (granted.isNotEmpty()) {
+        shadowAppCls.getMethod("grantPermissions", Array<String>::class.java)
+          .invoke(shadowApp, granted)
+      }
+    } catch (_: ClassNotFoundException) {
+      // No Robolectric on this classpath — `LocalPermissionsHost` opt-in still works for
+      // compositions that consult the controller directly. Production Android paths reach this
+      // controller only inside a Robolectric sandbox today, so the catch is defensive.
+    } catch (_: NoSuchMethodException) {
+      // Robolectric API surface drifted — fall back to controller-only state without crashing the
+      // render. A subsequent Robolectric bump that renames the methods will need a code update.
+    } catch (_: ReflectiveOperationException) {
+      // Underlying invocation failure (e.g. application not yet initialised). Drop silently — the
+      // controller's snapshot state still drives `LocalPermissionsHost` opt-in callers.
+    }
+  }
+}

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
@@ -1,0 +1,242 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
+import ee.schimke.composeai.daemon.protocol.PermissionsOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.permissions.Material3PermissionsProduct
+import ee.schimke.composeai.data.permissions.PermissionGrantWire
+import ee.schimke.composeai.data.permissions.PermissionsPayload
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.extensions.DataExtension
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Compose composition local exposing the live permission state to consumer screens. Two
+ * affordances:
+ *
+ * * [PermissionsHost.check] — returns the current grant for [permission] and records the query so
+ *   the `compose/permissions` data product can surface what the screen asked about. Reads from
+ *   the snapshot-state-backed [PermissionsController.grants], so a screen calling `check(...)`
+ *   inside a `@Composable` recomposes when the panel pushes a fresh
+ *   `renderNow.overrides.permissions`.
+ * * [PermissionsHost.grants] — direct read of the current grant map for screens that want to
+ *   iterate all granted/denied permissions without naming each up front.
+ *
+ * The `ContextCompat.checkSelfPermission(...)` platform path also works (the controller seeds
+ * Robolectric's `ShadowApplication`) — `LocalPermissionsHost` exists for screens that want
+ * tracking + automatic recomposition on flip without going through the platform call.
+ */
+val LocalPermissionsHost = compositionLocalOf<PermissionsHost> { ControllerPermissionsHost }
+
+/**
+ * Façade over [PermissionsController] for consumer code. Sealed so future facets (rationale flags,
+ * per-permission timestamps) can land without breaking the call shape.
+ */
+interface PermissionsHost {
+  /**
+   * Read [permission]'s current grant and record the query. Returns `null` when no override
+   * applies for [permission] — caller decides the default (Compose code typically treats this as
+   * `denied` to surface the "request permission" UI).
+   */
+  @Composable fun check(permission: String): PermissionGrantStateOverride?
+}
+
+private object ControllerPermissionsHost : PermissionsHost {
+  @Composable
+  override fun check(permission: String): PermissionGrantStateOverride? {
+    PermissionsController.recordQuery(permission)
+    // Read the snapshot-state map so the composition recomposes when the controller flips.
+    val current by PermissionsController.grants
+    return current[permission]
+  }
+}
+
+/**
+ * `AroundComposable` extension that owns the runtime-permissions surface. The extension is
+ * **always active** — the planner emits an instance for every render so [LocalPermissionsHost] is
+ * in scope and the controller's `recordQuery` path is wired regardless of whether the client sent
+ * an explicit `PermissionsOverride`.
+ *
+ * Lifecycle:
+ *
+ * * On enter — [PermissionsController.set] is called with the seed (clears the map when null).
+ *   `DisposableEffect(seed)` re-runs only when the override identity changes, so a subsequent
+ *   `renderNow.overrides.permissions` with the same shape doesn't churn the controller.
+ * * On dispose — clears the override (matches `KeyboardOverrideExtension`'s on-dispose semantics).
+ *
+ * Runs in [DataExtensionPhase.OuterEnvironment] so the shadow `LocalPermissionsHost` is in place
+ * before the user-environment phase reaches preview content — text fields, buttons, and any
+ * `LaunchedEffect`-driven permission check composed in user code see the controller's view.
+ */
+class PermissionsOverrideExtension(private val seed: PermissionsOverride? = null) :
+  AroundComposableExtension(
+    id = ID,
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.OuterEnvironment,
+        provides = setOf(DataExtensionCapability(PermissionsDataProductRegistry.KIND)),
+      ),
+  ) {
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    DisposableEffect(seed) {
+      PermissionsController.set(seed)
+      onDispose { PermissionsController.set(null) }
+    }
+    CompositionLocalProvider(LocalPermissionsHost provides ControllerPermissionsHost) { content() }
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId(PermissionsDataProductRegistry.KIND)
+  }
+}
+
+/**
+ * Planner that maps `renderNow.overrides.permissions` to a [PermissionsOverrideExtension].
+ * **Always** returns a non-null extension — like `KeyboardPreviewOverrideExtension`. The
+ * around-composable's `LocalPermissionsHost` needs to be in place on every render so a screen
+ * that consults the host (or one whose `checkSelfPermission` call lands in the shadow tracker)
+ * reaches the controller's tracking path.
+ */
+class PermissionsPreviewOverrideExtension : DataExtension<PreviewOverrides> {
+  override val id: DataExtensionId = PermissionsOverrideExtension.ID
+
+  override fun plan(request: PreviewOverrides): PlannedDataExtension =
+    PermissionsOverrideExtension(seed = request.permissions)
+}
+
+/**
+ * Daemon-side registry adapter for `compose/permissions`.
+ *
+ * The registry tracks two facets per preview id:
+ *
+ * * The effective grant map applied by the last `renderNow.overrides.permissions`.
+ * * The set of permissions the screen queried during the latest render (insertion order
+ *   preserved).
+ *
+ * A `data/fetch` after a permission-aware render returns the combined payload; before any render
+ * or after [clear], it returns [DataProductRegistry.Outcome.NotAvailable]. Clients update the
+ * state by sending a fresh `renderNow.overrides.permissions`; the panel's "what's queried" chip
+ * subscribes to refresh on every render.
+ */
+class PermissionsDataProductRegistry : DataProductRegistry {
+  private val latestPayloads = ConcurrentHashMap<String, PermissionsPayload>()
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        // Flipping a grant via a fresh `renderNow.overrides.permissions` triggers a re-render
+        // anyway, and the `LocalPermissionsHost`-based screens recompose live during a held
+        // session — no need to ask the dispatcher to queue an extra render.
+        requiresRerender = false,
+      )
+    )
+
+  fun capture(previewId: String?, payload: PermissionsPayload) {
+    if (previewId == null) return
+    latestPayloads[previewId] = payload
+  }
+
+  fun clear(previewId: String?) {
+    if (previewId == null) return
+    latestPayloads.remove(previewId)
+  }
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    val payload = latestPayloads[previewId] ?: return DataProductRegistry.Outcome.NotAvailable
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(PermissionsPayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (KIND !in kinds) return emptyList()
+    val payload = latestPayloads[previewId] ?: return emptyList()
+    return listOf(
+      DataProductAttachment(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(PermissionsPayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun onRender(previewId: String, result: RenderResult) {
+    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
+  }
+
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
+    // Capture even when no explicit override was sent — the screen may have queried permissions
+    // through the controller without a seed, and the panel still wants to surface that. An empty
+    // payload (no grants, no queries) is filtered out so we don't masquerade `NotAvailable`.
+    val grants = overrides?.permissions?.grants.orEmpty() + PermissionsController.grants.value
+    val queried = PermissionsController.queried.value
+    if (grants.isEmpty() && queried.isEmpty()) {
+      clear(previewId)
+      return
+    }
+    capture(previewId, payloadFor(grants, queried))
+  }
+
+  private fun payloadFor(
+    grants: Map<String, PermissionGrantStateOverride>,
+    queried: List<String>,
+  ): PermissionsPayload =
+    PermissionsPayload(
+      grants =
+        grants.mapValues { (_, v) ->
+          when (v) {
+            PermissionGrantStateOverride.GRANTED -> PermissionGrantWire.GRANTED
+            PermissionGrantStateOverride.DENIED -> PermissionGrantWire.DENIED
+          }
+        },
+      queried = queried,
+    )
+
+  companion object {
+    const val KIND: String = Material3PermissionsProduct.KIND
+    const val SCHEMA_VERSION: Int = Material3PermissionsProduct.SCHEMA_VERSION
+
+    private val json = Json {
+      encodeDefaults = true
+      prettyPrint = false
+    }
+  }
+}

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/ShadowContextWrapperPermissionTracker.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/ShadowContextWrapperPermissionTracker.kt
@@ -1,0 +1,77 @@
+package ee.schimke.composeai.daemon
+
+import android.content.ContextWrapper
+import android.content.pm.PackageManager
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.annotation.RealObject
+import org.robolectric.shadow.api.Shadow
+
+/**
+ * Robolectric shadow on `android.content.ContextWrapper.checkPermission(String, int, int)`.
+ *
+ * Purpose: every Android permission check eventually flows through either
+ * `Context.checkSelfPermission(String)` (which under the hood calls `checkPermission(perm,
+ * Process.myPid(), Process.myUid())` on the bound `Context`) or `ContextCompat.checkSelfPermission
+ * (context, perm)` (which calls the same `checkPermission(...)` triple). Both paths terminate at
+ * `ContextWrapper.checkPermission` for any non-trivial context (the base `Activity`,
+ * `Application`, or any wrapper around them) — shadowing the wrapper catches every consumer-side
+ * path without needing per-context shadows.
+ *
+ * Behaviour: forwards to the real implementation (so Robolectric's `ShadowApplication`-grant state
+ * still drives the actual return value), then records the queried permission in
+ * `PermissionsController.recordQuery(...)` for the data-product payload. Idempotent — duplicate
+ * queries for the same permission don't grow the list, only the first hit lands.
+ *
+ * The shadow targets `android.content.ContextWrapper` rather than `ContextImpl` because the
+ * platform's `ContextImpl` is a hidden class (Robolectric maps it in but consumers shouldn't
+ * touch). `Activity` extends `ContextThemeWrapper` extends `ContextWrapper`, and so does every
+ * `View`-derived context — so this single shadow covers every preview's Compose root.
+ *
+ * **Registration**: this shadow is registered conditionally on the consumer's classpath shape via
+ * `SandboxHoldingRunner.getExtraShadows(...)` in `:daemon:android`. The Robolectric sandbox loads
+ * the shadow class, sees the `@Implements` annotation, and from then on every
+ * `ContextWrapper.checkPermission` call routes through here.
+ */
+@Implements(ContextWrapper::class)
+class ShadowContextWrapperPermissionTracker {
+
+  @RealObject @Suppress("unused") private lateinit var realWrapper: ContextWrapper
+
+  @Implementation
+  fun checkPermission(permission: String?, pid: Int, uid: Int): Int {
+    // Forward to the real `ContextWrapper.checkPermission` so Robolectric's `ShadowApplication`
+    // grant state still drives the actual return value. `Shadow.directlyOn` re-enters the
+    // unwrapped method without going back through this shadow.
+    val result: Int =
+      Shadow.directlyOn<Int, ContextWrapper>(
+        realWrapper,
+        ContextWrapper::class.java,
+        "checkPermission",
+        org.robolectric.util.ReflectionHelpers.ClassParameter.from(String::class.java, permission),
+        org.robolectric.util.ReflectionHelpers.ClassParameter.from(
+          Int::class.javaPrimitiveType,
+          pid,
+        ),
+        org.robolectric.util.ReflectionHelpers.ClassParameter.from(
+          Int::class.javaPrimitiveType,
+          uid,
+        ),
+      ) ?: PackageManager.PERMISSION_DENIED
+    if (permission != null) {
+      PermissionsController.recordQuery(permission)
+    }
+    return result
+  }
+
+  companion object {
+    /**
+     * Fully-qualified name of the shadow class. Exposed as a string so non-connector modules
+     * (`:daemon:android`'s `SandboxHoldingRunner` / `RobolectricHost`) can refer to the shadow
+     * without taking a compile-time dependency on `:data-permissions-connector`. Mirrors
+     * [ShadowAmbientLifecycleObserver.SHADOW_FQN].
+     */
+    const val SHADOW_FQN: String =
+      "ee.schimke.composeai.daemon.ShadowContextWrapperPermissionTracker"
+  }
+}

--- a/data/permissions/connector/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsControllerTest.kt
+++ b/data/permissions/connector/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsControllerTest.kt
@@ -1,0 +1,105 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
+import ee.schimke.composeai.daemon.protocol.PermissionsOverride
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * State-only checks for [PermissionsController]. The Robolectric grant-sync path is exercised by
+ * `:daemon:android`'s in-sandbox tests where `ShadowApplication` actually exists; here we cover
+ * the snapshot-state behaviour the around-composable + data-product registry rely on.
+ */
+class PermissionsControllerTest {
+
+  @After fun tearDown() = PermissionsController.resetForNewSession()
+
+  @Test
+  fun `controller starts with empty grant map and queried list`() {
+    PermissionsController.resetForNewSession()
+    assertTrue(PermissionsController.grants.value.isEmpty())
+    assertTrue(PermissionsController.queried.value.isEmpty())
+  }
+
+  @Test
+  fun `set replaces the grant map`() {
+    PermissionsController.set(
+      PermissionsOverride(
+        grants = mapOf("android.permission.CAMERA" to PermissionGrantStateOverride.GRANTED)
+      )
+    )
+    assertEquals(
+      PermissionGrantStateOverride.GRANTED,
+      PermissionsController.grantFor("android.permission.CAMERA"),
+    )
+
+    // A subsequent override that drops CAMERA revokes it — no merge with previous state.
+    PermissionsController.set(
+      PermissionsOverride(
+        grants =
+          mapOf("android.permission.RECORD_AUDIO" to PermissionGrantStateOverride.DENIED)
+      )
+    )
+    assertNull(PermissionsController.grantFor("android.permission.CAMERA"))
+    assertEquals(
+      PermissionGrantStateOverride.DENIED,
+      PermissionsController.grantFor("android.permission.RECORD_AUDIO"),
+    )
+  }
+
+  @Test
+  fun `set with null clears the override`() {
+    PermissionsController.set(
+      PermissionsOverride(
+        grants = mapOf("android.permission.CAMERA" to PermissionGrantStateOverride.GRANTED)
+      )
+    )
+    PermissionsController.set(null)
+    assertTrue(PermissionsController.grants.value.isEmpty())
+  }
+
+  @Test
+  fun `recordQuery preserves insertion order and de-duplicates`() {
+    PermissionsController.recordQuery("android.permission.CAMERA")
+    PermissionsController.recordQuery("android.permission.RECORD_AUDIO")
+    PermissionsController.recordQuery("android.permission.CAMERA") // duplicate
+
+    assertEquals(
+      listOf("android.permission.CAMERA", "android.permission.RECORD_AUDIO"),
+      PermissionsController.queried.value,
+    )
+  }
+
+  @Test
+  fun `addChangeListener fires on every set transition`() {
+    var fires = 0
+    val unregister = PermissionsController.addChangeListener { fires += 1 }
+    try {
+      PermissionsController.set(
+        PermissionsOverride(
+          grants = mapOf("android.permission.CAMERA" to PermissionGrantStateOverride.GRANTED)
+        )
+      )
+      PermissionsController.set(null)
+      assertEquals(2, fires)
+    } finally {
+      unregister()
+    }
+  }
+
+  @Test
+  fun `resetForNewSession drops grants and queried`() {
+    PermissionsController.set(
+      PermissionsOverride(
+        grants = mapOf("android.permission.CAMERA" to PermissionGrantStateOverride.GRANTED)
+      )
+    )
+    PermissionsController.recordQuery("android.permission.CAMERA")
+    PermissionsController.resetForNewSession()
+    assertTrue(PermissionsController.grants.value.isEmpty())
+    assertTrue(PermissionsController.queried.value.isEmpty())
+  }
+}

--- a/data/permissions/connector/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsDataProductTest.kt
+++ b/data/permissions/connector/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsDataProductTest.kt
@@ -1,0 +1,216 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.KeyboardOverride
+import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
+import ee.schimke.composeai.daemon.protocol.PermissionsOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.permissions.Material3PermissionsProduct
+import ee.schimke.composeai.data.permissions.PermissionsPayload
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the contract of `:data-permissions-connector`'s extension + registry surface. Mirrors
+ * [KeyboardDataProductTest] — the planner is always-on so the controller's `LocalPermissionsHost`
+ * is in scope on every render, even when the client hasn't sent an explicit override.
+ */
+class PermissionsDataProductTest {
+
+  @After fun tearDown() = PermissionsController.resetForNewSession()
+
+  @Test
+  fun `permissions override extension declares around-composable hook in OuterEnvironment phase`() {
+    val extension =
+      PermissionsOverrideExtension(
+        PermissionsOverride(
+          grants =
+            mapOf("android.permission.CAMERA" to PermissionGrantStateOverride.GRANTED)
+        )
+      )
+    val hook: AroundComposableHook = extension
+
+    assertEquals(DataExtensionId(Material3PermissionsProduct.KIND), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.AroundComposable), extension.hooks)
+    assertEquals(DataExtensionPhase.OuterEnvironment, extension.constraints.phase)
+    assertTrue(extension.hasAroundComposableHook)
+    assertEquals(extension, hook)
+  }
+
+  @Test
+  fun `planner always returns an extension so the host is in scope even without an override`() {
+    val planner = PermissionsPreviewOverrideExtension()
+    val planned = planner.plan(PreviewOverrides())
+    assertNotNull(
+      "planner must always emit the extension so LocalPermissionsHost and the recordQuery path " +
+        "are in place for every render",
+      planned,
+    )
+    assertEquals(DataExtensionId(Material3PermissionsProduct.KIND), planned.id)
+    // Sibling overrides shouldn't change the always-on shape.
+    assertNotNull(planner.plan(PreviewOverrides(keyboard = KeyboardOverride(visible = true))))
+    assertNotNull(
+      planner.plan(
+        PreviewOverrides(
+          permissions =
+            PermissionsOverride(
+              grants =
+                mapOf("android.permission.RECORD_AUDIO" to PermissionGrantStateOverride.DENIED)
+            )
+        )
+      )
+    )
+  }
+
+  @Test
+  fun `capabilities advertise compose permissions as inline no-rerender product`() {
+    val registry = PermissionsDataProductRegistry()
+    val cap = registry.capabilities.single()
+    assertEquals("compose/permissions", cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertFalse(cap.requiresRerender)
+  }
+
+  @Test
+  fun `fetch before any render returns NotAvailable`() {
+    val registry = PermissionsDataProductRegistry()
+    val outcome = registry.fetch("preview-1", "compose/permissions", params = null, inline = true)
+    assertEquals(DataProductRegistry.Outcome.NotAvailable, outcome)
+  }
+
+  @Test
+  fun `fetch unknown kind returns Unknown`() {
+    val registry = PermissionsDataProductRegistry()
+    val outcome = registry.fetch("preview-1", "compose/wallpaper", params = null, inline = true)
+    assertEquals(DataProductRegistry.Outcome.Unknown, outcome)
+  }
+
+  @Test
+  fun `capture surfaces grants and queried lists via fetch and attachmentsFor`() {
+    val registry = PermissionsDataProductRegistry()
+    val payload =
+      PermissionsPayload(
+        grants =
+          mapOf(
+            "android.permission.CAMERA" to
+              ee.schimke.composeai.data.permissions.PermissionGrantWire.GRANTED,
+            "android.permission.RECORD_AUDIO" to
+              ee.schimke.composeai.data.permissions.PermissionGrantWire.DENIED,
+          ),
+        queried = listOf("android.permission.CAMERA", "android.permission.ACCESS_FINE_LOCATION"),
+      )
+    registry.capture("preview-1", payload)
+
+    val fetched = registry.fetch("preview-1", "compose/permissions", null, true)
+    val ok = fetched as DataProductRegistry.Outcome.Ok
+    val obj = ok.result.payload!!.jsonObject
+    val grants = obj["grants"]!!.jsonObject
+    assertEquals(
+      "granted",
+      grants["android.permission.CAMERA"]?.jsonPrimitive?.contentOrNull,
+    )
+    assertEquals(
+      "denied",
+      grants["android.permission.RECORD_AUDIO"]?.jsonPrimitive?.contentOrNull,
+    )
+    val queried = obj["queried"]!!.jsonArray.map { it.jsonPrimitive.content }
+    assertEquals(
+      listOf("android.permission.CAMERA", "android.permission.ACCESS_FINE_LOCATION"),
+      queried,
+    )
+
+    val attachments = registry.attachmentsFor("preview-1", setOf("compose/permissions"))
+    assertEquals(1, attachments.size)
+    assertEquals("compose/permissions", attachments.single().kind)
+  }
+
+  @Test
+  fun `clear drops the captured payload`() {
+    val registry = PermissionsDataProductRegistry()
+    registry.capture(
+      "preview-1",
+      PermissionsPayload(grants = emptyMap(), queried = listOf("android.permission.CAMERA")),
+    )
+    registry.clear("preview-1")
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-1", "compose/permissions", null, true),
+    )
+  }
+
+  @Test
+  fun `onRender captures override grants plus controller queries`() {
+    val registry = PermissionsDataProductRegistry()
+    // Seed the controller as if the around-composable had applied the override and a screen had
+    // queried two permissions during composition.
+    PermissionsController.set(
+      PermissionsOverride(
+        grants =
+          mapOf(
+            "android.permission.CAMERA" to PermissionGrantStateOverride.GRANTED,
+            "android.permission.RECORD_AUDIO" to PermissionGrantStateOverride.DENIED,
+          )
+      )
+    )
+    PermissionsController.recordQuery("android.permission.CAMERA")
+    PermissionsController.recordQuery("android.permission.RECORD_AUDIO")
+
+    val stubResult = RenderResult(id = 1L, classLoaderHashCode = 0, classLoaderName = "test")
+    registry.onRender(
+      "preview-1",
+      stubResult,
+      PreviewOverrides(
+        permissions =
+          PermissionsOverride(
+            grants =
+              mapOf(
+                "android.permission.CAMERA" to PermissionGrantStateOverride.GRANTED,
+                "android.permission.RECORD_AUDIO" to PermissionGrantStateOverride.DENIED,
+              )
+          )
+      ),
+      previewContext = null,
+    )
+
+    val fetched = registry.fetch("preview-1", "compose/permissions", null, true)
+    val ok = fetched as DataProductRegistry.Outcome.Ok
+    val obj = ok.result.payload!!.jsonObject
+    assertEquals(
+      "granted",
+      obj["grants"]!!.jsonObject["android.permission.CAMERA"]?.jsonPrimitive?.contentOrNull,
+    )
+    val queried = obj["queried"]!!.jsonArray.map { it.jsonPrimitive.content }
+    assertEquals(listOf("android.permission.CAMERA", "android.permission.RECORD_AUDIO"), queried)
+  }
+
+  @Test
+  fun `onRender with empty controller state and no overrides clears the payload`() {
+    val registry = PermissionsDataProductRegistry()
+    registry.capture(
+      "preview-1",
+      PermissionsPayload(grants = emptyMap(), queried = listOf("android.permission.CAMERA")),
+    )
+    val stubResult = RenderResult(id = 1L, classLoaderHashCode = 0, classLoaderName = "test")
+    registry.onRender("preview-1", stubResult, PreviewOverrides(), previewContext = null)
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-1", "compose/permissions", null, true),
+    )
+  }
+}

--- a/data/permissions/core/build.gradle.kts
+++ b/data/permissions/core/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // `daemon:core` carries `PreviewOverrides` and `PermissionsOverride` (the wire-shape the
+  // connector's planner reads from). Mirrors `:data-keyboard-core` / `:data-focus-core` /
+  // `:data-ambient-core` — the kind constant lives on a tiny JVM module so MCP clients in other
+  // languages can depend on the permissions product identity without dragging in the connector,
+  // Compose, or Robolectric.
+  api(project(":daemon:core"))
+  api(libs.kotlinx.serialization.json)
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-permissions-core",
+    displayName = "Compose Preview - Permissions Data Product Core",
+    description =
+      "Shared Android runtime-permissions data-product model classes for Compose Preview.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/permissions/core/src/main/kotlin/ee/schimke/composeai/data/permissions/PermissionsModels.kt
+++ b/data/permissions/core/src/main/kotlin/ee/schimke/composeai/data/permissions/PermissionsModels.kt
@@ -1,0 +1,46 @@
+package ee.schimke.composeai.data.permissions
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Stable identity of the `compose/permissions` data product. Lifted out of
+ * `PermissionsDataProductRegistry` so MCP clients and other connectors can depend on the payload
+ * schema without pulling in the daemon-side registry, Compose, or Robolectric. Mirrors
+ * `Material3KeyboardProduct` / `Material3AmbientProduct`.
+ */
+object Material3PermissionsProduct {
+  const val KIND: String = "compose/permissions"
+  const val SCHEMA_VERSION: Int = 1
+}
+
+/**
+ * Wire-shape returned by `data/fetch?kind=compose/permissions`.
+ *
+ * Two facets feed the panel's per-card chip:
+ *
+ * * [grants] reflects the effective grant state the around-composable applied for this render — the
+ *   union of `renderNow.overrides.permissions.grants` (explicit overrides) and any in-session
+ *   updates the `PermissionsController` accepted while a live preview is held. Permission names
+ *   match the Android `Manifest.permission.*` constant strings (e.g.
+ *   `"android.permission.CAMERA"`).
+ * * [queried] lists the permissions the screen asked about during the captured frame — either via
+ *   `ContextCompat.checkSelfPermission(...)` (intercepted by the connector's shadow on
+ *   `ContextWrapper.checkPermission`) or via the explicit `LocalPermissionsHost.check(...)` opt-in
+ *   helper. Order is insertion order so the panel can display queries in roughly the sequence the
+ *   composition issued them. Permissions that were not yet queried at capture time do not appear.
+ */
+@Serializable
+data class PermissionsPayload(
+  val grants: Map<String, PermissionGrantWire>,
+  val queried: List<String>,
+)
+
+/**
+ * Wire spelling for a permission's grant state. Matches the lower-case form `KeyboardOverride` /
+ * `AmbientStateOverride` use so JSON payloads stay consistent across data products.
+ */
+@Serializable
+enum class PermissionGrantWire {
+  @kotlinx.serialization.SerialName("granted") GRANTED,
+  @kotlinx.serialization.SerialName("denied") DENIED,
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -249,6 +249,14 @@ include(":data-displayfilter-connector")
 
 project(":data-displayfilter-connector").projectDir = file("data/displayfilter/connector")
 
+include(":data-permissions-core")
+
+project(":data-permissions-core").projectDir = file("data/permissions/core")
+
+include(":data-permissions-connector")
+
+project(":data-permissions-connector").projectDir = file("data/permissions/connector")
+
 // UIAutomator-shaped query/action API for the Compose preview renderer. Carries the matcher,
 // the Selector DSL, and the JSON wire format — consumed by `:daemon:android` for
 // `record_preview`'s `uia.*` script events.


### PR DESCRIPTION
Adds a new `compose/permissions` data product + override surface that
lets a preview run with a synthetic Android permission grant map and
records which permissions the screen queries during the render. Mirrors
the keyboard / ambient connector split: a small `:data-permissions-core`
module carrying the wire shape, and an Android-only
`:data-permissions-connector` module carrying the daemon-side machinery.

Highlights:

- `PermissionsController` — process-static state holder for the
  effective grant map + insertion-ordered queried-permissions list,
  with a reflection-driven hook that seeds Robolectric's
  `ShadowApplication.grantPermissions/denyPermissions` so the platform
  permission path returns the requested value.
- `PermissionsOverrideExtension` — always-on `AroundComposable` that
  applies the override on enter, clears on dispose, and installs a
  `LocalPermissionsHost` composition local so screens consulting it
  recompose live when a follow-up `renderNow.overrides.permissions`
  flips a grant.
- `ShadowContextWrapperPermissionTracker` — Robolectric shadow on
  `ContextWrapper.checkPermission(...)` that forwards to the real
  implementation and records the queried permission in the controller
  so `ContextCompat.checkSelfPermission(...)` calls land in the
  data-product payload automatically.
- `PermissionsDataProductRegistry` — serves `compose/permissions` with
  the captured grant map + queried list.

Wired through `:daemon:android` (planner registered in
`RobolectricHost.previewOverrideExtensions`, shadow registered in
`SandboxHoldingRunner.getExtraShadows`, registry registered in
`DaemonMain`'s `ExtensionRegistry`) and through the daemon-core
`PreviewOverrides` / `MergedPreviewOverrides` plumbing so both
`renderNow` and recording/interactive flows can apply the override.