### PR TITLE
refactor(data-permissions): drop LocalPermissionsHost; lean on standard Android APIs

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -499,11 +499,13 @@ data class PreviewOverrides(
    * Optional Android runtime-permissions override. Drives the connector-side
    * `PermissionsOverrideExtension` (see `:data-permissions-connector`). The around-composable seeds
    * Robolectric's `ShadowApplication` grant state from [PermissionsOverride.grants] so consumer
-   * code reading `ContextCompat.checkSelfPermission(...)` sees the requested value, *and* installs
-   * a `LocalPermissionsHost` composition local so a screen consulting it observes live updates the
-   * panel pushes via subsequent `renderNow.overrides.permissions` calls without a fresh render.
-   * Permission names are the `Manifest.permission.*` constant strings (e.g.
-   * `"android.permission.CAMERA"`). Android-only — the desktop backend ignores this field.
+   * code reading the standard Android permission APIs (`ContextCompat.checkSelfPermission`,
+   * `Activity.checkSelfPermission`, `Context.checkPermission`, accompanist's
+   * `rememberPermissionState`) sees the requested value — no connector-specific Compose API for the
+   * screen to opt into. A subsequent `renderNow.overrides.permissions` re-renders the held preview
+   * with the new grants so the next `checkSelfPermission` read observes the change. Permission
+   * names are the `Manifest.permission.*` constant strings (e.g. `"android.permission.CAMERA"`).
+   * Android-only — the desktop backend ignores this field.
    */
   val permissions: PermissionsOverride? = null,
 )

--- a/data/permissions/connector/build.gradle.kts
+++ b/data/permissions/connector/build.gradle.kts
@@ -7,10 +7,11 @@
 //    of permissions the screen has queried during the active render / interactive session.
 //  - `PermissionsOverrideExtension` / `PermissionsPreviewOverrideExtension` — `AroundComposable`
 //    plumbing that seeds Robolectric's `ShadowApplication.grantPermissions/denyPermissions` from
-//    the override and installs `LocalPermissionsHost` so consumer code can read the live grant
-//    state and recompose when the controller flips. Planner is always-on (like
-//    `KeyboardPreviewOverrideExtension`) so the controller's CompositionLocal is in place on every
-//    render — the panel still sees an empty `queried` list when no permission was checked.
+//    the override so consumer screens reading `ContextCompat.checkSelfPermission(...)` (or any
+//    standard Android check API) observe the requested value without a connector-specific Compose
+//    API. Planner is always-on (like `KeyboardPreviewOverrideExtension`) so the shadow tracker
+//    sees every query on every render — the panel still sees an empty `queried` list when no
+//    permission was checked.
 //  - `ShadowContextWrapperPermissionTracker` — Robolectric shadow that intercepts
 //    `ContextWrapper.checkPermission(String, int, int)` so `ContextCompat.checkSelfPermission(...)`
 //    calls land in `PermissionsController.recordQuery`. The shadow forwards to the real

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsController.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsController.kt
@@ -17,9 +17,10 @@ import java.util.concurrent.CopyOnWriteArrayList
  *    for the current render. Snapshot-state so a screen reading `LocalPermissionsHost.check(perm)`
  *    inside a `@Composable` recomposes when [set] flips a grant.
  * 2. **Query tracker** — the set of permissions the screen has asked about so far in the render /
- *    interactive session, in insertion order. Written by either the Robolectric shadow on
- *    `ContextWrapper.checkPermission(...)` (covering `ContextCompat.checkSelfPermission(...)`) or
- *    the explicit `LocalPermissionsHost.check(...)` opt-in helper.
+ *    interactive session, in insertion order. Written by the Robolectric shadow on
+ *    `ContextWrapper.checkPermission(...)`, which covers every standard Android check API
+ *    (`ContextCompat.checkSelfPermission`, `Activity.checkSelfPermission`,
+ *    `Context.checkPermission`, accompanist's `rememberPermissionState`).
  * 3. **Robolectric grant sync** — when the override is applied the controller calls into
  *    `ShadowApplication.grantPermissions(...)` / `denyPermissions(...)` via reflection so consumer
  *    code reading the permission through the platform path also sees the requested state without

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
@@ -1,10 +1,7 @@
 package ee.schimke.composeai.daemon
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.runtime.getValue
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
@@ -28,62 +25,40 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 /**
- * Compose composition local exposing the live permission state to consumer screens. Two
- * affordances:
- *
- * * [PermissionsHost.check] — returns the current grant for [permission] and records the query so
- *   the `compose/permissions` data product can surface what the screen asked about. Reads from
- *   the snapshot-state-backed [PermissionsController.grants], so a screen calling `check(...)`
- *   inside a `@Composable` recomposes when the panel pushes a fresh
- *   `renderNow.overrides.permissions`.
- * * [PermissionsHost.grants] — direct read of the current grant map for screens that want to
- *   iterate all granted/denied permissions without naming each up front.
- *
- * The `ContextCompat.checkSelfPermission(...)` platform path also works (the controller seeds
- * Robolectric's `ShadowApplication`) — `LocalPermissionsHost` exists for screens that want
- * tracking + automatic recomposition on flip without going through the platform call.
- */
-val LocalPermissionsHost = compositionLocalOf<PermissionsHost> { ControllerPermissionsHost }
-
-/**
- * Façade over [PermissionsController] for consumer code. Sealed so future facets (rationale flags,
- * per-permission timestamps) can land without breaking the call shape.
- */
-interface PermissionsHost {
-  /**
-   * Read [permission]'s current grant and record the query. Returns `null` when no override
-   * applies for [permission] — caller decides the default (Compose code typically treats this as
-   * `denied` to surface the "request permission" UI).
-   */
-  @Composable fun check(permission: String): PermissionGrantStateOverride?
-}
-
-private object ControllerPermissionsHost : PermissionsHost {
-  @Composable
-  override fun check(permission: String): PermissionGrantStateOverride? {
-    PermissionsController.recordQuery(permission)
-    // Read the snapshot-state map so the composition recomposes when the controller flips.
-    val current by PermissionsController.grants
-    return current[permission]
-  }
-}
-
-/**
  * `AroundComposable` extension that owns the runtime-permissions surface. The extension is
- * **always active** — the planner emits an instance for every render so [LocalPermissionsHost] is
- * in scope and the controller's `recordQuery` path is wired regardless of whether the client sent
- * an explicit `PermissionsOverride`.
+ * **always active** — the planner emits an instance for every render so the controller-driven
+ * Robolectric grant state is seeded and the shadow tracker's `recordQuery` path is wired
+ * regardless of whether the client sent an explicit `PermissionsOverride`.
+ *
+ * **No custom Compose API.** Consumer screens drive the standard Android permission APIs —
+ * `ContextCompat.checkSelfPermission(...)`, `Activity.checkSelfPermission(...)`,
+ * `PackageManager.checkPermission(...)`, accompanist's `rememberPermissionState`, and the
+ * AndroidX `ActivityResultContracts.RequestPermission` launcher — and the connector hooks them
+ * transparently:
+ *
+ * * **Apply overrides** — [PermissionsController.set] pushes the grant map into Robolectric's
+ *   `ShadowApplication.grantPermissions/denyPermissions`, so the platform `checkPermission`
+ *   path returns the requested value without the screen reaching for a connector-specific
+ *   composition local.
+ * * **Track queries** — [ShadowContextWrapperPermissionTracker] intercepts every
+ *   `ContextWrapper.checkPermission(...)` call (the union of all the public check APIs above)
+ *   and records the queried permission in the controller for the `compose/permissions`
+ *   data-product payload.
+ * * **Live updates** — a follow-up `renderNow.overrides.permissions` re-renders the held
+ *   preview with the new grants; the screen reads `ContextCompat.checkSelfPermission(...)` on
+ *   recomposition and observes the new value through the standard platform call.
  *
  * Lifecycle:
  *
  * * On enter — [PermissionsController.set] is called with the seed (clears the map when null).
  *   `DisposableEffect(seed)` re-runs only when the override identity changes, so a subsequent
  *   `renderNow.overrides.permissions` with the same shape doesn't churn the controller.
- * * On dispose — clears the override (matches `KeyboardOverrideExtension`'s on-dispose semantics).
+ * * On dispose — clears the override (matches `KeyboardOverrideExtension`'s on-dispose
+ *   semantics).
  *
- * Runs in [DataExtensionPhase.OuterEnvironment] so the shadow `LocalPermissionsHost` is in place
- * before the user-environment phase reaches preview content — text fields, buttons, and any
- * `LaunchedEffect`-driven permission check composed in user code see the controller's view.
+ * Runs in [DataExtensionPhase.OuterEnvironment] so the controller's Robolectric grant state is
+ * primed before the user-environment phase reaches preview content — any `LaunchedEffect`-driven
+ * permission check composed in user code sees the override.
  */
 class PermissionsOverrideExtension(private val seed: PermissionsOverride? = null) :
   AroundComposableExtension(
@@ -100,7 +75,7 @@ class PermissionsOverrideExtension(private val seed: PermissionsOverride? = null
       PermissionsController.set(seed)
       onDispose { PermissionsController.set(null) }
     }
-    CompositionLocalProvider(LocalPermissionsHost provides ControllerPermissionsHost) { content() }
+    content()
   }
 
   companion object {

--- a/data/permissions/core/src/main/kotlin/ee/schimke/composeai/data/permissions/PermissionsModels.kt
+++ b/data/permissions/core/src/main/kotlin/ee/schimke/composeai/data/permissions/PermissionsModels.kt
@@ -23,11 +23,12 @@ object Material3PermissionsProduct {
  *   updates the `PermissionsController` accepted while a live preview is held. Permission names
  *   match the Android `Manifest.permission.*` constant strings (e.g.
  *   `"android.permission.CAMERA"`).
- * * [queried] lists the permissions the screen asked about during the captured frame — either via
- *   `ContextCompat.checkSelfPermission(...)` (intercepted by the connector's shadow on
- *   `ContextWrapper.checkPermission`) or via the explicit `LocalPermissionsHost.check(...)` opt-in
- *   helper. Order is insertion order so the panel can display queries in roughly the sequence the
- *   composition issued them. Permissions that were not yet queried at capture time do not appear.
+ * * [queried] lists the permissions the screen asked about during the captured frame, captured by
+ *   the connector's shadow on `ContextWrapper.checkPermission` — the union of every standard
+ *   Android check API (`ContextCompat.checkSelfPermission`, `Activity.checkSelfPermission`,
+ *   `Context.checkPermission`, accompanist's `rememberPermissionState`). Order is insertion order
+ *   so the panel can display queries in roughly the sequence the composition issued them.
+ *   Permissions that were not yet queried at capture time do not appear.
  */
 @Serializable
 data class PermissionsPayload(


### PR DESCRIPTION
## Summary

Follow-up to #1370. The auto-merge of #1370 fired on the initial commit before the refactor push reached the PR branch, so the unused `LocalPermissionsHost` / `PermissionsHost` interface landed on main. This PR drops it.

Consumer screens should drive the standard Android permission APIs (`ContextCompat.checkSelfPermission`, `Activity.checkSelfPermission`, accompanist's `rememberPermissionState`, the AndroidX `ActivityResultContracts.RequestPermission` launcher) — not learn a connector-specific Compose API. Both sides of the data-product surface already work through the standard path:

- **Override side**: `PermissionsController.set(...)` seeds Robolectric's `ShadowApplication.grantPermissions/denyPermissions`, so every public Android check reads the requested value through `ContextWrapper.checkPermission`.
- **Query-tracking side**: `ShadowContextWrapperPermissionTracker` catches the same public APIs (they all funnel into `ContextWrapper.checkPermission`).
- **Live updates**: a follow-up `renderNow.overrides.permissions` re-renders the held preview with the new grants; the next `checkSelfPermission` read in the recomposition picks up the change through the platform call.

The `LocalPermissionsHost` composition local + `PermissionsHost` interface were duplicating the platform path with no extra reach. Remove them; the `AroundComposable` now just seeds the controller and clears on dispose. Documentation across the connector, core models, and protocol field updated to point consumers at the standard APIs.

## Test plan

- [x] `:data-permissions-connector:test`
- [x] `:daemon:android:compileReleaseKotlin`
- [x] `:data-permissions-core:ktfmtCheck`, `:data-permissions-connector:ktfmtCheck`, `:daemon:core:ktfmtCheck`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxsUFeto1VzD9vgtdmz3Nx)_