### PR TITLE
feat(vscode-extension): tint consumer nodes on theming swatch hover

### DIFF
--- a/vscode-extension/src/test/themingBundlePresenter.test.ts
+++ b/vscode-extension/src/test/themingBundlePresenter.test.ts
@@ -5,10 +5,13 @@
 
 import * as assert from "assert";
 import {
+    buildSemanticsBoundsMap,
     computeThemingBundleData,
+    consumerOverlayBoxes,
     cssFontFamily,
     parseFontWeight,
     parseShapeBorderRadius,
+    type SemanticsLookupPayload,
     type ThemePayload,
     type ThemingColorRow,
     type ThemingShapeRow,
@@ -357,5 +360,213 @@ describe("parseShapeBorderRadius", () => {
     it("returns null for shapes outside our parser's scope", () => {
         assert.strictEqual(parseShapeBorderRadius("GenericShape(...)"), null);
         assert.strictEqual(parseShapeBorderRadius(null), null);
+    });
+});
+
+describe("ThemingRow.consumerNodeIds", () => {
+    it("attaches deduped consumer node ids to color rows", () => {
+        const data = computeThemingBundleData(
+            theme({
+                resolvedTokens: {
+                    colorScheme: { primary: "#FF1976D2" },
+                    typography: {},
+                    shapes: {},
+                },
+                consumers: [
+                    { nodeId: "n1", tokens: ["primary"] },
+                    { nodeId: "n2", tokens: ["primary"] },
+                    // Same nodeId mentioning the same token twice
+                    // (Compose can do this when a single semantic node
+                    // resolves the token through two reads). The row's
+                    // overlay only needs one box per consumer, so the
+                    // builder dedupes.
+                    { nodeId: "n2", tokens: ["primary"] },
+                ],
+            }),
+            null,
+        );
+        const primary = data.rows.find(
+            (r) => r.kind === "color" && r.name === "primary",
+        ) as ThemingColorRow;
+        assert.deepStrictEqual([...primary.consumerNodeIds], ["n1", "n2"]);
+        // Count tracks unique consumers, matching the new field.
+        assert.strictEqual(primary.consumerCount, 2);
+    });
+
+    it("leaves wallpaper-derived color rows with an empty consumer list", () => {
+        // The daemon only emits `consumers` against `compose/theme`
+        // tokens. Wallpaper-derived rows are projections of the seed
+        // scheme and have no per-node attribution, so the array
+        // should stay empty rather than borrow tokens from elsewhere.
+        const data = computeThemingBundleData(
+            theme({
+                resolvedTokens: {
+                    colorScheme: { primary: "#FF1976D2" },
+                    typography: {},
+                    shapes: {},
+                },
+                consumers: [{ nodeId: "n1", tokens: ["primary"] }],
+            }),
+            wallpaper(),
+        );
+        const wp = data.rows.find(
+            (r) =>
+                r.kind === "color" &&
+                (r as ThemingColorRow).source === "wallpaper" &&
+                r.name === "primary",
+        ) as ThemingColorRow;
+        assert.ok(wp);
+        assert.deepStrictEqual([...wp.consumerNodeIds], []);
+    });
+
+    it("populates consumer ids on typography and shape rows", () => {
+        const data = computeThemingBundleData(
+            theme({
+                resolvedTokens: {
+                    colorScheme: {},
+                    typography: { titleLarge: {} },
+                    shapes: { large: "RoundedCornerShape(16.0.dp)" },
+                },
+                consumers: [
+                    { nodeId: "title-node", tokens: ["titleLarge"] },
+                    { nodeId: "shape-node", tokens: ["large"] },
+                ],
+            }),
+            null,
+        );
+        const typo = data.rows.find(
+            (r) => r.kind === "typography",
+        ) as ThemingTypographyRow;
+        const shape = data.rows.find(
+            (r) => r.kind === "shape",
+        ) as ThemingShapeRow;
+        assert.deepStrictEqual([...typo.consumerNodeIds], ["title-node"]);
+        assert.deepStrictEqual([...shape.consumerNodeIds], ["shape-node"]);
+    });
+
+    it("seed row carries no consumerNodeIds field — narrowing pin", () => {
+        // The seed row is a wallpaper summary, not a per-token row.
+        // The hover-overlay path in `main.ts` narrows via
+        // `"consumerNodeIds" in row` before reading; this test pins
+        // that the seed row lacks the field so the narrowing remains
+        // load-bearing.
+        const data = computeThemingBundleData(null, wallpaper());
+        const seed = data.rows.find((r) => r.kind === "seed") as ThemingSeedRow;
+        assert.ok(seed);
+        assert.strictEqual(
+            "consumerNodeIds" in seed,
+            false,
+            "seed row should not carry consumerNodeIds",
+        );
+    });
+});
+
+describe("buildSemanticsBoundsMap", () => {
+    it("returns an empty map when the payload is null or missing", () => {
+        assert.strictEqual(
+            buildSemanticsBoundsMap(null, "x").size,
+            0,
+            "null payload",
+        );
+        assert.strictEqual(
+            buildSemanticsBoundsMap(undefined, "x").size,
+            0,
+            "undefined payload",
+        );
+    });
+
+    it("walks children and parses boundsInRoot into OverlayBox bounds", () => {
+        const payload: SemanticsLookupPayload = {
+            root: {
+                nodeId: "root",
+                boundsInRoot: "0,0,100,200",
+                children: [
+                    {
+                        nodeId: "child-1",
+                        boundsInRoot: "10,10,50,40",
+                        children: [
+                            {
+                                nodeId: "grandchild",
+                                boundsInRoot: "20,20,40,30",
+                            },
+                        ],
+                    },
+                    {
+                        nodeId: "child-2",
+                        boundsInRoot: "60,10,80,40",
+                    },
+                ],
+            },
+        };
+        const map = buildSemanticsBoundsMap(payload, "theming-consumer");
+        assert.strictEqual(map.size, 4);
+        const child1 = map.get("child-1");
+        assert.ok(child1);
+        assert.strictEqual(child1!.id, "theming-consumer-child-1");
+        assert.deepStrictEqual(child1!.bounds, {
+            left: 10,
+            top: 10,
+            right: 50,
+            bottom: 40,
+        });
+        assert.strictEqual(child1!.level, "info");
+        assert.ok(map.has("grandchild"));
+    });
+
+    it("skips nodes whose boundsInRoot fails to parse", () => {
+        const payload: SemanticsLookupPayload = {
+            root: {
+                nodeId: "root",
+                boundsInRoot: "not-a-bounds-string",
+                children: [{ nodeId: "good", boundsInRoot: "0,0,10,10" }],
+            },
+        };
+        const map = buildSemanticsBoundsMap(payload, "x");
+        assert.strictEqual(map.has("root"), false);
+        assert.strictEqual(map.has("good"), true);
+    });
+});
+
+describe("consumerOverlayBoxes", () => {
+    it("returns the matching boxes in node-id order", () => {
+        const map = new Map([
+            [
+                "a",
+                {
+                    id: "x-a",
+                    bounds: { left: 0, top: 0, right: 1, bottom: 1 },
+                    level: "info" as const,
+                },
+            ],
+            [
+                "b",
+                {
+                    id: "x-b",
+                    bounds: { left: 1, top: 1, right: 2, bottom: 2 },
+                    level: "info" as const,
+                },
+            ],
+        ]);
+        const boxes = consumerOverlayBoxes(map, ["b", "a"]);
+        assert.deepStrictEqual(
+            boxes.map((b) => b.id),
+            ["x-b", "x-a"],
+        );
+    });
+
+    it("drops node ids that have no bounds entry", () => {
+        const map = new Map([
+            [
+                "a",
+                {
+                    id: "x-a",
+                    bounds: { left: 0, top: 0, right: 1, bottom: 1 },
+                    level: "info" as const,
+                },
+            ],
+        ]);
+        const boxes = consumerOverlayBoxes(map, ["a", "missing", "b"]);
+        assert.strictEqual(boxes.length, 1);
+        assert.strictEqual(boxes[0].id, "x-a");
     });
 });

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -81,11 +81,16 @@ import {
     renderPerformanceSections,
 } from "./performanceBundlePresenter";
 import {
+    buildSemanticsBoundsMap,
     computeThemingBundleData,
+    consumerOverlayBoxes,
     themingTableColumns,
+    type SemanticsLookupPayload,
     type ThemePayload,
+    type ThemingRow,
     type WallpaperPayload,
 } from "./themingBundlePresenter";
+import type { RowSelectedDetail } from "./components/DataTable";
 import {
     ambientTableColumns,
     computeAmbientBundleData,
@@ -1225,6 +1230,51 @@ export class PreviewApp extends LitElement {
                     import("./components/DataTable").DataTableColumn<unknown>
                 >,
             );
+            // Hover swatch → tint consumer nodes on the focused card.
+            // The join needs both Theming and Inspection bundles
+            // active (Theming for the consumers list, Inspection for
+            // the `compose/semantics` bounds). Hover-leave fires the
+            // same listener with `overlayId === null`; we clear the
+            // transient layer there. See #1104.
+            b.table.addEventListener("row-selected", (evt) => {
+                const det = (evt as CustomEvent<RowSelectedDetail<ThemingRow>>)
+                    .detail;
+                const focused = focusController?.focusedCard?.();
+                if (!focused) return;
+                const active = bundleController.state().activeBundles;
+                if (
+                    !active.includes("theming") ||
+                    !active.includes("inspection") ||
+                    det.row === null ||
+                    det.overlayId === null
+                ) {
+                    clearBundleBoxes(focused, "theming-consumers");
+                    return;
+                }
+                // ThemingSeedRow has no `consumerNodeIds` (the wallpaper
+                // seed isn't a per-token row) — narrow before reading.
+                const consumerIds =
+                    "consumerNodeIds" in det.row
+                        ? (det.row.consumerNodeIds ?? [])
+                        : [];
+                if (consumerIds.length === 0) {
+                    clearBundleBoxes(focused, "theming-consumers");
+                    return;
+                }
+                const focusedId = focused.dataset.previewId;
+                const byKind = focusedId
+                    ? dataProductsByPreview.get(focusedId)
+                    : undefined;
+                const semantics = byKind?.get("compose/semantics") as
+                    | SemanticsLookupPayload
+                    | undefined;
+                const boundsMap = buildSemanticsBoundsMap(
+                    semantics,
+                    "theming-consumer",
+                );
+                const boxes = consumerOverlayBoxes(boundsMap, consumerIds);
+                paintBundleBoxes(focused, "theming-consumers", boxes);
+            });
             bundleBodies.set("theming", b);
             return b;
         };
@@ -2149,7 +2199,15 @@ export class PreviewApp extends LitElement {
             if (s.activeBundles.includes("performance")) {
                 refreshPerformanceBundle();
             }
-            if (s.activeBundles.includes("theming")) refreshThemingBundle();
+            if (s.activeBundles.includes("theming")) {
+                refreshThemingBundle();
+            } else {
+                // Transient hover overlay — theming-consumers paints
+                // when a swatch row is hovered while both Theming +
+                // Inspection are active. Clear it when the chip turns
+                // off so a lingering layer doesn't survive teardown.
+                clearBundleBoxes(null, "theming-consumers");
+            }
             if (s.activeBundles.includes("display")) refreshDisplayBundle();
             if (s.activeBundles.includes("resources")) refreshResourcesBundle();
             if (s.activeBundles.includes("watch")) {
@@ -2180,6 +2238,10 @@ export class PreviewApp extends LitElement {
                 // so chip dismissal wipes every bundle-attached card
                 // surface.
                 clearBundleBoxes(null, "inspection");
+                // Inspection supplies the bounds for the theming-
+                // consumer hover overlay (#1104). With Inspection
+                // gone, any existing hover layer is stale.
+                clearBundleBoxes(null, "theming-consumers");
             }
             // Drop legend slices for bundles that are no longer
             // active so re-pressing the chip starts from a clean

--- a/vscode-extension/src/webview/preview/themingBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/themingBundlePresenter.ts
@@ -17,6 +17,8 @@
 import { html, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import type { DataTableColumn } from "./components/DataTable";
+import type { OverlayBox } from "./components/BoxOverlay";
+import { parseBounds } from "./cardData";
 
 /** Wire shape for one Material 3 typography token. Mirrors
  *  `TypographyToken` in `Material3ThemeModels.kt`. */
@@ -95,6 +97,14 @@ export interface ThemingColorRow {
     /** Number of `consumers[].nodeId` referencing this token; 0 when
      *  the wallpaper-derived scheme has no consumer data. */
     consumerCount: number;
+    /** Per-row consumer node ids referencing this token, sourced from
+     *  `theme.consumers[].nodeId` whose `tokens` array contains the
+     *  row's `name`. Empty for `wallpaper`-sourced rows (the daemon
+     *  doesn't ship per-derived-token consumers) and when the daemon
+     *  hasn't attached `consumers`. The host uses this to paint a
+     *  transient overlay on the focused card when the row is
+     *  hovered — bounds join via `compose/semantics`. */
+    consumerNodeIds: readonly string[];
     /** Provenance of this row — `theme` from `compose/theme`,
      *  `wallpaper` from the derived scheme. */
     source: ThemingColorSource;
@@ -111,6 +121,9 @@ export interface ThemingTypographyRow {
     style: string;
     lineHeight: string;
     letterSpacing: string;
+    /** Per-row consumer node ids — same shape and role as
+     *  `ThemingColorRow.consumerNodeIds`. */
+    consumerNodeIds: readonly string[];
     /** CSS `font-family` stack derived from the daemon's `FontFamily.X`
      *  toString. Used by the inline sample so the user sees the actual
      *  glyph shape rather than just the token name. */
@@ -129,6 +142,9 @@ export interface ThemingShapeRow {
     kind: "shape";
     name: string;
     value: string;
+    /** Per-row consumer node ids — same shape and role as
+     *  `ThemingColorRow.consumerNodeIds`. */
+    consumerNodeIds: readonly string[];
     /** CSS `border-radius` string derived from the shape value so the
      *  preview swatch paints the actual corner geometry. `null` when
      *  the shape couldn't be parsed (e.g. CutCornerShape, custom). */
@@ -175,7 +191,7 @@ export function computeThemingBundleData(
     previewId: string | null = null,
 ): ThemingBundleData {
     const rows: ThemingRow[] = [];
-    const consumerCount = countConsumersByToken(theme?.consumers ?? []);
+    const consumersByToken = indexConsumersByToken(theme?.consumers ?? []);
 
     // Seed + wallpaper-derived colours go first so the user reads top
     // to bottom: "this seed produced this scheme, layered into these
@@ -206,6 +222,7 @@ export function computeThemingBundleData(
                 hex,
                 swatchCss: cssColor(hex),
                 consumerCount: 0,
+                consumerNodeIds: [],
                 source: "wallpaper",
             });
         }
@@ -217,6 +234,7 @@ export function computeThemingBundleData(
     const scheme = theme?.resolvedTokens?.colorScheme ?? {};
     for (const name of Object.keys(scheme).sort()) {
         const hex = scheme[name];
+        const ids = consumersByToken.get(name) ?? [];
         rows.push({
             id: "theming-color-" + name,
             section: "Colors",
@@ -224,7 +242,8 @@ export function computeThemingBundleData(
             name,
             hex,
             swatchCss: cssColor(hex),
-            consumerCount: consumerCount.get(name) ?? 0,
+            consumerCount: ids.length,
+            consumerNodeIds: ids,
             source: "theme",
         });
     }
@@ -246,6 +265,7 @@ export function computeThemingBundleData(
                 tok.letterSpacing,
                 tok.letterSpacingUnit,
             ),
+            consumerNodeIds: consumersByToken.get(name) ?? [],
             cssFontFamily: cssFontFamily(tok.fontFamily),
             cssFontWeight: parseFontWeight(tok.fontWeight),
             cssFontStyle:
@@ -265,6 +285,7 @@ export function computeThemingBundleData(
             kind: "shape",
             name,
             value,
+            consumerNodeIds: consumersByToken.get(name) ?? [],
             previewBorderRadius: parseShapeBorderRadius(value),
         });
     }
@@ -277,6 +298,75 @@ export function computeThemingBundleData(
             wallpaper: wallpaper ?? null,
         },
     };
+}
+
+/** Lightweight view of a `compose/semantics` node carrying just the
+ *  fields the bounds-join needs. Mirrors the daemon's wire shape
+ *  (`ComposeSemanticsNode`) so callers can pass a raw payload through
+ *  without re-shaping. */
+export interface SemanticsLookupNode {
+    nodeId: string;
+    boundsInRoot: string;
+    children?: SemanticsLookupNode[];
+}
+
+/** Wire shape for `compose/semantics`; root + recursive children. */
+export interface SemanticsLookupPayload {
+    root: SemanticsLookupNode;
+}
+
+/**
+ * Build a `nodeId → OverlayBox` map from a `compose/semantics`
+ * payload. Used by the Theming and Resources bundles to paint
+ * transient hover overlays on the focused card: hovering a token row
+ * looks up the row's `consumerNodeIds` and asks this map for the
+ * bounds.
+ *
+ * Nodes whose `boundsInRoot` doesn't parse are skipped silently —
+ * the row's hover overlay simply leaves them out rather than
+ * crashing the panel.
+ *
+ * `null` / missing payload returns an empty map; callers should
+ * fall back to "no overlay" rather than rendering a phantom layer.
+ */
+export function buildSemanticsBoundsMap(
+    payload: SemanticsLookupPayload | null | undefined,
+    overlayIdPrefix: string,
+): Map<string, OverlayBox> {
+    const out = new Map<string, OverlayBox>();
+    if (!payload || !payload.root) return out;
+    const visit = (node: SemanticsLookupNode): void => {
+        const bounds = parseBounds(node.boundsInRoot);
+        if (bounds) {
+            out.set(node.nodeId, {
+                id: overlayIdPrefix + "-" + node.nodeId,
+                bounds,
+                level: "info",
+            });
+        }
+        for (const child of node.children ?? []) visit(child);
+    };
+    visit(payload.root);
+    return out;
+}
+
+/**
+ * Look [nodeIds] up in [boundsMap] and return the OverlayBoxes that
+ * have bounds. Ids without a hit are skipped silently — when the
+ * `compose/semantics` tree shrinks faster than a stale theming
+ * `consumers` array, an unmatched nodeId means "we don't know where
+ * this consumer is" and is preferable to a phantom box at (0,0).
+ */
+export function consumerOverlayBoxes(
+    boundsMap: ReadonlyMap<string, OverlayBox>,
+    nodeIds: readonly string[],
+): readonly OverlayBox[] {
+    const out: OverlayBox[] = [];
+    for (const id of nodeIds) {
+        const box = boundsMap.get(id);
+        if (box) out.push(box);
+    }
+    return out;
 }
 
 /**
@@ -428,16 +518,26 @@ function renderConsumers(row: ThemingRow): string {
     return String(row.consumerCount);
 }
 
-function countConsumersByToken(
+function indexConsumersByToken(
     consumers: readonly ThemeConsumer[],
-): Map<string, number> {
-    const counts = new Map<string, number>();
+): Map<string, readonly string[]> {
+    // First-seen order per token, deduped — a single consumer can
+    // list the same token twice (e.g. a Text that reads both
+    // `primary` and `onPrimary` from a wrapping container), but the
+    // overlay only wants one box per node.
+    const byToken = new Map<string, string[]>();
     for (const c of consumers) {
+        if (!c.nodeId) continue;
         for (const t of c.tokens ?? []) {
-            counts.set(t, (counts.get(t) ?? 0) + 1);
+            const existing = byToken.get(t);
+            if (!existing) {
+                byToken.set(t, [c.nodeId]);
+            } else if (!existing.includes(c.nodeId)) {
+                existing.push(c.nodeId);
+            }
         }
     }
-    return counts;
+    return byToken;
 }
 
 function formatScalar(


### PR DESCRIPTION
## Summary

The Theming bundle's `compose/theme` payload carries a `consumers` array that maps each token to the semantic nodes that read it. Until now the bundle table just rendered the count ("Uses: 3") and the per-node bounds-join was punted as a #1104 follow-through.

This PR adds the hover overlay: when both Theming + Inspection bundles are active and the user hovers a token row, every consumer node lights up on the focused card via a transient `data-bundle="theming-consumers"` `<box-overlay>` layer.

### Changes

- **`ThemingRow.consumerNodeIds: readonly string[]`** — populated on Color / Typography / Shape rows from a newly-indexed consumer map. Wallpaper-derived rows and the Seed summary stay empty (the daemon doesn't attach consumers to either).
- **`buildSemanticsBoundsMap(payload, prefix)`** + **`consumerOverlayBoxes(map, ids)`** helpers in `themingBundlePresenter.ts` do the bounds-join against a cached `compose/semantics` payload. Pure functions, reusable by the analogous Resources hover row (also tracked in #1104).
- **`main.ts`** wires a `row-selected` listener on the theming table: paint on hover-on, clear on hover-off, clear on chip-off of either Theming or Inspection.

Adds nine unit tests pinning the row shape (dedupe, wallpaper-empty, seed narrowing), the bounds-map walker (children + malformed bounds), and the consumer→box lookup (order + missing-id drop).

## Test plan

- [ ] `npm run compile` clean (host + webview)
- [ ] `npm test` — 1145 passing locally, including nine new cases under `ThemingRow.consumerNodeIds`, `buildSemanticsBoundsMap`, and `consumerOverlayBoxes`
- [ ] `npm run format:check` clean
- [ ] Manual: activate both Theming and Inspection chips on a CMP / Android sample, hover a colour row → confirm the consumer nodes' boxes light up; leave the row → boxes clear; turn either chip off → any lingering layer clears

Refs #1104.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9fK6gvrwKxV8ZpGdDiBZR)_