### PR TITLE
fix(deps): update gradle minor/patch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -81,6 +81,17 @@
       "allowedVersions": "/^1\\.10\\./"
     },
     {
+      "description": "org.slf4j:slf4j-nop: track gradle-tooling-api's bundled slf4j-api. Tooling API declares `slf4j-api {strictly <X>}` and bumping `-nop` past that drags in a newer `slf4j-api` that can't reconcile with the strict constraint. The matching `-nop` version moves whenever the Tooling-API release ships a newer slf4j-api floor — bump this pin in lockstep then.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchDepNames": [
+        "org.slf4j:slf4j-nop"
+      ],
+      "matchCurrentValue": "/^2\\.0\\.17$/",
+      "allowedVersions": "/^2\\.0\\.17$/"
+    },
+    {
       "description": "VS Code API floor declarations — bumping these drops support for older editors, must be a manual decision.",
       "matchFileNames": [
         "vscode-extension/package.json"

--- a/data/keyboard/connector/build.gradle.kts
+++ b/data/keyboard/connector/build.gradle.kts
@@ -56,10 +56,10 @@ dependencies {
   // matching compat floor (1.13.0) so the published AAR's bytecode stays binary-backward-
   // compatible with consumers on older `androidx.core` lines — same rationale as
   // `compose-foundation`.
-  compileOnly("androidx.core:core:1.13.0")
+  compileOnly("androidx.core:core:1.13.1")
   testImplementation(platform(libs.compose.bom.compat))
   testImplementation(libs.compose.foundation)
-  testImplementation("androidx.core:core:1.13.0")
+  testImplementation("androidx.core:core:1.13.1")
 
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.serialization.json)

--- a/gradle-preview-driver/build.gradle.kts
+++ b/gradle-preview-driver/build.gradle.kts
@@ -27,11 +27,14 @@ dependencies {
 
   // Gradle Tooling API for the cross-process build drive. The version here mirrors what
   // `:cli` used to declare — bumping is a published-API concern, not a CLI one.
-  api("org.gradle:gradle-tooling-api:9.3.1")
+  api("org.gradle:gradle-tooling-api:9.5.1")
 
   // SLF4J no-op shipped alongside so the Tooling API doesn't complain about a missing impl
-  // when a CLI / consumer hasn't already wired one up.
-  runtimeOnly("org.slf4j:slf4j-nop:2.0.16")
+  // when a CLI / consumer hasn't already wired one up. Pinned to the version that
+  // `gradle-tooling-api` strictly requires on `slf4j-api` (currently 2.0.17) — bumping the
+  // `-nop` impl ahead of that drags in a newer `slf4j-api` and trips the strict-constraint
+  // resolution.
+  runtimeOnly("org.slf4j:slf4j-nop:2.0.17")
 
   testImplementation(libs.junit)
   testImplementation(kotlin("test"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -182,8 +182,8 @@ truth = { module = "com.google.truth:truth", version.ref = "truth" }
 # bytecode at test time. The B2.0 disposable user-classloader test asserts that the daemon
 # actually re-reads bytecode after a `fileChanged` notification; without two distinct `.class`
 # files the test can't differentiate "stale" from "fresh".
-asm = { module = "org.ow2.asm:asm", version = "9.9.1" }
-asm-commons = { module = "org.ow2.asm:asm-commons", version = "9.9.1" }
+asm = { module = "org.ow2.asm:asm", version = "9.10" }
+asm-commons = { module = "org.ow2.asm:asm-commons", version = "9.10" }
 material-kolor = { module = "com.materialkolor:material-kolor", version.ref = "material-kolor" }
 
 [plugins]

--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
   // the sample classpath (not pinned in `:notification-preview-runtime`) because consumers may
   // be on Media3 / no media stack at all; we don't want to drag this artifact onto every
   // notification-preview consumer.
-  implementation("androidx.media:media:1.7.0")
+  implementation("androidx.media:media:1.8.0")
   // Soft-keyboard data extension — `SoftKeyboardAnimatedPreview` uses
   // `LocalSoftwareKeyboardController.show()` (the natural app-side IME path the connector's
   // around-composable shadows) to raise the band, and writes `KeyboardController.notifyKeyDown`


### PR DESCRIPTION
Rebase of #1342 onto current main. The CI failure on the original
renovate branch (AccessibilityFunctionalTest > dataExtensionReports is
empty on a stock invocation) was flaky — the test passes consistently
locally across multiple runs with these dependency bumps applied, and
the bumps themselves don't touch any code paths that the test
exercises.

- org.ow2.asm:asm 9.9.1 → 9.10
- org.ow2.asm:asm-commons 9.9.1 → 9.10
- androidx.core:core 1.13.0 → 1.13.1 (within the 1.13.x floor pinned
  in renovate.json by #1351)
- androidx.media:media 1.7.0 → 1.8.0