### PR TITLE
feat(data-remotecompose): add Remote Compose data extension

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -102,6 +102,19 @@ dependencies {
   // via `RobolectricHost.previewOverrideExtensions` and via the daemon's `ExtensionRegistry`
   // below.
   implementation(project(":data-permissions-connector"))
+  // Remote Compose connector — `RemoteComposeController` (process-static named-value map +
+  // host-action ring buffer + active profile state), the always-on `AroundComposable` extension
+  // that installs `LocalRemoteComposeHost` so user code inside a `RemotePreview { ... }` block
+  // can read seeded named values + the daemon-requested profile and report `HostAction` events
+  // back, the `RemoteComposePreviewOverrideExtension` planner consuming
+  // `renderNow.overrides.remoteCompose`, and the `RemoteComposeDataProductRegistry` serving the
+  // captured payload (`compose/remotecompose`). Registered on the engine via
+  // `RobolectricHost.previewOverrideExtensions` and via the daemon's `ExtensionRegistry` below;
+  // both registrations are gated on `androidx.compose.remote.*` being loadable from the sandbox
+  // classloader so plain-Android consumers without the alpha artifacts don't trip a
+  // `NoClassDefFoundError` on extension instantiation. Mirrors the
+  // `isWearAmbientAvailable`-gated `:data-ambient-connector` pattern.
+  implementation(project(":data-remotecompose-connector"))
   // Touch-event visualization connector — same module `:daemon:desktop` consumes. The
   // `TouchOverlayExtension` `AroundComposable` is pure Compose foundation/runtime so the single
   // shared JVM module works on both backends (no Android/desktop fork needed, unlike

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -371,6 +371,35 @@ fun main(args: Array<String>) {
               ),
           )
         }
+        // Remote Compose extension is gated on the consumer's classpath shipping
+        // `androidx.compose.remote.*`. The connector classes reference alpha API types at
+        // composition time (`HostAction`, `RcPlatformProfiles`); registering the extension on a
+        // non-Remote-Compose consumer would surface a confusing `NoClassDefFoundError` the first
+        // time a render fires the around-composable. Mirrors the Wear-AAR gate
+        // (`isWearAmbientAvailable`) used for `:data-ambient-connector`.
+        if (isRemoteComposeAvailable(javaClass.classLoader)) {
+          tryAdd("data/remotecompose") {
+            // Remote Compose data product. Registry serves the `compose/remotecompose` payload
+            // (named-value map applied / written during the render, ring-buffered HostAction
+            // emissions, active profile). The around-composable's `LocalRemoteComposeHost`
+            // composition local is in place on every render so a screen's `RemotePreview { ... }`
+            // block can read the daemon-seeded named values + profile and report fired actions
+            // back. `dataExtensionDescriptors` advertises the planner so the panel / MCP can
+            // discover the extension via `initialize.capabilities.dataExtensions`.
+            Extension(
+              id = "data/remotecompose",
+              displayName = "Remote Compose state + host actions",
+              dataProductRegistry = RemoteComposeDataProductRegistry(),
+              dataExtensionDescriptors =
+                listOf(
+                  DataExtensionDescriptor(
+                    id = RemoteComposeOverrideExtension.ID,
+                    displayName = "Remote Compose state + host actions",
+                  )
+                ),
+            )
+          }
+        }
         tryAdd("data/touch-overlay") {
           // Touch-event visualization overlay (`AroundComposableHook` from
           // `:data-touch-overlay-connector`) — paints a translucent ring at every active pointer

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1339,10 +1339,22 @@ open class RobolectricHost(
         } else {
           emptyList()
         }
+      // [RemoteComposePreviewOverrideExtension] instantiates [RemoteComposeOverrideExtension]
+      // every render, which reaches into `androidx.compose.remote.creation.compose.action
+      // .HostAction` / `RcPlatformProfiles` at composition time. The classloader gate skips
+      // registration on non-Remote-Compose consumers so the lazy init never tries to resolve
+      // those alpha-API types. Mirrors the Wear-AAR gate above.
+      val remoteComposeOverrides =
+        if (isRemoteComposeAvailable(javaClass.classLoader)) {
+          listOf(RemoteComposePreviewOverrideExtension())
+        } else {
+          emptyList()
+        }
       RenderEngine(
         previewOverrideExtensions =
           PreviewOverrideExtensions(
             ambientOverrides +
+              remoteComposeOverrides +
               listOf(
                 WallpaperPreviewOverrideExtension(),
                 Material3ThemePreviewOverrideExtension(),

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
@@ -141,6 +141,30 @@ internal fun isWearAmbientAvailable(loader: ClassLoader?): Boolean {
 }
 
 /**
+ * Returns `true` when `androidx.compose.remote.creation.compose.action.HostAction` is on the
+ * supplied classloader. Used to gate `:data-remotecompose-connector` registration on the consumer
+ * actually shipping the alpha `compose-remote` artifacts (`:samples:remotecompose` for the
+ * reference setup) — the connector's own classes reference these alpha types directly, so
+ * instantiating any of them on a non-Remote-Compose classpath raises `NoClassDefFoundError` at
+ * the lazy-init line. Mirrors [isWearAmbientAvailable] for the Wear ambient connector.
+ */
+internal fun isRemoteComposeAvailable(loader: ClassLoader?): Boolean {
+  val effective = loader ?: ClassLoader.getSystemClassLoader() ?: return false
+  return try {
+    Class.forName(
+      "androidx.compose.remote.creation.compose.action.HostAction",
+      false,
+      effective,
+    )
+    true
+  } catch (_: ClassNotFoundException) {
+    false
+  } catch (_: NoClassDefFoundError) {
+    false
+  }
+}
+
+/**
  * Cross-thread hints consumed by [SandboxHoldingRunner] during sandbox bootstrap. Lives at file
  * scope (not on a companion) so set/get is cheap and readable without instantiating a runner.
  *

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeClasspathDetectionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeClasspathDetectionTest.kt
@@ -1,0 +1,43 @@
+package ee.schimke.composeai.daemon
+
+import java.net.URLClassLoader
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Guards [isRemoteComposeAvailable] against the same regression class
+ * [AmbientClasspathDetectionTest] catches for Wear ambient: the
+ * `:data-remotecompose-connector` keeps `androidx.compose.remote:*` as `compileOnly`, so the
+ * daemon's main runtime classpath doesn't ship the alpha AAR. The host-side classloader probe has
+ * to return `false` for that case so DaemonMain skips registering `data/remotecompose` on
+ * plain-Android consumers (`:samples:android`) — the Robolectric sandbox classloader for a
+ * Remote-Compose-shipping consumer (`:samples:remotecompose`) gets a separate `true` answer when
+ * `RobolectricHost`'s lazy engine init asks the question via the sandbox loader. The
+ * remote-compose-positive direction is covered end-to-end on `:samples:remotecompose` —
+ * exercising it from a unit test would need the alpha AAR on the test classpath (it isn't) or a
+ * hand-rolled bytecode stub, neither of which adds meaningful coverage over the integration path.
+ */
+class RemoteComposeClasspathDetectionTest {
+
+  @Test
+  fun returnsFalseWhenRemoteComposeMissingFromLoader() {
+    val emptyLoader = URLClassLoader(emptyArray(), ClassLoader.getSystemClassLoader().parent)
+    assertFalse(
+      "HostAction must be reported absent on a classloader that does not ship it",
+      isRemoteComposeAvailable(emptyLoader),
+    )
+  }
+
+  @Test
+  fun returnsFalseWhenLoaderIsNullAndSystemClasspathLacksRemoteCompose() {
+    // The daemon/android module declares :data-remotecompose-connector as `implementation` and
+    // the connector keeps the alpha compose-remote artifacts as `compileOnly`, so the unit-test
+    // classpath here doesn't include `HostAction`. If that ever changes (a transitive bumps it
+    // onto the test runtime), this test starts failing — at which point the alpha AAR has crept
+    // into the daemon's main runtime classpath and the gating logic needs revisiting.
+    assertFalse(
+      "Daemon test classpath unexpectedly ships androidx.compose.remote.creation",
+      isRemoteComposeAvailable(null),
+    )
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PermissionsOverride
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
 import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.daemon.protocol.WallpaperOverride
 
@@ -33,6 +34,7 @@ data class PreviewOverrideBaseSpec(
   val focus: FocusOverride? = null,
   val touchOverlay: Boolean? = null,
   val permissions: PermissionsOverride? = null,
+  val remoteCompose: RemoteComposeOverride? = null,
 )
 
 data class MergedPreviewOverrides(
@@ -51,6 +53,7 @@ data class MergedPreviewOverrides(
   val focus: FocusOverride?,
   val touchOverlay: Boolean?,
   val permissions: PermissionsOverride?,
+  val remoteCompose: RemoteComposeOverride?,
 ) {
   /**
    * Project the merged overrides down to a [PreviewOverrides] bag that only carries fields
@@ -74,6 +77,7 @@ data class MergedPreviewOverrides(
         focus == null &&
         touchOverlay != true &&
         permissions == null &&
+        remoteCompose == null &&
         !isPseudolocale
     ) {
       return null
@@ -86,6 +90,7 @@ data class MergedPreviewOverrides(
       localeTag = if (isPseudolocale) localeTag else null,
       touchOverlay = touchOverlay,
       permissions = permissions,
+      remoteCompose = remoteCompose,
     )
   }
 }
@@ -131,6 +136,7 @@ fun mergePreviewOverrides(
       focus = base.focus,
       touchOverlay = base.touchOverlay,
       permissions = base.permissions,
+      remoteCompose = base.remoteCompose,
     )
   }
   val deviceOverride = overrides.device?.takeIf { it.isNotBlank() }
@@ -158,5 +164,6 @@ fun mergePreviewOverrides(
     focus = overrides.focus ?: base.focus,
     touchOverlay = overrides.touchOverlay ?: base.touchOverlay,
     permissions = overrides.permissions ?: base.permissions,
+    remoteCompose = overrides.remoteCompose ?: base.remoteCompose,
   )
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -506,6 +506,25 @@ data class PreviewOverrides(
    * `"android.permission.CAMERA"`). Android-only — the desktop backend ignores this field.
    */
   val permissions: PermissionsOverride? = null,
+  /**
+   * Optional Remote Compose override. Drives the connector-side `RemoteComposeOverrideExtension`
+   * (see `:data-remotecompose-connector`). The around-composable installs a
+   * `LocalRemoteComposeHost` composition local that user code inside a `RemotePreview { ... }`
+   * block consults to:
+   *
+   * * read the daemon-requested [RemoteComposeOverride.profile] (passed to `RemotePreview(profile =
+   *   …)`) and named-value seeds in [RemoteComposeOverride.namedValues] (bound to remote
+   *   `RemoteFloat` / `RemoteString` etc.),
+   * * push named-value writes back to the daemon (`data/fetch?kind=compose/remotecompose` returns
+   *   the current map), and
+   * * report `HostAction` events the remote runtime fires so the daemon can surface them through
+   *   the same data product.
+   *
+   * Sending a fresh `remoteCompose` on a subsequent `renderNow` updates the seeded state — the
+   * "live update" path the Remote Compose data product covers. Android-only; the desktop backend
+   * has no Remote Compose runtime and ignores this field.
+   */
+  val remoteCompose: RemoteComposeOverride? = null,
 )
 
 /**
@@ -692,6 +711,109 @@ enum class WallpaperPaletteStyle {
   @SerialName("fidelity") FIDELITY,
   @SerialName("content") CONTENT,
 }
+
+/**
+ * Remote Compose override for previews. Drives the connector-side `RemoteComposeOverrideExtension`
+ * (see `:data-remotecompose-connector`).
+ *
+ * Three facets, all optional:
+ *
+ * * [profile] — the `RcPlatformProfiles` variant the host wants the remote document compiled
+ *   against (`ANDROIDX` / `CORE_WATCH` / `CORE_WIDGET`). User code reads this from
+ *   `LocalRemoteComposeHost.current.profile` and passes it to `RemotePreview(profile = …)`.
+ * * [namedValues] — daemon-side seeds for named state variables in the remote document. Keys are
+ *   the names the user code binds (`LocalRemoteComposeHost.current.namedFloat("score", default =
+ *   0f)`) and values are typed via the [RemoteNamedValue] sum. A fresh `renderNow.overrides
+ *   .remoteCompose` with a different map replaces the seeded values; entries not present in the new
+ *   map fall back to the user code's defaults.
+ * * [acceptedHostActions] — when non-null, restricts the set of `HostAction` ids the connector
+ *   captures (insertion-recorded for `data/fetch?kind=compose/remotecompose`). Null captures every
+ *   action user code reports.
+ *
+ * Android-only — the desktop backend has no Remote Compose runtime and ignores this field.
+ */
+@Serializable
+data class RemoteComposeOverride(
+  val profile: RemoteComposeProfile? = null,
+  val namedValues: Map<String, RemoteNamedValue> = emptyMap(),
+  val acceptedHostActions: List<String>? = null,
+)
+
+/**
+ * Platform profile the remote document is compiled against. Mirrors
+ * `androidx.compose.remote.creation.profile.RcPlatformProfiles` — the connector maps each value to
+ * the upstream `Profile` constant at render time so the protocol stays free of the alpha API.
+ *
+ * Values match the names in `RcPlatformProfiles` (Compose Remote `1.0.0-alpha010`):
+ *
+ * * [ANDROIDX] — the rolling "latest" AndroidX profile (currently aliased to the newest
+ *   `ANDROIDX9`). Use this when you want the same target the live AndroidX runtime expects.
+ * * [ANDROIDX7] / [ANDROIDX8] / [ANDROIDX9] — pinned AndroidX revisions. Sending a pinned value
+ *   freezes the operation set the document gets compiled against, useful for regression captures
+ *   where a moving "latest" would re-baseline silently.
+ * * [WIDGETS_V6] / [WIDGETS_V7] — the platform-widgets profile floor that ships in Android-platform
+ *   widget hosts. Documents targeting these stay compatible with hosts that haven't rolled a fresh
+ *   `androidx` profile.
+ * * [WEAR_WIDGETS] — Wear-OS-specific widget profile (smaller operation surface for tile / watch-
+ *   face hosts).
+ */
+@Serializable
+enum class RemoteComposeProfile {
+  @SerialName("androidx") ANDROIDX,
+  @SerialName("androidx7") ANDROIDX7,
+  @SerialName("androidx8") ANDROIDX8,
+  @SerialName("androidx9") ANDROIDX9,
+  @SerialName("widgetsV6") WIDGETS_V6,
+  @SerialName("widgetsV7") WIDGETS_V7,
+  @SerialName("wearWidgets") WEAR_WIDGETS,
+}
+
+/**
+ * Typed named-value variant for the Remote Compose extension. Mirrors the Compose Remote DSL's own
+ * typed state APIs (`.rf` / `.rs` / `.rb` / `.rdp` / `RemoteColor`) so the wire shape carries the
+ * same type fidelity. The connector picks the matching binding (`RemoteFloat`, `RemoteString`,
+ * `RemoteBoolean`, `RemoteInt`, `RemoteColor`) when seeding into the live remote runtime.
+ *
+ * `@JsonClassDiscriminator("kind")` so JSON payloads look like `{ "kind": "float", "value": 1.5 }`
+ * rather than carrying the polymorphic class name.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+@kotlinx.serialization.json.JsonClassDiscriminator("kind")
+sealed class RemoteNamedValue {
+  /** Single-precision float. Matches `Float.rf` / `RemoteFloat`. */
+  @Serializable @SerialName("float") data class FloatValue(val value: Float) : RemoteNamedValue()
+
+  /**
+   * Density-independent pixel measurement. Carries the raw dp value; the connector wraps with
+   * `.rdp` at bind time so user code can read it as a `RemoteFloat` representing the dp.
+   */
+  @Serializable @SerialName("dp") data class DpValue(val value: Float) : RemoteNamedValue()
+
+  /** 32-bit integer. Matches `Int.rint` / `RemoteInt`. */
+  @Serializable @SerialName("int") data class IntValue(val value: Int) : RemoteNamedValue()
+
+  /** UTF-8 string. Matches `String.rs` / `RemoteString`. */
+  @Serializable @SerialName("string") data class StringValue(val value: String) : RemoteNamedValue()
+
+  /** Boolean flag. Matches `Boolean.rb` / `RemoteBoolean`. */
+  @Serializable @SerialName("bool") data class BooleanValue(val value: Boolean) : RemoteNamedValue()
+
+  /** Color as `#AARRGGBB`. Matches `RemoteColor(Color(...))`. */
+  @Serializable @SerialName("color") data class ColorValue(val argb: String) : RemoteNamedValue()
+}
+
+/**
+ * Wire shape of a `HostAction` event the remote document fired, captured for later inspection via
+ * `data/fetch?kind=compose/remotecompose`. Mirrors the
+ * `androidx.compose.remote.creation.compose.action.HostAction(payload: RemoteString, handlerId:
+ * RemoteFloat)` constructor — both fields surface unwrapped here.
+ *
+ * `firedAtMillis` is the receiver-side wall-clock at the moment the action was recorded so
+ * downstream consumers can order events without needing the remote runtime's own clock model.
+ */
+@Serializable
+data class RemoteHostAction(val payload: String, val handlerId: Float, val firedAtMillis: Long = 0L)
 
 @Serializable
 data class Material3ThemeOverrides(

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
@@ -6,6 +6,9 @@ import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
 import ee.schimke.composeai.daemon.protocol.PermissionsOverride
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
+import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.daemon.protocol.UiMode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -136,6 +139,32 @@ class PreviewOverrideMergeTest {
 
     assertEquals(override, merged.permissions)
     assertEquals(override, merged.toExtensionOverrides()?.permissions)
+  }
+
+  @Test
+  fun `remoteCompose override merges into the bag and flows through toExtensionOverrides`() {
+    val base =
+      PreviewOverrideBaseSpec(
+        widthPx = 320,
+        heightPx = 480,
+        density = 2.0f,
+        device = null,
+        localeTag = null,
+        fontScale = null,
+        uiMode = null,
+        orientation = null,
+        inspectionMode = null,
+      )
+
+    val override =
+      RemoteComposeOverride(
+        profile = RemoteComposeProfile.ANDROIDX,
+        namedValues = mapOf("score" to RemoteNamedValue.FloatValue(0.5f)),
+      )
+    val merged = mergePreviewOverrides(base, PreviewOverrides(remoteCompose = override))
+
+    assertEquals(override, merged.remoteCompose)
+    assertEquals(override, merged.toExtensionOverrides()?.remoteCompose)
   }
 
   @Test

--- a/data/remotecompose/connector/build.gradle.kts
+++ b/data/remotecompose/connector/build.gradle.kts
@@ -1,0 +1,132 @@
+// `:data-remotecompose-connector` glues `:data-remotecompose-core` (the wire-shape) to the daemon's
+// data-product / preview-override surface. Mirrors `:data-permissions-connector` / `:data-keyboard
+// -connector` — payload identity in the core module, daemon-side machinery (controller, around-
+// composable extension, planner, data product registry) here. Ships:
+//
+//  - `RemoteComposeController` — process-static state holder for the named-value map, the host-
+//    action ring buffer, and the active profile. Writers: the around-composable seeding from
+//    `RemoteComposeOverride`, and user code calling into `LocalRemoteComposeHost.current` from
+//    inside its `RemotePreview { ... }` block.
+//  - `RemoteComposeOverrideExtension` / `RemoteComposePreviewOverrideExtension` —
+//    `AroundComposable` plumbing that installs `LocalRemoteComposeHost` so user code can read the
+//    daemon-requested profile + seeded named values and report fired `HostAction`s back. Planner
+//    is always-on (like `KeyboardPreviewOverrideExtension`) so the composition local is in place
+//    on every render — a screen that only later begins using Remote Compose state still finds the
+//    host wired without needing a fresh override.
+//  - `RemoteComposeDataProductRegistry` — `compose/remotecompose` registry serving the captured
+//    payload (effective named values + host action buffer + active profile).
+//
+// Android-library because the public adapters bridge to `androidx.compose.remote.creation.compose
+// .action.HostAction` and `androidx.compose.remote.creation.profile.RcPlatformProfiles`. The
+// alpha `compose-remote` artifacts declare `minCompileSdk = 37`, so this module overrides the
+// repo-wide `compileSdk = 36` default from `composeai.android-conventions`. Daemon modules at
+// compileSdk 36 still consume the connector AAR because the alpha-API deps are `compileOnly`
+// (they never reach the daemon's resolved compile classpath); the connector class files are
+// loaded only when a consumer that itself depends on `compose-remote` (e.g. `:samples:
+// remotecompose`) lights up the around-composable, at which point the consumer's runtime
+// classpath supplies the missing types. `:daemon:android`'s registration guards on classloader
+// availability before registering the extension, mirroring the `:data-ambient-connector` /
+// Wear-AAR pattern.
+
+plugins {
+  id("composeai.maven-publishing")
+  id("composeai.android-conventions")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.compose.compiler)
+}
+
+android {
+  namespace = "ee.schimke.composeai.data.remotecompose.connector"
+  // The alpha `compose-remote` AARs (`androidx.compose.remote:remote-creation`,
+  // `:remote-creation-compose`, `:remote-tooling-preview` at `1.0.0-alpha010`) declare
+  // `minCompileSdk = 37` in their AAR metadata, so this module compiles against API 37 to see
+  // their types directly. Override the conventions plugin's `compileSdk = 36` default applied
+  // before this block runs. Same pattern `:samples:remotecompose` / `:samples:android-alpha` use
+  // for their alpha-channel pins.
+  compileSdk = 37
+  // The alpha artifacts also require `minSdk >= 29` at runtime. Override the conventions plugin's
+  // `minSdk = 24` default; previews referencing `RemotePreview { ... }` are themselves gated to
+  // `minSdk = 29` consumers (`:samples:remotecompose` for the reference setup) so this floor
+  // matches the smallest deployable target.
+  defaultConfig {
+    minSdk = 29
+    // Tell AGP this AAR is consumable from compileSdk 36 even though we compile against 37.
+    // Our `compileOnly` deps on `androidx.compose.remote.*` mean the connector's bytecode
+    // references alpha-API types, but those types are NOT propagated to consumers (so
+    // daemon:android at compileSdk 36 doesn't see them in its compile classpath). The runtime
+    // classloader gate (`isRemoteComposeAvailable` in `:daemon:android`) handles the case where
+    // the consumer's runtime classpath lacks compose-remote. Without this override AGP's AAR
+    // metadata check ("requires libraries and applications that depend on it to compile against
+    // version 37 or later") blocks consumption from daemon:android.
+    aarMetadata { minCompileSdk = 36 }
+  }
+  // The connector's around-composable references `androidx.compose.remote.creation.*` types
+  // marked `@RestrictTo(LIBRARY_GROUP)`. Match the `:samples:remotecompose` workaround: source-
+  // level `@file:Suppress("RestrictedApiAndroidX")` quiets the IDE, but AGP's lint runs the
+  // `RestrictedApi` check separately. AndroidX's own samples disable the lint id; we follow.
+  lint { disable += "RestrictedApi" }
+}
+
+dependencies {
+  // Wire-shape + product-kind constants. Re-exported via `api` so consumers (`:daemon:android`)
+  // can refer to `RemoteComposePayload` / `RemoteComposeProduct.KIND` without adding a second
+  // `project` dependency.
+  api(project(":data-remotecompose-core"))
+
+  // DataProductRegistry interface, DataExtension, AroundComposableExtension. Re-exported via
+  // `api` so the connector's planner / extension classes can be referenced from
+  // `RobolectricHost`'s `previewOverrideExtensions` list.
+  api(project(":daemon:core"))
+  api(project(":data-render-core"))
+  api(project(":data-render-compose"))
+
+  // Compose runtime + UI for `Composable`, `compositionLocalOf`, `CompositionLocalProvider`,
+  // `DisposableEffect`, `mutableStateOf`. `compileOnly` matches the pattern across other
+  // connectors — the consumer always brings its own Compose through its BOM.
+  compileOnly(platform(libs.compose.bom.compat))
+  compileOnly(libs.compose.runtime)
+  compileOnly(libs.compose.ui)
+  testImplementation(platform(libs.compose.bom.compat))
+  testImplementation(libs.compose.runtime)
+  testImplementation(libs.compose.ui)
+
+  // Alpha `compose-remote` artifacts. `compileOnly` so they don't surface in the connector AAR's
+  // resolved compile classpath for downstream consumers — `:daemon:android` stays at compileSdk
+  // 36 because it never sees these types directly, only the connector's own classes that
+  // reference them. Runtime resolution happens through the consumer's classpath (e.g.
+  // `:samples:remotecompose` already depends on these artifacts at 1.0.0-alpha010); when the
+  // consumer doesn't, `:daemon:android`'s registration step guards on classloader availability
+  // and skips the extension.
+  //
+  // The version coordinate is pinned to `compose-remote = 1.0.0-alpha010` in
+  // `libs.versions.toml`. `wear-compose-remote-material3` is intentionally NOT a dep here — the
+  // connector deals in the lower-level creation API (`HostAction`, `RemoteContext`,
+  // `RcPlatformProfiles`); the Wear Material 3 components live with consumer preview code.
+  compileOnly(libs.compose.remote.creation)
+  compileOnly(libs.compose.remote.creation.compose)
+  compileOnly(libs.compose.remote.tooling.preview)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.kotlinx.serialization.json)
+}
+
+mavenPublishing {
+  configure(
+    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
+      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
+      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
+      variant = "release",
+    )
+  )
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-remotecompose-connector",
+    displayName = "Compose Preview - Remote Compose Data Product Connector",
+    description =
+      "Daemon-side Remote Compose data-product connector: lets `renderNow.overrides.remoteCompose` seed named values + a profile into a `RemotePreview { ... }` block, captures HostAction events the remote runtime fires, and surfaces it all through `data/fetch?kind=compose/remotecompose`.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
@@ -1,0 +1,145 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
+import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
+import ee.schimke.composeai.daemon.protocol.RemoteHostAction
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.remotecompose.RemoteComposePayload
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Process-static state holder for the Remote Compose connector.
+ *
+ * Four responsibilities:
+ *
+ * 1. **Named-value map** — the effective name -> [RemoteNamedValue] map for the current render.
+ *    Snapshot-state so user code reading a value through `LocalRemoteComposeHost.current
+ *    .namedFloat(...)` recomposes when the daemon pushes a fresh
+ *    `renderNow.overrides.remoteCompose.namedValues` (or when user code writes back via
+ *    [setNamedValue]).
+ * 2. **Host-action buffer** — ring-buffered list of [RemoteHostAction]s the remote runtime fired.
+ *    Bounded by [RemoteComposePayload.HOST_ACTION_BUFFER_SIZE] so a runaway emitter doesn't grow
+ *    unboundedly. Each emission also fires registered [listeners] so a live
+ *    `data/subscribe(kind=compose/remotecompose)` session pushes the event to the panel without
+ *    waiting for the next render.
+ * 3. **Active profile** — the [RemoteComposeProfile] the override last requested; null when no
+ *    override is active. User code reads this via `LocalRemoteComposeHost.current.profile` and
+ *    passes it to `RemotePreview(profile = …)`.
+ * 4. **Accepted-action filter** — when the override carries [RemoteComposeOverride
+ *    .acceptedHostActions], the controller only records actions whose `payload` is in the set.
+ *    Null accepts everything. Lets a panel client constrain capture to events it actually wants
+ *    surfaced without depending on remote-code-side filtering.
+ *
+ * Reads happen only from inside [RemoteComposeOverrideExtension.AroundComposable] (and from
+ * `RemoteComposeDataProductRegistry.onRender`), which observe the snapshot-state via Compose's
+ * normal subscription pipeline. Writers can be on any thread — the daemon's render thread for
+ * `renderNow.overrides.remoteCompose` seeding, the composition thread for in-frame
+ * [setNamedValue] / [recordHostAction] calls. Snapshot-state and `CopyOnWriteArrayList` carry
+ * the cross-thread propagation.
+ */
+object RemoteComposeController {
+
+  private val namedValuesState: MutableState<Map<String, RemoteNamedValue>> =
+    mutableStateOf(emptyMap())
+
+  private val hostActionsState: MutableState<List<RemoteHostAction>> = mutableStateOf(emptyList())
+
+  private val profileState: MutableState<RemoteComposeProfile?> = mutableStateOf(null)
+
+  /**
+   * Optional allow-list for [recordHostAction]. `null` accepts every action; non-null filters by
+   * `payload` membership. Snapshot of the override's `acceptedHostActions`.
+   */
+  @Volatile private var acceptedActionPayloads: Set<String>? = null
+
+  /** Hooks notified whenever the named-value map or host-action buffer changes. */
+  private val listeners: MutableList<() -> Unit> = CopyOnWriteArrayList()
+
+  val namedValues: State<Map<String, RemoteNamedValue>>
+    get() = namedValuesState
+
+  val hostActions: State<List<RemoteHostAction>>
+    get() = hostActionsState
+
+  val profile: State<RemoteComposeProfile?>
+    get() = profileState
+
+  /**
+   * Read [name]'s current value, or `null` if no override / write has bound it. Caller decides the
+   * default (the `LocalRemoteComposeHost.namedFloat(name, default)` helpers default to the user-
+   * supplied fallback when this returns null).
+   */
+  fun valueOf(name: String): RemoteNamedValue? = namedValuesState.value[name]
+
+  /**
+   * Apply a fresh override. Replaces the entire named-value map, the active profile, and the
+   * accepted-action filter — a follow-up `renderNow.overrides.remoteCompose` with `namedValues =
+   * mapOf("score" to FloatValue(0f))` drops anything previously seeded that isn't in the new map.
+   * Matches `KeyboardController.seed` / `PermissionsController.set` semantics. `null` clears
+   * everything (empty map / no profile / accept-all filter).
+   *
+   * Does NOT clear the host-action buffer — captured events persist across overrides so a panel
+   * pushing a new seed mid-session keeps the audit trail of what fired before. Use
+   * [resetForNewSession] to drop both state and buffer.
+   */
+  fun set(override: RemoteComposeOverride?) {
+    namedValuesState.value = override?.namedValues ?: emptyMap()
+    profileState.value = override?.profile
+    acceptedActionPayloads = override?.acceptedHostActions?.toSet()
+    listeners.toList().forEach { it() }
+  }
+
+  /**
+   * Push a named-value write back from user code (typically from inside a `RemotePreview` block
+   * after the remote runtime computed a new value). Merges into the existing map rather than
+   * replacing — daemon-seeded entries the user code didn't touch stay intact. Idempotent: writing
+   * the same value twice doesn't notify listeners.
+   */
+  fun setNamedValue(name: String, value: RemoteNamedValue) {
+    val current = namedValuesState.value
+    if (current[name] == value) return
+    namedValuesState.value = current + (name to value)
+    listeners.toList().forEach { it() }
+  }
+
+  /**
+   * Record a `HostAction` emission. Filtered against the override's [RemoteComposeOverride
+   * .acceptedHostActions] set when present (null accepts every action). The ring buffer is capped
+   * at [RemoteComposePayload.HOST_ACTION_BUFFER_SIZE] entries — once full, the oldest entry drops
+   * on each new append so the most recent activity always wins. Listeners fire after every
+   * accepted entry so a `data/subscribe(kind=compose/remotecompose)` session sees the event
+   * without waiting for the next render.
+   */
+  fun recordHostAction(action: RemoteHostAction) {
+    val accepted = acceptedActionPayloads
+    if (accepted != null && action.payload !in accepted) return
+    val current = hostActionsState.value
+    val next =
+      if (current.size < RemoteComposePayload.HOST_ACTION_BUFFER_SIZE) current + action
+      else current.drop(current.size - RemoteComposePayload.HOST_ACTION_BUFFER_SIZE + 1) + action
+    hostActionsState.value = next
+    listeners.toList().forEach { it() }
+  }
+
+  /** Register a callback fired on every state change. Returns an unregister handle. */
+  fun addChangeListener(listener: () -> Unit): () -> Unit {
+    listeners.add(listener)
+    return { listeners.remove(listener) }
+  }
+
+  /**
+   * Cleanup hook for per-session reset (interactive close, recording stop, sandbox recycle). Drops
+   * the named-value map, the host-action buffer, and the active profile so the next preview
+   * starts fresh. Mirrors `KeyboardController.resetForNewSession` /
+   * `PermissionsController.resetForNewSession`.
+   */
+  fun resetForNewSession() {
+    namedValuesState.value = emptyMap()
+    hostActionsState.value = emptyList()
+    profileState.value = null
+    acceptedActionPayloads = null
+  }
+}

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProduct.kt
@@ -1,0 +1,356 @@
+@file:Suppress("RestrictedApiAndroidX")
+
+package ee.schimke.composeai.daemon
+
+import androidx.compose.remote.creation.compose.action.HostAction
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.profile.Profile
+import androidx.compose.remote.creation.profile.RcPlatformProfiles
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
+import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
+import ee.schimke.composeai.daemon.protocol.RemoteHostAction
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.remotecompose.RemoteComposePayload
+import ee.schimke.composeai.data.remotecompose.RemoteComposeProduct
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.extensions.DataExtension
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Compose composition local exposing the live Remote Compose state to consumer screens. Wired by
+ * [RemoteComposeOverrideExtension.AroundComposable] for every render so user code rendering a
+ * `RemotePreview { ... }` block can:
+ *
+ *  * read [RemoteComposeHost.profile] (the daemon-requested platform profile) and pass it to the
+ *    `RemotePreview(profile = …)` call,
+ *  * read seeded named values via the typed `namedFloat` / `namedString` / `namedBoolean` /
+ *    `namedInt` / `namedColor` helpers and bind them to a remote `RemoteFloat` / `RemoteString` /
+ *    etc.,
+ *  * report `HostAction` events the remote runtime fires through `reportHostAction(...)`.
+ *
+ * The composition local is always provided — even if no `renderNow.overrides.remoteCompose` was
+ * sent — so user code can speculatively consult the host without crashing. When no override is
+ * active, all reads fall back to the user-supplied defaults and the host action sink silently
+ * accumulates events for the next `data/fetch`.
+ */
+val LocalRemoteComposeHost = compositionLocalOf<RemoteComposeHost> { ControllerRemoteComposeHost }
+
+/**
+ * Façade over [RemoteComposeController] for consumer code. Sealed (via the `compose` package
+ * visibility on the controller) so future facets (e.g. per-name change subscriptions, scoped host-
+ * action sinks for nested `RemotePreview` blocks) can land without breaking the call shape.
+ */
+interface RemoteComposeHost {
+  /** Active platform profile the daemon requested, or `null` if no override is set. */
+  val profile: RemoteComposeProfile?
+
+  /**
+   * Read [name]'s current daemon-seeded float, or [default] when no value is bound (or when the
+   * bound value isn't a [RemoteNamedValue.FloatValue] / [RemoteNamedValue.DpValue]). Records the
+   * binding so a fresh override carrying this name triggers a recomposition.
+   */
+  @Composable fun namedFloat(name: String, default: Float): Float
+
+  /** Same as [namedFloat] for booleans. */
+  @Composable fun namedBoolean(name: String, default: Boolean): Boolean
+
+  /** Same as [namedFloat] for ints. */
+  @Composable fun namedInt(name: String, default: Int): Int
+
+  /** Same as [namedFloat] for strings. */
+  @Composable fun namedString(name: String, default: String): String
+
+  /** Same as [namedFloat] for colors. Returns the `#AARRGGBB` form so user code can parse. */
+  @Composable fun namedColor(name: String, default: String): String
+
+  /**
+   * Push a value computed by the remote runtime back into the controller so the next
+   * `data/fetch?kind=compose/remotecompose` returns it. Use from inside a `RemotePreview` block
+   * after the remote computation lands a new value the host should observe.
+   */
+  fun setNamedValue(name: String, value: RemoteNamedValue)
+
+  /**
+   * Report a `HostAction` emission. User code typically wires this in two places: (1) at preview
+   * construction time, capturing the [HostAction] payload/handlerId it built so the daemon knows
+   * what actions the document carries, and (2) at runtime, calling this from the click callback
+   * that wraps the remote `onClick = hostAction` binding. The connector filters by the override's
+   * accepted-actions list before recording.
+   */
+  fun reportHostAction(action: RemoteHostAction)
+}
+
+private object ControllerRemoteComposeHost : RemoteComposeHost {
+  override val profile: RemoteComposeProfile?
+    get() = RemoteComposeController.profile.value
+
+  @Composable
+  override fun namedFloat(name: String, default: Float): Float {
+    val current by RemoteComposeController.namedValues
+    return when (val v = current[name]) {
+      is RemoteNamedValue.FloatValue -> v.value
+      is RemoteNamedValue.DpValue -> v.value
+      is RemoteNamedValue.IntValue -> v.value.toFloat()
+      else -> default
+    }
+  }
+
+  @Composable
+  override fun namedBoolean(name: String, default: Boolean): Boolean {
+    val current by RemoteComposeController.namedValues
+    return (current[name] as? RemoteNamedValue.BooleanValue)?.value ?: default
+  }
+
+  @Composable
+  override fun namedInt(name: String, default: Int): Int {
+    val current by RemoteComposeController.namedValues
+    return when (val v = current[name]) {
+      is RemoteNamedValue.IntValue -> v.value
+      is RemoteNamedValue.FloatValue -> v.value.toInt()
+      else -> default
+    }
+  }
+
+  @Composable
+  override fun namedString(name: String, default: String): String {
+    val current by RemoteComposeController.namedValues
+    return (current[name] as? RemoteNamedValue.StringValue)?.value ?: default
+  }
+
+  @Composable
+  override fun namedColor(name: String, default: String): String {
+    val current by RemoteComposeController.namedValues
+    return (current[name] as? RemoteNamedValue.ColorValue)?.argb ?: default
+  }
+
+  override fun setNamedValue(name: String, value: RemoteNamedValue) {
+    RemoteComposeController.setNamedValue(name, value)
+  }
+
+  override fun reportHostAction(action: RemoteHostAction) {
+    RemoteComposeController.recordHostAction(action)
+  }
+}
+
+/**
+ * Maps a protocol [RemoteComposeProfile] to the upstream
+ * `androidx.compose.remote.creation.profile.Profile` constant carried by
+ * [RcPlatformProfiles]. Exposed so user code passing
+ * `LocalRemoteComposeHost.current.profile?.toRcPlatformProfile()` to `RemotePreview(profile = …)`
+ * doesn't need to fork the enum mapping.
+ *
+ * `RcPlatformProfiles` itself is a holder class with `static final Profile` fields — the
+ * `RemotePreview` API takes a `Profile`, not the holder. Match the sample's call site:
+ * `RemotePreview(profile = RcPlatformProfiles.ANDROIDX)` is implicitly passing
+ * `RcPlatformProfiles.ANDROIDX` (a `Profile`), so this returns the same.
+ */
+fun RemoteComposeProfile.toRcPlatformProfile(): Profile =
+  when (this) {
+    RemoteComposeProfile.ANDROIDX -> RcPlatformProfiles.ANDROIDX
+    RemoteComposeProfile.ANDROIDX7 -> RcPlatformProfiles.ANDROIDX7
+    RemoteComposeProfile.ANDROIDX8 -> RcPlatformProfiles.ANDROIDX8
+    RemoteComposeProfile.ANDROIDX9 -> RcPlatformProfiles.ANDROIDX9
+    RemoteComposeProfile.WIDGETS_V6 -> RcPlatformProfiles.WIDGETS_V6
+    RemoteComposeProfile.WIDGETS_V7 -> RcPlatformProfiles.WIDGETS_V7
+    RemoteComposeProfile.WEAR_WIDGETS -> RcPlatformProfiles.WEAR_WIDGETS
+  }
+
+/**
+ * Build a `HostAction` from the protocol payload. Mirrors the alpha API's constructor —
+ * `HostAction(payload: RemoteString, handlerId: RemoteFloat)` — wrapping the wire `(String,
+ * Float)` pair via the same `.rs` / `.rf` helpers the sample uses. Useful for user code that
+ * wants to materialise a daemon-supplied action descriptor into a live `RemoteButton(onClick =
+ * …)`.
+ */
+fun RemoteHostAction.toHostAction(): HostAction = HostAction(payload.rs, handlerId.rf)
+
+/**
+ * `AroundComposable` extension that owns the Remote Compose surface. The extension is **always
+ * active** — the planner emits an instance for every render so [LocalRemoteComposeHost] is in
+ * scope regardless of whether the client sent an explicit `RemoteComposeOverride`. User code that
+ * speculatively reads `LocalRemoteComposeHost.current.namedFloat("score", default = 0f)` always
+ * gets a sensible answer.
+ *
+ * Lifecycle:
+ *
+ * * On enter — [RemoteComposeController.set] is called with the seed (clears the map / profile
+ *   when null). `DisposableEffect(seed)` re-runs only when the override identity changes, so a
+ *   subsequent `renderNow.overrides.remoteCompose` with the same shape doesn't churn.
+ * * On dispose — clears the override and any captured host-action buffer (`resetForNewSession`).
+ *   Matches `KeyboardOverrideExtension` / `PermissionsOverrideExtension` semantics.
+ *
+ * Runs in [DataExtensionPhase.OuterEnvironment] so the composition local is in place before the
+ * user-environment phase reaches preview content — `RemotePreview` blocks composed by user code
+ * see the host.
+ */
+class RemoteComposeOverrideExtension(private val seed: RemoteComposeOverride? = null) :
+  AroundComposableExtension(
+    id = ID,
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.OuterEnvironment,
+        provides = setOf(DataExtensionCapability(RemoteComposeDataProductRegistry.KIND)),
+      ),
+  ) {
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    DisposableEffect(seed) {
+      RemoteComposeController.set(seed)
+      onDispose { RemoteComposeController.resetForNewSession() }
+    }
+    CompositionLocalProvider(LocalRemoteComposeHost provides ControllerRemoteComposeHost) {
+      content()
+    }
+  }
+
+  companion object {
+    val ID: DataExtensionId = DataExtensionId(RemoteComposeDataProductRegistry.KIND)
+  }
+}
+
+/**
+ * Planner that maps `renderNow.overrides.remoteCompose` to a [RemoteComposeOverrideExtension].
+ * **Always** returns a non-null extension — like `KeyboardPreviewOverrideExtension` /
+ * `PermissionsPreviewOverrideExtension`. The around-composable's [LocalRemoteComposeHost] needs
+ * to be in place on every render so a screen that consults the host (or one whose embedded
+ * `RemotePreview` block reads the profile / named values) reaches the controller's tracking path.
+ */
+class RemoteComposePreviewOverrideExtension : DataExtension<PreviewOverrides> {
+  override val id: DataExtensionId = RemoteComposeOverrideExtension.ID
+
+  override fun plan(request: PreviewOverrides): PlannedDataExtension =
+    RemoteComposeOverrideExtension(seed = request.remoteCompose)
+}
+
+/**
+ * Daemon-side registry adapter for `compose/remotecompose`.
+ *
+ * The registry tracks three facets per preview id:
+ *
+ * * The effective named-value map applied / written during the latest render.
+ * * The captured host-action ring buffer (insertion order preserved, capped at
+ *   [RemoteComposePayload.HOST_ACTION_BUFFER_SIZE]).
+ * * The active platform profile.
+ *
+ * A `data/fetch` after a Remote Compose-aware render returns the combined payload; before any
+ * render or after [clear], it returns [DataProductRegistry.Outcome.NotAvailable]. Clients update
+ * the state by sending a fresh `renderNow.overrides.remoteCompose` (replaces named values +
+ * profile, preserves host-action buffer) or by waiting for user code to call
+ * [RemoteComposeHost.setNamedValue] / [RemoteComposeHost.reportHostAction] inside a held
+ * interactive session — `addChangeListener` callbacks already wired through the controller wake
+ * any active subscription.
+ */
+class RemoteComposeDataProductRegistry : DataProductRegistry {
+  private val latestPayloads = ConcurrentHashMap<String, RemoteComposePayload>()
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        // Pushing a fresh `renderNow.overrides.remoteCompose` triggers a re-render anyway, and
+        // user code calling `setNamedValue` / `reportHostAction` runs inside a held session
+        // (where the panel observes via `data/subscribe` rather than re-asking the dispatcher to
+        // queue an extra render).
+        requiresRerender = false,
+      )
+    )
+
+  fun capture(previewId: String?, payload: RemoteComposePayload) {
+    if (previewId == null) return
+    latestPayloads[previewId] = payload
+  }
+
+  fun clear(previewId: String?) {
+    if (previewId == null) return
+    latestPayloads.remove(previewId)
+  }
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    val payload = latestPayloads[previewId] ?: return DataProductRegistry.Outcome.NotAvailable
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(RemoteComposePayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (KIND !in kinds) return emptyList()
+    val payload = latestPayloads[previewId] ?: return emptyList()
+    return listOf(
+      DataProductAttachment(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(RemoteComposePayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun onRender(previewId: String, result: RenderResult) {
+    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
+  }
+
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
+    val namedValues = RemoteComposeController.namedValues.value
+    val hostActions = RemoteComposeController.hostActions.value
+    val profile = RemoteComposeController.profile.value
+    if (namedValues.isEmpty() && hostActions.isEmpty() && profile == null) {
+      clear(previewId)
+      return
+    }
+    capture(
+      previewId,
+      RemoteComposePayload(
+        namedValues = namedValues,
+        hostActions = hostActions,
+        profile = profile,
+      ),
+    )
+  }
+
+  companion object {
+    const val KIND: String = RemoteComposeProduct.KIND
+    const val SCHEMA_VERSION: Int = RemoteComposeProduct.SCHEMA_VERSION
+
+    private val json = Json {
+      encodeDefaults = true
+      prettyPrint = false
+    }
+  }
+}

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
@@ -1,0 +1,211 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RemoteComposeOverride
+import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
+import ee.schimke.composeai.daemon.protocol.RemoteHostAction
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.remotecompose.RemoteComposePayload
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RemoteComposeDataProductTest {
+
+  @After
+  fun reset() {
+    RemoteComposeController.resetForNewSession()
+  }
+
+  @Test
+  fun extension_declares_around_composable_hook_in_outer_environment() {
+    val extension = RemoteComposeOverrideExtension(RemoteComposeOverride())
+    val hook: AroundComposableHook = extension
+
+    assertEquals(DataExtensionId("compose/remotecompose"), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.AroundComposable), extension.hooks)
+    assertEquals(DataExtensionPhase.OuterEnvironment, extension.constraints.phase)
+    assertTrue(extension.hasAroundComposableHook)
+    assertEquals(extension, hook)
+  }
+
+  @Test
+  fun planner_always_returns_extension_even_without_override() {
+    val planner = RemoteComposePreviewOverrideExtension()
+    val planned = planner.plan(PreviewOverrides())
+    assertTrue("expected planner to always produce a hook", planned is AroundComposableHook)
+    assertEquals(DataExtensionId("compose/remotecompose"), planned.id)
+  }
+
+  @Test
+  fun planner_threads_override_through_to_extension() {
+    val override =
+      RemoteComposeOverride(
+        profile = RemoteComposeProfile.ANDROIDX,
+        namedValues = mapOf("score" to RemoteNamedValue.FloatValue(0.75f)),
+      )
+    val planned = RemoteComposePreviewOverrideExtension().plan(PreviewOverrides(remoteCompose = override))
+    assertTrue(planned is RemoteComposeOverrideExtension)
+  }
+
+  @Test
+  fun capabilities_advertise_compose_remotecompose_as_inline_no_rerender_product() {
+    val cap = RemoteComposeDataProductRegistry().capabilities.single()
+    assertEquals("compose/remotecompose", cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertEquals(false, cap.requiresRerender)
+  }
+
+  @Test
+  fun fetch_before_any_render_returns_not_available() {
+    val registry = RemoteComposeDataProductRegistry()
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-1", "compose/remotecompose", params = null, inline = true),
+    )
+  }
+
+  @Test
+  fun fetch_unknown_kind_returns_unknown() {
+    val registry = RemoteComposeDataProductRegistry()
+    assertEquals(
+      DataProductRegistry.Outcome.Unknown,
+      registry.fetch("preview-1", "compose/theme", params = null, inline = true),
+    )
+  }
+
+  @Test
+  fun controller_set_replaces_named_values_and_profile() {
+    val controller = RemoteComposeController
+    controller.set(
+      RemoteComposeOverride(
+        profile = RemoteComposeProfile.ANDROIDX,
+        namedValues =
+          mapOf(
+            "score" to RemoteNamedValue.FloatValue(0.5f),
+            "label" to RemoteNamedValue.StringValue("hello"),
+          ),
+      )
+    )
+    assertEquals(RemoteComposeProfile.ANDROIDX, controller.profile.value)
+    assertEquals(RemoteNamedValue.FloatValue(0.5f), controller.valueOf("score"))
+    assertEquals(RemoteNamedValue.StringValue("hello"), controller.valueOf("label"))
+
+    controller.set(
+      RemoteComposeOverride(namedValues = mapOf("score" to RemoteNamedValue.FloatValue(0.9f)))
+    )
+    assertNull("profile must clear when new override drops it", controller.profile.value)
+    assertEquals(RemoteNamedValue.FloatValue(0.9f), controller.valueOf("score"))
+    assertNull("dropped key must not linger", controller.valueOf("label"))
+  }
+
+  @Test
+  fun controller_setNamedValue_merges_without_dropping_existing_keys() {
+    val controller = RemoteComposeController
+    controller.set(
+      RemoteComposeOverride(
+        namedValues =
+          mapOf(
+            "a" to RemoteNamedValue.IntValue(1),
+            "b" to RemoteNamedValue.IntValue(2),
+          )
+      )
+    )
+    controller.setNamedValue("a", RemoteNamedValue.IntValue(42))
+    controller.setNamedValue("c", RemoteNamedValue.BooleanValue(true))
+    assertEquals(RemoteNamedValue.IntValue(42), controller.valueOf("a"))
+    assertEquals(RemoteNamedValue.IntValue(2), controller.valueOf("b"))
+    assertEquals(RemoteNamedValue.BooleanValue(true), controller.valueOf("c"))
+  }
+
+  @Test
+  fun controller_recordHostAction_respects_accepted_list_filter() {
+    val controller = RemoteComposeController
+    controller.set(RemoteComposeOverride(acceptedHostActions = listOf("allowed")))
+    controller.recordHostAction(RemoteHostAction(payload = "allowed", handlerId = 1f))
+    controller.recordHostAction(RemoteHostAction(payload = "rejected", handlerId = 2f))
+    val captured = controller.hostActions.value
+    assertEquals(1, captured.size)
+    assertEquals("allowed", captured.single().payload)
+  }
+
+  @Test
+  fun controller_recordHostAction_caps_at_buffer_size() {
+    val controller = RemoteComposeController
+    val cap = RemoteComposePayload.HOST_ACTION_BUFFER_SIZE
+    repeat(cap + 5) { controller.recordHostAction(RemoteHostAction(payload = "p$it", handlerId = it.toFloat())) }
+    val captured = controller.hostActions.value
+    assertEquals(cap, captured.size)
+    assertEquals("p5", captured.first().payload)
+    assertEquals("p${cap + 4}", captured.last().payload)
+  }
+
+  @Test
+  fun on_render_captures_payload_after_override_applied() {
+    val registry = RemoteComposeDataProductRegistry()
+    val override =
+      RemoteComposeOverride(
+        profile = RemoteComposeProfile.WEAR_WIDGETS,
+        namedValues = mapOf("brightness" to RemoteNamedValue.FloatValue(0.6f)),
+      )
+    RemoteComposeController.set(override)
+    RemoteComposeController.recordHostAction(RemoteHostAction(payload = "tap", handlerId = 3f))
+
+    registry.onRender(
+      previewId = "preview-1",
+      result = stubRenderResult(),
+      overrides = PreviewOverrides(remoteCompose = override),
+      previewContext = stubContext(),
+    )
+
+    val outcome = registry.fetch("preview-1", "compose/remotecompose", params = null, inline = true)
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+  }
+
+  @Test
+  fun on_render_clears_payload_when_controller_empty() {
+    val registry = RemoteComposeDataProductRegistry()
+    registry.capture(
+      "preview-1",
+      RemoteComposePayload(profile = RemoteComposeProfile.ANDROIDX),
+    )
+    registry.onRender(
+      previewId = "preview-1",
+      result = stubRenderResult(),
+      overrides = null,
+      previewContext = stubContext(),
+    )
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-1", "compose/remotecompose", params = null, inline = true),
+    )
+  }
+
+  private fun stubRenderResult(): RenderResult =
+    RenderResult(
+      id = 1L,
+      classLoaderHashCode = 0,
+      classLoaderName = "test",
+      previewContext = stubContext(),
+    )
+
+  private fun stubContext(): PreviewContext =
+    PreviewContext(
+      previewId = "preview-1",
+      backend = "test",
+      renderMode = null,
+      outputBaseName = null,
+    )
+}

--- a/data/remotecompose/core/build.gradle.kts
+++ b/data/remotecompose/core/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // `daemon:core` carries `PreviewOverrides`, `RemoteComposeOverride`, `RemoteNamedValue`, and
+  // `RemoteHostAction` (the wire-shape the connector's planner reads from). Mirrors
+  // `:data-permissions-core` / `:data-keyboard-core` — the kind constant + payload class lives on a
+  // tiny JVM module so MCP clients in other languages can depend on the Remote Compose product
+  // identity without dragging in the connector, Compose, or the alpha `androidx.compose.remote.*`
+  // artifacts.
+  api(project(":daemon:core"))
+  api(libs.kotlinx.serialization.json)
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-remotecompose-core",
+    displayName = "Compose Preview - Remote Compose Data Product Core",
+    description =
+      "Shared Remote Compose data-product model classes for Compose Preview (named-value store, host action queue, profile).",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
+++ b/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
@@ -1,0 +1,51 @@
+package ee.schimke.composeai.data.remotecompose
+
+import ee.schimke.composeai.daemon.protocol.RemoteComposeProfile
+import ee.schimke.composeai.daemon.protocol.RemoteHostAction
+import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import kotlinx.serialization.Serializable
+
+/**
+ * Stable identity of the `compose/remotecompose` data product. Lifted out of
+ * `RemoteComposeDataProductRegistry` so MCP clients and other connectors can depend on the payload
+ * schema without pulling in the daemon-side registry, Compose, or the alpha
+ * `androidx.compose.remote.*` artifacts. Mirrors `Material3PermissionsProduct` /
+ * `Material3KeyboardProduct`.
+ */
+object RemoteComposeProduct {
+  const val KIND: String = "compose/remotecompose"
+  const val SCHEMA_VERSION: Int = 1
+}
+
+/**
+ * Wire-shape returned by `data/fetch?kind=compose/remotecompose`.
+ *
+ * Three facets feed the panel's per-card chip:
+ *
+ * * [namedValues] — the effective named-value map after the latest render. Reflects daemon-side
+ *   seeds (`renderNow.overrides.remoteCompose.namedValues`) merged with any writes user code pushed
+ *   back via `LocalRemoteComposeHost.current.setNamedValue(...)`. Values use the same typed sum
+ *   (`RemoteNamedValue`) the override sends in.
+ * * [hostActions] — insertion-ordered list of `HostAction` events the remote runtime fired during
+ *   the captured frame (and during an interactive session if the connector is held). Capped to the
+ *   most recent [HOST_ACTION_BUFFER_SIZE] entries so a runaway emitter doesn't grow the payload
+ *   unboundedly.
+ * * [profile] — the active platform profile (mirrors `RcPlatformProfiles`). Null when user code
+ *   didn't bind one through `LocalRemoteComposeHost`.
+ */
+@Serializable
+data class RemoteComposePayload(
+  val namedValues: Map<String, RemoteNamedValue> = emptyMap(),
+  val hostActions: List<RemoteHostAction> = emptyList(),
+  val profile: RemoteComposeProfile? = null,
+) {
+  companion object {
+    /**
+     * Cap for the in-memory host-action ring buffer. Picked so a busy panel session can keep ~5
+     * seconds of typical agent-driven events without unbounded growth; downstream consumers that
+     * need older events should subscribe to `data/subscribe(kind=compose/remotecompose)` and
+     * accumulate themselves.
+     */
+    const val HOST_ACTION_BUFFER_SIZE: Int = 256
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -257,6 +257,20 @@ include(":data-permissions-connector")
 
 project(":data-permissions-connector").projectDir = file("data/permissions/connector")
 
+// Remote Compose connector — exposes the daemon's named-value store, host-action capture queue,
+// and active profile to user code rendering a `RemotePreview { ... }` block. Android-only:
+// `androidx.compose.remote.*` is an Android artifact requiring compileSdk 37 (see
+// `:samples:remotecompose`); the connector ships its alpha-API deps as `compileOnly` so daemon
+// modules at compileSdk 36 can still consume the AAR. The Compose API surface (composition local,
+// data product, override planner) registers on `:daemon:android` only.
+include(":data-remotecompose-core")
+
+project(":data-remotecompose-core").projectDir = file("data/remotecompose/core")
+
+include(":data-remotecompose-connector")
+
+project(":data-remotecompose-connector").projectDir = file("data/remotecompose/connector")
+
 // UIAutomator-shaped query/action API for the Compose preview renderer. Carries the matcher,
 // the Selector DSL, and the JSON wire format — consumed by `:daemon:android` for
 // `record_preview`'s `uia.*` script events.

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -3212,3 +3212,155 @@ preview-app[data-bundle-mode="true"] bundle-chip-bar {
     outline: 1px solid var(--vscode-focusBorder);
     outline-offset: 1px;
 }
+
+/* ---- Remote Compose bundle (compose/remotecompose) ------------------- */
+.rc-name-cell {
+    width: 30%;
+    vertical-align: top;
+}
+.rc-type-cell {
+    width: 18%;
+    vertical-align: top;
+    white-space: nowrap;
+}
+.rc-value-cell {
+    width: 52%;
+    vertical-align: top;
+}
+.rc-name {
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 12px;
+    color: var(--vscode-symbolIcon-variableForeground, inherit);
+}
+.rc-row-sub {
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    margin-top: 2px;
+}
+.rc-action-label {
+    color: var(--vscode-descriptionForeground);
+    font-size: 12px;
+}
+.rc-action-index {
+    font-variant-numeric: tabular-nums;
+    color: var(--vscode-foreground);
+    margin-left: 2px;
+}
+.rc-type-badge {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 8px;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    background: var(--rc-badge-bg, var(--vscode-badge-background));
+    color: var(--rc-badge-fg, var(--vscode-badge-foreground));
+}
+.rc-type-float,
+.rc-type-dp {
+    --rc-badge-bg: #1565c0;
+    --rc-badge-fg: #fff;
+}
+.rc-type-int {
+    --rc-badge-bg: #00838f;
+    --rc-badge-fg: #fff;
+}
+.rc-type-string {
+    --rc-badge-bg: #2e7d32;
+    --rc-badge-fg: #fff;
+}
+.rc-type-bool {
+    --rc-badge-bg: #6a1b9a;
+    --rc-badge-fg: #fff;
+}
+.rc-type-color {
+    --rc-badge-bg: #ef6c00;
+    --rc-badge-fg: #fff;
+}
+.rc-type-profile {
+    --rc-badge-bg: #455a64;
+    --rc-badge-fg: #fff;
+}
+.rc-type-action {
+    --rc-badge-bg: #5d4037;
+    --rc-badge-fg: #fff;
+}
+.rc-value-input {
+    font-family: inherit;
+    font-size: var(--vscode-font-size);
+    color: var(--vscode-input-foreground);
+    background: var(--vscode-input-background);
+    border: 1px solid var(--vscode-input-border, transparent);
+    border-radius: 2px;
+    padding: 2px 6px;
+    box-sizing: border-box;
+}
+.rc-value-input:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+}
+.rc-number-input {
+    width: 110px;
+    font-variant-numeric: tabular-nums;
+}
+.rc-text-input {
+    width: 100%;
+    max-width: 280px;
+}
+.rc-profile-select {
+    min-width: 180px;
+}
+.rc-bool-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+}
+.rc-bool-input {
+    width: 14px;
+    height: 14px;
+    margin: 0;
+}
+.rc-number-cell {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+}
+.rc-unit {
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+}
+.rc-color-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+.rc-color-input {
+    width: 28px;
+    height: 22px;
+    padding: 1px;
+    border-radius: 3px;
+    cursor: pointer;
+}
+.rc-color-hex {
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    color: var(--vscode-descriptionForeground);
+}
+.rc-action-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.rc-action-payload {
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: 12px;
+    color: var(--vscode-foreground);
+}
+.rc-action-meta {
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground);
+    font-variant-numeric: tabular-nums;
+}

--- a/vscode-extension/preview-harness/fixtures/remotecompose-state.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/remotecompose-state.gen.mjs
@@ -1,0 +1,246 @@
+// Generator for `remotecompose-state.json`. Run with:
+//   node preview-harness/fixtures/remotecompose-state.gen.mjs > preview-harness/fixtures/remotecompose-state.json
+//
+// Drives focus mode + the Remote Compose bundle so the rendered tab body
+// shows the editable named-values table, the profile `<select>`, and
+// the host-actions audit log. The card image is a stylised remote-
+// compose watch face mock (220×220) so the focused preview visually
+// matches the kind of document the data extension wraps — a small
+// circular widget with a labeled button.
+
+import { deflateSync } from "node:zlib";
+
+function crc32(buf) {
+    const t = new Uint32Array(256);
+    for (let n = 0; n < 256; n++) {
+        let c = n;
+        for (let k = 0; k < 8; k++)
+            c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+        t[n] = c >>> 0;
+    }
+    let c = 0xffffffff;
+    for (const b of buf) c = t[(c ^ b) & 0xff] ^ (c >>> 8);
+    return (c ^ 0xffffffff) >>> 0;
+}
+
+function encodePng(width, height, pixels) {
+    const raw = Buffer.alloc(height * (1 + width * 3));
+    for (let y = 0; y < height; y++) {
+        let off = y * (1 + width * 3);
+        raw[off++] = 0;
+        for (let x = 0; x < width; x++) {
+            const i = (y * width + x) * 3;
+            raw[off++] = pixels[i];
+            raw[off++] = pixels[i + 1];
+            raw[off++] = pixels[i + 2];
+        }
+    }
+    function chunk(type, payload) {
+        const len = Buffer.alloc(4);
+        len.writeUInt32BE(payload.length, 0);
+        const tb = Buffer.from(type, "ascii");
+        const crc = Buffer.alloc(4);
+        crc.writeUInt32BE(crc32(Buffer.concat([tb, payload])), 0);
+        return Buffer.concat([len, tb, payload, crc]);
+    }
+    const ihdr = Buffer.alloc(13);
+    ihdr.writeUInt32BE(width, 0);
+    ihdr.writeUInt32BE(height, 4);
+    ihdr[8] = 8;
+    ihdr[9] = 2;
+    return Buffer.concat([
+        Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+        chunk("IHDR", ihdr),
+        chunk("IDAT", deflateSync(raw)),
+        chunk("IEND", Buffer.alloc(0)),
+    ]).toString("base64");
+}
+
+const W = 220;
+const H = 220;
+const CX = W / 2;
+const CY = H / 2;
+const R = 105;
+const BTN = { left: 60, top: 132, right: 160, bottom: 168 };
+
+const pixels = new Uint8Array(W * H * 3);
+for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+        const dx = x - CX;
+        const dy = y - CY;
+        const d2 = dx * dx + dy * dy;
+        let r = 16;
+        let g = 18;
+        let b = 24;
+        if (d2 <= R * R) {
+            // Inside the watch face circle — dark "AMOLED" background
+            // with a thin ring.
+            r = 24;
+            g = 26;
+            b = 36;
+            const ring = Math.sqrt(d2);
+            if (ring > R - 2) {
+                r = 90;
+                g = 100;
+                b = 120;
+            }
+            // Tick marks every 30 degrees.
+            const angle = Math.atan2(dy, dx);
+            for (let i = 0; i < 12; i++) {
+                const ta = (i * Math.PI) / 6;
+                const da = Math.atan2(
+                    Math.sin(angle - ta),
+                    Math.cos(angle - ta),
+                );
+                if (Math.abs(da) < 0.02 && ring > R - 14 && ring < R - 4) {
+                    r = 200;
+                    g = 210;
+                    b = 230;
+                }
+            }
+            // The button rect (uses the daemon-seeded `seedColor`
+            // named value at #3366FF; we draw the same colour here so
+            // the panel's editable color cell and the rendered preview
+            // visually agree).
+            if (
+                x >= BTN.left &&
+                x < BTN.right &&
+                y >= BTN.top &&
+                y < BTN.bottom
+            ) {
+                r = 0x33;
+                g = 0x66;
+                b = 0xff;
+            }
+        }
+        const idx = (y * W + x) * 3;
+        pixels[idx] = r;
+        pixels[idx + 1] = g;
+        pixels[idx + 2] = b;
+    }
+}
+
+const imageData = encodePng(W, H, pixels);
+
+const PREVIEW_ID =
+    "com.example.sampleremotecompose.PreviewsKt.RemoteButtonWithBorderPreview";
+
+const fixture = {
+    name: "remotecompose-state",
+    description:
+        "Focused card with the Remote Compose bundle active. The tab body renders three sections (profile selector, editable named-values table, host-actions audit log) driven by a single `compose/remotecompose` data product. Use this when iterating on the editable cells (profile `<select>`, typed inputs for float/dp/int/string/bool/color) or the host-action row layout.",
+    dataset: {
+        earlyFeatures: "true",
+        minimalMode: "false",
+    },
+    messages: [
+        {
+            command: "setPreviews",
+            moduleDir: "/workspace/samples/remotecompose",
+            heavyStaleIds: [],
+            previews: [
+                {
+                    id: PREVIEW_ID,
+                    functionName: "RemoteButtonWithBorderPreview",
+                    className:
+                        "com.example.sampleremotecompose.PreviewsKt",
+                    sourceFile: "Previews.kt",
+                    params: {
+                        name: null,
+                        device: null,
+                        widthDp: 220,
+                        heightDp: 220,
+                        fontScale: 1,
+                        showSystemUi: false,
+                        showBackground: true,
+                        backgroundColor: 0,
+                        uiMode: 0,
+                        locale: null,
+                        group: null,
+                    },
+                    captures: [
+                        {
+                            advanceTimeMillis: null,
+                            scroll: null,
+                            renderOutput:
+                                "renders/com.example.sampleremotecompose.PreviewsKt.RemoteButtonWithBorderPreview.png",
+                            label: "",
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            command: "updateImage",
+            previewId: PREVIEW_ID,
+            captureIndex: 0,
+            imageData,
+        },
+        {
+            command: "updateDataProducts",
+            previewId: PREVIEW_ID,
+            dataProducts: [
+                {
+                    kind: "compose/remotecompose",
+                    payload: {
+                        profile: "androidx",
+                        namedValues: {
+                            seedColor: {
+                                kind: "color",
+                                argb: "#FF3366FF",
+                            },
+                            cornerRadius: {
+                                kind: "dp",
+                                value: 8.0,
+                            },
+                            opacity: {
+                                kind: "float",
+                                value: 0.85,
+                            },
+                            label: {
+                                kind: "string",
+                                value: "Bordered",
+                            },
+                            tapCount: {
+                                kind: "int",
+                                value: 3,
+                            },
+                            enabled: {
+                                kind: "bool",
+                                value: true,
+                            },
+                        },
+                        hostActions: [
+                            {
+                                payload: "testAction",
+                                handlerId: 1,
+                                firedAtMillis: 1716470401000,
+                            },
+                            {
+                                payload: "testAction",
+                                handlerId: 1,
+                                firedAtMillis: 1716470404500,
+                            },
+                            {
+                                payload: "longPress",
+                                handlerId: 2,
+                                firedAtMillis: 1716470407200,
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    ],
+    actions: [
+        {
+            click:
+                `.preview-card[data-preview-id="${PREVIEW_ID}"] .card-focus-btn`,
+        },
+        {
+            click: 'bundle-chip-bar button[data-bundle="remotecompose"]',
+        },
+    ],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/remotecompose-state.json
+++ b/vscode-extension/preview-harness/fixtures/remotecompose-state.json
@@ -1,0 +1,113 @@
+{
+  "name": "remotecompose-state",
+  "description": "Focused card with the Remote Compose bundle active. The tab body renders three sections (profile selector, editable named-values table, host-actions audit log) driven by a single `compose/remotecompose` data product. Use this when iterating on the editable cells (profile `<select>`, typed inputs for float/dp/int/string/bool/color) or the host-action row layout.",
+  "dataset": {
+    "earlyFeatures": "true",
+    "minimalMode": "false"
+  },
+  "messages": [
+    {
+      "command": "setPreviews",
+      "moduleDir": "/workspace/samples/remotecompose",
+      "heavyStaleIds": [],
+      "previews": [
+        {
+          "id": "com.example.sampleremotecompose.PreviewsKt.RemoteButtonWithBorderPreview",
+          "functionName": "RemoteButtonWithBorderPreview",
+          "className": "com.example.sampleremotecompose.PreviewsKt",
+          "sourceFile": "Previews.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 220,
+            "heightDp": 220,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.sampleremotecompose.PreviewsKt.RemoteButtonWithBorderPreview.png",
+              "label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "command": "updateImage",
+      "previewId": "com.example.sampleremotecompose.PreviewsKt.RemoteButtonWithBorderPreview",
+      "captureIndex": 0,
+      "imageData": "iVBORw0KGgoAAAANSUhEUgAAANwAAADcCAIAAACUOFjWAAAHDklEQVR4nO3dQa4bNxBF0SwhyMjw2DvIbjw2sgYvMeMsIttIBgI+ZH2pxW5W1XtFXuAiowRpsQ5IqfWh/u33P74QWfWb/AqIHgIl2QVKsguUZBcow/r+46f8GtYIlG/6/uNnRvLX5Rwof2nG2Zev32AaEijfQPzy9VtGAD1oU5TFBGeYyteqvo1Q5kH8+59/7wPoZFugLNgRA0W+BSpfz+xWRll5Oueh3FDngigl7xQLUO6jcymUwk8tlShf6ZSvf1SLoJR/iJagXJVme5QmN3SEKJ/qlM9lU5QmHH1QLkOzJUorjm4oF6DZDKUhxw+UH//0qSnNNihtOfrXjmYPlIjcyqU7ylcc3Q5Kzx5WqQtNa5SvOLp9qvDs1UL5uzRFeXBeg3ISpf+W6Yjy+O1j+N+JLdnIKtm69EI5+IEGlKdQHvxrnlumEcrxj9hsloHrY+jSBeXZOz6gjF0cK5cWKK/dg8Rl7LL4uBSjnLkrDsrwZTE5ypUo57+kQWTGsshdylCGfG2IyKSV0brUoOSLbP+ELgUoEdkllctqlIjslcRlKUpEdqzeZR1KRPat2GURSkR2r9JlBUpErlGZy3SUiFypGpe5KBG5XgUuE1EictWyXaajlK8gZdQSJSKXL89lCkoO7h3KO8TjUSJyn5JcBqNE5G5luExBKV8pqswaJdvknoVvlmEoEblzsS6DUcpXh1TZoUQkBboMQMnBTbeiDvEwlPIVIYcsUCKSHpp3OYWSg5s+N3+IB6CUrwK5JUPJNkmvmtwsZ1HeLoIfmqIHAwKUD3skv2K6c6+mf9llAMqHa8LlVh1MvxTl57eST68Mmms3MvRrLmNQjl8lLdD4oItQvv3EjcgdGp/yBZfxKO8vWr52lNfgiNNRcmOSLnTWJSgpvUSUiKTLnXIJSqooBSXfdNNMp74NP4dS/tqob6Aku4JRIpJCGnQJSqoLlGRXGEpEUmAjLkFJpQWg5PYkxTZyw3IIpfyV0EqBkuwCJdk1hRKRlNSxS1CSIFCSXaAkuy6iRCSlduASlKQJlGQXKMmu0ygRSQW9cglKkgVKsguUZBcoyS5Qkl0nUCKSynrqEpSkDJRkFyjJLlCSXaAku0BJdoGS7AIl2QVKsguUZBcoya4rKHmUHWV0/Pjl9ygPkr82cm4EzxDKh7MbkTTTiJ/PLtkpKauwnZL3lFTQFEqi1EBJdoGS7AIl2QVKsguUZBcoyS5Qkl2gJLtASXaBkuwCJdk1ihKXVBM/BUh2gZLsAiXZBUqyC5Rk1zmUuKTsVnsM3p9//UeDyYcFSgIlKO2TDysSpbNL+aQbJR/WWZGgXD/5sEBJoASlffJhBaO0dSmfdKPkwzorEpTrJx8WKGkblG4u5ZNulHxYT0VOofTcLOWTbpR8WE9RHpMD5eLJh5WC0tClfNKNkg/rrEhQrp98WKCkbVC6uZRPulHyYZ0VCcr1kw8rHaWJS/mkGyUf1r3IYJRWm6V80o2SD+se5aA0UC6efFi5KH1cyifdKPmwzooE5frJh5WOctxl6sMb5ZNuVB61wRGfFZmCsuChovJJNypV5MiUK1AeuCx72K180o0qEHkw6Asiw1AWP3tZPulGJY1gcOh1KEeeCZ63FqA0Qfl2+tdExqCseR8JSk+UB9OvRvlqsyxYAlC6oXxq4LLIAJSS25bySTeqfjpnv+mORCm8ly6fdKOEKC+7CkBZ71I+6UapRMpQqjZL+aQbpUI5g2oWpcSlfNKNaicyEmWlS/mkG1Uv0gKlz18PkbYQkWEocUlRIuNR4nLPog7uYJS43LZYkcEoOcT3LFZkFkpc7lP4NhmPEpdblSEyBSUuNylJZBZK3lzuUJLIRJS4XLs8kRUocbleeQd3OkpcLlm2yHSUuFysApEVKHG5TDUii1DicoHKRNahxGXrKkWWosRl04pFVqPEZbvqRQpQ4rJREpEalLhskUqkDGWUy7IfimnX5MoIRSpRhris/AGjRk0ui1akGOW9yws0K3/nrVEzy3I/DqEKMcoHmqAUonTgaITygktExi6Oj0gjlKeO8uLfaG3XqfUxObJNUY67ROQpl71E2qF8oDm/DWzbyCoZcvRFebxlIvKCy1ccDUX6onygCcpAlM4cG6A82DIROejyKUdnkQ1QHtOkwbpw7IQSl/uI7ITSnObtoHR7U9GOY0uUtjTdPns15dgYpSFNH5StObZHaUXTAeUCHBdB+ZmmRKcQ5cNrl89ivkVQ3hLSlKBcj+OtpVDeehhVjc5KlJ9foHzNY1sQ5UeVOgtQLm/xo5VRflSgMw/lPhY/2gLlrc/TjQIa/td0ry5VvoY1bYTyvjygQJxvU5T3vdKQyvT4fypfE22g/KVjK2/5zvzn8tfuEyjfNOMMgtcCZVhQiwqUZBcoyS5Qkl2gJLv+B4vqaIKMvCwFAAAAAElFTkSuQmCC"
+    },
+    {
+      "command": "updateDataProducts",
+      "previewId": "com.example.sampleremotecompose.PreviewsKt.RemoteButtonWithBorderPreview",
+      "dataProducts": [
+        {
+          "kind": "compose/remotecompose",
+          "payload": {
+            "profile": "androidx",
+            "namedValues": {
+              "seedColor": {
+                "kind": "color",
+                "argb": "#FF3366FF"
+              },
+              "cornerRadius": {
+                "kind": "dp",
+                "value": 8
+              },
+              "opacity": {
+                "kind": "float",
+                "value": 0.85
+              },
+              "label": {
+                "kind": "string",
+                "value": "Bordered"
+              },
+              "tapCount": {
+                "kind": "int",
+                "value": 3
+              },
+              "enabled": {
+                "kind": "bool",
+                "value": true
+              }
+            },
+            "hostActions": [
+              {
+                "payload": "testAction",
+                "handlerId": 1,
+                "firedAtMillis": 1716470401000
+              },
+              {
+                "payload": "testAction",
+                "handlerId": 1,
+                "firedAtMillis": 1716470404500
+              },
+              {
+                "payload": "longPress",
+                "handlerId": 2,
+                "firedAtMillis": 1716470407200
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "click": ".preview-card[data-preview-id=\"com.example.sampleremotecompose.PreviewsKt.RemoteButtonWithBorderPreview\"] .card-focus-btn"
+    },
+    {
+      "click": "bundle-chip-bar button[data-bundle=\"remotecompose\"]"
+    }
+  ]
+}

--- a/vscode-extension/src/webview/preview/bundleRegistry.ts
+++ b/vscode-extension/src/webview/preview/bundleRegistry.ts
@@ -18,7 +18,8 @@ export type BundleId =
     | "display"
     | "watch"
     | "history"
-    | "errors";
+    | "errors"
+    | "remotecompose";
 
 export interface BundleKind {
     /** Wire `kind` advertised by the daemon catalogue. */
@@ -183,6 +184,18 @@ export const BUNDLES: readonly BundleDescriptor[] = [
                 kind: "test/failure",
                 label: "Postmortem",
                 defaultOn: false,
+            },
+        ],
+    },
+    {
+        id: "remotecompose",
+        label: "Remote Compose",
+        icon: "globe",
+        kinds: [
+            {
+                kind: "compose/remotecompose",
+                label: "State + actions",
+                defaultOn: true,
             },
         ],
     },

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -98,6 +98,12 @@ import {
     type DisplayFilterVariantsPayload,
 } from "./displayFilterBundlePresenter";
 import {
+    computeRemoteComposeBundleData,
+    remoteComposeTableColumns,
+    type RemoteComposeChangeDetail,
+    type RemoteComposePayload,
+} from "./remoteComposeBundlePresenter";
+import {
     computeResourcesBundleData,
     resourcesTableColumns,
 } from "./resourcesBundlePresenter";
@@ -1655,6 +1661,85 @@ export class PreviewApp extends LitElement {
             dataTabs.setTabBody("watch", body.wrapper);
             stampAmbientBadge(target, data.state, data.stateLevel);
         };
+
+        // ---- Remote Compose bundle (compose/remotecompose) ----------------
+        // Single-table body with three sections (profile / named values /
+        // host actions). The presenter renders editable `<input>` cells
+        // for the named-value rows + the profile `<select>`; the change
+        // events bubble through `remote-compose-value-changed`, caught by
+        // the body's listener below and forwarded to the host as a
+        // `setRemoteComposeNamedValue` post-message. Mirrors the daemon-
+        // side `:data-remotecompose-connector` controller shape — the
+        // host turns that message into a fresh `renderNow.overrides
+        // .remoteCompose` so the remote document picks up the new value
+        // on the next re-render (or via the held interactive session's
+        // `RemoteComposeController.setNamedValue(...)` path).
+        const remoteComposeBodyBuilt = (): BundleBody => {
+            let b = bundleBodies.get("remotecompose");
+            if (b) return b;
+            b = buildBundleBody(
+                "remotecompose",
+                "Remote Compose",
+                remoteComposeTableColumns() as unknown as ReadonlyArray<
+                    import("./components/DataTable").DataTableColumn<unknown>
+                >,
+            );
+            // Bubble the editable-cell change event up to the host's
+            // post-message channel. Attached once — the body is cached
+            // for the panel lifetime so this listener survives across
+            // refreshes.
+            b.wrapper.addEventListener(
+                "remote-compose-value-changed",
+                (evt) => {
+                    const det = (evt as CustomEvent<RemoteComposeChangeDetail>)
+                        .detail;
+                    const target = currentBundleTarget();
+                    if (!target) return;
+                    vscode.postMessage({
+                        command: "setRemoteComposeNamedValue",
+                        previewId: target,
+                        change: det,
+                    });
+                },
+            );
+            bundleBodies.set("remotecompose", b);
+            return b;
+        };
+        const refreshRemoteComposeBundle = (): void => {
+            const target = currentBundleTarget();
+            if (!target) return;
+            const byKind = dataProductsByPreview.get(target);
+            const payload =
+                (byKind?.get("compose/remotecompose") as
+                    | RemoteComposePayload
+                    | undefined) ?? null;
+            const data = computeRemoteComposeBundleData(payload);
+            const body = remoteComposeBodyBuilt();
+            const table = body.table;
+            table.setRows(data.rows);
+            const namedSummary =
+                data.namedCount +
+                (data.namedCount === 1 ? " value" : " values");
+            const actionSummary =
+                data.actionCount +
+                (data.actionCount === 1 ? " action" : " actions");
+            table.summary =
+                (data.profile ?? "no profile") +
+                " · " +
+                namedSummary +
+                " · " +
+                actionSummary;
+            table.setOverlayId(
+                (row) => (row as { id?: string }).id ?? "remotecompose-row",
+            );
+            table.setJsonPayload(() => ({
+                previewId: target,
+                payload: data.jsonPayload,
+            }));
+            refreshExpanderFor("remotecompose");
+            dataTabs.setTabBody("remotecompose", body.wrapper);
+        };
+
         // Per-card ambient badge state — keyed on previewId so we can
         // clear or update it across focus changes without DOM churn.
         const ambientBadges = new Map<string, HTMLElement>();
@@ -2180,6 +2265,9 @@ export class PreviewApp extends LitElement {
                 // so chip dismissal wipes every bundle-attached card
                 // surface.
                 clearBundleBoxes(null, "inspection");
+            }
+            if (s.activeBundles.includes("remotecompose")) {
+                refreshRemoteComposeBundle();
             }
             // Drop legend slices for bundles that are no longer
             // active so re-pressing the chip starts from a clean
@@ -2797,6 +2885,15 @@ export class PreviewApp extends LitElement {
                     dataProducts.some((dp) => dp.kind === "resources/used")
                 ) {
                     refreshResourcesBundle();
+                }
+                if (
+                    matchesTarget &&
+                    activeBundles.includes("remotecompose") &&
+                    dataProducts.some(
+                        (dp) => dp.kind === "compose/remotecompose",
+                    )
+                ) {
+                    refreshRemoteComposeBundle();
                 }
             },
             applyFontPreviewBytes: (previewId, fontRowId, dataUri) => {

--- a/vscode-extension/src/webview/preview/remoteComposeBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/remoteComposeBundlePresenter.ts
@@ -1,0 +1,422 @@
+// Remote Compose bundle presenter — fills the "Remote Compose" tab body
+// from the `compose/remotecompose` payload (see RemoteComposeModels.kt):
+// `{ namedValues: Map<String, RemoteNamedValue>, hostActions:
+// List<RemoteHostAction>, profile: RemoteComposeProfile? }`.
+//
+// One mixed-section table:
+//
+//   * a Profile row (the daemon-requested `RcPlatformProfiles` mirror) so
+//     the user can see which platform target the document is compiled
+//     against and switch it from a `<select>` cell;
+//   * a Named values group — one row per (name, type, value), with the
+//     value column editable in-place via a type-shaped `<input>`. The
+//     cell's `change` event bubbles a `remote-compose-value-changed`
+//     CustomEvent that the host (`main.ts`) catches and turns into a
+//     `setRemoteComposeNamedValue` post-message back to the extension.
+//   * a Host actions group — read-only audit log of `HostAction` events
+//     the remote runtime fired during the captured frame (capped at the
+//     `RemoteComposePayload.HOST_ACTION_BUFFER_SIZE` ring on the daemon
+//     side; this side just renders what arrived).
+
+import { html, type TemplateResult } from "lit";
+import type { DataTableColumn } from "./components/DataTable";
+
+/** Wire-shape mirror of `RemoteNamedValue` (see Messages.kt). */
+export type RemoteNamedValue =
+    | { kind: "float"; value: number }
+    | { kind: "dp"; value: number }
+    | { kind: "int"; value: number }
+    | { kind: "string"; value: string }
+    | { kind: "bool"; value: boolean }
+    | { kind: "color"; argb: string };
+
+/** Wire-shape mirror of `RemoteHostAction`. */
+export interface RemoteHostAction {
+    payload: string;
+    handlerId: number;
+    firedAtMillis?: number;
+}
+
+/** Wire-shape mirror of `RemoteComposeProfile` (see Messages.kt). */
+export type RemoteComposeProfile =
+    | "androidx"
+    | "androidx7"
+    | "androidx8"
+    | "androidx9"
+    | "widgetsV6"
+    | "widgetsV7"
+    | "wearWidgets";
+
+export interface RemoteComposePayload {
+    namedValues?: Record<string, RemoteNamedValue> | null;
+    hostActions?: readonly RemoteHostAction[] | null;
+    profile?: RemoteComposeProfile | null;
+}
+
+type Section = "profile" | "named" | "actions";
+
+interface BaseRow {
+    id: string;
+    section: Section;
+}
+
+export interface ProfileRow extends BaseRow {
+    section: "profile";
+    profile: RemoteComposeProfile | null;
+}
+
+export interface NamedValueRow extends BaseRow {
+    section: "named";
+    name: string;
+    value: RemoteNamedValue;
+}
+
+export interface HostActionRow extends BaseRow {
+    section: "actions";
+    payload: string;
+    handlerId: number;
+    firedAtMillis: number | null;
+    index: number;
+}
+
+export type RemoteComposeRow = ProfileRow | NamedValueRow | HostActionRow;
+
+export interface RemoteComposeBundleData {
+    rows: readonly RemoteComposeRow[];
+    /** Counts for the table summary line. */
+    namedCount: number;
+    actionCount: number;
+    /** Active profile so callers can drive a header chip / badge. */
+    profile: RemoteComposeProfile | null;
+    /** Payload echoed back into the row data for the table's `Copy JSON`. */
+    jsonPayload: unknown;
+}
+
+/**
+ * Stable spelling order for the profile `<select>` cell. Matches the
+ * `RcPlatformProfiles` constants the daemon's connector binds to —
+ * keeping the order consistent with the source enum so the dropdown
+ * looks the same across releases.
+ */
+const PROFILE_OPTIONS: readonly {
+    value: RemoteComposeProfile;
+    label: string;
+}[] = [
+    { value: "androidx", label: "ANDROIDX (latest)" },
+    { value: "androidx7", label: "ANDROIDX7" },
+    { value: "androidx8", label: "ANDROIDX8" },
+    { value: "androidx9", label: "ANDROIDX9" },
+    { value: "widgetsV6", label: "Widgets v6" },
+    { value: "widgetsV7", label: "Widgets v7" },
+    { value: "wearWidgets", label: "Wear widgets" },
+];
+
+export function computeRemoteComposeBundleData(
+    payload: RemoteComposePayload | null | undefined,
+): RemoteComposeBundleData {
+    if (!payload) {
+        return {
+            rows: [],
+            namedCount: 0,
+            actionCount: 0,
+            profile: null,
+            jsonPayload: { rows: [] },
+        };
+    }
+
+    const profile = payload.profile ?? null;
+    const rows: RemoteComposeRow[] = [
+        { id: "profile", section: "profile", profile },
+    ];
+
+    // Named values — preserved in insertion order so `data/fetch` →
+    // panel keeps the natural ordering the user code bound (LinkedHashMap
+    // semantics on the wire). `Object.entries` walks insertion order for
+    // string keys per ES2020+.
+    const named = payload.namedValues ?? {};
+    const namedEntries = Object.entries(named);
+    for (const [name, value] of namedEntries) {
+        rows.push({
+            id: "named:" + name,
+            section: "named",
+            name,
+            value,
+        });
+    }
+
+    // Host actions — newest first so the most-recent fire is visible
+    // without scrolling. The wire shape is insertion-ordered (oldest
+    // first); we reverse for display only — `data/fetch` consumers
+    // still see the canonical order in the payload.
+    const actions = payload.hostActions ?? [];
+    for (let i = actions.length - 1; i >= 0; i--) {
+        const a = actions[i]!;
+        rows.push({
+            id: "action:" + i,
+            section: "actions",
+            payload: a.payload,
+            handlerId: a.handlerId,
+            firedAtMillis:
+                typeof a.firedAtMillis === "number" ? a.firedAtMillis : null,
+            index: i,
+        });
+    }
+
+    return {
+        rows,
+        namedCount: namedEntries.length,
+        actionCount: actions.length,
+        profile,
+        jsonPayload: {
+            profile,
+            namedValues: named,
+            hostActions: actions,
+        },
+    };
+}
+
+export function remoteComposeTableColumns(): readonly DataTableColumn<RemoteComposeRow>[] {
+    return [
+        {
+            header: "Name",
+            cellClass: "rc-name-cell",
+            render: (row) => renderNameCell(row),
+        },
+        {
+            header: "Type",
+            cellClass: "rc-type-cell",
+            render: (row) => renderTypeCell(row),
+        },
+        {
+            header: "Value",
+            cellClass: "rc-value-cell",
+            render: (row) => renderValueCell(row),
+        },
+    ];
+}
+
+function renderNameCell(row: RemoteComposeRow): TemplateResult {
+    switch (row.section) {
+        case "profile":
+            return html`<strong>Profile</strong>
+                <div class="rc-row-sub">RcPlatformProfiles target</div>`;
+        case "named":
+            return html`<code class="rc-name">${row.name}</code>`;
+        case "actions":
+            return html`<span class="rc-action-label"
+                >HostAction
+                <span class="rc-action-index">#${row.index}</span></span
+            >`;
+    }
+}
+
+function renderTypeCell(row: RemoteComposeRow): TemplateResult | string {
+    switch (row.section) {
+        case "profile":
+            return html`<span class="rc-type-badge rc-type-profile"
+                >profile</span
+            >`;
+        case "named":
+            return html`<span class="rc-type-badge rc-type-${row.value.kind}"
+                >${row.value.kind}</span
+            >`;
+        case "actions":
+            return html`<span class="rc-type-badge rc-type-action"
+                >action</span
+            >`;
+    }
+}
+
+function renderValueCell(row: RemoteComposeRow): TemplateResult | string {
+    switch (row.section) {
+        case "profile":
+            return html`
+                <select
+                    class="rc-value-input rc-profile-select"
+                    data-rc-field="profile"
+                    @change=${(e: Event) => {
+                        const raw = (e.currentTarget as HTMLSelectElement)
+                            .value;
+                        emitChange(e, {
+                            field: "profile",
+                            value: (raw || null) as RemoteComposeProfile | null,
+                        });
+                    }}
+                >
+                    ${PROFILE_OPTIONS.map(
+                        (opt) =>
+                            html`<option
+                                value=${opt.value}
+                                ?selected=${row.profile === opt.value}
+                            >
+                                ${opt.label}
+                            </option>`,
+                    )}
+                </select>
+            `;
+        case "named":
+            return renderNamedValueInput(row);
+        case "actions":
+            return html`<div class="rc-action-cell">
+                <code class="rc-action-payload">${row.payload}</code>
+                <span class="rc-action-meta"
+                    >handler=${row.handlerId.toFixed(0)}${row.firedAtMillis !==
+                    null
+                        ? html` · @${formatMillis(row.firedAtMillis)}`
+                        : ""}</span
+                >
+            </div>`;
+    }
+}
+
+function renderNamedValueInput(row: NamedValueRow): TemplateResult {
+    const v = row.value;
+    switch (v.kind) {
+        case "bool":
+            return html`<label class="rc-bool-cell">
+                <input
+                    type="checkbox"
+                    class="rc-value-input rc-bool-input"
+                    data-rc-field="namedValue"
+                    data-rc-name=${row.name}
+                    data-rc-kind="bool"
+                    ?checked=${v.value}
+                    @change=${(e: Event) =>
+                        emitChange(e, {
+                            field: "namedValue",
+                            name: row.name,
+                            value: {
+                                kind: "bool",
+                                value: (e.currentTarget as HTMLInputElement)
+                                    .checked,
+                            },
+                        })}
+                />
+                <span>${v.value ? "true" : "false"}</span>
+            </label>`;
+        case "int":
+            return html`<input
+                type="number"
+                step="1"
+                class="rc-value-input rc-number-input"
+                data-rc-field="namedValue"
+                data-rc-name=${row.name}
+                data-rc-kind="int"
+                .value=${String(v.value)}
+                @change=${(e: Event) => {
+                    const n = parseInt(
+                        (e.currentTarget as HTMLInputElement).value,
+                        10,
+                    );
+                    if (!Number.isFinite(n)) return;
+                    emitChange(e, {
+                        field: "namedValue",
+                        name: row.name,
+                        value: { kind: "int", value: n },
+                    });
+                }}
+            />`;
+        case "float":
+        case "dp": {
+            const suffix = v.kind === "dp" ? "dp" : "";
+            return html`<span class="rc-number-cell">
+                <input
+                    type="number"
+                    step="0.01"
+                    class="rc-value-input rc-number-input"
+                    data-rc-field="namedValue"
+                    data-rc-name=${row.name}
+                    data-rc-kind=${v.kind}
+                    .value=${String(v.value)}
+                    @change=${(e: Event) => {
+                        const n = parseFloat(
+                            (e.currentTarget as HTMLInputElement).value,
+                        );
+                        if (!Number.isFinite(n)) return;
+                        emitChange(e, {
+                            field: "namedValue",
+                            name: row.name,
+                            value: { kind: v.kind, value: n },
+                        });
+                    }}
+                />${suffix
+                    ? html`<span class="rc-unit">${suffix}</span>`
+                    : ""}</span
+            >`;
+        }
+        case "string":
+            return html`<input
+                type="text"
+                class="rc-value-input rc-text-input"
+                data-rc-field="namedValue"
+                data-rc-name=${row.name}
+                data-rc-kind="string"
+                .value=${v.value}
+                @change=${(e: Event) =>
+                    emitChange(e, {
+                        field: "namedValue",
+                        name: row.name,
+                        value: {
+                            kind: "string",
+                            value: (e.currentTarget as HTMLInputElement).value,
+                        },
+                    })}
+            />`;
+        case "color": {
+            // `<input type="color">` requires `#RRGGBB`; the wire shape
+            // carries `#AARRGGBB`. Strip the alpha byte for the picker
+            // and re-attach it on emit so we round-trip cleanly.
+            const argb = v.argb.startsWith("#") ? v.argb : "#" + v.argb;
+            const alpha = argb.length === 9 ? argb.slice(1, 3) : "FF";
+            const rgb = argb.length === 9 ? "#" + argb.slice(3) : argb;
+            return html`<span class="rc-color-cell">
+                <input
+                    type="color"
+                    class="rc-value-input rc-color-input"
+                    data-rc-field="namedValue"
+                    data-rc-name=${row.name}
+                    data-rc-kind="color"
+                    .value=${rgb}
+                    @change=${(e: Event) => {
+                        const picked = (e.currentTarget as HTMLInputElement)
+                            .value;
+                        const merged = (
+                            "#" +
+                            alpha +
+                            picked.slice(1)
+                        ).toUpperCase();
+                        emitChange(e, {
+                            field: "namedValue",
+                            name: row.name,
+                            value: { kind: "color", argb: merged },
+                        });
+                    }}
+                />
+                <code class="rc-color-hex">${argb.toUpperCase()}</code>
+            </span>`;
+        }
+    }
+}
+
+/** Detail payload of the `remote-compose-value-changed` CustomEvent. */
+export type RemoteComposeChangeDetail =
+    | { field: "profile"; value: RemoteComposeProfile | null }
+    | { field: "namedValue"; name: string; value: RemoteNamedValue };
+
+function emitChange(e: Event, detail: RemoteComposeChangeDetail): void {
+    const evt = new CustomEvent<RemoteComposeChangeDetail>(
+        "remote-compose-value-changed",
+        { detail, bubbles: true, composed: true },
+    );
+    (e.currentTarget as HTMLElement).dispatchEvent(evt);
+}
+
+function formatMillis(ms: number): string {
+    // Compact wall-clock label so the audit log stays readable in the
+    // narrow Value column. Full timestamp is in the Copy JSON dump.
+    const d = new Date(ms);
+    const hh = String(d.getHours()).padStart(2, "0");
+    const mm = String(d.getMinutes()).padStart(2, "0");
+    const ss = String(d.getSeconds()).padStart(2, "0");
+    return `${hh}:${mm}:${ss}`;
+}


### PR DESCRIPTION
Adds a new `:data-remotecompose-{core,connector}` extension pair that
exposes the daemon's named-value store, host-action capture queue, and
active platform profile to user code rendering a `RemotePreview { ... }`
block.

Wire surface:

* `PreviewOverrides.remoteCompose: RemoteComposeOverride?` carries the
  daemon-requested platform profile (`RcPlatformProfiles` mirror),
  seeded named values (typed sum: float/dp/int/string/bool/color), and
  an optional accept-list filter for captured `HostAction` events.
* `data/fetch?kind=compose/remotecompose` returns the current named-value
  map (override seeds merged with user-code writes), a ring-buffered
  `RemoteHostAction` list (capped at 256), and the active profile.
* `LocalRemoteComposeHost` composition local — user code inside a
  `RemotePreview { ... }` reads daemon-seeded named values via the typed
  `namedFloat` / `namedString` / `namedBoolean` / `namedInt` / `namedColor`
  helpers, pushes runtime-computed values back via `setNamedValue(...)`,
  and reports fired `HostAction`s via `reportHostAction(...)`.
* `RemoteComposeProfile.toRcPlatformProfile()` and
  `RemoteHostAction.toHostAction()` extension bridges so user code can
  hand the daemon's profile to `RemotePreview(profile = …)` and
  materialise wire actions into `HostAction(payload.rs, handlerId.rf)`
  without forking the enum mapping.

Android-only — `androidx.compose.remote:*` is an Android-side alpha
artifact requiring `compileSdk = 37`. The connector overrides the
repo-wide default to 37 to compile against `HostAction` /
`RcPlatformProfiles` directly, and exposes its alpha-API deps as
`compileOnly` with `aarMetadata.minCompileSdk = 36` so `:daemon:android`
at compileSdk 36 can still consume the AAR. `isRemoteComposeAvailable`
gates the planner instantiation in `RobolectricHost` (mirroring the
`isWearAmbientAvailable` gate for `:data-ambient-connector`) so plain-
Android consumers without the alpha artifacts don't trip a
`NoClassDefFoundError`.