### PR TITLE
feat(vscode-extension): tint consumer nodes on resources row hover

### DIFF
--- a/vscode-extension/src/test/resourcesBundlePresenter.test.ts
+++ b/vscode-extension/src/test/resourcesBundlePresenter.test.ts
@@ -77,6 +77,48 @@ describe("computeResourcesBundleData", () => {
         });
         assert.strictEqual(data.rows[0].packageName, "");
         assert.strictEqual(data.rows[0].consumerCount, 0);
+        assert.deepStrictEqual([...data.rows[0].consumerNodeIds], []);
+    });
+
+    it("extracts unique consumer node ids in first-seen order", () => {
+        const data = computeResourcesBundleData({
+            references: [
+                {
+                    resourceType: "drawable",
+                    resourceName: "ic_launcher",
+                    consumers: [
+                        { nodeId: "n3" },
+                        { nodeId: "n1" },
+                        { nodeId: "n3" },
+                    ],
+                },
+            ],
+        });
+        // Deduped: n3 listed twice but emitted once.
+        assert.deepStrictEqual([...data.rows[0].consumerNodeIds], ["n3", "n1"]);
+        // consumerCount tracks unique ids (matches the hover overlay's
+        // per-row box count).
+        assert.strictEqual(data.rows[0].consumerCount, 2);
+    });
+
+    it("drops malformed consumer entries instead of crashing the panel", () => {
+        const data = computeResourcesBundleData({
+            references: [
+                {
+                    resourceType: "string",
+                    resourceName: "app_name",
+                    consumers: [
+                        { nodeId: "valid" },
+                        null,
+                        { nodeId: "" },
+                        { nodeId: 42 },
+                        "string-not-object",
+                        {},
+                    ],
+                },
+            ],
+        });
+        assert.deepStrictEqual([...data.rows[0].consumerNodeIds], ["valid"]);
     });
 
     it("emits stable ids derived from index + type + name", () => {

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -105,6 +105,7 @@ import {
 import {
     computeResourcesBundleData,
     resourcesTableColumns,
+    type ResourceUsedRow,
 } from "./resourcesBundlePresenter";
 import {
     computeErrorsBundleData,
@@ -1640,6 +1641,46 @@ export class PreviewApp extends LitElement {
                     import("./components/DataTable").DataTableColumn<unknown>
                 >,
             );
+            // Hover row → tint consumer nodes on the focused card.
+            // Same join as the Theming bundle hover (#1104): bounds
+            // come from cached `compose/semantics`, so the overlay
+            // is gated on both Resources and Inspection bundles being
+            // active.
+            b.table.addEventListener("row-selected", (evt) => {
+                const det = (
+                    evt as CustomEvent<RowSelectedDetail<ResourceUsedRow>>
+                ).detail;
+                const focused = focusController?.focusedCard?.();
+                if (!focused) return;
+                const active = bundleController.state().activeBundles;
+                if (
+                    !active.includes("resources") ||
+                    !active.includes("inspection") ||
+                    det.row === null ||
+                    det.overlayId === null
+                ) {
+                    clearBundleBoxes(focused, "resources-consumers");
+                    return;
+                }
+                const consumerIds = det.row.consumerNodeIds ?? [];
+                if (consumerIds.length === 0) {
+                    clearBundleBoxes(focused, "resources-consumers");
+                    return;
+                }
+                const focusedId = focused.dataset.previewId;
+                const byKind = focusedId
+                    ? dataProductsByPreview.get(focusedId)
+                    : undefined;
+                const semantics = byKind?.get("compose/semantics") as
+                    | SemanticsLookupPayload
+                    | undefined;
+                const boundsMap = buildSemanticsBoundsMap(
+                    semantics,
+                    "resources-consumer",
+                );
+                const boxes = consumerOverlayBoxes(boundsMap, consumerIds);
+                paintBundleBoxes(focused, "resources-consumers", boxes);
+            });
             bundleBodies.set("resources", b);
             return b;
         };
@@ -2209,7 +2250,14 @@ export class PreviewApp extends LitElement {
                 clearBundleBoxes(null, "theming-consumers");
             }
             if (s.activeBundles.includes("display")) refreshDisplayBundle();
-            if (s.activeBundles.includes("resources")) refreshResourcesBundle();
+            if (s.activeBundles.includes("resources")) {
+                refreshResourcesBundle();
+            } else {
+                // Same teardown rule as the Theming hover (#1104):
+                // the transient resources-consumers layer only makes
+                // sense while the Resources chip is on.
+                clearBundleBoxes(null, "resources-consumers");
+            }
             if (s.activeBundles.includes("watch")) {
                 refreshWatchBundle();
             } else {
@@ -2239,9 +2287,10 @@ export class PreviewApp extends LitElement {
                 // surface.
                 clearBundleBoxes(null, "inspection");
                 // Inspection supplies the bounds for the theming-
-                // consumer hover overlay (#1104). With Inspection
-                // gone, any existing hover layer is stale.
+                // and resources-consumer hover overlays (#1104). With
+                // Inspection gone, any existing hover layer is stale.
                 clearBundleBoxes(null, "theming-consumers");
+                clearBundleBoxes(null, "resources-consumers");
             }
             // Drop legend slices for bundles that are no longer
             // active so re-pressing the chip starts from a clean

--- a/vscode-extension/src/webview/preview/resourcesBundlePresenter.ts
+++ b/vscode-extension/src/webview/preview/resourcesBundlePresenter.ts
@@ -33,6 +33,13 @@ export interface ResourceUsedRow {
     resolvedFile: string | null;
     /** Number of node references that consumed this resource. */
     consumerCount: number;
+    /** Per-row consumer node ids sourced from
+     *  `ref.consumers[].nodeId`. Empty when the daemon attached no
+     *  consumers. The host uses this for the hover overlay: hovering
+     *  a row paints a transient layer over those nodes on the focused
+     *  card via `buildSemanticsBoundsMap` + `consumerOverlayBoxes`
+     *  (shared with the Theming bundle hover). */
+    consumerNodeIds: readonly string[];
 }
 
 export interface ResourcesBundleData {
@@ -60,6 +67,7 @@ export function computeResourcesBundleData(
         const resourceName =
             typeof ref.resourceName === "string" ? ref.resourceName : "";
         if (!resourceType || !resourceName) continue;
+        const consumerNodeIds = extractConsumerNodeIds(ref.consumers);
         rows.push({
             id: "resource-" + i + "-" + resourceType + "-" + resourceName,
             resourceType,
@@ -72,9 +80,8 @@ export function computeResourcesBundleData(
                     : null,
             resolvedFile:
                 typeof ref.resolvedFile === "string" ? ref.resolvedFile : null,
-            consumerCount: Array.isArray(ref.consumers)
-                ? ref.consumers.length
-                : 0,
+            consumerCount: consumerNodeIds.length,
+            consumerNodeIds,
         });
     }
     return { rows };
@@ -123,4 +130,25 @@ function renderResolved(row: ResourceUsedRow): TemplateResult | string {
         >`;
     }
     return "—";
+}
+
+/** Extract a unique, in-order list of consumer node ids from the
+ *  daemon's `consumers: [{ nodeId: string }, ...]` array. The wire
+ *  shape can shift across daemon versions — defensive narrowing
+ *  drops anything that isn't a `{ nodeId: string }`. Duplicates are
+ *  removed so the overlay paints one box per node even if the
+ *  daemon double-lists the same consumer. */
+function extractConsumerNodeIds(value: unknown): readonly string[] {
+    if (!Array.isArray(value)) return [];
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const entry of value) {
+        if (!entry || typeof entry !== "object") continue;
+        const id = (entry as { nodeId?: unknown }).nodeId;
+        if (typeof id !== "string" || id.length === 0) continue;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        out.push(id);
+    }
+    return out;
 }


### PR DESCRIPTION
## Summary

Mirrors the Theming hover overlay (#1376). The `resources/used` payload carries a `consumers: [{ nodeId }, ...]` array per row, and the same `buildSemanticsBoundsMap` + `consumerOverlayBoxes` helpers (introduced in #1376) land a transient overlay layer when the user hovers a resource row.

Gated on both Resources + Inspection bundles being active (the bounds source is `compose/semantics`, which Inspection subscribes to). Layer is keyed `data-bundle="resources-consumers"` so it coexists with the Theming hover layer when both are in play; chip dismissal on either Resources or Inspection clears it.

### Changes

- **`ResourceUsedRow.consumerNodeIds: readonly string[]`** — populated in `computeResourcesBundleData` via a defensive `extractConsumerNodeIds` walk that drops malformed entries (non-objects, empty/non-string nodeIds) and dedupes repeats. `consumerCount` now equals the unique-id count.
- **`main.ts`** wires a `row-selected` listener on the resources table that mirrors the theming hover code path — paint on hover-on, clear on hover-off, clear on chip-off of either Resources or Inspection.

Adds two unit tests pinning the consumer-node-id extraction (dedupe order + malformed-entry skip) and updates the existing `defaults packageName / consumerCount` case to assert the new field.

## Test plan

- [ ] `npm run compile` clean (host + webview)
- [ ] `npm test` — 1147 passing locally, including two new "extracts unique consumer node ids…" / "drops malformed consumer entries…" cases
- [ ] `npm run format:check` clean
- [ ] Manual: activate both Resources + Inspection chips on an Android sample, hover a `string`/`drawable` row → confirm the consumer nodes light up on the focused card; leave the row → boxes clear; turn either chip off → any lingering layer clears

Refs #1104.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9fK6gvrwKxV8ZpGdDiBZR)_