### PR TITLE
docs(data-permissions): scrub stale LocalPermissionsHost references

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -94,13 +94,12 @@ dependencies {
   // session's `dispatch(KEY_*)` path also calls into `KeyboardController` from this module.
   implementation(project(":data-keyboard-connector"))
   // Runtime-permissions connector — `PermissionsController` (process-static grant + queried-set
-  // state), the always-on `AroundComposable` extension that installs `LocalPermissionsHost` and
-  // pushes `renderNow.overrides.permissions` into Robolectric's `ShadowApplication` grant state,
-  // the `PermissionsPreviewOverrideExtension` planner, the `PermissionsDataProductRegistry`
-  // serving the captured payload, and `ShadowContextWrapperPermissionTracker` (Robolectric shadow
-  // that records every `ContextCompat.checkSelfPermission(...)` call). Registered on the engine
-  // via `RobolectricHost.previewOverrideExtensions` and via the daemon's `ExtensionRegistry`
-  // below.
+  // state), the always-on `AroundComposable` extension that pushes
+  // `renderNow.overrides.permissions` into Robolectric's `ShadowApplication` grant state, the
+  // `PermissionsPreviewOverrideExtension` planner, the `PermissionsDataProductRegistry` serving
+  // the captured payload, and `ShadowContextWrapperPermissionTracker` (Robolectric shadow that
+  // records every `ContextCompat.checkSelfPermission(...)` call). Registered on the engine via
+  // `RobolectricHost.previewOverrideExtensions` and via the daemon's `ExtensionRegistry` below.
   implementation(project(":data-permissions-connector"))
   // Touch-event visualization connector — same module `:daemon:desktop` consumes. The
   // `TouchOverlayExtension` `AroundComposable` is pure Compose foundation/runtime so the single

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -354,7 +354,7 @@ fun main(args: Array<String>) {
           // `compose/permissions` payload (effective grant map + permissions the screen has
           // queried). The actual planner lives in `RobolectricHost`'s
           // `previewOverrideExtensions` list — same wiring shape as keyboard / focus — so the
-          // around-composable's `LocalPermissionsHost` is in place even when no client has
+          // controller seed + shadow-tracker hookup are in place even when no client has
           // explicitly enabled this extension. `dataExtensionDescriptors` advertises the planner
           // so panel / MCP clients can gate their permission-override UI on the daemon actually
           // shipping it.

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1355,11 +1355,11 @@ open class RobolectricHost(
                 // `KeyboardController` state holder.
                 KeyboardPreviewOverrideExtension(),
                 // Runtime-permissions override + tracker. Planner always emits the extension so
-                // `LocalPermissionsHost` is in scope on every render and screens consulting it
-                // (or whose `ContextCompat.checkSelfPermission(...)` calls land in
-                // `ShadowContextWrapperPermissionTracker`) reach the controller's recordQuery
-                // path. `renderNow.overrides.permissions.grants` flips the effective
-                // `ShadowApplication` grant state and the `LocalPermissionsHost` snapshot map.
+                // every screen's `ContextCompat.checkSelfPermission(...)` (or any standard Android
+                // check API) lands in `ShadowContextWrapperPermissionTracker` and reaches the
+                // controller's recordQuery path. `renderNow.overrides.permissions.grants` flips
+                // the effective `ShadowApplication` grant state so the next platform check reads
+                // the requested value.
                 PermissionsPreviewOverrideExtension(),
                 // Touch-event visualization overlay. Mirrors `DesktopHost`'s registration — same
                 // `TouchOverlayPreviewOverrideExtension` planner from the shared

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsController.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsController.kt
@@ -14,8 +14,10 @@ import java.util.concurrent.CopyOnWriteArrayList
  * Three responsibilities:
  *
  * 1. **Grant map** — the effective permission -> grant-state mapping the around-composable applies
- *    for the current render. Snapshot-state so a screen reading `LocalPermissionsHost.check(perm)`
- *    inside a `@Composable` recomposes when [set] flips a grant.
+ *    for the current render. Held in snapshot state so future readers inside a `@Composable`
+ *    recompose on flips; nothing in-tree reads it from composition today (the override flows
+ *    through Robolectric's `ShadowApplication` grants) — kept observable so a future panel-driven
+ *    "live grants" mid-composition hook can plug in without changing the controller's shape.
  * 2. **Query tracker** — the set of permissions the screen has asked about so far in the render /
  *    interactive session, in insertion order. Written by the Robolectric shadow on
  *    `ContextWrapper.checkPermission(...)`, which covers every standard Android check API
@@ -146,15 +148,15 @@ object PermissionsController {
           .invoke(shadowApp, granted)
       }
     } catch (_: ClassNotFoundException) {
-      // No Robolectric on this classpath — `LocalPermissionsHost` opt-in still works for
-      // compositions that consult the controller directly. Production Android paths reach this
-      // controller only inside a Robolectric sandbox today, so the catch is defensive.
+      // No Robolectric on this classpath — the controller still tracks queries via the shadow
+      // and serves the captured set through the data product. Production Android paths reach
+      // this controller only inside a Robolectric sandbox today, so the catch is defensive.
     } catch (_: NoSuchMethodException) {
       // Robolectric API surface drifted — fall back to controller-only state without crashing the
       // render. A subsequent Robolectric bump that renames the methods will need a code update.
     } catch (_: ReflectiveOperationException) {
       // Underlying invocation failure (e.g. application not yet initialised). Drop silently — the
-      // controller's snapshot state still drives `LocalPermissionsHost` opt-in callers.
+      // controller's snapshot state still reflects the requested grants for the data product.
     }
   }
 }

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
@@ -86,9 +86,9 @@ class PermissionsOverrideExtension(private val seed: PermissionsOverride? = null
 /**
  * Planner that maps `renderNow.overrides.permissions` to a [PermissionsOverrideExtension].
  * **Always** returns a non-null extension — like `KeyboardPreviewOverrideExtension`. The
- * around-composable's `LocalPermissionsHost` needs to be in place on every render so a screen
- * that consults the host (or one whose `checkSelfPermission` call lands in the shadow tracker)
- * reaches the controller's tracking path.
+ * around-composable's controller seed + shadow-tracker hookup need to be in place on every render
+ * so a screen's `ContextCompat.checkSelfPermission(...)` (or any standard Android check API) lands
+ * in the controller's recordQuery path.
  */
 class PermissionsPreviewOverrideExtension : DataExtension<PreviewOverrides> {
   override val id: DataExtensionId = PermissionsOverrideExtension.ID
@@ -123,8 +123,9 @@ class PermissionsDataProductRegistry : DataProductRegistry {
         attachable = true,
         fetchable = true,
         // Flipping a grant via a fresh `renderNow.overrides.permissions` triggers a re-render
-        // anyway, and the `LocalPermissionsHost`-based screens recompose live during a held
-        // session — no need to ask the dispatcher to queue an extra render.
+        // anyway — the next `ContextCompat.checkSelfPermission(...)` read in the recomposition
+        // picks up the new value through the platform path — no need to ask the dispatcher to
+        // queue an extra render.
         requiresRerender = false,
       )
     )

--- a/data/permissions/connector/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsDataProductTest.kt
+++ b/data/permissions/connector/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsDataProductTest.kt
@@ -25,8 +25,9 @@ import org.junit.Test
 
 /**
  * Pins the contract of `:data-permissions-connector`'s extension + registry surface. Mirrors
- * [KeyboardDataProductTest] — the planner is always-on so the controller's `LocalPermissionsHost`
- * is in scope on every render, even when the client hasn't sent an explicit override.
+ * [KeyboardDataProductTest] — the planner is always-on so the controller seed + the shadow
+ * tracker's recordQuery path are wired on every render, even when the client hasn't sent an
+ * explicit override.
  */
 class PermissionsDataProductTest {
 
@@ -51,12 +52,12 @@ class PermissionsDataProductTest {
   }
 
   @Test
-  fun `planner always returns an extension so the host is in scope even without an override`() {
+  fun `planner always returns an extension so the tracker is wired even without an override`() {
     val planner = PermissionsPreviewOverrideExtension()
     val planned = planner.plan(PreviewOverrides())
     assertNotNull(
-      "planner must always emit the extension so LocalPermissionsHost and the recordQuery path " +
-        "are in place for every render",
+      "planner must always emit the extension so the controller seed + shadow tracker recordQuery " +
+        "path are in place for every render",
       planned,
     )
     assertEquals(DataExtensionId(Material3PermissionsProduct.KIND), planned.id)


### PR DESCRIPTION
## Summary

Cleanup follow-up to #1374. That PR removed the `LocalPermissionsHost` / `PermissionsHost` types but a handful of doc comments and one test description still referenced them. None of the references compiled into anything observable, but they're confusing to readers — every "LocalPermissionsHost is in scope" comment points at a type that no longer exists.

Rewrites the affected comments in `:data-permissions-connector` (controller doc, registry doc, planner doc, reflection catch-clause comments), the `:daemon:android` wiring comments (`build.gradle.kts`, `DaemonMain.kt`, `RobolectricHost.kt`), and one test description to point at the real wiring: the controller's grant seed + the shadow tracker on `ContextWrapper.checkPermission`.

## Test plan

- [x] `grep -rn 'LocalPermissionsHost\|PermissionsHost'` returns no matches under the repo
- [x] `:data-permissions-connector:test`
- [x] `:data-permissions-connector:ktfmtCheck`, `:daemon:android:ktfmtCheck`
- [x] `:daemon:android:compileReleaseKotlin`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxsUFeto1VzD9vgtdmz3Nx)_