### PR TITLE
docs(vscode-extension): note why Performance/Text bundle bodies stay separate from BundleBody

### DIFF
--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -945,6 +945,20 @@ export class PreviewApp extends LitElement {
         // We reuse the expander wiring from `buildBundleBody` but route
         // section painting through `renderPerformanceSections` instead
         // of the single `<data-table>` slot the other bundles use.
+        //
+        // We considered widening `buildBundleBody` to accept N tables so
+        // Performance / Text / Inspection could share one builder (see
+        // #1104). The two non-table sub-sections here (the SVG bar chart
+        // and the Perfetto button) don't fit the `<data-table>` row
+        // model — they need a free-form `host` element repainted by
+        // `renderPerformanceSections`. A generalised builder would have
+        // to mix "N tables" with "plus an optional host" with "plus an
+        // optional rowDetail" (which Performance doesn't have at all),
+        // and the per-bundle callsites' wiring (row-click routing,
+        // expander state, payload→table glue) stays bespoke regardless.
+        // The duplication saved is ~6 lines per bundle; the cost of the
+        // generalised shape is a wider abstraction that has to be
+        // navigated at every consumer. Net: keep the shapes separate.
         interface PerformanceBody {
             wrapper: HTMLElement;
             expander: BundleExpander;
@@ -986,6 +1000,15 @@ export class PreviewApp extends LitElement {
         // the Performance bundle. The expander toggles the default-OFF
         // `i18n/translations` kind; drawn text + fonts are default-ON
         // so they appear as soon as the chip is pressed.
+        //
+        // The three sub-tables carry distinct row shapes
+        // (`DrawnTextRow` / `FontRow` / `TranslationRow`), each with
+        // its own `RowClickedDetail<T>` listener routing to a per-shape
+        // row-detail builder, plus cross-table deselection logic that
+        // only this bundle needs. See the note on `PerformanceBody`
+        // above (#1104) for the rationale on keeping these shapes
+        // separate from the shared `BundleBody` / `buildBundleBody`
+        // helper rather than widening it to accept N tables.
         interface TextBody {
             wrapper: HTMLElement;
             expander: BundleExpander;


### PR DESCRIPTION
## Summary

#1104 left an open "consider widening `BundleBody` to accept N tables so the Performance / Text bundle bodies share the same builder" spotted-during-migration follow-up. This PR is the **decision-not-to-refactor** branch of that consideration, with a doc comment so the next person revisiting #1104 doesn't redo the analysis.

The three custom body interfaces (`PerformanceBody`, `TextBody`, `InspectionBody`) have genuinely different shapes:

- **PerformanceBody** mixes one `<data-table>` (recomposition) with a free-form `host` element used by `renderPerformanceSections` for the render-trace bar chart and the Perfetto handoff button. Neither fits the row model, and Performance has no `rowDetail` panel at all.
- **TextBody** stacks three `<data-table>`s with three distinct row shapes (`DrawnTextRow` / `FontRow` / `TranslationRow`), each routing `row-clicked` to its own row-detail builder, plus cross-table deselection logic only this bundle needs.
- **InspectionBody** is correctly already out of scope (tree-table primitive, not `<data-table>`).

A generalised `buildBundleBody({ sections, host?, rowDetail? })` would have to model "N tables + optional host + optional rowDetail" and the per-bundle callsites' wiring (row-click routing, expander state, payload→table glue) stays bespoke regardless. Duplication saved is ~6 lines per bundle; cost is a wider abstraction every consumer has to navigate plus a generic-narrowing type-cast tax.

Adds a 23-line block comment above `PerformanceBody` / `TextBody` summarising the trade-off so the issue can be closed without revisiting.

## Test plan

- [ ] `npm run compile` clean (host + webview)
- [ ] `npm test` — 1145 passing (no behavioural change)
- [ ] `npm run format:check` clean

Refs #1104.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9fK6gvrwKxV8ZpGdDiBZR)_