### PR TITLE
fix(contrib): document `java -cp` as the only supported CLI invocation

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -6,9 +6,11 @@ docs, opt-in CI) lives in the dedicated
 repo. The toolchain itself stays here — `compose-ai-contrib` consumes
 the published Maven Central artifacts:
 
-- `ee.schimke.composeai:preview-discovery` — ClassGraph scan + `previews.json` builder. Has a `java -jar` CLI ([`PreviewDiscoveryCli`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt)).
-- `ee.schimke.composeai:daemon-launch-builder` — typed `daemon-launch.json` builder + CLI ([`DaemonLaunchBuilderCli`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilderCli.kt)).
-- `ee.schimke.composeai:render-cli` — thin CLI over [`SubprocessRenderSessions`](../render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt).
+- `ee.schimke.composeai:preview-discovery` — ClassGraph scan + `previews.json` builder. Library API plus a [`PreviewDiscoveryCli`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt) entry point invoked as `java -cp <resolved-classpath> ee.schimke.composeai.discovery.PreviewDiscoveryCli …`. The published JAR is a slim library — the caller resolves `classgraph`, `asm`, `kotlinx-serialization`, and `kotlin-stdlib` through its own dep system, the same way it would for any other Maven library.
+- `ee.schimke.composeai:daemon-launch-builder` — typed `daemon-launch.json` builder. Library API plus a [`DaemonLaunchBuilderCli`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilderCli.kt) entry point invoked as `java -cp <resolved-classpath> ee.schimke.composeai.daemonlaunch.DaemonLaunchBuilderCli …`. Slim JAR; same classpath contract as `:preview-discovery`.
+- `ee.schimke.composeai:render-cli` — thin CLI over [`SubprocessRenderSessions`](../render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt), invoked as `java -cp <resolved-classpath> ee.schimke.composeai.render.cli.RenderCli …`. Slim JAR; same classpath contract.
+
+> The three CLI artifacts above are published as slim library JARs — there is no fat/shadow JAR and no `Class-Path:` manifest entry, so `java -jar <artifact>.jar …` does **not** work standalone (it fails with `NoClassDefFoundError` on the first transitive class). Bazel `rules_jvm_external` and Amper task definitions already resolve the transitive runtime closure and pass it as `-cp`, which is the intended integration shape.
 
 The wire-stable contract (`daemon-launch.json` + `previews.json`
 schemas, classpath layering, system properties) is documented in

--- a/docs/NON_GRADLE_INTEGRATION.md
+++ b/docs/NON_GRADLE_INTEGRATION.md
@@ -11,8 +11,8 @@ The two contracts you implement against:
 
 | Artifact | Schema | Wire-stable | Producer |
 | --- | --- | --- | --- |
-| `daemon-launch.json` | [`DaemonClasspathDescriptor.kt`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonClasspathDescriptor.kt) (published as `ee.schimke.composeai:daemon-launch-builder`) | `schemaVersion = 1` | You — or [`DaemonLaunchBuilder`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilder.kt) / its `java -jar` CLI |
-| `previews.json` | [`PreviewData.kt`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt) (published as `ee.schimke.composeai:preview-discovery`) | `schema = "compose-previews/v1"` | You — or [`PreviewDiscovery`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt) / its `java -jar` CLI |
+| `daemon-launch.json` | [`DaemonClasspathDescriptor.kt`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonClasspathDescriptor.kt) (published as `ee.schimke.composeai:daemon-launch-builder`) | `schemaVersion = 1` | You — or [`DaemonLaunchBuilder`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilder.kt) / its [`java -cp` CLI](#cli-invocation) |
+| `previews.json` | [`PreviewData.kt`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt) (published as `ee.schimke.composeai:preview-discovery`) | `schema = "compose-previews/v1"` | You — or [`PreviewDiscovery`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt) / its [`java -cp` CLI](#cli-invocation) |
 
 The consumer of both is the daemon JVM (`daemon/desktop` or `daemon/android`),
 driven by `RenderSessionFactory.open(...)` from the
@@ -275,8 +275,43 @@ Build-system-specific recipes (JetBrains Amper, Bazel) live in
 the dedicated repo for non-Gradle integrations. The recipes there
 drive the published `ee.schimke.composeai:preview-discovery` +
 `:daemon-launch-builder` + `:render-cli` artifacts through
-`java -jar` from a build-system-native rule. This document is the
-contract spec the recipes implement against.
+[`java -cp` invocations](#cli-invocation) from a build-system-native
+rule. This document is the contract spec the recipes implement
+against.
+
+## CLI invocation
+
+The three CLI-bearing artifacts (`preview-discovery`,
+`daemon-launch-builder`, `render-cli`) are published as **slim library
+JARs**. They carry a `Main-Class:` manifest entry as a convenience for
+build systems that have already materialised the runtime closure
+next to the artifact (e.g. Bazel's `runtime_jars` provider, or a
+hand-rolled `lib/` directory), but they do **not** carry a
+`Class-Path:` manifest entry and they do **not** bundle their
+transitive deps (`classgraph`, `asm`, `kotlinx-serialization`,
+`kotlin-stdlib`). Running `java -jar <artifact>.jar …` in isolation
+will fail immediately with `NoClassDefFoundError`.
+
+The integration shape these CLIs are designed for is the same shape
+Bazel `rules_jvm_external` and Amper task definitions already produce:
+ask the build system's resolver for the closure of the published
+Maven coordinate, then invoke
+
+```
+java -cp <resolved-classpath> ee.schimke.composeai.<package>.<Cli> [args]
+```
+
+with `<resolved-classpath>` being the platform-appropriate
+(`:`-separated on Unix, `;`-separated on Windows) join of every jar
+the resolver hands back. Concretely:
+
+| Artifact | Entry point |
+| --- | --- |
+| `ee.schimke.composeai:preview-discovery` | `ee.schimke.composeai.discovery.PreviewDiscoveryCli` |
+| `ee.schimke.composeai:daemon-launch-builder` | `ee.schimke.composeai.daemonlaunch.DaemonLaunchBuilderCli` |
+| `ee.schimke.composeai:render-cli` | `ee.schimke.composeai.render.cli.RenderCli` |
+
+Pass `--help` to any of them for the full flag list.
 
 ## Limitations and follow-ups
 

--- a/gradle-plugin/daemon-launch-builder/build.gradle.kts
+++ b/gradle-plugin/daemon-launch-builder/build.gradle.kts
@@ -47,9 +47,17 @@ composeAiMavenPublishing {
 }
 
 // CLI entry point (`DaemonLaunchBuilderCli`) is what Bazel rules and Amper tasks shell out
-// to. Same pattern as `:preview-discovery` — stamp the `Main-Class` so a build system can
-// invoke the artifact via `java -cp <classpath> ...DaemonLaunchBuilderCli ...` or
-// `java -jar` when transitive jars sit alongside.
+// to. Same pattern as `:preview-discovery`: slim library JAR (transitive deps —
+// kotlinx-serialization, kotlin-stdlib — are exposed as `api` and resolved by the consumer's
+// dep system), and the intended invocation is:
+//
+//     java -cp <resolved-classpath> ee.schimke.composeai.daemonlaunch.DaemonLaunchBuilderCli ...
+//
+// The `Main-Class:` stamp is a convenience for build systems that have already materialised
+// the full runtime closure next to the artifact (Bazel `runtime_jars`, hand-rolled `lib/`);
+// `java -jar` against the bare published JAR will NOT work — no `Class-Path:` manifest
+// entry, no shaded uber-JAR. See the "CLI invocation" section in
+// `docs/NON_GRADLE_INTEGRATION.md` for the consumer-facing contract.
 tasks.named<Jar>("jar").configure {
   manifest {
     attributes("Main-Class" to "ee.schimke.composeai.daemonlaunch.DaemonLaunchBuilderCli")

--- a/gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilder.kt
+++ b/gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilder.kt
@@ -10,8 +10,10 @@ import kotlinx.serialization.json.Json
  * sysprops + JVM args, emit a valid descriptor."
  *
  * Bazel rules and Amper tasks resolve their classpath through their own dep system
- * (`rules_jvm_external` / Amper's m2 cache) and hand the result to [build] (in-process) or
- * [DaemonLaunchBuilderCli] (via `java -jar`).
+ * (`rules_jvm_external` / Amper's m2 cache) and hand the result to [build] (in-process) or to
+ * [DaemonLaunchBuilderCli] via `java -cp <resolved-classpath>
+ * ee.schimke.composeai.daemonlaunch.DaemonLaunchBuilderCli …` (the published JAR is slim — see the
+ * CLI's KDoc for the full contract).
  */
 public object DaemonLaunchBuilder {
 

--- a/gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilderCli.kt
+++ b/gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilderCli.kt
@@ -4,13 +4,13 @@ import java.io.File
 import kotlin.system.exitProcess
 
 /**
- * `java -jar daemon-launch-builder-<version>.jar` entry point. Thin CLI wrapper over
- * [DaemonLaunchBuilder.build] for non-Gradle build systems. A Bazel `genrule` or an Amper task
- * can shell out here without buying into a Kotlin/JVM client.
+ * CLI entry point over [DaemonLaunchBuilder.build] for non-Gradle build systems. A Bazel `genrule`
+ * or an Amper task can shell out here without buying into a Kotlin/JVM client.
  *
- * Usage:
+ * The published `ee.schimke.composeai:daemon-launch-builder` JAR is a **slim library JAR** (no
+ * shaded uber-JAR, no `Class-Path:` manifest entry). The intended invocation is therefore:
  * ```
- * java -jar daemon-launch-builder.jar \
+ * java -cp <resolved-classpath> ee.schimke.composeai.daemonlaunch.DaemonLaunchBuilderCli \
  *   --module-path <path> \
  *   --variant <name> \
  *   --main-class <fqn> \
@@ -23,6 +23,13 @@ import kotlin.system.exitProcess
  *   --manifest-path <previews.json> \
  *   --out <daemon-launch.json>
  * ```
+ *
+ * where `<resolved-classpath>` is the runtime closure of
+ * `ee.schimke.composeai:daemon-launch-builder` as resolved by the caller's dep system (Bazel
+ * `rules_jvm_external`, Amper m2 cache, `mvn dependency:build-classpath`, etc.) and joined with the
+ * platform-appropriate `File.pathSeparator`. `java -jar <artifact>.jar` against the bare published
+ * JAR will fail with `NoClassDefFoundError` — see the "CLI invocation" section in
+ * `docs/NON_GRADLE_INTEGRATION.md`.
  *
  * `--classpath` accepts a `File.pathSeparator`-separated list and can be repeated; entries are
  * concatenated in order. `--jvm-arg` and `--system-property` are repeatable single-value flags
@@ -155,7 +162,7 @@ public object DaemonLaunchBuilderCli {
   private fun printUsage(out: java.io.PrintStream) {
     out.println(
       """
-      Usage: java -jar daemon-launch-builder.jar [options]
+      Usage: java -cp <resolved-classpath> ee.schimke.composeai.daemonlaunch.DaemonLaunchBuilderCli [options]
 
       Required:
         --module-path <path>           Module path (e.g. ":app", "//app", "app").

--- a/gradle-plugin/preview-discovery/build.gradle.kts
+++ b/gradle-plugin/preview-discovery/build.gradle.kts
@@ -19,8 +19,9 @@ ktfmt { googleStyle() }
 // Maven Central and produce conforming `previews.json` manifests by running the same scan the
 // gradle plugin uses — without dragging :gradle-plugin or AGP onto their classpath.
 //
-// A2c (next PR) adds a `java -jar` CLI main so a Bazel `genrule` or Amper task can wrap a
-// shell call to drive discovery; the library API exposed here is enough for in-process
+// A2c (next PR) adds a `java -cp` CLI main (`PreviewDiscoveryCli`) so a Bazel `genrule` or
+// Amper task can wrap a shell call to drive discovery once it has resolved the runtime
+// closure through its own dep system; the library API exposed here is enough for in-process
 // Kotlin/JVM consumers today.
 //
 // Lives inside the `gradle-plugin` composite build (rather than the outer build) so the
@@ -54,13 +55,22 @@ composeAiMavenPublishing {
   inceptionYear.set("2026")
 }
 
-// CLI entry point (`PreviewDiscoveryCli`) is what Bazel rules and Amper tasks shell out to —
-// stamping the `Main-Class` attribute lets a build system invoke the artifact via
-// `java -cp <classpath> ee.schimke.composeai.discovery.PreviewDiscoveryCli ...` or
-// `java -jar preview-discovery-<v>.jar ...` (the latter only when all transitive jars sit
-// next to the artifact, which is the shape a Bazel `runtime_jars` provider produces). The
-// transitive deps (classgraph, asm, kotlinx-serialization) are `api` so consumers resolving
-// the pom get the full classpath without extra work.
+// CLI entry point (`PreviewDiscoveryCli`) is what Bazel rules and Amper tasks shell out to.
+// The published artifact is a slim library JAR — the transitive deps (classgraph, asm,
+// kotlinx-serialization) are exposed as `api` so consumers resolving the POM through their
+// own dep system (Bazel `rules_jvm_external`, Amper m2 cache, etc.) get the full classpath,
+// and the intended invocation is:
+//
+//     java -cp <resolved-classpath> ee.schimke.composeai.discovery.PreviewDiscoveryCli ...
+//
+// The `Main-Class:` stamp is a convenience for build systems that have already materialised
+// the full runtime closure next to the artifact (e.g. Bazel's `runtime_jars` provider, or a
+// hand-rolled `lib/` directory); in that shape `java -jar preview-discovery-<v>.jar ...`
+// will work because the JVM happens to find every transitive class on the search path.
+// `java -jar` against the bare published JAR will NOT work — there is no `Class-Path:`
+// manifest entry and no shaded uber-JAR; it will fail with `NoClassDefFoundError`. See the
+// "CLI invocation" section in `docs/NON_GRADLE_INTEGRATION.md` for the consumer-facing
+// contract.
 tasks.named<Jar>("jar").configure {
   manifest {
     attributes("Main-Class" to "ee.schimke.composeai.discovery.PreviewDiscoveryCli")

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
@@ -5,13 +5,13 @@ import kotlin.system.exitProcess
 import kotlinx.serialization.json.Json
 
 /**
- * `java -jar preview-discovery-<version>.jar` entry point. Thin CLI wrapper over
- * [PreviewDiscovery.discover] for non-Gradle build systems — a Bazel `genrule` or an Amper
- * task can shell out here without buying into a Gradle Tooling-API client.
+ * CLI entry point over [PreviewDiscovery.discover] for non-Gradle build systems — a Bazel `genrule`
+ * or an Amper task can shell out here without buying into a Gradle Tooling-API client.
  *
- * Usage:
+ * The published `ee.schimke.composeai:preview-discovery` JAR is a **slim library JAR** (no shaded
+ * uber-JAR, no `Class-Path:` manifest entry). The intended invocation is therefore:
  * ```
- * java -jar preview-discovery.jar \
+ * java -cp <resolved-classpath> ee.schimke.composeai.discovery.PreviewDiscoveryCli \
  *   --classes <dir>[:<dir>...] \
  *   --dependency-jars <jar>[:<jar>...] \
  *   --source-files <file>[:<file>...] \
@@ -21,6 +21,12 @@ import kotlinx.serialization.json.Json
  *   [--fail-on-empty] \
  *   --out <path>
  * ```
+ *
+ * where `<resolved-classpath>` is the runtime closure of `ee.schimke.composeai:preview-discovery`
+ * as resolved by the caller's dep system (Bazel `rules_jvm_external`, Amper m2 cache, `mvn
+ * dependency:build-classpath`, etc.) and joined with the platform-appropriate `File.pathSeparator`.
+ * `java -jar <artifact>.jar` against the bare published JAR will fail with `NoClassDefFoundError` —
+ * see the "CLI invocation" section in `docs/NON_GRADLE_INTEGRATION.md`.
  *
  * `--classes`, `--dependency-jars`, `--source-files` accept a `File.pathSeparator`-separated
  * list (matching how `java -cp` already encodes classpaths on the consumer's platform) and can
@@ -138,7 +144,7 @@ public object PreviewDiscoveryCli {
   private fun printUsage(out: java.io.PrintStream) {
     out.println(
       """
-      Usage: java -jar preview-discovery.jar [options]
+      Usage: java -cp <resolved-classpath> ee.schimke.composeai.discovery.PreviewDiscoveryCli [options]
 
       Required:
         --module <name>             Logical module name; surfaces as PreviewManifest.module.

--- a/render-cli/build.gradle.kts
+++ b/render-cli/build.gradle.kts
@@ -3,10 +3,12 @@
 // and `:render-session-api`, both outer-build modules.
 //
 // Phase A of the contrib refactor (see `contrib/README.md`): contrib repo Bazel rules and
-// Amper tasks shell out to `java -jar render-cli.jar --descriptor X --previews Foo,Bar` to
-// drive a render, rather than re-implementing the JSON-RPC subprocess dance from scratch.
-// The library API surface lives in `:render-session-api`; this module is purely a CLI
-// adapter.
+// Amper tasks shell out to
+//   `java -cp <resolved-classpath> ee.schimke.composeai.render.cli.RenderCli \
+//      --descriptor X --previews Foo,Bar`
+// to drive a render, rather than re-implementing the JSON-RPC subprocess dance from
+// scratch. The library API surface lives in `:render-session-api`; this module is purely a
+// CLI adapter.
 
 plugins {
   id("composeai.maven-publishing")
@@ -33,18 +35,22 @@ composeAiMavenPublishing {
     artifactId = "render-cli",
     displayName = "Compose Preview — Render CLI",
     description =
-      "`java -jar` CLI over the render-session-subprocess library. Lets non-Gradle build " +
+      "`java -cp` CLI over the render-session-subprocess library. Lets non-Gradle build " +
         "systems (Bazel rules, Amper tasks) drive a render against an existing " +
         "`daemon-launch.json` without buying into a Kotlin/JVM client.",
   )
   inceptionYear.set("2026")
 }
 
-// `Main-Class` stamp lets a build system invoke the artifact via `java -jar render-cli.jar ...`
-// when all transitive jars (render-session-subprocess, render-session-api, daemon-core, mcp,
-// kotlinx-serialization) sit alongside, or via `java -cp <classpath> ...RenderCli ...` when
-// the build system resolves the classpath itself. Same pattern as `:preview-discovery`
-// and `:daemon-launch-builder`.
+// Slim library JAR; the intended invocation is
+//   `java -cp <resolved-classpath> ee.schimke.composeai.render.cli.RenderCli ...`
+// with the build system resolving the runtime closure (render-session-subprocess,
+// render-session-api, daemon-core, mcp, kotlinx-serialization) through its own dep system.
+// The `Main-Class:` stamp is a convenience for build systems that have already materialised
+// the full runtime closure next to the artifact (Bazel `runtime_jars`, hand-rolled `lib/`);
+// `java -jar` against the bare published JAR will NOT work — no `Class-Path:` manifest
+// entry, no shaded uber-JAR. Same pattern as `:preview-discovery` and
+// `:daemon-launch-builder`.
 tasks.named<Jar>("jar").configure {
   manifest { attributes("Main-Class" to "ee.schimke.composeai.render.cli.RenderCli") }
 }

--- a/render-cli/src/main/kotlin/ee/schimke/composeai/render/cli/RenderCli.kt
+++ b/render-cli/src/main/kotlin/ee/schimke/composeai/render/cli/RenderCli.kt
@@ -12,14 +12,14 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * `java -jar render-cli-<version>.jar` entry point. Thin CLI wrapper over
- * [SubprocessRenderSessions.open] for non-Gradle build systems. A Bazel `genrule` or an Amper task
- * can shell out here to drive a render against an existing `daemon-launch.json` without buying into
- * a Kotlin/JVM client.
+ * CLI entry point over [SubprocessRenderSessions.open] for non-Gradle build systems. A Bazel
+ * `genrule` or an Amper task can shell out here to drive a render against an existing
+ * `daemon-launch.json` without buying into a Kotlin/JVM client.
  *
- * Usage:
+ * The published `ee.schimke.composeai:render-cli` JAR is a **slim library JAR** (no shaded
+ * uber-JAR, no `Class-Path:` manifest entry). The intended invocation is therefore:
  * ```
- * java -jar render-cli.jar \
+ * java -cp <resolved-classpath> ee.schimke.composeai.render.cli.RenderCli \
  *   --descriptor <daemon-launch.json> \
  *   --workspace-root <dir> \
  *   --previews <id>[,<id>...] \
@@ -28,6 +28,12 @@ import kotlinx.serialization.json.jsonPrimitive
  *   [--timeout-seconds 60] \
  *   [--workspace-name <name>]
  * ```
+ *
+ * where `<resolved-classpath>` is the runtime closure of `ee.schimke.composeai:render-cli` as
+ * resolved by the caller's dep system (Bazel `rules_jvm_external`, Amper m2 cache, etc.) and
+ * joined with the platform-appropriate `File.pathSeparator`. `java -jar <artifact>.jar`
+ * against the bare published JAR will fail with `NoClassDefFoundError` — see the "CLI
+ * invocation" section in `docs/NON_GRADLE_INTEGRATION.md`.
  *
  * `--previews` accepts a comma-separated list and can be repeated. The CLI waits for one
  * `renderFinished` notification per requested preview id, prints the resulting PNG path to stdout
@@ -188,7 +194,7 @@ public object RenderCli {
   private fun printUsage(out: java.io.PrintStream) {
     out.println(
       """
-      Usage: java -jar render-cli.jar [options]
+      Usage: java -cp <resolved-classpath> ee.schimke.composeai.render.cli.RenderCli [options]
 
       Required:
         --descriptor <path>         Absolute path to daemon-launch.json.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -335,6 +335,6 @@ include(":render-session-embedded-desktop")
 
 project(":render-session-embedded-desktop").projectDir = file("render-session/embedded-desktop")
 
-// Thin `java -jar` CLI over `:render-session-subprocess` for non-Gradle build systems
+// Thin `java -cp` CLI over `:render-session-subprocess` for non-Gradle build systems
 // (Bazel rules, Amper tasks in `yschimke/compose-ai-contrib`). See `contrib/README.md`.
 include(":render-cli")


### PR DESCRIPTION
## Summary

`:preview-discovery`, `:daemon-launch-builder`, and `:render-cli` publish slim library JARs that stamp only `Main-Class:` — no `Class-Path:` manifest entry, no shaded uber-JAR, no bundled transitive deps. The advertised `java -jar <artifact>.jar` invocation therefore fails immediately with `NoClassDefFoundError` (the `-jar` launcher mode makes the JVM ignore `-cp`, so the transitive `classgraph` / `asm` / `kotlinx-serialization` / `kotlin-stdlib` jars are unreachable).

This PR picks **option (b) from the issue**: stop advertising standalone `java -jar` and document the `java -cp <resolved-classpath> <fqn>` shape that Bazel `rules_jvm_external` and Amper tasks already produce. Rationale:

- The published artifacts are explicitly designed as slim libraries that the consumer's dep resolver pulls into the runtime closure (the `api(libs.classgraph)` / `api(libs.kotlinx.serialization.json)` declarations make this the contract). A fat/shadow JAR would change the published artifact shape and duplicate the Maven dependency graph.
- The Gradle-side `:cli` does ship a real distribution via the `application` plugin (launcher script + `lib/` dir) — but `:render-cli` and the two `gradle-plugin/` subprojects do not, and they're not consumed that way: the in-repo Bazel/Amper recipes resolve the runtime closure and pass it as `-cp`. Matching docs to the intended integration shape is the lighter, more honest fix.
- The `Main-Class:` stamps stay in place as a convenience for build systems that have already materialised the runtime closure next to the artifact (Bazel `runtime_jars`, hand-rolled `lib/` dir).

### Changes

- `contrib/README.md`: per-artifact lines now spell out the `java -cp` call and the slim-JAR contract; a callout explains that `-jar` does not work standalone.
- `docs/NON_GRADLE_INTEGRATION.md`: producer cells link to a new "CLI invocation" section that documents the classpath contract end-to-end with an entry-point table.
- `gradle-plugin/preview-discovery/`, `gradle-plugin/daemon-launch-builder/`, `render-cli/` build files + Kotlin entry-point KDocs + `--help` output: replace `java -jar` with `java -cp …Cli` and explain the slim-JAR limitation.
- `settings.gradle.kts`: matches the comment on `:render-cli`.

## Test plan

- [x] `grep -rn "java -jar" docs/ contrib/` returns only negative mentions (warnings that it does NOT work).
- [x] `--help` usage strings on all three CLIs now advertise the `java -cp` form.
- [ ] CI: existing JVM tests for `PreviewDiscoveryCli`, `DaemonLaunchBuilderCli`, `RenderCli` continue to pass (no usage-string assertions in the test sources).

Closes #1361

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrokMktYqb8RkaWf9FKLgP)_