### PR TITLE
fix(preview-discovery): surface skip-reason warnings on failure path (#1364)

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -63,11 +63,17 @@ object PreviewDiscovery {
      * class isn't reachable on the ClassGraph classpath at all). [reason] is the one-line error
      * the adapter should surface as an exception message; [diagnostics] is the multi-line
      * dump (class dirs, dependency-jar sample, observed annotation FQNs) the adapter logs
-     * before the failure so users can see what the scan saw.
+     * before the failure so users can see what the scan saw. [warnings] are any per-method
+     * skip reasons collected during the scan (e.g. private `@Preview`, unsupported
+     * parameters) — they're the most actionable signal when discovery returned zero previews
+     * because methods were skipped, so the adapter should route them to its build system's
+     * WARN-level log alongside [diagnostics] before surfacing [reason]. Symmetric with
+     * [Success.warnings] so adapters can emit the same WARN stream on both branches.
      */
     data class Failure(
       val reason: String,
       val diagnostics: List<String>,
+      val warnings: List<String> = emptyList(),
     ) : Outcome()
   }
 
@@ -334,6 +340,7 @@ object PreviewDiscovery {
           "composePreview: discovered 0 previews in module '${input.moduleName}' — " +
             "$reason. See diagnostics above.",
         diagnostics = diagnostics,
+        warnings = warnings.toList(),
       )
     }
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
@@ -53,6 +53,10 @@ public object PreviewDiscoveryCli {
         exitProcess(0)
       }
       is PreviewDiscovery.Outcome.Failure -> {
+        // Mirror the success branch's WARN emission so the failure path doesn't drop per-method
+        // skip reasons (private @Preview, unsupported parameters) — they're the most actionable
+        // signal when failOnEmpty filtered the run to zero previews.
+        outcome.warnings.forEach { System.err.println("WARN: $it") }
         outcome.diagnostics.forEach { System.err.println(it) }
         System.err.println("preview-discovery: ${outcome.reason}")
         exitProcess(1)

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryFailureWarningsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryFailureWarningsTest.kt
@@ -1,0 +1,101 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.objectweb.asm.AnnotationVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+
+/**
+ * Regression coverage for [PreviewDiscovery.Outcome.Failure] carrying per-method `warnings`
+ * symmetrically with [PreviewDiscovery.Outcome.Success]. The historical bug: when
+ * `failOnEmpty=true` and every candidate method got filtered out (private `@Preview`, unsupported
+ * parameter shapes), discovery returned `Failure` with `diagnostics` only — the skip reasons
+ * collected during the scan were silently dropped, leaving the consumer with no actionable signal
+ * for "why didn't my preview show up". See issue #1364.
+ *
+ * Hand-rolls a `.class` file via ASM so the test exercises the real ClassGraph scan against a
+ * private-method-with-`@Preview`-annotation candidate, without round-tripping through Kotlin
+ * compilation.
+ */
+class PreviewDiscoveryFailureWarningsTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  @Test
+  fun `failure path carries per-method skip-reason warnings`() {
+    val classDir = tempDir.newFolder("classes")
+    writePrivatePreviewClass(classDir, internalName = "test/PrivatePreviewKt", methodName = "Hidden")
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = listOf(classDir),
+          dependencyJars = emptyList(),
+          sourceFiles = emptyList(),
+          moduleName = ":app",
+          variantName = "debug",
+          projectDirectory = classDir,
+          failOnEmpty = true,
+        )
+      )
+
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Failure::class.java)
+    val failure = outcome as PreviewDiscovery.Outcome.Failure
+    assertThat(failure.warnings).isNotEmpty()
+    // The actionable signal: name the method and explain WHY it was skipped.
+    val joined = failure.warnings.joinToString("\n")
+    assertThat(joined).contains("test.PrivatePreviewKt.Hidden")
+    assertThat(joined).contains("private")
+  }
+
+  @Test
+  fun `Failure warnings default to empty for source-compatibility`() {
+    // Existing callers constructing Failure positionally (reason, diagnostics) must keep
+    // working — `warnings` is a new optional field with an empty default.
+    val failure = PreviewDiscovery.Outcome.Failure(reason = "nope", diagnostics = listOf("d"))
+    assertThat(failure.warnings).isEmpty()
+  }
+
+  /**
+   * Writes a minimal `.class` file containing one private static method annotated with
+   * `androidx.compose.ui.tooling.preview.Preview`. Mirrors the JVM shape Kotlin's compiler
+   * produces for a top-level `private fun @Preview Hidden()` — file-class with a private static
+   * method, single annotation entry. The method body is a no-op (`RETURN`); discovery only
+   * inspects the annotation + visibility, never invokes the method.
+   */
+  private fun writePrivatePreviewClass(outDir: File, internalName: String, methodName: String) {
+    val cw = ClassWriter(0)
+    cw.visit(
+      Opcodes.V17,
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL or Opcodes.ACC_SUPER,
+      internalName,
+      null,
+      "java/lang/Object",
+      null,
+    )
+    val mv =
+      cw.visitMethod(
+        Opcodes.ACC_PRIVATE or Opcodes.ACC_STATIC,
+        methodName,
+        "()V",
+        null,
+        null,
+      )
+    val av: AnnotationVisitor =
+      mv.visitAnnotation("Landroidx/compose/ui/tooling/preview/Preview;", true)
+    av.visitEnd()
+    mv.visitCode()
+    mv.visitInsn(Opcodes.RETURN)
+    mv.visitMaxs(0, 0)
+    mv.visitEnd()
+    cw.visitEnd()
+
+    val classFile = File(outDir, "$internalName.class")
+    classFile.parentFile.mkdirs()
+    classFile.writeBytes(cw.toByteArray())
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -92,6 +92,11 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         outcome.infoMessages.forEach { logger.lifecycle(it) }
       }
       is PreviewDiscovery.Outcome.Failure -> {
+        // Surface per-method skip reasons (private @Preview, unsupported parameters) before the
+        // diagnostics dump so users can see WHY a method was filtered out — when failOnEmpty=true
+        // and every candidate was skipped, these warnings are the most actionable signal. Mirrors
+        // the Success branch's warning emission so the failure path doesn't drop them.
+        outcome.warnings.forEach { logger.warn(it) }
         outcome.diagnostics.forEach { logger.lifecycle(it) }
         throw GradleException(outcome.reason)
       }


### PR DESCRIPTION
## Summary

`DiscoverPreviewsTask` logged `outcome.diagnostics` and threw on `Failure`, but per-method warnings were only routed on the `Success` path. With `failOnEmpty=true`, when discovery returned zero previews because every candidate got skipped (private `@Preview`, unsupported parameter shapes), the skip reasons were silently dropped — leaving consumers with no actionable signal for "why didn't my preview appear".

- Surface `outcome.warnings` on the `Failure` branch (WARN level) before the diagnostics dump, mirroring the `Success` branch. Same treatment for `PreviewDiscoveryCli`'s failure path so the non-Gradle CLI emits the same `WARN:` stream.
- **Outcome schema was updated.** `Outcome.Failure` did not previously carry `warnings`. It now does, as a new optional `warnings: List<String>` field defaulting to `emptyList()` so any external callers constructing `Failure` positionally keep compiling. Symmetric with `Outcome.Success.warnings`.
- `PreviewDiscovery.discover` populates the new field from the same `warnings` list it was already collecting during the scan — the zero-preview `failOnEmpty` exit now hands them through instead of dropping them.

## Test plan

- [x] `./gradlew :gradle-plugin:preview-discovery:test :gradle-plugin:test` — green.
- [x] New `PreviewDiscoveryFailureWarningsTest` hand-rolls a `.class` file via ASM with a single private `@Preview` method and asserts the `Failure` carries the skip-reason warning naming the method and explaining the cause ("private"). Also pins the default-empty behaviour for the new field so positional construction stays source-compatible.
- [x] `./gradlew ktfmtCheckAll` clean.

Closes #1364

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrokMktYqb8RkaWf9FKLgP)_