### PR TITLE
fix(cli): gate auto-inject buildscript classpath per project

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -44,16 +44,24 @@ internal fun renderInitScript(pluginVersion: String): String =
 // Application uses pluginManager.withPlugin(...) (not afterEvaluate) so AGP
 // finalizeDsl / onVariants callbacks register before the DSL lock.
 //
-// Pre-applied detection: if any build file in the project tree declares the
-// plugin with a version — either literal `id("...") version "..."` or via
-// `alias(libs.plugins.<x>)` where the version catalog maps <x> to this
-// plugin id — we skip the buildscript classpath injection below. Gradle's
-// plugins {} DSL rejects `id(...) version "..."` when the same plugin is
-// also on the buildscript classpath ("the plugin is already on the
-// classpath with an unknown version, so compatibility cannot be checked"),
-// and the user's own declaration provides resolution via plugin marker
-// repos. The withPlugin hooks remain registered and no-op via the
-// plugins.hasPlugin(...) guard.
+// Pre-applied detection is *per project*: for each subproject whose build
+// file declares the plugin with a version — either literal
+// `id("...") version "..."` or via `alias(libs.plugins.<x>)` where the
+// version catalog maps <x> to this plugin id — we skip the buildscript
+// classpath injection for that project. Gradle's plugins {} DSL rejects
+// `id(...) version "..."` when the same plugin is also on the buildscript
+// classpath ("the plugin is already on the classpath with an unknown
+// version, so compatibility cannot be checked"), and the user's own
+// declaration provides resolution via plugin marker repos. Projects that
+// don't declare the plugin themselves still get the buildscript classpath
+// injection so the withPlugin / pluginManager.apply path can find the
+// plugin class — this is what mixed-shape multi-module projects need
+// (e.g. an `:app` module that applies the plugin via catalog alias, plus
+// a sibling `:rc-components` android-library module that doesn't; the init
+// script's withPlugin("com.android.library") hook fires in rc-components
+// too and the plugin must be resolvable from its buildscript classpath).
+// The withPlugin hooks in projects that already apply the plugin no-op via
+// the plugins.hasPlugin(...) guard.
 //
 // `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1` opts the buildscript repos into
 // `mavenLocal()` — exercised by the gradle-plugin functional tests, which
@@ -65,7 +73,7 @@ internal fun renderInitScript(pluginVersion: String): String =
 val pluginVersion = "$pluginVersion"
 val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
 
-var composeAiPreviewPreApplied = false
+var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()
 
 fun composeAiPreviewCatalogAccessors(rootDir: java.io.File): List<Regex> {
     val catalog = java.io.File(rootDir, "gradle/libs.versions.toml")
@@ -115,24 +123,29 @@ fun composeAiPreviewStripComments(source: String): String {
 fun scanForComposeAiPreviewDeclaration(
     rootDir: java.io.File,
     projectDirs: List<java.io.File>,
-): Boolean {
+): Set<java.io.File> {
     val catalogAccessors = composeAiPreviewCatalogAccessors(rootDir)
     val literalVersionedRe = Regex(
         "\\bid\\s*[(\\s]\\s*[\"']ee\\.schimke\\.composeai\\.preview[\"']\\s*\\)?\\s*(?:\\.\\s*)?version\\b"
     )
+    val declared = LinkedHashSet<java.io.File>()
     for (dir in projectDirs) {
         for (name in listOf("build.gradle.kts", "build.gradle")) {
             val buildFile = java.io.File(dir, name)
             if (!buildFile.isFile) continue
             val raw = runCatching { buildFile.readText() }.getOrNull() ?: continue
             val text = composeAiPreviewStripComments(raw)
-            if (literalVersionedRe.containsMatchIn(text)) return true
-            for (re in catalogAccessors) {
-                if (re.containsMatchIn(text)) return true
+            if (literalVersionedRe.containsMatchIn(text)) {
+                declared.add(dir)
+                break
+            }
+            if (catalogAccessors.any { it.containsMatchIn(text) }) {
+                declared.add(dir)
+                break
             }
         }
     }
-    return false
+    return declared
 }
 
 gradle.settingsEvaluated {
@@ -142,7 +155,7 @@ gradle.settingsEvaluated {
         descriptor.children.forEach { collect(it) }
     }
     collect(rootProject)
-    composeAiPreviewPreApplied = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)
+    composeAiPreviewPreAppliedDirs = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)
 
     // When opting into mavenLocal, also seed it at the settings level so the renderer-android AAR
     // and any other ee.schimke.composeai:* runtime artifacts resolve from ~/.m2 alongside the
@@ -172,7 +185,7 @@ gradle.settingsEvaluated {
 }
 
 allprojects {
-    if (!composeAiPreviewPreApplied) {
+    if (projectDir !in composeAiPreviewPreAppliedDirs) {
         buildscript {
             repositories {
                 gradlePluginPortal()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -509,25 +509,49 @@ class AutoInjectTest {
   }
 
   @Test
-  fun `init script gates the buildscript classpath injection on pre-applied detection`() {
+  fun `init script gates the buildscript classpath injection on per-project pre-applied detection`() {
+    // Regression for #305 (homeassistant-remotecompose): the original gate was a single global
+    // boolean, so a mixed-shape project where some modules declare the plugin via
+    // `alias(libs.plugins.compose.preview)` and others don't would skip buildscript injection
+    // *everywhere* and then `pluginManager.apply` from the withPlugin hooks would fail in the
+    // modules without the catalog alias ("Plugin with id 'ee.schimke.composeai.preview' not
+    // found."). The gate is now a per-project set of project directories that declare the
+    // plugin themselves.
     val script = renderInitScript("0.10.15")
     assertTrue(
-      script.contains("var composeAiPreviewPreApplied = false"),
-      "expected the pre-applied flag declaration",
+      script.contains("var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()"),
+      "expected the per-project pre-applied directory set declaration",
     )
     assertTrue(
       script.contains(
-        "composeAiPreviewPreApplied = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)"
+        "composeAiPreviewPreAppliedDirs = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)"
       ),
-      "expected the flag to be set during settingsEvaluated",
+      "expected the set to be populated during settingsEvaluated",
     )
     assertTrue(
-      script.contains("if (!composeAiPreviewPreApplied) {"),
-      "expected the buildscript block to be guarded by the flag",
+      script.contains("if (projectDir !in composeAiPreviewPreAppliedDirs) {"),
+      "expected the buildscript block to be guarded per-project on the directory set",
     )
     assertTrue(
       script.contains("gradle/libs.versions.toml"),
       "expected the catalog accessor scanner to read libs.versions.toml so alias(...) declarations are detected",
+    )
+  }
+
+  @Test
+  fun `init script's scanForComposeAiPreviewDeclaration returns the matching project dirs`() {
+    // Pins the per-project return shape so a future refactor doesn't silently drop back to a
+    // global Boolean (which is the #305 regression mode).
+    val script = renderInitScript("1.0.0")
+    assertTrue(
+      script.contains(
+        "fun scanForComposeAiPreviewDeclaration(\n    rootDir: java.io.File,\n    projectDirs: List<java.io.File>,\n): Set<java.io.File> {"
+      ),
+      "expected scanForComposeAiPreviewDeclaration to return Set<File> of pre-applied project dirs",
+    )
+    assertFalse(
+      script.contains("): Boolean {\n    val catalogAccessors = composeAiPreviewCatalogAccessors"),
+      "expected scanForComposeAiPreviewDeclaration to no longer return a single global Boolean",
     )
   }
 

--- a/vscode-extension/src/initScript.ts
+++ b/vscode-extension/src/initScript.ts
@@ -46,16 +46,24 @@ export function renderInitScript(
 // Application uses pluginManager.withPlugin(...) (not afterEvaluate) so
 // AGP finalizeDsl / onVariants callbacks register before the DSL lock.
 //
-// Pre-applied detection: if any build file in the project tree declares the
-// plugin with a version — either literal \`id("...") version "..."\` or via
-// \`alias(libs.plugins.<x>)\` where the version catalog maps <x> to this
-// plugin id — we skip the buildscript classpath injection below. Gradle's
-// plugins {} DSL rejects \`id(...) version "..."\` when the same plugin is
-// also on the buildscript classpath ("the plugin is already on the
-// classpath with an unknown version, so compatibility cannot be checked"),
-// and the user's own declaration provides resolution via plugin marker
-// repos. The withPlugin hooks remain registered and no-op via the
-// plugins.hasPlugin(...) guard.
+// Pre-applied detection is *per project*: for each subproject whose build
+// file declares the plugin with a version — either literal
+// \`id("...") version "..."\` or via \`alias(libs.plugins.<x>)\` where the
+// version catalog maps <x> to this plugin id — we skip the buildscript
+// classpath injection for that project. Gradle's plugins {} DSL rejects
+// \`id(...) version "..."\` when the same plugin is also on the buildscript
+// classpath ("the plugin is already on the classpath with an unknown
+// version, so compatibility cannot be checked"), and the user's own
+// declaration provides resolution via plugin marker repos. Projects that
+// don't declare the plugin themselves still get the buildscript classpath
+// injection so the withPlugin / pluginManager.apply path can find the
+// plugin class — this is what mixed-shape multi-module projects need
+// (e.g. an \`:app\` module that applies the plugin via catalog alias, plus
+// a sibling \`:rc-components\` android-library module that doesn't; the
+// init script's withPlugin("com.android.library") hook fires in
+// rc-components too and the plugin must be resolvable from its buildscript
+// classpath). The withPlugin hooks in projects that already apply the
+// plugin no-op via the plugins.hasPlugin(...) guard.
 //
 // \`COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1\` opts the buildscript repos into
 // \`mavenLocal()\` — mirrors the CLI's AutoInject.kt behavior. Useful for
@@ -67,7 +75,7 @@ export function renderInitScript(
 val pluginVersion = "${pluginVersion}"
 val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
 
-var composeAiPreviewPreApplied = false
+var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()
 
 fun composeAiPreviewCatalogAccessors(rootDir: java.io.File): List<Regex> {
     val catalog = java.io.File(rootDir, "gradle/libs.versions.toml")
@@ -119,24 +127,29 @@ fun composeAiPreviewStripComments(source: String): String {
 fun scanForComposeAiPreviewDeclaration(
     rootDir: java.io.File,
     projectDirs: List<java.io.File>,
-): Boolean {
+): Set<java.io.File> {
     val catalogAccessors = composeAiPreviewCatalogAccessors(rootDir)
     val literalVersionedRe = Regex(
         "\\\\bid\\\\s*[(\\\\s]\\\\s*[\\"']ee\\\\.schimke\\\\.composeai\\\\.preview[\\"']\\\\s*\\\\)?\\\\s*(?:\\\\.\\\\s*)?version\\\\b"
     )
+    val declared = LinkedHashSet<java.io.File>()
     for (dir in projectDirs) {
         for (name in listOf("build.gradle.kts", "build.gradle")) {
             val buildFile = java.io.File(dir, name)
             if (!buildFile.isFile) continue
             val raw = runCatching { buildFile.readText() }.getOrNull() ?: continue
             val text = composeAiPreviewStripComments(raw)
-            if (literalVersionedRe.containsMatchIn(text)) return true
-            for (re in catalogAccessors) {
-                if (re.containsMatchIn(text)) return true
+            if (literalVersionedRe.containsMatchIn(text)) {
+                declared.add(dir)
+                break
+            }
+            if (catalogAccessors.any { it.containsMatchIn(text) }) {
+                declared.add(dir)
+                break
             }
         }
     }
-    return false
+    return declared
 }
 
 gradle.settingsEvaluated {
@@ -146,7 +159,7 @@ gradle.settingsEvaluated {
         descriptor.children.forEach { collect(it) }
     }
     collect(rootProject)
-    composeAiPreviewPreApplied = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)
+    composeAiPreviewPreAppliedDirs = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)
 
     // When opting into mavenLocal, also seed it at the settings level so the renderer-android AAR
     // and any other ee.schimke.composeai:* runtime artifacts resolve from ~/.m2 alongside the
@@ -173,7 +186,7 @@ gradle.settingsEvaluated {
 }
 
 allprojects {
-    if (!composeAiPreviewPreApplied) {
+    if (projectDir !in composeAiPreviewPreAppliedDirs) {
         buildscript {
             repositories {
                 gradlePluginPortal()

--- a/vscode-extension/src/test/initScript.test.ts
+++ b/vscode-extension/src/test/initScript.test.ts
@@ -76,34 +76,48 @@ describe("renderInitScript", () => {
         );
     });
 
-    it("gates the buildscript classpath injection on pre-applied detection", () => {
-        // When the consumer already declares the plugin (via plugins {} with
-        // version, or `alias(libs.plugins.<x>)`), unconditionally injecting
-        // the plugin onto the buildscript classpath makes Gradle reject the
-        // user's plugins block with "plugin already on the classpath with an
-        // unknown version". The init script must scan the project tree and
-        // skip injection when any build file declares the plugin with a
-        // version.
+    it("gates the buildscript classpath injection on per-project pre-applied detection", () => {
+        // Regression for #305 (homeassistant-remotecompose): the original gate was a single
+        // global boolean, so a mixed-shape project where some modules declare the plugin via
+        // `alias(libs.plugins.compose.preview)` and others don't would skip buildscript
+        // injection *everywhere*. Then `pluginManager.apply` from the withPlugin hooks would
+        // fail in the modules without the catalog alias ("Plugin with id
+        // 'ee.schimke.composeai.preview' not found."). The gate is now a per-project set of
+        // project directories that declare the plugin themselves; modules without their own
+        // declaration still get the buildscript classpath injection so withPlugin's
+        // pluginManager.apply can resolve the plugin class.
         const script = renderInitScript();
         assert.ok(
-            script.includes("var composeAiPreviewPreApplied = false"),
-            "expected the pre-applied flag declaration",
+            script.includes(
+                "var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()",
+            ),
+            "expected the per-project pre-applied directory set declaration",
         );
         assert.ok(
             script.includes(
-                "composeAiPreviewPreApplied = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)",
+                "composeAiPreviewPreAppliedDirs = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)",
             ),
-            "expected the flag to be set during settingsEvaluated",
+            "expected the set to be populated during settingsEvaluated",
         );
         assert.ok(
-            script.includes("if (!composeAiPreviewPreApplied) {"),
-            "expected the buildscript block to be guarded by the flag",
+            script.includes(
+                "if (projectDir !in composeAiPreviewPreAppliedDirs) {",
+            ),
+            "expected the buildscript block to be guarded per-project on the directory set",
         );
         // Catalog alias resolution: the scanner must look at gradle/libs.versions.toml
         // so that `alias(libs.plugins.<x>)` references are detected.
         assert.ok(
             script.includes("gradle/libs.versions.toml"),
             "expected the catalog accessor scanner to read libs.versions.toml",
+        );
+        // Pin the per-project return shape so a future refactor doesn't silently drop back
+        // to the global Boolean (which is the #305 regression mode).
+        assert.ok(
+            script.includes(
+                "fun scanForComposeAiPreviewDeclaration(\n    rootDir: java.io.File,\n    projectDirs: List<java.io.File>,\n): Set<java.io.File> {",
+            ),
+            "expected scanForComposeAiPreviewDeclaration to return Set<File> of pre-applied project dirs",
         );
     });
 


### PR DESCRIPTION
The auto-inject init script used a single global boolean to decide whether
to inject the plugin onto the buildscript classpath. When any module in
a multi-module project declared the plugin via `alias(libs.plugins.compose.preview)`,
the script skipped buildscript injection everywhere. Then `pluginManager.apply(
"ee.schimke.composeai.preview")` fired from the `withPlugin("com.android.library")`
hook in sibling modules that did not apply the plugin themselves, and Gradle
failed with "Plugin with id 'ee.schimke.composeai.preview' not found."

Shifts the gate to a per-project set of project directories. Modules that
declare the plugin via `plugins {}` still skip injection (avoiding the
"plugin already on the classpath with an unknown version" DSL conflict);
modules that do not get the buildscript injection so the auto-apply hook
can resolve the plugin class.

Mirrors the change in the VS Code extension's `initScript.ts` so the two
auto-inject paths stay in lockstep.

Fixes yschimke/homeassistant-remotecompose#305.