### PR TITLE
feat(vscode-extension): wire Remote Compose tab body edits back to the daemon

### DIFF
--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -469,6 +469,20 @@ export interface PreviewOverrides {
      * app's natural IME signals.
      */
     keyboard?: KeyboardOverride;
+    /**
+     * Remote Compose override. Carries the daemon-requested platform
+     * profile (`RcPlatformProfiles` mirror), seeded named values (typed
+     * sum: float / dp / int / string / bool / color), and an optional
+     * accept-list filter for captured `HostAction` events. Drives the
+     * connector-side `RemoteComposeOverrideExtension` so user code inside
+     * a `RemotePreview { ... }` block can read seeded values via
+     * `LocalRemoteComposeHost.current.namedFloat(...)` and report fired
+     * actions via `reportHostAction(...)`. Sending a fresh `remoteCompose`
+     * on a subsequent `renderNow` replaces the named-value map + profile
+     * (host-action buffer persists across overrides until session reset).
+     * Android-only; desktop ignores.
+     */
+    remoteCompose?: RemoteComposeOverride;
 }
 
 /** Soft-keyboard (IME) override. See `PreviewOverrides.keyboard`. */
@@ -476,6 +490,37 @@ export interface KeyboardOverride {
     visible?: boolean;
     pressedKey?: string;
 }
+
+/**
+ * Remote Compose override. See `PreviewOverrides.remoteCompose`. The
+ * profile string matches `RemoteComposeProfile` in `types.ts` (re-typed
+ * here to keep daemon-protocol module standalone). `namedValues` keys
+ * are bound by user code via `LocalRemoteComposeHost`; values use the
+ * same typed sum the daemon's `data/fetch` returns so a round-trip
+ * (panel edit → renderNow → re-fetch) round-trips identity-equivalently.
+ */
+export interface RemoteComposeOverride {
+    profile?:
+        | "androidx"
+        | "androidx7"
+        | "androidx8"
+        | "androidx9"
+        | "widgetsV6"
+        | "widgetsV7"
+        | "wearWidgets"
+        | null;
+    namedValues?: Record<string, RemoteNamedValueWire>;
+    acceptedHostActions?: string[];
+}
+
+/** Wire-shape mirror of `RemoteNamedValue` (see Messages.kt). */
+export type RemoteNamedValueWire =
+    | { kind: "float"; value: number }
+    | { kind: "dp"; value: number }
+    | { kind: "int"; value: number }
+    | { kind: "string"; value: string }
+    | { kind: "bool"; value: boolean }
+    | { kind: "color"; argb: string };
 
 export interface RenderNowParams {
     previews: string[];

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -10,6 +10,7 @@ import {
     FileKind,
     HistoryAddedParams,
     HistoryPrunedParams,
+    PreviewOverrides,
     RenderFinishedParams,
     RenderTier,
     StreamFrameParams,
@@ -166,6 +167,7 @@ export interface DaemonScheduler {
         previewIds: string[],
         tier?: RenderTier,
         reason?: string,
+        overrides?: PreviewOverrides,
     ): Promise<boolean>;
     daemonEvents(moduleId: string): DaemonClientEvents;
 }
@@ -551,6 +553,7 @@ export class LiveDaemonScheduler implements DaemonScheduler {
         previewIds: string[],
         tier: RenderTier = "fast",
         reason?: string,
+        overrides?: PreviewOverrides,
     ): Promise<boolean> {
         const client = await this.gate.getOrSpawn(
             module,
@@ -564,6 +567,7 @@ export class LiveDaemonScheduler implements DaemonScheduler {
                 previews: previewIds,
                 tier,
                 reason,
+                overrides,
             });
             for (const r of result.rejected) {
                 this.logger.appendLine(

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -232,6 +232,19 @@ const previewModuleMap = new Map<string, ModuleInfo>();
  *  no longer participates in a11y at all — production is daemon-only —
  *  so this map drives daemon subscriptions only, never gradle args. */
 const moduleA11ySubscriptions = new Map<string, Set<string>>();
+/**
+ * previewId → latest Remote Compose override the panel pushed. The panel's
+ * editable tab body posts `setRemoteComposeNamedValue` per cell change; we
+ * merge into this map and forward the full bag on the next `renderNow` so
+ * the daemon's `RemoteComposeController.set(...)` applies the cumulative
+ * state. The map persists across renders so a user editing a value, then
+ * editing another, sees both reflected (the daemon-side controller resets
+ * on session close — this map mirrors that scope).
+ */
+const remoteComposeOverridesByPreview = new Map<
+    string,
+    import("./daemon/daemonProtocol").RemoteComposeOverride
+>();
 /** Tracks files saved at least once since activation. First save on a file
  *  renders immediately; subsequent saves go through the debounce path. */
 const firstSaveSeen = new Set<string>();
@@ -4606,6 +4619,21 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 );
             }
             break;
+        case "setRemoteComposeNamedValue":
+            // Panel-side Remote Compose tab body edit. Merges the change
+            // into the per-preview running override bag and dispatches a
+            // fresh `renderNow` so the daemon's
+            // `RemoteComposeOverrideExtension` re-seeds the controller
+            // for the next composition. Gated on early features so the
+            // panel surface ships behind the same flag as the other
+            // data-extension chips while the wire shape settles.
+            if (earlyFeaturesEnabled()) {
+                void handleSetRemoteComposeNamedValue(
+                    msg.previewId,
+                    msg.change,
+                );
+            }
+            break;
         case "openResourceFile":
             void openResourceFile(
                 {
@@ -4870,6 +4898,61 @@ async function handleSetDataExtensionEnabled(
             panel?.postMessage({ command: "updateA11y", ...update });
         }
     }
+}
+
+/**
+ * Apply one edit from the panel's Remote Compose tab body. Merges the
+ * change into [remoteComposeOverridesByPreview] and dispatches a fresh
+ * `renderNow` so the daemon's `RemoteComposeController.set(...)` picks
+ * up the new state on the next composition. Subsequent edits accumulate
+ * on the same override bag — the daemon-side controller treats
+ * `RemoteComposeOverride.namedValues` as a full-replacement map, so we
+ * carry the whole running snapshot in the message rather than letting
+ * the user lose previously-edited values on each new edit.
+ *
+ * No-op when the daemon scheduler isn't wired (Gradle-only mode) or the
+ * preview's owning module isn't yet known (panel rebuild race) — the
+ * webview will keep its optimistic value displayed in the input cell;
+ * the next `updateDataProducts` after a fresh render will reconcile it.
+ */
+async function handleSetRemoteComposeNamedValue(
+    previewId: string,
+    change: import("./types").RemoteComposeChangeDetail,
+): Promise<void> {
+    if (!daemonScheduler) {
+        return;
+    }
+    const moduleInfo = previewModuleMap.get(previewId);
+    if (!moduleInfo) {
+        return;
+    }
+    const prior =
+        remoteComposeOverridesByPreview.get(previewId) ??
+        ({} as import("./daemon/daemonProtocol").RemoteComposeOverride);
+    const next: import("./daemon/daemonProtocol").RemoteComposeOverride = {
+        profile: prior.profile,
+        namedValues: { ...(prior.namedValues ?? {}) },
+        acceptedHostActions: prior.acceptedHostActions,
+    };
+    if (change.field === "profile") {
+        next.profile = change.value;
+    } else {
+        next.namedValues = {
+            ...(next.namedValues ?? {}),
+            [change.name]: change.value,
+        };
+    }
+    remoteComposeOverridesByPreview.set(previewId, next);
+    logInfo(
+        `[panel] remoteCompose ${change.field === "profile" ? "profile=" + (change.value ?? "<none>") : "namedValue " + change.name + "=" + JSON.stringify(change.value)} for ${previewId}`,
+    );
+    void daemonScheduler.renderNow(
+        moduleInfo,
+        [previewId],
+        "fast",
+        "remotecompose-edit",
+        { remoteCompose: next },
+    );
 }
 
 /**

--- a/vscode-extension/src/test/remoteComposeBundlePresenter.test.ts
+++ b/vscode-extension/src/test/remoteComposeBundlePresenter.test.ts
@@ -1,0 +1,121 @@
+// Remote Compose bundle presenter — pins the payload → rows shape so
+// the editable tab body's table doesn't silently drift when wire types
+// change. Stateless; tests run the presenter directly without any DOM
+// (the `<input>` cell renderers are exercised separately by the panel
+// preview-harness snapshot — those would need a real Lit render to
+// assert against).
+
+import * as assert from "assert";
+import {
+    computeRemoteComposeBundleData,
+    type RemoteComposePayload,
+} from "../webview/preview/remoteComposeBundlePresenter";
+
+describe("computeRemoteComposeBundleData", () => {
+    it("returns empty rows + null profile for a null payload", () => {
+        const data = computeRemoteComposeBundleData(null);
+        assert.strictEqual(data.rows.length, 0);
+        assert.strictEqual(data.namedCount, 0);
+        assert.strictEqual(data.actionCount, 0);
+        assert.strictEqual(data.profile, null);
+    });
+
+    it("emits a profile row even when no named values are bound", () => {
+        const payload: RemoteComposePayload = { profile: "androidx" };
+        const data = computeRemoteComposeBundleData(payload);
+        // Single profile row, no value rows, no action rows.
+        assert.strictEqual(data.rows.length, 1);
+        assert.strictEqual(data.rows[0]?.section, "profile");
+        assert.strictEqual(data.profile, "androidx");
+        assert.strictEqual(data.namedCount, 0);
+        assert.strictEqual(data.actionCount, 0);
+    });
+
+    it("preserves insertion order of named values", () => {
+        const payload: RemoteComposePayload = {
+            profile: "androidx9",
+            namedValues: {
+                seedColor: { kind: "color", argb: "#FF3366FF" },
+                cornerRadius: { kind: "dp", value: 8 },
+                enabled: { kind: "bool", value: true },
+            },
+        };
+        const data = computeRemoteComposeBundleData(payload);
+        const namedRows = data.rows.filter((r) => r.section === "named");
+        assert.strictEqual(namedRows.length, 3);
+        assert.strictEqual(data.namedCount, 3);
+        // Object.entries walks insertion order for string keys per ES2020+;
+        // the wire shape is LinkedHashMap-equivalent on the daemon side so
+        // the panel's table matches the user-bound order.
+        assert.deepStrictEqual(
+            namedRows.map((r) => (r as { name: string }).name),
+            ["seedColor", "cornerRadius", "enabled"],
+        );
+    });
+
+    it("reverses host-action rows so newest fires render first", () => {
+        const payload: RemoteComposePayload = {
+            hostActions: [
+                { payload: "tap", handlerId: 1, firedAtMillis: 1000 },
+                { payload: "tap", handlerId: 1, firedAtMillis: 2000 },
+                { payload: "long", handlerId: 2, firedAtMillis: 3000 },
+            ],
+        };
+        const data = computeRemoteComposeBundleData(payload);
+        const actionRows = data.rows.filter((r) => r.section === "actions");
+        assert.strictEqual(actionRows.length, 3);
+        assert.strictEqual(data.actionCount, 3);
+        // Newest first: index 2 (the "long" press) appears first.
+        assert.strictEqual(
+            (actionRows[0] as { firedAtMillis: number | null }).firedAtMillis,
+            3000,
+        );
+        assert.strictEqual(
+            (actionRows[2] as { firedAtMillis: number | null }).firedAtMillis,
+            1000,
+        );
+        // The original (oldest-first) order is preserved in the JSON payload
+        // the table emits via Copy JSON.
+        const jsonActions = (
+            data.jsonPayload as {
+                hostActions: readonly { firedAtMillis: number }[];
+            }
+        ).hostActions;
+        assert.strictEqual(jsonActions[0]?.firedAtMillis, 1000);
+        assert.strictEqual(jsonActions[2]?.firedAtMillis, 3000);
+    });
+
+    it("carries every typed named-value variant through unchanged", () => {
+        const payload: RemoteComposePayload = {
+            namedValues: {
+                f: { kind: "float", value: 1.5 },
+                d: { kind: "dp", value: 8.0 },
+                i: { kind: "int", value: 42 },
+                s: { kind: "string", value: "hello" },
+                b: { kind: "bool", value: true },
+                c: { kind: "color", argb: "#FFAABBCC" },
+            },
+        };
+        const data = computeRemoteComposeBundleData(payload);
+        const byName = new Map(
+            data.rows
+                .filter((r) => r.section === "named")
+                .map((r) => [
+                    (r as { name: string }).name,
+                    (r as { value: unknown }).value,
+                ]),
+        );
+        assert.deepStrictEqual(byName.get("f"), { kind: "float", value: 1.5 });
+        assert.deepStrictEqual(byName.get("d"), { kind: "dp", value: 8.0 });
+        assert.deepStrictEqual(byName.get("i"), { kind: "int", value: 42 });
+        assert.deepStrictEqual(byName.get("s"), {
+            kind: "string",
+            value: "hello",
+        });
+        assert.deepStrictEqual(byName.get("b"), { kind: "bool", value: true });
+        assert.deepStrictEqual(byName.get("c"), {
+            kind: "color",
+            argb: "#FFAABBCC",
+        });
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -694,6 +694,36 @@ export interface DaemonDataExtensionDescriptor {
     requiresInteractive?: boolean;
 }
 
+/**
+ * Platform profile the remote document is compiled against. Mirrors
+ * `RemoteComposeProfile` on the wire / `RcPlatformProfiles` constants on
+ * the JVM side. Duplicated here so `types.ts` (shared host+webview
+ * surface) stays free of a `daemon/daemonProtocol.ts` dep — the host
+ * imports the same string union from both modules and forwards as-is.
+ */
+export type RemoteComposeProfile =
+    | "androidx"
+    | "androidx7"
+    | "androidx8"
+    | "androidx9"
+    | "widgetsV6"
+    | "widgetsV7"
+    | "wearWidgets";
+
+/** Wire-shape mirror of `RemoteNamedValue` (see Messages.kt). */
+export type RemoteNamedValue =
+    | { kind: "float"; value: number }
+    | { kind: "dp"; value: number }
+    | { kind: "int"; value: number }
+    | { kind: "string"; value: string }
+    | { kind: "bool"; value: boolean }
+    | { kind: "color"; argb: string };
+
+/** Detail bag carried by `setRemoteComposeNamedValue`. */
+export type RemoteComposeChangeDetail =
+    | { field: "profile"; value: RemoteComposeProfile | null }
+    | { field: "namedValue"; name: string; value: RemoteNamedValue };
+
 /** Messages from webview to extension */
 export type WebviewToExtension =
     /**
@@ -1031,6 +1061,24 @@ export type WebviewToExtension =
           previewId: string;
           fontRowId: string;
           sourceFile: string;
+      }
+    /**
+     * Edit dispatched from the panel's Remote Compose tab body. The
+     * presenter's editable cells (profile `<select>`, typed inputs per
+     * named value) dispatch a `remote-compose-value-changed` CustomEvent
+     * that bubbles to the tab body wrapper; the wrapper wraps it in this
+     * message so the extension host can rebuild a fresh
+     * `renderNow.overrides.remoteCompose` and forward to the daemon.
+     *
+     * `change.field` discriminates which control fired: `"profile"`
+     * carries the next `RcPlatformProfiles` selection (or `null` to
+     * clear); `"namedValue"` carries the typed-sum value the daemon's
+     * `RemoteComposeController.setNamedValue(...)` should merge.
+     */
+    | {
+          command: "setRemoteComposeNamedValue";
+          previewId: string;
+          change: RemoteComposeChangeDetail;
       };
 
 /**


### PR DESCRIPTION
Closes the loop the previous panel-UI PR left open: the
`remote-compose-value-changed` CustomEvent that the editable tab body
bubbles is now caught by the host's `handleWebviewMessage` switch and
forwarded as a fresh `renderNow` with the merged `PreviewOverrides
.remoteCompose` bag. The daemon's `RemoteComposeOverrideExtension`
re-seeds its controller from the bag on the next composition, so user
edits in the panel ride through to the rendered preview without a manual
re-render.

* `types.ts` — adds `setRemoteComposeNamedValue` to `WebviewToExtension`,
  plus the shared `RemoteComposeChangeDetail` / `RemoteNamedValue` /
  `RemoteComposeProfile` type aliases the webview and host both consume.
* `daemon/daemonProtocol.ts` — adds `remoteCompose?: RemoteComposeOverride`
  to `PreviewOverrides` (mirrors the Kotlin protocol).
* `daemon/daemonScheduler.ts` — `renderNow(...)` now accepts an
  `overrides?: PreviewOverrides` arg and threads it into `RenderNowParams`.
* `extension.ts`:
   - `remoteComposeOverridesByPreview` map carries the cumulative per-
     preview state across edits;
   - `handleSetRemoteComposeNamedValue(previewId, change)` merges the
     `profile` / `namedValue` change into the running bag and dispatches
     `daemonScheduler.renderNow(... overrides={ remoteCompose })`.
   - Dispatch site is gated on `earlyFeaturesEnabled()` mirroring the
     other data-extension chip handlers.
* `test/remoteComposeBundlePresenter.test.ts` — pins the payload → rows
  shape (empty payload, profile-only row, insertion-order preservation,
  newest-first host-action reversal, every typed-variant pass-through).

`data/subscribe(kind=compose/remotecompose)` is already wired through
`handleSetDataExtensionEnabled` — toggling the panel's Remote Compose
chip subscribes via the existing path, and the daemon's registry
advertises `fetchable=true` so subsequent renders push updates as
`updateDataProducts` posts.