### PR TITLE
feat(preview-data-api)!: drop v1 a11y fields, bump compose-preview-show to v2 (#1392)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/A11yReportRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/A11yReportRenderer.kt
@@ -1,9 +1,3 @@
-// Suppress at file scope: this is the deprecation slope. `A11yReportRenderer` populates and reads
-// `PreviewResult.a11yFindings` / `a11yAnnotatedPath` *by design* during the v1 → v2 window,
-// alongside the new `dataExtensions["a11y"]` payload. Once the deprecated fields are removed,
-// this file-level suppress goes away too.
-@file:Suppress("DEPRECATION")
-
 package ee.schimke.composeai.cli
 
 import kotlinx.serialization.json.Json
@@ -13,16 +7,17 @@ import kotlinx.serialization.json.Json
  * `ee.schimke.composeai.daemon.AccessibilityDataProductRegistry`. The standalone gradle path no
  * longer produces this file; it's strictly a daemon-mode artefact now.
  *
- * The DTOs (`AccessibilityFinding`, `AccessibilityEntry`, `AccessibilityReport`) carved out to
- * `:preview-data-api` alongside `PreviewResult` — they're the wire-format mirrors that the
- * deprecated `PreviewResult.a11yFindings` references. See `preview-data-api/A11yWireFormat.kt`.
+ * The DTOs (`AccessibilityFinding`, `AccessibilityEntry`, `AccessibilityReport`) live in
+ * `:preview-data-api/A11yWireFormat.kt` — they're the JVM-side typed-decode surface for the
+ * `compose-preview-data-a11y/v1` payload body. The renderer-side `:data-a11y-core` ships the
+ * canonical types in `ee.schimke.composeai.renderer`; this module mirrors them so JVM consumers
+ * (CLI, contrib) don't have to pull an `android-library` to decode.
  */
 
 /**
  * [ExtensionReportRenderer] for the built-in `a11y` extension. Reads each module's
- * `accessibility.json`, joins per-preview findings onto [PreviewResult.a11yFindings] (kept on the
- * result for back-compat with the v1 `compose-preview-show/v1` JSON wire format), and prints
- * findings grouped by preview with optional `--fail-on` thresholding.
+ * `accessibility.json`, packages each entry as a `dataExtensions["a11y"]` payload on the matching
+ * [PreviewResult], and prints findings grouped by preview with optional `--fail-on` thresholding.
  *
  * Owned state: [a11yByKey] is the per-preview lookup the [annotate] step reads from. It's built by
  * [load] and cached for the duration of one CLI invocation.
@@ -40,8 +35,8 @@ class A11yReportRenderer : ExtensionReportRenderer {
     encodeDefaults = true
   }
 
-  /** `"<module>/<previewId>"` -> (findings, absolute annotated PNG path). */
-  private var a11yByKey: Map<String, Pair<List<AccessibilityFinding>, String?>> = emptyMap()
+  /** `"<module>/<previewId>"` -> the decoded entry (findings + absolute annotated PNG path). */
+  private var a11yByKey: Map<String, AccessibilityEntry> = emptyMap()
 
   /** Set of module gradle-paths whose manifest claims a11y is enabled (pointer non-null). */
   private var enabledModules: Set<String> = emptySet()
@@ -50,7 +45,7 @@ class A11yReportRenderer : ExtensionReportRenderer {
     manifests: List<Pair<PreviewModule, PreviewManifest>>,
     verbose: Boolean,
   ): Set<String> {
-    val out = mutableMapOf<String, Pair<List<AccessibilityFinding>, String?>>()
+    val out = mutableMapOf<String, AccessibilityEntry>()
     val enabled = mutableSetOf<String>()
     for ((module, manifest) in manifests) {
       // Prefer the manifest pointer when a producer stamped one (legacy gradle-aggregated reports,
@@ -81,7 +76,10 @@ class A11yReportRenderer : ExtensionReportRenderer {
             ?.let { reportDir.resolve(it).canonicalFile }
             ?.takeIf { it.exists() }
             ?.absolutePath
-        out["${module.gradlePath}/${entry.previewId}"] = entry.findings to annotatedAbs
+        // Resolve `annotatedPath` to an absolute path now so downstream consumers don't have
+        // to know the sidecar dir. `null` when the renderer didn't produce one — same signal as
+        // before.
+        out["${module.gradlePath}/${entry.previewId}"] = entry.copy(annotatedPath = annotatedAbs)
       }
     }
     a11yByKey = out
@@ -91,49 +89,33 @@ class A11yReportRenderer : ExtensionReportRenderer {
 
   override fun annotate(result: PreviewResult, module: PreviewModule): PreviewResult {
     if (module.gradlePath !in enabledModules) return result
-    val pair = a11yByKey["${module.gradlePath}/${result.id}"]
-    val findings = pair?.first ?: emptyList()
-    val annotatedPath = pair?.second
-    // Populate the new generic `dataExtensions["a11y"]` carrier alongside the deprecated
-    // `a11yFindings` / `a11yAnnotatedPath` fields. Both are written for one release so external
-    // consumers can migrate to decoding from `dataExtensions` against `:data-a11y-core`'s
-    // typed DTOs at their own pace.
-    val a11yPayload =
+    // Module had a11y enabled but no findings for this preview: empty entry (not null) tells
+    // downstream consumers "checks ran and found nothing" vs "feature off."
+    val entry =
+      a11yByKey["${module.gradlePath}/${result.id}"]
+        ?: AccessibilityEntry(previewId = result.id, findings = emptyList())
+    val payload =
       ExtensionPayload(
         schema = A11Y_PAYLOAD_SCHEMA_V1,
-        payload =
-          json.encodeToJsonElement(
-            AccessibilityEntry.serializer(),
-            AccessibilityEntry(
-              previewId = result.id,
-              findings = findings,
-              annotatedPath = annotatedPath,
-            ),
-          ),
+        payload = json.encodeToJsonElement(AccessibilityEntry.serializer(), entry),
       )
-    // Module had a11y enabled but no findings for this preview: empty list (not null) tells
-    // downstream consumers "checks ran and found nothing" vs "feature off."
-    return result.copy(
-      a11yFindings = findings,
-      a11yAnnotatedPath = annotatedPath,
-      dataExtensions = result.dataExtensions + (id to a11yPayload),
-    )
+    return result.copy(dataExtensions = result.dataExtensions + (id to payload))
   }
 
-  override fun hasData(result: PreviewResult): Boolean = result.a11yFindings != null
+  override fun hasData(result: PreviewResult): Boolean = result.a11yEntry() != null
 
   override fun printAll(filtered: List<PreviewResult>) {
-    val totalFindings = filtered.sumOf { it.a11yFindings?.size ?: 0 }
+    val totalFindings = filtered.sumOf { it.a11yEntry()?.findings?.size ?: 0 }
     println("$totalFindings accessibility finding(s):")
     for (result in filtered) {
-      val findings = result.a11yFindings ?: continue
+      val entry = result.a11yEntry() ?: continue
       var annotatedPrinted = false
-      for (f in findings) {
+      for (f in entry.findings) {
         println("  [${f.level}] ${result.id} · ${f.type}")
         println("      ${f.message}")
         f.viewDescription?.let { println("      element: $it") }
         if (!annotatedPrinted) {
-          result.a11yAnnotatedPath?.let { println("      annotated: $it") }
+          entry.annotatedPath?.let { println("      annotated: $it") }
           annotatedPrinted = true
         }
       }
@@ -145,8 +127,12 @@ class A11yReportRenderer : ExtensionReportRenderer {
   }
 
   override fun thresholdExitCode(results: List<PreviewResult>, failOn: String?): Int? {
-    val errorCount = results.sumOf { it.a11yFindings?.count { f -> f.level == "ERROR" } ?: 0 }
-    val warnCount = results.sumOf { it.a11yFindings?.count { f -> f.level == "WARNING" } ?: 0 }
+    val errorCount = results.sumOf {
+      it.a11yEntry()?.findings?.count { f -> f.level == "ERROR" } ?: 0
+    }
+    val warnCount = results.sumOf {
+      it.a11yEntry()?.findings?.count { f -> f.level == "WARNING" } ?: 0
+    }
     return a11yExitCode(
         buildOk = true,
         errorCount = errorCount,
@@ -157,10 +143,33 @@ class A11yReportRenderer : ExtensionReportRenderer {
   }
 }
 
-// `A11Y_PAYLOAD_SCHEMA_V1` moved to `:preview-data-api/A11yWireFormat.kt` alongside the v1 mirror
-// types so contrib consumers can pin to it without a `:cli` dep. Same package
-// (`ee.schimke.composeai.cli`), so the existing `A11Y_PAYLOAD_SCHEMA_V1` references in this file
-// keep resolving without an `import`.
+/** Json decoder shared by every `a11yEntry()` call — Json instances are expensive to construct. */
+private val a11yDecodeJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * Decode the `dataExtensions["a11y"]` payload (if any) into a typed [AccessibilityEntry]. Returns
+ * `null` when ATF didn't run for this preview's module (no payload), the payload's schema doesn't
+ * match the v1 pin, or the body fails to decode. Same null-vs-empty semantics every consumer in
+ * this file relies on: `null` means "checks didn't run"; an entry with empty `findings` means
+ * "checks ran, nothing tripped."
+ *
+ * Internal — also used by `Commands.kt`'s `--brief` encoder for the a11y count.
+ */
+internal fun PreviewResult.a11yEntry(): AccessibilityEntry? {
+  val payload = dataExtensions["a11y"] ?: return null
+  if (payload.schema != A11Y_PAYLOAD_SCHEMA_V1) return null
+  return runCatching {
+      a11yDecodeJson.decodeFromJsonElement(AccessibilityEntry.serializer(), payload.payload)
+    }
+    .getOrNull()
+}
+
+/**
+ * a11y-finding count for `--brief` output. `null` when ATF didn't run for the preview's module,
+ * matching the v1 wire-format semantics agents already grep for.
+ */
+internal fun decodeA11yFindingsCount(result: PreviewResult): Int? =
+  result.a11yEntry()?.findings?.size
 
 /** Sentinel returned by [a11yExitCode] when `failOn` is not one of the accepted values. */
 internal const val EXIT_UNKNOWN_FAIL_ON = 1

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -87,7 +87,12 @@ data class BriefCapture(
   val scroll: String? = null,
 )
 
-internal const val SHOW_LIST_SCHEMA = "compose-preview-show/v1"
+// Bumped to `/v2` when `PreviewResult.a11yFindings` + `a11yAnnotatedPath` were removed —
+// consumers that read those top-level fields break here. Findings + annotated-path migrate to
+// `dataExtensions["a11y"]` against `AccessibilityEntry`. Brief format stays at `/v1`: the
+// `a11y: Int?` count field is unchanged (the count source migrated from `a11yFindings` to
+// decoded `dataExtensions["a11y"]`, but the wire shape is identical).
+internal const val SHOW_LIST_SCHEMA = "compose-preview-show/v2"
 internal const val SHOW_LIST_BRIEF_SCHEMA = "compose-preview-show-brief/v1"
 
 @Serializable private data class CliState(val shas: Map<String, String> = emptyMap())
@@ -540,10 +545,11 @@ abstract class Command(protected val args: List<String>) {
     if (brief) {
       val multiModule = results.map { it.module }.distinct().size > 1
       val brief = results.map { r ->
-        // v1 deprecation slope — `a11yFindings` stays populated alongside
-        // `dataExtensions["a11y"]` for one release. Read here so the `--brief` count keeps
-        // working for existing agents.
-        @Suppress("DEPRECATION") val a11yCount = r.a11yFindings?.size
+        // Decode the a11y count from the generic `dataExtensions["a11y"]` carrier — the
+        // previous `r.a11yFindings?.size` read disappeared with the v1→v2 bump. `null` when
+        // ATF didn't run for the module (no `dataExtensions["a11y"]` entry), matching the v1
+        // null vs. `0` semantics that agents already grep for.
+        val a11yCount = decodeA11yFindingsCount(r)
         BriefPreviewResult(
           id = r.id,
           module = r.module.takeIf { multiModule },

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yCommandTest.kt
@@ -105,7 +105,7 @@ class A11yCommandTest {
   }
 
   @Test
-  fun `json output preserves a11yFindings for enabled module`() {
+  fun `json output emits findings on the v2 dataExtensions a11y carrier`() {
     val cmd = TestableCommand(listOf("--json"))
     val results =
       listOf(
@@ -133,11 +133,26 @@ class A11yCommandTest {
     assertEquals(JsonPrimitive(SHOW_LIST_SCHEMA), payload["schema"])
     val previews = payload["previews"]?.jsonArray ?: error("missing previews")
     assertEquals(1, previews.size)
-    val findings = previews[0].jsonObject["a11yFindings"]?.jsonArray ?: error("missing findings")
+    // v2 wire format: findings live on `dataExtensions["a11y"].payload.findings`, not as a
+    // top-level `a11yFindings` array. Asserting both the schema pin and the body shape so a
+    // regression in either is caught here.
+    val dataExtensions =
+      previews[0].jsonObject["dataExtensions"]?.jsonObject ?: error("missing dataExtensions")
+    val a11y = dataExtensions["a11y"]?.jsonObject ?: error("missing dataExtensions[\"a11y\"]")
+    assertEquals(
+      JsonPrimitive(A11Y_PAYLOAD_SCHEMA_V1),
+      a11y["schema"],
+      "expected a11y payload schema pinned to v1",
+    )
+    val findings =
+      a11y["payload"]?.jsonObject?.get("findings")?.jsonArray ?: error("missing findings")
     assertEquals(2, findings.size)
     assertEquals("ERROR", findings[0].jsonObject["level"]?.jsonPrimitive?.contentOrNull)
     assertEquals("TouchTargetSize", findings[0].jsonObject["type"]?.jsonPrimitive?.contentOrNull)
     assertEquals("WARNING", findings[1].jsonObject["level"]?.jsonPrimitive?.contentOrNull)
+    // The dropped v1 top-level field must be absent.
+    assertNull(previews[0].jsonObject["a11yFindings"])
+    assertNull(previews[0].jsonObject["a11yAnnotatedPath"])
   }
 
   @Test
@@ -234,6 +249,22 @@ class A11yCommandTest {
         sha256 = null,
         changed = changed,
       )
+    val dataExtensions =
+      if (findings == null) {
+        emptyMap()
+      } else {
+        // Mirror what `A11yReportRenderer.annotate` writes in production: encode an
+        // `AccessibilityEntry` into the `dataExtensions["a11y"]` carrier with the v1 schema
+        // pin. `null` findings means "ATF didn't run for the module" — no carrier entry.
+        val entry = AccessibilityEntry(previewId = id, findings = findings)
+        mapOf(
+          "a11y" to
+            ExtensionPayload(
+              schema = A11Y_PAYLOAD_SCHEMA_V1,
+              payload = Json.encodeToJsonElement(AccessibilityEntry.serializer(), entry),
+            )
+        )
+      }
     return PreviewResult(
       id = id,
       module = ":sample",
@@ -245,8 +276,7 @@ class A11yCommandTest {
       pngPath = png,
       sha256 = null,
       changed = changed,
-      a11yFindings = findings,
-      a11yAnnotatedPath = null,
+      dataExtensions = dataExtensions,
     )
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yReportRendererTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yReportRendererTest.kt
@@ -1,9 +1,3 @@
-// Suppress at file scope: the renderer test asserts on the v1 `a11yFindings` field by design —
-// it covers the deprecation slope. A separate test (`a11y carrier dataExtensions payload …`)
-// covers the new `dataExtensions["a11y"]` path. When the deprecated fields are removed in v2,
-// the v1 assertions delete and this suppression goes with them.
-@file:Suppress("DEPRECATION")
-
 package ee.schimke.composeai.cli
 
 import java.io.ByteArrayOutputStream
@@ -17,13 +11,14 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
 
 /**
  * Unit coverage for the a11y strategy impl. The Gradle Tooling API path (the renders that produce
  * `accessibility.json`) isn't exercised here — we point [A11yReportRenderer.load] at a synthetic
- * on-disk JSON and verify the surrounding contract: it reads via the manifest's v2/v1 pointer,
- * populates [PreviewResult.a11yFindings], reports `hasData`, and prints what `A11yCommand` used to
- * print directly.
+ * on-disk JSON and verify the surrounding contract: it reads via the manifest pointer, populates
+ * `dataExtensions["a11y"]` (the v2 carrier), reports `hasData`, and prints what `A11yCommand` used
+ * to print directly.
  */
 class A11yReportRendererTest {
 
@@ -98,14 +93,16 @@ class A11yReportRendererTest {
     assertEquals(setOf("sample"), enabled)
 
     val foo = renderer.annotate(previewResult("Foo"), module())
-    assertEquals(1, foo.a11yFindings?.size)
-    assertEquals("ERROR", foo.a11yFindings?.first()?.level)
+    val fooEntry = foo.a11yEntry() ?: error("expected a11y entry on Foo")
+    assertEquals(1, fooEntry.findings.size)
+    assertEquals("ERROR", fooEntry.findings.first().level)
     assertTrue(renderer.hasData(foo))
 
-    // Same module, different preview that has no entry: a11yFindings is set to an empty list
-    // (the "checks ran, found nothing" signal) rather than null.
+    // Same module, different preview that has no entry in accessibility.json: the carrier still
+    // gets populated with an empty-findings entry (the "checks ran, found nothing" signal) so
+    // downstream `hasData` returns true.
     val bar = renderer.annotate(previewResult("Bar"), module())
-    assertEquals(emptyList(), bar.a11yFindings)
+    assertEquals(emptyList(), bar.a11yEntry()?.findings)
     assertTrue(renderer.hasData(bar))
   }
 
@@ -115,19 +112,17 @@ class A11yReportRendererTest {
     renderer.load(listOf(module() to manifest(reportsView = emptyMap())), verbose = false)
 
     val result = renderer.annotate(previewResult("Foo"), module())
-    assertNull(result.a11yFindings)
-    assertFalse(renderer.hasData(result))
-    // Same for the new generic carrier: no extension data when the pointer is absent.
     assertNull(result.dataExtensions["a11y"])
+    assertFalse(renderer.hasData(result))
   }
 
   /**
-   * Locks in the new generic `dataExtensions["a11y"]` carrier alongside the deprecated v1 fields.
-   * This is the path contrib scripting and other external consumers read from — the v1 fields
-   * disappear after the deprecation window but the carrier stays.
+   * Locks in the `dataExtensions["a11y"]` carrier shape — schema string pinned, decoded body
+   * matches the v1 `AccessibilityEntry`. External consumers (contrib scripting, third-party
+   * tooling) read this path.
    */
   @Test
-  fun `annotate populates the new dataExtensions a11y carrier with the AccessibilityEntry payload`() {
+  fun `annotate populates the dataExtensions a11y carrier with the AccessibilityEntry payload`() {
     writeReport(
       """
       {
@@ -153,11 +148,7 @@ class A11yReportRendererTest {
 
     val payload = foo.dataExtensions["a11y"] ?: error("expected dataExtensions[\"a11y\"] populated")
     assertEquals(A11Y_PAYLOAD_SCHEMA_V1, payload.schema)
-    val decoded =
-      kotlinx.serialization.json.Json.decodeFromJsonElement(
-        AccessibilityEntry.serializer(),
-        payload.payload,
-      )
+    val decoded = Json.decodeFromJsonElement(AccessibilityEntry.serializer(), payload.payload)
     assertEquals("Foo", decoded.previewId)
     assertEquals(1, decoded.findings.size)
     assertEquals("ERROR", decoded.findings.first().level)
@@ -209,14 +200,10 @@ class A11yReportRendererTest {
     val renderer = A11yReportRenderer()
     val errorRow =
       previewResult("Foo")
-        .copy(
-          a11yFindings = listOf(AccessibilityFinding(level = "ERROR", type = "X", message = "x"))
-        )
+        .withA11yFindings(AccessibilityFinding(level = "ERROR", type = "X", message = "x"))
     val warningRow =
       previewResult("Bar")
-        .copy(
-          a11yFindings = listOf(AccessibilityFinding(level = "WARNING", type = "Y", message = "y"))
-        )
+        .withA11yFindings(AccessibilityFinding(level = "WARNING", type = "Y", message = "y"))
 
     assertEquals(2, renderer.thresholdExitCode(listOf(errorRow), failOn = "errors"))
     assertNull(renderer.thresholdExitCode(listOf(warningRow), failOn = "errors"))
@@ -227,5 +214,19 @@ class A11yReportRendererTest {
       EXIT_UNKNOWN_FAIL_ON,
       renderer.thresholdExitCode(listOf(errorRow), failOn = "bogus"),
     )
+  }
+
+  /**
+   * Build a `dataExtensions["a11y"]` payload with the given findings — the v2 way to attach
+   * findings to a test fixture. Used in place of the dropped `copy(a11yFindings = ...)`.
+   */
+  private fun PreviewResult.withA11yFindings(vararg findings: AccessibilityFinding): PreviewResult {
+    val entry = AccessibilityEntry(previewId = id, findings = findings.toList())
+    val payload =
+      ExtensionPayload(
+        schema = A11Y_PAYLOAD_SCHEMA_V1,
+        payload = Json.encodeToJsonElement(AccessibilityEntry.serializer(), entry),
+      )
+    return copy(dataExtensions = dataExtensions + ("a11y" to payload))
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
@@ -60,11 +60,13 @@ class PreviewListResponseTest {
   }
 
   @Test
-  fun `default schema field stays at v1`() {
-    // Bump this test deliberately when rolling to v2 — guards against
-    // accidentally breaking the CLI→agent contract.
+  fun `default schema field pins to compose-preview-show v2`() {
+    // Bumped from v1 to v2 when `PreviewResult.a11yFindings` + `a11yAnnotatedPath` were
+    // dropped from the wire format — agents that read either field break here, that's the
+    // point. Findings + annotated path now live on `dataExtensions["a11y"]` (see
+    // `A11yReportRendererTest`).
     val response = PreviewListResponse(previews = emptyList())
-    assertEquals("compose-preview-show/v1", response.schema)
+    assertEquals("compose-preview-show/v2", response.schema)
   }
 
   @Test

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1439,12 +1439,12 @@ data class RecordingInputParams(
   val pixelY: Int? = null,
   /**
    * Per-pointer identifier for multi-touch dispatch in live recordings — distinct pointers (e.g. a
-   * two-finger pinch) share the current virtual `tMs` boundary while carrying their own id. Defaults
-   * to `0` for backwards compatibility, so existing single-pointer scripts (the vast majority) keep
-   * working unchanged. Required when dispatching pinch-to-zoom or any other multi-pointer gesture
-   * over live mode: each finger keeps its own id across `pointerDown` → `pointerMove`(s) →
-   * `pointerUp` so the daemon's pointer pipeline groups events into the right gesture. Ignored for
-   * non-pointer kinds (`keyDown`, `keyUp`, `rotaryScroll`).
+   * two-finger pinch) share the current virtual `tMs` boundary while carrying their own id.
+   * Defaults to `0` for backwards compatibility, so existing single-pointer scripts (the vast
+   * majority) keep working unchanged. Required when dispatching pinch-to-zoom or any other
+   * multi-pointer gesture over live mode: each finger keeps its own id across `pointerDown` →
+   * `pointerMove`(s) → `pointerUp` so the daemon's pointer pipeline groups events into the right
+   * gesture. Ignored for non-pointer kinds (`keyDown`, `keyUp`, `rotaryScroll`).
    *
    * Mirrors [InteractiveInputParams.pointerId] and [RecordingScriptEvent.pointerId] so the three
    * input wire-shapes carry the same multi-touch signal end-to-end.

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionLiveInputTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionLiveInputTest.kt
@@ -7,11 +7,12 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 /**
- * Regression coverage for compose-ai-tools#1360 finding #2: live-mode multi-touch was broken because
- * `DesktopRecordingSession.toScriptEvent` collapsed every live-recorded input to pointer 0,
+ * Regression coverage for compose-ai-tools#1360 finding #2: live-mode multi-touch was broken
+ * because `DesktopRecordingSession.toScriptEvent` collapsed every live-recorded input to pointer 0,
  * regardless of what the wire payload said. Two-finger pinches in `live = true` recordings never
- * reached Compose's gesture pipeline as simultaneous pointers, so `Modifier.transformable {}`'s zoom
- * / rotate callbacks silently no-opped despite the multi-pointer dispatch the same PR advertised.
+ * reached Compose's gesture pipeline as simultaneous pointers, so `Modifier.transformable {}`'s
+ * zoom / rotate callbacks silently no-opped despite the multi-pointer dispatch the same PR
+ * advertised.
  *
  * The mapping itself is pure data, so testing it in isolation — without spinning up a
  * `RenderEngine` / `ImageComposeScene` per assertion — is the cheapest way to pin the contract. The

--- a/data/pseudolocale/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleResourceCache.kt
+++ b/data/pseudolocale/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleResourceCache.kt
@@ -2,8 +2,8 @@ package ee.schimke.composeai.daemon
 
 /**
  * Reflective shim that clears Compose Multiplatform Resources' process-wide string-item cache. The
- * cache is the private static field `StringResourcesUtilsKt.stringItemsCache` (an `AsyncCache<String,
- * StringItem>`), keyed by `path/offset-size` and populated by the *first*
+ * cache is the private static field `StringResourcesUtilsKt.stringItemsCache` (an
+ * `AsyncCache<String, StringItem>`), keyed by `path/offset-size` and populated by the *first*
  * [org.jetbrains.compose.resources.ResourceReader] to answer a given key.
  *
  * **Why this exists.** `:data-pseudolocale-connector-desktop` wraps [LocalResourceReader] so every
@@ -59,15 +59,14 @@ internal object PseudolocaleResourceCache {
    * Safe to call from any thread; the underlying `Map.clear()` is a single instruction the JVM
    * publishes promptly enough that subsequent `getOrLoad` callers see an empty map. Concurrent
    * `getOrLoad` calls during the clear might still observe a transient value; we don't try to
-   * synchronize against `AsyncCache.mutex` because (a) it's a `kotlinx.coroutines.sync.Mutex` (not a
-   * `java.util.concurrent.locks.Lock` — no synchronous `lock()` we can call from outside a
+   * synchronize against `AsyncCache.mutex` because (a) it's a `kotlinx.coroutines.sync.Mutex` (not
+   * a `java.util.concurrent.locks.Lock` — no synchronous `lock()` we can call from outside a
    * coroutine context), and (b) the renderer issues renders sequentially anyway.
    */
   fun clearStringResourcesCacheBestEffort(): Boolean {
     return try {
       val utilsClass = Class.forName(UTILS_CLASS)
-      val cacheField =
-        utilsClass.getDeclaredField(CACHE_FIELD).apply { isAccessible = true }
+      val cacheField = utilsClass.getDeclaredField(CACHE_FIELD).apply { isAccessible = true }
       val asyncCache = cacheField.get(null) ?: return false
       val mapField =
         asyncCache.javaClass.getDeclaredField(ASYNC_CACHE_MAP_FIELD).apply { isAccessible = true }

--- a/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -149,9 +149,9 @@ data class CaptureResult(
  * CLI output DTO — enriches manifest entries with runtime data agents need.
  *
  * Extension data flows through [dataExtensions] — a generic id→payload map so the data API stays
- * agnostic of which extensions exist. The deprecated [a11yFindings] / [a11yAnnotatedPath] fields
- * are populated by `:cli`'s `A11yReportRenderer` alongside the new `dataExtensions["a11y"]` payload
- * for one release; after the deprecation window they're removed and the schema bumps to v2.
+ * agnostic of which extensions exist. Consumers decode each extension's payload against its typed
+ * DTOs (a11y: this module's [AccessibilityEntry] mirror — the JVM-side typed-decode surface for the
+ * `compose-preview-data-a11y/v1` payload body).
  */
 @Serializable
 data class PreviewResult(
@@ -175,33 +175,12 @@ data class PreviewResult(
   val changed: Boolean? = null,
   /**
    * Generic per-extension data carrier — keyed by extension id, value is the typed payload
-   * envelope. Consumers decode `dataExtensions["a11y"]?.payload` against `:data-a11y-core`'s
-   * `AccessibilityEntry`, `dataExtensions["theme"]` against the theme extension's published DTOs,
+   * envelope. Consumers decode `dataExtensions["a11y"]?.payload` against this module's
+   * [AccessibilityEntry], `dataExtensions["theme"]` against the theme extension's published DTOs,
    * and so on.
    *
-   * Replaces the per-extension fields (`a11yFindings`, `a11yAnnotatedPath`) that grew on this class
-   * — the data API has no business knowing which extensions exist. See `docs/AGENTS.md` "Important
+   * The data API has no business knowing which extensions exist — see `docs/AGENTS.md` "Important
    * constraints" / "No hardcoded special-case logic for extensions."
    */
   val dataExtensions: Map<String, ExtensionPayload> = emptyMap(),
-  /**
-   * ATF findings for this preview, or `null` when accessibility checks were disabled for this
-   * module. Empty list means checks ran and found nothing.
-   */
-  @Deprecated(
-    "Decode dataExtensions[\"a11y\"] against :data-a11y-core's AccessibilityEntry. Populated " +
-      "for back-compat during the v1→v2 deprecation window; will be removed when the " +
-      "compose-preview-show wire format bumps to v2."
-  )
-  val a11yFindings: List<AccessibilityFinding>? = null,
-  /**
-   * Absolute path to an annotated screenshot showing each finding as a numbered badge + legend.
-   * `null` when there were no findings or accessibility checks are disabled.
-   */
-  @Deprecated(
-    "Decode dataExtensions[\"a11y\"] and read AccessibilityEntry.annotatedPath. Populated for " +
-      "back-compat during the v1→v2 deprecation window; will be removed when the wire format " +
-      "bumps to v2."
-  )
-  val a11yAnnotatedPath: String? = null,
 )

--- a/render-cli/src/main/kotlin/ee/schimke/composeai/render/cli/RenderCli.kt
+++ b/render-cli/src/main/kotlin/ee/schimke/composeai/render/cli/RenderCli.kt
@@ -30,10 +30,10 @@ import kotlinx.serialization.json.jsonPrimitive
  * ```
  *
  * where `<resolved-classpath>` is the runtime closure of `ee.schimke.composeai:render-cli` as
- * resolved by the caller's dep system (Bazel `rules_jvm_external`, Amper m2 cache, etc.) and
- * joined with the platform-appropriate `File.pathSeparator`. `java -jar <artifact>.jar`
- * against the bare published JAR will fail with `NoClassDefFoundError` — see the "CLI
- * invocation" section in `docs/NON_GRADLE_INTEGRATION.md`.
+ * resolved by the caller's dep system (Bazel `rules_jvm_external`, Amper m2 cache, etc.) and joined
+ * with the platform-appropriate `File.pathSeparator`. `java -jar <artifact>.jar` against the bare
+ * published JAR will fail with `NoClassDefFoundError` — see the "CLI invocation" section in
+ * `docs/NON_GRADLE_INTEGRATION.md`.
  *
  * `--previews` accepts a comma-separated list and can be repeated. The CLI waits for one
  * `renderFinished` notification per requested preview id, prints the resulting PNG path to stdout


### PR DESCRIPTION
Closes #1392.

## Summary

Drops the deprecated `PreviewResult.a11yFindings` + `a11yAnnotatedPath` fields that lived through the v1 deprecation window kept in step A of the clean-API carve-out (#1084). Findings + annotated path migrate permanently to `dataExtensions["a11y"]` against the v1 a11y mirror types already published in `:preview-data-api`. The mirror types and `A11Y_PAYLOAD_SCHEMA_V1` constant **stay** — they're the JVM-side typed-decode surface for the payload body, which is unchanged. The wire-format break is at the outer level (drop of the top-level fields), not the inner extension body.

## Wire format

| Schema | Before | After | Reason |
|---|---|---|---|
| `compose-preview-show` | `/v1` | **`/v2`** | top-level `a11yFindings` + `a11yAnnotatedPath` removed |
| `compose-preview-show-brief` | `/v1` | `/v1` | `a11y: Int?` count field unchanged; only its source moved |
| `compose-preview-data-a11y` | `/v1` | `/v1` | `AccessibilityEntry` body unchanged |

Consumers that read `previews[].a11yFindings` from `compose-preview show --json` break here, that's the point — they switch to decoding `previews[].dataExtensions["a11y"].payload` against `AccessibilityEntry`.

## In-repo migrations

- `A11yReportRenderer.kt` — `annotate()` only populates the carrier; `hasData()` / `printAll()` / `thresholdExitCode()` decode through a new internal `a11yEntry()` helper. `@file:Suppress("DEPRECATION")` gone.
- `Commands.kt` — `--brief` encoder reads the count via `decodeA11yFindingsCount(result)` instead of the dropped field. Local suppress gone.
- `A11yReportRendererTest.kt` / `A11yCommandTest.kt` / `PreviewListResponseTest.kt` — assertions migrated to the carrier path; the v1 schema-pin guard rolls forward to v2.

## Out of scope

- **VSCode** — reads `accessibility.json` directly (gradle-side sidecar), populates its own in-memory `PreviewInfo.a11yFindings` TypeScript field, never consumed `compose-preview show --json`. The Kotlin field we dropped never crossed the VSCode boundary. Its TypeScript internals can be tidied separately if desired — they're not wire-format.
- **Contrib `compose-preview-scripting`** — decodes against the (kept) mirror types and reads from `previews.json` (unchanged). No migration required; existing scripts keep working.

## Drive-by

The pre-commit hook flagged repo-wide format drift on a handful of unrelated files (`daemon/core/protocol/Messages.kt`, `render-cli/RenderCli.kt`, `daemon/desktop/.../DesktopRecordingSessionLiveInputTest.kt`, `data/pseudolocale/.../PseudolocaleResourceCache.kt`) — they were already failing `ktfmtCheckAll` on main. Cleaned up in this PR since the hook insisted; flagging here so reviewers know they're not v2 changes.

## Test plan

- [x] `./gradlew ktfmtCheckAll` — green
- [x] `./gradlew :preview-data-api:check :gradle-preview-driver:check :cli:check :examples-scripting:check` — green
- [x] `./gradlew :cli:checkCliDaemonLibraryBoundary` — green
- [x] CLI smoke (`compose-preview --version`) — passes
- [x] `A11yCommandTest."json output emits findings on the v2 dataExtensions a11y carrier"` asserts the v2 shape AND that the dropped fields are absent from the wire output


---
_Generated by [Claude Code](https://claude.ai/code/session_019NeNsP4DL65LzdrcbLfNBP)_