### PR TITLE
ci(release): pass GITHUB_TOKEN explicitly to release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,6 +33,12 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: rp
         with:
+          # Pass GITHUB_TOKEN explicitly. v5 of the action falls back to the
+          # env token, but making the source explicit means a misconfigured
+          # job-level `permissions:` or a missing token surfaces here instead
+          # of as a "Bad credentials" failure on the first API call (which is
+          # what tanked the v0.11.1 release run).
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           # When the release PR is merged, release-please creates the tag and


### PR DESCRIPTION
## Summary

- v0.11.1's release PR merge run died with `Bad credentials` on the first API call inside `googleapis/release-please-action`, which skipped the chained `release` workflow and left the Release with no built artifacts (no Maven Central publish, no CLI/MCP/viewer tarballs, no VSIX). The workflow hadn't been touched since v0.11.0 shipped a day earlier, so this looks transient — but the failure mode is needlessly opaque.
- Pass `token: ${{ secrets.GITHUB_TOKEN }}` to the action explicitly. v5 falls back to the ambient token when nothing is passed, so this is a no-op on the happy path; on the unhappy path it documents the intended source at the call site and surfaces token problems as a clearer error instead of a generic 401 mid-action.
- Does **not** fix the missing v0.11.1 artifacts — that needs a manual `release.yml` dispatch with `tag=v0.11.1`. This PR is just to make the next time easier to debug.

## Test plan

- [ ] CI on this PR is green (the workflow itself doesn't fire on PRs, but YAML lint / zizmor should still parse it cleanly).
- [ ] After merge, when the next release PR is cut and merged, confirm `release-please-action` still produces `release_created=true` and the downstream `release` workflow_call still runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXv3uvHXN6DRCMznuYp1BA)_