### PR TITLE
fix(mcp): publish :mcp to Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,13 @@ jobs:
   # third-party tooling) can consume the daemon by coordinate. See
   # docs/daemon/DESIGN.md § 17 for the publishing decision and § 19 for the
   # captureToImage fallback if Roborazzi's API ever does break binary compat.
+  # `mcp` is published because `render-session-subprocess` and
+  # `render-session-embedded-desktop` compile-time-reference its `DaemonClient`
+  # + `SubprocessDaemonClientFactory` types; without it on Central, downstream
+  # `SubprocessRenderSessions.open(...)` calls fail with a linkage error. The
+  # standalone MCP server still ships as a `compose-preview-mcp-*.tar.gz`
+  # GitHub Release asset (see `build-applications` below) — the Maven jar is
+  # the library face of the same code.
   publish-gradle-plugin:
     needs: [build-applications, build-vscode-extension]
     runs-on: ubuntu-latest
@@ -91,7 +98,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - name: Publish plugin, renderer-android, data-*, preview-annotations, daemon-* to Maven Central
+      - name: Publish plugin, renderer-android, data-*, preview-annotations, daemon-*, mcp to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -8,24 +8,22 @@
 //
 // One server process can multiplex per-(workspace, module) daemons across multiple distinct
 // projects or worktrees — see `DaemonSupervisor` for the workspace-id derivation.
+//
+// Published to Maven Central as `ee.schimke.composeai:mcp` because :render-session-subprocess
+// and :render-session-embedded-desktop compile-time-reference its `DaemonClient` /
+// `SubprocessDaemonClientFactory` / `DaemonLaunchDescriptor` / `WorkspaceId` /
+// `RegisteredProject` / `DaemonSpawn` types. Without this coordinate on Central, downstream
+// consumers calling `SubprocessRenderSessions.open(...)` hit a runtime linkage failure even
+// though they resolved the rest of the published graph. The MCP server's `main()` ships in
+// the `compose-preview-mcp-*.tar.gz` GitHub Release artifact (see release.yml) — the Maven
+// jar is the library face of the same code.
 
 plugins {
-  id("composeai.jvm-conventions")
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
   application
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 base { archivesName.set("compose-preview-mcp") }
 
@@ -68,4 +66,17 @@ tasks.withType<Test>().configureEach {
   providers.gradleProperty("mcp.workdir").orNull?.let {
     systemProperty("composeai.mcp.workdir", it)
   }
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "mcp",
+    displayName = "Compose Preview — MCP Server",
+    description =
+      "Model Context Protocol server for the compose-preview daemon. Multiplexes per-(workspace, " +
+        "module) daemon JVMs spawned from launch descriptors emitted by composePreviewDaemonStart, " +
+        "and exposes the JSON-RPC `DaemonClient` / `SubprocessDaemonClientFactory` reused by the " +
+        "render-session-subprocess and render-session-embedded-desktop libraries.",
+  )
+  inceptionYear.set("2025")
 }


### PR DESCRIPTION
`:render-session-subprocess` (published) and `:render-session-embedded-desktop`
(published) have compile-time bytecode references to
`ee.schimke.composeai.mcp.{DaemonClient, DaemonClientFactory,
DaemonLaunchDescriptor, WorkspaceId, RegisteredProject, DaemonSpawn,
SubprocessDaemonClientFactory}`. Their POMs already declare `:mcp` as a
runtime-scope dependency, but `:mcp` was not published to Central — so
consumers calling `SubprocessRenderSessions.open(...)` hit a `NoClassDefFoundError`
linkage failure even after working around the resolution failure with an
`exclude(group="ee.schimke.composeai", module="mcp")`.

Swap `:mcp`'s `composeai.jvm-conventions` for `composeai.maven-publishing`
and add a coordinates block (`ee.schimke.composeai:mcp`). The `application`
plugin stays in place so the existing `compose-preview-mcp-*.tar.gz` GitHub
Release asset still builds; the new Maven jar is the library face of the
same code. All of `:mcp`'s implementation dependencies (`daemon-core`,
`render-session-api`, kotlinx-coroutines / serialization, mcp-kotlin-sdk)
are already on Central, so the published POM resolves cleanly.

Update release.yml's publish-step name and add a comment explaining why
`:mcp` is published. The root-level `publishAndReleaseToMavenCentral`
gradle target already fans out to every subproject applying the convention,
so no command-line change is needed.