### PR TITLE
feat(launcher-widget): add @LauncherWidgetPreview annotation + discovery

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -190,6 +190,37 @@ enum class AmbientCaptureState {
 }
 
 /**
+ * Per-preview launcher-widget container-size override discovered from a `@LauncherWidgetPreview`
+ * annotation. Stamped onto every capture of the annotated function — renderer wraps the composition
+ * with `:data-launcher-widget-connector`'s `LauncherWidgetExtension`, which mirrors `MyWidget`
+ * inside a `Box(Modifier.size(widthDp, heightDp))` at the resolved dp footprint.
+ *
+ * Field shape matches `LauncherWidgetOverride` in `:daemon:core` so the renderer can translate
+ * one-for-one. Optional bounds / cell size carry `null` here when the annotation left them at their
+ * `-1` sentinel — the connector then applies its defaults.
+ */
+@Serializable
+data class LauncherWidgetCapture(
+  val width: Int,
+  val height: Int,
+  val cellSizeDp: Int? = null,
+  val cellSpacingDp: Int? = null,
+  val minWidth: Int? = null,
+  val minHeight: Int? = null,
+  val maxWidth: Int? = null,
+  val maxHeight: Int? = null,
+  val resizeOrder: LauncherWidgetCaptureResizeOrder = LauncherWidgetCaptureResizeOrder.WidthFirst,
+)
+
+/** Mirror of `LauncherResizeOrder` in `:daemon:core`. */
+@Serializable
+enum class LauncherWidgetCaptureResizeOrder {
+  Diagonal,
+  WidthFirst,
+  HeightFirst,
+}
+
+/**
  * Cost catalogue, normalised so a static `@Preview` (single compose pass + one screenshot) is
  * `1.0`. The discovery task stamps the right value onto each [Capture]; tooling reads them back to
  * throttle interactive renders.
@@ -308,6 +339,13 @@ data class Capture(
    * `AmbientOverrideExtension` when present.
    */
   val ambient: AmbientCapture? = null,
+  /**
+   * `null` → no launcher-widget container-size override. Set when the preview carries a
+   * `@LauncherWidgetPreview` annotation. Renderer wraps the composition with
+   * `:data-launcher-widget-connector`'s `LauncherWidgetExtension` when present so the rendered PNG
+   * sizes to the resolved dp footprint of a launcher cell.
+   */
+  val launcherWidget: LauncherWidgetCapture? = null,
   /** Module-relative PNG path, e.g. `renders/<preview id>_TIME_500ms.png`. */
   val renderOutput: String = "",
   /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -12,17 +12,17 @@ import java.io.File
 
 /**
  * Pure-JVM library that scans compiled Kotlin classes for `@Preview`-annotated functions and
- * produces a [PreviewManifest] conforming to the `compose-previews/v1` schema. The Gradle
- * plugin's `DiscoverPreviewsTask` is one adapter; non-Gradle build systems (Bazel rules,
- * Amper task definitions in `yschimke/compose-ai-contrib`) call this directly to produce
- * conforming manifests without depending on Gradle or AGP.
+ * produces a [PreviewManifest] conforming to the `compose-previews/v1` schema. The Gradle plugin's
+ * `DiscoverPreviewsTask` is one adapter; non-Gradle build systems (Bazel rules, Amper task
+ * definitions in `yschimke/compose-ai-contrib`) call this directly to produce conforming manifests
+ * without depending on Gradle or AGP.
  *
  * Logger-agnostic — diagnostics are returned as structured strings, not emitted to a Gradle
  * `Logger`. Each adapter routes them to its build system's logging surface.
  *
- * Wire-stable contract: the [Outcome.Success.manifest] is `kotlinx-serialization`-encoded by
- * the caller (typically with `Json { prettyPrint = true; encodeDefaults = true }`) and lands
- * on disk as `previews.json`.
+ * Wire-stable contract: the [Outcome.Success.manifest] is `kotlinx-serialization`-encoded by the
+ * caller (typically with `Json { prettyPrint = true; encodeDefaults = true }`) and lands on disk as
+ * `previews.json`.
  */
 object PreviewDiscovery {
 
@@ -30,17 +30,26 @@ object PreviewDiscovery {
   data class Input(
     /** Directories of compiled `.class` files belonging to the consumer module. */
     val classDirs: List<File>,
-    /** Dependency JARs to merge onto the scan classpath. Filtered down to a preview-relevant subset by the scanner. */
+    /**
+     * Dependency JARs to merge onto the scan classpath. Filtered down to a preview-relevant subset
+     * by the scanner.
+     */
     val dependencyJars: List<File>,
     /** Source files used to attach module-relative `sourceFile` paths to each [PreviewInfo]. */
     val sourceFiles: List<File>,
-    /** Logical module name surfaced via [PreviewManifest.module]. Bazel rules use the target label; Gradle uses the project path. */
+    /**
+     * Logical module name surfaced via [PreviewManifest.module]. Bazel rules use the target label;
+     * Gradle uses the project path.
+     */
     val moduleName: String,
     /** Build variant ("debug" / "release" / "desktop"). Surfaced via [PreviewManifest.variant]. */
     val variantName: String,
     /** Module root — `PreviewInfo.sourceFile` is rendered relative to this. */
     val projectDirectory: File,
-    /** When `true` and zero previews are discovered, the scan returns [Outcome.Failure] with a diagnostics block. */
+    /**
+     * When `true` and zero previews are discovered, the scan returns [Outcome.Failure] with a
+     * diagnostics block.
+     */
     val failOnEmpty: Boolean,
   )
 
@@ -59,16 +68,16 @@ object PreviewDiscovery {
     ) : Outcome()
 
     /**
-     * The scan terminated with a hard failure (zero previews + `failOnEmpty`, or the @Preview
-     * class isn't reachable on the ClassGraph classpath at all). [reason] is the one-line error
-     * the adapter should surface as an exception message; [diagnostics] is the multi-line
-     * dump (class dirs, dependency-jar sample, observed annotation FQNs) the adapter logs
-     * before the failure so users can see what the scan saw. [warnings] are any per-method
-     * skip reasons collected during the scan (e.g. private `@Preview`, unsupported
-     * parameters) — they're the most actionable signal when discovery returned zero previews
-     * because methods were skipped, so the adapter should route them to its build system's
-     * WARN-level log alongside [diagnostics] before surfacing [reason]. Symmetric with
-     * [Success.warnings] so adapters can emit the same WARN stream on both branches.
+     * The scan terminated with a hard failure (zero previews + `failOnEmpty`, or the @Preview class
+     * isn't reachable on the ClassGraph classpath at all). [reason] is the one-line error the
+     * adapter should surface as an exception message; [diagnostics] is the multi-line dump (class
+     * dirs, dependency-jar sample, observed annotation FQNs) the adapter logs before the failure so
+     * users can see what the scan saw. [warnings] are any per-method skip reasons collected during
+     * the scan (e.g. private `@Preview`, unsupported parameters) — they're the most actionable
+     * signal when discovery returned zero previews because methods were skipped, so the adapter
+     * should route them to its build system's WARN-level log alongside [diagnostics] before
+     * surfacing [reason]. Symmetric with [Success.warnings] so adapters can emit the same WARN
+     * stream on both branches.
      */
     data class Failure(
       val reason: String,
@@ -108,6 +117,8 @@ object PreviewDiscovery {
   // @AnimatedPreview, same FQN-match policy. See `FocusedPreview.kt`.
   private const val FOCUSED_PREVIEW_FQN = "ee.schimke.composeai.preview.FocusedPreview"
   private const val AMBIENT_PREVIEW_FQN = "ee.schimke.composeai.preview.AmbientPreview"
+  private const val LAUNCHER_WIDGET_PREVIEW_FQN =
+    "ee.schimke.composeai.preview.LauncherWidgetPreview"
   // The stable FQN is shared by both Android's ui-tooling-preview and CMP's
   // `org.jetbrains.compose.components:components-ui-tooling-preview` — Kotlin
   // `expect`/`actual` collapses onto the same `androidx...` class name on
@@ -298,13 +309,9 @@ object PreviewDiscovery {
         dataExtensionReports = emptyMap(),
       )
 
-    infoMessages.add(
-      "Discovered ${normalized.size} preview(s) in module '${input.moduleName}':"
-    )
+    infoMessages.add("Discovered ${normalized.size} preview(s) in module '${input.moduleName}':")
     for (preview in normalized) {
-      infoMessages.add(
-        "  ${preview.className}.${preview.functionName}${describeVariant(preview)}"
-      )
+      infoMessages.add("  ${preview.className}.${preview.functionName}${describeVariant(preview)}")
     }
 
     // Unconditional fail: the plugin scanned non-empty class dirs but
@@ -579,6 +586,7 @@ object PreviewDiscovery {
     val focusSpecs = extractFocusSpecs(annotations)
     val focusGifSpec = extractFocusGifSpec(annotations)
     val ambientSpec = extractAmbientSpec(annotations)
+    val launcherWidgetSpec = extractLauncherWidgetSpec(annotations)
     // @RoboComposePreviewOptions, similarly, applies to the function as a
     // whole — each timing fans out into its own manifest entry, orthogonal
     // to any multi-preview expansion.
@@ -638,6 +646,7 @@ object PreviewDiscovery {
             focusSpecs,
             focusGifSpec,
             ambientSpec,
+            launcherWidgetSpec,
             timings,
             previewParameter,
             previewSourceFile,
@@ -660,6 +669,7 @@ object PreviewDiscovery {
           focusSpecs,
           focusGifSpec,
           ambientSpec,
+          launcherWidgetSpec,
           timings,
           previewParameter,
           previewSourceFile,
@@ -776,6 +786,7 @@ object PreviewDiscovery {
     focuses: List<FocusCapture>,
     focusGif: FocusGifCapture?,
     ambient: AmbientCapture?,
+    launcherWidget: LauncherWidgetCapture?,
     timings: List<Long>,
   ): PreviewOutputPlan {
     val isTile = ann.name == TILE_PREVIEW_FQN
@@ -798,6 +809,10 @@ object PreviewDiscovery {
     // previews render outside the Compose composition where the local lives, so the override is a
     // no-op there.
     val effectiveAmbient = if (nonComposable) null else ambient
+    // `@LauncherWidgetPreview` wraps the composition in a sized Box — same reasoning as ambient:
+    // non-composable previews have no Compose layout pass to wrap. The override is also dropped
+    // for tile / notification renders.
+    val effectiveLauncherWidget = if (nonComposable) null else launcherWidget
 
     // @AnimatedPreview and @FocusedPreview(gif = true) both produce a `.gif` output for the
     // function. When one is paired with anything else on the same function — scroll/time
@@ -820,6 +835,7 @@ object PreviewDiscovery {
           Capture(
             focusGif = effectiveFocusGif,
             ambient = effectiveAmbient,
+            launcherWidget = effectiveLauncherWidget,
             renderOutput = "renders/${previewId}${suffix}.gif",
             cost = FOCUS_GIF_COST,
           )
@@ -914,6 +930,7 @@ object PreviewDiscovery {
                 scroll = scroll,
                 focus = focus,
                 ambient = effectiveAmbient,
+                launcherWidget = effectiveLauncherWidget,
                 renderOutput =
                   "renders/${previewId}${scrollSuffix}${timeSuffix}${focusSuffix}.${ext}",
                 cost = captureCost,
@@ -1098,6 +1115,39 @@ object PreviewDiscovery {
     )
   }
 
+  /**
+   * Reads `@LauncherWidgetPreview(width, height, cellSizeDp, cellSpacingDp, minWidth, …)` off the
+   * function annotation list. Returns a single [LauncherWidgetCapture] when present, `null`
+   * otherwise. Mirrors `extractAmbientSpec` — single-shot per function, applied to every preview
+   * variant. Optional `Int` parameters use `-1` as the "not set" sentinel (annotation parameters
+   * can't be nullable in Kotlin); we map that back to `null` so the renderer / connector apply
+   * their own defaults rather than treating `-1` as a literal.
+   */
+  private fun extractLauncherWidgetSpec(annotations: List<AnnotationInfo>): LauncherWidgetCapture? {
+    val ann = annotations.firstOrNull { it.name == LAUNCHER_WIDGET_PREVIEW_FQN } ?: return null
+    val pv = ann.parameterValues
+    val width = (pv.getValue("width") as? Int) ?: return null
+    val height = (pv.getValue("height") as? Int) ?: return null
+    fun optionalInt(name: String): Int? = (pv.getValue(name) as? Int)?.takeIf { it >= 0 }
+    val orderName =
+      (pv.getValue("resizeOrder") as? AnnotationEnumValue)?.valueName
+        ?: LauncherWidgetCaptureResizeOrder.WidthFirst.name
+    val order =
+      runCatching { LauncherWidgetCaptureResizeOrder.valueOf(orderName) }
+        .getOrDefault(LauncherWidgetCaptureResizeOrder.WidthFirst)
+    return LauncherWidgetCapture(
+      width = width,
+      height = height,
+      cellSizeDp = optionalInt("cellSizeDp"),
+      cellSpacingDp = optionalInt("cellSpacingDp"),
+      minWidth = optionalInt("minWidth"),
+      minHeight = optionalInt("minHeight"),
+      maxWidth = optionalInt("maxWidth"),
+      maxHeight = optionalInt("maxHeight"),
+      resizeOrder = order,
+    )
+  }
+
   private fun extractFocusSpecs(annotations: List<AnnotationInfo>): List<FocusCapture> {
     val ann = annotations.firstOrNull { it.name == FOCUSED_PREVIEW_FQN } ?: return emptyList()
     return readFocusSteps(ann)
@@ -1262,6 +1312,7 @@ object PreviewDiscovery {
     focuses: List<FocusCapture>,
     focusGif: FocusGifCapture?,
     ambient: AmbientCapture?,
+    launcherWidget: LauncherWidgetCapture?,
     timings: List<Long>,
     previewParameter: Pair<String, Int>?,
     previewSourceFile: String?,
@@ -1272,7 +1323,17 @@ object PreviewDiscovery {
     val suffix = buildVariantSuffix(params)
     val id = fqn + suffix
     val outputPlan =
-      buildOutputPlan(ann, id, scrolls, animation, focuses, focusGif, ambient, timings)
+      buildOutputPlan(
+        ann,
+        id,
+        scrolls,
+        animation,
+        focuses,
+        focusGif,
+        ambient,
+        launcherWidget,
+        timings,
+      )
     // Tile / notification previews don't go through @Composable invocations — they return a
     // `TilePreviewData` / `Notification` and the renderer reflects them directly. Skipping the
     // lazy means the bytecode walk never runs for these methods.

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
@@ -28,10 +28,10 @@ import kotlinx.serialization.json.Json
  * `java -jar <artifact>.jar` against the bare published JAR will fail with `NoClassDefFoundError` —
  * see the "CLI invocation" section in `docs/NON_GRADLE_INTEGRATION.md`.
  *
- * `--classes`, `--dependency-jars`, `--source-files` accept a `File.pathSeparator`-separated
- * list (matching how `java -cp` already encodes classpaths on the consumer's platform) and can
- * be repeated to concatenate. Empty entries are skipped, so passing an empty value through is
- * harmless when a build rule's input list happens to be empty.
+ * `--classes`, `--dependency-jars`, `--source-files` accept a `File.pathSeparator`-separated list
+ * (matching how `java -cp` already encodes classpaths on the consumer's platform) and can be
+ * repeated to concatenate. Empty entries are skipped, so passing an empty value through is harmless
+ * when a build rule's input list happens to be empty.
  *
  * Exit codes: `0` on success (manifest written), `1` on discovery failure (e.g. zero previews
  * + `--fail-on-empty`), `2` on argument parsing failure.
@@ -96,8 +96,7 @@ public object PreviewDiscoveryCli {
         "--classes" -> classDirs += splitPathList(requireValue(args, i)).map { File(it) }
         "--dependency-jars" ->
           dependencyJars += splitPathList(requireValue(args, i)).map { File(it) }
-        "--source-files" ->
-          sourceFiles += splitPathList(requireValue(args, i)).map { File(it) }
+        "--source-files" -> sourceFiles += splitPathList(requireValue(args, i)).map { File(it) }
         "--module" -> moduleName = requireValue(args, i)
         "--variant" -> variantName = requireValue(args, i)
         "--project-directory" -> projectDirectory = File(requireValue(args, i))

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/LauncherWidgetPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/LauncherWidgetPreview.kt
@@ -1,0 +1,86 @@
+package ee.schimke.composeai.preview
+
+/**
+ * Opts a `@Preview` composable into launcher-widget container sizing.
+ *
+ * The compose-preview Gradle plugin's discovery task picks this up by FQN, mirroring
+ * [AmbientPreview] / [FocusedPreview]: consumers that want to use the annotation in their own code
+ * depend on `ee.schimke.composeai:preview-annotations`. The renderer translates the captured cell
+ * count into a `LauncherWidgetExtension` (see `:data-launcher-widget-connector`) wrapping the
+ * preview's composition, so the rendered PNG sizes to the resolved dp footprint a real Android
+ * launcher would assign — `cells = (4, 2)` at the default `72dp` cell size resolves to a `4*72 +
+ * 3*8 = 312.dp` wide by `2*72 + 1*8 = 152.dp` tall container.
+ *
+ * Static `@Preview` rendering through the plugin's per-capture loop applies the wrap before each
+ * capture; daemon-driven `renderNow.overrides.launcherWidget` already does the same through the
+ * connector's planner. Both paths end up at the same `AroundComposable` extension.
+ *
+ * Example:
+ * ```
+ * @Preview(showBackground = true)
+ * @LauncherWidgetPreview(width = 4, height = 2)
+ * @Composable
+ * fun MyWidgetPreview() {
+ *   MyWidget()
+ * }
+ * ```
+ *
+ * The annotation pairs naturally with the `GlanceAppWidgetContent` helper in
+ * `:glance-preview-runtime` or a hand-built `RemoteViews` body — the launcher-cell wrap is
+ * orthogonal to what's inside the cell.
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+@MustBeDocumented
+annotation class LauncherWidgetPreview(
+  /** Target whole-cell width on the launcher grid. Clamped into [minWidth]..[maxWidth]. */
+  val width: Int,
+  /** Target whole-cell height on the launcher grid. Clamped into [minHeight]..[maxHeight]. */
+  val height: Int,
+  /**
+   * Cell edge length in dp. `-1` (the default sentinel — annotation parameters can't be nullable)
+   * falls back to the connector's default (`72`), matching a Pixel launcher's `5×5` grid on a 411dp
+   * screen.
+   */
+  val cellSizeDp: Int = LAUNCHER_WIDGET_CELL_SIZE_DEFAULT,
+  /** Gap between adjacent cells in dp. `-1` falls back to the connector default (`8`). */
+  val cellSpacingDp: Int = LAUNCHER_WIDGET_CELL_SPACING_DEFAULT,
+  /** Inclusive lower bound on the cell width. `-1` falls back to `1`. */
+  val minWidth: Int = LAUNCHER_WIDGET_CELL_BOUND_DEFAULT,
+  /** Inclusive lower bound on the cell height. `-1` falls back to `1`. */
+  val minHeight: Int = LAUNCHER_WIDGET_CELL_BOUND_DEFAULT,
+  /** Inclusive upper bound on the cell width. `-1` falls back to `5`. */
+  val maxWidth: Int = LAUNCHER_WIDGET_CELL_BOUND_DEFAULT,
+  /** Inclusive upper bound on the cell height. `-1` falls back to `5`. */
+  val maxHeight: Int = LAUNCHER_WIDGET_CELL_BOUND_DEFAULT,
+  /**
+   * Hint for a future daemon-side resize-loop orchestrator on how to walk intermediate stops
+   * between two sizes. The single-shot static-preview path always snaps to ([width], [height]);
+   * this field is plumbed through the manifest so a loop driver can read it later.
+   */
+  val resizeOrder: LauncherWidgetResizeOrder = LauncherWidgetResizeOrder.WidthFirst,
+)
+
+/**
+ * Sentinel used by [LauncherWidgetPreview]'s optional `Int` parameters because annotation
+ * parameters cannot be nullable. Discovery treats the value as "fall back to the connector default"
+ * rather than as a literal `-1`.
+ */
+const val LAUNCHER_WIDGET_CELL_SIZE_DEFAULT: Int = -1
+
+/** Sentinel for [LauncherWidgetPreview.cellSpacingDp]. */
+const val LAUNCHER_WIDGET_CELL_SPACING_DEFAULT: Int = -1
+
+/** Sentinel for the [LauncherWidgetPreview] min / max cell bound parameters. */
+const val LAUNCHER_WIDGET_CELL_BOUND_DEFAULT: Int = -1
+
+/**
+ * Discoverable mirror of `LauncherResizeOrder` in `:daemon:core`. The Gradle plugin can't load the
+ * daemon-protocol module at discovery time, so we duplicate the relevant enum here and the renderer
+ * translates at render time.
+ */
+enum class LauncherWidgetResizeOrder {
+  Diagonal,
+  WidthFirst,
+  HeightFirst,
+}

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -54,6 +54,15 @@ dependencies {
   // architectural rule as focus: **no hardcoded ambient / `LocalAmbientModeManager` logic in
   // this module — extend the connector instead.**
   implementation(project(":data-ambient-connector"))
+  // Launcher-widget container-size connector. Owns `LauncherWidgetExtension` (the
+  // `AroundComposable` that wraps the preview in `Box(Modifier.size(...))` at the resolved cell
+  // footprint) and the `LauncherWidgetPreviewOverrideExtension` planner. The renderer reads
+  // `Capture.launcherWidget` (set when the consumer's `@Preview` carries a
+  // `@LauncherWidgetPreview`) and builds the extension directly via `toLauncherWidgetOverride()`;
+  // daemon-driven `renderNow.overrides.launcherWidget` lands at the same extension through the
+  // planner registered in `RobolectricHost`. Same architectural rule as ambient / focus: **no
+  // hardcoded launcher-widget sizing logic in this module — extend the connector instead.**
+  implementation(project(":data-launcher-widget-connector"))
   // Soft-keyboard (IME) connector. Owns `KeyboardController` (state) and
   // `KeyboardOverrideExtension`
   // (the `AroundComposable` that installs the shadow `LocalSoftwareKeyboardController` and overlays

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -96,6 +96,28 @@ data class AmbientCapture(
     val deviceHasLowBitAmbient: Boolean = false,
 )
 
+/** Renderer-side mirror of the plugin's `LauncherWidgetCaptureResizeOrder`. */
+@Serializable
+enum class LauncherWidgetCaptureResizeOrder {
+    Diagonal,
+    WidthFirst,
+    HeightFirst,
+}
+
+/** Renderer-side mirror of the plugin's `LauncherWidgetCapture`. */
+@Serializable
+data class LauncherWidgetCapture(
+    val width: Int,
+    val height: Int,
+    val cellSizeDp: Int? = null,
+    val cellSpacingDp: Int? = null,
+    val minWidth: Int? = null,
+    val minHeight: Int? = null,
+    val maxWidth: Int? = null,
+    val maxHeight: Int? = null,
+    val resizeOrder: LauncherWidgetCaptureResizeOrder = LauncherWidgetCaptureResizeOrder.WidthFirst,
+)
+
 /**
  * Heavy/fast threshold for [RenderPreviewCapture.cost]. Mirrors the plugin's
  * `HEAVY_COST_THRESHOLD` — anything strictly greater is considered "heavy"
@@ -150,6 +172,7 @@ data class RenderPreviewCapture(
     val focus: FocusCapture? = null,
     val focusGif: FocusGifCapture? = null,
     val ambient: AmbientCapture? = null,
+    val launcherWidget: LauncherWidgetCapture? = null,
     val renderOutput: String = "",
     /**
      * Estimated render cost normalised so a static `@Preview` is `1.0`. See

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -28,6 +28,7 @@ import com.github.takahirom.roborazzi.locale
 import com.github.takahirom.roborazzi.size
 import com.github.takahirom.roborazzi.uiMode
 import ee.schimke.composeai.daemon.AmbientOverrideExtension
+import ee.schimke.composeai.daemon.LauncherWidgetExtension
 import ee.schimke.composeai.daemon.FocusController
 import ee.schimke.composeai.daemon.FocusOverlay
 import ee.schimke.composeai.daemon.FocusOverrideExtension
@@ -35,6 +36,9 @@ import ee.schimke.composeai.daemon.KeyboardController
 import ee.schimke.composeai.daemon.KeyboardOverrideExtension
 import ee.schimke.composeai.daemon.protocol.AmbientOverride
 import ee.schimke.composeai.daemon.protocol.AmbientStateOverride
+import ee.schimke.composeai.daemon.protocol.LauncherResizeOrder
+import ee.schimke.composeai.daemon.protocol.LauncherWidgetOverride
+import ee.schimke.composeai.daemon.protocol.LauncherWidgetSize
 import ee.schimke.composeai.daemon.DisplayFilterConfig
 import ee.schimke.composeai.daemon.DisplayFilterDataProducer
 import ee.schimke.composeai.daemon.protocol.FocusOverride
@@ -698,6 +702,16 @@ abstract class RobolectricRenderTestBase(
                     preview.captures.firstNotNullOfOrNull { it.ambient }?.let {
                         AmbientOverrideExtension(it.toAmbientOverride())
                     }
+                // `@LauncherWidgetPreview` discovery stamps the same `LauncherWidgetCapture` onto
+                // every capture of an annotated function. Wrap the composition with
+                // `LauncherWidgetExtension` from `:data-launcher-widget-connector` so the rendered
+                // PNG sizes to the resolved dp footprint of a launcher cell. Daemon-driven
+                // `renderNow.overrides.launcherWidget` lands at the same extension via the
+                // `LauncherWidgetPreviewOverrideExtension` planner registered in `RobolectricHost`.
+                val launcherWidgetExtension =
+                    preview.captures.firstNotNullOfOrNull { it.launcherWidget }?.let {
+                        LauncherWidgetExtension(it.toLauncherWidgetOverride())
+                    }
                 // Pseudolocale: when `@Preview(locale = "en-XA" | "ar-XB")`, wrap composition with
                 // `PseudolocaleOverrideExtension` so `LocalContext.current.resources.getString(...)`
                 // — the path `androidx.compose.ui.res.stringResource` walks — returns the
@@ -775,11 +789,23 @@ abstract class RobolectricRenderTestBase(
                                 focusOrPlain()
                             }
                         }
-                        val pseudoOrPlain: @Composable () -> Unit = {
-                            if (pseudolocaleExtension != null) {
-                                pseudolocaleExtension.AroundComposable { ambientOrPlain() }
+                        // Launcher-widget sizing wraps OUTSIDE ambient/focus/curve so the
+                        // `Box.size(...)` constrains the visible viewport before any inner
+                        // override applies — the cell footprint is the launcher chrome, not
+                        // the preview's own surface chemistry. Matches the connector's
+                        // `DataExtensionPhase.OuterEnvironment` ordering.
+                        val launcherWidgetOrPlain: @Composable () -> Unit = {
+                            if (launcherWidgetExtension != null) {
+                                launcherWidgetExtension.AroundComposable { ambientOrPlain() }
                             } else {
                                 ambientOrPlain()
+                            }
+                        }
+                        val pseudoOrPlain: @Composable () -> Unit = {
+                            if (pseudolocaleExtension != null) {
+                                pseudolocaleExtension.AroundComposable { launcherWidgetOrPlain() }
+                            } else {
+                                launcherWidgetOrPlain()
                             }
                         }
                         keyboardExtension.AroundComposable { pseudoOrPlain() }
@@ -1976,6 +2002,31 @@ private fun AmbientCapture.toAmbientOverride(): AmbientOverride =
             },
         burnInProtectionRequired = burnInProtectionRequired,
         deviceHasLowBitAmbient = deviceHasLowBitAmbient,
+    )
+
+/**
+ * Maps the renderer-side [LauncherWidgetCapture] (read from `previews.json`) onto the
+ * connector's `protocol.LauncherWidgetOverride` wire shape. Discovery serialises optional
+ * `Int?` fields when the consumer left the annotation at its `-1` sentinel — those round-trip
+ * as `null` here and the connector applies its own defaults.
+ */
+private fun LauncherWidgetCapture.toLauncherWidgetOverride(): LauncherWidgetOverride =
+    LauncherWidgetOverride(
+        cells = LauncherWidgetSize(width, height),
+        cellSizeDp = cellSizeDp,
+        cellSpacingDp = cellSpacingDp,
+        minCells =
+            if (minWidth != null && minHeight != null) LauncherWidgetSize(minWidth, minHeight)
+            else null,
+        maxCells =
+            if (maxWidth != null && maxHeight != null) LauncherWidgetSize(maxWidth, maxHeight)
+            else null,
+        resizeOrder =
+            when (resizeOrder) {
+                LauncherWidgetCaptureResizeOrder.Diagonal -> LauncherResizeOrder.DIAGONAL
+                LauncherWidgetCaptureResizeOrder.WidthFirst -> LauncherResizeOrder.WIDTH_FIRST
+                LauncherWidgetCaptureResizeOrder.HeightFirst -> LauncherResizeOrder.HEIGHT_FIRST
+            },
     )
 
 /**

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/AppWidgetPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/AppWidgetPreviews.kt
@@ -30,6 +30,7 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider as GlanceFixedColorProvider
+import ee.schimke.composeai.preview.LauncherWidgetPreview
 import ee.schimke.composeai.preview.glance.GlanceAppWidgetContent
 
 // ---------------------------------------------------------------------------
@@ -94,8 +95,9 @@ fun AppWidgetContent(factory: (Context) -> RemoteViews) {
  * launcher grid (`cellSize = 72.dp`, `cellSpacing = 8.dp`) — the same arithmetic the
  * `LauncherWidgetExtension` daemon-side override uses when a client sends
  * `renderNow.overrides.launcherWidget = LauncherWidgetOverride(cells = (4, 2))`. The hard-coded
- * dimensions here let the preview render through the gradle plugin path (which doesn't have a
- * `@LauncherWidgetPreview` annotation yet — that's the next deliverable).
+ * dimensions here let the preview render through the gradle plugin path; the
+ * `@LauncherWidgetPreview`-annotated samples below drive the same cell footprint from discovery
+ * via the annotation in `:preview-annotations`.
  */
 @Preview(name = "RemoteViews widget — 4×2", widthDp = 312, heightDp = 152, showBackground = true)
 @Composable
@@ -183,4 +185,77 @@ fun GlanceWeatherWidgetPreview() {
     widget = WeatherGlanceAppWidget(),
     size = DpSize(width = 312.dp, height = 152.dp),
   )
+}
+
+// ---------------------------------------------------------------------------
+// `@LauncherWidgetPreview` annotation samples
+//
+// Same widget content as `RemoteViewsWeatherWidgetPreview` above, but the cell footprint is
+// driven by `@LauncherWidgetPreview(width, height)` instead of `@Preview(widthDp, heightDp)`.
+// The gradle plugin's discovery picks the annotation up by FQN, stamps a
+// `LauncherWidgetCapture` onto every capture of the function, and the renderer wraps the
+// composition with `:data-launcher-widget-connector`'s `LauncherWidgetExtension` — the same
+// around-composable a daemon-driven `renderNow.overrides.launcherWidget` would apply. The
+// surrounding `@Preview(widthDp, heightDp)` still sets the Robolectric sandbox window; the
+// annotation-driven wrap then constrains the visible cell-shaped region inside it.
+// ---------------------------------------------------------------------------
+
+/**
+ * Smallest cell shape supported by the default `1×1`..`5×5` bounds. Same widget body as
+ * [RemoteViewsWeatherWidgetPreview] but the cell footprint is annotation-driven.
+ */
+@Preview(name = "Launcher widget — 1×1", widthDp = 96, heightDp = 96, showBackground = true)
+@LauncherWidgetPreview(width = 1, height = 1)
+@Composable
+fun LauncherWidget1x1Preview() {
+  AppWidgetContent { context ->
+    RemoteViews(context.packageName, R.layout.widget_weather).apply {
+      setTextViewText(R.id.widget_title, "SF")
+      setTextViewText(R.id.widget_temperature, "67°")
+      setTextViewText(R.id.widget_condition, "")
+    }
+  }
+}
+
+/**
+ * Full `4×2` cell footprint via the annotation — mirror of [RemoteViewsWeatherWidgetPreview]'s
+ * `@Preview(widthDp = 312, heightDp = 152)` but driven from the discovery-stamped
+ * `LauncherWidgetCapture` instead of hand-tuned `@Preview` dimensions.
+ */
+@Preview(name = "Launcher widget — 4×2", widthDp = 312, heightDp = 152, showBackground = true)
+@LauncherWidgetPreview(width = 4, height = 2)
+@Composable
+fun LauncherWidget4x2Preview() {
+  AppWidgetContent { context ->
+    RemoteViews(context.packageName, R.layout.widget_weather).apply {
+      setTextViewText(R.id.widget_title, "San Francisco")
+      setTextViewText(R.id.widget_temperature, "67°")
+      setTextViewText(R.id.widget_condition, "Partly cloudy · H 70° / L 55°")
+    }
+  }
+}
+
+/**
+ * Demonstrates clamping: requested `7×7` is pegged into the configured `1×3`..`4×5` bounds, so
+ * the rendered footprint is `4×5`. Mirrors a real Android launcher's `minResizeWidth` /
+ * `minResizeHeight` behaviour.
+ */
+@Preview(name = "Launcher widget — clamped to 4×5", widthDp = 312, heightDp = 392, showBackground = true)
+@LauncherWidgetPreview(
+  width = 7,
+  height = 7,
+  minWidth = 1,
+  minHeight = 3,
+  maxWidth = 4,
+  maxHeight = 5,
+)
+@Composable
+fun LauncherWidgetClampedPreview() {
+  AppWidgetContent { context ->
+    RemoteViews(context.packageName, R.layout.widget_weather).apply {
+      setTextViewText(R.id.widget_title, "Clamped → 4×5")
+      setTextViewText(R.id.widget_temperature, "67°")
+      setTextViewText(R.id.widget_condition, "Partly cloudy")
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds `@LauncherWidgetPreview(width, height, …)` to `:preview-annotations` and wires it through discovery + the renderer so consumers can drive the launcher-widget cell-sized wrap (landed in #1368) from the `@Preview` site instead of via `renderNow.overrides.launcherWidget`.

- **`:preview-annotations`** — new `BINARY`-retained `FUNCTION`-targeted annotation. Required `width`, `height`; optional `cellSizeDp`, `cellSpacingDp`, `minWidth`, `minHeight`, `maxWidth`, `maxHeight`, `resizeOrder`. Annotation params can't be nullable in Kotlin, so the optional `Int`s use `-1` sentinels that discovery maps to `null` (connector then applies its defaults).
- **`:gradle-plugin:preview-discovery`** — registers `LAUNCHER_WIDGET_PREVIEW_FQN`, adds `extractLauncherWidgetSpec(...)` mirroring `extractAmbientSpec`, threads the spec through `buildOutputPlan` + `makePreview`, and stamps a `LauncherWidgetCapture` onto every capture of an annotated function. New `LauncherWidgetCapture` / `LauncherWidgetCaptureResizeOrder` round-trip through `previews.json`.
- **`:renderer-android`** — mirrors the same types in `RenderManifest.kt`, adds a `LauncherWidgetExtension` build site next to the existing ambient one, and wraps the composition via `launcherWidgetExtension.AroundComposable { ambientOrPlain() }` *outside* the ambient / focus / curve layers (matches the connector's `DataExtensionPhase.OuterEnvironment` ordering — the cell footprint is launcher chrome, not the preview's own surface chemistry). New `LauncherWidgetCapture.toLauncherWidgetOverride()` handles the `-1` → `null` sentinel mapping plus the `LauncherWidgetCaptureResizeOrder` → `LauncherResizeOrder` enum translation.
- **`:samples:android:AppWidgetPreviews.kt`** — three new previews exercising the annotation end-to-end:
  - `LauncherWidget1x1Preview` — smallest cell (72×72 dp), single-letter label inside.
  - `LauncherWidget4x2Preview` — full-content widget at `4×2` cells (312×152 dp).
  - `LauncherWidgetClampedPreview` — requested `7×7` pegged into configured `1×3`..`4×5` bounds, rendered at `4×5` (312×392 dp) to demonstrate the launcher's `minResizeWidth` / `minResizeHeight` analogue.

The daemon-driven `renderNow.overrides.launcherWidget` path landed in #1368 keeps working through the planner registered in `RobolectricHost`; the new annotation-driven path lands at the same `AroundComposable` so both paths share a single render seam.

## Test plan

- [x] `./gradlew :preview-annotations:compileKotlin` — annotation artifact compiles
- [x] `./gradlew :gradle-plugin:preview-discovery:test` — existing discovery tests stay green
- [x] `./gradlew :renderer-android:compileDebugKotlin` — `LauncherWidgetExtension` + override translator resolve against the bumped renderer build
- [x] `./gradlew :samples:android:composePreviewRenderAll` — all three annotation-driven previews render correctly through Robolectric: 1×1 (72×72), 4×2 (312×152), clamped 7×7 → 4×5 (312×392)
- [ ] Follow-up: native FQN discovery of `androidx.glance.preview.Preview` so Glance widgets can use their own preview annotation directly instead of the `GlanceAppWidgetContent` helper (research notes already mapped the seams)

---
_Generated by [Claude Code](https://claude.ai/code/session_016wQB16N6M2ey3nNLmZhrDc)_