### PR TITLE
ci: surface partial render failures in preview baseline + PR comment flows

### DIFF
--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -137,6 +137,20 @@ def _is_changed(
     return _perceptually_changed(prior, Path(png_path))
 
 
+def _collect_failures(rows: dict) -> list[tuple[str, dict]]:
+    """Return CLI rows whose render produced no PNG.
+
+    The CLI's `show` / `show-resources` envelopes carry every discovered
+    preview — including those whose `composePreviewRender` task completed but
+    the PNG never landed on disk (Robolectric sandbox crash, NO-SOURCE
+    classpath gap, etc.). Those rows have an empty `sha256`. Surfacing them as
+    "render failed in this run" lets the baseline and PR-comment flows push
+    the successful subset while still warning reviewers about the partial
+    state. Sorted by key so the markdown output is deterministic.
+    """
+    return [(key, info) for key, info in sorted(rows.items()) if not info.get("sha256")]
+
+
 def _capture_label(capture: dict) -> str:
     """Human-readable summary of a capture's non-null dimensions.
 
@@ -329,11 +343,33 @@ def cmd_generate(args: argparse.Namespace) -> int:
     out_dir = Path(args.output_dir)
     repo = args.repo
     branch = args.branch
+    prior_baselines_path = (
+        Path(args.prior_baselines) if getattr(args, "prior_baselines", None) else None
+    )
+    prior_renders = (
+        Path(args.prior_renders) if getattr(args, "prior_renders", None) else None
+    )
 
     previews = load_cli_output(cli_json)
     if not previews:
         print("No previews in CLI output.", file=sys.stderr)
         return 1
+
+    # When the CLI emitted a row with no `sha256`, the render task ran but no
+    # PNG landed on disk — treat the prior baseline branch as the source of
+    # truth for that preview so a flaky single-preview failure doesn't wipe
+    # the entry out of `compose-preview/main`. Empty / missing prior is fine;
+    # the row drops out of the baseline (same as today) and is listed as a
+    # "no baseline retained" failure in the README.
+    prior_baselines = (
+        _load_baselines(prior_baselines_path) if prior_baselines_path else {}
+    )
+    failures = _collect_failures(previews)
+    carried_over: dict[str, dict] = {}
+    for key, _info in failures:
+        prior = prior_baselines.get(key)
+        if isinstance(prior, dict) and prior.get("sha256") and prior.get("renderBasename"):
+            carried_over[key] = prior
 
     # --- baselines.json ---
     # Persist the renderBasename alongside the sha so the compare run can
@@ -350,6 +386,11 @@ def cmd_generate(args: argparse.Namespace) -> int:
         for key, info in previews.items()
         if info["sha256"]  # skip entries without a rendered PNG
     }
+    # Carry forward the prior entry as-is for previews that failed in this
+    # run. Same shape as `_load_baselines` returns, so downstream
+    # compare-on-PR keeps matching them.
+    for key, prior in carried_over.items():
+        baselines.setdefault(key, prior)
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "baselines.json").write_text(
         json.dumps(baselines, indent=2, sort_keys=True) + "\n")
@@ -370,6 +411,19 @@ def cmd_generate(args: argparse.Namespace) -> int:
         dest = renders_out / info["module"] / info["renderBasename"]
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(png, dest)
+    # Carry forward the prior PNG for previews whose render failed but had a
+    # prior baseline — keeps the README inline image resolving even though
+    # this run didn't produce a fresh capture.
+    if prior_renders is not None:
+        for key, prior in carried_over.items():
+            module = previews[key]["module"]
+            basename = prior["renderBasename"]
+            src = prior_renders / module / basename
+            if not src.exists():
+                continue
+            dest = renders_out / module / basename
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
 
     # --- README.md (browsable gallery) ---
     lines = [
@@ -378,6 +432,41 @@ def cmd_generate(args: argparse.Namespace) -> int:
         "Auto-generated from `main`. Browse inline or compare against PR branches.",
         "",
     ]
+    if failures:
+        retained = sum(1 for key, _ in failures if key in carried_over)
+        dropped = len(failures) - retained
+        warning_bits = []
+        if retained:
+            warning_bits.append(f"{retained} retained from the prior baseline")
+        if dropped:
+            warning_bits.append(f"{dropped} with no prior baseline to retain")
+        warning = (
+            f"> [!WARNING]"
+            f"\n> {len(failures)} preview(s) failed to render in the latest update"
+            f" ({'; '.join(warning_bits)}). See **Render Failures** below."
+        )
+        lines.append(warning)
+        lines.append("")
+        lines.append("## Render Failures")
+        lines.append("")
+        lines.append(
+            "The render task completed but no PNG was produced for these previews. "
+            "Entries with a prior baseline keep their previous image; the rest are "
+            "absent from the gallery until a successful render lands."
+        )
+        lines.append("")
+        lines.append("| Preview | Module | Function | Source | Baseline |")
+        lines.append("|---------|--------|----------|--------|----------|")
+        for key, info in failures:
+            label_suffix = f" · {info['captureLabel']}" if info.get("captureLabel") else ""
+            fn = f"{info.get('functionName', '?')}{label_suffix}"
+            source = info.get("sourceFile") or "—"
+            state = "retained" if key in carried_over else "none"
+            lines.append(
+                f"| `{key}` | {info.get('module', '?')} | `{fn}` | `{source}` | {state} |"
+            )
+        lines.append("")
+
     by_module: dict[str, list[tuple[str, dict]]] = {}
     for key, info in sorted(previews.items()):
         if not info["sha256"]:
@@ -401,8 +490,11 @@ def cmd_generate(args: argparse.Namespace) -> int:
 
     (out_dir / "README.md").write_text("\n".join(lines) + "\n")
 
-    print(f"Generated baselines for {len(baselines)} preview(s) in {out_dir}",
-          file=sys.stderr)
+    print(
+        f"Generated baselines for {len(baselines)} preview(s) "
+        f"({len(failures)} failure(s)) in {out_dir}",
+        file=sys.stderr,
+    )
     return 0
 
 
@@ -472,17 +564,27 @@ def cmd_compare(args: argparse.Namespace) -> int:
         if key not in current:
             removed.append((key, bl_info))
 
+    failures = _collect_failures(current)
+
     # --- generate markdown ---
     marker = "<!-- preview-diff -->"
     lines = [marker, "## Preview Changes", ""]
 
-    if not new and not changed and not removed:
+    if not new and not changed and not removed and not failures:
         lines.append("No visual changes detected.")
         lines.append("")
         if unchanged:
             lines.append(f"_{len(unchanged)} preview(s) unchanged._")
         print("\n".join(lines))
         return 0
+
+    if failures:
+        lines.append(
+            f"> [!WARNING]"
+            f"\n> {len(failures)} preview(s) failed to render in this PR's render run. "
+            f"The diff below covers only the previews that produced a PNG."
+        )
+        lines.append("")
 
     if changed:
         # Group changed variants by (module, functionName) — a function
@@ -555,6 +657,34 @@ def cmd_compare(args: argparse.Namespace) -> int:
         lines.append("")
         for fn in sorted(fn_set):
             lines.append(f"- ~`{fn}`~")
+        lines.append("")
+
+    if failures:
+        # Group by (module, functionName) so multi-capture failures land
+        # under one heading — mirrors how Changed/New collapse fan-outs.
+        fail_groups: dict[tuple[str, str], list[tuple[str, dict]]] = {}
+        for key, info in failures:
+            gk = (info.get("module", "?"), info.get("functionName", "?"))
+            fail_groups.setdefault(gk, []).append((key, info))
+        lines.append(
+            f"### Render Failures ({len(failures)} variant(s) across {len(fail_groups)} function(s))"
+        )
+        lines.append("")
+        lines.append(
+            "The render task completed but produced no PNG for these previews. "
+            "Common causes: Robolectric sandbox crash, `composePreviewRender` "
+            "NO-SOURCE, or a runtime exception inside the composable. Check the "
+            "`composePreviewRender-reports` artifact attached to this run."
+        )
+        lines.append("")
+        for (module, fn), entries in sorted(fail_groups.items()):
+            sources = sorted({info.get("sourceFile") or "" for _, info in entries})
+            sources = [s for s in sources if s]
+            source_hint = f" — `{sources[0]}`" if sources else ""
+            lines.append(f"- **`{fn}`** ({module}){source_hint}")
+            for key, info in entries:
+                label = info.get("captureLabel") or _entry_label(info)
+                lines.append(f"  - `{key}` · {label}")
         lines.append("")
 
     if unchanged:
@@ -704,6 +834,12 @@ def load_resource_results(cli_json_path: Path) -> dict[str, dict]:
 def cmd_generate_resources(args: argparse.Namespace) -> int:
     cli_json = Path(args.cli_json)
     out_dir = Path(args.output_dir)
+    prior_baselines_path = (
+        Path(args.prior_baselines) if getattr(args, "prior_baselines", None) else None
+    )
+    prior_renders = (
+        Path(args.prior_renders) if getattr(args, "prior_renders", None) else None
+    )
 
     entries = load_resource_results(cli_json)
     if not entries:
@@ -711,6 +847,20 @@ def cmd_generate_resources(args: argparse.Namespace) -> int:
         print("No Android resource manifests found; skipping resource baselines.",
               file=sys.stderr)
         return 0
+
+    # Carry-over flow mirrors `cmd_generate` for composables: when a resource
+    # render flakes (empty sha), keep the prior baseline entry + PNG so the
+    # branch keeps a usable gallery row instead of dropping the resource
+    # entirely.
+    prior_baselines = (
+        _load_baselines(prior_baselines_path) if prior_baselines_path else {}
+    )
+    failures = _collect_failures(entries)
+    carried_over: dict[str, dict] = {}
+    for key, _info in failures:
+        prior = prior_baselines.get(key)
+        if isinstance(prior, dict) and prior.get("sha256") and prior.get("renderBasename"):
+            carried_over[key] = prior
 
     out_dir.mkdir(parents=True, exist_ok=True)
     resource_baselines: dict[str, dict] = {}
@@ -732,7 +882,20 @@ def cmd_generate_resources(args: argparse.Namespace) -> int:
         }
         by_module.setdefault(info["module"], []).append((key, info))
 
-    if not resource_baselines:
+    # Carry forward the prior entry + PNG for resources that failed to render
+    # in this run. Same shape as `_load_baselines` returns for resources.
+    for key, prior in carried_over.items():
+        resource_baselines.setdefault(key, prior)
+        if prior_renders is not None:
+            module = entries[key]["module"]
+            basename = prior["renderBasename"]
+            src = prior_renders / module / basename
+            if src.exists():
+                dest = out_dir / "renders" / module / basename
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dest)
+
+    if not resource_baselines and not failures:
         print("Resource manifests existed but no rendered PNGs were on disk; "
               "skipping resource baselines.",
               file=sys.stderr)
@@ -759,6 +922,39 @@ def cmd_generate_resources(args: argparse.Namespace) -> int:
         "for the rendering catalogue.",
         "",
     ]
+    if failures:
+        retained = sum(1 for key, _ in failures if key in carried_over)
+        dropped = len(failures) - retained
+        warning_bits = []
+        if retained:
+            warning_bits.append(f"{retained} retained from the prior baseline")
+        if dropped:
+            warning_bits.append(f"{dropped} with no prior baseline to retain")
+        body_lines.append(
+            f"> [!WARNING]"
+            f"\n> {len(failures)} resource capture(s) failed to render in the latest update"
+            f" ({'; '.join(warning_bits)}). See **Resource Render Failures** below."
+        )
+        body_lines.append("")
+        body_lines.append("### Resource Render Failures")
+        body_lines.append("")
+        body_lines.append(
+            "The render task completed but no PNG was produced for these resource "
+            "captures. Entries with a prior baseline keep their previous image; the "
+            "rest are absent from the gallery until a successful render lands."
+        )
+        body_lines.append("")
+        body_lines.append("| Resource | Module | Type | Qualifiers | Shape | Baseline |")
+        body_lines.append("|---|---|---|---|---|---|")
+        for key, info in failures:
+            qualifiers = info.get("qualifiers") or "—"
+            shape = info.get("shape") or "—"
+            state = "retained" if key in carried_over else "none"
+            body_lines.append(
+                f"| `{info.get('resourceId', '?')}` | {info.get('module', '?')} | "
+                f"{info.get('resourceType', '')} | `{qualifiers}` | {shape} | {state} |"
+            )
+        body_lines.append("")
     for module in sorted(by_module):
         module_entries = sorted(by_module[module], key=lambda kv: kv[0])
         body_lines.append(f"### {module}")
@@ -904,15 +1100,25 @@ def cmd_compare_resources(args: argparse.Namespace) -> int:
         if key not in current:
             removed.append((key, bl_info))
 
+    failures = _collect_failures(current)
+
     marker = "<!-- preview-diff-resources -->"
-    if not (new or changed or removed):
-        # Empty stdout when nothing diffed — the action treats no output as
-        # "skip the resource comment entirely" rather than posting a "no
-        # changes" sticky comment that would clutter PRs that don't touch
-        # resources.
+    if not (new or changed or removed or failures):
+        # Empty stdout when nothing diffed and nothing failed — the action
+        # treats no output as "skip the resource comment entirely" rather
+        # than posting a "no changes" sticky comment that would clutter PRs
+        # that don't touch resources.
         return 0
 
     lines: list[str] = [marker, "## Resource Changes", ""]
+
+    if failures:
+        lines.append(
+            f"> [!WARNING]"
+            f"\n> {len(failures)} resource capture(s) failed to render in this PR's run. "
+            f"The diff below covers only the captures that produced a PNG."
+        )
+        lines.append("")
 
     if changed:
         # Group by (module, resourceId) so all captures of the same resource
@@ -983,6 +1189,31 @@ def cmd_compare_resources(args: argparse.Namespace) -> int:
             lines.append(f"- ~`{resource_id}`~ ({module})")
         lines.append("")
 
+    if failures:
+        # Group by (module, resourceId) so multi-capture failures collapse
+        # under one heading — same shape as Changed/New above.
+        fail_groups: dict[tuple[str, str], list[tuple[str, dict]]] = {}
+        for key, info in failures:
+            gk = (info.get("module", "?"), info.get("resourceId", "?"))
+            fail_groups.setdefault(gk, []).append((key, info))
+        lines.append(
+            f"### Render Failures ({len(failures)} variant(s) across {len(fail_groups)} resource(s))"
+        )
+        lines.append("")
+        lines.append(
+            "The render task completed but produced no PNG for these resource "
+            "captures. Check the `composePreviewRenderAndroidResources-reports` "
+            "artifact attached to this run."
+        )
+        lines.append("")
+        for (module, resource_id), entries in sorted(fail_groups.items()):
+            kind = entries[0][1].get("resourceType", "")
+            lines.append(f"- **`{resource_id}`** ({module}, {kind})")
+            for _key, info in entries:
+                label = _resource_label(info)
+                lines.append(f"  - {label}")
+        lines.append("")
+
     print("\n".join(lines))
     return 0
 
@@ -1003,6 +1234,16 @@ def main() -> int:
     gen.add_argument("--output-dir", required=True)
     gen.add_argument("--repo", required=True, help="owner/repo")
     gen.add_argument("--branch", default="compose-preview/main")
+    # Optional. When the render task produced no PNG for some previews,
+    # pull their prior entry from this `baselines.json` instead of dropping
+    # them — keeps `compose-preview/main` complete across flaky single-preview
+    # render failures. The matching `renders/` tree is the
+    # `--prior-renders` arg below.
+    gen.add_argument("--prior-baselines",
+                     help="Path to the existing baselines.json on the baseline branch.")
+    gen.add_argument("--prior-renders",
+                     help="Directory containing the existing renders/<module>/<basename> "
+                          "PNG tree on the baseline branch.")
 
     cmp = sub.add_parser("compare", help="Compare CLI output against baselines")
     cmp.add_argument("cli_json", help="Path to compose-preview show --json output")
@@ -1037,6 +1278,16 @@ def main() -> int:
     gen_res.add_argument("cli_json",
                          help="Path to compose-preview show-resources --json output")
     gen_res.add_argument("--output-dir", required=True)
+    # Same carry-over inputs as `generate` — when a resource render flakes,
+    # the prior baseline entry + PNG come from these paths so the branch
+    # keeps its gallery row instead of dropping the resource entirely.
+    gen_res.add_argument("--prior-baselines",
+                         help="Path to the existing resource-baselines.json on the "
+                              "resource baseline branch.")
+    gen_res.add_argument("--prior-renders",
+                         help="Directory containing the existing "
+                              "renders/<module>/resources/... PNG tree on the "
+                              "resource baseline branch.")
 
     cp_res = sub.add_parser(
         "copy-changed-resources",

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -389,11 +389,14 @@ class GenerateTest(unittest.TestCase):
             output_dir=str(self.out),
             repo="owner/repo",
             branch="compose-preview/main",
+            prior_baselines=None,
+            prior_renders=None,
         ))
         self.assertEqual(rc, 0)
 
         baselines = json.loads((self.out / "baselines.json").read_text())
-        # Only the entry with a sha lands in baselines.
+        # Only the entry with a sha lands in baselines (the failure for B has
+        # no prior to carry over, so it stays out of baselines.json).
         self.assertEqual(set(baselines), {"m/A"})
         self.assertEqual(baselines["m/A"]["sha256"], "sha-a")
 
@@ -401,9 +404,61 @@ class GenerateTest(unittest.TestCase):
         # README references the rendered PNG via the raw GitHub URL.
         self.assertIn("raw.githubusercontent.com/owner/repo/compose-preview/main", readme)
         self.assertIn("`Fn`", readme)
+        # Failure for `B` shows up under "Render Failures" with no prior baseline.
+        self.assertIn("## Render Failures", readme)
+        self.assertIn("`FnB`", readme)
+        self.assertIn("m/B", readme)
 
         # PNG copied under renders/<module>/<id>.png.
         self.assertTrue((self.out / "renders" / "m" / "A.png").exists())
+
+    def test_failed_render_carries_prior_baseline_forward(self):
+        # When a single preview fails on this run and `--prior-baselines`
+        # plus `--prior-renders` point at the existing baseline branch,
+        # the prior sha + PNG carry over so a flaky single-preview render
+        # doesn't drop the entry from compose-preview/main.
+        from types import SimpleNamespace
+
+        prior_dir = self.tmp / "prior"
+        prior_dir.mkdir()
+        prior_renders = prior_dir / "renders" / "m"
+        prior_renders.mkdir(parents=True)
+        prior_png = prior_renders / "B.png"
+        prior_png.write_bytes(b"old-png-bytes")
+        prior_baselines_path = prior_dir / "baselines.json"
+        prior_baselines_path.write_text(json.dumps({
+            "m/B": {
+                "sha256": "old-sha-b",
+                "functionName": "FnB",
+                "sourceFile": "src/B.kt",
+                "renderBasename": "B.png",
+                "captureLabel": "",
+            },
+        }))
+
+        rc = cp.cmd_generate(SimpleNamespace(
+            cli_json=str(self.cli_path),
+            output_dir=str(self.out),
+            repo="owner/repo",
+            branch="compose-preview/main",
+            prior_baselines=str(prior_baselines_path),
+            prior_renders=str(prior_dir / "renders"),
+        ))
+        self.assertEqual(rc, 0)
+
+        baselines = json.loads((self.out / "baselines.json").read_text())
+        # B carries forward from the prior baseline; A is fresh.
+        self.assertEqual(set(baselines), {"m/A", "m/B"})
+        self.assertEqual(baselines["m/B"]["sha256"], "old-sha-b")
+        # Prior PNG is replayed into the new renders/ tree so the README
+        # inline image still resolves on the baseline branch.
+        carried = self.out / "renders" / "m" / "B.png"
+        self.assertTrue(carried.exists())
+        self.assertEqual(carried.read_bytes(), b"old-png-bytes")
+        # README still calls out the failure but labels it as "retained".
+        readme = (self.out / "README.md").read_text()
+        self.assertIn("## Render Failures", readme)
+        self.assertIn("retained", readme)
 
 
 class PerceptualFilterTest(unittest.TestCase):
@@ -546,6 +601,39 @@ class CompareMarkdownTest(unittest.TestCase):
         )
         self.assertIn("raw.githubusercontent.com/owner/repo/deadbeef/", out)
         self.assertIn("raw.githubusercontent.com/owner/repo/cafef00d/", out)
+
+    def test_lists_render_failures_separately_from_diff(self):
+        # Previews whose render produced no PNG land in their own section
+        # with a [!WARNING] callout up top so reviewers see the partial-run
+        # state on the PR even when the diff itself is clean.
+        out = self._run(
+            {
+                "previews": [
+                    _entry(id="Ok", function="Same", sha="s", png="/ok.png"),
+                    _entry(id="Broken", function="Crashy", sha="", png="",
+                           source="src/Crashy.kt"),
+                ],
+            },
+            {"app/Ok": {"sha256": "s", "functionName": "Same"}},
+        )
+        self.assertIn("[!WARNING]", out)
+        self.assertIn("1 preview(s) failed to render", out)
+        self.assertIn("### Render Failures", out)
+        self.assertIn("`Crashy`", out)
+        self.assertIn("src/Crashy.kt", out)
+        self.assertIn("app/Broken", out)
+
+    def test_emits_failure_section_even_when_diff_is_otherwise_empty(self):
+        # A run with no successful renders but discovery still saw the
+        # preview must NOT short-circuit on the "no visual changes" path —
+        # the comment needs to surface the failure.
+        out = self._run(
+            {"previews": [_entry(id="Broken", function="Crashy", sha="", png="")]},
+            {},
+        )
+        self.assertNotIn("No visual changes detected.", out)
+        self.assertIn("### Render Failures", out)
+        self.assertIn("Crashy", out)
 
 
 class MultiCaptureLoadTest(unittest.TestCase):
@@ -930,7 +1018,10 @@ class GenerateResourcesTests(unittest.TestCase):
     def test_skips_captures_whose_pngs_arent_in_envelope(self) -> None:
         # CLI emits null pngPath/sha256 when discovery saw the resource but
         # the renderer didn't produce a PNG (capture too expensive, error,
-        # etc.). These shouldn't land in the baseline.
+        # etc.). The successful-renders side of the baseline is empty (we
+        # have no PNG to record), but the failure is surfaced in the README
+        # so reviewers can see which resources flaked. `resource-baselines.json`
+        # is still written so the next run has a stable target to diff against.
         self._write_envelope(_resource_entry(
             id="drawable/ghost", module="app",
             captures=[_resource_capture(
@@ -939,8 +1030,12 @@ class GenerateResourcesTests(unittest.TestCase):
             )],
         ))
         self.assertEqual(self._run(), 0)
-        # No baselines file should be written, since no PNG exists to record.
-        self.assertFalse((self.output / "resource-baselines.json").exists())
+        baselines_path = self.output / "resource-baselines.json"
+        self.assertTrue(baselines_path.exists())
+        self.assertEqual(json.loads(baselines_path.read_text()), {})
+        readme = (self.output / "README.md").read_text()
+        self.assertIn("Resource Render Failures", readme)
+        self.assertIn("drawable/ghost", readme)
 
     def test_records_adaptive_icon_shape_per_capture(self) -> None:
         circle = self._stage_png("ic_launcher_xhdpi_SHAPE_circle.png", b"circle")

--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -70,13 +70,31 @@ runs:
       shell: bash
       env:
         RENDER_TIMEOUT: ${{ inputs.timeout }}
-      run: compose-preview show --json --timeout "$RENDER_TIMEOUT" > _previews.json
+      # Don't fail the step on a non-zero CLI exit: the JSON envelope still
+      # carries the rows that did render (and flags the ones that didn't via
+      # empty `sha256`), so the downstream generate/push can push the partial
+      # update + a "Render Failures" section in the README. The trailing
+      # `Surface render failures` step sets the overall workflow status once
+      # the push has landed, so reviewers always see the partial state on
+      # `compose-preview/main` even when this run is flagged red.
+      run: |
+        set +e
+        compose-preview show --json --timeout "$RENDER_TIMEOUT" > _previews.json
+        rc=$?
+        echo "rc=$rc" >> "$GITHUB_OUTPUT"
+        if [ "$rc" -ne 0 ]; then
+          echo "compose-preview show exited $rc — continuing so the partial " \
+               "JSON envelope still drives a baseline update." >&2
+        fi
+        exit 0
 
     # When `composePreviewRender` fails the actual stack traces only live in
     # samples/*/build/reports/tests/composePreviewRender/ and test-results/.
-    # Upload them so the failure is debuggable from the run page.
+    # Upload them so the failure is debuggable from the run page. Fires on
+    # any non-zero CLI exit (full build failure or partial per-preview
+    # failure) so the reports are always one click away from the diff.
     - name: Upload composePreviewRender reports
-      if: failure() && steps.render.outcome == 'failure'
+      if: steps.render.outputs.rc != '0'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: composePreviewRender-reports
@@ -86,6 +104,34 @@ runs:
           _previews.json
         if-no-files-found: ignore
         retention-days: 14
+
+    # Fetch the existing baseline tree before generate runs so the prior
+    # entry + PNG for any preview that failed in this run can carry forward.
+    # Without this, a single flaky render would drop the entry from
+    # compose-preview/main until the next clean run lands. `git archive`
+    # writes to stdout so the working tree stays clean; absent branch (first
+    # run on a fresh repo) falls back to "no prior, treat every failure as
+    # dropped" — same shape as the existing first-run path.
+    - name: Fetch prior baselines for carry-over
+      shell: bash
+      env:
+        BASELINE_BRANCH: ${{ inputs.branch }}
+        REPO: ${{ github.repository }}
+        GITHUB_TOKEN_INLINE: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        mkdir -p _prior_baselines
+        if git ls-remote --exit-code \
+              "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git" \
+              "refs/heads/${BASELINE_BRANCH}" >/dev/null 2>&1; then
+          git fetch --depth=1 --quiet \
+              "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git" \
+              "${BASELINE_BRANCH}"
+          git show "FETCH_HEAD:baselines.json" > _prior_baselines/baselines.json \
+              2>/dev/null || true
+          git archive FETCH_HEAD renders 2>/dev/null \
+              | tar -x -C _prior_baselines/ 2>/dev/null || true
+        fi
 
     - name: Generate baselines
       shell: bash
@@ -97,7 +143,9 @@ runs:
         python3 "$ACTION_PATH/../lib/compare-previews.py" generate _previews.json \
           --output-dir _baselines \
           --repo "$REPO" \
-          --branch "$BASELINE_BRANCH"
+          --branch "$BASELINE_BRANCH" \
+          --prior-baselines _prior_baselines/baselines.json \
+          --prior-renders _prior_baselines/renders
 
     - name: Push to baselines branch
       shell: bash
@@ -165,10 +213,25 @@ runs:
       # `compose-preview show-resources` self-no-ops on workspaces without
       # any `resources.json` (exit 0 with "No Android resource previews
       # found.") — the subsequent generate / push steps then short-circuit.
-      run: compose-preview show-resources --json --timeout "$RENDER_TIMEOUT" > _resources.json
+      #
+      # Mirrors the composable render step: capture the exit code so partial
+      # failures don't abort the workflow before the prior baseline can be
+      # carried forward + the failure surfaced in the README. The trailing
+      # `Surface render failures` step at the end of the action raises the
+      # overall workflow status after the push lands.
+      run: |
+        set +e
+        compose-preview show-resources --json --timeout "$RENDER_TIMEOUT" > _resources.json
+        rc=$?
+        echo "rc=$rc" >> "$GITHUB_OUTPUT"
+        if [ "$rc" -ne 0 ]; then
+          echo "compose-preview show-resources exited $rc — continuing so the " \
+               "partial JSON envelope still drives a resource baseline update." >&2
+        fi
+        exit 0
 
     - name: Upload composePreviewRenderAndroidResources reports
-      if: failure() && steps.render-resources.outcome == 'failure'
+      if: steps.render-resources.outputs.rc != '0'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: composePreviewRenderAndroidResources-reports
@@ -178,6 +241,32 @@ runs:
           _resources.json
         if-no-files-found: ignore
         retention-days: 14
+
+    # Same carry-over flow as the composable side — fetch the prior resource
+    # baseline tree so per-capture flakes don't drop resources from
+    # compose-preview/resources/main. Absent branch is fine; we treat every
+    # failure as dropped in that case.
+    - name: Fetch prior resource baselines for carry-over
+      if: inputs.resource-branch != ''
+      shell: bash
+      env:
+        RESOURCE_BRANCH: ${{ inputs.resource-branch }}
+        REPO: ${{ github.repository }}
+        GITHUB_TOKEN_INLINE: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        mkdir -p _prior_resource_baselines
+        if git ls-remote --exit-code \
+              "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git" \
+              "refs/heads/${RESOURCE_BRANCH}" >/dev/null 2>&1; then
+          git fetch --depth=1 --quiet \
+              "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git" \
+              "${RESOURCE_BRANCH}"
+          git show "FETCH_HEAD:resource-baselines.json" \
+              > _prior_resource_baselines/resource-baselines.json 2>/dev/null || true
+          git archive FETCH_HEAD renders 2>/dev/null \
+              | tar -x -C _prior_resource_baselines/ 2>/dev/null || true
+        fi
 
     - name: Generate resource baselines
       if: inputs.resource-branch != ''
@@ -191,7 +280,9 @@ runs:
       run: |
         python3 "$ACTION_PATH/../lib/compare-previews.py" generate-resources \
           _resources.json \
-          --output-dir _resource_baselines
+          --output-dir _resource_baselines \
+          --prior-baselines _prior_resource_baselines/resource-baselines.json \
+          --prior-renders _prior_resource_baselines/renders
 
     - name: Push to resource baselines branch
       if: inputs.resource-branch != ''
@@ -237,3 +328,30 @@ runs:
           COMMIT=$(git commit-tree "$TREE" -m "$MSG")
         fi
         git push --quiet origin "${COMMIT}:refs/heads/${RESOURCE_BRANCH}"
+
+    # Surface render failures as a step failure now that the partial baseline
+    # has been pushed. We deferred the non-zero exit so the prior-baseline
+    # carry-over + README "Render Failures" section land on the branch even
+    # when the CLI flagged some previews as missing PNGs. The artifact upload
+    # steps above already attached the per-task reports for triage. Final
+    # exit code is the worst of the two CLI invocations.
+    - name: Surface render failures
+      shell: bash
+      env:
+        RENDER_RC: ${{ steps.render.outputs.rc }}
+        RESOURCE_RC: ${{ steps.render-resources.outputs.rc }}
+      run: |
+        rc_show="${RENDER_RC:-0}"
+        rc_res="${RESOURCE_RC:-0}"
+        if [ "$rc_show" -ne 0 ] || [ "$rc_res" -ne 0 ]; then
+          echo "::error::compose-preview render exited non-zero (show=$rc_show, " \
+               "show-resources=$rc_res). The partial baseline has been pushed; " \
+               "see the README on the baseline branch and the uploaded reports " \
+               "artifact for the failing previews." >&2
+          # Prefer the show exit code when both fired, fall back to the
+          # resource exit code, default to 1.
+          if [ "$rc_show" -ne 0 ]; then
+            exit "$rc_show"
+          fi
+          exit "$rc_res"
+        fi

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -80,10 +80,43 @@ runs:
         catalog-key: ${{ inputs.catalog-key }}
 
     - name: Render previews
+      id: render
       shell: bash
       env:
         RENDER_TIMEOUT: ${{ inputs.timeout }}
-      run: compose-preview show --json --timeout "$RENDER_TIMEOUT" > _previews.json
+      # Don't fail this step on a non-zero CLI exit: the JSON envelope still
+      # carries the rows that did render (and flags failed ones via empty
+      # `sha256`), so the downstream compare-on-PR + comment step can post a
+      # diff with a `Render Failures` section listing the rows that didn't
+      # produce a PNG. The trailing `Surface render failures` step at the
+      # end of the action raises the overall workflow status once the
+      # comment has landed.
+      run: |
+        set +e
+        compose-preview show --json --timeout "$RENDER_TIMEOUT" > _previews.json
+        rc=$?
+        echo "rc=$rc" >> "$GITHUB_OUTPUT"
+        if [ "$rc" -ne 0 ]; then
+          echo "compose-preview show exited $rc — continuing so the partial " \
+               "JSON envelope still drives a PR diff comment." >&2
+        fi
+        exit 0
+
+    # Mirrors `composePreviewRender-reports` on the baselines side: surface
+    # the per-task Robolectric stack traces whenever the CLI flagged a
+    # failure (build-wide or per-preview), regardless of whether the step
+    # itself succeeded.
+    - name: Upload composePreviewRender reports
+      if: steps.render.outputs.rc != '0'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: composePreviewRender-reports
+        path: |
+          **/build/reports/tests/composePreviewRender/
+          **/build/test-results/composePreviewRender/
+          _previews.json
+        if-no-files-found: ignore
+        retention-days: 14
 
     # Render Android XML resource previews (vector / animated-vector /
     # adaptive-icon) so the comment can include before/after for resource
@@ -98,13 +131,23 @@ runs:
       shell: bash
       env:
         RENDER_TIMEOUT: ${{ inputs.timeout }}
-      run: compose-preview show-resources --json --timeout "$RENDER_TIMEOUT" > _resources.json
+      # Same capture-don't-fail shape as the composable render above.
+      run: |
+        set +e
+        compose-preview show-resources --json --timeout "$RENDER_TIMEOUT" > _resources.json
+        rc=$?
+        echo "rc=$rc" >> "$GITHUB_OUTPUT"
+        if [ "$rc" -ne 0 ]; then
+          echo "compose-preview show-resources exited $rc — continuing so the " \
+               "partial JSON envelope still drives a PR diff comment." >&2
+        fi
+        exit 0
 
     # Same artifact-on-failure shape as `composePreviewRender-reports` for the
     # composable side — surfaces the actual stack trace from the
     # Robolectric run when it fails.
     - name: Upload composePreviewRenderAndroidResources reports
-      if: failure() && steps.render-resources.outcome == 'failure'
+      if: steps.render-resources.outputs.rc != '0'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: composePreviewRenderAndroidResources-reports
@@ -528,4 +571,30 @@ runs:
             -X PATCH -f body="$RESOLVED_BODY"
         elif [ "$COMMENT_ON_EMPTY_DIFF" = "true" ]; then
           gh pr comment "$PR_NUMBER" --body "$RESOLVED_BODY"
+        fi
+
+    # Surface render failures as a step failure now that the PR comment has
+    # been posted / updated. The comment body already carries the per-preview
+    # failure list (cmd_compare's `### Render Failures` section), and the
+    # reports artifact above attaches the per-task stack traces — this step
+    # just raises the workflow's overall status so a flaky render still flips
+    # the PR check red even though the diff was published. Final exit code
+    # is the worst of the two CLI invocations.
+    - name: Surface render failures
+      shell: bash
+      env:
+        RENDER_RC: ${{ steps.render.outputs.rc }}
+        RESOURCE_RC: ${{ steps.render-resources.outputs.rc }}
+      run: |
+        rc_show="${RENDER_RC:-0}"
+        rc_res="${RESOURCE_RC:-0}"
+        if [ "$rc_show" -ne 0 ] || [ "$rc_res" -ne 0 ]; then
+          echo "::error::compose-preview render exited non-zero (show=$rc_show, " \
+               "show-resources=$rc_res). The PR diff comment has been updated " \
+               "with a Render Failures section; the uploaded reports artifact " \
+               "has the per-task stack traces." >&2
+          if [ "$rc_show" -ne 0 ]; then
+            exit "$rc_show"
+          fi
+          exit "$rc_res"
         fi


### PR DESCRIPTION
Make the baseline and PR-comment workflows continue past per-preview render
failures so the partial update still lands and reviewers see the failure
state. The CLI already emits every discovered preview in its JSON envelope
(failed ones have an empty `sha256`); we now keep that envelope flowing
downstream instead of aborting the workflow.

Workflow changes
- `preview-baselines/action.yml` and `preview-comment/action.yml`:
  capture the CLI exit code into a step output instead of failing the
  step. A trailing `Surface render failures` step raises the workflow's
  overall status after the partial push / comment lands.
- `preview-baselines/action.yml`: fetch the existing baseline tree
  before generate so previews that flake in this run carry their prior
  entry + PNG forward instead of being dropped from the branch.

Output changes
- `compare-previews.py` generate / generate-resources: optional
  `--prior-baselines` and `--prior-renders` inputs drive the carry-over
  for failed previews; the README on the baseline branch grows a
  `Render Failures` section with retained-vs-dropped state per entry.
- `compare-previews.py` compare / compare-resources: PR-comment markdown
  carries a `[!WARNING]` callout and a `Render Failures` section so
  reviewers see which previews didn't produce a PNG in this run.

Tests
- `test_compare_previews.py`: cover the carry-over path, the
  failures-only compare path, and the updated all-failures generate path
  for resources.