### PR TITLE
fix(cli): skip auto-inject for KMP-Android modules

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -69,11 +69,22 @@ internal fun renderInitScript(pluginVersion: String): String =
 // rather than Maven Central. Plain users have no reason to flip this on:
 // it widens the search surface to whatever snapshots happen to be cached
 // locally and is therefore opt-in, not the default.
+//
+// Auto-inject is suppressed for modules that apply
+// `com.android.kotlin.multiplatform.library` — the AGP-KMP plugin's single
+// `android` variant trips a variant-ambiguity error on
+// `androidRuntimeClasspath` once the renderer-android artifact view kicks in,
+// breaking `compose-preview show` for any project where the plugin landed
+// purely via auto-inject. The supported KMP-Android layout
+// (samples/cmp-shared, with a `jvm("desktop")` target) still works when the
+// user adds `id("ee.schimke.composeai.preview")` to that module's plugins {}
+// block themselves — we just no longer apply it implicitly.
 
 val pluginVersion = "$pluginVersion"
 val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
 
 var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()
+var composeAiPreviewKmpAndroidDirs: Set<java.io.File> = emptySet()
 
 fun composeAiPreviewCatalogAccessors(rootDir: java.io.File): List<Regex> {
     val catalog = java.io.File(rootDir, "gradle/libs.versions.toml")
@@ -87,6 +98,30 @@ fun composeAiPreviewCatalogAccessors(rootDir: java.io.File): List<Regex> {
         "(?m)^[ \\t]*([A-Za-z0-9_.\\-]+)\\s*=\\s*(?:" +
             "\\{[^}]*\\bid\\s*=\\s*\"ee\\.schimke\\.composeai\\.preview\"[^}]*\\}|" +
             "\"ee\\.schimke\\.composeai\\.preview(?::[^\"]*)?\"" +
+            ")"
+    )
+    return entryRe.findAll(section).map { match ->
+        val accessor = match.groupValues[1].replace(Regex("[-_]"), ".")
+        Regex("\\blibs\\s*\\.\\s*plugins\\s*\\.\\s*" + Regex.escape(accessor) + "\\b")
+    }.toList()
+}
+
+// Catalog-alias accessors for `com.android.kotlin.multiplatform.library` — same shape as
+// composeAiPreviewCatalogAccessors but pinned to the KMP-Android plugin id so a module
+// declaring it via `alias(libs.plugins.android.kotlin.multiplatform.library)` is detected
+// alongside the literal `id("com.android.kotlin.multiplatform.library")` form.
+fun composeAiPreviewKmpAndroidCatalogAccessors(rootDir: java.io.File): List<Regex> {
+    val catalog = java.io.File(rootDir, "gradle/libs.versions.toml")
+    if (!catalog.isFile) return emptyList()
+    val text = runCatching { catalog.readText() }.getOrNull() ?: return emptyList()
+    val pluginsHeader = Regex("(?m)^\\[plugins\\]\\s*${'$'}").find(text) ?: return emptyList()
+    val sectionStart = pluginsHeader.range.last + 1
+    val nextSection = Regex("(?m)^\\[").find(text, sectionStart)
+    val section = text.substring(sectionStart, nextSection?.range?.first ?: text.length)
+    val entryRe = Regex(
+        "(?m)^[ \\t]*([A-Za-z0-9_.\\-]+)\\s*=\\s*(?:" +
+            "\\{[^}]*\\bid\\s*=\\s*\"com\\.android\\.kotlin\\.multiplatform\\.library\"[^}]*\\}|" +
+            "\"com\\.android\\.kotlin\\.multiplatform\\.library(?::[^\"]*)?\"" +
             ")"
     )
     return entryRe.findAll(section).map { match ->
@@ -148,6 +183,42 @@ fun scanForComposeAiPreviewDeclaration(
     return declared
 }
 
+// Scan for modules that apply `com.android.kotlin.multiplatform.library` — auto-inject
+// skips both the buildscript classpath injection and the withPlugin apply hooks for these
+// dirs. Applying compose-preview to a KMP-Android module trips an AGP-KMP variant model
+// mismatch on `androidRuntimeClasspath` once the consumer's CLI run resolves the renderer's
+// artifact view. Users who explicitly want previews on a KMP-Android module can add
+// `id("ee.schimke.composeai.preview")` to that module's plugins {} block themselves — the
+// supported layout in samples/cmp-shared (with a `jvm("desktop")` target) still works that
+// way; we just don't apply it implicitly anymore.
+fun scanForKmpAndroidDeclaration(
+    rootDir: java.io.File,
+    projectDirs: List<java.io.File>,
+): Set<java.io.File> {
+    val catalogAccessors = composeAiPreviewKmpAndroidCatalogAccessors(rootDir)
+    val literalRe = Regex(
+        "\\bid\\s*[(\\s]\\s*[\"']com\\.android\\.kotlin\\.multiplatform\\.library[\"']"
+    )
+    val declared = LinkedHashSet<java.io.File>()
+    for (dir in projectDirs) {
+        for (name in listOf("build.gradle.kts", "build.gradle")) {
+            val buildFile = java.io.File(dir, name)
+            if (!buildFile.isFile) continue
+            val raw = runCatching { buildFile.readText() }.getOrNull() ?: continue
+            val text = composeAiPreviewStripComments(raw)
+            if (literalRe.containsMatchIn(text)) {
+                declared.add(dir)
+                break
+            }
+            if (catalogAccessors.any { it.containsMatchIn(text) }) {
+                declared.add(dir)
+                break
+            }
+        }
+    }
+    return declared
+}
+
 gradle.settingsEvaluated {
     val projectDirs = mutableListOf<java.io.File>()
     fun collect(descriptor: org.gradle.api.initialization.ProjectDescriptor) {
@@ -156,6 +227,7 @@ gradle.settingsEvaluated {
     }
     collect(rootProject)
     composeAiPreviewPreAppliedDirs = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)
+    composeAiPreviewKmpAndroidDirs = scanForKmpAndroidDeclaration(rootDir, projectDirs)
 
     // When opting into mavenLocal, also seed it at the settings level so the renderer-android AAR
     // and any other ee.schimke.composeai:* runtime artifacts resolve from ~/.m2 alongside the
@@ -185,7 +257,15 @@ gradle.settingsEvaluated {
 }
 
 allprojects {
-    if (projectDir !in composeAiPreviewPreAppliedDirs) {
+    // Skip BOTH the buildscript classpath injection AND the apply hooks for KMP-Android
+    // modules. Doing only one half leaves the other half active: skipping the classpath
+    // injection alone still fires the withPlugin hooks (which then fail to find the plugin
+    // class), and skipping only the hooks still drags an unused plugin marker onto the
+    // buildscript classpath. Both halves gated together is the safe shape — see
+    // scanForKmpAndroidDeclaration() above for the rationale.
+    val composeAiPreviewSkipKmpAndroid = projectDir in composeAiPreviewKmpAndroidDirs
+
+    if (!composeAiPreviewSkipKmpAndroid && projectDir !in composeAiPreviewPreAppliedDirs) {
         buildscript {
             repositories {
                 gradlePluginPortal()
@@ -201,6 +281,8 @@ allprojects {
             }
         }
     }
+
+    if (composeAiPreviewSkipKmpAndroid) return@allprojects
 
     fun applyComposeAiPreview() {
         if (plugins.hasPlugin("ee.schimke.composeai.preview")) return

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -529,7 +529,7 @@ class AutoInjectTest {
       "expected the set to be populated during settingsEvaluated",
     )
     assertTrue(
-      script.contains("if (projectDir !in composeAiPreviewPreAppliedDirs) {"),
+      script.contains("projectDir !in composeAiPreviewPreAppliedDirs"),
       "expected the buildscript block to be guarded per-project on the directory set",
     )
     assertTrue(
@@ -635,6 +635,86 @@ class AutoInjectTest {
     assertTrue(
       script.contains("composeAiPreviewStripComments(raw)"),
       "expected the scanner to run text through the comment stripper",
+    )
+  }
+
+  @Test
+  fun `init script skips auto-inject for KMP-Android modules`() {
+    // Regression coverage for the meshcore-mobile report: applying compose-preview to a module
+    // that uses `com.android.kotlin.multiplatform.library` trips an AGP-KMP variant-ambiguity
+    // error on `androidRuntimeClasspath` once the renderer's artifact view kicks in, which
+    // breaks `compose-preview show` for any project where the plugin landed via auto-inject.
+    // Auto-inject must scan for the KMP-Android plugin id, mark those modules, and skip both
+    // the buildscript classpath injection AND the apply hooks for them — partial skipping
+    // leaves the other half active and still fails. Pins the wire shape of both halves.
+    val script = renderInitScript("0.11.4")
+    assertTrue(
+      script.contains("var composeAiPreviewKmpAndroidDirs: Set<java.io.File> = emptySet()"),
+      "expected the KMP-Android skip set declaration",
+    )
+    assertTrue(
+      script.contains(
+        "composeAiPreviewKmpAndroidDirs = scanForKmpAndroidDeclaration(rootDir, projectDirs)"
+      ),
+      "expected settingsEvaluated to populate the KMP-Android skip set",
+    )
+    assertTrue(
+      script.contains(
+        "val composeAiPreviewSkipKmpAndroid = projectDir in composeAiPreviewKmpAndroidDirs"
+      ),
+      "expected the per-project skip flag",
+    )
+    assertTrue(
+      script.contains(
+        "if (!composeAiPreviewSkipKmpAndroid && projectDir !in composeAiPreviewPreAppliedDirs) {"
+      ),
+      "expected the buildscript classpath injection to be gated on the KMP-Android skip flag too",
+    )
+    assertTrue(
+      script.contains("if (composeAiPreviewSkipKmpAndroid) return@allprojects"),
+      "expected the withPlugin apply hooks to short-circuit for KMP-Android modules",
+    )
+  }
+
+  @Test
+  fun `init script's scanForKmpAndroidDeclaration matches the literal id form`() {
+    // Pins the regex contract so a future refactor doesn't drop literal-id detection. The
+    // canonical KMP-Android module shape is `id("com.android.kotlin.multiplatform.library")`
+    // in a `plugins { ... }` block; the regex anchors on the `id (` / `id "` prefix and the
+    // exact plugin coordinate.
+    val script = renderInitScript("1.0.0")
+    assertTrue(
+      script.contains(
+        "fun scanForKmpAndroidDeclaration(\n    rootDir: java.io.File,\n    projectDirs: List<java.io.File>,\n): Set<java.io.File> {"
+      ),
+      "expected scanForKmpAndroidDeclaration to return Set<File> of KMP-Android project dirs",
+    )
+    assertTrue(
+      script.contains(
+        "\"\\\\bid\\\\s*[(\\\\s]\\\\s*[\\\"']com\\\\.android\\\\.kotlin\\\\.multiplatform\\\\.library[\\\"']\""
+      ),
+      "expected the literal-id regex for com.android.kotlin.multiplatform.library",
+    )
+  }
+
+  @Test
+  fun `init script's KMP-Android scan recognises catalog aliases`() {
+    // Mirrors the compose-preview catalog-accessor path so a project that declares the
+    // KMP-Android plugin in `gradle/libs.versions.toml` (e.g.
+    // `androidKotlinMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library",
+    // version = "..." }`) and references it via
+    // `alias(libs.plugins.androidKotlinMultiplatformLibrary)`
+    // is still detected — that's the shape the meshcore-mobile reproducer uses.
+    val script = renderInitScript("1.0.0")
+    assertTrue(
+      script.contains(
+        "fun composeAiPreviewKmpAndroidCatalogAccessors(rootDir: java.io.File): List<Regex>"
+      ),
+      "expected a catalog-accessor scanner pinned to the KMP-Android plugin id",
+    )
+    assertTrue(
+      script.contains("com\\\\.android\\\\.kotlin\\\\.multiplatform\\\\.library"),
+      "expected the catalog-accessor regex to anchor on the KMP-Android plugin id",
     )
   }
 


### PR DESCRIPTION
## Summary

The init script applies `ee.schimke.composeai.preview` to any project that
applies `org.jetbrains.compose`, which includes modules using
`com.android.kotlin.multiplatform.library`. Applying the plugin to a KMP-Android
module trips an AGP-KMP variant-ambiguity error on `androidRuntimeClasspath`
once the renderer's artifact view resolves, breaking `compose-preview show` for
projects that auto-injected onto their KMP-Android modules (reported against
0.11.0 and 0.11.3; pre-0.11 didn't auto-inject so users only got the plugin on
the modules they manually applied it to).

This PR makes the init script's settings-evaluated scan also recognise
`com.android.kotlin.multiplatform.library` declarations (literal
`id("com.android.kotlin.multiplatform.library")` plus the matching version-catalog
alias forms) and skip both halves of auto-inject — the buildscript classpath
injection and the `withPlugin` apply hooks — for those project dirs. Skipping
only one half leaves the other half active and still fails, so both gate on the
same `composeAiPreviewSkipKmpAndroid` flag.

Consumers who explicitly want previews on a KMP-Android module can still add
`id("ee.schimke.composeai.preview")` to that module's `plugins { }` block
themselves — the supported `samples/cmp-shared` layout (KMP-Android with a
`jvm("desktop")` target) keeps working that way; auto-inject just no longer
applies it implicitly.

The reproducer's workaround (`COMPOSE_PREVIEW_NO_AUTO_INJECT=1` + manual
plugin application on the standard Android modules) becomes unnecessary after
this fix — auto-inject hits `:app` / `:wear` and silently skips
`:meshcore-components` / `:meshcore-mobile`.

## Test plan

- [x] `:cli:test --tests AutoInjectTest` — three new tests pin the skip-set
      declaration, the per-project skip flag in `allprojects { }`, the
      `scanForKmpAndroidDeclaration` shape, and the KMP-Android catalog
      accessor scanner.
- [x] `:cli:ktfmtFormatMain :cli:ktfmtFormatTest` — formatter clean.
- [ ] CI: full `:cli:test` + functional tests on the integration matrix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWM23LVrFeqWtvzc3n6MvX)_