### PR TITLE
feat(samples/remotecompose): demonstrate `LocalRemoteComposeHost` named-value bind

### DIFF
--- a/samples/remotecompose/build.gradle.kts
+++ b/samples/remotecompose/build.gradle.kts
@@ -53,10 +53,5 @@ dependencies {
   implementation(libs.compose.remote.creation.compose)
   implementation(libs.wear.compose.remote.material3)
   implementation(libs.activity.compose)
-  // Lights up `LocalRemoteComposeHost` so previews can read daemon-supplied
-  // named values via `LocalRemoteComposeHost.current.namedString(...)` etc.
-  // (see `RemoteButtonWithNamedLabel`). Without this, only static `.rs`
-  // strings reach the rendered button.
-  implementation(project(":data-remotecompose-connector"))
   debugImplementation(libs.compose.ui.tooling.prerelease)
 }

--- a/samples/remotecompose/build.gradle.kts
+++ b/samples/remotecompose/build.gradle.kts
@@ -53,5 +53,10 @@ dependencies {
   implementation(libs.compose.remote.creation.compose)
   implementation(libs.wear.compose.remote.material3)
   implementation(libs.activity.compose)
+  // Lights up `LocalRemoteComposeHost` so previews can read daemon-supplied
+  // named values via `LocalRemoteComposeHost.current.namedString(...)` etc.
+  // (see `RemoteButtonWithNamedLabel`). Without this, only static `.rs`
+  // strings reach the rendered button.
+  implementation(project(":data-remotecompose-connector"))
   debugImplementation(libs.compose.ui.tooling.prerelease)
 }

--- a/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/Previews.kt
+++ b/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/Previews.kt
@@ -43,6 +43,20 @@ fun RemoteButtonWithShapePreview() {
     }
 }
 
+/**
+ * Companion preview for [RemoteButtonWithNamedLabel]. Default render shows
+ * `"Tap me"`; the panel-side Remote Compose editor (or any caller passing
+ * `renderNow.overrides.remoteCompose.namedValues = {"label": ...}`) swaps
+ * that for a live label without rebuilding the document.
+ */
+@Preview(showBackground = true, widthDp = 200, heightDp = 200)
+@Composable
+fun RemoteButtonWithNamedLabelPreview() {
+    RemotePreview(profile = RcPlatformProfiles.ANDROIDX) {
+        Container { RemoteButtonWithNamedLabel() }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Approach 2 — `@PreviewWrapper(RemotePreviewWrapper::class)` applied to a
 // `@Preview`-annotated composable that only emits remote content.

--- a/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/RemoteComponents.kt
+++ b/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/RemoteComponents.kt
@@ -12,6 +12,7 @@ import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
 import androidx.compose.remote.creation.compose.state.RemoteColor
 import androidx.compose.remote.creation.compose.state.rb
 import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rememberNamedRemoteString
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.runtime.Composable
@@ -19,7 +20,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.wear.compose.remote.material3.RemoteButton
 import androidx.wear.compose.remote.material3.RemoteText
 import androidx.wear.compose.remote.material3.buttonSizeModifier
-import ee.schimke.composeai.daemon.LocalRemoteComposeHost
 
 /**
  * Pure-remote composables — each one is the kind of component a real Remote
@@ -67,26 +67,21 @@ fun RemoteButtonWithBorder() {
 }
 
 /**
- * Reads its label from `LocalRemoteComposeHost.current.namedString("label", ...)` — the panel-side
- * Remote Compose editor sets the `label` named value via
- * `interactive/setRemoteCompose` / `renderNow.overrides.remoteCompose`, and the next render picks
- * it up here. Without an override the default `"Tap me"` shows, so the preview is still a useful
- * static screenshot in agent-driven `composePreviewRenderAll` runs.
- *
- * Demonstrates the consumer side of the named-value pipeline that
- * `:data-remotecompose-connector` installs: every render brings `LocalRemoteComposeHost` into
- * scope (the around-composable is always-on), so this read is safe even when no override has been
- * sent yet.
+ * Reads its label from a Remote Compose named-value binding declared via
+ * [rememberNamedRemoteString]. The panel-side Remote Compose editor sets the `label` named value
+ * via `interactive/setRemoteCompose` / `renderNow.overrides.remoteCompose`, and the next render
+ * picks it up here. Without an override the default `"Tap me"` shows, so the preview is still a
+ * useful static screenshot in agent-driven `composePreviewRenderAll` runs.
  */
 @Composable
 @RemoteComposable
 fun RemoteButtonWithNamedLabel() {
-  val label = LocalRemoteComposeHost.current.namedString("label", default = "Tap me")
-  RemoteButton(
-    onClick = testAction,
-    modifier = RemoteModifier.buttonSizeModifier(),
-    content = { RemoteText(label.rs) },
-  )
+    val label = rememberNamedRemoteString("label", "Tap me")
+    RemoteButton(
+        onClick = testAction,
+        modifier = RemoteModifier.buttonSizeModifier(),
+        content = { RemoteText(label) },
+    )
 }
 
 @Composable

--- a/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/RemoteComponents.kt
+++ b/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/RemoteComponents.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.wear.compose.remote.material3.RemoteButton
 import androidx.wear.compose.remote.material3.RemoteText
 import androidx.wear.compose.remote.material3.buttonSizeModifier
+import ee.schimke.composeai.daemon.LocalRemoteComposeHost
 
 /**
  * Pure-remote composables — each one is the kind of component a real Remote
@@ -63,6 +64,29 @@ fun RemoteButtonWithBorder() {
     ) {
         RemoteText("Bordered".rs)
     }
+}
+
+/**
+ * Reads its label from `LocalRemoteComposeHost.current.namedString("label", ...)` — the panel-side
+ * Remote Compose editor sets the `label` named value via
+ * `interactive/setRemoteCompose` / `renderNow.overrides.remoteCompose`, and the next render picks
+ * it up here. Without an override the default `"Tap me"` shows, so the preview is still a useful
+ * static screenshot in agent-driven `composePreviewRenderAll` runs.
+ *
+ * Demonstrates the consumer side of the named-value pipeline that
+ * `:data-remotecompose-connector` installs: every render brings `LocalRemoteComposeHost` into
+ * scope (the around-composable is always-on), so this read is safe even when no override has been
+ * sent yet.
+ */
+@Composable
+@RemoteComposable
+fun RemoteButtonWithNamedLabel() {
+  val label = LocalRemoteComposeHost.current.namedString("label", default = "Tap me")
+  RemoteButton(
+    onClick = testAction,
+    modifier = RemoteModifier.buttonSizeModifier(),
+    content = { RemoteText(label.rs) },
+  )
 }
 
 @Composable


### PR DESCRIPTION
Adds a fourth sample preview, `RemoteButtonWithNamedLabel`, whose button
text comes from
`LocalRemoteComposeHost.current.namedString("label", default = "Tap me")`
instead of a hard-coded `"Enabled".rs`. The default render shows
"Tap me" (captured under
`samples/remotecompose/build/compose-previews/renders/RemoteButtonWithNamedLabelPreview.png`),
and any caller that sets
`renderNow.overrides.remoteCompose.namedValues = {"label": …}`
— including the VS Code panel's Remote Compose tab body editor wired
in #1401 / #1406 — flips the label without rebuilding the document.

Mechanics:

* Adds `:data-remotecompose-connector` to the sample's compile
  classpath. The connector's around-composable is always-on at render
  time, so the read in `RemoteButtonWithNamedLabel` is safe even when
  no override has been sent yet (`LocalRemoteComposeHost`'s default
  `ControllerRemoteComposeHost` returns the `default` argument).
* The new `@RemoteComposable` reads through the host typed-accessor
  and binds the resulting `String` to a `RemoteText` via the same
  `.rs` extension the existing buttons use.
* `@Preview` sibling in `Previews.kt` follows the same
  `RemotePreview(profile = ANDROIDX) { Container { … } }` shape as
  the existing three previews.

Verified by `./gradlew :samples:remotecompose:composePreviewRenderAll`
— all four buttons render; the new one shows "Tap me".