### PR TITLE
feat(glance): native FQN discovery of androidx.glance.preview.Preview

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -8,12 +8,17 @@ import kotlinx.serialization.Serializable
  * functions returning `androidx.wear.tiles.tooling.preview.TilePreviewData` that need to be
  * inflated via `androidx.wear.tiles.renderer.TileRenderer`; [NOTIFICATION] previews are plain
  * functions taking a `Context` and returning `android.app.Notification`, inflated via
- * `Notification.Builder.recoverBuilder` + `RemoteViews.apply` (see issue #1249).
+ * `Notification.Builder.recoverBuilder` + `RemoteViews.apply` (see issue #1249); [GLANCE_APPWIDGET]
+ * previews are `@Composable @GlanceComposable` functions annotated with
+ * `androidx.glance.preview.Preview` — the renderer wraps the function in a synthetic
+ * `GlanceAppWidget.providePreview(...)`, runs `composeForPreview(...)` to materialise the tree to
+ * `RemoteViews`, and inflates the result the same way `NOTIFICATION` does.
  */
 enum class PreviewKind {
   COMPOSE,
   TILE,
   NOTIFICATION,
+  GLANCE_APPWIDGET,
 }
 
 /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -92,6 +92,7 @@ object PreviewDiscovery {
       "androidx.compose.desktop.ui.tooling.preview.Preview",
       TILE_PREVIEW_FQN,
       NOTIFICATION_PREVIEW_FQN,
+      GLANCE_APPWIDGET_PREVIEW_FQN,
     )
   private val CONTAINER_FQNS =
     setOf(
@@ -132,6 +133,12 @@ object PreviewDiscovery {
   // `(android.content.Context) -> android.app.Notification`; same FQN-match
   // policy as the other annotations we own. See `NotificationPreview.kt`.
   internal const val NOTIFICATION_PREVIEW_FQN = "ee.schimke.composeai.preview.NotificationPreview"
+
+  // Glance's own preview annotation. The annotation lives in `androidx.glance:glance-preview` and
+  // is `@ExperimentalGlancePreviewApi`-gated upstream — same FQN-match policy as notification /
+  // tile. The annotated function is a `@Composable @GlanceComposable () -> Unit` body invoked
+  // from a synthetic `GlanceAppWidget.providePreview(...)` at render time.
+  internal const val GLANCE_APPWIDGET_PREVIEW_FQN = "androidx.glance.preview.Preview"
 
   // failOnEmpty diagnostics: cap the JAR + annotation FQN sample sizes
   // so the lifecycle log stays readable on projects with huge classpaths.
@@ -599,9 +606,11 @@ object PreviewDiscovery {
     val previewParameter = extractPreviewParameter(method)
     val isTilePreview = isAnyTilePreviewAnnotation(annotations, scanResult)
     val isNotificationPreview = isAnyNotificationPreviewAnnotation(annotations, scanResult)
+    val isGlanceAppWidgetPreview = isAnyGlanceAppWidgetPreviewAnnotation(annotations, scanResult)
     val hasUnsupportedParameters =
       !isTilePreview &&
         !isNotificationPreview &&
+        !isGlanceAppWidgetPreview &&
         hasUnsupportedPreviewParameters(method, previewParameter)
     if (hasUnsupportedParameters) {
       warnings.add(
@@ -716,6 +725,27 @@ object PreviewDiscovery {
     return false
   }
 
+  /**
+   * Glance preview functions (`GLANCE_APPWIDGET_PREVIEW_FQN`) are `@Composable @GlanceComposable ()
+   * -> Unit` bodies — their JVM signature ends with the compiler-added `Composer, Int` pair the
+   * standard composable-parameter check would flag as "unsupported parameter(s)". Treat them the
+   * same way as tile / notification previews so the check is skipped: the renderer reflects the
+   * function and invokes it via a synthetic `GlanceAppWidget.providePreview(...)` instead.
+   */
+  private fun isAnyGlanceAppWidgetPreviewAnnotation(
+    annotations: List<AnnotationInfo>,
+    scanResult: ScanResult,
+  ): Boolean {
+    if (collectDirectPreviews(annotations).any { it.name == GLANCE_APPWIDGET_PREVIEW_FQN }) {
+      return true
+    }
+    for (ann in annotations) {
+      val resolved = resolveMultiPreview(ann, scanResult, mutableSetOf())
+      if (resolved.any { it.name == GLANCE_APPWIDGET_PREVIEW_FQN }) return true
+    }
+    return false
+  }
+
   private fun hasUnsupportedPreviewParameters(
     method: MethodInfo,
     previewParameter: Pair<String, Int>?,
@@ -794,7 +824,13 @@ object PreviewDiscovery {
     // owner. Treat them the same as tiles for every dimensional fan-out so the single-capture
     // path runs unmodified.
     val isNotification = ann.name == NOTIFICATION_PREVIEW_FQN
-    val nonComposable = isTile || isNotification
+    // Glance preview functions are technically `@Composable`, but they're a closed Glance
+    // composition driven by `composeForPreview(...)` rather than the standard Compose machinery.
+    // Treat them the same way as tile / notification for fan-out gating — no scroll / animation
+    // / focus drive, no `mainClock` tick, the renderer handles the whole materialise + inflate
+    // in one shot.
+    val isGlanceAppWidget = ann.name == GLANCE_APPWIDGET_PREVIEW_FQN
+    val nonComposable = isTile || isNotification || isGlanceAppWidget
     val effectiveTimings = if (nonComposable) emptyList() else timings
     val effectiveScrolls = if (nonComposable) emptyList() else scrolls
     // Tile / notification previews don't go through `mainClock` — there's no animation surface to
@@ -1338,7 +1374,12 @@ object PreviewDiscovery {
     // `TilePreviewData` / `Notification` and the renderer reflects them directly. Skipping the
     // lazy means the bytecode walk never runs for these methods.
     val targets =
-      if (params.kind == PreviewKind.TILE || params.kind == PreviewKind.NOTIFICATION) emptyList()
+      if (
+        params.kind == PreviewKind.TILE ||
+          params.kind == PreviewKind.NOTIFICATION ||
+          params.kind == PreviewKind.GLANCE_APPWIDGET
+      )
+        emptyList()
       else inferredTargets.value
     return PreviewInfo(
       id = id,
@@ -1418,6 +1459,19 @@ object PreviewDiscovery {
     // will be added when the variants matrix from #1249 lands.
     if (ann.name == NOTIFICATION_PREVIEW_FQN) {
       return PreviewParams(kind = PreviewKind.NOTIFICATION)
+    }
+    // Glance's own `androidx.glance.preview.Preview(widthDp, heightDp)`. The annotation's params
+    // started life as `()` in 1.0.x, gained `widthDp` / `heightDp` in 1.1.0-rc01. Read both
+    // optimistically; missing entries fall through to the renderer's default sandbox size.
+    if (ann.name == GLANCE_APPWIDGET_PREVIEW_FQN) {
+      val pv = ann.parameterValues
+      val widthDp = (pv.getValue("widthDp") as? Int)?.takeIf { it > 0 }
+      val heightDp = (pv.getValue("heightDp") as? Int)?.takeIf { it > 0 }
+      return PreviewParams(
+        kind = PreviewKind.GLANCE_APPWIDGET,
+        widthDp = widthDp,
+        heightDp = heightDp,
+      )
     }
     val pv = ann.parameterValues
     val kind = if (ann.name == TILE_PREVIEW_FQN) PreviewKind.TILE else PreviewKind.COMPOSE

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -152,6 +152,7 @@ jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
 glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance-appwidget" }
+glance-preview = { module = "androidx.glance:glance-preview", version.ref = "glance-appwidget" }
 wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", version.ref = "wear-compose" }
 wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wear-compose" }
 wear-compose-ui-tooling = { module = "androidx.wear.compose:compose-ui-tooling", version.ref = "wear-compose" }

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -63,6 +63,12 @@ dependencies {
   // planner registered in `RobolectricHost`. Same architectural rule as ambient / focus: **no
   // hardcoded launcher-widget sizing logic in this module — extend the connector instead.**
   implementation(project(":data-launcher-widget-connector"))
+  // Glance — drives the native `@androidx.glance.preview.Preview` strategy
+  // (`GlanceAppWidgetPreviewRenderer.kt`). `compileOnly` so the artefact isn't dragged onto every
+  // renderer-android consumer's unit-test classpath; consumers who annotate Glance previews must
+  // already have `androidx.glance:glance-appwidget` on their compile classpath, which then flows
+  // onto the test classpath via the discovery → render fanout.
+  compileOnly(libs.glance.appwidget)
   // Soft-keyboard (IME) connector. Owns `KeyboardController` (state) and
   // `KeyboardOverrideExtension`
   // (the `AroundComposable` that installs the shadow `LocalSoftwareKeyboardController` and overlays

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/GlanceAppWidgetPreviewRenderer.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/GlanceAppWidgetPreviewRenderer.kt
@@ -1,0 +1,128 @@
+@file:OptIn(androidx.glance.ExperimentalGlanceApi::class)
+
+package ee.schimke.composeai.renderer
+
+import android.appwidget.AppWidgetProviderInfo
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.glance.GlanceId
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.composeForPreview
+import androidx.glance.appwidget.provideContent
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Renders a Glance preview function — `@Composable @GlanceComposable () -> Unit` annotated with
+ * `androidx.glance.preview.Preview` — into the surrounding Compose tree via an [AndroidView]
+ * hosting the inflated `RemoteViews`. Mirrors the structure of [NotificationPreviewComposable]:
+ * reflect the user's function, hand it to a platform inflater, host the resulting View.
+ *
+ * Inflation path:
+ * 1. Build a [SyntheticGlanceAppWidget] whose `providePreview(...)` invokes the user's `@Composable`
+ *    via [getDeclaredComposableMethod] inside `provideContent { ... }` — the Glance composition
+ *    block where `@GlanceComposable` calls resolve.
+ * 2. `composeForPreview(context, widgetCategory, info)` runs the composition and materialises a
+ *    `RemoteViews` tree (Glance 1.2.0+).
+ * 3. `RemoteViews.apply(context, parent)` inflates the tree into a `View` we host inside the
+ *    `AndroidView` factory — the same path `AppWidgetHost.createView(...)` walks on-device.
+ *
+ * Sizing flows through a synthesised [AppWidgetProviderInfo]: `minWidth` / `minHeight` are set to
+ * `widthDp × density` so Glance's `SizeMode.Single` widgets compose at the right `LocalSize`. The
+ * surrounding `@Preview(widthDp, heightDp)` / discovery-resolved sandbox controls the
+ * Robolectric window; this helper just plumbs the same size into Glance's composition.
+ */
+@Composable
+fun GlanceAppWidgetPreviewComposable(
+    className: String,
+    functionName: String,
+    widthDp: Int,
+    heightDp: Int,
+    classLoader: ClassLoader? = null,
+) {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = { ctx ->
+            val parent =
+                FrameLayout(ctx).apply {
+                    layoutParams =
+                        ViewGroup.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                        )
+                }
+            val widget = SyntheticGlanceAppWidget(className, functionName, classLoader)
+            val info =
+                AppWidgetProviderInfo().apply {
+                    minWidth = with(density) { widthDp.dp.toPx() }.toInt()
+                    minHeight = with(density) { heightDp.dp.toPx() }.toInt()
+                }
+            val remoteViews =
+                runBlocking {
+                    widget.composeForPreview(
+                        context = context,
+                        widgetCategory = AppWidgetProviderInfo.WIDGET_CATEGORY_HOME_SCREEN,
+                        info = info,
+                    )
+                }
+            val view = remoteViews.apply(context, parent)
+            parent.addView(
+                view,
+                FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                ),
+            )
+            parent
+        },
+    )
+}
+
+/**
+ * A `GlanceAppWidget` whose `providePreview(...)` body reflects the user's `@Composable
+ * @GlanceComposable` function and invokes it. The function signature the Compose compiler emits
+ * for any `@Composable () -> Unit` is `(Composer, Int) -> Unit` at the JVM level, so the standard
+ * `getDeclaredComposableMethod` + `ComposableMethod.invoke(currentComposer, receiver)` path used
+ * by [ComposePreviewStrategy] applies unchanged — Glance's composition uses the same
+ * `androidx.compose.runtime.Composer` infrastructure.
+ *
+ * Receiver resolution mirrors [resolvePreviewReceiver] so top-level Glance previews (compiled into
+ * static methods on the file's synthetic `FooKt` class) and class-hosted previews (e.g. inside a
+ * `class ScreenshotTest`) both work.
+ *
+ * `provideGlance(...)` is a no-op — the production runtime path is invoked when the launcher binds
+ * a real widget, not when rendering an off-device preview.
+ */
+private class SyntheticGlanceAppWidget(
+    private val className: String,
+    private val functionName: String,
+    private val classLoader: ClassLoader?,
+) : GlanceAppWidget() {
+    override suspend fun providePreview(context: android.content.Context, widgetCategory: Int) {
+        provideContent {
+            val cls =
+                Class.forName(
+                    className,
+                    true,
+                    classLoader ?: Thread.currentThread().contextClassLoader,
+                )
+            val method = cls.getDeclaredComposableMethod(functionName)
+            val receiver = resolvePreviewReceiver(cls)
+            method.invoke(currentComposer, receiver)
+        }
+    }
+
+    override suspend fun provideGlance(context: android.content.Context, id: GlanceId) {
+        // Production runtime not exercised by previews.
+    }
+}

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -22,6 +22,7 @@ private val STRATEGIES: Map<PreviewKind, PreviewRenderStrategy> = mapOf(
     PreviewKind.COMPOSE to ComposePreviewStrategy,
     PreviewKind.TILE to TilePreviewStrategy,
     PreviewKind.NOTIFICATION to NotificationPreviewStrategy,
+    PreviewKind.GLANCE_APPWIDGET to GlanceAppWidgetPreviewStrategy,
 )
 
 internal fun strategyFor(kind: PreviewKind): PreviewRenderStrategy =
@@ -172,6 +173,24 @@ private object NotificationPreviewStrategy : PreviewRenderStrategy {
             className = preview.className,
             functionName = preview.functionName,
             previewId = preview.id,
+        )
+    }
+}
+
+/**
+ * Glance app-widget strategy: wrap the user's `@Composable @GlanceComposable` function in a
+ * synthetic `GlanceAppWidget.providePreview(...)`, materialise it to `RemoteViews` via
+ * `composeForPreview(...)`, and host the inflated tree inside an `AndroidView`. See
+ * [GlanceAppWidgetPreviewComposable] for the heavy lifting.
+ */
+private object GlanceAppWidgetPreviewStrategy : PreviewRenderStrategy {
+    @Composable
+    override fun Render(preview: RenderPreviewEntry, widthDp: Int, heightDp: Int, previewArgs: List<Any?>) {
+        GlanceAppWidgetPreviewComposable(
+            className = preview.className,
+            functionName = preview.functionName,
+            widthDp = widthDp,
+            heightDp = heightDp,
         )
     }
 }

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -7,6 +7,7 @@ enum class PreviewKind {
     COMPOSE,
     TILE,
     NOTIFICATION,
+    GLANCE_APPWIDGET,
 }
 
 /**

--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -99,6 +99,13 @@ dependencies {
   // (`RemoteViewsWeatherWidgetPreview`) doesn't use this — it builds the `RemoteViews` tree by
   // hand from `res/layout/widget_weather.xml`.
   implementation(project(":glance-preview-runtime"))
+  // `androidx.glance.preview.Preview` annotation (a separate `glance-preview` artefact from the
+  // appwidget runtime). Used by `NativeGlanceWidgetPreview` so the sample exercises the native
+  // FQN-discovered Glance preview path — discovery picks up the annotation, the renderer's
+  // `GlanceAppWidgetPreviewStrategy` wraps the body in a synthetic `GlanceAppWidget`, and
+  // `composeForPreview(...)` materialises the same `RemoteViews` tree the helper-based sample
+  // produces.
+  implementation(libs.glance.preview)
   debugImplementation("androidx.compose.ui:ui-tooling")
   // `@AnimatedPreview(showCurves = true)` reflectively probes
   // `androidx.compose.ui.tooling.animation.PreviewAnimationClock` /

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/AppWidgetPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/AppWidgetPreviews.kt
@@ -28,6 +28,8 @@ import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
+import androidx.glance.preview.ExperimentalGlancePreviewApi
+import androidx.glance.preview.Preview as GlancePreview
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider as GlanceFixedColorProvider
 import ee.schimke.composeai.preview.LauncherWidgetPreview
@@ -257,5 +259,53 @@ fun LauncherWidgetClampedPreview() {
       setTextViewText(R.id.widget_temperature, "67°")
       setTextViewText(R.id.widget_condition, "Partly cloudy")
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Native `@androidx.glance.preview.Preview` discovery
+//
+// Same Glance composable body as the `GlanceWeatherWidgetPreview` above, but the function is
+// annotated with Glance's own `@Preview` instead of the standard
+// `@androidx.compose.ui.tooling.preview.Preview` + `GlanceAppWidgetContent` helper. The gradle
+// plugin's discovery picks the FQN up, marks the entry as `PreviewKind.GLANCE_APPWIDGET`, and
+// the renderer wraps the function in a synthetic `GlanceAppWidget.providePreview(...)` driven
+// by `composeForPreview(...)` — same end-state as the helper-based path, just authored from a
+// single annotation.
+// ---------------------------------------------------------------------------
+
+/**
+ * Glance preview annotated with Glance's own `@androidx.glance.preview.Preview`. Discovery
+ * recognises the FQN and treats the function as `PreviewKind.GLANCE_APPWIDGET`; the renderer
+ * reflects the body into a synthetic `GlanceAppWidget` and materialises via
+ * `composeForPreview(...)`.
+ */
+@OptIn(ExperimentalGlancePreviewApi::class)
+@GlancePreview(widthDp = 312, heightDp = 152)
+@Composable
+fun NativeGlanceWidgetPreview() {
+  Column(
+    modifier =
+      GlanceModifier.fillMaxSize()
+        .background(GlanceFixedColorProvider(ComposeColor(0xFF1A237E)))
+        .padding(12.dp)
+  ) {
+    Text(
+      text = "Native @glance.preview.Preview",
+      style =
+        TextStyle(
+          color = GlanceFixedColorProvider(ComposeColor.White),
+          fontWeight = FontWeight.Bold,
+        ),
+    )
+    Spacer(GlanceModifier.height(8.dp))
+    Text(
+      text = "67°",
+      style = TextStyle(color = GlanceFixedColorProvider(ComposeColor.White)),
+    )
+    Text(
+      text = "Discovered by FQN",
+      style = TextStyle(color = GlanceFixedColorProvider(ComposeColor(0xB3FFFFFF))),
+    )
   }
 }


### PR DESCRIPTION
## Summary

Recognises Glance's own `@Preview` annotation (`androidx.glance.preview.Preview`) at discovery time and renders the body through a synthetic `GlanceAppWidget.providePreview(...)` → `composeForPreview(...)` → `RemoteViews.apply` chain. Same end-state as the existing `GlanceAppWidgetContent` helper (from `:glance-preview-runtime`, shipped in #1368), but driven from a single annotation on the consumer's function — no helper wrapper required.

- **`:gradle-plugin:preview-discovery`** — registers `GLANCE_APPWIDGET_PREVIEW_FQN = "androidx.glance.preview.Preview"` in `PREVIEW_FQNS`, adds `isAnyGlanceAppWidgetPreviewAnnotation(...)` so the standard `hasUnsupportedPreviewParameters` check is skipped (Glance functions carry the compile-added `Composer, Int` pair that check would flag), marks the kind as `PreviewKind.GLANCE_APPWIDGET` in `extractPreviewParams`, treats it as `nonComposable` in `buildOutputPlan` (no scroll / animation / focus drive), and extracts `widthDp` / `heightDp` from the annotation (added in Glance 1.1.0-rc01) into the manifest's `PreviewParams`.
- **`:renderer-android`** — new `GlanceAppWidgetPreviewRenderer.kt` with a `SyntheticGlanceAppWidget` that reflects the user's `@Composable` via `getDeclaredComposableMethod` + `resolvePreviewReceiver` inside `provideContent { ... }`, then drives `composeForPreview(...)` with a synthesised `AppWidgetProviderInfo` so `SizeMode.Single` widgets compose at the right `LocalSize`. New `GlanceAppWidgetPreviewStrategy` registered in `PreviewRenderStrategy.STRATEGIES`. `compileOnly(libs.glance.appwidget)` keeps the artefact off non-Glance consumers' test classpaths.
- **`:samples:android`** — new `NativeGlanceWidgetPreview` annotated with `@androidx.glance.preview.Preview(widthDp = 312, heightDp = 152)` — no `@Preview` from compose-ui-tooling, no helper wrapper. Adds the `glance-preview` dep: Glance's preview annotation ships in the separate `androidx.glance:glance-preview` artefact (NOT in `glance-appwidget` or the common `glance` module).
- **`gradle/libs.versions.toml`** — adds the `glance-preview` library entry reusing the existing `glance-appwidget` version pin (1.2.0-rc01).

## Test plan

- [x] `./gradlew :gradle-plugin:preview-discovery:test` — existing discovery tests stay green
- [x] `./gradlew :renderer-android:compileDebugKotlin` — strategy resolves against `getDeclaredComposableMethod` + the bumped Glance artefact
- [x] `./gradlew :samples:android:composePreviewRender` — `NativeGlanceWidgetPreview` renders a 312×152 PNG with the expected Glance content (title bold, temperature, subtitle on the dark blue background); discovery emits `PreviewKind.GLANCE_APPWIDGET` and the renderer routes through the new strategy
- [ ] Follow-up: the same FQN-discovery shape could host Wear-OS Glance Tiles previews once `androidx.glance.wear` ships (currently `1.3.0-alpha01`) — the strategy seam would split by `widgetCategory`

---
_Generated by [Claude Code](https://claude.ai/code/session_016wQB16N6M2ey3nNLmZhrDc)_