### PR TITLE
feat(vscode-extension): show all adaptive-icon variants on AndroidManifest.xml hover

### DIFF
--- a/vscode-extension/src/androidManifestCodeLensProvider.ts
+++ b/vscode-extension/src/androidManifestCodeLensProvider.ts
@@ -66,9 +66,16 @@ export class AndroidManifestCodeLensProvider
             );
             const pos = doc.positionAt(m.offset);
             const range = new vscode.Range(pos.line, 0, pos.line, 0);
+            // When a resource has multiple captures (typical for adaptive icons:
+            // FULL_COLOR / THEMED_LIGHT / THEMED_DARK / LEGACY) the lens flags
+            // that to the user — the hover provider renders the full grid, but
+            // a glance at the lens shouldn't suggest there's only one variant.
+            const variantCount = resource.captures.length;
+            const variantSuffix =
+                variantCount > 1 ? ` (${variantCount} variants)` : "";
             lenses.push(
                 new vscode.CodeLens(range, {
-                    title: `$(file-media) Preview ${resourceId}`,
+                    title: `$(file-media) Preview ${resourceId}${variantSuffix}`,
                     command: "composePreview.previewResource",
                     arguments: [pngPath, resourceId],
                 }),

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -23,6 +23,7 @@ import { PreviewGutterDecorations } from "./previewGutterDecorations";
 import { PreviewHoverProvider } from "./previewHoverProvider";
 import { PreviewCodeLensProvider } from "./previewCodeLensProvider";
 import { AndroidManifestCodeLensProvider } from "./androidManifestCodeLensProvider";
+import { ManifestResourceHoverProvider } from "./manifestResourceHoverProvider";
 import { PreviewA11yDiagnostics } from "./previewA11yDiagnostics";
 import { PreviewDoctorDiagnostics } from "./previewDoctorDiagnostics";
 import { moduleRelativeSourcePath, previewSourceMatches } from "./sourcePath";
@@ -1462,6 +1463,9 @@ export async function activate(
     const androidManifestCodeLensProvider = new AndroidManifestCodeLensProvider(
         gradleService,
     );
+    const manifestResourceHoverProvider = new ManifestResourceHoverProvider(
+        gradleService,
+    );
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(kotlinFiles, hoverProvider),
         vscode.languages.registerCodeLensProvider(
@@ -1471,6 +1475,10 @@ export async function activate(
         vscode.languages.registerCodeLensProvider(
             androidManifestFiles,
             androidManifestCodeLensProvider,
+        ),
+        vscode.languages.registerHoverProvider(
+            androidManifestFiles,
+            manifestResourceHoverProvider,
         ),
         codeLensProvider,
         androidManifestCodeLensProvider,

--- a/vscode-extension/src/manifestIconReferences.ts
+++ b/vscode-extension/src/manifestIconReferences.ts
@@ -7,6 +7,10 @@
 export interface ManifestIconMatch {
     /** Byte offset of the matched attribute within the document text. */
     offset: number;
+    /** Total length of the matched attribute (`android:icon="@drawable/foo"`), so callers can
+     *  build a Range that covers the whole attribute — important for the hover provider, which
+     *  fires anywhere within the attribute span rather than only at the `android:` prefix. */
+    length: number;
     /** Local attribute name without the `android:` prefix — `icon` / `roundIcon` / `logo` / `banner`. */
     attribute: "icon" | "roundIcon" | "logo" | "banner";
     /** `drawable` or `mipmap`. */
@@ -33,6 +37,7 @@ export function findManifestIconReferences(text: string): ManifestIconMatch[] {
     while ((match = re.exec(text)) !== null) {
         out.push({
             offset: match.index,
+            length: match[0].length,
             attribute: match[1] as ManifestIconMatch["attribute"],
             resourceType: match[3] as ManifestIconMatch["resourceType"],
             resourceName: match[4],

--- a/vscode-extension/src/manifestResourceHoverProvider.ts
+++ b/vscode-extension/src/manifestResourceHoverProvider.ts
@@ -1,0 +1,107 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { GradleService } from "./gradleService";
+import { findManifestIconReferences } from "./manifestIconReferences";
+import {
+    buildResourceVariantHoverMarkdown,
+    VariantImage,
+} from "./resourceVariantHover";
+import { ResourcePreview } from "./types";
+
+/**
+ * Renders a hover over every `android:icon` / `roundIcon` / `logo` / `banner` attribute in
+ * `AndroidManifest.xml` whose target resource resolved into the module's `resources.json`. The
+ * hover shows every rendered capture — adaptive-icon variants (FULL_COLOR / THEMED_LIGHT /
+ * THEMED_DARK / LEGACY), or a single image for vectors — so the user sees what the launcher
+ * actually looks like under themed-icon mode without leaving the editor.
+ *
+ * Pairs with [AndroidManifestCodeLensProvider]: the lens is the explicit "open in viewer" entry
+ * point, the hover is the at-a-glance peek. Both providers read `resources.json` directly and
+ * tolerate it being absent (consumer hasn't run `composePreviewRenderAndroidResources` yet).
+ */
+export class ManifestResourceHoverProvider implements vscode.HoverProvider {
+    constructor(private readonly gradleService: GradleService) {}
+
+    provideHover(
+        doc: vscode.TextDocument,
+        position: vscode.Position,
+    ): vscode.Hover | undefined {
+        if (!doc.fileName.endsWith("AndroidManifest.xml")) {
+            return undefined;
+        }
+        const module = this.gradleService.resolveModule(doc.uri.fsPath);
+        if (!module) {
+            return undefined;
+        }
+        const manifest = this.gradleService.readResourceManifest(module);
+        if (!manifest) {
+            return undefined;
+        }
+
+        const matches = findManifestIconReferences(doc.getText());
+        const offset = doc.offsetAt(position);
+        const hit = matches.find(
+            (m) => offset >= m.offset && offset <= m.offset + m.length,
+        );
+        if (!hit) {
+            return undefined;
+        }
+
+        const resourceId = `${hit.resourceType}/${hit.resourceName}`;
+        const resource = manifest.resources.find((r) => r.id === resourceId);
+        if (!resource) {
+            return undefined;
+        }
+
+        const moduleRoot = path.join(
+            this.gradleService.workspaceRoot,
+            module.projectDir,
+            "build",
+            "compose-previews",
+        );
+        const images = readVariantImages(resource, moduleRoot);
+        if (images.length === 0) {
+            return undefined;
+        }
+
+        const md = new vscode.MarkdownString(
+            buildResourceVariantHoverMarkdown({ resource, images }),
+        );
+        md.isTrusted = true;
+        md.supportHtml = true;
+
+        const startPos = doc.positionAt(hit.offset);
+        const endPos = doc.positionAt(hit.offset + hit.length);
+        return new vscode.Hover(md, new vscode.Range(startPos, endPos));
+    }
+}
+
+/**
+ * Read each capture's PNG/GIF off disk and base64-encode it for the markdown `<img>` tag.
+ * Captures whose file is missing are skipped silently — the renderer might have failed on that
+ * particular variant, or a heavy-tier filter could have dropped it; the hover still shows
+ * whichever variants did land.
+ *
+ * Exported for tests; production callers go through the hover provider.
+ */
+export function readVariantImages(
+    resource: ResourcePreview,
+    moduleBuildRoot: string,
+): VariantImage[] {
+    const out: VariantImage[] = [];
+    for (const capture of resource.captures) {
+        const abs = path.join(moduleBuildRoot, capture.renderOutput);
+        try {
+            const bytes = fs.readFileSync(abs);
+            out.push({
+                renderOutput: capture.renderOutput,
+                base64: bytes.toString("base64"),
+            });
+        } catch {
+            // File missing — render run produced no output for this variant.
+            // Drop silently; the hover renders whatever did land.
+        }
+    }
+    return out;
+}

--- a/vscode-extension/src/resourceVariantHover.ts
+++ b/vscode-extension/src/resourceVariantHover.ts
@@ -1,0 +1,180 @@
+// Pure host-side builder for the resource-preview hover markdown.
+//
+// Lives outside the VS Code provider so Mocha unit tests can exercise it
+// without the extension host — Mocha can't load `vscode` module imports.
+// The thin wrapper (`manifestResourceHoverProvider.ts`) is what reads PNG
+// bytes off disk, constructs a `MarkdownString`, and registers with the
+// editor.
+//
+// Each adaptive-icon `ResourcePreview` can have up to four captures
+// (FULL_COLOR / THEMED_LIGHT / THEMED_DARK / LEGACY) under the same
+// resource id; vector / animated-vector resources collapse to a single
+// capture. The markdown shows every available capture side by side,
+// labelled with shape + style so the user sees what a launcher icon
+// actually looks like under the themed-icon mode without leaving the
+// editor.
+
+import { ResourceCapture, ResourcePreview } from "./types";
+
+/**
+ * Square edge of each rendered variant `<img>` in the hover. Small enough
+ * that four adaptive-icon variants fit one row in VS Code's hover popover;
+ * large enough that the masked-shape and themed palette are legible.
+ * Matches the 120px peak used by `previewHoverProvider`'s single-image
+ * case at roughly two-thirds the area — four variants together stay
+ * under the popover's vertical budget.
+ */
+export const VARIANT_HOVER_IMG_PX = 80;
+
+/**
+ * One image the hover renderer wants to display. Host code reads PNG
+ * bytes off `<workspaceRoot>/<module.projectDir>/build/compose-previews/
+ * <renderOutput>` and base64-encodes them before handing to the builder
+ * — keeping I/O outside this module makes it trivially testable and
+ * portable to a future CLI surface that wants the same markdown.
+ */
+export interface VariantImage {
+    /** Module-relative path matched against `ResourceCapture.renderOutput`. */
+    renderOutput: string;
+    /** Base64-encoded PNG (or GIF for animated-vector) bytes. */
+    base64: string;
+}
+
+export interface VariantHoverInput {
+    resource: ResourcePreview;
+    images: VariantImage[];
+}
+
+/**
+ * Build the markdown body for [input]. Returns the raw markdown string;
+ * the caller wraps it in `new vscode.MarkdownString(...)` and sets
+ * `isTrusted` / `supportHtml` per provider conventions. Captures whose
+ * `renderOutput` doesn't appear in [VariantHoverInput.images] are
+ * skipped silently — the host decides which variants are worth the
+ * base64 cost (a tier=fast render might have skipped the heavy
+ * adaptive captures, for instance).
+ */
+export function buildResourceVariantHoverMarkdown(
+    input: VariantHoverInput,
+): string {
+    const lines: string[] = [];
+    lines.push(
+        `**${input.resource.id}** — ${friendlyType(input.resource.type)}`,
+    );
+    const byOutput = new Map(
+        input.images.map((i) => [i.renderOutput, i.base64]),
+    );
+    const imgs: string[] = [];
+    for (const capture of input.resource.captures) {
+        const base64 = byOutput.get(capture.renderOutput);
+        if (!base64) {
+            continue;
+        }
+        const mime = capture.renderOutput.toLowerCase().endsWith(".gif")
+            ? "image/gif"
+            : "image/png";
+        const label = captureLabel(capture);
+        imgs.push(
+            `<img src="data:${mime};base64,${base64}" ` +
+                `width="${VARIANT_HOVER_IMG_PX}" ` +
+                `height="${VARIANT_HOVER_IMG_PX}" ` +
+                `alt="${escapeAttr(label)}" ` +
+                `title="${escapeAttr(label)}" />`,
+        );
+    }
+    if (imgs.length === 0) {
+        lines.push("");
+        lines.push("_No rendered captures available._");
+        return lines.join("\n");
+    }
+    lines.push("");
+    lines.push(imgs.join(" "));
+    return lines.join("\n");
+}
+
+/**
+ * Human-readable single-line label for a [capture]. Used both as the
+ * `title`/`alt` attribute on the hover image and (in `#1418`/`#1419`)
+ * as a caption when the variant gallery webview lands. Vector captures
+ * with only a qualifier (no adaptive shape/style) fall back to the
+ * verbatim qualifier suffix (e.g. `'xhdpi'`).
+ */
+export function captureLabel(capture: ResourceCapture): string {
+    const v = capture.variant;
+    if (!v) {
+        return "default";
+    }
+    const parts: string[] = [];
+    if (v.shape) {
+        parts.push(friendlyShape(v.shape));
+    }
+    if (v.style) {
+        parts.push(friendlyStyle(v.style));
+    }
+    if (parts.length === 0 && v.qualifiers) {
+        parts.push(v.qualifiers);
+    }
+    return parts.length > 0 ? parts.join(" · ") : "default";
+}
+
+function friendlyShape(shape: string): string {
+    switch (shape) {
+        case "CIRCLE":
+            return "Circle";
+        case "SQUIRCLE":
+            return "Squircle";
+        case "ROUNDED_SQUARE":
+            return "Rounded square";
+        case "SQUARE":
+            return "Square";
+        default:
+            return shape;
+    }
+}
+
+function friendlyStyle(style: string): string {
+    switch (style) {
+        case "FULL_COLOR":
+            return "Full colour";
+        case "THEMED_LIGHT":
+            return "Themed light";
+        case "THEMED_DARK":
+            return "Themed dark";
+        case "LEGACY":
+            return "Legacy";
+        default:
+            return style;
+    }
+}
+
+function friendlyType(type: string): string {
+    switch (type) {
+        case "VECTOR":
+            return "Vector drawable";
+        case "ANIMATED_VECTOR":
+            return "Animated vector";
+        case "ADAPTIVE_ICON":
+            return "Adaptive icon";
+        default:
+            return type;
+    }
+}
+
+function escapeAttr(s: string): string {
+    return s.replace(/[&<>"']/g, (c) => {
+        switch (c) {
+            case "&":
+                return "&amp;";
+            case "<":
+                return "&lt;";
+            case ">":
+                return "&gt;";
+            case '"':
+                return "&quot;";
+            case "'":
+                return "&#39;";
+            default:
+                return c;
+        }
+    });
+}

--- a/vscode-extension/src/test/androidManifestCodeLensProvider.test.ts
+++ b/vscode-extension/src/test/androidManifestCodeLensProvider.test.ts
@@ -34,10 +34,18 @@ describe("findManifestIconReferences", () => {
         assert.strictEqual(matches.length, 1);
         assert.deepStrictEqual(matches[0], {
             offset: matches[0].offset,
+            length: matches[0].length,
             attribute: "icon",
             resourceType: "drawable",
             resourceName: "ic_settings",
         });
+        // length should span the whole `android:icon="@drawable/ic_settings"`
+        // attribute so the hover provider can fire across the full attribute,
+        // not just over the `android:` prefix.
+        assert.strictEqual(
+            xml.slice(matches[0].offset, matches[0].offset + matches[0].length),
+            'android:icon="@drawable/ic_settings"',
+        );
     });
 
     it("handles attributes split across lines with single quotes", () => {

--- a/vscode-extension/src/test/resourceVariantHover.test.ts
+++ b/vscode-extension/src/test/resourceVariantHover.test.ts
@@ -1,0 +1,190 @@
+import * as assert from "assert";
+import {
+    buildResourceVariantHoverMarkdown,
+    captureLabel,
+    VARIANT_HOVER_IMG_PX,
+} from "../resourceVariantHover";
+import { ResourcePreview } from "../types";
+
+const ADAPTIVE: ResourcePreview = {
+    id: "mipmap/ic_launcher",
+    type: "ADAPTIVE_ICON",
+    sourceFiles: {
+        "anydpi-v26": "src/main/res/mipmap-anydpi-v26/ic_launcher.xml",
+    },
+    captures: [
+        {
+            variant: {
+                qualifiers: "xhdpi",
+                shape: "CIRCLE",
+                style: "FULL_COLOR",
+            },
+            renderOutput: "renders/resources/mipmap/full.png",
+            cost: 4,
+        },
+        {
+            variant: {
+                qualifiers: "xhdpi",
+                shape: "SQUIRCLE",
+                style: "THEMED_LIGHT",
+            },
+            renderOutput: "renders/resources/mipmap/themed-light.png",
+            cost: 4,
+        },
+        {
+            variant: {
+                qualifiers: "xhdpi",
+                shape: "SQUIRCLE",
+                style: "THEMED_DARK",
+            },
+            renderOutput: "renders/resources/mipmap/themed-dark.png",
+            cost: 4,
+        },
+        {
+            variant: { qualifiers: "xhdpi", shape: null, style: "LEGACY" },
+            renderOutput: "renders/resources/mipmap/legacy.png",
+            cost: 4,
+        },
+    ],
+};
+
+const VECTOR: ResourcePreview = {
+    id: "drawable/ic_compose_logo",
+    type: "VECTOR",
+    sourceFiles: { "": "src/main/res/drawable/ic_compose_logo.xml" },
+    captures: [
+        {
+            variant: { qualifiers: "xhdpi", shape: null, style: null },
+            renderOutput:
+                "renders/resources/drawable/ic_compose_logo_xhdpi.png",
+            cost: 1,
+        },
+    ],
+};
+
+const ANIMATED: ResourcePreview = {
+    id: "drawable/avd_pulse",
+    type: "ANIMATED_VECTOR",
+    sourceFiles: { "": "src/main/res/drawable/avd_pulse.xml" },
+    captures: [
+        {
+            variant: { qualifiers: "xhdpi", shape: null, style: null },
+            renderOutput: "renders/resources/drawable/avd_pulse_xhdpi.gif",
+            cost: 35,
+        },
+    ],
+};
+
+describe("captureLabel", () => {
+    it("renders adaptive shape + style as a friendly two-part label", () => {
+        const label = captureLabel(ADAPTIVE.captures[0]);
+        assert.strictEqual(label, "Circle · Full colour");
+    });
+
+    it("renders LEGACY (no shape) with just the style", () => {
+        const label = captureLabel(ADAPTIVE.captures[3]);
+        assert.strictEqual(label, "Legacy");
+    });
+
+    it("falls back to the qualifier suffix for vectors with no shape/style", () => {
+        const label = captureLabel(VECTOR.captures[0]);
+        assert.strictEqual(label, "xhdpi");
+    });
+
+    it("returns 'default' for a capture with no variant at all", () => {
+        const label = captureLabel({
+            variant: null,
+            renderOutput: "x.png",
+            cost: 1,
+        });
+        assert.strictEqual(label, "default");
+    });
+
+    it("returns 'default' for a variant with no qualifier and no shape/style", () => {
+        const label = captureLabel({
+            variant: { qualifiers: null, shape: null, style: null },
+            renderOutput: "x.png",
+            cost: 1,
+        });
+        assert.strictEqual(label, "default");
+    });
+});
+
+describe("buildResourceVariantHoverMarkdown", () => {
+    it("renders one <img> per capture for an adaptive icon", () => {
+        const md = buildResourceVariantHoverMarkdown({
+            resource: ADAPTIVE,
+            images: ADAPTIVE.captures.map((c) => ({
+                renderOutput: c.renderOutput,
+                base64: "AAAA",
+            })),
+        });
+        assert.match(md, /\*\*mipmap\/ic_launcher\*\*/);
+        assert.match(md, /Adaptive icon/);
+        const imgCount = (md.match(/<img /g) ?? []).length;
+        assert.strictEqual(imgCount, 4);
+        assert.match(md, /title="Circle · Full colour"/);
+        assert.match(md, /title="Squircle · Themed light"/);
+        assert.match(md, /title="Squircle · Themed dark"/);
+        assert.match(md, /title="Legacy"/);
+        // PNG mime, fixed image size.
+        assert.match(md, /data:image\/png;base64,AAAA/);
+        assert.match(md, new RegExp(`width="${VARIANT_HOVER_IMG_PX}"`));
+    });
+
+    it("renders a single <img> for a vector drawable", () => {
+        const md = buildResourceVariantHoverMarkdown({
+            resource: VECTOR,
+            images: [
+                {
+                    renderOutput: VECTOR.captures[0].renderOutput,
+                    base64: "BBBB",
+                },
+            ],
+        });
+        assert.match(md, /Vector drawable/);
+        const imgCount = (md.match(/<img /g) ?? []).length;
+        assert.strictEqual(imgCount, 1);
+        assert.match(md, /title="xhdpi"/);
+    });
+
+    it("uses image/gif mime for animated-vector .gif captures", () => {
+        const md = buildResourceVariantHoverMarkdown({
+            resource: ANIMATED,
+            images: [
+                {
+                    renderOutput: ANIMATED.captures[0].renderOutput,
+                    base64: "CCCC",
+                },
+            ],
+        });
+        assert.match(md, /data:image\/gif;base64,CCCC/);
+        assert.doesNotMatch(md, /data:image\/png;base64,CCCC/);
+    });
+
+    it("skips captures whose image bytes weren't supplied", () => {
+        // Only THEMED_DARK provided. Renderer might have failed on the others,
+        // or a tier=fast run might have skipped the heavy captures.
+        const md = buildResourceVariantHoverMarkdown({
+            resource: ADAPTIVE,
+            images: [
+                {
+                    renderOutput: ADAPTIVE.captures[2].renderOutput,
+                    base64: "DDDD",
+                },
+            ],
+        });
+        const imgCount = (md.match(/<img /g) ?? []).length;
+        assert.strictEqual(imgCount, 1);
+        assert.match(md, /title="Squircle · Themed dark"/);
+    });
+
+    it("emits a placeholder when no images are available at all", () => {
+        const md = buildResourceVariantHoverMarkdown({
+            resource: ADAPTIVE,
+            images: [],
+        });
+        assert.match(md, /No rendered captures available/);
+        assert.doesNotMatch(md, /<img /);
+    });
+});


### PR DESCRIPTION
`resources.json` already carries every adaptive-icon capture (FULL_COLOR /
THEMED_LIGHT / THEMED_DARK / LEGACY) plus density/qualifier vector variants,
but the AndroidManifest CodeLens only linked the first one. Add a hover
provider over icon-bearing attributes that renders an `<img>` grid of every
capture, labelled with shape + style, and bump the CodeLens title to flag
the variant count so users know to look. Extracts the markdown builder to
a pure module so #1418 (activity backlink) and #1419 (Kotlin/layout XML
refs) can reuse it.

Closes #1417.