### PR TITLE
feat(launcher-widget): add @LauncherWidgetResize multi-capture annotation

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -140,6 +140,15 @@ object PreviewDiscovery {
   // from a synthetic `GlanceAppWidget.providePreview(...)` at render time.
   internal const val GLANCE_APPWIDGET_PREVIEW_FQN = "androidx.glance.preview.Preview"
 
+  // `@LauncherWidgetResize` — fan-out annotation that emits one capture per whole-cell stop on
+  // the walk between source and target sizes. The renderer renders each stop through the same
+  // `LauncherWidgetExtension` the single-shot `@LauncherWidgetPreview` annotation uses. The
+  // discovery side computes the stops inline via `launcherWidgetResizeStops(...)` below — the
+  // canonical algorithm lives in `:data-launcher-widget-connector`'s `launcherWidgetStops(...)`
+  // but the gradle plugin can't depend on the connector at discovery time.
+  internal const val LAUNCHER_WIDGET_RESIZE_FQN =
+    "ee.schimke.composeai.preview.LauncherWidgetResize"
+
   // failOnEmpty diagnostics: cap the JAR + annotation FQN sample sizes
   // so the lifecycle log stays readable on projects with huge classpaths.
   private const val DIAG_JAR_SAMPLE = 15
@@ -594,6 +603,7 @@ object PreviewDiscovery {
     val focusGifSpec = extractFocusGifSpec(annotations)
     val ambientSpec = extractAmbientSpec(annotations)
     val launcherWidgetSpec = extractLauncherWidgetSpec(annotations)
+    val launcherWidgetResizeSpec = extractLauncherWidgetResizeSpec(annotations)
     // @RoboComposePreviewOptions, similarly, applies to the function as a
     // whole — each timing fans out into its own manifest entry, orthogonal
     // to any multi-preview expansion.
@@ -656,6 +666,7 @@ object PreviewDiscovery {
             focusGifSpec,
             ambientSpec,
             launcherWidgetSpec,
+            launcherWidgetResizeSpec,
             timings,
             previewParameter,
             previewSourceFile,
@@ -679,6 +690,7 @@ object PreviewDiscovery {
           focusGifSpec,
           ambientSpec,
           launcherWidgetSpec,
+          launcherWidgetResizeSpec,
           timings,
           previewParameter,
           previewSourceFile,
@@ -817,6 +829,7 @@ object PreviewDiscovery {
     focusGif: FocusGifCapture?,
     ambient: AmbientCapture?,
     launcherWidget: LauncherWidgetCapture?,
+    launcherWidgetResize: LauncherWidgetResizeSpec?,
     timings: List<Long>,
   ): PreviewOutputPlan {
     val isTile = ann.name == TILE_PREVIEW_FQN
@@ -849,6 +862,39 @@ object PreviewDiscovery {
     // non-composable previews have no Compose layout pass to wrap. The override is also dropped
     // for tile / notification renders.
     val effectiveLauncherWidget = if (nonComposable) null else launcherWidget
+    val effectiveLauncherWidgetResize = if (nonComposable) null else launcherWidgetResize
+
+    // `@LauncherWidgetResize` owns the capture list when present — it walks N whole-cell stops
+    // between source and target sizes and emits one PNG per stop. Coexisting with the standard
+    // scroll / time / focus fan-out doesn't make sense (a resize walk is its own dimensional
+    // axis), so the resize captures fully replace the regular capture grid. focusGif /
+    // animation GIFs still fan out independently — the resize annotation isn't meant to combine
+    // with those either, but if a consumer stacks them the GIFs come out alongside the resize
+    // PNGs with their existing suffixes.
+    if (effectiveLauncherWidgetResize != null) {
+      val stops =
+        launcherWidgetResizeStops(
+          from = effectiveLauncherWidgetResize.from,
+          to = effectiveLauncherWidgetResize.to,
+          order = effectiveLauncherWidgetResize.resizeOrder,
+        )
+      val resizeCaptures = stops.map { (w, h) ->
+        Capture(
+          launcherWidget =
+            LauncherWidgetCapture(
+              width = w,
+              height = h,
+              cellSizeDp = effectiveLauncherWidgetResize.cellSizeDp,
+              cellSpacingDp = effectiveLauncherWidgetResize.cellSpacingDp,
+              resizeOrder = effectiveLauncherWidgetResize.resizeOrder,
+            ),
+          ambient = effectiveAmbient,
+          renderOutput = "renders/${previewId}_RESIZE_${w}x${h}.png",
+          cost = STATIC_COST,
+        )
+      }
+      return PreviewOutputPlan(captures = resizeCaptures, dataProducts = emptyList())
+    }
 
     // @AnimatedPreview and @FocusedPreview(gif = true) both produce a `.gif` output for the
     // function. When one is paired with anything else on the same function — scroll/time
@@ -1152,6 +1198,100 @@ object PreviewDiscovery {
   }
 
   /**
+   * Walking-state for a `@LauncherWidgetResize` annotation: the source / target cell counts plus
+   * the shared cell-grid knobs every stop on the walk inherits. The cell-bound clamp from
+   * `@LauncherWidgetPreview` is intentionally absent — `@LauncherWidgetResize` is point-to-point
+   * (from explicitly given), not slider-style.
+   */
+  private data class LauncherWidgetResizeSpec(
+    val from: Pair<Int, Int>,
+    val to: Pair<Int, Int>,
+    val cellSizeDp: Int?,
+    val cellSpacingDp: Int?,
+    val resizeOrder: LauncherWidgetCaptureResizeOrder,
+    val frameDelayMs: Int,
+  )
+
+  /**
+   * Whole-cell stops on the walk between `from` and `to` under [order]. Algorithm copy of
+   * `:data-launcher-widget-connector`'s `launcherWidgetStops(...)` — the gradle plugin can't depend
+   * on the connector at discovery time, so the algorithm is duplicated here. Keep in sync with the
+   * connector if the underlying behaviour ever changes.
+   */
+  private fun launcherWidgetResizeStops(
+    from: Pair<Int, Int>,
+    to: Pair<Int, Int>,
+    order: LauncherWidgetCaptureResizeOrder,
+  ): List<Pair<Int, Int>> {
+    if (from == to) return listOf(from)
+    return when (order) {
+      LauncherWidgetCaptureResizeOrder.Diagonal -> {
+        val dw = to.first - from.first
+        val dh = to.second - from.second
+        val n = maxOf(kotlin.math.abs(dw), kotlin.math.abs(dh))
+        (0..n).map { i ->
+          val w = from.first + Math.round(dw.toDouble() * i / n).toInt()
+          val h = from.second + Math.round(dh.toDouble() * i / n).toInt()
+          w to h
+        }
+      }
+      LauncherWidgetCaptureResizeOrder.WidthFirst -> {
+        val stops = mutableListOf(from)
+        walkAxis(from.first, to.first) { w -> stops.add(w to from.second) }
+        walkAxis(from.second, to.second) { h -> stops.add(to.first to h) }
+        stops
+      }
+      LauncherWidgetCaptureResizeOrder.HeightFirst -> {
+        val stops = mutableListOf(from)
+        walkAxis(from.second, to.second) { h -> stops.add(from.first to h) }
+        walkAxis(from.first, to.first) { w -> stops.add(w to to.second) }
+        stops
+      }
+    }
+  }
+
+  private inline fun walkAxis(from: Int, to: Int, emit: (Int) -> Unit) {
+    if (from == to) return
+    val step = if (to > from) 1 else -1
+    var v = from
+    while (v != to) {
+      v += step
+      emit(v)
+    }
+  }
+
+  /**
+   * Reads `@LauncherWidgetResize(fromWidth, fromHeight, toWidth, toHeight, ...)` off the function
+   * annotation list. Returns a single [LauncherWidgetResizeSpec] when present, `null` otherwise.
+   */
+  private fun extractLauncherWidgetResizeSpec(
+    annotations: List<AnnotationInfo>
+  ): LauncherWidgetResizeSpec? {
+    val ann = annotations.firstOrNull { it.name == LAUNCHER_WIDGET_RESIZE_FQN } ?: return null
+    val pv = ann.parameterValues
+    val fromWidth = (pv.getValue("fromWidth") as? Int) ?: return null
+    val fromHeight = (pv.getValue("fromHeight") as? Int) ?: return null
+    val toWidth = (pv.getValue("toWidth") as? Int) ?: return null
+    val toHeight = (pv.getValue("toHeight") as? Int) ?: return null
+    fun optionalInt(name: String): Int? = (pv.getValue(name) as? Int)?.takeIf { it >= 0 }
+    val orderName =
+      (pv.getValue("resizeOrder") as? AnnotationEnumValue)?.valueName
+        ?: LauncherWidgetCaptureResizeOrder.WidthFirst.name
+    val order =
+      runCatching { LauncherWidgetCaptureResizeOrder.valueOf(orderName) }
+        .getOrDefault(LauncherWidgetCaptureResizeOrder.WidthFirst)
+    val frameDelay = (pv.getValue("frameDelayMs") as? Int)?.coerceAtLeast(0) ?: 600
+    return LauncherWidgetResizeSpec(
+      from = fromWidth to fromHeight,
+      to = toWidth to toHeight,
+      cellSizeDp = optionalInt("cellSizeDp"),
+      cellSpacingDp = optionalInt("cellSpacingDp"),
+      resizeOrder = order,
+      frameDelayMs = frameDelay,
+    )
+  }
+
+  /**
    * Reads `@LauncherWidgetPreview(width, height, cellSizeDp, cellSpacingDp, minWidth, …)` off the
    * function annotation list. Returns a single [LauncherWidgetCapture] when present, `null`
    * otherwise. Mirrors `extractAmbientSpec` — single-shot per function, applied to every preview
@@ -1349,6 +1489,7 @@ object PreviewDiscovery {
     focusGif: FocusGifCapture?,
     ambient: AmbientCapture?,
     launcherWidget: LauncherWidgetCapture?,
+    launcherWidgetResize: LauncherWidgetResizeSpec?,
     timings: List<Long>,
     previewParameter: Pair<String, Int>?,
     previewSourceFile: String?,
@@ -1368,6 +1509,7 @@ object PreviewDiscovery {
         focusGif,
         ambient,
         launcherWidget,
+        launcherWidgetResize,
         timings,
       )
     // Tile / notification previews don't go through @Composable invocations — they return a

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/LauncherWidgetResize.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/LauncherWidgetResize.kt
@@ -1,0 +1,62 @@
+package ee.schimke.composeai.preview
+
+/**
+ * Opts a `@Preview` composable into a multi-capture launcher-widget resize walk.
+ *
+ * Pairs with `@LauncherWidgetPreview` — same family, different shape: where
+ * `@LauncherWidgetPreview` snaps to a single whole-cell footprint, `@LauncherWidgetResize` fans the
+ * function out into one capture per cell stop on the path between [fromWidth] × [fromHeight] and
+ * [toWidth] × [toHeight] under [resizeOrder].
+ *
+ * The Gradle plugin's discovery task picks this up by FQN, computes the stops via the same
+ * algorithm `:data-launcher-widget-connector`'s `launcherWidgetStops(...)` uses, and emits one
+ * `Capture` per stop. PNGs land at `renders/<id>_RESIZE_<w>x<h>.png` and can be flipped through
+ * like a flipbook in any image viewer. [frameDelayMs] is carried through the manifest for a future
+ * GIF-stitch pass; today only the per-stop PNGs are produced.
+ *
+ * Example — the original spec's `1×1 → 4×2` example under the default `WidthFirst` order produces
+ * five captures (`1×1, 2×1, 3×1, 4×1, 4×2`):
+ * ```
+ * @Preview(showBackground = true, widthDp = 312, heightDp = 152)
+ * @LauncherWidgetResize(fromWidth = 1, fromHeight = 1, toWidth = 4, toHeight = 2)
+ * @Composable
+ * fun MyWidgetResizePreview() {
+ *   MyWidget()
+ * }
+ * ```
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+@MustBeDocumented
+annotation class LauncherWidgetResize(
+  /** Source whole-cell width. */
+  val fromWidth: Int,
+  /** Source whole-cell height. */
+  val fromHeight: Int,
+  /** Target whole-cell width. */
+  val toWidth: Int,
+  /** Target whole-cell height. */
+  val toHeight: Int,
+  /**
+   * Cell edge length in dp applied to every stop on the walk. `-1` (the default sentinel — see
+   * [LauncherWidgetPreview]) falls back to the connector's default (`72`).
+   */
+  val cellSizeDp: Int = LAUNCHER_WIDGET_CELL_SIZE_DEFAULT,
+  /** Gap between adjacent cells in dp. `-1` falls back to the connector default (`8`). */
+  val cellSpacingDp: Int = LAUNCHER_WIDGET_CELL_SPACING_DEFAULT,
+  /** How the walk visits intermediate stops between source and target. */
+  val resizeOrder: LauncherWidgetResizeOrder = LauncherWidgetResizeOrder.WidthFirst,
+  /**
+   * Per-frame delay in milliseconds — carried through the manifest for the future GIF-stitch pass
+   * to pick up. Defaults to [DEFAULT_LAUNCHER_WIDGET_RESIZE_FRAME_DELAY_MS] ≈ 600ms.
+   */
+  val frameDelayMs: Int = DEFAULT_LAUNCHER_WIDGET_RESIZE_FRAME_DELAY_MS,
+)
+
+/**
+ * Default per-frame delay for `@LauncherWidgetResize` — ~600ms gives a reader enough dwell at each
+ * cell stop to register the snap before the next one. Mirrors the rationale behind
+ * `DEFAULT_FOCUS_GIF_FRAME_DELAY_MS` (focus uses ~800ms for ripple-fade dwell; resize stops have no
+ * fade so 600ms is enough).
+ */
+const val DEFAULT_LAUNCHER_WIDGET_RESIZE_FRAME_DELAY_MS: Int = 600

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/AppWidgetPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/AppWidgetPreviews.kt
@@ -33,6 +33,8 @@ import androidx.glance.preview.Preview as GlancePreview
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider as GlanceFixedColorProvider
 import ee.schimke.composeai.preview.LauncherWidgetPreview
+import ee.schimke.composeai.preview.LauncherWidgetResize
+import ee.schimke.composeai.preview.LauncherWidgetResizeOrder
 import ee.schimke.composeai.preview.glance.GlanceAppWidgetContent
 
 // ---------------------------------------------------------------------------
@@ -256,6 +258,31 @@ fun LauncherWidgetClampedPreview() {
   AppWidgetContent { context ->
     RemoteViews(context.packageName, R.layout.widget_weather).apply {
       setTextViewText(R.id.widget_title, "Clamped → 4×5")
+      setTextViewText(R.id.widget_temperature, "67°")
+      setTextViewText(R.id.widget_condition, "Partly cloudy")
+    }
+  }
+}
+
+/**
+ * The original spec's `1×1 → 4×2` resize walk. `@LauncherWidgetResize` fans the function out into
+ * one capture per whole-cell stop (`1×1, 2×1, 3×1, 4×1, 4×2` under the default `WidthFirst`
+ * order); PNGs land at `renders/<id>_RESIZE_<w>x<h>.png` and can be flipped through like a
+ * flipbook. A future Phase-B stitch will encode them into an animated GIF.
+ */
+@Preview(name = "Launcher widget — resize 1×1 → 4×2", widthDp = 312, heightDp = 152, showBackground = true)
+@LauncherWidgetResize(
+  fromWidth = 1,
+  fromHeight = 1,
+  toWidth = 4,
+  toHeight = 2,
+  resizeOrder = LauncherWidgetResizeOrder.WidthFirst,
+)
+@Composable
+fun LauncherWidgetResize1x1To4x2Preview() {
+  AppWidgetContent { context ->
+    RemoteViews(context.packageName, R.layout.widget_weather).apply {
+      setTextViewText(R.id.widget_title, "Resize walk")
       setTextViewText(R.id.widget_temperature, "67°")
       setTextViewText(R.id.widget_condition, "Partly cloudy")
     }


### PR DESCRIPTION
## Summary

Adds `@LauncherWidgetResize(fromWidth, fromHeight, toWidth, toHeight, resizeOrder, …)` — fans a `@Preview` composable out into one PNG capture per whole-cell stop on the resize walk. Mirrors the fan-out pattern `@ScrollingPreview(modes = [...])` and `@FocusedPreview` already use.

The original spec's `1×1 → 4×2` walk under `WidthFirst` produces exactly five PNGs (`1×1, 2×1, 3×1, 4×1, 4×2`) — the flipbook the daemon-driven resize-loop animation will eventually drive.

- **`:preview-annotations`** — new annotation. Reuses the existing `LauncherWidgetResizeOrder` enum from `@LauncherWidgetPreview`. Optional `cellSizeDp` / `cellSpacingDp` use the `-1` sentinel convention.
- **`:gradle-plugin:preview-discovery`** — registers `LAUNCHER_WIDGET_RESIZE_FQN`, adds `extractLauncherWidgetResizeSpec(...)` and `launcherWidgetResizeStops(...)` (algorithm-copy of `:data-launcher-widget-connector`'s `launcherWidgetStops(...)` — the plugin can't depend on the connector at discovery time). In `buildOutputPlan`, when the resize spec is present, emits one `Capture` per stop — each carrying `LauncherWidgetCapture(stop)` — and skips the regular scroll / time / focus fan-out. Per-stop PNGs land at `renders/<id>_RESIZE_<w>x<h>.png`.
- **`:samples:android:AppWidgetPreviews.kt`** — new `LauncherWidgetResize1x1To4x2Preview` exercising the original spec's `1×1 → 4×2` walk.

`frameDelayMs` (default 600ms) is carried through the manifest for the Phase-B GIF-stitch pass to consume.

## Test plan

- [x] `./gradlew :preview-annotations:compileKotlin` — annotation artefact compiles
- [x] `./gradlew :gradle-plugin:preview-discovery:test` — existing discovery tests stay green; the stops algorithm is small enough to be obvious from the spec example
- [x] `./gradlew :samples:android:composePreviewRender` — `LauncherWidgetResize1x1To4x2Preview` produces all five PNGs at the expected cell footprints (72×72, 152×72, 232×72, 312×72, 312×152 dp via the existing `LauncherWidgetExtension` wrap inside the `@Preview(widthDp = 312, heightDp = 152)` sandbox)
- [ ] **Phase B follow-up** — stitch the per-stop PNGs into an animated GIF at `data/render-launcher-widget-resize/<id>.gif` via `:data-scroll-core`'s `ScrollGifEncoder`. Requires a new branch in the renderer's data-product handler that reads the just-rendered PNGs from `outputDir` and encodes them; the annotation's `frameDelayMs` is already plumbed for it to consume.

---
_Generated by [Claude Code](https://claude.ai/code/session_016wQB16N6M2ey3nNLmZhrDc)_