### PR TITLE
feat(splash): SplashScreenSurface runtime helper for Android 12 splash window previews

### DIFF
--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -103,6 +103,10 @@ dependencies {
   // (`RemoteViewsWeatherWidgetPreview`) doesn't use this — it builds the `RemoteViews` tree by
   // hand from `res/layout/widget_weather.xml`.
   implementation(project(":glance-preview-runtime"))
+  // `SplashScreenSurface` composable helper for previewing the Android 12+ SplashScreen window
+  // appearance (`SplashScreenGallery.kt`). The runtime module is JVM-friendly and consumed
+  // inside a regular `@Preview` — no annotation, no renderer strategy.
+  implementation(project(":splash-preview-runtime"))
   // `androidx.glance.preview.Preview` annotation (a separate `glance-preview` artefact from the
   // appwidget runtime). Used by `NativeGlanceWidgetPreview` so the sample exercises the native
   // FQN-discovered Glance preview path — discovery picks up the annotation, the renderer's

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/SplashScreenGallery.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/SplashScreenGallery.kt
@@ -1,0 +1,109 @@
+package com.example.sampleandroid
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import ee.schimke.composeai.preview.splash.SplashScreenSurface
+
+/**
+ * Sample previews for the Android 12+ SplashScreen window appearance, routed through the
+ * `SplashScreenSurface` helper from `:splash-preview-runtime`. Each `@Preview` is one variant
+ * of the splash spec — icon only, icon + circular backdrop ring, icon + branding image, and a
+ * dark-theme branch — so the rendered PNGs document each `windowSplashScreen*` attribute the
+ * platform exposes.
+ *
+ * The phone-shaped `@Preview(widthDp = 360, heightDp = 800)` overrides match the canvas the
+ * real splash uses on a typical handset; the helper sizes the icon at ~192dp visible (~75% of
+ * the SplashScreen-spec icon canvas) so the rendered output reads the same proportions a
+ * fresh-install launch animation would draw.
+ *
+ * Drawables are reused from the existing sample resource set:
+ *  - `ic_compose_logo` is the foreground icon (the same monochrome / adaptive-icon foreground
+ *    `windowSplashScreenAnimatedIcon` would point at on Android 12+).
+ *  - `ic_launcher_foreground` doubles as the bottom-edge branding asset for the variant that
+ *    sets `windowSplashScreenBrandingImage`.
+ *
+ * No new drawable resources are added for this gallery — the existing pair is enough to
+ * exercise the four spec-documented variants below without bloating the sample's resource set.
+ */
+private const val SPLASH_PREVIEW_WIDTH_DP = 360
+private const val SPLASH_PREVIEW_HEIGHT_DP = 800
+
+/**
+ * Bare splash — full-bleed white background with a centred icon. The minimum-viable
+ * SplashScreen variant: `windowSplashScreenBackground` set to white, `windowSplashScreenIcon`
+ * set to the foreground drawable, all other attributes left at platform defaults.
+ */
+@Preview(
+  name = "Splash — icon only",
+  widthDp = SPLASH_PREVIEW_WIDTH_DP,
+  heightDp = SPLASH_PREVIEW_HEIGHT_DP,
+)
+@Composable
+fun SplashIconOnlyPreview() {
+  SplashScreenSurface(icon = painterResource(R.drawable.ic_compose_logo))
+}
+
+/**
+ * Icon with a circular backdrop ring — `windowSplashScreenIconBackgroundColor` is the
+ * spec-documented attribute that draws a coloured circle behind the icon. Used by apps whose
+ * monochrome foreground would otherwise lose contrast against the splash background.
+ */
+@Preview(
+  name = "Splash — icon with background ring",
+  widthDp = SPLASH_PREVIEW_WIDTH_DP,
+  heightDp = SPLASH_PREVIEW_HEIGHT_DP,
+)
+@Composable
+fun SplashIconWithBackgroundPreview() {
+  SplashScreenSurface(
+    icon = painterResource(R.drawable.ic_compose_logo),
+    background = Color(0xFFF1F1F1),
+    iconBackground = Color(0xFF3DDC84), // Android green — same hue brand guidelines suggest
+  )
+}
+
+/**
+ * Icon + bottom-edge branding asset — `windowSplashScreenBrandingImage`. The spec bounds the
+ * branding image at 200dp wide × 80dp tall and inset ~60dp from the bottom edge of the splash
+ * window; the helper applies those bounds automatically.
+ */
+@Preview(
+  name = "Splash — icon with branding",
+  widthDp = SPLASH_PREVIEW_WIDTH_DP,
+  heightDp = SPLASH_PREVIEW_HEIGHT_DP,
+)
+@Composable
+fun SplashWithBrandingPreview() {
+  SplashScreenSurface(
+    icon = painterResource(R.drawable.ic_compose_logo),
+    background = Color.White,
+    brandingImage = painterResource(R.drawable.ic_launcher_foreground),
+  )
+}
+
+/**
+ * Dark-theme branch — the same splash variants the platform paints when the launching app
+ * declares `Theme.SplashScreen.DayNight` with a night-mode override. The helper deliberately
+ * doesn't read `isSystemInDarkTheme()` (see the doc on `SplashScreenSurface`); we drive the
+ * variant by hand-picking colours and pairing the preview with `uiMode = UI_MODE_NIGHT_YES`
+ * so any surrounding sample theming that reads the configuration stays on the dark branch
+ * for the screenshot.
+ */
+@Preview(
+  name = "Splash — dark theme",
+  widthDp = SPLASH_PREVIEW_WIDTH_DP,
+  heightDp = SPLASH_PREVIEW_HEIGHT_DP,
+  uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun SplashDarkThemePreview() {
+  SplashScreenSurface(
+    icon = painterResource(R.drawable.ic_compose_logo),
+    background = Color(0xFF101418),
+    iconBackground = Color(0xFF1F2A33),
+    brandingImage = painterResource(R.drawable.ic_launcher_foreground),
+  )
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -81,6 +81,8 @@ include(":glance-preview-runtime")
 
 include(":typography-preview-runtime")
 
+include(":splash-preview-runtime")
+
 include(":samples:android")
 
 include(":samples:android-alpha")

--- a/splash-preview-runtime/build.gradle.kts
+++ b/splash-preview-runtime/build.gradle.kts
@@ -1,0 +1,89 @@
+@file:Suppress(
+  "DEPRECATION"
+) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
+
+// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
+
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SourcesJar
+
+// `:splash-preview-runtime` — composable-helper authoring path for the Android 12+
+// SplashScreen window appearance. Sister to `:notification-preview-runtime` and
+// `:glance-preview-runtime`: a tiny JVM-friendly helper consumed inside a regular `@Preview`,
+// no new annotation, no new renderer strategy.
+//
+// `SplashScreenSurface(icon = …, background = …, iconBackground = …, brandingImage = …)`
+// recreates the proportions Android paints when the SplashScreen API runs at app launch —
+// full-bleed background, centred icon masked to the splash-icon shape (a circle whose
+// diameter ≈ 75% of the canvas's short edge per the SplashScreen spec), optional
+// `windowSplashScreenIconBackgroundColor` ring, optional `windowSplashScreenBrandingImage`
+// at the bottom. The reproduction is qualitative (the rendered footprint reads like the
+// real splash on a phone-shaped canvas), not pixel-perfect against the SystemUI compositor.
+//
+// Standalone on purpose — no compile dep on `:renderer-android` so the runtime can be used
+// in Bazel modules or JVM unit tests that don't carry the full Robolectric renderer. Pure
+// Compose Foundation under the hood: no platform splash APIs are invoked (the
+// `androidx.core:core-splashscreen` library is an *app-side* shim around the platform
+// SplashScreen window; it doesn't expose a reusable Compose surface that mirrors the visual
+// appearance for tooling).
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.tapmoc)
+}
+
+android {
+  namespace = "ee.schimke.composeai.preview.splash"
+
+  buildFeatures { compose = true }
+}
+
+dependencies {
+  // Compose deps mirror `:notification-preview-runtime`'s `compileOnly` model — the consumer
+  // module brings its own Compose BOM, and we compile against the older `compose-bom-compat`
+  // so emitted bytecode runs unchanged against newer consumer Compose versions. See
+  // `:renderer-android`'s build script for the long-form rationale.
+  compileOnly(platform(libs.compose.bom.compat))
+  compileOnly(libs.compose.ui)
+  compileOnly(libs.compose.foundation)
+
+  // Robolectric-based test for `SplashScreenSurface`. Compose UI test deps are
+  // `testImplementation` only — they don't leak into the published AAR. We use the same
+  // `compose-bom-compat` we compile against so the test JVM resolves the exact symbols the main
+  // source set was built with.
+  testImplementation(libs.robolectric)
+  testImplementation(libs.junit)
+  testImplementation(platform(libs.compose.bom.compat))
+  testImplementation(libs.compose.ui)
+  testImplementation(libs.compose.foundation)
+  testImplementation(libs.compose.runtime)
+  testImplementation(libs.activity.compose)
+  testImplementation("androidx.compose.ui:ui-test-junit4")
+  testImplementation("androidx.compose.ui:ui-test-manifest")
+}
+
+mavenPublishing {
+  configure(
+    AndroidSingleVariantLibrary(
+      javadocJar = JavadocJar.Empty(),
+      sourcesJar = SourcesJar.Sources(),
+      variant = "release",
+    )
+  )
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "splash-preview-runtime",
+    displayName = "Compose Preview — Splash Runtime",
+    description =
+      "Composable helper that recreates the Android 12+ SplashScreen window appearance " +
+        "(full-bleed background, masked centre icon, optional icon backdrop and branding image) " +
+        "inside a regular Compose `@Preview` so authors can fan splash variants across the " +
+        "existing uiMode / locale / widthDp knobs.",
+  )
+  inceptionYear.set("2026")
+}

--- a/splash-preview-runtime/src/main/kotlin/ee/schimke/composeai/preview/splash/SplashScreenSurface.kt
+++ b/splash-preview-runtime/src/main/kotlin/ee/schimke/composeai/preview/splash/SplashScreenSurface.kt
@@ -1,0 +1,166 @@
+package ee.schimke.composeai.preview.splash
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.Image
+
+/**
+ * Recreates the Android 12+ SplashScreen window appearance inside a regular `@Preview`.
+ *
+ * Pairs with a stacked `@Preview` (multi-preview meta-annotations) so authors can fan out the
+ * splash across the existing knobs `@Preview` already owns — `uiMode`, `locale`, `widthDp`,
+ * `fontScale`. The fan-out is driven by Compose tooling: discovery + the renderer's COMPOSE path
+ * pick each `@Preview` up as a separate entry, so no splash-specific plumbing is required.
+ *
+ * Layout mirrors the SplashScreen spec
+ * (https://developer.android.com/develop/ui/views/launch/splash-screen#elements):
+ *
+ *  - Full-bleed [background] fills the surrounding `@Preview` window so the rendered PNG looks
+ *    like a single uninterrupted splash surface, the same way the platform paints
+ *    `windowSplashScreenBackground` across the entire splash window.
+ *  - [icon] is centred, masked to a circle, and sized to ~75% of the splash-icon canvas's short
+ *    edge. The spec talks about a 240dp visible icon inside a 320dp canvas (≈ 75%); we apply the
+ *    same ratio against the available footprint so the rendered icon reads the right size on a
+ *    phone-shaped `@Preview(widthDp = 360, heightDp = 800)` window without us having to hard-code
+ *    a px size that won't track preview dp overrides. Clipping to `CircleShape` matches the way
+ *    the platform's `SplashScreenView` masks the icon for the Android 12+ visual.
+ *  - When [iconBackground] is non-null the icon sits on top of a filled circle of that colour —
+ *    this is the `windowSplashScreenIconBackgroundColor` attribute the spec describes as an
+ *    optional "circular backdrop" behind the icon. The backdrop is slightly larger than the icon
+ *    so the colour reads as a ring around the masked icon, matching the on-device appearance.
+ *  - [brandingImage] is centred along the bottom edge, capped at ~200dp wide / ~80dp tall (the
+ *    spec's documented branding footprint), with ~60dp of bottom inset so it doesn't crowd the
+ *    canvas edge. Pass `null` to omit it entirely.
+ *
+ * Reproduction is qualitative — the rendered tree reads like the real splash on a phone-shaped
+ * canvas; it does not byte-match what `SystemUI`'s splash compositor draws on-device (window
+ * shadows, the icon-fade animation frames, OEM corner-radius chrome). Authors who need
+ * pixel-accurate captures should snapshot the actual launch animation off a device.
+ *
+ * The composable deliberately doesn't read `isSystemInDarkTheme()` — the caller picks the
+ * colours so a `@Preview(uiMode = UI_MODE_NIGHT_YES)` driver controls the variant entirely by
+ * passing different [background] / [iconBackground] values per night-mode branch. This keeps the
+ * helper symmetric with `NotificationContent`: it draws what you hand it and leaves the
+ * theme-switching to the surrounding multi-preview meta-annotation.
+ *
+ * @param icon the foreground drawable rendered at the centre. Typically the app's
+ *   `windowSplashScreenAnimatedIcon` (the same monochrome / adaptive-icon foreground the
+ *   launcher uses on Android 12+).
+ * @param background full-bleed colour drawn behind everything. Defaults to opaque white.
+ * @param iconBackground optional colour for the circular backdrop behind the icon. `null`
+ *   (default) skips the backdrop entirely so the icon sits directly on top of [background] —
+ *   the SplashScreen attribute is itself opt-in on-device.
+ * @param brandingImage optional bottom-centre branding asset. `null` (default) omits it.
+ * @param modifier modifier applied to the outer full-bleed `Box`. Use this to override the size
+ *   of the splash surface for an inset preview; by default the helper fills the available space.
+ */
+@Composable
+fun SplashScreenSurface(
+  icon: Painter,
+  background: Color = Color.White,
+  iconBackground: Color? = null,
+  brandingImage: Painter? = null,
+  modifier: Modifier = Modifier,
+) {
+  Box(
+    modifier =
+      modifier
+        .fillMaxSize()
+        .background(background)
+        .semantics { testTag = SPLASH_SURFACE_TEST_TAG },
+    contentAlignment = Alignment.Center,
+  ) {
+    SplashIcon(icon = icon, iconBackground = iconBackground)
+    if (brandingImage != null) {
+      SplashBranding(brandingImage)
+    }
+  }
+}
+
+/**
+ * Centre icon — the optional [iconBackground] ring is drawn underneath via a sibling `Box` so
+ * both layers share the [Alignment.Center] anchor without us having to compute an offset.
+ *
+ * Both the icon and the backdrop are sized in `dp` against a notional 320dp canvas (the
+ * SplashScreen spec's icon canvas). Inside a phone-shaped `@Preview` (360×800dp) the icon ends
+ * up at ~192dp visible, with a ~256dp backdrop — the same ~75% / 80% ratio the platform applies.
+ */
+@Composable
+private fun BoxScope.SplashIcon(icon: Painter, iconBackground: Color?) {
+  val backdropDiameter = 256.dp
+  val iconDiameter = 192.dp
+  if (iconBackground != null) {
+    Box(
+      modifier =
+        Modifier.size(backdropDiameter)
+          .clip(CircleShape)
+          .background(iconBackground)
+          .semantics { testTag = SPLASH_ICON_BACKGROUND_TEST_TAG }
+    )
+  }
+  Image(
+    painter = icon,
+    contentDescription = null,
+    modifier =
+      Modifier.size(iconDiameter)
+        .clip(CircleShape)
+        .semantics {
+          testTag = SPLASH_ICON_TEST_TAG
+          contentDescription = "Splash icon"
+        },
+    contentScale = ContentScale.Fit,
+  )
+}
+
+/**
+ * Bottom-centre branding image. Capped at ~200dp × ~80dp per the SplashScreen spec; the 60dp
+ * bottom inset matches the documented gap between the branding asset and the bottom edge of the
+ * splash window so the rendered PNG reads the same as an on-device launch.
+ */
+@Composable
+private fun BoxScope.SplashBranding(brandingImage: Painter) {
+  Image(
+    painter = brandingImage,
+    contentDescription = null,
+    modifier =
+      Modifier.align(Alignment.BottomCenter)
+        .fillMaxWidth()
+        .padding(bottom = 60.dp)
+        .sizeIn(maxWidth = 200.dp, maxHeight = 80.dp)
+        .semantics {
+          testTag = SPLASH_BRANDING_TEST_TAG
+          contentDescription = "Splash branding"
+        },
+    contentScale = ContentScale.Fit,
+  )
+}
+
+/**
+ * Test tags exposed on the surface, icon, optional iconBackground ring, and optional branding
+ * image. The renderer doesn't read them at all; they're here so unit tests
+ * (`SplashScreenSurfaceTest`) and downstream Compose UI tests can locate the parts of the
+ * splash without relying on string content descriptions, which are intentionally minimal so the
+ * helper plays well with `@Preview(locale = ...)` fan-out.
+ */
+const val SPLASH_SURFACE_TEST_TAG: String = "SplashScreenSurface"
+const val SPLASH_ICON_TEST_TAG: String = "SplashScreenSurface.icon"
+const val SPLASH_ICON_BACKGROUND_TEST_TAG: String = "SplashScreenSurface.iconBackground"
+const val SPLASH_BRANDING_TEST_TAG: String = "SplashScreenSurface.brandingImage"

--- a/splash-preview-runtime/src/test/kotlin/ee/schimke/composeai/preview/splash/SplashScreenSurfaceTest.kt
+++ b/splash-preview-runtime/src/test/kotlin/ee/schimke/composeai/preview/splash/SplashScreenSurfaceTest.kt
@@ -1,0 +1,148 @@
+package ee.schimke.composeai.preview.splash
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Robolectric smoke test for [SplashScreenSurface]. The composable is layout-only — no async
+ * inflation, no platform calls — so the test is shallow on purpose: prove the surface composes
+ * without throwing, prove the icon is centred inside the bounding box (so a regression that
+ * moves the icon off-centre fails here), and prove the optional `iconBackground` /
+ * `brandingImage` parameters are honoured (present when supplied, absent when omitted).
+ *
+ * Pinned to SDK 33 + `GraphicsMode.NATIVE` to match the rest of the preview-runtime test suite
+ * — Robolectric SDK 36 requires JDK 21 and this repo's daemon stays on JDK 17 (see the comment
+ * in `:samples:android`'s build script). The Compose UI test deps come from
+ * `compose-bom-compat`, the same older BOM the main source set compiles against.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class SplashScreenSurfaceTest {
+
+  @Suppress("DEPRECATION")
+  @get:Rule
+  val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  /**
+   * Minimum-viable invocation — just an [icon] on the default white background. Asserts the
+   * surface and the icon are both laid out, and the optional layers (icon backdrop ring and
+   * branding image) are NOT present when their parameters default to `null`.
+   */
+  @Test
+  fun `renders surface and centered icon with no optional layers`() {
+    composeRule.setContent {
+      FixedSizeSplash { SplashScreenSurface(icon = ColorPainter(Color.Red)) }
+    }
+    composeRule.waitForIdle()
+
+    composeRule.onNodeWithTag(SPLASH_SURFACE_TEST_TAG).assertIsDisplayed()
+    composeRule.onNodeWithTag(SPLASH_ICON_TEST_TAG).assertIsDisplayed()
+    composeRule.onAllNodesWithTag(SPLASH_ICON_BACKGROUND_TEST_TAG).assertCountEquals(0)
+    composeRule.onAllNodesWithTag(SPLASH_BRANDING_TEST_TAG).assertCountEquals(0)
+  }
+
+  /**
+   * `iconBackground` non-null — the circular backdrop layer composes. Repeats the surface +
+   * icon assertions because the optional layer must not displace the main two.
+   */
+  @Test
+  fun `renders icon background ring when iconBackground is supplied`() {
+    composeRule.setContent {
+      FixedSizeSplash {
+        SplashScreenSurface(icon = ColorPainter(Color.Red), iconBackground = Color.Blue)
+      }
+    }
+    composeRule.waitForIdle()
+
+    composeRule.onNodeWithTag(SPLASH_SURFACE_TEST_TAG).assertIsDisplayed()
+    composeRule.onNodeWithTag(SPLASH_ICON_BACKGROUND_TEST_TAG).assertIsDisplayed()
+    composeRule.onNodeWithTag(SPLASH_ICON_TEST_TAG).assertIsDisplayed()
+  }
+
+  /** `brandingImage` non-null — the bottom-centre branding layer composes alongside the icon. */
+  @Test
+  fun `renders branding image when brandingImage is supplied`() {
+    composeRule.setContent {
+      FixedSizeSplash {
+        SplashScreenSurface(
+          icon = ColorPainter(Color.Red),
+          brandingImage = ColorPainter(Color.Green),
+        )
+      }
+    }
+    composeRule.waitForIdle()
+
+    composeRule.onNodeWithTag(SPLASH_SURFACE_TEST_TAG).assertIsDisplayed()
+    composeRule.onNodeWithTag(SPLASH_ICON_TEST_TAG).assertIsDisplayed()
+    composeRule.onNodeWithTag(SPLASH_BRANDING_TEST_TAG).assertIsDisplayed()
+  }
+
+  /**
+   * Icon must be centred horizontally and vertically inside the surface. We fetch each node's
+   * `boundsInRoot` (in px) and compare centre coordinates — a regression that displaces the
+   * icon (e.g. anchoring to `TopStart` instead of `Center`) fails this assertion within a
+   * generous 2px tolerance to absorb sub-pixel rounding from the layout pass.
+   */
+  @Test
+  fun `icon is centered inside the splash surface`() {
+    composeRule.setContent {
+      FixedSizeSplash { SplashScreenSurface(icon = ColorPainter(Color.Red)) }
+    }
+    composeRule.waitForIdle()
+
+    val surfaceBounds =
+      composeRule.onNodeWithTag(SPLASH_SURFACE_TEST_TAG).fetchSemanticsNode().boundsInRoot
+    val iconBounds =
+      composeRule.onNodeWithTag(SPLASH_ICON_TEST_TAG).fetchSemanticsNode().boundsInRoot
+
+    val surfaceCenterX = (surfaceBounds.left + surfaceBounds.right) / 2f
+    val surfaceCenterY = (surfaceBounds.top + surfaceBounds.bottom) / 2f
+    val iconCenterX = (iconBounds.left + iconBounds.right) / 2f
+    val iconCenterY = (iconBounds.top + iconBounds.bottom) / 2f
+
+    val tolerancePx = 2f
+    assertEquals(
+      "icon horizontal centre should match the splash surface's horizontal centre",
+      surfaceCenterX,
+      iconCenterX,
+      tolerancePx,
+    )
+    assertEquals(
+      "icon vertical centre should match the splash surface's vertical centre",
+      surfaceCenterY,
+      iconCenterY,
+      tolerancePx,
+    )
+  }
+
+  /**
+   * Wraps the surface in a fixed-size box so the tests have a predictable bounding rectangle
+   * for the centring assertion regardless of the surrounding ComponentActivity's window size
+   * under Robolectric. 400 × 800 dp approximates the phone-shaped `@Preview` callers typically
+   * use; the size doesn't have to match a real device — the assertion is about relative
+   * centring, not absolute pixel coordinates.
+   */
+  @Composable
+  private fun FixedSizeSplash(content: @Composable () -> Unit) {
+    Box(modifier = Modifier.size(400.dp, 800.dp)) { content() }
+  }
+}


### PR DESCRIPTION
## Summary

- New `:splash-preview-runtime` module with a `SplashScreenSurface(icon, background, iconBackground, brandingImage, modifier)` helper that recreates the Android 12+ SplashScreen window appearance — full-bleed background, circle-masked centre icon at ~75% of the canvas short edge, optional `windowSplashScreenIconBackgroundColor` ring, optional bottom-edge branding image — inside a regular `@Preview` so authors fan out splash variants across the existing `uiMode` / `locale` / `widthDp` knobs.
- Sister to `:notification-preview-runtime` and `:glance-preview-runtime`: `compileOnly` Compose deps against `compose-bom-compat`, no new annotation, no new renderer strategy, no compile dep on `:renderer-android`.
- `samples/android/SplashScreenGallery.kt` demonstrates four spec-documented variants (icon only, icon with background ring, icon with branding, dark theme) reusing the existing `ic_compose_logo` / `ic_launcher_foreground` drawables.

## Test plan

- [x] `./gradlew ktfmtFormatAll && ./gradlew ktfmtCheckAll` clean.
- [x] `./gradlew :splash-preview-runtime:test` — Robolectric `SplashScreenSurfaceTest` covers the surface, icon, optional layers, and a centring assertion against `boundsInRoot`.
- [x] `./gradlew :samples:android:composePreviewRender` discovers and renders all four splash previews end-to-end.

Refs #1416.