### PR TITLE
feat(resources): keyframe filmstrip output for AVD previews

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -540,6 +540,20 @@ const val RESOURCE_ADAPTIVE_COST: Float = 4.0f
 const val RESOURCE_ANIMATED_COST: Float = 35.0f
 
 /**
+ * Per-capture cost for an [ResourceType.ANIMATED_VECTOR] filmstrip render. Fewer frames than the
+ * GIF capture (5 keyframes vs ~30) and no GIF encode loop — a small constant factor of the GIF cost
+ * is a fair approximation.
+ */
+const val RESOURCE_ANIMATED_FILMSTRIP_COST: Float = RESOURCE_ANIMATED_COST / 5f
+
+/**
+ * Default keyframe fractions for an AnimatedVectorDrawable filmstrip capture — 0%, 25%, 50%, 75%,
+ * 100% of the animation's reported `totalDuration`. Five cells gives reviewers enough sampling to
+ * see the start/mid/end shape of a typical UI animation without the GIF's scrubbing overhead.
+ */
+val DEFAULT_RESOURCE_FILMSTRIP_FRACTIONS: List<Float> = listOf(0.0f, 0.25f, 0.5f, 0.75f, 1.0f)
+
+/**
  * Per-capture cost for a 9-patch stretch render. Each capture is one `NinePatchDrawable.draw` into
  * a target-sized bitmap plus a PNG encode — within a constant factor of [RESOURCE_STATIC_COST].
  * The 4-stretch fan-out per qualifier means the aggregate cost for one 9-patch is ~6x a vector;
@@ -634,6 +648,11 @@ enum class AdaptiveStyle {
  * [stretch] is the 9-patch-only axis. Non-null on [ResourceType.NINE_PATCH] captures, `null`
  * elsewhere. Carried alongside [shape] / [style] rather than overloading them so the renderer can
  * switch on the type-specific axis without inspecting the resource type up front.
+ *
+ * [filmstrip] is the [ResourceType.ANIMATED_VECTOR]-only axis. `true` means the capture is the
+ * keyframe filmstrip PNG (one cell per fraction in [ResourceCapture.filmstripFractions], composited
+ * side-by-side) rather than the per-frame GIF. Mutually exclusive with the GIF capture on the same
+ * variant — both captures fan out together when [ResourcePreviewsExtension.filmstrip] is enabled.
  */
 @Serializable
 data class ResourceVariant(
@@ -641,6 +660,7 @@ data class ResourceVariant(
   val shape: AdaptiveShape? = null,
   val style: AdaptiveStyle? = null,
   val stretch: NinePatchStretch? = null,
+  val filmstrip: Boolean = false,
 )
 
 @Serializable
@@ -648,6 +668,15 @@ data class ResourceCapture(
   val variant: ResourceVariant? = null,
   val renderOutput: String = "",
   val cost: Float = RESOURCE_STATIC_COST,
+  /**
+   * Animation keyframe fractions for filmstrip captures (`variant.filmstrip == true`). Empty on
+   * every other capture. Each value is a fraction of the resolved animation duration in `[0, 1]`;
+   * the renderer samples one bitmap per fraction via `AnimatorSet.setCurrentPlayTime` and
+   * composites them side-by-side into a single horizontal PNG. Default values are seeded from
+   * [DEFAULT_RESOURCE_FILMSTRIP_FRACTIONS] but the consumer can override via
+   * `composePreview.resourcePreviews.filmstripFractions`.
+   */
+  val filmstripFractions: List<Float> = emptyList(),
 )
 
 /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -202,6 +202,8 @@ internal object AndroidPreviewSupport {
       shapes.set(extension.resourcePreviews.shapes)
       styles.set(extension.resourcePreviews.styles)
       stretches.set(extension.resourcePreviews.stretches)
+      filmstrip.set(extension.resourcePreviews.filmstrip)
+      filmstripFractions.set(extension.resourcePreviews.filmstripFractions)
       projectDirectory.set(projectRoot)
       outputFile.set(previewOutputDir.map { it.file("resources.json") })
     }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverAndroidResourcesTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverAndroidResourcesTask.kt
@@ -56,6 +56,10 @@ abstract class DiscoverAndroidResourcesTask : DefaultTask() {
 
   @get:Input abstract val stretches: ListProperty<NinePatchStretch>
 
+  @get:Input abstract val filmstrip: Property<Boolean>
+
+  @get:Input abstract val filmstripFractions: ListProperty<Float>
+
   /**
    * Project root path used to render module-relative paths in the manifest. Captured at
    * configuration time (via `project.layout.projectDirectory.asFile.absolutePath`) so the task
@@ -77,6 +81,8 @@ abstract class DiscoverAndroidResourcesTask : DefaultTask() {
           shapes = shapes.get(),
           styles = styles.get(),
           stretches = stretches.get(),
+          filmstrip = filmstrip.get(),
+          filmstripFractions = filmstripFractions.get(),
           sourceRootRelativePath = { root -> root.toRelativeStringSafe(projectRoot) },
         )
       )

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -307,4 +307,31 @@ abstract class ResourcePreviewsExtension @Inject constructor(objects: ObjectFact
    */
   val stretches: ListProperty<NinePatchStretch> =
     objects.listProperty(NinePatchStretch::class.java).convention(NinePatchStretch.entries.toList())
+
+  /**
+   * When `true` (default), every [ResourceType.ANIMATED_VECTOR] resource gets a second capture per
+   * qualifier — a horizontal PNG composited from keyframe Bitmaps sampled at [filmstripFractions] ×
+   * the animation's reported `totalDuration`. Lets reviewers diff stills in code review without
+   * scrubbing the sibling GIF.
+   *
+   * Filename ends `_filmstrip.png` (e.g.
+   * `renders/resources/drawable/avd_pulse_xhdpi_filmstrip.png`). Cost is ~`RESOURCE_ANIMATED_COST /
+   * 5` — fewer frames than the GIF and no encode loop.
+   *
+   * Set `false` on modules where the GIF is enough and the extra PNG would be noise.
+   */
+  val filmstrip: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+
+  /**
+   * Keyframe fractions for the filmstrip capture. Each value is a fraction of the resolved
+   * animation duration in `[0, 1]`; the renderer samples one bitmap per fraction via
+   * `AnimatorSet.setCurrentPlayTime` and composites the frames side-by-side. Cell count = list
+   * size; the rendered PNG width is `intrinsicWidth × fractionsCount`.
+   *
+   * Default: `[0.0, 0.25, 0.5, 0.75, 1.0]` (5 cells, equally spaced). Override to e.g. `[0.0, 0.5,
+   * 1.0]` for a 3-cell strip on long animations, or `[0.0, 0.2, 0.4, 0.6, 0.8, 1.0]` for a
+   * finer-grained 6-cell sweep.
+   */
+  val filmstripFractions: ListProperty<Float> =
+    objects.listProperty(Float::class.java).convention(DEFAULT_RESOURCE_FILMSTRIP_FRACTIONS)
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ResourceDiscovery.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ResourceDiscovery.kt
@@ -29,6 +29,18 @@ object ResourceDiscovery {
     val shapes: List<AdaptiveShape>,
     val styles: List<AdaptiveStyle> = AdaptiveStyle.entries.toList(),
     val stretches: List<NinePatchStretch> = DEFAULT_NINE_PATCH_STRETCHES,
+    /**
+     * When `true`, every [ResourceType.ANIMATED_VECTOR] capture is paired with a sibling filmstrip
+     * capture sampling [filmstripFractions] × `totalDuration`. Mirror of
+     * `composePreview.resourcePreviews.filmstrip`.
+     */
+    val filmstrip: Boolean = true,
+    /**
+     * Keyframe fractions for the [ResourceType.ANIMATED_VECTOR] filmstrip capture. Each value in
+     * `[0, 1]`. Defaults to [DEFAULT_RESOURCE_FILMSTRIP_FRACTIONS] — 5 cells at
+     * 0%/25%/50%/75%/100%.
+     */
+    val filmstripFractions: List<Float> = DEFAULT_RESOURCE_FILMSTRIP_FRACTIONS,
     /** Module-relative path to use as the [ManifestReference.source] root, e.g. `src/main`. */
     val sourceRootRelativePath: (File) -> String = { it.path },
   )
@@ -97,6 +109,8 @@ object ResourceDiscovery {
     resourceId: String,
     styles: List<AdaptiveStyle> = AdaptiveStyle.entries.toList(),
     stretches: List<NinePatchStretch> = DEFAULT_NINE_PATCH_STRETCHES,
+    filmstrip: Boolean = true,
+    filmstripFractions: List<Float> = DEFAULT_RESOURCE_FILMSTRIP_FRACTIONS,
   ): List<ResourceCapture> {
     val out = linkedSetOf<ResourceCapture>()
     val baseQualifierSets =
@@ -164,6 +178,23 @@ object ResourceDiscovery {
                   ),
                 cost = RESOURCE_ANIMATED_COST,
               )
+            if (filmstrip && filmstripFractions.isNotEmpty()) {
+              out +=
+                ResourceCapture(
+                  variant = ResourceVariant(qualifiers = combined, filmstrip = true),
+                  renderOutput =
+                    renderOutputPath(
+                      resourceId = resourceId,
+                      qualifier = combined,
+                      shape = null,
+                      style = null,
+                      extension = "png",
+                      filmstrip = true,
+                    ),
+                  cost = RESOURCE_ANIMATED_FILMSTRIP_COST,
+                  filmstripFractions = filmstripFractions,
+                )
+            }
           }
           ResourceType.VECTOR -> {
             out +=
@@ -241,6 +272,7 @@ object ResourceDiscovery {
     style: AdaptiveStyle?,
     extension: String,
     stretch: NinePatchStretch? = null,
+    filmstrip: Boolean = false,
   ): String {
     val (base, name) = resourceId.split('/', limit = 2).let { it[0] to it[1] }
     val safeName = sanitiseFilename(name)
@@ -257,6 +289,7 @@ object ResourceDiscovery {
         AdaptiveStyle.LEGACY -> add("LEGACY")
       }
       if (stretch != null) add("STRETCH_${stretch.name.lowercase()}")
+      if (filmstrip) add("filmstrip")
     }
     return "renders/resources/$base/${parts.joinToString("_")}.$extension"
   }
@@ -286,6 +319,8 @@ object ResourceDiscovery {
           resourceId = id,
           styles = config.styles,
           stretches = config.stretches,
+          filmstrip = config.filmstrip,
+          filmstripFractions = config.filmstripFractions,
         )
       return ResourcePreview(
         id = id,

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResourceDiscoveryTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResourceDiscoveryTest.kt
@@ -38,6 +38,8 @@ class ResourceDiscoveryTest {
     shapes: List<AdaptiveShape> = listOf(AdaptiveShape.CIRCLE, AdaptiveShape.SQUARE),
     styles: List<AdaptiveStyle> = listOf(AdaptiveStyle.FULL_COLOR),
     stretches: List<NinePatchStretch> = NinePatchStretch.entries.toList(),
+    filmstrip: Boolean = true,
+    filmstripFractions: List<Float> = DEFAULT_RESOURCE_FILMSTRIP_FRACTIONS,
   ): List<ResourcePreview> =
     ResourceDiscovery.discover(
       ResourceDiscovery.Config(
@@ -46,6 +48,8 @@ class ResourceDiscoveryTest {
         shapes = shapes,
         styles = styles,
         stretches = stretches,
+        filmstrip = filmstrip,
+        filmstripFractions = filmstripFractions,
         sourceRootRelativePath = { "res" },
       )
     )
@@ -138,11 +142,62 @@ class ResourceDiscoveryTest {
   @Test
   fun `animated vector emits gif renderOutput`() {
     writeXml("drawable", "avd_pulse.xml", "<animated-vector />")
-    val preview = discover().single()
+    val preview = discover(filmstrip = false).single()
     assertThat(preview.type).isEqualTo(ResourceType.ANIMATED_VECTOR)
     assertThat(preview.captures.single().renderOutput)
       .isEqualTo("renders/resources/drawable/avd_pulse_xhdpi.gif")
     assertThat(preview.captures.single().cost).isEqualTo(RESOURCE_ANIMATED_COST)
+  }
+
+  @Test
+  fun `animated vector filmstrip emits one extra capture per qualifier`() {
+    writeXml("drawable", "avd_pulse.xml", "<animated-vector />")
+    val preview = discover().single()
+    assertThat(preview.captures.map { it.renderOutput })
+      .containsExactly(
+        "renders/resources/drawable/avd_pulse_xhdpi.gif",
+        "renders/resources/drawable/avd_pulse_xhdpi_filmstrip.png",
+      )
+      .inOrder()
+    val filmstripCapture = preview.captures[1]
+    assertThat(filmstripCapture.variant?.filmstrip).isTrue()
+    assertThat(filmstripCapture.cost).isEqualTo(RESOURCE_ANIMATED_FILMSTRIP_COST)
+    assertThat(filmstripCapture.filmstripFractions)
+      .containsExactly(0.0f, 0.25f, 0.5f, 0.75f, 1.0f)
+      .inOrder()
+  }
+
+  @Test
+  fun `animated vector filmstrip false suppresses the filmstrip capture`() {
+    writeXml("drawable", "avd_pulse.xml", "<animated-vector />")
+    val preview = discover(filmstrip = false).single()
+    assertThat(preview.captures.map { it.renderOutput })
+      .containsExactly("renders/resources/drawable/avd_pulse_xhdpi.gif")
+    assertThat(preview.captures.single().variant?.filmstrip).isFalse()
+    assertThat(preview.captures.single().filmstripFractions).isEmpty()
+  }
+
+  @Test
+  fun `animated vector filmstripFractions controls cell count and fraction list`() {
+    writeXml("drawable", "avd_pulse.xml", "<animated-vector />")
+    val preview = discover(filmstripFractions = listOf(0.0f, 0.5f, 1.0f)).single()
+    val filmstripCapture = preview.captures.single { it.variant?.filmstrip == true }
+    assertThat(filmstripCapture.filmstripFractions).containsExactly(0.0f, 0.5f, 1.0f).inOrder()
+  }
+
+  @Test
+  fun `animated vector filmstrip fans out across qualifiers`() {
+    writeXml("drawable", "avd_pulse.xml", "<animated-vector />")
+    writeXml("drawable-night", "avd_pulse.xml", "<animated-vector />")
+    val preview = discover().single()
+    assertThat(preview.captures.map { it.renderOutput })
+      .containsExactly(
+        "renders/resources/drawable/avd_pulse_xhdpi.gif",
+        "renders/resources/drawable/avd_pulse_xhdpi_filmstrip.png",
+        "renders/resources/drawable/avd_pulse_night-xhdpi.gif",
+        "renders/resources/drawable/avd_pulse_night-xhdpi_filmstrip.png",
+      )
+      .inOrder()
   }
 
   @Test

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderResourceManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderResourceManifest.kt
@@ -53,6 +53,12 @@ data class RenderResourceVariant(
   val shape: RenderAdaptiveShape? = null,
   val style: RenderAdaptiveStyle? = null,
   val stretch: RenderNinePatchStretch? = null,
+  /**
+   * `true` for an [RenderResourceType.ANIMATED_VECTOR] keyframe filmstrip capture (horizontal PNG
+   * compositing one cell per fraction in [RenderResourceCapture.filmstripFractions]). `false` for
+   * the per-frame GIF capture and for every non-AVD capture.
+   */
+  val filmstrip: Boolean = false,
 )
 
 @Serializable
@@ -60,6 +66,11 @@ data class RenderResourceCapture(
   val variant: RenderResourceVariant? = null,
   val renderOutput: String = "",
   val cost: Float = 1.0f,
+  /**
+   * Animation keyframe fractions for filmstrip captures (`variant.filmstrip == true`); each value
+   * is a fraction of the resolved animation duration in `[0, 1]`. Empty on every other capture.
+   */
+  val filmstripFractions: List<Float> = emptyList(),
 )
 
 @Serializable

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
@@ -14,8 +14,10 @@ import android.graphics.drawable.NinePatchDrawable
 import androidx.core.content.ContextCompat
 import androidx.test.core.app.ApplicationProvider
 import ee.schimke.composeai.scroll.ScrollGifEncoder
+import java.awt.Graphics2D
 import java.awt.image.BufferedImage
 import java.io.File
+import javax.imageio.ImageIO
 import kotlinx.serialization.json.Json
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -29,7 +31,8 @@ import org.robolectric.annotation.Config
  * PNG / GIF to the directory pointed at by `composeai.resources.outputDir`.
  *
  * Supported types: `VECTOR` (PNG), `ADAPTIVE_ICON` (PNG with shape mask + LEGACY fallback),
- * `ANIMATED_VECTOR` (GIF), `NINE_PATCH` (PNG per stretch variant).
+ * `ANIMATED_VECTOR` (GIF, plus a horizontal keyframe filmstrip PNG when
+ * `composePreview.resourcePreviews.filmstrip` is enabled), `NINE_PATCH` (PNG per stretch variant).
  *
  * Robolectric setup mirrors [RobolectricRenderTest]'s pin: SDK 35, NATIVE graphics, paused looper,
  * hardware pixel-copy. The Gradle task wiring (`composePreviewRenderAndroidResources`) sets the same system
@@ -140,7 +143,19 @@ class ResourcePreviewRenderTest {
               missing++
               continue
             }
-            renderAnimatedVector(drawable, animatable, outFile)
+            if (capture.variant?.filmstrip == true) {
+              val fractions = capture.filmstripFractions
+              if (fractions.isEmpty()) {
+                System.err.println(
+                  "compose-preview: ${preview.id} filmstrip capture has no fractions; skipping"
+                )
+                missing++
+                continue
+              }
+              renderAnimatedVectorFilmstrip(drawable, animatable, fractions, outFile)
+            } else {
+              renderAnimatedVector(drawable, animatable, outFile)
+            }
             rendered++
           }
           RenderResourceType.NINE_PATCH -> {
@@ -380,6 +395,104 @@ class ResourcePreviewRenderTest {
       outputFile = outFile,
       frameDelayMs = ANIMATED_FRAME_INTERVAL_MS.toInt(),
     )
+  }
+
+  /**
+   * Filmstrip companion to [renderAnimatedVector]: samples one Bitmap per fraction in [fractions] ×
+   * the animator's `totalDuration`, composites them side-by-side into a horizontal PNG.
+   *
+   * Reuses the [extractAnimatorSet] reflection seam — `AnimatorSet.setCurrentPlayTime` is the same
+   * timeline driver the GIF path uses, so a sample point that ticks under one path ticks under the
+   * other. Falls back to a single-cell strip rendered from one `draw()` call when reflection misses
+   * (same degradation contract as the GIF path's single-frame fallback). The PNG extension stays
+   * intact either way.
+   *
+   * Fractions outside `[0, 1]` are clamped; values are NOT sorted — the renderer respects the
+   * authoring order so a consumer can supply `[0.0, 1.0, 0.5]` to put the midpoint last if that's
+   * what they want. Each cell is `width × height` (the drawable's intrinsic size); the output
+   * BufferedImage is `(width × fractions.size, height)` ARGB.
+   */
+  private fun renderAnimatedVectorFilmstrip(
+    drawable: Drawable,
+    animatable: Animatable,
+    fractions: List<Float>,
+    outFile: File,
+  ) {
+    val width = drawable.intrinsicWidth.coerceAtLeast(1)
+    val height = drawable.intrinsicHeight.coerceAtLeast(1)
+    drawable.setBounds(0, 0, width, height)
+    drawable.setVisible(true, true)
+    val cells =
+      try {
+        val animatorSet = extractAnimatorSet(drawable, animatable)
+        if (animatorSet != null) {
+          captureFilmstripCells(drawable, animatorSet, fractions, width, height)
+        } else {
+          // Reflection miss — degrade to one cell per fraction holding the same t=0 frame, so the
+          // output dimensions still match the consumer's fractions count and downstream tooling
+          // (which keys on cell count) keeps working.
+          val singleFrame = captureSingleFrame(drawable, width, height)
+          List(fractions.size) { singleFrame }
+        }
+      } finally {
+        drawable.setVisible(false, false)
+      }
+    val composite = BufferedImage(width * fractions.size, height, BufferedImage.TYPE_INT_ARGB)
+    val g: Graphics2D = composite.createGraphics()
+    try {
+      for ((index, cell) in cells.withIndex()) {
+        g.drawImage(cell, index * width, 0, null)
+      }
+    } finally {
+      g.dispose()
+    }
+    ImageIO.write(composite, "PNG", outFile)
+  }
+
+  /**
+   * Walks [fractions] × [animatorSet].totalDuration (bounded by [ANIMATED_DURATION_MS] when the
+   * animator reports `DURATION_INFINITE` — same ceiling the GIF path uses) and captures one bitmap
+   * per fraction. Same `setCurrentPlayTime` + `invalidateSelf` + `draw()` sequence as
+   * [captureAnimatedFrames], so the sample points tick consistently with the GIF.
+   */
+  private fun captureFilmstripCells(
+    drawable: Drawable,
+    animatorSet: AnimatorSet,
+    fractions: List<Float>,
+    width: Int,
+    height: Int,
+  ): List<BufferedImage> {
+    val rawDuration = animatorSet.totalDuration
+    val duration =
+      if (rawDuration <= 0L || rawDuration == AnimatorSet.DURATION_INFINITE) {
+        ANIMATED_DURATION_MS
+      } else {
+        rawDuration.coerceAtMost(ANIMATED_DURATION_MS)
+      }
+    val cells = ArrayList<BufferedImage>(fractions.size)
+    animatorSet.start()
+    try {
+      for (fraction in fractions) {
+        val clamped = fraction.coerceIn(0f, 1f)
+        // Clamp to (duration - 1) for parity with the GIF path — `setCurrentPlayTime(duration)`
+        // on a non-looping animator snaps to the end state, while `duration - 1` keeps us inside
+        // the running range. The 1ms difference is invisible at the densities we render at.
+        val t = (clamped * duration).toLong().coerceIn(0L, (duration - 1).coerceAtLeast(0L))
+        animatorSet.currentPlayTime = t
+        drawable.invalidateSelf()
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        try {
+          val canvas = Canvas(bitmap)
+          drawable.draw(canvas)
+          cells += bitmap.toBufferedImage()
+        } finally {
+          bitmap.recycle()
+        }
+      }
+    } finally {
+      animatorSet.cancel()
+    }
+    return cells
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds a second capture per qualifier for every `ResourceType.ANIMATED_VECTOR`: a horizontal PNG composited from keyframe Bitmaps sampled at fractions of the animation duration, sibling to the existing per-frame GIF. Filename ends `_filmstrip.png`.
- New DSL knobs `composePreview.resourcePreviews.filmstrip: Boolean` (default `true`) and `filmstripFractions: List<Float>` (default `[0.0, 0.25, 0.5, 0.75, 1.0]`); fractions thread through to the renderer via a new `filmstripFractions` field on `ResourceCapture` (plus a `filmstrip` discriminator on `ResourceVariant`), so each capture carries its own sample points without a global sidecar.
- Renderer reuses the existing `AnimatorSet` reflection + `setCurrentPlayTime` seam the GIF path drives — same timeline, fewer samples, no GIF encode loop. Output is `intrinsicWidth × fractions.size` wide; verified end-to-end on `:samples:android`'s `avd_pulse` (480×96, five cells, opaque-pixel counts trace the 0.6→1.2 scale curve).

Branched from `agent/preview-coverage-gaps` (#1423) so the NINE_PATCH plumbing is ambient; until that PR merges its commits will appear in this diff and squash out on merge.

Refs #1416.

## Test plan

- [x] `./gradlew ktfmtFormatAll` / `ktfmtCheckAll`
- [x] `./gradlew :gradle-plugin:test` (extended `ResourceDiscoveryTest` with four new cases: filmstrip emits one extra capture per qualifier, `filmstrip = false` suppresses it, `filmstripFractions` controls cell count, multi-qualifier fan-out)
- [x] `./gradlew :gradle-plugin:preview-discovery:test`
- [x] `./gradlew :samples:android:composePreviewRenderAndroidResources` — produces `samples/android/build/compose-previews/renders/resources/drawable/avd_pulse_xhdpi_filmstrip.png` at 480×96 alongside the existing 96×96 GIF; per-cell opaque-pixel counts `[700, 1538, 2700, 1538, 704]` confirm `setCurrentPlayTime` is ticking the AVD timeline at the requested sample points.