### PR TITLE
feat(launcher-widget): add data product registry + VS Code protocol types

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -425,11 +425,14 @@ fun main(args: Array<String>) {
         tryAdd("data/launcher-widget") {
           // Launcher-widget container-size override — same shape as the touch-overlay registration
           // above. The actual planner is wired into `RobolectricHost.previewOverrideExtensions`;
-          // this entry only carries the discoverable descriptor so the panel / MCP can report the
-          // extension via `extensions/list` and `initialize.capabilities.dataExtensions`.
+          // this entry carries the discoverable descriptor for `extensions/list` and the
+          // `LauncherWidgetDataProductRegistry` that captures the applied size for
+          // `data/fetch?kind=compose/launcher-widget`. The registry has no state besides the
+          // captured per-preview payload and is safe to construct lazily here.
           Extension(
             id = "data/launcher-widget",
             displayName = "Launcher widget container size",
+            dataProductRegistry = LauncherWidgetDataProductRegistry(),
             dataExtensionDescriptors =
               listOf(
                 DataExtensionDescriptor(

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -902,6 +902,45 @@ data class LauncherWidgetOverride(
   val resizeOrder: LauncherResizeOrder? = null,
 )
 
+/**
+ * Captured launcher-widget state for a preview, surfaced via
+ * `data/fetch?kind=compose/launcher-widget`.
+ *
+ * Written by `LauncherWidgetDataProductRegistry` after each render that carried a
+ * `renderNow.overrides.launcherWidget` — clients can read back the resolved (post-clamp) cell count
+ * and the dp footprint the renderer actually applied. Useful for the panel's per-card "size: 4×2
+ * (312×152 dp)" badge and for any client that wants to confirm what shape the daemon settled on.
+ *
+ * Distinct from the request shape ([LauncherWidgetOverride]) on purpose: the override carries the
+ * user's request (which may exceed `maxCells` or include `null`-default knobs); the payload is the
+ * resolved end-state the renderer rendered.
+ */
+@Serializable
+data class LauncherWidgetPayload(
+  /** Resolved (post-clamp) cell count the renderer applied. */
+  val cells: LauncherWidgetSize,
+  /** Resolved per-cell edge length in dp. */
+  val cellSizeDp: Int,
+  /** Resolved inter-cell spacing in dp. */
+  val cellSpacingDp: Int,
+  /**
+   * Computed container footprint in dp — `cellSizeDp * cells.width + cellSpacingDp * (cells.width -
+   * 1)`.
+   */
+  val widthDp: Int,
+  /**
+   * Computed container footprint in dp — `cellSizeDp * cells.height + cellSpacingDp *
+   * (cells.height - 1)`.
+   */
+  val heightDp: Int,
+  /**
+   * Echo of the resize-order hint from the request, plumbed for a future orchestrator. The
+   * single-shot around-composable doesn't consume the field — clients can use it to render a "next
+   * resize would walk: width-first" hint alongside the current size badge.
+   */
+  val resizeOrder: LauncherResizeOrder? = null,
+)
+
 @Serializable
 data class Material3ThemeOverrides(
   /** Material 3 color role -> `#RRGGBB` or `#AARRGGBB`. */

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -141,6 +141,7 @@ fun runDaemon(
   val recompositionRegistry = RecompositionDataProductRegistry()
   val themeRegistry = ThemeDataProductRegistry()
   val wallpaperRegistry = WallpaperDataProductRegistry()
+  val launcherWidgetRegistry = LauncherWidgetDataProductRegistry()
 
   // B2.1 — wire Tier-1 classpath fingerprinting (DESIGN § 8). Cheap-signal file set comes from
   // `composeai.daemon.cheapSignalFiles` (set by the gradle plugin's composePreviewDaemonStart).
@@ -235,6 +236,7 @@ fun runDaemon(
         recompositionRegistry = recompositionRegistry,
         themeRegistry = themeRegistry,
         wallpaperRegistry = wallpaperRegistry,
+        launcherWidgetRegistry = launcherWidgetRegistry,
         historyManager = historyManager,
         dataRoot = dataRoot,
         composeTraceEnabled = composeTraceEnabled,
@@ -491,6 +493,7 @@ internal fun buildDesktopExtensions(
   recompositionRegistry: RecompositionDataProductRegistry,
   themeRegistry: ThemeDataProductRegistry,
   wallpaperRegistry: WallpaperDataProductRegistry,
+  launcherWidgetRegistry: LauncherWidgetDataProductRegistry,
   historyManager: HistoryManager?,
   dataRoot: File?,
   composeTraceEnabled: Boolean,
@@ -633,6 +636,7 @@ internal fun buildDesktopExtensions(
     Extension(
       id = "data/launcher-widget",
       displayName = "Launcher widget container size",
+      dataProductRegistry = launcherWidgetRegistry,
       previewOverrideExtensions = listOf(LauncherWidgetPreviewOverrideExtension()),
       dataExtensionDescriptors =
         listOf(

--- a/data/launcher-widget/connector/src/main/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProduct.kt
+++ b/data/launcher-widget/connector/src/main/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProduct.kt
@@ -5,17 +5,26 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.daemon.protocol.LauncherResizeOrder
 import ee.schimke.composeai.daemon.protocol.LauncherWidgetOverride
+import ee.schimke.composeai.daemon.protocol.LauncherWidgetPayload
 import ee.schimke.composeai.daemon.protocol.LauncherWidgetSize
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtension
 import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
 import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.abs
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 
 /**
  * `AroundComposable` extension that wraps a preview in a launcher-widget-shaped grid-cell
@@ -177,5 +186,116 @@ private inline fun walkAxis(from: Int, to: Int, emit: (Int) -> Unit) {
   while (v != to) {
     v += step
     emit(v)
+  }
+}
+
+/**
+ * Daemon-side registry adapter for `compose/launcher-widget`.
+ *
+ * Captures the resolved (post-clamp) cell count + dp footprint last applied via
+ * `renderNow.overrides.launcherWidget` per preview. A `data/fetch` after a launcher-widget-aware
+ * render returns the captured payload; before any render or after the override is dropped, it
+ * returns [DataProductRegistry.Outcome.NotAvailable]. There is no re-render mode — clients update
+ * the cells by sending a fresh `renderNow.overrides.launcherWidget`.
+ *
+ * Mirrors the shape of [WallpaperDataProductRegistry] one-for-one.
+ */
+class LauncherWidgetDataProductRegistry : DataProductRegistry {
+  private val latestPayloads = ConcurrentHashMap<String, LauncherWidgetPayload>()
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      )
+    )
+
+  fun capture(previewId: String?, payload: LauncherWidgetPayload) {
+    if (previewId == null) return
+    latestPayloads[previewId] = payload
+  }
+
+  fun clear(previewId: String?) {
+    if (previewId == null) return
+    latestPayloads.remove(previewId)
+  }
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    val payload = latestPayloads[previewId] ?: return DataProductRegistry.Outcome.NotAvailable
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(LauncherWidgetPayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (KIND !in kinds) return emptyList()
+    val payload = latestPayloads[previewId] ?: return emptyList()
+    return listOf(
+      DataProductAttachment(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(LauncherWidgetPayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun onRender(previewId: String, result: RenderResult) {
+    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
+  }
+
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
+    val applied = overrides?.launcherWidget
+    if (applied == null) {
+      clear(previewId)
+      return
+    }
+    val resolved = applied.resolve()
+    val widthDp =
+      resolved.cellSizeDp * resolved.cells.width +
+        resolved.cellSpacingDp * maxOf(0, resolved.cells.width - 1)
+    val heightDp =
+      resolved.cellSizeDp * resolved.cells.height +
+        resolved.cellSpacingDp * maxOf(0, resolved.cells.height - 1)
+    capture(
+      previewId,
+      LauncherWidgetPayload(
+        cells = resolved.cells,
+        cellSizeDp = resolved.cellSizeDp,
+        cellSpacingDp = resolved.cellSpacingDp,
+        widthDp = widthDp,
+        heightDp = heightDp,
+        resizeOrder = applied.resizeOrder,
+      ),
+    )
+  }
+
+  companion object {
+    const val KIND: String = "compose/launcher-widget"
+    const val SCHEMA_VERSION: Int = 1
+
+    private val json = Json {
+      encodeDefaults = true
+      prettyPrint = false
+    }
   }
 }

--- a/data/launcher-widget/connector/src/test/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProductTest.kt
+++ b/data/launcher-widget/connector/src/test/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProductTest.kt
@@ -1,15 +1,19 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.daemon.protocol.LauncherResizeOrder
 import ee.schimke.composeai.daemon.protocol.LauncherWidgetOverride
 import ee.schimke.composeai.daemon.protocol.LauncherWidgetSize
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.WallpaperOverride
+import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
 import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
@@ -220,4 +224,128 @@ class LauncherWidgetDataProductTest {
       )
     assertEquals(forward.reversed(), reverse)
   }
+
+  // -----------------------------------------------------------------------
+  // LauncherWidgetDataProductRegistry — captures the resolved cells + dp
+  // footprint per preview for `data/fetch?kind=compose/launcher-widget`.
+  // -----------------------------------------------------------------------
+
+  @Test
+  fun registry_capabilities_advertise_inline_no_rerender_product() {
+    val registry = LauncherWidgetDataProductRegistry()
+    val cap = registry.capabilities.single()
+    assertEquals("compose/launcher-widget", cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertEquals(false, cap.requiresRerender)
+  }
+
+  @Test
+  fun registry_fetch_before_any_render_returns_not_available() {
+    val registry = LauncherWidgetDataProductRegistry()
+    val outcome =
+      registry.fetch("preview-1", "compose/launcher-widget", params = null, inline = true)
+    assertEquals(DataProductRegistry.Outcome.NotAvailable, outcome)
+  }
+
+  @Test
+  fun registry_on_render_with_override_captures_resolved_size_and_dp_footprint() {
+    val registry = LauncherWidgetDataProductRegistry()
+    val result = stubRenderResult()
+    val overrides =
+      PreviewOverrides(launcherWidget = LauncherWidgetOverride(cells = LauncherWidgetSize(4, 2)))
+
+    registry.onRender("preview-1", result, overrides, previewContext = null)
+
+    val outcome =
+      registry.fetch("preview-1", "compose/launcher-widget", params = null, inline = true)
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val payload = (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
+    val cells = payload["cells"]!!.jsonObject
+    assertEquals(4, cells["width"]!!.jsonPrimitive.content.toInt())
+    assertEquals(2, cells["height"]!!.jsonPrimitive.content.toInt())
+    // 4*72 + 3*8 = 312, 2*72 + 1*8 = 152 at the connector defaults
+    assertEquals(72, payload["cellSizeDp"]!!.jsonPrimitive.content.toInt())
+    assertEquals(8, payload["cellSpacingDp"]!!.jsonPrimitive.content.toInt())
+    assertEquals(312, payload["widthDp"]!!.jsonPrimitive.content.toInt())
+    assertEquals(152, payload["heightDp"]!!.jsonPrimitive.content.toInt())
+  }
+
+  @Test
+  fun registry_on_render_with_clamping_captures_post_clamp_cells() {
+    val registry = LauncherWidgetDataProductRegistry()
+    val overrides =
+      PreviewOverrides(
+        launcherWidget =
+          LauncherWidgetOverride(
+            cells = LauncherWidgetSize(7, 7),
+            minCells = LauncherWidgetSize(1, 3),
+            maxCells = LauncherWidgetSize(4, 5),
+          )
+      )
+
+    registry.onRender("preview-1", stubRenderResult(), overrides, previewContext = null)
+
+    val outcome =
+      registry.fetch("preview-1", "compose/launcher-widget", null, true)
+        as DataProductRegistry.Outcome.Ok
+    val cells = outcome.result.payload!!.jsonObject["cells"]!!.jsonObject
+    assertEquals(4, cells["width"]!!.jsonPrimitive.content.toInt())
+    assertEquals(5, cells["height"]!!.jsonPrimitive.content.toInt())
+  }
+
+  @Test
+  fun registry_on_render_without_override_drops_previous_capture() {
+    val registry = LauncherWidgetDataProductRegistry()
+    val result = stubRenderResult()
+
+    registry.onRender(
+      "preview-1",
+      result,
+      PreviewOverrides(launcherWidget = LauncherWidgetOverride(cells = LauncherWidgetSize(2, 2))),
+      previewContext = null,
+    )
+    assertTrue(
+      registry.fetch("preview-1", "compose/launcher-widget", null, true)
+        is DataProductRegistry.Outcome.Ok
+    )
+
+    registry.onRender("preview-1", result, overrides = null, previewContext = null)
+
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-1", "compose/launcher-widget", null, true),
+    )
+  }
+
+  @Test
+  fun registry_attachments_returned_for_subscribed_kind() {
+    val registry = LauncherWidgetDataProductRegistry()
+    registry.onRender(
+      "preview-1",
+      stubRenderResult(),
+      PreviewOverrides(launcherWidget = LauncherWidgetOverride(cells = LauncherWidgetSize(2, 2))),
+      previewContext = null,
+    )
+
+    val attachments = registry.attachmentsFor("preview-1", setOf("compose/launcher-widget"))
+    assertEquals(1, attachments.size)
+    assertEquals("compose/launcher-widget", attachments.single().kind)
+  }
+
+  private fun stubRenderResult(): RenderResult =
+    RenderResult(
+      id = 1L,
+      classLoaderHashCode = 0,
+      classLoaderName = "test",
+      previewContext =
+        PreviewContext(
+          previewId = "preview-1",
+          backend = "test",
+          renderMode = null,
+          outputBaseName = null,
+        ),
+    )
 }

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -483,6 +483,80 @@ export interface PreviewOverrides {
      * Android-only; desktop ignores.
      */
     remoteCompose?: RemoteComposeOverride;
+    /**
+     * Launcher-widget container-size override. Drives the connector-side
+     * `LauncherWidgetExtension` (see `:data-launcher-widget-connector`) so a held preview can
+     * be laid out at a specific whole-cell size on the host's launcher grid — `cells = (4, 2)`
+     * at the default `72dp` cell size resolves to a `4*72 + 3*8 = 312.dp` wide by
+     * `2*72 + 1*8 = 152.dp` tall container. Value is clamped into `minCells`..`maxCells`
+     * (defaulting to `1×1`..`5×5`) before reaching the layout pass. A single `renderNow` snaps
+     * to the target. The daemon's `compose/launcher-widget` data product surfaces the
+     * resolved (post-clamp) cells + dp footprint on `data/fetch` for the panel's
+     * "size: 4×2 (312×152 dp)" badge.
+     */
+    launcherWidget?: LauncherWidgetOverride;
+}
+
+/** Whole-cell size on a launcher's grid, expressed as integer cell counts. */
+export interface LauncherWidgetSize {
+    /** Cell count along the width axis. Negative values are rejected; `0` is "below min". */
+    width: number;
+    /** Cell count along the height axis. Negative values are rejected; `0` is "below min". */
+    height: number;
+}
+
+/**
+ * How an orchestrator walks per-axis steps when animating the launcher-widget container between
+ * two whole-cell sizes. Real Android launcher widgets have edge handles, not corner handles —
+ * the user grabs one edge and drags it, so width and height never change simultaneously in a
+ * single gesture. `"widthFirst"` and `"heightFirst"` mirror that two-gesture path; `"diagonal"`
+ * is the relaxed mode that advances both axes in lock-step. The single-shot around-composable
+ * connector ignores this field; a future daemon-side stepping loop reads it.
+ */
+export type LauncherResizeOrder = "diagonal" | "widthFirst" | "heightFirst";
+
+/** Launcher-widget container-size override. See `PreviewOverrides.launcherWidget`. */
+export interface LauncherWidgetOverride {
+    /** Target whole-cell size on the grid. Clamped into `minCells`..`maxCells`. */
+    cells: LauncherWidgetSize;
+    /**
+     * One cell's edge length in dp. `null` falls back to the connector's default (`72`),
+     * matching a Pixel launcher's `5×5` grid on a 411dp screen.
+     */
+    cellSizeDp?: number;
+    /** Gap between adjacent cells in dp. `null` falls back to the connector default (`8`). */
+    cellSpacingDp?: number;
+    /** Inclusive lower bound on the cell count (per axis). `null` falls back to `1×1`. */
+    minCells?: LauncherWidgetSize;
+    /** Inclusive upper bound on the cell count (per axis). `null` falls back to `5×5`. */
+    maxCells?: LauncherWidgetSize;
+    /**
+     * Hint for a future daemon-side resize-loop orchestrator on how to walk intermediate stops
+     * between two sizes. The single-shot around-composable ignores this field — it always snaps
+     * to `cells`.
+     */
+    resizeOrder?: LauncherResizeOrder;
+}
+
+/**
+ * Captured launcher-widget state for a preview, returned by
+ * `data/fetch?kind=compose/launcher-widget`. Carries the resolved (post-clamp) cells + dp
+ * footprint the renderer actually applied — distinct from the request shape
+ * (`LauncherWidgetOverride`) which may exceed `maxCells` or use `null`-default knobs.
+ */
+export interface LauncherWidgetPayload {
+    /** Resolved (post-clamp) cell count the renderer applied. */
+    cells: LauncherWidgetSize;
+    /** Resolved per-cell edge length in dp. */
+    cellSizeDp: number;
+    /** Resolved inter-cell spacing in dp. */
+    cellSpacingDp: number;
+    /** Computed container footprint in dp — `cellSizeDp * cells.width + cellSpacingDp * (cells.width - 1)`. */
+    widthDp: number;
+    /** Computed container footprint in dp — `cellSizeDp * cells.height + cellSpacingDp * (cells.height - 1)`. */
+    heightDp: number;
+    /** Echo of the resize-order hint from the request, plumbed for a future orchestrator. */
+    resizeOrder?: LauncherResizeOrder;
 }
 
 /** Soft-keyboard (IME) override. See `PreviewOverrides.keyboard`. */

--- a/vscode-extension/src/webview/preview/bundleRegistry.ts
+++ b/vscode-extension/src/webview/preview/bundleRegistry.ts
@@ -125,6 +125,11 @@ export const BUNDLES: readonly BundleDescriptor[] = [
                 label: "Permissions",
                 defaultOn: false,
             },
+            {
+                kind: "compose/launcher-widget",
+                label: "Launcher widget size",
+                defaultOn: false,
+            },
         ],
     },
     {


### PR DESCRIPTION
## Summary

Two pieces, queued together so the VS Code panel can both author the `launcherWidget` override (via typed access) and read back the resolved size for a future "size: 4×2 (312×152 dp)" badge.

### Daemon (Kotlin) — part 3
- **`daemon/core/.../protocol/Messages.kt`** — new `LauncherWidgetPayload` data class (`cells`, `cellSizeDp`, `cellSpacingDp`, `widthDp`, `heightDp`, `resizeOrder`). Distinct from `LauncherWidgetOverride` on purpose: override is the request shape (may exceed `maxCells`, use `null`-default knobs); payload is the resolved end-state the renderer rendered.
- **`:data-launcher-widget-connector`** — new `LauncherWidgetDataProductRegistry` capturing the post-clamp cells + dp footprint per preview on every render that carried `renderNow.overrides.launcherWidget`. Mirrors `WallpaperDataProductRegistry` one-for-one. Six new unit tests covering capabilities, fetch-before-render, capture with override, capture with clamping (`7×7` request → `4×5` resolved), drop-on-override-removal, and attachment surfacing.
- **Daemon `tryAdd("data/launcher-widget")` entries** (desktop + android) now carry `dataProductRegistry = launcherWidgetRegistry` alongside the existing planner so render results flow into `data/fetch?kind=compose/launcher-widget`.

### VS Code (TypeScript) — part 1 + part 3
- **`daemonProtocol.ts`** — adds `LauncherWidgetSize`, `LauncherResizeOrder` (string union: `"diagonal" | "widthFirst" | "heightFirst"`), `LauncherWidgetOverride`, `LauncherWidgetPayload`, and the `launcherWidget?` field on `PreviewOverrides`. Mirrors the Kotlin protocol exactly.
- **`bundleRegistry.ts`** — adds `compose/launcher-widget` to the **Inspection** bundle as a configure-only entry (`defaultOn: false`). Discoverable in the configure expander; doesn't subscribe by default since most previews don't carry the override.

## Test plan

- [x] `./gradlew :data-launcher-widget-connector:test` — all 20 unit tests pass (14 existing + 6 new registry tests)
- [x] `./gradlew :daemon:core:compileKotlin :daemon:desktop:compileKotlin :daemon:android:compileDebugKotlin` — both DaemonMains pick up the new registry without configuration-cache drift
- [x] `npm run compile --prefix vscode-extension` — TS compiles, no `tsc` errors
- [x] `npm test --prefix vscode-extension` — all 1182 existing tests pass; the bundle-registry entry and new protocol types are non-breaking additions
- [ ] **Follow-up (part 2)** — per-card interactive resize control (slider / cell-grid picker) that flips `overrides.launcherWidget.cells` from the panel. Design discussion next.

---
_Generated by [Claude Code](https://claude.ai/code/session_016wQB16N6M2ey3nNLmZhrDc)_