### PR TITLE
feat(vscode-extension): surface manifest-backed icon when an Activity Kotlin file is open

### DIFF
--- a/vscode-extension/src/activityIconCodeLensProvider.ts
+++ b/vscode-extension/src/activityIconCodeLensProvider.ts
@@ -1,0 +1,101 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { findIconForActivityFqn } from "./activityIconLookup";
+import { GradleService } from "./gradleService";
+import {
+    extractClassDeclarations,
+    extractPackage,
+    isActivityLikeDeclaration,
+} from "./kotlinClassFqn";
+
+/**
+ * Surfaces a CodeLens above each top-level class declaration whose FQN
+ * resolves to a manifest-declared (or `<application>`-fallback) icon.
+ * Click → opens the rendered PNG via the same `composePreview.previewResource`
+ * command used by [AndroidManifestCodeLensProvider], so the user lands
+ * on a familiar editor surface.
+ *
+ * Discovery affordance for the [ActivityIconHoverProvider]: without a
+ * visible lens nothing tells the user there's a hover to try.
+ */
+export class ActivityIconCodeLensProvider implements vscode.CodeLensProvider {
+    private readonly emitter = new vscode.EventEmitter<void>();
+    readonly onDidChangeCodeLenses = this.emitter.event;
+
+    constructor(private readonly gradleService: GradleService) {}
+
+    /** Re-emit lenses after a render run produces new captures. */
+    refresh(): void {
+        this.emitter.fire();
+    }
+
+    provideCodeLenses(doc: vscode.TextDocument): vscode.CodeLens[] {
+        if (doc.languageId !== "kotlin") {
+            return [];
+        }
+        const module = this.gradleService.resolveModule(doc.uri.fsPath);
+        if (!module) {
+            return [];
+        }
+        const manifest = this.gradleService.readResourceManifest(module);
+        if (!manifest) {
+            return [];
+        }
+
+        const text = doc.getText();
+        const declarations = extractClassDeclarations(text);
+        if (declarations.length === 0) {
+            return [];
+        }
+        const pkg = extractPackage(text);
+
+        const lenses: vscode.CodeLens[] = [];
+        for (const decl of declarations) {
+            const fqn = pkg ? `${pkg}.${decl.name}` : decl.name;
+            const match = findIconForActivityFqn(
+                manifest,
+                fqn,
+                isActivityLikeDeclaration(decl),
+            );
+            if (!match) {
+                continue;
+            }
+            const resourceId = `${match.reference.resourceType}/${match.reference.resourceName}`;
+            const resource = manifest.resources.find(
+                (r) => r.id === resourceId,
+            );
+            if (!resource) {
+                continue;
+            }
+            const firstCapture = resource.captures.find((c) => c.renderOutput);
+            if (!firstCapture) {
+                continue;
+            }
+            const pngPath = path.join(
+                this.gradleService.workspaceRoot,
+                module.projectDir,
+                "build",
+                "compose-previews",
+                firstCapture.renderOutput,
+            );
+            const startPos = doc.positionAt(decl.nameOffset);
+            const range = new vscode.Range(startPos.line, 0, startPos.line, 0);
+            const title =
+                match.source === "direct"
+                    ? `$(file-media) Activity icon: ${resourceId}`
+                    : `$(file-media) Application icon: ${resourceId} (no override)`;
+            lenses.push(
+                new vscode.CodeLens(range, {
+                    title,
+                    command: "composePreview.previewResource",
+                    arguments: [pngPath, resourceId],
+                }),
+            );
+        }
+        return lenses;
+    }
+
+    dispose(): void {
+        this.emitter.dispose();
+    }
+}

--- a/vscode-extension/src/activityIconHoverProvider.ts
+++ b/vscode-extension/src/activityIconHoverProvider.ts
@@ -1,0 +1,125 @@
+import * as vscode from "vscode";
+import { findIconForActivityFqn } from "./activityIconLookup";
+import { GradleService } from "./gradleService";
+import {
+    extractClassDeclarations,
+    extractPackage,
+    isActivityLikeDeclaration,
+    KotlinClassDeclaration,
+} from "./kotlinClassFqn";
+import { readVariantImages } from "./manifestResourceHoverProvider";
+import { buildResourceVariantHoverMarkdown } from "./resourceVariantHover";
+import { ResourcePreview } from "./types";
+import * as path from "node:path";
+
+/**
+ * Surfaces the AndroidManifest-declared icon for the Activity (or
+ * Service / Receiver / Provider) the user is currently editing. Hover
+ * the class-name identifier on a line like `class MainActivity :
+ * ComponentActivity()` and see the same variant grid the manifest
+ * hover renders for `android:icon="@drawable/ic_settings"`.
+ *
+ * Joins three sources of truth:
+ *  - The file's package + top-level class names ([extractPackage],
+ *    [extractClassDeclarations]).
+ *  - `ResourceManifest.manifestReferences` — the recorder-emitted
+ *    `(componentFqn, attributeName, resourceType, resourceName)` index
+ *    from the merged `AndroidManifest.xml`.
+ *  - `ResourceManifest.resources` — the rendered captures for each
+ *    drawable / mipmap.
+ *
+ * Falls back to the `<application>` icon when a class extends a
+ * platform component base (`ComponentActivity` / `Activity` / `Service`
+ * / ...) but has no `android:icon` override of its own — matching what
+ * the OS will actually show on the launcher / task switcher.
+ */
+export class ActivityIconHoverProvider implements vscode.HoverProvider {
+    constructor(private readonly gradleService: GradleService) {}
+
+    provideHover(
+        doc: vscode.TextDocument,
+        position: vscode.Position,
+    ): vscode.Hover | undefined {
+        if (doc.languageId !== "kotlin") {
+            return undefined;
+        }
+        const module = this.gradleService.resolveModule(doc.uri.fsPath);
+        if (!module) {
+            return undefined;
+        }
+        const manifest = this.gradleService.readResourceManifest(module);
+        if (!manifest) {
+            return undefined;
+        }
+
+        const text = doc.getText();
+        const declarations = extractClassDeclarations(text);
+        if (declarations.length === 0) {
+            return undefined;
+        }
+        const offset = doc.offsetAt(position);
+        const hitDecl = declarations.find(
+            (d) =>
+                offset >= d.nameOffset && offset <= d.nameOffset + d.nameLength,
+        );
+        if (!hitDecl) {
+            return undefined;
+        }
+
+        const pkg = extractPackage(text);
+        const fqn = pkg ? `${pkg}.${hitDecl.name}` : hitDecl.name;
+        const match = findIconForActivityFqn(
+            manifest,
+            fqn,
+            isActivityLikeDeclaration(hitDecl),
+        );
+        if (!match) {
+            return undefined;
+        }
+
+        const resourceId = `${match.reference.resourceType}/${match.reference.resourceName}`;
+        const resource = manifest.resources.find((r) => r.id === resourceId);
+        if (!resource) {
+            return undefined;
+        }
+
+        const moduleRoot = path.join(
+            this.gradleService.workspaceRoot,
+            module.projectDir,
+            "build",
+            "compose-previews",
+        );
+        const images = readVariantImages(resource, moduleRoot);
+        if (images.length === 0) {
+            return undefined;
+        }
+
+        const md = new vscode.MarkdownString(
+            renderHoverBody(hitDecl, fqn, resource, images, match.source),
+        );
+        md.isTrusted = true;
+        md.supportHtml = true;
+
+        const start = doc.positionAt(hitDecl.nameOffset);
+        const end = doc.positionAt(hitDecl.nameOffset + hitDecl.nameLength);
+        return new vscode.Hover(md, new vscode.Range(start, end));
+    }
+}
+
+function renderHoverBody(
+    decl: KotlinClassDeclaration,
+    fqn: string,
+    resource: ResourcePreview,
+    images: ReturnType<typeof readVariantImages>,
+    source: "direct" | "application-fallback",
+): string {
+    const variantMarkdown = buildResourceVariantHoverMarkdown({
+        resource,
+        images,
+    });
+    const attribution =
+        source === "direct"
+            ? `Manifest icon for **${decl.name}** (\`${fqn}\`)`
+            : `No \`android:icon\` on **${decl.name}** — falling back to \`<application>\` icon`;
+    return [attribution, "", variantMarkdown].join("\n");
+}

--- a/vscode-extension/src/activityIconLookup.ts
+++ b/vscode-extension/src/activityIconLookup.ts
@@ -1,0 +1,70 @@
+// Pure lookup: given the FQN of a class in the editor and a
+// `ResourceManifest`, find the best `ManifestReference` whose rendered
+// resource should be surfaced as that file's "icon". Used by
+// [ActivityIconHoverProvider] / gutter decorations.
+//
+// Lives outside the VS Code surface so Mocha unit tests can drive it
+// without the extension host.
+
+import { ManifestReference, ResourceManifest } from "./types";
+
+/**
+ * Result of [findIconForActivityFqn] — pairs the resolved reference
+ * with a tag that says how it was resolved, so the hover surface can
+ * label the fallback case ("(no override — using `<application>`
+ * icon)") differently from a direct match.
+ */
+export interface ActivityIconMatch {
+    reference: ManifestReference;
+    /**
+     * `"direct"` — the activity itself declared `android:icon`.
+     * `"application-fallback"` — no override on the activity; this is
+     * the `<application>` icon, which is what the OS shows for any
+     * component without one.
+     */
+    source: "direct" | "application-fallback";
+}
+
+/**
+ * Look up the icon for the activity (or service / receiver / provider)
+ * whose FQN is [fqn]. Resolution order:
+ *
+ *  1. **Direct override.** A `ManifestReference` whose `componentName`
+ *     equals [fqn] and whose attribute is `android:icon`. Wins over
+ *     all other options — the user explicitly set this.
+ *  2. **Application fallback** (only when [activityLike] is `true`).
+ *     The `<application>` icon, which the OS shows for any component
+ *     without an override. Gated on the caller's "this class looks
+ *     like an Android component" check so we don't surface the app
+ *     icon next to a random data class.
+ *
+ * Returns `null` when neither applies. `android:roundIcon` /
+ * `android:logo` / `android:banner` are deliberately ignored at v1 —
+ * they cover the same resources at different DPIs / form factors and
+ * the hover for `android:icon` is what users overwhelmingly want;
+ * surfacing all four would crowd the popover.
+ */
+export function findIconForActivityFqn(
+    manifest: ResourceManifest,
+    fqn: string,
+    activityLike: boolean,
+): ActivityIconMatch | null {
+    const direct = manifest.manifestReferences.find(
+        (r) => r.componentName === fqn && r.attributeName === "android:icon",
+    );
+    if (direct) {
+        return { reference: direct, source: "direct" };
+    }
+    if (!activityLike) {
+        return null;
+    }
+    const appIcon = manifest.manifestReferences.find(
+        (r) =>
+            r.componentKind === "application" &&
+            r.componentName === null &&
+            r.attributeName === "android:icon",
+    );
+    return appIcon
+        ? { reference: appIcon, source: "application-fallback" }
+        : null;
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -24,6 +24,8 @@ import { PreviewHoverProvider } from "./previewHoverProvider";
 import { PreviewCodeLensProvider } from "./previewCodeLensProvider";
 import { AndroidManifestCodeLensProvider } from "./androidManifestCodeLensProvider";
 import { ManifestResourceHoverProvider } from "./manifestResourceHoverProvider";
+import { ActivityIconHoverProvider } from "./activityIconHoverProvider";
+import { ActivityIconCodeLensProvider } from "./activityIconCodeLensProvider";
 import { PreviewA11yDiagnostics } from "./previewA11yDiagnostics";
 import { PreviewDoctorDiagnostics } from "./previewDoctorDiagnostics";
 import { moduleRelativeSourcePath, previewSourceMatches } from "./sourcePath";
@@ -1466,11 +1468,25 @@ export async function activate(
     const manifestResourceHoverProvider = new ManifestResourceHoverProvider(
         gradleService,
     );
+    const activityIconHoverProvider = new ActivityIconHoverProvider(
+        gradleService,
+    );
+    const activityIconCodeLensProvider = new ActivityIconCodeLensProvider(
+        gradleService,
+    );
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(kotlinFiles, hoverProvider),
+        vscode.languages.registerHoverProvider(
+            kotlinFiles,
+            activityIconHoverProvider,
+        ),
         vscode.languages.registerCodeLensProvider(
             kotlinFiles,
             codeLensProvider,
+        ),
+        vscode.languages.registerCodeLensProvider(
+            kotlinFiles,
+            activityIconCodeLensProvider,
         ),
         vscode.languages.registerCodeLensProvider(
             androidManifestFiles,
@@ -1482,6 +1498,7 @@ export async function activate(
         ),
         codeLensProvider,
         androidManifestCodeLensProvider,
+        activityIconCodeLensProvider,
         gutterDecorations,
         a11yDiagnostics,
         doctorDiagnostics,

--- a/vscode-extension/src/kotlinClassFqn.ts
+++ b/vscode-extension/src/kotlinClassFqn.ts
@@ -1,0 +1,158 @@
+// Pure regex-based extractor for the FQN(s) of top-level classes in a
+// Kotlin source file, plus a hint for "is this class an Android
+// component" (Activity / Service / Receiver / Provider subclass). Used
+// by [ActivityIconHoverProvider] to look up the manifest icon for the
+// file the user is editing.
+//
+// Lives outside the VS Code surface so Mocha unit tests can drive it
+// without the extension host — Mocha can't load `vscode` outside an
+// extension host. The thin wrapper in the hover provider reads document
+// text and forwards.
+//
+// Why regex instead of `vscode.executeDocumentSymbolProvider`:
+// activity/service/receiver/provider classes always live at the top
+// level of a file and have predictable shapes. The LSP path is async
+// and only available when a Kotlin language server is attached — the
+// regex path works even in pure-text mode and is the same trade-off
+// `findManifestIconReferences` makes for the manifest side.
+
+/**
+ * One top-level class declaration. The hover provider needs both the
+ * class name (to compose into an FQN against the file's `package`) and
+ * the textual position so it can hang the hover off the class-name
+ * range rather than firing across the whole class body.
+ */
+export interface KotlinClassDeclaration {
+    /** Simple class name — `MainActivity`, never the FQN. */
+    name: string;
+    /** Byte offset of the class-name identifier within the source. */
+    nameOffset: number;
+    /** Length of the class-name identifier (always `name.length`). */
+    nameLength: number;
+    /**
+     * The substring from the start of the `class` keyword to the next
+     * `{` or end of line, inclusive of any `: Base()` superclass clause.
+     * Used by [isActivityLikeDeclaration] to recognise Android
+     * components without bringing in a parser.
+     */
+    declaration: string;
+}
+
+const PACKAGE_RE = /^\s*package\s+([\w.]+)\s*;?\s*$/m;
+
+/**
+ * Recognised Kotlin modifiers + annotation prefixes that may appear
+ * between the start of a line and the `class` keyword. Doesn't have to
+ * be exhaustive — anything we miss falls through to "no class found
+ * here" which is the same as the user not having an Activity class on
+ * that line.
+ */
+const CLASS_MODIFIERS =
+    "(?:public|internal|private|protected|open|final|abstract|sealed|data|inner|enum|annotation|inline|value|companion)";
+
+/**
+ * Match `class Name` declarations anywhere in the file, capturing the
+ * preceding whitespace + modifiers + annotations chain. Multiline /
+ * gm so we can iterate across the file. Annotation args are matched
+ * non-greedily and limited to one line to avoid swallowing the file on
+ * a malformed source — the LSP handles the real parsing; we just need
+ * the obvious shapes.
+ */
+const CLASS_RE = new RegExp(
+    "^\\s*" +
+        "(?:" +
+        "@[\\w.]+(?:\\([^\\n)]*\\))?\\s+" +
+        "|" +
+        CLASS_MODIFIERS +
+        "\\s+" +
+        ")*" +
+        "class\\s+([A-Z][\\w]*)",
+    "gm",
+);
+
+const ACTIVITY_LIKE_BASE_RE =
+    /\b(?:ComponentActivity|FragmentActivity|AppCompatActivity|Activity|Service|BroadcastReceiver|ContentProvider)\b/;
+
+/** Extract `package x.y.z` from the file, or `null` when none is declared. */
+export function extractPackage(source: string): string | null {
+    const m = PACKAGE_RE.exec(source);
+    return m ? m[1] : null;
+}
+
+/**
+ * Walk [source] and return every `class Name` declaration that looks
+ * top-level (matched by [CLASS_RE]). May include nested classes the
+ * regex couldn't disambiguate from top-level — downstream the manifest
+ * lookup filters those out (no FQN match = no icon shown), so a small
+ * amount of over-match is fine.
+ */
+export function extractClassDeclarations(
+    source: string,
+): KotlinClassDeclaration[] {
+    const out: KotlinClassDeclaration[] = [];
+    CLASS_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = CLASS_RE.exec(source)) !== null) {
+        const name = match[1];
+        // Locate the identifier within the matched substring so the
+        // hover can fire on the class name itself, not the whole line.
+        const nameInMatchOffset = match[0].lastIndexOf(name);
+        const nameOffset = match.index + nameInMatchOffset;
+        const declarationEnd = findDeclarationEnd(source, match.index);
+        const declaration = source.substring(match.index, declarationEnd);
+        out.push({
+            name,
+            nameOffset,
+            nameLength: name.length,
+            declaration,
+        });
+    }
+    return out;
+}
+
+/** Pair [extractPackage] with [extractClassDeclarations] to produce FQNs. */
+export function topLevelClassFqns(source: string): string[] {
+    const pkg = extractPackage(source);
+    return extractClassDeclarations(source).map((decl) =>
+        pkg ? `${pkg}.${decl.name}` : decl.name,
+    );
+}
+
+/**
+ * True iff the [declaration] mentions one of the platform component
+ * base classes — used to decide whether the `<application>` icon is a
+ * sensible fallback when the file's FQN has no manifest override. Plain
+ * substring match: we'd rather miss an unusual base (and skip the
+ * fallback) than show the app icon next to a random data class.
+ */
+export function isActivityLikeDeclaration(
+    decl: KotlinClassDeclaration,
+): boolean {
+    return ACTIVITY_LIKE_BASE_RE.test(decl.declaration);
+}
+
+/**
+ * Walk forward from the `class` keyword to the next `{` or `\n\n` (end
+ * of declaration). Bounded to the first 4 lines so a malformed source
+ * doesn't run away — superclass clauses with constructor args don't
+ * usually exceed two physical lines.
+ */
+function findDeclarationEnd(source: string, classStartIndex: number): number {
+    const maxLineLookahead = 4;
+    let idx = classStartIndex;
+    let linesSeen = 0;
+    while (idx < source.length) {
+        const ch = source.charAt(idx);
+        if (ch === "{") {
+            return idx;
+        }
+        if (ch === "\n") {
+            linesSeen += 1;
+            if (linesSeen >= maxLineLookahead) {
+                return idx;
+            }
+        }
+        idx += 1;
+    }
+    return source.length;
+}

--- a/vscode-extension/src/test/activityIconLookup.test.ts
+++ b/vscode-extension/src/test/activityIconLookup.test.ts
@@ -1,0 +1,100 @@
+import * as assert from "assert";
+import { findIconForActivityFqn } from "../activityIconLookup";
+import { ManifestReference, ResourceManifest } from "../types";
+
+const APP_ICON: ManifestReference = {
+    source: "src/main/AndroidManifest.xml",
+    componentKind: "application",
+    componentName: null,
+    attributeName: "android:icon",
+    resourceType: "mipmap",
+    resourceName: "ic_launcher",
+};
+
+const ACTIVITY_ICON_OVERRIDE: ManifestReference = {
+    source: "src/main/AndroidManifest.xml",
+    componentKind: "activity",
+    componentName: "com.example.MainActivity",
+    attributeName: "android:icon",
+    resourceType: "drawable",
+    resourceName: "ic_settings",
+};
+
+const ROUND_ICON_OVERRIDE: ManifestReference = {
+    source: "src/main/AndroidManifest.xml",
+    componentKind: "activity",
+    componentName: "com.example.RoundOnlyActivity",
+    attributeName: "android:roundIcon",
+    resourceType: "mipmap",
+    resourceName: "ic_launcher_round",
+};
+
+function manifest(refs: ManifestReference[]): ResourceManifest {
+    return {
+        module: "sample",
+        variant: "debug",
+        resources: [],
+        manifestReferences: refs,
+    };
+}
+
+describe("findIconForActivityFqn", () => {
+    it("prefers a direct android:icon override over the application fallback", () => {
+        const m = manifest([APP_ICON, ACTIVITY_ICON_OVERRIDE]);
+        const match = findIconForActivityFqn(
+            m,
+            "com.example.MainActivity",
+            true,
+        );
+        assert.ok(match);
+        assert.strictEqual(match.source, "direct");
+        assert.strictEqual(match.reference.resourceName, "ic_settings");
+    });
+
+    it("falls back to <application> icon for an activity-like class with no override", () => {
+        const m = manifest([APP_ICON]);
+        const match = findIconForActivityFqn(
+            m,
+            "com.example.UnrelatedActivity",
+            true,
+        );
+        assert.ok(match);
+        assert.strictEqual(match.source, "application-fallback");
+        assert.strictEqual(match.reference.resourceName, "ic_launcher");
+    });
+
+    it("does NOT surface the <application> icon when the class is not activity-like", () => {
+        const m = manifest([APP_ICON]);
+        const match = findIconForActivityFqn(
+            m,
+            "com.example.PlainDataClass",
+            false,
+        );
+        assert.strictEqual(match, null);
+    });
+
+    it("returns null when no application icon exists either", () => {
+        const m = manifest([]);
+        const match = findIconForActivityFqn(
+            m,
+            "com.example.MainActivity",
+            true,
+        );
+        assert.strictEqual(match, null);
+    });
+
+    it("ignores android:roundIcon overrides at v1 (icon is what users want)", () => {
+        const m = manifest([APP_ICON, ROUND_ICON_OVERRIDE]);
+        // The class has a roundIcon but no icon — we want to fall through to
+        // the application icon rather than promote the roundIcon to primary,
+        // because the OS only uses roundIcon on circular-icon launchers.
+        const match = findIconForActivityFqn(
+            m,
+            "com.example.RoundOnlyActivity",
+            true,
+        );
+        assert.ok(match);
+        assert.strictEqual(match.source, "application-fallback");
+        assert.strictEqual(match.reference.resourceName, "ic_launcher");
+    });
+});

--- a/vscode-extension/src/test/kotlinClassFqn.test.ts
+++ b/vscode-extension/src/test/kotlinClassFqn.test.ts
@@ -1,0 +1,152 @@
+import * as assert from "assert";
+import {
+    extractClassDeclarations,
+    extractPackage,
+    isActivityLikeDeclaration,
+    topLevelClassFqns,
+} from "../kotlinClassFqn";
+
+describe("extractPackage", () => {
+    it("extracts a simple package declaration", () => {
+        const src = "package com.example.foo\n\nclass X\n";
+        assert.strictEqual(extractPackage(src), "com.example.foo");
+    });
+
+    it("returns null when there is no package declaration", () => {
+        const src = "class X\n";
+        assert.strictEqual(extractPackage(src), null);
+    });
+
+    it("tolerates a trailing semicolon (the Java-ism Kotlin permits)", () => {
+        const src = "package com.example.foo;\n\nclass X\n";
+        assert.strictEqual(extractPackage(src), "com.example.foo");
+    });
+});
+
+describe("extractClassDeclarations", () => {
+    it("captures the class name and its identifier range", () => {
+        const src =
+            "package com.example\n\nclass MainActivity : ComponentActivity() {\n}\n";
+        const decls = extractClassDeclarations(src);
+        assert.strictEqual(decls.length, 1);
+        assert.strictEqual(decls[0].name, "MainActivity");
+        const nameSlice = src.substring(
+            decls[0].nameOffset,
+            decls[0].nameOffset + decls[0].nameLength,
+        );
+        assert.strictEqual(nameSlice, "MainActivity");
+    });
+
+    it("captures common Kotlin modifiers without losing the class name", () => {
+        const cases = [
+            "internal class Foo : Activity()",
+            "abstract class Foo : Activity()",
+            "open class Foo : Activity()",
+            "sealed class Foo : Activity()",
+            "data class Foo(val x: Int)",
+        ];
+        for (const src of cases) {
+            const decls = extractClassDeclarations(src);
+            assert.strictEqual(decls.length, 1, `failed to match: ${src}`);
+            assert.strictEqual(decls[0].name, "Foo");
+        }
+    });
+
+    it("captures annotation prefixes (single-line and with args)", () => {
+        const cases: Array<[string, string]> = [
+            ["@AndroidEntryPoint\nclass Foo : ComponentActivity()", "Foo"],
+            ['@Suppress("unused")\nclass Foo : ComponentActivity()', "Foo"],
+            ["@Foo @Bar class Baz : Activity()", "Baz"],
+        ];
+        for (const [src, expectedName] of cases) {
+            const decls = extractClassDeclarations(src);
+            assert.strictEqual(decls.length, 1, `failed to match: ${src}`);
+            assert.strictEqual(decls[0].name, expectedName);
+        }
+    });
+
+    it("captures the declaration up to the opening brace", () => {
+        const src =
+            "class MainActivity : ComponentActivity() {\n    override fun onCreate() {}\n}\n";
+        const decls = extractClassDeclarations(src);
+        assert.strictEqual(decls.length, 1);
+        // Declaration substring covers the superclass clause — this is what
+        // isActivityLikeDeclaration() reads.
+        assert.ok(
+            decls[0].declaration.includes("ComponentActivity"),
+            `declaration was: ${decls[0].declaration}`,
+        );
+        assert.ok(
+            !decls[0].declaration.includes("override fun"),
+            "declaration should stop at the opening brace",
+        );
+    });
+
+    it("returns multiple declarations for a file with multiple top-level classes", () => {
+        const src = `package com.example
+
+class FirstActivity : ComponentActivity()
+
+class SecondActivity : ComponentActivity()
+`;
+        const decls = extractClassDeclarations(src);
+        assert.strictEqual(decls.length, 2);
+        assert.deepStrictEqual(
+            decls.map((d) => d.name),
+            ["FirstActivity", "SecondActivity"],
+        );
+    });
+
+    it("returns an empty list when the file has no class declarations", () => {
+        const src = "package com.example\n\nfun foo() = 1\n";
+        assert.deepStrictEqual(extractClassDeclarations(src), []);
+    });
+});
+
+describe("topLevelClassFqns", () => {
+    it("joins package + class name into a dotted FQN", () => {
+        const src =
+            "package com.example.app\n\nclass MainActivity : ComponentActivity()\n";
+        assert.deepStrictEqual(topLevelClassFqns(src), [
+            "com.example.app.MainActivity",
+        ]);
+    });
+
+    it("returns bare class names when the file has no package", () => {
+        const src = "class Bare : Activity()\n";
+        assert.deepStrictEqual(topLevelClassFqns(src), ["Bare"]);
+    });
+});
+
+describe("isActivityLikeDeclaration", () => {
+    const recognised = [
+        "class A : ComponentActivity()",
+        "class A : FragmentActivity()",
+        "class A : AppCompatActivity()",
+        "class A : Activity()",
+        "class A : Service()",
+        "class A : BroadcastReceiver()",
+        "class A : ContentProvider()",
+    ];
+    for (const src of recognised) {
+        it(`treats '${src}' as activity-like`, () => {
+            const [decl] = extractClassDeclarations(src);
+            assert.ok(decl, `failed to parse: ${src}`);
+            assert.ok(isActivityLikeDeclaration(decl));
+        });
+    }
+
+    it("does not treat a plain data class as activity-like", () => {
+        const [decl] = extractClassDeclarations(
+            "data class Settings(val v: Int)",
+        );
+        assert.ok(decl);
+        assert.strictEqual(isActivityLikeDeclaration(decl), false);
+    });
+
+    it("does not treat an unrelated subclass as activity-like", () => {
+        const [decl] = extractClassDeclarations("class Foo : ViewModel()");
+        assert.ok(decl);
+        assert.strictEqual(isActivityLikeDeclaration(decl), false);
+    });
+});


### PR DESCRIPTION
## Summary

- Joins `ResourceManifest.manifestReferences` (already records `(componentFqn, attributeName, resourceType, resourceName)` from the merged manifest) with a regex-based FQN extractor over the open Kotlin file.
- When the file has a top-level class whose FQN matches an `android:icon` reference, render the variant grid from #1420 in a hover on the class-name identifier, and add a CodeLens above the class as a discovery affordance.
- Falls back to the `<application>` icon for activity-like classes (`ComponentActivity` / `Activity` / `Service` / ...) with no override, matching what the OS shows on the launcher. Non-component classes (data classes, view models) get no surface so random files don't gain icon decorations.

Closes #1418. Builds on #1420.

## Test plan

- [x] `npm --prefix vscode-extension run compile` — clean
- [x] `npm --prefix vscode-extension test` — 1207 passing (25 new specs cover `extractPackage` / `extractClassDeclarations` / `topLevelClassFqns` / `isActivityLikeDeclaration` / `findIconForActivityFqn`)
- [x] `npm --prefix vscode-extension run format:check` — clean
- [ ] Open `samples/android/.../MainActivity.kt` in an extension host: hover the `MainActivity` class name shows the `@drawable/ic_settings` variant grid; CodeLens reads `Activity icon: drawable/ic_settings`.
- [ ] Add an Activity to the sample without an `android:icon` override, confirm fallback hover/lens reads `Application icon: mipmap/ic_launcher (no override)`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QoJvbXWi8ysrujjMJLjX6v)_