### PR TITLE
ci(preview-comment): re-enable composable + resource preview diff comments on PRs

### DIFF
--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -1,21 +1,37 @@
-name: Preview Comment (Legacy / Manual)
+name: Preview Comment
+
+# Renders the sample projects' composable `@Preview`s and Android XML resource previews on every
+# PR, diffs them against the long-lived `compose-preview/main` and `compose-preview/resources/main`
+# baselines, pushes changed PNGs to the per-PR `compose-preview/pr` / `compose-preview/resources/pr`
+# branches, and upserts two sibling sticky comments — one for composable changes, one for resource
+# changes — pinned to the just-pushed SHAs so the image URLs stay resolvable after merge.
+#
+# The baseline side (push to main) is owned by `preview-baselines.yml`; this workflow only handles
+# the PR diff. Notification + a11y previews live in their own dedicated workflows
+# (`notification-previews.yml`, `a11y-report.yml`) because they're disjoint surfaces with their own
+# baseline branches.
 
 on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
   workflow_dispatch:
 
-# Legacy preview-comment flow remains supported; disabled by default in this repo to avoid duplicate PR comments.
 permissions:
   contents: read
 
 concurrency:
-  group: preview-comment-manual
+  # Per-PR group so concurrent PRs don't cancel each other; manual dispatches share one slot.
+  group: preview-comment-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   compare:
-    name: Compare previews (legacy)
+    name: Compare previews
     runs-on: ubuntu-latest
     permissions:
+      # Composite action pushes per-PR PNGs to `compose-preview/pr` /
+      # `compose-preview/resources/pr` and upserts sticky PR comments.
       contents: write
       pull-requests: write
     steps:

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -14,7 +14,7 @@ name: Preview Comment
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Flips `.github/workflows/preview-comment.yml` from `workflow_dispatch`-only to firing on `pull_request: main` (manual dispatch is preserved).
- The composite action it wraps (`.github/actions/preview-comment`) already diffs **both** composable and Android XML resource previews in a single invocation — sibling sticky comments under `<!-- preview-diff -->` and `<!-- preview-diff-resources -->` against the `compose-preview/main` and `compose-preview/resources/main` baselines.
- Baselines themselves are already maintained by `preview-baselines.yml` on `push: main` (it pushes to both baseline branches via the `preview-baselines` composite); this PR is purely the PR-side comment surface.

Closes the gap noted while reviewing #1416's PRs: 9-patch (#1423), typography (#1424), splash (#1425), and AVD filmstrip (#1426) all landed without before/after preview comments because this workflow was disabled. Notifications and a11y stay on their dedicated per-surface workflows.

## Test plan

- [x] YAML syntax via `git diff` — single trigger flip + concurrency group change.
- [ ] On the next PR opened against `main` (this PR itself, since `.github/workflows/preview-comment.yml` is in the diff): the workflow should fire, render the samples, push to `compose-preview/pr` + `compose-preview/resources/pr`, and upsert two sticky comments. If the diff is empty, `comment-on-empty-diff: 'false'` (composite default) means no comment posts on first run — that's expected.

---
_Generated by [Claude Code](https://claude.ai/code/session_012NJgHWQ5EczeqLek4BjBVU)_