### PR TITLE
feat(vscode-extension): hover + CodeLens for R.drawable / R.mipmap references in Kotlin and res XML

### DIFF
--- a/vscode-extension/src/androidResourceReferences.ts
+++ b/vscode-extension/src/androidResourceReferences.ts
@@ -1,0 +1,123 @@
+// Pure regex extractors for Android resource references that surface in
+// editor text — `R.drawable.foo` / `R.mipmap.foo` in Kotlin, and
+// `@drawable/foo` / `@mipmap/foo` in res-tree XML (layouts, drawable
+// XML, menus, etc.). Mirrors the design of `manifestIconReferences.ts`:
+// regex over full XML / Kotlin parsing because the shapes are simple
+// enough and the cost of a real parser isn't worth it for the editor
+// surfaces.
+//
+// Stays free of `vscode` imports so Mocha unit tests can drive it
+// directly without an extension host.
+
+/**
+ * One drawable / mipmap reference found in source text. The hover and
+ * CodeLens providers use `offset` + `length` to build the editor range,
+ * and `(resourceType, resourceName)` to join against
+ * `ResourceManifest.resources`.
+ */
+export interface ResourceRef {
+    offset: number;
+    length: number;
+    resourceType: "drawable" | "mipmap";
+    resourceName: string;
+}
+
+/**
+ * Find every `R.drawable.foo` / `R.mipmap.foo` reference in [text].
+ *
+ * Explicitly skips `android.R.drawable.…` framework refs (the AOSP
+ * resources aren't in our `resources.json`) by requiring a preceding
+ * non-`.` character. `R::class.drawable` etc. is intentionally
+ * unhandled — extremely rare and would need a real parser to
+ * disambiguate.
+ *
+ * Returns refs in source order; deduping is the CodeLens / hover
+ * provider's job (the hover doesn't need it, the CodeLens does).
+ */
+export function findKotlinResourceReferences(text: string): ResourceRef[] {
+    const re = /(^|[^.\w])R\.(drawable|mipmap)\.([A-Za-z0-9_]+)\b/g;
+    const out: ResourceRef[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(text)) !== null) {
+        const leadingLen = match[1].length;
+        // Start at the `R` so the editor range covers `R.drawable.foo`
+        // exactly, not the character before it.
+        const offset = match.index + leadingLen;
+        const length = match[0].length - leadingLen;
+        out.push({
+            offset,
+            length,
+            resourceType: match[2] as "drawable" | "mipmap",
+            resourceName: match[3],
+        });
+    }
+    return out;
+}
+
+/**
+ * Find every `@drawable/foo` / `@mipmap/foo` reference in an XML
+ * resource file (layouts, adaptive-icon XML, menus, anything under
+ * `res/`). Matches the value position of an attribute or an XML text
+ * node — we only care about the reference itself, not the attribute
+ * name that carries it.
+ *
+ * Same exclusions as the Kotlin extractor: framework references
+ * (`@android:drawable/...`) and theme refs (`?attr/...`) drop out
+ * because the leading-character anchor requires `@`.
+ *
+ * Accepts the `@+drawable/foo` resource-id form (rare but legal). The
+ * `+` is consumed and not surfaced — downstream consumers care about
+ * the resolved name, not the syntactic difference.
+ */
+export function findXmlResourceReferences(text: string): ResourceRef[] {
+    const re = /(["'>])@\+?(drawable|mipmap)\/([A-Za-z0-9_]+)(?=["'<\s/])/g;
+    const out: ResourceRef[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(text)) !== null) {
+        // Skip the opening delimiter character so the range starts at `@`.
+        const offset = match.index + match[1].length;
+        const length = match[0].length - match[1].length;
+        out.push({
+            offset,
+            length,
+            resourceType: match[2] as "drawable" | "mipmap",
+            resourceName: match[3],
+        });
+    }
+    return out;
+}
+
+/**
+ * Find the [ResourceRef] in [refs] whose source range contains
+ * [offset], or `null` when none does. Used by the hover provider — it
+ * receives a `position`, converts to a byte offset, and asks this to
+ * find the ref under the cursor.
+ */
+export function refAt(refs: ResourceRef[], offset: number): ResourceRef | null {
+    for (const r of refs) {
+        if (offset >= r.offset && offset <= r.offset + r.length) {
+            return r;
+        }
+    }
+    return null;
+}
+
+/**
+ * Collapse [refs] to one entry per unique `(resourceType, resourceName)`
+ * pair, keeping the first occurrence's position. Used by the CodeLens
+ * provider to emit one lens per resource per file (a layout referencing
+ * the same `@drawable/foo` four times shouldn't get four lenses).
+ */
+export function dedupRefsByResource(refs: ResourceRef[]): ResourceRef[] {
+    const seen = new Set<string>();
+    const out: ResourceRef[] = [];
+    for (const r of refs) {
+        const key = `${r.resourceType}/${r.resourceName}`;
+        if (seen.has(key)) {
+            continue;
+        }
+        seen.add(key);
+        out.push(r);
+    }
+    return out;
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -26,6 +26,8 @@ import { AndroidManifestCodeLensProvider } from "./androidManifestCodeLensProvid
 import { ManifestResourceHoverProvider } from "./manifestResourceHoverProvider";
 import { ActivityIconHoverProvider } from "./activityIconHoverProvider";
 import { ActivityIconCodeLensProvider } from "./activityIconCodeLensProvider";
+import { ResourceReferenceHoverProvider } from "./resourceReferenceHoverProvider";
+import { ResourceReferenceCodeLensProvider } from "./resourceReferenceCodeLensProvider";
 import { PreviewA11yDiagnostics } from "./previewA11yDiagnostics";
 import { PreviewDoctorDiagnostics } from "./previewDoctorDiagnostics";
 import { moduleRelativeSourcePath, previewSourceMatches } from "./sourcePath";
@@ -1474,11 +1476,32 @@ export async function activate(
     const activityIconCodeLensProvider = new ActivityIconCodeLensProvider(
         gradleService,
     );
+    const resourceReferenceHoverProvider = new ResourceReferenceHoverProvider(
+        gradleService,
+    );
+    const resourceReferenceCodeLensProvider =
+        new ResourceReferenceCodeLensProvider(gradleService);
+    // `@drawable/foo` references in any XML under res/ — layouts, drawable
+    // XML (adaptive icons reference their sublayers this way), menus,
+    // anims, etc. Excludes `AndroidManifest.xml` which has its own
+    // dedicated providers above to avoid double-hover.
+    const resourceXmlFiles: vscode.DocumentSelector = {
+        scheme: "file",
+        pattern: "**/res/**/*.xml",
+    };
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(kotlinFiles, hoverProvider),
         vscode.languages.registerHoverProvider(
             kotlinFiles,
             activityIconHoverProvider,
+        ),
+        vscode.languages.registerHoverProvider(
+            kotlinFiles,
+            resourceReferenceHoverProvider,
+        ),
+        vscode.languages.registerHoverProvider(
+            resourceXmlFiles,
+            resourceReferenceHoverProvider,
         ),
         vscode.languages.registerCodeLensProvider(
             kotlinFiles,
@@ -1487,6 +1510,14 @@ export async function activate(
         vscode.languages.registerCodeLensProvider(
             kotlinFiles,
             activityIconCodeLensProvider,
+        ),
+        vscode.languages.registerCodeLensProvider(
+            kotlinFiles,
+            resourceReferenceCodeLensProvider,
+        ),
+        vscode.languages.registerCodeLensProvider(
+            resourceXmlFiles,
+            resourceReferenceCodeLensProvider,
         ),
         vscode.languages.registerCodeLensProvider(
             androidManifestFiles,
@@ -1499,6 +1530,7 @@ export async function activate(
         codeLensProvider,
         androidManifestCodeLensProvider,
         activityIconCodeLensProvider,
+        resourceReferenceCodeLensProvider,
         gutterDecorations,
         a11yDiagnostics,
         doctorDiagnostics,

--- a/vscode-extension/src/resourceReferenceCodeLensProvider.ts
+++ b/vscode-extension/src/resourceReferenceCodeLensProvider.ts
@@ -1,0 +1,84 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { dedupRefsByResource } from "./androidResourceReferences";
+import { GradleService } from "./gradleService";
+import { referencesFor } from "./resourceReferenceHoverProvider";
+
+/**
+ * Surfaces a `$(file-media) Preview <type>/<name>` CodeLens above the
+ * first occurrence of each unique drawable / mipmap reference in the
+ * open file. One lens per unique resource per file — a layout that
+ * references `@drawable/foo` four times gets one lens, not four. Click
+ * → opens the rendered PNG via the existing `composePreview.previewResource`
+ * command.
+ *
+ * Pairs with [ResourceReferenceHoverProvider]: the lens advertises that
+ * a preview exists, the hover shows it.
+ */
+export class ResourceReferenceCodeLensProvider
+    implements vscode.CodeLensProvider
+{
+    private readonly emitter = new vscode.EventEmitter<void>();
+    readonly onDidChangeCodeLenses = this.emitter.event;
+
+    constructor(private readonly gradleService: GradleService) {}
+
+    /** Re-emit after a render run produces new captures. */
+    refresh(): void {
+        this.emitter.fire();
+    }
+
+    provideCodeLenses(doc: vscode.TextDocument): vscode.CodeLens[] {
+        const refs = dedupRefsByResource(referencesFor(doc));
+        if (refs.length === 0) {
+            return [];
+        }
+        const module = this.gradleService.resolveModule(doc.uri.fsPath);
+        if (!module) {
+            return [];
+        }
+        const manifest = this.gradleService.readResourceManifest(module);
+        if (!manifest) {
+            return [];
+        }
+
+        const lenses: vscode.CodeLens[] = [];
+        for (const ref of refs) {
+            const resourceId = `${ref.resourceType}/${ref.resourceName}`;
+            const resource = manifest.resources.find(
+                (r) => r.id === resourceId,
+            );
+            if (!resource) {
+                continue;
+            }
+            const firstCapture = resource.captures.find((c) => c.renderOutput);
+            if (!firstCapture) {
+                continue;
+            }
+            const pngPath = path.join(
+                this.gradleService.workspaceRoot,
+                module.projectDir,
+                "build",
+                "compose-previews",
+                firstCapture.renderOutput,
+            );
+            const startPos = doc.positionAt(ref.offset);
+            const range = new vscode.Range(startPos.line, 0, startPos.line, 0);
+            const variantCount = resource.captures.length;
+            const variantSuffix =
+                variantCount > 1 ? ` (${variantCount} variants)` : "";
+            lenses.push(
+                new vscode.CodeLens(range, {
+                    title: `$(file-media) Preview ${resourceId}${variantSuffix}`,
+                    command: "composePreview.previewResource",
+                    arguments: [pngPath, resourceId],
+                }),
+            );
+        }
+        return lenses;
+    }
+
+    dispose(): void {
+        this.emitter.dispose();
+    }
+}

--- a/vscode-extension/src/resourceReferenceHoverProvider.ts
+++ b/vscode-extension/src/resourceReferenceHoverProvider.ts
@@ -1,0 +1,115 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import {
+    findKotlinResourceReferences,
+    findXmlResourceReferences,
+    refAt,
+    ResourceRef,
+} from "./androidResourceReferences";
+import { GradleService } from "./gradleService";
+import { readVariantImages } from "./manifestResourceHoverProvider";
+import { buildResourceVariantHoverMarkdown } from "./resourceVariantHover";
+
+/**
+ * Hovers over `R.drawable.foo` / `R.mipmap.foo` in Kotlin source, and
+ * `@drawable/foo` / `@mipmap/foo` in res-tree XML, reusing the same
+ * variant-grid markdown as the AndroidManifest hover. Lets the user
+ * peek the rendered asset without leaving the call site.
+ *
+ * Kotlin and layout XML share one provider (instance gated on
+ * languageId / fileName) rather than two near-identical classes — the
+ * only branching is the source-text extractor, which is cheap and
+ * keeps the wiring in `extension.ts` flat.
+ *
+ * Pairs with [ResourceReferenceCodeLensProvider]: the lens is the
+ * one-per-file discovery affordance, the hover is the per-occurrence
+ * peek.
+ */
+export class ResourceReferenceHoverProvider implements vscode.HoverProvider {
+    constructor(private readonly gradleService: GradleService) {}
+
+    provideHover(
+        doc: vscode.TextDocument,
+        position: vscode.Position,
+    ): vscode.Hover | undefined {
+        const refs = referencesFor(doc);
+        if (refs.length === 0) {
+            return undefined;
+        }
+        const offset = doc.offsetAt(position);
+        const ref = refAt(refs, offset);
+        if (!ref) {
+            return undefined;
+        }
+        const module = this.gradleService.resolveModule(doc.uri.fsPath);
+        if (!module) {
+            return undefined;
+        }
+        const manifest = this.gradleService.readResourceManifest(module);
+        if (!manifest) {
+            return undefined;
+        }
+        const resourceId = `${ref.resourceType}/${ref.resourceName}`;
+        const resource = manifest.resources.find((r) => r.id === resourceId);
+        if (!resource) {
+            return undefined;
+        }
+
+        const moduleRoot = path.join(
+            this.gradleService.workspaceRoot,
+            module.projectDir,
+            "build",
+            "compose-previews",
+        );
+        const images = readVariantImages(resource, moduleRoot);
+        if (images.length === 0) {
+            return undefined;
+        }
+
+        const md = new vscode.MarkdownString(
+            buildResourceVariantHoverMarkdown({ resource, images }),
+        );
+        md.isTrusted = true;
+        md.supportHtml = true;
+
+        const start = doc.positionAt(ref.offset);
+        const end = doc.positionAt(ref.offset + ref.length);
+        return new vscode.Hover(md, new vscode.Range(start, end));
+    }
+}
+
+/**
+ * Choose the right extractor for [doc]. Exported so the CodeLens
+ * provider can share it — both surfaces need the same Kotlin /
+ * res-tree-XML routing and we don't want it to drift.
+ *
+ * `AndroidManifest.xml` deliberately returns no refs here: it already
+ * has its own hover ([ManifestResourceHoverProvider]) that knows about
+ * the icon-attribute semantics, and double-registration would surface
+ * two overlapping popovers.
+ */
+export function referencesFor(doc: vscode.TextDocument): ResourceRef[] {
+    if (doc.languageId === "kotlin") {
+        return findKotlinResourceReferences(doc.getText());
+    }
+    if (isResourceXml(doc)) {
+        return findXmlResourceReferences(doc.getText());
+    }
+    return [];
+}
+
+/**
+ * True iff [doc] is an XML file under a `res/` directory (any qualifier
+ * suffix) **other than** `AndroidManifest.xml`. Matches the natural
+ * scope of `@drawable/...` references — layouts, drawable XML,
+ * adaptive-icon XML, menus, anims, etc.
+ */
+export function isResourceXml(doc: vscode.TextDocument): boolean {
+    if (doc.fileName.endsWith("AndroidManifest.xml")) {
+        return false;
+    }
+    if (!doc.fileName.toLowerCase().endsWith(".xml")) {
+        return false;
+    }
+    return /[/\\]res[/\\]/.test(doc.fileName);
+}

--- a/vscode-extension/src/test/androidResourceReferences.test.ts
+++ b/vscode-extension/src/test/androidResourceReferences.test.ts
@@ -1,0 +1,194 @@
+import * as assert from "assert";
+import {
+    dedupRefsByResource,
+    findKotlinResourceReferences,
+    findXmlResourceReferences,
+    refAt,
+} from "../androidResourceReferences";
+
+describe("findKotlinResourceReferences", () => {
+    it("extracts R.drawable / R.mipmap references", () => {
+        const src = `
+            Image(painterResource(R.drawable.ic_compose_logo))
+            setSmallIcon(R.mipmap.ic_launcher)
+        `;
+        const refs = findKotlinResourceReferences(src);
+        assert.strictEqual(refs.length, 2);
+        assert.deepStrictEqual(
+            refs.map((r) => [r.resourceType, r.resourceName]),
+            [
+                ["drawable", "ic_compose_logo"],
+                ["mipmap", "ic_launcher"],
+            ],
+        );
+    });
+
+    it("ignores android.R.drawable framework references", () => {
+        const src = "setSmallIcon(android.R.drawable.ic_dialog_email)";
+        assert.deepStrictEqual(findKotlinResourceReferences(src), []);
+    });
+
+    it("ignores Foo.R.drawable.* — the leading qualifier means it's not the project R", () => {
+        const src = "use(some.lib.R.drawable.foo)";
+        assert.deepStrictEqual(findKotlinResourceReferences(src), []);
+    });
+
+    it("ignores R.string / R.color / R.dimen / etc (out of scope for previews)", () => {
+        const src = `
+            stringResource(R.string.app_name)
+            colorResource(R.color.primary)
+            dimensionResource(R.dimen.padding)
+        `;
+        assert.deepStrictEqual(findKotlinResourceReferences(src), []);
+    });
+
+    it("records source offset + length covering the full `R.<type>.<name>` span", () => {
+        const src = "val x = R.drawable.ic_settings";
+        const refs = findKotlinResourceReferences(src);
+        assert.strictEqual(refs.length, 1);
+        const slice = src.substring(
+            refs[0].offset,
+            refs[0].offset + refs[0].length,
+        );
+        assert.strictEqual(slice, "R.drawable.ic_settings");
+    });
+
+    it("matches at the start of the file (no preceding non-word character)", () => {
+        const src = "R.drawable.first_thing";
+        const refs = findKotlinResourceReferences(src);
+        assert.strictEqual(refs.length, 1);
+        assert.strictEqual(refs[0].resourceName, "first_thing");
+    });
+
+    it("returns multiple refs for repeated occurrences (dedup is the consumer's job)", () => {
+        const src = `
+            painterResource(R.drawable.foo)
+            painterResource(R.drawable.foo)
+        `;
+        const refs = findKotlinResourceReferences(src);
+        assert.strictEqual(refs.length, 2);
+        assert.notStrictEqual(refs[0].offset, refs[1].offset);
+    });
+});
+
+describe("findXmlResourceReferences", () => {
+    it("extracts @drawable / @mipmap from attribute values", () => {
+        const xml = `
+            <ImageView android:src="@drawable/ic_compose_logo" />
+            <ImageView android:src='@mipmap/ic_launcher' />
+        `;
+        const refs = findXmlResourceReferences(xml);
+        assert.strictEqual(refs.length, 2);
+        assert.deepStrictEqual(
+            refs.map((r) => [r.resourceType, r.resourceName]),
+            [
+                ["drawable", "ic_compose_logo"],
+                ["mipmap", "ic_launcher"],
+            ],
+        );
+    });
+
+    it("extracts refs from adaptive-icon sublayer drawable attributes", () => {
+        const xml = `
+            <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+                <background android:drawable="@drawable/ic_launcher_background" />
+                <foreground android:drawable="@drawable/ic_launcher_foreground" />
+                <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+            </adaptive-icon>
+        `;
+        const refs = findXmlResourceReferences(xml);
+        assert.strictEqual(refs.length, 3);
+        assert.deepStrictEqual(
+            refs.map((r) => r.resourceName),
+            [
+                "ic_launcher_background",
+                "ic_launcher_foreground",
+                "ic_launcher_foreground",
+            ],
+        );
+    });
+
+    it("ignores framework drawables (@android:drawable/...)", () => {
+        const xml = `<ImageView android:src="@android:drawable/ic_dialog_email" />`;
+        assert.deepStrictEqual(findXmlResourceReferences(xml), []);
+    });
+
+    it("ignores theme refs (?attr/...)", () => {
+        const xml = `<ImageView android:src="?attr/iconResource" />`;
+        assert.deepStrictEqual(findXmlResourceReferences(xml), []);
+    });
+
+    it("ignores non-drawable / non-mipmap types", () => {
+        const xml = `
+            <View android:background="@color/primary" />
+            <TextView android:text="@string/app_name" />
+            <Animator android:duration="@integer/short_anim" />
+        `;
+        assert.deepStrictEqual(findXmlResourceReferences(xml), []);
+    });
+
+    it("accepts the @+drawable/ resource-id syntax (rare but legal)", () => {
+        const xml = `<ImageView android:src="@+drawable/new_icon" />`;
+        const refs = findXmlResourceReferences(xml);
+        assert.strictEqual(refs.length, 1);
+        assert.strictEqual(refs[0].resourceName, "new_icon");
+    });
+
+    it("records a range that starts at `@` and covers `@drawable/foo`", () => {
+        const xml = '<ImageView android:src="@drawable/foo" />';
+        const refs = findXmlResourceReferences(xml);
+        assert.strictEqual(refs.length, 1);
+        const slice = xml.substring(
+            refs[0].offset,
+            refs[0].offset + refs[0].length,
+        );
+        assert.strictEqual(slice, "@drawable/foo");
+    });
+});
+
+describe("refAt", () => {
+    it("finds the ref whose range contains the offset", () => {
+        const src = "val x = R.drawable.foo; val y = R.mipmap.bar";
+        const refs = findKotlinResourceReferences(src);
+        const fooIndex = src.indexOf("foo") + 1;
+        const barIndex = src.indexOf("bar") + 1;
+        assert.strictEqual(refAt(refs, fooIndex)!.resourceName, "foo");
+        assert.strictEqual(refAt(refs, barIndex)!.resourceName, "bar");
+    });
+
+    it("returns null when no ref covers the offset", () => {
+        const refs = findKotlinResourceReferences("R.drawable.foo");
+        assert.strictEqual(refAt(refs, 100), null);
+    });
+});
+
+describe("dedupRefsByResource", () => {
+    it("keeps the first occurrence of each unique resource", () => {
+        const src = `
+            R.drawable.foo
+            R.drawable.foo
+            R.drawable.bar
+        `;
+        const refs = findKotlinResourceReferences(src);
+        assert.strictEqual(refs.length, 3);
+        const deduped = dedupRefsByResource(refs);
+        assert.strictEqual(deduped.length, 2);
+        assert.deepStrictEqual(
+            deduped.map((r) => r.resourceName),
+            ["foo", "bar"],
+        );
+        // Position should be the *first* occurrence's offset.
+        assert.strictEqual(deduped[0].offset, refs[0].offset);
+    });
+
+    it("treats drawable/foo and mipmap/foo as different resources", () => {
+        const src = "R.drawable.foo R.mipmap.foo";
+        const refs = findKotlinResourceReferences(src);
+        const deduped = dedupRefsByResource(refs);
+        assert.strictEqual(deduped.length, 2);
+    });
+
+    it("returns an empty list when the input is empty", () => {
+        assert.deepStrictEqual(dedupRefsByResource([]), []);
+    });
+});


### PR DESCRIPTION
## Summary

- Extends the resource-preview surfaces beyond `AndroidManifest.xml` to every call site: `R.drawable.foo` / `R.mipmap.foo` in Kotlin, and `@drawable/foo` / `@mipmap/foo` in res-tree XML (layouts, drawable XML, menus, adaptive-icon sublayers, ...).
- One CodeLens per unique resource per file (dedup by `(type, name)`, anchored at the first occurrence), so a layout that references `@drawable/foo` four times gets one lens — not four. Hover fires per-occurrence.
- Both hover and lens reuse the variant-grid markdown from #1420; CodeLens title carries the variant count suffix already used by the manifest provider.
- Framework refs (`android.R.drawable.…`, `@android:drawable/…`) and theme refs (`?attr/…`) are skipped — they have no consumer source for the renderer to capture.
- `R.string` / `R.color` / `R.dimen` deliberately out of scope: those would be value popovers (resolved text / color swatch), not previews, and belong in a sibling story.

Closes #1419. Builds on #1420 and #1429.

## Test plan

- [x] `npm --prefix vscode-extension run compile` — clean
- [x] `npm --prefix vscode-extension test` — 1226 passing (19 new specs cover Kotlin extractor, XML extractor, framework / theme / non-{drawable,mipmap} exclusions, dedup, `refAt` offset lookup)
- [x] `npm --prefix vscode-extension run format:check` — clean
- [ ] Open a Kotlin file with `painterResource(R.drawable.ic_compose_logo)`: hover shows the rendered PNG; CodeLens above the line reads `Preview drawable/ic_compose_logo`.
- [ ] Open `mipmap-anydpi-v26/ic_launcher.xml`: hovering each `<background android:drawable="@drawable/…" />` reveals the sublayer drawable.
- [ ] File with three identical `R.drawable.foo` references shows one lens.
- [ ] `android.R.drawable.ic_dialog_email` is ignored.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QoJvbXWi8ysrujjMJLjX6v)_