### PR TITLE
feat(launcher-widget): plumb Glance previewSizeMode into payload constraints

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -997,7 +997,42 @@ data class LauncherWidgetPayload(
    * resize would walk: width-first" hint alongside the current size badge.
    */
   val resizeOrder: LauncherResizeOrder? = null,
+  /**
+   * Set of cell sizes the underlying widget declared support for, surfaced so a picker UI can gate
+   * user-selectable sizes to what the widget actually supports.
+   *
+   * Sources, in order of preference (later overrides earlier):
+   * 1. The `@LauncherWidgetPreview(minCells, maxCells)` rectangle, if present (current default).
+   * 2. A `GlanceAppWidget.previewSizeMode = SizeMode.Responsive(setOf(DpSize, …))` — the sparse set
+   *    of dp sizes the widget composes correctly at, converted to cells.
+   * 3. `<appwidget-provider android:targetCellWidth/Height android:resizeMode="…" />` in `res/xml/`
+   *    — auto-discovered by matching the rendered layout id / receiver class.
+   *
+   * `null` means "no constraint surfaced"; the picker falls back to a default rectangle. An empty
+   * list means "no resizing allowed" (Glance `SizeMode.Single` or `resizeMode="none"`).
+   */
+  val supportedCells: List<LauncherWidgetSize>? = null,
+  /**
+   * Which resize axes the underlying widget declared support for. Mirrors the
+   * `AppWidgetProviderInfo.resizeMode` bitmask (`none | horizontal | vertical | both`). Glance
+   * `SizeMode.Single` maps to `None`; `SizeMode.Responsive` and `SizeMode.Exact` to `Both`. The
+   * picker uses this to grey out axis-locked drag handles.
+   */
+  val resizeAxes: LauncherResizeAxes = LauncherResizeAxes.BOTH,
 )
+
+/**
+ * Which axes the launcher-widget container can be resized along, mirroring
+ * `AppWidgetProviderInfo.resizeMode`. Surfaced on [LauncherWidgetPayload.resizeAxes] so a picker UI
+ * can lock the axes the widget doesn't support.
+ */
+@Serializable
+enum class LauncherResizeAxes {
+  @SerialName("none") NONE,
+  @SerialName("horizontal") HORIZONTAL,
+  @SerialName("vertical") VERTICAL,
+  @SerialName("both") BOTH,
+}
 
 @Serializable
 data class Material3ThemeOverrides(

--- a/data/launcher-widget/connector/src/main/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProduct.kt
+++ b/data/launcher-widget/connector/src/main/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProduct.kt
@@ -9,6 +9,7 @@ import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.LauncherResizeAxes
 import ee.schimke.composeai.daemon.protocol.LauncherResizeOrder
 import ee.schimke.composeai.daemon.protocol.LauncherWidgetOverride
 import ee.schimke.composeai.daemon.protocol.LauncherWidgetPayload
@@ -265,26 +266,34 @@ class LauncherWidgetDataProductRegistry : DataProductRegistry {
     previewContext: PreviewContext?,
   ) {
     val applied = overrides?.launcherWidget
-    if (applied == null) {
+    // Drain the per-preview metadata channel even when no override is set — a Glance widget
+    // might still want to surface its `previewSizeMode` so a picker UI can constrain itself,
+    // even before the first override fires. The channel is single-shot per preview; the read
+    // also clears so the same metadata doesn't bleed into the next render of a different
+    // preview that happens to reuse the channel slot.
+    val metadata = LauncherWidgetMetadataChannel.consume(previewId)
+    if (applied == null && metadata == null) {
       clear(previewId)
       return
     }
-    val resolved = applied.resolve()
-    val widthDp =
-      resolved.cellSizeDp * resolved.cells.width +
-        resolved.cellSpacingDp * maxOf(0, resolved.cells.width - 1)
-    val heightDp =
-      resolved.cellSizeDp * resolved.cells.height +
-        resolved.cellSpacingDp * maxOf(0, resolved.cells.height - 1)
+    val resolved = applied?.resolve()
+    val cells =
+      resolved?.cells ?: metadata?.supportedCells?.firstOrNull() ?: LauncherWidgetSize(1, 1)
+    val cellSizeDp = resolved?.cellSizeDp ?: 72
+    val cellSpacingDp = resolved?.cellSpacingDp ?: 8
+    val widthDp = cellSizeDp * cells.width + cellSpacingDp * maxOf(0, cells.width - 1)
+    val heightDp = cellSizeDp * cells.height + cellSpacingDp * maxOf(0, cells.height - 1)
     capture(
       previewId,
       LauncherWidgetPayload(
-        cells = resolved.cells,
-        cellSizeDp = resolved.cellSizeDp,
-        cellSpacingDp = resolved.cellSpacingDp,
+        cells = cells,
+        cellSizeDp = cellSizeDp,
+        cellSpacingDp = cellSpacingDp,
         widthDp = widthDp,
         heightDp = heightDp,
-        resizeOrder = applied.resizeOrder,
+        resizeOrder = applied?.resizeOrder,
+        supportedCells = metadata?.supportedCells,
+        resizeAxes = metadata?.resizeAxes ?: LauncherResizeAxes.BOTH,
       ),
     )
   }
@@ -299,3 +308,60 @@ class LauncherWidgetDataProductRegistry : DataProductRegistry {
     }
   }
 }
+
+/**
+ * Per-preview widget metadata snapshot — captured by render-side helpers (Glance's
+ * [androidx.glance.appwidget.GlanceAppWidget.previewSizeMode] reflection in
+ * `:glance-preview-runtime`, and a future `appwidget-provider/...xml` auto-discovery pass) before
+ * [LauncherWidgetDataProductRegistry.onRender] runs, then drained into the rendered payload.
+ *
+ * Held off the payload type itself because the metadata sources live in modules that don't (and
+ * shouldn't) depend on `:daemon:core` — the connector is the lowest module both the registry and
+ * the metadata sources can share. The channel keeps the consumer-facing [LauncherWidgetExtension] /
+ * `GlanceAppWidgetContent` APIs free of an explicit `previewId` parameter: the renderer sets
+ * [currentPreviewId] before each render, the helpers read it.
+ */
+object LauncherWidgetMetadataChannel {
+  private val pending = java.util.concurrent.ConcurrentHashMap<String, LauncherWidgetMetadata>()
+  private val currentPreviewIdHolder = ThreadLocal<String?>()
+
+  /**
+   * Renderer-side: set the preview id for the current render thread before invoking the preview's
+   * composition; clear in a `finally`. The helpers ([offer]) read this via [currentPreviewId] so
+   * consumer-facing APIs don't need an explicit `previewId` parameter.
+   */
+  fun setCurrentPreviewId(previewId: String?) {
+    if (previewId == null) currentPreviewIdHolder.remove()
+    else currentPreviewIdHolder.set(previewId)
+  }
+
+  /** Current render thread's preview id, or `null` outside a render. */
+  fun currentPreviewId(): String? = currentPreviewIdHolder.get()
+
+  /**
+   * Stash metadata for the current render's preview. No-op when [currentPreviewId] is unset (e.g.
+   * running outside a daemon render — bare unit tests, IDE preview pane). Multiple offers for the
+   * same preview within one render replace the previous entry.
+   */
+  fun offer(metadata: LauncherWidgetMetadata) {
+    val previewId = currentPreviewIdHolder.get() ?: return
+    pending[previewId] = metadata
+  }
+
+  /** Drain (read + remove) the metadata for [previewId]. */
+  internal fun consume(previewId: String): LauncherWidgetMetadata? = pending.remove(previewId)
+}
+
+/**
+ * Widget-source-agnostic metadata bag the channel transports. Populated by whichever source can
+ * speak to the widget's declared constraints; consumed by [LauncherWidgetDataProductRegistry].
+ *
+ * @property supportedCells whole-cell sizes the widget composes correctly at, or `null` when the
+ *   source doesn't enumerate (e.g. Glance `SizeMode.Exact`). An empty list means "no resizing"
+ *   (Glance `SizeMode.Single` or `resizeMode="none"`).
+ * @property resizeAxes which axes the widget allows resizing along.
+ */
+data class LauncherWidgetMetadata(
+  val supportedCells: List<LauncherWidgetSize>? = null,
+  val resizeAxes: LauncherResizeAxes = LauncherResizeAxes.BOTH,
+)

--- a/data/launcher-widget/connector/src/test/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProductTest.kt
+++ b/data/launcher-widget/connector/src/test/kotlin/ee/schimke/composeai/daemon/LauncherWidgetDataProductTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.LauncherResizeAxes
 import ee.schimke.composeai.daemon.protocol.LauncherResizeOrder
 import ee.schimke.composeai.daemon.protocol.LauncherWidgetOverride
 import ee.schimke.composeai.daemon.protocol.LauncherWidgetSize
@@ -12,6 +13,7 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
 import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
@@ -348,4 +350,73 @@ class LauncherWidgetDataProductTest {
           outputBaseName = null,
         ),
     )
+
+  // -----------------------------------------------------------------------
+  // LauncherWidgetMetadataChannel — per-render carrier for widget-source
+  // metadata (Glance previewSizeMode reflection, future XML auto-discovery).
+  // Verified via the registry's onRender path since the channel's consume is
+  // internal and the registry is the only intended reader.
+  // -----------------------------------------------------------------------
+
+  @Test
+  fun channel_offer_no_op_when_current_preview_id_unset() {
+    val registry = LauncherWidgetDataProductRegistry()
+    LauncherWidgetMetadataChannel.setCurrentPreviewId(null)
+    // Should silently no-op — no id to key on.
+    LauncherWidgetMetadataChannel.offer(
+      LauncherWidgetMetadata(resizeAxes = LauncherResizeAxes.NONE)
+    )
+    registry.onRender("preview-x", stubRenderResult(), overrides = null, previewContext = null)
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch("preview-x", "compose/launcher-widget", null, true),
+    )
+  }
+
+  @Test
+  fun registry_on_render_picks_up_channel_metadata_for_glance_responsive() {
+    val registry = LauncherWidgetDataProductRegistry()
+    val responsive =
+      LauncherWidgetMetadata(
+        supportedCells = listOf(LauncherWidgetSize(2, 1), LauncherWidgetSize(4, 2)),
+        resizeAxes = LauncherResizeAxes.BOTH,
+      )
+    LauncherWidgetMetadataChannel.setCurrentPreviewId("preview-1")
+    try {
+      LauncherWidgetMetadataChannel.offer(responsive)
+    } finally {
+      LauncherWidgetMetadataChannel.setCurrentPreviewId(null)
+    }
+    // No override — the registry should still surface a payload from the channel alone.
+    registry.onRender("preview-1", stubRenderResult(), overrides = null, previewContext = null)
+
+    val outcome =
+      registry.fetch("preview-1", "compose/launcher-widget", null, true)
+        as DataProductRegistry.Outcome.Ok
+    val payload = outcome.result.payload!!.jsonObject
+    val supported = payload["supportedCells"]!!.jsonArray
+    assertEquals(2, supported.size)
+    assertEquals("both", payload["resizeAxes"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun registry_on_render_glance_single_signals_no_resize() {
+    val registry = LauncherWidgetDataProductRegistry()
+    LauncherWidgetMetadataChannel.setCurrentPreviewId("preview-1")
+    try {
+      LauncherWidgetMetadataChannel.offer(
+        LauncherWidgetMetadata(supportedCells = emptyList(), resizeAxes = LauncherResizeAxes.NONE)
+      )
+    } finally {
+      LauncherWidgetMetadataChannel.setCurrentPreviewId(null)
+    }
+    registry.onRender("preview-1", stubRenderResult(), overrides = null, previewContext = null)
+
+    val outcome =
+      registry.fetch("preview-1", "compose/launcher-widget", null, true)
+        as DataProductRegistry.Outcome.Ok
+    val payload = outcome.result.payload!!.jsonObject
+    assertEquals(0, payload["supportedCells"]!!.jsonArray.size)
+    assertEquals("none", payload["resizeAxes"]!!.jsonPrimitive.content)
+  }
 }

--- a/glance-preview-runtime/build.gradle.kts
+++ b/glance-preview-runtime/build.gradle.kts
@@ -46,6 +46,12 @@ dependencies {
   // 1.2.0+ is required for that API; pin via libs.versions.toml so a consumer-side bump moves
   // the entire toolchain together.
   api(libs.glance.appwidget)
+
+  // `LauncherWidgetMetadataChannel` — the helper reflectively reads `widget.previewSizeMode` and
+  // offers it into the per-render channel so `LauncherWidgetDataProductRegistry` can surface the
+  // declared supported sizes / resize-axes on the payload. Without this dep the helper still
+  // renders the widget; the payload just doesn't carry the size-mode constraints.
+  implementation(project(":data-launcher-widget-connector"))
 }
 
 mavenPublishing {

--- a/glance-preview-runtime/src/main/kotlin/ee/schimke/composeai/preview/glance/GlanceAppWidgetContent.kt
+++ b/glance-preview-runtime/src/main/kotlin/ee/schimke/composeai/preview/glance/GlanceAppWidgetContent.kt
@@ -13,7 +13,14 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.SizeMode
 import androidx.glance.appwidget.composeForPreview
+import ee.schimke.composeai.daemon.LauncherWidgetMetadata
+import ee.schimke.composeai.daemon.LauncherWidgetMetadataChannel
+import ee.schimke.composeai.daemon.protocol.LauncherResizeAxes
+import ee.schimke.composeai.daemon.protocol.LauncherWidgetSize
+import kotlin.math.max
+import kotlin.math.roundToInt
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -82,6 +89,11 @@ fun GlanceAppWidgetContent(
             minHeight = with(density) { it.height.toPx() }.toInt()
           }
         }
+      // Offer the widget's declared size mode into the per-render metadata channel BEFORE the
+      // compose call so `LauncherWidgetDataProductRegistry.onRender` (which runs after the
+      // render completes) picks up the supported-cells + resize-axes constraints. No-op when
+      // running outside a daemon render (the channel's ThreadLocal previewId is unset).
+      offerSizeModeMetadata(widget)
       val remoteViews =
         runBlocking { widget.composeForPreview(context, widgetCategory, info) }
       val view = remoteViews.apply(context, parent)
@@ -95,4 +107,63 @@ fun GlanceAppWidgetContent(
       parent
     },
   )
+}
+
+/**
+ * Reads the [GlanceAppWidget.previewSizeMode] and translates it into a [LauncherWidgetMetadata]
+ * snapshot the channel transports to the connector's registry post-render. Cell counts derive
+ * from each declared [DpSize] using the same `72dp` cell / `8dp` spacing arithmetic the
+ * connector applies — `widthCells = round((widthDp + spacing) / (cell + spacing))`, clamped to
+ * at least 1.
+ *
+ * Translation table:
+ * - [SizeMode.Single] → `supportedCells = [theDefaultSize]`, `resizeAxes = None` (the widget
+ *   declared one fixed size and doesn't respond to other layouts).
+ * - [SizeMode.Responsive] → `supportedCells = set.toCells()`, `resizeAxes = Both`. Picker
+ *   should show only these sizes; Glance won't lay out at others.
+ * - [SizeMode.Exact] → `supportedCells = null`, `resizeAxes = Both`. Widget composes at
+ *   whatever size it's given; no constraint to surface.
+ */
+private fun offerSizeModeMetadata(widget: GlanceAppWidget) {
+  if (LauncherWidgetMetadataChannel.currentPreviewId() == null) return
+  val mode = widget.previewSizeMode
+  val metadata =
+    when (mode) {
+      is SizeMode.Single ->
+        LauncherWidgetMetadata(
+          supportedCells = emptyList(),
+          resizeAxes = LauncherResizeAxes.NONE,
+        )
+      is SizeMode.Responsive ->
+        LauncherWidgetMetadata(
+          supportedCells = mode.sizes.map { it.toCells() },
+          resizeAxes = LauncherResizeAxes.BOTH,
+        )
+      else ->
+        // `SizeMode.Exact` (and any future SizeMode the connector doesn't recognise) — leave
+        // supportedCells null so the picker falls back to its default rectangle, but still
+        // signal that resizing is allowed.
+        LauncherWidgetMetadata(supportedCells = null, resizeAxes = LauncherResizeAxes.BOTH)
+    }
+  LauncherWidgetMetadataChannel.offer(metadata)
+}
+
+private const val DEFAULT_CELL_SIZE_DP: Int = 72
+private const val DEFAULT_CELL_SPACING_DP: Int = 8
+
+private fun DpSize.toCells(): LauncherWidgetSize =
+  LauncherWidgetSize(
+    width = dpToCells(width.value),
+    height = dpToCells(height.value),
+  )
+
+/**
+ * Inverse of the connector's `widthDp = cellSize * cells + spacing * (cells - 1)` arithmetic:
+ * `cells = round((dp + spacing) / (cell + spacing))`, floored at 1. Matches what a launcher's
+ * cell-snap logic does when laying out a Glance widget at a Responsive `DpSize`.
+ */
+private fun dpToCells(dp: Float): Int {
+  val divisor = (DEFAULT_CELL_SIZE_DP + DEFAULT_CELL_SPACING_DP).toFloat()
+  val raw = ((dp + DEFAULT_CELL_SPACING_DP) / divisor).roundToInt()
+  return max(1, raw)
 }

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -433,6 +433,12 @@ abstract class RobolectricRenderTestBase(
         // `require`/`check` calls in user code surface the same way as
         // RuntimeExceptions. JVM-fatal throwables already terminated the
         // JVM before we got here.
+        // Stamp the current preview id onto the launcher-widget metadata channel so render-side
+        // helpers (`:glance-preview-runtime`'s `GlanceAppWidgetContent`) can `offer(...)` widget
+        // metadata without an explicit `previewId` parameter. The connector's registry consumes
+        // the offered entry post-render via the same id. Cleared in `finally` so the next
+        // preview's render doesn't accidentally carry this one's id.
+        ee.schimke.composeai.daemon.LauncherWidgetMetadataChannel.setCurrentPreviewId(preview.id)
         try {
             renderDefault(
                 params = params,
@@ -455,6 +461,8 @@ abstract class RobolectricRenderTestBase(
             // travels through the sidecar; VS Code reads it via
             // `gradleService.readPreviewRenderError` and shows the
             // exception detail on the failing card.
+        } finally {
+            ee.schimke.composeai.daemon.LauncherWidgetMetadataChannel.setCurrentPreviewId(null)
         }
     }
 

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -594,7 +594,28 @@ export interface LauncherWidgetPayload {
     heightDp: number;
     /** Echo of the resize-order hint from the request, plumbed for a future orchestrator. */
     resizeOrder?: LauncherResizeOrder;
+    /**
+     * Set of cell sizes the underlying widget declared support for. Populated by render-side
+     * metadata sources (today: Glance's `previewSizeMode` reflection; future:
+     * `appwidget-provider/...xml` auto-discovery). `null` means "no constraint surfaced"
+     * (picker falls back to a default rectangle). Empty array means "no resizing" (Glance
+     * `SizeMode.Single`, `resizeMode="none"`).
+     */
+    supportedCells?: LauncherWidgetSize[] | null;
+    /**
+     * Which axes the underlying widget allows resizing along, mirroring
+     * `AppWidgetProviderInfo.resizeMode`. Picker should grey out drag handles for locked axes.
+     * Defaults to `"both"` when no metadata source surfaced a constraint.
+     */
+    resizeAxes?: LauncherResizeAxes;
 }
+
+/**
+ * Which axes the launcher-widget container can be resized along. Mirrors Glance's
+ * `previewSizeMode` (`SizeMode.Single` → `"none"`; `SizeMode.Responsive` / `SizeMode.Exact` →
+ * `"both"`) and `AppWidgetProviderInfo.resizeMode` (`horizontal | vertical | both | none`).
+ */
+export type LauncherResizeAxes = "none" | "horizontal" | "vertical" | "both";
 
 /** Soft-keyboard (IME) override. See `PreviewOverrides.keyboard`. */
 export interface KeyboardOverride {


### PR DESCRIPTION
## Summary

**v2** of the picker-constraints work: surfaces Glance's `previewSizeMode` metadata on `LauncherWidgetPayload` so a picker UI can constrain itself to what the widget actually supports — no `@LauncherWidgetPreview`-style annotation params required, no consumer code changes.

The Glance widget's `previewSizeMode` is the single source of truth; the rendering pipeline picks it up automatically.

### Plumbing

- **`daemon/core/.../Messages.kt`** — extends `LauncherWidgetPayload` with `supportedCells: List<LauncherWidgetSize>?` and `resizeAxes: LauncherResizeAxes` (new enum: `none | horizontal | vertical | both`). Source-agnostic by design: Glance feeds it now, AppWidget XML auto-discovery (v3) will feed the same fields later. Picker is the single consumer downstream.

- **`:data-launcher-widget-connector`** — new `LauncherWidgetMetadataChannel`, a thread-safe per-render carrier keyed by a `ThreadLocal currentPreviewId`. Render-side helpers `offer(metadata)` without passing previewId; the registry's `onRender` drains. Registry's `onRender` also extended to accept channel-only metadata (no override required) so a Glance widget surfaces its declared sizes even before the first user-driven `renderNow.overrides.launcherWidget`.

- **`:glance-preview-runtime`'s `GlanceAppWidgetContent`** — reflectively reads `widget.previewSizeMode` and translates:
  | Glance value | `supportedCells` | `resizeAxes` |
  |---|---|---|
  | `SizeMode.Single` | `[]` | `NONE` |
  | `SizeMode.Responsive(setOf(DpSize, …))` | `set.toCells()` (sparse list) | `BOTH` |
  | `SizeMode.Exact` | `null` (open) | `BOTH` |

- **`:renderer-android`** — `renderDefault(...)` sets/clears the channel's `currentPreviewId` in a `try/finally` around each render so the helper's `offer(...)` reaches the right key without any consumer-facing changes.

- **`vscode-extension/.../daemonProtocol.ts`** — TS mirror of the new payload fields + `LauncherResizeAxes` string union.

### Why a channel and not a direct registry call

Glance's helper (`GlanceAppWidgetContent`) lives in `:glance-preview-runtime`; the registry lives in `:data-launcher-widget-connector`. The channel is the lowest module both can share without bringing the registry's render-pipeline surface into the helper module. It also keeps the consumer-facing API (`GlanceAppWidgetContent(widget, size)`) free of an explicit `previewId` parameter — the renderer's ThreadLocal handles that transparently.

## Test plan

- [x] `./gradlew :data-launcher-widget-connector:test` — all 23 tests pass (20 existing + 3 new: offer-no-op-when-id-unset, Responsive flows to payload, Single signals NONE axes)
- [x] `./gradlew :daemon:core:compileKotlin :renderer-android:compileDebugKotlin :glance-preview-runtime:compileDebugKotlin` — full Kotlin chain green
- [x] `npm test --prefix vscode-extension` — all 1226 TS tests pass; new payload fields are non-breaking additions
- [ ] **Next:** v3 — `appwidget-provider/*.xml` auto-discovery for legacy RemoteViews widgets. Same channel, different source (a `WidgetMetadataIndex` populated by scanning `res/xml/` and resolving via `RemoteViews.layoutId` post-inflate).
- [ ] **Then:** the picker — pure payload consumer; constrains the cell-grid UI by `supportedCells` (sparse rendering for Responsive) and `resizeAxes` (lock axes the widget doesn't support).

---
_Generated by [Claude Code](https://claude.ai/code/session_016wQB16N6M2ey3nNLmZhrDc)_