### PR TITLE
feat(vscode-extension): move per-card touch / keyboard / controls toggles into focus bar

### DIFF
--- a/vscode-extension/src/test/liveCardControls.test.ts
+++ b/vscode-extension/src/test/liveCardControls.test.ts
@@ -18,10 +18,7 @@
 
 import * as assert from "assert";
 import {
-    ensureControlsToggleButton,
-    ensureKeyboardBandToggleButton,
     ensureLiveCardControls,
-    ensureTouchOverlayToggleButton,
     removeControlsToggleButton,
     removeKeyboardBandToggleButton,
     removeTouchOverlayToggleButton,
@@ -194,7 +191,12 @@ describe("ensureLiveCardControls", () => {
     });
 });
 
-describe("ensureControlsToggleButton (issue #1203)", () => {
+// Legacy per-card overlay toggles (touch-overlay, soft-keyboard band, #1203
+// controls) used to be stamped on top of the rendered preview. They now live
+// on the focus-controls bar — the `removeXxx` helpers below are the cleanup
+// path for webview state restored from an older release. Pin the cleanup is
+// idempotent (no throw on cards that never had the button).
+describe("removeXxxToggleButton cleanup helpers", () => {
     beforeEach(() => {
         document.body.innerHTML = "";
     });
@@ -202,236 +204,31 @@ describe("ensureControlsToggleButton (issue #1203)", () => {
         document.body.innerHTML = "";
     });
 
-    it("stamps a .card-controls-toggle-btn with the right shape + pressed state", () => {
-        const card = buildCard();
-        ensureControlsToggleButton(card, {
-            enabled: false,
-            onToggle: () => {},
-        });
-        const btn = card.querySelector(
-            ".card-controls-toggle-btn",
-        ) as HTMLButtonElement | null;
-        assert.ok(btn, "controls toggle should appear in image-container");
-        assert.strictEqual(btn!.type, "button");
-        assert.strictEqual(btn!.classList.contains("icon-button"), true);
-        assert.strictEqual(btn!.getAttribute("aria-pressed"), "false");
-        assert.ok(
-            /Turn on/.test(btn!.title),
-            "off-state title should say 'Turn on'",
-        );
-        assert.ok(btn!.querySelector("i.codicon.codicon-keyboard"));
-    });
+    function buildCardWithLegacyButton(cls: string): HTMLElement {
+        const card = document.createElement("div");
+        card.className = "preview-card";
+        const container = document.createElement("div");
+        container.className = "image-container";
+        const btn = document.createElement("button");
+        btn.className = `icon-button ${cls}`;
+        container.appendChild(btn);
+        card.appendChild(container);
+        document.body.appendChild(card);
+        return card;
+    }
 
-    it("reflects the enabled state via aria-pressed + title", () => {
-        const card = buildCard();
-        ensureControlsToggleButton(card, { enabled: true, onToggle: () => {} });
-        const btn = card.querySelector(
-            ".card-controls-toggle-btn",
-        ) as HTMLButtonElement;
-        assert.strictEqual(btn.getAttribute("aria-pressed"), "true");
-        assert.ok(
-            /Turn off/.test(btn.title),
-            "on-state title should say 'Turn off'",
-        );
-    });
-
-    it("is idempotent — repeat calls don't duplicate the button or restack handlers", () => {
-        const card = buildCard();
-        let calls: boolean[] = [];
-        ensureControlsToggleButton(card, {
-            enabled: false,
-            onToggle: (_c, next) => calls.push(next),
-        });
-        // A second call with a different onToggle must not stack a new handler.
-        ensureControlsToggleButton(card, {
-            enabled: false,
-            onToggle: () => calls.push(true),
-        });
-        assert.strictEqual(
-            card.querySelectorAll(".card-controls-toggle-btn").length,
-            1,
-            "duplicate calls must not stamp a second button",
-        );
-        const btn = card.querySelector(
-            ".card-controls-toggle-btn",
-        ) as HTMLButtonElement;
-        btn.click();
-        assert.deepStrictEqual(
-            calls,
-            [true],
-            "the FIRST call's onToggle is bound; second-call onToggle stays disconnected",
-        );
-    });
-
-    it("click toggles between aria-pressed = false → true by invoking onToggle with !current", () => {
-        const card = buildCard();
-        const seen: boolean[] = [];
-        ensureControlsToggleButton(card, {
-            enabled: false,
-            onToggle: (_c, next) => seen.push(next),
-        });
-        const btn = card.querySelector(
-            ".card-controls-toggle-btn",
-        ) as HTMLButtonElement;
-        btn.click(); // aria-pressed = "false" → onToggle(true)
-        // Simulate the controller updating state.
-        ensureControlsToggleButton(card, { enabled: true, onToggle: () => {} });
-        // Re-bind onToggle to capture the next call (handler stays original — so use
-        // the first onToggle by leaving binding alone). Note this verifies that the
-        // pressed state reflects the latest enabled flag passed to ensure().
-        assert.strictEqual(btn.getAttribute("aria-pressed"), "true");
-        assert.deepStrictEqual(seen, [true]);
-        // Toggle off — handler was bound on the first call, so seen should grow.
-        btn.click(); // aria-pressed = "true" → onToggle(false)
-        assert.deepStrictEqual(seen, [true, false]);
-    });
-
-    it("click suppresses default and stops propagation", () => {
-        const card = buildCard();
-        let bubbled = 0;
-        card.addEventListener("click", () => bubbled++);
-        ensureControlsToggleButton(card, {
-            enabled: false,
-            onToggle: () => {},
-        });
-        const btn = card.querySelector(
-            ".card-controls-toggle-btn",
-        ) as HTMLButtonElement;
-        const evt = new Event("click", { bubbles: true, cancelable: true });
-        btn.dispatchEvent(evt);
-        assert.strictEqual(evt.defaultPrevented, true);
-        assert.strictEqual(bubbled, 0);
-    });
-
-    it("is a silent no-op when .image-container is missing", () => {
-        const card = buildBareCard();
-        assert.doesNotThrow(() =>
-            ensureControlsToggleButton(card, {
-                enabled: false,
-                onToggle: () => {},
-            }),
-        );
-        assert.strictEqual(
-            card.querySelector(".card-controls-toggle-btn"),
-            null,
-        );
-        assert.strictEqual(card.children.length, 0);
-    });
-
-    it("removeControlsToggleButton drops the button and is idempotent on a button-less card", () => {
-        const card = buildCard();
-        ensureControlsToggleButton(card, {
-            enabled: false,
-            onToggle: () => {},
-        });
-        assert.ok(card.querySelector(".card-controls-toggle-btn"));
+    it("removeControlsToggleButton drops a legacy .card-controls-toggle-btn and is a no-op on a clean card", () => {
+        const card = buildCardWithLegacyButton("card-controls-toggle-btn");
         removeControlsToggleButton(card);
         assert.strictEqual(
             card.querySelector(".card-controls-toggle-btn"),
             null,
         );
-        // Second call is a no-op.
         assert.doesNotThrow(() => removeControlsToggleButton(card));
     });
-});
 
-describe("ensureTouchOverlayToggleButton", () => {
-    beforeEach(() => {
-        document.body.innerHTML = "";
-    });
-    afterEach(() => {
-        document.body.innerHTML = "";
-    });
-
-    it("stamps a .card-touch-overlay-toggle-btn with the codicon-target icon", () => {
-        const card = buildCard();
-        ensureTouchOverlayToggleButton(card, {
-            enabled: false,
-            onToggle: () => {},
-        });
-        const btn = card.querySelector(
-            ".card-touch-overlay-toggle-btn",
-        ) as HTMLButtonElement | null;
-        assert.ok(btn, "touch-overlay toggle should appear in image-container");
-        assert.strictEqual(btn!.type, "button");
-        assert.strictEqual(btn!.classList.contains("icon-button"), true);
-        assert.strictEqual(btn!.getAttribute("aria-pressed"), "false");
-        assert.ok(
-            /Turn on/.test(btn!.title),
-            `off-state title should say 'Turn on'; got '${btn!.title}'`,
-        );
-        assert.ok(btn!.querySelector("i.codicon.codicon-target"));
-    });
-
-    it("reflects the enabled state via aria-pressed + title", () => {
-        const card = buildCard();
-        ensureTouchOverlayToggleButton(card, {
-            enabled: true,
-            onToggle: () => {},
-        });
-        const btn = card.querySelector(
-            ".card-touch-overlay-toggle-btn",
-        ) as HTMLButtonElement;
-        assert.strictEqual(btn.getAttribute("aria-pressed"), "true");
-        assert.ok(/Turn off/.test(btn.title));
-    });
-
-    it("re-stamping doesn't duplicate the button or rebind the click handler", () => {
-        const card = buildCard();
-        let clicks = 0;
-        ensureTouchOverlayToggleButton(card, {
-            enabled: false,
-            onToggle: () => {
-                clicks++;
-            },
-        });
-        // Re-stamp twice. Same DOM element must persist; click handler must
-        // still fire exactly once per real click.
-        ensureTouchOverlayToggleButton(card, {
-            enabled: true,
-            onToggle: () => {
-                clicks++;
-            },
-        });
-        ensureTouchOverlayToggleButton(card, {
-            enabled: false,
-            onToggle: () => {
-                clicks++;
-            },
-        });
-        assert.strictEqual(
-            card.querySelectorAll(".card-touch-overlay-toggle-btn").length,
-            1,
-        );
-        const btn = card.querySelector(
-            ".card-touch-overlay-toggle-btn",
-        ) as HTMLButtonElement;
-        btn.click();
-        assert.strictEqual(clicks, 1, "click should fire onToggle once");
-    });
-
-    it("click inverts the current pressed state and calls onToggle with the new value", () => {
-        const card = buildCard();
-        const calls: { id: string; next: boolean }[] = [];
-        ensureTouchOverlayToggleButton(card, {
-            enabled: false,
-            onToggle: (c, next) =>
-                calls.push({ id: c.dataset.previewId!, next }),
-        });
-        const btn = card.querySelector(
-            ".card-touch-overlay-toggle-btn",
-        ) as HTMLButtonElement;
-        btn.click();
-        assert.deepStrictEqual(calls, [{ id: "com.example.A", next: true }]);
-    });
-
-    it("removeTouchOverlayToggleButton drops the button and is idempotent", () => {
-        const card = buildCard();
-        ensureTouchOverlayToggleButton(card, {
-            enabled: false,
-            onToggle: () => {},
-        });
-        assert.ok(card.querySelector(".card-touch-overlay-toggle-btn"));
+    it("removeTouchOverlayToggleButton drops a legacy .card-touch-overlay-toggle-btn and is a no-op on a clean card", () => {
+        const card = buildCardWithLegacyButton("card-touch-overlay-toggle-btn");
         removeTouchOverlayToggleButton(card);
         assert.strictEqual(
             card.querySelector(".card-touch-overlay-toggle-btn"),
@@ -439,44 +236,9 @@ describe("ensureTouchOverlayToggleButton", () => {
         );
         assert.doesNotThrow(() => removeTouchOverlayToggleButton(card));
     });
-});
 
-describe("ensureKeyboardBandToggleButton", () => {
-    beforeEach(() => {
-        document.body.innerHTML = "";
-    });
-    afterEach(() => {
-        document.body.innerHTML = "";
-    });
-
-    it("stamps a .card-keyboard-band-toggle-btn with the codicon-symbol-keyword icon", () => {
-        const card = buildCard();
-        ensureKeyboardBandToggleButton(card, {
-            enabled: false,
-            onToggle: () => {},
-        });
-        const btn = card.querySelector(
-            ".card-keyboard-band-toggle-btn",
-        ) as HTMLButtonElement | null;
-        assert.ok(btn);
-        assert.strictEqual(btn!.getAttribute("aria-pressed"), "false");
-        assert.ok(/Force/.test(btn!.title));
-        assert.ok(btn!.querySelector("i.codicon.codicon-symbol-keyword"));
-    });
-
-    it("toggles on click and removes idempotently", () => {
-        const card = buildCard();
-        const calls: boolean[] = [];
-        ensureKeyboardBandToggleButton(card, {
-            enabled: false,
-            onToggle: (_c, next) => calls.push(next),
-        });
-        (
-            card.querySelector(
-                ".card-keyboard-band-toggle-btn",
-            ) as HTMLButtonElement
-        ).click();
-        assert.deepStrictEqual(calls, [true]);
+    it("removeKeyboardBandToggleButton drops a legacy .card-keyboard-band-toggle-btn and is a no-op on a clean card", () => {
+        const card = buildCardWithLegacyButton("card-keyboard-band-toggle-btn");
         removeKeyboardBandToggleButton(card);
         assert.strictEqual(
             card.querySelector(".card-keyboard-band-toggle-btn"),

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -190,9 +190,8 @@ export class FocusController {
      * Push the touch-overlay / keyboard-band / controls toggle state for the
      * focused preview onto the focus-toolbar buttons. These were previously
      * stamped as per-card overlay icons on top of the rendered preview
-     * (`ensureTouchOverlayToggleButton` & friends in `liveCardControls.ts`); in
-     * focus mode they now live in the focus bar so they stop covering the
-     * preview content.
+     * (the legacy `card-*-toggle-btn` overlays); they now live exclusively in
+     * the focus-controls bar so they stop covering the preview content.
      */
     applyFocusedToggleButtonStates(): void {
         const inFocus = this.inFocus();

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -187,6 +187,42 @@ export class FocusController {
     }
 
     /**
+     * Push the touch-overlay / keyboard-band / controls toggle state for the
+     * focused preview onto the focus-toolbar buttons. These were previously
+     * stamped as per-card overlay icons on top of the rendered preview
+     * (`ensureTouchOverlayToggleButton` & friends in `liveCardControls.ts`); in
+     * focus mode they now live in the focus bar so they stop covering the
+     * preview content.
+     */
+    applyFocusedToggleButtonStates(): void {
+        const inFocus = this.inFocus();
+        const card = inFocus
+            ? this.getVisibleCards()[this.config.getFocusIndex()]
+            : null;
+        const previewId = card?.dataset.previewId ?? null;
+        const live = this.config.liveState;
+        this.config.focusToolbar.applyTouchOverlayButtonState({
+            inFocus,
+            focusedPreviewId: previewId,
+            advertised: live.isTouchOverlayAdvertised(),
+            enabled:
+                previewId !== null && live.isTouchOverlayEnabled(previewId),
+        });
+        this.config.focusToolbar.applyKeyboardBandButtonState({
+            inFocus,
+            focusedPreviewId: previewId,
+            advertised: live.isKeyboardBandAdvertised(),
+            enabled: previewId !== null && live.isKeyboardBandForced(previewId),
+        });
+        this.config.focusToolbar.applyControlsButtonState({
+            inFocus,
+            focusedPreviewId: previewId,
+            advertised: live.isControlsAdvertised(),
+            enabled: previewId !== null && live.isControlsEnabled(previewId),
+        });
+    }
+
+    /**
      * D2 — clicking the a11y toggle subscribes/unsubscribes via the
      * extension. When turning OFF, the extension also pushes an empty
      * updateA11y so the cached overlay tears down immediately rather
@@ -294,6 +330,7 @@ export class FocusController {
         this.applyInteractiveButtonState();
         this.applyRecordingButtonState();
         this.applyA11yOverlayButtonState();
+        this.applyFocusedToggleButtonStates();
         this.applyEarlyFeatureVisibility();
         this.config.refreshBundleLegend();
     }

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -248,9 +248,8 @@ export class FocusToolbarController {
 
     /**
      * Touch-event visualization toggle for the focused preview. Mirrors the
-     * `ensureTouchOverlayToggleButton` per-card overlay that used to sit on top
-     * of the preview — moved into the focus bar so the icon stops covering the
-     * rendered frame.
+     * Replaces the legacy per-card overlay that used to sit on top of the
+     * rendered preview, so the icon stops covering the frame.
      */
     applyTouchOverlayButtonState(s: FocusedToggleButtonState): void {
         const visible =

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -30,6 +30,9 @@ export interface FocusToolbarElements {
     btnInteractive: HTMLButtonElement;
     btnStopInteractive: HTMLButtonElement;
     btnRecording: HTMLButtonElement;
+    btnTouchOverlay: HTMLButtonElement;
+    btnKeyboardBand: HTMLButtonElement;
+    btnControls: HTMLButtonElement;
     btnExportBundle: HTMLButtonElement;
     btnExitFocus: HTMLButtonElement;
     recordingFormat: HTMLSelectElement;
@@ -89,6 +92,21 @@ export interface A11yOverlayButtonState {
     a11yOverlayId: string | null;
 }
 
+/**
+ * Common shape for the three preview-override / interactive-input toggles that
+ * follow the focused card (touch overlay, soft-keyboard band, #1203 controls).
+ * `advertised` reflects the daemon capability gate — when the daemon doesn't
+ * ship the matching planner / interactive-only extension the button stays hidden.
+ */
+export interface FocusedToggleButtonState {
+    inFocus: boolean;
+    focusedPreviewId: string | null;
+    /** Daemon advertises the backing extension / capability. */
+    advertised: boolean;
+    /** Current per-preview toggle state for the focused card. */
+    enabled: boolean;
+}
+
 export class FocusToolbarController {
     constructor(private readonly el: FocusToolbarElements) {}
 
@@ -112,6 +130,16 @@ export class FocusToolbarController {
             daemonHidden || !s.earlyFeatures || !s.inFocus;
         this.el.recordingFormat.hidden =
             daemonHidden || !s.earlyFeatures || !s.inFocus;
+        // Touch overlay / keyboard band / controls toggles — the per-button
+        // `applyXxxButtonState` hooks below refine visibility based on the
+        // daemon advertising the backing extension and a focused preview being
+        // present, but force them hidden up front in bundle mode until the
+        // bundle daemon is ready.
+        if (daemonHidden || !s.inFocus) {
+            this.el.btnTouchOverlay.hidden = true;
+            this.el.btnKeyboardBand.hidden = true;
+            this.el.btnControls.hidden = true;
+        }
         if (!s.earlyFeatures) {
             this.el.focusInspector.hidden = true;
         }
@@ -216,6 +244,77 @@ export class FocusToolbarController {
             ? "Hide accessibility overlay"
             : "Show accessibility overlay";
         this.el.btnA11yOverlay.classList.toggle("a11y-overlay-on", on);
+    }
+
+    /**
+     * Touch-event visualization toggle for the focused preview. Mirrors the
+     * `ensureTouchOverlayToggleButton` per-card overlay that used to sit on top
+     * of the preview — moved into the focus bar so the icon stops covering the
+     * rendered frame.
+     */
+    applyTouchOverlayButtonState(s: FocusedToggleButtonState): void {
+        const visible =
+            s.inFocus && s.advertised && s.focusedPreviewId !== null;
+        this.el.btnTouchOverlay.hidden = !visible;
+        if (!visible) {
+            this.el.btnTouchOverlay.setAttribute("aria-pressed", "false");
+            return;
+        }
+        this.el.btnTouchOverlay.setAttribute(
+            "aria-pressed",
+            s.enabled ? "true" : "false",
+        );
+        this.el.btnTouchOverlay.title = s.enabled
+            ? "Turn off touch-event visualization"
+            : "Turn on touch-event visualization (paints rings at dispatched pointers)";
+        this.el.btnTouchOverlay.setAttribute(
+            "aria-label",
+            this.el.btnTouchOverlay.title,
+        );
+    }
+
+    /** Soft-keyboard band override toggle for the focused preview. */
+    applyKeyboardBandButtonState(s: FocusedToggleButtonState): void {
+        const visible =
+            s.inFocus && s.advertised && s.focusedPreviewId !== null;
+        this.el.btnKeyboardBand.hidden = !visible;
+        if (!visible) {
+            this.el.btnKeyboardBand.setAttribute("aria-pressed", "false");
+            return;
+        }
+        this.el.btnKeyboardBand.setAttribute(
+            "aria-pressed",
+            s.enabled ? "true" : "false",
+        );
+        this.el.btnKeyboardBand.title = s.enabled
+            ? "Hide soft-keyboard band"
+            : "Force soft-keyboard band visible";
+        this.el.btnKeyboardBand.setAttribute(
+            "aria-label",
+            this.el.btnKeyboardBand.title,
+        );
+    }
+
+    /** Issue #1203 — interactive controls (keyboard input) toggle. */
+    applyControlsButtonState(s: FocusedToggleButtonState): void {
+        const visible =
+            s.inFocus && s.advertised && s.focusedPreviewId !== null;
+        this.el.btnControls.hidden = !visible;
+        if (!visible) {
+            this.el.btnControls.setAttribute("aria-pressed", "false");
+            return;
+        }
+        this.el.btnControls.setAttribute(
+            "aria-pressed",
+            s.enabled ? "true" : "false",
+        );
+        this.el.btnControls.title = s.enabled
+            ? "Turn off interactive controls (keyboard input)"
+            : "Turn on interactive controls (keyboard input). Enters live mode.";
+        this.el.btnControls.setAttribute(
+            "aria-label",
+            this.el.btnControls.title,
+        );
     }
 }
 

--- a/vscode-extension/src/webview/preview/liveCardControls.ts
+++ b/vscode-extension/src/webview/preview/liveCardControls.ts
@@ -46,171 +46,24 @@ export function ensureLiveCardControls(
 }
 
 /**
- * Idempotently inject a `.card-controls-toggle-btn` overlay into [card]'s
- * `.image-container`. This is the per-card entry point for issue #1203
- * interactive-only data extensions (canonical case: `input.keyboard`).
- *
- * Clicking the button toggles the panel-side "controls" flag for the
- * preview. When that flag flips on, [onToggle] is responsible for both
- * (a) entering live mode for the card (interactive dispatch can't land
- * outside a held composition — see `LiveStateController.extensionRequiresInteractive`)
- * and (b) attaching the keyboard listener.
- *
- * The button stays in the DOM across capability / live-state changes;
- * [enabled] only controls the pressed visual state. Visibility is driven
- * by adding / removing the element rather than re-creating it, so the
- * click handler is bound exactly once per card.
- */
-export function ensureControlsToggleButton(
-    card: HTMLElement,
-    opts: {
-        enabled: boolean;
-        onToggle: (card: HTMLElement, next: boolean) => void;
-    },
-): void {
-    const container = card.querySelector(".image-container");
-    if (!container) return;
-    let btn = container.querySelector<HTMLButtonElement>(
-        ".card-controls-toggle-btn",
-    );
-    if (!btn) {
-        btn = document.createElement("button");
-        btn.type = "button";
-        btn.className = "icon-button card-controls-toggle-btn";
-        btn.innerHTML =
-            '<i class="codicon codicon-keyboard" aria-hidden="true"></i>';
-        btn.addEventListener("click", (evt) => {
-            evt.preventDefault();
-            evt.stopPropagation();
-            const wasEnabled = btn!.getAttribute("aria-pressed") === "true";
-            opts.onToggle(card, !wasEnabled);
-        });
-        container.appendChild(btn);
-    }
-    btn.setAttribute("aria-pressed", opts.enabled ? "true" : "false");
-    btn.title = opts.enabled
-        ? "Turn off interactive controls (keyboard input)"
-        : "Turn on interactive controls (keyboard input). Enters live mode.";
-    btn.setAttribute("aria-label", btn.title);
-}
-
-/**
- * Remove the controls-toggle button from [card] when the daemon stops
- * advertising any interactive-only extension. Idempotent: no-op when the
- * button isn't present.
+ * Remove a stale `.card-controls-toggle-btn` overlay from [card]. Earlier
+ * builds stamped this button inside `.image-container`; the toggle now lives
+ * on the focus-controls bar (see `FocusController.applyFocusedToggleButtonStates`),
+ * so this helper only cleans up so a webview state restored from an older
+ * release doesn't leave the icon sitting on top of the rendered preview.
  */
 export function removeControlsToggleButton(card: HTMLElement): void {
     const btn = card.querySelector(".card-controls-toggle-btn");
     if (btn) btn.remove();
 }
 
-// -----------------------------------------------------------------------------
-// Per-card toggles for the `data/touch-overlay` + `data/keyboard` preview-override
-// extensions. Both follow the same pattern as `ensureControlsToggleButton` but
-// drive `PreviewOverrides` fields (`touchOverlay`, `keyboard.visible`) carried on
-// `requestStreamStart` rather than a webview-internal flag. See `liveState.ts`
-// for the wiring + restart-on-toggle behaviour.
-//
-// Why two dedicated helpers (not one generic `ensureExtensionToggleButton`):
-// each button has its own codicon + accessible label, and tests assert the
-// button's specific class name. A registry-based generic would save ~30 lines
-// but reduce the per-test grep affordance for "where does the touch button
-// come from?" — and we only have two such extensions today.
-// -----------------------------------------------------------------------------
-
-/**
- * Idempotently inject a `.card-touch-overlay-toggle-btn` into [card]'s
- * `.image-container`. Wires `PreviewOverrides.touchOverlay` for the next
- * `requestStreamStart` — when on, the daemon installs the `TouchOverlayExtension`
- * (cyan rings at every pressed pointer + expanding down/up pulses) for the
- * session and the streamed frames carry the visualization.
- *
- * Visibility stays in the DOM across capability changes; [enabled] only flips
- * the pressed visual state. Click handler bound exactly once per card (idempotent
- * across re-stamps from `applyPerCardToggleButtons`).
- */
-export function ensureTouchOverlayToggleButton(
-    card: HTMLElement,
-    opts: {
-        enabled: boolean;
-        onToggle: (card: HTMLElement, next: boolean) => void;
-    },
-): void {
-    const container = card.querySelector(".image-container");
-    if (!container) return;
-    let btn = container.querySelector<HTMLButtonElement>(
-        ".card-touch-overlay-toggle-btn",
-    );
-    if (!btn) {
-        btn = document.createElement("button");
-        btn.type = "button";
-        btn.className = "icon-button card-touch-overlay-toggle-btn";
-        btn.innerHTML =
-            '<i class="codicon codicon-target" aria-hidden="true"></i>';
-        btn.addEventListener("click", (evt) => {
-            evt.preventDefault();
-            evt.stopPropagation();
-            const wasEnabled = btn!.getAttribute("aria-pressed") === "true";
-            opts.onToggle(card, !wasEnabled);
-        });
-        container.appendChild(btn);
-    }
-    btn.setAttribute("aria-pressed", opts.enabled ? "true" : "false");
-    btn.title = opts.enabled
-        ? "Turn off touch-event visualization"
-        : "Turn on touch-event visualization (paints rings at dispatched pointers)";
-    btn.setAttribute("aria-label", btn.title);
-}
-
-/** Idempotent removal. No-op when the button isn't present. */
+/** Symmetric cleanup for the legacy per-card touch-overlay button. */
 export function removeTouchOverlayToggleButton(card: HTMLElement): void {
     const btn = card.querySelector(".card-touch-overlay-toggle-btn");
     if (btn) btn.remove();
 }
 
-/**
- * Idempotently inject a `.card-keyboard-band-toggle-btn` into [card]'s
- * `.image-container`. Wires `PreviewOverrides.keyboard.visible = true` for the
- * next `requestStreamStart` — when on, the daemon's always-active `data/keyboard`
- * connector forces its Gboard-shaped band visible regardless of what the app's
- * `LocalSoftwareKeyboardController` / focus state would naturally do, so the
- * preview shows the IME band even for screens that don't focus a text field on
- * first composition.
- */
-export function ensureKeyboardBandToggleButton(
-    card: HTMLElement,
-    opts: {
-        enabled: boolean;
-        onToggle: (card: HTMLElement, next: boolean) => void;
-    },
-): void {
-    const container = card.querySelector(".image-container");
-    if (!container) return;
-    let btn = container.querySelector<HTMLButtonElement>(
-        ".card-keyboard-band-toggle-btn",
-    );
-    if (!btn) {
-        btn = document.createElement("button");
-        btn.type = "button";
-        btn.className = "icon-button card-keyboard-band-toggle-btn";
-        btn.innerHTML =
-            '<i class="codicon codicon-symbol-keyword" aria-hidden="true"></i>';
-        btn.addEventListener("click", (evt) => {
-            evt.preventDefault();
-            evt.stopPropagation();
-            const wasEnabled = btn!.getAttribute("aria-pressed") === "true";
-            opts.onToggle(card, !wasEnabled);
-        });
-        container.appendChild(btn);
-    }
-    btn.setAttribute("aria-pressed", opts.enabled ? "true" : "false");
-    btn.title = opts.enabled
-        ? "Hide soft-keyboard band"
-        : "Force soft-keyboard band visible";
-    btn.setAttribute("aria-label", btn.title);
-}
-
-/** Idempotent removal. No-op when the button isn't present. */
+/** Symmetric cleanup for the legacy per-card soft-keyboard band button. */
 export function removeKeyboardBandToggleButton(card: HTMLElement): void {
     const btn = card.querySelector(".card-keyboard-band-toggle-btn");
     if (btn) btn.remove();

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -47,10 +47,7 @@ import { attachInteractiveInputHandlers } from "./interactiveInput";
 import type { InteractiveInputConfig } from "./interactiveInput";
 import { stampLiveBadgesOnGrid } from "./liveBadge";
 import {
-    ensureControlsToggleButton,
-    ensureKeyboardBandToggleButton,
     ensureLiveCardControls,
-    ensureTouchOverlayToggleButton,
     removeControlsToggleButton,
     removeKeyboardBandToggleButton,
     removeTouchOverlayToggleButton,
@@ -390,64 +387,17 @@ export class LiveStateController {
      * overrides, not input dispatch.
      */
     applyControlsToggleButtons(): void {
-        const advertised = this.moduleInteractiveOnlyExtensions.size > 0;
-        // Per-extension gating — touch-overlay and keyboard-band buttons appear only when the
-        // daemon actually ships the matching planner (descriptor advertised via #1312/#1313).
-        // The previous "any interactive backend" gate was loose: it surfaced buttons on hosts
-        // that would silently ignore the override, leaving dead toggles in the UI.
-        const touchOverlayAdvertised = this.anyModuleAdvertisesExtension(
-            TOUCH_OVERLAY_EXTENSION_ID,
-        );
-        const keyboardBandAdvertised = this.anyModuleAdvertisesExtension(
-            KEYBOARD_BAND_EXTENSION_ID,
-        );
-        // In focus mode these toggles live on the focus-controls bar (see
-        // `FocusController.applyFocusedToggleButtonStates`) rather than as
-        // per-card overlay icons painted on top of the rendered preview. Strip
-        // any leftover per-card buttons so a layout flip from grid → focus
-        // doesn't leave the icons covering the focused frame.
-        const inFocus = this.cfg.inFocus();
+        // The touch-overlay, soft-keyboard band, and #1203 controls toggles
+        // now live exclusively on the focus-controls bar (see
+        // `FocusController.applyFocusedToggleButtonStates`); they no longer
+        // stamp icons on top of the rendered preview. Strip any leftover
+        // per-card buttons in case an older webview state left them behind.
         const cards = document.querySelectorAll<HTMLElement>(".preview-card");
         for (const card of cards) {
-            const previewId = card.dataset.previewId;
-            if (!previewId || inFocus) {
-                removeControlsToggleButton(card);
-                removeTouchOverlayToggleButton(card);
-                removeKeyboardBandToggleButton(card);
-                continue;
-            }
-            // Existing #1203 controls (keyboard input dispatch) — gated on the
-            // daemon advertising an interactive-only extension.
-            if (advertised) {
-                ensureControlsToggleButton(card, {
-                    enabled: this.controlsEnabledPreviewIds.has(previewId),
-                    onToggle: (c, next) => this.toggleControlsForCard(c, next),
-                });
-            } else {
-                removeControlsToggleButton(card);
-            }
-            if (touchOverlayAdvertised) {
-                ensureTouchOverlayToggleButton(card, {
-                    enabled: this.touchOverlayEnabledPreviewIds.has(previewId),
-                    onToggle: (c, next) =>
-                        this.toggleTouchOverlayForCard(c, next),
-                });
-            } else {
-                removeTouchOverlayToggleButton(card);
-            }
-            if (keyboardBandAdvertised) {
-                ensureKeyboardBandToggleButton(card, {
-                    enabled: this.keyboardBandForcedPreviewIds.has(previewId),
-                    onToggle: (c, next) =>
-                        this.toggleKeyboardBandForCard(c, next),
-                });
-            } else {
-                removeKeyboardBandToggleButton(card);
-            }
+            removeControlsToggleButton(card);
+            removeTouchOverlayToggleButton(card);
+            removeKeyboardBandToggleButton(card);
         }
-        // Focus-bar mirrors for the three toggles — driven from the same state
-        // as the per-card overlays above. Skipped when no callback was wired
-        // (e.g. legacy tests that don't construct a focus toolbar).
         this.cfg.applyFocusedToggleButtonStates?.();
     }
 

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -95,6 +95,14 @@ export interface LiveStateConfig {
     /** Re-run focus-toolbar button-state hooks after a state change. */
     applyInteractiveButtonState(): void;
     applyRecordingButtonState(): void;
+    /**
+     * Re-stamp the focus-bar mirrors for the per-card touch-overlay /
+     * keyboard-band / controls toggles. Wired from `main.ts` to
+     * `FocusController.applyFocusedToggleButtonStates`. Optional so legacy
+     * tests that construct `LiveStateController` without a focus controller
+     * stay green — the per-card overlay path runs unchanged.
+     */
+    applyFocusedToggleButtonStates?(): void;
     /** Re-render the focus inspector for [card] — the inspector reads
      *  `isLive` / `isRecording` to keep its Tools strip in sync. */
     renderInspector(card: HTMLElement | null): void;
@@ -289,6 +297,35 @@ export class LiveStateController {
         return false;
     }
 
+    /** Daemon advertises the touch-overlay extension on any known module. */
+    isTouchOverlayAdvertised(): boolean {
+        return this.anyModuleAdvertisesExtension(TOUCH_OVERLAY_EXTENSION_ID);
+    }
+
+    /** Daemon advertises the soft-keyboard band extension on any known module. */
+    isKeyboardBandAdvertised(): boolean {
+        return this.anyModuleAdvertisesExtension(KEYBOARD_BAND_EXTENSION_ID);
+    }
+
+    /**
+     * Issue #1203 — any module advertises an interactive-only data extension,
+     * which is the gate for the per-preview "Controls" toggle (keyboard input
+     * dispatch).
+     */
+    isControlsAdvertised(): boolean {
+        return this.moduleInteractiveOnlyExtensions.size > 0;
+    }
+
+    /** Current per-preview touch-overlay toggle state. */
+    isTouchOverlayEnabled(previewId: string): boolean {
+        return this.touchOverlayEnabledPreviewIds.has(previewId);
+    }
+
+    /** Current per-preview soft-keyboard band override state. */
+    isKeyboardBandForced(previewId: string): boolean {
+        return this.keyboardBandForcedPreviewIds.has(previewId);
+    }
+
     /**
      * Issue #1203 — entry point for a panel toggle that enables an interactive-only
      * data extension on [card]. Idempotent: if the card is already live, this is a no-op.
@@ -364,11 +401,16 @@ export class LiveStateController {
         const keyboardBandAdvertised = this.anyModuleAdvertisesExtension(
             KEYBOARD_BAND_EXTENSION_ID,
         );
+        // In focus mode these toggles live on the focus-controls bar (see
+        // `FocusController.applyFocusedToggleButtonStates`) rather than as
+        // per-card overlay icons painted on top of the rendered preview. Strip
+        // any leftover per-card buttons so a layout flip from grid → focus
+        // doesn't leave the icons covering the focused frame.
+        const inFocus = this.cfg.inFocus();
         const cards = document.querySelectorAll<HTMLElement>(".preview-card");
         for (const card of cards) {
             const previewId = card.dataset.previewId;
-            if (!previewId) {
-                // No previewId — strip every toggle, can't bind state.
+            if (!previewId || inFocus) {
                 removeControlsToggleButton(card);
                 removeTouchOverlayToggleButton(card);
                 removeKeyboardBandToggleButton(card);
@@ -403,6 +445,10 @@ export class LiveStateController {
                 removeKeyboardBandToggleButton(card);
             }
         }
+        // Focus-bar mirrors for the three toggles — driven from the same state
+        // as the per-card overlays above. Skipped when no callback was wired
+        // (e.g. legacy tests that don't construct a focus toolbar).
+        this.cfg.applyFocusedToggleButtonStates?.();
     }
 
     /**

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -239,6 +239,9 @@ export class PreviewApp extends LitElement {
     private _btnStopInteractive!: HTMLButtonElement;
     @query("#btn-recording") private _btnRecording!: HTMLButtonElement;
     @query("#recording-format") private _recordingFormat!: HTMLSelectElement;
+    @query("#btn-touch-overlay") private _btnTouchOverlay!: HTMLButtonElement;
+    @query("#btn-keyboard-band") private _btnKeyboardBand!: HTMLButtonElement;
+    @query("#btn-controls") private _btnControls!: HTMLButtonElement;
     @query("#btn-export-bundle") private _btnExportBundle!: HTMLButtonElement;
     @query("#btn-exit-focus") private _btnExitFocus!: HTMLButtonElement;
 
@@ -384,6 +387,39 @@ export class PreviewApp extends LitElement {
                     <option value="apng">APNG</option>
                     <option value="mp4">MP4</option>
                 </select>
+                <button
+                    class="icon-button"
+                    id="btn-touch-overlay"
+                    title="Turn on touch-event visualization (paints rings at dispatched pointers)"
+                    aria-label="Toggle touch-event visualization"
+                    aria-pressed="false"
+                    hidden
+                >
+                    <i class="codicon codicon-target" aria-hidden="true"></i>
+                </button>
+                <button
+                    class="icon-button"
+                    id="btn-keyboard-band"
+                    title="Force soft-keyboard band visible"
+                    aria-label="Toggle soft-keyboard band"
+                    aria-pressed="false"
+                    hidden
+                >
+                    <i
+                        class="codicon codicon-symbol-keyword"
+                        aria-hidden="true"
+                    ></i>
+                </button>
+                <button
+                    class="icon-button"
+                    id="btn-controls"
+                    title="Turn on interactive controls (keyboard input). Enters live mode."
+                    aria-label="Toggle interactive controls"
+                    aria-pressed="false"
+                    hidden
+                >
+                    <i class="codicon codicon-keyboard" aria-hidden="true"></i>
+                </button>
                 <button
                     class="icon-button"
                     id="btn-export-bundle"
@@ -591,6 +627,9 @@ export class PreviewApp extends LitElement {
         const btnStopInteractive = this._btnStopInteractive;
         const btnRecording = this._btnRecording;
         const recordingFormat = this._recordingFormat;
+        const btnTouchOverlay = this._btnTouchOverlay;
+        const btnKeyboardBand = this._btnKeyboardBand;
+        const btnControls = this._btnControls;
         const btnExportBundle = this._btnExportBundle;
         const btnExitFocus = this._btnExitFocus;
         const focusToolbar = new FocusToolbarController({
@@ -601,6 +640,9 @@ export class PreviewApp extends LitElement {
             btnInteractive,
             btnStopInteractive,
             btnRecording,
+            btnTouchOverlay,
+            btnKeyboardBand,
+            btnControls,
             btnExportBundle,
             btnExitFocus,
             recordingFormat,
@@ -2558,6 +2600,8 @@ export class PreviewApp extends LitElement {
                 focusController.applyInteractiveButtonState(),
             applyRecordingButtonState: () =>
                 focusController.applyRecordingButtonState(),
+            applyFocusedToggleButtonStates: () =>
+                focusController.applyFocusedToggleButtonStates(),
             renderInspector: (card) => inspector.render(card),
         });
 
@@ -2736,6 +2780,30 @@ export class PreviewApp extends LitElement {
         btnRecording.addEventListener("click", () =>
             liveState.toggleRecording(),
         );
+        // Focus-bar mirrors for the per-card touch-overlay / keyboard-band /
+        // controls toggles — clicking each forwards to the same per-preview
+        // mutator the per-card overlay used to call, against the currently
+        // focused card.
+        btnTouchOverlay.addEventListener("click", () => {
+            const card = focusController.focusedCard();
+            if (!card) return;
+            const enabled =
+                btnTouchOverlay.getAttribute("aria-pressed") === "true";
+            liveState.toggleTouchOverlayForCard(card, !enabled);
+        });
+        btnKeyboardBand.addEventListener("click", () => {
+            const card = focusController.focusedCard();
+            if (!card) return;
+            const enabled =
+                btnKeyboardBand.getAttribute("aria-pressed") === "true";
+            liveState.toggleKeyboardBandForCard(card, !enabled);
+        });
+        btnControls.addEventListener("click", () => {
+            const card = focusController.focusedCard();
+            if (!card) return;
+            const enabled = btnControls.getAttribute("aria-pressed") === "true";
+            liveState.toggleControlsForCard(card, !enabled);
+        });
         btnExportBundle.addEventListener("click", () =>
             requestExportPreviewBundle(),
         );


### PR DESCRIPTION
The touch-overlay, soft-keyboard band, and #1203 controls toggle buttons
used to be stamped as icons on top of the rendered preview image, where
they covered content the user was trying to inspect. In focus mode they
now ride the existing focus-controls bar alongside the a11y / interactive
/ recording toggles; grid / flow / column modes keep the per-card overlay
since the focus bar is hidden there.