### PR TITLE
fix(vscode-extension): route daemon static PNG to the matching capture slot

### DIFF
--- a/vscode-extension/src/captureLabels.ts
+++ b/vscode-extension/src/captureLabels.ts
@@ -98,3 +98,23 @@ export function withDataProductCaptures(preview: PreviewInfo): PreviewInfo {
         captures: [...baseCaptures, ...products.map(dataProductToCapture)],
     };
 }
+
+/** Returns the index in [preview]'s displayed captures (post
+ *  [withDataProductCaptures]) of the static representative capture — the one
+ *  with no `scroll` and no `advanceTimeMillis`. Returns `-1` when no such
+ *  slot survives the fold.
+ *
+ *  The daemon's v1 `renderFinished` targets the representative (static)
+ *  capture only; the host posts `updateImage` to this slot rather than
+ *  blindly index 0. When `@ScrollingPreview(LONG/GIF)` replaces the static
+ *  base with a data product, the daemon's PNG has nowhere to go and the
+ *  caller skips the paint — otherwise the daemon's non-scrolling bytes
+ *  would clobber the scroll-long card with the wrong image. */
+export function staticBaseCaptureIndex(preview: PreviewInfo): number {
+    const display = withDataProductCaptures(preview);
+    for (let i = 0; i < display.captures.length; i++) {
+        const c = display.captures[i];
+        if (c.advanceTimeMillis == null && c.scroll == null) return i;
+    }
+    return -1;
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -42,7 +42,11 @@ import {
 import { formatRenderErrorMessage } from "./renderError";
 import { openResourceFile } from "./resourceFileResolver";
 import { readFontPreview, resolveFontPreviewPath } from "./fontPreviewLoader";
-import { captureLabel, withDataProductCaptures } from "./captureLabels";
+import {
+    captureLabel,
+    staticBaseCaptureIndex,
+    withDataProductCaptures,
+} from "./captureLabels";
 import {
     DaemonGate,
     GradleOnlyDaemonGate,
@@ -854,14 +858,33 @@ export async function activate(
                                   `[interactive] frame ${previewId} bytes=${imageBase64.length}`,
                               );
                           }
-                          // Capture index 0 — the daemon's v1 renderFinished targets the
-                          // representative capture only. Multi-capture (animated) renders
-                          // still come through the Gradle path; the daemon's predictive
-                          // pre-warm focuses on the cheap interactive loop.
+                          // The daemon's v1 renderFinished targets the static
+                          // representative capture only. Route it to the matching
+                          // slot in the displayed captures — for the common no-data-
+                          // product preview that's index 0, but when
+                          // `@ScrollingPreview(LONG/GIF)` replaced the static base
+                          // with a data product, `staticBaseCaptureIndex` returns
+                          // -1 and we skip the paint so the daemon's non-scrolling
+                          // bytes don't clobber the scroll-long/gif card.
+                          // Multi-capture (animated) renders still come through the
+                          // Gradle path; the daemon's predictive pre-warm focuses
+                          // on the cheap interactive loop.
+                          const ownerModule = previewModuleMap.get(previewId);
+                          const previewInfo = ownerModule
+                              ? moduleManifestCache
+                                    .get(ownerModule.modulePath)
+                                    ?.find((p) => p.id === previewId)
+                              : undefined;
+                          const captureIndex = previewInfo
+                              ? staticBaseCaptureIndex(previewInfo)
+                              : 0;
+                          if (captureIndex < 0) {
+                              return;
+                          }
                           panel.postMessage({
                               command: "updateImage",
                               previewId,
-                              captureIndex: 0,
+                              captureIndex,
                               imageData: imageBase64,
                           });
                       },

--- a/vscode-extension/src/test/captureLabels.test.ts
+++ b/vscode-extension/src/test/captureLabels.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import {
     captureLabel,
     isAnimatedPreview,
+    staticBaseCaptureIndex,
     withDataProductCaptures,
 } from "../captureLabels";
 import { PreviewInfo } from "../types";
@@ -213,5 +214,73 @@ describe("withDataProductCaptures", () => {
             isAnimatedPreview(withDataProductCaptures(preview)),
             true,
         );
+    });
+});
+
+describe("staticBaseCaptureIndex", () => {
+    it("returns 0 for a vanilla static preview", () => {
+        assert.strictEqual(staticBaseCaptureIndex(makePreview()), 0);
+    });
+
+    it("returns -1 when LONG/GIF data products dropped the static base", () => {
+        // Regression for the "daemon's static representative paints into the
+        // scroll-long card" bug — when @ScrollingPreview(LONG) is on a
+        // function, withDataProductCaptures drops the static slot and the
+        // scroll-long product takes index 0. The daemon's onPreviewImageReady
+        // must skip rather than overwrite that slot with the non-scrolling
+        // bytes it just rendered.
+        const longScroll = {
+            mode: "LONG",
+            axis: "VERTICAL",
+            maxScrollPx: 0,
+            reduceMotion: false,
+            atEnd: true,
+            reachedPx: null,
+        };
+        const preview = makePreview({
+            dataProducts: [
+                {
+                    kind: "render/scroll/long",
+                    advanceTimeMillis: null,
+                    scroll: longScroll,
+                    output: "data/render-scroll-long/x.png",
+                    cost: 20,
+                },
+            ],
+        });
+        assert.strictEqual(staticBaseCaptureIndex(preview), -1);
+    });
+
+    it("returns the surviving static base index when other captures shift it", () => {
+        const topScroll = {
+            mode: "TOP",
+            axis: "VERTICAL",
+            maxScrollPx: 0,
+            reduceMotion: false,
+            atEnd: false,
+            reachedPx: null,
+        };
+        const preview = makePreview({
+            captures: [
+                {
+                    advanceTimeMillis: 250,
+                    scroll: null,
+                    renderOutput: "renders/animated.png",
+                },
+                {
+                    advanceTimeMillis: null,
+                    scroll: null,
+                    renderOutput: "renders/static.png",
+                },
+                {
+                    advanceTimeMillis: null,
+                    scroll: topScroll,
+                    renderOutput: "renders/top.png",
+                },
+            ],
+        });
+        // No data products → withDataProductCaptures returns captures
+        // verbatim; static base is at index 1.
+        assert.strictEqual(staticBaseCaptureIndex(preview), 1);
     });
 });


### PR DESCRIPTION
When @ScrollingPreview(LONG/GIF) ships a data product, the host's
withDataProductCaptures drops the static base capture so the carousel
shows only the scroll-long/gif slot at index 0. The daemon's v1
renderFinished, however, always rendered the static representative and
the host blindly posted updateImage with captureIndex: 0 — clobbering
the scroll-long card with the non-scrolling render every time the
daemon completed a render.

Add staticBaseCaptureIndex(preview) that returns the index of the
surviving static slot (or -1 when only data products remain), and have
the daemon's onPreviewImageReady look up the displayed preview to route
the paint correctly: matching slot when one exists, skip when every
slot is a data product the daemon didn't actually render.