### PR TITLE
fix(touch-overlay): stamp pulses with event uptimeMillis so single clicks render

### DIFF
--- a/data/touch-overlay/connector/src/main/kotlin/ee/schimke/composeai/daemon/TouchOverlayDataProduct.kt
+++ b/data/touch-overlay/connector/src/main/kotlin/ee/schimke/composeai/daemon/TouchOverlayDataProduct.kt
@@ -106,12 +106,24 @@ class TouchOverlayExtension :
               val event = awaitPointerEvent(PointerEventPass.Initial)
               for (change in event.changes) {
                 val id = change.id.value
+                // Stamp pulses with the event's own `uptimeMillis` rather than the
+                // composition-side `nowMs`. The latter only advances when `withFrameNanos`
+                // resumes (i.e., on a rendered frame), so a CLICK dispatched between renders
+                // would stamp its DOWN pulse with a stale (much earlier) `nowMs`. By the time
+                // the next `render()` advances `nowMs` to wall time, the DOWN pulse would
+                // already look expired (age ≥ PULSE_LIFETIME_MS) and get pruned/faded before
+                // the user ever saw it — so clicks rendered as nothing while drags still
+                // showed via their persistent active-pointer ring. `change.uptimeMillis` is
+                // populated from the dispatcher's `sendPointerEvent(timeMillis = …)`, which
+                // is the same monotonic clock that drives `withFrameNanos`, so the pruning
+                // comparison stays consistent.
+                val eventMs = change.uptimeMillis
                 if (change.pressed) {
                   // First press for this id → emit a DOWN pulse so the first frame after the down
                   // shows a bright ring even if no `Move` arrives. Subsequent same-id events just
                   // update the position.
                   if (!activePointers.containsKey(id)) {
-                    pulses.add(Pulse(change.position, nowMs, PulseKind.DOWN))
+                    pulses.add(Pulse(change.position, eventMs, PulseKind.DOWN))
                   }
                   activePointers[id] = change.position
                 } else {
@@ -121,7 +133,7 @@ class TouchOverlayExtension :
                   // release per id, so a non-pressed event for a tracked id is unambiguously the
                   // up.
                   if (activePointers.remove(id) != null) {
-                    pulses.add(Pulse(change.position, nowMs, PulseKind.UP))
+                    pulses.add(Pulse(change.position, eventMs, PulseKind.UP))
                   }
                 }
               }

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -210,7 +210,14 @@ export class FocusController {
         this.config.focusToolbar.applyKeyboardBandButtonState({
             inFocus,
             focusedPreviewId: previewId,
-            advertised: live.isKeyboardBandAdvertised(),
+            // Wear OS surfaces have no software keyboard to force open, so
+            // the toggle is meaningless there — hide it on round-watch
+            // previews instead of showing a dead button on an already
+            // cramped focus toolbar. `data-wear-preview` is stamped by
+            // cardBuilder/cardMetadata via `isWearPreview`.
+            advertised:
+                live.isKeyboardBandAdvertised() &&
+                card?.dataset.wearPreview !== "1",
             enabled: previewId !== null && live.isKeyboardBandForced(previewId),
         });
         this.config.focusToolbar.applyControlsButtonState({


### PR DESCRIPTION
The DOWN/UP pulse `emittedAtMs` was being set from the composition-side
`nowMs` field, which only advances when `withFrameNanos` resumes (i.e.,
on a rendered frame). A `CLICK` dispatched between renders stamped its
DOWN pulse with a stale (much earlier) timestamp; by the time the next
`render()` advanced `nowMs` to wall time, the DOWN pulse already looked
expired (age ≥ PULSE_LIFETIME_MS) and was pruned/faded before the user
ever saw it. Drags didn't show the bug because the persistent
active-pointer ring stays painted for the whole gesture.

Use `change.uptimeMillis` from the event itself — populated from the
dispatcher's `sendPointerEvent(timeMillis = …)` against the same
monotonic clock that drives `withFrameNanos` — so the pruning math is
consistent and a single tap renders both pulses for their full lifetime.

fix(vscode-extension): hide keyboard-band toggle on Wear preview cards

Wear OS surfaces have no software keyboard to force open, so the
`Force soft-keyboard band` toggle was a dead button on round-watch
preview cards (which are already cramped). Gate the
`ensureKeyboardBandToggleButton` call on `data-wear-preview === "0"`,
mirroring the existing `isWearPreview` heuristic stamped onto every
card by `cardBuilder`/`cardMetadata`.