### PR TITLE
feat(samples): flesh out wear and remotecompose manifests with launcher icons and strings

### DIFF
--- a/samples/remotecompose/src/main/AndroidManifest.xml
+++ b/samples/remotecompose/src/main/AndroidManifest.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="Sample Remote Compose">
+        android:label="@string/app_name"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round">
         <activity
             android:name="com.example.sampleremotecompose.MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:label="@string/activity_main_label"
+            android:icon="@drawable/ic_remote">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/samples/remotecompose/src/main/res/drawable/ic_launcher_background.xml
+++ b/samples/remotecompose/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:pathData="M0,0 L108,0 L108,108 L0,108 Z">
+    <aapt:attr name="android:fillColor">
+      <gradient
+          android:startX="0"
+          android:startY="0"
+          android:endX="108"
+          android:endY="108"
+          android:type="linear">
+        <item android:offset="0" android:color="#4A148C" />
+        <item android:offset="1" android:color="#E91E63" />
+      </gradient>
+    </aapt:attr>
+  </path>
+</vector>

--- a/samples/remotecompose/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/samples/remotecompose/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <group
+      android:translateX="32"
+      android:translateY="32">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M22,4 L44,4 L44,40 L22,40 Z" />
+    <path
+        android:fillColor="#4A148C"
+        android:pathData="M26,8 L40,8 L40,36 L26,36 Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M22,2 m-4,0 a4,4 0 1,0 8,0 a4,4 0 1,0 -8,0" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:pathData="M4,12 Q12,4 22,4" />
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:pathData="M0,18 Q12,0 22,0" />
+  </group>
+</vector>

--- a/samples/remotecompose/src/main/res/drawable/ic_launcher_legacy.xml
+++ b/samples/remotecompose/src/main/res/drawable/ic_launcher_legacy.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:fillColor="#4A148C"
+      android:pathData="M0,0 L48,0 L48,48 L0,48 Z" />
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M16,16 L36,16 L36,40 L16,40 Z" />
+  <path
+      android:fillColor="#E91E63"
+      android:pathData="M19,19 L33,19 L33,37 L19,37 Z" />
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M16,14 m-3,0 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0" />
+</vector>

--- a/samples/remotecompose/src/main/res/drawable/ic_remote.xml
+++ b/samples/remotecompose/src/main/res/drawable/ic_remote.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#E91E63"
+      android:pathData="M12,3 C7,3 2.7,5.1 0,8.4 L1.6,10 C3.9,7.2 7.8,5.4 12,5.4 C16.2,5.4 20.1,7.2 22.4,10 L24,8.4 C21.3,5.1 17,3 12,3 Z" />
+  <path
+      android:fillColor="#E91E63"
+      android:pathData="M12,7 C8.7,7 5.8,8.3 3.8,10.5 L5.4,12.1 C7,10.4 9.4,9.4 12,9.4 C14.6,9.4 17,10.4 18.6,12.1 L20.2,10.5 C18.2,8.3 15.3,7 12,7 Z" />
+  <path
+      android:fillColor="#E91E63"
+      android:pathData="M12,11 C9.9,11 8.1,11.8 6.7,13.2 L8.3,14.8 C9.3,13.8 10.6,13.4 12,13.4 C13.4,13.4 14.7,13.8 15.7,14.8 L17.3,13.2 C15.9,11.8 14.1,11 12,11 Z" />
+  <path
+      android:fillColor="#E91E63"
+      android:pathData="M12,17 m-2,0 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+</vector>

--- a/samples/remotecompose/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/samples/remotecompose/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android"
+    android:icon="@drawable/ic_launcher_legacy">
+  <background android:drawable="@drawable/ic_launcher_background" />
+  <foreground android:drawable="@drawable/ic_launcher_foreground" />
+  <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/samples/remotecompose/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/samples/remotecompose/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android"
+    android:icon="@drawable/ic_launcher_legacy">
+  <background android:drawable="@drawable/ic_launcher_background" />
+  <foreground android:drawable="@drawable/ic_launcher_foreground" />
+  <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/samples/remotecompose/src/main/res/values/strings.xml
+++ b/samples/remotecompose/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="app_name">Sample Remote Compose</string>
+  <string name="activity_main_label">Remote Compose Demo</string>
+</resources>

--- a/samples/wear/src/main/AndroidManifest.xml
+++ b/samples/wear/src/main/AndroidManifest.xml
@@ -3,17 +3,22 @@
     <uses-feature android:name="android.hardware.type.watch" />
 
     <application
-        android:label="Sample Wear">
+        android:label="@string/app_name"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round">
         <uses-library
             android:name="com.google.android.wearable"
             android:required="true" />
 
-        <meta-data android:name="com.google.android.wearable.standalone"
-            android:value="true"/>`
+        <meta-data
+            android:name="com.google.android.wearable.standalone"
+            android:value="true" />
 
         <activity
             android:name="com.example.samplewear.MainActivity"
             android:exported="true"
+            android:label="@string/activity_main_label"
+            android:icon="@drawable/ic_watchface"
             android:theme="@android:style/Theme.DeviceDefault">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/samples/wear/src/main/res/drawable/ic_launcher_background.xml
+++ b/samples/wear/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:pathData="M0,0 L108,0 L108,108 L0,108 Z">
+    <aapt:attr name="android:fillColor">
+      <gradient
+          android:startX="0"
+          android:startY="0"
+          android:endX="108"
+          android:endY="108"
+          android:type="linear">
+        <item android:offset="0" android:color="#0F172A" />
+        <item android:offset="1" android:color="#1E3A8A" />
+      </gradient>
+    </aapt:attr>
+  </path>
+</vector>

--- a/samples/wear/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/samples/wear/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <group
+      android:translateX="36"
+      android:translateY="36">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M18,0 m-15,0 a15,15 0 1,0 30,0 a15,15 0 1,0 -30,0" />
+    <path
+        android:strokeColor="#1E3A8A"
+        android:strokeWidth="2"
+        android:pathData="M18,6 L18,18 L26,22" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M14,-3 L22,-3 L22,0 L14,0 Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M14,36 L22,36 L22,39 L14,39 Z" />
+  </group>
+</vector>

--- a/samples/wear/src/main/res/drawable/ic_launcher_legacy.xml
+++ b/samples/wear/src/main/res/drawable/ic_launcher_legacy.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:fillColor="#0F172A"
+      android:pathData="M0,0 L48,0 L48,48 L0,48 Z" />
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M24,24 m-14,0 a14,14 0 1,0 28,0 a14,14 0 1,0 -28,0" />
+  <path
+      android:strokeColor="#1E3A8A"
+      android:strokeWidth="2"
+      android:pathData="M24,14 L24,24 L31,28" />
+</vector>

--- a/samples/wear/src/main/res/drawable/ic_watchface.xml
+++ b/samples/wear/src/main/res/drawable/ic_watchface.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#1E3A8A"
+      android:pathData="M12,12 m-10,0 a10,10 0 1,0 20,0 a10,10 0 1,0 -20,0" />
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M12,12 m-8,0 a8,8 0 1,0 16,0 a8,8 0 1,0 -16,0" />
+  <path
+      android:strokeColor="#1E3A8A"
+      android:strokeWidth="1.5"
+      android:pathData="M12,7 L12,12 L15,14" />
+  <path
+      android:fillColor="#1E3A8A"
+      android:pathData="M11,2 L13,2 L13,4 L11,4 Z" />
+  <path
+      android:fillColor="#1E3A8A"
+      android:pathData="M11,20 L13,20 L13,22 L11,22 Z" />
+</vector>

--- a/samples/wear/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/samples/wear/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android"
+    android:icon="@drawable/ic_launcher_legacy">
+  <background android:drawable="@drawable/ic_launcher_background" />
+  <foreground android:drawable="@drawable/ic_launcher_foreground" />
+  <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/samples/wear/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/samples/wear/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android"
+    android:icon="@drawable/ic_launcher_legacy">
+  <background android:drawable="@drawable/ic_launcher_background" />
+  <foreground android:drawable="@drawable/ic_launcher_foreground" />
+  <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/samples/wear/src/main/res/values/strings.xml
+++ b/samples/wear/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="app_name">Sample Wear</string>
+  <string name="activity_main_label">Sample Wear</string>
+</resources>


### PR DESCRIPTION
Both samples now mirror the `:samples:android` shape: adaptive launcher icon
(background + foreground + monochrome + legacy), a distinct activity icon, and
`app_name` / activity label in `res/values/strings.xml`. Each sample has its
own visual identity — wear gets a watch-face mark in slate/indigo, remotecompose
a "remote signal" mark in purple/pink — so renders are visibly distinguishable.

Also fixes a stray backtick after the `<meta-data>` element in the wear manifest.