### PR TITLE
fix(daemon): honour @PreviewWrapper in render engine

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.runtime.tooling.CompositionData
@@ -39,6 +40,7 @@ import ee.schimke.composeai.data.render.extensions.ExtensionContextValue
 import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
 import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
 import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.loadPreviewWrapperClass
 import ee.schimke.composeai.data.render.extensions.provides
 import ee.schimke.composeai.renderer.AccessibilityDataProducts
 import ee.schimke.composeai.renderer.AccessibilityHierarchyContextKeys
@@ -346,7 +348,7 @@ class RenderEngine(
                             previewId = spec.previewId,
                           )
                         } else {
-                          InvokeComposable(composableMethod!!)
+                          InvokeWithOptionalWrapper(composableMethod!!)
                         }
                       }
                     }
@@ -848,6 +850,75 @@ internal fun isRoundDevice(device: String?): Boolean {
 @Composable
 private fun InvokeComposable(composableMethod: ComposableMethod) {
   composableMethod.invoke(currentComposer, null)
+}
+
+/**
+ * Wraps [InvokeComposable] in the preview's `@PreviewWrapper(SomeProvider::class)` `Wrap { … }` if
+ * one is present on the composable method. Without this the daemon would call the preview body
+ * directly and bypass the wrapper — e.g. `@PreviewWrapper(RemotePreviewWrapper::class)` previews
+ * would crash with `IllegalStateException: Invalid applier` the moment they emit a
+ * `RemoteBox` / `RemoteColumn` / `RemoteRow`, because those composables require the RemoteCompose
+ * applier the wrapper installs. `:renderer-android` does the equivalent in
+ * [ee.schimke.composeai.renderer.PreviewRenderStrategy]'s ComposePreviewStrategy.
+ *
+ * Wrapper class resolution flows through [loadPreviewWrapperClass], so connector-provided SPI
+ * substitutions (e.g. `:data-remotecompose-connector` swapping `RemotePreviewWrapper` for
+ * `RemoteOverridablePreviewWrapper`) apply transparently.
+ */
+@Composable
+private fun InvokeWithOptionalWrapper(composableMethod: ComposableMethod) {
+  val wrapper = remember(composableMethod) { resolveWrapperOrNull(composableMethod) }
+  if (wrapper == null) {
+    InvokeComposable(composableMethod)
+  } else {
+    val (wrapMethod, wrapperInstance) = wrapper
+    val body: @Composable () -> Unit = { InvokeComposable(composableMethod) }
+    wrapMethod.invoke(currentComposer, wrapperInstance, body)
+  }
+}
+
+/**
+ * Reads `@androidx.compose.ui.tooling.preview.PreviewWrapper(SomeProvider::class)` reflectively off
+ * the composable's underlying JVM method, then resolves the wrapper's `Wrap(content)` method plus a
+ * fresh instance. Returns null when the annotation is absent, the wrapper class can't be loaded, or
+ * instantiation fails — callers fall back to invoking the preview body directly.
+ *
+ * Reflective lookup (rather than a compile-time import of `PreviewWrapper`) keeps the daemon
+ * runnable on older Compose runtimes that predate the annotation (1.11.0-beta+). The annotation
+ * parameter name (`wrapper`) matches what the ClassGraph-based discovery in
+ * `gradle-plugin/preview-discovery` reads.
+ */
+private fun resolveWrapperOrNull(composableMethod: ComposableMethod): Pair<ComposableMethod, Any>? {
+  val jvmMethod = composableMethod.asMethod()
+  val ann =
+    jvmMethod.annotations.firstOrNull {
+      it.annotationClass.java.name == "androidx.compose.ui.tooling.preview.PreviewWrapper"
+    } ?: return null
+  val wrapperValue =
+    runCatching { ann.annotationClass.java.getDeclaredMethod("wrapper").invoke(ann) }.getOrNull()
+      ?: return null
+  val wrapperFqn =
+    when (wrapperValue) {
+      is Class<*> -> wrapperValue.name
+      is kotlin.reflect.KClass<*> -> wrapperValue.java.name
+      else -> return null
+    }
+  return runCatching {
+      val resolved = loadPreviewWrapperClass(wrapperFqn)
+      val instance = resolved.getDeclaredConstructor().apply { isAccessible = true }.newInstance()
+      // PreviewWrapperProvider.Wrap(content: @Composable () -> Unit) compiles to
+      // Wrap(Function2, Composer, int); getDeclaredComposableMethod handles the synthetic
+      // Composer/changed tail, so we look up by the content param's JVM type.
+      val wrapMethod = resolved.getDeclaredComposableMethod("Wrap", Function2::class.java)
+      wrapMethod to instance
+    }
+    .onFailure { t ->
+      System.err.println(
+        "compose-ai-daemon: [render] wrapper resolution failed for $wrapperFqn " +
+          "(${t.javaClass.simpleName}: ${t.message}); rendering without wrapper"
+      )
+    }
+    .getOrNull()
 }
 
 @Composable

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -888,7 +888,9 @@ private fun InvokeWithOptionalWrapper(composableMethod: ComposableMethod) {
  * parameter name (`wrapper`) matches what the ClassGraph-based discovery in
  * `gradle-plugin/preview-discovery` reads.
  */
-private fun resolveWrapperOrNull(composableMethod: ComposableMethod): Pair<ComposableMethod, Any>? {
+internal fun resolveWrapperOrNull(
+  composableMethod: ComposableMethod
+): Pair<ComposableMethod, Any>? {
   val jvmMethod = composableMethod.asMethod()
   val ann =
     jvmMethod.annotations.firstOrNull {

--- a/daemon/android/src/test/kotlin/androidx/compose/ui/tooling/preview/PreviewWrapperStandIn.kt
+++ b/daemon/android/src/test/kotlin/androidx/compose/ui/tooling/preview/PreviewWrapperStandIn.kt
@@ -1,0 +1,19 @@
+@file:Suppress("PackageDirectoryMismatch")
+
+package androidx.compose.ui.tooling.preview
+
+import kotlin.reflect.KClass
+
+/**
+ * Test-only stand-in for the upstream `androidx.compose.ui.tooling.preview.PreviewWrapper`
+ * annotation, declared under the same FQN so [ee.schimke.composeai.daemon.RenderEngine]'s
+ * `resolveWrapperOrNull` (which matches by FQN string) drives the production code path.
+ *
+ * The real annotation ships in `compose-ui-tooling-preview` 1.11.0-beta+. The daemon module's
+ * compose-bom-compat floor pins 1.9.5, so the upstream class isn't on the test classpath and there
+ * is no FQN collision. Matches the upstream `wrapper` parameter name (also used by ClassGraph
+ * discovery in `gradle-plugin/preview-discovery`).
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class PreviewWrapper(val wrapper: KClass<*>)

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperResolutionFixtures.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperResolutionFixtures.kt
@@ -1,0 +1,35 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewWrapper
+
+/**
+ * Wrapper class for [PreviewWrapperResolutionTest]. Mirrors the shape of upstream's
+ * `PreviewWrapperProvider`: a public no-arg ctor + a `@Composable fun Wrap(content)` method that
+ * `getDeclaredComposableMethod("Wrap", Function2::class.java)` can resolve.
+ *
+ * Body is the simplest possible — just invokes `content()` — because the test asserts on the
+ * resolved JVM `Method` shape, not on rendered pixels. The renderer-android counterpart
+ * ([ee.schimke.composeai.renderer.PreviewWrapperTest]) paints a green border to verify the
+ * wrapper actually composes around the body; the daemon side gets that integration coverage from
+ * the planned `:samples:remotecompose` harness scenario (see the follow-up issue).
+ */
+class GreenBorderWrapper {
+  @Composable
+  fun Wrap(content: @Composable () -> Unit) {
+    content()
+  }
+}
+
+@PreviewWrapper(GreenBorderWrapper::class)
+@Composable
+fun WrappedFixturePreview() {
+  Box(modifier = Modifier)
+}
+
+@Composable
+fun UnwrappedFixturePreview() {
+  Box(modifier = Modifier)
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperResolutionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperResolutionTest.kt
@@ -1,0 +1,51 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Regression guard for the `@PreviewWrapper` annotation reading + wrapper-class resolution path
+ * the daemon's [RenderEngine] uses. Before this guard existed the daemon ignored
+ * `@PreviewWrapper(SomeProvider::class)` entirely, so samples relying on a custom applier (e.g.
+ * `@PreviewWrapper(RemotePreviewWrapper::class)` in `samples/remotecompose`) crashed with
+ * `IllegalStateException: Invalid applier`.
+ *
+ * `:renderer-android` has a parallel test ([ee.schimke.composeai.renderer.PreviewWrapperTest]) for
+ * its own `resolveWrapper`; this one covers the duplicated daemon path that the v2 reconciliation
+ * (see [RenderEngine] kdoc) eventually folds back into a shared helper.
+ *
+ * The daemon's `:compose-bom-compat` floor (1.9.5) doesn't ship the real
+ * `androidx.compose.ui.tooling.preview.PreviewWrapper` annotation — that landed in 1.11.0-beta+ —
+ * so a same-FQN stand-in lives next to this test (see
+ * `PreviewWrapperStandIn.kt`). The daemon's resolver matches by FQN string, so the synthetic
+ * annotation is indistinguishable from the real one at runtime for the resolution path.
+ */
+class PreviewWrapperResolutionTest {
+
+  @Test
+  fun `resolveWrapperOrNull returns wrapper Wrap method when annotation is present`() {
+    val method =
+      Class.forName("ee.schimke.composeai.daemon.PreviewWrapperResolutionFixturesKt")
+        .getDeclaredComposableMethod("WrappedFixturePreview")
+
+    val resolved = resolveWrapperOrNull(method)
+
+    assertNotNull("wrapper must resolve when @PreviewWrapper is present", resolved)
+    val (wrapMethod, instance) = resolved!!
+    assertSame(GreenBorderWrapper::class.java, instance.javaClass)
+    assertEquals("Wrap", wrapMethod.asMethod().name)
+  }
+
+  @Test
+  fun `resolveWrapperOrNull returns null when annotation is absent`() {
+    val method =
+      Class.forName("ee.schimke.composeai.daemon.PreviewWrapperResolutionFixturesKt")
+        .getDeclaredComposableMethod("UnwrappedFixturePreview")
+
+    assertNull(resolveWrapperOrNull(method))
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.tooling.CompositionData
 import androidx.compose.runtime.tooling.LocalInspectionTables
 import androidx.compose.ui.ImageComposeScene
@@ -33,6 +34,7 @@ import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
 import ee.schimke.composeai.data.render.extensions.compose.ComposeDataExtensionPipeline
 import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionCompositionSink
+import ee.schimke.composeai.data.render.extensions.loadPreviewWrapperClass
 import ee.schimke.composeai.data.theme.ThemePayload
 import java.io.File
 import java.util.Base64
@@ -262,8 +264,9 @@ class RenderEngine(
                   sink = RecordingExtensionCompositionSink(),
                 ) {
                   // Trampoline through a @Composable so the reflective invocation lands inside the
-                  // running composition. Mirrors `:renderer-desktop`'s InvokeComposable.
-                  InvokeComposable(composableMethod)
+                  // running composition. Mirrors `:renderer-desktop`'s InvokeComposable. Honours
+                  // `@PreviewWrapper(SomeProvider::class)` by routing through the wrapper's `Wrap`.
+                  InvokeWithOptionalWrapper(composableMethod)
                 }
               }
             }
@@ -665,6 +668,67 @@ data class RenderSpec(
 @androidx.compose.runtime.Composable
 private fun InvokeComposable(composableMethod: ComposableMethod) {
   composableMethod.invoke(currentComposer, null)
+}
+
+/**
+ * Wraps [InvokeComposable] in the preview's `@PreviewWrapper(SomeProvider::class)` `Wrap { … }` if
+ * one is present on the composable method. Without this the daemon would call the preview body
+ * directly and bypass the wrapper — e.g. `@PreviewWrapper(RemotePreviewWrapper::class)` previews
+ * would crash with `IllegalStateException: Invalid applier` the moment they emit a `RemoteBox` /
+ * `RemoteColumn` / `RemoteRow`, because those composables require the RemoteCompose applier the
+ * wrapper installs. Mirrors the Android daemon and `:renderer-android`'s `PreviewRenderStrategy`.
+ * Wrapper class resolution flows through [loadPreviewWrapperClass], so connector-provided SPI
+ * substitutions apply transparently.
+ */
+@Composable
+private fun InvokeWithOptionalWrapper(composableMethod: ComposableMethod) {
+  val wrapper = remember(composableMethod) { resolveWrapperOrNull(composableMethod) }
+  if (wrapper == null) {
+    InvokeComposable(composableMethod)
+  } else {
+    val (wrapMethod, wrapperInstance) = wrapper
+    val body: @Composable () -> Unit = { InvokeComposable(composableMethod) }
+    wrapMethod.invoke(currentComposer, wrapperInstance, body)
+  }
+}
+
+/**
+ * Reads `@androidx.compose.ui.tooling.preview.PreviewWrapper(SomeProvider::class)` reflectively off
+ * the composable's underlying JVM method, then resolves the wrapper's `Wrap(content)` method plus a
+ * fresh instance. Returns null when the annotation is absent, the wrapper class can't be loaded, or
+ * instantiation fails — callers fall back to invoking the preview body directly.
+ *
+ * Reflective lookup (rather than a compile-time import of `PreviewWrapper`) keeps the daemon
+ * runnable on older Compose runtimes that predate the annotation (1.11.0-beta+).
+ */
+private fun resolveWrapperOrNull(composableMethod: ComposableMethod): Pair<ComposableMethod, Any>? {
+  val jvmMethod = composableMethod.asMethod()
+  val ann =
+    jvmMethod.annotations.firstOrNull {
+      it.annotationClass.java.name == "androidx.compose.ui.tooling.preview.PreviewWrapper"
+    } ?: return null
+  val wrapperValue =
+    runCatching { ann.annotationClass.java.getDeclaredMethod("wrapper").invoke(ann) }.getOrNull()
+      ?: return null
+  val wrapperFqn =
+    when (wrapperValue) {
+      is Class<*> -> wrapperValue.name
+      is kotlin.reflect.KClass<*> -> wrapperValue.java.name
+      else -> return null
+    }
+  return runCatching {
+      val resolved = loadPreviewWrapperClass(wrapperFqn)
+      val instance = resolved.getDeclaredConstructor().apply { isAccessible = true }.newInstance()
+      val wrapMethod = resolved.getDeclaredComposableMethod("Wrap", Function2::class.java)
+      wrapMethod to instance
+    }
+    .onFailure { t ->
+      System.err.println(
+        "compose-ai-daemon: [render] wrapper resolution failed for $wrapperFqn " +
+          "(${t.javaClass.simpleName}: ${t.message}); rendering without wrapper"
+      )
+    }
+    .getOrNull()
 }
 
 @Composable


### PR DESCRIPTION
The daemon render engine called the resolved composable directly,
bypassing any `@PreviewWrapper(SomeProvider::class)` annotation. With
the `:data-remotecompose-connector` SPI in place, only the standalone
`:renderer-android` path applied the wrapper; daemon-driven renders
(used by the VS Code extension) skipped it.

That broke previews relying on the wrapper to install a custom
applier — e.g. `RemoteButtonWith{Border,NamedLabel}Preview` in
`samples/remotecompose`, where `RemoteBox` aborts with
`IllegalStateException: Invalid applier` outside the wrapper's
composition.

Wire a reflective `@PreviewWrapper` lookup into both daemon backends
(Android Robolectric + desktop Skiko): read the annotation off the
underlying JVM method, resolve the wrapper class through
`loadPreviewWrapperClass` (so SPI substitutions still apply), and
invoke its `Wrap(content)` around the preview body. Falls through to
the previous direct-invoke path when no annotation is present or
resolution fails, so existing previews are unaffected.

Reflection avoids a compile-time dependency on the
`androidx.compose.ui.tooling.preview.PreviewWrapper` symbol, which
ships in Compose 1.11.0-beta+ — the daemon itself still builds
against the older compose-bom-compat floor.