### PR TITLE
fix(vscode-extension): trust boundary for workspace `resources.json` hover

### DIFF
--- a/vscode-extension/src/activityIconHoverProvider.ts
+++ b/vscode-extension/src/activityIconHoverProvider.ts
@@ -7,7 +7,7 @@ import {
     isActivityLikeDeclaration,
     KotlinClassDeclaration,
 } from "./kotlinClassFqn";
-import { readVariantImages } from "./manifestResourceHoverProvider";
+import { readVariantImages } from "./manifestResourceHoverImages";
 import { buildResourceVariantHoverMarkdown } from "./resourceVariantHover";
 import { ResourcePreview } from "./types";
 import * as path from "node:path";

--- a/vscode-extension/src/manifestResourceHoverImages.ts
+++ b/vscode-extension/src/manifestResourceHoverImages.ts
@@ -1,0 +1,58 @@
+// Disk-reader for the manifest-resource hover. Split out of
+// `manifestResourceHoverProvider.ts` so Mocha tests can drive it without
+// loading the `vscode` host module — the provider's only host-side
+// dependency was this `fs.readFileSync` + path arithmetic, so isolating
+// it keeps the security-sensitive boundary in a unit-testable module.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { VariantImage } from "./resourceVariantHover";
+import { ResourcePreview } from "./types";
+
+/**
+ * Read each capture's PNG/GIF off disk and base64-encode it for the markdown
+ * `<img>` tag. Captures whose file is missing are skipped silently — the
+ * renderer might have failed on that particular variant, or a heavy-tier
+ * filter could have dropped it; the hover still shows whichever variants
+ * did land.
+ *
+ * `capture.renderOutput` comes from the workspace `resources.json`, which is
+ * user-controlled. Each candidate is resolved and forced to stay strictly
+ * underneath [moduleBuildRoot] before any disk I/O — an entry like
+ * `'../../../etc/passwd'` would otherwise let a hovering user trigger
+ * arbitrary local-file reads. Variants outside the root (or absolute paths
+ * that escape it) are skipped silently, same as a missing file; we don't
+ * throw the whole hover. See issue #1442.
+ */
+export function readVariantImages(
+    resource: ResourcePreview,
+    moduleBuildRoot: string,
+): VariantImage[] {
+    // Anchor the boundary check on the resolved absolute path of the build
+    // root, and require candidates to live strictly underneath — `+ path.sep`
+    // stops `/foo/bar/baz` from passing when the root is `/foo/bar`.
+    const resolvedRoot = path.resolve(moduleBuildRoot);
+    const rootPrefix = resolvedRoot.endsWith(path.sep)
+        ? resolvedRoot
+        : resolvedRoot + path.sep;
+    const out: VariantImage[] = [];
+    for (const capture of resource.captures) {
+        const abs = path.resolve(resolvedRoot, capture.renderOutput);
+        if (!abs.startsWith(rootPrefix)) {
+            // Path-traversal attempt or absolute escape — drop the variant.
+            continue;
+        }
+        try {
+            const bytes = fs.readFileSync(abs);
+            out.push({
+                renderOutput: capture.renderOutput,
+                base64: bytes.toString("base64"),
+            });
+        } catch {
+            // File missing — render run produced no output for this variant.
+            // Drop silently; the hover renders whatever did land.
+        }
+    }
+    return out;
+}

--- a/vscode-extension/src/manifestResourceHoverProvider.ts
+++ b/vscode-extension/src/manifestResourceHoverProvider.ts
@@ -1,13 +1,9 @@
-import * as fs from "node:fs";
 import * as path from "node:path";
 import * as vscode from "vscode";
 import { GradleService } from "./gradleService";
+import { readVariantImages } from "./manifestResourceHoverImages";
 import { findManifestIconReferences } from "./manifestIconReferences";
-import {
-    buildResourceVariantHoverMarkdown,
-    VariantImage,
-} from "./resourceVariantHover";
-import { ResourcePreview } from "./types";
+import { buildResourceVariantHoverMarkdown } from "./resourceVariantHover";
 
 /**
  * Renders a hover over every `android:icon` / `roundIcon` / `logo` / `banner` attribute in
@@ -80,33 +76,4 @@ export class ManifestResourceHoverProvider implements vscode.HoverProvider {
         const endPos = doc.positionAt(hit.offset + hit.length);
         return new vscode.Hover(md, new vscode.Range(startPos, endPos));
     }
-}
-
-/**
- * Read each capture's PNG/GIF off disk and base64-encode it for the markdown `<img>` tag.
- * Captures whose file is missing are skipped silently — the renderer might have failed on that
- * particular variant, or a heavy-tier filter could have dropped it; the hover still shows
- * whichever variants did land.
- *
- * Exported for tests; production callers go through the hover provider.
- */
-export function readVariantImages(
-    resource: ResourcePreview,
-    moduleBuildRoot: string,
-): VariantImage[] {
-    const out: VariantImage[] = [];
-    for (const capture of resource.captures) {
-        const abs = path.join(moduleBuildRoot, capture.renderOutput);
-        try {
-            const bytes = fs.readFileSync(abs);
-            out.push({
-                renderOutput: capture.renderOutput,
-                base64: bytes.toString("base64"),
-            });
-        } catch {
-            // File missing — render run produced no output for this variant.
-            // Drop silently; the hover renders whatever did land.
-        }
-    }
-    return out;
 }

--- a/vscode-extension/src/manifestResourceHoverProvider.ts
+++ b/vscode-extension/src/manifestResourceHoverProvider.ts
@@ -68,7 +68,12 @@ export class ManifestResourceHoverProvider implements vscode.HoverProvider {
         const md = new vscode.MarkdownString(
             buildResourceVariantHoverMarkdown({ resource, images }),
         );
-        md.isTrusted = true;
+        // `resources.json` is workspace-controlled (could be authored by an
+        // attacker if a victim opens a hostile project). The hover only needs
+        // `supportHtml` for the inline data-URI `<img>` previews — it never
+        // emits `command:` links — so leave `isTrusted` off and the markdown
+        // builder also escapes interpolated fields. See issue #1442.
+        md.isTrusted = false;
         md.supportHtml = true;
 
         const startPos = doc.positionAt(hit.offset);

--- a/vscode-extension/src/resourceReferenceHoverProvider.ts
+++ b/vscode-extension/src/resourceReferenceHoverProvider.ts
@@ -7,7 +7,7 @@ import {
     ResourceRef,
 } from "./androidResourceReferences";
 import { GradleService } from "./gradleService";
-import { readVariantImages } from "./manifestResourceHoverProvider";
+import { readVariantImages } from "./manifestResourceHoverImages";
 import { buildResourceVariantHoverMarkdown } from "./resourceVariantHover";
 
 /**

--- a/vscode-extension/src/resourceVariantHover.ts
+++ b/vscode-extension/src/resourceVariantHover.ts
@@ -48,18 +48,24 @@ export interface VariantHoverInput {
 /**
  * Build the markdown body for [input]. Returns the raw markdown string;
  * the caller wraps it in `new vscode.MarkdownString(...)` and sets
- * `isTrusted` / `supportHtml` per provider conventions. Captures whose
+ * `supportHtml` per provider conventions (the hover does NOT need
+ * `isTrusted` — see `manifestResourceHoverProvider.ts`). Captures whose
  * `renderOutput` doesn't appear in [VariantHoverInput.images] are
  * skipped silently — the host decides which variants are worth the
  * base64 cost (a tier=fast render might have skipped the heavy
  * adaptive captures, for instance).
+ *
+ * `resource.id` and `resource.type` originate from the workspace
+ * `resources.json`, which is user-controlled input — both fields are
+ * escaped before being interpolated into markdown so a crafted manifest
+ * cannot inject markdown / HTML structure into the hover.
  */
 export function buildResourceVariantHoverMarkdown(
     input: VariantHoverInput,
 ): string {
     const lines: string[] = [];
     lines.push(
-        `**${input.resource.id}** — ${friendlyType(input.resource.type)}`,
+        `**${escapeMarkdown(input.resource.id)}** — ${escapeMarkdown(friendlyType(input.resource.type))}`,
     );
     const byOutput = new Map(
         input.images.map((i) => [i.renderOutput, i.base64]),
@@ -177,4 +183,21 @@ function escapeAttr(s: string): string {
                 return c;
         }
     });
+}
+
+/**
+ * Escape markdown / HTML metacharacters in a workspace-controlled string
+ * (`resource.id`, `resource.type`) before splicing it into the hover.
+ *
+ * Defense in depth: the hover provider already renders with
+ * `isTrusted = false`, so `command:` links cannot fire even if smuggled
+ * in. This escaper additionally prevents structural injection — bold
+ * markers, raw HTML tags, link constructors, code spans, and pipes —
+ * so a crafted `resources.json` cannot rewrite the hover layout. Also
+ * defangs a leading `command:` substring so it cannot read as a link
+ * target if a future caller flips `isTrusted` on.
+ */
+function escapeMarkdown(s: string): string {
+    const defanged = s.replace(/^command:/i, "command​:");
+    return defanged.replace(/[\\`*_{}\[\]()#+\-!|<>]/g, (c) => `\\${c}`);
 }

--- a/vscode-extension/src/test/manifestResourceHoverImages.test.ts
+++ b/vscode-extension/src/test/manifestResourceHoverImages.test.ts
@@ -1,0 +1,120 @@
+// Unit tests for the disk-reader that backs the manifest-resource
+// hover. The interesting behaviour is the path-traversal containment
+// check — `capture.renderOutput` comes from the workspace
+// `resources.json`, which is user-controlled, and must not be allowed
+// to escape `<module>/build/compose-previews`.
+
+import * as assert from "assert";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { readVariantImages } from "../manifestResourceHoverImages";
+import { ResourcePreview } from "../types";
+
+function makeResource(renderOutputs: string[]): ResourcePreview {
+    return {
+        id: "drawable/x",
+        type: "VECTOR",
+        sourceFiles: { "": "src/main/res/drawable/x.xml" },
+        captures: renderOutputs.map((renderOutput) => ({
+            variant: { qualifiers: "xhdpi", shape: null, style: null },
+            renderOutput,
+            cost: 1,
+        })),
+    };
+}
+
+describe("readVariantImages", () => {
+    let tmpRoot: string;
+    let moduleBuildRoot: string;
+
+    beforeEach(() => {
+        tmpRoot = fs.mkdtempSync(
+            path.join(os.tmpdir(), "manifest-hover-images-"),
+        );
+        moduleBuildRoot = path.join(tmpRoot, "build", "compose-previews");
+        fs.mkdirSync(path.join(moduleBuildRoot, "renders", "resources"), {
+            recursive: true,
+        });
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it("reads bytes for a capture inside the build root", () => {
+        const rel = "renders/resources/ok.png";
+        fs.writeFileSync(path.join(moduleBuildRoot, rel), Buffer.from([1, 2]));
+        const images = readVariantImages(makeResource([rel]), moduleBuildRoot);
+        assert.strictEqual(images.length, 1);
+        assert.strictEqual(images[0]?.renderOutput, rel);
+        assert.strictEqual(
+            images[0]?.base64,
+            Buffer.from([1, 2]).toString("base64"),
+        );
+    });
+
+    it("skips captures whose file is missing without throwing", () => {
+        const images = readVariantImages(
+            makeResource(["renders/resources/missing.png"]),
+            moduleBuildRoot,
+        );
+        assert.deepStrictEqual(images, []);
+    });
+
+    // Issue #1442: a crafted workspace `resources.json` with a
+    // `renderOutput` like `../../../etc/passwd` could otherwise make
+    // `readVariantImages` read arbitrary local files when a user hovers
+    // an icon attribute in `AndroidManifest.xml`.
+    it("rejects a renderOutput that escapes the build root via ..", () => {
+        // Plant a file outside the build root that the traversal would target.
+        const sneak = path.join(tmpRoot, "secret.txt");
+        fs.writeFileSync(sneak, "very-private");
+        // Module root is `<tmp>/build/compose-previews`; `../../secret.txt`
+        // resolves to `<tmp>/secret.txt`, which must be refused.
+        const images = readVariantImages(
+            makeResource(["../../secret.txt"]),
+            moduleBuildRoot,
+        );
+        assert.deepStrictEqual(images, []);
+    });
+
+    it("rejects an absolute renderOutput that points outside the build root", () => {
+        const sneak = path.join(tmpRoot, "absolute.txt");
+        fs.writeFileSync(sneak, "abs-secret");
+        const images = readVariantImages(
+            makeResource([sneak]),
+            moduleBuildRoot,
+        );
+        assert.deepStrictEqual(images, []);
+    });
+
+    it("rejects a sibling path with the build root as a string prefix", () => {
+        // The classic `startsWith` mistake: `/foo/bar-evil` starts with
+        // `/foo/bar` as a *string*, even though it isn't underneath the
+        // `/foo/bar` directory. The fix appends `path.sep` so siblings
+        // are correctly refused.
+        const sibling = `${moduleBuildRoot}-evil`;
+        fs.mkdirSync(sibling, { recursive: true });
+        const file = path.join(sibling, "evil.png");
+        fs.writeFileSync(file, Buffer.from([9]));
+        const images = readVariantImages(makeResource([file]), moduleBuildRoot);
+        assert.deepStrictEqual(images, []);
+    });
+
+    it("accepts a renderOutput that traverses but lands back inside the root", () => {
+        // `renders/../renders/resources/inner.png` ultimately resolves
+        // inside the build root, which is fine — the check is about
+        // the final resolved location, not the syntactic form.
+        const rel = "renders/resources/inner.png";
+        fs.writeFileSync(path.join(moduleBuildRoot, rel), Buffer.from([7]));
+        const tricky = "renders/../renders/resources/inner.png";
+        const images = readVariantImages(
+            makeResource([tricky]),
+            moduleBuildRoot,
+        );
+        assert.strictEqual(images.length, 1);
+        assert.strictEqual(images[0]?.renderOutput, tricky);
+    });
+});

--- a/vscode-extension/src/test/resourceVariantHover.test.ts
+++ b/vscode-extension/src/test/resourceVariantHover.test.ts
@@ -119,7 +119,8 @@ describe("buildResourceVariantHoverMarkdown", () => {
                 base64: "AAAA",
             })),
         });
-        assert.match(md, /\*\*mipmap\/ic_launcher\*\*/);
+        // The resource id `_` is escaped so markdown can't read it as italics.
+        assert.match(md, /\*\*mipmap\/ic\\_launcher\*\*/);
         assert.match(md, /Adaptive icon/);
         const imgCount = (md.match(/<img /g) ?? []).length;
         assert.strictEqual(imgCount, 4);
@@ -186,5 +187,51 @@ describe("buildResourceVariantHoverMarkdown", () => {
         });
         assert.match(md, /No rendered captures available/);
         assert.doesNotMatch(md, /<img /);
+    });
+
+    // Issue #1442: `resources.json` is workspace-controlled; a hostile
+    // project could craft `resource.id` / `resource.type` to inject
+    // markdown structure (raw `<img>`, `command:` links, italic /
+    // emphasis takeover, broken-out HTML) into the hover. The provider
+    // renders with `isTrusted = false` so `command:` cannot execute, and
+    // the builder additionally escapes structural metacharacters so the
+    // rendered hover preserves the user's literal text.
+    it("escapes markdown / HTML metacharacters in resource.id and resource.type", () => {
+        const hostile: ResourcePreview = {
+            id: "drawable/x](command:foo)![pwn",
+            type: "<script>alert(1)</script>",
+            sourceFiles: { "": "src/main/res/drawable/x.xml" },
+            captures: [],
+        };
+        const md = buildResourceVariantHoverMarkdown({
+            resource: hostile,
+            images: [],
+        });
+        // Brackets / parens / `<` / `>` / `!` all escaped — no raw HTML
+        // tag, no link constructor, no image constructor survive.
+        assert.doesNotMatch(md, /<script>/);
+        assert.doesNotMatch(md, /\]\(command:/);
+        assert.doesNotMatch(md, /!\[pwn/);
+        // The literal escaped form is what reaches the renderer.
+        assert.match(md, /drawable\/x\\\]\\\(command:foo\\\)\\!\\\[pwn/);
+        assert.match(md, /\\<script\\>alert\\\(1\\\)\\<\/script\\>/);
+    });
+
+    it("defangs a leading 'command:' so resource.id can't masquerade as a link target", () => {
+        const hostile: ResourcePreview = {
+            id: "command:workbench.action.terminal.sendSequence",
+            type: "VECTOR",
+            sourceFiles: { "": "src/main/res/drawable/x.xml" },
+            captures: [],
+        };
+        const md = buildResourceVariantHoverMarkdown({
+            resource: hostile,
+            images: [],
+        });
+        // Bold marker is still there, but `command:` is no longer the
+        // literal prefix VS Code would accept as a trusted link target
+        // (a zero-width-space is inserted between `command` and `:`).
+        assert.doesNotMatch(md, /\*\*command:workbench/);
+        assert.match(md, /\*\*command​:workbench/);
     });
 });


### PR DESCRIPTION
Closes #1442.

## Summary

Both P1 codex findings on #1420 treated workspace-supplied `resources.json` as trusted. This PR closes both.

### 1. Trusted markdown hover → untrusted + escape (`58623228`)

`ManifestResourceHoverProvider.provideHover` was flagging the hover text as trusted HTML even though the markdown is assembled by interpolating `resource.id` / `resource.type` directly from the workspace manifest. A crafted `resources.json` could inject `command:` links or raw HTML that executes on click.

- Flipped `md.isTrusted = false`. Kept `supportHtml = true` because the hover still needs to render inline `<img data:…>` previews — it never emits `command:` links, so dropping trusted-command execution is loss-free.
- Belt-and-braces: added an `escapeMarkdown(...)` pass over the interpolated fields. Escapes `` \`*_{}[]()#+-!|<> `` and zero-width-spaces a leading `command:` so structural injection (bold takeover, raw HTML tags, link constructors) stays defanged even if a future caller flips `isTrusted` back on.

### 2. Capture-image path traversal → containment check (`97d7d1a9`)

`readVariantImages` was joining `capture.renderOutput` directly and reading the result from disk. A `renderOutput` like `../../../etc/passwd` made hover processing read arbitrary local files when a user hovered an icon attribute.

- Moved `readVariantImages` out of `manifestResourceHoverProvider.ts` (which imports `vscode` and couldn't be unit-tested under Mocha) into a new `manifestResourceHoverImages.ts`. Two existing callers (`activityIconHoverProvider`, `resourceReferenceHoverProvider`) re-pointed and get the fix transparently.
- Containment rule: `path.resolve(moduleBuildRoot, capture.renderOutput)` and require the result to start with `resolvedRoot + path.sep`. The trailing separator stops the classic `/foo/bar-evil` sibling-prefix slip when the root is `/foo/bar`.
- Variants that fail the check are dropped silently (same as a missing file), so one bad entry never throws the whole hover.

## Test plan

Regression tests added (all green; full extension suite: 1230 passing):
- `vscode-extension/src/test/manifestResourceHoverImages.test.ts` — 6 cases: happy path, missing-file silence, `..` traversal, absolute-path escape, sibling-prefix `startsWith` trap, and the legitimate "traverses but lands back inside" case.
- `vscode-extension/src/test/resourceVariantHover.test.ts` — 2 new cases: metacharacter escape and `command:` defanging; existing adaptive-icon test adjusted (`mipmap/ic_launcher` now renders as `mipmap/ic\_launcher`).

---
_Generated by [Claude Code](https://claude.ai/code/session_0164TDPHM3haDqw2BPDGQPQA)_