### PR TITLE
fix: address simple codex review findings from last 24h

### DIFF
--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
@@ -128,10 +128,15 @@ object RemoteComposeController {
   fun recordHostAction(action: RemoteHostAction) {
     val accepted = acceptedActionPayloads
     if (accepted != null && action.payload !in accepted) return
+    // Stamp receiver-side wall-clock at ingest so consumers can order/time events;
+    // most callers default to 0, which would otherwise emit zero timestamps downstream.
+    val stamped =
+      if (action.firedAtMillis == 0L) action.copy(firedAtMillis = System.currentTimeMillis())
+      else action
     val current = hostActionsState.value
     val next =
-      if (current.size < RemoteComposePayload.HOST_ACTION_BUFFER_SIZE) current + action
-      else current.drop(current.size - RemoteComposePayload.HOST_ACTION_BUFFER_SIZE + 1) + action
+      if (current.size < RemoteComposePayload.HOST_ACTION_BUFFER_SIZE) current + stamped
+      else current.drop(current.size - RemoteComposePayload.HOST_ACTION_BUFFER_SIZE + 1) + stamped
     hostActionsState.value = next
     listeners.toList().forEach { it() }
   }

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
@@ -123,8 +123,11 @@ internal fun applyConnectorOverrides(
       is RemoteNamedValue.DpValue -> updater.setUserLocalFloat(name, value.value)
       is RemoteNamedValue.BooleanValue -> updater.setUserLocalInt(name, if (value.value) 1 else 0)
       is RemoteNamedValue.ColorValue -> {
-        val argb = value.argb.removePrefix("#").toLong(16).toInt()
-        updater.setUserLocalColor(name, argb)
+        // Wire model accepts an arbitrary string for argb (a typo in a panel value
+        // would otherwise crash the render path). Skip invalid hex instead of throwing.
+        val hex = value.argb.removePrefix("#")
+        val argb = hex.toLongOrNull(16)?.toInt()
+        if (argb != null) updater.setUserLocalColor(name, argb)
       }
     }
   }

--- a/splash-preview-runtime/src/main/kotlin/ee/schimke/composeai/preview/splash/SplashScreenSurface.kt
+++ b/splash-preview-runtime/src/main/kotlin/ee/schimke/composeai/preview/splash/SplashScreenSurface.kt
@@ -142,7 +142,6 @@ private fun BoxScope.SplashBranding(brandingImage: Painter) {
     contentDescription = null,
     modifier =
       Modifier.align(Alignment.BottomCenter)
-        .fillMaxWidth()
         .padding(bottom = 60.dp)
         .sizeIn(maxWidth = 200.dp, maxHeight = 80.dp)
         .semantics {

--- a/vscode-extension/src/androidResourceReferences.ts
+++ b/vscode-extension/src/androidResourceReferences.ts
@@ -70,7 +70,9 @@ export function findKotlinResourceReferences(text: string): ResourceRef[] {
  * the resolved name, not the syntactic difference.
  */
 export function findXmlResourceReferences(text: string): ResourceRef[] {
-    const re = /(["'>])@\+?(drawable|mipmap)\/([A-Za-z0-9_]+)(?=["'<\s/])/g;
+    // Allow whitespace before `@` so indented text-node refs match too
+    // (`<item>\n    @drawable/foo\n</item>` — common in style/item XML).
+    const re = /(["'>\s])@\+?(drawable|mipmap)\/([A-Za-z0-9_]+)(?=["'<\s/])/g;
     const out: ResourceRef[] = [];
     let match: RegExpExecArray | null;
     while ((match = re.exec(text)) !== null) {

--- a/vscode-extension/src/test/androidResourceReferences.test.ts
+++ b/vscode-extension/src/test/androidResourceReferences.test.ts
@@ -144,6 +144,23 @@ describe("findXmlResourceReferences", () => {
         );
         assert.strictEqual(slice, "@drawable/foo");
     });
+
+    it("extracts indented text-node refs (style/item patterns)", () => {
+        const xml = `
+            <item name="android:windowBackground">
+                @drawable/ic_launcher_background
+            </item>
+        `;
+        const refs = findXmlResourceReferences(xml);
+        assert.strictEqual(refs.length, 1);
+        assert.strictEqual(refs[0].resourceType, "drawable");
+        assert.strictEqual(refs[0].resourceName, "ic_launcher_background");
+        const slice = xml.substring(
+            refs[0].offset,
+            refs[0].offset + refs[0].length,
+        );
+        assert.strictEqual(slice, "@drawable/ic_launcher_background");
+    });
 });
 
 describe("refAt", () => {


### PR DESCRIPTION
## Summary

Four small, independent codex follow-ups picked off as part of the broader triage (see #1440 / #1441 / #1442 / #1443 for the larger clusters). Each is one-or-two lines, isolated to a single module.

- **`fix(data-remotecompose): guard hex parse when applying ColorValue override`** — `applyConnectorOverrides` was running `argb.removePrefix("#").toLong(16)` with no validation. Wire model accepts an arbitrary string, so a typo crashed the whole render path. Swap to `toLongOrNull(16)` and skip invalid entries. (codex P1 on #1422)
- **`fix(splash-preview): drop fillMaxWidth before sizeIn cap`** — `SplashBranding` had `fillMaxWidth()` ahead of `sizeIn(maxWidth = 200.dp, …)`, so the cap could never take effect and branding rendered full-width. `BottomCenter` alignment already centres it. (codex P1 on #1425)
- **`fix(vscode-extension): match indented XML text-node resource refs`** — `findXmlResourceReferences` regex required `"`, `'`, or `>` before `@`, missing common `<item>\n    @drawable/foo\n</item>` shapes. Added whitespace to the leading-char class + regression test. (codex P2 on #1431)
- **`fix(data-remotecompose): stamp host action timestamp at ingest`** — `RemoteHostAction.firedAtMillis` defaults to `0`; most callers left the default in place, so `compose/remotecompose` payloads carried zero timestamps. Stamp `System.currentTimeMillis()` on ingest when the field is `0`, leaving explicit values untouched. (codex P2 on #1378)

## Test plan

- [x] `ktfmtCheckAll` (pre-commit)
- [x] vscode-extension Prettier check (pre-commit)
- [ ] CI: full Gradle + extension test suites
- [ ] Spot-check a `Splash` preview render (branding now respects the cap)
- [ ] Spot-check a Remote Compose host-action log (firedAtMillis is non-zero downstream)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164TDPHM3haDqw2BPDGQPQA)_