### PR TITLE
fix: close live-edit override pipeline gaps

### DIFF
--- a/glance-preview-runtime/src/main/kotlin/ee/schimke/composeai/preview/glance/GlanceAppWidgetContent.kt
+++ b/glance-preview-runtime/src/main/kotlin/ee/schimke/composeai/preview/glance/GlanceAppWidgetContent.kt
@@ -116,33 +116,39 @@ fun GlanceAppWidgetContent(
  * connector applies — `widthCells = round((widthDp + spacing) / (cell + spacing))`, clamped to
  * at least 1.
  *
+ * `previewSizeMode` describes how Glance generates **preview** compositions — not whether the
+ * installed widget is actually resizable. Resizability is a property of the launcher widget's
+ * provider metadata XML (`android:resizeMode`, `android:targetCellWidth`, etc.) and is not
+ * recoverable from `SizeMode` alone. So:
+ *
  * Translation table:
- * - [SizeMode.Single] → `supportedCells = [theDefaultSize]`, `resizeAxes = None` (the widget
- *   declared one fixed size and doesn't respond to other layouts).
- * - [SizeMode.Responsive] → `supportedCells = set.toCells()`, `resizeAxes = Both`. Picker
- *   should show only these sizes; Glance won't lay out at others.
- * - [SizeMode.Exact] → `supportedCells = null`, `resizeAxes = Both`. Widget composes at
- *   whatever size it's given; no constraint to surface.
+ * - [SizeMode.Single] → `supportedCells = null`, `resizeAxes = Both`. Glance composes a single
+ *   preview at the default size, but that says nothing about the installed widget; defer the
+ *   constraint fields to provider metadata.
+ * - [SizeMode.Responsive] → `supportedCells = set.toCells()`, `resizeAxes = Both`. The widget
+ *   author explicitly enumerated a size catalogue here, so we surface it; the picker should
+ *   show only these sizes.
+ * - [SizeMode.Exact] (and any future SizeMode the connector doesn't recognise) →
+ *   `supportedCells = null`, `resizeAxes = Both`. Widget composes at whatever size it's given;
+ *   no constraint to surface.
  */
 private fun offerSizeModeMetadata(widget: GlanceAppWidget) {
   if (LauncherWidgetMetadataChannel.currentPreviewId() == null) return
   val mode = widget.previewSizeMode
   val metadata =
     when (mode) {
-      is SizeMode.Single ->
-        LauncherWidgetMetadata(
-          supportedCells = emptyList(),
-          resizeAxes = LauncherResizeAxes.NONE,
-        )
       is SizeMode.Responsive ->
         LauncherWidgetMetadata(
           supportedCells = mode.sizes.map { it.toCells() },
           resizeAxes = LauncherResizeAxes.BOTH,
         )
       else ->
-        // `SizeMode.Exact` (and any future SizeMode the connector doesn't recognise) — leave
-        // supportedCells null so the picker falls back to its default rectangle, but still
-        // signal that resizing is allowed.
+        // `SizeMode.Single`, `SizeMode.Exact`, and any future SizeMode the connector doesn't
+        // recognise — leave supportedCells null so the picker falls back to provider metadata
+        // (or its default rectangle), and signal that resizing is allowed. `SizeMode.Single`
+        // is a preview-generation directive, not a "widget is non-resizable" advertisement —
+        // mapping it to `resizeAxes = NONE` falsely disabled drag handles for widgets whose
+        // provider metadata says they're resizable.
         LauncherWidgetMetadata(supportedCells = null, resizeAxes = LauncherResizeAxes.BOTH)
     }
   LauncherWidgetMetadataChannel.offer(metadata)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -2018,6 +2018,16 @@ private fun AmbientCapture.toAmbientOverride(): AmbientOverride =
  * connector's `protocol.LauncherWidgetOverride` wire shape. Discovery serialises optional
  * `Int?` fields when the consumer left the annotation at its `-1` sentinel — those round-trip
  * as `null` here and the connector applies its own defaults.
+ *
+ * Each axis of `minCells` / `maxCells` falls back independently: specifying just `minWidth`
+ * (or just `maxHeight`) emits an override that combines the user-supplied bound with the
+ * connector's default for the other axis. The annotation contract is per-axis, so dropping
+ * the whole `LauncherWidgetSize` when one axis is at the sentinel value would silently swallow
+ * a half-set constraint.
+ *
+ * The other-axis defaults must mirror `LauncherWidgetOverride.resolve()`'s
+ * `DEFAULT_MIN_CELLS = 1×1` / `DEFAULT_MAX_CELLS = 5×5`. They're `private` in the connector
+ * module, so we inline the literals with this comment as the cross-reference.
  */
 private fun LauncherWidgetCapture.toLauncherWidgetOverride(): LauncherWidgetOverride =
     LauncherWidgetOverride(
@@ -2025,10 +2035,12 @@ private fun LauncherWidgetCapture.toLauncherWidgetOverride(): LauncherWidgetOver
         cellSizeDp = cellSizeDp,
         cellSpacingDp = cellSpacingDp,
         minCells =
-            if (minWidth != null && minHeight != null) LauncherWidgetSize(minWidth, minHeight)
+            if (minWidth != null || minHeight != null)
+                LauncherWidgetSize(minWidth ?: 1, minHeight ?: 1)
             else null,
         maxCells =
-            if (maxWidth != null && maxHeight != null) LauncherWidgetSize(maxWidth, maxHeight)
+            if (maxWidth != null || maxHeight != null)
+                LauncherWidgetSize(maxWidth ?: 5, maxHeight ?: 5)
             else null,
         resizeOrder =
             when (resizeOrder) {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -255,6 +255,29 @@ const remoteComposeOverridesByPreview = new Map<
     string,
     import("./daemon/daemonProtocol").RemoteComposeOverride
 >();
+/**
+ * previewId → latest `compose/remotecompose` payload the daemon attached. Used to seed
+ * [remoteComposeOverridesByPreview] when the user makes the *first* edit for a preview:
+ * `RemoteComposeController.set(...)` applies full-replacement map semantics on each
+ * `renderNow.overrides.remoteCompose`, so a partial bag built from the empty override
+ * map would erase every named value the user code originally bound. Seeding from the
+ * last-seen payload preserves those values on the first edit; subsequent edits merge
+ * into the accumulated bag the normal way.
+ *
+ * Captured from `onDataProductsAttached` for the `compose/remotecompose` kind. Both
+ * `namedValues` and `profile` are mirrored. The map persists for the lifetime of the
+ * extension activation, mirroring [remoteComposeOverridesByPreview]'s scope.
+ */
+const latestRemoteComposeByPreview = new Map<
+    string,
+    {
+        profile?: import("./daemon/daemonProtocol").RemoteComposeOverride["profile"];
+        namedValues?: Record<
+            string,
+            import("./daemon/daemonProtocol").RemoteNamedValueWire
+        >;
+    }
+>();
 /** Tracks files saved at least once since activation. First save on a file
  *  renders immediately; subsequent saves go through the debounce path. */
 const firstSaveSeen = new Set<string>();
@@ -950,6 +973,41 @@ export async function activate(
                                   findings: decoded.findings ?? undefined,
                                   nodes: decoded.nodes ?? undefined,
                               });
+                          }
+                          // Capture the latest `compose/remotecompose` payload so the next
+                          // panel-side edit can seed [remoteComposeOverridesByPreview] with the
+                          // user code's bound named values + profile. Without this seed the
+                          // first edit's `renderNow.overrides.remoteCompose` would carry only
+                          // the edited field, and `RemoteComposeController.set(...)` would
+                          // full-replace away every other value. Runs whether or not the panel
+                          // is wired — the user can open the panel after a render and edit
+                          // immediately, before the next attach refreshes the snapshot.
+                          for (const dp of dataProducts) {
+                              if (dp.kind !== "compose/remotecompose") continue;
+                              const raw =
+                                  dp.payload ??
+                                  (isJsonDataProduct(dp)
+                                      ? readJsonPath(dp.path, outputChannel)
+                                      : undefined);
+                              if (
+                                  raw &&
+                                  typeof raw === "object" &&
+                                  !Array.isArray(raw)
+                              ) {
+                                  const payload = raw as {
+                                      profile?: import("./daemon/daemonProtocol").RemoteComposeOverride["profile"];
+                                      namedValues?: Record<
+                                          string,
+                                          import("./daemon/daemonProtocol").RemoteNamedValueWire
+                                      >;
+                                  };
+                                  latestRemoteComposeByPreview.set(previewId, {
+                                      profile: payload.profile,
+                                      namedValues: payload.namedValues
+                                          ? { ...payload.namedValues }
+                                          : undefined,
+                                  });
+                              }
                           }
                           if (panel) {
                               const payloads = dataProducts
@@ -5059,14 +5117,41 @@ async function handleSetRemoteComposeNamedValue(
     if (!moduleInfo) {
         return;
     }
-    const prior = remoteComposeOverridesByPreview.get(previewId);
-    const next = mergeRemoteComposeChange(prior, change);
+    // On the first edit, `remoteComposeOverridesByPreview` is empty for this preview;
+    // `RemoteComposeController.set(...)` applies full-replacement semantics on the next
+    // `renderNow.overrides.remoteCompose`, so a bag containing only the edited field
+    // would erase every other value the user code bound. Seed from the last-seen
+    // `compose/remotecompose` payload so the merge result is "snapshot + this edit".
+    // After the first edit the override bag is the source of truth — the snapshot seed
+    // would shadow user edits with stale values from the last-attached payload.
+    const priorOverride = remoteComposeOverridesByPreview.get(previewId);
+    let seed:
+        | import("./daemon/daemonProtocol").RemoteComposeOverride
+        | undefined = priorOverride;
+    if (!seed) {
+        const snapshot = latestRemoteComposeByPreview.get(previewId);
+        if (snapshot) {
+            seed = {
+                profile: snapshot.profile,
+                namedValues: snapshot.namedValues
+                    ? { ...snapshot.namedValues }
+                    : undefined,
+            };
+        }
+    }
+    const next = mergeRemoteComposeChange(seed, change);
     remoteComposeOverridesByPreview.set(previewId, next);
 
     // Prefer the live path when a `composestream/1` session is up — sub-frame controller
     // mutation beats a full re-render every time. `activeInteractiveStreams` is the legacy
     // `interactive/start` map (still used by recording); both can carry the live streamId,
     // and either is a valid routing key for `interactive/setRemoteCompose`.
+    //
+    // Even after sending the notification we fall through to the `renderNow` dispatch so
+    // version-skew daemons (and any daemon that doesn't implement the notification, e.g.
+    // a backend without a live `RemoteComposeController` binding) still apply the edit.
+    // The notification is a snappy-paint optimisation; `renderNow` is the canonical
+    // source-of-truth path and an idempotent re-application on healthy daemons.
     const liveStreamId =
         activeStreamFrameStreams.get(previewId) ??
         activeInteractiveStreams.get(previewId);
@@ -5077,13 +5162,12 @@ async function handleSetRemoteComposeNamedValue(
         );
         if (client) {
             logInfo(
-                `[panel] remoteCompose ${change.field === "profile" ? "profile=" + (change.value ?? "<none>") : "namedValue " + change.name + "=" + JSON.stringify(change.value)} for ${previewId} via live session ${liveStreamId}`,
+                `[panel] remoteCompose ${change.field === "profile" ? "profile=" + (change.value ?? "<none>") : "namedValue " + change.name + "=" + JSON.stringify(change.value)} for ${previewId} via live session ${liveStreamId} (+ renderNow fallback)`,
             );
             client.interactiveSetRemoteCompose({
                 frameStreamId: liveStreamId,
                 change,
             });
-            return;
         }
     }
 

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -326,6 +326,14 @@ export class GradleService {
         Promise<PreviewManifest | null>
     >();
     /**
+     * Whether the in-flight `coldStartBundle` for each module is running with
+     * discover folded in. Lets a caller that requested discover (warmModule /
+     * refresh) decide whether to coalesce onto an in-flight daemon-only
+     * bootstrap (no — they need the manifest) or wait for it (yes — discover
+     * is on the way). Cleared in lockstep with [inFlightColdStart].
+     */
+    private inFlightColdStartIncludesDiscover = new Map<string, boolean>();
+    /**
      * In-flight standalone `composePreviewApplied` invocation, when one is
      * running. Cross-checked by [coldStartBundle] so the bundle can drop
      * `composePreviewApplied` from its task list (and just await this) instead
@@ -377,14 +385,26 @@ export class GradleService {
         if (inFlight) {
             return inFlight;
         }
-        // The cold-start bundle includes `:<module>:composePreviewDiscover` and
-        // writes the manifest into [manifestCache] on completion. Awaiting an
+        // The cold-start bundle may include `:<module>:composePreviewDiscover` and
+        // write the manifest into [manifestCache] on completion. Awaiting an
         // in-flight bundle here keeps the post-warm `reconcilePreviewManifestAfterDaemonReady`
         // call from starting a second Gradle invocation while the bundle's
         // own discover is still on the daemon's queue.
+        //
+        // A daemon-only bootstrap bundle (no discover, see [runDaemonBootstrap])
+        // doesn't produce a manifest, so we don't coalesce onto it — we wait
+        // for it to finish (so we don't race the daemon-start invocation on
+        // the serialised Gradle queue) and then start a fresh discover.
         const inFlightBundle = this.inFlightColdStart.get(key);
         if (inFlightBundle) {
-            return inFlightBundle;
+            if (this.inFlightColdStartIncludesDiscover.get(key)) {
+                return inFlightBundle;
+            }
+            try {
+                await inFlightBundle;
+            } catch {
+                /* surfaced by the bootstrap originator; we'll try discover anyway */
+            }
         }
         const cached = this.manifestCache.get(key);
         if (cached && Date.now() - cached.timestamp < MANIFEST_CACHE_TTL_MS) {
@@ -1133,45 +1153,71 @@ export class GradleService {
      * descriptor (`build/compose-previews/daemon-launch.json`) is up to date.
      * Cheap and cacheable — emits a small JSON. The caller (DaemonGate) handles errors.
      *
-     * Delegates to [coldStartBundle] so the daemon-start invocation also
-     * folds in `composePreviewApplied` (when not already fresh) and the
-     * per-module `composePreviewDiscover`. All three tasks share a single
-     * Gradle invocation, which means one configuration-cache entry to warm
-     * on first launch instead of three.
+     * Delegates to [coldStartBundle] with `includeDiscover = false` so the
+     * daemon-start invocation also folds in `composePreviewApplied` (when not
+     * already fresh) into a single Gradle invocation — one configuration-cache
+     * entry to warm on first launch instead of two. Discovery is **not**
+     * bundled here: `warmModule` treats any bootstrap error as a daemon-start
+     * failure, so a transient Kotlin compile error in `composePreviewDiscover`
+     * would surface as a hard "daemon failed to start". Discovery runs
+     * post-warm via [reconcilePreviewManifestAfterDaemonReady], where its
+     * errors flow through the refresh / compile-error UX instead.
      */
     async runDaemonBootstrap(module: ModuleInfo): Promise<void> {
-        await this.coldStartBundle(module);
+        await this.coldStartBundle(module, undefined, {
+            includeDiscover: false,
+        });
     }
 
     /**
      * Cold-start path for a single module: bundles `composePreviewApplied`
      * (when markers aren't fresh), `:<module>:composePreviewDaemonStart`, and
-     * `:<module>:composePreviewDiscover` into a single Gradle invocation. The
-     * payoff is the configuration-cache entry: one cold task-graph calculation
-     * instead of one per task family, cutting ~2 min × 2 off first-launch
-     * latency on this workspace.
+     * (optionally) `:<module>:composePreviewDiscover` into a single Gradle
+     * invocation. The payoff is the configuration-cache entry: one cold
+     * task-graph calculation instead of one per task family, cutting ~2 min × 2
+     * off first-launch latency on this workspace.
+     *
+     * Set `bundleOpts.includeDiscover = false` to omit discovery so a
+     * transient discover failure can't take down a daemon-start that would
+     * otherwise have succeeded. The `runDaemonBootstrap` path uses this; the
+     * `warmModule` / refresh callers leave it at the default (`true`) so they
+     * still get the bundle perf win for the common case.
      *
      * Side effects:
      *   - Populates [manifestCache] from the resulting `previews.json` so the
      *     post-warm `reconcilePreviewManifestAfterDaemonReady` hits the cache
-     *     instead of starting another Gradle round-trip.
+     *     instead of starting another Gradle round-trip. Skipped when
+     *     `bundleOpts.includeDiscover = false` since the manifest isn't
+     *     written by this invocation.
      *   - Bumps [appliedMarkersFreshUntilMs] when the bundle included
      *     `composePreviewApplied`, so a concurrent [bootstrapAppliedMarkers]
      *     skips its own redundant run.
      *
      * Returns the discovered manifest, or null when discover produced no
      * `previews.json` (rare — usually means the module hasn't compiled
-     * cleanly). Errors propagate so the daemon scheduler can surface
-     * bootstrap failures the same way it did under the previous
-     * single-task path.
+     * cleanly) or when discovery was skipped. Errors propagate so the daemon
+     * scheduler can surface bootstrap failures the same way it did under the
+     * previous single-task path.
      */
     async coldStartBundle(
         module: ModuleInfo,
         opts?: TaskOptions,
+        bundleOpts?: { includeDiscover?: boolean },
     ): Promise<PreviewManifest | null> {
+        const includeDiscover = bundleOpts?.includeDiscover ?? true;
         const key = module.modulePath;
         const inFlight = this.inFlightColdStart.get(key);
-        if (inFlight) {
+        // An in-flight bundle that *includes* discover is always at least as
+        // useful as one that doesn't, so coalesce onto it regardless. The
+        // reverse direction is dodgier: a daemon-only bundle landing on top of
+        // a pending discover-bundle caller would deny the caller its manifest.
+        // We only coalesce when this caller doesn't need discover or the
+        // in-flight bundle already covers it.
+        if (
+            inFlight &&
+            (!includeDiscover ||
+                this.inFlightColdStartIncludesDiscover.get(key))
+        ) {
             return inFlight;
         }
         const includeApplied =
@@ -1188,9 +1234,9 @@ export class GradleService {
         const headTask = includeApplied
             ? "composePreviewApplied"
             : daemonStartTask;
-        const tailTasks = includeApplied
-            ? [daemonStartTask, discoverTask]
-            : [discoverTask];
+        const tailTasks: string[] = [];
+        if (includeApplied) tailTasks.push(daemonStartTask);
+        if (includeDiscover) tailTasks.push(discoverTask);
         const inner = (async (): Promise<PreviewManifest | null> => {
             // If a standalone `composePreviewApplied` is already running,
             // wait for it to finish before we add a per-module Gradle
@@ -1211,6 +1257,11 @@ export class GradleService {
                 this.appliedMarkersFreshUntilMs =
                     Date.now() + APPLIED_MARKERS_FRESHNESS_TTL_MS;
             }
+            if (!includeDiscover) {
+                // No manifest was written by this invocation — defer to a
+                // post-warm `composePreviewDiscover` to populate the cache.
+                return null;
+            }
             const manifest = this.readManifest(module);
             if (manifest) {
                 this.manifestCache.set(key, {
@@ -1223,9 +1274,11 @@ export class GradleService {
         const promise = inner.finally(() => {
             if (this.inFlightColdStart.get(key) === promise) {
                 this.inFlightColdStart.delete(key);
+                this.inFlightColdStartIncludesDiscover.delete(key);
             }
         });
         this.inFlightColdStart.set(key, promise);
+        this.inFlightColdStartIncludesDiscover.set(key, includeDiscover);
         // Publish the bundle's lifetime as an `appliedBootstrapPromise` when it
         // includes `composePreviewApplied`. A concurrent `bootstrapAppliedMarkers`
         // call then awaits this bundle instead of kicking off its own redundant

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -1332,6 +1332,63 @@ describe("GradleService", () => {
                 await Promise.all([bundle, discover]);
             }),
         );
+
+        it(
+            "omits :module:composePreviewDiscover when the caller is runDaemonBootstrap so a transient discover failure can't kill daemon-start",
+            withTempDir(async (dir, api) => {
+                const service = new GradleService(dir, api);
+
+                await service.runDaemonBootstrap({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
+
+                assert.strictEqual(
+                    api.runCalls.length,
+                    1,
+                    "the bootstrap path must still collapse to one Gradle invocation",
+                );
+                assert.strictEqual(
+                    api.runCalls[0].taskName,
+                    "composePreviewApplied",
+                );
+                assert.deepStrictEqual(
+                    api.runCalls[0].args,
+                    [":mod:composePreviewDaemonStart"],
+                    "runDaemonBootstrap must not bundle composePreviewDiscover — daemon-start should come up even when discovery is failing",
+                );
+            }),
+        );
+
+        it(
+            "runs a fresh composePreviewDiscover after a daemon-only bootstrap so the manifest still arrives",
+            withTempDir(async (dir, api) => {
+                writeManifest(dir, "mod");
+                const service = new GradleService(dir, api);
+
+                await service.runDaemonBootstrap({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
+                assert.strictEqual(api.runCalls.length, 1);
+
+                const manifest = await service.composePreviewDiscover({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
+
+                assert.notStrictEqual(manifest, null);
+                assert.strictEqual(
+                    api.runCalls.length,
+                    2,
+                    "post-bootstrap discover should run on its own because the bootstrap bundle did not include it",
+                );
+                assert.strictEqual(
+                    api.runCalls[1].taskName,
+                    ":mod:composePreviewDiscover",
+                );
+            }),
+        );
     });
 
     describe("cancel", () => {


### PR DESCRIPTION
Closes #1441.

Five codex findings on the override / live-edit / widget-constraint pipeline, addressed in four commits (a + b share a function so they ride together).

## Summary

- **`1d1d6973` fix(vscode-extension): seed remoteCompose merge bag from latest payload and keep renderNow fallback** — covers (a) + (b). New `latestRemoteComposeByPreview` map captured from `onDataProductsAttached` for the `compose/remotecompose` kind; it seeds the merge bag on the *first* edit so unrelated named values aren't erased by full-replacement semantics. Subsequent edits flow through the existing override map as before. Also drops the early `return` after the `interactive/setRemoteCompose` notification so the canonical `renderNow` dispatch always runs as fallback when the daemon doesn't implement (or drops) the notify path. Notification stays as the snappy-paint optimisation; renderNow is idempotent on healthy daemons.
- **`330d6767` fix(vscode-extension): exclude composePreviewDiscover from daemon bootstrap bundle** — covers (c). Added an `includeDiscover` flag to `coldStartBundle` (default `true` for refresh/warm callers; `runDaemonBootstrap` passes `false`). Bootstrap now bundles only `composePreviewApplied + :module:composePreviewDaemonStart`; the post-warm `reconcilePreviewManifestAfterDaemonReady` runs discover separately so its errors flow through the refresh / compile-error UX. Coalescing in `composePreviewDiscover` learns to distinguish discover-inclusive vs daemon-only bundles.
- **`52a597ca` fix(glance-preview-runtime): stop mapping SizeMode.Single to no-resize constraints** — covers (d). Dropped the `SizeMode.Single` arm of the `when` in `offerSizeModeMetadata`; it now falls through to the same `supportedCells = null, resizeAxes = BOTH` shape as `SizeMode.Exact`, deferring resizability to provider metadata instead of advertising a false hard constraint.
- **`0da19415` fix(renderer-android): emit minCells/maxCells when only one axis is specified** — covers (e). Flipped the `&&` guards in `toLauncherWidgetOverride` to `||` and inlined the connector defaults (`1×1` / `5×5`) for the missing axis, so a `minWidth`-only (or `maxHeight`-only) `@LauncherWidgetPreview` no longer drops silently.

## Test plan

- [x] `./gradlew ktfmtCheckAll` green
- [x] `npm --prefix vscode-extension run format:check` green
- [x] `npm --prefix vscode-extension run compile:host` green
- [x] `npm --prefix vscode-extension run test` — 1224 tests pass (incl. two new `coldStartBundle` tests covering the daemon-only bootstrap path)
- [ ] CI: full Gradle suite (Android compile not exercised locally; the (d)/(e) changes are mechanical Kotlin shape changes)
- [ ] Spot-check on a real preview: trigger a daemon bootstrap with a broken discovery state — daemon should come up and the failure should land in the refresh UX, not the warmup "daemon failed to start" path.
- [ ] Spot-check on a Remote Compose live-edit session: edit one `namedValue`, confirm other values from the original payload persist.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164TDPHM3haDqw2BPDGQPQA)_