### PR TITLE
fix(daemon): plumb @PreviewWrapper FQN through manifest and dispatch GLANCE_APPWIDGET

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -685,6 +685,7 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
     uiMode = uiMode,
     orientation = defaults.orientation,
     kind = params.kind ?: defaults.kind,
+    wrapperClassName = params.wrapperClassName ?: defaults.wrapperClassName,
   )
 }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -136,6 +136,16 @@ class PreviewManifestRouter(
       (inbound["kind"] ?: resolved.kind)?.takeIf { it.isNotBlank() }?.let {
         append("kind=").append(it).append(';')
       }
+      // `@PreviewWrapper(SomeProvider::class)` FQN sourced from `previews.json` (the gradle
+      // plugin's `extractWrapperFqn` reads it off the class-file annotation tables — the
+      // upstream annotation is `AnnotationRetention.BINARY` and not visible via
+      // `Method.annotations` at runtime, so this manifest-side plumbing is the only path that
+      // can recover the wrapper FQN for the render body). Forwarded into the `RenderSpec`
+      // payload so [RenderEngine]'s `InvokeWithOptionalWrapper` can route through the
+      // wrapper's `Wrap(content)` without resorting to runtime reflection on the composable.
+      resolved.wrapperClassName?.takeIf { it.isNotBlank() }?.let {
+        append("wrapperClassName=").append(it).append(';')
+      }
       append("outputBaseName=").append(resolved.outputBaseName)
     }
   }
@@ -179,6 +189,7 @@ private fun PreviewManifestEntry.renderSpec(): RenderSpec {
     device = resolved.device,
     outputBaseName = resolved.outputBaseName,
     kind = resolved.kind,
+    wrapperClassName = resolved.wrapperClassName,
   )
 }
 
@@ -239,6 +250,7 @@ data class PreviewManifestEntry(
     val backgroundColor = backgroundColor ?: p?.backgroundColor ?: 0L
     val device = device ?: p?.device
     val kind = kind ?: p?.kind
+    val wrapperClassName = p?.wrapperClassName
     return ResolvedRenderParams(
       widthPx = widthPx,
       heightPx = heightPx,
@@ -248,6 +260,7 @@ data class PreviewManifestEntry(
       device = device,
       outputBaseName = outputBaseName ?: id,
       kind = kind,
+      wrapperClassName = wrapperClassName,
     )
   }
 }
@@ -268,12 +281,23 @@ data class PreviewParamsEntry(
   val showBackground: Boolean = false,
   val backgroundColor: Long = 0L,
   /**
-   * `"COMPOSE"` / `"TILE"` — mirrors `ee.schimke.composeai.plugin.PreviewKind`. Forwarded through
-   * the router so the daemon's render path can dispatch tile previews to
-   * `renderer.TilePreviewComposable` instead of the Compose-method reflection path (which
-   * throws `NoSuchMethodException` on a non-composable tile entrypoint).
+   * `"COMPOSE"` / `"TILE"` / `"NOTIFICATION"` / `"GLANCE_APPWIDGET"` — mirrors
+   * `ee.schimke.composeai.discovery.PreviewKind`. Forwarded through the router so the daemon's
+   * render path can dispatch tile / notification / Glance previews to their dedicated renderer
+   * helpers instead of the Compose-method reflection path (which throws `NoSuchMethodException`
+   * on non-composable entrypoints, and produces an unwrapped misrender for Glance entrypoints).
    */
   val kind: String? = null,
+  /**
+   * FQN of the `PreviewWrapperProvider` from `@PreviewWrapper(SomeProvider::class)` when the
+   * source preview is annotated. Read at discovery time by `extractWrapperFqn` against the
+   * class-file annotation tables — the upstream annotation has `AnnotationRetention.BINARY`, so
+   * `Method.annotations` is empty for it at runtime. The daemon's render path consumes this
+   * field to drive `InvokeWithOptionalWrapper`; without the manifest plumbing the daemon would
+   * see no wrapper present and render the preview body directly (the original "Invalid applier"
+   * crash that motivated `@PreviewWrapper` in the first place).
+   */
+  val wrapperClassName: String? = null,
 )
 
 /** Output of [PreviewManifestEntry.resolved] — flat, fully-defaulted, ready to format into a
@@ -287,4 +311,5 @@ data class ResolvedRenderParams(
   val device: String?,
   val outputBaseName: String,
   val kind: String? = null,
+  val wrapperClassName: String? = null,
 )

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -199,17 +199,22 @@ class RenderEngine(
 
     val isTile = spec.kind.equals(TILE_KIND, ignoreCase = true)
     val isNotification = spec.kind.equals(NOTIFICATION_KIND, ignoreCase = true)
-    val nonComposable = isTile || isNotification
+    val isGlanceAppWidget = spec.kind.equals(GLANCE_APPWIDGET_KIND, ignoreCase = true)
     val clazz = trace.section("classloader:loadPreviewClass") { Class.forName(spec.className, true, classLoader) }
     // Tile / notification previews are non-composable top-level functions returning
     // `TilePreviewData` / `android.app.Notification`; routing them through
     // `getDeclaredComposableMethod` would throw `NoSuchMethodException` (the Compose-method
-    // lookup expects `(Composer, Int, …)` trailing params). The non-composable paths skip
-    // composable resolution entirely and paint the inflated View through
-    // [renderer.TilePreviewComposable] / [renderer.NotificationPreviewComposable] in the
-    // setContent body below.
+    // lookup expects `(Composer, Int, …)` trailing params). Glance previews ARE `@Composable`
+    // but need to be hosted inside a `GlanceAppWidget.providePreview(...)` → `composeForPreview(...)`
+    // → `RemoteViews.apply` pipeline (handed off to `:renderer-android`'s
+    // [renderer.GlanceAppWidgetPreviewComposable]); invoking them directly through the regular
+    // Compose path would skip the `RemoteViews` materialisation entirely and render an unwrapped
+    // body that fails the moment a Glance composable touches the GlanceComposition applier. The
+    // dedicated branches skip top-level composable resolution and paint the result through the
+    // matching renderer helper in the setContent body below.
+    val nonComposableInvocation = isTile || isNotification || isGlanceAppWidget
     val composableMethod: ComposableMethod? =
-      if (nonComposable) null
+      if (nonComposableInvocation) null
       else trace.section("compose:resolveComposable") { clazz.getDeclaredComposableMethod(spec.functionName) }
 
     // Self-diagnostic — surfaces in the VS Code extension's output channel as `[daemon stderr] …`.
@@ -347,8 +352,31 @@ class RenderEngine(
                             // `composePreviewRender` Test task).
                             previewId = spec.previewId,
                           )
+                        } else if (isGlanceAppWidget) {
+                          // `@androidx.glance.preview.Preview` — mirrors the standalone
+                          // renderer's `GlanceAppWidgetPreviewStrategy`. The user's @Composable
+                          // is hosted inside a `SyntheticGlanceAppWidget.providePreview(...)`
+                          // and its output is materialised to `RemoteViews` via
+                          // `GlanceAppWidget.composeForPreview(...)`, then inflated into the
+                          // captured `AndroidView`. Without this branch Glance previews would
+                          // fall through to `InvokeWithOptionalWrapper` and execute the
+                          // `@GlanceComposable` body directly against the regular Compose
+                          // applier, producing either a misrender or a hard crash when the
+                          // body touches Glance-only composables.
+                          val widthDp = pxToDp(spec.widthPx, spec.density)
+                          val heightDp = pxToDp(spec.heightPx, spec.density)
+                          ee.schimke.composeai.renderer.GlanceAppWidgetPreviewComposable(
+                            className = spec.className,
+                            functionName = spec.functionName,
+                            widthDp = widthDp,
+                            heightDp = heightDp,
+                            classLoader = classLoader,
+                          )
                         } else {
-                          InvokeWithOptionalWrapper(composableMethod!!)
+                          InvokeWithOptionalWrapper(
+                            composableMethod = composableMethod!!,
+                            wrapperFqnFromSpec = spec.wrapperClassName,
+                          )
                         }
                       }
                     }
@@ -815,6 +843,15 @@ class RenderEngine(
     const val NOTIFICATION_KIND: String = "NOTIFICATION"
 
     /**
+     * `RenderSpec.kind` value flagging an `@androidx.glance.preview.Preview` Glance app-widget
+     * preview. Routes through `:renderer-android`'s `GlanceAppWidgetPreviewComposable`, which
+     * hosts the user's `@GlanceComposable` inside a `GlanceAppWidget.providePreview(...)` and
+     * materialises the tree to `RemoteViews` via `composeForPreview(...)`. Mirrors
+     * `ee.schimke.composeai.discovery.PreviewKind.GLANCE_APPWIDGET`.
+     */
+    const val GLANCE_APPWIDGET_KIND: String = "GLANCE_APPWIDGET"
+
+    /**
      * Virtual time to advance before capture in the paused-`mainClock` path, in milliseconds.
      * Mirrors `RobolectricRenderTest.CAPTURE_ADVANCE_MS` exactly so daemon-rendered PNGs match
      * the standalone JUnit path's settle point.
@@ -854,20 +891,38 @@ private fun InvokeComposable(composableMethod: ComposableMethod) {
 
 /**
  * Wraps [InvokeComposable] in the preview's `@PreviewWrapper(SomeProvider::class)` `Wrap { … }` if
- * one is present on the composable method. Without this the daemon would call the preview body
- * directly and bypass the wrapper — e.g. `@PreviewWrapper(RemotePreviewWrapper::class)` previews
- * would crash with `IllegalStateException: Invalid applier` the moment they emit a
- * `RemoteBox` / `RemoteColumn` / `RemoteRow`, because those composables require the RemoteCompose
- * applier the wrapper installs. `:renderer-android` does the equivalent in
+ * one is present, sourcing the wrapper FQN from [wrapperFqnFromSpec] (the discovery-time
+ * class-file read) with a best-effort runtime-reflection fallback for direct-payload callers that
+ * bypass the manifest. Without this the daemon would call the preview body directly and bypass
+ * the wrapper — e.g. `@PreviewWrapper(RemotePreviewWrapper::class)` previews would crash with
+ * `IllegalStateException: Invalid applier` the moment they emit a `RemoteBox` / `RemoteColumn` /
+ * `RemoteRow`, because those composables require the RemoteCompose applier the wrapper installs.
+ * `:renderer-android` does the equivalent in
  * [ee.schimke.composeai.renderer.PreviewRenderStrategy]'s ComposePreviewStrategy.
+ *
+ * **Why the FQN comes from the spec rather than `Method.annotations`.** The upstream
+ * `androidx.compose.ui.tooling.preview.PreviewWrapper` annotation has `AnnotationRetention.BINARY`
+ * (issue #1440): it's emitted into the class file but not retained at runtime, so
+ * `jvmMethod.annotations` will never include it. The gradle plugin's `extractWrapperFqn` reads
+ * the FQN off the class-file annotation tables via ClassGraph and writes it into `previews.json`;
+ * the daemon's [PreviewManifestRouter] threads it into [RenderSpec.wrapperClassName] and we read
+ * it from there. The runtime-reflection fallback is retained for legacy callers and the
+ * compose-bom-compat regression test (`PreviewWrapperResolutionTest`), which uses a same-FQN
+ * stand-in annotation with binary retention to mirror the production retention exactly.
  *
  * Wrapper class resolution flows through [loadPreviewWrapperClass], so connector-provided SPI
  * substitutions (e.g. `:data-remotecompose-connector` swapping `RemotePreviewWrapper` for
  * `RemoteOverridablePreviewWrapper`) apply transparently.
  */
 @Composable
-private fun InvokeWithOptionalWrapper(composableMethod: ComposableMethod) {
-  val wrapper = remember(composableMethod) { resolveWrapperOrNull(composableMethod) }
+private fun InvokeWithOptionalWrapper(
+  composableMethod: ComposableMethod,
+  wrapperFqnFromSpec: String?,
+) {
+  val wrapper =
+    remember(composableMethod, wrapperFqnFromSpec) {
+      resolveWrapperOrNull(composableMethod, wrapperFqnFromSpec)
+    }
   if (wrapper == null) {
     InvokeComposable(composableMethod)
   } else {
@@ -878,10 +933,22 @@ private fun InvokeWithOptionalWrapper(composableMethod: ComposableMethod) {
 }
 
 /**
- * Reads `@androidx.compose.ui.tooling.preview.PreviewWrapper(SomeProvider::class)` reflectively off
- * the composable's underlying JVM method, then resolves the wrapper's `Wrap(content)` method plus a
- * fresh instance. Returns null when the annotation is absent, the wrapper class can't be loaded, or
- * instantiation fails — callers fall back to invoking the preview body directly.
+ * Resolves the `@PreviewWrapper`'s `PreviewWrapperProvider` into a `Wrap(content)` method plus an
+ * instance.
+ *
+ * Strategy (in order):
+ *  1. Use [wrapperFqnFromSpec] when supplied — production path, sourced from `previews.json`
+ *     (the gradle plugin's `extractWrapperFqn` reads it from the class file at discovery time,
+ *     where the `AnnotationRetention.BINARY` annotation is still visible).
+ *  2. Otherwise, look up `@androidx.compose.ui.tooling.preview.PreviewWrapper` reflectively off
+ *     [composableMethod]'s underlying JVM method. This is a fallback for direct-payload callers
+ *     (a few internal tests and the legacy stub path) and **does not work in production** —
+ *     the upstream annotation is `AnnotationRetention.BINARY`, so the lookup misses every
+ *     real-world preview. Kept for compatibility with the existing
+ *     `PreviewWrapperResolutionTest` regression guard, which now uses a binary-retained stand-in
+ *     and the spec-driven path.
+ *
+ * Returns null when no wrapper is resolvable.
  *
  * Reflective lookup (rather than a compile-time import of `PreviewWrapper`) keeps the daemon
  * runnable on older Compose runtimes that predate the annotation (1.11.0-beta+). The annotation
@@ -889,8 +956,22 @@ private fun InvokeWithOptionalWrapper(composableMethod: ComposableMethod) {
  * `gradle-plugin/preview-discovery` reads.
  */
 internal fun resolveWrapperOrNull(
-  composableMethod: ComposableMethod
+  composableMethod: ComposableMethod,
+  wrapperFqnFromSpec: String? = null,
 ): Pair<ComposableMethod, Any>? {
+  val wrapperFqn = wrapperFqnFromSpec?.takeIf { it.isNotBlank() }
+    ?: resolveWrapperFqnViaReflection(composableMethod)
+    ?: return null
+  return loadWrapperByFqnOrNull(wrapperFqn)
+}
+
+/**
+ * Fallback path used only when [resolveWrapperOrNull] was called without a spec-supplied FQN.
+ * Production previews come through with [RenderSpec.wrapperClassName] populated by the gradle
+ * plugin's class-file scan; this path is here for legacy direct-payload tests + the binary-
+ * retained regression-test stand-in (which is now also exercised via the spec path).
+ */
+private fun resolveWrapperFqnViaReflection(composableMethod: ComposableMethod): String? {
   val jvmMethod = composableMethod.asMethod()
   val ann =
     jvmMethod.annotations.firstOrNull {
@@ -899,20 +980,22 @@ internal fun resolveWrapperOrNull(
   val wrapperValue =
     runCatching { ann.annotationClass.java.getDeclaredMethod("wrapper").invoke(ann) }.getOrNull()
       ?: return null
-  val wrapperFqn =
-    when (wrapperValue) {
-      is Class<*> -> wrapperValue.name
-      is kotlin.reflect.KClass<*> -> wrapperValue.java.name
-      else -> return null
-    }
-  return runCatching {
+  return when (wrapperValue) {
+    is Class<*> -> wrapperValue.name
+    is kotlin.reflect.KClass<*> -> wrapperValue.java.name
+    else -> null
+  }
+}
+
+private fun loadWrapperByFqnOrNull(wrapperFqn: String): Pair<ComposableMethod, Any>? =
+  runCatching {
       val resolved = loadPreviewWrapperClass(wrapperFqn)
       val instance = resolved.getDeclaredConstructor().apply { isAccessible = true }.newInstance()
       // PreviewWrapperProvider.Wrap(content: @Composable () -> Unit) compiles to
       // Wrap(Function2, Composer, int); getDeclaredComposableMethod handles the synthetic
       // Composer/changed tail, so we look up by the content param's JVM type.
       val wrapMethod = resolved.getDeclaredComposableMethod("Wrap", Function2::class.java)
-      wrapMethod to instance
+      wrapMethod to (instance as Any)
     }
     .onFailure { t ->
       System.err.println(
@@ -921,7 +1004,6 @@ internal fun resolveWrapperOrNull(
       )
     }
     .getOrNull()
-}
 
 @Composable
 private fun CaptureMaterialTheme(
@@ -1049,11 +1131,22 @@ data class RenderSpec(
    */
   val overrides: PreviewOverrides? = null,
   /**
-   * Preview flavour, mirroring `ee.schimke.composeai.plugin.PreviewKind` (`"COMPOSE"` / `"TILE"`).
-   * Drives renderer selection: `"TILE"` routes through [renderer.TilePreviewComposable] instead of
-   * the Compose-method reflection path. `null` and `"COMPOSE"` both render as a normal @Composable.
+   * Preview flavour, mirroring `ee.schimke.composeai.plugin.PreviewKind` (`"COMPOSE"` / `"TILE"` /
+   * `"NOTIFICATION"` / `"GLANCE_APPWIDGET"`). Drives renderer selection: `"TILE"` routes through
+   * [renderer.TilePreviewComposable], `"NOTIFICATION"` through `NotificationPreviewComposable`,
+   * `"GLANCE_APPWIDGET"` through `GlanceAppWidgetPreviewComposable`. `null` / `"COMPOSE"` render
+   * as a normal `@Composable`.
    */
   val kind: String? = null,
+  /**
+   * FQN of the `PreviewWrapperProvider` from `@PreviewWrapper(SomeProvider::class)` when the
+   * source preview is annotated. Sourced from the gradle plugin's discovery JSON (`extractWrapperFqn`
+   * reads it off the class-file annotation tables — the upstream annotation has
+   * `AnnotationRetention.BINARY` and is invisible to `Method.annotations` at runtime). The render
+   * body drives `InvokeWithOptionalWrapper` off this field when set; null falls back to the
+   * (best-effort) runtime-reflection lookup for direct-payload callers that bypass the manifest.
+   */
+  val wrapperClassName: String? = null,
 ) {
 
   enum class SpecUiMode {
@@ -1121,6 +1214,7 @@ data class RenderSpec(
         inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull(),
         overrides = map["overrides"]?.decodePreviewOverrides(),
         kind = map["kind"]?.takeIf { it.isNotBlank() },
+        wrapperClassName = map["wrapperClassName"]?.takeIf { it.isNotBlank() },
       )
     }
 

--- a/daemon/android/src/test/kotlin/androidx/compose/ui/tooling/preview/PreviewWrapperStandIn.kt
+++ b/daemon/android/src/test/kotlin/androidx/compose/ui/tooling/preview/PreviewWrapperStandIn.kt
@@ -6,14 +6,23 @@ import kotlin.reflect.KClass
 
 /**
  * Test-only stand-in for the upstream `androidx.compose.ui.tooling.preview.PreviewWrapper`
- * annotation, declared under the same FQN so [ee.schimke.composeai.daemon.RenderEngine]'s
- * `resolveWrapperOrNull` (which matches by FQN string) drives the production code path.
+ * annotation, declared under the same FQN so the gradle plugin's class-file scan
+ * (`extractWrapperFqn`) sees the same annotation shape it does in production.
  *
  * The real annotation ships in `compose-ui-tooling-preview` 1.11.0-beta+. The daemon module's
  * compose-bom-compat floor pins 1.9.5, so the upstream class isn't on the test classpath and there
  * is no FQN collision. Matches the upstream `wrapper` parameter name (also used by ClassGraph
  * discovery in `gradle-plugin/preview-discovery`).
+ *
+ * **Retention.** Mirrors upstream: `AnnotationRetention.BINARY` — the annotation is emitted into
+ * the class file but **not** retained at runtime, so `Method.annotations` will never include it.
+ * Issue #1440: an earlier version of this stand-in used `AnnotationRetention.RUNTIME`, which made
+ * the daemon's `Method.annotations`-based `resolveWrapperOrNull` path appear to work in tests
+ * even though production previews never resolved the wrapper. The production fix routes the
+ * wrapper FQN from `previews.json` (read at discovery time from the class-file annotation
+ * tables) into [ee.schimke.composeai.daemon.RenderSpec.wrapperClassName]; the regression test
+ * now exercises that path explicitly.
  */
 @Target(AnnotationTarget.FUNCTION)
-@Retention(AnnotationRetention.RUNTIME)
+@Retention(AnnotationRetention.BINARY)
 annotation class PreviewWrapper(val wrapper: KClass<*>)

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouterRoutingTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouterRoutingTest.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Plumbing-only coverage for [PreviewManifestRouter.routePayload]. Issue #1440 added two new wire
+ * tokens to the routed `RenderSpec` payload — `wrapperClassName` and `kind=GLANCE_APPWIDGET` —
+ * sourced from the nested `params` block the gradle plugin's discovery emits. The end-to-end
+ * coverage (real rendering through `RobolectricHost`) for the same fields lives in the harness's
+ * S3.5+/S4 scenarios; this test sits on the routing layer alone so it stays cheap and runs in the
+ * unit-test source set.
+ *
+ * The wrapper case asserts that a `params.wrapperClassName` set in the manifest emerges in the
+ * routed payload as a top-level `wrapperClassName=` token — without this the render body cannot
+ * route `@PreviewWrapper` previews through the wrapper's `Wrap(content)` (the upstream annotation
+ * has `AnnotationRetention.BINARY`, so the runtime-reflection fallback misses every real-world
+ * preview).
+ *
+ * The Glance case asserts that `params.kind=GLANCE_APPWIDGET` propagates through routing so the
+ * render body dispatches through `GlanceAppWidgetPreviewComposable` instead of falling through to
+ * `InvokeComposable`.
+ */
+class PreviewManifestRouterRoutingTest {
+
+  @Test
+  fun `routePayload forwards wrapperClassName from nested params`() {
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "wrapped",
+              className = "com.example.PreviewsKt",
+              functionName = "Wrapped",
+              params =
+                PreviewParamsEntry(
+                  widthDp = 100,
+                  heightDp = 100,
+                  wrapperClassName = "com.example.RemotePreviewWrapper",
+                ),
+            )
+          )
+      )
+    val router = PreviewManifestRouter(manifest = manifest)
+
+    val routed = router.routePayload("previewId=wrapped")
+
+    assertTrue(
+      "routed payload must carry wrapperClassName so RenderEngine can route through Wrap(content). " +
+        "payload=$routed",
+      routed.contains("wrapperClassName=com.example.RemotePreviewWrapper"),
+    )
+  }
+
+  @Test
+  fun `routePayload omits wrapperClassName when params has none`() {
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "plain",
+              className = "com.example.PreviewsKt",
+              functionName = "Plain",
+              params = PreviewParamsEntry(widthDp = 100, heightDp = 100),
+            )
+          )
+      )
+    val router = PreviewManifestRouter(manifest = manifest)
+
+    val routed = router.routePayload("previewId=plain")
+
+    assertFalse(
+      "no wrapperClassName in manifest → no wrapperClassName= token in routed payload. payload=$routed",
+      routed.contains("wrapperClassName="),
+    )
+  }
+
+  @Test
+  fun `routePayload forwards GLANCE_APPWIDGET kind from nested params`() {
+    // The gradle plugin's discovery emits `params.kind = "GLANCE_APPWIDGET"` for
+    // `@androidx.glance.preview.Preview` functions; the daemon's render path needs the `kind=`
+    // token in the rewritten payload to dispatch to `GlanceAppWidgetPreviewComposable`.
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "glance",
+              className = "com.example.GlancePreviewsKt",
+              functionName = "MyWidgetPreview",
+              params = PreviewParamsEntry(widthDp = 200, heightDp = 200, kind = "GLANCE_APPWIDGET"),
+            )
+          )
+      )
+    val router = PreviewManifestRouter(manifest = manifest)
+
+    val routed = router.routePayload("previewId=glance")
+
+    assertTrue(
+      "Glance previews must carry kind=GLANCE_APPWIDGET so RenderEngine routes through " +
+        "GlanceAppWidgetPreviewComposable. payload=$routed",
+      routed.contains("kind=GLANCE_APPWIDGET"),
+    )
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperResolutionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperResolutionTest.kt
@@ -8,40 +8,63 @@ import org.junit.Assert.assertSame
 import org.junit.Test
 
 /**
- * Regression guard for the `@PreviewWrapper` annotation reading + wrapper-class resolution path
- * the daemon's [RenderEngine] uses. Before this guard existed the daemon ignored
+ * Regression guard for the `@PreviewWrapper` wrapper-class resolution path the daemon's
+ * [RenderEngine] uses. Before this guard existed the daemon ignored
  * `@PreviewWrapper(SomeProvider::class)` entirely, so samples relying on a custom applier (e.g.
  * `@PreviewWrapper(RemotePreviewWrapper::class)` in `samples/remotecompose`) crashed with
  * `IllegalStateException: Invalid applier`.
  *
- * `:renderer-android` has a parallel test ([ee.schimke.composeai.renderer.PreviewWrapperTest]) for
- * its own `resolveWrapper`; this one covers the duplicated daemon path that the v2 reconciliation
- * (see [RenderEngine] kdoc) eventually folds back into a shared helper.
+ * **Why the spec-driven path is the production path** (issue #1440). The upstream
+ * `androidx.compose.ui.tooling.preview.PreviewWrapper` annotation has
+ * `AnnotationRetention.BINARY`, so `Method.annotations` never returns it at runtime — the
+ * `@Method.annotations`-based fallback inside [resolveWrapperOrNull] is a best-effort backup for
+ * direct-payload callers and **does not** fire in real-world preview renders. The gradle plugin's
+ * `extractWrapperFqn` reads the FQN from the class-file annotation tables and writes it into
+ * `previews.json` (where the annotation IS still visible); the daemon threads it into
+ * [RenderSpec.wrapperClassName] via [PreviewManifestRouter]. The first test below covers that
+ * spec-driven production path; the second covers the reflection fallback by stamping the same
+ * stand-in annotation on a fixture (note the stand-in deliberately uses
+ * `AnnotationRetention.BINARY` now to mirror upstream — see `PreviewWrapperStandIn.kt`, so the
+ * fallback path actually misses for the binary annotation, and the spec-driven path is the only
+ * one that resolves).
  *
- * The daemon's `:compose-bom-compat` floor (1.9.5) doesn't ship the real
- * `androidx.compose.ui.tooling.preview.PreviewWrapper` annotation — that landed in 1.11.0-beta+ —
- * so a same-FQN stand-in lives next to this test (see
- * `PreviewWrapperStandIn.kt`). The daemon's resolver matches by FQN string, so the synthetic
- * annotation is indistinguishable from the real one at runtime for the resolution path.
+ * `:renderer-android` has a parallel test ([ee.schimke.composeai.renderer.PreviewWrapperTest])
+ * for its own `resolveWrapper`; this one covers the duplicated daemon path that the v2
+ * reconciliation (see [RenderEngine] kdoc) eventually folds back into a shared helper.
  */
 class PreviewWrapperResolutionTest {
 
   @Test
-  fun `resolveWrapperOrNull returns wrapper Wrap method when annotation is present`() {
+  fun `resolveWrapperOrNull with spec FQN returns wrapper Wrap method`() {
     val method =
       Class.forName("ee.schimke.composeai.daemon.PreviewWrapperResolutionFixturesKt")
         .getDeclaredComposableMethod("WrappedFixturePreview")
 
-    val resolved = resolveWrapperOrNull(method)
+    val resolved = resolveWrapperOrNull(method, GreenBorderWrapper::class.java.name)
 
-    assertNotNull("wrapper must resolve when @PreviewWrapper is present", resolved)
+    assertNotNull("wrapper must resolve when spec FQN is present", resolved)
     val (wrapMethod, instance) = resolved!!
     assertSame(GreenBorderWrapper::class.java, instance.javaClass)
     assertEquals("Wrap", wrapMethod.asMethod().name)
   }
 
   @Test
-  fun `resolveWrapperOrNull returns null when annotation is absent`() {
+  fun `resolveWrapperOrNull returns null when spec FQN is absent and annotation has binary retention`() {
+    // `PreviewWrapperStandIn.kt`'s `@PreviewWrapper` mirrors upstream's `AnnotationRetention.BINARY`,
+    // so `Method.annotations` won't include it. This guards issue #1440's first regression: the
+    // pre-fix code relied on runtime reflection, which silently no-ops in production.
+    val method =
+      Class.forName("ee.schimke.composeai.daemon.PreviewWrapperResolutionFixturesKt")
+        .getDeclaredComposableMethod("WrappedFixturePreview")
+
+    assertNull(
+      "binary-retained @PreviewWrapper must NOT resolve via reflection — spec FQN is the only path",
+      resolveWrapperOrNull(method, wrapperFqnFromSpec = null),
+    )
+  }
+
+  @Test
+  fun `resolveWrapperOrNull returns null when no annotation is present and no FQN supplied`() {
     val method =
       Class.forName("ee.schimke.composeai.daemon.PreviewWrapperResolutionFixturesKt")
         .getDeclaredComposableMethod("UnwrappedFixturePreview")

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -124,15 +124,23 @@ data class PreviewParamsDto(
    */
   val backgroundColor: Long? = null,
   /**
-   * Preview flavour — mirrors `ee.schimke.composeai.plugin.PreviewKind` (`"COMPOSE"` / `"TILE"`).
-   * String-typed so the daemon's renderer-agnostic surface doesn't depend on the plugin's enum;
-   * `null` and `"COMPOSE"` both mean the default Compose path. `"TILE"` routes through the
-   * tile-render strategy on the Android backend (top-level
-   * `@androidx.wear.tiles.tooling.preview.Preview` functions are not `@Composable`, so the
-   * Compose-method reflection path throws `NoSuchMethodException` unless the renderer is told to
-   * dispatch differently).
+   * Preview flavour — mirrors `ee.schimke.composeai.plugin.PreviewKind` (`"COMPOSE"` / `"TILE"` /
+   * `"NOTIFICATION"` / `"GLANCE_APPWIDGET"`). String-typed so the daemon's renderer-agnostic
+   * surface doesn't depend on the plugin's enum; `null` and `"COMPOSE"` both mean the default
+   * Compose path. The non-default values route through dedicated render strategies on the Android
+   * backend (top-level Tile / Notification functions are not `@Composable`; Glance previews ARE
+   * `@Composable` but must be hosted inside a `GlanceAppWidget.providePreview(...)` →
+   * `composeForPreview(...)` → `RemoteViews.apply` pipeline, see issue #1440).
    */
   val kind: String? = null,
+  /**
+   * FQN of the `PreviewWrapperProvider` from `@PreviewWrapper(SomeProvider::class)` when the source
+   * preview is annotated. Read at discovery time by `extractWrapperFqn` against the class-file
+   * annotation tables (the upstream annotation has `AnnotationRetention.BINARY`, so
+   * `Method.annotations` is empty for it at runtime — see issue #1440). Threaded into
+   * `RenderSpec.wrapperClassName` for the render body.
+   */
+  val wrapperClassName: String? = null,
 )
 
 /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -448,6 +448,7 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
     fontScale = params.fontScale ?: defaults.fontScale,
     uiMode = uiMode,
     orientation = defaults.orientation,
+    wrapperClassName = params.wrapperClassName ?: defaults.wrapperClassName,
   )
 }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -131,6 +131,14 @@ class PreviewManifestRouter(
             inbound["captureAdvanceMs"]?.let { append("captureAdvanceMs=").append(it).append(';') }
             inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
             inbound["overrides"]?.let { append("overrides=").append(it).append(';') }
+            // `@PreviewWrapper(SomeProvider::class)` FQN sourced from `previews.json` (the
+            // gradle plugin's `extractWrapperFqn` reads it off the class-file annotation tables
+            // — the upstream annotation is `AnnotationRetention.BINARY` and invisible to
+            // `Method.annotations` at runtime, so this manifest-side plumbing is the only path
+            // that can recover the wrapper FQN for the render body). See issue #1440.
+            resolved.wrapperClassName
+              ?.takeIf { it.isNotBlank() }
+              ?.let { append("wrapperClassName=").append(it).append(';') }
             append("outputBaseName=").append(resolved.outputBaseName)
           },
       )
@@ -181,6 +189,7 @@ class PreviewManifestRouter(
           showBackground = resolved.showBackground,
           backgroundColor = resolved.backgroundColor,
           device = resolved.device,
+          wrapperClassName = resolved.wrapperClassName,
         )
       }
     }
@@ -236,6 +245,7 @@ data class PreviewManifestEntry(
     val showBackground = showBackground ?: p?.showBackground ?: true
     val backgroundColor = backgroundColor ?: p?.backgroundColor ?: 0L
     val device = device ?: p?.device
+    val wrapperClassName = p?.wrapperClassName
     return ResolvedRenderParams(
       widthPx = widthPx,
       heightPx = heightPx,
@@ -244,6 +254,7 @@ data class PreviewManifestEntry(
       backgroundColor = backgroundColor,
       device = device,
       outputBaseName = outputBaseName ?: id,
+      wrapperClassName = wrapperClassName,
     )
   }
 }
@@ -262,6 +273,14 @@ data class PreviewParamsEntry(
   val density: Float? = null,
   val showBackground: Boolean = false,
   val backgroundColor: Long = 0L,
+  /**
+   * FQN of the `PreviewWrapperProvider` from `@PreviewWrapper(SomeProvider::class)` when the source
+   * preview is annotated. Read at discovery time by `extractWrapperFqn` against the class-file
+   * annotation tables (the upstream annotation has `AnnotationRetention.BINARY`, so
+   * `Method.annotations` is empty for it at runtime — see issue #1440). Threaded into
+   * [RenderSpec.wrapperClassName] for the render body.
+   */
+  val wrapperClassName: String? = null,
 )
 
 /**
@@ -276,4 +295,5 @@ data class ResolvedRenderParams(
   val backgroundColor: Long,
   val device: String?,
   val outputBaseName: String,
+  val wrapperClassName: String? = null,
 )

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -266,7 +266,7 @@ class RenderEngine(
                   // Trampoline through a @Composable so the reflective invocation lands inside the
                   // running composition. Mirrors `:renderer-desktop`'s InvokeComposable. Honours
                   // `@PreviewWrapper(SomeProvider::class)` by routing through the wrapper's `Wrap`.
-                  InvokeWithOptionalWrapper(composableMethod)
+                  InvokeWithOptionalWrapper(composableMethod, spec.wrapperClassName)
                 }
               }
             }
@@ -573,6 +573,16 @@ data class RenderSpec(
    * adding a new override-driven feature is purely a connector concern.
    */
   val overrides: PreviewOverrides? = null,
+  /**
+   * FQN of the `PreviewWrapperProvider` from `@PreviewWrapper(SomeProvider::class)` when the source
+   * preview is annotated. Sourced from the gradle plugin's discovery JSON (`extractWrapperFqn`
+   * reads it off the class-file annotation tables — the upstream annotation has
+   * `AnnotationRetention.BINARY` and is invisible to `Method.annotations` at runtime, see
+   * issue #1440). The render body drives `InvokeWithOptionalWrapper` off this field when set; null
+   * falls back to the (best-effort) runtime-reflection lookup for direct-payload callers that
+   * bypass the manifest.
+   */
+  val wrapperClassName: String? = null,
 ) {
 
   enum class SpecUiMode {
@@ -643,6 +653,7 @@ data class RenderSpec(
           },
         inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull(),
         overrides = map["overrides"]?.decodePreviewOverrides(),
+        wrapperClassName = map["wrapperClassName"]?.takeIf { it.isNotBlank() },
       )
     }
 
@@ -672,17 +683,34 @@ private fun InvokeComposable(composableMethod: ComposableMethod) {
 
 /**
  * Wraps [InvokeComposable] in the preview's `@PreviewWrapper(SomeProvider::class)` `Wrap { … }` if
- * one is present on the composable method. Without this the daemon would call the preview body
- * directly and bypass the wrapper — e.g. `@PreviewWrapper(RemotePreviewWrapper::class)` previews
- * would crash with `IllegalStateException: Invalid applier` the moment they emit a `RemoteBox` /
- * `RemoteColumn` / `RemoteRow`, because those composables require the RemoteCompose applier the
- * wrapper installs. Mirrors the Android daemon and `:renderer-android`'s `PreviewRenderStrategy`.
+ * one is present, sourcing the wrapper FQN from [wrapperFqnFromSpec] (the discovery-time class-file
+ * read) with a best-effort runtime-reflection fallback. Without this the daemon would call the
+ * preview body directly and bypass the wrapper — e.g.
+ * `@PreviewWrapper(RemotePreviewWrapper::class)` previews would crash with `IllegalStateException:
+ * Invalid applier` the moment they emit a `RemoteBox` / `RemoteColumn` / `RemoteRow`, because those
+ * composables require the RemoteCompose applier the wrapper installs. Mirrors the Android daemon
+ * and `:renderer-android`'s `PreviewRenderStrategy`.
+ *
+ * **Why the FQN comes from the spec rather than `Method.annotations`.** The upstream
+ * `androidx.compose.ui.tooling.preview.PreviewWrapper` annotation has `AnnotationRetention.BINARY`
+ * (issue #1440): it's emitted into the class file but not retained at runtime. The gradle plugin's
+ * `extractWrapperFqn` reads the FQN from the class-file annotation tables (where it IS still
+ * visible) and writes it into `previews.json`; the daemon threads it into
+ * [RenderSpec.wrapperClassName] via [PreviewManifestRouter]. The reflection fallback is retained
+ * for direct-payload callers and remains best-effort.
+ *
  * Wrapper class resolution flows through [loadPreviewWrapperClass], so connector-provided SPI
  * substitutions apply transparently.
  */
 @Composable
-private fun InvokeWithOptionalWrapper(composableMethod: ComposableMethod) {
-  val wrapper = remember(composableMethod) { resolveWrapperOrNull(composableMethod) }
+private fun InvokeWithOptionalWrapper(
+  composableMethod: ComposableMethod,
+  wrapperFqnFromSpec: String?,
+) {
+  val wrapper =
+    remember(composableMethod, wrapperFqnFromSpec) {
+      resolveWrapperOrNull(composableMethod, wrapperFqnFromSpec)
+    }
   if (wrapper == null) {
     InvokeComposable(composableMethod)
   } else {
@@ -693,15 +721,33 @@ private fun InvokeWithOptionalWrapper(composableMethod: ComposableMethod) {
 }
 
 /**
- * Reads `@androidx.compose.ui.tooling.preview.PreviewWrapper(SomeProvider::class)` reflectively off
- * the composable's underlying JVM method, then resolves the wrapper's `Wrap(content)` method plus a
- * fresh instance. Returns null when the annotation is absent, the wrapper class can't be loaded, or
- * instantiation fails — callers fall back to invoking the preview body directly.
+ * Resolves the `@PreviewWrapper`'s `PreviewWrapperProvider` to a `Wrap(content)` method plus an
+ * instance.
+ *
+ * Strategy (in order):
+ * 1. Use [wrapperFqnFromSpec] when supplied — production path, sourced from `previews.json`.
+ * 2. Otherwise, look up `@androidx.compose.ui.tooling.preview.PreviewWrapper` reflectively off the
+ *    composable's underlying JVM method. This is best-effort: the upstream annotation has
+ *    `AnnotationRetention.BINARY`, so `Method.annotations` will not return it for real-world
+ *    previews. Kept for direct-payload callers and back-compat.
+ *
+ * Returns null when no wrapper is resolvable.
  *
  * Reflective lookup (rather than a compile-time import of `PreviewWrapper`) keeps the daemon
  * runnable on older Compose runtimes that predate the annotation (1.11.0-beta+).
  */
-private fun resolveWrapperOrNull(composableMethod: ComposableMethod): Pair<ComposableMethod, Any>? {
+internal fun resolveWrapperOrNull(
+  composableMethod: ComposableMethod,
+  wrapperFqnFromSpec: String? = null,
+): Pair<ComposableMethod, Any>? {
+  val wrapperFqn =
+    wrapperFqnFromSpec?.takeIf { it.isNotBlank() }
+      ?: resolveWrapperFqnViaReflection(composableMethod)
+      ?: return null
+  return loadWrapperByFqnOrNull(wrapperFqn)
+}
+
+private fun resolveWrapperFqnViaReflection(composableMethod: ComposableMethod): String? {
   val jvmMethod = composableMethod.asMethod()
   val ann =
     jvmMethod.annotations.firstOrNull {
@@ -710,17 +756,19 @@ private fun resolveWrapperOrNull(composableMethod: ComposableMethod): Pair<Compo
   val wrapperValue =
     runCatching { ann.annotationClass.java.getDeclaredMethod("wrapper").invoke(ann) }.getOrNull()
       ?: return null
-  val wrapperFqn =
-    when (wrapperValue) {
-      is Class<*> -> wrapperValue.name
-      is kotlin.reflect.KClass<*> -> wrapperValue.java.name
-      else -> return null
-    }
-  return runCatching {
+  return when (wrapperValue) {
+    is Class<*> -> wrapperValue.name
+    is kotlin.reflect.KClass<*> -> wrapperValue.java.name
+    else -> null
+  }
+}
+
+private fun loadWrapperByFqnOrNull(wrapperFqn: String): Pair<ComposableMethod, Any>? =
+  runCatching {
       val resolved = loadPreviewWrapperClass(wrapperFqn)
       val instance = resolved.getDeclaredConstructor().apply { isAccessible = true }.newInstance()
       val wrapMethod = resolved.getDeclaredComposableMethod("Wrap", Function2::class.java)
-      wrapMethod to instance
+      wrapMethod to (instance as Any)
     }
     .onFailure { t ->
       System.err.println(
@@ -729,7 +777,6 @@ private fun resolveWrapperOrNull(composableMethod: ComposableMethod): Pair<Compo
       )
     }
     .getOrNull()
-}
 
 @Composable
 private fun CaptureMaterialTheme(

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestEntryResolveTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestEntryResolveTest.kt
@@ -100,4 +100,19 @@ class PreviewManifestEntryResolveTest {
     assertEquals("id:wearos_small_round", resolved.device)
     assertEquals(384, resolved.widthPx) // 192 * 2.0 default density
   }
+
+  @Test
+  fun `nested params wrapperClassName propagates into ResolvedRenderParams`() {
+    // Issue #1440 — the gradle plugin emits `params.wrapperClassName` from
+    // `@PreviewWrapper(SomeProvider::class)` via class-file annotation scanning (the upstream
+    // annotation is `AnnotationRetention.BINARY` and unavailable to runtime reflection). The
+    // resolver must surface it so the router can thread it into the `RenderSpec` payload.
+    val raw =
+      """{"id":"wrapped","className":"X","functionName":"R",""" +
+        """"params":{"widthDp":100,"heightDp":100,""" +
+        """"wrapperClassName":"com.example.RemotePreviewWrapper"}}"""
+    val entry = json.decodeFromString(PreviewManifestEntry.serializer(), raw)
+    val resolved = entry.resolved()
+    assertEquals("com.example.RemotePreviewWrapper", resolved.wrapperClassName)
+  }
 }


### PR DESCRIPTION
Closes #1440.

Both sub-items addressed in one commit (`7c1121d2`) — they share the routing/spec plumbing, so splitting would have meant duplicating the manifest-field round-trip.

## Summary

### 1. `@PreviewWrapper` resolution — stop relying on runtime reflection

The upstream `@androidx.compose.ui.tooling.preview.PreviewWrapper` annotation has `AnnotationRetention.BINARY`, so `Method.annotations` never sees it at runtime. #1439 added a reflective lookup that always missed on the real annotation, and the regression test masked the bug by using `AnnotationRetention.RUNTIME` on its stand-in.

Switched to sourcing the wrapper FQN from `previews.json` (where discovery already has access to the class-file metadata). Plumbed `wrapperClassName` through:

```
PreviewParamsEntry → ResolvedRenderParams → PreviewManifestRouter.routePayload → RenderSpec → PreviewParamsDto → renderSpecFromInfo
```

on both Android and Desktop backends. `InvokeWithOptionalWrapper` now takes a `wrapperFqnFromSpec` arg and prefers it; the runtime-reflection lookup is retained as a best-effort fallback for non-spec entry points.

- Fixed `PreviewWrapperStandIn.kt` to use `AnnotationRetention.BINARY` matching upstream.
- Updated the regression test so it explicitly proves the binary annotation cannot be resolved via reflection — only via the spec path.

### 2. `GLANCE_APPWIDGET` dispatch

Added `RenderEngine.GLANCE_APPWIDGET_KIND` and a dedicated branch in the Android `RenderEngine` that dispatches to `:renderer-android`'s existing `GlanceAppWidgetPreviewComposable`, mirroring how `:renderer-android`'s `GlanceAppWidgetPreviewStrategy` handles the same kind. No new build-side dependency needed — the daemon already `implementation`-deps `:renderer-android`.

## Test plan

- [x] `:daemon:android:compileDebugUnitTestKotlin`, `:daemon:desktop:compileKotlin`, `:daemon:core:compileKotlin` clean
- [x] `PreviewWrapperResolutionTest`, `PreviewManifestRouterRoutingTest` (new), `RenderSpecFromInfoTest` pass
- [x] `ktfmtCheckAll` clean
- [ ] CI: full Gradle suite + Android UI tests
- [ ] Spot-check `RemoteButtonWithBorderPreview` (the original crash repro) on a daemon-driven render
- [ ] Spot-check a Glance preview through the VS Code daemon path

> Note: pre-existing `BuildDesktopExtensionsTest` compile failure on `:daemon:desktop:compileTestKotlin` and an unrelated `:daemon:core:compileTestKotlin` internal-compiler-error are present on `origin/main` ahead of this branch — verified by stashing the agent's diff. Not introduced here.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164TDPHM3haDqw2BPDGQPQA)_