### PR TITLE
fix: codex follow-ups — discovery, inspection UI, install + publishing

### DIFF
--- a/.github/actions/install/resolve-version.py
+++ b/.github/actions/install/resolve-version.py
@@ -71,6 +71,34 @@ def _release_is_complete(release: dict) -> bool:
     return False
 
 
+_MAX_RELEASES_PAGES = 5
+_RELEASES_PER_PAGE = 30
+
+
+def _parse_next_link(link_header: str | None) -> str | None:
+    """Extract the `rel="next"` URL from a GitHub `Link` response header.
+
+    GitHub returns paginated endpoints with `Link: <url>; rel="next", <url>; rel="last"`;
+    we follow the `next` URL verbatim (it already carries the right `page=…` query
+    parameter) until exhausted. Returns `None` when the header is missing or has
+    no `next` segment, signalling we've reached the last page.
+    """
+    if not link_header:
+        return None
+    for part in link_header.split(","):
+        segment = part.strip()
+        if not segment.startswith("<"):
+            continue
+        close = segment.find(">")
+        if close == -1:
+            continue
+        url = segment[1:close]
+        params = segment[close + 1 :]
+        if 'rel="next"' in params:
+            return url
+    return None
+
+
 def latest_version() -> str:
     """Resolve `latest` to the most recent release with a complete CLI asset.
 
@@ -78,42 +106,63 @@ def latest_version() -> str:
     the first tag whose CLI tarball is fully uploaded. This avoids the race
     window where `/releases/latest` returns a tag whose assets haven't been
     uploaded yet — see _release_is_complete for the failure mode.
+
+    Paginates the listing because busy repos with frequent prereleases / drafts
+    can fill page 1 entirely with skipped entries before a complete published
+    release shows up. Bounded at `_MAX_RELEASES_PAGES` pages
+    (`= _MAX_RELEASES_PAGES * _RELEASES_PER_PAGE` entries) so a misconfigured
+    pipeline fails loudly instead of walking the whole release history.
     """
-    # `per_page=30` is the API default and covers ~weeks of releases at the
-    # project's current cadence; a half-baked release at the head plus its
-    # complete predecessor will both be on page 1. Skip pagination — if the
-    # first 30 releases are all incomplete the right answer is to fail loudly,
-    # not to walk further back.
-    try:
-        with urllib.request.urlopen(_api_request("releases?per_page=30"), timeout=15) as resp:
-            releases = json.load(resp)
-    except urllib.error.URLError as exc:
-        fail(f"could not reach api.github.com: {exc}")
-    if not isinstance(releases, list):
-        fail("releases payload was not a list")
-
     skipped: list[str] = []
-    for release in releases:
-        if release.get("draft") or release.get("prerelease"):
-            continue
-        tag = release.get("tag_name")
-        if not tag:
-            continue
-        if _release_is_complete(release):
-            if skipped:
-                # Surface the fall-back so a flaky release pipeline shows up
-                # in run logs instead of silently pinning consumers backwards.
-                print(
-                    f"::warning::compose-preview install: skipped incomplete release(s) "
-                    f"{', '.join(skipped)} (CLI tarball not yet uploaded); "
-                    f"resolved latest to {tag}",
-                    file=sys.stderr,
-                )
-            return tag.lstrip("v")
-        skipped.append(tag)
+    next_url: str | None = (
+        f"https://api.github.com/repos/{REPO}/releases?per_page={_RELEASES_PER_PAGE}"
+    )
+    pages_fetched = 0
+    while next_url and pages_fetched < _MAX_RELEASES_PAGES:
+        req = urllib.request.Request(
+            next_url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        token = os.environ.get("GITHUB_TOKEN", "")
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                releases = json.load(resp)
+                link_header = resp.headers.get("Link")
+        except urllib.error.URLError as exc:
+            fail(f"could not reach api.github.com: {exc}")
+        pages_fetched += 1
+        if not isinstance(releases, list):
+            fail("releases payload was not a list")
 
+        for release in releases:
+            if release.get("draft") or release.get("prerelease"):
+                continue
+            tag = release.get("tag_name")
+            if not tag:
+                continue
+            if _release_is_complete(release):
+                if skipped:
+                    # Surface the fall-back so a flaky release pipeline shows up
+                    # in run logs instead of silently pinning consumers backwards.
+                    print(
+                        f"::warning::compose-preview install: skipped incomplete release(s) "
+                        f"{', '.join(skipped)} (CLI tarball not yet uploaded); "
+                        f"resolved latest to {tag}",
+                        file=sys.stderr,
+                    )
+                return tag.lstrip("v")
+            skipped.append(tag)
+
+        next_url = _parse_next_link(link_header)
+
+    cap = _MAX_RELEASES_PAGES * _RELEASES_PER_PAGE
     fail(
-        "no published release in the last 30 has a fully-uploaded CLI tarball; "
+        f"no published release in the last {cap} has a fully-uploaded CLI tarball; "
         f"checked: {', '.join(skipped) if skipped else '(none)'}"
     )
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -215,6 +215,13 @@ data class LauncherWidgetCapture(
   val maxWidth: Int? = null,
   val maxHeight: Int? = null,
   val resizeOrder: LauncherWidgetCaptureResizeOrder = LauncherWidgetCaptureResizeOrder.WidthFirst,
+  /**
+   * Per-frame delay carried through from `@LauncherWidgetResize.frameDelayMs`. `null` when the
+   * capture didn't originate from a resize walk (single `@LauncherWidgetPreview` doesn't author a
+   * GIF, so the field is absent there). The future GIF-stitch pass reads this off the per-stop
+   * captures; the value is identical across every stop in the same walk by construction.
+   */
+  val frameDelayMs: Int? = null,
 )
 
 /** Mirror of `LauncherResizeOrder` in `:daemon:core`. */
@@ -555,19 +562,19 @@ val DEFAULT_RESOURCE_FILMSTRIP_FRACTIONS: List<Float> = listOf(0.0f, 0.25f, 0.5f
 
 /**
  * Per-capture cost for a 9-patch stretch render. Each capture is one `NinePatchDrawable.draw` into
- * a target-sized bitmap plus a PNG encode — within a constant factor of [RESOURCE_STATIC_COST].
- * The 4-stretch fan-out per qualifier means the aggregate cost for one 9-patch is ~6x a vector;
- * tier alongside other static captures.
+ * a target-sized bitmap plus a PNG encode — within a constant factor of [RESOURCE_STATIC_COST]. The
+ * 4-stretch fan-out per qualifier means the aggregate cost for one 9-patch is ~6x a vector; tier
+ * alongside other static captures.
  */
 const val RESOURCE_NINE_PATCH_COST: Float = 1.5f
 
 /**
  * Drawable / mipmap resources the renderer knows how to handle. [VECTOR], [ANIMATED_VECTOR], and
  * [ADAPTIVE_ICON] come from XML root tags (classified by [ResourceXmlClassifier] in the plugin
- * module). [NINE_PATCH] comes from the `.9.png` file-extension convention — AAPT2 strips the
- * 1-px guide border at build time and stamps an `npTc` chunk into the compiled PNG, and at render
- * time Android resolves the drawable to a `NinePatchDrawable` whose `draw()` interpolates the
- * patches against whatever bounds we set.
+ * module). [NINE_PATCH] comes from the `.9.png` file-extension convention — AAPT2 strips the 1-px
+ * guide border at build time and stamps an `npTc` chunk into the compiled PNG, and at render time
+ * Android resolves the drawable to a `NinePatchDrawable` whose `draw()` interpolates the patches
+ * against whatever bounds we set.
  */
 @Serializable
 enum class ResourceType {

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -864,13 +864,25 @@ object PreviewDiscovery {
     val effectiveLauncherWidget = if (nonComposable) null else launcherWidget
     val effectiveLauncherWidgetResize = if (nonComposable) null else launcherWidgetResize
 
-    // `@LauncherWidgetResize` owns the capture list when present — it walks N whole-cell stops
-    // between source and target sizes and emits one PNG per stop. Coexisting with the standard
-    // scroll / time / focus fan-out doesn't make sense (a resize walk is its own dimensional
-    // axis), so the resize captures fully replace the regular capture grid. focusGif /
-    // animation GIFs still fan out independently — the resize annotation isn't meant to combine
-    // with those either, but if a consumer stacks them the GIFs come out alongside the resize
-    // PNGs with their existing suffixes.
+    // @AnimatedPreview and @FocusedPreview(gif = true) both produce a `.gif` output for the
+    // function. When one is paired with anything else on the same function — scroll/time
+    // fan-out, or each other, or a `@LauncherWidgetResize` PNG fan-out — they need
+    // disambiguating suffixes so neither silently overwrites the other. Plain filename only
+    // when a single GIF mode owns the function with no scroll/time/resize siblings.
+    val gifSharesFn =
+      effectiveScrolls.isNotEmpty() ||
+        effectiveTimings.isNotEmpty() ||
+        effectiveLauncherWidgetResize != null ||
+        (effectiveAnimation != null && effectiveFocusGif != null)
+
+    // `@LauncherWidgetResize` owns the static capture list when present — it walks N whole-cell
+    // stops between source and target sizes and emits one PNG per stop. Coexisting with the
+    // standard scroll / time / focus fan-out doesn't make sense (a resize walk is its own
+    // dimensional axis), so the resize captures fully replace the regular capture grid.
+    // focusGif / animation GIFs still fan out independently — the resize annotation isn't meant
+    // to combine with those either, but if a consumer stacks them the GIFs come out alongside
+    // the resize PNGs with their existing suffixes (computed below using the shared
+    // `gifSharesFn` flag).
     if (effectiveLauncherWidgetResize != null) {
       val stops =
         launcherWidgetResizeStops(
@@ -893,18 +905,37 @@ object PreviewDiscovery {
           cost = STATIC_COST,
         )
       }
-      return PreviewOutputPlan(captures = resizeCaptures, dataProducts = emptyList())
+      val focusGifCaptures: List<Capture> =
+        if (effectiveFocusGif == null) emptyList()
+        else {
+          val suffix = if (gifSharesFn) "_focus_gif" else ""
+          listOf(
+            Capture(
+              focusGif = effectiveFocusGif,
+              ambient = effectiveAmbient,
+              launcherWidget = effectiveLauncherWidget,
+              renderOutput = "renders/${previewId}${suffix}.gif",
+              cost = FOCUS_GIF_COST,
+            )
+          )
+        }
+      val animationCaptures: List<Capture> =
+        if (effectiveAnimation == null) emptyList()
+        else {
+          val suffix = if (gifSharesFn) "_anim" else ""
+          listOf(
+            Capture(
+              animation = effectiveAnimation,
+              renderOutput = "renders/${previewId}${suffix}.gif",
+              cost = ANIMATION_COST,
+            )
+          )
+        }
+      return PreviewOutputPlan(
+        captures = resizeCaptures + focusGifCaptures + animationCaptures,
+        dataProducts = emptyList(),
+      )
     }
-
-    // @AnimatedPreview and @FocusedPreview(gif = true) both produce a `.gif` output for the
-    // function. When one is paired with anything else on the same function — scroll/time
-    // fan-out, or each other — they need disambiguating suffixes so neither silently
-    // overwrites the other. Plain filename only when a single GIF mode owns the function with
-    // no scroll/time siblings.
-    val gifSharesFn =
-      effectiveScrolls.isNotEmpty() ||
-        effectiveTimings.isNotEmpty() ||
-        (effectiveAnimation != null && effectiveFocusGif != null)
 
     // @FocusedPreview(gif = true): one GIF capture per annotated function, dimension-flat —
     // doesn't cross with scrolls / timings / focus fan-out. Mirrors @AnimatedPreview's

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -899,6 +899,7 @@ object PreviewDiscovery {
               cellSizeDp = effectiveLauncherWidgetResize.cellSizeDp,
               cellSpacingDp = effectiveLauncherWidgetResize.cellSpacingDp,
               resizeOrder = effectiveLauncherWidgetResize.resizeOrder,
+              frameDelayMs = effectiveLauncherWidgetResize.frameDelayMs,
             ),
           ambient = effectiveAmbient,
           renderOutput = "renders/${previewId}_RESIZE_${w}x${h}.png",

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -43,13 +43,13 @@ dependencies {
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.json)
   implementation(libs.mcp.kotlin.sdk.server)
-  // For DaemonClasspathDescriptor (read at supervisor spawn time) and the protocol message types
-  // exchanged with daemon JVMs.
-  implementation(project(":daemon:core"))
-  // Public render-session API. `SupervisedDaemon` exposes a `RenderSession` view of its private
-  // `DaemonClient` so callers that prefer the published library surface have a path. The
-  // implementation stays internal to `:mcp` for now — the supervisor owns subprocess lifecycle.
-  implementation(project(":render-session-api"))
+  // `:daemon:core` and `:render-session-api` are advertised as `api` because `:mcp` exposes
+  // their types on its public surface (e.g. `SupervisedDaemon.session: RenderSession`,
+  // `DaemonClasspathDescriptor`, the protocol message types reused by
+  // `:render-session-subprocess`). Without `api` the generated POM scopes them as `runtime`
+  // only and consumers resolving from POM metadata fail to compile against the MCP APIs.
+  api(project(":daemon:core"))
+  api(project(":render-session-api"))
 
   testImplementation(libs.junit)
   testImplementation(libs.truth)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -117,6 +117,11 @@ data class LauncherWidgetCapture(
     val maxWidth: Int? = null,
     val maxHeight: Int? = null,
     val resizeOrder: LauncherWidgetCaptureResizeOrder = LauncherWidgetCaptureResizeOrder.WidthFirst,
+    /**
+     * Per-frame delay carried through from `@LauncherWidgetResize.frameDelayMs` for the
+     * future GIF-stitch pass. `null` when the capture didn't originate from a resize walk.
+     */
+    val frameDelayMs: Int? = null,
 )
 
 /**

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -869,12 +869,15 @@ export async function activate(
                           // Multi-capture (animated) renders still come through the
                           // Gradle path; the daemon's predictive pre-warm focuses
                           // on the cheap interactive loop.
-                          const ownerModule = previewModuleMap.get(previewId);
-                          const previewInfo = ownerModule
-                              ? moduleManifestCache
-                                    .get(ownerModule.modulePath)
-                                    ?.find((p) => p.id === previewId)
-                              : undefined;
+                          //
+                          // Resolve the owning manifest directly from `moduleId`
+                          // (which is the daemon-side module path); previewModuleMap
+                          // is keyed on previewId only, which is ambiguous if two
+                          // modules share an id, and would land the frame in the
+                          // wrong capture slot.
+                          const previewInfo = moduleManifestCache
+                              .get(moduleId)
+                              ?.find((p) => p.id === previewId);
                           const captureIndex = previewInfo
                               ? staticBaseCaptureIndex(previewInfo)
                               : 0;

--- a/vscode-extension/src/kotlinClassFqn.ts
+++ b/vscode-extension/src/kotlinClassFqn.ts
@@ -119,16 +119,68 @@ export function topLevelClassFqns(source: string): string[] {
 }
 
 /**
- * True iff the [declaration] mentions one of the platform component
- * base classes — used to decide whether the `<application>` icon is a
- * sensible fallback when the file's FQN has no manifest override. Plain
- * substring match: we'd rather miss an unusual base (and skip the
- * fallback) than show the app icon next to a random data class.
+ * True iff the [declaration]'s supertype clause names one of the platform
+ * component base classes — used to decide whether the `<application>` icon
+ * is a sensible fallback when the file's FQN has no manifest override.
+ *
+ * The match is scoped to the supertype clause (the substring after the
+ * `:` separating the class header from its base list). A whole-declaration
+ * match would false-positive on classes that merely mention `Activity` /
+ * `Service` in a constructor parameter type — e.g.
+ * `class Foo(private val host: Activity) : ViewModel()` would incorrectly
+ * pick up the app icon under the old whole-string match.
  */
 export function isActivityLikeDeclaration(
     decl: KotlinClassDeclaration,
 ): boolean {
-    return ACTIVITY_LIKE_BASE_RE.test(decl.declaration);
+    const supertypeClause = extractSupertypeClause(decl.declaration);
+    if (supertypeClause === null) return false;
+    return ACTIVITY_LIKE_BASE_RE.test(supertypeClause);
+}
+
+/**
+ * Return the substring of [declaration] starting at the supertype-list
+ * `:`, or `null` when the declaration has no supertype clause.
+ *
+ * Skips over the primary-constructor parameter list so a `:` inside the
+ * ctor's parameter types (`val x: Activity`) doesn't get mistaken for the
+ * supertype separator. When there's no primary ctor (or the primary
+ * ctor's `(` follows the supertype `:` — only possible with malformed
+ * Kotlin, but we want to be defensive) the first `:` is the supertype
+ * separator and is returned as-is.
+ */
+function extractSupertypeClause(declaration: string): string | null {
+    const parenOpen = declaration.indexOf("(");
+    const firstColon = declaration.indexOf(":");
+    if (firstColon === -1) return null;
+    if (parenOpen === -1 || firstColon < parenOpen) {
+        return declaration.substring(firstColon);
+    }
+    const parenClose = findMatchingClose(declaration, parenOpen);
+    if (parenClose === -1) return null;
+    const colon = declaration.indexOf(":", parenClose + 1);
+    if (colon === -1) return null;
+    return declaration.substring(colon);
+}
+
+/**
+ * Find the index of the `)` matching the `(` at [openIndex] in [source].
+ * Returns `-1` when unbalanced. Naive depth counter — kotlin allows
+ * nested parens inside default-value expressions, and the discovery
+ * regex bounds the scanned substring to a few lines, so a full Kotlin
+ * lexer would be overkill.
+ */
+function findMatchingClose(source: string, openIndex: number): number {
+    let depth = 0;
+    for (let i = openIndex; i < source.length; i += 1) {
+        const ch = source.charAt(i);
+        if (ch === "(") depth += 1;
+        else if (ch === ")") {
+            depth -= 1;
+            if (depth === 0) return i;
+        }
+    }
+    return -1;
 }
 
 /**

--- a/vscode-extension/src/test/kotlinClassFqn.test.ts
+++ b/vscode-extension/src/test/kotlinClassFqn.test.ts
@@ -149,4 +149,20 @@ describe("isActivityLikeDeclaration", () => {
         assert.ok(decl);
         assert.strictEqual(isActivityLikeDeclaration(decl), false);
     });
+
+    it("does not match Activity mentioned only in a constructor parameter", () => {
+        const [decl] = extractClassDeclarations(
+            "class Foo(private val host: Activity) : ViewModel()",
+        );
+        assert.ok(decl);
+        assert.strictEqual(isActivityLikeDeclaration(decl), false);
+    });
+
+    it("matches when the supertype is Activity even with a ctor parameter", () => {
+        const [decl] = extractClassDeclarations(
+            "class Foo(private val helper: Helper) : Activity()",
+        );
+        assert.ok(decl);
+        assert.ok(isActivityLikeDeclaration(decl));
+    });
 });

--- a/vscode-extension/src/webview/preview/inspectionPresenters.ts
+++ b/vscode-extension/src/webview/preview/inspectionPresenters.ts
@@ -24,6 +24,11 @@ import {
 import type { OverlayBox } from "./components/BoxOverlay";
 import { parseBounds as parseCardBounds } from "./cardData";
 import { buildSelectorSnippet } from "./uiaSelector";
+import {
+    computePermissionsBundleData,
+    type PermissionsPayload,
+    type PermissionRow,
+} from "./permissionsBundlePresenter";
 
 // ---- compose/semantics --------------------------------------------------
 
@@ -194,7 +199,11 @@ export interface InspectionKindData {
 export interface InspectionBundleData {
     /** Per-kind sections, in the kind order the bundle registry declares. */
     sections: ReadonlyArray<{
-        kind: "compose/semantics" | "layout/inspector" | "uia/hierarchy";
+        kind:
+            | "compose/semantics"
+            | "layout/inspector"
+            | "uia/hierarchy"
+            | "compose/permissions";
         data: InspectionKindData;
     }>;
     /**
@@ -230,7 +239,8 @@ export type InspectionNodeRecord =
 export type InspectionKind =
     | "compose/semantics"
     | "layout/inspector"
-    | "uia/hierarchy";
+    | "uia/hierarchy"
+    | "compose/permissions";
 
 export interface InspectionPayloadLookup {
     (kind: InspectionKind): unknown;
@@ -278,6 +288,13 @@ export function computeInspectionBundleData(
             | undefined;
         const data = computeUiaHierarchyBundleData(payload, nodeById);
         if (data) sections.push({ kind: "uia/hierarchy", data });
+    }
+    if (enabledKinds.has("compose/permissions")) {
+        const payload = getPayload("compose/permissions") as
+            | PermissionsPayload
+            | undefined;
+        const data = computePermissionsInspectionData(payload);
+        if (data) sections.push({ kind: "compose/permissions", data });
     }
 
     const overlay = mergeOverlayBoxes(sections.map((s) => s.data.overlay));
@@ -471,6 +488,96 @@ function computeUiaHierarchyBundleData(
         },
     });
     return { body, summary, overlay };
+}
+
+/**
+ * `compose/permissions` doesn't fit the tree-table abstraction the other three
+ * kinds share (no hierarchy, no overlay bounds), so we render two flat rows
+ * tables — grants and queried — under one `<section>`. The body sits in the
+ * inspection bundle's host alongside the tree-tables; the bundle's merged
+ * overlay stays empty for this kind.
+ */
+function computePermissionsInspectionData(
+    payload: PermissionsPayload | undefined,
+): InspectionKindData | null {
+    if (!payload) return null;
+    const data = computePermissionsBundleData(payload);
+    if (data.grantRows.length === 0 && data.queriedRows.length === 0) {
+        return null;
+    }
+    const summary =
+        data.allPermissions.length +
+        " permission" +
+        (data.allPermissions.length === 1 ? "" : "s");
+    const body = document.createElement("section");
+    body.className = "inspection-permissions-section";
+    const header = document.createElement("header");
+    header.className = "inspection-permissions-header";
+    header.textContent = "Permissions · " + summary;
+    body.appendChild(header);
+    if (data.grantRows.length > 0) {
+        body.appendChild(
+            buildPermissionsTable("Effective grants", data.grantRows, [
+                "Permission",
+                "Grant",
+                "Queried?",
+            ]),
+        );
+    }
+    if (data.queriedRows.length > 0) {
+        body.appendChild(
+            buildPermissionsTable("Queried", data.queriedRows, [
+                "Permission",
+                "Effective grant",
+            ]),
+        );
+    }
+    return { body, summary, overlay: [] };
+}
+
+function buildPermissionsTable(
+    title: string,
+    rows: readonly PermissionRow[],
+    headers: readonly string[],
+): HTMLElement {
+    const wrap = document.createElement("section");
+    wrap.className = "inspection-permissions-table";
+    const heading = document.createElement("h4");
+    heading.textContent = title;
+    wrap.appendChild(heading);
+    const table = document.createElement("table");
+    const thead = document.createElement("thead");
+    const headerRow = document.createElement("tr");
+    for (const h of headers) {
+        const th = document.createElement("th");
+        th.textContent = h;
+        headerRow.appendChild(th);
+    }
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+    const tbody = document.createElement("tbody");
+    for (const row of rows) {
+        const tr = document.createElement("tr");
+        tr.dataset.permissionLevel = row.level;
+        const permCell = document.createElement("td");
+        const code = document.createElement("code");
+        code.textContent = row.shortLabel;
+        permCell.appendChild(code);
+        tr.appendChild(permCell);
+        const grantCell = document.createElement("td");
+        grantCell.textContent =
+            row.grant ?? (headers.length === 3 ? "—" : "unknown");
+        tr.appendChild(grantCell);
+        if (headers.length === 3) {
+            const queriedCell = document.createElement("td");
+            queriedCell.textContent = row.queried ? "yes" : "no";
+            tr.appendChild(queriedCell);
+        }
+        tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    wrap.appendChild(table);
+    return wrap;
 }
 
 /** Namespace a node id with its kind so cross-kind dedupe stays clean. */

--- a/vscode-extension/src/webview/preview/liveCardControls.ts
+++ b/vscode-extension/src/webview/preview/liveCardControls.ts
@@ -46,24 +46,137 @@ export function ensureLiveCardControls(
 }
 
 /**
- * Remove a stale `.card-controls-toggle-btn` overlay from [card]. Earlier
- * builds stamped this button inside `.image-container`; the toggle now lives
- * on the focus-controls bar (see `FocusController.applyFocusedToggleButtonStates`),
- * so this helper only cleans up so a webview state restored from an older
- * release doesn't leave the icon sitting on top of the rendered preview.
+ * Idempotently inject a `.card-controls-toggle-btn` overlay into [card]'s
+ * `.image-container`. Used in grid / flow / column layouts where the focus
+ * toolbar is hidden — the per-card overlay is the only path to the #1203
+ * interactive-controls toggle outside focus mode. In focus mode the
+ * focus-controls bar owns the toggle and the per-card button is stripped
+ * by `removeControlsToggleButton`.
+ */
+export function ensureControlsToggleButton(
+    card: HTMLElement,
+    opts: {
+        enabled: boolean;
+        onToggle: (card: HTMLElement, next: boolean) => void;
+    },
+): void {
+    const container = card.querySelector(".image-container");
+    if (!container) return;
+    let btn = container.querySelector<HTMLButtonElement>(
+        ".card-controls-toggle-btn",
+    );
+    if (!btn) {
+        btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "icon-button card-controls-toggle-btn";
+        btn.innerHTML =
+            '<i class="codicon codicon-keyboard" aria-hidden="true"></i>';
+        btn.addEventListener("click", (evt) => {
+            evt.preventDefault();
+            evt.stopPropagation();
+            const wasEnabled = btn!.getAttribute("aria-pressed") === "true";
+            opts.onToggle(card, !wasEnabled);
+        });
+        container.appendChild(btn);
+    }
+    btn.setAttribute("aria-pressed", opts.enabled ? "true" : "false");
+    btn.title = opts.enabled
+        ? "Turn off interactive controls (keyboard input)"
+        : "Turn on interactive controls (keyboard input). Enters live mode.";
+    btn.setAttribute("aria-label", btn.title);
+}
+
+/**
+ * Idempotent removal of the `.card-controls-toggle-btn`. Used both to strip
+ * stale state from older webview snapshots and to hide the button when the
+ * focus-controls bar takes over in focus mode.
  */
 export function removeControlsToggleButton(card: HTMLElement): void {
     const btn = card.querySelector(".card-controls-toggle-btn");
     if (btn) btn.remove();
 }
 
-/** Symmetric cleanup for the legacy per-card touch-overlay button. */
+/**
+ * Idempotently inject a `.card-touch-overlay-toggle-btn` overlay into [card]'s
+ * `.image-container`. Same focus-bar-vs-grid story as the controls toggle.
+ */
+export function ensureTouchOverlayToggleButton(
+    card: HTMLElement,
+    opts: {
+        enabled: boolean;
+        onToggle: (card: HTMLElement, next: boolean) => void;
+    },
+): void {
+    const container = card.querySelector(".image-container");
+    if (!container) return;
+    let btn = container.querySelector<HTMLButtonElement>(
+        ".card-touch-overlay-toggle-btn",
+    );
+    if (!btn) {
+        btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "icon-button card-touch-overlay-toggle-btn";
+        btn.innerHTML =
+            '<i class="codicon codicon-target" aria-hidden="true"></i>';
+        btn.addEventListener("click", (evt) => {
+            evt.preventDefault();
+            evt.stopPropagation();
+            const wasEnabled = btn!.getAttribute("aria-pressed") === "true";
+            opts.onToggle(card, !wasEnabled);
+        });
+        container.appendChild(btn);
+    }
+    btn.setAttribute("aria-pressed", opts.enabled ? "true" : "false");
+    btn.title = opts.enabled
+        ? "Turn off touch-event visualization"
+        : "Turn on touch-event visualization (paints rings at dispatched pointers)";
+    btn.setAttribute("aria-label", btn.title);
+}
+
+/** Idempotent removal of the touch-overlay toggle. */
 export function removeTouchOverlayToggleButton(card: HTMLElement): void {
     const btn = card.querySelector(".card-touch-overlay-toggle-btn");
     if (btn) btn.remove();
 }
 
-/** Symmetric cleanup for the legacy per-card soft-keyboard band button. */
+/**
+ * Idempotently inject a `.card-keyboard-band-toggle-btn` overlay into [card]'s
+ * `.image-container`. Same focus-bar-vs-grid story as the touch-overlay toggle.
+ */
+export function ensureKeyboardBandToggleButton(
+    card: HTMLElement,
+    opts: {
+        enabled: boolean;
+        onToggle: (card: HTMLElement, next: boolean) => void;
+    },
+): void {
+    const container = card.querySelector(".image-container");
+    if (!container) return;
+    let btn = container.querySelector<HTMLButtonElement>(
+        ".card-keyboard-band-toggle-btn",
+    );
+    if (!btn) {
+        btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "icon-button card-keyboard-band-toggle-btn";
+        btn.innerHTML =
+            '<i class="codicon codicon-symbol-keyword" aria-hidden="true"></i>';
+        btn.addEventListener("click", (evt) => {
+            evt.preventDefault();
+            evt.stopPropagation();
+            const wasEnabled = btn!.getAttribute("aria-pressed") === "true";
+            opts.onToggle(card, !wasEnabled);
+        });
+        container.appendChild(btn);
+    }
+    btn.setAttribute("aria-pressed", opts.enabled ? "true" : "false");
+    btn.title = opts.enabled
+        ? "Hide soft-keyboard band"
+        : "Force soft-keyboard band visible";
+    btn.setAttribute("aria-label", btn.title);
+}
+
+/** Idempotent removal of the keyboard-band toggle. */
 export function removeKeyboardBandToggleButton(card: HTMLElement): void {
     const btn = card.querySelector(".card-keyboard-band-toggle-btn");
     if (btn) btn.remove();

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -47,7 +47,10 @@ import { attachInteractiveInputHandlers } from "./interactiveInput";
 import type { InteractiveInputConfig } from "./interactiveInput";
 import { stampLiveBadgesOnGrid } from "./liveBadge";
 import {
+    ensureControlsToggleButton,
+    ensureKeyboardBandToggleButton,
     ensureLiveCardControls,
+    ensureTouchOverlayToggleButton,
     removeControlsToggleButton,
     removeKeyboardBandToggleButton,
     removeTouchOverlayToggleButton,
@@ -387,16 +390,52 @@ export class LiveStateController {
      * overrides, not input dispatch.
      */
     applyControlsToggleButtons(): void {
-        // The touch-overlay, soft-keyboard band, and #1203 controls toggles
-        // now live exclusively on the focus-controls bar (see
-        // `FocusController.applyFocusedToggleButtonStates`); they no longer
-        // stamp icons on top of the rendered preview. Strip any leftover
-        // per-card buttons in case an older webview state left them behind.
+        // The focus-controls bar is the home for these toggles when the user
+        // is in focus mode — the per-card overlay versions stay stripped there
+        // so they don't double up with (and cover the preview alongside) the
+        // bar mirrors. In grid / flow / column layouts the focus bar is hidden
+        // (`FocusController.applyLayout`), so we re-stamp the per-card
+        // overlays as the only UI path to touch / keyboard / controls
+        // toggles outside focus mode.
+        const inFocus = this.cfg.inFocus();
+        const controlsAdvertised = this.isControlsAdvertised();
+        const touchOverlayAdvertised = this.isTouchOverlayAdvertised();
+        const keyboardBandAdvertised = this.isKeyboardBandAdvertised();
         const cards = document.querySelectorAll<HTMLElement>(".preview-card");
         for (const card of cards) {
-            removeControlsToggleButton(card);
-            removeTouchOverlayToggleButton(card);
-            removeKeyboardBandToggleButton(card);
+            const previewId = card.dataset.previewId;
+            if (inFocus || !previewId) {
+                removeControlsToggleButton(card);
+                removeTouchOverlayToggleButton(card);
+                removeKeyboardBandToggleButton(card);
+                continue;
+            }
+            if (controlsAdvertised) {
+                ensureControlsToggleButton(card, {
+                    enabled: this.controlsEnabledPreviewIds.has(previewId),
+                    onToggle: (c, next) => this.toggleControlsForCard(c, next),
+                });
+            } else {
+                removeControlsToggleButton(card);
+            }
+            if (touchOverlayAdvertised) {
+                ensureTouchOverlayToggleButton(card, {
+                    enabled: this.touchOverlayEnabledPreviewIds.has(previewId),
+                    onToggle: (c, next) =>
+                        this.toggleTouchOverlayForCard(c, next),
+                });
+            } else {
+                removeTouchOverlayToggleButton(card);
+            }
+            if (keyboardBandAdvertised) {
+                ensureKeyboardBandToggleButton(card, {
+                    enabled: this.keyboardBandForcedPreviewIds.has(previewId),
+                    onToggle: (c, next) =>
+                        this.toggleKeyboardBandForCard(c, next),
+                });
+            } else {
+                removeKeyboardBandToggleButton(card);
+            }
         }
         this.cfg.applyFocusedToggleButtonStates?.();
     }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -2349,8 +2349,24 @@ export class PreviewApp extends LitElement {
             // panel doesn't reserve layout space next to the preview.
             bundleLegend.hidden = count === 0;
         };
+        // Track the previous active tab so we can tear down the transient
+        // theming-/resources-consumers hover overlay when the user switches
+        // tabs away from those bundles. The overlay was painted from
+        // `row-selected` events; if the user moves to another tab while
+        // still hovering a row, the hover-leave never fires and the tint
+        // would persist on the focused card. See #1380.
+        let lastActiveTab: BundleId | null = bundleController.state().activeTab;
         const reflectBundleState = (): void => {
             const s = bundleController.state();
+            if (lastActiveTab !== s.activeTab) {
+                if (lastActiveTab === "theming") {
+                    clearBundleBoxes(null, "theming-consumers");
+                }
+                if (lastActiveTab === "resources") {
+                    clearBundleBoxes(null, "resources-consumers");
+                }
+                lastActiveTab = s.activeTab;
+            }
             // Without early features only the graduated bundles (a11y for
             // now) show their chip — the rest are still in-progress and
             // shouldn't surface from the always-visible chip bar.
@@ -2500,6 +2516,14 @@ export class PreviewApp extends LitElement {
                     postSetDataExtensionEnabled(prev, [...prevKinds], false);
                 }
             }
+            // Transient hover overlays (`theming-consumers`,
+            // `resources-consumers`) are painted on whichever card was
+            // focused when the user hovered a row. When the focus moves
+            // to a different card the hover-leave never fires on the old
+            // card, so any existing tint there has to be cleared
+            // explicitly. See #1380.
+            clearBundleBoxes(null, "theming-consumers");
+            clearBundleBoxes(null, "resources-consumers");
             if (!next) return;
             const desired = desiredKindsForActiveBundles();
             if (desired.length === 0) return;

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -2204,6 +2204,7 @@ export class PreviewApp extends LitElement {
                 "compose/semantics",
                 "layout/inspector",
                 "uia/hierarchy",
+                "compose/permissions",
             ] as const) {
                 if (enabledKindsRaw.has(k)) enabledKinds.add(k);
             }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -1314,9 +1314,20 @@ export class PreviewApp extends LitElement {
                 const focused = focusController?.focusedCard?.();
                 if (!focused) return;
                 const active = bundleController.state().activeBundles;
+                // `theming-consumers` boxes are positioned from
+                // `compose/semantics` bounds — when the user disables that
+                // specific kind inside the Inspection bundle, the cached
+                // semantics tree stops repainting and any stale tint would
+                // sit on bounds the bundle no longer claims. Gate the join
+                // on the kind being enabled too, not just the Inspection
+                // bundle as a whole.
+                const inspectionKinds = bundleController
+                    .state()
+                    .enabledKinds("inspection");
                 if (
                     !active.includes("theming") ||
                     !active.includes("inspection") ||
+                    !inspectionKinds.includes("compose/semantics") ||
                     det.row === null ||
                     det.overlayId === null
                 ) {


### PR DESCRIPTION
Closes #1443.

Ten codex findings, one commit per finding for review-ability.

## Summary

### Discovery / output
- **`00d42ecb` fix(discovery): emit GIF captures alongside @LauncherWidgetResize stops** — recompute `gifSharesFn` upfront; append `focusGif` / animation captures inside the resize branch instead of early-returning before them.
- **`b59a7200` fix(discovery): carry @LauncherWidgetResize frameDelayMs through manifests** — added optional `frameDelayMs` to `LauncherWidgetCapture` (plugin + renderer mirror), stamped per stop.

### Inspection UI gating (vscode-extension)
- **`4a804b70` fix(vscode-extension): render compose/permissions in inspection bundle** — extended `InspectionKind`; added a flat-table section that reuses `permissionsBundlePresenter`.
- **`10f7cc78` fix(vscode-extension): re-stamp per-card toggles outside focus mode** — restored `ensure*ToggleButton` helpers and gated re-stamping on `inFocus()` so grid/flow/column show the per-card overlays.
- **`a6d2bdcd` fix(vscode-extension): clear theming hover tint when semantics is disabled** — added `enabledKinds("inspection").includes("compose/semantics")` check.
- **`fcb15c26` fix(vscode-extension): tear down hover tint on tab + focus change** — clears both transient layers on tab change (`reflectBundleState`) and focus change (`rebindBundleTarget`).
- **`9a79b064` fix(vscode-extension): resolve daemon frame manifest by moduleId** — replaced ambiguous `previewModuleMap.get(previewId)` lookup with `moduleManifestCache.get(moduleId)`.
- **`c4467c7a` fix(vscode-extension): scope isActivityLikeDeclaration to supertype clause** — added `extractSupertypeClause` (skips primary-ctor parens), two regression tests; all 11 `kotlinClassFqn` tests pass.

### Install / publishing
- **`fbf28f9f` fix(mcp): publish daemon-core + render-session-api with api scope** — switched both deps to `api`; verified `:mcp:generatePomFileForMavenPublication` now emits `<scope>compile</scope>` for both.
- **`10b721ef` fix(install-action): paginate releases lookup beyond first 30** — follow `Link: rel="next"` up to 5 pages (150 entries), updated failure message.

## Test plan

- [x] Per-finding manual checks: `ktfmtCheckAll`, `npx tsc --noEmit`, `npx mocha`, prettier check
- [x] POM verification for #1404 via `:mcp:generatePomFileForMavenPublication`
- [ ] CI: full Gradle + extension suites

## Notes

> Pre-existing ktfmt drift in `gradle-plugin/preview-discovery/build.gradle.kts`, `PreviewDiscoveryCliTest.kt`, `PreviewDiscoveryFailureWarningsTest.kt` is on `origin/main` ahead of this branch and not touched here — needs a separate cleanup if/when CI flags it.
>
> `core.hooksPath` is set repo-wide but the worktree was using its own hooks dir (no installed pre-commit), so the `ktfmtCheckAll` hook didn't run automatically on these commits — manual checks were used instead. Worth confirming CI catches anything missed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164TDPHM3haDqw2BPDGQPQA)_