### PR TITLE
feat(vscode-extension): add launcher-widget cell-grid picker module

### DIFF
--- a/vscode-extension/src/test/launcherWidgetPicker.test.ts
+++ b/vscode-extension/src/test/launcherWidgetPicker.test.ts
@@ -1,0 +1,229 @@
+// Launcher-widget picker — pure-logic + DOM-helper coverage.
+//
+// Asserts the picker's cell-clickability gating tracks the constraint
+// payload populated by the three discovery layers (annotation bounds, Glance
+// `previewSizeMode`, AppWidget XML auto-discovery) uniformly. The picker is
+// payload-shape-driven, so a single test set covers all three sources.
+
+import * as assert from "assert";
+import type {
+    LauncherWidgetPayload,
+    LauncherWidgetSize,
+} from "../daemon/daemonProtocol";
+import {
+    DEFAULT_PICKER_MAX,
+    buildLauncherWidgetPickerCells,
+    renderLauncherWidgetPicker,
+} from "../webview/preview/launcherWidgetPicker";
+
+function payload(
+    overrides: Partial<LauncherWidgetPayload> = {},
+): LauncherWidgetPayload {
+    return {
+        cells: { width: 4, height: 2 },
+        cellSizeDp: 72,
+        cellSpacingDp: 8,
+        widthDp: 312,
+        heightDp: 152,
+        ...overrides,
+    };
+}
+
+function cells(width: number, height: number): LauncherWidgetSize {
+    return { width, height };
+}
+
+describe("launcherWidgetPicker — buildLauncherWidgetPickerCells", () => {
+    it("falls back to a default rectangle when payload is null", () => {
+        const grid = buildLauncherWidgetPickerCells(null, cells(1, 1));
+        assert.strictEqual(grid.length, DEFAULT_PICKER_MAX);
+        assert.strictEqual(grid[0].length, DEFAULT_PICKER_MAX);
+        // Every cell is clickable, no constraint to gate.
+        assert.ok(grid.flat().every((c) => c.clickable));
+    });
+
+    it("marks cells inside the current rectangle as inCurrent", () => {
+        const grid = buildLauncherWidgetPickerCells(null, cells(3, 2));
+        // (1..3) × (1..2) — 6 cells flagged.
+        const inCurrentCount = grid.flat().filter((c) => c.inCurrent).length;
+        assert.strictEqual(inCurrentCount, 6);
+        // Edge case: (4, 1) is outside the current rectangle.
+        assert.strictEqual(grid[0][3].inCurrent, false);
+    });
+
+    it("respects supportedCells as a sparse set (Glance Responsive)", () => {
+        // Glance widget declares two responsive sizes.
+        const supported = [cells(2, 1), cells(4, 2)];
+        const grid = buildLauncherWidgetPickerCells(
+            payload({ supportedCells: supported, resizeAxes: "both" }),
+            cells(2, 1),
+        );
+        // Grid extends to the largest supported cell (4×2).
+        assert.strictEqual(grid.length, 2);
+        assert.strictEqual(grid[0].length, 4);
+        // Only the two declared cells are clickable.
+        const clickable = grid.flat().filter((c) => c.clickable);
+        assert.strictEqual(clickable.length, 2);
+        assert.ok(clickable.some((c) => c.width === 2 && c.height === 1));
+        assert.ok(clickable.some((c) => c.width === 4 && c.height === 2));
+    });
+
+    it("respects supportedCells as a dense rectangle (AppWidget XML)", () => {
+        // AppWidget XML declares min 1×1 → max 3×2 — every cell in the
+        // rectangle is clickable.
+        const supported: LauncherWidgetSize[] = [];
+        for (let w = 1; w <= 3; w++)
+            for (let h = 1; h <= 2; h++) supported.push(cells(w, h));
+        const grid = buildLauncherWidgetPickerCells(
+            payload({ supportedCells: supported, resizeAxes: "both" }),
+            cells(2, 1),
+        );
+        assert.strictEqual(grid.length, 2);
+        assert.strictEqual(grid[0].length, 3);
+        assert.strictEqual(grid.flat().filter((c) => c.clickable).length, 6);
+    });
+
+    it("resizeAxes = none locks every cell except the current one", () => {
+        // Glance `SizeMode.Single` translates to `supportedCells = [single]`,
+        // `resizeAxes = "none"`. The picker is read-only.
+        const grid = buildLauncherWidgetPickerCells(
+            payload({
+                supportedCells: [cells(3, 2)],
+                resizeAxes: "none",
+            }),
+            cells(3, 2),
+        );
+        const clickable = grid.flat().filter((c) => c.clickable);
+        assert.strictEqual(clickable.length, 1);
+        assert.strictEqual(clickable[0].width, 3);
+        assert.strictEqual(clickable[0].height, 2);
+    });
+
+    it("resizeAxes = horizontal locks the height axis at current", () => {
+        const grid = buildLauncherWidgetPickerCells(
+            payload({ supportedCells: null, resizeAxes: "horizontal" }),
+            cells(2, 3),
+        );
+        // Only cells on row h=3 are clickable.
+        const clickable = grid.flat().filter((c) => c.clickable);
+        assert.ok(clickable.length > 0);
+        assert.ok(clickable.every((c) => c.height === 3));
+    });
+
+    it("resizeAxes = vertical locks the width axis at current", () => {
+        const grid = buildLauncherWidgetPickerCells(
+            payload({ supportedCells: null, resizeAxes: "vertical" }),
+            cells(2, 3),
+        );
+        const clickable = grid.flat().filter((c) => c.clickable);
+        assert.ok(clickable.length > 0);
+        assert.ok(clickable.every((c) => c.width === 2));
+    });
+
+    it("grid extends to cover the current cell even past supported max", () => {
+        // Edge case: payload constraint is 1..2, but the override the daemon
+        // already applied is (3, 3) — pre-flight clamp may not have run, or
+        // the widget's metadata changed since last render. Grid should still
+        // include (3, 3) so the inCurrent highlight is whole.
+        const grid = buildLauncherWidgetPickerCells(
+            payload({
+                supportedCells: [cells(1, 1), cells(2, 2)],
+                resizeAxes: "both",
+            }),
+            cells(3, 3),
+        );
+        assert.strictEqual(grid.length, 3);
+        assert.strictEqual(grid[0].length, 3);
+    });
+});
+
+describe("launcherWidgetPicker — renderLauncherWidgetPicker DOM helper", () => {
+    // happy-dom is set up globally via `.mocharc.json`'s `file: setup-dom.ts`,
+    // so `document` / `HTMLElement` are already on globalThis. No per-suite
+    // fixture needed — same shape `a11yBundlePresenter.test.ts` and friends
+    // use.
+
+    it("renders a row per cell-height and a button per cell-width", () => {
+        const table = renderLauncherWidgetPicker(
+            payload({ supportedCells: null, resizeAxes: "both" }),
+            cells(2, 1),
+            () => {},
+        );
+        const rows = table.querySelectorAll("tr");
+        assert.strictEqual(rows.length, DEFAULT_PICKER_MAX);
+        const cellsInFirstRow = rows[0].querySelectorAll(
+            ".launcher-widget-picker-cell",
+        );
+        assert.strictEqual(cellsInFirstRow.length, DEFAULT_PICKER_MAX);
+    });
+
+    it("disables non-clickable cells with .disabled and disabled=true", () => {
+        const supported = [cells(2, 1), cells(4, 2)];
+        const table = renderLauncherWidgetPicker(
+            payload({ supportedCells: supported, resizeAxes: "both" }),
+            cells(2, 1),
+            () => {},
+        );
+        const disabled = table.querySelectorAll<HTMLButtonElement>(
+            ".launcher-widget-picker-cell.disabled",
+        );
+        // Grid is 2×4 = 8 cells, supported has 2, so 6 disabled.
+        assert.strictEqual(disabled.length, 6);
+        for (const btn of Array.from(disabled)) {
+            assert.strictEqual(btn.disabled, true);
+        }
+    });
+
+    it("click on clickable cell fires onSelect with the picked size", () => {
+        let picked: LauncherWidgetSize | null = null;
+        const table = renderLauncherWidgetPicker(
+            payload({ supportedCells: null, resizeAxes: "both" }),
+            cells(1, 1),
+            (c) => {
+                picked = c;
+            },
+        );
+        const btn = table.querySelector<HTMLButtonElement>(
+            '.launcher-widget-picker-cell[data-width="3"][data-height="2"]',
+        );
+        assert.ok(btn);
+        btn?.click();
+        assert.deepStrictEqual(picked, { width: 3, height: 2 });
+    });
+
+    it("click on disabled cell does not fire onSelect", () => {
+        let calls = 0;
+        // Grid extends to 4×4 (max of supportedCells), but only (1,1) and
+        // (4,4) are clickable — (3,3) is disabled.
+        const table = renderLauncherWidgetPicker(
+            payload({
+                supportedCells: [cells(1, 1), cells(4, 4)],
+                resizeAxes: "both",
+            }),
+            cells(1, 1),
+            () => {
+                calls += 1;
+            },
+        );
+        const btn = table.querySelector<HTMLButtonElement>(
+            '.launcher-widget-picker-cell[data-width="3"][data-height="3"]',
+        );
+        assert.ok(btn);
+        // Button is `disabled=true` — click event fires no handler.
+        btn?.click();
+        assert.strictEqual(calls, 0);
+    });
+
+    it("inCurrent cells get the .in-current class", () => {
+        const table = renderLauncherWidgetPicker(
+            payload({ supportedCells: null, resizeAxes: "both" }),
+            cells(2, 2),
+            () => {},
+        );
+        const inCurrent = table.querySelectorAll(
+            ".launcher-widget-picker-cell.in-current",
+        );
+        // (1..2) × (1..2) = 4 cells in the current rectangle.
+        assert.strictEqual(inCurrent.length, 4);
+    });
+});

--- a/vscode-extension/src/webview/preview/launcherWidgetPicker.ts
+++ b/vscode-extension/src/webview/preview/launcherWidgetPicker.ts
@@ -1,0 +1,204 @@
+// Launcher-widget cell-grid picker.
+//
+// Pure logic + DOM helper for a `5×5`-style picker that lets the user choose a
+// `LauncherWidgetOverride.cells` value for the focused preview. Reads the
+// `LauncherWidgetPayload` (`supportedCells`, `resizeAxes`, current `cells`)
+// surfaced by the `compose/launcher-widget` data product to gate which cells
+// are clickable and which are read-only.
+//
+// Source of constraints, in payload-population order (later overrides earlier):
+//   1. Annotation bounds via `@LauncherWidgetPreview(minCells, maxCells)`.
+//   2. Glance `previewSizeMode = SizeMode.Single | Responsive | Exact`
+//      (`:glance-preview-runtime`).
+//   3. `<appwidget-provider>` XML auto-discovery from
+//      `AppWidgetManager.installedProviders` (`:appwidget-preview-runtime`).
+//
+// The picker is source-agnostic — it consumes `LauncherWidgetPayload` fields
+// uniformly regardless of which layer populated them.
+//
+// Module split:
+//   * `buildLauncherWidgetPickerCells(...)` — pure function returning a
+//     `PickerCell[][]` grid the renderer can stamp into the DOM. Testable
+//     without a DOM environment.
+//   * `renderLauncherWidgetPicker(...)` — DOM helper that wires the cells
+//     into a `<table>` with click handlers. The toolbar consumer (a future
+//     `focusToolbar.ts` integration) drops this into a popover.
+
+import type {
+    LauncherResizeAxes,
+    LauncherWidgetPayload,
+    LauncherWidgetSize,
+} from "../../daemon/daemonProtocol";
+
+/**
+ * One cell in the rendered picker grid.
+ *
+ * `clickable` is the read+act gate: cells that fall outside the widget's
+ * declared constraints (`!supportedCells.contains((w, h))`) or on a locked
+ * axis (`resizeAxes = "horizontal"` with height differing from current) are
+ * `clickable: false` and styled as disabled.
+ *
+ * `inCurrent` highlights the rectangle from `(1, 1)` to the current `cells`
+ * — visually emphasises what the widget is laid out as right now, so a click
+ * to expand reads as a drag-to-resize gesture.
+ */
+export interface PickerCell {
+    width: number;
+    height: number;
+    clickable: boolean;
+    inCurrent: boolean;
+}
+
+/** Default upper bound when the payload doesn't surface one. */
+export const DEFAULT_PICKER_MAX = 5;
+
+/**
+ * Build the 2-D picker grid for [payload] with the given [currentCells] as
+ * the highlight target. Returns a `rows × cols` array where each cell has
+ * `clickable` set per the payload's resize-axis lock + `supportedCells`
+ * membership test, and `inCurrent` set for cells inside the current
+ * rectangle (top-left to current).
+ *
+ * Grid bounds: when `payload.supportedCells` is non-null and non-empty, the
+ * grid extends to `max(cell.width)` × `max(cell.height)` across the supported
+ * set. Otherwise falls back to [DEFAULT_PICKER_MAX]. The grid always extends
+ * to at least the current cell so the "inCurrent" highlight is fully drawn.
+ */
+export function buildLauncherWidgetPickerCells(
+    payload: LauncherWidgetPayload | null,
+    currentCells: LauncherWidgetSize,
+): PickerCell[][] {
+    const supported = payload?.supportedCells ?? undefined;
+    const resizeAxes: LauncherResizeAxes = payload?.resizeAxes ?? "both";
+
+    // Pick grid dimensions. Prefer the supported-cells extent; fall back to
+    // the default; always cover the current cell so the highlight is whole.
+    const supportedMaxW =
+        supported && supported.length > 0
+            ? Math.max(...supported.map((c) => c.width))
+            : DEFAULT_PICKER_MAX;
+    const supportedMaxH =
+        supported && supported.length > 0
+            ? Math.max(...supported.map((c) => c.height))
+            : DEFAULT_PICKER_MAX;
+    const maxW = Math.max(supportedMaxW, currentCells.width, 1);
+    const maxH = Math.max(supportedMaxH, currentCells.height, 1);
+
+    // Fast lookup: which (w, h) pairs are in the supported set?
+    const supportedKey = (w: number, h: number): string => `${w}x${h}`;
+    const supportedSet =
+        supported !== undefined
+            ? new Set(supported.map((c) => supportedKey(c.width, c.height)))
+            : null;
+
+    const rows: PickerCell[][] = [];
+    for (let h = 1; h <= maxH; h++) {
+        const row: PickerCell[] = [];
+        for (let w = 1; w <= maxW; w++) {
+            row.push({
+                width: w,
+                height: h,
+                clickable: isClickable(
+                    w,
+                    h,
+                    currentCells,
+                    resizeAxes,
+                    supportedSet,
+                ),
+                inCurrent: w <= currentCells.width && h <= currentCells.height,
+            });
+        }
+        rows.push(row);
+    }
+    return rows;
+}
+
+function isClickable(
+    w: number,
+    h: number,
+    current: LauncherWidgetSize,
+    resizeAxes: LauncherResizeAxes,
+    supportedSet: Set<string> | null,
+): boolean {
+    // `none` — widget declared "no resize", the picker is read-only and only
+    // the current cell is "clickable" in the sense that re-selecting it is
+    // a no-op but visually it stays the active one.
+    if (resizeAxes === "none") {
+        return w === current.width && h === current.height;
+    }
+    // Axis-locked modes — only the unlocked axis can move.
+    if (resizeAxes === "horizontal" && h !== current.height) return false;
+    if (resizeAxes === "vertical" && w !== current.width) return false;
+    // Supported-set membership: if a set is declared, the cell must be in
+    // it. Otherwise (null set) any cell in the grid is clickable.
+    if (supportedSet !== null) {
+        return supportedSet.has(`${w}x${h}`);
+    }
+    return true;
+}
+
+/**
+ * DOM helper that renders the picker grid as a `<table>` and wires click
+ * handlers. Returns the root `<table>` element — caller drops it into a
+ * popover / dialog / inline container.
+ *
+ * Click handler fires [onSelect] with the picked `(w, h)` when the user
+ * clicks a clickable cell; non-clickable cells receive no event handler so
+ * VoiceOver / Talkback skip past them. Each row is a `<tr>`, each cell a
+ * `<button>` inside a `<td>` (button so keyboard `Enter` / `Space` works).
+ *
+ * CSS classes the caller should style:
+ *   * `.launcher-widget-picker` — root table
+ *   * `.launcher-widget-picker-cell` — every cell button
+ *   * `.launcher-widget-picker-cell.in-current` — cells inside the active rectangle
+ *   * `.launcher-widget-picker-cell.disabled` — non-clickable cells (axis lock /
+ *     unsupported size)
+ */
+export function renderLauncherWidgetPicker(
+    payload: LauncherWidgetPayload | null,
+    currentCells: LauncherWidgetSize,
+    onSelect: (cells: LauncherWidgetSize) => void,
+): HTMLTableElement {
+    const grid = buildLauncherWidgetPickerCells(payload, currentCells);
+    const table = document.createElement("table");
+    table.className = "launcher-widget-picker";
+    table.setAttribute("role", "grid");
+    table.setAttribute(
+        "aria-label",
+        `Launcher widget cell picker — current size ${currentCells.width}×${currentCells.height}`,
+    );
+    for (const row of grid) {
+        const tr = document.createElement("tr");
+        tr.setAttribute("role", "row");
+        for (const cell of row) {
+            const td = document.createElement("td");
+            td.setAttribute("role", "gridcell");
+            const btn = document.createElement("button");
+            btn.type = "button";
+            btn.className = "launcher-widget-picker-cell";
+            btn.dataset.width = String(cell.width);
+            btn.dataset.height = String(cell.height);
+            btn.setAttribute(
+                "aria-label",
+                `${cell.width}×${cell.height} cells`,
+            );
+            if (cell.inCurrent) {
+                btn.classList.add("in-current");
+            }
+            if (cell.clickable) {
+                btn.addEventListener("click", (evt) => {
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    onSelect({ width: cell.width, height: cell.height });
+                });
+            } else {
+                btn.classList.add("disabled");
+                btn.disabled = true;
+            }
+            td.appendChild(btn);
+            tr.appendChild(td);
+        }
+        table.appendChild(tr);
+    }
+    return table;
+}


### PR DESCRIPTION
Introduces a payload-shape-driven picker for choosing
`LauncherWidgetOverride.cells`. The pure-logic `buildLauncherWidgetPickerCells`
returns a clickability-gated grid; `renderLauncherWidgetPicker` stamps it into
a `<table role="grid">` of buttons that toolbar/popover consumers can drop in.

Gating consumes `LauncherWidgetPayload.supportedCells` + `resizeAxes`
uniformly, so the same picker covers all three discovery layers (annotation
bounds, Glance `previewSizeMode`, AppWidget XML auto-discovery).