### PR TITLE
fix(a11y): surface ATF-unavailable instead of synthesising "no findings"

### DIFF
--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -77,12 +77,23 @@ def variant_label(device: str | None) -> str:
 # Manifest loading
 # ---------------------------------------------------------------------------
 
-def load_previews(build_dir: Path) -> tuple[dict, dict]:
-    """Return ``(manifest, a11y_by_id)`` for one module's build output.
+#: Value the CLI stamps into ``accessibility.json``'s ``status`` field when the
+#: daemon was unable to return ATF data for any preview in the module. Mirrors
+#: ``A11Y_REPORT_STATUS_ATF_UNAVAILABLE`` in preview-data-api's A11yWireFormat.kt
+#: — change in lockstep with the Kotlin constant.
+ATF_UNAVAILABLE: str = "atf-unavailable"
+
+
+def load_previews(build_dir: Path) -> tuple[dict, dict, str | None]:
+    """Return ``(manifest, a11y_by_id, status)`` for one module's build output.
 
     ``manifest`` is the raw ``previews.json`` dict. ``a11y_by_id`` maps each
     previewId to its accessibility entry (findings + relative annotatedPath),
     or ``None`` when ``accessibility.json`` is absent (a11y not enabled).
+    ``status`` is the top-level ``status`` field from ``accessibility.json`` —
+    typically ``None`` for a clean run, or ``"atf-unavailable"`` when the
+    daemon couldn't return ATF data and the empty entries list should NOT be
+    interpreted as "ran cleanly, found nothing." See issue #1453.
     """
     manifest_path = build_dir / "previews.json"
     if not manifest_path.exists():
@@ -90,12 +101,14 @@ def load_previews(build_dir: Path) -> tuple[dict, dict]:
     manifest = json.loads(manifest_path.read_text())
 
     a11y_by_id: dict = {}
+    status: str | None = None
     a11y_path = build_dir / "accessibility.json"
     if a11y_path.exists():
         report = json.loads(a11y_path.read_text())
+        status = report.get("status")
         for entry in report.get("entries", []):
             a11y_by_id[entry["previewId"]] = entry
-    return manifest, a11y_by_id
+    return manifest, a11y_by_id, status
 
 
 def is_dynamic_preview(preview: dict) -> bool:
@@ -180,7 +193,7 @@ def select_variants(manifest: dict, a11y_by_id: dict) -> list[dict]:
 def cmd_copy_annotated(args: argparse.Namespace) -> int:
     build_dir = Path(args.build_dir)
     out_dir = Path(args.output_dir)
-    manifest, a11y_by_id = load_previews(build_dir)
+    manifest, a11y_by_id, status = load_previews(build_dir)
     rows = select_variants(manifest, a11y_by_id)
 
     module = manifest["module"]
@@ -226,16 +239,31 @@ def cmd_copy_annotated(args: argparse.Namespace) -> int:
         })
 
     out_dir.mkdir(parents=True, exist_ok=True)
+    # ``status`` propagates verbatim from accessibility.json so downstream
+    # consumers (the readme / comment subcommands, future MCP integrations)
+    # can tell "ran cleanly with zero findings" from "didn't run." Omitted
+    # from the JSON entirely on a normal run to keep diffs against the
+    # baseline trivially clean.
+    summary_payload: dict = {"entries": findings_summary}
+    if status:
+        summary_payload["status"] = status
     (out_dir / "findings.json").write_text(
-        json.dumps({"entries": findings_summary}, indent=2, sort_keys=True) + "\n"
+        json.dumps(summary_payload, indent=2, sort_keys=True) + "\n"
     )
 
     total_findings = sum(len(r["findings"]) for r in findings_summary)
-    print(
-        f"Copied {len(findings_summary)} preview(s) with "
-        f"{total_findings} finding(s) to {out_dir}",
-        file=sys.stderr,
-    )
+    if status == ATF_UNAVAILABLE:
+        print(
+            f"ATF data unavailable for {manifest['module']} — "
+            f"emitted {len(findings_summary)} preview(s) with empty findings.",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"Copied {len(findings_summary)} preview(s) with "
+            f"{total_findings} finding(s) to {out_dir}",
+            file=sys.stderr,
+        )
     return 0
 
 
@@ -316,6 +344,7 @@ def cmd_readme(args: argparse.Namespace) -> int:
     findings_path = Path(args.findings)
     payload = json.loads(findings_path.read_text())
     entries: list[dict] = payload.get("entries", [])
+    status: str | None = payload.get("status")
 
     err, warn, info = _level_counts(entries)
     findings_count = err + warn + info
@@ -335,6 +364,14 @@ def cmd_readme(args: argparse.Namespace) -> int:
         "baseline branch so links keep resolving after merge.",
         "",
     ]
+    if status == ATF_UNAVAILABLE:
+        lines.extend([
+            "> [!WARNING]",
+            "> ATF data unavailable for this run — the daemon did not return "
+            "accessibility findings. The renders below are **not** "
+            "accessibility-checked.",
+            "",
+        ])
     if findings_count == 0:
         lines.append("No accessibility findings.")
         lines.append("")
@@ -358,15 +395,21 @@ def cmd_readme(args: argparse.Namespace) -> int:
 # comment
 # ---------------------------------------------------------------------------
 
-def _findings_fingerprint(entries: list[dict]) -> tuple:
-    """Stable representation of (preview, findings) used for change detection.
+def _findings_fingerprint(entries: list[dict], status: str | None = None) -> tuple:
+    """Stable representation of (status, preview, findings) used for change detection.
 
-    Compares only the data a reviewer would care about — module, previewId,
-    and the findings list itself. Filenames (`cleanBasename`,
-    `annotatedBasename`) are excluded because identical findings can move
-    around between files when the renderer renames variants, and we don't
-    want to wake the PR comment for that. Findings are tuple-ified so the
-    comparison is hash-stable and order-insensitive (sorted below).
+    Compares only the data a reviewer would care about — top-level status,
+    plus per-entry module, previewId, and findings list. Filenames
+    (`cleanBasename`, `annotatedBasename`) are excluded because identical
+    findings can move around between files when the renderer renames variants,
+    and we don't want to wake the PR comment for that. Findings are
+    tuple-ified so the comparison is hash-stable and order-insensitive
+    (sorted below).
+
+    ``status`` is included so the fingerprint diverges when the daemon goes
+    from "ran cleanly" to "atf-unavailable" or vice versa — without this, a
+    daemon crash would match a clean baseline and the workflow would stay
+    silent on the very condition the comment needs to surface.
     """
     def finding_tuple(f: dict) -> tuple:
         return (
@@ -376,7 +419,7 @@ def _findings_fingerprint(entries: list[dict]) -> tuple:
             f.get("viewDescription"),
             f.get("boundsInScreen"),
         )
-    return tuple(
+    return (status,) + tuple(
         (
             e["module"],
             e["previewId"],
@@ -390,12 +433,18 @@ def cmd_comment(args: argparse.Namespace) -> int:
     findings_path = Path(args.findings)
     payload = json.loads(findings_path.read_text())
     entries: list[dict] = payload.get("entries", [])
+    status: str | None = payload.get("status")
 
     # When a baseline (the on-`compose-preview/a11y/main` findings.json) is provided, stay
     # silent if nothing has changed — the workflow runs on every PR and a
     # comment that says "no findings" on PRs that don't touch a11y was
     # noted as distracting in user feedback. Empty stdout signals the
     # action to skip both the push and the upsert.
+    #
+    # `status` participates in the fingerprint so an atf-unavailable run on
+    # this side never matches a clean-run baseline — that flips on the
+    # comment so reviewers see the daemon failure rather than the misleading
+    # "no findings" the bug in #1453 produced.
     if args.baseline:
         baseline_path = Path(args.baseline)
         if baseline_path.exists():
@@ -404,7 +453,11 @@ def cmd_comment(args: argparse.Namespace) -> int:
             except json.JSONDecodeError:
                 baseline_payload = {"entries": []}
             baseline_entries = baseline_payload.get("entries", [])
-            if _findings_fingerprint(entries) == _findings_fingerprint(baseline_entries):
+            baseline_status = baseline_payload.get("status")
+            if (
+                _findings_fingerprint(entries, status)
+                == _findings_fingerprint(baseline_entries, baseline_status)
+            ):
                 return 0  # silent
 
     err, warn, info = _level_counts(entries)
@@ -419,10 +472,26 @@ def cmd_comment(args: argparse.Namespace) -> int:
         marker,
         "## Accessibility Report",
         "",
+    ]
+    if status == ATF_UNAVAILABLE:
+        # Header replaces the usual finding-counts line when ATF didn't run
+        # — the counts would be misleadingly zero. The link to the CI logs
+        # is left abstract on purpose; the workflow's failure step already
+        # surfaces a direct link, and we don't want to embed the job URL
+        # here (the python helper doesn't know it).
+        lines.extend([
+            "> [!WARNING]",
+            "> ATF data unavailable — the preview daemon did not return "
+            "accessibility findings for this run. The renders below are "
+            "**not** accessibility-checked; see the CI logs for the daemon "
+            "failure.",
+            "",
+        ])
+    lines.extend([
         f"{err} error(s) · {warn} warning(s) · {info} info "
         f"across {len(entries)} preview(s).",
         "",
-    ]
+    ])
 
     if findings_count == 0:
         lines.append("No accessibility findings.")

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -246,6 +246,9 @@ class CopyAnnotatedTest(unittest.TestCase):
         self.assertEqual((renders_out / "Good_large.a11y.png").read_bytes(), b"overlay-good")
         findings = json.loads((out / "findings.json").read_text())
         self.assertEqual(len(findings["entries"]), 2)
+        # Normal runs omit `status` entirely — keeps diffs against the baseline
+        # trivially clean for the fingerprint comparison in cmd_comment.
+        self.assertNotIn("status", findings)
         by_fn = {e["functionName"]: e for e in findings["entries"]}
         self.assertEqual(by_fn["Bad"]["cleanBasename"], "Bad_small.png")
         self.assertEqual(by_fn["Bad"]["annotatedBasename"], "Bad_small.a11y.png")
@@ -253,6 +256,25 @@ class CopyAnnotatedTest(unittest.TestCase):
         self.assertEqual(by_fn["Good"]["cleanBasename"], "Good_large.png")
         self.assertEqual(by_fn["Good"]["annotatedBasename"], "Good_large.a11y.png")
         self.assertEqual(by_fn["Good"]["findings"], [])
+
+    def test_propagates_atf_unavailable_status_to_findings(self):
+        # Simulate the daemon-failure shape `DaemonA11yFetcher` writes when no
+        # per-preview ATF fetch succeeds: top-level `status` set, entries
+        # empty. The copy-annotated step must propagate the status into
+        # findings.json so the downstream comment subcommand can surface it.
+        (self.build / "accessibility.json").write_text(json.dumps({
+            "module": "sample-wear",
+            "entries": [],
+            "status": "atf-unavailable",
+        }))
+        out = self.tmp / "out"
+        import argparse
+        ar.cmd_copy_annotated(argparse.Namespace(
+            build_dir=str(self.build),
+            output_dir=str(out),
+        ))
+        findings = json.loads((out / "findings.json").read_text())
+        self.assertEqual(findings["status"], "atf-unavailable")
 
 
 class ReadmeTest(unittest.TestCase):
@@ -334,13 +356,26 @@ class CommentTest(unittest.TestCase):
             "findings": findings or [],
         }
 
-    def _run_comment(self, current_entries, *, baseline_entries=None):
+    def _run_comment(
+        self,
+        current_entries,
+        *,
+        baseline_entries=None,
+        status=None,
+        baseline_status=None,
+    ):
         findings_path = self.tmp / "findings.json"
-        findings_path.write_text(json.dumps({"entries": current_entries}))
+        current_payload: dict = {"entries": current_entries}
+        if status is not None:
+            current_payload["status"] = status
+        findings_path.write_text(json.dumps(current_payload))
         baseline_path = None
         if baseline_entries is not None:
             baseline_path = self.tmp / "baseline.json"
-            baseline_path.write_text(json.dumps({"entries": baseline_entries}))
+            baseline_payload: dict = {"entries": baseline_entries}
+            if baseline_status is not None:
+                baseline_payload["status"] = baseline_status
+            baseline_path.write_text(json.dumps(baseline_payload))
 
         import argparse, io, contextlib
         buf = io.StringIO()
@@ -387,6 +422,45 @@ class CommentTest(unittest.TestCase):
             baseline_entries=[self._entry(findings=[])],
         )
         self.assertEqual(body, "")
+
+    def test_atf_unavailable_surfaces_warning_in_comment(self):
+        # Regression for #1453: when the daemon fails, the report carries
+        # status="atf-unavailable" and the comment must surface that rather
+        # than silently rendering "no findings."
+        body = self._run_comment(
+            [],
+            status="atf-unavailable",
+        )
+        self.assertIn("<!-- a11y-report -->", body)
+        self.assertIn("[!WARNING]", body)
+        self.assertIn("ATF data unavailable", body)
+
+    def test_atf_unavailable_breaks_silence_against_clean_baseline(self):
+        # The bug in #1453 is that an atf-unavailable run fingerprints
+        # identically to a clean run with zero findings — so the comment
+        # subcommand stayed silent. With status in the fingerprint, the
+        # comment must fire so reviewers see the daemon failure.
+        body = self._run_comment(
+            [],
+            baseline_entries=[],
+            status="atf-unavailable",
+            baseline_status=None,
+        )
+        self.assertNotEqual(body, "")
+        self.assertIn("ATF data unavailable", body)
+
+    def test_clean_run_still_silent_against_atf_unavailable_baseline(self):
+        # Inverse direction: an atf-unavailable baseline shouldn't keep the
+        # comment silent when the PR has recovered to a clean run — the
+        # fingerprints differ on status alone, so the comment fires with
+        # the normal "no findings" body.
+        body = self._run_comment(
+            [self._entry(findings=[])],
+            baseline_entries=[],
+            baseline_status="atf-unavailable",
+        )
+        self.assertNotEqual(body, "")
+        self.assertIn("No accessibility findings", body)
 
 
 if __name__ == "__main__":

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -850,6 +850,15 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
     manifests: List<Pair<PreviewModule, PreviewManifest>>,
   ) {}
 
+  /**
+   * Optional subclass hook for "the data product we just tried to produce wasn't actually
+   * available" — e.g. `compose-preview a11y` couldn't get ATF data from the daemon for any module.
+   * Returning a non-null message causes [run] to print it to stderr and exit with code 2 *before*
+   * the JSON / table output, so the consumer never sees a misleading "no findings" report. Default:
+   * null (no override).
+   */
+  protected open fun atfUnavailableExitMessage(): String? = null
+
   override fun run() {
     val renderer =
       extensionRenderers[extensionId]
@@ -868,6 +877,13 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
     val raw = renderModules(silenceStdout = jsonOutput, gradleArguments = gradleArgsWithForce())
     val manifests = readAllManifests(raw.modules)
     produceAdditionalDataProducts(raw.modules, manifests)
+    // After production runs, give the subclass a chance to abort the run when its data product
+    // wasn't actually available — without this, a daemon-crash in `compose-preview a11y` looks
+    // identical to a clean run with zero findings (issue #1453).
+    atfUnavailableExitMessage()?.let { message ->
+      System.err.println(message)
+      exitProcess(2)
+    }
     val results = if (manifests.isEmpty()) emptyList() else buildResults(manifests)
     val outcome =
       RenderModulesOutcome(
@@ -924,6 +940,16 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
  * against the same coordinates.
  */
 class A11yCommand(args: List<String>) : ReportCommand(args, "a11y") {
+  /**
+   * Tracks ATF availability across modules so [run] can fail the CLI when no module successfully
+   * produced any a11y data. Read by [atfUnavailableExitMessage]; set by
+   * [produceAdditionalDataProducts]. The list of [unavailableModules] is used purely for the
+   * user-facing error message.
+   */
+  private var attemptedAnyModule: Boolean = false
+  private var anyModuleAtfOk: Boolean = false
+  private val unavailableModules: MutableList<String> = mutableListOf()
+
   override fun produceAdditionalDataProducts(
     modules: List<PreviewModule>,
     manifests: List<Pair<PreviewModule, PreviewManifest>>,
@@ -939,14 +965,22 @@ class A11yCommand(args: List<String>) : ReportCommand(args, "a11y") {
     if (!daemonStartOk) {
       System.err.println(
         "compose-preview a11y: composePreviewDaemonStart failed; skipping daemon-driven a11y " +
-          "fetch. Findings will be empty."
+          "fetch."
       )
+      // Treat a failed daemon-start as ATF-unavailable for every module that has previews — the
+      // user needs to see the run fail rather than receive a misleading "no findings" report.
+      for ((module, manifest) in manifests) {
+        if (manifest.previews.isEmpty()) continue
+        attemptedAnyModule = true
+        unavailableModules += module.gradlePath
+      }
       return
     }
     val fetcher = DaemonA11yFetcher(onLog = { System.err.println("[daemon a11y] $it") })
     for ((module, manifest) in manifests) {
       val previewIds = manifest.previews.map { it.id }
       if (previewIds.isEmpty()) continue
+      attemptedAnyModule = true
       val outcome =
         fetcher.fetch(
           projectDir = module.projectDir,
@@ -955,25 +989,54 @@ class A11yCommand(args: List<String>) : ReportCommand(args, "a11y") {
           previewIds = previewIds,
         )
       when (outcome) {
-        is DaemonA11yFetcher.Outcome.Ok ->
-          if (verbose) {
+        is DaemonA11yFetcher.Outcome.Ok -> {
+          if (outcome.atfAvailable) {
+            anyModuleAtfOk = true
+            if (verbose) {
+              System.err.println(
+                "compose-preview a11y: ${module.gradlePath} wrote ${outcome.reportFile.path} " +
+                  "(${outcome.entryCount} entr${if (outcome.entryCount == 1) "y" else "ies"})"
+              )
+            }
+          } else {
+            unavailableModules += module.gradlePath
             System.err.println(
-              "compose-preview a11y: ${module.gradlePath} wrote ${outcome.reportFile.path} " +
-                "(${outcome.entryCount} entr${if (outcome.entryCount == 1) "y" else "ies"})"
+              "compose-preview a11y: ${module.gradlePath} ATF data unavailable — every " +
+                "per-preview fetch failed (see daemon log above)."
             )
           }
-        is DaemonA11yFetcher.Outcome.DescriptorMissing ->
+        }
+        is DaemonA11yFetcher.Outcome.DescriptorMissing -> {
+          unavailableModules += module.gradlePath
           System.err.println(
             "compose-preview a11y: ${module.gradlePath} missing daemon-launch.json at " +
               "${outcome.expected.path}"
           )
-        is DaemonA11yFetcher.Outcome.OpenFailed ->
+        }
+        is DaemonA11yFetcher.Outcome.OpenFailed -> {
+          unavailableModules += module.gradlePath
           System.err.println(
             "compose-preview a11y: ${module.gradlePath} failed to open render session " +
               "(${outcome.reason})"
           )
+        }
       }
     }
+  }
+
+  /**
+   * Fail the CLI when ATF was requested for at least one module and no module produced any ATF
+   * data. Without this, a broken daemon (classpath issue, missing descriptor) silently degrades to
+   * a "no findings" report indistinguishable from a healthy clean run — see issue #1453. Returning
+   * `null` falls through to the default exit-code policy.
+   */
+  override fun atfUnavailableExitMessage(): String? {
+    if (!attemptedAnyModule) return null
+    if (anyModuleAtfOk) return null
+    val moduleList =
+      if (unavailableModules.isEmpty()) "all modules" else unavailableModules.joinToString(", ")
+    return "compose-preview a11y: ATF data unavailable for $moduleList — failing run rather " +
+      "than reporting an empty findings list. See daemon log above."
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
@@ -56,7 +56,10 @@ internal class DaemonA11yFetcher(
     workspaceRoot: File = projectDir,
   ): Outcome {
     val descriptorFile = File(projectDir, "build/compose-previews/daemon-launch.json")
-    if (!descriptorFile.isFile) return Outcome.DescriptorMissing(descriptorFile)
+    if (!descriptorFile.isFile) {
+      writeAtfUnavailableReport(projectDir, moduleName)
+      return Outcome.DescriptorMissing(descriptorFile)
+    }
 
     val config =
       RenderSessionConfig(
@@ -70,6 +73,7 @@ internal class DaemonA11yFetcher(
       try {
         factory.open(config)
       } catch (e: RenderSessionException) {
+        writeAtfUnavailableReport(projectDir, moduleName)
         return Outcome.OpenFailed(reason = e.message ?: e.javaClass.simpleName)
       }
 
@@ -85,6 +89,7 @@ internal class DaemonA11yFetcher(
         onLog("extensions/enable for 'a11y' failed: ${e.message}")
       }
       val entries = mutableListOf<AccessibilityEntry>()
+      var anyFetchOk = false
       for (previewId in previewIds) {
         val payload =
           try {
@@ -103,6 +108,7 @@ internal class DaemonA11yFetcher(
             onLog("a11y fetch for '$previewId' transport error: ${e.message}")
             null
           }
+        if (payload != null) anyFetchOk = true
         val findings = payload?.let(::parseFindings).orEmpty()
         entries.add(
           AccessibilityEntry(
@@ -112,12 +118,44 @@ internal class DaemonA11yFetcher(
           )
         )
       }
-      val reportFile = projectDir.resolve("build/compose-previews/accessibility.json")
-      reportFile.parentFile?.mkdirs()
-      val report = AccessibilityReport(module = moduleName, entries = entries)
-      reportFile.writeText(json.encodeToString(AccessibilityReport.serializer(), report))
-      Outcome.Ok(reportFile = reportFile, entryCount = entries.size)
+      // If we attempted at least one preview and none succeeded, the empty-findings entries we
+      // accumulated above are indistinguishable from a clean run. Stamp the report-level status
+      // so downstream consumers (the python PR-comment helper, CLI exit-code policy) can tell
+      // "ATF didn't run" apart from "ATF ran cleanly." When `previewIds` is empty there's nothing
+      // to report on either way, so leave `status` null.
+      val atfAvailable = anyFetchOk || previewIds.isEmpty()
+      val status = if (atfAvailable) null else A11Y_REPORT_STATUS_ATF_UNAVAILABLE
+      val reportFile = writeReport(projectDir, moduleName, entries = entries, status = status)
+      Outcome.Ok(reportFile = reportFile, entryCount = entries.size, atfAvailable = atfAvailable)
     }
+  }
+
+  /**
+   * Write an `accessibility.json` stamped with `status = "atf-unavailable"` and no entries, for
+   * cases where we can't even open a render session (descriptor missing / open failed). Lets the
+   * python PR-comment helper see the same signal it gets on a per-preview-failure run instead of
+   * silently finding nothing on disk.
+   */
+  private fun writeAtfUnavailableReport(projectDir: File, moduleName: String) {
+    writeReport(
+      projectDir,
+      moduleName,
+      entries = emptyList(),
+      status = A11Y_REPORT_STATUS_ATF_UNAVAILABLE,
+    )
+  }
+
+  private fun writeReport(
+    projectDir: File,
+    moduleName: String,
+    entries: List<AccessibilityEntry>,
+    status: String?,
+  ): File {
+    val reportFile = projectDir.resolve("build/compose-previews/accessibility.json")
+    reportFile.parentFile?.mkdirs()
+    val report = AccessibilityReport(module = moduleName, entries = entries, status = status)
+    reportFile.writeText(json.encodeToString(AccessibilityReport.serializer(), report))
+    return reportFile
   }
 
   /**
@@ -143,7 +181,14 @@ internal class DaemonA11yFetcher(
   }
 
   sealed interface Outcome {
-    data class Ok(val reportFile: File, val entryCount: Int) : Outcome
+    /**
+     * Render session opened and per-preview fetches completed (possibly with some failures — see
+     * [atfAvailable]). [atfAvailable] is `true` when at least one preview's `a11y/atf` fetch
+     * succeeded, or when the module had no previews to attempt; `false` only when every attempted
+     * fetch failed. The on-disk `accessibility.json` carries the same signal via its `status`
+     * field.
+     */
+    data class Ok(val reportFile: File, val entryCount: Int, val atfAvailable: Boolean) : Outcome
 
     data class DescriptorMissing(val expected: File) : Outcome
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
@@ -27,10 +27,13 @@ import ee.schimke.composeai.render.session.NotificationListener
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionBackend
 import ee.schimke.composeai.render.session.RenderSessionConfig
+import ee.schimke.composeai.render.session.RenderSessionException
 import ee.schimke.composeai.render.session.RenderSessionFactory
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
@@ -68,12 +71,14 @@ class DaemonA11yFetcherTest {
       )
 
     assertTrue(outcome is DaemonA11yFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    assertTrue(outcome.atfAvailable, "expected atfAvailable=true on successful fetches")
     val report =
       Companion.json.decodeFromString(
         AccessibilityReport.serializer(),
         File(projectDir, "build/compose-previews/accessibility.json").readText(),
       )
     assertEquals("sample", report.module)
+    assertNull(report.status, "successful run should not stamp a status")
     assertEquals(listOf("AlphaPreview", "BetaPreview"), report.entries.map { it.previewId })
     assertEquals(1, report.entries[0].findings.size)
     assertEquals("ERROR", report.entries[0].findings.first().level)
@@ -82,7 +87,7 @@ class DaemonA11yFetcherTest {
   }
 
   @Test
-  fun `returns DescriptorMissing when daemon-launch_json is absent`() {
+  fun `returns DescriptorMissing when daemon-launch_json is absent and writes atf-unavailable sidecar`() {
     val projectDir = newTempFolder("module-no-descriptor")
     val fetcher = DaemonA11yFetcher(factory = FakeFactory(emptyMap()))
 
@@ -95,12 +100,106 @@ class DaemonA11yFetcherTest {
       )
 
     assertTrue(outcome is DaemonA11yFetcher.Outcome.DescriptorMissing)
+    // The python PR-comment helper reads accessibility.json directly, so we stamp a sidecar
+    // even when the session can't open — otherwise the workflow can't tell apart "no module
+    // tried" from "the daemon descriptor was missing."
+    val reportFile = File(projectDir, "build/compose-previews/accessibility.json")
+    assertTrue(reportFile.exists(), "expected an atf-unavailable sidecar")
+    val report =
+      Companion.json.decodeFromString(AccessibilityReport.serializer(), reportFile.readText())
+    assertEquals(A11Y_REPORT_STATUS_ATF_UNAVAILABLE, report.status)
+    assertEquals(emptyList(), report.entries.map { it.previewId })
+  }
+
+  @Test
+  fun `stamps atf-unavailable status when every per-preview fetch errors`() {
+    val projectDir = newTempFolder("module-fetches-fail")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+
+    // Null payload simulates a fetch that errored (the fake session below returns null payloads
+    // verbatim; the production fetcher wraps DataProductException / RenderSessionException to
+    // the same `null` here).
+    val fetcher =
+      DaemonA11yFetcher(factory = FakeFactory(mapOf("AlphaPreview" to null, "BetaPreview" to null)))
+
+    val outcome =
+      fetcher.fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previewIds = listOf("AlphaPreview", "BetaPreview"),
+      )
+
+    assertTrue(outcome is DaemonA11yFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    assertFalse(outcome.atfAvailable, "no fetches succeeded → atfAvailable should be false")
+    val report =
+      Companion.json.decodeFromString(
+        AccessibilityReport.serializer(),
+        File(projectDir, "build/compose-previews/accessibility.json").readText(),
+      )
+    assertEquals(A11Y_REPORT_STATUS_ATF_UNAVAILABLE, report.status)
+  }
+
+  @Test
+  fun `partial fetch success leaves status null`() {
+    val projectDir = newTempFolder("module-partial")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+
+    val fetcher =
+      DaemonA11yFetcher(
+        factory =
+          FakeFactory(mapOf("AlphaPreview" to atfPayload(emptyList()), "BetaPreview" to null))
+      )
+
+    val outcome =
+      fetcher.fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previewIds = listOf("AlphaPreview", "BetaPreview"),
+      )
+
+    assertTrue(outcome is DaemonA11yFetcher.Outcome.Ok, "expected Ok, got $outcome")
+    assertTrue(outcome.atfAvailable, "one successful fetch is enough to keep atfAvailable=true")
+    val report =
+      Companion.json.decodeFromString(
+        AccessibilityReport.serializer(),
+        File(projectDir, "build/compose-previews/accessibility.json").readText(),
+      )
+    assertNull(report.status, "partial success should not stamp a status")
+  }
+
+  @Test
+  fun `OpenFailed writes atf-unavailable sidecar`() {
+    val projectDir = newTempFolder("module-open-fails")
+    File(projectDir, "build/compose-previews").mkdirs()
+    File(projectDir, "build/compose-previews/daemon-launch.json").writeText("{}")
+
+    val fetcher = DaemonA11yFetcher(factory = OpenFailFactory())
+
+    val outcome =
+      fetcher.fetch(
+        projectDir = projectDir,
+        modulePath = "",
+        moduleName = "sample",
+        previewIds = listOf("AlphaPreview"),
+      )
+
+    assertTrue(outcome is DaemonA11yFetcher.Outcome.OpenFailed)
+    val reportFile = File(projectDir, "build/compose-previews/accessibility.json")
+    assertTrue(reportFile.exists())
+    val report =
+      Companion.json.decodeFromString(AccessibilityReport.serializer(), reportFile.readText())
+    assertEquals(A11Y_REPORT_STATUS_ATF_UNAVAILABLE, report.status)
   }
 
   // -------------------------------------------------------------------------
   // Fake factory + session
 
-  private class FakeFactory(private val payloads: Map<String, JsonElement>) : RenderSessionFactory {
+  private class FakeFactory(private val payloads: Map<String, JsonElement?>) :
+    RenderSessionFactory {
     override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
 
     override fun open(config: RenderSessionConfig): RenderSession =
@@ -112,13 +211,23 @@ class DaemonA11yFetcherTest {
   }
 
   /**
+   * Factory that always fails `open()` — drives the [DaemonA11yFetcher.Outcome.OpenFailed] branch.
+   */
+  private class OpenFailFactory : RenderSessionFactory {
+    override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
+
+    override fun open(config: RenderSessionConfig): RenderSession =
+      throw RenderSessionException("simulated daemon open failure")
+  }
+
+  /**
    * Minimal [RenderSession] that returns canned a11y/atf payloads. Every other method throws — the
    * fetcher only calls fetchData and close.
    */
   private class FakeSession(
     override val workspaceRoot: String,
     override val modulePath: String,
-    private val payloads: Map<String, JsonElement>,
+    private val payloads: Map<String, JsonElement?>,
   ) : RenderSession {
     override val initializeResult: InitializeResult =
       InitializeResult(

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityModels.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityModels.kt
@@ -28,6 +28,14 @@ import kotlinx.serialization.Serializable
 data class AccessibilityReport(
     val module: String,
     val entries: List<AccessibilityEntry>,
+    /**
+     * Run-level status. `null` for a normal run; non-null (e.g. `"atf-unavailable"`) when the
+     * producer couldn't return ATF data for the module and downstream consumers should surface
+     * that rather than treat the empty entries list as a clean run. The CLI mirror in
+     * `:preview-data-api`'s `A11yWireFormat.kt` is the canonical definition for the
+     * `"atf-unavailable"` constant.
+     */
+    val status: String? = null,
 )
 
 @Serializable

--- a/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/A11yWireFormat.kt
+++ b/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/A11yWireFormat.kt
@@ -44,7 +44,19 @@ data class AccessibilityEntry(
 )
 
 @Serializable
-data class AccessibilityReport(val module: String, val entries: List<AccessibilityEntry>)
+data class AccessibilityReport(
+  val module: String,
+  val entries: List<AccessibilityEntry>,
+  /**
+   * Run-level status for this module's ATF pass. `null` for a normal run — `entries` reflects what
+   * ATF returned, and an entry with empty `findings` means "checks ran, found nothing." Set to
+   * [A11Y_REPORT_STATUS_ATF_UNAVAILABLE] when the daemon could not return ATF data for any preview
+   * attempted (descriptor missing, render-session open failed, every per-preview fetch errored, …)
+   * so downstream consumers can surface that rather than treating the empty findings list as a
+   * clean run.
+   */
+  val status: String? = null,
+)
 
 /**
  * Schema string stamped into `ExtensionPayload.schema` for the `a11y` entry of
@@ -55,3 +67,10 @@ data class AccessibilityReport(val module: String, val entries: List<Accessibili
  * tooling) can pin to it without taking a CLI dependency.
  */
 const val A11Y_PAYLOAD_SCHEMA_V1: String = "compose-preview-data-a11y/v1"
+
+/**
+ * Value emitted in [AccessibilityReport.status] when ATF data could not be produced for any preview
+ * in the module (daemon classpath issue, render-session open failed, every per-preview fetch
+ * errored). The python helper and PR-comment renderer check for this string verbatim.
+ */
+const val A11Y_REPORT_STATUS_ATF_UNAVAILABLE: String = "atf-unavailable"


### PR DESCRIPTION
When the preview daemon fails to return ATF data (classpath issue, every
per-preview fetch errors out, etc.), `compose-preview a11y` previously
wrote a clean-looking `accessibility.json` with empty findings — and the
PR-comment workflow rendered it as "0 error(s) · 0 warning(s)" with
plain (non-overlaid) renders. The report shape was structurally
identical to a healthy run with zero findings, masking real regressions.

This change does both things issue #1453 suggested:

* CLI fails the run. `DaemonA11yFetcher` tracks whether any per-preview
  fetch succeeded and reports it on `Outcome.Ok.atfAvailable`. When no
  module produced any ATF data, `A11yCommand` exits with code 2 and a
  user-facing message via a new `atfUnavailableExitMessage()` hook on
  `ReportCommand`, before any JSON output goes out.
* Wire format carries the signal. `AccessibilityReport` grows an
  optional `status` field (`null` for clean, `"atf-unavailable"`
  otherwise). The fetcher stamps it on every path that fails to deliver
  ATF — including `DescriptorMissing` and `OpenFailed`, which now write
  an atf-unavailable sidecar instead of leaving no file at all.

The python PR-comment helper propagates the status through
`findings.json`, includes it in the fingerprint comparison so an
atf-unavailable run can never silently match a clean baseline, and
surfaces a `> [!WARNING]` block in both the PR comment and the
baseline README so reviewers see what happened.

Tests cover the new outcomes end-to-end on both the Kotlin and Python
sides, including the partial-success case (one module fails, others
succeed — status stays null).

Fixes #1453