### PR TITLE
test(vscode-extension): electron-driven bundle chip↔tab↔overlay chain (#1391)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -490,6 +490,25 @@ export interface ComposePreviewTestApi {
         enabled: boolean,
     ): Promise<void>;
     /**
+     * Drive `BundleController.toggleBundle` in the webview by posting
+     * a `triggerBundleToggle` message. Activating the chip from the
+     * webview side cascades through the production code path:
+     * `reflectBundleState` paints the chip / tab / overlay surfaces
+     * and calls `host.setKindsEnabled`, which posts
+     * `setDataExtensionEnabled` back to the extension and triggers a
+     * daemon `data/subscribe`. Returns once the message has been sent
+     * — the test should poll `webviewBundleState` for the expected
+     * surface state.
+     *
+     * Used by the bundle chip ↔ tab ↔ overlay e2e suite (issue
+     * #1391). `triggerSetDataExtensionEnabled` skips the webview chip
+     * by subscribing the daemon directly; this is the chip-driven
+     * counterpart that covers `firstUpdated` wiring,
+     * `reflectBundleState` ordering, and the focus-mode visibility
+     * gates the issue calls out.
+     */
+    triggerWebviewBundleToggle(bundleId: string): void;
+    /**
      * Run the same `composePreviewDaemonStart` + JVM spawn the activation
      * flow does, so chip-toggle tests can issue `data/subscribe` against a
      * live daemon. Resolves to whether the daemon ended up ready. Used by
@@ -2011,6 +2030,12 @@ export async function activate(
                 enabled: boolean,
             ): Promise<void> {
                 return handleSetDataExtensionEnabled(previewId, kinds, enabled);
+            },
+            triggerWebviewBundleToggle(bundleId: string): void {
+                panel?.postMessage({
+                    command: "triggerBundleToggle",
+                    bundleId,
+                });
             },
             triggerWarmDaemon(filePath: string): Promise<boolean> {
                 return warmDaemonForFile(filePath);
@@ -4632,6 +4657,23 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                     `kinds=[${msg.kinds.join(",")}]`,
             );
             break;
+        case "webviewBundleState": {
+            // Chip ↔ tab ↔ overlay surface diagnostic. The webview emits
+            // this after every `reflectBundleState()` and from the data-
+            // update handlers that repaint overlays; the e2e bundle-chain
+            // suite asserts on it through `getReceivedMessages()`.
+            const overlayPairs = Object.entries(msg.overlayCountByBundle)
+                .map(([k, v]) => `${k}=${v}`)
+                .join(",");
+            logInfo(
+                `[daemon] webview ack bundleState ` +
+                    `active=[${msg.activeBundles.join(",")}] ` +
+                    `tab=${msg.activeTab ?? "<none>"} ` +
+                    `tabs=${msg.tabHandleCount} ` +
+                    `overlays={${overlayPairs}}`,
+            );
+            break;
+        }
         case "openFile":
             openPreviewSource(msg.className, msg.functionName);
             break;

--- a/vscode-extension/src/test/electron/suite/e2eBundleChain.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eBundleChain.test.ts
@@ -1,0 +1,380 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import type { ComposePreviewTestApi } from "../../../extension";
+import { RealGradleApi } from "../realGradleApi";
+
+/**
+ * Electron-driven e2e for the bundle chip ↔ tab ↔ overlay chain
+ * (issue #1391, follow-up to #1104). Companion to the controller-level
+ * `chipTabOverlayChain.test.ts` unit test — the unit test wires a
+ * stub controller against synthetic DOM and asserts the three surfaces
+ * stay in sync; this one runs the same contract against a real daemon
+ * round-trip on `:samples:wear` so the assertions also catch:
+ *
+ *   - `main.ts` `firstUpdated` ordering bugs (a single bundle's
+ *     `refreshXxxBundle` wired the wrong side of the controller).
+ *   - the daemon ↔ panel subscription path —
+ *     `triggerWebviewBundleToggle` activates the chip in the webview,
+ *     which posts `setDataExtensionEnabled` back to the extension,
+ *     which subscribes the daemon, which emits attachments, which
+ *     paint overlays back in the webview.
+ *   - `webviewBundleState` ack fidelity — `tabHandleCount` /
+ *     `overlayCountByBundle` must reflect what's actually mounted in
+ *     the DOM, not stale controller bookkeeping.
+ *
+ * Gated on `COMPOSE_PREVIEW_E2E=1` next to the existing real-Gradle
+ * suite; piggybacks on the wear daemon already warmed by
+ * `e2eA11y.test.ts` when both run in the same Mocha process. The
+ * Accessibility bundle is the chosen target because both
+ * `a11y/hierarchy` (positive node count → overlay boxes) and the
+ * underlying daemon registry are already exercised by #1006's tests,
+ * so this suite focuses on chip/tab/overlay synchrony rather than
+ * proving the data path again. History was the original sketch in
+ * #1391 but requires a baseline render archived in `historyManager`
+ * before `history/diff/regions` resolves, which is a separate setup
+ * burden out of scope for this suite.
+ *
+ * The verification surface is the `webviewBundleState` ack the panel
+ * emits after every `reflectBundleState()` and from the data-update
+ * paths after `refreshXxxBundle()` repaints overlays. Reading the
+ * webview DOM directly across the extension-host / webview boundary
+ * is awkward, and asserting on host-side posts alone wouldn't catch
+ * a webview-side regression in the chip / tab / overlay paint.
+ * Mirrors `webviewA11yState` (data-side ack) for the chip-surface
+ * side of the chain.
+ */
+
+const E2E = process.env.COMPOSE_PREVIEW_E2E === "1";
+const describeE2E = E2E ? describe : describe.skip;
+
+interface PostedMessage {
+    command: string;
+    [key: string]: unknown;
+}
+
+interface BundleStateAck extends PostedMessage {
+    command: "webviewBundleState";
+    activeBundles: string[];
+    activeTab: string | null;
+    tabHandleCount: number;
+    overlayCountByBundle: Record<string, number>;
+}
+
+async function waitFor<T>(
+    description: string,
+    timeoutMs: number,
+    pollMs: number,
+    probe: () => T | undefined,
+): Promise<T> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const value = probe();
+        if (value !== undefined) {
+            return value;
+        }
+        await new Promise((r) => setTimeout(r, pollMs));
+    }
+    throw new Error(
+        `Timed out after ${timeoutMs}ms waiting for: ${description}`,
+    );
+}
+
+interface PreviewSummary {
+    id: string;
+    functionName: string;
+    params?: { device?: string | null; name?: string | null };
+}
+
+describeE2E("Compose Preview bundle chip↔tab↔overlay e2e (wear)", function () {
+    // Suite ceiling matches the sibling wear suites — first cold render
+    // on `:samples:wear` is the slowest path and dwarfs every subsequent
+    // chip toggle.
+    this.timeout(15 * 60_000);
+
+    let api: ComposePreviewTestApi;
+    let wearKotlinFile: string;
+    let priorEarlyFeatures: boolean | undefined;
+    let wearPreviews: PreviewSummary[];
+
+    before(async function () {
+        this.timeout(15 * 60_000);
+
+        const folders = vscode.workspace.workspaceFolders;
+        assert.ok(folders && folders.length > 0, "workspace must be open");
+        const repoRoot = folders[0].uri.fsPath;
+        wearKotlinFile = path.join(
+            repoRoot,
+            "samples",
+            "wear",
+            "src",
+            "main",
+            "kotlin",
+            "com",
+            "example",
+            "samplewear",
+            "Previews.kt",
+        );
+        assert.ok(
+            fs.existsSync(wearKotlinFile),
+            `expected wear sample file at ${wearKotlinFile}`,
+        );
+
+        // Chip bar / tab row / overlays are gated on `earlyFeatures`
+        // for non-graduated bundles; a11y is graduated so the chip
+        // would show regardless, but flipping the flag keeps this
+        // suite's setup mirrored with `e2eA11y` for future bundles.
+        // Global scope so `@vscode/test-electron`'s isolated
+        // `.vscode-test/user-data/` holds the value and the repo's
+        // `.vscode/` stays clean.
+        const config = vscode.workspace.getConfiguration("composePreview");
+        priorEarlyFeatures = config.get<boolean>("earlyFeatures.enabled");
+        await config.update(
+            "earlyFeatures.enabled",
+            true,
+            vscode.ConfigurationTarget.Global,
+        );
+
+        const ext = vscode.extensions.getExtension<ComposePreviewTestApi>(
+            "yuri-schimke.compose-preview",
+        );
+        assert.ok(ext, "compose-preview extension must be present");
+        const exported = await ext.activate();
+        assert.ok(
+            exported,
+            "activate() must return ComposePreviewTestApi under COMPOSE_PREVIEW_TEST_MODE=1",
+        );
+        api = exported;
+        api.injectGradleApi(
+            new RealGradleApi(repoRoot, (line) => console.log(line), []),
+        );
+
+        // Same dance as `e2eA11y` — focus the panel so the webview
+        // resolves, then wait for the ready latch / inbound message.
+        await vscode.commands.executeCommand("composePreview.panel.focus");
+        await waitFor(
+            "webviewReady from the resolved webview",
+            30_000,
+            100,
+            () => {
+                if (api.isWebviewReady()) return true;
+                const inbound = api.getReceivedMessages();
+                return inbound.find(
+                    (m) => (m as PostedMessage).command === "webviewReady",
+                );
+            },
+        );
+
+        // The chip toggle's outbound `setDataExtensionEnabled` lands
+        // in `handleSetDataExtensionEnabled`, which needs a live daemon
+        // to subscribe against. `COMPOSE_PREVIEW_TEST_MODE=1` skips the
+        // activation auto-refresh, so the warm has to be explicit.
+        const warmed = await api.triggerWarmDaemon(wearKotlinFile);
+        assert.ok(
+            warmed,
+            "wear daemon must warm before chip toggles" +
+                (warmed
+                    ? ""
+                    : `; cause: ${api.getLastWarmDaemonError() ?? "<unknown>"}`),
+        );
+
+        // One full-tier render to populate the grid + scope a current
+        // bundle target. `currentBundleTarget()` in the webview returns
+        // the first visible card, which is the previewId the chip's
+        // outbound subscribe targets.
+        api.resetMessages();
+        await api.triggerRefresh(wearKotlinFile, /* force */ true, "full");
+        const setPreviews = await waitFor(
+            "non-empty setPreviews for samples/wear",
+            this.timeout(),
+            500,
+            () => {
+                const msgs = api.getPostedMessages();
+                for (let i = msgs.length - 1; i >= 0; i--) {
+                    const m = msgs[i] as PostedMessage;
+                    if (m.command !== "setPreviews") continue;
+                    const previews = m.previews as PreviewSummary[] | undefined;
+                    if (previews && previews.length > 0) return m;
+                }
+                return undefined;
+            },
+        );
+        wearPreviews = setPreviews.previews as PreviewSummary[];
+        console.log(
+            `[e2e-bundle-chain] wear setPreviews carried ${wearPreviews.length} previews`,
+        );
+        // Wait for the webview to actually render the cards so
+        // `currentBundleTarget()` resolves to a real previewId rather
+        // than `null` when the chip toggle fires.
+        await waitFor(
+            "webviewPreviewsRendered for samples/wear",
+            this.timeout(),
+            500,
+            () => {
+                const inbound = api.getReceivedMessages();
+                return inbound.find(
+                    (m) =>
+                        (m as PostedMessage).command ===
+                        "webviewPreviewsRendered",
+                );
+            },
+        );
+    });
+
+    after(async () => {
+        const config = vscode.workspace.getConfiguration("composePreview");
+        await config.update(
+            "earlyFeatures.enabled",
+            priorEarlyFeatures,
+            vscode.ConfigurationTarget.Global,
+        );
+    });
+
+    function findBundleAck(
+        match: (ack: BundleStateAck) => boolean,
+    ): BundleStateAck | undefined {
+        const inbound = api.getReceivedMessages();
+        // Scan in reverse for the latest matching snapshot — the chip
+        // toggle emits at activation time (overlays empty) and again
+        // after the daemon attachment lands (overlays populated). A
+        // forward scan would lock onto the first emit and never see
+        // the post-paint state.
+        for (let i = inbound.length - 1; i >= 0; i--) {
+            const m = inbound[i] as PostedMessage;
+            if (m.command !== "webviewBundleState") continue;
+            const ack = m as BundleStateAck;
+            if (match(ack)) return ack;
+        }
+        return undefined;
+    }
+
+    it("activate → chip on, tab opens, overlays paint after daemon attachment", async function () {
+        // Sanity baseline: at suite entry no bundle is active (the wear
+        // suite hasn't toggled anything yet, and the initial
+        // `reflectBundleState()` runs with `active=[]`).
+        const initial = findBundleAck(
+            (a) => a.activeBundles.length === 0 && a.tabHandleCount === 0,
+        );
+        assert.ok(
+            initial,
+            "expected an initial webviewBundleState with no active bundles before the toggle",
+        );
+
+        // Reset only the inbound buffer so we can scan the toggle's
+        // emits without the initial empty-state acks confusing the
+        // "post-paint overlay count" probe.
+        api.resetMessages();
+
+        console.log("[e2e-bundle-chain] triggering chip activation for a11y");
+        api.triggerWebviewBundleToggle("a11y");
+
+        // First milestone: the chip activation itself. `reflectBundle
+        // State()` runs synchronously on `controller.fire()`, so the
+        // ack should land within the next webview tick.
+        const activated = await waitFor(
+            "webviewBundleState with a11y active + tab open",
+            this.timeout(),
+            500,
+            () =>
+                findBundleAck(
+                    (a) =>
+                        a.activeBundles.includes("a11y") &&
+                        a.activeTab === "a11y" &&
+                        a.tabHandleCount >= 1,
+                ),
+        );
+        console.log(
+            `[e2e-bundle-chain] chip-on snapshot: ` +
+                `active=[${activated.activeBundles.join(",")}] ` +
+                `tabs=${activated.tabHandleCount} ` +
+                `overlays.a11y=${activated.overlayCountByBundle["a11y"] ?? 0}`,
+        );
+
+        // Second milestone: daemon attachment lands → `refreshA11y
+        // Bundle()` repaints overlays → bundle state re-emits with a
+        // positive overlay count. The chip-on activation emits with
+        // overlay count = 0 (cache empty); we're looking for a later
+        // snapshot where the count is non-zero. Every wear preview
+        // ships at least one accessibility-relevant node, so the
+        // first-visible-card subscription is guaranteed to produce
+        // at least one overlay box.
+        const painted = await waitFor(
+            "webviewBundleState with a11y overlay painted",
+            this.timeout(),
+            500,
+            () =>
+                findBundleAck(
+                    (a) =>
+                        a.activeBundles.includes("a11y") &&
+                        (a.overlayCountByBundle["a11y"] ?? 0) > 0,
+                ),
+        );
+        assert.ok(
+            (painted.overlayCountByBundle["a11y"] ?? 0) > 0,
+            `expected overlayCountByBundle.a11y > 0 after daemon attachment, ` +
+                `got ${painted.overlayCountByBundle["a11y"] ?? 0}`,
+        );
+        // Tab handle should still be there alongside the painted
+        // overlay — a regression where the overlay paint clobbers the
+        // tab row (or vice versa) would surface here.
+        assert.ok(
+            painted.tabHandleCount >= 1,
+            `expected tabHandleCount >= 1 with paint, got ${painted.tabHandleCount}`,
+        );
+    });
+
+    it("toggle off → chip off, tab closed, overlays cleared", async function () {
+        // Prereq: chip on with overlays painted. The previous `it`
+        // toggled the chip on and left it that way; if Mocha re-orders
+        // (e.g. a future `--retries` setting) the assertion below
+        // would surface that as a real failure rather than a spurious
+        // off-by-one against the test order.
+        const stillOn = findBundleAck((a) => a.activeBundles.includes("a11y"));
+        assert.ok(
+            stillOn,
+            "expected a11y to still be active from the prior chip-on test; " +
+                "either Mocha re-ordered the suite or the prior toggle never landed",
+        );
+
+        api.resetMessages();
+        console.log("[e2e-bundle-chain] triggering chip teardown for a11y");
+        api.triggerWebviewBundleToggle("a11y");
+
+        const torn = await waitFor(
+            "webviewBundleState with a11y deactivated",
+            this.timeout(),
+            500,
+            () =>
+                findBundleAck(
+                    (a) =>
+                        !a.activeBundles.includes("a11y") &&
+                        a.tabHandleCount === 0 &&
+                        (a.overlayCountByBundle["a11y"] ?? 0) === 0,
+                ),
+        );
+        assert.deepStrictEqual(
+            torn.activeBundles.includes("a11y"),
+            false,
+            "a11y must be removed from activeBundles after toggle off",
+        );
+        assert.strictEqual(
+            torn.tabHandleCount,
+            0,
+            "tab handle row must be empty after the only active bundle closes",
+        );
+        assert.strictEqual(
+            torn.overlayCountByBundle["a11y"] ?? 0,
+            0,
+            "every card's a11y box-overlay layer must be cleared on close",
+        );
+        // Active tab follows activeBundles to `null` when nothing is
+        // left — locks the closure rule the unit test pins at
+        // chipTabOverlayChain.test.ts:191.
+        assert.strictEqual(
+            torn.activeTab,
+            null,
+            "activeTab must be null when no bundle is active",
+        );
+    });
+});

--- a/vscode-extension/src/test/handleErrorMessagePromote.test.ts
+++ b/vscode-extension/src/test/handleErrorMessagePromote.test.ts
@@ -73,6 +73,7 @@ function buildContextStub(): ContextWithSpy {
         promoteErrorsBundle: () => {
             calls.promote += 1;
         },
+        toggleBundle: noop,
     };
     return { ctx, promoteCalls: () => calls.promote };
 }

--- a/vscode-extension/src/test/handleTriggerBundleToggle.test.ts
+++ b/vscode-extension/src/test/handleTriggerBundleToggle.test.ts
@@ -1,0 +1,98 @@
+// Dispatcher routing for the `triggerBundleToggle` message — proves
+// the extension-side test trigger
+// (`ComposePreviewTestApi.triggerWebviewBundleToggle`) reaches the
+// webview's `BundleController.toggleBundle` via
+// `handleExtensionMessage`. Without this contract the e2e bundle-chain
+// suite would silently pass when the trigger drops on the floor.
+
+import * as assert from "assert";
+import {
+    handleExtensionMessage,
+    type PreviewMessageContext,
+} from "../webview/preview/messageHandlers";
+import type { ExtensionToWebview } from "../types";
+
+interface ContextWithSpy {
+    ctx: PreviewMessageContext;
+    toggleCalls(): string[];
+}
+
+function buildContextStub(): ContextWithSpy {
+    const calls: string[] = [];
+    const noop = () => {};
+    const ctx: PreviewMessageContext = {
+        vscode: {
+            postMessage: noop,
+            getState: () => undefined,
+            setState: noop,
+        } as PreviewMessageContext["vscode"],
+        grid: {} as PreviewMessageContext["grid"],
+        filterToolbar: {
+            setFunctionOptions: noop,
+            setGroupOptions: noop,
+            setFunctionValue: noop,
+        } as PreviewMessageContext["filterToolbar"],
+        liveState: {} as PreviewMessageContext["liveState"],
+        staleBadge: {} as PreviewMessageContext["staleBadge"],
+        loadingOverlay: {} as PreviewMessageContext["loadingOverlay"],
+        diffOverlayConfig: {} as PreviewMessageContext["diffOverlayConfig"],
+        streamingPainter: {} as PreviewMessageContext["streamingPainter"],
+        earlyFeatures: () => true,
+        getA11yOverlayId: () => null,
+        setA11yOverlayId: noop,
+        setAllPreviews: noop,
+        setModuleDir: noop,
+        setLastScopedPreviewId: noop,
+        renderPreviews: noop,
+        applyRelativeSizing: noop,
+        applyFilters: noop,
+        applyLayout: noop,
+        applyPendingFocusRestore: noop,
+        applyInteractiveButtonState: noop,
+        applyRecordingButtonState: noop,
+        saveFilterState: noop,
+        restoreFilterState: noop,
+        ensureNotBlank: noop,
+        applyA11yUpdate: noop,
+        updateDataProducts: noop,
+        applyFontPreviewBytes: noop,
+        focusOnCard: noop,
+        deactivateAllBundles: noop,
+        refreshBundleState: noop,
+        promoteErrorsBundle: noop,
+        toggleBundle: (bundleId: string) => {
+            calls.push(bundleId);
+        },
+    };
+    return { ctx, toggleCalls: () => calls };
+}
+
+describe("handleExtensionMessage triggerBundleToggle", () => {
+    it("routes triggerBundleToggle to ctx.toggleBundle with the bundleId", () => {
+        const { ctx, toggleCalls } = buildContextStub();
+        const msg: ExtensionToWebview = {
+            command: "triggerBundleToggle",
+            bundleId: "a11y",
+        };
+        handleExtensionMessage(msg, ctx);
+        assert.deepStrictEqual(toggleCalls(), ["a11y"]);
+    });
+
+    it("forwards the literal bundleId — no normalisation or validation in the dispatch layer", () => {
+        // Validation belongs in `BundleController.toggleBundle` (it
+        // short-circuits unknown ids via `getBundle`). Keeping the
+        // dispatcher transparent matches the rest of the message
+        // handlers and lets future bundle ids land without
+        // touching this file.
+        const { ctx, toggleCalls } = buildContextStub();
+        handleExtensionMessage(
+            { command: "triggerBundleToggle", bundleId: "history" },
+            ctx,
+        );
+        handleExtensionMessage(
+            { command: "triggerBundleToggle", bundleId: "not-a-bundle" },
+            ctx,
+        );
+        assert.deepStrictEqual(toggleCalls(), ["history", "not-a-bundle"]);
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -665,6 +665,25 @@ export type ExtensionToWebview =
           previewId: string;
           fontRowId: string;
           dataUri: string | null;
+      }
+    /**
+     * Test-only chip-toggle driver. Lets `ComposePreviewTestApi.
+     * triggerWebviewBundleToggle` reach the webview's
+     * `BundleController.toggleBundle` so the e2e bundle-chain suite
+     * exercises the full chip-click code path (chip activates →
+     * `reflectBundleState` paints chip+tab+overlay → `setKindsEnabled`
+     * cascades back through the extension to subscribe the daemon).
+     *
+     * Not driven from production paths — the chip's primary entry
+     * point stays the webview-side `BundleChipBar` click. The host
+     * doesn't gate on `COMPOSE_PREVIEW_TEST_MODE` when posting because
+     * `panel.postMessage` is reachable only from the extension and
+     * the message is harmless in production (it would just toggle a
+     * chip the user could toggle themselves).
+     */
+    | {
+          command: "triggerBundleToggle";
+          bundleId: string;
       };
 
 /**
@@ -780,6 +799,27 @@ export type WebviewToExtension =
           command: "webviewDataProductsState";
           previewId: string;
           kinds: string[];
+      }
+    /**
+     * Webview reports the current bundle UI surface state — chip bar,
+     * tab row, and per-bundle overlay box count. Emitted from
+     * `reflectBundleState` (chip / tab transitions) and from the data-
+     * update paths after `refreshXxxBundle` repaints overlays. Lets the
+     * e2e bundle chain suite assert the full chip ↔ tab ↔ overlay
+     * pipeline at the wire layer without scraping the webview DOM —
+     * counterpart to the unit-level coverage in
+     * `chipTabOverlayChain.test.ts`. `activeBundles` / `activeTab` are
+     * plain bundle id strings (the `BundleId` union lives in the webview-
+     * only `bundleRegistry.ts`); the host doesn't need to validate
+     * against the union because the values come straight from the
+     * controller state.
+     */
+    | {
+          command: "webviewBundleState";
+          activeBundles: string[];
+          activeTab: string | null;
+          tabHandleCount: number;
+          overlayCountByBundle: Record<string, number>;
       }
     | { command: "openFile"; className: string; functionName: string }
     | { command: "selectModule"; value: string }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -2493,6 +2493,37 @@ export class PreviewApp extends LitElement {
             if (focusController) {
                 inspector.render(focusController.focusedCard());
             }
+            postBundleState();
+        };
+        // Snapshot the chip / tab / overlay surface for the e2e
+        // bundle-chain suite. Fired at the tail of every
+        // `reflectBundleState()` (chip + tab transitions) and from the
+        // data-update handlers after each `refreshXxxBundle()` repaints
+        // overlays — so the test sees `tabHandleCount=1, overlayCount=0`
+        // immediately on chip-on and a follow-up snapshot with
+        // `overlayCount>0` once the daemon attachment lands. Counterpart
+        // to `webviewA11yState` for the chip-surface side of the chain.
+        const postBundleState = (): void => {
+            const s = bundleController.state();
+            const tabHandleCount = dataTabs.querySelectorAll(
+                ".data-tab-handle[data-bundle]",
+            ).length;
+            const overlayCountByBundle: Record<string, number> = {};
+            const overlayNodes = document.querySelectorAll<HTMLElement>(
+                "box-overlay[data-bundle]",
+            );
+            for (const el of Array.from(overlayNodes)) {
+                const id = el.dataset.bundle;
+                if (!id) continue;
+                overlayCountByBundle[id] = (overlayCountByBundle[id] ?? 0) + 1;
+            }
+            vscode.postMessage({
+                command: "webviewBundleState",
+                activeBundles: [...s.activeBundles],
+                activeTab: s.activeTab,
+                tabHandleCount,
+                overlayCountByBundle,
+            });
         };
         bundleController.onChange(() => reflectBundleState());
         reflectBundleState();
@@ -3016,6 +3047,11 @@ export class PreviewApp extends LitElement {
                     currentBundleTarget() === previewId
                 ) {
                     refreshA11yBundle();
+                    // Re-emit the bundle-state snapshot so the e2e
+                    // chain test sees the post-paint overlay count.
+                    // The chip activation itself emits with count=0
+                    // (no data yet); the daemon attachment lands here.
+                    postBundleState();
                 }
             },
             updateDataProducts: (previewId, dataProducts) => {
@@ -3133,6 +3169,14 @@ export class PreviewApp extends LitElement {
                 ) {
                     refreshRemoteComposeBundle();
                 }
+                // Re-emit the bundle-state snapshot if any refresh ran
+                // — same rationale as the `applyA11yUpdate` post above.
+                // Cheap to over-emit (the helper just walks a few DOM
+                // queries); the e2e test polls for a specific
+                // overlay-count threshold so noise is harmless.
+                if (matchesTarget && activeBundles.length > 0) {
+                    postBundleState();
+                }
             },
             applyFontPreviewBytes: (previewId, fontRowId, dataUri) => {
                 // Stash the response (null included — represents "host
@@ -3168,6 +3212,8 @@ export class PreviewApp extends LitElement {
             refreshBundleState: () => reflectBundleState(),
             promoteErrorsBundle: () =>
                 bundleController.handleExternalKindToggle("test/failure", true),
+            toggleBundle: (bundleId) =>
+                bundleController.toggleBundle(bundleId as BundleId),
         };
         window.addEventListener("message", (event) => {
             handleExtensionMessage(event.data, messageContext);

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -133,6 +133,16 @@ export interface PreviewMessageContext {
      */
     deactivateAllBundles(): void;
     /**
+     * Drive `BundleController.toggleBundle` from an extension-side
+     * trigger. Used by the e2e bundle-chain suite via
+     * `ComposePreviewTestApi.triggerWebviewBundleToggle`: posting
+     * `setDataExtensionEnabled` only subscribes the daemon and never
+     * activates the webview's chip, so the test needs a webview-bound
+     * entry point that drives the full chip-click code path
+     * (chip / tab / overlay paint + outbound subscribe).
+     */
+    toggleBundle(bundleId: string): void;
+    /**
      * Re-render the bundle chip bar / tab row from the controller's
      * current state. The chip bar filters which bundle chips paint
      * based on the early-features snapshot, so the host runs this
@@ -219,6 +229,9 @@ export function handleExtensionMessage(
                 msg.fontRowId,
                 msg.dataUri,
             );
+            return;
+        case "triggerBundleToggle":
+            ctx.toggleBundle(msg.bundleId);
             return;
         case "setModules":
             // Module selector removed from UI — module is resolved from the


### PR DESCRIPTION
Add the e2e suite called out in #1391 — the missing electron-driven
counterpart to the unit-level `chipTabOverlayChain.test.ts`. The unit
test wires a stub controller against synthetic DOM and asserts the
three surfaces (chip bar, data-tab handles, per-card box overlays)
stay in sync; the new suite runs the same contract against a real
daemon round-trip on `:samples:wear` so it also catches `firstUpdated`
ordering bugs, the daemon ↔ panel subscription path, and chip/tab/
overlay paint regressions.

The verification surface is a new `webviewBundleState` ack the panel
emits after every `reflectBundleState()` and from the data-update
paths after `refreshXxxBundle()` repaints overlays — counterpart to
`webviewA11yState` for the chip-surface side of the chain. The ack
carries `activeBundles`, `activeTab`, `tabHandleCount`, and a per-
bundle overlay-box count so the test asserts on the same shape the
unit test asserts at the DOM layer.

Driving the chip from a test needs a new entry point: the existing
`triggerSetDataExtensionEnabled` only subscribes the daemon and
never activates the webview's chip, so a new
`triggerWebviewBundleToggle(bundleId)` posts a `triggerBundleToggle`
message that the webview routes to `BundleController.toggleBundle`.
That exercises the full chip-click code path (chip activates →
`reflectBundleState` paints chip+tab+overlay → `setKindsEnabled`
cascades back through the extension to subscribe the daemon).

Picked the Accessibility bundle over the issue's History sketch
because History requires a baseline render archived in
`historyManager` before `history/diff/regions` resolves — out of
scope for this suite. A11y is graduated, both daemon registries are
already exercised by #1006, and every wear preview ships at least
one accessibility node so the first-visible-card subscription is
guaranteed to produce non-zero overlay boxes.

Gated on `COMPOSE_PREVIEW_E2E=1` next to the existing real-Gradle
suite; piggybacks on the wear daemon `e2eA11y.test.ts` already
warms when both run in the same Mocha process. The existing
`vscode-extension-e2e.yml` workflow auto-picks the new `e2e*.test.js`
file — no workflow change needed.

Closes #1391.