### PR TITLE
refactor(mcp): route McpCommand gradle invocation through GradlePreviewDriver

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -125,19 +125,18 @@ internal class McpCommand(args: List<String>) {
     val moduleFilter = args.flagValuesAll("--module").map { it.removePrefix(":") }.toSet()
 
     val injectArgs = autoInjectInitScriptArgs(args, projectRoot = projectDir)
-    val connection =
-      GradleConnection(
+    val driver =
+      GradlePreviewDriver(
         projectDir,
-        verbose = "--verbose" in args || "-v" in args,
-        extraArguments = injectArgs,
+        DriverOptions(verbose = "--verbose" in args || "-v" in args, extraArguments = injectArgs),
       )
     warnIfPluginNotPreApplied(
       args,
       projectRoot = projectDir,
       autoInjectActive = injectArgs.isNotEmpty(),
     )
-    connection.use { gc ->
-      val allModules = gc.findPreviewModules()
+    driver.use {
+      val allModules = driver.discoverModules()
       val modules =
         if (moduleFilter.isEmpty()) allModules
         else allModules.filter { it.gradlePath in moduleFilter }
@@ -152,9 +151,6 @@ internal class McpCommand(args: List<String>) {
 
       // Two batched runs: bootstrap every descriptor, then re-run discovery so previews.json sits
       // alongside. Single Gradle invocation per phase keeps configuration cache hits warm.
-      val daemonTasks = modules.map { ":${it.gradlePath}:composePreviewDaemonStart" }
-      val discoverTasks = modules.map { ":${it.gradlePath}:composePreviewDiscover" }
-
       System.err.println(
         "==> bootstrapping daemon descriptors for ${modules.size} module(s): " +
           modules.joinToString(", ") { ":${it.gradlePath}" }
@@ -162,7 +158,15 @@ internal class McpCommand(args: List<String>) {
       // No `-P` propagation here: DaemonExtension's `enabled` property is intentionally not wired
       // to a Gradle property (see DaemonExtension.kt KDoc). We populate the descriptor by running
       // the task and then patch the JSON ourselves below — same as the smoke script does.
-      val daemonOk = gc.runTasks(*daemonTasks.toTypedArray())
+      val daemonOk =
+        driver
+          .render(
+            RenderRequest(
+              modules = modules,
+              taskFor = { ":${it.gradlePath}:composePreviewDaemonStart" },
+            )
+          )
+          .buildOk
       if (!daemonOk) {
         System.err.println("composePreviewDaemonStart failed; aborting.")
         exitProcess(1)
@@ -187,7 +191,15 @@ internal class McpCommand(args: List<String>) {
       }
 
       System.err.println("==> running composePreviewDiscover so previews.json is up to date")
-      val discoverOk = gc.runTasks(*discoverTasks.toTypedArray())
+      val discoverOk =
+        driver
+          .render(
+            RenderRequest(
+              modules = modules,
+              taskFor = { ":${it.gradlePath}:composePreviewDiscover" },
+            )
+          )
+          .buildOk
       if (!discoverOk) {
         System.err.println("composePreviewDiscover failed; descriptors are still in place.")
         exitProcess(1)
@@ -354,14 +366,15 @@ internal class McpCommand(args: List<String>) {
     val moduleFilter = args.flagValuesAll("--module").map { it.removePrefix(":") }.toSet()
 
     val injectArgs = autoInjectInitScriptArgs(args, projectRoot = projectDir)
-    val connection = GradleConnection(projectDir, verbose = false, extraArguments = injectArgs)
+    val driver =
+      GradlePreviewDriver(projectDir, DriverOptions(verbose = false, extraArguments = injectArgs))
     warnIfPluginNotPreApplied(
       args,
       projectRoot = projectDir,
       autoInjectActive = injectArgs.isNotEmpty(),
     )
-    connection.use { gc ->
-      val allModules = gc.findPreviewModules()
+    driver.use {
+      val allModules = driver.discoverModules()
       val modules =
         if (moduleFilter.isEmpty()) allModules
         else allModules.filter { it.gradlePath in moduleFilter }

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -18,6 +18,10 @@
 // the `compose-preview-mcp-*.tar.gz` GitHub Release artifact (see release.yml) — the Maven
 // jar is the library face of the same code.
 
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.TaskAction
+
 plugins {
   id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
@@ -80,3 +84,35 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2025")
 }
+
+// Boundary check: `:mcp` must NOT pull `gradle-tooling-api` (directly or transitively). Cold-shell
+// gradle invocation for the MCP install / doctor flow lives in `:cli`'s `McpCommand` and routes
+// through `:gradle-preview-driver`; the daemon-driven path in `:mcp` itself never talks to Gradle.
+// Without this guard, a future change adding `:gradle-preview-driver` to `:mcp` would silently
+// drag tooling-api onto the MCP server's runtime — exactly the duplication issue #1394 closed.
+abstract class CheckMcpToolingApiBoundary : DefaultTask() {
+  @get:org.gradle.api.tasks.Classpath abstract val runtimeClasspath: ConfigurableFileCollection
+
+  @TaskAction
+  fun check() {
+    val forbidden =
+      runtimeClasspath.files
+        .map { it.name }
+        .filter { it.startsWith("gradle-tooling-api") && it.endsWith(".jar") }
+        .sorted()
+    check(forbidden.isEmpty()) {
+      ":mcp must not depend on gradle-tooling-api; route cold-shell gradle work through " +
+        ":gradle-preview-driver from :cli instead. Found on runtimeClasspath: " +
+        forbidden.joinToString(", ")
+    }
+  }
+}
+
+val checkMcpToolingApiBoundary =
+  tasks.register<CheckMcpToolingApiBoundary>("checkMcpToolingApiBoundary") {
+    description = "Fails if gradle-tooling-api leaks onto :mcp's runtime classpath."
+    group = "verification"
+    runtimeClasspath.from(configurations.named("runtimeClasspath"))
+  }
+
+tasks.named("check") { dependsOn(checkMcpToolingApiBoundary) }


### PR DESCRIPTION
`compose-preview mcp install` / `doctor` were using `:gradle-preview-driver`'s
lower-level `GradleConnection` directly instead of going through the published
`GradlePreviewDriver` library entry point. Switch both to the driver so the
MCP-side gradle path matches the CLI / contrib path — single source of truth
for module discovery and task invocation.

Adds a `:mcp:check` boundary task that fails if `gradle-tooling-api` ever
leaks onto `:mcp`'s runtime classpath. The daemon-driven MCP server itself
must never talk to Gradle directly; cold-shell gradle work belongs in `:cli`
routed through `:gradle-preview-driver`.

Closes #1394.