### PR TITLE
feat(vscode-extension): add launcher-widget cell-grid picker module

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -3364,3 +3364,70 @@ preview-app[data-bundle-mode="true"] bundle-chip-bar {
     color: var(--vscode-descriptionForeground);
     font-variant-numeric: tabular-nums;
 }
+
+/* Launcher-widget cell-size picker — popover anchored to its toggle button.
+   The picker contents are stamped by `./launcherWidgetPicker.ts` into the
+   `<table class="launcher-widget-picker">` it returns; the parent
+   `.launcher-widget-picker-popover` is the host container that handles
+   positioning + the dialog chrome. */
+.launcher-widget-picker-popover {
+    position: absolute;
+    z-index: 20;
+    margin-top: 4px;
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    background: var(--vscode-editorWidget-background, var(--card-bg));
+    border: 1px solid var(--card-border);
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+.launcher-widget-picker-popover[hidden] {
+    display: none;
+}
+.launcher-widget-picker {
+    border-collapse: separate;
+    border-spacing: 2px;
+}
+.launcher-widget-picker-cell {
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    background: var(--vscode-editor-background);
+    border: 1px solid var(--card-border);
+    border-radius: 2px;
+    cursor: pointer;
+    color: inherit;
+}
+.launcher-widget-picker-cell:hover:not(.disabled) {
+    background: var(
+        --vscode-button-secondaryHoverBackground,
+        color-mix(in srgb, var(--vscode-button-background) 60%, transparent)
+    );
+}
+.launcher-widget-picker-cell.in-current {
+    background: var(--vscode-button-background);
+    border-color: var(--vscode-button-background);
+}
+.launcher-widget-picker-cell.disabled {
+    background: var(--vscode-editor-background);
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+.launcher-widget-picker-reset {
+    align-self: stretch;
+    padding: 4px 8px;
+    background: transparent;
+    border: 1px solid var(--card-border);
+    border-radius: 2px;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+}
+.launcher-widget-picker-reset:hover {
+    background: var(
+        --vscode-button-secondaryHoverBackground,
+        color-mix(in srgb, var(--vscode-button-background) 60%, transparent)
+    );
+}

--- a/vscode-extension/src/test/launcherWidgetPicker.test.ts
+++ b/vscode-extension/src/test/launcherWidgetPicker.test.ts
@@ -1,0 +1,229 @@
+// Launcher-widget picker — pure-logic + DOM-helper coverage.
+//
+// Asserts the picker's cell-clickability gating tracks the constraint
+// payload populated by the three discovery layers (annotation bounds, Glance
+// `previewSizeMode`, AppWidget XML auto-discovery) uniformly. The picker is
+// payload-shape-driven, so a single test set covers all three sources.
+
+import * as assert from "assert";
+import type {
+    LauncherWidgetPayload,
+    LauncherWidgetSize,
+} from "../daemon/daemonProtocol";
+import {
+    DEFAULT_PICKER_MAX,
+    buildLauncherWidgetPickerCells,
+    renderLauncherWidgetPicker,
+} from "../webview/preview/launcherWidgetPicker";
+
+function payload(
+    overrides: Partial<LauncherWidgetPayload> = {},
+): LauncherWidgetPayload {
+    return {
+        cells: { width: 4, height: 2 },
+        cellSizeDp: 72,
+        cellSpacingDp: 8,
+        widthDp: 312,
+        heightDp: 152,
+        ...overrides,
+    };
+}
+
+function cells(width: number, height: number): LauncherWidgetSize {
+    return { width, height };
+}
+
+describe("launcherWidgetPicker — buildLauncherWidgetPickerCells", () => {
+    it("falls back to a default rectangle when payload is null", () => {
+        const grid = buildLauncherWidgetPickerCells(null, cells(1, 1));
+        assert.strictEqual(grid.length, DEFAULT_PICKER_MAX);
+        assert.strictEqual(grid[0].length, DEFAULT_PICKER_MAX);
+        // Every cell is clickable, no constraint to gate.
+        assert.ok(grid.flat().every((c) => c.clickable));
+    });
+
+    it("marks cells inside the current rectangle as inCurrent", () => {
+        const grid = buildLauncherWidgetPickerCells(null, cells(3, 2));
+        // (1..3) × (1..2) — 6 cells flagged.
+        const inCurrentCount = grid.flat().filter((c) => c.inCurrent).length;
+        assert.strictEqual(inCurrentCount, 6);
+        // Edge case: (4, 1) is outside the current rectangle.
+        assert.strictEqual(grid[0][3].inCurrent, false);
+    });
+
+    it("respects supportedCells as a sparse set (Glance Responsive)", () => {
+        // Glance widget declares two responsive sizes.
+        const supported = [cells(2, 1), cells(4, 2)];
+        const grid = buildLauncherWidgetPickerCells(
+            payload({ supportedCells: supported, resizeAxes: "both" }),
+            cells(2, 1),
+        );
+        // Grid extends to the largest supported cell (4×2).
+        assert.strictEqual(grid.length, 2);
+        assert.strictEqual(grid[0].length, 4);
+        // Only the two declared cells are clickable.
+        const clickable = grid.flat().filter((c) => c.clickable);
+        assert.strictEqual(clickable.length, 2);
+        assert.ok(clickable.some((c) => c.width === 2 && c.height === 1));
+        assert.ok(clickable.some((c) => c.width === 4 && c.height === 2));
+    });
+
+    it("respects supportedCells as a dense rectangle (AppWidget XML)", () => {
+        // AppWidget XML declares min 1×1 → max 3×2 — every cell in the
+        // rectangle is clickable.
+        const supported: LauncherWidgetSize[] = [];
+        for (let w = 1; w <= 3; w++)
+            for (let h = 1; h <= 2; h++) supported.push(cells(w, h));
+        const grid = buildLauncherWidgetPickerCells(
+            payload({ supportedCells: supported, resizeAxes: "both" }),
+            cells(2, 1),
+        );
+        assert.strictEqual(grid.length, 2);
+        assert.strictEqual(grid[0].length, 3);
+        assert.strictEqual(grid.flat().filter((c) => c.clickable).length, 6);
+    });
+
+    it("resizeAxes = none locks every cell except the current one", () => {
+        // Glance `SizeMode.Single` translates to `supportedCells = [single]`,
+        // `resizeAxes = "none"`. The picker is read-only.
+        const grid = buildLauncherWidgetPickerCells(
+            payload({
+                supportedCells: [cells(3, 2)],
+                resizeAxes: "none",
+            }),
+            cells(3, 2),
+        );
+        const clickable = grid.flat().filter((c) => c.clickable);
+        assert.strictEqual(clickable.length, 1);
+        assert.strictEqual(clickable[0].width, 3);
+        assert.strictEqual(clickable[0].height, 2);
+    });
+
+    it("resizeAxes = horizontal locks the height axis at current", () => {
+        const grid = buildLauncherWidgetPickerCells(
+            payload({ supportedCells: null, resizeAxes: "horizontal" }),
+            cells(2, 3),
+        );
+        // Only cells on row h=3 are clickable.
+        const clickable = grid.flat().filter((c) => c.clickable);
+        assert.ok(clickable.length > 0);
+        assert.ok(clickable.every((c) => c.height === 3));
+    });
+
+    it("resizeAxes = vertical locks the width axis at current", () => {
+        const grid = buildLauncherWidgetPickerCells(
+            payload({ supportedCells: null, resizeAxes: "vertical" }),
+            cells(2, 3),
+        );
+        const clickable = grid.flat().filter((c) => c.clickable);
+        assert.ok(clickable.length > 0);
+        assert.ok(clickable.every((c) => c.width === 2));
+    });
+
+    it("grid extends to cover the current cell even past supported max", () => {
+        // Edge case: payload constraint is 1..2, but the override the daemon
+        // already applied is (3, 3) — pre-flight clamp may not have run, or
+        // the widget's metadata changed since last render. Grid should still
+        // include (3, 3) so the inCurrent highlight is whole.
+        const grid = buildLauncherWidgetPickerCells(
+            payload({
+                supportedCells: [cells(1, 1), cells(2, 2)],
+                resizeAxes: "both",
+            }),
+            cells(3, 3),
+        );
+        assert.strictEqual(grid.length, 3);
+        assert.strictEqual(grid[0].length, 3);
+    });
+});
+
+describe("launcherWidgetPicker — renderLauncherWidgetPicker DOM helper", () => {
+    // happy-dom is set up globally via `.mocharc.json`'s `file: setup-dom.ts`,
+    // so `document` / `HTMLElement` are already on globalThis. No per-suite
+    // fixture needed — same shape `a11yBundlePresenter.test.ts` and friends
+    // use.
+
+    it("renders a row per cell-height and a button per cell-width", () => {
+        const table = renderLauncherWidgetPicker(
+            payload({ supportedCells: null, resizeAxes: "both" }),
+            cells(2, 1),
+            () => {},
+        );
+        const rows = table.querySelectorAll("tr");
+        assert.strictEqual(rows.length, DEFAULT_PICKER_MAX);
+        const cellsInFirstRow = rows[0].querySelectorAll(
+            ".launcher-widget-picker-cell",
+        );
+        assert.strictEqual(cellsInFirstRow.length, DEFAULT_PICKER_MAX);
+    });
+
+    it("disables non-clickable cells with .disabled and disabled=true", () => {
+        const supported = [cells(2, 1), cells(4, 2)];
+        const table = renderLauncherWidgetPicker(
+            payload({ supportedCells: supported, resizeAxes: "both" }),
+            cells(2, 1),
+            () => {},
+        );
+        const disabled = table.querySelectorAll<HTMLButtonElement>(
+            ".launcher-widget-picker-cell.disabled",
+        );
+        // Grid is 2×4 = 8 cells, supported has 2, so 6 disabled.
+        assert.strictEqual(disabled.length, 6);
+        for (const btn of Array.from(disabled)) {
+            assert.strictEqual(btn.disabled, true);
+        }
+    });
+
+    it("click on clickable cell fires onSelect with the picked size", () => {
+        let picked: LauncherWidgetSize | null = null;
+        const table = renderLauncherWidgetPicker(
+            payload({ supportedCells: null, resizeAxes: "both" }),
+            cells(1, 1),
+            (c) => {
+                picked = c;
+            },
+        );
+        const btn = table.querySelector<HTMLButtonElement>(
+            '.launcher-widget-picker-cell[data-width="3"][data-height="2"]',
+        );
+        assert.ok(btn);
+        btn?.click();
+        assert.deepStrictEqual(picked, { width: 3, height: 2 });
+    });
+
+    it("click on disabled cell does not fire onSelect", () => {
+        let calls = 0;
+        // Grid extends to 4×4 (max of supportedCells), but only (1,1) and
+        // (4,4) are clickable — (3,3) is disabled.
+        const table = renderLauncherWidgetPicker(
+            payload({
+                supportedCells: [cells(1, 1), cells(4, 4)],
+                resizeAxes: "both",
+            }),
+            cells(1, 1),
+            () => {
+                calls += 1;
+            },
+        );
+        const btn = table.querySelector<HTMLButtonElement>(
+            '.launcher-widget-picker-cell[data-width="3"][data-height="3"]',
+        );
+        assert.ok(btn);
+        // Button is `disabled=true` — click event fires no handler.
+        btn?.click();
+        assert.strictEqual(calls, 0);
+    });
+
+    it("inCurrent cells get the .in-current class", () => {
+        const table = renderLauncherWidgetPicker(
+            payload({ supportedCells: null, resizeAxes: "both" }),
+            cells(2, 2),
+            () => {},
+        );
+        const inCurrent = table.querySelectorAll(
+            ".launcher-widget-picker-cell.in-current",
+        );
+        // (1..2) × (1..2) = 4 cells in the current rectangle.
+        assert.strictEqual(inCurrent.length, 4);
+    });
+});

--- a/vscode-extension/src/test/liveState.test.ts
+++ b/vscode-extension/src/test/liveState.test.ts
@@ -1,0 +1,101 @@
+// LiveStateController — launcher-widget override coverage.
+//
+// Pins the picker → wire-payload contract: writing a `LauncherWidgetSize`
+// via `setLauncherWidgetCellsForCard` surfaces as
+// `overrides.launcherWidget = { cells }` on the next `overridesForPreview`,
+// and clearing the override (passing `null`) removes that branch. Also
+// asserts the override is stored per-preview, not globally — a write
+// against one card leaves another card's payload undefined.
+
+import * as assert from "assert";
+import type { LauncherWidgetSize } from "../daemon/daemonProtocol";
+import { LiveStateController } from "../webview/preview/liveState";
+
+function makeCard(previewId: string): HTMLElement {
+    const el = document.createElement("div");
+    el.className = "preview-card";
+    el.dataset.previewId = previewId;
+    return el;
+}
+
+function makeController(): LiveStateController {
+    const recordingFormat = document.createElement("select");
+    return new LiveStateController({
+        vscode: {
+            postMessage: () => {},
+            getState: () => undefined,
+            setState: () => {},
+        },
+        recordingFormat,
+        interactiveInputConfig: {
+            vscode: {
+                postMessage: () => {},
+                getState: () => undefined,
+                setState: () => {},
+            },
+            isLive: () => false,
+        },
+        earlyFeatures: () => true,
+        inFocus: () => false,
+        focusedCard: () => null,
+        applyInteractiveButtonState: () => {},
+        applyRecordingButtonState: () => {},
+        renderInspector: () => {},
+    });
+}
+
+describe("LiveStateController — launcher-widget override", () => {
+    it("returns undefined overrides when no toggles have been written", () => {
+        const live = makeController();
+        assert.strictEqual(live.overridesForPreview("preview:A"), undefined);
+        assert.strictEqual(
+            live.launcherWidgetCellsForPreview("preview:A"),
+            null,
+        );
+    });
+
+    it("setLauncherWidgetCellsForCard surfaces in overridesForPreview", () => {
+        const live = makeController();
+        const card = makeCard("preview:A");
+        const cells: LauncherWidgetSize = { width: 4, height: 2 };
+        live.setLauncherWidgetCellsForCard(card, cells);
+        assert.deepStrictEqual(
+            live.launcherWidgetCellsForPreview("preview:A"),
+            cells,
+        );
+        assert.deepStrictEqual(live.overridesForPreview("preview:A"), {
+            launcherWidget: { cells: { width: 4, height: 2 } },
+        });
+    });
+
+    it("clears the override when called with null", () => {
+        const live = makeController();
+        const card = makeCard("preview:A");
+        live.setLauncherWidgetCellsForCard(card, { width: 3, height: 3 });
+        live.setLauncherWidgetCellsForCard(card, null);
+        assert.strictEqual(
+            live.launcherWidgetCellsForPreview("preview:A"),
+            null,
+        );
+        assert.strictEqual(live.overridesForPreview("preview:A"), undefined);
+    });
+
+    it("scopes the override per-preview", () => {
+        const live = makeController();
+        live.setLauncherWidgetCellsForCard(makeCard("preview:A"), {
+            width: 5,
+            height: 1,
+        });
+        assert.deepStrictEqual(live.overridesForPreview("preview:A"), {
+            launcherWidget: { cells: { width: 5, height: 1 } },
+        });
+        assert.strictEqual(live.overridesForPreview("preview:B"), undefined);
+    });
+
+    it("is a no-op when card has no previewId", () => {
+        const live = makeController();
+        const card = document.createElement("div");
+        live.setLauncherWidgetCellsForCard(card, { width: 2, height: 2 });
+        assert.strictEqual(live.overridesForPreview(""), undefined);
+    });
+});

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -219,6 +219,14 @@ export class FocusController {
             advertised: live.isControlsAdvertised(),
             enabled: previewId !== null && live.isControlsEnabled(previewId),
         });
+        this.config.focusToolbar.applyLauncherWidgetButtonState({
+            inFocus,
+            focusedPreviewId: previewId,
+            advertised: live.isLauncherWidgetAdvertised(),
+            enabled:
+                previewId !== null &&
+                live.launcherWidgetCellsForPreview(previewId) !== null,
+        });
     }
 
     /**

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -33,6 +33,7 @@ export interface FocusToolbarElements {
     btnTouchOverlay: HTMLButtonElement;
     btnKeyboardBand: HTMLButtonElement;
     btnControls: HTMLButtonElement;
+    btnLauncherWidget: HTMLButtonElement;
     btnExportBundle: HTMLButtonElement;
     btnExitFocus: HTMLButtonElement;
     recordingFormat: HTMLSelectElement;
@@ -139,6 +140,7 @@ export class FocusToolbarController {
             this.el.btnTouchOverlay.hidden = true;
             this.el.btnKeyboardBand.hidden = true;
             this.el.btnControls.hidden = true;
+            this.el.btnLauncherWidget.hidden = true;
         }
         if (!s.earlyFeatures) {
             this.el.focusInspector.hidden = true;
@@ -291,6 +293,34 @@ export class FocusToolbarController {
         this.el.btnKeyboardBand.setAttribute(
             "aria-label",
             this.el.btnKeyboardBand.title,
+        );
+    }
+
+    /**
+     * Launcher-widget container-size picker toggle. `enabled` means the focused
+     * preview currently carries a `LauncherWidgetOverride` (picker has been
+     * used at least once for this card); the button paints its pressed state
+     * to flag the non-default sizing. Clicking opens / closes the popover —
+     * that wiring (and the `aria-expanded` flip) lives in `main.ts`.
+     */
+    applyLauncherWidgetButtonState(s: FocusedToggleButtonState): void {
+        const visible =
+            s.inFocus && s.advertised && s.focusedPreviewId !== null;
+        this.el.btnLauncherWidget.hidden = !visible;
+        if (!visible) {
+            this.el.btnLauncherWidget.setAttribute("aria-pressed", "false");
+            return;
+        }
+        this.el.btnLauncherWidget.setAttribute(
+            "aria-pressed",
+            s.enabled ? "true" : "false",
+        );
+        this.el.btnLauncherWidget.title = s.enabled
+            ? "Launcher-widget cell size — click to change or reset"
+            : "Pick launcher-widget cell size";
+        this.el.btnLauncherWidget.setAttribute(
+            "aria-label",
+            this.el.btnLauncherWidget.title,
         );
     }
 

--- a/vscode-extension/src/webview/preview/launcherWidgetPicker.ts
+++ b/vscode-extension/src/webview/preview/launcherWidgetPicker.ts
@@ -1,0 +1,204 @@
+// Launcher-widget cell-grid picker.
+//
+// Pure logic + DOM helper for a `5×5`-style picker that lets the user choose a
+// `LauncherWidgetOverride.cells` value for the focused preview. Reads the
+// `LauncherWidgetPayload` (`supportedCells`, `resizeAxes`, current `cells`)
+// surfaced by the `compose/launcher-widget` data product to gate which cells
+// are clickable and which are read-only.
+//
+// Source of constraints, in payload-population order (later overrides earlier):
+//   1. Annotation bounds via `@LauncherWidgetPreview(minCells, maxCells)`.
+//   2. Glance `previewSizeMode = SizeMode.Single | Responsive | Exact`
+//      (`:glance-preview-runtime`).
+//   3. `<appwidget-provider>` XML auto-discovery from
+//      `AppWidgetManager.installedProviders` (`:appwidget-preview-runtime`).
+//
+// The picker is source-agnostic — it consumes `LauncherWidgetPayload` fields
+// uniformly regardless of which layer populated them.
+//
+// Module split:
+//   * `buildLauncherWidgetPickerCells(...)` — pure function returning a
+//     `PickerCell[][]` grid the renderer can stamp into the DOM. Testable
+//     without a DOM environment.
+//   * `renderLauncherWidgetPicker(...)` — DOM helper that wires the cells
+//     into a `<table>` with click handlers. The toolbar consumer (a future
+//     `focusToolbar.ts` integration) drops this into a popover.
+
+import type {
+    LauncherResizeAxes,
+    LauncherWidgetPayload,
+    LauncherWidgetSize,
+} from "../../daemon/daemonProtocol";
+
+/**
+ * One cell in the rendered picker grid.
+ *
+ * `clickable` is the read+act gate: cells that fall outside the widget's
+ * declared constraints (`!supportedCells.contains((w, h))`) or on a locked
+ * axis (`resizeAxes = "horizontal"` with height differing from current) are
+ * `clickable: false` and styled as disabled.
+ *
+ * `inCurrent` highlights the rectangle from `(1, 1)` to the current `cells`
+ * — visually emphasises what the widget is laid out as right now, so a click
+ * to expand reads as a drag-to-resize gesture.
+ */
+export interface PickerCell {
+    width: number;
+    height: number;
+    clickable: boolean;
+    inCurrent: boolean;
+}
+
+/** Default upper bound when the payload doesn't surface one. */
+export const DEFAULT_PICKER_MAX = 5;
+
+/**
+ * Build the 2-D picker grid for [payload] with the given [currentCells] as
+ * the highlight target. Returns a `rows × cols` array where each cell has
+ * `clickable` set per the payload's resize-axis lock + `supportedCells`
+ * membership test, and `inCurrent` set for cells inside the current
+ * rectangle (top-left to current).
+ *
+ * Grid bounds: when `payload.supportedCells` is non-null and non-empty, the
+ * grid extends to `max(cell.width)` × `max(cell.height)` across the supported
+ * set. Otherwise falls back to [DEFAULT_PICKER_MAX]. The grid always extends
+ * to at least the current cell so the "inCurrent" highlight is fully drawn.
+ */
+export function buildLauncherWidgetPickerCells(
+    payload: LauncherWidgetPayload | null,
+    currentCells: LauncherWidgetSize,
+): PickerCell[][] {
+    const supported = payload?.supportedCells ?? undefined;
+    const resizeAxes: LauncherResizeAxes = payload?.resizeAxes ?? "both";
+
+    // Pick grid dimensions. Prefer the supported-cells extent; fall back to
+    // the default; always cover the current cell so the highlight is whole.
+    const supportedMaxW =
+        supported && supported.length > 0
+            ? Math.max(...supported.map((c) => c.width))
+            : DEFAULT_PICKER_MAX;
+    const supportedMaxH =
+        supported && supported.length > 0
+            ? Math.max(...supported.map((c) => c.height))
+            : DEFAULT_PICKER_MAX;
+    const maxW = Math.max(supportedMaxW, currentCells.width, 1);
+    const maxH = Math.max(supportedMaxH, currentCells.height, 1);
+
+    // Fast lookup: which (w, h) pairs are in the supported set?
+    const supportedKey = (w: number, h: number): string => `${w}x${h}`;
+    const supportedSet =
+        supported !== undefined
+            ? new Set(supported.map((c) => supportedKey(c.width, c.height)))
+            : null;
+
+    const rows: PickerCell[][] = [];
+    for (let h = 1; h <= maxH; h++) {
+        const row: PickerCell[] = [];
+        for (let w = 1; w <= maxW; w++) {
+            row.push({
+                width: w,
+                height: h,
+                clickable: isClickable(
+                    w,
+                    h,
+                    currentCells,
+                    resizeAxes,
+                    supportedSet,
+                ),
+                inCurrent: w <= currentCells.width && h <= currentCells.height,
+            });
+        }
+        rows.push(row);
+    }
+    return rows;
+}
+
+function isClickable(
+    w: number,
+    h: number,
+    current: LauncherWidgetSize,
+    resizeAxes: LauncherResizeAxes,
+    supportedSet: Set<string> | null,
+): boolean {
+    // `none` — widget declared "no resize", the picker is read-only and only
+    // the current cell is "clickable" in the sense that re-selecting it is
+    // a no-op but visually it stays the active one.
+    if (resizeAxes === "none") {
+        return w === current.width && h === current.height;
+    }
+    // Axis-locked modes — only the unlocked axis can move.
+    if (resizeAxes === "horizontal" && h !== current.height) return false;
+    if (resizeAxes === "vertical" && w !== current.width) return false;
+    // Supported-set membership: if a set is declared, the cell must be in
+    // it. Otherwise (null set) any cell in the grid is clickable.
+    if (supportedSet !== null) {
+        return supportedSet.has(`${w}x${h}`);
+    }
+    return true;
+}
+
+/**
+ * DOM helper that renders the picker grid as a `<table>` and wires click
+ * handlers. Returns the root `<table>` element — caller drops it into a
+ * popover / dialog / inline container.
+ *
+ * Click handler fires [onSelect] with the picked `(w, h)` when the user
+ * clicks a clickable cell; non-clickable cells receive no event handler so
+ * VoiceOver / Talkback skip past them. Each row is a `<tr>`, each cell a
+ * `<button>` inside a `<td>` (button so keyboard `Enter` / `Space` works).
+ *
+ * CSS classes the caller should style:
+ *   * `.launcher-widget-picker` — root table
+ *   * `.launcher-widget-picker-cell` — every cell button
+ *   * `.launcher-widget-picker-cell.in-current` — cells inside the active rectangle
+ *   * `.launcher-widget-picker-cell.disabled` — non-clickable cells (axis lock /
+ *     unsupported size)
+ */
+export function renderLauncherWidgetPicker(
+    payload: LauncherWidgetPayload | null,
+    currentCells: LauncherWidgetSize,
+    onSelect: (cells: LauncherWidgetSize) => void,
+): HTMLTableElement {
+    const grid = buildLauncherWidgetPickerCells(payload, currentCells);
+    const table = document.createElement("table");
+    table.className = "launcher-widget-picker";
+    table.setAttribute("role", "grid");
+    table.setAttribute(
+        "aria-label",
+        `Launcher widget cell picker — current size ${currentCells.width}×${currentCells.height}`,
+    );
+    for (const row of grid) {
+        const tr = document.createElement("tr");
+        tr.setAttribute("role", "row");
+        for (const cell of row) {
+            const td = document.createElement("td");
+            td.setAttribute("role", "gridcell");
+            const btn = document.createElement("button");
+            btn.type = "button";
+            btn.className = "launcher-widget-picker-cell";
+            btn.dataset.width = String(cell.width);
+            btn.dataset.height = String(cell.height);
+            btn.setAttribute(
+                "aria-label",
+                `${cell.width}×${cell.height} cells`,
+            );
+            if (cell.inCurrent) {
+                btn.classList.add("in-current");
+            }
+            if (cell.clickable) {
+                btn.addEventListener("click", (evt) => {
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    onSelect({ width: cell.width, height: cell.height });
+                });
+            } else {
+                btn.classList.add("disabled");
+                btn.disabled = true;
+            }
+            td.appendChild(btn);
+            tr.appendChild(td);
+        }
+        table.appendChild(tr);
+    }
+    return table;
+}

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -40,7 +40,10 @@
 // triggered after the extension or daemon has already torn the streams down,
 // and re-posting would race the flush.
 
-import type { PreviewOverrides } from "../../daemon/daemonProtocol";
+import type {
+    LauncherWidgetSize,
+    PreviewOverrides,
+} from "../../daemon/daemonProtocol";
 import { liveToggleCommand } from "../../daemon/liveCommand";
 import { planFollowFocusTeardown } from "./followFocus";
 import { attachInteractiveInputHandlers } from "./interactiveInput";
@@ -71,6 +74,15 @@ const TOUCH_OVERLAY_EXTENSION_ID = "touch-overlay";
  * [TOUCH_OVERLAY_EXTENSION_ID].
  */
 const KEYBOARD_BAND_EXTENSION_ID = "compose/keyboard";
+
+/**
+ * `DataExtensionDescriptor.id` of the launcher-widget container-size extension
+ * (`LauncherWidgetExtension.ID` on the Kotlin side — see
+ * `:data-launcher-widget-connector`). Pinned here so the value stays in lockstep
+ * with the daemon constant; a value drift would silently hide the picker
+ * button forever. Same gating story as [TOUCH_OVERLAY_EXTENSION_ID].
+ */
+const LAUNCHER_WIDGET_EXTENSION_ID = "compose/launcher-widget";
 
 export interface LiveStateConfig {
     vscode: VsCodeApi<unknown>;
@@ -129,6 +141,15 @@ export class LiveStateController {
     // stops live, and starts again gets the same overlay back.
     private touchOverlayEnabledPreviewIds: Set<string> = new Set<string>();
     private keyboardBandForcedPreviewIds: Set<string> = new Set<string>();
+    // Per-preview launcher-widget cell-size override. Read by `overridesForPreview`
+    // when building the `requestStreamStart` payload so the daemon's session
+    // installs a `LauncherWidgetExtension` planning to the chosen cells. The
+    // picker popover writes via `setLauncherWidgetCellsForCard`; clearing the
+    // entry (null) drops the override on the next live restart. Sticky across
+    // live mode tear-down — same shape as the touch-overlay / keyboard-band
+    // toggles above.
+    private launcherWidgetCellsByPreviewId: Map<string, LauncherWidgetSize> =
+        new Map<string, LauncherWidgetSize>();
 
     // Per-module availability — written from `setInteractiveAvailability`
     // via `setAvailability`, read by the focus toolbar predicates through
@@ -418,6 +439,46 @@ export class LiveStateController {
         this.applyControlsToggleButtons();
     }
 
+    /** Daemon advertises the launcher-widget container-size extension on any known module. */
+    isLauncherWidgetAdvertised(): boolean {
+        return this.anyModuleAdvertisesExtension(LAUNCHER_WIDGET_EXTENSION_ID);
+    }
+
+    /**
+     * Current per-preview launcher-widget cell-size override, or `null` when
+     * no override is set. Read by the focus toolbar's button-state hook to
+     * decide whether the picker button shows its "modified" pressed state,
+     * and by the picker popover to highlight the active rectangle.
+     */
+    launcherWidgetCellsForPreview(
+        previewId: string,
+    ): LauncherWidgetSize | null {
+        return this.launcherWidgetCellsByPreviewId.get(previewId) ?? null;
+    }
+
+    /**
+     * Picker-popover entry point — store the chosen [cells] (or clear, when
+     * passed `null`) and restart the live stream so the daemon picks up
+     * `overrides.launcherWidget = { cells }` for the new session. Sticky when
+     * not live: the choice is remembered for the next `requestStreamStart`.
+     */
+    setLauncherWidgetCellsForCard(
+        card: HTMLElement,
+        cells: LauncherWidgetSize | null,
+    ): void {
+        const previewId = card.dataset.previewId;
+        if (!previewId) return;
+        const was = this.launcherWidgetCellsByPreviewId.get(previewId) ?? null;
+        if (sameCells(was, cells)) return;
+        if (cells === null) {
+            this.launcherWidgetCellsByPreviewId.delete(previewId);
+        } else {
+            this.launcherWidgetCellsByPreviewId.set(previewId, cells);
+        }
+        this.restartLiveIfActive(previewId);
+        this.applyControlsToggleButtons();
+    }
+
     /** Symmetric to {@link toggleTouchOverlayForCard} for the soft-keyboard band. */
     toggleKeyboardBandForCard(card: HTMLElement, enabled: boolean): void {
         const previewId = card.dataset.previewId;
@@ -438,10 +499,13 @@ export class LiveStateController {
     overridesForPreview(previewId: string): PreviewOverrides | undefined {
         const touch = this.touchOverlayEnabledPreviewIds.has(previewId);
         const keyboardOn = this.keyboardBandForcedPreviewIds.has(previewId);
-        if (!touch && !keyboardOn) return undefined;
+        const launcherCells =
+            this.launcherWidgetCellsByPreviewId.get(previewId);
+        if (!touch && !keyboardOn && !launcherCells) return undefined;
         const overrides: PreviewOverrides = {};
         if (touch) overrides.touchOverlay = true;
         if (keyboardOn) overrides.keyboard = { visible: true };
+        if (launcherCells) overrides.launcherWidget = { cells: launcherCells };
         return overrides;
     }
 
@@ -776,4 +840,14 @@ export class LiveStateController {
         ensureLiveCardControls(card, (c) => this.stopInteractiveForCard(c));
         attachInteractiveInputHandlers(card, this.cfg.interactiveInputConfig);
     }
+}
+
+/** Structural equality for the LauncherWidgetSize compare in setLauncherWidgetCellsForCard. */
+function sameCells(
+    a: LauncherWidgetSize | null,
+    b: LauncherWidgetSize | null,
+): boolean {
+    if (a === b) return true;
+    if (a === null || b === null) return false;
+    return a.width === b.width && a.height === b.height;
 }

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -156,6 +156,7 @@ import {
     isFocusedModuleReady,
 } from "./focusToolbar";
 import { FrameCarouselController } from "./frameCarousel";
+import { renderLauncherWidgetPicker } from "./launcherWidgetPicker";
 import { LiveStateController } from "./liveState";
 import { LoadingOverlay } from "./loadingOverlay";
 import {
@@ -242,6 +243,10 @@ export class PreviewApp extends LitElement {
     @query("#btn-touch-overlay") private _btnTouchOverlay!: HTMLButtonElement;
     @query("#btn-keyboard-band") private _btnKeyboardBand!: HTMLButtonElement;
     @query("#btn-controls") private _btnControls!: HTMLButtonElement;
+    @query("#btn-launcher-widget")
+    private _btnLauncherWidget!: HTMLButtonElement;
+    @query("#launcher-widget-picker-popover")
+    private _launcherWidgetPickerPopover!: HTMLElement;
     @query("#btn-export-bundle") private _btnExportBundle!: HTMLButtonElement;
     @query("#btn-exit-focus") private _btnExitFocus!: HTMLButtonElement;
 
@@ -420,6 +425,29 @@ export class PreviewApp extends LitElement {
                 >
                     <i class="codicon codicon-keyboard" aria-hidden="true"></i>
                 </button>
+                <button
+                    class="icon-button"
+                    id="btn-launcher-widget"
+                    title="Pick launcher-widget cell size"
+                    aria-label="Pick launcher-widget cell size"
+                    aria-pressed="false"
+                    aria-haspopup="dialog"
+                    aria-expanded="false"
+                    aria-controls="launcher-widget-picker-popover"
+                    hidden
+                >
+                    <i
+                        class="codicon codicon-multiple-windows"
+                        aria-hidden="true"
+                    ></i>
+                </button>
+                <div
+                    id="launcher-widget-picker-popover"
+                    class="launcher-widget-picker-popover"
+                    role="dialog"
+                    aria-label="Launcher-widget cell size picker"
+                    hidden
+                ></div>
                 <button
                     class="icon-button"
                     id="btn-export-bundle"
@@ -630,6 +658,8 @@ export class PreviewApp extends LitElement {
         const btnTouchOverlay = this._btnTouchOverlay;
         const btnKeyboardBand = this._btnKeyboardBand;
         const btnControls = this._btnControls;
+        const btnLauncherWidget = this._btnLauncherWidget;
+        const launcherWidgetPickerPopover = this._launcherWidgetPickerPopover;
         const btnExportBundle = this._btnExportBundle;
         const btnExitFocus = this._btnExitFocus;
         const focusToolbar = new FocusToolbarController({
@@ -643,6 +673,7 @@ export class PreviewApp extends LitElement {
             btnTouchOverlay,
             btnKeyboardBand,
             btnControls,
+            btnLauncherWidget,
             btnExportBundle,
             btnExitFocus,
             recordingFormat,
@@ -2804,6 +2835,68 @@ export class PreviewApp extends LitElement {
             const enabled = btnControls.getAttribute("aria-pressed") === "true";
             liveState.toggleControlsForCard(card, !enabled);
         });
+
+        // Launcher-widget container-size picker. Click opens a popover with a
+        // 5×5-style cell grid (rendered by `./launcherWidgetPicker.ts`); a
+        // cell click writes the override via `liveState` and closes the
+        // popover. The popover is dismissed on outside click or Escape; the
+        // payload (`supportedCells` / `resizeAxes` constraints from
+        // `compose/launcher-widget`) isn't plumbed in yet, so the picker
+        // falls back to its default 5×5 unconstrained grid — sufficient to
+        // exercise the override pipeline; constraint-aware rendering lands
+        // when `LauncherWidgetPayload` is wired into the panel state.
+        const closeLauncherWidgetPicker = (): void => {
+            launcherWidgetPickerPopover.hidden = true;
+            launcherWidgetPickerPopover.replaceChildren();
+            btnLauncherWidget.setAttribute("aria-expanded", "false");
+        };
+        const openLauncherWidgetPicker = (): void => {
+            const card = focusController.focusedCard();
+            const previewId = card?.dataset.previewId ?? null;
+            if (!card || !previewId) return;
+            const current = liveState.launcherWidgetCellsForPreview(
+                previewId,
+            ) ?? { width: 5, height: 5 };
+            const table = renderLauncherWidgetPicker(null, current, (cells) => {
+                liveState.setLauncherWidgetCellsForCard(card, cells);
+                closeLauncherWidgetPicker();
+            });
+            const resetBtn = document.createElement("button");
+            resetBtn.type = "button";
+            resetBtn.className = "launcher-widget-picker-reset";
+            resetBtn.textContent = "Reset";
+            resetBtn.title = "Clear launcher-widget size override";
+            resetBtn.addEventListener("click", () => {
+                liveState.setLauncherWidgetCellsForCard(card, null);
+                closeLauncherWidgetPicker();
+            });
+            launcherWidgetPickerPopover.replaceChildren(table, resetBtn);
+            launcherWidgetPickerPopover.hidden = false;
+            btnLauncherWidget.setAttribute("aria-expanded", "true");
+        };
+        btnLauncherWidget.addEventListener("click", (evt) => {
+            evt.stopPropagation();
+            if (launcherWidgetPickerPopover.hidden) {
+                openLauncherWidgetPicker();
+            } else {
+                closeLauncherWidgetPicker();
+            }
+        });
+        launcherWidgetPickerPopover.addEventListener("click", (evt) =>
+            evt.stopPropagation(),
+        );
+        document.addEventListener("click", () => {
+            if (!launcherWidgetPickerPopover.hidden) {
+                closeLauncherWidgetPicker();
+            }
+        });
+        document.addEventListener("keydown", (evt) => {
+            if (evt.key === "Escape" && !launcherWidgetPickerPopover.hidden) {
+                closeLauncherWidgetPicker();
+                btnLauncherWidget.focus();
+            }
+        });
+
         btnExportBundle.addEventListener("click", () =>
             requestExportPreviewBundle(),
         );

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -28,6 +28,7 @@
         "src/webview/preview/interactiveInput.ts",
         "src/webview/preview/liveBadge.ts",
         "src/webview/preview/liveCardControls.ts",
+        "src/webview/preview/liveState.ts",
         "src/webview/preview/liveTransitions.ts",
         "src/webview/preview/liveViewportThrottle.ts",
         "src/webview/preview/loadingOverlay.ts",


### PR DESCRIPTION
Introduces a payload-shape-driven picker for choosing
`LauncherWidgetOverride.cells`. The pure-logic `buildLauncherWidgetPickerCells`
returns a clickability-gated grid; `renderLauncherWidgetPicker` stamps it into
a `<table role="grid">` of buttons that toolbar/popover consumers can drop in.

Gating consumes `LauncherWidgetPayload.supportedCells` + `resizeAxes`
uniformly, so the same picker covers all three discovery layers (annotation
bounds, Glance `previewSizeMode`, AppWidget XML auto-discovery).