### PR TITLE
test: reorder daemon warm after render in e2e tests

### DIFF
--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -216,6 +216,22 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
         // daemon scheduler.
         await api.triggerBootstrapAppliedMarkers();
 
+        // Render first, warm second. The daemon JVM is launched with
+        // `-Dcomposeai.harness.previewsManifest=…/previews.json` baked into
+        // its `daemon-launch.json`; `PreviewManifestRouter.loadManifest`
+        // throws at startup when the file isn't on disk, taking the JVM
+        // down with exit code 1 before the channel handshake even begins.
+        // `composePreviewDaemonStart` (what `runDaemonBootstrap` invokes)
+        // writes the launch descriptor but NOT the manifest, so it has to
+        // run after the renderAll that writes `previews.json`. This matches
+        // production `runActivationRefresh` ordering: refresh → warm.
+        //
+        // One refresh bootstraps every `it`: the wear composePreviewRenderAll
+        // cold path is the slowest piece of the suite, so paying for it
+        // once and reusing the `setPreviews` payload keeps the total
+        // wall-clock close to a single render plus three chip toggles.
+        wearPreviews = await refreshAndGetPreviews(15 * 60_000);
+
         // The chip toggles below send `data/subscribe` through the daemon
         // scheduler, which requires a live daemon and therefore a
         // `composePreviewDaemonStart`-produced launch descriptor. Activation
@@ -235,12 +251,6 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
             warmed,
             `wear daemon must warm before chip subscriptions\ncause: ${api.getLastWarmDaemonError() ?? "<unknown>"}`,
         );
-
-        // One refresh bootstraps every `it`: the wear composePreviewRenderAll
-        // cold path is the slowest piece of the suite, so paying for it
-        // once and reusing the `setPreviews` payload keeps the total
-        // wall-clock close to a single render plus three chip toggles.
-        wearPreviews = await refreshAndGetPreviews(15 * 60_000);
     });
 
     after(async () => {

--- a/vscode-extension/src/test/electron/suite/e2eBundleChain.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eBundleChain.test.ts
@@ -166,19 +166,16 @@ describeE2E("Compose Preview bundle chip↔tab↔overlay e2e (wear)", function (
             },
         );
 
-        // The chip toggle's outbound `setDataExtensionEnabled` lands
-        // in `handleSetDataExtensionEnabled`, which needs a live daemon
-        // to subscribe against. `COMPOSE_PREVIEW_TEST_MODE=1` skips the
-        // activation auto-refresh, so the warm has to be explicit.
-        const warmed = await api.triggerWarmDaemon(wearKotlinFile);
-        assert.ok(
-            warmed,
-            "wear daemon must warm before chip toggles" +
-                (warmed
-                    ? ""
-                    : `; cause: ${api.getLastWarmDaemonError() ?? "<unknown>"}`),
-        );
-
+        // Render first, warm second. The daemon JVM is launched with
+        // `-Dcomposeai.harness.previewsManifest=…/previews.json` baked into
+        // its `daemon-launch.json`; `PreviewManifestRouter.loadManifest`
+        // throws at startup when the file isn't on disk, taking the JVM
+        // down with exit code 1 before the channel handshake even begins.
+        // `composePreviewDaemonStart` (what `runDaemonBootstrap` invokes)
+        // writes the launch descriptor but NOT the manifest, so it has to
+        // run after the renderAll that writes `previews.json`. This matches
+        // production `runActivationRefresh` ordering: refresh → warm.
+        //
         // One full-tier render to populate the grid + scope a current
         // bundle target. `currentBundleTarget()` in the webview returns
         // the first visible card, which is the previewId the chip's
@@ -219,6 +216,19 @@ describeE2E("Compose Preview bundle chip↔tab↔overlay e2e (wear)", function (
                         "webviewPreviewsRendered",
                 );
             },
+        );
+
+        // The chip toggle's outbound `setDataExtensionEnabled` lands
+        // in `handleSetDataExtensionEnabled`, which needs a live daemon
+        // to subscribe against. `COMPOSE_PREVIEW_TEST_MODE=1` skips the
+        // activation auto-refresh, so the warm has to be explicit.
+        const warmed = await api.triggerWarmDaemon(wearKotlinFile);
+        assert.ok(
+            warmed,
+            "wear daemon must warm before chip toggles" +
+                (warmed
+                    ? ""
+                    : `; cause: ${api.getLastWarmDaemonError() ?? "<unknown>"}`),
         );
     });
 


### PR DESCRIPTION
## Summary
Reorders the daemon warm operation to occur after the initial render in two e2e test suites. This fixes a race condition where the daemon JVM was being started before the `previews.json` manifest file was written to disk.

## Changes
- **e2eBundleChain.test.ts**: Moved `triggerWarmDaemon` call to after the `renderAll` operation that populates `previews.json`
- **e2eA11y.test.ts**: Moved `refreshAndGetPreviews` call to before `triggerWarmDaemon`, ensuring the manifest exists before daemon startup

## Implementation Details
The daemon JVM is launched with `-Dcomposeai.harness.previewsManifest=…/previews.json` baked into its `daemon-launch.json`. The `PreviewManifestRouter.loadManifest` throws at startup when this file doesn't exist on disk, causing the JVM to exit with code 1 before the channel handshake can begin.

The `composePreviewDaemonStart` function writes the launch descriptor but NOT the manifest file, so it must run after the render operation that writes `previews.json`. This ordering matches the production `runActivationRefresh` behavior: refresh → warm.

Updated comments explain the dependency chain and why this ordering is necessary.

https://claude.ai/code/session_01DqRdHonEF5vgUYCSrkfqNv