### PR TITLE
test: add per-test timeout caps to a11y and bundle e2e tests

### DIFF
--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -310,6 +310,13 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
     }
 
     it("paints hierarchy overlay when the chip toggles ON for ActivityListPreview", async function () {
+        // Per-test cap. The wear daemon is already warm by `before()`; chip
+        // toggles are sub-second on a warm runner (observed 2-3s including
+        // daemon-side a11y render). 60s leaves 20× headroom while letting
+        // a stuck waitFor surface in a minute instead of inheriting the
+        // suite-level 15 min ceiling (which previously hid a hang in the
+        // post-#1461 run for the whole 60-min workflow budget).
+        this.timeout(60_000);
         const target = pickPreview(
             wearPreviews,
             "ActivityListPreview",
@@ -352,6 +359,7 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
     });
 
     it("paints findings legend when the chip toggles ON for BadWearButtonPreview", async function () {
+        this.timeout(60_000);
         const target = pickPreview(wearPreviews, "BadWearButtonPreview");
         console.log(
             `[e2e-a11y] subscribing a11y/atf for ${target.functionName} (${target.params?.device})`,
@@ -390,6 +398,7 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
     });
 
     it("tears down the hierarchy overlay when the chip toggles OFF", async function () {
+        this.timeout(60_000);
         const target = pickPreview(
             wearPreviews,
             "ActivityListPreview",

--- a/vscode-extension/src/test/electron/suite/e2eBundleChain.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eBundleChain.test.ts
@@ -260,6 +260,13 @@ describeE2E("Compose Preview bundle chip↔tab↔overlay e2e (wear)", function (
     }
 
     it("activate → chip on, tab opens, overlays paint after daemon attachment", async function () {
+        // Per-test cap. The wear daemon is already warm by `before()`; chip
+        // toggles + tab/overlay paint round-trip in seconds on a warm
+        // runner. 60s leaves comfortable headroom while letting a stuck
+        // waitFor surface in a minute instead of inheriting the suite-level
+        // 15 min ceiling (which previously hid hangs for the whole 60 min
+        // workflow budget).
+        this.timeout(60_000);
         // Sanity baseline: at suite entry no bundle is active (the wear
         // suite hasn't toggled anything yet, and the initial
         // `reflectBundleState()` runs with `active=[]`).
@@ -335,6 +342,7 @@ describeE2E("Compose Preview bundle chip↔tab↔overlay e2e (wear)", function (
     });
 
     it("toggle off → chip off, tab closed, overlays cleared", async function () {
+        this.timeout(60_000);
         // Prereq: chip on with overlays painted. The previous `it`
         // toggled the chip on and left it that way; if Mocha re-orders
         // (e.g. a future `--retries` setting) the assertion below


### PR DESCRIPTION
## Summary
Add explicit per-test timeout caps (60 seconds) to several e2e test cases that interact with the wear daemon. This prevents slow or hung tests from consuming the entire suite-level timeout budget (15 minutes), allowing stuck `waitFor` calls to surface within a reasonable timeframe rather than silently timing out after the full workflow budget.

## Changes
- **e2eA11y.test.ts**: Added `this.timeout(60_000)` to three test cases:
  - "paints hierarchy overlay when the chip toggles ON for ActivityListPreview" (with detailed comment explaining the rationale)
  - "paints findings legend when the chip toggles ON for BadWearButtonPreview"
  - "tears down the hierarchy overlay when the chip toggles OFF"

- **e2eBundleChain.test.ts**: Added `this.timeout(60_000)` to two test cases:
  - "activate → chip on, tab opens, overlays paint after daemon attachment" (with detailed comment explaining the rationale)
  - "toggle off → chip off, tab closed, overlays cleared"

## Implementation Details
The 60-second timeout provides approximately 20× headroom for typical operations (chip toggles and overlay painting observed at 2–3 seconds on warm runners) while ensuring that any stuck operations surface within a minute rather than inheriting the suite-level 15-minute ceiling. This improves test failure visibility and debugging experience.

https://claude.ai/code/session_01DqRdHonEF5vgUYCSrkfqNv