### PR TITLE
test: fix a11y subscription e2e test flakiness with cleanup

### DIFF
--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -114,6 +114,15 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
     let wearKotlinFile: string;
     let priorEarlyFeatures: boolean | undefined;
     let wearPreviews: PreviewSummary[];
+    // PreviewIds the suite has subscribed a11y data products on. `afterEach`
+    // walks this and unsubscribes both kinds so each `it()` starts with a
+    // clean daemon-side subscription state. Required because
+    // `LiveDaemonScheduler.setDataProductSubscription` is idempotent
+    // (daemonScheduler.ts:499 skips when `enabled === already`): re-issuing
+    // a subscribe for an already-subscribed pair produces no fresh
+    // `updateA11y` and therefore no `webviewA11yState` ack, so a test that
+    // assumes "subscribe → ack" would hang against the per-test 60s cap.
+    const touchedPreviewIds = new Set<string>();
 
     before(async function () {
         // Cold first-render bootstrap; each `it` reuses `wearPreviews`
@@ -253,6 +262,24 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
         );
     });
 
+    afterEach(async () => {
+        // Drop every a11y subscription this test created so the next
+        // `it()` re-issuing a subscribe sees a fresh transition (and
+        // therefore a fresh `webviewA11yState` ack). Unsubscribing a
+        // never-subscribed pair is a no-op in
+        // `setDataProductSubscription`, so passing both kinds for every
+        // touched preview is safe and avoids per-test bookkeeping.
+        if (!api) return;
+        for (const previewId of touchedPreviewIds) {
+            await api.triggerSetDataExtensionEnabled(
+                previewId,
+                ["a11y/hierarchy", "a11y/atf"],
+                false,
+            );
+        }
+        touchedPreviewIds.clear();
+    });
+
     after(async () => {
         const config = vscode.workspace.getConfiguration("composePreview");
         await config.update(
@@ -325,6 +352,7 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
         console.log(
             `[e2e-a11y] subscribing a11y/hierarchy for ${target.functionName} (${target.params?.device})`,
         );
+        touchedPreviewIds.add(target.id);
         api.resetMessages();
 
         await api.triggerSetDataExtensionEnabled(
@@ -364,6 +392,7 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
         console.log(
             `[e2e-a11y] subscribing a11y/atf for ${target.functionName} (${target.params?.device})`,
         );
+        touchedPreviewIds.add(target.id);
         api.resetMessages();
 
         await api.triggerSetDataExtensionEnabled(target.id, ["a11y/atf"], true);
@@ -404,6 +433,7 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
             "ActivityListPreview",
             "Large Round",
         );
+        touchedPreviewIds.add(target.id);
         api.resetMessages();
 
         await api.triggerSetDataExtensionEnabled(


### PR DESCRIPTION
## Summary
Fix flaky a11y subscription e2e tests by properly cleaning up daemon-side subscription state between test cases. The tests were hanging due to idempotent subscription behavior in `LiveDaemonScheduler.setDataProductSubscription`.

## Problem
When a test re-issued a subscription for an already-subscribed preview, the daemon would skip the operation (idempotent behavior), resulting in no fresh `updateA11y` message and no `webviewA11yState` ack. Tests expecting "subscribe → ack" would timeout against the 60-second per-test limit.

## Solution
- Added `touchedPreviewIds` Set to track which previews each test subscribes to
- Implemented `afterEach` hook that unsubscribes from all touched previews after each test
- Updated subscription calls to register preview IDs in the tracking set
- Unsubscribing never-subscribed pairs is a no-op, so this approach is safe and avoids per-test bookkeeping

## Key Changes
- Track preview IDs that have a11y subscriptions via `touchedPreviewIds` Set
- Add `afterEach` cleanup that unsubscribes both `a11y/hierarchy` and `a11y/atf` for all touched previews
- Register preview IDs when subscribing in three test cases (hierarchy, atf, and large round tests)

https://claude.ai/code/session_01DqRdHonEF5vgUYCSrkfqNv