### PR TITLE
fix: skip composite-included builds in init script

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -219,7 +219,23 @@ fun scanForKmpAndroidDeclaration(
     return declared
 }
 
+// Skip composite-included builds entirely — both the settings scan and the `allprojects`
+// injection. The init script is evaluated once per build in a composite (root + each
+// `includeBuild(...)`), so without this guard `allprojects { buildscript { repositories { ... } } }`
+// fires for the included build's projects too. That breaks any included build whose
+// `pluginManagement.repositories` declares `exclusiveContent { ... }`: Gradle 9.3+ rejects
+// adding to `buildscript.repositories` once exclusiveContent is in
+// `settings.pluginManagement.repositories` (e.g. Confetti's `:build-logic`, which excludes
+// `com.apollographql.execution` SNAPSHOTs to an Apollo bucket). Included builds in this pattern
+// are conventionally plugin builds (`build-logic`, `gradle-conventions`) that don't host
+// `@Preview` composables, so injecting the plugin classpath there is unnecessary — and the
+// existing pre-applied / KMP-Android scans only walk the *root* build's project hierarchy
+// anyway, so included-build projects were never tracked. An included build's `Gradle` instance
+// has a non-null `parent`; the root build's is `null`.
+val composeAiPreviewIsIncludedBuild = gradle.parent != null
+
 gradle.settingsEvaluated {
+    if (composeAiPreviewIsIncludedBuild) return@settingsEvaluated
     val projectDirs = mutableListOf<java.io.File>()
     fun collect(descriptor: org.gradle.api.initialization.ProjectDescriptor) {
         projectDirs.add(descriptor.projectDir)
@@ -237,12 +253,9 @@ gradle.settingsEvaluated {
     // literal-`id(...) version "..."` case where resolution goes through the plugins DSL instead
     // of our buildscript classpath injection.
     //
-    // `gradle.settingsEvaluated` fires for every build, including composite-included builds
-    // (e.g. androidchka's `build-logic`). Gradle only auto-adds the default Plugin Portal when
-    // `pluginManagement.repositories` is empty after settings evaluation — once we explicitly add
-    // `mavenLocal()` the list is non-empty and the default is suppressed, so a `build-logic`
-    // module that relies on the implicit default for `kotlin-dsl` (resolved via plugin marker
-    // from the Gradle Plugin Portal) fails. Restore those defaults explicitly when the build
+    // Gradle only auto-adds the default Plugin Portal when `pluginManagement.repositories` is
+    // empty after settings evaluation — once we explicitly add `mavenLocal()` the list is
+    // non-empty and the default is suppressed, so restore the defaults explicitly when the build
     // didn't declare any plugin repos of its own.
     if (useMavenLocal) {
         val seedPluginDefaults = pluginManagement.repositories.isEmpty()
@@ -257,6 +270,7 @@ gradle.settingsEvaluated {
 }
 
 allprojects {
+    if (composeAiPreviewIsIncludedBuild) return@allprojects
     // Skip BOTH the buildscript classpath injection AND the apply hooks for KMP-Android
     // modules. Doing only one half leaves the other half active: skipping the classpath
     // injection alone still fires the withPlugin hooks (which then fail to find the plugin

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -698,6 +698,33 @@ class AutoInjectTest {
   }
 
   @Test
+  fun `init script skips composite-included builds in settingsEvaluated and allprojects`() {
+    // Regression for the Confetti report: with `includeBuild("build-logic")` whose
+    // settings.gradle.kts declares `exclusiveContent { ... }` in `pluginManagement.repositories`,
+    // Gradle 9.3+ rejects any project that adds to `buildscript.repositories`. The init script
+    // is evaluated once per build in a composite, so the unguarded `allprojects { buildscript
+    // { repositories { ... } } }` previously fired against the included build and tripped the
+    // validation. Pins the early-return shape so it doesn't regress. An included build's
+    // `gradle.parent` is non-null; the root build's is null, so the guard is a one-liner that
+    // costs the root build nothing.
+    val script = renderInitScript("0.11.6")
+    assertTrue(
+      script.contains("val composeAiPreviewIsIncludedBuild = gradle.parent != null"),
+      "expected the included-build flag derived from gradle.parent",
+    )
+    assertTrue(
+      script.contains("if (composeAiPreviewIsIncludedBuild) return@settingsEvaluated"),
+      "expected settingsEvaluated to short-circuit for composite-included builds",
+    )
+    assertTrue(
+      script.contains("if (composeAiPreviewIsIncludedBuild) return@allprojects"),
+      "expected allprojects to short-circuit for composite-included builds so " +
+        "buildscript.repositories isn't touched in included builds (would conflict with " +
+        "exclusiveContent in settings.pluginManagement.repositories)",
+    )
+  }
+
+  @Test
   fun `init script's KMP-Android scan recognises catalog aliases`() {
     // Mirrors the compose-preview catalog-accessor path so a project that declares the
     // KMP-Android plugin in `gradle/libs.versions.toml` (e.g.

--- a/vscode-extension/src/initScript.ts
+++ b/vscode-extension/src/initScript.ts
@@ -152,7 +152,22 @@ fun scanForComposeAiPreviewDeclaration(
     return declared
 }
 
+// Skip composite-included builds entirely — both the settings scan and the \`allprojects\`
+// injection. The init script is evaluated once per build in a composite (root + each
+// \`includeBuild(...)\`), so without this guard \`allprojects { buildscript { repositories { ... } } }\`
+// fires for the included build's projects too. That breaks any included build whose
+// \`pluginManagement.repositories\` declares \`exclusiveContent { ... }\`: Gradle 9.3+ rejects
+// adding to \`buildscript.repositories\` once exclusiveContent is in
+// \`settings.pluginManagement.repositories\` (e.g. Confetti's \`:build-logic\`). Included builds in
+// this pattern are conventionally plugin builds (\`build-logic\`, \`gradle-conventions\`) that don't
+// host \`@Preview\` composables, so injecting the plugin classpath there is unnecessary — and the
+// existing pre-applied scan only walks the *root* build's project hierarchy anyway, so
+// included-build projects were never tracked. An included build's \`Gradle\` instance has a
+// non-null \`parent\`; the root build's is \`null\`.
+val composeAiPreviewIsIncludedBuild = gradle.parent != null
+
 gradle.settingsEvaluated {
+    if (composeAiPreviewIsIncludedBuild) return@settingsEvaluated
     val projectDirs = mutableListOf<java.io.File>()
     fun collect(descriptor: org.gradle.api.initialization.ProjectDescriptor) {
         projectDirs.add(descriptor.projectDir)
@@ -170,9 +185,8 @@ gradle.settingsEvaluated {
     //
     // Gradle only auto-adds the default Plugin Portal when \`pluginManagement.repositories\` is empty
     // after settings evaluation — once we explicitly add \`mavenLocal()\` the list is non-empty and
-    // the default is suppressed, so a \`build-logic\` module that relies on the implicit default for
-    // \`kotlin-dsl\` (resolved via plugin marker from the Gradle Plugin Portal) fails. Restore those
-    // defaults explicitly when the build didn't declare any plugin repos of its own.
+    // the default is suppressed, so restore the defaults explicitly when the build didn't declare
+    // any plugin repos of its own.
     if (useMavenLocal) {
         val seedPluginDefaults = pluginManagement.repositories.isEmpty()
         pluginManagement.repositories.mavenLocal()
@@ -186,6 +200,7 @@ gradle.settingsEvaluated {
 }
 
 allprojects {
+    if (composeAiPreviewIsIncludedBuild) return@allprojects
     if (projectDir !in composeAiPreviewPreAppliedDirs) {
         buildscript {
             repositories {

--- a/vscode-extension/src/test/initScript.test.ts
+++ b/vscode-extension/src/test/initScript.test.ts
@@ -121,6 +121,36 @@ describe("renderInitScript", () => {
         );
     });
 
+    it("skips composite-included builds in settingsEvaluated and allprojects", () => {
+        // Regression for the Confetti report: with `includeBuild("build-logic")` whose
+        // settings.gradle.kts declares `exclusiveContent { ... }` in
+        // `pluginManagement.repositories`, Gradle 9.3+ rejects any project that adds to
+        // `buildscript.repositories`. The init script is evaluated once per build in a
+        // composite, so the unguarded `allprojects { buildscript { repositories { ... } } }`
+        // previously fired against the included build and tripped the validation. Pins the
+        // early-return shape so it doesn't regress. An included build's `gradle.parent` is
+        // non-null; the root build's is null.
+        const script = renderInitScript();
+        assert.ok(
+            script.includes(
+                "val composeAiPreviewIsIncludedBuild = gradle.parent != null",
+            ),
+            "expected the included-build flag derived from gradle.parent",
+        );
+        assert.ok(
+            script.includes(
+                "if (composeAiPreviewIsIncludedBuild) return@settingsEvaluated",
+            ),
+            "expected settingsEvaluated to short-circuit for composite-included builds",
+        );
+        assert.ok(
+            script.includes(
+                "if (composeAiPreviewIsIncludedBuild) return@allprojects",
+            ),
+            "expected allprojects to short-circuit for composite-included builds",
+        );
+    });
+
     it("limits the scan to included project descriptors, not the filesystem", () => {
         // Codex P1 review on PR #1183: an unrelated nested build (e.g., a tooling
         // build or sample app checked into the workspace but not part of this


### PR DESCRIPTION
## Summary

Fixes a regression where the generated Gradle init script would attempt to modify `buildscript.repositories` in composite-included builds (e.g., `build-logic`), causing failures in Gradle 9.3+ when those builds declare `exclusiveContent` in `pluginManagement.repositories`.

## Changes

- **Init script generation**: Added an early-return guard to skip both `settingsEvaluated` and `allprojects` blocks for composite-included builds by checking if `gradle.parent != null`
- **Test coverage**: Added regression tests in both TypeScript (VSCode extension) and Kotlin (CLI) test suites to verify the guard is present and functional
- **Documentation**: Updated inline comments to clarify why the guard is necessary and that included builds (conventionally plugin builds) don't host `@Preview` composables anyway

## Implementation Details

The fix leverages the fact that an included build's `Gradle` instance has a non-null `parent` property, while the root build's is `null`. This allows a simple one-liner guard that costs the root build nothing while preventing the init script from firing against included builds.

The guard is applied at two points:
1. In `gradle.settingsEvaluated` to skip the project directory scan
2. In `allprojects` to skip the buildscript classpath injection

This prevents conflicts with `exclusiveContent` declarations in included builds' `pluginManagement.repositories` while maintaining full functionality for the root build.

https://claude.ai/code/session_01DrsQmmX9GsTUPuxz1oQcKk