### PR TITLE
fix: abort pending refresh before preloading previews

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1811,6 +1811,16 @@ export async function activate(
                 // this file's module. Once daemon startup finishes we run a
                 // second discover pass and pre-render the shown previews so
                 // the first edit doesn't have to pay JVM/sandbox startup.
+                //
+                // Abort any in-flight refresh for the previous file NOW,
+                // before preloadCachedPreviews. Without this early abort,
+                // the old refresh's post-discover continuation can resume
+                // while preload awaits disk reads and overwrite the preloaded
+                // state (clearAll, hasPreviewsLoaded=false, setPreviews for
+                // the wrong module) before refresh() for the new file ever
+                // fires the abort signal itself.
+                pendingRefresh?.abort();
+                pendingRefreshKey = null;
                 void (async () => {
                     // Paint on-disk cache for the new file before
                     // composePreviewDiscover runs so the panel isn't
@@ -4637,7 +4647,13 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 } else {
                     // Mirror the runActivationRefresh sequence: paint the
                     // on-disk cache first so the grid is never blank while
-                    // composePreviewDiscover re-runs.
+                    // composePreviewDiscover re-runs. Abort any in-flight
+                    // refresh before preload for the same reason as the
+                    // onDidChangeActiveTextEditor path: a concurrent
+                    // discover completion can overwrite preloaded state
+                    // before refresh() fires the abort itself.
+                    pendingRefresh?.abort();
+                    pendingRefreshKey = null;
                     const scopeFile = currentScopeFile;
                     void (async () => {
                         const preloaded =


### PR DESCRIPTION
## Summary
Fix a race condition where in-flight refresh operations could overwrite preloaded preview state when switching files or triggering manual refreshes.

## Changes
- Added early abort of `pendingRefresh` before `preloadCachedPreviews` in the `onDidChangeActiveTextEditor` handler
- Added early abort of `pendingRefresh` before preload in the webview message handler for manual refresh requests
- Reset `pendingRefreshKey` to null after aborting to ensure clean state

## Details
Without these early aborts, a concurrent discover completion from a previous file's refresh could resume while the new file's preview preload is awaiting disk reads. This would cause the old refresh's post-discover continuation to overwrite the preloaded state (clearing previews, resetting `hasPreviewsLoaded`, and setting previews for the wrong module) before the new file's refresh even fires its own abort signal.

By aborting pending refreshes before initiating preload, we ensure that any in-flight operations from the previous context are terminated before new state is established, preventing state corruption.

https://claude.ai/code/session_017YEcvURB2jtmpn6jhjtai6