### PR TITLE
test: add diagnostics for e2e-external warm daemon failures

### DIFF
--- a/vscode-extension/src/test/electron/realGradleApi.ts
+++ b/vscode-extension/src/test/electron/realGradleApi.ts
@@ -51,6 +51,17 @@ export class RealGradleApi implements GradleApi {
             `[realGradleApi] ${gradlewPath} ${gradleArgs.join(" ")} (cwd=${opts.projectFolder})`,
         );
 
+        // Under e2e-external the underlying gradleService routes Gradle output
+        // to the extension's `outputChannel` (via `logger.append`), which
+        // doesn't surface in CI stdout. That makes a silent `composePreviewApplied`
+        // failure or a missing-marker fan-out invisible — the test fails with
+        // "resolveModule returned null" and no Gradle context. Forward stderr
+        // verbatim and stdout selectively (build status + task names + errors)
+        // to console.log so the CI log has enough to triage. Cheap: this is a
+        // test-only realGradleApi, not the production GradleApi path.
+        const diagE2e = process.env.COMPOSE_PREVIEW_E2E_EXTERNAL === "1";
+        const stdoutDiagRe =
+            /BUILD\s+(SUCCESSFUL|FAILED)|composePreviewApplied|FAILURE|^Configuring |Could not resolve|Exception/m;
         return new Promise((resolve, reject) => {
             const child = spawn(gradlewPath, gradleArgs, {
                 cwd: opts.projectFolder,
@@ -58,6 +69,13 @@ export class RealGradleApi implements GradleApi {
                 stdio: ["ignore", "pipe", "pipe"],
             });
             child.stdout.on("data", (chunk: Buffer) => {
+                if (diagE2e) {
+                    const text = chunk.toString("utf-8");
+                    for (const line of text.split("\n")) {
+                        if (stdoutDiagRe.test(line))
+                            console.log(`[gradle stdout] ${line}`);
+                    }
+                }
                 opts.onOutput?.({
                     getOutputBytes: () => new Uint8Array(chunk),
                     // 0 = stdout, matches the bytes-shaped contract the
@@ -66,6 +84,9 @@ export class RealGradleApi implements GradleApi {
                 });
             });
             child.stderr.on("data", (chunk: Buffer) => {
+                if (diagE2e) {
+                    process.stderr.write(`[gradle stderr] ${chunk}`);
+                }
                 opts.onOutput?.({
                     getOutputBytes: () => new Uint8Array(chunk),
                     getOutputType: () => 1,
@@ -73,6 +94,11 @@ export class RealGradleApi implements GradleApi {
             });
             child.once("error", reject);
             child.once("close", (code) => {
+                if (diagE2e) {
+                    console.log(
+                        `[gradle exit] code=${code} args=${gradleArgs.join(" ")}`,
+                    );
+                }
                 if (code === 0) {
                     resolve();
                 } else {

--- a/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
@@ -228,6 +228,89 @@ describeExternal(
             // stderr tail is already in the channel log thanks to
             // issue #1326's wrapping (`formatDaemonSpawnFailure`).
             const warmed = await api.triggerWarmDaemon(kotlinFile);
+            if (!warmed) {
+                // Post-mortem: surface every applied.json the workspace has on
+                // disk so the CI log shows whether `composePreviewApplied` fanned
+                // out to any module at all, and which `modulePath`s it wrote. A
+                // null `resolveModule` with zero markers means the plugin wasn't
+                // applied anywhere; a marker for `:shared` but not `:androidApp`
+                // means the alias detection slipped on the test target. Limited
+                // to depth 4 + skipping `.git`/`build` non-marker dirs so a KMP
+                // project's `build/intermediates` tree doesn't drown the log.
+                const markers: string[] = [];
+                const skipTopLevel = new Set([
+                    ".git",
+                    "node_modules",
+                    ".gradle",
+                ]);
+                const walk = (rel: string, depth: number): void => {
+                    if (depth > 4) return;
+                    let entries: fs.Dirent[];
+                    try {
+                        entries = fs.readdirSync(
+                            path.join(workspaceRoot, rel),
+                            { withFileTypes: true },
+                        );
+                    } catch {
+                        return;
+                    }
+                    for (const entry of entries) {
+                        if (depth === 0 && skipTopLevel.has(entry.name))
+                            continue;
+                        const child = rel ? `${rel}/${entry.name}` : entry.name;
+                        if (entry.isFile() && entry.name === "applied.json") {
+                            markers.push(child);
+                            continue;
+                        }
+                        if (entry.isDirectory()) walk(child, depth + 1);
+                    }
+                };
+                walk("", 0);
+                console.log(
+                    `[e2e-external-diag] warm aborted; ` +
+                        `${markers.length} applied.json marker(s) on disk after composePreviewApplied:`,
+                );
+                for (const m of markers) {
+                    try {
+                        const body = fs.readFileSync(
+                            path.join(workspaceRoot, m),
+                            "utf-8",
+                        );
+                        console.log(
+                            `[e2e-external-diag]   ${m}: ${body.trim()}`,
+                        );
+                    } catch (err) {
+                        console.log(
+                            `[e2e-external-diag]   ${m}: <read failed: ${
+                                (err as Error).message
+                            }>`,
+                        );
+                    }
+                }
+                // Also surface what the consumer's `:androidApp/build.gradle.kts`
+                // looks like so we can tell apart "alias detection failed" from
+                // "the upstream pin moved the plugin off this module entirely".
+                const appBuild = path.join(
+                    workspaceRoot,
+                    "androidApp",
+                    "build.gradle.kts",
+                );
+                if (fs.existsSync(appBuild)) {
+                    const head = fs
+                        .readFileSync(appBuild, "utf-8")
+                        .split("\n")
+                        .slice(0, 30)
+                        .join("\n");
+                    console.log(
+                        `[e2e-external-diag] :androidApp/build.gradle.kts head:\n${head}`,
+                    );
+                } else {
+                    console.log(
+                        `[e2e-external-diag] :androidApp/build.gradle.kts missing — ` +
+                            "upstream layout drifted",
+                    );
+                }
+            }
             assert.ok(
                 warmed,
                 "warm aborted — see daemon channel log for the spawn-failure " +


### PR DESCRIPTION
## Summary
Add comprehensive diagnostics to help triage failures in the e2e-external test when the warm daemon fails to initialize. This includes surfacing Gradle output to CI logs and inspecting workspace state.

## Key Changes

- **e2eExternal.test.ts**: When `triggerWarmDaemon` fails, walk the workspace to collect all `applied.json` marker files and log their contents. This reveals whether the `composePreviewApplied` plugin was applied to any modules and which ones. Also surface the first 30 lines of `:androidApp/build.gradle.kts` to distinguish between alias detection failures and upstream layout changes.

- **realGradleApi.ts**: When `COMPOSE_PREVIEW_E2E_EXTERNAL=1` is set, forward Gradle stderr verbatim and selectively forward stdout (build status, task names, errors, and `composePreviewApplied` mentions) to `console.log` so CI logs capture Gradle context. Also log the exit code and arguments. This ensures silent failures in the Gradle invocation are visible in CI output.

## Implementation Details

The diagnostics are gated behind the `COMPOSE_PREVIEW_E2E_EXTERNAL` environment variable to avoid noise in other test runs. The workspace walk is limited to depth 4 and skips common non-marker directories (`.git`, `node_modules`, `.gradle`) to keep logs manageable in large projects.

https://claude.ai/code/session_01DqRdHonEF5vgUYCSrkfqNv