### PR TITLE
fix: preserve gradle args in compose preview test mode

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2025,11 +2025,20 @@ export async function activate(
     if (isTestMode) {
         const testApi: ComposePreviewTestApi = {
             injectGradleApi(api: GradleApi): void {
+                // Preserve the activation-time argsProvider — without
+                // `--init-script <path>` Gradle never sees the
+                // `pluginManagement.repositories.mavenLocal()` add the script
+                // performs under `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1`, so
+                // the e2e-external test's Confetti workspace can't resolve
+                // the local SNAPSHOT and `composePreviewApplied` fails with
+                // "Plugin not found in any of the following sources". The
+                // `--console=plain` arg matters less for the test path but
+                // costs nothing to keep.
                 gradleService = new GradleService(
                     workspaceRoot,
                     api,
                     outputChannel,
-                    () => [],
+                    () => [...baseGradleArgs, ...initScriptArgs],
                     logFilter,
                 );
             },


### PR DESCRIPTION
## Summary
Fix the Compose Preview test API to preserve Gradle initialization arguments when injecting a custom Gradle API, ensuring that Maven local repository configuration and other critical build settings are properly applied during testing.

## Changes
- Modified `injectGradleApi()` in the test mode setup to pass `baseGradleArgs` and `initScriptArgs` to the `GradleService` instead of an empty array
- This ensures that `--init-script` and `--console=plain` arguments are preserved, allowing the e2e-external test's Confetti workspace to properly resolve local SNAPSHOT dependencies via `pluginManagement.repositories.mavenLocal()`

## Implementation Details
The test was failing with "Plugin not found in any of the following sources" because the Gradle initialization script (which adds Maven local repository support when `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1` is set) was never being passed to Gradle. By preserving the activation-time args provider, the `--init-script` argument is now correctly included, allowing the plugin resolution to succeed.

https://claude.ai/code/session_01DqRdHonEF5vgUYCSrkfqNv