### PR TITLE
fix: handle missing ambient connector in wear sandbox bootstrap

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
@@ -107,9 +107,18 @@ class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(testClas
    */
   override fun getExtraShadows(method: FrameworkMethod): Array<Class<*>> {
     val shadows = mutableListOf<Class<*>>()
-    // Wear ambient shadow — only when the wear AAR is on the classpath (issue #1244).
+    // Wear ambient shadow — only when the wear AAR is on the classpath (issue #1244) AND
+    // the daemon's connector module is also available. The connector (ShadowAmbientLifecycleObserver
+    // and friends) is bundled inside the extension artifact; when the artifact predates the
+    // connector being added, the wear AAR check passes but the connector class is absent,
+    // causing NoClassDefFoundError mid-sandbox-bootstrap. Catching here lets the daemon
+    // limp along without ambient support rather than crashing all sandbox workers.
     if (isWearAmbientAvailable(javaClass.classLoader)) {
-      shadows += ShadowAmbientLifecycleObserver::class.java
+      try {
+        shadows += ShadowAmbientLifecycleObserver::class.java
+      } catch (_: NoClassDefFoundError) {
+        // connector not on classpath — skip ambient shadow
+      }
     }
     // Runtime-permissions tracker shadow. Always registered — `android.content.ContextWrapper`
     // is core Android, present on every consumer classpath, so the symbolic links the shadow


### PR DESCRIPTION
## Summary
Adds defensive error handling in `SandboxHoldingRunner.getExtraShadows()` to gracefully handle cases where the wear AAR is available but the ambient connector classes are missing from the classpath.

## Changes
- Wrapped `ShadowAmbientLifecycleObserver` class loading in a try-catch block to catch `NoClassDefFoundError`
- When the connector is unavailable, the ambient shadow is skipped rather than crashing the sandbox bootstrap
- Updated the comment to explain the scenario: older extension artifacts may have the wear AAR but predate the connector being added to the artifact

## Details
This fixes a bootstrap failure that occurs when:
1. The wear AAR is present on the classpath (passes the `isWearAmbientAvailable()` check)
2. But the connector module (`ShadowAmbientLifecycleObserver` and related classes) is absent

This can happen with older versions of the extension artifact. Rather than crashing all sandbox workers with a `NoClassDefFoundError`, the daemon now gracefully degrades by skipping ambient support.

https://claude.ai/code/session_017YEcvURB2jtmpn6jhjtai6