### PR TITLE
fix: improve kotlin file detection during extension activation

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2015,9 +2015,19 @@ export async function activate(
             if (active?.document.languageId === "kotlin") {
                 void runActivationRefresh(active.document.uri.fsPath);
             } else {
-                // No Kotlin file in focus — let refresh() emit the empty-state
-                // message without trying to load anything.
-                refresh(false);
+                // No Kotlin file active — look for one in a visible editor (the
+                // preview panel itself is often focused at startup, pushing the
+                // Kotlin file to "visible" rather than "active"). If one is found,
+                // run the full activation sequence so cached images are preloaded
+                // before the discover round-trip returns.
+                const { file: scopeFile } = resolveScopeFile();
+                if (scopeFile) {
+                    void runActivationRefresh(scopeFile);
+                } else {
+                    // No Kotlin preview file visible anywhere — emit the
+                    // empty-state message without trying to load anything.
+                    refresh(false);
+                }
             }
         }, INIT_DELAY_MS);
     }


### PR DESCRIPTION
## Summary
Improve the extension activation flow to detect Kotlin preview files in visible editors, not just the active editor. This ensures cached images are preloaded before the discover round-trip returns, even when the preview panel is focused at startup.

## Changes
- Modified the activation logic to call `resolveScopeFile()` when no Kotlin file is currently active
- If a Kotlin file is found in a visible editor, run the full activation sequence via `runActivationRefresh()`
- Only emit the empty-state message if no Kotlin preview file is visible anywhere in the editor

## Implementation Details
The preview panel often takes focus at startup, pushing the Kotlin file to "visible" rather than "active" status. By checking visible editors in addition to the active editor, we can trigger the full activation sequence earlier and preload cached images before the discover operation completes.

https://claude.ai/code/session_017YEcvURB2jtmpn6jhjtai6