### PR TITLE
fix: load compose-preview plugin via initscript classpath instead of buildscript injection

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -35,11 +35,22 @@ internal fun renderInitScript(pluginVersion: String): String =
   """// Compose Preview auto-inject init script.
 //
 // Materialised by the compose-preview CLI and passed via --init-script on
-// every Gradle invocation the CLI makes. Applies ee.schimke.composeai.preview
-// (version pinned to $pluginVersion) to every project that already applies
-// com.android.application, com.android.library, or org.jetbrains.compose —
-// so consumers don't have to edit their build files. Disable per-run with
-// --no-auto-inject or COMPOSE_PREVIEW_NO_AUTO_INJECT=1.
+// every Gradle invocation the CLI makes. Loads
+// ee.schimke.composeai.preview (version pinned to $pluginVersion) into
+// the init-script classloader so every project that already applies
+// com.android.application, com.android.library, or org.jetbrains.compose
+// can have it applied via `pluginManager.apply(...)` without us ever
+// mutating that project's `buildscript.repositories` — Gradle 9.3+
+// rejects adding to `buildscript.repositories` once any settings file in
+// the composite declares `exclusiveContent { ... }` inside
+// `pluginManagement.repositories`, so the previous
+// `allprojects { buildscript { repositories { ... } } }` injection was
+// load-bearing for the conflict (issues #1470, #1482). The init-script
+// classpath sits on a parent classloader of every project's plugin
+// classloader, so `pluginManager.apply` resolves the plugin via its
+// META-INF/gradle-plugins descriptor without touching any project repo
+// list at all. Disable per-run with --no-auto-inject or
+// COMPOSE_PREVIEW_NO_AUTO_INJECT=1.
 //
 // Application uses pluginManager.withPlugin(...) (not afterEvaluate) so AGP
 // finalizeDsl / onVariants callbacks register before the DSL lock.
@@ -47,28 +58,23 @@ internal fun renderInitScript(pluginVersion: String): String =
 // Pre-applied detection is *per project*: for each subproject whose build
 // file declares the plugin with a version — either literal
 // `id("...") version "..."` or via `alias(libs.plugins.<x>)` where the
-// version catalog maps <x> to this plugin id — we skip the buildscript
-// classpath injection for that project. Gradle's plugins {} DSL rejects
-// `id(...) version "..."` when the same plugin is also on the buildscript
-// classpath ("the plugin is already on the classpath with an unknown
-// version, so compatibility cannot be checked"), and the user's own
-// declaration provides resolution via plugin marker repos. Projects that
-// don't declare the plugin themselves still get the buildscript classpath
-// injection so the withPlugin / pluginManager.apply path can find the
-// plugin class — this is what mixed-shape multi-module projects need
-// (e.g. an `:app` module that applies the plugin via catalog alias, plus
-// a sibling `:rc-components` android-library module that doesn't; the init
-// script's withPlugin("com.android.library") hook fires in rc-components
-// too and the plugin must be resolvable from its buildscript classpath).
-// The withPlugin hooks in projects that already apply the plugin no-op via
-// the plugins.hasPlugin(...) guard.
+// version catalog maps <x> to this plugin id — we skip the withPlugin
+// apply hooks entirely. The user's own `plugins { }` block resolves and
+// applies the plugin from a project-scoped classloader (a child of the
+// init-script one); double-applying via our hook would risk a duplicate-
+// application error or class-identity confusion across classloaders, and
+// the user's declaration already does the right thing. The
+// `plugins.hasPlugin(...)` guard inside applyComposeAiPreview() is the
+// defence-in-depth backstop for projects the scanner missed (e.g.
+// non-versioned `id("ee.schimke.composeai.preview")` apply blocks).
 //
-// `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1` opts the buildscript repos into
-// `mavenLocal()` — exercised by the gradle-plugin functional tests, which
-// resolve the plugin from `~/.m2` (where `:publishToMavenLocal` puts it)
-// rather than Maven Central. Plain users have no reason to flip this on:
-// it widens the search surface to whatever snapshots happen to be cached
-// locally and is therefore opt-in, not the default.
+// `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1` opts the init-script's plugin-
+// resolution repos into `mavenLocal()` — exercised by the gradle-plugin
+// functional tests, which resolve the plugin from `~/.m2` (where
+// `:publishToMavenLocal` puts it) rather than Maven Central. Plain users
+// have no reason to flip this on: it widens the search surface to
+// whatever snapshots happen to be cached locally and is therefore opt-in,
+// not the default.
 //
 // Auto-inject is suppressed for modules that apply
 // `com.android.kotlin.multiplatform.library` — the AGP-KMP plugin's single
@@ -80,7 +86,19 @@ internal fun renderInitScript(pluginVersion: String): String =
 // user adds `id("ee.schimke.composeai.preview")` to that module's plugins {}
 // block themselves — we just no longer apply it implicitly.
 
-val pluginVersion = "$pluginVersion"
+initscript {
+    val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+        if (useMavenLocal) mavenLocal()
+    }
+    dependencies {
+        classpath("ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:$pluginVersion")
+    }
+}
+
 val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
 
 var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()
@@ -220,18 +238,16 @@ fun scanForKmpAndroidDeclaration(
 }
 
 // Skip composite-included builds entirely — both the settings scan and the `allprojects`
-// injection. The init script is evaluated once per build in a composite (root + each
-// `includeBuild(...)`), so without this guard `allprojects { buildscript { repositories { ... } } }`
-// fires for the included build's projects too. That breaks any included build whose
-// `pluginManagement.repositories` declares `exclusiveContent { ... }`: Gradle 9.3+ rejects
-// adding to `buildscript.repositories` once exclusiveContent is in
-// `settings.pluginManagement.repositories` (e.g. Confetti's `:build-logic`, which excludes
-// `com.apollographql.execution` SNAPSHOTs to an Apollo bucket). Included builds in this pattern
-// are conventionally plugin builds (`build-logic`, `gradle-conventions`) that don't host
-// `@Preview` composables, so injecting the plugin classpath there is unnecessary — and the
-// existing pre-applied / KMP-Android scans only walk the *root* build's project hierarchy
-// anyway, so included-build projects were never tracked. An included build's `Gradle` instance
-// has a non-null `parent`; the root build's is `null`.
+// hooks. The init script is evaluated once per build in a composite (root + each
+// `includeBuild(...)`), so an unguarded `allprojects { ... }` fires for the included build's
+// projects too. Included builds in the conventional pattern (`build-logic`,
+// `gradle-conventions`) don't host `@Preview` composables, so applying the plugin there is
+// wasteful, and the pre-applied / KMP-Android scans only walk the *root* build's project
+// hierarchy anyway. With the init-script classpath approach this is no longer load-bearing
+// for Gradle 9.3+'s `exclusiveContent` validation (issue #1482) — we never touch
+// `buildscript.repositories` anywhere — but the guard stays as defence-in-depth and to skip
+// pointless work in plugin-only builds. An included build's `Gradle` instance has a non-null
+// `parent`; the root build's is `null`.
 val composeAiPreviewIsIncludedBuild = gradle.parent != null
 
 gradle.settingsEvaluated {
@@ -245,18 +261,20 @@ gradle.settingsEvaluated {
     composeAiPreviewPreAppliedDirs = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)
     composeAiPreviewKmpAndroidDirs = scanForKmpAndroidDeclaration(rootDir, projectDirs)
 
-    // When opting into mavenLocal, also seed it at the settings level so the renderer-android AAR
-    // and any other ee.schimke.composeai:* runtime artifacts resolve from ~/.m2 alongside the
-    // plugin classpath. Consumers with `RepositoriesMode.FAIL_ON_PROJECT_REPOS` (e.g. wear-os-
-    // samples WearTilesKotlin) refuse per-project repos, so settings-level seeding is the only
-    // path that survives. pluginManagement.repositories.mavenLocal() covers the catalog-alias /
-    // literal-`id(...) version "..."` case where resolution goes through the plugins DSL instead
-    // of our buildscript classpath injection.
+    // When opting into mavenLocal, seed it at the settings level so the renderer-android AAR
+    // and any other ee.schimke.composeai:* runtime artifacts resolve from ~/.m2 at task-
+    // execution time. The plugin class itself comes from the init-script classloader, so
+    // this only matters for the runtime artifacts — but consumers with
+    // `RepositoriesMode.FAIL_ON_PROJECT_REPOS` (e.g. wear-os-samples WearTilesKotlin) refuse
+    // per-project repos, so settings-level seeding is the only path that survives.
+    // pluginManagement.repositories.mavenLocal() covers the catalog-alias /
+    // literal-`id(...) version "..."` case where the user resolves the plugin via the
+    // plugins DSL instead of relying on our init-script classpath.
     //
     // Gradle only auto-adds the default Plugin Portal when `pluginManagement.repositories` is
     // empty after settings evaluation — once we explicitly add `mavenLocal()` the list is
-    // non-empty and the default is suppressed, so restore the defaults explicitly when the build
-    // didn't declare any plugin repos of its own.
+    // non-empty and the default is suppressed, so restore the defaults explicitly when the
+    // build didn't declare any plugin repos of its own.
     if (useMavenLocal) {
         val seedPluginDefaults = pluginManagement.repositories.isEmpty()
         pluginManagement.repositories.mavenLocal()
@@ -271,32 +289,16 @@ gradle.settingsEvaluated {
 
 allprojects {
     if (composeAiPreviewIsIncludedBuild) return@allprojects
-    // Skip BOTH the buildscript classpath injection AND the apply hooks for KMP-Android
-    // modules. Doing only one half leaves the other half active: skipping the classpath
-    // injection alone still fires the withPlugin hooks (which then fail to find the plugin
-    // class), and skipping only the hooks still drags an unused plugin marker onto the
-    // buildscript classpath. Both halves gated together is the safe shape — see
-    // scanForKmpAndroidDeclaration() above for the rationale.
-    val composeAiPreviewSkipKmpAndroid = projectDir in composeAiPreviewKmpAndroidDirs
-
-    if (!composeAiPreviewSkipKmpAndroid && projectDir !in composeAiPreviewPreAppliedDirs) {
-        buildscript {
-            repositories {
-                gradlePluginPortal()
-                mavenCentral()
-                google()
-                if (useMavenLocal) mavenLocal()
-            }
-            dependencies {
-                add(
-                    "classpath",
-                    "ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:${'$'}pluginVersion",
-                )
-            }
-        }
-    }
-
-    if (composeAiPreviewSkipKmpAndroid) return@allprojects
+    // Skip the apply hooks for projects that already declare the plugin themselves. The
+    // user's `plugins { id("...") version "..." }` resolves the plugin from a project-scoped
+    // classloader; double-applying via our hook would risk class-identity confusion across
+    // classloaders. The hasPlugin() guard inside applyComposeAiPreview() is the defence in
+    // depth backstop for non-versioned apply forms the scanner doesn't catch.
+    if (projectDir in composeAiPreviewPreAppliedDirs) return@allprojects
+    // Skip KMP-Android modules — applying compose-preview there trips an AGP-KMP variant-
+    // ambiguity error on `androidRuntimeClasspath` once the renderer's artifact view kicks
+    // in. See scanForKmpAndroidDeclaration() above for the rationale.
+    if (projectDir in composeAiPreviewKmpAndroidDirs) return@allprojects
 
     fun applyComposeAiPreview() {
         if (plugins.hasPlugin("ee.schimke.composeai.preview")) return

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -21,17 +21,49 @@ class AutoInjectTest {
     Files.createTempDirectory(prefix).toFile().also { tempDirs += it }
 
   @Test
-  fun `init script bakes the plugin version into the source`() {
+  fun `init script bakes the plugin version into the initscript classpath coordinate`() {
     val script = renderInitScript("9.9.9-test")
     assertTrue(
-      script.contains("val pluginVersion = \"9.9.9-test\""),
-      "expected the plugin version to be interpolated into the script",
+      script.contains(
+        "classpath(\"ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:9.9.9-test\")"
+      ),
+      "expected the pinned coordinate baked into the initscript classpath dependency",
+    )
+  }
+
+  @Test
+  fun `init script loads the plugin via initscript classpath instead of buildscript injection`() {
+    // Regression for the Confetti follow-up (#1482): Gradle 9.3+ rejects mutating
+    // `buildscript.repositories` in *any* build whose `pluginManagement.repositories` declares
+    // `exclusiveContent { ... }`. The previous fix (#1470) only guarded composite-included
+    // builds; the same shape at the root build still tripped the validation. Switching to an
+    // initscript-level classpath load means we never touch `buildscript.repositories` on any
+    // consumer project at any level, sidestepping the validation entirely.
+    val script = renderInitScript("0.11.7")
+    assertTrue(
+      script.contains("initscript {"),
+      "expected an initscript { ... } block that loads the plugin into the init classloader",
     )
     assertTrue(
       script.contains(
-        "ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:\$pluginVersion"
+        "classpath(\"ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:0.11.7\")"
       ),
-      "expected the buildscript classpath coordinate to reference the pinned coordinate",
+      "expected the initscript dependencies block to declare the plugin classpath",
+    )
+    // The previous shape was `allprojects { ... buildscript { repositories { ... } } }`. The
+    // explanatory header comment legitimately mentions buildscript by name, so check for the
+    // injection-call wire shape rather than the word — the literal `add("classpath", ...)`
+    // form the old code used, and the surrounding indentation that marks it as inside
+    // allprojects.
+    assertFalse(
+      script.contains("add(\n                    \"classpath\","),
+      "init script must not add buildscript classpath dependencies in allprojects { ... } — " +
+        "that's the shape Gradle 9.3+ rejects when exclusiveContent is present in " +
+        "pluginManagement.repositories at any level",
+    )
+    assertFalse(
+      script.contains("        buildscript {\n            repositories {"),
+      "init script must not declare per-project buildscript { repositories { ... } } injection",
     )
   }
 
@@ -108,8 +140,16 @@ class AutoInjectTest {
     materializeInitScript(dir, "1.0.0")
     val target = materializeInitScript(dir, "2.0.0")
     val onDisk = target.readText()
-    assertTrue(onDisk.contains("val pluginVersion = \"2.0.0\""))
-    assertFalse(onDisk.contains("val pluginVersion = \"1.0.0\""))
+    assertTrue(
+      onDisk.contains(
+        "ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:2.0.0"
+      )
+    )
+    assertFalse(
+      onDisk.contains(
+        "ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:1.0.0"
+      )
+    )
   }
 
   @Test
@@ -509,14 +549,14 @@ class AutoInjectTest {
   }
 
   @Test
-  fun `init script gates the buildscript classpath injection on per-project pre-applied detection`() {
-    // Regression for #305 (homeassistant-remotecompose): the original gate was a single global
-    // boolean, so a mixed-shape project where some modules declare the plugin via
-    // `alias(libs.plugins.compose.preview)` and others don't would skip buildscript injection
-    // *everywhere* and then `pluginManager.apply` from the withPlugin hooks would fail in the
-    // modules without the catalog alias ("Plugin with id 'ee.schimke.composeai.preview' not
-    // found."). The gate is now a per-project set of project directories that declare the
-    // plugin themselves.
+  fun `init script gates the apply hooks on per-project pre-applied detection`() {
+    // Successor to the #305 regression coverage: the per-project pre-applied scan used to gate
+    // the buildscript classpath injection; that injection is gone (replaced by initscript
+    // classpath, #1482) so the scan now gates the apply hooks instead. Skipping the hooks for
+    // a project that already declares the plugin via `plugins { id(...) version "..." }`
+    // avoids class-identity confusion: the user's plugins-DSL resolution loads the plugin
+    // into a project-scoped classloader, while pluginManager.apply from the hook would
+    // resolve via the init-script classloader.
     val script = renderInitScript("0.10.15")
     assertTrue(
       script.contains("var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()"),
@@ -529,8 +569,8 @@ class AutoInjectTest {
       "expected the set to be populated during settingsEvaluated",
     )
     assertTrue(
-      script.contains("projectDir !in composeAiPreviewPreAppliedDirs"),
-      "expected the buildscript block to be guarded per-project on the directory set",
+      script.contains("if (projectDir in composeAiPreviewPreAppliedDirs) return@allprojects"),
+      "expected the apply hooks to short-circuit per-project on the directory set",
     )
     assertTrue(
       script.contains("gradle/libs.versions.toml"),
@@ -585,11 +625,16 @@ class AutoInjectTest {
     // restrictive `RepositoriesMode`s and lets integration CI resolve our SNAPSHOT runtime deps
     // from `~/.m2`. `pluginManagement.repositories.mavenLocal()` covers the plugins-DSL resolution
     // path for the catalog-alias / literal-`id(...) version "..."` case where we skip our own
-    // buildscript classpath injection.
+    // apply hooks. The initscript block also seeds `mavenLocal()` so the plugin itself can
+    // resolve from ~/.m2 when functional tests publish to local-maven.
     val script = renderInitScript("0.1.0-SNAPSHOT")
     assertTrue(
+      script.contains("if (useMavenLocal) mavenLocal()"),
+      "expected the initscript repositories block to gate mavenLocal on the env flag",
+    )
+    assertTrue(
       script.contains("if (useMavenLocal) {"),
-      "expected the mavenLocal seeding to be gated on the COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL flag",
+      "expected the settingsEvaluated mavenLocal seeding to be gated on the env flag too",
     )
     assertTrue(
       script.contains("pluginManagement.repositories.mavenLocal()"),
@@ -644,9 +689,9 @@ class AutoInjectTest {
     // that uses `com.android.kotlin.multiplatform.library` trips an AGP-KMP variant-ambiguity
     // error on `androidRuntimeClasspath` once the renderer's artifact view kicks in, which
     // breaks `compose-preview show` for any project where the plugin landed via auto-inject.
-    // Auto-inject must scan for the KMP-Android plugin id, mark those modules, and skip both
-    // the buildscript classpath injection AND the apply hooks for them — partial skipping
-    // leaves the other half active and still fails. Pins the wire shape of both halves.
+    // Auto-inject must scan for the KMP-Android plugin id, mark those modules, and skip the
+    // apply hooks for them. (The buildscript-classpath injection that used to be gated
+    // alongside this is gone — replaced by initscript classpath in #1482.)
     val script = renderInitScript("0.11.4")
     assertTrue(
       script.contains("var composeAiPreviewKmpAndroidDirs: Set<java.io.File> = emptySet()"),
@@ -659,19 +704,7 @@ class AutoInjectTest {
       "expected settingsEvaluated to populate the KMP-Android skip set",
     )
     assertTrue(
-      script.contains(
-        "val composeAiPreviewSkipKmpAndroid = projectDir in composeAiPreviewKmpAndroidDirs"
-      ),
-      "expected the per-project skip flag",
-    )
-    assertTrue(
-      script.contains(
-        "if (!composeAiPreviewSkipKmpAndroid && projectDir !in composeAiPreviewPreAppliedDirs) {"
-      ),
-      "expected the buildscript classpath injection to be gated on the KMP-Android skip flag too",
-    )
-    assertTrue(
-      script.contains("if (composeAiPreviewSkipKmpAndroid) return@allprojects"),
+      script.contains("if (projectDir in composeAiPreviewKmpAndroidDirs) return@allprojects"),
       "expected the withPlugin apply hooks to short-circuit for KMP-Android modules",
     )
   }
@@ -699,14 +732,14 @@ class AutoInjectTest {
 
   @Test
   fun `init script skips composite-included builds in settingsEvaluated and allprojects`() {
-    // Regression for the Confetti report: with `includeBuild("build-logic")` whose
-    // settings.gradle.kts declares `exclusiveContent { ... }` in `pluginManagement.repositories`,
-    // Gradle 9.3+ rejects any project that adds to `buildscript.repositories`. The init script
-    // is evaluated once per build in a composite, so the unguarded `allprojects { buildscript
-    // { repositories { ... } } }` previously fired against the included build and tripped the
-    // validation. Pins the early-return shape so it doesn't regress. An included build's
-    // `gradle.parent` is non-null; the root build's is null, so the guard is a one-liner that
-    // costs the root build nothing.
+    // Originally the Confetti regression (#1470): we touched `buildscript.repositories` in
+    // every project of every build in a composite, and Gradle 9.3+ rejects that once
+    // exclusiveContent is on settings.pluginManagement.repositories. The fix moved plugin
+    // resolution to initscript classpath (#1482), so this guard is no longer load-bearing for
+    // that validation — but the early return stays so we don't waste time scanning and
+    // applying the plugin in plugin-only included builds (`build-logic`,
+    // `gradle-conventions`) that never host @Preview composables. An included build's
+    // `gradle.parent` is non-null; the root build's is null.
     val script = renderInitScript("0.11.6")
     assertTrue(
       script.contains("val composeAiPreviewIsIncludedBuild = gradle.parent != null"),
@@ -718,9 +751,7 @@ class AutoInjectTest {
     )
     assertTrue(
       script.contains("if (composeAiPreviewIsIncludedBuild) return@allprojects"),
-      "expected allprojects to short-circuit for composite-included builds so " +
-        "buildscript.repositories isn't touched in included builds (would conflict with " +
-        "exclusiveContent in settings.pluginManagement.repositories)",
+      "expected allprojects to short-circuit for composite-included builds",
     )
   }
 

--- a/vscode-extension/src/initScript.ts
+++ b/vscode-extension/src/initScript.ts
@@ -37,11 +37,19 @@ export function renderInitScript(
     return `// Compose Preview auto-inject init script.
 //
 // Materialised by the Compose Preview VS Code extension and passed via
-// --init-script on every Gradle invocation the extension makes. Applies
-// ee.schimke.composeai.preview (version pinned to ${pluginVersion}) to every
-// project that already applies com.android.application,
-// com.android.library, or org.jetbrains.compose — so consumers don't have
-// to edit their build files.
+// --init-script on every Gradle invocation the extension makes. Loads
+// ee.schimke.composeai.preview (version pinned to ${pluginVersion}) into
+// the init-script classloader so every project that already applies
+// com.android.application, com.android.library, or org.jetbrains.compose
+// can have it applied via \`pluginManager.apply(...)\` without us ever
+// mutating that project's \`buildscript.repositories\` — Gradle 9.3+
+// rejects adding to \`buildscript.repositories\` once any settings file in
+// the composite declares \`exclusiveContent { ... }\` inside
+// \`pluginManagement.repositories\` (issues #1470, #1482). The init-script
+// classpath sits on a parent classloader of every project's plugin
+// classloader, so \`pluginManager.apply\` resolves the plugin via its
+// META-INF/gradle-plugins descriptor without touching any project repo
+// list at all.
 //
 // Application uses pluginManager.withPlugin(...) (not afterEvaluate) so
 // AGP finalizeDsl / onVariants callbacks register before the DSL lock.
@@ -49,30 +57,35 @@ export function renderInitScript(
 // Pre-applied detection is *per project*: for each subproject whose build
 // file declares the plugin with a version — either literal
 // \`id("...") version "..."\` or via \`alias(libs.plugins.<x>)\` where the
-// version catalog maps <x> to this plugin id — we skip the buildscript
-// classpath injection for that project. Gradle's plugins {} DSL rejects
-// \`id(...) version "..."\` when the same plugin is also on the buildscript
-// classpath ("the plugin is already on the classpath with an unknown
-// version, so compatibility cannot be checked"), and the user's own
-// declaration provides resolution via plugin marker repos. Projects that
-// don't declare the plugin themselves still get the buildscript classpath
-// injection so the withPlugin / pluginManager.apply path can find the
-// plugin class — this is what mixed-shape multi-module projects need
-// (e.g. an \`:app\` module that applies the plugin via catalog alias, plus
-// a sibling \`:rc-components\` android-library module that doesn't; the
-// init script's withPlugin("com.android.library") hook fires in
-// rc-components too and the plugin must be resolvable from its buildscript
-// classpath). The withPlugin hooks in projects that already apply the
-// plugin no-op via the plugins.hasPlugin(...) guard.
+// version catalog maps <x> to this plugin id — we skip the withPlugin
+// apply hooks entirely. The user's own \`plugins { }\` block resolves and
+// applies the plugin from a project-scoped classloader (a child of the
+// init-script one); double-applying via our hook would risk a duplicate-
+// application error or class-identity confusion across classloaders. The
+// \`plugins.hasPlugin(...)\` guard inside applyComposeAiPreview() is the
+// defence-in-depth backstop for non-versioned apply forms.
 //
-// \`COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1\` opts the buildscript repos into
-// \`mavenLocal()\` — mirrors the CLI's AutoInject.kt behavior. Useful for
-// pointing the extension at a locally-published SNAPSHOT of the plugin
-// during dev (e.g. \`./gradlew publishToMavenLocal\` against this repo, then
-// launch VS Code with the flag set). Off by default so cached snapshots
-// don't widen the search surface for normal users.
+// \`COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1\` opts the init-script's
+// plugin-resolution repos into \`mavenLocal()\` — mirrors the CLI's
+// AutoInject.kt behavior. Useful for pointing the extension at a locally-
+// published SNAPSHOT of the plugin during dev (e.g. \`./gradlew
+// publishToMavenLocal\` against this repo, then launch VS Code with the
+// flag set). Off by default so cached snapshots don't widen the search
+// surface for normal users.
 
-val pluginVersion = "${pluginVersion}"
+initscript {
+    val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+        if (useMavenLocal) mavenLocal()
+    }
+    dependencies {
+        classpath("ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:${pluginVersion}")
+    }
+}
+
 val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
 
 var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()
@@ -153,17 +166,16 @@ fun scanForComposeAiPreviewDeclaration(
 }
 
 // Skip composite-included builds entirely — both the settings scan and the \`allprojects\`
-// injection. The init script is evaluated once per build in a composite (root + each
-// \`includeBuild(...)\`), so without this guard \`allprojects { buildscript { repositories { ... } } }\`
-// fires for the included build's projects too. That breaks any included build whose
-// \`pluginManagement.repositories\` declares \`exclusiveContent { ... }\`: Gradle 9.3+ rejects
-// adding to \`buildscript.repositories\` once exclusiveContent is in
-// \`settings.pluginManagement.repositories\` (e.g. Confetti's \`:build-logic\`). Included builds in
-// this pattern are conventionally plugin builds (\`build-logic\`, \`gradle-conventions\`) that don't
-// host \`@Preview\` composables, so injecting the plugin classpath there is unnecessary — and the
-// existing pre-applied scan only walks the *root* build's project hierarchy anyway, so
-// included-build projects were never tracked. An included build's \`Gradle\` instance has a
-// non-null \`parent\`; the root build's is \`null\`.
+// hooks. The init script is evaluated once per build in a composite (root + each
+// \`includeBuild(...)\`), so an unguarded \`allprojects { ... }\` fires for the included build's
+// projects too. Included builds in the conventional pattern (\`build-logic\`,
+// \`gradle-conventions\`) don't host \`@Preview\` composables, so applying the plugin there is
+// wasteful, and the pre-applied scan only walks the *root* build's project hierarchy anyway.
+// With the init-script classpath approach this is no longer load-bearing for Gradle 9.3+'s
+// \`exclusiveContent\` validation (issue #1482) — we never touch \`buildscript.repositories\`
+// anywhere — but the guard stays as defence-in-depth and to skip pointless work in plugin-
+// only builds. An included build's \`Gradle\` instance has a non-null \`parent\`; the root
+// build's is \`null\`.
 val composeAiPreviewIsIncludedBuild = gradle.parent != null
 
 gradle.settingsEvaluated {
@@ -176,17 +188,19 @@ gradle.settingsEvaluated {
     collect(rootProject)
     composeAiPreviewPreAppliedDirs = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)
 
-    // When opting into mavenLocal, also seed it at the settings level so the renderer-android AAR
-    // and any other ee.schimke.composeai:* runtime artifacts resolve from ~/.m2 alongside the
-    // plugin classpath. Consumers with \`RepositoriesMode.FAIL_ON_PROJECT_REPOS\` refuse per-project
-    // repos, so settings-level seeding is the only path that survives. pluginManagement.repositories
-    // .mavenLocal() covers the catalog-alias / literal-\`id(...) version "..."\` case where resolution
-    // goes through the plugins DSL instead of our buildscript classpath injection.
+    // When opting into mavenLocal, seed it at the settings level so the renderer-android AAR
+    // and any other ee.schimke.composeai:* runtime artifacts resolve from ~/.m2 at task-
+    // execution time. The plugin class itself comes from the init-script classloader, so this
+    // only matters for the runtime artifacts — but consumers with
+    // \`RepositoriesMode.FAIL_ON_PROJECT_REPOS\` refuse per-project repos, so settings-level
+    // seeding is the only path that survives. pluginManagement.repositories.mavenLocal()
+    // covers the catalog-alias / literal-\`id(...) version "..."\` case where the user resolves
+    // the plugin via the plugins DSL instead of relying on our init-script classpath.
     //
-    // Gradle only auto-adds the default Plugin Portal when \`pluginManagement.repositories\` is empty
-    // after settings evaluation — once we explicitly add \`mavenLocal()\` the list is non-empty and
-    // the default is suppressed, so restore the defaults explicitly when the build didn't declare
-    // any plugin repos of its own.
+    // Gradle only auto-adds the default Plugin Portal when \`pluginManagement.repositories\` is
+    // empty after settings evaluation — once we explicitly add \`mavenLocal()\` the list is
+    // non-empty and the default is suppressed, so restore the defaults explicitly when the
+    // build didn't declare any plugin repos of its own.
     if (useMavenLocal) {
         val seedPluginDefaults = pluginManagement.repositories.isEmpty()
         pluginManagement.repositories.mavenLocal()
@@ -201,22 +215,12 @@ gradle.settingsEvaluated {
 
 allprojects {
     if (composeAiPreviewIsIncludedBuild) return@allprojects
-    if (projectDir !in composeAiPreviewPreAppliedDirs) {
-        buildscript {
-            repositories {
-                gradlePluginPortal()
-                mavenCentral()
-                google()
-                if (useMavenLocal) mavenLocal()
-            }
-            dependencies {
-                add(
-                    "classpath",
-                    "ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:$pluginVersion",
-                )
-            }
-        }
-    }
+    // Skip the apply hooks for projects that already declare the plugin themselves. The
+    // user's \`plugins { id("...") version "..." }\` resolves the plugin from a project-scoped
+    // classloader; double-applying via our hook would risk class-identity confusion across
+    // classloaders. The hasPlugin() guard inside applyComposeAiPreview() is the defence-in-
+    // depth backstop for non-versioned apply forms the scanner doesn't catch.
+    if (projectDir in composeAiPreviewPreAppliedDirs) return@allprojects
 
     fun applyComposeAiPreview() {
         if (plugins.hasPlugin("ee.schimke.composeai.preview")) return

--- a/vscode-extension/src/test/initScript.test.ts
+++ b/vscode-extension/src/test/initScript.test.ts
@@ -27,24 +27,39 @@ function withTempDir(
 }
 
 describe("renderInitScript", () => {
-    it("bakes the pinned plugin version into the script", () => {
+    it("bakes the pinned plugin version into the initscript classpath coordinate", () => {
         const script = renderInitScript("9.9.9-test");
-        assert.match(
-            script,
-            /val pluginVersion = "9\.9\.9-test"/,
-            "expected the plugin version to be interpolated",
-        );
-        assert.match(
-            script,
-            /ee\.schimke\.composeai\.preview:ee\.schimke\.composeai\.preview\.gradle\.plugin:\$pluginVersion/,
-            "expected the buildscript classpath coordinate to reference the version variable",
+        assert.ok(
+            script.includes(
+                'classpath("ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:9.9.9-test")',
+            ),
+            "expected the pinned coordinate baked into the initscript dependency",
         );
     });
 
     it("falls back to BUNDLED_PLUGIN_VERSION when no argument is given", () => {
         const script = renderInitScript();
         assert.ok(
-            script.includes(`val pluginVersion = "${BUNDLED_PLUGIN_VERSION}"`),
+            script.includes(
+                `classpath("ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:${BUNDLED_PLUGIN_VERSION}")`,
+            ),
+        );
+    });
+
+    it("loads the plugin via initscript classpath instead of buildscript injection", () => {
+        // Regression for the Confetti follow-up (#1482): Gradle 9.3+ rejects mutating
+        // `buildscript.repositories` in *any* build whose `pluginManagement.repositories`
+        // declares `exclusiveContent { ... }`. The previous fix only guarded composite-
+        // included builds; the same shape at the root build still tripped the validation.
+        // Switching to initscript-level classpath load sidesteps the validation entirely.
+        const script = renderInitScript();
+        assert.ok(
+            script.includes("initscript {"),
+            "expected an initscript { ... } block that loads the plugin into the init classloader",
+        );
+        assert.ok(
+            !script.includes("buildscript {"),
+            "init script must not declare per-project buildscript { ... } injection",
         );
     });
 
@@ -76,16 +91,12 @@ describe("renderInitScript", () => {
         );
     });
 
-    it("gates the buildscript classpath injection on per-project pre-applied detection", () => {
-        // Regression for #305 (homeassistant-remotecompose): the original gate was a single
-        // global boolean, so a mixed-shape project where some modules declare the plugin via
-        // `alias(libs.plugins.compose.preview)` and others don't would skip buildscript
-        // injection *everywhere*. Then `pluginManager.apply` from the withPlugin hooks would
-        // fail in the modules without the catalog alias ("Plugin with id
-        // 'ee.schimke.composeai.preview' not found."). The gate is now a per-project set of
-        // project directories that declare the plugin themselves; modules without their own
-        // declaration still get the buildscript classpath injection so withPlugin's
-        // pluginManager.apply can resolve the plugin class.
+    it("gates the apply hooks on per-project pre-applied detection", () => {
+        // Successor to the #305 coverage: the per-project pre-applied scan used to gate the
+        // buildscript classpath injection; that injection is gone (replaced by initscript
+        // classpath, #1482) so the scan now gates the apply hooks instead. Skipping the
+        // hooks for a project that already declares the plugin avoids class-identity
+        // confusion across the init-script vs project-scoped classloaders.
         const script = renderInitScript();
         assert.ok(
             script.includes(
@@ -101,9 +112,9 @@ describe("renderInitScript", () => {
         );
         assert.ok(
             script.includes(
-                "if (projectDir !in composeAiPreviewPreAppliedDirs) {",
+                "if (projectDir in composeAiPreviewPreAppliedDirs) return@allprojects",
             ),
-            "expected the buildscript block to be guarded per-project on the directory set",
+            "expected the apply hooks to short-circuit per-project on the directory set",
         );
         // Catalog alias resolution: the scanner must look at gradle/libs.versions.toml
         // so that `alias(libs.plugins.<x>)` references are detected.
@@ -209,7 +220,7 @@ describe("renderInitScript", () => {
         );
         assert.ok(
             script.includes("if (useMavenLocal) mavenLocal()"),
-            "expected mavenLocal() to be guarded by useMavenLocal in buildscript repos",
+            "expected mavenLocal() to be guarded by useMavenLocal in initscript repos",
         );
         assert.ok(
             script.includes("pluginManagement.repositories.mavenLocal()"),
@@ -294,8 +305,16 @@ describe("materializeInitScript", () => {
             materializeInitScript(dir, "1.0.0");
             const target = materializeInitScript(dir, "2.0.0");
             const onDisk = fs.readFileSync(target, "utf-8");
-            assert.match(onDisk, /val pluginVersion = "2\.0\.0"/);
-            assert.ok(!onDisk.includes('val pluginVersion = "1.0.0"'));
+            assert.ok(
+                onDisk.includes(
+                    "ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:2.0.0",
+                ),
+            );
+            assert.ok(
+                !onDisk.includes(
+                    "ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:1.0.0",
+                ),
+            );
         }),
     );
 });


### PR DESCRIPTION
## Summary

Resolves Gradle 9.3+ validation failures when `pluginManagement.repositories` declares `exclusiveContent { ... }` by moving plugin resolution from per-project buildscript injection to initscript-level classpath loading. This eliminates the need to mutate `buildscript.repositories` on consumer projects entirely.

## Key Changes

- **Initscript classpath loading**: Added an `initscript { repositories { ... } dependencies { ... } }` block that loads the compose-preview plugin into the init-script classloader, making it available to all projects without touching their buildscript configurations.

- **Removed per-project buildscript injection**: Eliminated the `allprojects { buildscript { repositories { ... } dependencies { ... } } }` pattern that was causing Gradle 9.3+ to reject builds with `exclusiveContent` in `pluginManagement.repositories`.

- **Updated pre-applied detection logic**: The per-project `composeAiPreviewPreAppliedDirs` set now gates the `pluginManager.apply(...)` hooks instead of buildscript injection. Projects that declare the plugin themselves via `plugins { id(...) version "..." }` skip the hooks to avoid class-identity confusion across classloaders (user's plugins-DSL resolution uses a project-scoped classloader; our hook would resolve via the init-script classloader).

- **Simplified KMP-Android handling**: Removed the intermediate `composeAiPreviewSkipKmpAndroid` flag; the set-based guards now directly short-circuit both the settings scan and apply hooks with early returns.

- **Updated documentation**: Rewrote extensive comments explaining the new architecture, why initscript classpath avoids the Gradle 9.3+ validation issue, and how classloader hierarchy enables plugin resolution without repository mutation.

## Implementation Details

- The initscript block respects `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1` to support local development workflows (functional tests publishing to `~/.m2`).
- Settings-level `pluginManagement.repositories.mavenLocal()` seeding remains for runtime artifact resolution and catalog-alias/literal-`id(...) version "..."` cases where users resolve the plugin via the plugins DSL.
- Composite-included build guards remain as defence-in-depth to skip unnecessary work in plugin-only builds, even though the initscript approach no longer requires them for Gradle 9.3+ validation.
- Applied consistently across both CLI (`AutoInject.kt`) and VS Code extension (`initScript.ts`) implementations.

## Fixes

- Resolves issue #1482 (Gradle 9.3+ `exclusiveContent` validation failures)
- Maintains compatibility with issue #1470 (composite-included builds)
- Preserves per-project pre-applied detection from issue #305 (mixed-shape multi-module projects)

https://claude.ai/code/session_01DuCgzpFTpuvJ5YbFWA2wUS