### PR TITLE
fix: apply plugin by Class reference instead of id in init script

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -39,18 +39,17 @@ internal fun renderInitScript(pluginVersion: String): String =
 // ee.schimke.composeai.preview (version pinned to $pluginVersion) into
 // the init-script classloader so every project that already applies
 // com.android.application, com.android.library, or org.jetbrains.compose
-// can have it applied via `pluginManager.apply(...)` without us ever
-// mutating that project's `buildscript.repositories` — Gradle 9.3+
-// rejects adding to `buildscript.repositories` once any settings file in
-// the composite declares `exclusiveContent { ... }` inside
-// `pluginManagement.repositories`, so the previous
+// can have the plugin applied via `pluginManager.apply(Class<...>)`
+// without us ever mutating that project's `buildscript.repositories` —
+// Gradle 9.3+ rejects adding to `buildscript.repositories` once any
+// settings file in the composite declares `exclusiveContent { ... }`
+// inside `pluginManagement.repositories`, so the previous
 // `allprojects { buildscript { repositories { ... } } }` injection was
-// load-bearing for the conflict (issues #1470, #1482). The init-script
-// classpath sits on a parent classloader of every project's plugin
-// classloader, so `pluginManager.apply` resolves the plugin via its
-// META-INF/gradle-plugins descriptor without touching any project repo
-// list at all. Disable per-run with --no-auto-inject or
-// COMPOSE_PREVIEW_NO_AUTO_INJECT=1.
+// load-bearing for the conflict (issues #1470, #1482). We apply by
+// Class reference (not id) because the init-script classloader is a
+// *sibling* of the project's plugin classloader, not an ancestor — id-
+// based `apply(id)` would miss the META-INF descriptor. Disable per-run
+// with --no-auto-inject or COMPOSE_PREVIEW_NO_AUTO_INJECT=1.
 //
 // Application uses pluginManager.withPlugin(...) (not afterEvaluate) so AGP
 // finalizeDsl / onVariants callbacks register before the DSL lock.
@@ -287,6 +286,19 @@ gradle.settingsEvaluated {
     }
 }
 
+// Resolve the plugin Class once from the init-script classloader (where the `initscript {
+// classpath ... }` block loaded it). `pluginManager.apply(id)` does NOT find a plugin via the
+// init-script classpath — the init-script classloader is a sibling of the project's plugin
+// classloader, not an ancestor, so the id-based `META-INF/gradle-plugins/<id>.properties`
+// lookup misses it ("Plugin with id '...' not found.", PR #1483 follow-up). Applying by
+// Class reference works because we hand Gradle the loaded class directly; Gradle then
+// records the plugin under its id (from the META-INF file on the *class's* defining
+// classloader, which IS the init-script one), so subsequent `plugins.hasPlugin(id)` calls
+// resolve correctly.
+val composeAiPreviewPluginClass: Class<out org.gradle.api.Plugin<*>> =
+    Class.forName("ee.schimke.composeai.plugin.ComposePreviewPlugin")
+        .asSubclass(org.gradle.api.Plugin::class.java)
+
 allprojects {
     if (composeAiPreviewIsIncludedBuild) return@allprojects
     // Skip the apply hooks for projects that already declare the plugin themselves. The
@@ -302,7 +314,7 @@ allprojects {
 
     fun applyComposeAiPreview() {
         if (plugins.hasPlugin("ee.schimke.composeai.preview")) return
-        pluginManager.apply("ee.schimke.composeai.preview")
+        pluginManager.apply(composeAiPreviewPluginClass)
     }
 
     pluginManager.withPlugin("com.android.application") { applyComposeAiPreview() }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -32,6 +32,31 @@ class AutoInjectTest {
   }
 
   @Test
+  fun `init script applies the plugin by Class reference, not by id`() {
+    // The init-script classloader is a sibling of the project's plugin classloader, not an
+    // ancestor — `pluginManager.apply(id)` would miss the META-INF/gradle-plugins descriptor
+    // and fail with "Plugin with id 'ee.schimke.composeai.preview' not found." (the
+    // regression that surfaced after the first cut of PR #1483 against ComposeStarter).
+    // Applying by Class reference works because Gradle is handed the loaded class directly;
+    // it then records the plugin under its id from the META-INF file on the class's defining
+    // classloader (the init-script's), so subsequent hasPlugin(id) lookups still resolve.
+    val script = renderInitScript("0.11.7")
+    assertTrue(
+      script.contains("Class.forName(\"ee.schimke.composeai.plugin.ComposePreviewPlugin\")"),
+      "expected the plugin class to be resolved by reflection from the init-script classloader",
+    )
+    assertTrue(
+      script.contains("pluginManager.apply(composeAiPreviewPluginClass)"),
+      "expected the apply hook to apply by Class reference",
+    )
+    assertFalse(
+      script.contains("pluginManager.apply(\"ee.schimke.composeai.preview\")"),
+      "expected NOT to apply by id — the init-script classpath is not visible to id-based " +
+        "resolution from a project's plugin classloader",
+    )
+  }
+
+  @Test
   fun `init script loads the plugin via initscript classpath instead of buildscript injection`() {
     // Regression for the Confetti follow-up (#1482): Gradle 9.3+ rejects mutating
     // `buildscript.repositories` in *any* build whose `pluginManagement.repositories` declares

--- a/vscode-extension/src/initScript.ts
+++ b/vscode-extension/src/initScript.ts
@@ -41,15 +41,14 @@ export function renderInitScript(
 // ee.schimke.composeai.preview (version pinned to ${pluginVersion}) into
 // the init-script classloader so every project that already applies
 // com.android.application, com.android.library, or org.jetbrains.compose
-// can have it applied via \`pluginManager.apply(...)\` without us ever
-// mutating that project's \`buildscript.repositories\` — Gradle 9.3+
-// rejects adding to \`buildscript.repositories\` once any settings file in
-// the composite declares \`exclusiveContent { ... }\` inside
-// \`pluginManagement.repositories\` (issues #1470, #1482). The init-script
-// classpath sits on a parent classloader of every project's plugin
-// classloader, so \`pluginManager.apply\` resolves the plugin via its
-// META-INF/gradle-plugins descriptor without touching any project repo
-// list at all.
+// can have the plugin applied via \`pluginManager.apply(Class<...>)\`
+// without us ever mutating that project's \`buildscript.repositories\` —
+// Gradle 9.3+ rejects adding to \`buildscript.repositories\` once any
+// settings file in the composite declares \`exclusiveContent { ... }\`
+// inside \`pluginManagement.repositories\` (issues #1470, #1482). We
+// apply by Class reference (not id) because the init-script classloader
+// is a *sibling* of the project's plugin classloader, not an ancestor —
+// id-based \`apply(id)\` would miss the META-INF descriptor.
 //
 // Application uses pluginManager.withPlugin(...) (not afterEvaluate) so
 // AGP finalizeDsl / onVariants callbacks register before the DSL lock.
@@ -213,6 +212,16 @@ gradle.settingsEvaluated {
     }
 }
 
+// Resolve the plugin Class once from the init-script classloader (where the \`initscript {
+// classpath ... }\` block loaded it). \`pluginManager.apply(id)\` does NOT find a plugin via
+// the init-script classpath — the init-script classloader is a sibling of the project's
+// plugin classloader, not an ancestor, so the id-based META-INF lookup misses it ("Plugin
+// with id '...' not found.", PR #1483 follow-up). Applying by Class reference works
+// because we hand Gradle the loaded class directly.
+val composeAiPreviewPluginClass: Class<out org.gradle.api.Plugin<*>> =
+    Class.forName("ee.schimke.composeai.plugin.ComposePreviewPlugin")
+        .asSubclass(org.gradle.api.Plugin::class.java)
+
 allprojects {
     if (composeAiPreviewIsIncludedBuild) return@allprojects
     // Skip the apply hooks for projects that already declare the plugin themselves. The
@@ -224,7 +233,7 @@ allprojects {
 
     fun applyComposeAiPreview() {
         if (plugins.hasPlugin("ee.schimke.composeai.preview")) return
-        pluginManager.apply("ee.schimke.composeai.preview")
+        pluginManager.apply(composeAiPreviewPluginClass)
     }
 
     pluginManager.withPlugin("com.android.application") { applyComposeAiPreview() }

--- a/vscode-extension/src/test/initScript.test.ts
+++ b/vscode-extension/src/test/initScript.test.ts
@@ -46,6 +46,31 @@ describe("renderInitScript", () => {
         );
     });
 
+    it("applies the plugin by Class reference, not by id", () => {
+        // The init-script classloader is a sibling of the project's plugin classloader, not
+        // an ancestor — `pluginManager.apply(id)` would miss the META-INF descriptor and
+        // fail with "Plugin with id '...' not found." (regression after the first cut of
+        // PR #1483 against ComposeStarter).
+        const script = renderInitScript();
+        assert.ok(
+            script.includes(
+                'Class.forName("ee.schimke.composeai.plugin.ComposePreviewPlugin")',
+            ),
+            "expected the plugin class to be resolved by reflection from the init-script classloader",
+        );
+        assert.ok(
+            script.includes("pluginManager.apply(composeAiPreviewPluginClass)"),
+            "expected the apply hook to apply by Class reference",
+        );
+        assert.ok(
+            !script.includes(
+                'pluginManager.apply("ee.schimke.composeai.preview")',
+            ),
+            "expected NOT to apply by id — the init-script classpath is not visible to " +
+                "id-based resolution from a project's plugin classloader",
+        );
+    });
+
     it("loads the plugin via initscript classpath instead of buildscript injection", () => {
         // Regression for the Confetti follow-up (#1482): Gradle 9.3+ rejects mutating
         // `buildscript.repositories` in *any* build whose `pluginManagement.repositories`


### PR DESCRIPTION
## Summary

Fix plugin application in the init script to use Class reference instead of plugin id, resolving a classloader hierarchy issue where id-based plugin resolution fails.

## Problem

The init-script classloader is a *sibling* of the project's plugin classloader, not an ancestor. When using `pluginManager.apply(id)`, Gradle attempts to resolve the plugin via the `META-INF/gradle-plugins/<id>.properties` descriptor, but this lookup fails because the init-script classpath is not visible to the project's plugin classloader. This causes a "Plugin with id 'ee.schimke.composeai.preview' not found" error.

## Solution

- Changed plugin application from `pluginManager.apply("ee.schimke.composeai.preview")` to `pluginManager.apply(composeAiPreviewPluginClass)`
- Added explicit Class resolution via `Class.forName()` in the init script, executed in the init-script classloader context where the plugin is actually loaded
- Gradle records the plugin under its id when applied by Class reference, so subsequent `plugins.hasPlugin(id)` calls still resolve correctly

## Changes

- **cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt**: Updated init script generation to resolve plugin class and apply by reference; clarified comments explaining the classloader hierarchy
- **vscode-extension/src/initScript.ts**: Mirrored changes to the TypeScript init script template
- **cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt**: Added test verifying Class-based application and absence of id-based application
- **vscode-extension/src/test/initScript.test.ts**: Added corresponding test for the TypeScript implementation

## Implementation Details

The plugin class is resolved once at init-script evaluation time using `Class.forName()` and stored in a module-level variable `composeAiPreviewPluginClass`. This ensures the class is loaded by the init-script classloader, and passing the Class object directly to `pluginManager.apply()` bypasses the id-based META-INF lookup entirely.

https://claude.ai/code/session_01DuCgzpFTpuvJ5YbFWA2wUS