### PR TITLE
feat: cap preview image magnification with --preview-max-zoom

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -16,6 +16,14 @@
         var(--toolbar-hover)
     );
     --control-height: 22px;
+    /* Max magnification for previews with a known widthDp. Caps how many
+       times their natural pixel size the image-container is allowed to
+       stretch to — without this a 40dp Switch grows to fill a 200px grid
+       cell (5×) or the whole focus viewport (~20×) and dominates the
+       layout. The focus cap is higher because Focus is the inspector
+       view: the user wants room to see detail without it sprawling. */
+    --preview-max-zoom: 3;
+    --preview-max-zoom-focus: 6;
 }
 
 body {
@@ -1356,6 +1364,22 @@ preview-app {
 .preview-card[style*="--aspect-ratio"] .image-container img {
     height: 100%;
     object-fit: contain;
+}
+
+/* Magnification cap — cards with known widthDp don't stretch beyond
+   `--preview-max-zoom × natural` (the layout-focus override below bumps
+   that to `--preview-max-zoom-focus`). Centred via `margin-inline: auto`
+   so a capped image sits in the middle of an oversized card/cell rather
+   than pinning to the left edge. Treating widthDp as 1 px matches the
+   theming presenter's 1 dp ≈ 1 px convention. */
+.preview-card[style*="--width-dp"] .image-container {
+    max-width: calc(var(--width-dp) * var(--preview-max-zoom) * 1px);
+    margin-inline: auto;
+}
+.preview-grid.layout-focus
+    .preview-card[style*="--width-dp"].focused
+    .image-container {
+    max-width: calc(var(--width-dp) * var(--preview-max-zoom-focus) * 1px);
 }
 
 .image-container img.fade-in {

--- a/vscode-extension/src/test/relativeSizing.test.ts
+++ b/vscode-extension/src/test/relativeSizing.test.ts
@@ -58,7 +58,7 @@ afterEach(() => {
 });
 
 describe("applyRelativeSizing", () => {
-    it("sets --size-ratio and --aspect-ratio per card from widthDp/heightDp", () => {
+    it("sets --size-ratio, --aspect-ratio and --width-dp per card from widthDp/heightDp", () => {
         const previews = [
             preview("com.example.A", { widthDp: 100, heightDp: 200 }),
             preview("com.example.B", { widthDp: 200, heightDp: 400 }),
@@ -73,6 +73,7 @@ describe("applyRelativeSizing", () => {
             a.style.getPropertyValue("--aspect-ratio"),
             "100 / 200",
         );
+        assert.strictEqual(a.style.getPropertyValue("--width-dp"), "100");
 
         const b = cards.get("com.example.B")!;
         // 200 / 200 = 1
@@ -81,6 +82,7 @@ describe("applyRelativeSizing", () => {
             b.style.getPropertyValue("--aspect-ratio"),
             "200 / 400",
         );
+        assert.strictEqual(b.style.getPropertyValue("--width-dp"), "200");
     });
 
     it("fixes --size-ratio to 4 decimal places", () => {
@@ -95,7 +97,7 @@ describe("applyRelativeSizing", () => {
         assert.strictEqual(c.style.getPropertyValue("--size-ratio"), "0.1429");
     });
 
-    it("removes both CSS vars when widthDp / heightDp are missing", () => {
+    it("removes all CSS vars when widthDp / heightDp are missing", () => {
         const previews = [
             preview("com.example.E"), // no width/height
         ];
@@ -105,10 +107,12 @@ describe("applyRelativeSizing", () => {
         cards
             .get("com.example.E")!
             .style.setProperty("--aspect-ratio", "100 / 200");
+        cards.get("com.example.E")!.style.setProperty("--width-dp", "100");
         applyRelativeSizing(previews);
         const e = cards.get("com.example.E")!;
         assert.strictEqual(e.style.getPropertyValue("--size-ratio"), "");
         assert.strictEqual(e.style.getPropertyValue("--aspect-ratio"), "");
+        assert.strictEqual(e.style.getPropertyValue("--width-dp"), "");
     });
 
     it("removes vars from a card whose width is set but height isn't (and vice versa)", () => {

--- a/vscode-extension/src/webview/preview/relativeSizing.ts
+++ b/vscode-extension/src/webview/preview/relativeSizing.ts
@@ -36,9 +36,11 @@ export function applyRelativeSizing(previews: readonly PreviewInfo[]): void {
         if (w && h && maxW > 0) {
             card.style.setProperty("--size-ratio", (w / maxW).toFixed(4));
             card.style.setProperty("--aspect-ratio", w + " / " + h);
+            card.style.setProperty("--width-dp", String(w));
         } else {
             card.style.removeProperty("--size-ratio");
             card.style.removeProperty("--aspect-ratio");
+            card.style.removeProperty("--width-dp");
         }
     }
 }


### PR DESCRIPTION
## Summary
Add magnification caps for preview images to prevent small components (like a 40dp Switch) from dominating the layout when stretched to fill grid cells or the focus viewport.

## Changes
- **CSS variables**: Introduce `--preview-max-zoom` (3×) and `--preview-max-zoom-focus` (6×) to cap how much preview images can stretch beyond their natural pixel size
- **CSS rules**: Add `.preview-card[style*="--width-dp"] .image-container` selector to apply max-width constraints based on the component's `widthDp` value, with a higher cap for focused cards in the inspector view
- **Relative sizing**: Extend `applyRelativeSizing()` to set and remove the `--width-dp` CSS variable alongside existing `--size-ratio` and `--aspect-ratio` variables
- **Tests**: Update test descriptions and assertions to cover the new `--width-dp` variable

## Implementation Details
- The magnification cap treats `widthDp` as 1 px (matching the theming presenter's 1 dp ≈ 1 px convention)
- Images are centered via `margin-inline: auto` so capped images sit in the middle of oversized cards rather than pinning to the left edge
- The focus viewport uses a higher zoom cap (6×) to give users more room to see detail in the inspector view

https://claude.ai/code/session_019X346FybgZFw5b8LDdLXFT