### PR TITLE
fix: tolerate KMP-Android per-target Kotlin compile task names

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -314,6 +314,16 @@ internal object AndroidPreviewSupport {
     // `${variant}ScreenshotTestRuntimeClasspath` configuration we need.
     val screenshotTestEnabled = project.pluginManager.hasPlugin("com.android.compose.screenshot")
 
+    // `kotlin("multiplatform") + com.android.library` (issue #1492 / Confetti `:shared` shape):
+    // KGP creates per-target compile tasks like `compileDebugKotlinAndroid` instead of the plain
+    // `compileDebugKotlin` an android-library-only module exposes, and routes class output to
+    // `build/classes/kotlin/<targetName>/<variantName>/` rather than `build/tmp/kotlin-classes/…`.
+    // Both names / paths are added as candidates — whichever exists in the consumer's actual
+    // shape is picked up by `tasks.matching` / DiscoverPreviewsTask's silent skip-missing-dirs
+    // behaviour. The default `androidTarget()` name is "android"; consumers who renamed it
+    // (`androidTarget("foo")`) still need the workaround flagged in the issue.
+    val isKmp = project.pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform")
+
     val sourceClassDirs =
       project.files(
         project.layout.buildDirectory.dir("tmp/kotlin-classes/$variantName"),
@@ -322,6 +332,9 @@ internal object AndroidPreviewSupport {
           "intermediates/built_in_kotlinc/$variantName/compile${capVariant}Kotlin/classes"
         ),
       )
+    if (isKmp) {
+      sourceClassDirs.from(project.layout.buildDirectory.dir("classes/kotlin/android/$variantName"))
+    }
     if (screenshotTestEnabled) {
       sourceClassDirs.from(
         project.layout.buildDirectory.dir(
@@ -339,8 +352,16 @@ internal object AndroidPreviewSupport {
         project.configurations.findByName("${variantName}ScreenshotTestRuntimeClasspath")
       } else null
 
-    val mainCompileTaskName = "compile${capVariant}Kotlin"
-    val screenshotCompileTaskName = "compile${capVariant}ScreenshotTestKotlin"
+    val mainCompileTaskNames =
+      if (isKmp) listOf("compile${capVariant}Kotlin", "compile${capVariant}KotlinAndroid")
+      else listOf("compile${capVariant}Kotlin")
+    val screenshotCompileTaskNames =
+      if (isKmp)
+        listOf(
+          "compile${capVariant}ScreenshotTestKotlin",
+          "compile${capVariant}ScreenshotTestKotlinAndroid",
+        )
+      else listOf("compile${capVariant}ScreenshotTestKotlin")
     val discoverTask =
       ComposePreviewTasks.registerDiscoverTask(
         project,
@@ -349,10 +370,13 @@ internal object AndroidPreviewSupport {
         previewOutputDir,
         extension,
       ) {
-        dependsOn(mainCompileTaskName)
+        // Lazy `tasks.matching` rather than strict `dependsOn(taskName)` so KMP-Android modules
+        // (where `compileDebugKotlin` doesn't exist — only `compileDebugKotlinAndroid` does)
+        // don't crash whole-project listings at task-graph-build time. See issue #1492.
+        dependsOn(project.tasks.matching { it.name in mainCompileTaskNames })
         // No opt-in-extension wiring on `composePreviewDiscover` — a11y is daemon-only.
         if (screenshotTestEnabled) {
-          dependsOn(screenshotCompileTaskName)
+          dependsOn(project.tasks.matching { it.name in screenshotCompileTaskNames })
           screenshotTestRuntimeConfig?.let { stConfig ->
             dependencyJars.from(
               stConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files
@@ -375,7 +399,7 @@ internal object AndroidPreviewSupport {
     ComposePreviewTasks.registerCompileOnlyTask(
       project,
       extension,
-      compileTaskNames = listOf(mainCompileTaskName),
+      compileTaskNames = mainCompileTaskNames,
     )
 
     // Writes the plugin-side compat findings (CompatRules) to

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposePreviewCompileTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposePreviewCompileTaskTest.kt
@@ -26,6 +26,33 @@ class ComposePreviewCompileTaskTest {
   }
 
   @Test
+  fun `compile-only task wires whichever candidate exists`() {
+    // Issue #1492 / Confetti `:shared`: KMP+com.android.library modules expose
+    // `compileDebugKotlinAndroid` instead of `compileDebugKotlin`. The Android
+    // path in [AndroidPreviewSupport.registerAndroidTasks] passes both names as
+    // candidates so whichever shape the consumer is in resolves cleanly. The
+    // lazy `tasks.matching` membership check inside `registerCompileOnlyTask`
+    // must tolerate the missing name without crashing.
+    val project = ProjectBuilder.builder().build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+
+    val compileOnly =
+      ComposePreviewTasks.registerCompileOnlyTask(
+        project,
+        extension,
+        compileTaskNames = listOf("compileDebugKotlin", "compileDebugKotlinAndroid"),
+      )
+    // Only the KMP-Android-flavored name is registered — the plain
+    // `compileDebugKotlin` doesn't exist on this project.
+    val kmpCompileTask =
+      project.tasks.register("compileDebugKotlinAndroid", DefaultTask::class.java)
+
+    val deps = compileOnly.get().taskDependencies.getDependencies(compileOnly.get())
+
+    assertThat(deps).contains(kmpCompileTask.get())
+  }
+
+  @Test
   fun `desktop discover task picks up compile task registered later`() {
     val project = ProjectBuilder.builder().build()
     val extension = project.extensions.create("composePreview", PreviewExtension::class.java)


### PR DESCRIPTION
`kotlin("multiplatform") + com.android.library` (Confetti `:shared` shape)
makes KGP namespace the per-target compile task as `compileDebugKotlinAndroid`
instead of the plain `compileDebugKotlin` an Android-library-only module
exposes. The Android variant-discovery path treated `compileDebugKotlin` as
the canonical name and crashed whole-project listings ("Task with name
'compileDebugKotlin' not found in project ':shared'.") at task-graph-build
time.

Detect `org.jetbrains.kotlin.multiplatform` on the project; when present, add
the `compile${Cap}KotlinAndroid` name (and the
`build/classes/kotlin/android/<variantName>` output dir KGP routes its
KotlinAndroidTarget output into) as discovery candidates. Switch the strict
`dependsOn(taskName)` to lazy `tasks.matching { it.name in candidates }` so a
missing name silently contributes zero dependencies rather than aborting the
whole listing — matches what the desktop path already does and lines up with
DiscoverPreviewsTask's skip-missing-dirs behaviour.

Single-module commands (`compose-preview list --module shared`) and
whole-project listings now both succeed against the KMP+Android-library
shape.