### PR TITLE
fix: skip classpath dep injection for modules without buildscript repos in exclusiveContent shape

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -81,18 +81,20 @@ internal fun renderInitScript(pluginVersion: String): String =
 // block themselves — we just no longer apply it implicitly.
 //
 // When the consumer's settings file declares `exclusiveContent { ... }`
-// inside `pluginManagement { repositories { ... } }` (or shares its repos
-// with `dependencyResolutionManagement` so the same declaration applies
-// — the Confetti shape), Gradle 9.3+ rejects *adding* to
-// `buildscript.repositories` from any project (issues #1470, #1482). We
-// detect that shape and skip our own `buildscript.repositories` add — but
-// keep adding the classpath dependency and registering the apply hooks.
-// If the consumer's existing buildscript repositories can resolve the
-// plugin coordinate (cached, or declared in their own
-// `buildscript { repositories { ... } }`), auto-inject still works.
-// Otherwise Gradle fails naturally with a clear "Could not resolve"
-// message and the user's escape hatch is the documented manual
-// `plugins { id("ee.schimke.composeai.preview") version "X" }` apply.
+// inside `pluginManagement { repositories { ... } }` (the Confetti shape;
+// issues #1470, #1482), Gradle 9.3+ rejects *adding* to
+// `buildscript.repositories` from any project. We detect that shape and
+// fork the behaviour per-project: modules that have their own
+// `buildscript { repositories { ... } }` declared get the classpath dep
+// injected (resolution can succeed via the consumer's repos); modules
+// that don't are skipped entirely (the classpath dep would be unresolvable
+// and would `Cannot resolve external dependency ... because no
+// repositories are defined`, crashing the whole Tooling API query — the
+// 0.11.8 regression). Skipped modules silently miss the plugin; the user's
+// escape hatch is the documented manual `plugins { id("ee.schimke.composeai
+// .preview") version "X" }` apply, surfaced via a one-time lifecycle log
+// emitted at settingsEvaluated time when the exclusiveContent shape is
+// detected.
 //
 // PR #1483 tried to dodge the validation by loading the plugin via init-
 // script classpath. That works for the validation but breaks every AGP-
@@ -109,6 +111,15 @@ val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
 var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()
 var composeAiPreviewKmpAndroidDirs: Set<java.io.File> = emptySet()
 var composeAiPreviewSettingsHasExclusiveContent: Boolean = false
+// Projects that declare their own `buildscript { repositories { ... } }` block — populated
+// at settingsEvaluated time. Only consulted when composeAiPreviewSettingsHasExclusiveContent
+// is true: in that case we can't add repos to buildscript.repositories ourselves (Gradle
+// 9.3+ validation), so the only projects where our classpath dep can possibly resolve are
+// the ones that already have their own buildscript repos. For all other projects we skip
+// the injection entirely to avoid `Cannot resolve external dependency ... because no
+// repositories are defined` failures that crash the whole Tooling API query (issue from
+// 0.11.8 follow-up).
+var composeAiPreviewProjectsWithOwnBuildscriptRepos: Set<java.io.File> = emptySet()
 
 fun composeAiPreviewCatalogAccessors(rootDir: java.io.File): List<Regex> {
     val catalog = java.io.File(rootDir, "gradle/libs.versions.toml")
@@ -307,6 +318,53 @@ fun composeAiPreviewSettingsDeclaresExclusiveContent(settingsDir: java.io.File):
     return false
 }
 
+// Returns project directories that declare their own `buildscript { repositories { ... } }`
+// block. Brace-balance walks the build script: find `buildscript`, find its `{...}` body,
+// then check whether that body contains a `repositories` declaration. Used exclusively in
+// the exclusiveContent branch to decide where our classpath dep can possibly resolve.
+fun scanForProjectsWithBuildscriptRepos(
+    projectDirs: List<java.io.File>,
+): Set<java.io.File> {
+    val declared = LinkedHashSet<java.io.File>()
+    for (dir in projectDirs) {
+        for (name in listOf("build.gradle.kts", "build.gradle")) {
+            val buildFile = java.io.File(dir, name)
+            if (!buildFile.isFile) continue
+            val raw = runCatching { buildFile.readText() }.getOrNull() ?: continue
+            val text = composeAiPreviewStripComments(raw)
+            var i = 0
+            var found = false
+            while (i < text.length && !found) {
+                val match = Regex("\\bbuildscript\\b").find(text, i) ?: break
+                var j = match.range.last + 1
+                while (j < text.length && text[j].isWhitespace()) j++
+                if (j >= text.length || text[j] != '{') {
+                    i = match.range.last + 1
+                    continue
+                }
+                var depth = 1
+                var k = j + 1
+                while (k < text.length && depth > 0) {
+                    when (text[k]) {
+                        '{' -> depth++
+                        '}' -> depth--
+                    }
+                    k++
+                }
+                val blockEnd = if (depth == 0) k - 1 else text.length
+                val block = text.substring(j + 1, blockEnd)
+                if (Regex("\\brepositories\\b").containsMatchIn(block)) {
+                    declared.add(dir)
+                    found = true
+                }
+                i = blockEnd + 1
+            }
+            if (found) break
+        }
+    }
+    return declared
+}
+
 // Skip composite-included builds entirely — both the settings scan and the `allprojects`
 // injection. The init script is evaluated once per build in a composite (root + each
 // `includeBuild(...)`), so without this guard `allprojects { buildscript { repositories { ... } } }`
@@ -334,6 +392,24 @@ gradle.settingsEvaluated {
     composeAiPreviewKmpAndroidDirs = scanForKmpAndroidDeclaration(rootDir, projectDirs)
     composeAiPreviewSettingsHasExclusiveContent =
         composeAiPreviewSettingsDeclaresExclusiveContent(settingsDir)
+    // Only walk the buildscript-repos scan when it matters — in the non-exclusiveContent
+    // path we add repos ourselves, so we don't care whether the project already has any.
+    if (composeAiPreviewSettingsHasExclusiveContent) {
+        composeAiPreviewProjectsWithOwnBuildscriptRepos =
+            scanForProjectsWithBuildscriptRepos(projectDirs)
+        // One-time lifecycle log so users hitting the Confetti shape know why auto-inject
+        // looks degraded — without this, modules silently miss the plugin and the only sign
+        // is a "no previews" result with no diagnostic.
+        gradle.rootProject {
+            logger.lifecycle(
+                "[compose-preview] settings.gradle.kts declares exclusiveContent in " +
+                    "pluginManagement.repositories; auto-inject is limited to modules that " +
+                    "pre-apply the plugin (via plugins { id(\"ee.schimke.composeai.preview\") " +
+                    "version \"...\") }) or declare their own buildscript { repositories { ... } }. " +
+                    "Modules in neither bucket: add the plugin via plugins { } to opt in."
+            )
+        }
+    }
 
     // When opting into mavenLocal, also seed it at the settings level so the renderer-android AAR
     // and any other ee.schimke.composeai:* runtime artifacts resolve from ~/.m2 alongside the
@@ -369,18 +445,29 @@ allprojects {
     // scanForKmpAndroidDeclaration() above for the rationale.
     val composeAiPreviewSkipKmpAndroid = projectDir in composeAiPreviewKmpAndroidDirs
 
-    if (!composeAiPreviewSkipKmpAndroid && projectDir !in composeAiPreviewPreAppliedDirs) {
+    // In the exclusiveContent shape we can't add repositories to buildscript.repositories
+    // (Gradle 9.3+ rejects it; issues #1470, #1482), so projects that don't already have
+    // their own buildscript repos have no way to resolve our classpath dep — adding it
+    // there would only produce `Cannot resolve external dependency ... because no
+    // repositories are defined` at configuration time, which short-circuits the entire
+    // Tooling API query (the 0.11.8 regression). Skip the injection wholesale for those
+    // projects; they silently miss the plugin, the same as projects that we explicitly
+    // skip for KMP-Android, and the user's recourse is the same plugins { } DSL apply.
+    val composeAiPreviewSkipExclusiveContentClasspathDep =
+        composeAiPreviewSettingsHasExclusiveContent &&
+            projectDir !in composeAiPreviewProjectsWithOwnBuildscriptRepos
+
+    if (!composeAiPreviewSkipKmpAndroid &&
+        !composeAiPreviewSkipExclusiveContentClasspathDep &&
+        projectDir !in composeAiPreviewPreAppliedDirs) {
         buildscript {
             // When the settings file declares `exclusiveContent { ... }` in `pluginManagement {
             // repositories { ... } }`, Gradle 9.3+ rejects any attempt to *add* repositories to
             // `buildscript.repositories` from any project (issues #1470, #1482). We still add
-            // the classpath dependency though — if the consumer has their own
-            // `buildscript { repositories { ... } }` block declaring a repo that hosts the
-            // plugin coordinate (gradlePluginPortal / mavenCentral / google), or has a cached
-            // copy locally, resolution can still succeed and auto-inject continues to work.
-            // When it can't resolve, Gradle fails the build naturally with a clear
-            // "Could not resolve" error; the user's escape hatch is to apply the plugin
-            // manually via `plugins { id("ee.schimke.composeai.preview") version "X" }`.
+            // the classpath dependency though — at this point we've confirmed the project has
+            // its own buildscript { repositories { ... } } declared (via the scan above), so
+            // resolution can succeed via those repos. Outside the exclusiveContent branch we
+            // both add our repos and add the dep, the original auto-inject happy path.
             if (!composeAiPreviewSettingsHasExclusiveContent) {
                 repositories {
                     gradlePluginPortal()
@@ -399,6 +486,12 @@ allprojects {
     }
 
     if (composeAiPreviewSkipKmpAndroid) return@allprojects
+    // No buildscript classpath dep was injected and the project doesn't pre-apply, so
+    // `pluginManager.apply(...)` from the withPlugin hooks would fail with "Plugin with id
+    // ... not found." Skipping the hooks keeps the failure mode quiet — non-preview
+    // projects (e.g. Confetti's :backend) configure cleanly with no diagnostic noise.
+    if (composeAiPreviewSkipExclusiveContentClasspathDep &&
+        projectDir !in composeAiPreviewPreAppliedDirs) return@allprojects
 
     fun applyComposeAiPreview() {
         if (plugins.hasPlugin("ee.schimke.composeai.preview")) return
@@ -540,6 +633,49 @@ internal fun settingsDeclaresExclusiveContentInPluginManagement(projectRoot: Fil
       val blockEnd = if (depth == 0) k - 1 else text.length
       val block = text.substring(j + 1, blockEnd)
       if (Regex("""\bexclusiveContent\b""").containsMatchIn(block)) return true
+      i = blockEnd + 1
+    }
+  }
+  return false
+}
+
+/**
+ * Mirrors the rendered init script's `scanForProjectsWithBuildscriptRepos`. Returns true when
+ * [projectDir]'s `build.gradle[.kts]` declares its own `buildscript { repositories { ... } }` block
+ * — the only shape where our classpath dep can possibly resolve in the
+ * `exclusiveContent`-in-`pluginManagement.repositories` branch. Brace-balances the script body to
+ * scope the `repositories` check to the buildscript block (so an unrelated top-level `repositories
+ * { ... }` block doesn't falsely flag the project).
+ *
+ * Visible for tests.
+ */
+internal fun projectHasBuildscriptRepositories(projectDir: File): Boolean {
+  for (name in listOf("build.gradle.kts", "build.gradle")) {
+    val buildFile = File(projectDir, name)
+    if (!buildFile.isFile) continue
+    val raw = runCatching { buildFile.readText() }.getOrNull() ?: continue
+    val text = stripGradleComments(raw)
+    var i = 0
+    while (i < text.length) {
+      val match = Regex("""\bbuildscript\b""").find(text, i) ?: break
+      var j = match.range.last + 1
+      while (j < text.length && text[j].isWhitespace()) j++
+      if (j >= text.length || text[j] != '{') {
+        i = match.range.last + 1
+        continue
+      }
+      var depth = 1
+      var k = j + 1
+      while (k < text.length && depth > 0) {
+        when (text[k]) {
+          '{' -> depth++
+          '}' -> depth--
+        }
+        k++
+      }
+      val blockEnd = if (depth == 0) k - 1 else text.length
+      val block = text.substring(j + 1, blockEnd)
+      if (Regex("""\brepositories\b""").containsMatchIn(block)) return true
       i = blockEnd + 1
     }
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -665,10 +665,10 @@ class AutoInjectTest {
       "expected the per-project skip flag",
     )
     assertTrue(
-      script.contains(
-        "if (!composeAiPreviewSkipKmpAndroid && projectDir !in composeAiPreviewPreAppliedDirs) {"
-      ),
-      "expected the buildscript classpath injection to be gated on the KMP-Android skip flag too",
+      script.contains("!composeAiPreviewSkipKmpAndroid &&") &&
+        script.contains("projectDir !in composeAiPreviewPreAppliedDirs"),
+      "expected the buildscript classpath injection to be gated on the KMP-Android skip flag " +
+        "and the pre-applied dir set",
     )
     assertTrue(
       script.contains("if (composeAiPreviewSkipKmpAndroid) return@allprojects"),
@@ -1087,6 +1087,129 @@ class AutoInjectTest {
   fun `settingsDeclaresExclusiveContentInPluginManagement returns false when settings file is missing`() {
     val root = tempDir()
     assertFalse(settingsDeclaresExclusiveContentInPluginManagement(root))
+  }
+
+  @Test
+  fun `projectHasBuildscriptRepositories detects an explicit buildscript repositories block`() {
+    // Used in the exclusiveContent branch — modules that don't already have their own
+    // `buildscript { repositories { ... } }` would crash configuration if we still injected
+    // the classpath dep (Confetti's :backend shape; 0.11.8 regression).
+    val dir = tempDir()
+    File(dir, "build.gradle.kts")
+      .writeText(
+        """
+        buildscript {
+            repositories { mavenCentral() }
+            dependencies { classpath("com.example:some-plugin:1.0") }
+        }
+        plugins { kotlin("jvm") }
+        """
+          .trimIndent()
+      )
+    assertTrue(projectHasBuildscriptRepositories(dir))
+  }
+
+  @Test
+  fun `projectHasBuildscriptRepositories returns false for a modern plugins-DSL-only build script`() {
+    // Confetti's :backend and friends — modern projects route everything through settings'
+    // pluginManagement / dependencyResolutionManagement. With no per-project buildscript
+    // repos, our classpath dep can't resolve in the exclusiveContent branch.
+    val dir = tempDir()
+    File(dir, "build.gradle.kts")
+      .writeText(
+        """
+        plugins {
+            kotlin("jvm") version "2.2.21"
+        }
+        """
+          .trimIndent()
+      )
+    assertFalse(projectHasBuildscriptRepositories(dir))
+  }
+
+  @Test
+  fun `projectHasBuildscriptRepositories ignores a top-level repositories block outside buildscript`() {
+    // A `repositories { ... }` at the project level (for runtime deps) is different from
+    // `buildscript { repositories { ... } }` (for plugin classpath). The scanner must scope
+    // the check to inside the buildscript block.
+    val dir = tempDir()
+    File(dir, "build.gradle.kts")
+      .writeText(
+        """
+        plugins { kotlin("jvm") }
+        repositories { mavenCentral() }
+        """
+          .trimIndent()
+      )
+    assertFalse(projectHasBuildscriptRepositories(dir))
+  }
+
+  @Test
+  fun `projectHasBuildscriptRepositories ignores commented-out blocks`() {
+    val dir = tempDir()
+    File(dir, "build.gradle.kts")
+      .writeText(
+        """
+        // buildscript {
+        //     repositories { mavenCentral() }
+        // }
+        plugins { kotlin("jvm") }
+        """
+          .trimIndent()
+      )
+    assertFalse(projectHasBuildscriptRepositories(dir))
+  }
+
+  @Test
+  fun `projectHasBuildscriptRepositories returns false when no build script exists`() {
+    // Confetti's :backend has no build.gradle.kts at all — it's a parent project with
+    // `include(":backend")` and `include(":backend:foo")` declared in settings, but no build
+    // script of its own.
+    val dir = tempDir()
+    assertFalse(projectHasBuildscriptRepositories(dir))
+  }
+
+  @Test
+  fun `init script gates buildscript classpath dep injection on per-project buildscript repos in exclusiveContent branch`() {
+    // Successor to the 0.11.8 follow-up regression: in the exclusiveContent branch, the
+    // classpath dep is unresolvable on modules without their own buildscript repos. Pins the
+    // wire shape so that the scanner and the per-project skip both survive future refactors.
+    val script = renderInitScript("0.11.9")
+    assertTrue(
+      script.contains(
+        "var composeAiPreviewProjectsWithOwnBuildscriptRepos: Set<java.io.File> = emptySet()"
+      ),
+      "expected the per-project buildscript-repos set declaration",
+    )
+    assertTrue(
+      script.contains(
+        "fun scanForProjectsWithBuildscriptRepos(\n    projectDirs: List<java.io.File>,\n): Set<java.io.File> {"
+      ),
+      "expected the scanner function in the rendered script",
+    )
+    assertTrue(
+      script.contains(
+        "composeAiPreviewProjectsWithOwnBuildscriptRepos =\n            scanForProjectsWithBuildscriptRepos(projectDirs)"
+      ),
+      "expected the set to be populated inside the exclusiveContent branch at settingsEvaluated time",
+    )
+    assertTrue(
+      script.contains(
+        "val composeAiPreviewSkipExclusiveContentClasspathDep =\n        composeAiPreviewSettingsHasExclusiveContent &&\n            projectDir !in composeAiPreviewProjectsWithOwnBuildscriptRepos"
+      ),
+      "expected the per-project skip flag in allprojects",
+    )
+    assertTrue(
+      script.contains(
+        "if (composeAiPreviewSkipExclusiveContentClasspathDep &&\n        projectDir !in composeAiPreviewPreAppliedDirs) return@allprojects"
+      ),
+      "expected the apply hooks to short-circuit for skipped modules (otherwise " +
+        "pluginManager.apply would fail with 'Plugin with id ... not found')",
+    )
+    assertTrue(
+      script.contains("[compose-preview] settings.gradle.kts declares exclusiveContent in"),
+      "expected the one-time lifecycle log so users know why auto-inject looks degraded",
+    )
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/InitScriptExclusiveContentReproducerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/InitScriptExclusiveContentReproducerTest.kt
@@ -4,8 +4,11 @@ import java.io.File
 import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
 
 /**
  * End-to-end reproducer for the Confetti shape (https://github.com/joreilly/Confetti `main`):
@@ -15,15 +18,18 @@ import org.gradle.testkit.runner.GradleRunner
  * 'buildscript.repositories'.`
  *
  * Asserts that the rendered init script's `allprojects { buildscript { repositories { ... } } }`
- * sub-block is suppressed when the settings file matches this shape, so the build configures
- * cleanly. The classpath dependency and apply hooks are intentionally kept — if the consumer's
- * existing buildscript repositories can resolve the plugin coordinate, auto-inject still works.
+ * sub-block is suppressed when the settings file matches this shape AND that the classpath
+ * dependency injection is also skipped for modules without their own `buildscript { repositories {
+ * ... } }` — adding the dep there would crash configuration with `Cannot resolve external
+ * dependency ... because no repositories are defined`, short-circuiting the entire Tooling API
+ * query (the 0.11.8 regression; the bug filed against the v0.11.8 follow-up to PRs #1483/#1490).
  *
- * PR #1483 tried to dodge this with an `initscript { classpath ... }` load, but that broke
- * plugins-that-reference-AGP at runtime (`NoClassDefFoundError:
+ * PR #1483 tried to dodge the validation with an `initscript { classpath ... }` load, but that
+ * broke plugins-that-reference-AGP at runtime (`NoClassDefFoundError:
  * com/android/build/api/variant/AndroidComponentsExtension` — init-script-loaded plugins sit on a
  * sibling classloader of AGP). The current fix keeps the plugin on the project's buildscript
- * classloader and detects the settings shape via text scan in [renderInitScript].
+ * classloader and forks per-project: modules with their own buildscript repos get the classpath dep
+ * injected (resolution can succeed via those); modules without are skipped entirely.
  *
  * Uses TestKit's default Gradle (the wrapper version) so the test fires the same validation that
  * production users hit; older Gradle wouldn't see the validation at all.
@@ -44,10 +50,10 @@ class InitScriptExclusiveContentReproducerTest {
    * Sets up a minimal project that mirrors Confetti's settings shape: `exclusiveContent` declared
    * inside `pluginManagement { listOf(repositories, dependencyResolutionManagement.repositories)
    * .forEach { ... } }`. The `:app` subproject applies a `plugins { }` block — required to make
-   * Gradle actually evaluate the buildscript dependency injection (an empty build script
-   * short-circuits before the validation can fire, so the regression doesn't reproduce on the
-   * empty-app fixture). A plain Kotlin JVM plugin is fine; the regression is repo-side, not
-   * plugin-side.
+   * Gradle actually evaluate the buildscript classpath, which is where our injection fires.
+   * Crucially `:app/build.gradle.kts` does NOT declare its own `buildscript { repositories { ... }
+   * }` — that matches the realistic Confetti shape where modules route everything through
+   * pluginManagement / dependencyResolutionManagement.
    */
   private fun createConfettiShapedProject(): File {
     val root = tempDir()
@@ -73,58 +79,57 @@ class InitScriptExclusiveContentReproducerTest {
       )
     File(root, "build.gradle.kts").writeText("// root build script — intentionally empty\n")
     val app = File(root, "app").apply { mkdirs() }
-    // The plugins {} block forces Gradle to evaluate buildscript classpath — that's where our
-    // init script's `allprojects { buildscript { repositories { ... } } }` injection tries to
-    // add gradlePluginPortal()/mavenCentral()/google() and (without the exclusiveContent skip)
-    // trips Gradle 9.3+'s validation. An empty :app build file would short-circuit before any
-    // of that runs and the regression wouldn't reproduce.
     File(app, "build.gradle.kts").writeText("""plugins { kotlin("jvm") version "2.2.21" }""")
     return root
   }
 
   @Test
-  fun `rendered init script does not trip exclusiveContent validation against the Confetti shape`() {
-    // Pre-fix: without the repositories skip, this build fails with
+  fun `init script configures cleanly against a Confetti-shaped project with no module buildscript repos`() {
+    // Original 0.11.7 regression: `allprojects { buildscript { repositories { ... } } }`
+    // tripped Gradle 9.3+'s
     //   "When using exclusive repository content in 'settings.pluginManagement.repositories',
     //    you cannot add repositories to 'buildscript.repositories'."
-    // Post-fix: our buildscript injection skips the repositories add. The classpath dep is
-    // still added and resolution is still attempted — if the consumer has their own
-    // `buildscript { repositories { ... } }` declaring a repo that hosts the plugin, the
-    // plugin resolves and auto-inject works. In this test fixture the consumer has no
-    // buildscript repos, so Gradle fails with a clear "Cannot resolve external dependency
-    // ... because no repositories are defined" — that's the intended escape hatch, and
-    // crucially it is NOT the exclusiveContent validation. The user's documented fallback
-    // is to apply the plugin manually via `plugins { id("ee.schimke.composeai.preview")
-    // version "X" }`.
+    // 0.11.8 fix sidestepped that validation but still injected the classpath dep, which then
+    // failed with "Cannot resolve external dependency ... because no repositories are defined"
+    // for any module without its own buildscript { repositories { ... } } — that crashed the
+    // whole Tooling API query (the 0.11.8 follow-up regression). The current fix skips both
+    // the repos add and the classpath dep injection on modules that have no buildscript repos
+    // of their own, so configuration completes cleanly. Modules silently miss the plugin in
+    // this branch; the lifecycle log tells the user to apply via `plugins { }` DSL.
     val project = createConfettiShapedProject()
-    val initScript = materializeInitScript(tempDir(), "0.11.7")
+    val initScript = materializeInitScript(tempDir(), "0.11.9")
 
-    // `:app:help` forces configuration of the :app subproject (its `plugins { kotlin("jvm") }`
-    // block triggers buildscript evaluation, which is what surfaces the exclusiveContent
-    // validation against our init script's allprojects-level buildscript injection). A bare
-    // `:help` on root wouldn't configure :app and the regression would silently not reproduce.
-    val output =
-      try {
-        GradleRunner.create()
-          .withProjectDir(project)
-          .withArguments(":app:help", "--init-script", initScript.absolutePath, "--stacktrace")
-          .forwardOutput()
-          .build()
-          .output
-      } catch (e: org.gradle.testkit.runner.UnexpectedBuildFailure) {
-        e.buildResult.output
-      }
+    val result =
+      GradleRunner.create()
+        .withProjectDir(project)
+        .withArguments(":app:help", "--init-script", initScript.absolutePath, "--stacktrace")
+        .forwardOutput()
+        .build()
 
     assertFalse(
-      output.contains("exclusive repository content"),
+      result.output.contains("exclusive repository content"),
       "init script tripped the exclusiveContent validation — the repositories sub-block of " +
-        "the buildscript injection isn't being suppressed for the Confetti shape; full " +
-        "output:\n$output",
+        "the buildscript injection isn't being suppressed; full output:\n${result.output}",
+    )
+    assertFalse(
+      result.output.contains("Cannot resolve external dependency"),
+      "init script tried to inject the classpath dep on a module without buildscript " +
+        "repositories — would crash the whole Tooling API query; full output:\n${result.output}",
+    )
+    assertEquals(
+      TaskOutcome.SUCCESS,
+      result.task(":app:help")?.outcome,
+      "expected :app:help to succeed against a Confetti-shaped project; got:\n${result.output}",
+    )
+    assertTrue(
+      result.output.contains("settings.gradle.kts declares exclusiveContent"),
+      "expected the lifecycle log nudging the user toward manual plugins { } DSL apply; got:\n" +
+        result.output,
     )
   }
 
   @Test
-  fun `rendered init script applies the buildscript classpath injection when settings has no exclusiveContent`() {
+  fun `init script still injects buildscript classpath when settings has no exclusiveContent`() {
     // Sanity check that the guard is narrow — a settings file WITHOUT exclusiveContent must still
     // see the buildscript injection (the auto-inject happy path the CLI is built around; issue
     // #305 and friends). We can't easily verify successful plugin resolution end-to-end here
@@ -145,7 +150,7 @@ class InitScriptExclusiveContentReproducerTest {
       )
     File(root, "build.gradle.kts").writeText("// intentionally empty\n")
 
-    val initScript = materializeInitScript(tempDir(), "0.11.7")
+    val initScript = materializeInitScript(tempDir(), "0.11.9")
 
     val runner =
       GradleRunner.create()
@@ -153,14 +158,10 @@ class InitScriptExclusiveContentReproducerTest {
         .withArguments("help", "--init-script", initScript.absolutePath)
         .forwardOutput()
 
-    // Either path is acceptable for *this* assertion; we only care that the failure (if any) is
-    // not the exclusiveContent validation. `build()` / `buildAndFail()` both return a
-    // `BuildResult` we can read `.output` from.
     val output =
       try {
         runner.build().output
       } catch (e: Exception) {
-        // BuildResult-bearing runtime exceptions surface stdout/stderr in their message.
         e.message.orEmpty()
       }
     assertFalse(

--- a/vscode-extension/src/initScript.ts
+++ b/vscode-extension/src/initScript.ts
@@ -86,6 +86,7 @@ val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
 
 var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()
 var composeAiPreviewSettingsHasExclusiveContent: Boolean = false
+var composeAiPreviewProjectsWithOwnBuildscriptRepos: Set<java.io.File> = emptySet()
 
 fun composeAiPreviewCatalogAccessors(rootDir: java.io.File): List<Regex> {
     val catalog = java.io.File(rootDir, "gradle/libs.versions.toml")
@@ -203,6 +204,53 @@ fun composeAiPreviewSettingsDeclaresExclusiveContent(settingsDir: java.io.File):
     return false
 }
 
+// Returns project directories that declare their own \`buildscript { repositories { ... } }\`
+// block. Used in the exclusiveContent branch to decide where our classpath dep can possibly
+// resolve — modules without their own buildscript repos can't resolve it and would crash
+// the whole Tooling API query at configuration time.
+fun scanForProjectsWithBuildscriptRepos(
+    projectDirs: List<java.io.File>,
+): Set<java.io.File> {
+    val declared = LinkedHashSet<java.io.File>()
+    for (dir in projectDirs) {
+        for (name in listOf("build.gradle.kts", "build.gradle")) {
+            val buildFile = java.io.File(dir, name)
+            if (!buildFile.isFile) continue
+            val raw = runCatching { buildFile.readText() }.getOrNull() ?: continue
+            val text = composeAiPreviewStripComments(raw)
+            var i = 0
+            var found = false
+            while (i < text.length && !found) {
+                val match = Regex("\\\\bbuildscript\\\\b").find(text, i) ?: break
+                var j = match.range.last + 1
+                while (j < text.length && text[j].isWhitespace()) j++
+                if (j >= text.length || text[j] != '{') {
+                    i = match.range.last + 1
+                    continue
+                }
+                var depth = 1
+                var k = j + 1
+                while (k < text.length && depth > 0) {
+                    when (text[k]) {
+                        '{' -> depth++
+                        '}' -> depth--
+                    }
+                    k++
+                }
+                val blockEnd = if (depth == 0) k - 1 else text.length
+                val block = text.substring(j + 1, blockEnd)
+                if (Regex("\\\\brepositories\\\\b").containsMatchIn(block)) {
+                    declared.add(dir)
+                    found = true
+                }
+                i = blockEnd + 1
+            }
+            if (found) break
+        }
+    }
+    return declared
+}
+
 // Skip composite-included builds entirely — both the settings scan and the \`allprojects\`
 // injection. The init script is evaluated once per build in a composite (root + each
 // \`includeBuild(...)\`), so without this guard \`allprojects { buildscript { repositories { ... } } }\`
@@ -228,6 +276,18 @@ gradle.settingsEvaluated {
     composeAiPreviewPreAppliedDirs = scanForComposeAiPreviewDeclaration(rootDir, projectDirs)
     composeAiPreviewSettingsHasExclusiveContent =
         composeAiPreviewSettingsDeclaresExclusiveContent(settingsDir)
+    if (composeAiPreviewSettingsHasExclusiveContent) {
+        composeAiPreviewProjectsWithOwnBuildscriptRepos =
+            scanForProjectsWithBuildscriptRepos(projectDirs)
+        gradle.rootProject {
+            logger.lifecycle(
+                "[compose-preview] settings.gradle.kts declares exclusiveContent in " +
+                    "pluginManagement.repositories; auto-inject is limited to modules that " +
+                    "pre-apply the plugin or declare their own buildscript { repositories { ... } }. " +
+                    "Other modules: apply id(\\"ee.schimke.composeai.preview\\") via plugins { } to opt in."
+            )
+        }
+    }
 
     // When opting into mavenLocal, also seed it at the settings level so the renderer-android AAR
     // and any other ee.schimke.composeai:* runtime artifacts resolve from ~/.m2 alongside the
@@ -254,12 +314,20 @@ gradle.settingsEvaluated {
 
 allprojects {
     if (composeAiPreviewIsIncludedBuild) return@allprojects
-    if (projectDir !in composeAiPreviewPreAppliedDirs) {
+    // In the exclusiveContent shape, modules without their own buildscript repos have no way
+    // to resolve our classpath dep — adding it would crash configuration. Skip both the
+    // injection and the apply hooks for those modules.
+    val composeAiPreviewSkipExclusiveContentClasspathDep =
+        composeAiPreviewSettingsHasExclusiveContent &&
+            projectDir !in composeAiPreviewProjectsWithOwnBuildscriptRepos
+
+    if (!composeAiPreviewSkipExclusiveContentClasspathDep &&
+        projectDir !in composeAiPreviewPreAppliedDirs) {
         buildscript {
             // When the settings file declares exclusiveContent in pluginManagement.repositories,
-            // Gradle 9.3+ rejects *adding* to buildscript.repositories (issue #1482). Skip the
-            // repos add but keep the classpath dep — if the consumer's existing buildscript
-            // repositories can resolve the plugin coordinate, auto-inject still works.
+            // Gradle 9.3+ rejects *adding* to buildscript.repositories (issue #1482). The
+            // outer guard above means we only reach here for modules whose own buildscript
+            // already declares repositories, so resolution can succeed via those.
             if (!composeAiPreviewSettingsHasExclusiveContent) {
                 repositories {
                     gradlePluginPortal()
@@ -276,6 +344,9 @@ allprojects {
             }
         }
     }
+
+    if (composeAiPreviewSkipExclusiveContentClasspathDep &&
+        projectDir !in composeAiPreviewPreAppliedDirs) return@allprojects
 
     fun applyComposeAiPreview() {
         if (plugins.hasPlugin("ee.schimke.composeai.preview")) return

--- a/vscode-extension/src/test/initScript.test.ts
+++ b/vscode-extension/src/test/initScript.test.ts
@@ -100,9 +100,7 @@ describe("renderInitScript", () => {
             "expected the set to be populated during settingsEvaluated",
         );
         assert.ok(
-            script.includes(
-                "if (projectDir !in composeAiPreviewPreAppliedDirs) {",
-            ),
+            script.includes("projectDir !in composeAiPreviewPreAppliedDirs"),
             "expected the buildscript block to be guarded per-project on the directory set",
         );
         // Catalog alias resolution: the scanner must look at gradle/libs.versions.toml
@@ -151,17 +149,13 @@ describe("renderInitScript", () => {
         );
     });
 
-    it("skips only the buildscript repositories add when settings declares exclusiveContent", () => {
-        // Confetti follow-up (#1482): root-level `pluginManagement { repositories {
-        // exclusiveContent { ... } } }` (directly or via the `listOf(repositories,
-        // dependencyResolutionManagement.repositories).forEach` Confetti pattern) trips
-        // Gradle 9.3+'s "you cannot add repositories to 'buildscript.repositories'"
-        // validation. We gate just the repositories sub-block of our buildscript injection
-        // — the classpath dependency and the withPlugin apply hooks still run, so if the
-        // consumer's existing buildscript repositories can resolve the plugin coordinate,
-        // auto-inject still works. PR #1483 tried to dodge the validation by loading the
-        // plugin via initscript classpath but that broke AGP classloader visibility at
-        // runtime.
+    it("gates buildscript classpath injection on per-project buildscript repos in the exclusiveContent branch", () => {
+        // Successor to the 0.11.8 follow-up regression: simply skipping the repositories add
+        // (the 0.11.8 fix) wasn't enough — modules without their own buildscript repos still
+        // got the classpath dep injected and crashed with "Cannot resolve external dependency
+        // ... because no repositories are defined", short-circuiting the entire Tooling API
+        // query. The fix forks per-project: modules with their own buildscript repos get the
+        // dep injected (resolution can succeed); modules without are skipped entirely.
         const script = renderInitScript();
         assert.ok(
             script.includes(
@@ -171,29 +165,39 @@ describe("renderInitScript", () => {
         );
         assert.ok(
             script.includes(
-                "fun composeAiPreviewSettingsDeclaresExclusiveContent(settingsDir: java.io.File): Boolean {",
+                "var composeAiPreviewProjectsWithOwnBuildscriptRepos: Set<java.io.File> = emptySet()",
+            ),
+            "expected the per-project buildscript-repos set declaration",
+        );
+        assert.ok(
+            script.includes(
+                "fun scanForProjectsWithBuildscriptRepos(\n    projectDirs: List<java.io.File>,\n): Set<java.io.File> {",
             ),
             "expected the scanner function in the rendered script",
         );
         assert.ok(
             script.includes(
-                "composeAiPreviewSettingsHasExclusiveContent =\n        composeAiPreviewSettingsDeclaresExclusiveContent(settingsDir)",
+                "composeAiPreviewProjectsWithOwnBuildscriptRepos =\n            scanForProjectsWithBuildscriptRepos(projectDirs)",
             ),
-            "expected settingsEvaluated to populate the flag from the scanner",
+            "expected the set to be populated inside the exclusiveContent branch",
         );
         assert.ok(
             script.includes(
                 "if (!composeAiPreviewSettingsHasExclusiveContent) {\n                repositories {",
             ),
-            "expected the buildscript repositories add to be the only thing guarded — " +
-                "the classpath dep and apply hooks must stay reachable",
+            "expected the buildscript repositories add to be guarded by the exclusiveContent flag",
+        );
+        assert.ok(
+            script.includes(
+                "val composeAiPreviewSkipExclusiveContentClasspathDep =\n        composeAiPreviewSettingsHasExclusiveContent &&\n            projectDir !in composeAiPreviewProjectsWithOwnBuildscriptRepos",
+            ),
+            "expected the per-project skip flag derived from settings flag + buildscript repos scan",
         );
         assert.ok(
             !script.includes(
                 "if (composeAiPreviewSettingsHasExclusiveContent) return@allprojects",
             ),
-            "the early-return for exclusiveContent is too aggressive; only the repositories add " +
-                "must be skipped",
+            "the global early-return for exclusiveContent is wrong — must fork per-project",
         );
     });
 


### PR DESCRIPTION
## Summary

- 0.11.8's exclusiveContent fix skipped adding to `buildscript.repositories` (avoiding Gradle 9.3+'s validation) but still injected the classpath dep on every non-pre-applied project. For modules with no `buildscript { repositories { ... } }` of their own — the realistic Confetti shape, where everything routes through `pluginManagement` — that crashed configuration with `Cannot resolve external dependency ... because no repositories are defined` and short-circuited the entire Tooling API query. Even `--module <name>` workarounds couldn't dodge it because Tooling API configures every project before returning any model.
- Fork the exclusiveContent branch per-project at `settingsEvaluated` time: scan each project's build script for an own `buildscript { repositories { ... } }` block; inject the classpath dep only there (resolution can succeed via the consumer's repos), and skip both the injection and the apply hooks on modules that have none. Skipped modules silently miss the plugin; the user's recourse stays the documented manual `plugins { id("ee.schimke.composeai.preview") version "X" }`.
- Add a one-time lifecycle log when the exclusiveContent shape is detected so users hitting this branch see why auto-inject looks degraded.
- Reproducer (`InitScriptExclusiveContentReproducerTest`) drives a Confetti-shaped fixture through real Gradle TestKit and asserts `:app:help` succeeds + the lifecycle log fires. Verified the reproducer fails with the exact 0.11.8 error mode (`Cannot resolve external dependency ...`) when the new per-project skip is disabled.

## Test plan

- [x] `./gradlew :cli:test` — unit tests for the new scanner + wire-shape pins + the Gradle-TestKit reproducer all green
- [x] `npm --prefix vscode-extension test` — 1257 tests passing, including the mirrored VS Code wire-shape assertion
- [x] `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest` + prettier — formatting clean
- [x] Verified the reproducer **fails** with `Cannot resolve external dependency ...` when the new `composeAiPreviewSkipExclusiveContentClasspathDep` guard is commented out, so the regression test and the fix are paired
- [ ] Sanity-check against the real Confetti repo (`git clone https://github.com/joreilly/Confetti && compose-preview list`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DuCgzpFTpuvJ5YbFWA2wUS)_