### PR TITLE
fix: retry daemon bootstrap on cancellation and coalesce concurrent warms

### DIFF
--- a/vscode-extension/src/daemon/daemonGate.ts
+++ b/vscode-extension/src/daemon/daemonGate.ts
@@ -92,6 +92,14 @@ export class LiveDaemonGate implements DaemonGate {
     private readonly spawns = new Map<string, Promise<DaemonClient>>();
     private disposed = false;
     private readonly warnedBuildDisabled = new Set<string>();
+    /**
+     * Modules where we've already logged the "no launch descriptor"
+     * message. Interactive paths (`setVisible`, `setFocus`, rotary scroll)
+     * each call `getOrSpawn`; without dedup a single scroll session emits
+     * the same line dozens of times. Cleared once a descriptor appears so
+     * the next missing-descriptor episode logs again.
+     */
+    private readonly warnedMissingDescriptor = new Set<string>();
 
     constructor(
         private readonly workspaceRoot: string,
@@ -136,9 +144,13 @@ export class LiveDaemonGate implements DaemonGate {
             const message =
                 `[daemon] no launch descriptor for ${module.modulePath}; ` +
                 `run ${module.modulePath}:composePreviewDaemonStart first`;
-            this.logger.appendLine(message);
+            if (!this.warnedMissingDescriptor.has(key)) {
+                this.warnedMissingDescriptor.add(key);
+                this.logger.appendLine(message);
+            }
             throw new Error(message);
         }
+        this.warnedMissingDescriptor.delete(key);
         if (!descriptor.enabled) {
             if (!this.warnedBuildDisabled.has(key)) {
                 this.warnedBuildDisabled.add(key);

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -233,6 +233,15 @@ export class LiveDaemonScheduler implements DaemonScheduler {
      *  Stops the per-render ENOENT spam when the daemon (B1.5) emits
      *  synthetic `daemon-stub-N.png` paths that don't exist on disk. */
     private warnedStubModules = new Set<string>();
+    /**
+     * In-flight `warmModule` promises per module. Concurrent callers
+     * coalesce onto the same promise so a second refresh that arrives
+     * mid-bootstrap doesn't start a second `composePreviewDaemonStart`
+     * (which the first invocation would then cancel). Cleared on settle so
+     * a later call — for instance, the retry after a cancellation — starts
+     * a fresh warm rather than getting a stale rejected promise.
+     */
+    private readonly warmsInFlight = new Map<string, Promise<boolean>>();
 
     constructor(
         private readonly gate: DaemonGate,
@@ -274,6 +283,32 @@ export class LiveDaemonScheduler implements DaemonScheduler {
         module: ModuleInfo,
         progress?: WarmProgress,
     ): Promise<boolean> {
+        const key = module.modulePath;
+        const existing = this.warmsInFlight.get(key);
+        if (existing) {
+            if (this.gate.isDaemonReady(key)) {
+                progress?.("ready");
+            }
+            return existing;
+        }
+        const promise = this.warmModuleInner(
+            gradleService,
+            module,
+            progress,
+        ).finally(() => {
+            if (this.warmsInFlight.get(key) === promise) {
+                this.warmsInFlight.delete(key);
+            }
+        });
+        this.warmsInFlight.set(key, promise);
+        return promise;
+    }
+
+    private async warmModuleInner(
+        gradleService: GradleService,
+        module: ModuleInfo,
+        progress?: WarmProgress,
+    ): Promise<boolean> {
         if (this.gate.isDaemonReady(module.modulePath)) {
             progress?.("ready");
             return true;
@@ -291,14 +326,33 @@ export class LiveDaemonScheduler implements DaemonScheduler {
                     "running composePreviewDaemonStart",
             );
         }
-        try {
-            progress?.("bootstrapping");
-            await gradleService.runDaemonBootstrap(module);
-        } catch (err) {
-            this.logger.appendLine(
-                `[daemon] bootstrap task failed for ${module.modulePath}: ${(err as Error).message}`,
-            );
-            throw err;
+        // Bootstrap may race with sibling refreshes that fire
+        // `gradleService.cancel(...)`. The cancel pool spares
+        // `composePreviewDaemonStart`, but extension shutdown / file-watcher
+        // churn / Tooling-API timeouts can still cancel mid-flight. When that
+        // happens the bootstrap throws "was cancelled" and the caller would
+        // otherwise be stuck without a descriptor until the user manually
+        // re-triggered warm. Retry once on cancellation so a transient kill
+        // doesn't strand the daemon for the rest of the session.
+        for (let attempt = 0; attempt < 2; attempt++) {
+            try {
+                progress?.("bootstrapping");
+                await gradleService.runDaemonBootstrap(module);
+                break;
+            } catch (err) {
+                const message = (err as Error).message ?? String(err);
+                const isCancellation = /cancel/i.test(message);
+                if (isCancellation && attempt === 0) {
+                    this.logger.appendLine(
+                        `[daemon] bootstrap cancelled for ${module.modulePath}: ${message}; retrying`,
+                    );
+                    continue;
+                }
+                this.logger.appendLine(
+                    `[daemon] bootstrap task failed for ${module.modulePath}: ${message}`,
+                );
+                throw err;
+            }
         }
         progress?.("spawning");
         let ok = false;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2742,9 +2742,46 @@ async function warmDaemonForFile(
         lastWarmDaemonError = `warm aborted: resolveModule returned null for ${filePath} (no applied.json marker and no plugin id in build.gradle.kts)`;
         return false;
     }
+    return warmDaemonForModuleImpl(module, { filePath, ...opts });
+}
+
+/**
+ * Module-level warm entry. Use when the caller has a `ModuleInfo` but no
+ * specific file path — interactive entry (`handleSetInteractive`,
+ * `handleRequestStreamStart`) reaches this after a prior warm was
+ * cancelled, so a rotary scroll session doesn't go through the Gradle
+ * fallback for the rest of the session. The `daemonScheduler.warmModule`
+ * call coalesces concurrent warms via its own in-flight map, so a burst
+ * of interactive events triggers at most one bootstrap. Silent on failure
+ * (no modal) because the caller is mid-interaction and already updates
+ * the chip / live-mode UI on failure.
+ */
+async function warmDaemonForModule(module: ModuleInfo): Promise<boolean> {
+    if (!daemonGate || !daemonScheduler || !gradleService) {
+        return false;
+    }
+    return warmDaemonForModuleImpl(module, { silentOnFailure: true });
+}
+
+async function warmDaemonForModuleImpl(
+    module: ModuleInfo,
+    opts: {
+        filePath?: string;
+        refreshAfterReady?: boolean;
+        silentOnFailure?: boolean;
+    },
+): Promise<boolean> {
+    if (!daemonGate || !daemonScheduler || !gradleService) {
+        return false;
+    }
+    const filePath = opts.filePath;
     const moduleKey = module.modulePath;
     if (daemonBootstrappedModules.has(moduleKey)) {
-        if (daemonGate.isDaemonReady(moduleKey) && opts.refreshAfterReady) {
+        if (
+            daemonGate.isDaemonReady(moduleKey) &&
+            opts.refreshAfterReady &&
+            filePath
+        ) {
             await refreshAfterDaemonReady(filePath, "view-open");
         }
         const ready = daemonGate.isDaemonReady(moduleKey);
@@ -2774,8 +2811,10 @@ async function warmDaemonForFile(
             lastWarmDaemonError = null;
             continuousCompileManager?.ensureWorker(module);
         }
-        finishDaemonStartupProgress(module, filePath, warmed);
-        if (warmed && opts.refreshAfterReady) {
+        if (filePath) {
+            finishDaemonStartupProgress(module, filePath, warmed);
+        }
+        if (warmed && opts.refreshAfterReady && filePath) {
             await refreshAfterDaemonReady(filePath, "view-open");
         }
         return warmed;
@@ -2786,9 +2825,11 @@ async function warmDaemonForFile(
         const reason = String((err as Error).message ?? err);
         lastWarmDaemonError = `warm threw for ${moduleKey}: ${reason}`;
         logLine(`daemon: warm failed for ${moduleKey}: ${reason}`);
-        vscode.window.showErrorMessage(
-            "Compose Preview daemon failed to start. Preview saves will not render until the daemon is fixed.",
-        );
+        if (!opts.silentOnFailure) {
+            vscode.window.showErrorMessage(
+                "Compose Preview daemon failed to start. Preview saves will not render until the daemon is fixed.",
+            );
+        }
         return false;
     }
 }
@@ -6220,6 +6261,14 @@ async function handleSetInteractive(
         logLine(`[interactive] live mode off for ${previewId}`);
         return;
     }
+    // A prior `warmDaemonForFile` may have been cancelled (refresh
+    // superseded mid-bootstrap). Without this, the next getOrSpawn throws
+    // "no launch descriptor" and the rest of the interactive session falls
+    // through to the Gradle render path. warmModule coalesces concurrent
+    // callers, so this is cheap when warm is already in flight or done.
+    if (!daemonGate.isDaemonReady(module.modulePath)) {
+        await warmDaemonForModule(module);
+    }
     const client = await daemonGate?.getOrSpawn(
         module,
         daemonScheduler.daemonEvents(module.modulePath),
@@ -6294,6 +6343,11 @@ async function handleRequestStreamStart(
             `[stream] no module for ${previewId}; ignoring requestStreamStart`,
         );
         return;
+    }
+    // Same recovery as `handleSetInteractive`: a cancelled prior warm
+    // would otherwise leave stream start stuck on the Gradle fallback.
+    if (!daemonGate.isDaemonReady(module.modulePath)) {
+        await warmDaemonForModule(module);
     }
     const client = await daemonGate?.getOrSpawn(
         module,

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -140,8 +140,19 @@ class FakeGate {
 class FakeGradleService {
     public bootstrapCalls: string[] = [];
     public bootstrapShouldThrow: Error | null = null;
+    /**
+     * When non-empty, each `runDaemonBootstrap` call shifts one Error off the
+     * front and throws it; once the queue is empty the call succeeds. Lets
+     * tests model "first attempt cancelled, retry succeeds" without touching
+     * `bootstrapShouldThrow` (which throws on every call).
+     */
+    public bootstrapThrowQueue: Error[] = [];
     async runDaemonBootstrap(module: ModuleLike): Promise<void> {
         this.bootstrapCalls.push(module.modulePath);
+        const queued = this.bootstrapThrowQueue.shift();
+        if (queued) {
+            throw queued;
+        }
         if (this.bootstrapShouldThrow) {
             throw this.bootstrapShouldThrow;
         }
@@ -702,6 +713,142 @@ describe("DaemonScheduler", () => {
                 /Gradle config-cache rejected/,
             );
             assert.deepStrictEqual(states, ["spawning", "bootstrapping"]);
+        });
+
+        it("retries once when the bootstrap task is cancelled mid-flight", async () => {
+            // A sibling refresh's `gradleService.cancel(...)` (or Tooling-API
+            // timeout, or extension shutdown signal) can kill the bootstrap
+            // task even though the cancel pool spares it. Without retry, the
+            // daemon stays cold for the rest of the session and every
+            // subsequent interactive event falls back to the Gradle path.
+            const { gate, scheduler, log } = build();
+            gate.getOrSpawnErrors.push(
+                new Error("[daemon] no launch descriptor for mod"),
+            );
+            const gradle = new FakeGradleService();
+            gradle.bootstrapThrowQueue.push(
+                new Error(
+                    "Gradle task :mod:composePreviewDaemonStart was cancelled.",
+                ),
+            );
+            const states: string[] = [];
+            const ok = await scheduler.warmModule(
+                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
+                mod("mod"),
+                (s) => states.push(s),
+            );
+            assert.strictEqual(ok, true);
+            assert.deepStrictEqual(
+                gradle.bootstrapCalls,
+                [":mod", ":mod"],
+                "cancellation should trigger one bootstrap retry",
+            );
+            assert.ok(
+                log.some((l) => l.includes("bootstrap cancelled")),
+                `expected retry log, got: ${log.join(" / ")}`,
+            );
+            assert.deepStrictEqual(states, [
+                "spawning",
+                "bootstrapping",
+                "bootstrapping",
+                "spawning",
+                "ready",
+            ]);
+        });
+
+        it("does not retry forever — gives up after the second bootstrap cancellation", async () => {
+            const { gate, scheduler } = build();
+            gate.getOrSpawnErrors.push(
+                new Error("[daemon] no launch descriptor for mod"),
+            );
+            const gradle = new FakeGradleService();
+            gradle.bootstrapThrowQueue.push(
+                new Error("Gradle task was cancelled."),
+                new Error("Gradle task was cancelled."),
+            );
+            await assert.rejects(
+                scheduler.warmModule(
+                    gradle as unknown as Parameters<
+                        typeof scheduler.warmModule
+                    >[0],
+                    mod("mod"),
+                ),
+                /cancelled/,
+            );
+            assert.deepStrictEqual(gradle.bootstrapCalls, [":mod", ":mod"]);
+        });
+
+        it("coalesces concurrent warm calls onto a single bootstrap", async () => {
+            // Without dedup, a second refresh arriving mid-warm would kick off
+            // a second `composePreviewDaemonStart` — and the cancel pool spare
+            // doesn't help when the second invocation cancels the first
+            // through the Gradle daemon's own scheduling.
+            const { gate, scheduler } = build();
+            gate.getOrSpawnErrors.push(
+                new Error("[daemon] no launch descriptor for mod"),
+            );
+            const gradle = new FakeGradleService();
+            const [a, b, c] = await Promise.all([
+                scheduler.warmModule(
+                    gradle as unknown as Parameters<
+                        typeof scheduler.warmModule
+                    >[0],
+                    mod("mod"),
+                ),
+                scheduler.warmModule(
+                    gradle as unknown as Parameters<
+                        typeof scheduler.warmModule
+                    >[0],
+                    mod("mod"),
+                ),
+                scheduler.warmModule(
+                    gradle as unknown as Parameters<
+                        typeof scheduler.warmModule
+                    >[0],
+                    mod("mod"),
+                ),
+            ]);
+            assert.strictEqual(a, true);
+            assert.strictEqual(b, true);
+            assert.strictEqual(c, true);
+            assert.deepStrictEqual(
+                gradle.bootstrapCalls,
+                [":mod"],
+                "three concurrent warms should issue exactly one bootstrap",
+            );
+            assert.deepStrictEqual(
+                gate.getOrSpawnCalls,
+                [":mod", ":mod"],
+                "three concurrent warms should only spawn once",
+            );
+        });
+
+        it("starts a fresh warm after the previous one settled", async () => {
+            // The in-flight memo must clear on settle so a follow-up warm
+            // (e.g. after a manual restart that clears the descriptor)
+            // actually re-bootstraps instead of returning the prior promise.
+            const { gate, scheduler } = build();
+            gate.getOrSpawnErrors.push(
+                new Error("[daemon] no launch descriptor for mod"),
+            );
+            const gradle = new FakeGradleService();
+            const okFirst = await scheduler.warmModule(
+                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
+                mod("mod"),
+            );
+            assert.strictEqual(okFirst, true);
+            // Simulate the descriptor going missing again (daemon JVM died,
+            // user ran `restartDaemon`, etc.) — the next warm has to bootstrap
+            // a second time, not return the cached prior resolution.
+            gate.getOrSpawnErrors.push(
+                new Error("[daemon] no launch descriptor for mod"),
+            );
+            const okSecond = await scheduler.warmModule(
+                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
+                mod("mod"),
+            );
+            assert.strictEqual(okSecond, true);
+            assert.deepStrictEqual(gradle.bootstrapCalls, [":mod", ":mod"]);
         });
 
         it("reports fallback only when the daemon is explicitly unavailable after bootstrap", async () => {


### PR DESCRIPTION
## Summary

Improves daemon warm reliability by retrying bootstrap when cancelled mid-flight and coalescing concurrent warm requests onto a single bootstrap operation. This prevents the daemon from getting stuck in a cold state when transient cancellations occur (e.g., from extension shutdown, file-watcher churn, or Tooling-API timeouts), and avoids redundant bootstrap invocations when multiple interactive events arrive simultaneously.

## Key Changes

- **Bootstrap retry on cancellation**: `LiveDaemonScheduler.warmModuleInner` now retries the bootstrap once if it fails with a "cancelled" error, allowing transient kills to recover without user intervention. Gives up after the second cancellation to avoid infinite loops.

- **Concurrent warm coalescing**: Added `warmsInFlight` map to `LiveDaemonScheduler` to deduplicate concurrent `warmModule` calls for the same module. Multiple callers coalesce onto a single bootstrap promise, preventing a second refresh from starting a redundant `composePreviewDaemonStart` that would cancel the first.

- **In-flight memo cleanup**: The coalescing map clears on promise settlement, ensuring follow-up warms (e.g., after manual daemon restart) actually re-bootstrap instead of returning a stale rejected promise.

- **Interactive recovery paths**: `handleSetInteractive` and `handleRequestStreamStart` now call `warmDaemonForModule` if the daemon isn't ready, recovering from prior cancelled warms so interactive sessions don't fall back to the Gradle render path for the rest of the session.

- **Module-level warm entry**: Extracted `warmDaemonForModuleImpl` to support warming by `ModuleInfo` alone (without a file path), used by interactive entry points. Supports silent failure mode to avoid modals during mid-interaction recovery.

- **Descriptor warning dedup**: `LiveDaemonGate` now deduplicates "no launch descriptor" log messages per module, clearing the dedup set once a descriptor appears. Prevents spam during interactive sessions (scroll, focus changes) that repeatedly call `getOrSpawn`.

- **Test coverage**: Added four new test cases covering bootstrap cancellation retry, retry exhaustion, concurrent warm coalescing, and fresh warm after prior settlement.

## Implementation Details

- Bootstrap retry uses a simple loop with a cancellation check (`/cancel/i.test(message)`) to identify transient kills vs. permanent failures.
- The `warmsInFlight` map uses module path as the key and clears entries in a `.finally()` block to handle both success and failure cases.
- Descriptor warning dedup is cleared when a descriptor is successfully retrieved, allowing the next missing-descriptor episode to log again.
- `FakeGradleService` test helper gains `bootstrapThrowQueue` to model "first attempt fails, retry succeeds" scenarios without affecting the always-throw `bootstrapShouldThrow` flag.

https://claude.ai/code/session_01E3RvjU7xbKAnJowPmbLwXN