### PR TITLE
test: fix Kotlin language ID setup in e2e cached preload test

### DIFF
--- a/vscode-extension/src/test/electron/suite/e2eCachedPreloadOnSwitch.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eCachedPreloadOnSwitch.test.ts
@@ -254,9 +254,24 @@ describeE2E("Compose Preview cached preload on module switch", function () {
         // `showTextDocument` rather than `triggerRefresh` because the
         // production preload path hangs off `onDidChangeActiveTextEditor`,
         // which only fires for actual editor focus changes.
-        await vscode.window.showTextDocument(vscode.Uri.file(cmpKotlinFile), {
-            preview: false,
-        });
+        //
+        // Force the document's `languageId` to "kotlin" before showing
+        // it. The production handler at extension.ts:1788 bails out
+        // unless `editor.document.languageId === "kotlin"`. The test
+        // electron host only loads `compose-preview` + the
+        // `fake-vscode-gradle` stub — neither contributes a Kotlin
+        // language — so `.kt` files resolve to a non-`"kotlin"` id and
+        // the preload path is never entered. Setting the languageId
+        // *before* `showTextDocument` matters: the editor-change event
+        // reads the document's languageId at fire time, so a
+        // post-show `setTextDocumentLanguage` would lose the race.
+        const cmpDoc = await vscode.workspace.openTextDocument(
+            vscode.Uri.file(cmpKotlinFile),
+        );
+        if (cmpDoc.languageId !== "kotlin") {
+            await vscode.languages.setTextDocumentLanguage(cmpDoc, "kotlin");
+        }
+        await vscode.window.showTextDocument(cmpDoc, { preview: false });
         // Let the cmp activation settle (preload + refresh kickoff) so
         // its in-flight refresh isn't dangling when we switch. 1s is
         // generous — the preload itself is <100ms; the refresh
@@ -266,9 +281,13 @@ describeE2E("Compose Preview cached preload on module switch", function () {
 
         api.resetMessages();
         const switchedAt = Date.now();
-        await vscode.window.showTextDocument(vscode.Uri.file(wearKotlinFile), {
-            preview: false,
-        });
+        const wearDoc = await vscode.workspace.openTextDocument(
+            vscode.Uri.file(wearKotlinFile),
+        );
+        if (wearDoc.languageId !== "kotlin") {
+            await vscode.languages.setTextDocumentLanguage(wearDoc, "kotlin");
+        }
+        await vscode.window.showTextDocument(wearDoc, { preview: false });
 
         // Window the preload (+ updateImage + webview ack) must land
         // inside after the editor switch. 5s was the original target


### PR DESCRIPTION
## Summary
Fixes the e2e test for Compose Preview cached preload on module switch by ensuring Kotlin files have the correct `languageId` before displaying them in the editor.

## Key Changes
- Modified the test to explicitly open documents and set their language ID to "kotlin" before calling `showTextDocument`
- Applied this fix to both the initial Compose module document and the Wear module document
- Added conditional checks to only set the language ID if it's not already "kotlin"

## Implementation Details
The production handler at extension.ts:1788 requires `editor.document.languageId === "kotlin"` to proceed with the preload path. The test environment only loads `compose-preview` and `fake-vscode-gradle` stub, neither of which contributes a Kotlin language definition, causing `.kt` files to resolve to a non-"kotlin" language ID.

The fix uses `vscode.workspace.openTextDocument()` followed by `vscode.languages.setTextDocumentLanguage()` before `showTextDocument()`. This ordering is critical because the editor-change event reads the document's languageId at fire time, so setting it after showing the document would lose the race condition.

https://claude.ai/code/session_01VBxV39PfzFBhuRtmajRCn5