### PR TITLE
feat: add missing-renders policy to apply action

### DIFF
--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -72,6 +72,18 @@ inputs:
       pipeline. Applied after disk discovery, so modules listed here are
       built but their PNGs are dropped from the combined report.
     default: ''
+  missing-renders:
+    description: >
+      Policy when `composePreviewRenderAll` finds previews in the manifest
+      that produced no output PNG: `fail` (default — historical hard
+      error), `warn` (log + keep going), or `ignore` (silent). Useful for
+      multi-module runs where one module has a handful of stubborn
+      previews you don't want to gate CI on. The action passes the value
+      through as the `composePreview.missingRenders` Gradle property, so
+      consumers don't need to wire it into their build files. Applies
+      globally to every module the action invokes Gradle for (notifications
+      pipeline + the compose / a11y pipelines via the CLI).
+    default: 'fail'
   pr-number:
     description: 'Override for PR number when context is ambiguous.'
     default: ''
@@ -255,6 +267,7 @@ runs:
         A11Y_SKIP_MODULES: ${{ inputs.a11y-skip-modules }}
         NOTIFY_MODULES: ${{ inputs.notifications-module }}
         NOTIFY_SKIP_MODULES: ${{ inputs.notifications-skip-modules }}
+        MISSING_RENDERS: ${{ inputs.missing-renders }}
         BASELINE_BRANCH: 'compose-preview/main'
         RESOURCE_BRANCH: 'compose-preview/resources/main'
         PR_HEAD_BRANCH: 'compose-preview/pr'

--- a/.github/actions/apply/pipelines/a11y.sh
+++ b/.github/actions/apply/pipelines/a11y.sh
@@ -53,6 +53,9 @@ if [ "${#ALLOW_MODULES[@]}" -gt 0 ]; then
     cli_args+=(--module ":${m}")
   done
 fi
+if [ -n "${MISSING_RENDERS:-}" ]; then
+  cli_args+=(--missing-renders "${MISSING_RENDERS}")
+fi
 
 # Use the same CLI that the install step put on $PATH (release tarball or
 # source build); the legacy `:cli:installDist` rebuild was a leftover from

--- a/.github/actions/apply/pipelines/compose.sh
+++ b/.github/actions/apply/pipelines/compose.sh
@@ -38,7 +38,14 @@ if [ "${SKIP_RENDER:-false}" = "true" ]; then
   echo "0" > "$GITHUB_WORKSPACE/_compose_render_rc"
 else
   # Render. Don't fail on non-zero — partial envelope still drives the rest.
-  compose-preview show --json --timeout "$RENDER_TIMEOUT" > _previews.json
+  show_args=(show --json --timeout "$RENDER_TIMEOUT")
+  # Forwards as `-PcomposePreview.missingRenders=<value>` to the Gradle
+  # `composePreviewRenderAll` task the CLI spawns; default `fail` is a
+  # no-op vs the plugin's own default so always-pass is safe.
+  if [ -n "${MISSING_RENDERS:-}" ]; then
+    show_args+=(--missing-renders "${MISSING_RENDERS}")
+  fi
+  compose-preview "${show_args[@]}" > _previews.json
   RENDER_RC=$?
   echo "$RENDER_RC" > "$GITHUB_WORKSPACE/_compose_render_rc"
 fi

--- a/.github/actions/apply/pipelines/notifications.sh
+++ b/.github/actions/apply/pipelines/notifications.sh
@@ -58,6 +58,13 @@ else
   gradle_args+=("composePreviewRenderAll")
 fi
 
+# Passed through to the Gradle plugin's `composePreviewRenderAll`
+# validation. Default `fail` is a no-op — matches the plugin's own default
+# — so always forwarding is safe.
+if [ -n "${MISSING_RENDERS:-}" ]; then
+  gradle_args+=("-PcomposePreview.missingRenders=${MISSING_RENDERS}")
+fi
+
 # In auto-detect mode an absent task is a "project doesn't ship notification
 # previews" signal rather than an error — drop into soft-skip so consumers
 # don't have to remember to `skip: notifications`. With an explicit

--- a/.github/actions/apply/pipelines/resources.sh
+++ b/.github/actions/apply/pipelines/resources.sh
@@ -30,7 +30,11 @@ if [ "${SKIP_RENDER:-false}" = "true" ]; then
   echo "resources pipeline: skip-render=true; reusing pre-staged _resources.json."
   echo "0" > "$GITHUB_WORKSPACE/_resources_render_rc"
 else
-  compose-preview show-resources --json --timeout "$RENDER_TIMEOUT" > _resources.json
+  res_args=(show-resources --json --timeout "$RENDER_TIMEOUT")
+  if [ -n "${MISSING_RENDERS:-}" ]; then
+    res_args+=(--missing-renders "${MISSING_RENDERS}")
+  fi
+  compose-preview "${res_args[@]}" > _resources.json
   RENDER_RC=$?
   echo "$RENDER_RC" > "$GITHUB_WORKSPACE/_resources_render_rc"
 fi

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -180,6 +180,22 @@ abstract class Command(protected val args: List<String>) {
     return listOf("-PcomposePreview.activeExtensions=${all.joinToString(",")}")
   }
 
+  /**
+   * `--missing-renders <fail|warn|ignore>` passes through as
+   * `-PcomposePreview.missingRenders=<value>` so the Gradle-plugin-side validation in
+   * `composePreviewRenderAll` knows whether to escalate, warn, or stay silent when a preview listed
+   * in the manifest produced no PNG. The CLI doesn't validate the value — invalid values fall
+   * through to the plugin's "fail" default. Empty / absent means "don't pass the flag at all",
+   * which keeps the historical behaviour intact.
+   */
+  protected val missingRendersPolicy: String? =
+    args.flagValue("--missing-renders")?.trim()?.takeIf { it.isNotEmpty() }
+
+  protected fun missingRendersGradleArgs(): List<String> {
+    val v = missingRendersPolicy ?: return emptyList()
+    return listOf("-PcomposePreview.missingRenders=$v")
+  }
+
   private val forceNoticePrinted = AtomicBoolean(false)
 
   /**
@@ -194,7 +210,8 @@ abstract class Command(protected val args: List<String>) {
    */
   protected fun gradleArgsWithForce(extra: List<String> = emptyList()): List<String> {
     val extensionArgs = extensionGradleArgs()
-    val withExtras = extra + extensionArgs
+    val missingRendersArgs = missingRendersGradleArgs()
+    val withExtras = extra + extensionArgs + missingRendersArgs
     val reason = forceReason ?: return withExtras
     if (forceNoticePrinted.compareAndSet(false, true)) {
       System.err.println(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -196,6 +196,21 @@ abstract class Command(protected val args: List<String>) {
     return listOf("-PcomposePreview.missingRenders=$v")
   }
 
+  /**
+   * Whether the CLI's own "Render task completed but produced no PNG for N of M" post-check should
+   * escalate to a non-zero exit. The Gradle-plugin-side validation in `composePreviewRenderAll`
+   * already honours `composePreview.missingRenders` for the throw vs warn vs silent decision; this
+   * mirrors the policy on the CLI side so a `warn` or `ignore` run actually surfaces as exit 0 to
+   * the apply action / shell caller. Unknown values fall through to "fail" — same hard-fail
+   * fallback the plugin uses.
+   */
+  protected fun shouldFailOnMissingRenders(): Boolean =
+    when (missingRendersPolicy?.lowercase()) {
+      "warn",
+      "ignore" -> false
+      else -> true
+    }
+
   private val forceNoticePrinted = AtomicBoolean(false)
 
   /**
@@ -722,8 +737,14 @@ class ShowCommand(args: List<String>) : Command(args) {
     // "Missing" = at least one capture failed to produce a PNG.
     val missing = filtered.filter { r -> r.captures.any { it.pngPath == null } }
     if (missing.isNotEmpty()) {
+      // Diagnostic stays under warn/ignore so CI logs remain grep-able — only the exit code
+      // changes. `--missing-renders warn|ignore` is the explicit opt-down; everything else
+      // (including unset) keeps the historical hard fail.
+      val policy = missingRendersPolicy?.lowercase()
+      val prefix =
+        if (policy in setOf("warn", "ignore")) "missing-renders policy=$policy — " else ""
       System.err.println(
-        "Render task completed but produced no PNG for ${missing.size} of ${filtered.size} preview(s)."
+        "${prefix}Render task completed but produced no PNG for ${missing.size} of ${filtered.size} preview(s)."
       )
       System.err.println(
         "Check the Gradle output above — a common cause is the `composePreviewRender` task " +
@@ -731,7 +752,7 @@ class ShowCommand(args: List<String>) : Command(args) {
           "testClassesDirs."
       )
       System.out.flush()
-      exitProcess(2)
+      if (shouldFailOnMissingRenders()) exitProcess(2)
     }
     System.out.flush()
   }
@@ -823,11 +844,14 @@ class RenderCommand(args: List<String>) : Command(args) {
         val changedCount = filtered.count { it.anyChanged() }
         if (changedCount > 0) println("  $changedCount changed since last run")
         if (missing.isNotEmpty()) {
+          val policy = missingRendersPolicy?.lowercase()
+          val prefix =
+            if (policy in setOf("warn", "ignore")) "missing-renders policy=$policy — " else ""
           System.err.println(
-            "Render task completed but produced no PNG for ${missing.size} preview(s):"
+            "${prefix}Render task completed but produced no PNG for ${missing.size} preview(s):"
           )
           for (r in missing) System.err.println("  ${r.id}")
-          exitProcess(2)
+          if (shouldFailOnMissingRenders()) exitProcess(2)
         }
       }
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -34,6 +34,7 @@ fun main(args: Array<String>) {
       "--message",
       "--with-extension",
       "--with",
+      "--missing-renders",
     )
   var commandIndex = -1
   var i = 0
@@ -155,6 +156,13 @@ private fun printUsage() {
                            --rerun-tasks to Gradle so every input task re-executes. Does NOT
                            run :clean and does NOT touch build/classes/. Each use is logged
                            with a pointer to issue #924 — please report the freshness gap.
+      --missing-renders <fail|warn|ignore>
+                           Forwarded as `-PcomposePreview.missingRenders=<value>`. Controls
+                           how `composePreviewRenderAll` reacts when a preview is listed in
+                           the manifest but produced no PNG: `fail` (Gradle plugin default —
+                           throws), `warn` (logs + keeps going), `ignore` (silent). Useful
+                           for multi-module CI where a handful of stubborn previews would
+                           otherwise gate the whole run.
       --daemon             doctor: also spawn each module's preview daemon and confirm the
                            `initialize` round-trip succeeds. Adds ~600ms (Desktop) or 3-10s
                            (Android/Robolectric) per module — opt-in because plain `doctor`

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRendersPolicyTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRendersPolicyTest.kt
@@ -1,0 +1,64 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers the CLI-side half of `--missing-renders`. The Gradle-plugin-side throw-vs-warn-vs-silent
+ * branch is covered by `RenderFunctionalTest`; this exercises the matching CLI exit-code policy so
+ * a `compose-preview show --missing-renders warn` run that legitimately produces some empty
+ * captures doesn't get bumped back to exit 2 by `ShowCommand`'s post-check.
+ */
+class MissingRendersPolicyTest {
+  // Tiny concrete subclass — `Command` is abstract and the policy helpers are `protected`, so
+  // exercising them needs an in-package shim. Run is unused.
+  private class Probe(args: List<String>) : Command(args) {
+    override fun run() = Unit
+
+    fun policy(): String? = missingRendersPolicy
+
+    fun gradleArgs(): List<String> = missingRendersGradleArgs()
+
+    fun shouldFail(): Boolean = shouldFailOnMissingRenders()
+  }
+
+  @Test
+  fun `absent flag defaults to fail and emits no gradle arg`() {
+    val p = Probe(listOf("show"))
+    assertEquals(null, p.policy())
+    assertEquals(emptyList(), p.gradleArgs())
+    assertTrue(p.shouldFail(), "default policy must keep the historical exit-2 behaviour")
+  }
+
+  @Test
+  fun `warn opts down both the CLI exit and forwards the gradle property`() {
+    val p = Probe(listOf("show", "--missing-renders", "warn"))
+    assertEquals("warn", p.policy())
+    assertEquals(listOf("-PcomposePreview.missingRenders=warn"), p.gradleArgs())
+    assertFalse(p.shouldFail())
+  }
+
+  @Test
+  fun `ignore also opts down the CLI exit`() {
+    val p = Probe(listOf("show", "--missing-renders", "ignore"))
+    assertFalse(p.shouldFail())
+  }
+
+  @Test
+  fun `unknown values fall back to fail`() {
+    // Mirrors the Gradle-plugin-side fallback: a typo or garbage value must not silently widen
+    // the policy. The CLI just forwards the value verbatim; the plugin will see it, fall back
+    // to fail too, and the CLI's own post-check stays hard.
+    val p = Probe(listOf("show", "--missing-renders", "bogus"))
+    assertTrue(p.shouldFail())
+  }
+
+  @Test
+  fun `equals-form flag is accepted`() {
+    val p = Probe(listOf("show", "--missing-renders=warn"))
+    assertEquals("warn", p.policy())
+    assertFalse(p.shouldFail())
+  }
+}

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
@@ -186,4 +186,81 @@ class RenderFunctionalTest {
     assertThat(result.output).contains("render produced no output file")
     assertThat(result.output).contains(preview.id)
   }
+
+  @Test
+  fun `composePreviewRenderAll missing-renders=warn does not fail the build`() {
+    val projectDir = createTestProject()
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments(
+          "composePreviewRenderAll",
+          "-x",
+          "composePreviewRender",
+          "-PcomposePreview.missingRenders=warn",
+          "--stacktrace",
+        )
+        .withPluginClasspath()
+        .build()
+
+    // The warn line carries the same diagnostic the throw used to ship —
+    // so consumers grepping CI logs still see the missing-output signal,
+    // they just don't get gated on it.
+    assertThat(result.output).contains("missing-renders policy=warn")
+    assertThat(result.output).contains("render produced no output file")
+    // Validation marker is still written under warn so downstream tasks
+    // that wire off the marker (pixel-test gates, baselines) keep running.
+    assertThat(File(projectDir, "build/compose-previews/composePreviewRenderAll.validated"))
+      .exists()
+  }
+
+  @Test
+  fun `composePreviewRenderAll missing-renders=ignore stays silent`() {
+    val projectDir = createTestProject()
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments(
+          "composePreviewRenderAll",
+          "-x",
+          "composePreviewRender",
+          "-PcomposePreview.missingRenders=ignore",
+          "--stacktrace",
+        )
+        .withPluginClasspath()
+        .build()
+
+    // Ignore should not surface the "render produced no output file"
+    // string anywhere in the log — the whole point of the policy is to
+    // suppress the diagnostic for projects that accept some missing
+    // previews as the steady state.
+    assertThat(result.output).doesNotContain("render produced no output file")
+    assertThat(File(projectDir, "build/compose-previews/composePreviewRenderAll.validated"))
+      .exists()
+  }
+
+  @Test
+  fun `composePreviewRenderAll missing-renders=garbage falls back to fail`() {
+    val projectDir = createTestProject()
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments(
+          "composePreviewRenderAll",
+          "-x",
+          "composePreviewRender",
+          "-PcomposePreview.missingRenders=bogus",
+          "--stacktrace",
+        )
+        .withPluginClasspath()
+        .buildAndFail()
+
+    // Typos must not silently widen the policy — anything we don't
+    // recognise resolves to `fail` so the historical hard error still
+    // catches whole-module classpath misconfig.
+    assertThat(result.output).contains("render produced no output file")
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -753,6 +753,29 @@ internal object ComposePreviewTasks {
       .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
       .orElse("full")
 
+  /**
+   * `Provider<String>` for the `composePreview.missingRenders` Gradle property. Controls how
+   * `composePreviewRenderAll` reacts when a preview is listed in the manifest but produced no
+   * on-disk output: `"fail"` (default — throws), `"warn"` (logs a `WARN` line + writes the
+   * validation marker), `"ignore"` (silent + writes the marker). Set via
+   * `-PcomposePreview.missingRenders=warn` or the corresponding env var
+   * (`ORG_GRADLE_PROJECT_composePreview.missingRenders=warn`) — the `apply` GitHub action exposes
+   * the same knob as the `missing-renders` input so consumers don't have to wire it into their
+   * build files. Unknown values fall through to `"fail"` so a typo can't silently widen the policy.
+   */
+  internal fun missingRendersProperty(project: Project): Provider<String> =
+    project.providers
+      .gradleProperty("composePreview.missingRenders")
+      .map { raw ->
+        when (raw.trim().lowercase()) {
+          "warn",
+          "ignore",
+          "fail" -> raw.trim().lowercase()
+          else -> "fail"
+        }
+      }
+      .orElse("fail")
+
   fun registerDiscoverTask(
     project: Project,
     sourceClassDirs: FileCollection,
@@ -862,6 +885,7 @@ internal object ComposePreviewTasks {
         .gradleProperty("composePreview.tier")
         .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
         .orElse("full")
+    val missingRendersProvider = missingRendersProperty(project)
     project.tasks.register("composePreviewRenderAll", DefaultTask::class.java) {
       group = "compose preview"
       dependsOn(renderTask)
@@ -870,9 +894,11 @@ internal object ComposePreviewTasks {
         .withPathSensitivity(PathSensitivity.NONE)
         .withPropertyName("manifest")
       inputs.property("tier", tierProvider)
+      inputs.property("missingRenders", missingRendersProvider)
       outputs.file(validationMarker).withPropertyName("validationMarker")
       doLast {
         val isFastTier = tierProvider.get() == "fast"
+        val missingPolicy = missingRendersProvider.get()
         val manifestOnDisk = manifestFile.get().asFile
         if (!manifestOnDisk.exists()) return@doLast
         val manifest =
@@ -911,7 +937,17 @@ internal object ComposePreviewTasks {
         val missing = missingPreviewOutputIds(manifest, outDir, isFastTier)
         if (missing.isNotEmpty()) {
           val sidecars = readErrorSidecarsFor(manifest, missing, outDir)
-          throw GradleException(formatMissingPreviewsMessage(manifest, missing, sidecars))
+          val message = formatMissingPreviewsMessage(manifest, missing, sidecars)
+          // `composePreview.missingRenders` controls escalation: `fail` (default) preserves
+          // the historical hard error that catches whole-module classpath misconfig; `warn`
+          // and `ignore` let multi-module CI runs ride out a handful of stubborn previews
+          // without losing the rest of the report. Marker is still written so downstream
+          // tasks that wire off the validation outcome see the run as "validated".
+          when (missingPolicy) {
+            "warn" -> logger.warn("composePreviewRenderAll: missing-renders policy=warn — $message")
+            "ignore" -> Unit
+            else -> throw GradleException(message)
+          }
         }
         val marker = validationMarker.get().asFile
         marker.parentFile?.mkdirs()


### PR DESCRIPTION
## Summary

Adds a `missing-renders` knob on the apply action so a multi-module run isn't taken out by a handful of stubborn previews in one module. Driven from the action's `with:` block — consumers don't need to add `composePreview { ... }` DSL to their build files.

```yaml
- uses: yschimke/compose-ai-tools/.github/actions/apply@vX
  with:
    missing-renders: warn   # fail (default) | warn | ignore
    # ...
```

### How it flows through

1. Action input `missing-renders` → env var `MISSING_RENDERS` on the pipelines step.
2. **notifications.sh**: appends `-PcomposePreview.missingRenders=$MISSING_RENDERS` to the direct `./gradlew composePreviewRenderAll` call.
3. **compose.sh / resources.sh / a11y.sh**: appends `--missing-renders $MISSING_RENDERS` to the `compose-preview` CLI call.
4. **CLI**: the new `--missing-renders` flag forwards as `-PcomposePreview.missingRenders=<value>` via `gradleArgsWithForce`, same plumbing the existing `--with-extension` translation uses.
5. **Gradle plugin** (`ComposePreviewTasks.kt:865-988`): reads the property at config time, branches in the `doLast` validation:
   - `fail` (default) — throws `GradleException` exactly as today; catches whole-module classpath misconfig like the original Robolectric NO-SOURCE case.
   - `warn` — logs the same diagnostic at `WARN` level + writes the validation marker so downstream tasks (pixel-test gates, baselines) keep running.
   - `ignore` — writes the marker silently.
   - Anything else (typo, garbage) — falls back to `fail`. A slip in the action input can't accidentally widen the policy.

### Why the GH action input rather than a `composePreview` DSL block

Consumers like the linked confetti report don't want their `build.gradle.kts` carrying CI-specific opt-downs. The action input + Gradle property combo means the policy is set per-workflow (different default for nightly vs PR if you want it) and the build file stays clean. Users running the CLI directly get the same knob via `compose-preview --missing-renders warn show` for parity.

### Open question I picked a default for

You said "global is fine" for the per-module question. For the second open question (whether `warn` should still emit the missing entries into `findings.json`), I went with: **warn keeps the marker written and lets the rest of the pipeline run unchanged** — so `findings.json` still gets the entries that DID render, the missing ones are just absent from disk. The warn log line carries the same diagnostic the throw used to ship, so CI logs are still grep-able for the missing-output signature.

## Test plan

- [x] `./gradlew :gradle-plugin:ktfmtFormatMain :gradle-plugin:ktfmtFormatFunctionalTest :cli:ktfmtFormatMain` — clean
- [x] `bash -n` + `shellcheck` clean on all four pipeline scripts
- [ ] CI `:gradle-plugin:functionalTest` — three new cases covering warn / ignore / bogus-value fallback
- [ ] End-to-end run against a real PR with `missing-renders: warn` configured

## Notes

- Branch is `agent/missing-renders-policy` (renamed from the `claude/...` branch the harness handed me).
- Built on top of #1495 which is already merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbS3cphkvKVRDwdKJu2gUQ)_