### PR TITLE
feat: surface preview render errors from .error.json sidecars

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -402,6 +402,38 @@ internal object AndroidPreviewSupport {
       compileTaskNames = mainCompileTaskNames,
     )
 
+    // `composePreviewCheckDebugPreviews` — only meaningful when the Google
+    // screenshot plugin is on the project, so we register conditionally
+    // rather than as a permanent no-op task. See [CheckDebugPreviewsTask]
+    // for the motivation; tl;dr `src/debug/` previews compiled against the
+    // `screenshotTest` dependency closure routinely fail in confusing ways
+    // (compile-time NoSuchSymbol or render-time `.error.json` with no PNG),
+    // and the fix is to move them to `src/screenshotTest/{java,kotlin}/`.
+    if (screenshotTestEnabled) {
+      val debugSrcTree =
+        project.fileTree(project.projectDir.resolve("src/debug")) {
+          include("**/*.kt", "**/*.java")
+        }
+      val checkDebugTask =
+        project.tasks.register(
+          "composePreviewCheckDebugPreviews",
+          CheckDebugPreviewsTask::class.java,
+        ) {
+          group = "compose preview"
+          description =
+            "Warn when @Preview functions live in src/debug/ on a module with the " +
+              "com.android.compose.screenshot plugin (move them to src/screenshotTest/)"
+          debugSourceFiles.from(debugSrcTree)
+          projectDirectory.set(project.layout.projectDirectory.asFile.absolutePath)
+        }
+      // `finalizedBy` rather than `dependsOn` so discovery itself never
+      // waits on this check, and a check failure (shouldn't happen — the
+      // task only warns) doesn't block downstream render tasks. Runs once
+      // per discover invocation, skipped when no debug sources exist
+      // (`@SkipWhenEmpty` on `debugSourceFiles`).
+      discoverTask.configure { finalizedBy(checkDebugTask) }
+    }
+
     // Writes the plugin-side compat findings (CompatRules) to
     // `build/compose-previews/doctor.json`. The CLI doesn't need this
     // file (it reads the same data via the ComposePreviewModel Tooling

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/CheckDebugPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/CheckDebugPreviewsTask.kt
@@ -1,0 +1,80 @@
+package ee.schimke.composeai.plugin
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.IgnoreEmptyDirectories
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Warns when `@Preview` functions live in `src/debug/` on a module that applied Google's
+ * `com.android.compose.screenshot` plugin. That source set is part of the main debug variant, so it
+ * compiles against `debugImplementation` + `implementation` only — NOT
+ * `screenshotTestImplementation`. Preview-only helpers (theme wrappers, fixture composables)
+ * written against the `screenshotTest` dependency closure end up failing in two ways once dropped
+ * into `src/debug/`:
+ *
+ * 1. Compile-time: `compileDebugKotlin` fails with `Unresolved reference` on the
+ *    screenshotTest-only symbols.
+ * 2. Render-time (when the file still compiles): `composePreviewDiscover` picks the previews up via
+ *    the shared `build/tmp/kotlin-classes/debug/` output, but their dependency tail isn't on
+ *    `composePreviewRender`'s classpath and the preview throws on `Class.forName` / first
+ *    composition, producing an `.error.json` sidecar with no PNG.
+ *
+ * Both modes leave the user with a confusing failure pointing at our pipeline. This task surfaces
+ * the source-set mismatch at discovery time so the fix ("move it to `src/screenshotTest/`") is
+ * obvious.
+ *
+ * Match is by `@Preview` text occurrence — deliberately coarse. A false positive on a Kotlin
+ * comment or string literal mentioning `@Preview` is cheap (one warn line); a false negative would
+ * silently leak the confusing failure back through. Wired as a finalizer of
+ * `composePreviewDiscover` so it never blocks discovery itself.
+ */
+abstract class CheckDebugPreviewsTask : DefaultTask() {
+
+  @get:InputFiles
+  @get:SkipWhenEmpty
+  @get:IgnoreEmptyDirectories
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val debugSourceFiles: ConfigurableFileCollection
+
+  /**
+   * Project root path used to render module-relative source paths in the warning. Captured at
+   * configuration time so the task action stays configuration-cache-safe (no `project` access at
+   * execution).
+   */
+  @get:Input abstract val projectDirectory: Property<String>
+
+  @TaskAction
+  fun check() {
+    val hits =
+      debugSourceFiles.files
+        .filter { it.isFile && (it.extension == "kt" || it.extension == "java") }
+        .filter { it.readText().contains("@Preview") }
+    if (hits.isEmpty()) return
+    val projectRoot = java.io.File(projectDirectory.get())
+    val rels = hits.map { it.relativeTo(projectRoot).path }
+    logger.warn(
+      buildString {
+        append("composePreviewCheckDebugPreviews: found ")
+        append(hits.size)
+        append(" file(s) under `src/debug/` containing `@Preview` while the ")
+        append("`com.android.compose.screenshot` plugin is applied:\n")
+        rels.take(10).forEach { append("  - ").append(it).append('\n') }
+        if (rels.size > 10) append("  (+").append(rels.size - 10).append(" more)\n")
+        append(
+          "  `src/debug/` is part of the main debug variant — it sees " +
+            "`debugImplementation` deps but NOT `screenshotTestImplementation`. " +
+            "Preview-only code is typically authored against the screenshotTest " +
+            "closure and will fail to compile or render here. " +
+            "Move these files to `src/screenshotTest/{java,kotlin}/...` instead."
+        )
+      }
+    )
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -910,16 +910,8 @@ internal object ComposePreviewTasks {
         // part of `Foo`'s fan-out.
         val missing = missingPreviewOutputIds(manifest, outDir, isFastTier)
         if (missing.isNotEmpty()) {
-          val preview = missing.take(3).joinToString(", ")
-          val andMore = if (missing.size > 3) " (+${missing.size - 3} more)" else ""
-          throw GradleException(
-            "composePreviewRenderAll: render produced no output file for ${missing.size} of " +
-              "${manifest.previews.size} preview(s): $preview$andMore. This means " +
-              "`composePreviewRender` was skipped or silently did nothing — on Android " +
-              "that usually means it reported NO-SOURCE because " +
-              "RobolectricRenderTest.class wasn't discoverable on its " +
-              "testClassesDirs. Run with --info to see the task outcome."
-          )
+          val sidecars = readErrorSidecarsFor(manifest, missing, outDir)
+          throw GradleException(formatMissingPreviewsMessage(manifest, missing, sidecars))
         }
         val marker = validationMarker.get().asFile
         marker.parentFile?.mkdirs()
@@ -956,6 +948,131 @@ internal object ComposePreviewTasks {
   }
 
   private val PIXEL_TEST_UNIT_TEST_TASKS = setOf("testDebugUnitTest", "testReleaseUnitTest")
+
+  /**
+   * Per-preview error-sidecar payload as the gradle plugin reads it. We mirror only the fields used
+   * by [formatMissingPreviewsMessage]; the sidecar schema itself lives next to the renderer that
+   * writes it (`renderer-android/.../RenderErrorSidecar.kt` and the desktop equivalent).
+   * `ignoreUnknownKeys` keeps us compatible with future sidecar fields without a coordinated bump.
+   */
+  @kotlinx.serialization.Serializable
+  internal data class ErrorSidecar(
+    val exception: String = "",
+    val message: String = "",
+    val topAppFrame: TopAppFrame? = null,
+  ) {
+    @kotlinx.serialization.Serializable
+    internal data class TopAppFrame(
+      val file: String = "",
+      val line: Int = 0,
+      val function: String = "",
+    )
+  }
+
+  /**
+   * For each missing preview, look for the `<png>.error.json` sidecar the renderer writes on a
+   * per-preview throw. The renderer catches `Throwable` around each preview's `setContent` so one
+   * broken preview doesn't fail the whole `Test` task — it writes a sidecar instead, and leaves no
+   * PNG. Without this lookup, the renderAll wrapper sees "missing PNG" and emits a generic "render
+   * was skipped" message that masks the actual exception.
+   *
+   * Returns one entry per preview that had AT LEAST one capture-or-product sidecar; preview ids
+   * without any sidecar (true silent skip / NO-SOURCE) are absent from the map.
+   */
+  internal fun readErrorSidecarsFor(
+    manifest: PreviewManifest,
+    missingIds: List<String>,
+    outDir: java.io.File,
+  ): Map<String, ErrorSidecar> {
+    val json = Json { ignoreUnknownKeys = true }
+    val byId = manifest.previews.associateBy { it.id }
+    val result = mutableMapOf<String, ErrorSidecar>()
+    for (id in missingIds) {
+      val preview = byId[id] ?: continue
+      val candidatePaths =
+        preview.captures.map { it.renderOutput.ifEmpty { "renders/$id.png" } } +
+          preview.dataProducts.map { it.output }
+      val sidecar =
+        candidatePaths
+          .asSequence()
+          .mapNotNull { rel ->
+            val sidecarFile = java.io.File(outDir, "$rel.error.json")
+            if (!sidecarFile.isFile) null
+            else
+              runCatching {
+                  json.decodeFromString(ErrorSidecar.serializer(), sidecarFile.readText())
+                }
+                .getOrNull()
+          }
+          .firstOrNull()
+      if (sidecar != null) result[id] = sidecar
+    }
+    return result
+  }
+
+  internal fun formatMissingPreviewsMessage(
+    manifest: PreviewManifest,
+    missingIds: List<String>,
+    sidecars: Map<String, ErrorSidecar>,
+  ): String {
+    val total = manifest.previews.size
+    val n = missingIds.size
+    return if (sidecars.isEmpty()) {
+      // No sidecars anywhere — the render task really was skipped or
+      // silently NO-SOURCE'd. Keep the original guidance so the
+      // testClassesDirs / RobolectricRenderTest.class diagnosis stays in
+      // place for the case it was written for.
+      val sample = missingIds.take(3).joinToString(", ")
+      val andMore = if (n > 3) " (+${n - 3} more)" else ""
+      "composePreviewRenderAll: render produced no output file for $n of " +
+        "$total preview(s): $sample$andMore. This means " +
+        "`composePreviewRender` was skipped or silently did nothing — on Android " +
+        "that usually means it reported NO-SOURCE because " +
+        "RobolectricRenderTest.class wasn't discoverable on its " +
+        "testClassesDirs. Run with --info to see the task outcome."
+    } else {
+      // At least one sidecar exists: the render task DID run, but the
+      // preview threw. Surface the actual exception(s) so the user sees
+      // a `Class.forName` / `NoSuchMethodError` / consumer-code failure
+      // instead of a misleading "NO-SOURCE" boilerplate.
+      val withSidecar = missingIds.filter { it in sidecars }
+      val withoutSidecar = missingIds.filterNot { it in sidecars }
+      val sb = StringBuilder()
+      sb
+        .append("composePreviewRenderAll: render produced no output file for ")
+        .append(n)
+        .append(" of ")
+        .append(total)
+        .append(" preview(s).")
+      if (withSidecar.isNotEmpty()) {
+        sb.append("\n\nPer-preview render errors (from .error.json sidecars):")
+        for (id in withSidecar.take(5)) {
+          val s = sidecars.getValue(id)
+          sb.append("\n  - ").append(id).append(": ").append(s.exception.substringAfterLast('.'))
+          if (s.message.isNotBlank()) sb.append(": ").append(s.message)
+          s.topAppFrame?.let { f ->
+            if (f.file.isNotBlank()) {
+              sb.append(" (at ").append(f.file)
+              if (f.line > 0) sb.append(':').append(f.line)
+              sb.append(')')
+            }
+          }
+        }
+        if (withSidecar.size > 5) {
+          sb.append("\n  (+").append(withSidecar.size - 5).append(" more with sidecars)")
+        }
+      }
+      if (withoutSidecar.isNotEmpty()) {
+        sb
+          .append("\n\nNo sidecar (render was skipped or silently produced nothing) for: ")
+          .append(withoutSidecar.take(5).joinToString(", "))
+        if (withoutSidecar.size > 5) {
+          sb.append(" (+").append(withoutSidecar.size - 5).append(" more)")
+        }
+      }
+      sb.toString()
+    }
+  }
 
   internal fun missingPreviewOutputIds(
     manifest: PreviewManifest,

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MissingPreviewMessageTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/MissingPreviewMessageTest.kt
@@ -1,0 +1,170 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.discovery.Capture
+import ee.schimke.composeai.discovery.PreviewInfo
+import ee.schimke.composeai.discovery.PreviewManifest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class MissingPreviewMessageTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private fun previewWithCapture(id: String, renderOutput: String) =
+    PreviewInfo(
+      id = id,
+      functionName = id,
+      className = "com.example.PreviewsKt",
+      captures = listOf(Capture(renderOutput = renderOutput)),
+    )
+
+  @Test
+  fun `formatMissingPreviewsMessage keeps legacy guidance when no sidecars exist`() {
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews = listOf(previewWithCapture("A", "renders/A.png")),
+      )
+
+    val msg =
+      ComposePreviewTasks.formatMissingPreviewsMessage(
+        manifest = manifest,
+        missingIds = listOf("A"),
+        sidecars = emptyMap(),
+      )
+
+    // The renderAll wrapper's original "NO-SOURCE" diagnosis stays
+    // intact when no .error.json sidecars are present — the task really
+    // was skipped (or genuinely produced nothing), which is what the
+    // legacy message was written for.
+    assertThat(msg).contains("composePreviewRender")
+    assertThat(msg).contains("NO-SOURCE")
+    assertThat(msg).contains("1 of 1")
+  }
+
+  @Test
+  fun `formatMissingPreviewsMessage surfaces sidecar exception details`() {
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews =
+          listOf(previewWithCapture("A", "renders/A.png"), previewWithCapture("B", "renders/B.png")),
+      )
+
+    val sidecars =
+      mapOf(
+        "A" to
+          ComposePreviewTasks.ErrorSidecar(
+            exception = "java.lang.ClassNotFoundException",
+            message = "com.example.PreviewsKt",
+            topAppFrame =
+              ComposePreviewTasks.ErrorSidecar.TopAppFrame(
+                file = "Previews.kt",
+                line = 42,
+                function = "Greeting",
+              ),
+          )
+      )
+
+    val msg =
+      ComposePreviewTasks.formatMissingPreviewsMessage(
+        manifest = manifest,
+        missingIds = listOf("A", "B"),
+        sidecars = sidecars,
+      )
+
+    // The misleading "NO-SOURCE / RobolectricRenderTest.class" sentence
+    // is the whole reason this code exists — make sure we DON'T emit it
+    // when at least one sidecar was found.
+    assertThat(msg).doesNotContain("NO-SOURCE")
+    assertThat(msg).doesNotContain("RobolectricRenderTest")
+    // The sidecar's exception class + message + frame should all be in
+    // the body so the user sees the actual failure rather than having
+    // to grep for an .error.json file by hand.
+    assertThat(msg).contains("ClassNotFoundException")
+    assertThat(msg).contains("com.example.PreviewsKt")
+    assertThat(msg).contains("Previews.kt:42")
+    assertThat(msg).contains("A:")
+    // Previews without a sidecar still get called out separately so a
+    // mixed "some threw, some were skipped" run doesn't hide the
+    // skip-class entries.
+    assertThat(msg).contains("No sidecar")
+    assertThat(msg).contains("B")
+  }
+
+  @Test
+  fun `readErrorSidecarsFor parses sidecar JSON next to each missing preview's render path`() {
+    val outDir = tempDir.root.resolve("compose-previews")
+    val rendersDir = outDir.resolve("renders").apply { mkdirs() }
+    // Schema mirrors RenderErrorSidecar.write — verifies we stay
+    // compatible with the renderer-side encoder without taking a
+    // cross-module dependency on the writer.
+    rendersDir
+      .resolve("A.png.error.json")
+      .writeText(
+        """
+        {
+          "schema": "compose-preview-error/v1",
+          "exception": "java.lang.NoSuchMethodError",
+          "message": "ComposeUiNode.setCompositeKeyHash",
+          "topAppFrame": {"file": "MyPreview.kt", "line": 17, "function": "Greet"},
+          "stackTrace": "..."
+        }
+        """
+          .trimIndent()
+      )
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews =
+          listOf(previewWithCapture("A", "renders/A.png"), previewWithCapture("B", "renders/B.png")),
+      )
+
+    val sidecars = ComposePreviewTasks.readErrorSidecarsFor(manifest, listOf("A", "B"), outDir)
+
+    // A has a sidecar; B does not. The map shape is exactly
+    // {id -> ErrorSidecar} for the ones present — `formatMissingPreviewsMessage`
+    // relies on `id !in sidecars` to bucket "skipped" vs "threw" previews.
+    assertThat(sidecars.keys).containsExactly("A")
+    val a = sidecars.getValue("A")
+    assertThat(a.exception).isEqualTo("java.lang.NoSuchMethodError")
+    assertThat(a.message).isEqualTo("ComposeUiNode.setCompositeKeyHash")
+    assertThat(a.topAppFrame?.file).isEqualTo("MyPreview.kt")
+    assertThat(a.topAppFrame?.line).isEqualTo(17)
+  }
+
+  @Test
+  fun `formatMissingPreviewsMessage truncates long sidecar lists`() {
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews = (1..10).map { previewWithCapture("P$it", "renders/P$it.png") },
+      )
+    val sidecars =
+      (1..10).associate { i ->
+        "P$i" to
+          ComposePreviewTasks.ErrorSidecar(
+            exception = "java.lang.RuntimeException",
+            message = "boom $i",
+          )
+      }
+
+    val msg =
+      ComposePreviewTasks.formatMissingPreviewsMessage(
+        manifest = manifest,
+        missingIds = (1..10).map { "P$it" },
+        sidecars = sidecars,
+      )
+
+    // Cap at 5 sidecar entries to keep the error block readable —
+    // anything past that gets a "(+N more with sidecars)" footer rather
+    // than scrolling the user off-screen.
+    assertThat(msg).contains("(+5 more with sidecars)")
+  }
+}


### PR DESCRIPTION
## Summary

Improve error messaging when preview renders fail by reading and surfacing exception details from `.error.json` sidecars written by the renderer. This replaces a generic "NO-SOURCE / RobolectricRenderTest.class" message with actual exception types, messages, and stack frame locations, making it much easier for users to diagnose preview failures.

## Key Changes

- **Error sidecar reading**: Added `readErrorSidecarsFor()` to parse `.error.json` files written by the renderer alongside missing preview outputs. The function looks for sidecars next to each preview's render output path and returns a map of preview IDs to parsed error details.

- **Enhanced error formatting**: Implemented `formatMissingPreviewsMessage()` to generate context-aware error messages:
  - When sidecars exist: surfaces the actual exception class, message, and source location (file:line) for each failed preview
  - When no sidecars exist: preserves the original "NO-SOURCE" guidance for cases where render was genuinely skipped
  - Truncates long error lists (capped at 5 entries) with a "+N more" footer to keep output readable
  - Separates previews with sidecars from those without (true skips) so mixed failure modes are clear

- **Error sidecar data model**: Added `ErrorSidecar` serializable class to deserialize the renderer's error payload, with `ignoreUnknownKeys` for forward compatibility.

- **Debug source set validation**: Added `CheckDebugPreviewsTask` to warn when `@Preview` functions are placed in `src/debug/` on modules with the `com.android.compose.screenshot` plugin. This catches a common configuration error where previews compiled against `screenshotTestImplementation` dependencies fail at render time with confusing `.error.json` sidecars.

- **Task integration**: Wired `CheckDebugPreviewsTask` as a finalizer of `composePreviewDiscover` so it runs after discovery without blocking the discovery task itself.

## Testing

Added comprehensive test coverage in `MissingPreviewMessageTest`:
- Verifies legacy "NO-SOURCE" message is preserved when no sidecars exist
- Confirms sidecar exception details are surfaced and "NO-SOURCE" is suppressed when sidecars are present
- Tests sidecar JSON parsing against the renderer's schema
- Validates truncation of long error lists

https://claude.ai/code/session_01Az6q936kydyvhPK6tVgkP5