### PR TITLE
refactor(vscode-extension): extract RefreshQueue as an explicit FSM

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
@@ -63,4 +63,7 @@ class CompositeDataProductRegistry(private val registries: List<DataProductRegis
   override fun onUnsubscribe(previewId: String, kind: String) {
     registries.firstOrNull { it.isKnown(kind) }?.onUnsubscribe(previewId, kind)
   }
+
+  override fun renderModeFor(kind: String): String? =
+    registries.firstOrNull { it.isKnown(kind) }?.renderModeFor(kind)
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
@@ -117,6 +117,18 @@ interface DataProductRegistry {
   fun onUnsubscribe(previewId: String, kind: String) {}
 
   /**
+   * Renderer-mode tag the dispatcher should stamp into a render when [kind] has at least one sticky
+   * subscription for the target preview. Returning a non-null value asks the renderer to run in
+   * that mode (e.g. `"a11y"` enables ATF + hierarchy capture). Returning `null` — the default —
+   * means "no special mode required, render with the standard pipeline."
+   *
+   * The dispatcher calls this with kinds the producer advertises in [capabilities]; producers can
+   * return `null` for kinds whose data is harvested opportunistically without a mode switch. See
+   * [JsonRpcServer.subscriptionDrivenRenderMode] for the resolution rule.
+   */
+  fun renderModeFor(kind: String): String? = null
+
+  /**
    * Tagged outcome of a [fetch]. The dispatcher maps each case to its wire-error counterpart in
    * `JsonRpcServer.handleDataFetch`.
    */

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -328,12 +328,13 @@ class JsonRpcServer(
       ?: DEFAULT_RENDER_TIMEOUT_MS
 
   /**
-   * D1 — sticky `(previewId, kind)` subscriptions installed by `data/subscribe`. The map is keyed
-   * by previewId so [setVisible] can drop entries for previews that are no longer on screen — see
-   * [pruneSubscriptionsToVisible]. Inner sets are wrapped via [ConcurrentHashMap.newKeySet] so
-   * subscribe / unsubscribe / attachment-build can race without locking.
+   * D1 — sticky `(previewId, kind)` subscriptions installed by `data/subscribe`. All read / write /
+   * prune access goes through [SubscriptionStore]; the three teardown paths (sticky- while-visible
+   * prune from `setVisible`, explicit `data/unsubscribe`, extension-disable kind sweep) hand back
+   * the dropped pairs so this file routes the producer `onUnsubscribe` notifications with the right
+   * registry surface.
    */
-  private val subscriptions = ConcurrentHashMap<String, MutableSet<String>>()
+  private val subscriptions = SubscriptionStore()
 
   /**
    * D3 — per-render `data/fetch` waiters. When `data/fetch` triggers a re-render via
@@ -1040,7 +1041,8 @@ class JsonRpcServer(
    * it owns "which kinds are advertised."
    */
   private fun subscriptionDrivenRenderMode(previewId: String): String? {
-    val kinds = subscriptions[previewId] ?: return null
+    val kinds = subscriptions.kindsFor(previewId)
+    if (kinds.isEmpty()) return null
     if (kinds.any { it.startsWith("a11y/") }) return "a11y"
     return null
   }
@@ -1648,14 +1650,13 @@ class JsonRpcServer(
     // anything for this render (e.g. an a11y producer on a render whose mode skipped a11y), so
     // a missing attachment never blocks the renderFinished. We omit the field entirely when the
     // resulting list is empty so pre-D1 fixtures keep round-tripping.
-    val requestedKinds: Set<String> =
-      (subscriptions[previewId]?.toSet() ?: emptySet()) + globalAttachKinds
+    val requestedKinds: Set<String> = subscriptions.kindsFor(previewId) + globalAttachKinds
     val attachments: List<DataProductAttachment> =
       if (requestedKinds.isEmpty()) emptyList()
       else extensions.publicDataProducts().attachmentsFor(previewId, requestedKinds)
     System.err.println(
       "compose-ai-daemon: [renderFinished] previewId=$previewId " +
-        "subscribedKinds=${subscriptions[previewId]?.sorted() ?: emptyList<String>()} " +
+        "subscribedKinds=${subscriptions.kindsFor(previewId).sorted()} " +
         "globalAttachKinds=${globalAttachKinds.sorted()} " +
         "attachments=${attachments.map { it.kind }}"
     )
@@ -1920,22 +1921,16 @@ class JsonRpcServer(
         )
         return
       }
-      subscriptions
-        .computeIfAbsent(params.previewId) { ConcurrentHashMap.newKeySet() }
-        .add(params.kind)
+      subscriptions.subscribe(params.previewId, params.kind)
       // Notify producers AFTER bookkeeping so a producer that throws during onSubscribe still
       // leaves the dispatcher state consistent with the client's view (a subsequent unsubscribe
       // will clear it). Re-subscribes pass the latest `params` through verbatim — producers that
       // care about reset-on-re-subscribe handle that themselves.
       extensions.publicDataProducts().onSubscribe(params.previewId, params.kind, params.params)
     } else {
-      val existed = subscriptions[params.previewId]?.remove(params.kind) == true
-      // Drop the inner set when its last subscription cleared so the bookkeeping doesn't
-      // accumulate empty entries for previews the user has cycled through.
-      subscriptions.computeIfPresent(params.previewId) { _, v -> if (v.isEmpty()) null else v }
-      // Notify the producer — but only if there was actually a live subscription. Calling
-      // onUnsubscribe for a never-subscribed pair would invite producers to log spurious
-      // "no such subscription" warnings.
+      // Only dispatch onUnsubscribe when there was actually a live subscription — spurious
+      // tear-down notifications invite producers to log "no such subscription" warnings.
+      val existed = subscriptions.unsubscribe(params.previewId, params.kind)
       if (existed) extensions.publicDataProducts().onUnsubscribe(params.previewId, params.kind)
     }
     sendResponse(req.id, encode(DataSubscribeResult.serializer(), DataSubscribeResult.OK))
@@ -1952,10 +1947,8 @@ class JsonRpcServer(
    * down even when the client doesn't send an explicit `data/unsubscribe`.
    */
   private fun pruneSubscriptionsToVisible(visible: Set<String>) {
-    val toDrop = subscriptions.keys - visible
-    for (id in toDrop) {
-      val droppedKinds = subscriptions.remove(id) ?: continue
-      for (kind in droppedKinds) extensions.publicDataProducts().onUnsubscribe(id, kind)
+    for ((id, kind) in subscriptions.retainVisible(visible)) {
+      extensions.publicDataProducts().onUnsubscribe(id, kind)
     }
   }
 
@@ -2033,19 +2026,11 @@ class JsonRpcServer(
     val outcome = extensions.disable(params.ids)
     val nowPublic = extensions.publicDataProductCapabilities().map { it.kind }.toSet()
     val droppedKinds = priorPublic - nowPublic
-    if (droppedKinds.isNotEmpty()) {
-      for ((previewId, kinds) in subscriptions) {
-        val toRemove = kinds.intersect(droppedKinds)
-        if (toRemove.isEmpty()) continue
-        kinds.removeAll(toRemove)
-        // We can't dispatch onUnsubscribe through `publicDataProducts()` here because the kind is
-        // no longer public. Reach through the active set instead so the producer still tears down
-        // its per-subscription state.
-        for (kind in toRemove) {
-          extensions.activeDataProducts().onUnsubscribe(previewId, kind)
-        }
-      }
-      subscriptions.values.removeIf { it.isEmpty() }
+    // We can't dispatch onUnsubscribe through `publicDataProducts()` here because the kind is no
+    // longer public. Reach through the active set instead so the producer still tears down its
+    // per-subscription state.
+    for ((previewId, kind) in subscriptions.removeKinds(droppedKinds)) {
+      extensions.activeDataProducts().onUnsubscribe(previewId, kind)
     }
     val result =
       ExtensionsDisableResult(

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1034,17 +1034,18 @@ class JsonRpcServer(
 
   /**
    * D2.2 — pick the renderer-mode tag implied by [previewId]'s active subscriptions, or `null` if
-   * no subscription demands a mode. Today only the `a11y/...` kind family maps to a mode
-   * (`"a11y"`); future producers that need sticky subscription-driven render modes can extend by
-   * introducing their own kind prefix → mode mapping. Stays in [JsonRpcServer] (rather than each
-   * producer registry) so the dispatcher owns "what mode does the renderer need next" the same way
-   * it owns "which kinds are advertised."
+   * no subscription demands a mode. The dispatcher asks each subscribed kind's owning registry via
+   * [DataProductRegistry.renderModeFor] — producers declare which kinds need a mode switch next to
+   * the artefacts they produce, so adding a new mode-driving family (e.g. layout inspector) means
+   * an override on the contributing producer, not a new branch here. Returns the first non-null
+   * mode encountered; multi-mode reconciliation isn't a real scenario yet (a11y is the only mode in
+   * flight) so first-wins keeps the contract simple.
    */
   private fun subscriptionDrivenRenderMode(previewId: String): String? {
     val kinds = subscriptions.kindsFor(previewId)
     if (kinds.isEmpty()) return null
-    if (kinds.any { it.startsWith("a11y/") }) return "a11y"
-    return null
+    val products = extensions.publicDataProducts()
+    return kinds.firstNotNullOfOrNull { kind -> products.renderModeFor(kind) }
   }
 
   private val renderResultsQueue = LinkedBlockingQueue<Any>()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/SubscriptionStore.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/SubscriptionStore.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.daemon
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Sticky `(previewId, kind)` subscription bookkeeping installed by `data/subscribe` and torn down
+ * by `data/unsubscribe`, [retainVisible] (sticky-while-visible — see PROTOCOL.md), and
+ * [removeKinds] (extension disable). All three teardown paths previously inlined identical "for
+ * each affected pair, drop it and notify the producer" logic against the same
+ * `ConcurrentHashMap<previewId, Set<kind>>`; concentrating the bookkeeping here keeps the map's
+ * invariants in one place and lets producer-side `onUnsubscribe` routing stay at the callsite (the
+ * daemon dispatches through `publicDataProducts()` for the subscribe / visibility paths and through
+ * `activeDataProducts()` for the extension-disable path — same store mutation, different routing of
+ * the side effect).
+ *
+ * Thread-safety: backed by [ConcurrentHashMap] with [ConcurrentHashMap.newKeySet] inner sets so the
+ * render thread's [kindsFor] reads can race the read thread's subscribe / unsubscribe / prune
+ * writes without locking — same guarantee the inlined version offered.
+ */
+internal class SubscriptionStore {
+  private val byPreview = ConcurrentHashMap<String, MutableSet<String>>()
+
+  /** Records the `(previewId, kind)` pair. Returns true iff the pair was newly added. */
+  fun subscribe(previewId: String, kind: String): Boolean {
+    val set = byPreview.computeIfAbsent(previewId) { ConcurrentHashMap.newKeySet() }
+    return set.add(kind)
+  }
+
+  /**
+   * Drops the `(previewId, kind)` pair. Returns true iff the pair was previously present — callers
+   * use the verdict to decide whether to dispatch `onUnsubscribe` (spurious tear-down notifications
+   * invite producers to log "no such subscription" warnings).
+   */
+  fun unsubscribe(previewId: String, kind: String): Boolean {
+    var existed = false
+    byPreview.computeIfPresent(previewId) { _, set ->
+      existed = set.remove(kind)
+      if (set.isEmpty()) null else set
+    }
+    return existed
+  }
+
+  /** Snapshot of currently subscribed kinds for [previewId]. Empty when none — never null. */
+  fun kindsFor(previewId: String): Set<String> = byPreview[previewId]?.toSet() ?: emptySet()
+
+  /** True iff at least one subscription is recorded for [previewId]. */
+  fun hasAny(previewId: String): Boolean = !byPreview[previewId].isNullOrEmpty()
+
+  /**
+   * Sticky-while-visible prune: drop every pair whose `previewId` is not in [visible]. Returns the
+   * dropped pairs in insertion-agnostic order so the caller can dispatch `onUnsubscribe` with the
+   * routing it controls.
+   */
+  fun retainVisible(visible: Set<String>): List<Pair<String, String>> {
+    val toDrop = byPreview.keys - visible
+    if (toDrop.isEmpty()) return emptyList()
+    val drops = mutableListOf<Pair<String, String>>()
+    for (id in toDrop) {
+      val kinds = byPreview.remove(id) ?: continue
+      for (kind in kinds) drops += id to kind
+    }
+    return drops
+  }
+
+  /**
+   * Extension-disable prune: drop every pair whose `kind` is in [kinds]. Returns the dropped pairs
+   * so the caller can dispatch `onUnsubscribe` against the appropriate producer set (the extension
+   * that owns the kind has already been deactivated, so the public producer surface no longer
+   * advertises it — callers reach through `activeDataProducts()` instead).
+   */
+  fun removeKinds(kinds: Set<String>): List<Pair<String, String>> {
+    if (kinds.isEmpty()) return emptyList()
+    val drops = mutableListOf<Pair<String, String>>()
+    for ((previewId, current) in byPreview) {
+      val toRemove = current.intersect(kinds)
+      if (toRemove.isEmpty()) continue
+      current.removeAll(toRemove)
+      for (k in toRemove) drops += previewId to k
+    }
+    byPreview.values.removeIf { it.isEmpty() }
+    return drops
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistryTest.kt
@@ -1,0 +1,94 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import kotlinx.serialization.json.JsonElement
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Targeted tests for [CompositeDataProductRegistry]'s routing rules. The fan-out semantics matter
+ * the most for [renderModeFor], which moved the kind-to-render-mode mapping out of
+ * [JsonRpcServer]'s hardcoded `a11y/` prefix check and into the owning producer registry. These
+ * tests pin "delegates to the registry that advertises the kind" so the dispatcher's
+ * subscription-driven render-mode injection keeps working as new mode-driving kinds get added.
+ */
+class CompositeDataProductRegistryTest {
+
+  /** Minimal producer stub: advertises [kind] and returns [renderMode] from [renderModeFor]. */
+  private class StubProducer(private val kind: String, private val renderMode: String? = null) :
+    DataProductRegistry {
+    override val capabilities =
+      listOf(
+        DataProductCapability(
+          kind = kind,
+          schemaVersion = 1,
+          transport = DataProductTransport.INLINE,
+          attachable = true,
+          fetchable = true,
+          requiresRerender = false,
+        )
+      )
+
+    override fun isKnown(kind: String): Boolean = kind == this.kind
+
+    override fun fetch(
+      previewId: String,
+      kind: String,
+      params: JsonElement?,
+      inline: Boolean,
+    ): DataProductRegistry.Outcome = DataProductRegistry.Outcome.Unknown
+
+    override fun attachmentsFor(
+      previewId: String,
+      kinds: Set<String>,
+    ): List<DataProductAttachment> = emptyList()
+
+    override fun renderModeFor(kind: String): String? = if (kind == this.kind) renderMode else null
+  }
+
+  @Test
+  fun `delegates renderModeFor to the registry that advertises the kind`() {
+    val composite =
+      CompositeDataProductRegistry(
+        listOf(
+          StubProducer("a11y/atf", renderMode = "a11y"),
+          StubProducer("compose/recomposition", renderMode = null),
+        )
+      )
+    assertEquals("a11y", composite.renderModeFor("a11y/atf"))
+    assertNull(composite.renderModeFor("compose/recomposition"))
+  }
+
+  @Test
+  fun `returns null for kinds that no registry advertises`() {
+    val composite = CompositeDataProductRegistry(listOf(StubProducer("a11y/atf", "a11y")))
+    assertNull(composite.renderModeFor("unknown/kind"))
+  }
+
+  @Test
+  fun `default DataProductRegistry renderModeFor returns null`() {
+    // Regression: producers without an explicit override (every existing connector except a11y)
+    // must report "no mode required" so the dispatcher leaves the standard render pipeline alone.
+    val producer = StubProducer("compose/recomposition") // renderMode defaults to null
+    assertNull(producer.renderModeFor("compose/recomposition"))
+  }
+
+  @Test
+  fun `picks the first matching registry when multiple advertise the same kind`() {
+    // CompositeDataProductRegistry already documents "kind routing uses the first registry that
+    // advertises the kind" for fetch / onSubscribe / onUnsubscribe; renderModeFor follows the
+    // same rule so future stacks that layer producers (e.g. a test override on top of the real
+    // a11y registry) get consistent routing across every fan-out method.
+    val composite =
+      CompositeDataProductRegistry(
+        listOf(
+          StubProducer("a11y/atf", renderMode = "a11y-override"),
+          StubProducer("a11y/atf", renderMode = "a11y"),
+        )
+      )
+    assertEquals("a11y-override", composite.renderModeFor("a11y/atf"))
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/SubscriptionStoreTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/SubscriptionStoreTest.kt
@@ -1,0 +1,152 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Targeted tests for [SubscriptionStore]. The store backs every `(previewId, kind)` mutation in
+ * [JsonRpcServer] -- subscribe, unsubscribe, the three pruning paths -- and replaced an inlined
+ * `ConcurrentHashMap` whose invariants ("drop the inner set when it goes empty", "only notify
+ * onUnsubscribe when the pair really existed") were only enforced by callsite discipline. Tests
+ * here pin those invariants directly so future callsite refactors can't quietly drift them.
+ */
+class SubscriptionStoreTest {
+
+  @Test
+  fun `subscribe records the pair and returns true on first add`() {
+    val store = SubscriptionStore()
+    assertTrue(store.subscribe("p1", "a11y/atf"))
+    assertEquals(setOf("a11y/atf"), store.kindsFor("p1"))
+  }
+
+  @Test
+  fun `subscribe is idempotent -- second add returns false`() {
+    val store = SubscriptionStore()
+    store.subscribe("p1", "a11y/atf")
+    assertFalse(store.subscribe("p1", "a11y/atf"))
+    assertEquals(setOf("a11y/atf"), store.kindsFor("p1"))
+  }
+
+  @Test
+  fun `multiple kinds for the same preview accumulate in one set`() {
+    val store = SubscriptionStore()
+    store.subscribe("p1", "a11y/atf")
+    store.subscribe("p1", "a11y/hierarchy")
+    assertEquals(setOf("a11y/atf", "a11y/hierarchy"), store.kindsFor("p1"))
+  }
+
+  @Test
+  fun `kindsFor returns an empty set for an unknown preview`() {
+    val store = SubscriptionStore()
+    assertEquals(emptySet<String>(), store.kindsFor("nope"))
+  }
+
+  @Test
+  fun `unsubscribe returns true when the pair was present`() {
+    val store = SubscriptionStore()
+    store.subscribe("p1", "a11y/atf")
+    assertTrue(store.unsubscribe("p1", "a11y/atf"))
+    assertEquals(emptySet<String>(), store.kindsFor("p1"))
+  }
+
+  @Test
+  fun `unsubscribe returns false on a never-subscribed pair`() {
+    val store = SubscriptionStore()
+    assertFalse(store.unsubscribe("p1", "a11y/atf"))
+  }
+
+  @Test
+  fun `unsubscribe returns false on a kind that was subscribed under a different preview`() {
+    val store = SubscriptionStore()
+    store.subscribe("p1", "a11y/atf")
+    assertFalse(store.unsubscribe("p2", "a11y/atf"))
+    // The original pair is untouched.
+    assertEquals(setOf("a11y/atf"), store.kindsFor("p1"))
+  }
+
+  @Test
+  fun `unsubscribing the last kind clears hasAny for that preview`() {
+    // Regression for the "empty inner set leaks" invariant: the old code called
+    // computeIfPresent after every unsubscribe to drop the empty entry. The
+    // store has to keep that behaviour or hasAny lies.
+    val store = SubscriptionStore()
+    store.subscribe("p1", "a11y/atf")
+    store.unsubscribe("p1", "a11y/atf")
+    assertFalse(store.hasAny("p1"))
+  }
+
+  @Test
+  fun `retainVisible drops every pair for previews not in the visible set`() {
+    val store = SubscriptionStore()
+    store.subscribe("p1", "a11y/atf")
+    store.subscribe("p1", "a11y/hierarchy")
+    store.subscribe("p2", "a11y/atf")
+    store.subscribe("p3", "compose/recomposition")
+    val dropped = store.retainVisible(setOf("p1"))
+    assertEquals(setOf("p2" to "a11y/atf", "p3" to "compose/recomposition"), dropped.toSet())
+    assertEquals(setOf("a11y/atf", "a11y/hierarchy"), store.kindsFor("p1"))
+    assertFalse(store.hasAny("p2"))
+    assertFalse(store.hasAny("p3"))
+  }
+
+  @Test
+  fun `retainVisible returns an empty list when nothing needs to drop`() {
+    val store = SubscriptionStore()
+    store.subscribe("p1", "a11y/atf")
+    assertEquals(emptyList<Pair<String, String>>(), store.retainVisible(setOf("p1", "p2")))
+    assertEquals(setOf("a11y/atf"), store.kindsFor("p1"))
+  }
+
+  @Test
+  fun `retainVisible with an empty visible set drops everything`() {
+    val store = SubscriptionStore()
+    store.subscribe("p1", "a11y/atf")
+    store.subscribe("p2", "compose/recomposition")
+    val dropped = store.retainVisible(emptySet())
+    assertEquals(setOf("p1" to "a11y/atf", "p2" to "compose/recomposition"), dropped.toSet())
+    assertFalse(store.hasAny("p1"))
+    assertFalse(store.hasAny("p2"))
+  }
+
+  @Test
+  fun `removeKinds drops every pair whose kind is in the set, across all previews`() {
+    val store = SubscriptionStore()
+    store.subscribe("p1", "a11y/atf")
+    store.subscribe("p1", "compose/recomposition")
+    store.subscribe("p2", "a11y/atf")
+    val dropped = store.removeKinds(setOf("a11y/atf"))
+    assertEquals(setOf("p1" to "a11y/atf", "p2" to "a11y/atf"), dropped.toSet())
+    // p1 still has the surviving kind; p2 was fully cleared and must report empty.
+    assertEquals(setOf("compose/recomposition"), store.kindsFor("p1"))
+    assertFalse(store.hasAny("p2"))
+  }
+
+  @Test
+  fun `removeKinds returns an empty list when no kind matches`() {
+    val store = SubscriptionStore()
+    store.subscribe("p1", "a11y/atf")
+    assertEquals(emptyList<Pair<String, String>>(), store.removeKinds(setOf("layout/inspector")))
+    assertEquals(setOf("a11y/atf"), store.kindsFor("p1"))
+  }
+
+  @Test
+  fun `removeKinds with an empty kind set is a no-op`() {
+    val store = SubscriptionStore()
+    store.subscribe("p1", "a11y/atf")
+    assertEquals(emptyList<Pair<String, String>>(), store.removeKinds(emptySet()))
+    assertEquals(setOf("a11y/atf"), store.kindsFor("p1"))
+  }
+
+  @Test
+  fun `removeKinds clears the previewId entry when its last kind goes`() {
+    // Regression: the old code called `subscriptions.values.removeIf { it.isEmpty() }` after
+    // the per-preview kind sweep so the bookkeeping wouldn't accumulate empty entries. The
+    // store has to keep that invariant.
+    val store = SubscriptionStore()
+    store.subscribe("p1", "a11y/atf")
+    store.removeKinds(setOf("a11y/atf"))
+    assertFalse(store.hasAny("p1"))
+  }
+}

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
@@ -229,6 +229,15 @@ class AccessibilityDataProductRegistry(private val rootDir: File) :
   override fun missingOutcome(previewId: String, kind: String): DataProductRegistry.Outcome =
     DataProductRegistry.Outcome.RequiresRerender("a11y")
 
+  /**
+   * Every advertised kind here is gated on the renderer's a11y mode (`writeArtifacts` only fires
+   * when `effectiveRunAccessibility` is true) — so a sticky subscription for any of them implies
+   * the next render must run with mode=a11y. Returning the mode from the producer puts the
+   * mapping next to the artefacts it produces; [JsonRpcServer.subscriptionDrivenRenderMode]
+   * routes through the registry instead of pattern-matching on the kind string.
+   */
+  override fun renderModeFor(kind: String): String? = if (isKnown(kind)) "a11y" else null
+
   /** The overlay kind is a PNG — never parse it as JSON, even on `inline = true`. */
   override fun allowInlineUpgrade(kind: String): Boolean =
     kind != AccessibilityDataProducer.KIND_OVERLAY

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
@@ -191,6 +191,15 @@ class RenderFunctionalTest {
   fun `composePreviewRenderAll missing-renders=warn does not fail the build`() {
     val projectDir = createTestProject()
 
+    // Discover first so `previews.json` exists as `composePreviewRenderAll`'s
+    // `inputs.file(...)` — same warmup the loud-failure tests above use. Without
+    // it the task fails validation before the missing-renders policy is read.
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover")
+      .withPluginClasspath()
+      .build()
+
     val result =
       GradleRunner.create()
         .withProjectDir(projectDir)
@@ -211,13 +220,21 @@ class RenderFunctionalTest {
     assertThat(result.output).contains("render produced no output file")
     // Validation marker is still written under warn so downstream tasks
     // that wire off the marker (pixel-test gates, baselines) keep running.
-    assertThat(File(projectDir, "build/compose-previews/composePreviewRenderAll.validated"))
-      .exists()
+    assertThat(
+        File(projectDir, "build/compose-previews/composePreviewRenderAll.validated").exists()
+      )
+      .isTrue()
   }
 
   @Test
   fun `composePreviewRenderAll missing-renders=ignore stays silent`() {
     val projectDir = createTestProject()
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover")
+      .withPluginClasspath()
+      .build()
 
     val result =
       GradleRunner.create()
@@ -237,13 +254,21 @@ class RenderFunctionalTest {
     // suppress the diagnostic for projects that accept some missing
     // previews as the steady state.
     assertThat(result.output).doesNotContain("render produced no output file")
-    assertThat(File(projectDir, "build/compose-previews/composePreviewRenderAll.validated"))
-      .exists()
+    assertThat(
+        File(projectDir, "build/compose-previews/composePreviewRenderAll.validated").exists()
+      )
+      .isTrue()
   }
 
   @Test
   fun `composePreviewRenderAll missing-renders=garbage falls back to fail`() {
     val projectDir = createTestProject()
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover")
+      .withPluginClasspath()
+      .build()
 
     val result =
       GradleRunner.create()

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -96,6 +96,21 @@ export interface SchedulerEvents {
 const HEAVY_TIER_DEFAULT: RenderTier = "fast";
 
 /**
+ * Outcome of {@link DaemonScheduler.setDataProductSubscription}. The transition
+ * field reports whether the module crossed an a11y first-on / last-off
+ * boundary in this call; the panel uses it to gate a follow-up refresh that
+ * repaints with the freshly-arrived (or now-absent) data products.
+ */
+export interface DataProductSubscriptionResult {
+    a11yTransition: "enabled" | "disabled" | "unchanged";
+}
+
+/** Predicate: does this kind contribute to the module's a11y aggregate? */
+function isA11yKind(kind: string): boolean {
+    return kind.startsWith("a11y/");
+}
+
+/**
  * D2 — kinds the focus-mode "Show a11y overlay" button toggles. Pinned to the a11y producer
  * so the local finding + hierarchy overlays light up together; a future panel that wants to
  * subscribe to other kinds (`compose/recomposition`, `layout/inspector`) will export its own list.
@@ -154,12 +169,20 @@ export interface DaemonScheduler {
         visible: string[],
         predicted?: string[],
     ): Promise<void>;
+    /**
+     * Update one or more `(previewId, kind)` subscriptions for `module`.
+     * Returns whether the module's overall a11y enablement crossed a
+     * first-on / last-off boundary — callers (the panel) use that to
+     * decide whether to kick a follow-up refresh so the next render's
+     * data-product set is repainted. Non-a11y kinds never trip the
+     * transition; a no-op subscribe / unsubscribe returns `"unchanged"`.
+     */
     setDataProductSubscription(
         module: ModuleInfo,
         previewId: string,
         kinds: readonly string[],
         enabled: boolean,
-    ): Promise<void>;
+    ): Promise<DataProductSubscriptionResult>;
     /**
      * Resolves once every in-flight `data/subscribe` for [moduleId] has been
      * acknowledged by the daemon (or has settled — failures count as drained).
@@ -538,13 +561,14 @@ export class LiveDaemonScheduler implements DaemonScheduler {
         previewId: string,
         kinds: readonly string[],
         enabled: boolean,
-    ): Promise<void> {
+    ): Promise<DataProductSubscriptionResult> {
+        const wasA11yActive = this.moduleHasA11ySubscription(module.modulePath);
         const client = await this.gate.getOrSpawn(
             module,
             this.daemonEvents(module.modulePath),
         );
         if (!client) {
-            return;
+            return { a11yTransition: "unchanged" };
         }
         let subscribedAny = false;
         for (const kind of kinds) {
@@ -604,6 +628,33 @@ export class LiveDaemonScheduler implements DaemonScheduler {
                     );
                 });
         }
+        const isA11yActive = this.moduleHasA11ySubscription(module.modulePath);
+        return {
+            a11yTransition:
+                wasA11yActive === isA11yActive
+                    ? "unchanged"
+                    : isA11yActive
+                      ? "enabled"
+                      : "disabled",
+        };
+    }
+
+    /**
+     * True when any `(previewId, a11y/*)` pair under [modulePath] is currently
+     * subscribed. Derived from {@link subscribedPairs} on every call so there's
+     * no separate aggregate to keep in sync.
+     */
+    private moduleHasA11ySubscription(modulePath: string): boolean {
+        const prefix = `${modulePath}::`;
+        for (const key of this.subscribedPairs) {
+            if (!key.startsWith(prefix)) continue;
+            const rest = key.slice(prefix.length);
+            const kindSep = rest.indexOf("::");
+            if (kindSep < 0) continue;
+            const kind = rest.slice(kindSep + 2);
+            if (isA11yKind(kind)) return true;
+        }
+        return false;
     }
 
     /**
@@ -892,8 +943,9 @@ export class GradleOnlyDaemonScheduler implements DaemonScheduler {
         _previewId: string,
         _kinds: readonly string[],
         _enabled: boolean,
-    ): Promise<void> {
+    ): Promise<DataProductSubscriptionResult> {
         /* no-op: data extensions are disabled in minimal mode */
+        return { a11yTransition: "unchanged" };
     }
 
     async awaitPendingSubscribes(_moduleId: string): Promise<void> {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -235,13 +235,6 @@ const registry = new PreviewRegistry();
 /** previewId → module, updated on every refresh. Used to look up the
  *  owning module when the webview posts a per-preview action. */
 const previewModuleMap = new Map<string, ModuleInfo>();
-/** modulePath → set of previewIds with at least one `a11y/*` data-extension
- *  subscription active. The webview chip toggle keeps this state so the
- *  daemon scheduler can attach (or stop attaching) the post-capture a11y
- *  walk on each preview's next render. The standalone Gradle render task
- *  no longer participates in a11y at all — production is daemon-only —
- *  so this map drives daemon subscriptions only, never gradle args. */
-const moduleA11ySubscriptions = new Map<string, Set<string>>();
 /**
  * previewId → latest Remote Compose override the panel pushed. The panel's
  * editable tab body posts `setRemoteComposeNamedValue` per cell change; we
@@ -5028,40 +5021,6 @@ async function handleLoadFontPreview(
 }
 
 /**
- * Updates `moduleA11ySubscriptions` for a chip toggle and reports whether
- * the module's overall a11y-enabled state changed. Non-a11y kinds always
- * return `"unchanged"`. The transition value tells the caller whether to
- * kick a panel refresh after the daemon-side subscription change — when
- * a11y first turns on / off for the module, the data-product set on the
- * next render is different, so the panel needs a fresh `refresh()` to
- * pull the new state. (a11y itself is enabled / disabled inside the
- * daemon; the gradle render task does not participate.)
- */
-function updateModuleA11ySubscription(
-    modulePath: string,
-    previewId: string,
-    kind: string,
-    enabled: boolean,
-): "enabled" | "disabled" | "unchanged" {
-    if (!kind.startsWith("a11y/")) return "unchanged";
-    let subs = moduleA11ySubscriptions.get(modulePath);
-    const wasActive = !!subs && subs.size > 0;
-    if (enabled) {
-        if (!subs) {
-            subs = new Set();
-            moduleA11ySubscriptions.set(modulePath, subs);
-        }
-        subs.add(previewId);
-    } else if (subs) {
-        subs.delete(previewId);
-        if (subs.size === 0) moduleA11ySubscriptions.delete(modulePath);
-    }
-    const isActive = (moduleA11ySubscriptions.get(modulePath)?.size ?? 0) > 0;
-    if (wasActive === isActive) return "unchanged";
-    return isActive ? "enabled" : "disabled";
-}
-
-/**
  * Bundle / focus-inspector data-extension toggle. Routes one or more
  * `(previewId, kind)` subscriptions through the daemon scheduler in a
  * single call so `data/subscribe` per kind is followed by exactly one
@@ -5128,22 +5087,6 @@ async function handleSetDataExtensionEnabled(
     if (filteredKinds.length === 0) {
         return;
     }
-    // Update the module's a11y tracker per-kind, but the
-    // first-on / last-off transition is what gates the follow-up
-    // refresh — collapse the per-kind verdicts into one. A bundle
-    // activation enables every a11y kind at once, so only the first
-    // kind in the batch can trip the transition; the rest stay
-    // "unchanged" and must not override that.
-    let a11yTransition: "enabled" | "disabled" | "unchanged" = "unchanged";
-    for (const kind of filteredKinds) {
-        const t = updateModuleA11ySubscription(
-            moduleId.modulePath,
-            previewId,
-            kind,
-            enabled,
-        );
-        if (t !== "unchanged") a11yTransition = t;
-    }
     // Start the progress indicator BEFORE awaiting the subscribe call so
     // the user sees feedback the instant they click. The tracker resolves
     // on `onDataProductsAttached`, on disable, or on its own safety timeout.
@@ -5160,8 +5103,11 @@ async function handleSetDataExtensionEnabled(
     // kind followed by exactly one `renderNow`. Per-kind dispatch
     // would interleave with the daemon's mode-lock-on-first-
     // subscribe and the second kind's data product (e.g. `a11y/atf`)
-    // would silently miss the in-flight render.
-    await daemonScheduler.setDataProductSubscription(
+    // would silently miss the in-flight render. The scheduler owns the
+    // module's a11y subscription aggregate (derived from its
+    // `subscribedPairs`) and reports the first-on / last-off transition
+    // here so the panel can decide whether to repaint.
+    const { a11yTransition } = await daemonScheduler.setDataProductSubscription(
         moduleId,
         previewId,
         filteredKinds,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -106,6 +106,7 @@ import {
     hasFreshRenderStamp,
     writeRenderFreshnessStamp,
 } from "./renderFreshness";
+import { RefreshQueue, defaultRefreshQueueEffects } from "./refreshQueue";
 import {
     BUNDLED_PLUGIN_VERSION,
     hasIncludedPluginBuild,
@@ -203,7 +204,6 @@ const moduleManifestCache = new Map<string, PreviewInfo[]>();
  */
 const heavyRefreshOptIns = new Map<string, Set<string>>();
 let panel: PreviewPanel | null = null;
-let debounceTimer: NodeJS.Timeout | null = null;
 let selectedModule: string | null = null;
 let pendingRefresh: AbortController | null = null;
 // Args of the most recent `[refresh] start` line we emitted. Used to suppress
@@ -278,18 +278,21 @@ const latestRemoteComposeByPreview = new Map<
         >;
     }
 >();
-/** Tracks files saved at least once since activation. First save on a file
- *  renders immediately; subsequent saves go through the debounce path. */
-const firstSaveSeen = new Set<string>();
 /** Last edited preview function name per Kotlin file, captured from in-memory edits and
  * consumed on save to prioritize that preview's refresh. */
 const lastEditedPreviewFunctionByFile = new Map<string, string>();
-/** Save-driven refresh coalescing state. See {@link enqueueSaveRefresh}. */
-let pendingSavePath: string | null = null;
-let debounceElapsed = true;
-let refreshInFlight = false;
+/** Save-driven refresh coalescing as an explicit FSM — replaces the prior
+ *  `firstSaveSeen` / `pendingSavePath` / `debounceElapsed` / `refreshInFlight`
+ *  quintet. See [RefreshQueue]. Constructed in activate() so it captures the
+ *  live `runRefreshExclusiveImpl` / `invalidateModuleCache` references. */
+let refreshQueue: RefreshQueue = new RefreshQueue(
+    defaultRefreshQueueEffects(
+        (target) => runRefreshExclusiveImpl(target),
+        (target) => invalidateModuleCache(target),
+    ),
+);
 /** Edit→preview-update journey timers, keyed by moduleId. Started when a
- *  save kicks off `runRefreshExclusive`, ended when either the gradle
+ *  save kicks off `runRefreshExclusiveImpl` via the queue, ended when either the gradle
  *  refresh finishes posting images or the daemon emits the first
  *  `onPreviewImageReady` for that module. Latest save overwrites any
  *  in-flight entry so the metric tracks the most recent edit. */
@@ -1293,7 +1296,7 @@ export async function activate(
             // than ours and are already calibrated against module history.
             // The status-bar item still reflects the data-extension activity
             // so the signal isn't lost.
-            if (refreshInFlight) return;
+            if (refreshQueue.isInFlight()) return;
             panel?.postMessage({
                 command: "setProgress",
                 phase: "dataExtension",
@@ -1303,7 +1306,7 @@ export async function activate(
             });
         },
         onClear: () => {
-            if (refreshInFlight) return;
+            if (refreshQueue.isInFlight()) return;
             panel?.postMessage({ command: "clearProgress" });
         },
         onStatus: (summary) => applyDataExtensionStatus(summary),
@@ -1927,7 +1930,7 @@ export async function activate(
             // replace the existing render with a placeholder; the panel
             // should keep the last-good image until the user clicks Refresh.
             if (inMinimalMode()) {
-                firstSaveSeen.add(doc.uri.fsPath);
+                refreshQueue.markSeen(doc.uri.fsPath);
                 panel?.postMessage({ command: "minimalSavePending" });
                 return;
             }
@@ -1943,18 +1946,11 @@ export async function activate(
             // — either path runs, never both. See `pickRefreshMode` for the
             // health gate. When the daemon flag is off (default) the gate
             // always returns 'gradle' so behaviour is byte-identical to today.
-            if (
-                !firstSaveSeen.has(doc.uri.fsPath) &&
-                !refreshInFlight &&
-                pendingSavePath === null
-            ) {
-                firstSaveSeen.add(doc.uri.fsPath);
-                invalidateModuleCache(doc.uri.fsPath);
-                void runRefreshExclusive(doc.uri.fsPath);
-            } else {
-                firstSaveSeen.add(doc.uri.fsPath);
-                enqueueSaveRefresh(doc.uri.fsPath);
-            }
+            const target = doc.uri.fsPath;
+            refreshQueue.dispatchSave(target, {
+                allowImmediate: true,
+                debounceMs: refreshDebounceMsFor(target),
+            });
         }),
     );
     context.subscriptions.push(
@@ -1973,9 +1969,14 @@ export async function activate(
         if (inMinimalMode()) {
             return;
         }
-        if (isSourceFile(uri.fsPath)) {
-            enqueueSaveRefresh(uri.fsPath);
+        if (!isSourceFile(uri.fsPath)) {
+            return;
         }
+        const target = resolveWatcherTarget(uri.fsPath);
+        refreshQueue.dispatchSave(target, {
+            allowImmediate: false,
+            debounceMs: refreshDebounceMsFor(target),
+        });
     };
     for (const glob of ["**/*.kt", "**/res/**/*.xml"]) {
         const watcher = vscode.workspace.createFileSystemWatcher(glob);
@@ -2103,9 +2104,7 @@ export async function activate(
 }
 
 export function deactivate() {
-    if (debounceTimer) {
-        clearTimeout(debounceTimer);
-    }
+    refreshQueue.dispose();
     stopAllDaemonStartupProgress();
     pendingRefresh?.abort();
     // Tell the daemon to release every interactive stream this session opened
@@ -3100,7 +3099,7 @@ async function refreshAfterDaemonReady(
     if (currentScopeFile && currentScopeFile !== filePath) {
         return;
     }
-    if (pendingRefresh || refreshInFlight) {
+    if (pendingRefresh || refreshQueue.isInFlight()) {
         logLine(
             `daemon: skip post-warm refresh for ${module.modulePath}; refresh already active`,
         );
@@ -3376,7 +3375,7 @@ function emitDataExtensionTimeoutDiagnostics(
     );
     const moduleReady = daemonGate?.isDaemonReady(diag.moduleId) ?? false;
     lines.push(
-        `    daemonReady=${moduleReady} refreshInFlight=${refreshInFlight}`,
+        `    daemonReady=${moduleReady} refreshInFlight=${refreshQueue.isInFlight()}`,
     );
     const snap = daemonGate?.getCapabilitiesSnapshot(diag.moduleId);
     if (!snap) {
@@ -3612,122 +3611,93 @@ function writeCalibration(module: ModuleInfo, latest: PhaseDurations): void {
     void extensionContext.workspaceState.update(PROGRESS_CALIBRATION_KEY, all);
 }
 
+/** Active-editor-aware debounce: edits to the currently-scoped preview file
+ *  use the short `SCOPE_DEBOUNCE_MS` so the panel feels responsive; everything
+ *  else falls back to the longer `DEBOUNCE_MS` that absorbs burst saves
+ *  across multiple files. */
+function refreshDebounceMsFor(target: string): number {
+    return target === currentScopeFile ? SCOPE_DEBOUNCE_MS : DEBOUNCE_MS;
+}
+
+/** Resolve a watcher event's file path to the refresh target. Watcher events
+ *  can fire on non-Kotlin files (e.g. resource XML); prefer the active Kotlin
+ *  editor in that case so the refresh runs against the file the user is
+ *  looking at, not the resource that changed underneath. */
+function resolveWatcherTarget(filePath: string): string {
+    if (filePath.endsWith(".kt")) return filePath;
+    const active = vscode.window.activeTextEditor;
+    if (active?.document.languageId === "kotlin") {
+        return active.document.uri.fsPath;
+    }
+    return filePath;
+}
+
 /**
- * Coalesce save-driven refreshes. The next refresh fires when BOTH:
- *   1. `DEBOUNCE_MS` has elapsed since the last save (absorbs bursts), and
- *   2. any in-flight refresh has finished (never stacks builds).
- * Whichever takes longer wins — effectively `max(1.5s, in-flight completion)`.
- * Rapid saves collapse into a single final refresh scoped to the latest file.
+ * Performs one save-driven refresh. Wrapped by {@link RefreshQueue}, which
+ * owns the "never stack builds" + "coalesce bursts" gating; this function
+ * just does the work.
+ *
+ * Picks daemon-vs-Gradle deliberately — never runs both for the same save.
+ * Saves use the daemon path; if the daemon is unavailable we surface an
+ * error instead of rendering via Gradle. The build can still opt out
+ * per-module via `composePreview { daemon { enabled = false } }`, in which
+ * case the Gradle render path runs.
+ *
+ * **Recompile-before-notify invariant.** In the daemon path the compile
+ * step runs *first*, then the daemon is notified. The daemon's
+ * `fileChanged({kind:source})` swaps its `URLClassLoader` and `renderNow`
+ * reads `.class` files from `build/intermediates/.../classes/` — so those
+ * files must be fresh when the swap happens.
+ *
+ * Save-driven: always `tier='fast'`. Heavy captures (LONG / GIF / animated)
+ * keep their previous PNG/GIF on disk and surface as stale in the panel —
+ * the user re-renders them on demand via the refresh command, which uses
+ * `tier='full'`.
  */
-function enqueueSaveRefresh(filePath: string): void {
-    // Prefer the saved file path, but fall back to the active editor when the
-    // saved file isn't a Kotlin source (e.g. a resource XML changed).
-    const target = filePath.endsWith(".kt")
-        ? filePath
-        : vscode.window.activeTextEditor?.document.languageId === "kotlin"
-          ? vscode.window.activeTextEditor.document.uri.fsPath
-          : filePath;
-    pendingSavePath = target;
-    invalidateModuleCache(target);
-
-    const delay = target === currentScopeFile ? SCOPE_DEBOUNCE_MS : DEBOUNCE_MS;
-    if (debounceTimer) {
-        clearTimeout(debounceTimer);
-    }
-    debounceElapsed = false;
-    debounceTimer = setTimeout(() => {
-        debounceTimer = null;
-        debounceElapsed = true;
-        maybeFirePendingRefresh();
-    }, delay);
-}
-
-/** Fires the pending refresh only when the debounce window has elapsed AND
- *  no other refresh is running. Called from the debounce timer and from the
- *  tail of {@link runRefreshExclusive}. */
-function maybeFirePendingRefresh(): void {
-    if (refreshInFlight || !debounceElapsed || pendingSavePath === null) {
-        return;
-    }
-    const target = pendingSavePath;
-    pendingSavePath = null;
-    void runRefreshExclusive(target);
-}
-
-/** Runs {@link refresh} with the `refreshInFlight` gate so the debounce queue
- *  can tell whether to defer. On completion picks up anything that arrived
- *  during the run, re-applying the debounce-elapsed check.
- *
- *  Picks daemon-vs-Gradle deliberately — never runs both for the same save.
- *  Saves use the daemon path; if the daemon is unavailable we surface an error instead of
- *  rendering via Gradle. The build can still opt out per-module via
- *  `composePreview { daemon { enabled = false } }`, in which case the Gradle render path runs.
- *
- *  **Recompile-before-notify invariant.** In the daemon path the compile
- *  step runs *first*, then the daemon is notified. The daemon's
- *  `fileChanged({kind:source})` swaps its `URLClassLoader` and `renderNow`
- *  reads `.class` files from `build/intermediates/.../classes/` — so those
- *  files must be fresh when the swap happens. We invoke
- *  `composePreviewCompile` (the same `compileKotlin*` upstream that
- *  `composePreviewDiscover` depends on, minus the ClassGraph scan over every
- *  dependency JAR) — the heavy classpath walk is now the daemon's job via
- *  `IncrementalDiscovery`, surfaced through `discoveryUpdated` only when
- *  the preview set actually drifted.
- *
- *  Save-driven: always `tier='fast'`. Heavy captures (LONG / GIF / animated)
- *  keep their previous PNG/GIF on disk and surface as stale in the panel —
- *  the user re-renders them on demand via the refresh command, which uses
- *  `tier='full'`. Keeps every save in the cheap interactive loop. */
-async function runRefreshExclusive(filePath: string): Promise<void> {
-    refreshInFlight = true;
+async function runRefreshExclusiveImpl(filePath: string): Promise<void> {
     // The journey timer is started by the `onDidSaveTextDocument` handler
     // (not here) so it captures the debounce wait too. Manual refreshes
     // that bypass save have no timer running, in which case
     // `endEditJourney` no-ops below.
     const journeyModuleKey =
         gradleService?.resolveModule(filePath)?.modulePath ?? null;
-    try {
-        const mode = pickRefreshMode(filePath);
-        if (mode === "daemon") {
-            const compileOk = await runDaemonCompileOnly(filePath);
-            if (!compileOk) {
-                if (journeyModuleKey) {
-                    editJourneyByModule.delete(journeyModuleKey);
-                }
-                vscode.window.showErrorMessage(
-                    "Compose Preview daemon refresh failed because compile failed. Fix the compile error and save again.",
-                );
-                return;
-            }
-            const result = await notifyDaemonOfSave(filePath);
-            if (result === "accepted") {
-                // End-of-journey log fires from `onPreviewImageReady` when the
-                // first rendered image arrives. Until then the timer stays in
-                // `editJourneyByModule`.
-                return;
-            }
-            if (result === "disabled") {
-                await refresh(true, filePath, "fast");
-                if (journeyModuleKey) {
-                    endEditJourney(journeyModuleKey);
-                }
-                return;
-            }
+    const mode = pickRefreshMode(filePath);
+    if (mode === "daemon") {
+        const compileOk = await runDaemonCompileOnly(filePath);
+        if (!compileOk) {
             if (journeyModuleKey) {
                 editJourneyByModule.delete(journeyModuleKey);
             }
             vscode.window.showErrorMessage(
-                "Compose Preview daemon is unavailable. Restart the preview daemon after fixing the daemon issue.",
+                "Compose Preview daemon refresh failed because compile failed. Fix the compile error and save again.",
             );
             return;
         }
-        await refresh(true, filePath, "fast");
-        if (journeyModuleKey) {
-            endEditJourney(journeyModuleKey);
+        const result = await notifyDaemonOfSave(filePath);
+        if (result === "accepted") {
+            // End-of-journey log fires from `onPreviewImageReady` when the
+            // first rendered image arrives. Until then the timer stays in
+            // `editJourneyByModule`.
+            return;
         }
-    } finally {
-        refreshInFlight = false;
-        maybeFirePendingRefresh();
+        if (result === "disabled") {
+            await refresh(true, filePath, "fast");
+            if (journeyModuleKey) {
+                endEditJourney(journeyModuleKey);
+            }
+            return;
+        }
+        if (journeyModuleKey) {
+            editJourneyByModule.delete(journeyModuleKey);
+        }
+        vscode.window.showErrorMessage(
+            "Compose Preview daemon is unavailable. Restart the preview daemon after fixing the daemon issue.",
+        );
+        return;
+    }
+    await refresh(true, filePath, "fast");
+    if (journeyModuleKey) {
+        endEditJourney(journeyModuleKey);
     }
 }
 

--- a/vscode-extension/src/refreshQueue.ts
+++ b/vscode-extension/src/refreshQueue.ts
@@ -1,0 +1,167 @@
+/**
+ * Save-driven refresh coalescing as an explicit state machine.
+ *
+ * State:
+ *   { inFlight, pendingTarget, debounceElapsed, seenFiles }
+ *
+ * Events:
+ *   - dispatchSave(target, opts) — caller observed a save/watcher event
+ *   - DEBOUNCE_ELAPSED (internal, fired from the injected timer)
+ *   - REFRESH_COMPLETED (internal, fired from runRefresh resolution)
+ *
+ * Fire rule (single point):
+ *   pendingTarget !== null && debounceElapsed && !inFlight  →  run pending
+ *
+ * Save dispatch rule:
+ *   allowImmediate && firstSeen && !inFlight && pendingTarget === null
+ *     → mark seen, invalidate cache, run immediately
+ *   otherwise
+ *     → if allowImmediate: mark seen
+ *     → set pendingTarget, invalidate cache, restart debounce timer
+ *
+ * Timer and refresh runner are injected so unit tests can drive transitions
+ * with a fake clock. Default effects use the global timers and accept any
+ * Promise-returning runRefresh.
+ */
+
+export interface RefreshQueueTimer {}
+
+export interface RefreshQueueEffects {
+    /** Kick off the actual refresh work. Resolves when done (success or failure).
+     *  Errors are swallowed by the queue — callers handle their own UX. */
+    runRefresh: (target: string) => Promise<void>;
+    /** Drop any cached module info for `target`. Called once at dispatch time
+     *  so the subsequent runRefresh resolves modules from fresh disk state. */
+    invalidateModuleCache: (target: string) => void;
+    /** Schedule `cb` to fire after `ms`. Returns an opaque handle for cancel. */
+    setTimeout: (cb: () => void, ms: number) => RefreshQueueTimer;
+    /** Cancel a pending timer. Safe to call on an already-fired handle. */
+    clearTimeout: (timer: RefreshQueueTimer) => void;
+}
+
+export interface SaveDispatchOptions {
+    /** When true, eligible saves take the first-seen fast path (immediate
+     *  refresh, no debounce wait). Onsave events from VS Code's
+     *  `onDidSaveTextDocument` set this to true; file-system watchers and
+     *  programmatic re-enqueues set it to false so external file mutations
+     *  (git checkout, refactor tools) never bypass debounce. */
+    allowImmediate: boolean;
+    /** Debounce duration applied if this save needs to be queued. */
+    debounceMs: number;
+}
+
+export interface RefreshQueueSnapshot {
+    inFlight: boolean;
+    pendingTarget: string | null;
+    debounceElapsed: boolean;
+    seenFiles: ReadonlySet<string>;
+}
+
+export class RefreshQueue {
+    private inFlight = false;
+    private pendingTarget: string | null = null;
+    private debounceElapsed = true;
+    private debounceTimer: RefreshQueueTimer | null = null;
+    private readonly seenFiles = new Set<string>();
+
+    constructor(private readonly effects: RefreshQueueEffects) {}
+
+    /** Single entry point for save events from VS Code and file watchers. */
+    dispatchSave(target: string, opts: SaveDispatchOptions): void {
+        const firstSeen = !this.seenFiles.has(target);
+        const idle = !this.inFlight && this.pendingTarget === null;
+        if (opts.allowImmediate && firstSeen && idle) {
+            this.seenFiles.add(target);
+            this.effects.invalidateModuleCache(target);
+            this.startRefresh(target);
+            return;
+        }
+        if (opts.allowImmediate) {
+            this.seenFiles.add(target);
+        }
+        this.scheduleDebounce(target, opts.debounceMs);
+    }
+
+    /** Mark a file as seen without scheduling work. Used by minimal-mode
+     *  save handlers that bypass the queue but should still affect a later
+     *  first-seen decision once the user leaves minimal mode. */
+    markSeen(target: string): void {
+        this.seenFiles.add(target);
+    }
+
+    isInFlight(): boolean {
+        return this.inFlight;
+    }
+
+    snapshot(): RefreshQueueSnapshot {
+        return {
+            inFlight: this.inFlight,
+            pendingTarget: this.pendingTarget,
+            debounceElapsed: this.debounceElapsed,
+            seenFiles: this.seenFiles,
+        };
+    }
+
+    /** Cancel the debounce timer. Caller responsibility on shutdown. Does
+     *  not touch inFlight — an already-running refresh runs to completion. */
+    dispose(): void {
+        if (this.debounceTimer !== null) {
+            this.effects.clearTimeout(this.debounceTimer);
+            this.debounceTimer = null;
+        }
+    }
+
+    private scheduleDebounce(target: string, debounceMs: number): void {
+        this.pendingTarget = target;
+        this.effects.invalidateModuleCache(target);
+        this.debounceElapsed = false;
+        if (this.debounceTimer !== null) {
+            this.effects.clearTimeout(this.debounceTimer);
+        }
+        this.debounceTimer = this.effects.setTimeout(() => {
+            this.debounceTimer = null;
+            this.debounceElapsed = true;
+            this.tryFire();
+        }, debounceMs);
+    }
+
+    private tryFire(): void {
+        if (
+            this.inFlight ||
+            !this.debounceElapsed ||
+            this.pendingTarget === null
+        ) {
+            return;
+        }
+        const target = this.pendingTarget;
+        this.pendingTarget = null;
+        this.startRefresh(target);
+    }
+
+    private startRefresh(target: string): void {
+        this.inFlight = true;
+        void this.effects.runRefresh(target).then(
+            () => this.onRefreshSettled(),
+            () => this.onRefreshSettled(),
+        );
+    }
+
+    private onRefreshSettled(): void {
+        this.inFlight = false;
+        this.tryFire();
+    }
+}
+
+/** Default effects backed by Node/VS Code globals. Production callers use
+ *  this; tests inject a fake-clock variant. */
+export function defaultRefreshQueueEffects(
+    runRefresh: (target: string) => Promise<void>,
+    invalidateModuleCache: (target: string) => void,
+): RefreshQueueEffects {
+    return {
+        runRefresh,
+        invalidateModuleCache,
+        setTimeout: (cb, ms) => setTimeout(cb, ms),
+        clearTimeout: (timer) => clearTimeout(timer as NodeJS.Timeout),
+    };
+}

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -1318,5 +1318,115 @@ describe("DaemonScheduler", () => {
                 `warm-up renderNow at ${warmRenderIdx} must come after dataSubscribe at ${subIdx}; wire was ${wire.join(", ")}`,
             );
         });
+
+        describe("a11y transition", () => {
+            it("reports 'enabled' on the first a11y subscribe for a module", async () => {
+                const { scheduler } = build();
+                const result = await scheduler.setDataProductSubscription(
+                    mod("mod"),
+                    "a",
+                    ["a11y/atf", "a11y/hierarchy"],
+                    true,
+                );
+                assert.strictEqual(result.a11yTransition, "enabled");
+            });
+
+            it("reports 'unchanged' on a second a11y subscribe for the same module", async () => {
+                const { scheduler } = build();
+                await scheduler.setDataProductSubscription(
+                    mod("mod"),
+                    "a",
+                    ["a11y/atf"],
+                    true,
+                );
+                // Second preview's first a11y subscribe — module already has
+                // at least one a11y pair, so no first-on/last-off boundary.
+                const result = await scheduler.setDataProductSubscription(
+                    mod("mod"),
+                    "b",
+                    ["a11y/atf"],
+                    true,
+                );
+                assert.strictEqual(result.a11yTransition, "unchanged");
+            });
+
+            it("reports 'disabled' only when the LAST a11y pair for the module goes away", async () => {
+                const { scheduler } = build();
+                await scheduler.setDataProductSubscription(
+                    mod("mod"),
+                    "a",
+                    ["a11y/atf"],
+                    true,
+                );
+                await scheduler.setDataProductSubscription(
+                    mod("mod"),
+                    "b",
+                    ["a11y/atf"],
+                    true,
+                );
+                // Dropping one of two pairs is not a transition.
+                const stillActive = await scheduler.setDataProductSubscription(
+                    mod("mod"),
+                    "a",
+                    ["a11y/atf"],
+                    false,
+                );
+                assert.strictEqual(stillActive.a11yTransition, "unchanged");
+                // Dropping the last pair is.
+                const lastOff = await scheduler.setDataProductSubscription(
+                    mod("mod"),
+                    "b",
+                    ["a11y/atf"],
+                    false,
+                );
+                assert.strictEqual(lastOff.a11yTransition, "disabled");
+            });
+
+            it("ignores non-a11y kinds — pure-non-a11y toggles never transition", async () => {
+                const { scheduler } = build();
+                const result = await scheduler.setDataProductSubscription(
+                    mod("mod"),
+                    "a",
+                    ["compose/recomposition"],
+                    true,
+                );
+                assert.strictEqual(result.a11yTransition, "unchanged");
+            });
+
+            it("isolates the transition per module", async () => {
+                const { scheduler } = build();
+                await scheduler.setDataProductSubscription(
+                    mod("mod-a"),
+                    "a",
+                    ["a11y/atf"],
+                    true,
+                );
+                // Subscribing under a different module is a 'first on' for
+                // THAT module, not 'unchanged' — module aggregates must not
+                // leak across modulePath boundaries.
+                const result = await scheduler.setDataProductSubscription(
+                    mod("mod-b"),
+                    "a",
+                    ["a11y/atf"],
+                    true,
+                );
+                assert.strictEqual(result.a11yTransition, "enabled");
+            });
+
+            it("reports 'unchanged' when the daemon gate has no client", async () => {
+                // GradleOnly scheduler stand-in: gate.getOrSpawn returns
+                // null, so no subscribe lands. The transition must stay
+                // 'unchanged' so the panel doesn't kick a spurious refresh.
+                const { gate, scheduler } = build();
+                gate.client = null;
+                const result = await scheduler.setDataProductSubscription(
+                    mod("mod"),
+                    "a",
+                    ["a11y/atf"],
+                    true,
+                );
+                assert.strictEqual(result.a11yTransition, "unchanged");
+            });
+        });
     });
 });

--- a/vscode-extension/src/test/refreshQueue.test.ts
+++ b/vscode-extension/src/test/refreshQueue.test.ts
@@ -1,0 +1,326 @@
+import * as assert from "assert";
+import {
+    RefreshQueue,
+    RefreshQueueEffects,
+    RefreshQueueTimer,
+} from "../refreshQueue";
+
+/**
+ * Deterministic fake clock: schedules callbacks with a virtual delay and
+ * fires them only when `advance(ms)` crosses their deadline. Lets every
+ * transition assertion run synchronously — no `setImmediate` /
+ * `await flushMicrotasks()` dance.
+ */
+class FakeClock {
+    private now = 0;
+    private nextHandle = 1;
+    private readonly pending = new Map<
+        number,
+        { dueAt: number; cb: () => void }
+    >();
+
+    setTimeout(cb: () => void, ms: number): RefreshQueueTimer {
+        const handle = this.nextHandle++;
+        this.pending.set(handle, { dueAt: this.now + ms, cb });
+        return handle as unknown as RefreshQueueTimer;
+    }
+
+    clearTimeout(timer: RefreshQueueTimer): void {
+        this.pending.delete(timer as unknown as number);
+    }
+
+    /** Advance virtual time and fire any callbacks whose deadline passes. */
+    advance(ms: number): void {
+        const target = this.now + ms;
+        while (true) {
+            const next = this.dueBefore(target);
+            if (next === null) break;
+            this.now = next.dueAt;
+            this.pending.delete(next.handle);
+            next.cb();
+        }
+        this.now = target;
+    }
+
+    pendingCount(): number {
+        return this.pending.size;
+    }
+
+    private dueBefore(
+        target: number,
+    ): { handle: number; dueAt: number; cb: () => void } | null {
+        let best: { handle: number; dueAt: number; cb: () => void } | null =
+            null;
+        for (const [handle, entry] of this.pending) {
+            if (
+                entry.dueAt <= target &&
+                (best === null || entry.dueAt < best.dueAt)
+            ) {
+                best = { handle, ...entry };
+            }
+        }
+        return best;
+    }
+}
+
+/**
+ * Captures the queue's interactions with its effects and offers a manually
+ * resolvable `runRefresh` so tests can simulate long-running renders.
+ */
+class RecordingEffects implements RefreshQueueEffects {
+    public readonly runRefreshCalls: string[] = [];
+    public readonly invalidateCalls: string[] = [];
+    private pendingResolves: Array<() => void> = [];
+
+    constructor(public readonly clock: FakeClock) {}
+
+    runRefresh = (target: string): Promise<void> => {
+        this.runRefreshCalls.push(target);
+        return new Promise<void>((resolve) => {
+            this.pendingResolves.push(resolve);
+        });
+    };
+
+    invalidateModuleCache = (target: string): void => {
+        this.invalidateCalls.push(target);
+    };
+
+    setTimeout = (cb: () => void, ms: number): RefreshQueueTimer =>
+        this.clock.setTimeout(cb, ms);
+
+    clearTimeout = (timer: RefreshQueueTimer): void =>
+        this.clock.clearTimeout(timer);
+
+    /** Resolve the most recent in-flight runRefresh. */
+    completeLastRefresh(): Promise<void> {
+        const resolve = this.pendingResolves.shift();
+        assert.ok(resolve, "no in-flight refresh to complete");
+        resolve();
+        // Let the queue's .then() handler run before the next assertion.
+        return new Promise((r) => setImmediate(r));
+    }
+
+    inFlightCount(): number {
+        return this.pendingResolves.length;
+    }
+}
+
+function makeQueue(): {
+    queue: RefreshQueue;
+    effects: RecordingEffects;
+    clock: FakeClock;
+} {
+    const clock = new FakeClock();
+    const effects = new RecordingEffects(clock);
+    const queue = new RefreshQueue(effects);
+    return { queue, effects, clock };
+}
+
+const FAST = { allowImmediate: true, debounceMs: 300 };
+const SLOW = { allowImmediate: true, debounceMs: 1500 };
+const WATCHER = { allowImmediate: false, debounceMs: 300 };
+
+describe("RefreshQueue", () => {
+    describe("first-seen fast path", () => {
+        it("runs the first save of a file immediately, no debounce", () => {
+            const { queue, effects, clock } = makeQueue();
+            queue.dispatchSave("/a.kt", FAST);
+            assert.deepStrictEqual(effects.runRefreshCalls, ["/a.kt"]);
+            assert.deepStrictEqual(effects.invalidateCalls, ["/a.kt"]);
+            assert.strictEqual(clock.pendingCount(), 0);
+            assert.strictEqual(queue.isInFlight(), true);
+        });
+
+        it("does NOT take the fast path on the second save of the same file", async () => {
+            const { queue, effects, clock } = makeQueue();
+            queue.dispatchSave("/a.kt", FAST);
+            await effects.completeLastRefresh();
+            // Second save: file already in seen set; not idle? It IS idle now,
+            // but the firstSeen predicate filters it out. Must debounce.
+            queue.dispatchSave("/a.kt", FAST);
+            assert.strictEqual(effects.runRefreshCalls.length, 1);
+            assert.strictEqual(clock.pendingCount(), 1);
+            clock.advance(300);
+            assert.deepStrictEqual(effects.runRefreshCalls, ["/a.kt", "/a.kt"]);
+        });
+
+        it("debounces a first-seen save when another refresh is already in flight", () => {
+            const { queue, effects, clock } = makeQueue();
+            queue.dispatchSave("/a.kt", FAST);
+            // While A is in flight, B's first save lands. It cannot fast-path
+            // because the queue is busy — must debounce.
+            queue.dispatchSave("/b.kt", FAST);
+            assert.deepStrictEqual(effects.runRefreshCalls, ["/a.kt"]);
+            assert.strictEqual(clock.pendingCount(), 1);
+            assert.strictEqual(queue.snapshot().pendingTarget, "/b.kt");
+        });
+    });
+
+    describe("debounce", () => {
+        it("collapses a burst of saves of the same file into one refresh", async () => {
+            const { queue, effects, clock } = makeQueue();
+            // First save warms the seen-set and runs immediately.
+            queue.dispatchSave("/a.kt", FAST);
+            await effects.completeLastRefresh();
+            // Now a burst: 5 saves within the debounce window.
+            for (let i = 0; i < 5; i++) {
+                queue.dispatchSave("/a.kt", FAST);
+                clock.advance(50);
+            }
+            assert.strictEqual(effects.runRefreshCalls.length, 1);
+            // Only after the debounce elapses without another save does the
+            // refresh fire — and exactly once.
+            clock.advance(300);
+            assert.deepStrictEqual(effects.runRefreshCalls, ["/a.kt", "/a.kt"]);
+        });
+
+        it("latest target wins when the burst spans multiple files", async () => {
+            const { queue, effects, clock } = makeQueue();
+            queue.dispatchSave("/a.kt", FAST);
+            await effects.completeLastRefresh();
+            queue.dispatchSave("/a.kt", FAST);
+            clock.advance(100);
+            queue.dispatchSave("/b.kt", FAST);
+            clock.advance(100);
+            queue.dispatchSave("/c.kt", FAST);
+            clock.advance(300);
+            assert.deepStrictEqual(effects.runRefreshCalls, ["/a.kt", "/c.kt"]);
+        });
+
+        it("uses the dispatcher's chosen debounceMs (scope vs normal)", async () => {
+            const { queue, effects, clock } = makeQueue();
+            queue.dispatchSave("/a.kt", FAST);
+            await effects.completeLastRefresh();
+            // Normal (long) debounce queued: short tick must NOT fire it.
+            queue.dispatchSave("/a.kt", SLOW);
+            clock.advance(300);
+            assert.strictEqual(effects.runRefreshCalls.length, 1);
+            clock.advance(1200);
+            assert.strictEqual(effects.runRefreshCalls.length, 2);
+        });
+
+        it("restarts the timer on each save so a steady stream defers indefinitely", async () => {
+            const { queue, effects, clock } = makeQueue();
+            queue.dispatchSave("/a.kt", FAST);
+            await effects.completeLastRefresh();
+            for (let i = 0; i < 10; i++) {
+                queue.dispatchSave("/a.kt", FAST);
+                // Save more frequently than the debounce window — the timer
+                // restarts each time, so nothing fires.
+                clock.advance(200);
+            }
+            assert.strictEqual(effects.runRefreshCalls.length, 1);
+            clock.advance(300);
+            assert.strictEqual(effects.runRefreshCalls.length, 2);
+        });
+    });
+
+    describe("never stack builds", () => {
+        it("queues a save that arrives mid-refresh and fires it on completion", async () => {
+            const { queue, effects, clock } = makeQueue();
+            queue.dispatchSave("/a.kt", FAST);
+            assert.strictEqual(effects.inFlightCount(), 1);
+            // Save during the in-flight render.
+            queue.dispatchSave("/a.kt", FAST);
+            clock.advance(300); // debounce elapses while still in-flight
+            // tryFire bails because inFlight; pending sticks around.
+            assert.strictEqual(effects.runRefreshCalls.length, 1);
+            assert.strictEqual(queue.snapshot().pendingTarget, "/a.kt");
+            await effects.completeLastRefresh();
+            // Completion drains the pending refresh.
+            assert.deepStrictEqual(effects.runRefreshCalls, ["/a.kt", "/a.kt"]);
+        });
+
+        it("only fires once when both debounce-elapsed and completion happen together", async () => {
+            const { queue, effects, clock } = makeQueue();
+            queue.dispatchSave("/a.kt", FAST);
+            queue.dispatchSave("/a.kt", FAST);
+            // Race: debounce elapses BEFORE completion.
+            clock.advance(300);
+            assert.strictEqual(effects.runRefreshCalls.length, 1);
+            await effects.completeLastRefresh();
+            assert.strictEqual(effects.runRefreshCalls.length, 2);
+            // …and no extra fires after that.
+            assert.strictEqual(queue.snapshot().pendingTarget, null);
+        });
+
+        it("a refresh that throws still settles inFlight and drains the next pending", async () => {
+            const clock = new FakeClock();
+            const rejecters: Array<() => void> = [];
+            const effects: RefreshQueueEffects = {
+                runRefresh: (_target) =>
+                    new Promise<void>((_resolve, reject) => {
+                        rejecters.push(() =>
+                            reject(new Error("render bombed")),
+                        );
+                    }),
+                invalidateModuleCache: () => {},
+                setTimeout: (cb, ms) => clock.setTimeout(cb, ms),
+                clearTimeout: (t) => clock.clearTimeout(t),
+            };
+            const queue = new RefreshQueue(effects);
+            queue.dispatchSave("/a.kt", FAST);
+            queue.dispatchSave("/b.kt", FAST);
+            clock.advance(300);
+            assert.strictEqual(queue.isInFlight(), true);
+            assert.strictEqual(rejecters.length, 1);
+            rejecters[0]();
+            await new Promise((r) => setImmediate(r));
+            // After the failure: inFlight cleared, pending /b.kt fired.
+            assert.strictEqual(queue.isInFlight(), true); // /b.kt is now in flight
+            assert.strictEqual(queue.snapshot().pendingTarget, null);
+        });
+    });
+
+    describe("watcher events (allowImmediate=false)", () => {
+        it("never takes the fast path, even on a never-before-seen file", () => {
+            const { queue, effects, clock } = makeQueue();
+            queue.dispatchSave("/a.kt", WATCHER);
+            assert.deepStrictEqual(effects.runRefreshCalls, []);
+            assert.strictEqual(clock.pendingCount(), 1);
+            clock.advance(300);
+            assert.deepStrictEqual(effects.runRefreshCalls, ["/a.kt"]);
+        });
+
+        it("does not mark the file as seen, so a later editor save of the same file can still fast-path", async () => {
+            const { queue, effects, clock } = makeQueue();
+            queue.dispatchSave("/a.kt", WATCHER);
+            clock.advance(300);
+            await effects.completeLastRefresh();
+            // Now the editor saves /a.kt for the first time. Should fast-path
+            // because the file was never marked seen by the watcher.
+            queue.dispatchSave("/a.kt", FAST);
+            assert.deepStrictEqual(effects.runRefreshCalls, ["/a.kt", "/a.kt"]);
+            assert.strictEqual(clock.pendingCount(), 0);
+        });
+    });
+
+    describe("markSeen", () => {
+        it("blocks a later first-seen fast path", () => {
+            const { queue, effects, clock } = makeQueue();
+            queue.markSeen("/a.kt");
+            queue.dispatchSave("/a.kt", FAST);
+            // The file is already in seen, so even though the queue is idle,
+            // dispatch falls through to debounce.
+            assert.deepStrictEqual(effects.runRefreshCalls, []);
+            assert.strictEqual(clock.pendingCount(), 1);
+        });
+    });
+
+    describe("dispose", () => {
+        it("cancels the pending debounce timer", () => {
+            const { queue, effects, clock } = makeQueue();
+            queue.dispatchSave("/a.kt", FAST);
+            // Burn the first refresh so subsequent saves debounce.
+            // We can't easily complete it without async here, so dispatch a
+            // second save which schedules a timer.
+            queue.dispatchSave("/b.kt", FAST);
+            assert.strictEqual(clock.pendingCount(), 1);
+            queue.dispose();
+            assert.strictEqual(clock.pendingCount(), 0);
+            // Advancing time after dispose must not fire anything.
+            clock.advance(10_000);
+            assert.strictEqual(effects.runRefreshCalls.length, 1);
+        });
+    });
+});

--- a/vscode-extension/src/test/refreshQueueIntegration.test.ts
+++ b/vscode-extension/src/test/refreshQueueIntegration.test.ts
@@ -1,0 +1,168 @@
+import * as assert from "assert";
+import { RefreshQueue, defaultRefreshQueueEffects } from "../refreshQueue";
+
+/**
+ * End-to-end integration test for {@link RefreshQueue} against the real
+ * `setTimeout` / `clearTimeout` from Node. The unit-test sister file uses a
+ * fake clock; this file proves that the queue behaves correctly when wired
+ * to the same timer primitives production uses.
+ *
+ * Debounce values are deliberately small (10–40 ms) so the suite still
+ * completes inside a few hundred ms even though every assertion waits on
+ * real wall-clock time.
+ */
+
+const TINY_DEBOUNCE_MS = 20;
+const LONG_DEBOUNCE_MS = 60;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((r) => setTimeout(r, ms));
+}
+
+interface Recorder {
+    runs: string[];
+    invalidations: string[];
+    /** Optional per-target hold so a test can pin runRefresh in flight. */
+    holdMs?: number;
+}
+
+function makeQueueAgainstRealTimers(rec: Recorder): RefreshQueue {
+    const effects = defaultRefreshQueueEffects(
+        async (target) => {
+            rec.runs.push(target);
+            if (rec.holdMs && rec.holdMs > 0) {
+                await sleep(rec.holdMs);
+            }
+        },
+        (target) => {
+            rec.invalidations.push(target);
+        },
+    );
+    return new RefreshQueue(effects);
+}
+
+describe("RefreshQueue (real-timer integration)", () => {
+    it("end-to-end: first save fires immediately, burst collapses, watcher event coalesces", async () => {
+        const rec: Recorder = { runs: [], invalidations: [], holdMs: 5 };
+        const queue = makeQueueAgainstRealTimers(rec);
+        try {
+            // 1) First editor save — fast path.
+            queue.dispatchSave("/a.kt", {
+                allowImmediate: true,
+                debounceMs: TINY_DEBOUNCE_MS,
+            });
+            assert.deepStrictEqual(rec.runs, ["/a.kt"]);
+            // Let the in-flight refresh settle before the next phase so we're
+            // not also testing the never-stack-builds path here.
+            await sleep(rec.holdMs! + 5);
+            assert.strictEqual(queue.isInFlight(), false);
+
+            // 2) Burst of three saves of the same file within the debounce
+            //    window — must collapse to a single refresh.
+            queue.dispatchSave("/a.kt", {
+                allowImmediate: true,
+                debounceMs: TINY_DEBOUNCE_MS,
+            });
+            await sleep(5);
+            queue.dispatchSave("/a.kt", {
+                allowImmediate: true,
+                debounceMs: TINY_DEBOUNCE_MS,
+            });
+            await sleep(5);
+            queue.dispatchSave("/a.kt", {
+                allowImmediate: true,
+                debounceMs: TINY_DEBOUNCE_MS,
+            });
+            // No refresh yet — debounce hasn't elapsed.
+            assert.strictEqual(rec.runs.length, 1);
+            await sleep(TINY_DEBOUNCE_MS + rec.holdMs! + 10);
+            assert.deepStrictEqual(rec.runs, ["/a.kt", "/a.kt"]);
+
+            // 3) A watcher event for a never-before-seen file. Must NOT take
+            //    the fast path — debounce first, then fire.
+            queue.dispatchSave("/b.kt", {
+                allowImmediate: false,
+                debounceMs: TINY_DEBOUNCE_MS,
+            });
+            assert.strictEqual(rec.runs.length, 2);
+            await sleep(TINY_DEBOUNCE_MS + rec.holdMs! + 10);
+            assert.deepStrictEqual(rec.runs, ["/a.kt", "/a.kt", "/b.kt"]);
+        } finally {
+            queue.dispose();
+        }
+    });
+
+    it("end-to-end: a save during an in-flight refresh drains exactly once on completion", async () => {
+        const rec: Recorder = { runs: [], invalidations: [], holdMs: 60 };
+        const queue = makeQueueAgainstRealTimers(rec);
+        try {
+            queue.dispatchSave("/a.kt", {
+                allowImmediate: true,
+                debounceMs: TINY_DEBOUNCE_MS,
+            });
+            assert.strictEqual(queue.isInFlight(), true);
+            // While /a.kt is held in flight, fire two more saves of /a.kt.
+            await sleep(10);
+            queue.dispatchSave("/a.kt", {
+                allowImmediate: true,
+                debounceMs: TINY_DEBOUNCE_MS,
+            });
+            await sleep(5);
+            queue.dispatchSave("/a.kt", {
+                allowImmediate: true,
+                debounceMs: TINY_DEBOUNCE_MS,
+            });
+            // Debounce window passes while still in flight — tryFire bails.
+            await sleep(TINY_DEBOUNCE_MS + 5);
+            assert.strictEqual(rec.runs.length, 1);
+            assert.strictEqual(queue.snapshot().pendingTarget, "/a.kt");
+            // Wait for completion + drain.
+            await sleep(rec.holdMs!);
+            // The drained refresh now runs (and holds for holdMs more).
+            await sleep(rec.holdMs! + 10);
+            assert.deepStrictEqual(rec.runs, ["/a.kt", "/a.kt"]);
+        } finally {
+            queue.dispose();
+        }
+    });
+
+    it("end-to-end: long debounce honours its duration against the real clock", async () => {
+        const rec: Recorder = { runs: [], invalidations: [] };
+        const queue = makeQueueAgainstRealTimers(rec);
+        try {
+            queue.dispatchSave("/a.kt", {
+                allowImmediate: true,
+                debounceMs: TINY_DEBOUNCE_MS,
+            });
+            await sleep(10);
+            // Subsequent save uses the LONG debounce. Wait less than that —
+            // refresh must NOT have fired yet.
+            queue.dispatchSave("/a.kt", {
+                allowImmediate: true,
+                debounceMs: LONG_DEBOUNCE_MS,
+            });
+            await sleep(TINY_DEBOUNCE_MS + 10);
+            assert.strictEqual(rec.runs.length, 1);
+            await sleep(LONG_DEBOUNCE_MS);
+            assert.strictEqual(rec.runs.length, 2);
+        } finally {
+            queue.dispose();
+        }
+    });
+
+    it("end-to-end: dispose cancels the timer so no refresh fires after teardown", async () => {
+        const rec: Recorder = { runs: [], invalidations: [] };
+        const queue = makeQueueAgainstRealTimers(rec);
+        // Use a watcher event so the FIRST dispatch goes through debounce
+        // (the editor-save fast path would fire synchronously and there'd be
+        // no pending timer for dispose to cancel).
+        queue.dispatchSave("/a.kt", {
+            allowImmediate: false,
+            debounceMs: LONG_DEBOUNCE_MS,
+        });
+        assert.strictEqual(rec.runs.length, 0);
+        queue.dispose();
+        await sleep(LONG_DEBOUNCE_MS + 10);
+        assert.strictEqual(rec.runs.length, 0);
+    });
+});


### PR DESCRIPTION
The save-driven refresh path in extension.ts coordinated five module-level
mutables (firstSaveSeen, pendingSavePath, debounceElapsed, refreshInFlight,
debounceTimer) across three functions plus four call sites, with invariants
documented only in surrounding comment blocks. Extract this into a single
RefreshQueue class with explicit state, a single fire rule, and injected
timer/refresh effects so it can be unit-tested deterministically.

Behaviour is preserved: first-save fast path, scope-vs-normal debounce,
in-flight gating, latest-target-wins coalescing, watcher events that never
fast-path. Added a markSeen() helper for minimal mode and an isInFlight()
accessor for the three external readers (data-extension progress filter,
post-warm reconcile guard, diagnostic log).

Tests: 14 fake-clock unit tests cover every transition (first-seen path,
debounce coalescing, never-stack-builds, watcher events, dispose, refresh
that throws). 4 real-timer integration tests prove the queue behaves the
same against the actual setTimeout/clearTimeout it ships against.