### PR TITLE
refactor(daemon): extract DeferredDiscoveryQueue with injectable watchdog

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DeferredDiscoveryQueue.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DeferredDiscoveryQueue.kt
@@ -1,0 +1,73 @@
+package ee.schimke.composeai.daemon
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+/**
+ * "Run incremental discovery for this source path, but defer it until after the next render
+ * finishes or a watchdog window elapses." Used by [JsonRpcServer]'s `fileChanged({kind:source})`
+ * handler so a save NEVER surfaces a `discoveryUpdated` metadata event before the corresponding
+ * render notification — renders are what the user actually looks at; the metadata reconcile is a
+ * quiet background pass that only paints the panel when the preview set actually drifted.
+ *
+ * Two drain triggers race the queue:
+ *
+ * 1. [JsonRpcServer.emitRenderFinished] calls [drain] after the render notification has flushed, so
+ *    the metadata event lands in order behind it.
+ * 2. A per-enqueue watchdog calls [drain] after [watchdogMs], so a save against a file with no
+ *    focused previews (no `renderNow` follows) still eventually runs the cascade.
+ *
+ * Both paths poll the same atomic queue; whichever wins runs the scan, the loser sees an empty
+ * queue and returns. The dedup is correctness-safe under contention; identity-dedup of enqueued
+ * paths isn't worth it (two saves of the same file scan twice, but each scan is scoped and the
+ * daemon is bounded by editor cadence).
+ */
+internal class DeferredDiscoveryQueue(
+  private val watchdogMs: Long,
+  private val runForPath: (String) -> Unit,
+  /**
+   * Schedules [action] to run after [delayMs] milliseconds. The default uses a fresh daemon thread
+   * per enqueue, matching the prior inline implementation. Tests inject a synchronous scheduler so
+   * [enqueue] / [drain] interleavings can be asserted without real wall-clock waits.
+   */
+  private val watchdogScheduler: (delayMs: Long, action: () -> Unit) -> Unit =
+    ::defaultWatchdogScheduler,
+) {
+  private val pending = ConcurrentLinkedQueue<String>()
+
+  /** Queue [path] for a deferred discovery run and start the watchdog timer. */
+  fun enqueue(path: String) {
+    pending.add(path)
+    watchdogScheduler(watchdogMs) { drain() }
+  }
+
+  /**
+   * Drain every pending path through [runForPath]. Safe to call from multiple threads; each path is
+   * polled atomically so it runs at most once per enqueue.
+   */
+  fun drain() {
+    while (true) {
+      val path = pending.poll() ?: return
+      runForPath(path)
+    }
+  }
+
+  /** Test/observability hook — current queue depth. */
+  fun pendingCount(): Int = pending.size
+}
+
+private fun defaultWatchdogScheduler(delayMs: Long, action: () -> Unit) {
+  Thread(
+      {
+        try {
+          Thread.sleep(delayMs)
+        } catch (_: InterruptedException) {
+          Thread.currentThread().interrupt()
+          return@Thread
+        }
+        action()
+      },
+      "compose-ai-daemon-discovery-watchdog",
+    )
+    .apply { isDaemon = true }
+    .start()
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -3018,60 +3018,39 @@ class JsonRpcServer(
   }
 
   /**
-   * Paths waiting on a deferred discovery scan — populated by [queueDiscoveryAfterRender] from the
-   * `fileChanged({kind:source})` handler, drained by either [emitRenderFinished] (after the next
-   * render notification has flushed) or by a watchdog timer (when no render arrives within
-   * [discoveryWatchdogMs]).
-   *
-   * Identity dedup isn't worth it: two saves of the same file in quick succession scan twice, but
-   * each scan is scoped (one classpath element) and the daemon is bounded by the user's editor
-   * cadence anyway. The queue is correctness-safe under contention thanks to the atomic poll.
+   * Deferred discovery coordination: queue + watchdog + drain race semantics live in
+   * [DeferredDiscoveryQueue]; this file just supplies the per-path scan via
+   * [runIncrementalDiscoveryNow]. Enqueue from the `fileChanged({kind:source})` handler via
+   * [queueDiscoveryAfterRender] (which short-circuits when no [incrementalDiscovery] is wired);
+   * drain from [emitRenderFinished] after the render notification flushes.
    */
-  private val pendingDiscoveryPaths = ConcurrentLinkedQueue<String>()
+  private val deferredDiscovery =
+    DeferredDiscoveryQueue(
+      watchdogMs = discoveryWatchdogMs,
+      runForPath = { path -> runIncrementalDiscoveryNow(path) },
+    )
 
   /**
-   * Queues [path] for a deferred discovery cascade and starts a watchdog so the work always runs
-   * eventually — even when the save lands on a file with no focused previews and no `renderNow`
-   * follows.
-   *
-   * The user-visible invariant this enforces (matching the editor save-loop design): a save NEVER
-   * surfaces a metadata event before the corresponding render. Renders are what the user actually
-   * looks at; the metadata reconcile is a quiet background pass that only paints the panel when the
-   * preview set actually drifted (`discoveryUpdated` is silent on an empty diff — see
-   * [runIncrementalDiscoveryNow]).
+   * Queues [path] for a deferred discovery cascade. The user-visible invariant this enforces
+   * (matching the editor save-loop design): a save NEVER surfaces a metadata event before the
+   * corresponding render. Renders are what the user actually looks at; the metadata reconcile is a
+   * quiet background pass that only paints the panel when the preview set actually drifted
+   * (`discoveryUpdated` is silent on an empty diff — see [runIncrementalDiscoveryNow]).
    *
    * No-op when [incrementalDiscovery] is null — preserves the pre-phase-2 contract for in-process
    * integration tests and the fake-mode harness scenarios that don't wire one.
    */
   private fun queueDiscoveryAfterRender(path: String) {
     if (incrementalDiscovery == null) return
-    pendingDiscoveryPaths.add(path)
-    Thread(
-        {
-          try {
-            Thread.sleep(discoveryWatchdogMs)
-          } catch (_: InterruptedException) {
-            Thread.currentThread().interrupt()
-            return@Thread
-          }
-          drainPendingDiscovery()
-        },
-        "compose-ai-daemon-discovery-watchdog",
-      )
-      .apply { isDaemon = true }
-      .start()
+    deferredDiscovery.enqueue(path)
   }
 
   /**
-   * Drains [pendingDiscoveryPaths] and runs the discovery cascade for each path. Idempotent:
-   * concurrent callers (the watchdog vs. [emitRenderFinished]) compete via the atomic queue poll,
-   * so each path runs at most once.
+   * Drains every pending deferred-discovery scan. Called from [emitRenderFinished] after the render
+   * notification flushes; the queue's own watchdog races this and the loser sees an empty queue.
    */
   private fun drainPendingDiscovery() {
-    while (true) {
-      val path = pendingDiscoveryPaths.poll() ?: return
-      runIncrementalDiscoveryNow(path)
-    }
+    deferredDiscovery.drain()
   }
 
   /**

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DeferredDiscoveryQueueTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DeferredDiscoveryQueueTest.kt
@@ -1,0 +1,175 @@
+package ee.schimke.composeai.daemon
+
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Targeted tests for [DeferredDiscoveryQueue]. Pins the queue + watchdog race semantics that matter
+ * for the daemon's "discovery never precedes the render notification" invariant: each enqueue
+ * starts a watchdog, but the queue is correctness-safe whether the watchdog or an external [drain]
+ * caller wins. Tests use a manual scheduler so the race is deterministic.
+ */
+class DeferredDiscoveryQueueTest {
+
+  /**
+   * Manual scheduler: collects every (delayMs, action) pair the queue scheduled. Tests fire the
+   * actions explicitly so timing is deterministic; nothing depends on real wall-clock waits.
+   */
+  private class ManualScheduler {
+    private val scheduled = mutableListOf<Pair<Long, () -> Unit>>()
+
+    fun schedule(delayMs: Long, action: () -> Unit) {
+      scheduled.add(delayMs to action)
+    }
+
+    fun count(): Int = scheduled.size
+
+    fun lastDelay(): Long = scheduled.last().first
+
+    /** Fire every queued action in scheduled order. */
+    fun fireAll() {
+      val snapshot = scheduled.toList()
+      scheduled.clear()
+      for ((_, action) in snapshot) action()
+    }
+  }
+
+  private fun newQueue(
+    watchdogMs: Long = 250L,
+    scheduler: ManualScheduler = ManualScheduler(),
+    runForPath: (String) -> Unit = {},
+  ): Pair<DeferredDiscoveryQueue, ManualScheduler> {
+    val q = DeferredDiscoveryQueue(watchdogMs, runForPath, scheduler::schedule)
+    return q to scheduler
+  }
+
+  @Test
+  fun `enqueue records the path and schedules a watchdog with the configured delay`() {
+    val (q, scheduler) = newQueue(watchdogMs = 250L)
+    q.enqueue("/a.kt")
+    assertEquals(1, q.pendingCount())
+    assertEquals(1, scheduler.count())
+    assertEquals(250L, scheduler.lastDelay())
+  }
+
+  @Test
+  fun `drain runs the per-path action for every queued entry then leaves the queue empty`() {
+    val ran = mutableListOf<String>()
+    val (q, _) = newQueue(runForPath = { ran.add(it) })
+    q.enqueue("/a.kt")
+    q.enqueue("/b.kt")
+    q.enqueue("/c.kt")
+    q.drain()
+    assertEquals(listOf("/a.kt", "/b.kt", "/c.kt"), ran)
+    assertEquals(0, q.pendingCount())
+  }
+
+  @Test
+  fun `the watchdog drains the queue when no external drain caller arrived`() {
+    val ran = mutableListOf<String>()
+    val (q, scheduler) = newQueue(runForPath = { ran.add(it) })
+    q.enqueue("/a.kt")
+    // Simulate the watchdog firing — no render arrived, no external drain.
+    scheduler.fireAll()
+    assertEquals(listOf("/a.kt"), ran)
+    assertEquals(0, q.pendingCount())
+  }
+
+  @Test
+  fun `an external drain before the watchdog leaves the watchdog with nothing to do`() {
+    val ran = mutableListOf<String>()
+    val (q, scheduler) = newQueue(runForPath = { ran.add(it) })
+    q.enqueue("/a.kt")
+    // The render path arrives first and calls drain() directly.
+    q.drain()
+    assertEquals(listOf("/a.kt"), ran)
+    // Now the watchdog finally fires — must see an empty queue and no-op.
+    scheduler.fireAll()
+    assertEquals(listOf("/a.kt"), ran)
+  }
+
+  @Test
+  fun `same path enqueued twice runs twice -- identity dedup is intentionally absent`() {
+    // Regression for the documented "two saves of the same file scan twice" behaviour. The queue
+    // is bounded by the user's editor cadence; per-scan idempotency is the cheaper invariant.
+    val ran = mutableListOf<String>()
+    val (q, _) = newQueue(runForPath = { ran.add(it) })
+    q.enqueue("/a.kt")
+    q.enqueue("/a.kt")
+    q.drain()
+    assertEquals(listOf("/a.kt", "/a.kt"), ran)
+  }
+
+  @Test
+  fun `enqueue schedules one watchdog per call (one chance per save to fire)`() {
+    val (q, scheduler) = newQueue()
+    q.enqueue("/a.kt")
+    q.enqueue("/b.kt")
+    q.enqueue("/c.kt")
+    // Three enqueues => three independent watchdogs. Each is a safety net for its own save; any
+    // surviving one drains the whole queue, which is fine.
+    assertEquals(3, scheduler.count())
+  }
+
+  @Test
+  fun `the runForPath thrower does not poison the rest of the drain`() {
+    // Per the production scan path's outer try/catch, a single bad path logs and continues.
+    // The queue itself should not swallow drains for the survivors.
+    val ran = mutableListOf<String>()
+    val errors = AtomicInteger(0)
+    val (q, _) =
+      newQueue(
+        runForPath = { path ->
+          try {
+            if (path == "/bad.kt") error("simulated scan failure")
+            ran.add(path)
+          } catch (t: Throwable) {
+            errors.incrementAndGet()
+          }
+        }
+      )
+    q.enqueue("/a.kt")
+    q.enqueue("/bad.kt")
+    q.enqueue("/c.kt")
+    q.drain()
+    assertEquals(listOf("/a.kt", "/c.kt"), ran)
+    assertEquals(1, errors.get())
+  }
+
+  @Test
+  fun `drain on an empty queue is a no-op`() {
+    val ran = mutableListOf<String>()
+    val (q, _) = newQueue(runForPath = { ran.add(it) })
+    q.drain()
+    assertTrue(ran.isEmpty())
+  }
+
+  @Test
+  fun `concurrent drain callers each handle a distinct subset of the queue`() {
+    // Two threads racing drain() must between them run every queued path exactly once. Mirrors
+    // the production race: emitRenderFinished and the watchdog can both call drain() at once.
+    val ran = java.util.concurrent.ConcurrentLinkedQueue<String>()
+    val (q, _) = newQueue(runForPath = { ran.add(it) })
+    val barrier = java.util.concurrent.CountDownLatch(1)
+    for (i in 1..200) q.enqueue("/p$i.kt")
+    val t1 = Thread {
+      barrier.await()
+      q.drain()
+    }
+    val t2 = Thread {
+      barrier.await()
+      q.drain()
+    }
+    t1.start()
+    t2.start()
+    barrier.countDown()
+    t1.join()
+    t2.join()
+    val seen = ran.toList()
+    assertEquals(200, seen.size)
+    assertEquals(200, seen.toSet().size) // every path ran exactly once
+    assertEquals(0, q.pendingCount())
+  }
+}


### PR DESCRIPTION
JsonRpcServer's pendingDiscoveryPaths queue, the per-enqueue watchdog
Thread that drained it after discoveryWatchdogMs, and the drain helper
were all inlined private members coordinating the "discovery never
precedes the render notification" invariant. The drain races (the
render-finished caller vs. the watchdog) are correctness-safe via the
ConcurrentLinkedQueue's atomic poll, but the coordination was hard to
test without real wall-clock sleeps.

Move the queue + watchdog + drain into DeferredDiscoveryQueue with an
injectable scheduler hook. Production uses the daemon-thread default
that matches the prior inline implementation; tests inject a manual
scheduler so each enqueue / drain / watchdog-fire ordering is
deterministic and assertable without sleeps.

JsonRpcServer keeps the "no incrementalDiscovery wired => no-op"
short-circuit at the enqueue call site so the pre-phase-2 contract for
the in-process integration tests and fake-mode harness is preserved.
The per-path scan invocation (runIncrementalDiscoveryNow) stays in
JsonRpcServer as the queue's runForPath callback.

Tests: 9 DeferredDiscoveryQueueTest cases pinning the documented
race semantics — watchdog-wins, external-drain-wins, drain-then-late-
watchdog no-op, the intentional identity-no-dedup, the run-thrower-
does-not-poison invariant, and a 200-path two-thread concurrent
drain proving every path runs exactly once. Existing
JsonRpcServerIntegrationTest / DataFetchRerenderTest / SubscriptionStoreTest
all pass unchanged.