### PR TITLE
refactor(vscode-extension): split LiveDaemonScheduler bookkeeping into three classes

### DIFF
--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -4,6 +4,11 @@ import { GradleService, ModuleInfo } from "../gradleService";
 import { DaemonClientEvents } from "./daemonClient";
 import { DaemonGate } from "./daemonGate";
 import {
+    SpeculationCache,
+    VisibilityMemo,
+    WarmCoalescer,
+} from "./schedulerState";
+import {
     DataProductAttachment,
     DiscoveryUpdatedParams,
     FileChangeType,
@@ -224,10 +229,8 @@ export interface DaemonScheduler {
  * has the moduleId, previewId, and pngPath that a history archiver needs.
  */
 export class LiveDaemonScheduler implements DaemonScheduler {
-    /** Last-known-visible IDs per module — let us dedup setVisible spam. */
-    private lastVisible = new Map<string, string[]>();
-    /** Last `setFocus` per module so editor refocus on the same file is a no-op. */
-    private lastFocus = new Map<string, string[]>();
+    /** Per-module `setVisible` / `setFocus` dedup memo. See {@link VisibilityMemo}. */
+    private readonly visibility = new VisibilityMemo();
     /**
      * D2 — `(moduleId, previewId)` pairs we've already issued `data/subscribe` for. Subscribed kinds
      * are pinned at [DEFAULT_SUBSCRIBED_KINDS] today; per-kind tracking moves here when the panel
@@ -249,22 +252,15 @@ export class LiveDaemonScheduler implements DaemonScheduler {
         string,
         Set<Promise<unknown>>
     >();
-    /** Cards we've already speculatively requested so scrolling back over
-     *  them doesn't re-queue identical work. Keyed by `${moduleId}::${id}`. */
-    private speculated = new Set<string>();
+    /** Per-`(module, previewId)` idempotency cache for speculative renders. See
+     *  {@link SpeculationCache}. */
+    private readonly speculation = new SpeculationCache();
     /** Modules where we've already logged a "daemon at stub stage" notice.
      *  Stops the per-render ENOENT spam when the daemon (B1.5) emits
      *  synthetic `daemon-stub-N.png` paths that don't exist on disk. */
     private warnedStubModules = new Set<string>();
-    /**
-     * In-flight `warmModule` promises per module. Concurrent callers
-     * coalesce onto the same promise so a second refresh that arrives
-     * mid-bootstrap doesn't start a second `composePreviewDaemonStart`
-     * (which the first invocation would then cancel). Cleared on settle so
-     * a later call — for instance, the retry after a cancellation — starts
-     * a fresh warm rather than getting a stale rejected promise.
-     */
-    private readonly warmsInFlight = new Map<string, Promise<boolean>>();
+    /** Coalesces concurrent `warmModule` calls per module. See {@link WarmCoalescer}. */
+    private readonly warmCoalescer = new WarmCoalescer<boolean>();
 
     constructor(
         private readonly gate: DaemonGate,
@@ -306,25 +302,19 @@ export class LiveDaemonScheduler implements DaemonScheduler {
         module: ModuleInfo,
         progress?: WarmProgress,
     ): Promise<boolean> {
-        const key = module.modulePath;
-        const existing = this.warmsInFlight.get(key);
-        if (existing) {
-            if (this.gate.isDaemonReady(key)) {
-                progress?.("ready");
-            }
-            return existing;
+        // Surface "ready" progress to a piggy-backing caller when the underlying daemon is
+        // already up — the in-flight promise itself won't re-emit progress events. The
+        // coalescer's getOrStart short-circuits to the existing promise; the side effect
+        // here just keeps the second caller's UI in sync.
+        if (
+            this.warmCoalescer.isInFlight(module) &&
+            this.gate.isDaemonReady(module.modulePath)
+        ) {
+            progress?.("ready");
         }
-        const promise = this.warmModuleInner(
-            gradleService,
-            module,
-            progress,
-        ).finally(() => {
-            if (this.warmsInFlight.get(key) === promise) {
-                this.warmsInFlight.delete(key);
-            }
-        });
-        this.warmsInFlight.set(key, promise);
-        return promise;
+        return this.warmCoalescer.getOrStart(module, () =>
+            this.warmModuleInner(gradleService, module, progress),
+        );
     }
 
     private async warmModuleInner(
@@ -453,14 +443,13 @@ export class LiveDaemonScheduler implements DaemonScheduler {
      * IDs. These are rendered first when the queue drains.
      */
     async setFocus(module: ModuleInfo, previewIds: string[]): Promise<void> {
-        const key = module.modulePath;
-        if (sameSet(this.lastFocus.get(key), previewIds)) {
+        if (this.visibility.sameFocusAsLast(module, previewIds)) {
             return;
         }
-        this.lastFocus.set(key, [...previewIds]);
+        this.visibility.recordFocus(module, previewIds);
         const client = await this.gate.getOrSpawn(
             module,
-            this.daemonEvents(key),
+            this.daemonEvents(module.modulePath),
         );
         if (!client) {
             return;
@@ -482,12 +471,12 @@ export class LiveDaemonScheduler implements DaemonScheduler {
     ): Promise<void> {
         const moduleKey = module.modulePath;
         if (
-            sameSet(this.lastVisible.get(moduleKey), visible) &&
+            this.visibility.sameVisibleAsLast(module, visible) &&
             predicted.length === 0
         ) {
             return;
         }
-        this.lastVisible.set(moduleKey, [...visible]);
+        this.visibility.recordVisible(module, visible);
         const client = await this.gate.getOrSpawn(
             module,
             this.daemonEvents(moduleKey),
@@ -525,13 +514,13 @@ export class LiveDaemonScheduler implements DaemonScheduler {
         const visibleSet = new Set(visible);
         const fresh = predicted
             .filter((id) => !visibleSet.has(id))
-            .filter((id) => !this.speculated.has(specKey(moduleKey, id)))
+            .filter((id) => !this.speculation.has(module, id))
             .slice(0, SPECULATIVE_BUDGET);
         if (fresh.length === 0) {
             return;
         }
         for (const id of fresh) {
-            this.speculated.add(specKey(moduleKey, id));
+            this.speculation.mark(module, id);
         }
         try {
             await client.renderNow({
@@ -758,11 +747,7 @@ export class LiveDaemonScheduler implements DaemonScheduler {
             onClasspathDirty: (params: { detail: string }) => {
                 // Drop the speculative cache for this module so a re-spawned
                 // daemon doesn't think we already pre-warmed those IDs.
-                for (const k of [...this.speculated]) {
-                    if (k.startsWith(`${moduleId}::`)) {
-                        this.speculated.delete(k);
-                    }
-                }
+                this.speculation.forgetModule({ modulePath: moduleId });
                 this.events.onClasspathDirty(moduleId, params.detail);
             },
             onDiscoveryUpdated: (params: DiscoveryUpdatedParams) => {
@@ -780,13 +765,9 @@ export class LiveDaemonScheduler implements DaemonScheduler {
             onChannelClosed: () => {
                 // Daemon died; clear caches so the next call re-issues them
                 // against a fresh JVM.
-                this.lastVisible.delete(moduleId);
-                this.lastFocus.delete(moduleId);
-                for (const k of [...this.speculated]) {
-                    if (k.startsWith(`${moduleId}::`)) {
-                        this.speculated.delete(k);
-                    }
-                }
+                const modRef = { modulePath: moduleId };
+                this.visibility.forgetModule(modRef);
+                this.speculation.forgetModule(modRef);
                 // D2 — wipe data-product subscription state so the next daemon spawn re-issues
                 // `data/subscribe` against the fresh JVM. Subscriptions don't survive daemon
                 // restarts (PROTOCOL.md / DATA-PRODUCTS.md § "Wire surface").
@@ -812,7 +793,7 @@ export class LiveDaemonScheduler implements DaemonScheduler {
             // Speculative entries graduate to "real" once they actually render —
             // drop them from the dedup set so a subsequent fileChanged for the
             // same preview can re-render via the reactive path.
-            this.speculated.delete(specKey(moduleId, params.id));
+            this.speculation.forget({ modulePath: moduleId }, params.id);
 
             // INTERACTIVE.md § 5 frame dedup. Daemon already determined the bytes are
             // byte-identical to the prior frame; skip the disk read + base64 + postMessage
@@ -984,18 +965,6 @@ function classifyKind(absPath: string): FileKind {
         return "resource";
     }
     return "source";
-}
-
-function sameSet(a: string[] | undefined, b: string[]): boolean {
-    if (!a || a.length !== b.length) {
-        return false;
-    }
-    const set = new Set(a);
-    return b.every((id) => set.has(id));
-}
-
-function specKey(moduleId: string, previewId: string): string {
-    return `${moduleId}::${previewId}`;
 }
 
 /**

--- a/vscode-extension/src/daemon/schedulerState.ts
+++ b/vscode-extension/src/daemon/schedulerState.ts
@@ -1,0 +1,136 @@
+/**
+ * Structural reference to a Gradle module — only the `modulePath` key is used by the scheduler
+ * state classes. Accepts both full `ModuleInfo` instances from the gradle service and the
+ * minimal `{ modulePath: string }` shapes the daemon-events handlers reconstruct from
+ * `moduleId: string`.
+ */
+export interface ModuleRef {
+    readonly modulePath: string;
+}
+
+/**
+ * Coalesces concurrent `warmModule` calls so a second caller arriving mid-bootstrap returns
+ * the in-flight promise instead of starting a second `composePreviewDaemonStart` (which the
+ * first invocation would then cancel). Promises are cleared on settle so a later retry after
+ * a cancellation starts fresh rather than getting a rejected promise back.
+ */
+export class WarmCoalescer<T> {
+    private readonly inFlight = new Map<string, Promise<T>>();
+
+    /**
+     * If a warm for [module] is already in flight, return its promise. Otherwise start one via
+     * [factory], remember it for the duration of the call, and return the new promise.
+     */
+    getOrStart(module: ModuleRef, factory: () => Promise<T>): Promise<T> {
+        const key = module.modulePath;
+        const existing = this.inFlight.get(key);
+        if (existing) {
+            return existing;
+        }
+        const promise = factory().finally(() => {
+            // Identity check guards against the (rare) case where a second warm started after
+            // ours settled but before our `finally` ran — we'd otherwise delete its entry.
+            if (this.inFlight.get(key) === promise) {
+                this.inFlight.delete(key);
+            }
+        });
+        this.inFlight.set(key, promise);
+        return promise;
+    }
+
+    /** True if a warm for [module] is currently in flight. Used by callers that want to
+     *  branch on "is the bootstrap already happening?" before kicking auxiliary UX. */
+    isInFlight(module: ModuleRef): boolean {
+        return this.inFlight.has(module.modulePath);
+    }
+}
+
+/**
+ * Per-`(module, previewId)` idempotency cache for the scheduler's speculative renders. Bounded
+ * by the scroll-ahead budget enforced at the caller; this class just tracks "have we already
+ * speculated this pair so a scroll-back doesn't re-queue identical work?".
+ */
+export class SpeculationCache {
+    private readonly seen = new Set<string>();
+
+    has(module: ModuleRef, previewId: string): boolean {
+        return this.seen.has(this.key(module, previewId));
+    }
+
+    mark(module: ModuleRef, previewId: string): void {
+        this.seen.add(this.key(module, previewId));
+    }
+
+    /** Drop one pair — used when a render for it completes so a subsequent file-change can
+     *  re-render via the reactive path. */
+    forget(module: ModuleRef, previewId: string): void {
+        this.seen.delete(this.key(module, previewId));
+    }
+
+    /** Drop every pair under [module]. Used on `onClasspathDirty` and `onChannelClosed` so a
+     *  re-spawned daemon doesn't think it's already pre-warmed those IDs. */
+    forgetModule(module: ModuleRef): void {
+        const prefix = `${module.modulePath}::`;
+        for (const k of [...this.seen]) {
+            if (k.startsWith(prefix)) this.seen.delete(k);
+        }
+    }
+
+    size(): number {
+        return this.seen.size;
+    }
+
+    private key(module: ModuleRef, previewId: string): string {
+        return `${module.modulePath}::${previewId}`;
+    }
+}
+
+/**
+ * Per-module dedup memo for the two protocol notifications whose payload often repeats:
+ * `setVisible` (visible IDs) and `setFocus` (focused IDs). Both fire on every editor focus
+ * change / scroll event, but the daemon only reacts when the set actually changed — caching
+ * the last value here cuts wire chatter without the call site having to manage two parallel
+ * maps. Cleared per-module on `onChannelClosed` so a re-spawned daemon sees fresh state.
+ */
+export class VisibilityMemo {
+    private readonly visible = new Map<string, string[]>();
+    private readonly focus = new Map<string, string[]>();
+
+    /** True iff the last `setVisible` for [module] was the same set of ids. */
+    sameVisibleAsLast(module: ModuleRef, ids: readonly string[]): boolean {
+        return sameSet(this.visible.get(module.modulePath), ids);
+    }
+
+    /** Remember the last `setVisible` ids for [module]. */
+    recordVisible(module: ModuleRef, ids: readonly string[]): void {
+        this.visible.set(module.modulePath, [...ids]);
+    }
+
+    /** True iff the last `setFocus` for [module] was the same set of ids. */
+    sameFocusAsLast(module: ModuleRef, ids: readonly string[]): boolean {
+        return sameSet(this.focus.get(module.modulePath), ids);
+    }
+
+    /** Remember the last `setFocus` ids for [module]. */
+    recordFocus(module: ModuleRef, ids: readonly string[]): void {
+        this.focus.set(module.modulePath, [...ids]);
+    }
+
+    /** Drop every memoised value for [module]. Used on `onChannelClosed` so a fresh daemon
+     *  spawn sees the next visible/focus call as "different" and re-issues it. */
+    forgetModule(module: ModuleRef): void {
+        const key = module.modulePath;
+        this.visible.delete(key);
+        this.focus.delete(key);
+    }
+}
+
+/** Set equality with order-independence and undefined-as-empty. */
+function sameSet(
+    a: readonly string[] | undefined,
+    b: readonly string[],
+): boolean {
+    if (!a || a.length !== b.length) return false;
+    const set = new Set(a);
+    return b.every((id) => set.has(id));
+}

--- a/vscode-extension/src/test/schedulerState.test.ts
+++ b/vscode-extension/src/test/schedulerState.test.ts
@@ -1,0 +1,200 @@
+import * as assert from "assert";
+import {
+    SpeculationCache,
+    VisibilityMemo,
+    WarmCoalescer,
+} from "../daemon/schedulerState";
+
+const modA = { modulePath: ":app" };
+const modB = { modulePath: ":lib" };
+
+describe("WarmCoalescer", () => {
+    it("starts a fresh warm when no in-flight promise exists", async () => {
+        const coalescer = new WarmCoalescer<boolean>();
+        let callCount = 0;
+        const promise = coalescer.getOrStart(modA, async () => {
+            callCount++;
+            return true;
+        });
+        assert.strictEqual(coalescer.isInFlight(modA), true);
+        const result = await promise;
+        assert.strictEqual(result, true);
+        assert.strictEqual(callCount, 1);
+        assert.strictEqual(coalescer.isInFlight(modA), false);
+    });
+
+    it("coalesces a second call onto the in-flight promise without re-invoking the factory", async () => {
+        // Regression: a second warm arriving mid-bootstrap must NOT start a second
+        // composePreviewDaemonStart (which the first invocation would then cancel).
+        const coalescer = new WarmCoalescer<boolean>();
+        let callCount = 0;
+        let resolve!: (v: boolean) => void;
+        const factory = () => {
+            callCount++;
+            return new Promise<boolean>((r) => (resolve = r));
+        };
+        const p1 = coalescer.getOrStart(modA, factory);
+        const p2 = coalescer.getOrStart(modA, factory);
+        assert.strictEqual(callCount, 1);
+        assert.strictEqual(p1, p2);
+        resolve(true);
+        assert.strictEqual(await p1, true);
+        assert.strictEqual(await p2, true);
+    });
+
+    it("isolates in-flight tracking per module", async () => {
+        const coalescer = new WarmCoalescer<boolean>();
+        let callCount = 0;
+        const factory = () => {
+            callCount++;
+            return Promise.resolve(true);
+        };
+        const pA = coalescer.getOrStart(modA, factory);
+        const pB = coalescer.getOrStart(modB, factory);
+        assert.notStrictEqual(pA, pB);
+        assert.strictEqual(callCount, 2);
+        await Promise.all([pA, pB]);
+    });
+
+    it("clears in-flight after settle so a later call starts a fresh warm", async () => {
+        // Regression for the "previous warm cancelled, retry must not get a stale rejected
+        // promise back" invariant — the old code's `finally` did this; the class does too.
+        const coalescer = new WarmCoalescer<boolean>();
+        let callCount = 0;
+        await coalescer.getOrStart(modA, async () => {
+            callCount++;
+            return true;
+        });
+        await coalescer.getOrStart(modA, async () => {
+            callCount++;
+            return true;
+        });
+        assert.strictEqual(callCount, 2);
+    });
+
+    it("clears in-flight even when the factory promise rejects", async () => {
+        const coalescer = new WarmCoalescer<boolean>();
+        await coalescer
+            .getOrStart(modA, () => Promise.reject(new Error("boom")))
+            .catch(() => {});
+        // Next call should start fresh.
+        let secondRan = false;
+        await coalescer.getOrStart(modA, async () => {
+            secondRan = true;
+            return true;
+        });
+        assert.strictEqual(secondRan, true);
+    });
+});
+
+describe("SpeculationCache", () => {
+    it("has returns false for never-marked pairs", () => {
+        const cache = new SpeculationCache();
+        assert.strictEqual(cache.has(modA, "p1"), false);
+    });
+
+    it("mark + has round-trips per (module, previewId) pair", () => {
+        const cache = new SpeculationCache();
+        cache.mark(modA, "p1");
+        assert.strictEqual(cache.has(modA, "p1"), true);
+        assert.strictEqual(cache.has(modA, "p2"), false);
+        assert.strictEqual(cache.has(modB, "p1"), false);
+    });
+
+    it("forget drops one pair, leaving siblings intact", () => {
+        const cache = new SpeculationCache();
+        cache.mark(modA, "p1");
+        cache.mark(modA, "p2");
+        cache.forget(modA, "p1");
+        assert.strictEqual(cache.has(modA, "p1"), false);
+        assert.strictEqual(cache.has(modA, "p2"), true);
+    });
+
+    it("forgetModule drops every pair under that module, leaving other modules intact", () => {
+        // Regression: the old inline code spelled this out at two callsites (classpath dirty +
+        // channel closed). The class method must match — only the named module's entries go,
+        // sibling modules' speculations survive.
+        const cache = new SpeculationCache();
+        cache.mark(modA, "p1");
+        cache.mark(modA, "p2");
+        cache.mark(modB, "p1");
+        cache.forgetModule(modA);
+        assert.strictEqual(cache.has(modA, "p1"), false);
+        assert.strictEqual(cache.has(modA, "p2"), false);
+        assert.strictEqual(cache.has(modB, "p1"), true);
+    });
+
+    it("does not confuse modules whose modulePath is a prefix of another", () => {
+        // The keying uses '::' as separator; a prefix-match prune must not catch a longer
+        // sibling key. Belt-and-braces test since the production code keys are user-facing
+        // Gradle module paths.
+        const cache = new SpeculationCache();
+        const short = { modulePath: ":app" };
+        const longer = { modulePath: ":app:feature" };
+        cache.mark(short, "p1");
+        cache.mark(longer, "p1");
+        cache.forgetModule(short);
+        assert.strictEqual(cache.has(short, "p1"), false);
+        assert.strictEqual(cache.has(longer, "p1"), true);
+    });
+});
+
+describe("VisibilityMemo", () => {
+    it("sameVisibleAsLast returns false until a value has been recorded", () => {
+        const memo = new VisibilityMemo();
+        assert.strictEqual(memo.sameVisibleAsLast(modA, ["a"]), false);
+    });
+
+    it("sameVisibleAsLast is order-insensitive", () => {
+        // setVisible's dedup intent is "same set of visible IDs", not "same array". The
+        // memo must collapse permutations or the daemon sees spurious updates.
+        const memo = new VisibilityMemo();
+        memo.recordVisible(modA, ["a", "b", "c"]);
+        assert.strictEqual(memo.sameVisibleAsLast(modA, ["c", "b", "a"]), true);
+        assert.strictEqual(memo.sameVisibleAsLast(modA, ["a", "b"]), false);
+    });
+
+    it("sameVisibleAsLast vs sameFocusAsLast are independent per module", () => {
+        const memo = new VisibilityMemo();
+        memo.recordVisible(modA, ["v1"]);
+        memo.recordFocus(modA, ["f1"]);
+        assert.strictEqual(memo.sameVisibleAsLast(modA, ["v1"]), true);
+        assert.strictEqual(memo.sameVisibleAsLast(modA, ["f1"]), false);
+        assert.strictEqual(memo.sameFocusAsLast(modA, ["f1"]), true);
+        assert.strictEqual(memo.sameFocusAsLast(modA, ["v1"]), false);
+    });
+
+    it("records are per module", () => {
+        const memo = new VisibilityMemo();
+        memo.recordVisible(modA, ["a"]);
+        // modB's last is undefined, so even if you re-pass modA's value it's different.
+        assert.strictEqual(memo.sameVisibleAsLast(modB, ["a"]), false);
+    });
+
+    it("recordVisible snapshots the array so a caller-side mutation doesn't poison the memo", () => {
+        // The prior code spread `[...visible]` at the callsite for exactly this reason.
+        // The class method must do the snapshot internally so callers can't accidentally
+        // share array identity with the memo.
+        const memo = new VisibilityMemo();
+        const live = ["a", "b"];
+        memo.recordVisible(modA, live);
+        live.push("c");
+        assert.strictEqual(memo.sameVisibleAsLast(modA, ["a", "b"]), true);
+        assert.strictEqual(
+            memo.sameVisibleAsLast(modA, ["a", "b", "c"]),
+            false,
+        );
+    });
+
+    it("forgetModule drops both visible and focus memos for that module", () => {
+        const memo = new VisibilityMemo();
+        memo.recordVisible(modA, ["v"]);
+        memo.recordFocus(modA, ["f"]);
+        memo.recordVisible(modB, ["v"]);
+        memo.forgetModule(modA);
+        assert.strictEqual(memo.sameVisibleAsLast(modA, ["v"]), false);
+        assert.strictEqual(memo.sameFocusAsLast(modA, ["f"]), false);
+        // modB's memo survives.
+        assert.strictEqual(memo.sameVisibleAsLast(modB, ["v"]), true);
+    });
+});


### PR DESCRIPTION
## Summary

`LiveDaemonScheduler` held seven per-module bookkeeping fields directly, mixing three distinct concerns. The per-module purge logic for `speculated` and the `lastVisible` / `lastFocus` clears was spelled out inline at multiple sites (`onClasspathDirty`, `onChannelClosed`), with `[...this.speculated]` defensive spreads each time.

Move them into three single-purpose classes in `vscode-extension/src/daemon/schedulerState.ts`:

- **`WarmCoalescer<T>`** — `getOrStart(module, factory)` returns the in-flight promise or starts a new one, clears on settle (including rejection), with an `isInFlight` query for the "ready" progress hop.
- **`SpeculationCache`** — `has` / `mark` / `forget` per `(module, previewId)` pair plus `forgetModule` for the per-module sweep.
- **`VisibilityMemo`** — `sameVisibleAsLast` / `recordVisible` (and the focus equivalents) collapse the parallel maps; `forgetModule` drops both at once.

All three accept any `{ modulePath: string }` (new `ModuleRef` structural type), so the event-handler sites that only have `moduleId: string` reconstruct a `ModuleRef` literal without a fake `ModuleInfo`.

The local `sameSet` and `specKey` helpers in `daemonScheduler.ts` had no callers left after the move and were removed.

`subscribedPairs` and `pendingSubscribes` are **intentionally not moved** — they're part of the existing documented subscription state and are tightly coupled to `setDataProductSubscription` / `awaitPendingSubscribes`.

## Test plan

- [x] 16 new `schedulerState.test.ts` cases pinning each invariant:
  - **WarmCoalescer**: fresh-start, factory-not-re-invoked on second call, per-module isolation, post-settle clear, post-rejection clear.
  - **SpeculationCache**: never-marked returns false, mark/has round-trip per pair, forget drops one pair only, forgetModule drops module's entries while leaving siblings, prefix-confusion regression (`:app` vs `:app:feature`).
  - **VisibilityMemo**: returns false before any record, order-insensitive set equality, visible/focus tracked independently, per-module isolation, snapshots the input array, forgetModule clears both visible and focus.
- [x] Full extension test suite 1300 → 1316 passing.
- [x] `npm run compile:host` clean, `npm run format` no-op.

Pairs with the documented [State seams](https://github.com/yschimke/compose-ai-tools/pull/1506) note — the three new classes get listed there once both land.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHMXjmHqVzF8ituEJNyqXG)_