### PR TITLE
feat(vscode-extension): trace preload skips + gradle cancel source

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -108,6 +108,7 @@ import {
 } from "./renderFreshness";
 import { RefreshQueue, defaultRefreshQueueEffects } from "./refreshQueue";
 import { EditorScope, PreviewModuleIndex } from "./editorScope";
+import { describePreloadOutcome, loadCachedPreviews } from "./previewPreload";
 import {
     BUNDLED_PLUGIN_VERSION,
     hasIncludedPluginBuild,
@@ -2587,81 +2588,24 @@ async function preloadCachedPreviews(filePath: string): Promise<boolean> {
     if (!gradleService || !panel) {
         return false;
     }
-    if (!isPreviewSourceFile(filePath)) {
-        return false;
-    }
-    const module = gradleService.resolveModule(filePath);
-    if (!module) {
-        return false;
-    }
-    const manifest = gradleService.readManifest(module);
-    if (!manifest || manifest.previews.length === 0) {
-        return false;
-    }
-
-    const visiblePreviews = previewsForFile(
-        manifest.previews,
-        module,
-        filePath,
-    );
-    if (visiblePreviews.length === 0) {
-        return false;
-    }
-
-    for (const p of visiblePreviews) {
-        for (const capture of p.captures) {
-            capture.label = captureLabel(capture);
-        }
-        previewModuleIndex.set(p.id, module);
-    }
-
-    const displayPreviews = visiblePreviews.map(withDataProductCaptures);
-
-    panel.postMessage({
-        command: "setPreviews",
-        previews: displayPreviews,
-        moduleDir: module.projectDir,
-        heavyStaleIds: [],
+    const localPanel = panel;
+    const outcome = await loadCachedPreviews(filePath, {
+        gradleService,
+        postMessage: (msg) => localPanel.postMessage(msg),
+        setImage: (id, imageData) => registry.setImage(id, imageData),
+        setPreviewModule: (id, mod) => previewModuleIndex.set(id, mod),
+        isPreviewSourceFile,
     });
-
-    const imageJobs: Promise<void>[] = [];
-    for (const preview of displayPreviews) {
-        for (let idx = 0; idx < preview.captures.length; idx++) {
-            const capture = preview.captures[idx];
-            if (!capture.renderOutput) {
-                continue;
-            }
-            const captureIndex = idx;
-            imageJobs.push(
-                (async () => {
-                    const imageData = await gradleService!.readPreviewImage(
-                        module,
-                        capture.renderOutput,
-                    );
-                    if (!imageData || !panel) {
-                        return;
-                    }
-                    if (captureIndex === 0) {
-                        registry.setImage(preview.id, imageData);
-                    }
-                    panel.postMessage({
-                        command: "updateImage",
-                        previewId: preview.id,
-                        captureIndex,
-                        imageData,
-                    });
-                })(),
-            );
-        }
+    logLine(describePreloadOutcome(filePath, outcome));
+    if (outcome.kind !== "painted") {
+        return false;
     }
-    await Promise.all(imageJobs);
-
     // Sync the extension-side state the upcoming refresh() reads so it
     // takes the stealth-refresh path (no clearAll) rather
     // than tearing down what we just painted.
     hasPreviewsLoaded = true;
-    lastLoadedModules = [module.modulePath];
-    moduleManifestCache.set(module.modulePath, visiblePreviews);
+    lastLoadedModules = [outcome.module.modulePath];
+    moduleManifestCache.set(outcome.module.modulePath, outcome.previews);
     setCurrentScopeFile(filePath);
     return true;
 }
@@ -4182,7 +4126,10 @@ async function refresh(
     // `GradleService.composePreviewDiscover`, the subsequent `composePreviewDiscover`
     // call this refresh issues awaits the same Gradle run instead of
     // starting a duplicate.
-    gradleService.cancel({ keepDiscoverFor: module.modulePath });
+    gradleService.cancel({
+        keepDiscoverFor: module.modulePath,
+        reason: `refresh(${path.basename(activeFile ?? "?")})`,
+    });
 
     // Forward progress-bar updates to the webview. Single tracker per refresh
     // — single instance feeds the Gradle phase signals (compile/discover/

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -888,7 +888,17 @@ export class GradleService {
         }
     }
 
-    async cancel(opts?: { keepDiscoverFor?: string }): Promise<void> {
+    async cancel(opts?: {
+        keepDiscoverFor?: string;
+        /**
+         * Human-readable origin for the cancel — surfaced in the log so a
+         * triage capture can tell which call site (refresh-on-save,
+         * focus-change, dispose, …) cancelled an in-flight task. Optional so
+         * existing callers don't have to update at once; the log line drops
+         * the suffix when missing.
+         */
+        reason?: string;
+    }): Promise<void> {
         // Three task families are intentionally excluded from the cancel pool.
         // The spare matches on the head task of the Gradle invocation, so
         // bundles started by [coldStartBundle] — whose head is either
@@ -941,6 +951,17 @@ export class GradleService {
             }
         }
         this.activeKeys = toKeep;
+        if (toCancel.length > 0) {
+            const reasonSuffix = opts?.reason ? ` reason=${opts.reason}` : "";
+            const keepSuffix = opts?.keepDiscoverFor
+                ? ` keepDiscoverFor=${opts.keepDiscoverFor}`
+                : "";
+            this.logger.appendLine(
+                `[gradle] cancel: tasks=[${toCancel
+                    .map((k) => taskFromKey(k))
+                    .join(", ")}]${keepSuffix}${reasonSuffix}`,
+            );
+        }
         for (const key of toCancel) {
             try {
                 await this.gradleApi.cancelRunTask({

--- a/vscode-extension/src/previewPreload.ts
+++ b/vscode-extension/src/previewPreload.ts
@@ -1,0 +1,165 @@
+import * as path from "path";
+import { GradleService, ModuleInfo } from "./gradleService";
+import { captureLabel, withDataProductCaptures } from "./captureLabels";
+import { visiblePreviewsForFile } from "./previewScope";
+import { ExtensionToWebview, PreviewInfo } from "./types";
+
+/**
+ * Tagged outcome of {@link loadCachedPreviews}. The five `skipped` reasons replace what were
+ * previously silent `return false`s in the inlined preload — each is now visible to logging and
+ * pinned by a regression test. The `painted` variant carries the state the caller must commit
+ * (the visible-preview list, the owning module) so the orchestration globals
+ * (`hasPreviewsLoaded`, `moduleManifestCache`, the scope) stay at the call site rather than
+ * being mutated from inside the preload helper.
+ */
+export type PreloadOutcome =
+    | {
+          kind: "painted";
+          module: ModuleInfo;
+          /** The previews actually painted (filtered by `previewsForFile` to the active file). */
+          previews: PreviewInfo[];
+      }
+    | {
+          kind: "skipped";
+          reason: PreloadSkipReason;
+          /** The resolved module when known — included on `no-manifest` / `empty-manifest` /
+           *  `no-visible-previews` so log lines can name which module preload bailed on. Null
+           *  when the skip happened before module resolution. */
+          module: ModuleInfo | null;
+      };
+
+export type PreloadSkipReason =
+    /** The file isn't a Kotlin / XML source the extension previews. */
+    | "not-preview-file"
+    /** `gradleService.resolveModule` returned null — no `applied.json` marker yet, or the file
+     *  is outside any preview-applying module. */
+    | "no-module"
+    /** `gradleService.readManifest` returned null — `previews.json` doesn't exist on disk yet
+     *  (cold start; nothing to preload). */
+    | "no-manifest"
+    /** Manifest loaded but contained zero previews (module compiled but no @Preview functions). */
+    | "empty-manifest"
+    /** Manifest had previews, but none of them belong to the requested file. */
+    | "no-visible-previews";
+
+export interface PreloadDeps {
+    readonly gradleService: GradleService;
+    /** Forwards a panel message. Decoupled from `vscode.Webview` so tests can use a recorder. */
+    postMessage(msg: ExtensionToWebview): void;
+    /** Caches the rendered image bytes against [previewId] in the host-side registry. */
+    setImage(previewId: string, imageData: string): void;
+    /** Records the owning module for a preview id in the host-side index. */
+    setPreviewModule(previewId: string, module: ModuleInfo): void;
+    /** Predicate the host uses to decide which files have previews. */
+    isPreviewSourceFile(filePath: string): boolean;
+}
+
+/**
+ * Paint previously-rendered cached PNGs from `build/compose-previews/` onto the panel so the
+ * user never opens onto an empty screen while Gradle warms up. Returns an outcome the caller
+ * uses to log the skip reason or commit the painted state.
+ *
+ * Side effects when `kind === "painted"`:
+ * - Posts `setPreviews` + one `updateImage` per capture to the webview.
+ * - Calls `setImage` / `setPreviewModule` on the host registry / index so subsequent reads see
+ *   the cached state immediately.
+ * - Does NOT update the editor scope, `hasPreviewsLoaded`, or any manifest cache — those
+ *   belong to the caller (so the orchestration semantics stay visible in one place).
+ */
+export async function loadCachedPreviews(
+    filePath: string,
+    deps: PreloadDeps,
+): Promise<PreloadOutcome> {
+    if (!deps.isPreviewSourceFile(filePath)) {
+        return { kind: "skipped", reason: "not-preview-file", module: null };
+    }
+    const module = deps.gradleService.resolveModule(filePath);
+    if (!module) {
+        return { kind: "skipped", reason: "no-module", module: null };
+    }
+    const manifest = deps.gradleService.readManifest(module);
+    if (!manifest) {
+        return { kind: "skipped", reason: "no-manifest", module };
+    }
+    if (manifest.previews.length === 0) {
+        return { kind: "skipped", reason: "empty-manifest", module };
+    }
+
+    const visiblePreviews = visiblePreviewsForFile(
+        manifest.previews,
+        deps.gradleService.workspaceRoot,
+        module,
+        filePath,
+    );
+    if (visiblePreviews.length === 0) {
+        return { kind: "skipped", reason: "no-visible-previews", module };
+    }
+
+    for (const p of visiblePreviews) {
+        for (const capture of p.captures) {
+            capture.label = captureLabel(capture);
+        }
+        deps.setPreviewModule(p.id, module);
+    }
+
+    const displayPreviews = visiblePreviews.map(withDataProductCaptures);
+
+    deps.postMessage({
+        command: "setPreviews",
+        previews: displayPreviews,
+        moduleDir: module.projectDir,
+        heavyStaleIds: [],
+    });
+
+    const imageJobs: Promise<void>[] = [];
+    for (const preview of displayPreviews) {
+        for (let idx = 0; idx < preview.captures.length; idx++) {
+            const capture = preview.captures[idx];
+            if (!capture.renderOutput) {
+                continue;
+            }
+            const captureIndex = idx;
+            imageJobs.push(
+                (async () => {
+                    const imageData = await deps.gradleService.readPreviewImage(
+                        module,
+                        capture.renderOutput,
+                    );
+                    if (!imageData) {
+                        return;
+                    }
+                    if (captureIndex === 0) {
+                        deps.setImage(preview.id, imageData);
+                    }
+                    deps.postMessage({
+                        command: "updateImage",
+                        previewId: preview.id,
+                        captureIndex,
+                        imageData,
+                    });
+                })(),
+            );
+        }
+    }
+    await Promise.all(imageJobs);
+
+    return { kind: "painted", module, previews: visiblePreviews };
+}
+
+/**
+ * Human-readable label for a {@link PreloadOutcome}, used in the extension's diagnostic log.
+ * Kept here (not at the call site) so the wording stays in lockstep with the outcome shape.
+ */
+export function describePreloadOutcome(
+    filePath: string,
+    outcome: PreloadOutcome,
+): string {
+    const file = path.basename(filePath);
+    if (outcome.kind === "painted") {
+        return `preload: painted ${outcome.previews.length} cached preview(s) for ${file} (module=${outcome.module.modulePath})`;
+    }
+    const moduleSuffix = outcome.module
+        ? ` (module=${outcome.module.modulePath})`
+        : "";
+    return `preload: skipped ${file} — ${outcome.reason}${moduleSuffix}`;
+}

--- a/vscode-extension/src/test/previewPreload.test.ts
+++ b/vscode-extension/src/test/previewPreload.test.ts
@@ -1,0 +1,336 @@
+import * as assert from "assert";
+import * as path from "path";
+import {
+    describePreloadOutcome,
+    loadCachedPreviews,
+    PreloadDeps,
+    PreloadOutcome,
+} from "../previewPreload";
+import { GradleService, ModuleInfo } from "../gradleService";
+import { ExtensionToWebview, PreviewInfo, PreviewManifest } from "../types";
+
+const mod = (modulePath: string): ModuleInfo =>
+    ({
+        modulePath,
+        projectDir: modulePath.replace(/^:/, "").replace(/:/g, "/"),
+    }) as ModuleInfo;
+
+interface FakeGradleOptions {
+    workspaceRoot?: string;
+    resolveModule?: (filePath: string) => ModuleInfo | null;
+    readManifest?: (module: ModuleInfo) => PreviewManifest | null;
+    readPreviewImage?: (
+        module: ModuleInfo,
+        renderOutput: string,
+    ) => Promise<string | null>;
+}
+
+function fakeGradleService(opts: FakeGradleOptions = {}): GradleService {
+    const workspaceRoot = opts.workspaceRoot ?? "/ws";
+    return {
+        workspaceRoot,
+        resolveModule: opts.resolveModule ?? (() => mod(":app")),
+        readManifest: opts.readManifest ?? (() => null),
+        readPreviewImage: opts.readPreviewImage ?? (async () => null),
+    } as unknown as GradleService;
+}
+
+function preview(id: string, sourceFile: string): PreviewInfo {
+    return {
+        id,
+        functionName: id.split(".").pop()!,
+        className: id.substring(0, id.lastIndexOf(".")),
+        sourceFile,
+        params: {
+            name: null,
+            device: null,
+            widthDp: null,
+            heightDp: null,
+            fontScale: 1,
+            showSystemUi: false,
+            showBackground: false,
+            backgroundColor: 0,
+            uiMode: 0,
+            locale: null,
+            group: null,
+        },
+        captures: [
+            {
+                advanceTimeMillis: null,
+                scroll: null,
+                renderOutput: `renders/${id}.png`,
+            },
+        ],
+    } as PreviewInfo;
+}
+
+function manifestWith(...previews: PreviewInfo[]): PreviewManifest {
+    return { previews } as PreviewManifest;
+}
+
+interface Captured {
+    messages: ExtensionToWebview[];
+    imageSets: Array<{ previewId: string; imageData: string }>;
+    moduleSets: Array<{ previewId: string; module: ModuleInfo }>;
+}
+
+function makeDeps(
+    overrides: Partial<PreloadDeps> = {},
+    captured?: Captured,
+): PreloadDeps {
+    const cap = captured ?? {
+        messages: [],
+        imageSets: [],
+        moduleSets: [],
+    };
+    return {
+        gradleService: fakeGradleService(),
+        postMessage: (msg) => cap.messages.push(msg),
+        setImage: (previewId, imageData) =>
+            cap.imageSets.push({ previewId, imageData }),
+        setPreviewModule: (previewId, module) =>
+            cap.moduleSets.push({ previewId, module }),
+        isPreviewSourceFile: () => true,
+        ...overrides,
+    };
+}
+
+describe("loadCachedPreviews — skip outcomes", () => {
+    it("not-preview-file when the file isn't recognised as a preview source", async () => {
+        const outcome = await loadCachedPreviews(
+            "/ws/app/src/main/AndroidManifest.xml",
+            makeDeps({ isPreviewSourceFile: () => false }),
+        );
+        assert.deepStrictEqual(outcome, {
+            kind: "skipped",
+            reason: "not-preview-file",
+            module: null,
+        });
+    });
+
+    it("no-module when gradleService.resolveModule returns null", async () => {
+        const outcome = await loadCachedPreviews(
+            "/ws/orphan/src/main/kotlin/Orphan.kt",
+            makeDeps({
+                gradleService: fakeGradleService({ resolveModule: () => null }),
+            }),
+        );
+        assert.deepStrictEqual(outcome, {
+            kind: "skipped",
+            reason: "no-module",
+            module: null,
+        });
+    });
+
+    it("no-manifest when previews.json is absent", async () => {
+        const module = mod(":app");
+        const outcome = await loadCachedPreviews(
+            "/ws/app/src/main/kotlin/Previews.kt",
+            makeDeps({
+                gradleService: fakeGradleService({
+                    resolveModule: () => module,
+                    readManifest: () => null,
+                }),
+            }),
+        );
+        assert.deepStrictEqual(outcome, {
+            kind: "skipped",
+            reason: "no-manifest",
+            module,
+        });
+    });
+
+    it("empty-manifest when the manifest loaded but listed zero previews", async () => {
+        const module = mod(":app");
+        const outcome = await loadCachedPreviews(
+            "/ws/app/src/main/kotlin/Previews.kt",
+            makeDeps({
+                gradleService: fakeGradleService({
+                    resolveModule: () => module,
+                    readManifest: () => manifestWith(),
+                }),
+            }),
+        );
+        assert.deepStrictEqual(outcome, {
+            kind: "skipped",
+            reason: "empty-manifest",
+            module,
+        });
+    });
+
+    it("no-visible-previews when the manifest has entries but none belong to the requested file", async () => {
+        // Regression: this case happens routinely on multi-file modules. The manifest is
+        // populated with every preview in the module; preloadCachedPreviews must report
+        // "no-visible-previews" rather than the broader "empty-manifest" so the log says
+        // why a non-empty manifest still didn't paint anything.
+        const module = mod(":app");
+        const outcome = await loadCachedPreviews(
+            "/ws/app/src/main/kotlin/com/example/Previews.kt",
+            makeDeps({
+                gradleService: fakeGradleService({
+                    workspaceRoot: "/ws",
+                    resolveModule: () => module,
+                    readManifest: () =>
+                        manifestWith(
+                            preview(
+                                "com.example.Other.OtherPreview",
+                                "src/main/kotlin/com/example/Other.kt",
+                            ),
+                        ),
+                }),
+            }),
+        );
+        assert.strictEqual(outcome.kind, "skipped");
+        if (outcome.kind === "skipped") {
+            assert.strictEqual(outcome.reason, "no-visible-previews");
+            assert.strictEqual(outcome.module, module);
+        }
+    });
+});
+
+describe("loadCachedPreviews — painted outcome", () => {
+    it("paints visible previews, posts setPreviews + updateImage, returns the painted set", async () => {
+        const module = mod(":app");
+        const p1 = preview(
+            "com.example.PreviewsKt.RedBoxPreview",
+            "src/main/kotlin/com/example/Previews.kt",
+        );
+        const captured: Captured = {
+            messages: [],
+            imageSets: [],
+            moduleSets: [],
+        };
+        const outcome = await loadCachedPreviews(
+            "/ws/app/src/main/kotlin/com/example/Previews.kt",
+            makeDeps(
+                {
+                    gradleService: fakeGradleService({
+                        workspaceRoot: "/ws",
+                        resolveModule: () => module,
+                        readManifest: () => manifestWith(p1),
+                        readPreviewImage: async () => "BASE64IMAGEDATA",
+                    }),
+                },
+                captured,
+            ),
+        );
+        assert.strictEqual(outcome.kind, "painted");
+        if (outcome.kind === "painted") {
+            assert.strictEqual(outcome.module, module);
+            assert.deepStrictEqual(
+                outcome.previews.map((p) => p.id),
+                [p1.id],
+            );
+        }
+        // The webview gets a setPreviews followed by an updateImage for each capture.
+        const commands = captured.messages.map(
+            (m) => (m as { command: string }).command,
+        );
+        assert.deepStrictEqual(commands, ["setPreviews", "updateImage"]);
+        // The image registry got the bytes too, and the previewId → module index was
+        // populated so subsequent per-preview handlers can route to the right module.
+        assert.deepStrictEqual(captured.imageSets, [
+            { previewId: p1.id, imageData: "BASE64IMAGEDATA" },
+        ]);
+        assert.deepStrictEqual(captured.moduleSets, [
+            { previewId: p1.id, module },
+        ]);
+    });
+
+    it("skips updateImage for previews whose render file is unreadable, still paints the rest", async () => {
+        // Regression: a cached preview whose PNG was deleted out from under us must not block
+        // the rest of the preload. The setPreviews + module-index registration still happens
+        // for the unreadable preview; the image just doesn't arrive.
+        const module = mod(":app");
+        const p1 = preview(
+            "com.example.PreviewsKt.RedBoxPreview",
+            "src/main/kotlin/com/example/Previews.kt",
+        );
+        const p2 = preview(
+            "com.example.PreviewsKt.BlueBoxPreview",
+            "src/main/kotlin/com/example/Previews.kt",
+        );
+        const captured: Captured = {
+            messages: [],
+            imageSets: [],
+            moduleSets: [],
+        };
+        await loadCachedPreviews(
+            "/ws/app/src/main/kotlin/com/example/Previews.kt",
+            makeDeps(
+                {
+                    gradleService: fakeGradleService({
+                        workspaceRoot: "/ws",
+                        resolveModule: () => module,
+                        readManifest: () => manifestWith(p1, p2),
+                        readPreviewImage: async (_module, renderOutput) =>
+                            renderOutput.includes("RedBox") ? "REDBYTES" : null,
+                    }),
+                },
+                captured,
+            ),
+        );
+        const updateImageMessages = captured.messages.filter(
+            (m) => (m as { command: string }).command === "updateImage",
+        );
+        assert.strictEqual(updateImageMessages.length, 1);
+        assert.strictEqual(captured.imageSets.length, 1);
+        // Both previews still got registered with the module index.
+        assert.deepStrictEqual(
+            captured.moduleSets.map((s) => s.previewId).sort(),
+            [p1.id, p2.id].sort(),
+        );
+    });
+});
+
+describe("describePreloadOutcome", () => {
+    const file = "/ws/app/src/main/kotlin/Previews.kt";
+
+    it("names the painted preview count and module", () => {
+        const module = mod(":app");
+        const previews = [
+            preview(
+                "com.example.RedBoxPreview",
+                "src/main/kotlin/com/example/Previews.kt",
+            ),
+        ];
+        const msg = describePreloadOutcome(file, {
+            kind: "painted",
+            module,
+            previews,
+        });
+        assert.ok(msg.includes("painted 1"), `missing painted count: ${msg}`);
+        assert.ok(msg.includes(":app"), `missing module: ${msg}`);
+        assert.ok(
+            msg.includes(path.basename(file)),
+            `missing basename: ${msg}`,
+        );
+    });
+
+    it("names the skip reason and module when known", () => {
+        const module = mod(":app");
+        const msg = describePreloadOutcome(file, {
+            kind: "skipped",
+            reason: "no-visible-previews",
+            module,
+        });
+        assert.ok(
+            msg.includes("no-visible-previews"),
+            `missing reason: ${msg}`,
+        );
+        assert.ok(msg.includes(":app"), `missing module: ${msg}`);
+    });
+
+    it("omits the module suffix when the skip happened before module resolution", () => {
+        const msg = describePreloadOutcome(file, {
+            kind: "skipped",
+            reason: "no-module",
+            module: null,
+        });
+        assert.ok(msg.includes("no-module"), `missing reason: ${msg}`);
+        assert.ok(
+            !msg.includes("module="),
+            `should not include module= suffix when module is null: ${msg}`,
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Two live bugs reported on the panel — "initial cached images don't load" and "post-warm discover sometimes gets cancelled" — have been hard to diagnose because both paths swallow information silently. This PR makes both visible without changing behaviour, so the next user log capture pins the actual cause before the bigger orchestrator refactor lands.

**Preload outcomes.** Extract `loadCachedPreviews` into `vscode-extension/src/previewPreload.ts` with a tagged `PreloadOutcome` (`painted` | `skipped`) carrying the skip reason and the resolved module when known. The five distinct silent skip reasons — `not-preview-file`, `no-module`, `no-manifest`, `empty-manifest`, `no-visible-previews` — are now logged through `describePreloadOutcome`:

```
preload: skipped Previews.kt — no-visible-previews (module=:samples:cmp)
preload: painted 4 cached preview(s) for Previews.kt (module=:samples:cmp)
```

The painted variant returns the previews + module so orchestration globals (`hasPreviewsLoaded`, `moduleManifestCache`, the editor scope) stay mutated at the call site rather than inside the helper.

**Gradle cancel source.** Add an optional `reason: string` to `GradleService.cancel()`. When at least one task is cancelled the line:

```
[gradle] cancel: tasks=[:samples:android:composePreviewDiscover] keepDiscoverFor=:samples:android reason=refresh(AnimatedPreviews.kt)
```

names the caller. The post-warm discover cancellation reported in the bug capture will now name its source from the log.

## Test plan

- [x] 10 new `previewPreload.test.ts` cases:
  - Each skip reason has a regression test (not-preview-file, no-module, no-manifest, empty-manifest, no-visible-previews).
  - Painted-outcome test asserts the `setPreviews` → `updateImage` message sequence, the image-registry write, the module-index registration.
  - Partial-success test: a preview whose PNG is unreadable still gets module-index registration; the rest of the previews paint.
  - `describePreloadOutcome` wording covered for painted, skipped-with-module, skipped-without-module.
- [x] Full extension test suite 1316 → 1326 passing.
- [x] No behaviour change — every code path that returned `false` before still returns `false`; every successful path still posts the same messages in the same order.

This commit does not fix either bug — the user's next log capture should identify (a) which preload skip reason fires on the affected files and (b) which call site cancels the post-warm discover. Followups (#TBD orchestrator extraction, #TBD consistency-verify command) target the actual failure once we know it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHMXjmHqVzF8ituEJNyqXG)_