### PR TITLE
feat(vscode-extension): add 'Compose Preview: Verify' consistency-check command

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -85,6 +85,11 @@
                 "category": "Compose Preview"
             },
             {
+                "command": "composePreview.verify",
+                "title": "Verify (cross-check manifest, disk, and panel state)",
+                "category": "Compose Preview"
+            },
+            {
                 "command": "composePreview.copyDoctorReport",
                 "title": "Copy Doctor Report (for bug reports)",
                 "category": "Compose Preview",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -109,6 +109,11 @@ import {
 import { RefreshQueue, defaultRefreshQueueEffects } from "./refreshQueue";
 import { EditorScope, PreviewModuleIndex } from "./editorScope";
 import {
+    describeVerifyResult,
+    realFileExists,
+    verifyConsistency,
+} from "./previewConsistency";
+import {
     BUNDLED_PLUGIN_VERSION,
     hasIncludedPluginBuild,
     materializeInitScript,
@@ -1692,6 +1697,9 @@ export async function activate(
         );
     };
     context.subscriptions.push(
+        vscode.commands.registerCommand("composePreview.verify", () => {
+            runVerifyConsistency();
+        }),
         vscode.commands.registerCommand("composePreview.runDoctor", () => {
             void vscode.window.withProgress(
                 {
@@ -2089,6 +2097,67 @@ export async function activate(
             },
         };
         return testApi;
+    }
+}
+
+/**
+ * Cross-check the manifest, the on-disk PNGs, and the host's image registry for the file
+ * the panel is currently scoped to. Triggered via the `composePreview.verify` command
+ * (Command Palette → "Compose Preview: Verify").
+ *
+ * The check exists because the user-reported bug ("cached images don't load on startup")
+ * lives at the seam between three pieces of state that should always agree: what
+ * `previews.json` claims exists, what files are actually on disk under `build/compose-previews/`,
+ * and what bytes the in-memory registry is feeding the webview. When they disagree, the
+ * card stays a placeholder. Reporting the disagreement directly takes the guesswork out of
+ * "is this a missing file or a stale registry?".
+ */
+function runVerifyConsistency(): void {
+    if (!gradleService) {
+        vscode.window.showWarningMessage(
+            "Compose Preview verify: extension still initialising — try again in a moment.",
+        );
+        return;
+    }
+    const filePath = editorScope.file;
+    const result = verifyConsistency(filePath, {
+        gradleService,
+        registryGetImage: (id) => registry.getImage(id),
+        fileExists: realFileExists,
+    });
+    const summary = describeVerifyResult(filePath, result);
+    logForce(summary);
+    for (const issue of result.inconsistencies) {
+        if (issue.kind === "disk-has-png-registry-empty") {
+            logForce(
+                `  ⚠ ${issue.previewId}: PNG on disk at ${issue.pngPath} but registry is empty (panel is showing a placeholder unnecessarily)`,
+            );
+        } else {
+            logForce(
+                `  · ${issue.previewId}: never rendered (no PNG, no registry entry; expected ${issue.expectedPngPath})`,
+            );
+        }
+    }
+    if (
+        result.inconsistencies.some(
+            (i) => i.kind === "disk-has-png-registry-empty",
+        )
+    ) {
+        vscode.window
+            .showWarningMessage(
+                summary +
+                    " — see Compose Preview output channel for the per-preview list.",
+                "Show output",
+            )
+            .then((choice) => {
+                if (choice === "Show output") {
+                    vscode.commands.executeCommand(
+                        "workbench.action.output.toggleOutput",
+                    );
+                }
+            });
+    } else {
+        vscode.window.showInformationMessage(summary);
     }
 }
 

--- a/vscode-extension/src/previewConsistency.ts
+++ b/vscode-extension/src/previewConsistency.ts
@@ -1,0 +1,200 @@
+import * as fs from "fs";
+import * as path from "path";
+import { GradleService, ModuleInfo } from "./gradleService";
+import { PreviewInfo } from "./types";
+
+/**
+ * The user-visible bug the verify command targets: "I'm seeing a placeholder card on screen,
+ * but there's a perfectly good PNG sitting in `build/compose-previews/` for that preview." A
+ * stale image is OK (the daemon will replace it on the next render); an absent image when one
+ * exists on disk is NOT.
+ *
+ * The check is host-side: it compares the manifest (extension's view of the world), the
+ * filesystem (what's actually on disk under `build/compose-previews/`), and the host's image
+ * registry (the in-memory cache that backs the panel's per-card image bytes). If the registry
+ * mirror is missing bytes for a preview whose PNG is on disk, the panel is showing a
+ * placeholder unnecessarily and we report it.
+ */
+export type Inconsistency =
+    /** Preview's PNG exists on disk but the host's image registry doesn't have its bytes —
+     *  the most direct read of "user sees a placeholder while disk has the picture". */
+    | {
+          kind: "disk-has-png-registry-empty";
+          previewId: string;
+          pngPath: string;
+      }
+    /** Manifest lists a preview, but neither the registry nor the disk has any image for it.
+     *  Not necessarily a bug — could just be never-rendered — but reported separately so the
+     *  "what's missing where" picture is complete. */
+    | {
+          kind: "no-image-anywhere";
+          previewId: string;
+          expectedPngPath: string;
+      };
+
+export interface VerifyDeps {
+    readonly gradleService: GradleService;
+    /** Resolves the cached image bytes for a preview, or `null` when the registry has
+     *  nothing for it. The host's `PreviewRegistry` already exposes this shape. */
+    registryGetImage(previewId: string): string | null;
+    /** True when a file exists on disk. Decoupled from `fs` so tests can fake it. */
+    fileExists(filePath: string): boolean;
+}
+
+export interface VerifyResult {
+    /** Module the verify ran against. `null` when the file's module couldn't be resolved or
+     *  no `previews.json` was on disk. */
+    module: ModuleInfo | null;
+    /** Total previews the manifest claimed exist (including ones outside the active scope). */
+    manifestCount: number;
+    /** Previews whose first-capture PNG was found on disk. */
+    diskPngCount: number;
+    /** Previews whose host registry currently holds image bytes. */
+    registryImageCount: number;
+    /** Detected mismatches. Empty list = consistent. */
+    inconsistencies: Inconsistency[];
+}
+
+/**
+ * Resolves the on-disk path for a preview's first capture, the one the panel uses as its
+ * primary image. Mirrors `GradleService.readPreviewImage`'s lookup so the verify check reads
+ * from the exact same directory the host loads images from.
+ */
+export function pngPathFor(
+    workspaceRoot: string,
+    module: ModuleInfo,
+    preview: PreviewInfo,
+): string | null {
+    const capture = preview.captures.find((c) => !!c.renderOutput);
+    if (!capture || !capture.renderOutput) {
+        return null;
+    }
+    return path.join(
+        workspaceRoot,
+        module.projectDir,
+        "build",
+        "compose-previews",
+        capture.renderOutput,
+    );
+}
+
+/**
+ * Cross-check the manifest, the filesystem, and the host's image registry for the file
+ * currently scoped to the preview panel. Returns a structured report the caller surfaces to
+ * the user via an output channel + a status message.
+ *
+ * Designed to be cheap (one stat per preview + one Map lookup) so the user can invoke it
+ * repeatedly via the command palette without measurable cost.
+ */
+export function verifyConsistency(
+    filePath: string | null,
+    deps: VerifyDeps,
+): VerifyResult {
+    if (!filePath) {
+        return {
+            module: null,
+            manifestCount: 0,
+            diskPngCount: 0,
+            registryImageCount: 0,
+            inconsistencies: [],
+        };
+    }
+    const module = deps.gradleService.resolveModule(filePath);
+    if (!module) {
+        return {
+            module: null,
+            manifestCount: 0,
+            diskPngCount: 0,
+            registryImageCount: 0,
+            inconsistencies: [],
+        };
+    }
+    const manifest = deps.gradleService.readManifest(module);
+    if (!manifest) {
+        return {
+            module,
+            manifestCount: 0,
+            diskPngCount: 0,
+            registryImageCount: 0,
+            inconsistencies: [],
+        };
+    }
+    const inconsistencies: Inconsistency[] = [];
+    let diskPngCount = 0;
+    let registryImageCount = 0;
+    for (const preview of manifest.previews) {
+        const pngPath = pngPathFor(
+            deps.gradleService.workspaceRoot,
+            module,
+            preview,
+        );
+        const onDisk = pngPath !== null && deps.fileExists(pngPath);
+        const inRegistry = deps.registryGetImage(preview.id) !== null;
+        if (onDisk) diskPngCount++;
+        if (inRegistry) registryImageCount++;
+        if (onDisk && !inRegistry && pngPath !== null) {
+            inconsistencies.push({
+                kind: "disk-has-png-registry-empty",
+                previewId: preview.id,
+                pngPath,
+            });
+        } else if (!onDisk && !inRegistry && pngPath !== null) {
+            inconsistencies.push({
+                kind: "no-image-anywhere",
+                previewId: preview.id,
+                expectedPngPath: pngPath,
+            });
+        }
+    }
+    return {
+        module,
+        manifestCount: manifest.previews.length,
+        diskPngCount,
+        registryImageCount,
+        inconsistencies,
+    };
+}
+
+/**
+ * One-line summary suitable for the status bar / window message. The verbose breakdown
+ * (per-preview inconsistencies) goes into the output channel separately.
+ */
+export function describeVerifyResult(
+    filePath: string | null,
+    result: VerifyResult,
+): string {
+    if (!filePath) {
+        return "verify: no scope file";
+    }
+    if (!result.module) {
+        return `verify: no module for ${path.basename(filePath)}`;
+    }
+    if (result.manifestCount === 0) {
+        return `verify: no manifest for ${result.module.modulePath}`;
+    }
+    const stalePlaceholders = result.inconsistencies.filter(
+        (i) => i.kind === "disk-has-png-registry-empty",
+    ).length;
+    const neverRendered = result.inconsistencies.filter(
+        (i) => i.kind === "no-image-anywhere",
+    ).length;
+    const consistent = result.inconsistencies.length === 0;
+    return (
+        `verify: ${path.basename(filePath)} ` +
+        `manifest=${result.manifestCount} ` +
+        `disk=${result.diskPngCount} ` +
+        `registry=${result.registryImageCount} ` +
+        (consistent
+            ? "→ consistent"
+            : `→ ${stalePlaceholders} placeholder(s) with PNG on disk, ${neverRendered} never-rendered`)
+    );
+}
+
+/** Production-side {@link VerifyDeps.fileExists} backed by `fs.existsSync`. */
+export function realFileExists(filePath: string): boolean {
+    try {
+        return fs.existsSync(filePath);
+    } catch {
+        return false;
+    }
+}

--- a/vscode-extension/src/previewRegistry.ts
+++ b/vscode-extension/src/previewRegistry.ts
@@ -88,6 +88,13 @@ export class PreviewRegistry {
         );
     }
 
+    /** Image bytes the registry currently holds for [previewId], or `null` when the entry
+     *  is unknown or has never been set. Used by the consistency-verify command to detect
+     *  "panel shows placeholder while disk has a PNG" without exposing the internal Map. */
+    getImage(previewId: string): string | null {
+        return this.byId.get(previewId)?.imageBase64 ?? null;
+    }
+
     dispose(): void {
         this._onDidChange.dispose();
     }

--- a/vscode-extension/src/test/previewConsistency.test.ts
+++ b/vscode-extension/src/test/previewConsistency.test.ts
@@ -1,0 +1,269 @@
+import * as assert from "assert";
+import {
+    describeVerifyResult,
+    pngPathFor,
+    VerifyDeps,
+    verifyConsistency,
+} from "../previewConsistency";
+import { GradleService, ModuleInfo } from "../gradleService";
+import { PreviewInfo, PreviewManifest } from "../types";
+
+const mod = (modulePath: string): ModuleInfo =>
+    ({
+        modulePath,
+        projectDir: modulePath.replace(/^:/, "").replace(/:/g, "/"),
+    }) as ModuleInfo;
+
+function preview(id: string, renderOutput: string): PreviewInfo {
+    return {
+        id,
+        functionName: id.split(".").pop()!,
+        className: id.substring(0, id.lastIndexOf(".")),
+        sourceFile: "src/main/kotlin/Previews.kt",
+        params: {
+            name: null,
+            device: null,
+            widthDp: null,
+            heightDp: null,
+            fontScale: 1,
+            showSystemUi: false,
+            showBackground: false,
+            backgroundColor: 0,
+            uiMode: 0,
+            locale: null,
+            group: null,
+        },
+        captures: [{ advanceTimeMillis: null, scroll: null, renderOutput }],
+    } as PreviewInfo;
+}
+
+function fakeGradleService(opts: {
+    workspaceRoot?: string;
+    resolveModule?: (filePath: string) => ModuleInfo | null;
+    readManifest?: (module: ModuleInfo) => PreviewManifest | null;
+}): GradleService {
+    return {
+        workspaceRoot: opts.workspaceRoot ?? "/ws",
+        resolveModule: opts.resolveModule ?? (() => mod(":app")),
+        readManifest: opts.readManifest ?? (() => null),
+    } as unknown as GradleService;
+}
+
+function makeDeps(
+    gradle: GradleService,
+    registryImages: Map<string, string>,
+    diskFiles: Set<string>,
+): VerifyDeps {
+    return {
+        gradleService: gradle,
+        registryGetImage: (id) => registryImages.get(id) ?? null,
+        fileExists: (filePath) => diskFiles.has(filePath),
+    };
+}
+
+describe("verifyConsistency — empty / null cases", () => {
+    it("returns empty result when filePath is null", () => {
+        const result = verifyConsistency(
+            null,
+            makeDeps(fakeGradleService({}), new Map(), new Set()),
+        );
+        assert.strictEqual(result.module, null);
+        assert.strictEqual(result.manifestCount, 0);
+        assert.deepStrictEqual(result.inconsistencies, []);
+    });
+
+    it("returns empty result when the file resolves to no module", () => {
+        const result = verifyConsistency(
+            "/ws/orphan/X.kt",
+            makeDeps(
+                fakeGradleService({ resolveModule: () => null }),
+                new Map(),
+                new Set(),
+            ),
+        );
+        assert.strictEqual(result.module, null);
+        assert.strictEqual(result.manifestCount, 0);
+    });
+
+    it("returns module-only result when the manifest is absent", () => {
+        const module = mod(":app");
+        const result = verifyConsistency(
+            "/ws/app/Previews.kt",
+            makeDeps(
+                fakeGradleService({
+                    resolveModule: () => module,
+                    readManifest: () => null,
+                }),
+                new Map(),
+                new Set(),
+            ),
+        );
+        assert.strictEqual(result.module, module);
+        assert.strictEqual(result.manifestCount, 0);
+    });
+});
+
+describe("verifyConsistency — disagreement detection", () => {
+    it("reports disk-has-png-registry-empty when the PNG exists on disk but the registry is missing it", () => {
+        // The exact bug the verify command targets — user sees a placeholder card on screen
+        // while there's a perfectly good PNG under build/compose-previews/ on disk.
+        const module = mod(":app");
+        const p1 = preview("com.example.RedPreview", "renders/Red.png");
+        const expectedPath = "/ws/app/build/compose-previews/renders/Red.png";
+        const result = verifyConsistency(
+            "/ws/app/Previews.kt",
+            makeDeps(
+                fakeGradleService({
+                    workspaceRoot: "/ws",
+                    resolveModule: () => module,
+                    readManifest: () => ({ previews: [p1] }) as PreviewManifest,
+                }),
+                new Map(), // registry empty
+                new Set([expectedPath]), // disk has the PNG
+            ),
+        );
+        assert.strictEqual(result.manifestCount, 1);
+        assert.strictEqual(result.diskPngCount, 1);
+        assert.strictEqual(result.registryImageCount, 0);
+        assert.deepStrictEqual(result.inconsistencies, [
+            {
+                kind: "disk-has-png-registry-empty",
+                previewId: p1.id,
+                pngPath: expectedPath,
+            },
+        ]);
+    });
+
+    it("reports no-image-anywhere when neither disk nor registry has bytes for a manifest preview", () => {
+        const module = mod(":app");
+        const p1 = preview("com.example.RedPreview", "renders/Red.png");
+        const result = verifyConsistency(
+            "/ws/app/Previews.kt",
+            makeDeps(
+                fakeGradleService({
+                    workspaceRoot: "/ws",
+                    resolveModule: () => module,
+                    readManifest: () => ({ previews: [p1] }) as PreviewManifest,
+                }),
+                new Map(), // registry empty
+                new Set(), // disk empty
+            ),
+        );
+        assert.strictEqual(result.inconsistencies.length, 1);
+        assert.strictEqual(result.inconsistencies[0].kind, "no-image-anywhere");
+    });
+
+    it("is silent when the registry has the bytes — stale or fresh, the panel is showing something", () => {
+        // Per the user's spec: "we are ok with using stale cached images, as long as they
+        // will be replaced once regenerated". The check must NOT flag a registry hit, even
+        // if the on-disk PNG is missing.
+        const module = mod(":app");
+        const p1 = preview("com.example.RedPreview", "renders/Red.png");
+        const result = verifyConsistency(
+            "/ws/app/Previews.kt",
+            makeDeps(
+                fakeGradleService({
+                    workspaceRoot: "/ws",
+                    resolveModule: () => module,
+                    readManifest: () => ({ previews: [p1] }) as PreviewManifest,
+                }),
+                new Map([[p1.id, "BYTES"]]),
+                new Set(), // disk missing the PNG
+            ),
+        );
+        assert.deepStrictEqual(result.inconsistencies, []);
+        assert.strictEqual(result.registryImageCount, 1);
+    });
+
+    it("reports each affected preview independently when several have the same problem", () => {
+        const module = mod(":app");
+        const p1 = preview("com.example.RedPreview", "renders/Red.png");
+        const p2 = preview("com.example.BluePreview", "renders/Blue.png");
+        const p3 = preview("com.example.GreenPreview", "renders/Green.png");
+        const result = verifyConsistency(
+            "/ws/app/Previews.kt",
+            makeDeps(
+                fakeGradleService({
+                    workspaceRoot: "/ws",
+                    resolveModule: () => module,
+                    readManifest: () =>
+                        ({ previews: [p1, p2, p3] }) as PreviewManifest,
+                }),
+                new Map([[p2.id, "BYTES"]]), // only Blue is in the registry
+                new Set([
+                    "/ws/app/build/compose-previews/renders/Red.png",
+                    "/ws/app/build/compose-previews/renders/Blue.png",
+                ]), // Red + Blue on disk, Green missing
+            ),
+        );
+        // Red: disk has, registry doesn't → flagged
+        // Blue: both have → consistent
+        // Green: neither → no-image-anywhere
+        assert.strictEqual(result.inconsistencies.length, 2);
+        const flagged = result.inconsistencies.find(
+            (i) => i.kind === "disk-has-png-registry-empty",
+        );
+        const missing = result.inconsistencies.find(
+            (i) => i.kind === "no-image-anywhere",
+        );
+        assert.strictEqual(flagged?.previewId, p1.id);
+        assert.strictEqual(missing?.previewId, p3.id);
+    });
+});
+
+describe("pngPathFor", () => {
+    it("uses the first capture's renderOutput under build/compose-previews/", () => {
+        const module = mod(":app");
+        const p1 = preview("com.example.RedPreview", "renders/Red.png");
+        assert.strictEqual(
+            pngPathFor("/ws", module, p1),
+            "/ws/app/build/compose-previews/renders/Red.png",
+        );
+    });
+
+    it("returns null when the preview has no renderOutput", () => {
+        const module = mod(":app");
+        const p = {
+            ...preview("com.example.Nope", "x.png"),
+            captures: [{ advanceTimeMillis: null, scroll: null }],
+        } as unknown as PreviewInfo;
+        assert.strictEqual(pngPathFor("/ws", module, p), null);
+    });
+});
+
+describe("describeVerifyResult", () => {
+    it("reports the consistent case explicitly", () => {
+        const msg = describeVerifyResult("/ws/app/Previews.kt", {
+            module: mod(":app"),
+            manifestCount: 4,
+            diskPngCount: 4,
+            registryImageCount: 4,
+            inconsistencies: [],
+        });
+        assert.ok(msg.includes("consistent"), msg);
+        assert.ok(msg.includes("manifest=4"), msg);
+    });
+
+    it("counts placeholder and never-rendered separately", () => {
+        const msg = describeVerifyResult("/ws/app/Previews.kt", {
+            module: mod(":app"),
+            manifestCount: 3,
+            diskPngCount: 2,
+            registryImageCount: 1,
+            inconsistencies: [
+                {
+                    kind: "disk-has-png-registry-empty",
+                    previewId: "p1",
+                    pngPath: "/x",
+                },
+                {
+                    kind: "no-image-anywhere",
+                    previewId: "p2",
+                    expectedPngPath: "/y",
+                },
+            ],
+        });
+        assert.ok(msg.includes("1 placeholder"), msg);
+        assert.ok(msg.includes("1 never-rendered"), msg);
+    });
+});


### PR DESCRIPTION
## Summary

User-reported bug: "I see a placeholder card on screen while there's a perfectly good PNG sitting in `build/compose-previews/` on disk." Stale images are fine (the daemon replaces them on the next render); missing-from-UI when present-on-disk is not.

Add a **`Compose Preview: Verify`** command (Command Palette) that cross-checks three sources of truth:

- `previews.json` — the manifest the extension currently sees
- the filesystem — PNGs actually under `build/compose-previews/`
- the host's `PreviewRegistry` — in-memory image bytes the panel reads

When a preview's PNG is on disk but the registry has no bytes — the panel is showing a placeholder unnecessarily — the command reports it:

```
verify: Previews.kt manifest=4 disk=4 registry=2 → 2 placeholder(s) with PNG on disk, 0 never-rendered
  ⚠ com.example.PreviewsKt.RedBoxPreview: PNG on disk at <path> but registry is empty (panel is showing a placeholder unnecessarily)
```

A `no-image-anywhere` case is reported separately so the breakdown reads cleanly. **Registry-has-bytes cases are silent** per the user's spec ("we are ok with using stale cached images").

Surfaces:
- **Warning dialog** with a "Show output" action when placeholders-with-disk-PNG appear (jumps to the Compose Preview output channel for the per-preview list).
- **Information message** when consistent.

`PreviewRegistry` gets a small `getImage` accessor so the check reads the existing byte map without the call site reaching into the internal `byId` Map.

## Test plan

- [x] 11 new `previewConsistency.test.ts` cases:
  - Empty / null paths (no file, no module, no manifest).
  - Three disagreement shapes: `disk-has-png-registry-empty`, `no-image-anywhere`, and the critical **silent-when-registry-has-bytes** case (stale images OK).
  - Multi-preview independence (each affected preview reported separately).
  - `pngPathFor` lookup shape; `describeVerifyResult` wording for both consistent and mixed.
- [x] Full extension test suite 1316 → 1327 passing.
- [x] Command registered in `package.json`, surfaces as **"Compose Preview: Verify (cross-check manifest, disk, and panel state)"**.

This is the diagnostic surface for the broader "previews don't load" class of bugs. The orchestrator extraction (followup) will use the same cross-check structure as a test invariant.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHMXjmHqVzF8ituEJNyqXG)_