### PR TITLE
fix: stream large PR comment bodies via file to avoid ARG_MAX

### DIFF
--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -548,13 +548,14 @@ runs:
         # resolved body, no-diff+no-prior → only post resolved if
         # comment-on-empty-diff=true.
         RESOLVED_BODY="${MARKER}"$'\n'"## Resource Changes"$'\n\n'"_No resource changes in this PR's latest render._"
+        # Stream body via file when present — large resource diffs would
+        # otherwise blow ARG_MAX. RESOLVED_BODY is small and stays inline.
         if [ -s _comment_body_resources.md ]; then
-          BODY=$(cat _comment_body_resources.md)
           if [ -n "$COMMENT_ID" ]; then
             gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
-              -X PATCH -f body="$BODY"
+              -X PATCH -f "body=@_comment_body_resources.md"
           else
-            gh pr comment "$PR_NUMBER" --body "$BODY"
+            gh pr comment "$PR_NUMBER" --body-file _comment_body_resources.md
           fi
         elif [ -n "$COMMENT_ID" ]; then
           gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \

--- a/.github/actions/apply/lib/post-comment.sh
+++ b/.github/actions/apply/lib/post-comment.sh
@@ -20,7 +20,10 @@ set -euo pipefail
 : "${BODY_FILE:?BODY_FILE required}"
 : "${GH_TOKEN:?GH_TOKEN required}"
 
-BODY=$(cat "$BODY_FILE")
+# Pass the body via file rather than argv — preview/a11y diffs can exceed
+# ARG_MAX (~128KB on Linux), which fails with "Argument list too long".
+# `gh pr comment --body-file` and `gh api -f key=@file` both stream from
+# the file instead of expanding it into the command line.
 
 COMMENT_ID=$(gh api \
   "repos/${REPO}/issues/${PR_NUMBER}/comments" \
@@ -30,7 +33,7 @@ COMMENT_ID=$(gh api \
 
 if [ -n "$COMMENT_ID" ]; then
   gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
-    -X PATCH -f body="$BODY"
+    -X PATCH -f "body=@${BODY_FILE}"
 else
-  gh pr comment "$PR_NUMBER" --body "$BODY"
+  gh pr comment "$PR_NUMBER" --body-file "$BODY_FILE"
 fi


### PR DESCRIPTION
## Summary

Fixes an issue where large PR comment bodies (particularly preview/a11y diffs) could exceed the system's `ARG_MAX` limit (~128KB on Linux), causing "Argument list too long" errors when posting comments.

## Changes

- **post-comment.sh**: Modified to stream comment body from file instead of expanding it into command arguments
  - Removed inline `BODY=$(cat "$BODY_FILE")` variable expansion
  - Updated `gh api` call to use `-f "body=@${BODY_FILE}"` for streaming
  - Updated `gh pr comment` call to use `--body-file` flag instead of `--body`
  - Added explanatory comment about why file streaming is necessary

- **action.yml**: Applied the same fix to resource diff comment posting logic
  - Removed inline body variable expansion
  - Updated `gh api` call to use `-f "body=@_comment_body_resources.md"`
  - Updated `gh pr comment` call to use `--body-file` flag
  - Added comment explaining the file streaming approach

## Implementation Details

Both `gh pr comment --body-file` and `gh api -f key=@file` stream the file content directly rather than expanding it into the command line, avoiding the ARG_MAX limit. This allows arbitrarily large diffs to be posted without hitting system argument size restrictions.

https://claude.ai/code/session_014jhxy25KvfsiPvjtSSgVwd