### PR TITLE
fix(cli): auto-enable mavenLocal for SNAPSHOT plugin versions

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -63,12 +63,16 @@ internal fun renderInitScript(pluginVersion: String): String =
 // The withPlugin hooks in projects that already apply the plugin no-op via
 // the plugins.hasPlugin(...) guard.
 //
-// `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1` opts the buildscript repos into
-// `mavenLocal()` — exercised by the gradle-plugin functional tests, which
-// resolve the plugin from `~/.m2` (where `:publishToMavenLocal` puts it)
-// rather than Maven Central. Plain users have no reason to flip this on:
-// it widens the search surface to whatever snapshots happen to be cached
-// locally and is therefore opt-in, not the default.
+// `mavenLocal()` is added to the buildscript / settings repos automatically
+// when [pluginVersion] ends in `-SNAPSHOT` — the only place an unpublished
+// SNAPSHOT plugin can live is `~/.m2`, so a SNAPSHOT CLI that doesn't seed
+// it is unusable. Released CLIs leave `~/.m2` untouched: the plugin is on
+// Plugin Portal / Maven Central, and widening the search surface to local
+// snapshots would only invite accidental version mismatches.
+// `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1` still forces the seed on for
+// non-SNAPSHOT runs — used by the gradle-plugin functional tests, which
+// publish the CLI's own release version to `~/.m2` and resolve from there
+// rather than Maven Central.
 //
 // Auto-inject is suppressed for modules that apply
 // `com.android.kotlin.multiplatform.library` — the AGP-KMP plugin's single
@@ -106,7 +110,8 @@ internal fun renderInitScript(pluginVersion: String): String =
 // AGP visibility stays intact.
 
 val pluginVersion = "$pluginVersion"
-val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
+val useMavenLocal = pluginVersion.endsWith("-SNAPSHOT") ||
+    System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
 
 var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()
 var composeAiPreviewKmpAndroidDirs: Set<java.io.File> = emptySet()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -577,7 +577,7 @@ class AutoInjectTest {
   }
 
   @Test
-  fun `init script seeds settings-level mavenLocal when COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL is set`() {
+  fun `init script seeds settings-level mavenLocal automatically for SNAPSHOT versions`() {
     // wear-os-samples WearTilesKotlin (and any consumer that sets
     // `RepositoriesMode.FAIL_ON_PROJECT_REPOS` in settings.gradle.kts) refuses per-project repos —
     // a per-project `mavenLocal()` is not enough for renderer-android AAR resolution. The
@@ -586,10 +586,19 @@ class AutoInjectTest {
     // from `~/.m2`. `pluginManagement.repositories.mavenLocal()` covers the plugins-DSL resolution
     // path for the catalog-alias / literal-`id(...) version "..."` case where we skip our own
     // buildscript classpath injection.
+    //
+    // SNAPSHOT versions enable the seed unconditionally — an unpublished SNAPSHOT plugin can only
+    // live in `~/.m2`, so a SNAPSHOT CLI that doesn't add mavenLocal is unusable against
+    // consumers that don't already have it in their settings. Released versions still gate on the
+    // `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1` env var (asserted in the sibling test below).
     val script = renderInitScript("0.1.0-SNAPSHOT")
     assertTrue(
       script.contains("if (useMavenLocal) {"),
-      "expected the mavenLocal seeding to be gated on the COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL flag",
+      "expected the mavenLocal seeding to live under a runtime `useMavenLocal` gate",
+    )
+    assertTrue(
+      script.contains("pluginVersion.endsWith(\"-SNAPSHOT\")"),
+      "expected SNAPSHOT versions to auto-enable useMavenLocal",
     )
     assertTrue(
       script.contains("pluginManagement.repositories.mavenLocal()"),
@@ -598,6 +607,18 @@ class AutoInjectTest {
     assertTrue(
       script.contains("dependencyResolutionManagement.repositories.mavenLocal()"),
       "expected dependencyResolutionManagement-level mavenLocal seeding for runtime AAR resolution",
+    )
+  }
+
+  @Test
+  fun `init script keeps COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL escape hatch for non-SNAPSHOT runs`() {
+    // The gradle-plugin functional tests publish the CLI's own release version to `~/.m2` and
+    // resolve from there rather than Maven Central. Releasing the SNAPSHOT auto-seed regression
+    // shouldn't take the env-var path with it.
+    val script = renderInitScript("0.11.10")
+    assertTrue(
+      script.contains("System.getenv(\"COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL\") == \"1\""),
+      "expected the env-var escape hatch to survive for release builds",
     )
   }
 

--- a/vscode-extension/src/initScript.ts
+++ b/vscode-extension/src/initScript.ts
@@ -65,12 +65,15 @@ export function renderInitScript(
 // classpath). The withPlugin hooks in projects that already apply the
 // plugin no-op via the plugins.hasPlugin(...) guard.
 //
-// \`COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1\` opts the buildscript repos into
-// \`mavenLocal()\` — mirrors the CLI's AutoInject.kt behavior. Useful for
-// pointing the extension at a locally-published SNAPSHOT of the plugin
-// during dev (e.g. \`./gradlew publishToMavenLocal\` against this repo, then
-// launch VS Code with the flag set). Off by default so cached snapshots
-// don't widen the search surface for normal users.
+// \`mavenLocal()\` is added to the buildscript / settings repos automatically
+// when \`pluginVersion\` ends in \`-SNAPSHOT\` — mirrors the CLI's AutoInject.kt
+// behavior. The only place an unpublished SNAPSHOT plugin can live is
+// \`~/.m2\` (\`./gradlew publishToMavenLocal\` against this repo), so a SNAPSHOT
+// build that doesn't seed it is unusable. Released versions leave \`~/.m2\`
+// alone: the plugin is on Plugin Portal / Maven Central, and widening the
+// search surface to local snapshots would only invite version skew.
+// \`COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1\` still forces the seed on for
+// non-SNAPSHOT runs.
 
 // Auto-inject is suppressed when the consumer's settings file declares
 // \`exclusiveContent { ... }\` inside \`pluginManagement { repositories { ... } }\`
@@ -82,7 +85,8 @@ export function renderInitScript(
 // "plugin not applied" warning still directs users to apply the plugin manually.
 
 val pluginVersion = "${pluginVersion}"
-val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
+val useMavenLocal = pluginVersion.endsWith("-SNAPSHOT") ||
+    System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"
 
 var composeAiPreviewPreAppliedDirs: Set<java.io.File> = emptySet()
 var composeAiPreviewSettingsHasExclusiveContent: Boolean = false

--- a/vscode-extension/src/test/initScript.test.ts
+++ b/vscode-extension/src/test/initScript.test.ts
@@ -250,12 +250,14 @@ describe("renderInitScript", () => {
         // Mirrors the CLI's AutoInject.kt — the env var is read inside the
         // rendered Kotlin (at Gradle invocation time), so users can flip
         // mavenLocal on per-invocation without re-rendering the script.
+        // SNAPSHOT versions auto-enable the seed; non-SNAPSHOT runs still
+        // honor the env-var escape hatch.
         const script = renderInitScript();
         assert.ok(
             script.includes(
-                'val useMavenLocal = System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"',
+                'val useMavenLocal = pluginVersion.endsWith("-SNAPSHOT") ||\n    System.getenv("COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL") == "1"',
             ),
-            "expected useMavenLocal to be read from env inside the rendered Kotlin",
+            "expected useMavenLocal to be SNAPSHOT-aware with an env-var escape hatch",
         );
         assert.ok(
             script.includes("if (useMavenLocal) mavenLocal()"),


### PR DESCRIPTION
## Summary
- Auto-inject's `useMavenLocal` flag now flips on whenever the rendered `pluginVersion` ends in `-SNAPSHOT`. Released CLIs still leave `~/.m2` alone.
- Removes the footgun where running a locally-built CLI (e.g. against cadence, meshcore-mobile, homeassistant-remotecompose) required exporting `COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL=1` to find the matching SNAPSHOT plugin classpath — failure mode was `Could not find ee.schimke.composeai.preview:...:X.Y.Z-SNAPSHOT`, no hint at the env var.
- The env var still works as an escape hatch for the gradle-plugin functional tests, which publish the *release* version to `~/.m2` and resolve from there.
- Mirrored in `vscode-extension/src/initScript.ts` plus unit tests on both sides.

## Test plan
- [x] `./gradlew :cli:test --tests AutoInjectTest` passes
- [x] `cd vscode-extension && npm test` passes (1326 tests)
- [x] Smoke: `compose-preview list` against cadence (37 previews), meshcore-mobile (63), homeassistant-remotecompose (268) — no env var set
- [x] Smoke: `compose-preview render` against cadence (36 rendered) and HA (266 rendered) — no env var set