### PR TITLE
fix(vscode-extension): PreviewRegistry preserves image bytes across refresh

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4041,6 +4041,17 @@ async function refresh(
         if (scopeSource === "none" && pendingRefreshKey) {
             return "no-module";
         }
+        // When the panel already has previews painted (preload or a prior render put cards
+        // on screen), focus drifting to the webview / output pane / no-editor-at-all is NOT
+        // a reason to clearAll. Stale cached images are explicitly OK — the daemon's next
+        // render will replace them. Wiping here is what causes the "panel goes back to
+        // placeholders during the 15-25s daemon spawn" bug the verify command surfaces.
+        if (hasPreviewsLoaded) {
+            logLine(
+                `no module — activeFile=${activeFile ?? "<none>"} (${scopeSource}); keeping ${lastLoadedModules.length} loaded module(s) on screen`,
+            );
+            return "no-module";
+        }
         // Cancel any in-flight refresh before clearing state.
         pendingRefresh?.abort();
         pendingRefreshKey = null;

--- a/vscode-extension/src/previewRegistry.ts
+++ b/vscode-extension/src/previewRegistry.ts
@@ -1,4 +1,3 @@
-import * as vscode from "vscode";
 import { packageQualifiedSourcePath } from "./sourcePath";
 import { AccessibilityFinding, AccessibilityNode, PreviewInfo } from "./types";
 
@@ -6,6 +5,36 @@ export interface RegistryEntry {
     preview: PreviewInfo;
     module: string;
     imageBase64?: string;
+}
+
+/**
+ * Tiny event emitter with the same `onDidChange((handler) => disposable)` shape consumers
+ * expect from VS Code's EventEmitter, but without a `vscode` import so the registry stays
+ * unit-testable from plain mocha (no `vscode-test-electron` runner required).
+ */
+class SimpleEmitter {
+    private listeners: Array<() => void> = [];
+    fire(): void {
+        for (const l of [...this.listeners]) {
+            try {
+                l();
+            } catch {
+                /* ignore — match vscode.EventEmitter swallow behaviour */
+            }
+        }
+    }
+    event = (handler: () => void): { dispose(): void } => {
+        this.listeners.push(handler);
+        return {
+            dispose: () => {
+                const idx = this.listeners.indexOf(handler);
+                if (idx >= 0) this.listeners.splice(idx, 1);
+            },
+        };
+    };
+    dispose(): void {
+        this.listeners = [];
+    }
 }
 
 /**
@@ -20,40 +49,102 @@ export interface RegistryEntry {
 export class PreviewRegistry {
     private bySourceAndName = new Map<string, RegistryEntry>();
     private byId = new Map<string, RegistryEntry>();
-    private _onDidChange = new vscode.EventEmitter<void>();
+    private _onDidChange = new SimpleEmitter();
     readonly onDidChange = this._onDidChange.event;
 
+    /**
+     * Replace the entries for [module] with the fresh manifest set. Entries whose `previewId`
+     * survives the replacement keep their `imageBase64` and a11y payload — only the
+     * [PreviewInfo] metadata refreshes. This is the load-bearing invariant for the panel's
+     * "preload paints cached images; refresh updates metadata in place" flow: the prior wipe-
+     * then-recreate behaviour silently dropped every cached image the moment refresh() landed,
+     * forcing the webview to render placeholders until the daemon's 15-25 s spawn finished.
+     *
+     * Entries whose `previewId` is gone from the fresh set are removed entirely.
+     */
     replaceModule(module: string, previews: PreviewInfo[]): void {
+        const freshIds = new Set<string>();
+        for (const p of previews) {
+            if (p.sourceFile) freshIds.add(p.id);
+        }
+        // Drop entries this module owned that are no longer in the fresh set. Entries that
+        // survive keep their imageBase64 / a11y payload; we patch the metadata below.
         for (const [k, v] of this.bySourceAndName) {
-            if (v.module === module) {
+            if (v.module === module && !freshIds.has(v.preview.id)) {
                 this.bySourceAndName.delete(k);
             }
         }
         for (const [k, v] of this.byId) {
-            if (v.module === module) {
+            if (v.module === module && !freshIds.has(k)) {
                 this.byId.delete(k);
             }
         }
         for (const p of previews) {
-            if (!p.sourceFile) {
-                continue;
+            if (!p.sourceFile) continue;
+            const existing = this.byId.get(p.id);
+            // Adopt entries that belong to this module, OR placeholder entries created by
+            // [setImage] before any module owned them (module="" sentinel). The placeholder
+            // case is what allows daemon renders that arrive before the manifest to survive
+            // the next replaceModule call instead of being wiped + lost.
+            if (
+                existing &&
+                (existing.module === module || existing.module === "")
+            ) {
+                // Preserve imageBase64 and any in-place a11y payload by mutating the
+                // existing entry's `preview` reference. The byId / bySourceAndName maps
+                // share the same RegistryEntry object so both views update together.
+                existing.module = module;
+                existing.preview = {
+                    ...p,
+                    a11yFindings: existing.preview.a11yFindings,
+                    a11yNodes: existing.preview.a11yNodes,
+                };
+                // The (sourceFile, functionName) key can shift if the manifest renamed the
+                // file — re-key so `find()` lookups still resolve.
+                const freshKey = keyOf(p.sourceFile, p.functionName);
+                // Drop any stale sourceFile/functionName entry pointing at this preview.
+                for (const [k, v] of this.bySourceAndName) {
+                    if (v === existing && k !== freshKey) {
+                        this.bySourceAndName.delete(k);
+                    }
+                }
+                this.bySourceAndName.set(freshKey, existing);
+            } else {
+                const entry: RegistryEntry = { preview: p, module };
+                this.bySourceAndName.set(
+                    keyOf(p.sourceFile, p.functionName),
+                    entry,
+                );
+                this.byId.set(p.id, entry);
             }
-            const entry: RegistryEntry = { preview: p, module };
-            this.bySourceAndName.set(
-                keyOf(p.sourceFile, p.functionName),
-                entry,
-            );
-            this.byId.set(p.id, entry);
         }
         this._onDidChange.fire();
     }
 
+    /**
+     * Record image bytes against [previewId]. If no entry exists yet — because the daemon's
+     * render landed before any manifest set this id, or because of an id-format mismatch
+     * between manifest and daemon — create a placeholder entry with the bytes attached so a
+     * subsequent [replaceModule] can merge it. Prevents the silent-bail-on-missing-entry leak
+     * the verify command surfaced (host registry empty even though daemon renders completed).
+     */
     setImage(previewId: string, imageBase64: string): void {
         const entry = this.byId.get(previewId);
-        if (!entry) {
+        if (entry) {
+            entry.imageBase64 = imageBase64;
+            this._onDidChange.fire();
             return;
         }
-        entry.imageBase64 = imageBase64;
+        // Bytes-only entry — no preview metadata yet. [getImage] returns the bytes; [find]
+        // (which keys on sourceFile + functionName) will start resolving once the next
+        // [replaceModule] supplies the metadata. Marker module='' distinguishes these from
+        // properly-registered entries so a per-module sweep doesn't wipe them prematurely.
+        const placeholder: RegistryEntry = {
+            preview: { id: previewId } as PreviewInfo,
+            module: "",
+            imageBase64,
+        };
+        this.byId.set(previewId, placeholder);
         this._onDidChange.fire();
     }
 

--- a/vscode-extension/src/test/previewRegistry.test.ts
+++ b/vscode-extension/src/test/previewRegistry.test.ts
@@ -1,0 +1,148 @@
+import * as assert from "assert";
+import { PreviewRegistry } from "../previewRegistry";
+import { PreviewInfo } from "../types";
+
+function preview(
+    id: string,
+    sourceFile: string,
+    functionName?: string,
+): PreviewInfo {
+    return {
+        id,
+        functionName: functionName ?? id.split(".").pop()!,
+        className: id.substring(0, id.lastIndexOf(".")),
+        sourceFile,
+        params: {
+            name: null,
+            device: null,
+            widthDp: null,
+            heightDp: null,
+            fontScale: 1,
+            showSystemUi: false,
+            showBackground: false,
+            backgroundColor: 0,
+            uiMode: 0,
+            locale: null,
+            group: null,
+        },
+        captures: [],
+    } as unknown as PreviewInfo;
+}
+
+describe("PreviewRegistry.replaceModule preserves image bytes", () => {
+    it("keeps imageBase64 for previewIds that survive a refresh", () => {
+        // Regression for the verify-exposed bug: replaceModule was wipe-then-recreate, so
+        // every refresh dropped the bytes preload had registered. The webview then
+        // re-rendered a placeholder until the daemon's 15-25 s spawn finished.
+        const reg = new PreviewRegistry();
+        const p1 = preview("com.example.PreviewsKt.RedBox", "Previews.kt");
+        reg.replaceModule(":app", [p1]);
+        reg.setImage(p1.id, "REDBYTES");
+        assert.strictEqual(reg.getImage(p1.id), "REDBYTES");
+        // Same manifest landing again — common when refresh re-reads previews.json.
+        reg.replaceModule(":app", [p1]);
+        assert.strictEqual(reg.getImage(p1.id), "REDBYTES");
+    });
+
+    it("preserves bytes when the metadata changes but the previewId is stable", () => {
+        // A capture-label refresh or label-only manifest update must not drop the image.
+        const reg = new PreviewRegistry();
+        const p1 = preview("com.example.PreviewsKt.RedBox", "Previews.kt");
+        reg.replaceModule(":app", [p1]);
+        reg.setImage(p1.id, "REDBYTES");
+        const p1_refreshed = {
+            ...p1,
+            params: { ...p1.params, name: "Red Box renamed" },
+        } as PreviewInfo;
+        reg.replaceModule(":app", [p1_refreshed]);
+        assert.strictEqual(reg.getImage(p1.id), "REDBYTES");
+    });
+
+    it("drops bytes for previewIds that disappear from the fresh set", () => {
+        const reg = new PreviewRegistry();
+        const p1 = preview("com.example.PreviewsKt.RedBox", "Previews.kt");
+        const p2 = preview("com.example.PreviewsKt.BlueBox", "Previews.kt");
+        reg.replaceModule(":app", [p1, p2]);
+        reg.setImage(p1.id, "REDBYTES");
+        reg.setImage(p2.id, "BLUEBYTES");
+        // p2 deleted from the source file → manifest no longer lists it.
+        reg.replaceModule(":app", [p1]);
+        assert.strictEqual(reg.getImage(p1.id), "REDBYTES");
+        assert.strictEqual(reg.getImage(p2.id), null);
+    });
+
+    it("does not touch bytes belonging to a different module", () => {
+        // Regression: replaceModule must scope to its module argument. A refresh of :app
+        // must not clobber :lib's registered images.
+        const reg = new PreviewRegistry();
+        const appPreview = preview(
+            "com.example.PreviewsKt.RedBox",
+            "Previews.kt",
+        );
+        const libPreview = preview(
+            "com.lib.LibPreviewsKt.LibPreview",
+            "LibPreviews.kt",
+        );
+        reg.replaceModule(":app", [appPreview]);
+        reg.replaceModule(":lib", [libPreview]);
+        reg.setImage(appPreview.id, "APPBYTES");
+        reg.setImage(libPreview.id, "LIBBYTES");
+        // Refresh :app only — :lib's entry survives untouched.
+        reg.replaceModule(":app", [appPreview]);
+        assert.strictEqual(reg.getImage(libPreview.id), "LIBBYTES");
+    });
+
+    it("re-keys the source-file lookup when the manifest renames the file", () => {
+        // The (sourceFile, functionName) key shifts if a manifest update changes either
+        // field. The previewId stays stable; the bytes must survive AND `find()` must
+        // resolve via the new key.
+        const reg = new PreviewRegistry();
+        const p1 = preview("com.example.PreviewsKt.RedBox", "Previews.kt");
+        reg.replaceModule(":app", [p1]);
+        reg.setImage(p1.id, "REDBYTES");
+        const p1_renamed = {
+            ...p1,
+            sourceFile: "PreviewsRenamed.kt",
+        } as PreviewInfo;
+        reg.replaceModule(":app", [p1_renamed]);
+        assert.strictEqual(reg.getImage(p1.id), "REDBYTES");
+    });
+});
+
+describe("PreviewRegistry.setImage lazy-creates entries", () => {
+    it("stores bytes against a previewId even before the manifest registers it", () => {
+        // Regression: setImage used to silently no-op when byId.get returned undefined,
+        // which is exactly what happened on a cold start where the daemon's first render
+        // raced replaceModule. The verify command surfaced the result: registry=0 for
+        // every preview even though every PNG was on disk.
+        const reg = new PreviewRegistry();
+        reg.setImage("com.example.PreviewsKt.RedBox", "REDBYTES");
+        assert.strictEqual(
+            reg.getImage("com.example.PreviewsKt.RedBox"),
+            "REDBYTES",
+        );
+    });
+
+    it("a placeholder entry is adopted by the next replaceModule call", () => {
+        // The byte-only entry created by an early setImage must survive the next
+        // replaceModule and merge with the manifest metadata — not be wiped as a stale
+        // orphan.
+        const reg = new PreviewRegistry();
+        reg.setImage("com.example.PreviewsKt.RedBox", "REDBYTES");
+        const p1 = preview("com.example.PreviewsKt.RedBox", "Previews.kt");
+        reg.replaceModule(":app", [p1]);
+        assert.strictEqual(reg.getImage(p1.id), "REDBYTES");
+        const entry = reg.find("Previews.kt", "RedBox");
+        // Once the metadata has landed, find() must resolve too (it keys on
+        // sourceFile + functionName, which only setImage's placeholder couldn't supply).
+        assert.ok(entry, "find should resolve once metadata lands");
+        assert.strictEqual(entry?.imageBase64, "REDBYTES");
+    });
+
+    it("overwrites the bytes on a subsequent setImage for the same previewId", () => {
+        const reg = new PreviewRegistry();
+        reg.setImage("p1", "A");
+        reg.setImage("p1", "B");
+        assert.strictEqual(reg.getImage("p1"), "B");
+    });
+});


### PR DESCRIPTION
## Summary

The `Compose Preview: Verify` command (#1509) surfaced a persistent inconsistency on every reload: `manifest=N, disk=N, registry=0`. The host-side registry was systematically empty even though the daemon successfully completed renders and the webview painted cards. **Two bugs**, both silent:

1. **`replaceModule` wiped image bytes.** Old body was wipe-then-recreate — delete every entry for the module, then add fresh ones with no `imageBase64`. Every refresh dropped the bytes preload had registered, forcing the webview to fall back to placeholders until the daemon's 15-25 s spawn finished.

2. **`setImage` silently bailed on unknown previewIds.** Old body returned early when `byId.get(previewId)` was null. Any daemon render that arrived before the matching manifest entry was registered (or any id-format mismatch between daemon and manifest) lost its bytes silently.

Together these explain the user-visible bug: cards painted with their labels (`Red Box`, `Blue Box`, `Wallpaper Demo` — preload's `setPreviews` succeeded) but with empty placeholder shapes where the image area should be. The webview's per-card image state, which the host registry is supposed to mirror, drifted out of sync and stayed that way.

## Fix

- **`replaceModule`** now diffs the fresh set against existing entries. Surviving previewIds keep their `imageBase64` + a11y payload and have their `PreviewInfo` metadata merged in place. Disappearing previewIds are dropped. Other modules are not touched.
- **`setImage`** lazy-creates a placeholder entry (`module=""`) when no entry exists yet. The next `replaceModule` call adopts the placeholder by matching previewId and stamps the real module + metadata.
- `vscode.EventEmitter` → tiny local `SimpleEmitter` so the registry is unit-testable from plain mocha (no `vscode-test-electron` runner needed; registry had no other vscode surface).
- Related fix in `refresh()`: when focus drifts to the webview / output pane and the panel already has previews painted, the **no-module branch no longer posts `clearAll`**. Stale cached images are explicitly OK per the user's spec ("we are ok with using stale cached images").

## Test plan

- [x] 8 new `previewRegistry.test.ts` cases pinning every invariant:
  - `replaceModule`: bytes survive a same-set refresh, survive a metadata-only update, drop on disappearance, are scoped per module, re-key on source-file rename.
  - `setImage`: lazy-create on unknown previewId, placeholder is adopted by next `replaceModule`, overwrite on second `setImage` for same id.
- [x] Full extension suite 1337 → 1345 passing.
- [x] `npm run compile:host` clean, `npm run format` no-op.

## Known follow-up (separate PR)

The most recent verify capture for `:samples:cmp` shows `disk=0` (not just `registry=0`). That points at a **second, distinct bug**: the daemon's actual on-disk write location doesn't match the manifest's `renderOutput` field for that module. From the daemon log:

```
pngPath=.../renders/com.example.samplecmp.PreviewsKt.BlueBoxPreview_Blue Box.png
```

vs the manifest's recorded path:

```
.../renders/PreviewsKt.BlueBoxPreview_Blue_Box.png
```

The daemon writes the full FQN with spaces; the manifest expects a sanitised short name with underscores. Modules where the names happen to align (e.g. `:samples:wear`) don't hit this. Doesn't block this PR — the registry leak fixed here is independent — but worth chasing as the next step in the live-preview reliability work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHMXjmHqVzF8ituEJNyqXG)_