### PR TITLE
test: improve a11y e2e diagnostics and add kotlin language stub

### DIFF
--- a/.github/workflows/vscode-extension-e2e-external.yml
+++ b/.github/workflows/vscode-extension-e2e-external.yml
@@ -81,11 +81,28 @@ jobs:
 
       # Publish the plugin + every supporting module to mavenLocal so
       # the consumer's catalog resolves to *this* commit, not the
-      # already-released coordinate Maven Central serves. `publishToMavenLocal`
-      # without a project filter fans out to every module the
-      # `composeai.maven-publishing` convention plugin applies to.
+      # already-released coordinate Maven Central serves.
+      #
+      # The root `./gradlew publishToMavenLocal` fans out across every
+      # *outer-build* module the `composeai.maven-publishing` convention
+      # plugin applies to (preview-annotations, preview-data-api,
+      # renderer-desktop, the data-* runtimes, etc.) — but `:gradle-plugin`
+      # itself is wired into the outer build via `includeBuild("gradle-plugin")`,
+      # and task-name fan-out does NOT cross composite-build boundaries.
+      # So a plain `publishToMavenLocal` from the root leaves Maven Central
+      # to serve the *released* plugin coordinate, against which the
+      # consumer-resolved catalog rewrite — pointing at the about-to-publish
+      # SNAPSHOT — can't resolve. The Confetti `composePreviewApplied`
+      # warmup then fails with:
+      #   Plugin [id: 'ee.schimke.composeai.preview', version: '<X>-SNAPSHOT']
+      #     was not found in any of the following sources
+      # Drive the included build's own `publishToMavenLocal` task explicitly
+      # via `-p gradle-plugin` so its build script's fan-out
+      # (`:preview-discovery` + `:daemon-launch-builder`) runs too.
       - name: Publish plugin to mavenLocal
-        run: ./gradlew publishToMavenLocal --no-daemon
+        run: |
+          ./gradlew publishToMavenLocal --no-daemon
+          ./gradlew -p gradle-plugin publishToMavenLocal --no-daemon
 
       - name: Install extension dependencies
         working-directory: vscode-extension

--- a/.github/workflows/vscode-extension-e2e.yml
+++ b/.github/workflows/vscode-extension-e2e.yml
@@ -82,6 +82,7 @@ jobs:
           name: e2e-renders
           path: |
             samples/cmp/build/compose-previews/
+            samples/wear/build/compose-previews/
             vscode-extension/.vscode-test/user-data/logs/
           if-no-files-found: ignore
           retention-days: 7

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -552,6 +552,18 @@ export interface ComposePreviewTestApi {
     /** Drop both message buffers (posted + received). */
     resetMessages(): void;
     /**
+     * Snapshot of the last [n] lines written to the `Compose Preview` output
+     * channel since extension activation. Used by e2e tests to dump the
+     * daemon channel (`[daemon] dataSubscribe(...) failed: ...` etc.) when a
+     * `waitFor` for a webview ack times out — those failures are otherwise
+     * silent because the scheduler catches and swallows the underlying
+     * dataSubscribe / post-subscribe renderNow rejection. Capped at 2000
+     * lines internally so a long suite can't OOM the host. Empty unless
+     * COMPOSE_PREVIEW_TEST_MODE=1, but the test electron host always sets
+     * that.
+     */
+    getOutputChannelTail(n?: number): string[];
+    /**
      * `true` once the resolved webview has signalled `webviewReady` at
      * least once this session. Survives [resetMessages] so a later test
      * suite can confirm the webview is alive without depending on a
@@ -714,8 +726,54 @@ export async function activate(
 
     extensionContext = context;
     const workspaceRoot = workspaceFolders[0].uri.fsPath;
-    const outputChannel = vscode.window.createOutputChannel("Compose Preview");
-    context.subscriptions.push(outputChannel);
+    const rawOutputChannel =
+        vscode.window.createOutputChannel("Compose Preview");
+    context.subscriptions.push(rawOutputChannel);
+    // E2E diagnostic capture. The wear a11y suite times out 60s after a
+    // `data/subscribe` call without surfacing why — the daemon channel's
+    // `dataSubscribe(...) failed` / `post-subscribe renderNow(...) failed`
+    // lines have the answer but live only in the `Compose Preview` output
+    // channel, which is not part of the test electron host's serialised
+    // logs. Under COMPOSE_PREVIEW_TEST_MODE=1 wrap the channel with a
+    // capped ring buffer so tests can dump the tail when a wait-for
+    // times out. Bounded so a long-running suite can't OOM the host.
+    const outputChannelTail: string[] = [];
+    const OUTPUT_CHANNEL_TAIL_MAX = 2000;
+    const captureOutputChannelLine =
+        process.env.COMPOSE_PREVIEW_TEST_MODE === "1"
+            ? (line: string) => {
+                  outputChannelTail.push(line);
+                  if (outputChannelTail.length > OUTPUT_CHANNEL_TAIL_MAX) {
+                      outputChannelTail.splice(
+                          0,
+                          outputChannelTail.length - OUTPUT_CHANNEL_TAIL_MAX,
+                      );
+                  }
+              }
+            : null;
+    const outputChannel: vscode.OutputChannel = captureOutputChannelLine
+        ? new Proxy(rawOutputChannel, {
+              get(target, prop, receiver) {
+                  if (prop === "appendLine") {
+                      return (value: string) => {
+                          captureOutputChannelLine(value);
+                          target.appendLine(value);
+                      };
+                  }
+                  if (prop === "append") {
+                      return (value: string) => {
+                          // `append` doesn't add a newline; treat the call as
+                          // a partial line for capture purposes (good enough
+                          // for diagnostic tail — production output is
+                          // overwhelmingly appendLine).
+                          captureOutputChannelLine(value);
+                          target.append(value);
+                      };
+                  }
+                  return Reflect.get(target, prop, receiver);
+              },
+          })
+        : rawOutputChannel;
     // `composePreview.logging.level` is read on every emit so a settings.json
     // edit takes effect immediately without a window reload.
     const logFilter = new LogFilter(() =>
@@ -2092,6 +2150,13 @@ export async function activate(
             resetMessages(): void {
                 postedMessageLog.length = 0;
                 receivedMessageLog.length = 0;
+            },
+            getOutputChannelTail(n?: number): string[] {
+                if (typeof n !== "number" || n >= outputChannelTail.length) {
+                    return [...outputChannelTail];
+                }
+                if (n <= 0) return [];
+                return outputChannelTail.slice(-n);
             },
             isWebviewReady(): boolean {
                 return webviewEverReady;

--- a/vscode-extension/src/test/electron/fixtures/fake-kotlin-language/package.json
+++ b/vscode-extension/src/test/electron/fixtures/fake-kotlin-language/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "fake-kotlin-language",
+    "displayName": "Kotlin language id (test stub)",
+    "description": "Test-only fixture that registers the `kotlin` languageId so .kt files in the e2e workspaces resolve to it. The compose-preview extension's onDidChangeActiveTextEditor preload path bails unless `editor.document.languageId === \"kotlin\"`, and the test electron host doesn't load a real Kotlin extension. Contributes language metadata only — no grammar, no client.",
+    "publisher": "test",
+    "version": "0.0.0-test",
+    "engines": {
+        "vscode": "^1.85.0"
+    },
+    "contributes": {
+        "languages": [
+            {
+                "id": "kotlin",
+                "extensions": [
+                    ".kt",
+                    ".kts"
+                ],
+                "aliases": [
+                    "Kotlin"
+                ]
+            }
+        ]
+    }
+}

--- a/vscode-extension/src/test/electron/runTest.ts
+++ b/vscode-extension/src/test/electron/runTest.ts
@@ -61,6 +61,17 @@ async function main(): Promise<void> {
         fixturesRoot,
         "fake-vscode-gradle",
     );
+    // Contributes the `kotlin` languageId so .kt files in the e2e workspaces
+    // resolve to it. The compose-preview extension's
+    // `onDidChangeActiveTextEditor` preload path bails unless
+    // `editor.document.languageId === "kotlin"`, and the test electron host
+    // doesn't bundle a real Kotlin extension. Without this, the cached-preload
+    // suite trips on `setTextDocumentLanguage(doc, "kotlin")` with
+    // `Error: Unknown language id: kotlin`.
+    const fakeKotlinLanguagePath = path.join(
+        fixturesRoot,
+        "fake-kotlin-language",
+    );
 
     console.log(
         `[runTest] extensionDevelopmentPath=${extensionDevelopmentPath}`,
@@ -68,6 +79,7 @@ async function main(): Promise<void> {
     console.log(`[runTest] extensionTestsPath=${extensionTestsPath}`);
     console.log(`[runTest] workspacePath=${workspacePath}`);
     console.log(`[runTest] fakeGradleExtensionPath=${fakeGradleExtensionPath}`);
+    console.log(`[runTest] fakeKotlinLanguagePath=${fakeKotlinLanguagePath}`);
 
     const vscodeExecutablePath = await downloadAndUnzipVSCode("stable");
     console.log(`[runTest] vscodeExecutablePath=${vscodeExecutablePath}`);
@@ -85,6 +97,7 @@ async function main(): Promise<void> {
         extensionDevelopmentPath: [
             extensionDevelopmentPath,
             fakeGradleExtensionPath,
+            fakeKotlinLanguagePath,
         ],
         extensionTestsPath,
         // CI-friendly launch args:

--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -69,6 +69,67 @@ async function waitFor<T>(
     );
 }
 
+/**
+ * Dumps the daemon output channel tail + the latest host-side message
+ * traffic to the workflow log when a `waitFor` for a webview ack times
+ * out. The wear a11y suite has historically failed silently (60s mocha
+ * cap with no actionable detail) because the scheduler swallows
+ * `dataSubscribe` / post-subscribe `renderNow` rejections — only the
+ * `Compose Preview` output channel records the reason, and that channel
+ * isn't persisted by `@vscode/test-electron`'s log uploads. Reading the
+ * tail via the test API surfaces it on stdout where the workflow log
+ * captures it.
+ *
+ * `tailLines` is a rough bound on signal-to-noise: ~120 lines covers
+ * the latest renderAll + warm + subscribe sequence comfortably without
+ * burying the recent failure under cmp suite history.
+ */
+function dumpA11yFailureDiagnostics(
+    api: ComposePreviewTestApi,
+    label: string,
+    previewId: string,
+    tailLines = 120,
+): void {
+    const tail = api.getOutputChannelTail(tailLines);
+    const posted = api.getPostedMessages();
+    const received = api.getReceivedMessages();
+    console.log(
+        `[e2e-a11y-diag] ${label} previewId=${previewId} ` +
+            `posted=${posted.length} received=${received.length} ` +
+            `outputChannelTail=${tail.length}line(s)`,
+    );
+    for (const line of tail) {
+        console.log(`[e2e-a11y-diag/channel] ${line}`);
+    }
+    const stableSummary = (raw: unknown): string => {
+        const m = raw as { command?: string; previewId?: string };
+        const cmd = m?.command ?? "<no-command>";
+        const id = m?.previewId ? ` previewId=${m.previewId}` : "";
+        return `${cmd}${id}`;
+    };
+    for (const raw of posted.slice(-30)) {
+        console.log(`[e2e-a11y-diag/posted] ${stableSummary(raw)}`);
+    }
+    for (const raw of received.slice(-30)) {
+        console.log(`[e2e-a11y-diag/received] ${stableSummary(raw)}`);
+    }
+}
+
+async function waitForA11yAck<T>(
+    api: ComposePreviewTestApi,
+    label: string,
+    previewId: string,
+    timeoutMs: number,
+    probe: () => T | undefined,
+): Promise<T> {
+    try {
+        return await waitFor(label, timeoutMs, 500, probe);
+    } catch (err) {
+        dumpA11yFailureDiagnostics(api, label, previewId);
+        throw err;
+    }
+}
+
 interface PreviewSummary {
     id: string;
     functionName: string;
@@ -361,10 +422,11 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
             true,
         );
 
-        const ack = await waitFor(
+        const ack = await waitForA11yAck(
+            api,
             `webviewA11yState with nodes for ${target.id}`,
+            target.id,
             this.timeout(),
-            500,
             () =>
                 findA11yAck(
                     target.id,
@@ -397,10 +459,11 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
 
         await api.triggerSetDataExtensionEnabled(target.id, ["a11y/atf"], true);
 
-        const ack = await waitFor(
+        const ack = await waitForA11yAck(
+            api,
             `webviewA11yState with findings for ${target.id}`,
+            target.id,
             this.timeout(),
-            500,
             () =>
                 findA11yAck(
                     target.id,
@@ -441,10 +504,11 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
             ["a11y/hierarchy"],
             true,
         );
-        await waitFor(
+        await waitForA11yAck(
+            api,
             `nodes-painted ack for ${target.id}`,
+            target.id,
             this.timeout(),
-            500,
             () =>
                 findA11yAck(
                     target.id,
@@ -460,10 +524,11 @@ describeE2E("Compose Preview a11y subscription e2e (wear)", function () {
             ["a11y/hierarchy"],
             false,
         );
-        const teardown = await waitFor(
+        const teardown = await waitForA11yAck(
+            api,
             `webviewA11yState teardown for ${target.id}`,
+            target.id,
             this.timeout(),
-            500,
             () => findA11yAck(target.id, (a) => a.nodesCount === 0),
         );
         assert.strictEqual(teardown.nodesCount, 0);


### PR DESCRIPTION
## Summary

Enhance the wear a11y e2e test suite with better failure diagnostics and fix test infrastructure issues that were causing silent timeouts.

## Key Changes

- **Add diagnostic output capture for a11y test failures**: Introduce `dumpA11yFailureDiagnostics()` and `waitForA11yAck()` to capture and log daemon output channel tail and message traffic when webview ack timeouts occur. The wear a11y suite was timing out silently (60s mocha cap) because the scheduler swallows `dataSubscribe` / post-subscribe `renderNow` rejections — only the `Compose Preview` output channel records the reason, which wasn't persisted by test logs.

- **Implement output channel tail buffering**: Wrap the output channel with a capped ring buffer (2000 lines max) under `COMPOSE_PREVIEW_TEST_MODE=1` to allow tests to dump recent daemon output when diagnostics are needed. This surfaces otherwise-hidden failure reasons on stdout where workflow logs capture them.

- **Add `getOutputChannelTail()` to test API**: Expose the buffered output channel tail via `ComposePreviewTestApi` so e2e tests can retrieve and log diagnostic information on demand.

- **Add fake Kotlin language extension**: Create a test-only fixture that registers the `kotlin` languageId so `.kt` files in e2e workspaces resolve correctly. The compose-preview extension's `onDidChangeActiveTextEditor` preload path requires `editor.document.languageId === "kotlin"`, and the test electron host doesn't bundle a real Kotlin extension.

- **Fix gradle-plugin publishing in CI**: Update the e2e external workflow to explicitly publish the included `:gradle-plugin` build's modules to mavenLocal. Task fan-out doesn't cross composite-build boundaries, so the root `publishToMavenLocal` was leaving the released plugin coordinate in Maven Central, causing catalog resolution failures for SNAPSHOT versions.

- **Update test artifact collection**: Add `samples/wear/build/compose-previews/` to the e2e workflow artifact paths for consistency.

## Implementation Details

- Output channel capture uses a Proxy to intercept `appendLine()` and `append()` calls only when test mode is enabled, avoiding overhead in production.
- The diagnostic dump includes the last 30 posted/received messages and up to 120 output channel lines (configurable) to balance signal-to-noise.
- All four a11y test `waitFor` calls are updated to use `waitForA11yAck()` for consistent diagnostic capture on timeout.

https://claude.ai/code/session_017pwPFw2a8N3yqqgG2PRmVg