### PR TITLE
feat: add inline image rendering for terminal preview display

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -656,6 +656,17 @@ abstract class Command(protected val args: List<String>) {
 
 class ShowCommand(args: List<String>) : Command(args) {
   private val jsonOutput = "--json" in args
+  // Auto-on when stdout is an interactive TTY in a kitty-graphics-capable terminal. Users
+  // opt out with `--images=off`; `--images=kitty` forces it on (still TTY-gated). `--json`
+  // always wins — escape sequences would corrupt the JSON envelope.
+  private val imagesMode: TerminalImages.Mode =
+    if (jsonOutput) TerminalImages.Mode.OFF
+    else
+      TerminalImages.resolve(
+        modeArg = args.flagValue("--images"),
+        env = { System.getenv(it) },
+        isTty = System.console() != null,
+      )
 
   override fun run() {
     val outcome =
@@ -731,6 +742,7 @@ class ShowCommand(args: List<String>) : Command(args) {
             println("  [$coord]$tag ${c.pngPath ?: ""}")
           }
         }
+        emitInlineImage(r)
       }
     }
 
@@ -755,6 +767,29 @@ class ShowCommand(args: List<String>) : Command(args) {
       if (shouldFailOnMissingRenders()) exitProcess(2)
     }
     System.out.flush()
+  }
+
+  /**
+   * Emit the rendered PNG(s) inline using the resolved terminal-images mode. Multi-capture previews
+   * — paused-clock frames with increasing `advanceTimeMillis` — become a native kitty animation;
+   * single-capture previews emit a still. Captures with no PNG (render produced nothing) are
+   * skipped so the animation doesn't include a phantom hole; the surrounding `[no PNG]` text tags
+   * still tell the user what happened.
+   */
+  private fun emitInlineImage(r: PreviewResult) {
+    if (imagesMode == TerminalImages.Mode.OFF) return
+    val rendered = r.captures.filter { it.pngPath != null }
+    if (rendered.isEmpty()) return
+    val pngs = rendered.mapNotNull { c -> c.pngPath?.let { File(it) }?.takeIf { it.isFile } }
+    if (pngs.size != rendered.size) return // some path didn't exist on disk — skip silently
+    val bytes = pngs.map { it.readBytes() }
+    if (bytes.size == 1) {
+      TerminalImages.emitStill(System.out, bytes[0])
+    } else {
+      val frames = TerminalImages.framesFromCaptures(bytes, rendered.map { it.advanceTimeMillis })
+      TerminalImages.emitAnimation(System.out, frames)
+    }
+    println()
   }
 }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -140,6 +140,16 @@ private fun printUsage() {
       --brief              JSON only: drop functionName/className/sourceFile/params
       --changed-only       JSON only (show, a11y): drop previews with no changed capture
       --output <path>      Copy matched preview PNG to this path (render)
+      --images[=<mode>]    show: emit rendered PNGs inline using the terminal's image protocol.
+                           Default `auto` — on by default in an interactive TTY when a
+                           kitty-graphics-capable terminal is detected (`KITTY_WINDOW_ID`,
+                           `TERM_PROGRAM` ∈ {WezTerm, ghostty}, or `TERM=xterm-kitty`); silent
+                           on every other terminal. Modes: `auto`, `kitty` (force; still
+                           TTY-gated), `off` (explicit silence). Multi-capture previews
+                           (paused-clock animation frames) emit as a native kitty animation;
+                           inter-frame gaps come from `advanceTimeMillis` deltas so playback
+                           matches the simulated clock. Always off when stdout is piped or
+                           `--json` is set so escape sequences don't pollute captured output.
       --progress           Print per-task milestone/heartbeat lines to stderr
       --verbose, -v        Show full Gradle build output (implies --progress)
       --timeout <seconds>  Gradle build timeout (default: 300)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/TerminalImages.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/TerminalImages.kt
@@ -1,0 +1,145 @@
+package ee.schimke.composeai.cli
+
+import java.io.PrintStream
+import java.util.Base64
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Inline image rendering for `compose-preview show --images`. Today implements kitty's graphics
+ * protocol — kitty/Ghostty/WezTerm all speak it. A multi-capture preview (paused-clock animation
+ * frames at increasing `advanceTimeMillis`) is emitted as a native kitty animation rather than a
+ * flipbook: the first frame transmits with `a=T`, subsequent frames extend with `a=f,z=<gap_ms>`,
+ * and playback starts via `a=a,s=3` (loop indefinitely). Inter-frame delays come from the
+ * `advanceTimeMillis` deltas so playback matches the simulated clock.
+ *
+ * iTerm2 / sixel / chafa fallbacks are not implemented yet — `auto` resolves them to [Mode.OFF].
+ *
+ * Reference: https://sw.kovidgoyal.net/kitty/graphics-protocol/
+ */
+object TerminalImages {
+  enum class Mode {
+    KITTY,
+    OFF,
+  }
+
+  private const val ESC = "\u001b"
+  // Kitty graphics control sequence envelope: `ESC _ G <controls> ; <payload> ESC \`.
+  internal const val APC = "${ESC}_G"
+  internal const val ST = "$ESC\\"
+
+  /**
+   * Resolve `--images=<value>` plus the environment into the effective mode. Pure for testability:
+   * call sites pass [System.getenv] and a precomputed `isTty`.
+   *
+   * Default (flag absent) is `auto`: when stdout is an interactive TTY we sniff the env and resolve
+   * KITTY for kitty-graphics-capable terminals (`KITTY_WINDOW_ID`, `TERM_PROGRAM` ∈ {WezTerm,
+   * ghostty}, or `TERM=xterm-kitty`); everywhere else we stay OFF. A redirected / piped stdout
+   * always resolves to OFF — escape sequences in a captured file are just noise. `off` is the
+   * explicit opt-out for users who want to silence images even inside a kitty terminal (e.g.
+   * screen-readers, terminal recordings).
+   */
+  fun resolve(modeArg: String?, env: (String) -> String?, isTty: Boolean): Mode {
+    val tag = modeArg?.lowercase()
+    if (tag == "off") return Mode.OFF
+    if (!isTty) return Mode.OFF
+    if (tag == "kitty") return Mode.KITTY
+    // null (flag absent) and "auto" both mean "sniff the env on a TTY".
+    if (env("KITTY_WINDOW_ID") != null) return Mode.KITTY
+    val termProgram = env("TERM_PROGRAM")?.lowercase()
+    if (termProgram == "wezterm" || termProgram == "ghostty") return Mode.KITTY
+    if (env("TERM") == "xterm-kitty") return Mode.KITTY
+    return Mode.OFF
+  }
+
+  /** One animation frame: the raw PNG bytes plus how long to dwell before the next frame. */
+  data class Frame(val pngBytes: ByteArray, val gapMillis: Int)
+
+  /**
+   * Build inter-frame gaps from a paused-clock capture series. Each frame's dwell is the delta to
+   * the next frame's `advanceTimeMillis`; the last frame inherits the previous gap (or
+   * [defaultGapMillis] when there's nothing to inherit). Non-positive or null deltas fall back to
+   * [defaultGapMillis] so the loop doesn't stall.
+   */
+  fun framesFromCaptures(
+    pngs: List<ByteArray>,
+    advanceTimeMillis: List<Long?>,
+    defaultGapMillis: Int = 100,
+  ): List<Frame> {
+    require(pngs.size == advanceTimeMillis.size) { "pngs and times must align" }
+    if (pngs.isEmpty()) return emptyList()
+    val gaps = IntArray(pngs.size) { defaultGapMillis }
+    for (i in 0 until pngs.size - 1) {
+      val a = advanceTimeMillis[i]
+      val b = advanceTimeMillis[i + 1]
+      if (a != null && b != null) {
+        val delta = (b - a).toInt()
+        if (delta > 0) gaps[i] = delta
+      }
+    }
+    if (pngs.size >= 2) gaps[pngs.size - 1] = gaps[pngs.size - 2]
+    return pngs.mapIndexed { i, bytes -> Frame(bytes, gaps[i]) }
+  }
+
+  private val nextImageId = AtomicInteger(1)
+
+  /** Emit a single still image using kitty's graphics protocol. */
+  fun emitStill(out: PrintStream, pngBytes: ByteArray) {
+    val id = nextImageId.getAndIncrement()
+    writeKittyChunks(out, controls = "a=T,f=100,i=$id,q=2", payload = base64(pngBytes))
+    out.flush()
+  }
+
+  /**
+   * Emit a multi-frame kitty animation. Transmit frame 1 with `a=T`, add each subsequent frame with
+   * `a=f,z=<gap_ms>`, then start looping playback with `a=a,s=3`. Single-frame inputs degrade to
+   * [emitStill].
+   */
+  fun emitAnimation(out: PrintStream, frames: List<Frame>) {
+    if (frames.isEmpty()) return
+    if (frames.size == 1) {
+      emitStill(out, frames[0].pngBytes)
+      return
+    }
+    val id = nextImageId.getAndIncrement()
+    val first = frames[0]
+    writeKittyChunks(
+      out,
+      controls = "a=T,f=100,i=$id,z=${first.gapMillis},q=2",
+      payload = base64(first.pngBytes),
+    )
+    for (i in 1 until frames.size) {
+      val f = frames[i]
+      writeKittyChunks(
+        out,
+        controls = "a=f,f=100,i=$id,z=${f.gapMillis},q=2",
+        payload = base64(f.pngBytes),
+      )
+    }
+    out.print("${APC}a=a,i=$id,s=3,v=0,q=2$ST")
+    out.flush()
+  }
+
+  /**
+   * Kitty APC payloads cap at 4096 base64 chars; longer payloads use `m=1` on every chunk except
+   * the last (`m=0`). Control fields ride only on the first chunk.
+   */
+  private fun writeKittyChunks(out: PrintStream, controls: String, payload: String) {
+    val chunkSize = 4096
+    if (payload.length <= chunkSize) {
+      out.print("$APC$controls;$payload$ST")
+      return
+    }
+    var offset = 0
+    var first = true
+    while (offset < payload.length) {
+      val end = (offset + chunkSize).coerceAtMost(payload.length)
+      val isLast = end == payload.length
+      val header = if (first) "$controls,m=${if (isLast) 0 else 1}" else "m=${if (isLast) 0 else 1}"
+      out.print("$APC$header;${payload.substring(offset, end)}$ST")
+      first = false
+      offset = end
+    }
+  }
+
+  private fun base64(bytes: ByteArray): String = Base64.getEncoder().encodeToString(bytes)
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/TerminalImagesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/TerminalImagesTest.kt
@@ -1,0 +1,237 @@
+package ee.schimke.composeai.cli
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.util.Base64
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Exercises the kitty graphics protocol formatter behind `compose-preview show --images`. The APC
+ * envelope (`ESC _ G ... ESC \`), control-field shape, and frame-extension/animate sequence are
+ * load-bearing — kitty silently ignores malformed sequences, so a broken emitter shows up only as
+ * "no image appeared" in the user's terminal. Tests assert the literal bytes a kitty would see.
+ */
+class TerminalImagesTest {
+  private val ESC = "\u001b"
+  private val APC = "${ESC}_G"
+  private val ST = "$ESC\\"
+
+  private fun captureStdout(block: (PrintStream) -> Unit): String {
+    val baos = ByteArrayOutputStream()
+    val ps = PrintStream(baos, true, Charsets.UTF_8)
+    block(ps)
+    return baos.toString(Charsets.UTF_8)
+  }
+
+  // --- Mode resolution --------------------------------------------------------
+
+  @Test
+  fun `absent flag resolves KITTY on an interactive kitty terminal`() {
+    // Default is "auto" — `compose-preview show` in a kitty TTY shows images without the user
+    // typing `--images`. Pipelines stay safe because non-TTY stdout still resolves OFF (see the
+    // dedicated TTY-gate test below).
+    val mode =
+      TerminalImages.resolve(
+        modeArg = null,
+        env = { if (it == "KITTY_WINDOW_ID") "abc" else null },
+        isTty = true,
+      )
+    assertEquals(TerminalImages.Mode.KITTY, mode)
+  }
+
+  @Test
+  fun `absent flag on a non-kitty terminal stays OFF`() {
+    // Default-auto must not blast escape sequences at terminals that don't speak the protocol.
+    val mode =
+      TerminalImages.resolve(
+        modeArg = null,
+        env = { if (it == "TERM_PROGRAM") "Apple_Terminal" else null },
+        isTty = true,
+      )
+    assertEquals(TerminalImages.Mode.OFF, mode)
+  }
+
+  @Test
+  fun `absent flag with piped stdout stays OFF even on a kitty terminal`() {
+    val mode =
+      TerminalImages.resolve(
+        modeArg = null,
+        env = { if (it == "KITTY_WINDOW_ID") "abc" else null },
+        isTty = false,
+      )
+    assertEquals(TerminalImages.Mode.OFF, mode)
+  }
+
+  @Test
+  fun `auto sniffs KITTY_WINDOW_ID`() {
+    val mode =
+      TerminalImages.resolve(
+        modeArg = "auto",
+        env = { if (it == "KITTY_WINDOW_ID") "12345" else null },
+        isTty = true,
+      )
+    assertEquals(TerminalImages.Mode.KITTY, mode)
+  }
+
+  @Test
+  fun `auto sniffs TERM_PROGRAM for wezterm and ghostty`() {
+    val wez =
+      TerminalImages.resolve("auto", env = { if (it == "TERM_PROGRAM") "WezTerm" else null }, true)
+    assertEquals(TerminalImages.Mode.KITTY, wez)
+    val ghostty =
+      TerminalImages.resolve("auto", env = { if (it == "TERM_PROGRAM") "ghostty" else null }, true)
+    assertEquals(TerminalImages.Mode.KITTY, ghostty)
+  }
+
+  @Test
+  fun `auto falls back to OFF when no kitty-capable env signal is present`() {
+    val mode =
+      TerminalImages.resolve(
+        "auto",
+        env = { if (it == "TERM_PROGRAM") "Apple_Terminal" else null },
+        isTty = true,
+      )
+    assertEquals(TerminalImages.Mode.OFF, mode)
+  }
+
+  @Test
+  fun `non-TTY forces OFF even with explicit --images=kitty`() {
+    // A redirected stdout (`> out.txt`) can't render images; emitting APCs would just garbage
+    // up the captured file. The whole point of the TTY gate is to keep `compose-preview show`
+    // safe to redirect.
+    val mode = TerminalImages.resolve("kitty", env = { null }, isTty = false)
+    assertEquals(TerminalImages.Mode.OFF, mode)
+  }
+
+  @Test
+  fun `explicit off short-circuits even on a kitty terminal`() {
+    val mode =
+      TerminalImages.resolve(
+        "off",
+        env = { if (it == "KITTY_WINDOW_ID") "abc" else null },
+        isTty = true,
+      )
+    assertEquals(TerminalImages.Mode.OFF, mode)
+  }
+
+  @Test
+  fun `unknown mode value resolves OFF`() {
+    val mode = TerminalImages.resolve("magic", env = { null }, isTty = true)
+    assertEquals(TerminalImages.Mode.OFF, mode)
+  }
+
+  // --- Still image emission ---------------------------------------------------
+
+  @Test
+  fun `emitStill wraps PNG in a single APC with a=T, f=100, q=2`() {
+    val png = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01)
+    val out = captureStdout { TerminalImages.emitStill(it, png) }
+    assertTrue(out.startsWith(APC), "expected APC introducer, got: ${out.take(8).map { it.code }}")
+    assertTrue(out.endsWith(ST))
+    assertContains(out, "a=T")
+    assertContains(out, "f=100") // f=100 == PNG transmission format
+    assertContains(out, "q=2") // suppress kitty's response chatter
+    val payload = out.substringAfter(';').substringBefore(ST)
+    assertEquals(Base64.getEncoder().encodeToString(png), payload)
+  }
+
+  // --- Animation emission -----------------------------------------------------
+
+  @Test
+  fun `emitAnimation with one frame degrades to a single still`() {
+    val out = captureStdout {
+      TerminalImages.emitAnimation(it, listOf(TerminalImages.Frame(byteArrayOf(1, 2, 3), 50)))
+    }
+    assertContains(out, "a=T")
+    assertFalse(out.contains("a=f"), "single-frame path must not extend with a=f")
+    assertFalse(out.contains("a=a"), "single-frame path must not start the animation engine")
+  }
+
+  @Test
+  fun `emitAnimation sends a=T, then a=f per extra frame, then a=a to start playback`() {
+    val frames =
+      listOf(
+        TerminalImages.Frame(byteArrayOf(1), 16),
+        TerminalImages.Frame(byteArrayOf(2), 33),
+        TerminalImages.Frame(byteArrayOf(3), 50),
+      )
+    val out = captureStdout { TerminalImages.emitAnimation(it, frames) }
+
+    // Split into APC commands by the ST terminator (drop trailing empty after final ST).
+    val commands = out.split(ST).filter { it.isNotEmpty() }
+    assertEquals(4, commands.size, "expected 3 frame APCs + 1 animate APC, got: ${commands.size}")
+
+    // Frame 1: base image transmit.
+    assertContains(commands[0], "a=T")
+    assertContains(commands[0], "z=16")
+    // Frame 2 + 3: add-frame extensions.
+    assertContains(commands[1], "a=f")
+    assertContains(commands[1], "z=33")
+    assertContains(commands[2], "a=f")
+    assertContains(commands[2], "z=50")
+    // Final command: start playback. s=3 = loop forever.
+    assertContains(commands[3], "a=a")
+    assertContains(commands[3], "s=3")
+  }
+
+  @Test
+  fun `all frames in one animation share the same image id`() {
+    // The graphics protocol routes `a=f` and `a=a` to a frame's base image by `i=` — if the IDs
+    // diverge across frames, kitty drops the extra frames silently and the user sees a still.
+    val frames = (1..3).map { TerminalImages.Frame(byteArrayOf(it.toByte()), 16) }
+    val out = captureStdout { TerminalImages.emitAnimation(it, frames) }
+    val ids = Regex("i=(\\d+)").findAll(out).map { it.groupValues[1] }.toList()
+    assertEquals(4, ids.size, "expected an i= on each of 4 APCs")
+    assertEquals(1, ids.toSet().size, "all APCs in one animation must share i=, got $ids")
+  }
+
+  // --- Frame timing from advanceTimeMillis ------------------------------------
+
+  @Test
+  fun `framesFromCaptures derives gaps from advanceTimeMillis deltas`() {
+    val pngs = listOf(byteArrayOf(1), byteArrayOf(2), byteArrayOf(3))
+    val times = listOf<Long?>(0L, 32L, 96L)
+    val frames = TerminalImages.framesFromCaptures(pngs, times, defaultGapMillis = 100)
+    assertEquals(3, frames.size)
+    assertEquals(32, frames[0].gapMillis) // 32 - 0
+    assertEquals(64, frames[1].gapMillis) // 96 - 32
+    // Last frame inherits the previous gap so the loop returns to frame 0 at a sensible cadence
+    // — not the default, which would jolt animations whose real cadence is much faster/slower.
+    assertEquals(64, frames[2].gapMillis)
+  }
+
+  @Test
+  fun `framesFromCaptures falls back to default when advanceTimeMillis is missing or backwards`() {
+    val pngs = listOf(byteArrayOf(1), byteArrayOf(2), byteArrayOf(3))
+    val times = listOf<Long?>(null, 50L, 40L) // null + non-monotonic
+    val frames = TerminalImages.framesFromCaptures(pngs, times, defaultGapMillis = 100)
+    assertEquals(100, frames[0].gapMillis) // null endpoint → default
+    assertEquals(100, frames[1].gapMillis) // 40 - 50 = -10 → default
+    assertEquals(100, frames[2].gapMillis) // last-frame inherit-then-default
+  }
+
+  // --- Chunking for large payloads --------------------------------------------
+
+  @Test
+  fun `payload larger than 4096 base64 chars splits across m=1 chunks ending with m=0`() {
+    // 4 KiB base64 = 3072 raw bytes. Use 5000 raw → ~6668 base64 → 2 chunks.
+    val big = ByteArray(5000) { (it % 251).toByte() }
+    val out = captureStdout { TerminalImages.emitStill(it, big) }
+    val commands = out.split(ST).filter { it.isNotEmpty() }
+    assertEquals(2, commands.size, "expected exactly 2 APC chunks for 5000-byte payload")
+    // First chunk: carries the full control set plus m=1 (more follow).
+    assertContains(commands[0], "a=T")
+    assertContains(commands[0], "f=100")
+    assertContains(commands[0], "m=1")
+    // Last chunk: m=0 terminator, no a=T (control fields ride only on the first chunk).
+    assertContains(commands[1], "m=0")
+    assertFalse(
+      commands[1].contains("a=T"),
+      "control fields must not repeat on continuation chunks",
+    )
+  }
+}


### PR DESCRIPTION
Add support for rendering preview PNGs inline in the terminal using the kitty graphics protocol, with automatic detection of capable terminals.

## Summary

Implements inline image rendering for `compose-preview show --images`, enabling users to see rendered previews directly in their terminal without saving to disk. Multi-frame previews (paused-clock animations with increasing `advanceTimeMillis`) are emitted as native kitty animations with inter-frame delays derived from the capture timestamps.

## Key Changes

- **New `TerminalImages` object** (`cli/src/main/kotlin/ee/schimke/composeai/cli/TerminalImages.kt`):
  - `resolve()` function for mode detection: auto-enables KITTY mode on interactive TTYs in kitty-graphics-capable terminals (`KITTY_WINDOW_ID`, `TERM_PROGRAM` ∈ {WezTerm, ghostty}, `TERM=xterm-kitty`); respects explicit `--images=off` and `--images=kitty` flags; always OFF for non-TTY output (pipes, redirects)
  - `emitStill()` for single-frame PNG output via kitty APC sequences
  - `emitAnimation()` for multi-frame animations: transmits first frame with `a=T`, extends with `a=f,z=<gap_ms>` per additional frame, starts playback with `a=a,s=3` (loop indefinitely)
  - `framesFromCaptures()` to derive inter-frame gaps from `advanceTimeMillis` deltas
  - Chunking support for payloads >4096 base64 chars using `m=1`/`m=0` continuation markers
  - Image ID tracking to ensure all frames in an animation share the same ID

- **Updated `ShowCommand`** (`cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt`):
  - Added `imagesMode` field resolved from `--images` flag, environment, and TTY status
  - New `emitInlineImage()` method to render captured PNGs inline after preview output
  - Skips rendering if `--json` is set (escape sequences would corrupt JSON)
  - Gracefully handles missing PNG files or single-capture previews

- **Updated usage documentation** (`cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt`):
  - Added `--images[=<mode>]` flag documentation with mode descriptions and behavior

- **Comprehensive test suite** (`cli/src/test/kotlin/ee/schimke/composeai/cli/TerminalImagesTest.kt`):
  - Mode resolution tests covering auto-detection, TTY gating, explicit flags, and fallbacks
  - Still image emission tests validating APC envelope and base64 encoding
  - Animation emission tests for frame sequencing, timing, and image ID consistency
  - Frame timing derivation tests with null/non-monotonic timestamp handling
  - Payload chunking tests for large images

## Implementation Details

- Uses kitty graphics protocol APC sequences (`ESC_G ... ESC\`) with control fields (`a=T` for transmit, `a=f` for frame extension, `a=a` for animate)
- Frame timing from `advanceTimeMillis` deltas ensures animation playback matches simulated clock speed
- TTY detection via `System.console()` prevents escape sequences from corrupting piped/redirected output
- Atomic image ID counter ensures each animation gets a unique ID for kitty routing
- Single-frame previews degrade to still images (no animation overhead)

https://claude.ai/code/session_01ShdAJWrmqYrWHhzay5GtKd