### PR TITLE
fix(vscode-extension): backfill @ScrollingPreview image data products via Gradle

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -42,6 +42,7 @@ import {
 import { formatRenderErrorMessage } from "./renderError";
 import { openResourceFile } from "./resourceFileResolver";
 import { readFontPreview, resolveFontPreviewPath } from "./fontPreviewLoader";
+import { findMissingImageDataProducts } from "./scrollDataProductRender";
 import {
     captureLabel,
     staticBaseCaptureIndex,
@@ -205,6 +206,19 @@ async function isSourceNewerThanRenders(
 }
 
 const moduleManifestCache = new Map<string, PreviewInfo[]>();
+/**
+ * Per-session dedup for the scroll/animation data-product backfill: modules where we've
+ * already kicked off `composePreviewRender('full')` to populate missing image data
+ * products (today: `@ScrollingPreview(LONG/GIF)` outputs). The daemon's renderNow
+ * produces only the static base capture and scroll producers are renderer-side only
+ * (`docs/daemon/DATA-PRODUCTS.md` § "data/scroll is renderer-side only"), so daemon-only
+ * flows leave scroll cards permanently placeholdered without this fallback. One Gradle
+ * render per module per session is the upper bound — re-arms on `restart`/extension
+ * activation, not on file focus changes, so a fresh save doesn't loop. Failure (no
+ * scroll PNG produced even after Gradle) intentionally doesn't re-arm; the user's
+ * "Render Previews" command remains the manual escape hatch.
+ */
+const scrollBackfillRequested = new Set<string>();
 /**
  * Heavy previews the user explicitly asked to keep fresh for the current
  * editor focus scope. Cleared when focus leaves the backing Kotlin file.
@@ -713,6 +727,52 @@ function readJsonPath(
             `[daemon] could not read data-product JSON at ${p}: ${(err as Error).message}`,
         );
         return undefined;
+    }
+}
+
+/**
+ * Backfill one module's missing image data products (scroll/long PNG, scroll/gif GIF)
+ * via `composePreviewRender('full')`, then read the newly-produced files and post one
+ * `updateImage` per backfilled capture so the panel's placeholder cards repaint with
+ * the actual content. Fire-and-forget — failure is logged but doesn't surface to the
+ * user, on the theory that the manual "Render Previews" command is the right escape
+ * hatch when the renderer truly can't produce the artifact.
+ */
+async function backfillScrollDataProducts(
+    module: ModuleInfo,
+    missing: readonly {
+        previewId: string;
+        captureIndex: number;
+        renderOutput: string;
+    }[],
+): Promise<void> {
+    if (!gradleService) return;
+    try {
+        await gradleService.composePreviewRender(module, "full");
+    } catch (err) {
+        logLine(
+            `scroll backfill: composePreviewRender failed for ${module.modulePath}: ${(err as Error).message}`,
+        );
+        return;
+    }
+    if (!panel) return;
+    for (const entry of missing) {
+        const imageData = await gradleService.readPreviewImage(
+            module,
+            entry.renderOutput,
+        );
+        if (!imageData) {
+            logLine(
+                `scroll backfill: render finished but ${entry.renderOutput} still missing for ${entry.previewId}`,
+            );
+            continue;
+        }
+        panel.postMessage({
+            command: "updateImage",
+            previewId: entry.previewId,
+            captureIndex: entry.captureIndex,
+            imageData,
+        });
     }
 }
 
@@ -4610,6 +4670,41 @@ async function refresh(
             // called finish().
             tracker.finish();
             writeCalibration(module, tracker.phaseDurations);
+        }
+
+        // Backfill `@ScrollingPreview(LONG/GIF)` image data products that no producer
+        // has filled in. Scroll outputs are renderer-side only (the daemon's renderNow
+        // produces just the static base capture, which the panel correctly drops for
+        // scroll previews) so daemon-only flows leave these cards permanently empty.
+        // Skip when we're already in the forceRender path — that pass just produced
+        // everything Gradle could produce. Skip in minimal mode — the user opted out
+        // of auto-renders and would expect to drive `composePreviewRender` themselves.
+        // Per-module session dedup via `scrollBackfillRequested` keeps a project that
+        // genuinely can't produce the scroll PNG (broken @ScrollingPreview wiring,
+        // renderer crash) from looping a Gradle invocation on every focus change.
+        if (!abort.signal.aborted && !forceRender && !inMinimalMode()) {
+            const missingByModule = findMissingImageDataProducts(
+                displayPreviews,
+                (id) => previewModuleIndex.get(id),
+                gradleService.workspaceRoot,
+            );
+            for (const [modulePath, missing] of missingByModule) {
+                if (scrollBackfillRequested.has(modulePath)) continue;
+                scrollBackfillRequested.add(modulePath);
+                const owningModule = previewModuleIndex.get(
+                    missing[0].previewId,
+                );
+                if (!owningModule) continue;
+                logLine(
+                    `scroll backfill: ${modulePath} has ${missing.length} missing image data product(s); kicking composePreviewRender('full')`,
+                );
+                // Fire-and-forget so this doesn't block the in-flight refresh. The follow-up
+                // re-reads the newly-produced PNGs and posts `updateImage` for each — the
+                // existing image-load path keys on `captureIndex` in the displayed (post-
+                // `withDataProductCaptures`) captures, so `missing[].captureIndex` lines up
+                // with the slot the card carousel paints.
+                void backfillScrollDataProducts(owningModule, missing);
+            }
         }
 
         // Source-newer-than-renders auto-refresh. Replaces the old "Showing

--- a/vscode-extension/src/previewConsistency.ts
+++ b/vscode-extension/src/previewConsistency.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import { withDataProductCaptures } from "./captureLabels";
 import { GradleService, ModuleInfo } from "./gradleService";
 import { PreviewInfo } from "./types";
 
@@ -56,16 +57,23 @@ export interface VerifyResult {
 }
 
 /**
- * Resolves the on-disk path for a preview's first capture, the one the panel uses as its
- * primary image. Mirrors `GradleService.readPreviewImage`'s lookup so the verify check reads
- * from the exact same directory the host loads images from.
+ * Resolves the on-disk path for the preview's primary displayed capture — the one the panel
+ * actually paints into the card. Mirrors `GradleService.readPreviewImage`'s lookup so the
+ * verify check reads from the exact same directory the host loads images from.
+ *
+ * Uses `withDataProductCaptures` so `@ScrollingPreview(LONG/GIF)` previews resolve to their
+ * `data/render-scroll-*` data-product output (which is what the card displays) rather than
+ * the manifest's static base capture (which the panel drops). Without this fold the verify
+ * would call a missing scroll PNG a "stale placeholder with PNG on disk" — the daemon's
+ * static base PNG that the panel correctly ignores.
  */
 export function pngPathFor(
     workspaceRoot: string,
     module: ModuleInfo,
     preview: PreviewInfo,
 ): string | null {
-    const capture = preview.captures.find((c) => !!c.renderOutput);
+    const display = withDataProductCaptures(preview);
+    const capture = display.captures.find((c) => !!c.renderOutput);
     if (!capture || !capture.renderOutput) {
         return null;
     }

--- a/vscode-extension/src/scrollDataProductRender.ts
+++ b/vscode-extension/src/scrollDataProductRender.ts
@@ -1,0 +1,81 @@
+import * as fs from "fs";
+import * as path from "path";
+import { withDataProductCaptures } from "./captureLabels";
+import { ModuleInfo } from "./gradleService";
+import { PreviewInfo } from "./types";
+
+/**
+ * One displayed capture slot whose image data product is missing from disk — the
+ * panel paints a placeholder for it because the daemon's normal renderNow only
+ * produces the static base capture and `@ScrollingPreview(LONG/GIF)` data products
+ * are renderer-side only (see `docs/daemon/DATA-PRODUCTS.md` § "data/scroll is
+ * renderer-side only"). Gradle's `composePreviewRender` is the only producer.
+ *
+ * Carries the `captureIndex` in the displayed (post-fold) captures so the caller
+ * can post `updateImage` to the right slot once Gradle fills the gap.
+ */
+export interface MissingImageDataProduct {
+    previewId: string;
+    captureIndex: number;
+    /** Module-relative output path, e.g. `data/render-scroll-long/<id>.png`. */
+    renderOutput: string;
+    /** Absolute path under `<module>/build/compose-previews/`. */
+    absolutePath: string;
+}
+
+/**
+ * For each preview, finds image data-product output files (`render/scroll/long` →
+ * `.png`, `render/scroll/gif` → `.gif`) declared in the manifest but absent from
+ * disk. Groups by owning module's `modulePath` so callers can fire one Gradle
+ * render per module rather than one per missing product.
+ *
+ * `moduleFor(previewId)` resolves the owning module — extension keeps this in
+ * `previewModuleIndex`; injected here so the helper stays testable.
+ *
+ * The `captureIndex` is computed against `withDataProductCaptures(preview)` (the
+ * same fold the panel uses), so the value can feed `updateImage` directly.
+ * Captures whose data product doesn't surface in the displayed fold (no
+ * corresponding output, scroll dropped by the renderer, etc.) are skipped.
+ */
+export function findMissingImageDataProducts(
+    previews: readonly PreviewInfo[],
+    moduleFor: (previewId: string) => ModuleInfo | undefined,
+    workspaceRoot: string,
+    fileExists: (p: string) => boolean = (p) => fs.existsSync(p),
+): Map<string, MissingImageDataProduct[]> {
+    const byModule = new Map<string, MissingImageDataProduct[]>();
+    for (const preview of previews) {
+        const mod = moduleFor(preview.id);
+        if (!mod) continue;
+        const dataProducts = preview.dataProducts ?? [];
+        if (dataProducts.length === 0) continue;
+        const display = withDataProductCaptures(preview);
+        for (const dp of dataProducts) {
+            const out = dp.output;
+            if (!out) continue;
+            const lower = out.toLowerCase();
+            if (!lower.endsWith(".png") && !lower.endsWith(".gif")) continue;
+            const abs = path.join(
+                workspaceRoot,
+                mod.projectDir,
+                "build",
+                "compose-previews",
+                out,
+            );
+            if (fileExists(abs)) continue;
+            const captureIndex = display.captures.findIndex(
+                (c) => c.renderOutput === out,
+            );
+            if (captureIndex < 0) continue;
+            const bucket = byModule.get(mod.modulePath) ?? [];
+            bucket.push({
+                previewId: preview.id,
+                captureIndex,
+                renderOutput: out,
+                absolutePath: abs,
+            });
+            byModule.set(mod.modulePath, bucket);
+        }
+    }
+    return byModule;
+}

--- a/vscode-extension/src/test/previewConsistency.test.ts
+++ b/vscode-extension/src/test/previewConsistency.test.ts
@@ -229,6 +229,90 @@ describe("pngPathFor", () => {
         } as unknown as PreviewInfo;
         assert.strictEqual(pngPathFor("/ws", module, p), null);
     });
+
+    it("resolves to the scroll data-product output for @ScrollingPreview(LONG)", () => {
+        // The static base PNG the daemon writes (`renders/X.png`) is dropped by the panel
+        // — `withDataProductCaptures` replaces it with `data/render-scroll-long/X.png` so
+        // verify must check the data-product slot, not the daemon's static representative.
+        // Without this, missing scroll PNGs are misreported as "stale placeholder with PNG
+        // on disk" because the daemon's discarded base PNG happens to exist.
+        const module = mod(":app");
+        const p = {
+            ...preview("com.example.LongScroll", "renders/LongScroll.png"),
+            dataProducts: [
+                {
+                    kind: "render/scroll/long",
+                    advanceTimeMillis: null,
+                    scroll: {
+                        mode: "LONG",
+                        axis: "VERTICAL",
+                        maxScrollPx: 0,
+                        reduceMotion: false,
+                        atEnd: false,
+                        reachedPx: null,
+                    },
+                    output: "data/render-scroll-long/LongScroll.png",
+                },
+            ],
+        } as unknown as PreviewInfo;
+        assert.strictEqual(
+            pngPathFor("/ws", module, p),
+            "/ws/app/build/compose-previews/data/render-scroll-long/LongScroll.png",
+        );
+    });
+});
+
+describe("verifyConsistency — scroll/data-product previews", () => {
+    it("reports no-image-anywhere when the scroll PNG is missing even if the daemon's static base PNG sits on disk", () => {
+        // Real-world repro from a Wear sample: 8 stuck placeholders, all scroll-long/gif.
+        // Pre-fix the verify counted the daemon's static `renders/<id>.png` as on-disk and
+        // reported "stale placeholder with PNG on disk" — but the panel ignores that PNG
+        // and was waiting for `data/render-scroll-long/<id>.png`, which never arrives in a
+        // daemon-only flow. After the fold, verify checks the correct slot.
+        const module = mod(":wear");
+        const p = {
+            ...preview(
+                "com.example.ActivityListLongPreview",
+                "renders/ActivityListLongPreview.png",
+            ),
+            dataProducts: [
+                {
+                    kind: "render/scroll/long",
+                    advanceTimeMillis: null,
+                    scroll: {
+                        mode: "LONG",
+                        axis: "VERTICAL",
+                        maxScrollPx: 0,
+                        reduceMotion: false,
+                        atEnd: false,
+                        reachedPx: null,
+                    },
+                    output: "data/render-scroll-long/ActivityListLongPreview.png",
+                },
+            ],
+        } as unknown as PreviewInfo;
+        const result = verifyConsistency(
+            "/ws/wear/Previews.kt",
+            makeDeps(
+                fakeGradleService({
+                    workspaceRoot: "/ws",
+                    resolveModule: () => module,
+                    readManifest: () => ({ previews: [p] }) as PreviewManifest,
+                }),
+                new Map(),
+                // Daemon's static base PNG happens to exist on disk; the scroll
+                // data-product PNG does not. Pre-fix this misreported as a stale
+                // placeholder; post-fix verify checks the scroll slot and reports
+                // the truthful "never rendered" state.
+                new Set([
+                    "/ws/wear/build/compose-previews/renders/ActivityListLongPreview.png",
+                ]),
+            ),
+        );
+        assert.strictEqual(result.inconsistencies.length, 1);
+        assert.strictEqual(result.inconsistencies[0].kind, "no-image-anywhere");
+        assert.strictEqual(result.diskPngCount, 0);
+    });
 });
 
 describe("describeVerifyResult", () => {

--- a/vscode-extension/src/test/scrollDataProductRender.test.ts
+++ b/vscode-extension/src/test/scrollDataProductRender.test.ts
@@ -1,0 +1,231 @@
+import * as assert from "assert";
+import { ModuleInfo } from "../gradleService";
+import { findMissingImageDataProducts } from "../scrollDataProductRender";
+import { PreviewInfo, ScrollCapture } from "../types";
+
+const mod = (modulePath: string): ModuleInfo =>
+    ({
+        modulePath,
+        projectDir: modulePath.replace(/^:/, "").replace(/:/g, "/"),
+    }) as ModuleInfo;
+
+function preview(opts: {
+    id: string;
+    renderOutput?: string;
+    dataProducts?: PreviewInfo["dataProducts"];
+}): PreviewInfo {
+    return {
+        id: opts.id,
+        functionName: opts.id.split(".").pop()!,
+        className: opts.id.substring(0, opts.id.lastIndexOf(".")),
+        sourceFile: "src/main/kotlin/Previews.kt",
+        params: {
+            name: null,
+            device: null,
+            widthDp: null,
+            heightDp: null,
+            fontScale: 1,
+            showSystemUi: false,
+            showBackground: false,
+            backgroundColor: 0,
+            uiMode: 0,
+            locale: null,
+            group: null,
+        },
+        captures: [
+            {
+                advanceTimeMillis: null,
+                scroll: null,
+                renderOutput: opts.renderOutput ?? "renders/x.png",
+            },
+        ],
+        dataProducts: opts.dataProducts,
+    } as PreviewInfo;
+}
+
+const longScroll: ScrollCapture = {
+    mode: "LONG",
+    axis: "VERTICAL",
+    maxScrollPx: 0,
+    reduceMotion: false,
+    atEnd: false,
+    reachedPx: null,
+};
+
+const gifScroll: ScrollCapture = {
+    mode: "GIF",
+    axis: "VERTICAL",
+    maxScrollPx: 0,
+    reduceMotion: false,
+    atEnd: false,
+    reachedPx: null,
+};
+
+describe("findMissingImageDataProducts", () => {
+    it("returns empty when no preview has data products", () => {
+        const p = preview({ id: "com.example.Plain" });
+        const result = findMissingImageDataProducts(
+            [p],
+            () => mod(":wear"),
+            "/ws",
+            () => false,
+        );
+        assert.strictEqual(result.size, 0);
+    });
+
+    it("flags a scroll-long preview when the data-product PNG is missing on disk", () => {
+        // Exact repro from the user's bug: daemon writes the static base PNG, panel drops
+        // it for scroll-long, scroll-long PNG never lands because no producer ran.
+        const p = preview({
+            id: "com.example.LongScroll",
+            renderOutput: "renders/LongScroll.png",
+            dataProducts: [
+                {
+                    kind: "render/scroll/long",
+                    advanceTimeMillis: null,
+                    scroll: longScroll,
+                    output: "data/render-scroll-long/LongScroll.png",
+                },
+            ],
+        });
+        const result = findMissingImageDataProducts(
+            [p],
+            () => mod(":wear"),
+            "/ws",
+            // Daemon's static base happens to be on disk — verify must still see the
+            // SCROLL PNG as missing (which is what's actually displayed).
+            (file) =>
+                file ===
+                "/ws/wear/build/compose-previews/renders/LongScroll.png",
+        );
+        assert.strictEqual(result.size, 1);
+        const missing = result.get(":wear");
+        assert.ok(missing && missing.length === 1);
+        assert.deepStrictEqual(missing[0], {
+            previewId: "com.example.LongScroll",
+            // Scroll-long drops the static base, so its data-product output lands at
+            // displayed-capture index 0.
+            captureIndex: 0,
+            renderOutput: "data/render-scroll-long/LongScroll.png",
+            absolutePath:
+                "/ws/wear/build/compose-previews/data/render-scroll-long/LongScroll.png",
+        });
+    });
+
+    it("flags a scroll-gif preview targeting a .gif output", () => {
+        // GIF data products carry mediaType image/gif; the panel renders them via
+        // `mimeFor` which sniffs the extension. Both .png and .gif extensions count
+        // as image data products for the missing-on-disk scan.
+        const p = preview({
+            id: "com.example.GifScroll",
+            dataProducts: [
+                {
+                    kind: "render/scroll/gif",
+                    advanceTimeMillis: null,
+                    scroll: gifScroll,
+                    output: "data/render-scroll-gif/GifScroll.gif",
+                },
+            ],
+        });
+        const result = findMissingImageDataProducts(
+            [p],
+            () => mod(":wear"),
+            "/ws",
+            () => false,
+        );
+        const missing = result.get(":wear");
+        assert.ok(missing && missing.length === 1);
+        assert.strictEqual(missing[0].captureIndex, 0);
+        assert.ok(missing[0].renderOutput.endsWith(".gif"));
+    });
+
+    it("skips data products whose file is already on disk", () => {
+        const p = preview({
+            id: "com.example.ReadyScroll",
+            dataProducts: [
+                {
+                    kind: "render/scroll/long",
+                    advanceTimeMillis: null,
+                    scroll: longScroll,
+                    output: "data/render-scroll-long/Ready.png",
+                },
+            ],
+        });
+        const result = findMissingImageDataProducts(
+            [p],
+            () => mod(":wear"),
+            "/ws",
+            () => true,
+        );
+        assert.strictEqual(result.size, 0);
+    });
+
+    it("skips non-image data products (a11y JSON outputs)", () => {
+        // Only image kinds drive a Gradle re-render. JSON data products (a11y/atf,
+        // compose/semantics, etc.) come through the daemon's attach path and would
+        // never benefit from a Gradle composePreviewRender.
+        const p = preview({
+            id: "com.example.A11y",
+            dataProducts: [
+                {
+                    kind: "a11y/hierarchy",
+                    advanceTimeMillis: null,
+                    scroll: null,
+                    output: "data/a11y/hierarchy/X.json",
+                },
+            ],
+        });
+        const result = findMissingImageDataProducts(
+            [p],
+            () => mod(":wear"),
+            "/ws",
+            () => false,
+        );
+        assert.strictEqual(result.size, 0);
+    });
+
+    it("groups multiple missing products by module so callers can dedup the Gradle render", () => {
+        const wearA = preview({
+            id: "com.example.A",
+            dataProducts: [
+                {
+                    kind: "render/scroll/long",
+                    advanceTimeMillis: null,
+                    scroll: longScroll,
+                    output: "data/render-scroll-long/A.png",
+                },
+            ],
+        });
+        const wearB = preview({
+            id: "com.example.B",
+            dataProducts: [
+                {
+                    kind: "render/scroll/gif",
+                    advanceTimeMillis: null,
+                    scroll: gifScroll,
+                    output: "data/render-scroll-gif/B.gif",
+                },
+            ],
+        });
+        const androidC = preview({
+            id: "com.example.C",
+            dataProducts: [
+                {
+                    kind: "render/scroll/long",
+                    advanceTimeMillis: null,
+                    scroll: longScroll,
+                    output: "data/render-scroll-long/C.png",
+                },
+            ],
+        });
+        const result = findMissingImageDataProducts(
+            [wearA, wearB, androidC],
+            (id) => (id === "com.example.C" ? mod(":android") : mod(":wear")),
+            "/ws",
+            () => false,
+        );
+        assert.strictEqual(result.size, 2);
+        assert.strictEqual(result.get(":wear")?.length, 2);
+        assert.strictEqual(result.get(":android")?.length, 1);
+    });
+});


### PR DESCRIPTION
Daemon renderNow only produces the static base capture; render/scroll/long and
render/scroll/gif outputs are renderer-side only (no daemon-side producer per
docs/daemon/DATA-PRODUCTS.md). The panel correctly drops the daemon's static
PNG for scroll previews via captureLabels.staticBaseCaptureIndex, but nothing
ever populated the data-product slot in a daemon-only flow, so scroll-long /
scroll-gif cards sat permanently as placeholders.

After the main image-load pass, scan the displayed previews for image data
products whose output file is missing on disk, group by module, and fire a
one-shot composePreviewRender('full') per module (per-session dedup via
scrollBackfillRequested). When Gradle finishes, read the newly-produced PNG/GIF
and post updateImage to the panel's data-product capture slot.

Also fix verify: previewConsistency.pngPathFor now resolves against
withDataProductCaptures(preview), so the "8 placeholder(s) with PNG on disk"
output no longer counts the daemon's discarded base PNG and a missing scroll
PNG now reports as no-image-anywhere instead of a stale placeholder.