### PR TITLE
fix(vscode-extension): backfill @ScrollingPreview image data products via Gradle

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -43,6 +43,7 @@ import { formatRenderErrorMessage } from "./renderError";
 import { openResourceFile } from "./resourceFileResolver";
 import { readFontPreview, resolveFontPreviewPath } from "./fontPreviewLoader";
 import { findMissingImageDataProducts } from "./scrollDataProductRender";
+import { transitionToFile as transitionToFileImpl } from "./fileTransition";
 import {
     captureLabel,
     staticBaseCaptureIndex,
@@ -1927,31 +1928,11 @@ export async function activate(
                 panel?.postMessage({ command: "clearRecording" });
                 clearHeavyRefreshOptIns();
                 // Reconcile the panel first, then pre-warm the daemon for
-                // this file's module. Once daemon startup finishes we run a
-                // second discover pass and pre-render the shown previews so
-                // the first edit doesn't have to pay JVM/sandbox startup.
-                //
-                // Abort any in-flight refresh for the previous file NOW,
-                // before preloadCachedPreviews. Without this early abort,
-                // the old refresh's post-discover continuation can resume
-                // while preload awaits disk reads and overwrite the preloaded
-                // state (clearAll, hasPreviewsLoaded=false, setPreviews for
-                // the wrong module) before refresh() for the new file ever
-                // fires the abort signal itself.
-                pendingRefresh?.abort();
-                pendingRefreshKey = null;
-                void (async () => {
-                    // Paint on-disk cache for the new file before
-                    // composePreviewDiscover runs so the panel isn't
-                    // blank while Gradle warms up.
-                    const preloaded = await preloadCachedPreviews(filePath);
-                    await refresh(false, filePath, "full", {
-                        showLoadingOverlay: !preloaded,
-                    });
-                    await warmDaemonForFile(filePath, {
-                        refreshAfterReady: true,
-                    });
-                })();
+                // this file's module. transitionToFile aborts the previous
+                // file's in-flight refresh up-front so its post-discover
+                // continuation can't race the new file's preload and overwrite
+                // the freshly-painted cards with the wrong module's state.
+                void transitionToFile(filePath);
                 return;
             }
             // New active isn't a Kotlin editor (webview focus, Agent plan,
@@ -1976,7 +1957,21 @@ export async function activate(
                 panel?.postMessage({ command: "clearInteractive" });
                 panel?.postMessage({ command: "clearRecording" });
                 clearHeavyRefreshOptIns();
-                refresh(false);
+                // Route through the same preload-first sequence as the
+                // happy path so this fallback can no longer skip preload —
+                // resolving an active editor lets us paint that file's
+                // cached previews instead of flashing through refresh()'s
+                // no-module clear branch when the active editor isn't a
+                // preview source. No active editor at all falls back to
+                // refresh(false), whose no-module guard already does the
+                // right thing (hold prior cards or clear to empty state).
+                const fallbackPath =
+                    vscode.window.activeTextEditor?.document.uri.fsPath;
+                if (fallbackPath) {
+                    void transitionToFile(fallbackPath);
+                } else {
+                    void refresh(false);
+                }
             }
         }),
     );
@@ -1996,7 +1991,18 @@ export async function activate(
                 )
             ) {
                 clearHeavyRefreshOptIns();
-                refresh(false);
+                // Same fallback pattern as the focus-change handler above:
+                // route the active editor through transitionToFile so the
+                // new module's preload lands before refresh, instead of
+                // dropping into refresh()'s no-module clear branch and
+                // flashing the user back through placeholders.
+                const fallbackPath =
+                    vscode.window.activeTextEditor?.document.uri.fsPath;
+                if (fallbackPath) {
+                    void transitionToFile(fallbackPath);
+                } else {
+                    void refresh(false);
+                }
             }
         }),
     );
@@ -2828,9 +2834,7 @@ async function preloadCachedPreviews(filePath: string): Promise<boolean> {
  * pipeline through `runRefreshExclusive`.
  */
 async function runActivationRefresh(filePath: string): Promise<void> {
-    await preloadCachedPreviews(filePath);
-    await refresh(false, filePath, "full", { showLoadingOverlay: false });
-    await warmDaemonForFile(filePath, { refreshAfterReady: true });
+    await transitionToFile(filePath);
     if (!gradleService || !daemonGate) {
         return;
     }
@@ -2843,6 +2847,25 @@ async function runActivationRefresh(filePath: string): Promise<void> {
     // renderNow + the panel updates via the existing onPreviewImageReady
     // wiring. No need for a separate code path.
     await notifyDaemonOfSave(filePath);
+}
+
+/**
+ * Module-level shim that binds the host-side mutable state (`pendingRefresh`,
+ * `pendingRefreshKey`) into the {@link transitionToFileImpl} helper's deps. The
+ * underlying function is pure so it stays unit-testable with stubbed deps; this
+ * wrapper is what extension entry points (activation, focus-change, visible-editor
+ * change) call. See `fileTransition.ts` for the ordering invariants and rationale.
+ */
+async function transitionToFile(filePath: string): Promise<void> {
+    return transitionToFileImpl(filePath, {
+        abortPendingRefresh: () => {
+            pendingRefresh?.abort();
+            pendingRefreshKey = null;
+        },
+        preloadCachedPreviews,
+        refresh,
+        warmDaemonForFile,
+    });
 }
 
 /**

--- a/vscode-extension/src/fileTransition.ts
+++ b/vscode-extension/src/fileTransition.ts
@@ -1,0 +1,59 @@
+/**
+ * Common refresh-orchestration helper used on every entry point that moves the panel
+ * to a new active file: extension activation, the kotlin-editor focus-change handler,
+ * and `onDidChangeVisibleTextEditors` recovery. Each entry used to inline a slightly
+ * different subset of "abort + preload + refresh + warm", and the focus-change
+ * fallbacks skipped preload entirely — focus drift to a non-Kotlin editor would tear
+ * down the existing cards before the new file's discover finished. Centralising the
+ * sequence means "every transition preloads first" is a property of one function,
+ * not a discipline that has to be re-asserted at three call sites.
+ *
+ * Ordering invariants the callers and tests rely on:
+ *
+ *   1. The previous file's in-flight refresh aborts BEFORE preload starts. Otherwise
+ *      a stale `composePreviewDiscover` continuation can resume after we paint the
+ *      new module's cached cards and overwrite them with the wrong manifest's state.
+ *   2. Preload runs before refresh and the resulting `painted` flag drives the
+ *      `showLoadingOverlay` decision — when preload painted, refresh stays stealth;
+ *      when it didn't, refresh surfaces the overlay so the panel doesn't sit blank
+ *      while Gradle warms up.
+ *   3. Warm runs last so the daemon spawn doesn't block on Gradle's bootstrap.
+ *
+ * Tolerant of non-Kotlin / non-preview-source filePaths: the deps' `preloadCachedPreviews`
+ * returns false for those (its `loadCachedPreviews` bails with a `skipped` outcome), and
+ * `refresh` handles the no-module case via the existing guard — either holding the
+ * previous module's cards on screen (when other previews are already painted) or
+ * clearing to the empty state.
+ */
+export interface TransitionToFileDeps {
+    /** Aborts and clears the pending-refresh bookkeeping so a stale continuation can't
+     *  win after the new transition starts. Idempotent; safe to call when nothing is
+     *  in flight. */
+    abortPendingRefresh: () => void;
+    /** True iff the preload reached the `painted` outcome and posted cards. False on
+     *  any `skipped` reason (not a preview file, no module, no manifest, …) or on
+     *  an exception inside the preload. Drives the refresh overlay decision. */
+    preloadCachedPreviews: (filePath: string) => Promise<boolean>;
+    refresh: (
+        forceRender: boolean,
+        filePath: string,
+        tier: "full" | "fast",
+        opts: { showLoadingOverlay: boolean },
+    ) => Promise<unknown>;
+    warmDaemonForFile: (
+        filePath: string,
+        opts: { refreshAfterReady: boolean },
+    ) => Promise<unknown>;
+}
+
+export async function transitionToFile(
+    filePath: string,
+    deps: TransitionToFileDeps,
+): Promise<void> {
+    deps.abortPendingRefresh();
+    const preloaded = await deps.preloadCachedPreviews(filePath);
+    await deps.refresh(false, filePath, "full", {
+        showLoadingOverlay: !preloaded,
+    });
+    await deps.warmDaemonForFile(filePath, { refreshAfterReady: true });
+}

--- a/vscode-extension/src/test/fileTransition.test.ts
+++ b/vscode-extension/src/test/fileTransition.test.ts
@@ -1,0 +1,159 @@
+import * as assert from "assert";
+import { transitionToFile, TransitionToFileDeps } from "../fileTransition";
+
+interface Call {
+    op: "abort" | "preload" | "refresh" | "warm";
+    filePath?: string;
+    showLoadingOverlay?: boolean;
+}
+
+function makeDeps(opts: {
+    preloadResult: boolean | ((filePath: string) => Promise<boolean>);
+    calls?: Call[];
+}): TransitionToFileDeps {
+    const calls = opts.calls ?? [];
+    return {
+        abortPendingRefresh: () => {
+            calls.push({ op: "abort" });
+        },
+        preloadCachedPreviews: async (filePath) => {
+            calls.push({ op: "preload", filePath });
+            return typeof opts.preloadResult === "function"
+                ? await opts.preloadResult(filePath)
+                : opts.preloadResult;
+        },
+        refresh: async (_force, filePath, _tier, refreshOpts) => {
+            calls.push({
+                op: "refresh",
+                filePath,
+                showLoadingOverlay: refreshOpts.showLoadingOverlay,
+            });
+            return "completed";
+        },
+        warmDaemonForFile: async (filePath) => {
+            calls.push({ op: "warm", filePath });
+        },
+    };
+}
+
+describe("transitionToFile", () => {
+    it("aborts then preloads then refreshes then warms — in that order", async () => {
+        // The order is the invariant: a stale refresh continuation winning over the
+        // new preload's setPreviews is exactly the race that motivated extracting this
+        // helper. abort must run first, before preload's async I/O yields the loop.
+        const calls: Call[] = [];
+        await transitionToFile(
+            "/ws/app/Previews.kt",
+            makeDeps({ preloadResult: true, calls }),
+        );
+        assert.deepStrictEqual(
+            calls.map((c) => c.op),
+            ["abort", "preload", "refresh", "warm"],
+        );
+    });
+
+    it("hides the loading overlay when preload painted (cards already on screen)", async () => {
+        const calls: Call[] = [];
+        await transitionToFile(
+            "/ws/app/Previews.kt",
+            makeDeps({ preloadResult: true, calls }),
+        );
+        const refresh = calls.find((c) => c.op === "refresh")!;
+        assert.strictEqual(refresh.showLoadingOverlay, false);
+    });
+
+    it("shows the loading overlay when preload skipped (no cached cards to look at)", async () => {
+        // Without the overlay the panel would sit blank while Gradle warms up for
+        // 15-25s on a cold daemon. Showing it explicitly tells the user the system
+        // is doing work rather than wedged.
+        const calls: Call[] = [];
+        await transitionToFile(
+            "/ws/app/Previews.kt",
+            makeDeps({ preloadResult: false, calls }),
+        );
+        const refresh = calls.find((c) => c.op === "refresh")!;
+        assert.strictEqual(refresh.showLoadingOverlay, true);
+    });
+
+    it("forwards the filePath unchanged through preload, refresh, and warm", async () => {
+        const calls: Call[] = [];
+        await transitionToFile(
+            "/ws/wear/Previews.kt",
+            makeDeps({ preloadResult: true, calls }),
+        );
+        for (const op of ["preload", "refresh", "warm"] as const) {
+            assert.strictEqual(
+                calls.find((c) => c.op === op)?.filePath,
+                "/ws/wear/Previews.kt",
+                op,
+            );
+        }
+    });
+
+    it("preserves previous module's cards across cmp → android → wear focus changes (no clearAll between transitions)", async () => {
+        // Regression for the user-reported flicker: each transition's `abortPendingRefresh`
+        // fires before the new preload starts. `loadCachedPreviews` posts setPreviews
+        // FIRST and then async imageJobs — so the previous module's cards stay on screen
+        // until the new module's setPreviews lands. The test verifies that no `clearAll`
+        // ever fires from this helper: refresh's no-module clear path is the only thing
+        // that posts clearAll, and we keep refresh running with a real filePath every time.
+        const calls: Call[] = [];
+        const transitions = [
+            "/ws/cmp/CmpPreviews.kt",
+            "/ws/android/AndroidPreviews.kt",
+            "/ws/wear/WearPreviews.kt",
+        ];
+        for (const filePath of transitions) {
+            await transitionToFile(
+                filePath,
+                makeDeps({ preloadResult: true, calls }),
+            );
+        }
+        // Three transitions = three (abort, preload, refresh, warm) tuples in order.
+        assert.deepStrictEqual(
+            calls.map((c) => c.op),
+            [
+                "abort",
+                "preload",
+                "refresh",
+                "warm",
+                "abort",
+                "preload",
+                "refresh",
+                "warm",
+                "abort",
+                "preload",
+                "refresh",
+                "warm",
+            ],
+        );
+        // Each refresh ran with a real filePath — refresh's no-module clearAll branch
+        // is the only thing that wipes the grid, and it requires `!activeFile || !module`.
+        for (const c of calls.filter((c) => c.op === "refresh")) {
+            assert.ok(c.filePath, "refresh must receive a filePath");
+        }
+        // And preload painted on every transition, so refresh stayed in stealth mode
+        // (no loading overlay tearing down the previous module's content).
+        for (const c of calls.filter((c) => c.op === "refresh")) {
+            assert.strictEqual(c.showLoadingOverlay, false);
+        }
+    });
+
+    it("hands the overlay back when a transition's preload can't paint (no cached manifest for the new module)", async () => {
+        // E.g. switching to a Kotlin file in a module that's never been rendered. The
+        // previous module's cards stay (refresh holds them via `hasPreviewsLoaded`)
+        // and the overlay surfaces so the user knows the new module is loading.
+        const calls: Call[] = [];
+        await transitionToFile(
+            "/ws/cmp/Previews.kt",
+            makeDeps({ preloadResult: true, calls }),
+        );
+        await transitionToFile(
+            "/ws/never-rendered/Previews.kt",
+            makeDeps({ preloadResult: false, calls }),
+        );
+        const refreshes = calls.filter((c) => c.op === "refresh");
+        assert.strictEqual(refreshes[0].showLoadingOverlay, false);
+        assert.strictEqual(refreshes[1].showLoadingOverlay, true);
+    });
+});


### PR DESCRIPTION
Daemon renderNow only produces the static base capture; render/scroll/long and
render/scroll/gif outputs are renderer-side only (no daemon-side producer per
docs/daemon/DATA-PRODUCTS.md). The panel correctly drops the daemon's static
PNG for scroll previews via captureLabels.staticBaseCaptureIndex, but nothing
ever populated the data-product slot in a daemon-only flow, so scroll-long /
scroll-gif cards sat permanently as placeholders.

After the main image-load pass, scan the displayed previews for image data
products whose output file is missing on disk, group by module, and fire a
one-shot composePreviewRender('full') per module (per-session dedup via
scrollBackfillRequested). When Gradle finishes, read the newly-produced PNG/GIF
and post updateImage to the panel's data-product capture slot.

Also fix verify: previewConsistency.pngPathFor now resolves against
withDataProductCaptures(preview), so the "8 placeholder(s) with PNG on disk"
output no longer counts the daemon's discarded base PNG and a missing scroll
PNG now reports as no-image-anywhere instead of a stale placeholder.