### PR TITLE
test: track Confetti main + richer a11y dump fields

### DIFF
--- a/.github/workflows/vscode-extension-e2e-external.yml
+++ b/.github/workflows/vscode-extension-e2e-external.yml
@@ -3,9 +3,10 @@ name: VS Code Extension E2E (external consumer)
 # Companion to `vscode-extension-e2e.yml`. That workflow drives the
 # extension against `:samples:cmp` / `:samples:wear`, both wired via
 # `includeBuild("gradle-plugin")` — the dev-loop path. This workflow drives
-# the extension against `joreilly/Confetti` (pinned SHA), with the plugin
-# resolved through the consumer's `gradle/libs.versions.toml` against the
-# local SNAPSHOT just `publishToMavenLocal`'d. That closes the published-
+# the extension against `joreilly/Confetti` (tracking `main`, override via
+# `EXTERNAL_REPO_REF` from workflow_dispatch), with the plugin resolved
+# through the consumer's `gradle/libs.versions.toml` against the local
+# SNAPSHOT just `publishToMavenLocal`'d. That closes the published-
 # plugin-coordinate gap: the in-repo suite can't catch regressions where the
 # plugin works fine via `includeBuild` but fails as a published artifact
 # against a real KMP/AGP/Compose classpath.
@@ -30,7 +31,7 @@ on:
   workflow_dispatch:
     inputs:
       confetti_ref:
-        description: "Confetti git SHA / branch / tag (defaults to the pin in setup-external-e2e.sh)"
+        description: "Confetti git SHA / branch / tag (defaults to `main`; see setup-external-e2e.sh)"
         required: false
         type: string
   push:
@@ -112,11 +113,11 @@ jobs:
         working-directory: vscode-extension
         run: npm run compile
 
-      # Prepare the external workspace: clone Confetti at the pinned SHA
-      # (or the workflow_dispatch override), rewrite its catalog to
-      # point at the SNAPSHOT we just published, seed local.properties
-      # with the runner's Android SDK path. Stdout is the prepared
-      # workspace path — capture it and forward to the test runner.
+      # Prepare the external workspace: clone Confetti at `main` (or the
+      # `EXTERNAL_REPO_REF` workflow_dispatch override), rewrite its
+      # catalog to point at the SNAPSHOT we just published, seed
+      # local.properties with the runner's Android SDK path. Stdout is the
+      # prepared workspace path — capture it and forward to the test runner.
       - name: Prepare external workspace (Confetti)
         id: prepare
         env:

--- a/vscode-extension/scripts/setup-external-e2e.sh
+++ b/vscode-extension/scripts/setup-external-e2e.sh
@@ -34,11 +34,14 @@
 set -euo pipefail
 
 DEFAULT_REPO_URL="https://github.com/joreilly/Confetti.git"
-# Pinned to the commit that bumped composeai-preview to 0.9.1 (PR #1689).
-# Picked because it's the most recent point where the catalog declares our
-# plugin id, so future Confetti reshuffles can't silently break the suite.
-# Bump when we want to test against newer downstream code.
-DEFAULT_REPO_REF="2044dcc7efe90773b71eecf84ebc318327837984"
+# Track `main` rather than a pinned SHA. Lets the suite pick up upstream
+# fixes (e.g. catalog dep adjustments needed for new plugin task wiring)
+# without requiring a separate bump PR, and the catalog rewrite below
+# still pins our plugin version to the SNAPSHOT we just published, so the
+# only drift we're tracking is Confetti's own code. Override with
+# `EXTERNAL_REPO_REF=<sha>` from `workflow_dispatch` when reproducing a
+# specific regression.
+DEFAULT_REPO_REF="main"
 
 target_dir="${1:-/tmp/compose-preview-external-e2e}"
 repo_url="${EXTERNAL_REPO_URL:-$DEFAULT_REPO_URL}"

--- a/vscode-extension/scripts/setup-external-e2e.sh
+++ b/vscode-extension/scripts/setup-external-e2e.sh
@@ -91,7 +91,14 @@ else
     current="$(git rev-parse HEAD)"
     if [[ "$current" != "$repo_ref"* ]]; then
       git fetch --depth 1 origin "$repo_ref"
-      git checkout -q FETCH_HEAD
+      # `--force` discards uncommitted edits in the existing checkout
+      # before moving HEAD. Required because the catalog rewrite below
+      # is regenerated on every run and stays uncommitted: a plain
+      # `checkout` would refuse with "your local changes would be
+      # overwritten" the moment upstream advances `libs.versions.toml`
+      # itself. The rewrite is re-applied right below, so dropping it
+      # here is safe.
+      git checkout -fq FETCH_HEAD
     fi
   )
 fi

--- a/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eA11y.test.ts
@@ -101,17 +101,94 @@ function dumpA11yFailureDiagnostics(
     for (const line of tail) {
         console.log(`[e2e-a11y-diag/channel] ${line}`);
     }
-    const stableSummary = (raw: unknown): string => {
-        const m = raw as { command?: string; previewId?: string };
-        const cmd = m?.command ?? "<no-command>";
-        const id = m?.previewId ? ` previewId=${m.previewId}` : "";
-        return `${cmd}${id}`;
-    };
-    for (const raw of posted.slice(-30)) {
-        console.log(`[e2e-a11y-diag/posted] ${stableSummary(raw)}`);
+    // Compact the chatty `setProgress`/`clearProgress` stream so they don't
+    // crowd out the actually-interesting `updateA11y` / `webviewA11yState` /
+    // `updateDataProducts` lines when the buffer holds dozens of progress
+    // frames per render. Each summarised group counts the run; the first
+    // non-progress message ends the group.
+    interface Counted {
+        kind: "single" | "progress-group";
+        text: string;
     }
-    for (const raw of received.slice(-30)) {
-        console.log(`[e2e-a11y-diag/received] ${stableSummary(raw)}`);
+    const compact = (msgs: unknown[]): Counted[] => {
+        const out: Counted[] = [];
+        let groupCmd: string | null = null;
+        let groupCount = 0;
+        const flush = () => {
+            if (groupCmd && groupCount > 0) {
+                out.push({
+                    kind: "progress-group",
+                    text: `${groupCmd} ×${groupCount}`,
+                });
+            }
+            groupCmd = null;
+            groupCount = 0;
+        };
+        for (const raw of msgs) {
+            const m = raw as {
+                command?: string;
+                previewId?: string;
+                nodesCount?: unknown;
+                findingsCount?: unknown;
+                kinds?: unknown;
+                findings?: unknown[];
+                nodes?: unknown[];
+                dataProducts?: unknown[];
+            };
+            const cmd = m?.command ?? "<no-command>";
+            if (cmd === "setProgress" || cmd === "clearProgress") {
+                if (cmd === groupCmd) {
+                    groupCount++;
+                } else {
+                    flush();
+                    groupCmd = cmd;
+                    groupCount = 1;
+                }
+                continue;
+            }
+            flush();
+            const fields: string[] = [];
+            if (typeof m?.previewId === "string") {
+                fields.push(`previewId=${m.previewId}`);
+            }
+            // Detail fields useful for the wear-a11y diagnosis: full
+            // count surface of webviewA11yState, plus the upstream
+            // updateA11y shape that drives it (findings/nodes arrays
+            // on host posts). `updateDataProducts` carries the daemon's
+            // attached payload kinds, which is what we ultimately need
+            // to know "did the daemon emit a11y data this render?".
+            if ("nodesCount" in m) fields.push(`nodesCount=${m.nodesCount}`);
+            if ("findingsCount" in m)
+                fields.push(`findingsCount=${m.findingsCount}`);
+            if (Array.isArray(m?.findings))
+                fields.push(`findings=${m.findings.length}`);
+            if (Array.isArray(m?.nodes)) fields.push(`nodes=${m.nodes.length}`);
+            if (Array.isArray(m?.dataProducts)) {
+                const kinds = (m.dataProducts as Array<{ kind?: string }>).map(
+                    (dp) => dp?.kind ?? "<?>",
+                );
+                fields.push(`dataProducts=[${kinds.join(",")}]`);
+            }
+            if (Array.isArray(m?.kinds)) {
+                fields.push(`kinds=[${(m.kinds as unknown[]).join(",")}]`);
+            }
+            out.push({
+                kind: "single",
+                text: `${cmd}${fields.length ? " " + fields.join(" ") : ""}`,
+            });
+        }
+        flush();
+        return out;
+    };
+    // Cap the tail we dump so a long suite doesn't drown the workflow log,
+    // but keep enough room (60) for renderStarted + per-card setProgress
+    // burst + renderFinished + updateA11y + ack from a fresh render to
+    // fit comfortably.
+    for (const entry of compact(posted).slice(-60)) {
+        console.log(`[e2e-a11y-diag/posted] ${entry.text}`);
+    }
+    for (const entry of compact(received).slice(-60)) {
+        console.log(`[e2e-a11y-diag/received] ${entry.text}`);
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1514. Two commits cherry-picked off the merged branch that didn't make it onto `main`:

- **`test(vscode-extension): log a11y ack counts + collapse setProgress in dump`** — the first round of a11y diagnostics from #1514 narrowed the wear failures but the dump summary only logged `command + previewId`, which couldn't tell three plausible causes apart:
  - (a) `webviewA11yState` arrives with `nodesCount: 0` (empty hierarchy)
  - (b) `webviewA11yState` arrives with `nodesCount: null` (wrong kind attached)
  - (c) ack arrives for a previewId that doesn't match `target.id` (stale ack)

  Expands the compactor to log `nodesCount` / `findingsCount` on the ack, `findings` / `nodes` array sizes on the upstream `updateA11y` post, and the daemon's `dataProducts` kinds, plus collapses `setProgress` / `clearProgress` runs into `setProgress ×N` so they don't crowd out the rest. Widens the tail cap from 30 to 60 lines so a full `renderStarted → setProgress×N → renderFinished → updateA11y → ack` sequence fits.

- **`test(external-e2e): track Confetti main instead of pinned SHA`** — the previous SHA pin (`2044dcc7…`) meant consumer-side regressions only surfaced when someone manually bumped the pin. Most recent failure (`composePreviewDaemonStart` task missing on `:androidApp`) was exactly the shape of problem that should follow upstream rather than wait on a manual nudge. The catalog rewrite still pins our plugin coordinate to the freshly-published SNAPSHOT, so the only thing tracking upstream is Confetti's own code. Manual reproduction of a specific regression remains a one-flag override via `EXTERNAL_REPO_REF` on workflow_dispatch.

## Test plan

- `npm test` (1359 passing) locally.
- Workflow effect lands on the next `workflow_dispatch` of `vscode-extension-e2e.yml` (wear a11y diag) and `vscode-extension-e2e-external.yml` (Confetti `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_017pwPFw2a8N3yqqgG2PRmVg)_