### PR TITLE
fix: stop emitting phantom static capture for @ScrollingPreview LONG/GIF-only

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
@@ -130,11 +130,9 @@ class PreviewListResponseTest {
   @Test
   fun `scroll artifact data products surface as preview captures`() {
     val projectDir = Files.createTempDirectory("preview-result-test").toFile()
-    val clean =
-      projectDir.resolve("build/compose-previews/renders/LongPreview.png").also {
-        it.parentFile.mkdirs()
-        it.writeBytes(byteArrayOf(1, 2, 3))
-      }
+    // `@ScrollingPreview(modes = [LONG])` with nothing else now produces a manifest with NO
+    // static capture and just the data product (issue #1524). The data product surfaces as
+    // the result's single capture.
     val long =
       projectDir.resolve("build/compose-previews/data/render-scroll-long/LongPreview.png").also {
         it.parentFile.mkdirs()
@@ -150,7 +148,7 @@ class PreviewListResponseTest {
               id = "com.example.LongPreview",
               functionName = "LongPreview",
               className = "com.example.PreviewsKt",
-              captures = listOf(Capture(renderOutput = "renders/${clean.name}")),
+              captures = emptyList(),
               dataProducts =
                 listOf(
                   PreviewDataProduct(

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1008,12 +1008,16 @@ object PreviewDiscovery {
 
     // When ONLY @AnimatedPreview (or @FocusedPreview(gif = true)) is on the function, the
     // scroll/time/focus cross-product would still emit one (null, null, null) row — i.e. a
-    // static PNG capture. Suppress that to keep single-output annotations clean.
+    // static PNG capture. Suppress that to keep single-output annotations clean. The same
+    // applies to @ScrollingPreview with only data-product modes (LONG/GIF): the data product
+    // IS the rendered output (the tall stitched PNG / scrolling GIF), so a sibling static
+    // `renders/<id>.png` would just be the unscrolled initial frame — misleading, and the
+    // exact regression issue #1524 reported.
     val emitStaticCross =
       captureScrolls.isNotEmpty() ||
         effectiveTimings.isNotEmpty() ||
         effectiveFocuses.isNotEmpty() ||
-        (effectiveAnimation == null && effectiveFocusGif == null)
+        (effectiveAnimation == null && effectiveFocusGif == null && productScrolls.isEmpty())
 
     val scrollTimeCaptures: List<Capture> =
       if (!emitStaticCross) emptyList()

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -649,7 +649,11 @@ class DiscoveryFunctionalTest {
     }
 
     val longPreview = manifest.previews.single { it.functionName == "LongScrollPreview" }
-    assertThat(longPreview.captures.single().scroll).isNull()
+    // `@ScrollingPreview(modes = [LONG])` with nothing else cross-products to a static frame
+    // produces ONLY a data product — no phantom `renders/<id>.png` capture. The data product
+    // IS the rendered output; emitting a sibling static would just write the unscrolled
+    // initial frame to renders/, which is what issue #1524 reported as confusing.
+    assertThat(longPreview.captures).isEmpty()
     assertThat(longPreview.dataProducts.single().scroll)
       .isEqualTo(
         ScrollCapture(
@@ -691,8 +695,8 @@ class DiscoveryFunctionalTest {
     // `_SCROLL_gif` suffix) and round-trips `frameIntervalMs` onto the
     // manifest so the renderer can honour it.
     val gifOnly = manifest.previews.single { it.functionName == "GifScrollPreview" }
-    assertThat(gifOnly.captures).hasSize(1)
-    assertThat(gifOnly.captures.single().scroll).isNull()
+    // GIF-only follows the same rule as LONG-only — pure data product, no static sibling.
+    assertThat(gifOnly.captures).isEmpty()
     assertThat(gifOnly.dataProducts.single().scroll)
       .isEqualTo(
         ScrollCapture(

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
@@ -43,10 +43,9 @@ class CleanStaleRendersTest {
   @Test
   fun `missing output check includes scroll data products`() {
     val outDir = tempDir.root.resolve("build/compose-previews")
-    outDir.resolve("renders/Foo.png").also {
-      it.parentFile.mkdirs()
-      it.writeBytes(byteArrayOf(1))
-    }
+    // `@ScrollingPreview(modes = [LONG])` alone produces ONLY a data product — discovery
+    // no longer emits a phantom `renders/<id>.png` capture (issue #1524). The product must
+    // still exist on disk for the preview to be considered rendered.
     val manifest =
       PreviewManifest(
         module = "app",
@@ -57,7 +56,7 @@ class CleanStaleRendersTest {
               id = "Foo",
               functionName = "Foo",
               className = "com.example.PreviewsKt",
-              captures = listOf(Capture(renderOutput = "renders/Foo.png")),
+              captures = emptyList(),
               dataProducts =
                 listOf(
                   PreviewDataProduct(
@@ -85,10 +84,6 @@ class CleanStaleRendersTest {
   @Test
   fun `fast tier tolerates missing heavy data products`() {
     val outDir = tempDir.root.resolve("build/compose-previews")
-    outDir.resolve("renders/Foo.png").also {
-      it.parentFile.mkdirs()
-      it.writeBytes(byteArrayOf(1))
-    }
     val manifest =
       PreviewManifest(
         module = "app",
@@ -99,7 +94,7 @@ class CleanStaleRendersTest {
               id = "Foo",
               functionName = "Foo",
               className = "com.example.PreviewsKt",
-              captures = listOf(Capture(renderOutput = "renders/Foo.png")),
+              captures = emptyList(),
               dataProducts =
                 listOf(
                   PreviewDataProduct(

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -418,7 +418,12 @@ abstract class RobolectricRenderTestBase(
         // Drop any stale .error.json from a prior run before attempting a
         // fresh render. If today's render succeeds, the panel doesn't want
         // to surface yesterday's exception alongside the new PNG.
-        val pngFile = outputFileFor(preview.captures.first(), outputDir)
+        // `@ScrollingPreview(modes = [LONG/GIF])` with no other captures lands
+        // here with an empty captures list (issue #1524) — use the first data
+        // product as the sidecar anchor instead so the same per-output error
+        // surface keeps working.
+        val pngFile = preview.captures.firstOrNull()?.let { outputFileFor(it, outputDir) }
+            ?: outputFileFor(preview.dataProducts.first(), outputDir)
         RenderErrorSidecar.deleteStale(pngFile)
 
         // Catch Throwable per preview. Today, a throw inside the preview

--- a/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderShardTest.kt
+++ b/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderShardTest.kt
@@ -31,11 +31,13 @@ class PreviewManifestLoaderShardTest {
     }
 
     private fun productRow(id: String, cost: Float): PreviewRow {
+        // `@ScrollingPreview(modes = [LONG])` alone produces ONLY a data product — no static
+        // capture sibling (issue #1524). Sharding still needs to weigh data-product cost.
         val entry = RenderPreviewEntry(
             id = id,
             functionName = id,
             className = "com.example.PreviewsKt",
-            captures = listOf(RenderPreviewCapture(renderOutput = "renders/$id.png", cost = 1f)),
+            captures = emptyList(),
             dataProducts =
                 listOf(
                     RenderPreviewDataProduct(


### PR DESCRIPTION
`@ScrollingPreview(modes = [LONG])` (or `[GIF]`) with no other captures was
emitting two manifest entries: a static `renders/<id>.png` capture for the
unscrolled initial frame, and the actual `data/render-scroll-long/<id>.png`
data product with the stitched tall PNG. Agents browsing `renders/` got the
misleading static thumbnail (e.g. 454x454 for a Wear preview that should be
454x697) — VS Code's `withDataProductCaptures` fold and the CLI's
`PreviewResultBuilder.isSingleStaticCapture` fallback both already
hide the phantom static, but the file on disk and the manifest itself
still surfaced it.

Suppress the static cross-product at discovery time when the only scroll
modes are data products (LONG/GIF) and no timings/focuses/animations
cross-product anything else. Closes the gap on what the annotation doc
already says ("LONG and GIF are mapped to data products").

`RobolectricRenderTest` previously dereferenced `preview.captures.first()`
to anchor stale-sidecar cleanup; falls back to the first data product when
captures is empty so the empty-captures path works end-to-end.

Fixes #1524.