### PR TITLE
refactor(vscode-extension): gate @ScrollingPreview Gradle backfill on viewport

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -42,7 +42,11 @@ import {
 import { formatRenderErrorMessage } from "./renderError";
 import { openResourceFile } from "./resourceFileResolver";
 import { readFontPreview, resolveFontPreviewPath } from "./fontPreviewLoader";
-import { findMissingImageDataProducts } from "./scrollDataProductRender";
+import {
+    findMissingImageDataProducts,
+    MissingImageDataProduct,
+} from "./scrollDataProductRender";
+import { modulesNeedingViewportBackfill } from "./viewportScrollBackfill";
 import { RefreshOrchestrator } from "./refreshOrchestrator";
 import {
     captureLabel,
@@ -220,6 +224,16 @@ const moduleManifestCache = new Map<string, PreviewInfo[]>();
  * "Render Previews" command remains the manual escape hatch.
  */
 const scrollBackfillRequested = new Set<string>();
+/**
+ * Missing image data products from the most recent refresh, grouped by owning
+ * module. Computed once at the tail end of `refresh()` (when we know the displayed
+ * preview set) and consumed by `notifyDaemonViewport` to decide whether the latest
+ * viewport push has brought a `@ScrollingPreview` card into view that still needs a
+ * Gradle backfill. Empty when the active scope has no missing image data products,
+ * which makes the viewport-side check a no-op for the overwhelmingly common case of
+ * a project without scroll/animation previews.
+ */
+let pendingScrollBackfill: Map<string, MissingImageDataProduct[]> = new Map();
 /**
  * Heavy previews the user explicitly asked to keep fresh for the current
  * editor focus scope. Cleared when focus leaves the backing Kotlin file.
@@ -4229,6 +4243,10 @@ async function refresh(
         });
         lastLoadedModules = [];
         hasPreviewsLoaded = false;
+        // Scope is gone — any previously-stashed scroll backfill targets the file
+        // we just transitioned away from. Drop them so a stray viewport report
+        // doesn't fire a Gradle render against a module the panel is no longer on.
+        pendingScrollBackfill = new Map();
         setCurrentScopeFile(null);
         clearHeavyRefreshOptIns();
         historyScopeRef.current = null;
@@ -4726,39 +4744,32 @@ async function refresh(
             writeCalibration(module, tracker.phaseDurations);
         }
 
-        // Backfill `@ScrollingPreview(LONG/GIF)` image data products that no producer
-        // has filled in. Scroll outputs are renderer-side only (the daemon's renderNow
-        // produces just the static base capture, which the panel correctly drops for
-        // scroll previews) so daemon-only flows leave these cards permanently empty.
-        // Skip when we're already in the forceRender path — that pass just produced
-        // everything Gradle could produce. Skip in minimal mode — the user opted out
-        // of auto-renders and would expect to drive `composePreviewRender` themselves.
-        // Per-module session dedup via `scrollBackfillRequested` keeps a project that
-        // genuinely can't produce the scroll PNG (broken @ScrollingPreview wiring,
-        // renderer crash) from looping a Gradle invocation on every focus change.
+        // Compute `@ScrollingPreview(LONG/GIF)` image data products that no producer
+        // has filled in yet, and stash them for the viewport-driven trigger. Scroll
+        // outputs are renderer-side only (the daemon's renderNow produces just the
+        // static base capture, which the panel correctly drops for scroll previews)
+        // so daemon-only flows leave these cards permanently empty. Skip in the
+        // forceRender path — that pass just produced everything Gradle could produce.
+        // Skip in minimal mode — the user opted out of auto-renders and would expect
+        // to drive `composePreviewRender` themselves.
+        //
+        // The actual `composePreviewRender('full')` trigger fires from
+        // `notifyDaemonViewport` once a missing-PNG preview enters the viewport's
+        // visible-or-predicted set. Replaces the prior pattern of always firing a
+        // module-wide Gradle render at activation time — a project with 50 scroll
+        // previews where the user only sees the top few no longer pays the full
+        // module's cost up-front. Per-module session dedup via
+        // `scrollBackfillRequested` still keeps the trigger one-shot.
         if (!abort.signal.aborted && !forceRender && !inMinimalMode()) {
-            const missingByModule = findMissingImageDataProducts(
+            pendingScrollBackfill = findMissingImageDataProducts(
                 displayPreviews,
                 (id) => previewModuleIndex.get(id),
                 gradleService.workspaceRoot,
             );
-            for (const [modulePath, missing] of missingByModule) {
-                if (scrollBackfillRequested.has(modulePath)) continue;
-                scrollBackfillRequested.add(modulePath);
-                const owningModule = previewModuleIndex.get(
-                    missing[0].previewId,
-                );
-                if (!owningModule) continue;
-                logLine(
-                    `scroll backfill: ${modulePath} has ${missing.length} missing image data product(s); kicking composePreviewRender('full')`,
-                );
-                // Fire-and-forget so this doesn't block the in-flight refresh. The follow-up
-                // re-reads the newly-produced PNGs and posts `updateImage` for each — the
-                // existing image-load path keys on `captureIndex` in the displayed (post-
-                // `withDataProductCaptures`) captures, so `missing[].captureIndex` lines up
-                // with the slot the card carousel paints.
-                void backfillScrollDataProducts(owningModule, missing);
-            }
+        } else if (forceRender) {
+            // forceRender ran composePreviewRender directly — no backfill follow-up
+            // needed, and any prior stash is now stale.
+            pendingScrollBackfill = new Map();
         }
 
         // Source-newer-than-renders auto-refresh. Replaces the old "Showing
@@ -6963,6 +6974,38 @@ async function notifyDaemonViewport(
             visibleByModule.get(modulePath) ?? [],
             predictedByModule.get(modulePath) ?? [],
         );
+    }
+    // Demand-driven `@ScrollingPreview` backfill. Cheap when `pendingScrollBackfill`
+    // is empty (the common case for projects without scroll/animation previews);
+    // the intersection check only matters when refresh() stashed missing entries
+    // AND a visible-or-predicted preview is one of them.
+    triggerViewportScrollBackfill(visible, predicted);
+}
+
+function triggerViewportScrollBackfill(
+    visible: readonly string[],
+    predicted: readonly string[],
+): void {
+    if (inMinimalMode()) return;
+    const candidates = modulesNeedingViewportBackfill(
+        pendingScrollBackfill,
+        visible,
+        predicted,
+        scrollBackfillRequested,
+    );
+    for (const candidate of candidates) {
+        scrollBackfillRequested.add(candidate.modulePath);
+        const owningModule = previewModuleIndex.get(
+            candidate.missing[0].previewId,
+        );
+        if (!owningModule) continue;
+        logLine(
+            `scroll backfill: ${candidate.modulePath} has ${candidate.missing.length} missing image data product(s) in viewport; kicking composePreviewRender('full')`,
+        );
+        // Fire-and-forget. After Gradle resolves, the helper re-reads the produced
+        // PNGs and posts `updateImage` for each captureIndex; the panel paints the
+        // previously-placeholdered scroll cards in place.
+        void backfillScrollDataProducts(owningModule, candidate.missing);
     }
 }
 

--- a/vscode-extension/src/test/viewportScrollBackfill.test.ts
+++ b/vscode-extension/src/test/viewportScrollBackfill.test.ts
@@ -1,0 +1,125 @@
+import * as assert from "assert";
+import { MissingImageDataProduct } from "../scrollDataProductRender";
+import { modulesNeedingViewportBackfill } from "../viewportScrollBackfill";
+
+function missing(
+    previewId: string,
+    output = "data/render-scroll-long/x.png",
+): MissingImageDataProduct {
+    return {
+        previewId,
+        captureIndex: 0,
+        renderOutput: output,
+        absolutePath: `/ws/whatever/build/compose-previews/${output}`,
+    };
+}
+
+describe("modulesNeedingViewportBackfill", () => {
+    it("returns no candidates when nothing is missing", () => {
+        const result = modulesNeedingViewportBackfill(
+            new Map(),
+            ["com.example.A"],
+            [],
+            new Set(),
+        );
+        assert.deepStrictEqual(result, []);
+    });
+
+    it("returns no candidates when the viewport is empty", () => {
+        // Webview hasn't reported any visible cards yet — defer the backfill until
+        // we actually know what the user is looking at. The current behaviour is to
+        // burn a module-wide Gradle invocation on the activation event regardless;
+        // the viewport-gated trigger is the improvement.
+        const result = modulesNeedingViewportBackfill(
+            new Map([[":wear", [missing("com.example.Long")]]]),
+            [],
+            [],
+            new Set(),
+        );
+        assert.deepStrictEqual(result, []);
+    });
+
+    it("returns the module when one of its missing previews is visible", () => {
+        const result = modulesNeedingViewportBackfill(
+            new Map([
+                [
+                    ":wear",
+                    [missing("com.example.Long"), missing("com.example.Gif")],
+                ],
+            ]),
+            ["com.example.Long"],
+            [],
+            new Set(),
+        );
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].modulePath, ":wear");
+        assert.strictEqual(result[0].missing.length, 2);
+    });
+
+    it("returns the module when one of its missing previews is in the predicted set (about to scroll into view)", () => {
+        // Pre-warm parity with the daemon's speculative renderNow path — backfill
+        // fires for cards the panel believes the user is about to see, so the
+        // placeholder window stays short rather than waiting for the card to land
+        // in the strict visible set first.
+        const result = modulesNeedingViewportBackfill(
+            new Map([[":wear", [missing("com.example.Long")]]]),
+            [],
+            ["com.example.Long"],
+            new Set(),
+        );
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].modulePath, ":wear");
+    });
+
+    it("skips a module whose missing previews are entirely outside the viewport", () => {
+        // Headline case the viewport gate solves: a project with 50 scroll
+        // previews where the user only sees the top 3 shouldn't trigger a full
+        // module re-render until the user actually scrolls down to one of the
+        // missing-PNG cards. Pre-fix the trigger fired regardless; here it waits.
+        const result = modulesNeedingViewportBackfill(
+            new Map([
+                [
+                    ":wear",
+                    [
+                        missing("com.example.Bottom1"),
+                        missing("com.example.Bottom2"),
+                    ],
+                ],
+            ]),
+            ["com.example.Top1", "com.example.Top2", "com.example.Top3"],
+            ["com.example.Top4"],
+            new Set(),
+        );
+        assert.deepStrictEqual(result, []);
+    });
+
+    it("skips a module that's already been backfilled this session", () => {
+        // Session dedup keeps the trigger one-shot per module — a project whose
+        // @ScrollingPreview wiring is broken shouldn't loop Gradle invocations
+        // every time the user scrolls back to the failing card.
+        const result = modulesNeedingViewportBackfill(
+            new Map([[":wear", [missing("com.example.Long")]]]),
+            ["com.example.Long"],
+            [],
+            new Set([":wear"]),
+        );
+        assert.deepStrictEqual(result, []);
+    });
+
+    it("returns each module that has its own viewport intersection independently", () => {
+        const result = modulesNeedingViewportBackfill(
+            new Map([
+                [":wear", [missing("com.example.WearScroll")]],
+                [":android", [missing("com.example.AndroidScroll")]],
+                [":cmp", [missing("com.example.CmpScroll")]],
+            ]),
+            ["com.example.WearScroll"],
+            ["com.example.AndroidScroll"],
+            new Set(),
+        );
+        // :cmp's scroll isn't in viewport → skipped. :wear visible, :android
+        // predicted → both backfill.
+        const paths = result.map((c) => c.modulePath).sort();
+        assert.deepStrictEqual(paths, [":android", ":wear"]);
+    });
+});

--- a/vscode-extension/src/viewportScrollBackfill.ts
+++ b/vscode-extension/src/viewportScrollBackfill.ts
@@ -1,0 +1,41 @@
+import { MissingImageDataProduct } from "./scrollDataProductRender";
+
+/**
+ * Viewport-aware filter for the `@ScrollingPreview` Gradle backfill. The naive trigger
+ * from the first cut fired `composePreviewRender('full')` whenever ANY preview in the
+ * active file's scope had a missing image data product, on every refresh — wasting a
+ * Gradle invocation on a module's full preview set even when the user couldn't see the
+ * affected cards.
+ *
+ * This helper takes the visible + predicted preview ids reported by the webview's
+ * `viewportTracker` (the same set already used to drive the daemon's `setVisible`) and
+ * groups the missing products into the modules whose missing previews intersect that
+ * set. Modules whose missing previews are entirely outside the viewport are skipped —
+ * the user hasn't asked to look at them, so we don't pay the Gradle cost yet.
+ *
+ * Predicted ids (cards the panel believes the user is about to scroll into) count as
+ * viewport intersections too: pre-warming the backfill before the card lands keeps the
+ * placeholder window short, matching the daemon's existing speculative-renderNow path.
+ */
+export interface ViewportBackfillCandidate {
+    modulePath: string;
+    missing: readonly MissingImageDataProduct[];
+}
+
+export function modulesNeedingViewportBackfill(
+    missingByModule: ReadonlyMap<string, readonly MissingImageDataProduct[]>,
+    visible: readonly string[],
+    predicted: readonly string[],
+    alreadyRequested: ReadonlySet<string>,
+): ViewportBackfillCandidate[] {
+    if (missingByModule.size === 0) return [];
+    const want = new Set<string>([...visible, ...predicted]);
+    if (want.size === 0) return [];
+    const result: ViewportBackfillCandidate[] = [];
+    for (const [modulePath, missing] of missingByModule) {
+        if (alreadyRequested.has(modulePath)) continue;
+        if (!missing.some((m) => want.has(m.previewId))) continue;
+        result.push({ modulePath, missing });
+    }
+    return result;
+}


### PR DESCRIPTION
The previous backfill fired composePreviewRender('full') for any module whose
displayed previews had a missing image data product, on every refresh() — a
project with 50 scroll previews where the user only sees the top few paid the
full module's Gradle cost up-front at activation time.

Move the trigger from "refresh() finished and the file's manifest declares
@ScrollingPreview data products" to "the webview's viewport reported a visible
or predicted preview whose PNG is missing." The missing-set is computed once
in refresh() (cheap, single-pass over displayPreviews) and stashed in
`pendingScrollBackfill`; the actual Gradle render fires from
`notifyDaemonViewport` after intersecting the stash with the visible+predicted
ids the webview just sent. Predicted ids (the speculative scroll-ahead set
the daemon already pre-renders against) count as intersections so the
placeholder window stays short — the backfill pre-warms cards the panel
believes the user is about to scroll into rather than waiting for the strict
visible set first.

Per-module session dedup (`scrollBackfillRequested`) still applies — a
project whose @ScrollingPreview wiring is broken doesn't loop Gradle every
time the user scrolls back to the failing card. The forceRender and
minimal-mode skips are preserved. `pendingScrollBackfill` clears on
file-scope loss (the no-module guard in refresh) so a stray viewport report
from the previous file's preview ids can't fire a render against a module
the panel is no longer on.

Empty-stash short-circuit in modulesNeedingViewportBackfill keeps the
viewport handler a no-op for the overwhelmingly common case of a project
without scroll/animation previews.