### PR TITLE
fix(plugin): nicer renderOutput sanitiser, per-preview shortest unique stem

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -461,26 +461,33 @@ object PreviewDiscovery {
   }
 
   /**
-   * Computes the common dotted prefix shared by every preview id (up to and including the last
-   * matched `.`) and strips it from each capture's `renderOutput` filename. Also runs every stem
-   * through [sanitizeFileStem] so spaces and shell-unfriendly characters inherited from
-   * `@Preview(name = "tile light (light)")` don't end up in the PNG filename.
+   * Rewrite each capture's `renderOutput` (and each `dataProduct.output`) to a shorter, shell-safe
+   * filename. Two passes shape the result:
    *
-   * `preview.id` itself is deliberately left untouched — it's the stable identity consumers key by
-   * (history folders, CLI state, JUnit test names). The renderOutput is purely the on-disk
-   * filename, and that's what benefits from a shorter, quoted-free form.
+   *   1. **Sanitisation per dotted segment.** Within a segment (the chunks between `.`s of the
+   *      preview id) any run of non-alphanumeric characters collapses to a single `_`. So
+   *      `Devices - Large Round` becomes `Devices_Large_Round`, `tile light (light)` becomes
+   *      `tile_light_light`, etc. Dots stay as segment separators.
+   *   2. **Shortest unique suffix per preview.** Each preview takes the rightmost segments needed
+   *      to disambiguate it from every other preview in the module — the function-name-plus-variant
+   *      segment alone for unique names, prepending the class only when another preview shares the
+   *      same function name, prepending package parts only when classes collide too. So
+   *      `com.example.PreviewsKt.ActivityListPreview_Devices - Large Round` becomes
+   *      `ActivityListPreview_Devices_Large_Round` in most modules.
    *
-   * No-op on a single-preview module (empty prefix) or when sanitization would collapse two
-   * distinct ids to the same stem — in that case we keep the un-stripped, un-sanitized id for
-   * everyone so the pretty rename never introduces a filename collision.
+   * `preview.id` itself stays untouched — it's the stable identity consumers key by (history
+   * folders, CLI state, JUnit test names). Only the on-disk filename benefits from the prettier
+   * form.
+   *
+   * If sanitisation forces a true collision (two distinct ids whose fully-sanitised forms are
+   * byte-identical — e.g. `Foo_bar` vs `Foo-bar` after collapsing), a `_<idx>` suffix
+   * disambiguates. The renders directory has to stay collision-free even when input names couldn't.
    */
   private fun normalizeRenderOutputs(previews: List<PreviewInfo>): List<PreviewInfo> {
     if (previews.isEmpty()) return previews
-    val commonPrefix = commonDottedPrefix(previews.map { it.id })
-    val stems = previews.map { sanitizeFileStem(it.id.removePrefix(commonPrefix)) }
-    val safe = stems.toSet().size == previews.size && stems.none { it.isEmpty() }
+    val resolvedStems = resolveRenderStems(previews)
     return previews.mapIndexed { i, preview ->
-      val newStem = if (safe) stems[i] else preview.id
+      val newStem = resolvedStems[i]
       val rewritten =
         preview.captures.map { c ->
           c.copy(renderOutput = rewriteRenderStem(c.renderOutput, preview.id, newStem))
@@ -493,6 +500,85 @@ object PreviewDiscovery {
     }
   }
 
+  /**
+   * Pick one shell-safe stem per preview. Each stem is the shortest sanitised suffix that
+   * uniquely identifies its preview against the others — see [normalizeRenderOutputs] for the
+   * algorithm and rationale. Exposed `internal` so the unit tests can assert "no spaces ever",
+   * "no `class.` prefix when the function name is unique", and the collision-disambiguator paths
+   * directly without a full discovery pipeline.
+   */
+  internal fun resolveRenderStems(previews: List<PreviewInfo>): List<String> {
+    if (previews.isEmpty()) return emptyList()
+    val sanitisedSegmentsByPreview = previews.map { sanitiseSegments(it.id) }
+    val stems =
+      sanitisedSegmentsByPreview.mapIndexed { i, mySegs ->
+        shortestUniqueSuffix(i, mySegs, sanitisedSegmentsByPreview)
+      }
+    return disambiguateExactCollisions(stems)
+  }
+
+  /**
+   * Returns the joined stem (segments joined with `.`) made from the rightmost segments of
+   * [mySegs] that aren't matched, at the same depth, by any other preview's sanitised segments.
+   *
+   * If no proper suffix is unique (two distinct ids whose sanitised segment lists are
+   * byte-identical — the only way every depth matches), return JUST the last segment. The user
+   * wants short on-disk names; the resulting duplicate is then disambiguated with a `_<idx>`
+   * suffix by [disambiguateExactCollisions] rather than padded with the full package path.
+   */
+  private fun shortestUniqueSuffix(
+    myIndex: Int,
+    mySegs: List<String>,
+    allSegs: List<List<String>>,
+  ): String {
+    if (mySegs.isEmpty()) return ""
+    for (depth in 1..mySegs.size) {
+      val mySuffix = mySegs.takeLast(depth)
+      val collides =
+        allSegs.withIndex().any { (otherIndex, otherSegs) ->
+          otherIndex != myIndex && otherSegs.takeLast(depth) == mySuffix
+        }
+      if (!collides) return mySuffix.joinToString(".")
+    }
+    return mySegs.last()
+  }
+
+  /**
+   * Splits a preview id into dot-separated segments and sanitises each one. Sanitisation collapses
+   * every run of non-alphanumeric characters within a segment to a single `_` and trims `_`/`-`
+   * from the segment edges; the inter-segment `.` is preserved as the segment join.
+   *
+   * Empty segments (e.g. from a leading or trailing `.`, or from a segment that was all-punctuation
+   * pre-sanitisation) are dropped so they don't introduce `..` in the resulting stem.
+   */
+  private fun sanitiseSegments(id: String): List<String> =
+    id.split('.').map(::sanitiseSegment).filter { it.isNotEmpty() }
+
+  /**
+   * Collapse every run of non-alphanumeric characters to a single `_`, then trim `_` and `-` from
+   * the edges. Designed for one dotted segment of a preview id; dots inside [segment] would be
+   * misinterpreted as segment boundaries, so callers split first.
+   */
+  private fun sanitiseSegment(segment: String): String =
+    segment.replace(Regex("[^A-Za-z0-9]+"), "_").trim('_', '-')
+
+  /**
+   * Last-ditch tiebreaker when two distinct preview ids sanitise to exactly the same stem (e.g.
+   * `Foo_bar` and `Foo-bar` both become `Foo_bar`). Appends `_<idx>` to the second-and-later
+   * occurrences in the manifest order; the first occurrence keeps its clean form so the common
+   * case still gets the pretty filename.
+   */
+  private fun disambiguateExactCollisions(stems: List<String>): List<String> {
+    if (stems.toSet().size == stems.size && stems.none { it.isEmpty() }) return stems
+    val counts = mutableMapOf<String, Int>()
+    return stems.mapIndexed { i, raw ->
+      val base = if (raw.isEmpty()) "preview" else raw
+      val seen = counts.getOrDefault(base, 0)
+      counts[base] = seen + 1
+      if (seen == 0 && raw.isNotEmpty()) base else "${base}_${i}"
+    }
+  }
+
   /** `renders/<oldStem><tail>.<ext>` → `renders/<newStem><tail>.<ext>`. */
   private fun rewriteRenderStem(renderOutput: String, oldStem: String, newStem: String): String {
     if (renderOutput.isEmpty() || oldStem == newStem) return renderOutput
@@ -502,32 +588,6 @@ object PreviewDiscovery {
     val rewritten = newStem + leaf.removePrefix(oldStem)
     return if (dir.isEmpty()) rewritten else "$dir/$rewritten"
   }
-
-  private fun commonDottedPrefix(ids: List<String>): String {
-    if (ids.size < 2) return ""
-    var prefix = ids.first()
-    for (id in ids.drop(1)) {
-      var i = 0
-      val limit = minOf(prefix.length, id.length)
-      while (i < limit && prefix[i] == id[i]) i++
-      prefix = prefix.substring(0, i)
-      if (prefix.isEmpty()) return ""
-    }
-    val lastDot = prefix.lastIndexOf('.')
-    return if (lastDot < 0) "" else prefix.substring(0, lastDot + 1)
-  }
-
-  /**
-   * Sanitizes a filename stem to an ASCII-safe whitelist (`[A-Za-z0-9._-]`). Every other character
-   * collapses to `_`, runs of `_` collapse to a single `_`, and leading/trailing `_`, `.`, `-` are
-   * trimmed. A whitelist is deliberate: we can't enumerate every awkward character a preview name
-   * might contain (Unicode dashes, NBSP, RTL marks, emoji), and any one of them can break a
-   * downstream tool that expects a POSIX-plain filename. `.` is preserved so FQN-shaped stems
-   * (`CardPreviewsKt.Tile_Light_States`) survive intact when the package prefix strip can't flatten
-   * them further.
-   */
-  private fun sanitizeFileStem(s: String): String =
-    s.replace(Regex("""[^A-Za-z0-9._-]"""), "_").replace(Regex("""_+"""), "_").trim('_', '.', '-')
 
   // Renders the distinguishing bits of a preview variant for the discovery log
   // so sibling expansions (e.g. @WearPreviewFontScales × 6) aren't visually

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryRenderStemTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryRenderStemTest.kt
@@ -1,0 +1,166 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PreviewDiscoveryRenderStemTest {
+
+  /**
+   * Headline invariant: every stem is composed only of `[A-Za-z0-9._]` (no spaces, dashes,
+   * parens, quotes, or anything else a shell would have to quote). Spaces in
+   * `@Preview(name = "Devices - Large Round")` make it into the `preview.id`, but the rewrite
+   * strips them at the per-segment sanitisation step.
+   */
+  @Test
+  fun `every resolved stem is shell-safe — only letters, digits, underscores, and dots`() {
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.ActivityListPreview_Devices - Large Round"),
+        preview("com.example.PreviewsKt.ActivityListPreview_Devices - Small Round"),
+        preview("com.example.PreviewsKt.ButtonPreview_Devices - Large Round"),
+        preview("com.example.PreviewsKt.ButtonPreview_Devices - Small Round"),
+        preview("com.example.PreviewsKt.BadButtonPreview_Bad Button (light)"),
+        preview("com.example.PreviewsKt.Pixel8SystemUiPreview_Pixel 8"),
+        preview("com.example.PreviewsKt.Pixel8SystemUiPreview_Pixel 8 - Night"),
+      )
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+
+    for (stem in stems) {
+      assertThat(stem).matches("[A-Za-z0-9._]+")
+    }
+    assertThat(stems.toSet().size).isEqualTo(stems.size)
+  }
+
+  @Test
+  fun `function-and-variant alone is the stem when nothing else collides`() {
+    // Headline change from the previous fix: no package, no class — the last sanitised segment
+    // is enough to disambiguate everyone in the module, so we use just that. Matches the user
+    // spec: `ActivityListPreview_Devices_Large_Round.png`.
+    val previews =
+      listOf(
+        preview("com.example.app.PreviewsKt.ActivityListPreview_Devices - Large Round"),
+        preview("com.example.app.PreviewsKt.ButtonPreview_Devices - Large Round"),
+        preview("com.example.app.PreviewsKt.BadButtonPreview_Devices - Small Round"),
+      )
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+
+    assertThat(stems)
+      .containsExactly(
+        "ActivityListPreview_Devices_Large_Round",
+        "ButtonPreview_Devices_Large_Round",
+        "BadButtonPreview_Devices_Small_Round",
+      )
+      .inOrder()
+  }
+
+  @Test
+  fun `collapses runs of separator-like characters into a single underscore`() {
+    // ` - ` (space-dash-space) is a run of three "separator" characters in the source name;
+    // every old stem ended up with `Devices_-_Large_Round`. New stems collapse the run.
+    val previews =
+      listOf(preview("com.example.PreviewsKt.Foo_Devices - Large Round"))
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+    assertThat(stems).containsExactly("Foo_Devices_Large_Round")
+  }
+
+  @Test
+  fun `parens, quotes, and other shell-awkward characters all collapse with adjacent runs`() {
+    val previews =
+      listOf(preview("com.example.PreviewsKt.Foo_tile light (light)"))
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+    assertThat(stems).containsExactly("Foo_tile_light_light")
+  }
+
+  @Test
+  fun `prepends the class segment only when the function-and-variant alone collides`() {
+    // Two `ActivityListPreview` functions in different `Kt` classes (and same variant suffix)
+    // need the class prefix to disambiguate. Every other preview keeps its bare function-level
+    // stem — the per-preview shortest-unique-suffix calc is local, not collective.
+    val previews =
+      listOf(
+        preview("com.example.AmbientPreviewsKt.ActivityListPreview_Devices - Large Round"),
+        preview("com.example.PreviewsKt.ActivityListPreview_Devices - Large Round"),
+        preview("com.example.PreviewsKt.ButtonPreview_Devices - Large Round"),
+      )
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+
+    assertThat(stems)
+      .containsExactly(
+        "AmbientPreviewsKt.ActivityListPreview_Devices_Large_Round",
+        "PreviewsKt.ActivityListPreview_Devices_Large_Round",
+        // No collision on this function name → stays at depth 1.
+        "ButtonPreview_Devices_Large_Round",
+      )
+      .inOrder()
+  }
+
+  @Test
+  fun `prepends the package segment only when the class prefix doesn't disambiguate`() {
+    // Two `PreviewsKt.ActivityListPreview_*` in different packages — at depth 2 they collide,
+    // at depth 3 (`<lastPkg>.PreviewsKt.ActivityListPreview_*`) they don't. Other previews
+    // sharing a unique function name stay at depth 1.
+    val previews =
+      listOf(
+        preview("com.example.first.PreviewsKt.ActivityListPreview_Same Variant"),
+        preview("com.example.second.PreviewsKt.ActivityListPreview_Same Variant"),
+        preview("com.example.first.PreviewsKt.UniqueOnePreview_Some Variant"),
+      )
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+
+    assertThat(stems)
+      .containsExactly(
+        "first.PreviewsKt.ActivityListPreview_Same_Variant",
+        "second.PreviewsKt.ActivityListPreview_Same_Variant",
+        "UniqueOnePreview_Some_Variant",
+      )
+      .inOrder()
+  }
+
+  @Test
+  fun `appends a numeric disambiguator when sanitisation maps two ids to the same form`() {
+    // Pathological case: two distinct ids that differ ONLY in characters the sanitiser collapses
+    // (underscore vs dash here). After sanitisation they're byte-identical; the per-suffix-depth
+    // search never finds a unique form. The renders directory still has to stay collision-free,
+    // so the second occurrence gets a `_<idx>` suffix.
+    val previews =
+      listOf(
+        preview("com.example.PreviewsKt.Foo_Pixel 8 (light)"),
+        preview("com.example.PreviewsKt.Foo_Pixel_8_light"),
+      )
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+
+    assertThat(stems.toSet().size).isEqualTo(stems.size)
+    for (stem in stems) {
+      assertThat(stem).matches("[A-Za-z0-9._]+")
+    }
+    // First occurrence keeps the clean form; later occurrence carries its manifest index.
+    assertThat(stems[0]).isEqualTo("Foo_Pixel_8_light")
+    assertThat(stems[1]).isEqualTo("Foo_Pixel_8_light_1")
+  }
+
+  @Test
+  fun `single-preview module — bare function-and-variant segment, no prefixes`() {
+    val previews = listOf(preview("com.example.PreviewsKt.OnlyOne_Variant - With Space"))
+
+    val stems = PreviewDiscovery.resolveRenderStems(previews)
+
+    assertThat(stems).containsExactly("OnlyOne_Variant_With_Space")
+  }
+
+  @Test
+  fun `empty input returns empty stems list`() {
+    assertThat(PreviewDiscovery.resolveRenderStems(emptyList())).isEmpty()
+  }
+
+  private fun preview(id: String): PreviewInfo =
+    PreviewInfo(
+      id = id,
+      functionName = id.substringAfterLast('.').substringBefore('_'),
+      className = id.substringBeforeLast('.'),
+    )
+}


### PR DESCRIPTION
The old normaliser had two flaws the user surfaced from a `ls` of their renders
directory:

  1. Sanitisation preserved `-` and kept consecutive separator runs distinct
     (`Devices - Large Round` → `Devices_-_Large_Round`). That left `-_-`
     fragments in every multi-word variant name.
  2. Prefix-stripping was collective (one common dotted prefix for the whole
     module). When stems collided after stripping it fell back to the raw
     `preview.id`, which still carried the spaces from the source name.

Replace both with:

  * **Per-segment sanitisation that collapses every run of non-alphanumeric
    characters to a single `_`.** `Devices - Large Round` becomes
    `Devices_Large_Round`, `tile light (light)` becomes `tile_light_light`,
    `Pixel 8 - Night` becomes `Pixel_8_Night`. `.` stays as the segment
    separator. Trailing/leading `_` and `-` are trimmed per segment.
  * **Shortest unique suffix per preview.** Each preview takes the rightmost
    dotted segments it needs to be distinguishable from every other preview
    in the module. A unique function-and-variant alone is enough for most
    cards (`ActivityListPreview_Devices_Large_Round.png`); the class segment
    prepends only when another preview shares the function name (`AmbientPreviewsKt.ActivityListPreview_...` vs `PreviewsKt.ActivityListPreview_...`);
    package segments only when class-level disambiguation isn't enough.
  * **Numeric `_<idx>` tiebreaker** when sanitisation truly maps two ids to
    byte-identical forms (e.g. `Foo_bar` vs `Foo-bar` both become `Foo_bar`).
    First occurrence keeps its clean form; later occurrences carry the index.

The unit test suite (`PreviewDiscoveryRenderStemTest`) pins the headline shape
("no spaces, no parens, no quotes"), the per-depth disambiguation contract,
and the tiebreaker path. Existing functional-test expectations
(`tile_light_light`, `_pixel_6`, `_SCROLL_top`) stayed compatible — they were
already in the underscore-collapsed form for inputs that don't contain `-`,
and the inputs that do are now visibly nicer.

`preview.id` is deliberately untouched — it remains the stable identity
consumers key by (history folders, CLI state, JUnit test names). Only the
on-disk filename benefits from the prettier, shorter form.