### PR TITLE
test: Update preview filenames to match new render naming

### DIFF
--- a/samples/android-alpha/src/test/kotlin/com/example/samplealpha/FocusedPreviewPixelTest.kt
+++ b/samples/android-alpha/src/test/kotlin/com/example/samplealpha/FocusedPreviewPixelTest.kt
@@ -31,7 +31,7 @@ class FocusedPreviewPixelTest {
     // `RenderFilenames` strips the package + class qualifier and converts spaces to underscores
     // for on-disk paths — see docs/RENDER_FILENAMES.md. Kept as plain literals here so the test
     // breaks loudly if filename normalisation changes shape.
-    private val fanOutBase = "InsetFocusRingFanOutPreview_Inset_Focus_Ring_fan-out"
+    private val fanOutBase = "InsetFocusRingFanOutPreview_Inset_Focus_Ring_fan_out"
     private val traversalBase = "FocusTraversalPreview_Focus_Traversal"
     private val overlayBase = "FocusOverlayPreview_Focus_Overlay"
     private val movingBase = "InsetFocusRingMovingPreview_Inset_Focus_Ring_moving"

--- a/samples/android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
+++ b/samples/android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
@@ -20,7 +20,7 @@ import org.junit.Test
 class ScrollPreviewPixelTest {
 
     private val rendersDir = File("build/compose-previews/renders")
-    private val baseName = "ScrollPreviewsKt.RedToBlueScrollPreview_Scroll"
+    private val baseName = "RedToBlueScrollPreview_Scroll"
 
     private data class Avg(val r: Double, val g: Double, val b: Double) {
         fun dominant(): Char = when {
@@ -81,7 +81,7 @@ class ScrollPreviewPixelTest {
      */
     @Test
     fun `GIF capture animates red to blue`() {
-        val gifName = "ScrollPreviewsKt.RedToBlueScrollGifPreview_ScrollGif.gif"
+        val gifName = "RedToBlueScrollGifPreview_ScrollGif.gif"
         val file = File(rendersDir, gifName)
         assertThat(file.exists()).isTrue()
 
@@ -112,7 +112,7 @@ class ScrollPreviewPixelTest {
      */
     @Test
     fun `GIF capture following END resets scroll and still animates`() {
-        val base = "ScrollPreviewsKt.RedToBlueEndThenGifPreview_EndThenGif"
+        val base = "RedToBlueEndThenGifPreview_EndThenGif"
         val endPng = File(rendersDir, "${base}_SCROLL_end.png")
         val gif = File(rendersDir, "${base}_SCROLL_gif.gif")
         assertThat(endPng.exists()).isTrue()

--- a/samples/android/src/test/kotlin/com/example/sampleandroid/TransparentBackgroundPreviewPixelTest.kt
+++ b/samples/android/src/test/kotlin/com/example/sampleandroid/TransparentBackgroundPreviewPixelTest.kt
@@ -20,7 +20,7 @@ class TransparentBackgroundPreviewPixelTest {
 
     private val rendersDir = File("build/compose-previews/renders")
     private val pngName =
-        "TransparentBackgroundPreviewsKt.CircleButtonTransparentPreview_Circle_Button_Transparent.png"
+        "CircleButtonTransparentPreview_Circle_Button_Transparent.png"
 
     @Test
     fun `circle button preview keeps alpha=0 in the corners outside the circle`() {

--- a/samples/wear/src/test/kotlin/com/example/samplewear/AmbientPreviewPixelTest.kt
+++ b/samples/wear/src/test/kotlin/com/example/samplewear/AmbientPreviewPixelTest.kt
@@ -27,10 +27,10 @@ class AmbientPreviewPixelTest {
   private val rendersDir = File("build/compose-previews/renders")
 
   private val interactivePng =
-    File(rendersDir, "AmbientPreviewsKt.AmbientStatusInteractivePreview_Ambient_body_interactive.png")
+    File(rendersDir, "AmbientStatusInteractivePreview_Ambient_body_interactive.png")
 
   private val ambientPng =
-    File(rendersDir, "AmbientPreviewsKt.AmbientStatusAmbientPreview_Ambient_body_ambient.png")
+    File(rendersDir, "AmbientStatusAmbientPreview_Ambient_body_ambient.png")
 
   /**
    * Both PNGs must exist and differ — same composition body, the only difference is the

--- a/samples/wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
+++ b/samples/wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
@@ -21,7 +21,7 @@ class LongScrollPreviewPixelTest {
 
     private val longPng = File(
         "build/compose-previews/data/render-scroll-long/" +
-            "PreviewsKt.ActivityListLongPreview_Devices_-_Large_Round.png",
+            "ActivityListLongPreview_Devices_Large_Round.png",
     )
 
     @Test


### PR DESCRIPTION
Updates test fixture filenames to match changes in the preview render filename generation logic. The render filename format has been simplified to remove the class qualifier prefix (e.g., `ScrollPreviewsKt.`) and normalize special characters in preview names.

## Changes

- **Android ScrollPreviewPixelTest**: Updated `baseName` and `gifName` variables to remove `ScrollPreviewsKt.` prefix
- **Wear AmbientPreviewPixelTest**: Updated file paths to remove `AmbientPreviewsKt.` prefix from both interactive and ambient preview filenames
- **Android-alpha FocusedPreviewPixelTest**: Updated `fanOutBase` to replace hyphens with underscores in the filename (`fan-out` → `fan_out`)
- **Android TransparentBackgroundPreviewPixelTest**: Updated `pngName` to remove `TransparentBackgroundPreviewsKt.` prefix
- **Wear LongScrollPreviewPixelTest**: Updated file path to remove `PreviewsKt.` prefix and normalize special characters (hyphens and spaces to underscores)

These changes align the test expectations with the updated render filename normalization documented in `docs/RENDER_FILENAMES.md`.

https://claude.ai/code/session_01K9dKfKnG96SFBYpjWb5btv