### PR TITLE
test: add logging for skipped data product subscriptions

### DIFF
--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -564,6 +564,20 @@ export class LiveDaemonScheduler implements DaemonScheduler {
             const subKey = `${module.modulePath}::${previewId}::${kind}`;
             const already = this.subscribedPairs.has(subKey);
             if (enabled === already) {
+                // No-op short-circuit. The log line surfaces the silent path that
+                // bites a11y toggling when host bookkeeping drifts away from the
+                // daemon's actual subscription state: a stale `subscribedPairs`
+                // entry from a previous toggle makes `subscribedAny` stay false,
+                // which suppresses the follow-up renderNow at the bottom of this
+                // method, which leaves the daemon without a `mode=a11y` render —
+                // the chip stays checked but data products never attach and the
+                // dataExtensionTracker hits its 30 s safety timeout. Emitting
+                // this line means a triage capture can tell "subscribed and the
+                // daemon dropped it" from "host thought it was already done."
+                this.logger.appendLine(
+                    `[daemon] data${enabled ? "Subscribe" : "Unsubscribe"}` +
+                        `(${previewId}, ${kind}) skipped (already ${enabled ? "subscribed" : "unsubscribed"} per host bookkeeping)`,
+                );
                 continue;
             }
             if (enabled) {

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -1029,6 +1029,67 @@ describe("DaemonScheduler", () => {
             assert.strictEqual(subs.length, 1);
         });
 
+        it("logs each skipped subscribe so a triage capture can tell when host bookkeeping was the no-op cause", async () => {
+            // Regression context: when host's `subscribedPairs` already has the
+            // entry, the dedup at the top of the loop silently `continue`s. That
+            // suppresses the follow-up `client.renderNow`, which leaves the
+            // daemon without a `mode=a11y` render, which leaves the panel's
+            // dataExtensionTracker waiting 30 s for `onDataProductsAttached` to
+            // arrive — it never does. The log line is the only diagnostic the
+            // user can paste back into a triage report to distinguish this
+            // host-side skip from a daemon-side dropped subscribe.
+            const { scheduler, log } = build();
+            await scheduler.setDataProductSubscription(
+                mod("mod"),
+                "a",
+                ["a11y/atf", "a11y/hierarchy"],
+                true,
+            );
+            log.length = 0;
+            await scheduler.setDataProductSubscription(
+                mod("mod"),
+                "a",
+                ["a11y/atf", "a11y/hierarchy"],
+                true,
+            );
+            assert.ok(
+                log.some(
+                    (line) =>
+                        line.includes("dataSubscribe(a, a11y/atf)") &&
+                        line.includes("skipped"),
+                ),
+                `expected a skipped-subscribe log line for a11y/atf, got: ${log.join(" | ")}`,
+            );
+            assert.ok(
+                log.some(
+                    (line) =>
+                        line.includes("dataSubscribe(a, a11y/hierarchy)") &&
+                        line.includes("skipped"),
+                ),
+                `expected a skipped-subscribe log line for a11y/hierarchy, got: ${log.join(" | ")}`,
+            );
+        });
+
+        it("logs each skipped unsubscribe (mirror of the subscribe skip path)", async () => {
+            const { scheduler, log } = build();
+            // No prior subscribe — turning OFF a never-on kind should also
+            // surface the no-op so the user can see why nothing changed.
+            await scheduler.setDataProductSubscription(
+                mod("mod"),
+                "a",
+                ["a11y/atf"],
+                false,
+            );
+            assert.ok(
+                log.some(
+                    (line) =>
+                        line.includes("dataUnsubscribe(a, a11y/atf)") &&
+                        line.includes("skipped"),
+                ),
+                `expected a skipped-unsubscribe log line, got: ${log.join(" | ")}`,
+            );
+        });
+
         it("setDataProductSubscription(false) issues data/unsubscribe and forgets the pair", async () => {
             const { gate, scheduler } = build();
             await scheduler.setDataProductSubscription(


### PR DESCRIPTION
## Summary
Add diagnostic logging when data product subscriptions or unsubscriptions are skipped due to host-side bookkeeping already reflecting the desired state. This helps distinguish host-side no-ops from daemon-side dropped subscriptions during triage.

## Changes
- **daemonScheduler.ts**: Added a log line in the no-op short-circuit path when `enabled === already` to surface when subscriptions/unsubscriptions are skipped due to existing host state
- **daemonScheduler.test.ts**: Added two test cases:
  - Test that logs each skipped subscribe when attempting to re-subscribe to already-subscribed data products
  - Test that logs each skipped unsubscribe when attempting to unsubscribe from never-subscribed data products

## Implementation Details
The logging addresses a regression where stale `subscribedPairs` entries cause the host to skip calling `client.renderNow()`, leaving the daemon without a `mode=a11y` render. This results in the panel's dataExtensionTracker timing out waiting for `onDataProductsAttached`. The log line is the only diagnostic available to distinguish this host-side skip from a daemon-side dropped subscription during user triage.

https://claude.ai/code/session_01K9dKfKnG96SFBYpjWb5btv