### PR TITLE
fix(vscode-extension): a11y toggle works without composePreview.early…

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5135,24 +5135,32 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             break;
         }
         case "setA11yOverlay":
-            if (earlyFeaturesEnabled()) {
-                logInfo(
-                    `[panel] a11y overlay ${msg.enabled ? "enabled" : "disabled"} for ${msg.previewId}`,
-                );
-                void handleSetA11yOverlay(msg.previewId, msg.enabled);
-            }
+            // a11y is the one bundle that's graduated past the early-features
+            // gate — the chip bar at `main.ts:2415` shows the a11y chip even
+            // when `composePreview.earlyFeatures.enabled` is false, so the
+            // matching host handler has to fire too. Other bundles' UIs stay
+            // hidden in basic mode (see `availableBundles`), so dropping the
+            // gate here doesn't widen the surface they post against.
+            logInfo(
+                `[panel] a11y overlay ${msg.enabled ? "enabled" : "disabled"} for ${msg.previewId}`,
+            );
+            void handleSetA11yOverlay(msg.previewId, msg.enabled);
             break;
         case "setDataExtensionEnabled":
-            if (earlyFeaturesEnabled()) {
-                logInfo(
-                    `[panel] extension ${msg.kinds.join(",")} ${msg.enabled ? "enabled" : "disabled"} for ${msg.previewId}`,
-                );
-                void handleSetDataExtensionEnabled(
-                    msg.previewId,
-                    msg.kinds,
-                    msg.enabled,
-                );
-            }
+            // Same reasoning as `setA11yOverlay`: a11y is reachable from the
+            // chip bar in basic mode, so a chip click must always dispatch.
+            // Other bundles' chips don't render without early features
+            // (`availableBundles` filter in `main.ts`), so this gate-drop
+            // doesn't surface non-a11y kinds when the user opted out of the
+            // experimental UI.
+            logInfo(
+                `[panel] extension ${msg.kinds.join(",")} ${msg.enabled ? "enabled" : "disabled"} for ${msg.previewId}`,
+            );
+            void handleSetDataExtensionEnabled(
+                msg.previewId,
+                msg.kinds,
+                msg.enabled,
+            );
             break;
         case "setRemoteComposeNamedValue":
             // Panel-side Remote Compose tab body edit. Merges the change

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -244,7 +244,10 @@ export class FocusController {
      * preview, first turn the previous one off so the wire stays clean.
      */
     toggleA11yOverlay(): void {
-        if (!this.config.earlyFeatures()) return;
+        // a11y is the graduated bundle — no early-features gate (the chip bar
+        // and the focus-toolbar button are both visible in basic mode, the
+        // host's `setA11yOverlay` handler also drops its gate). Other entry
+        // points (`launch-on-device`, `record`, `export-bundle`) keep theirs.
         if (!this.inFocus()) return;
         const card = this.getVisibleCards()[this.config.getFocusIndex()];
         const previewId = card ? card.dataset.previewId : null;

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -125,8 +125,12 @@ export class FocusToolbarController {
         // sidebar panels gate daemon-readiness per-button via the
         // individual `applyXxxButtonState` hooks).
         const daemonHidden = bundle && !s.bundleDaemonReady;
-        this.el.btnA11yOverlay.hidden =
-            daemonHidden || !s.earlyFeatures || !s.inFocus;
+        // a11y is the one bundle graduated out of `earlyFeatures` — the
+        // chip-bar filter at `main.ts:2415` already surfaces it in basic
+        // mode, and the focus-toolbar button is the matching focus-mode
+        // entry point. Other early-features buttons (recording, export
+        // bundle, …) stay gated until those features graduate too.
+        this.el.btnA11yOverlay.hidden = daemonHidden || !s.inFocus;
         this.el.btnRecording.hidden =
             daemonHidden || !s.earlyFeatures || !s.inFocus;
         this.el.recordingFormat.hidden =
@@ -229,9 +233,13 @@ export class FocusToolbarController {
      * inside focus mode `aria-pressed` tracks whether the currently
      * focused preview has the overlay subscription on.
      */
+    // applyA11yOverlayButtonState applies the in-mode pressed-state +
+    // tooltip refresh; the higher-level visibility gate is owned by
+    // applyButtonVisibility above (and intentionally no longer requires
+    // earlyFeatures, since a11y is the graduated bundle).
     applyA11yOverlayButtonState(s: A11yOverlayButtonState): void {
-        this.el.btnA11yOverlay.hidden = !s.earlyFeatures || !s.inFocus;
-        if (!s.earlyFeatures || !s.inFocus) {
+        this.el.btnA11yOverlay.hidden = !s.inFocus;
+        if (!s.inFocus) {
             this.el.btnA11yOverlay.setAttribute("aria-pressed", "false");
             return;
         }


### PR DESCRIPTION
…Features.enabled

The webview chip-bar filter at `main.ts:2415` already surfaces the a11y bundle in basic mode (`availableBundles = ["a11y"]` when early features are off) — a11y graduated out of the experimental UI. But the matching host handlers and the focus-toolbar a11y button still required `composePreview.earlyFeatures.enabled` to be true, so the chip was visible but the click was a silent no-op against the host, and the focus-toolbar button was hidden entirely.

Drop the `earlyFeaturesEnabled()` gates from:
- the `setA11yOverlay` message-bus handler (extension.ts) — the focus-toolbar a11y button's dedicated post path.
- the `setDataExtensionEnabled` handler — the bundle-chip path. Other bundles' chips still don't render without early features (`availableBundles` filters them out), so this doesn't widen the wire surface for non-a11y kinds.
- the focus-toolbar `btnA11yOverlay` visibility gate (focusToolbar.ts in both `applyButtonVisibility` and `applyA11yOverlayButtonState`). The button now follows the same in-focus-mode-only rule the chip bar does. Sibling buttons (recording, export-bundle) keep their early-features gate intact — they're still in-progress.

With the gates dropped, a click on the a11y chip in basic mode dispatches `setDataExtensionEnabled` → `setDataProductSubscription` → daemon `data/subscribe`
+ `renderNow`, the same path early-features mode has always taken.