### PR TITLE
fix(daemon): ScopedDataProducts forwards renderModeFor to the owning …

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ExtensionRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ExtensionRegistry.kt
@@ -208,6 +208,21 @@ class ExtensionRegistry(extensions: List<Extension>) {
     override fun isKnown(kind: String): Boolean =
       ids().any { byId.getValue(it).dataProductRegistry?.isKnown(kind) == true }
 
+    /**
+     * Delegates to the owning extension's registry — matches the pattern used by [fetch],
+     * [onSubscribe], and [onUnsubscribe]. Without this override the facade falls back to the
+     * [DataProductRegistry.renderModeFor] interface default of `null`, which silently breaks
+     * [JsonRpcServer.subscriptionDrivenRenderMode]: the dispatcher asks `publicDataProducts()` for
+     * the mode tag implied by a preview's subscribed kinds, gets `null` for every kind, and the
+     * follow-up `renderNow` runs without `mode=a11y`. The renderer then produces no a11y artefacts
+     * and the panel's `dataExtensionTracker` times out after 30 s waiting for attachments. See the
+     * regression note above the previous fix in [JsonRpcServer.subscriptionDrivenRenderMode].
+     */
+    override fun renderModeFor(kind: String): String? =
+      ids()
+        .firstOrNull { byId.getValue(it).dataProductRegistry?.isKnown(kind) == true }
+        ?.let { byId.getValue(it).dataProductRegistry?.renderModeFor(kind) }
+
     override fun fetch(
       previewId: String,
       kind: String,

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/ExtensionRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/ExtensionRegistryTest.kt
@@ -154,6 +154,57 @@ class ExtensionRegistryTest {
   }
 
   @Test
+  fun `publicDataProducts forwards renderModeFor to the owning extension's registry`() {
+    // Regression: pre-fix `ScopedDataProducts` didn't override `renderModeFor` and fell back to
+    // the interface default of null. `JsonRpcServer.subscriptionDrivenRenderMode` asks
+    // `publicDataProducts()` for the mode tag implied by a preview's subscribed kinds; without
+    // this delegation it always got null and the follow-up renderNow ran without `mode=a11y`,
+    // leaving the panel waiting 30 s for a11y attachments that the renderer never produced.
+    val a11yProducer =
+      object : DataProductRegistry {
+        override val capabilities = listOf(cap("a11y/atf"), cap("a11y/hierarchy"))
+
+        override fun fetch(
+          previewId: String,
+          kind: String,
+          params: JsonElement?,
+          inline: Boolean,
+        ): DataProductRegistry.Outcome =
+          DataProductRegistry.Outcome.Ok(DataFetchResult(kind = kind, schemaVersion = 1))
+
+        override fun attachmentsFor(
+          previewId: String,
+          kinds: Set<String>,
+        ): List<DataProductAttachment> = emptyList()
+
+        override fun isKnown(kind: String): Boolean = kind == "a11y/atf" || kind == "a11y/hierarchy"
+
+        override fun renderModeFor(kind: String): String? = if (isKnown(kind)) "a11y" else null
+      }
+    val theming = RecordingRegistry("compose/theme")
+    val registry =
+      ExtensionRegistry(
+        listOf(
+          Extension(id = "ext/a11y", dataProductRegistry = a11yProducer),
+          Extension(id = "ext/theming", dataProductRegistry = theming),
+        )
+      )
+    registry.enable(listOf("ext/a11y", "ext/theming"))
+
+    val products = registry.publicDataProducts()
+    assertEquals("a11y", products.renderModeFor("a11y/atf"))
+    assertEquals("a11y", products.renderModeFor("a11y/hierarchy"))
+    // Kinds whose owning registry doesn't declare a mode keep returning null, so the dispatcher's
+    // `firstNotNullOfOrNull` lookup picks the a11y-driving kind without being short-circuited by
+    // an earlier theming subscription on the same preview.
+    assertEquals(null, products.renderModeFor("compose/theme"))
+    // Unknown kinds resolve to null too (no producer claimed them) — important for the
+    // subscriptionDrivenRenderMode contract: missing producers don't accidentally synthesise a
+    // mode tag the renderer can't honour.
+    assertEquals(null, products.renderModeFor("does/not/exist"))
+  }
+
+  @Test
   fun `disabling a public extension keeps it active when another dependent extension still wants it`() {
     val a = RecordingRegistry("a/kind")
     val b = RecordingRegistry("b/kind")


### PR DESCRIPTION
…extension's registry

The subscription-driven render-mode injection at
`JsonRpcServer.subscriptionDrivenRenderMode` asks `extensions.publicDataProducts()` for the mode tag implied by a preview's subscribed kinds. Pre-fix the returned `ScopedDataProducts` facade did not override `renderModeFor`, so the call fell back to the `DataProductRegistry.renderModeFor` interface default of `null` for every kind. The follow-up `renderNow` therefore ran without `mode=a11y`, the renderer produced no a11y artefacts, and the host's `dataExtensionTracker` timed out 30 s after every chip toggle waiting for attachments that the daemon never sent.

The regression was introduced by #1503 (RefreshQueue refactor) which replaced the hard-coded `kinds.any { it.startsWith("a11y/") } -> "a11y"` branch in `subscriptionDrivenRenderMode` with a delegating implementation that asks `publicDataProducts().renderModeFor(kind)` — semantically the right shape so new producers (layout inspector etc.) can opt in to their own mode tag, but the facade needs to actually forward the call. Add an override that delegates to the first publicly enabled extension whose registry knows the kind. Same pattern the existing `fetch` / `onSubscribe` / `onUnsubscribe` overrides use.

Regression test pins the surface: an extension registry whose `renderModeFor` returns "a11y" for its kinds is queryable via `publicDataProducts()` after the extension is enabled; sibling kinds whose owning registry returns null keep returning null; unknown kinds return null.