### PR TITLE
feat: add per-card loading spinner for data extension subscriptions

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -163,6 +163,11 @@ let dataExtensionStatusItem: vscode.StatusBarItem | null = null;
  *  window. Constructed in activate() so the timer callbacks are bound to
  *  the live `panel` / `outputChannel` references. See dataExtensionProgress.ts. */
 let dataExtensionTracker: DataExtensionProgressTracker | null = null;
+/** Preview ids currently displaying the per-card spinner overlay we drop on a
+ *  data-extension subscribe (see `handleSetDataExtensionEnabled`). Owned by the
+ *  host so the clearLoading post stays paired with the setLoading post even on
+ *  paths where the tracker resolves through callbacks (timeout, attach). */
+const extensionPendingPreviews = new Set<string>();
 /** Unfiltered emitter onto the "Compose Preview" output channel. Used by
  *  failure-data dumps (data-extension safety timeout, doctor report) that
  *  must surface regardless of `composePreview.logging.level`. */
@@ -1110,6 +1115,19 @@ export async function activate(
                               previewId,
                               dataProducts.map((dp) => dp.kind),
                           );
+                          // Tear down the per-card spinner once the first
+                          // payload arrives — `updateImage` already strips
+                          // the overlay when the primary PNG is dirty, but
+                          // subscription-driven renders routinely return
+                          // `unchanged=true` (the data product travels in
+                          // a separate file), so we'd otherwise leave the
+                          // spinner pinned until the safety timeout.
+                          if (extensionPendingPreviews.delete(previewId)) {
+                              panel?.postMessage({
+                                  command: "clearLoading",
+                                  previewId,
+                              });
+                          }
                           const decoded = applyDataProductsToRegistry(
                               registry,
                               previewId,
@@ -1444,6 +1462,7 @@ export async function activate(
         dispose: () => {
             dataExtensionTracker?.dispose();
             dataExtensionTracker = null;
+            extensionPendingPreviews.clear();
         },
     });
 
@@ -3536,6 +3555,15 @@ function applyDataExtensionStatus(
 function emitDataExtensionTimeoutDiagnostics(
     diag: DataExtensionPendingDiagnostics,
 ): void {
+    // Safety-net teardown for the per-card spinner: if the daemon never
+    // attached payloads, the overlay would otherwise stick until the next
+    // refresh painted over it.
+    if (extensionPendingPreviews.delete(diag.previewId)) {
+        panel?.postMessage({
+            command: "clearLoading",
+            previewId: diag.previewId,
+        });
+    }
     const lines: string[] = [];
     lines.push(
         `[data-extension-timeout] previewId=${diag.previewId} module=${diag.moduleId} ` +
@@ -5348,8 +5376,19 @@ async function handleSetDataExtensionEnabled(
             moduleId.modulePath,
             filteredKinds,
         );
+        // Drop the per-card spinner overlay onto the focused preview so the
+        // user gets immediate visual feedback for the in-flight subscribe.
+        // The slim panel-wide progress bar at the top is too subtle for a
+        // single-card toggle (and has a 200 ms paint delay that swallows
+        // fast-cache round-trips entirely). Cleared on resolve, on the
+        // tracker's safety timeout, and on the disable branch below.
+        extensionPendingPreviews.add(previewId);
+        panel?.postMessage({ command: "setLoading", previewId });
     } else {
         dataExtensionTracker?.resolve(previewId, filteredKinds);
+        if (extensionPendingPreviews.delete(previewId)) {
+            panel?.postMessage({ command: "clearLoading", previewId });
+        }
     }
     // Single subscription call so the wire sees `data/subscribe` per
     // kind followed by exactly one `renderNow`. Per-kind dispatch

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -462,6 +462,7 @@ export type ExtensionToWebview =
           replaceExisting?: boolean;
       }
     | { command: "setLoading"; previewId?: string }
+    | { command: "clearLoading"; previewId: string }
     | { command: "markAllLoading" }
     | { command: "setError"; previewId: string; message: string }
     | { command: "showMessage"; text: string }

--- a/vscode-extension/src/webview/preview/messageHandlers.ts
+++ b/vscode-extension/src/webview/preview/messageHandlers.ts
@@ -248,6 +248,8 @@ export function handleExtensionMessage(
             return;
         case "setLoading":
             return handleSetLoading(msg, ctx);
+        case "clearLoading":
+            return handleClearLoading(msg, ctx);
         case "setError":
         case "setImageError":
             return handleErrorMessage(msg, ctx);
@@ -444,6 +446,18 @@ function handleSetLoading(
     overlay.className = "loading-overlay";
     overlay.innerHTML = '<div class="spinner" aria-label="Rendering"></div>';
     container.appendChild(overlay);
+}
+
+function handleClearLoading(
+    msg: Extract<ExtensionToWebview, { command: "clearLoading" }>,
+    ctx: PreviewMessageContext,
+): void {
+    void ctx;
+    const card = document.getElementById(
+        "preview-" + sanitizeId(msg.previewId),
+    );
+    if (!card) return;
+    card.querySelector(".image-container .loading-overlay")?.remove();
 }
 
 function handleErrorMessage(


### PR DESCRIPTION
## Summary
Add a per-card loading spinner overlay that displays when a data extension subscription is initiated, providing immediate visual feedback to users. The spinner is cleared when the first payload arrives, on timeout, or when the subscription is disabled.

## Changes
- **Extension host (`extension.ts`)**:
  - Introduce `extensionPendingPreviews` Set to track which preview cards have active loading spinners
  - Show spinner overlay when `handleSetDataExtensionEnabled` initiates a subscription via `setLoading` message
  - Clear spinner when first data product payload arrives in the subscription callback
  - Clear spinner on safety timeout in `emitDataExtensionTimeoutDiagnostics`
  - Clear spinner when subscription is disabled
  - Clean up pending previews on extension disposal

- **Webview message handler (`messageHandlers.ts`)**:
  - Add `handleClearLoading` function to remove the loading overlay from a specific preview card
  - Wire up `clearLoading` command in message dispatcher

- **Type definitions (`types.ts`)**:
  - Add `clearLoading` command type to `ExtensionToWebview` union with required `previewId` field

## Implementation Details
The per-card spinner provides more immediate and localized feedback than the panel-wide progress bar, which has a 200ms paint delay that can be swallowed by fast cache round-trips. The spinner is guaranteed to be cleared through three paths: normal payload arrival, safety timeout, or explicit disable, ensuring it never gets stuck on screen.

https://claude.ai/code/session_01K9dKfKnG96SFBYpjWb5btv