### PR TITLE
feat: add permissions override UI to inspection panel

### DIFF
--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsOverrideIntegrationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsOverrideIntegrationTest.kt
@@ -1,0 +1,208 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
+import ee.schimke.composeai.daemon.protocol.PermissionsOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.Base64
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end verification that `renderNow.overrides.permissions` actually drives a
+ * permission-gated composable to its granted branch. Mirrors the
+ * [OverrideIntegrationTest.uiModeOverrideFlipsDarkAwareComposable] shape — render the same
+ * fixture twice with different overrides and assert the bytes differ in the expected way —
+ * but targets the runtime-permissions surface added in #1370 / #1374 / #1381 / #1395 and
+ * unblocks the panel-side override-toggle UI from #1400 part 2.
+ *
+ * The override is built panel-side as a [PreviewOverrides] bag, base64-serialised by
+ * [JsonRpcServer.encodeRenderPayload] into the wire payload's `overrides=<b64>` token, and
+ * round-tripped on the renderer side via [RenderEngine]'s `decodePreviewOverrides`. The
+ * planner ([PermissionsPreviewOverrideExtension]) lifts the override into a
+ * [PermissionsOverrideExtension], whose around-composable seeds Robolectric's
+ * `ShadowApplication.grantPermissions/denyPermissions`. From there the standard Android path
+ * (`Context.checkSelfPermission(...)` → `ContextWrapper.checkPermission(String, int, int)`)
+ * returns the requested value — including through the
+ * [ShadowContextWrapperPermissionTracker] shadow, which forwards to the real implementation
+ * before recording the query. Without all five rungs the pixels never flip.
+ *
+ * Encoding the bag directly (rather than going through [JsonRpcServer]'s renderNow path) keeps
+ * the test focused on the renderer-side leg and avoids the JSON-RPC plumbing — the encoder
+ * leg is covered separately by [PermissionsOverrideEncodingTest] in `:daemon:core`. Together
+ * the two tests pin the full panel → daemon → renderer → shadow chain.
+ *
+ * Out of scope here: asserting `data/fetch?kind=compose/permissions` returns the queried
+ * list — that capture happens inside the sandbox's [PermissionsController] static state, and
+ * the daemon-side `PermissionsDataProductRegistry` reads it from there. Cross-classloader
+ * read-out from the JUnit runner would need a dedicated surfacing channel; the unit-level
+ * `PermissionsDataProductTest.onRender captures override grants plus controller queries`
+ * pins the registry's behaviour for now. Pixel correctness is the strongest single E2E
+ * signal: it can only succeed if every rung worked.
+ */
+class PermissionsOverrideIntegrationTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+  }
+
+  @Test
+  fun permissionsOverrideGrantsCameraAndFlipsTheCompositionToTheGrantedBranch() {
+    val outputDir = tempFolder.newFolder("renders-permissions")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "permission-gated",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "PermissionGatedSquare",
+              widthPx = 32,
+              heightPx = 32,
+              density = 1.0f,
+              outputBaseName = "permission-gated",
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      // Default render — no override sent. Robolectric's manifest baseline denies CAMERA,
+      // so the fixture lands on the red branch.
+      val denied = renderAndDecode(host, "previewId=permission-gated", "denied")
+      val deniedRedPct = pixelMatchPct(denied, expectedRgb = 0xEF5350, perChannelTolerance = 8)
+      assertTrue(
+        "default render should be mostly red (denied branch); got" +
+          " ${"%.2f".format(deniedRedPct * 100)}% red",
+        deniedRedPct >= 0.95,
+      )
+
+      // Override pushes CAMERA = GRANTED through the same wire shape the panel produces.
+      // The around-composable's `init` seeds the controller (which pushes the grant into
+      // `ShadowApplication.grantPermissions(...)`) BEFORE the first composition starts, so the
+      // very first `checkSelfPermission` read in the composition returns GRANTED and the
+      // composition lands on the green branch on this render — no warm-up second render needed.
+      val grantedPayload =
+        "previewId=permission-gated;overrides=" +
+          encodeOverridesBag(
+            PreviewOverrides(
+              permissions =
+                PermissionsOverride(
+                  grants =
+                    mapOf(
+                      "android.permission.CAMERA" to
+                        PermissionGrantStateOverride.GRANTED
+                    )
+                )
+            )
+          )
+      val granted = renderAndDecode(host, grantedPayload, "granted")
+      val grantedGreenPct =
+        pixelMatchPct(granted, expectedRgb = 0x66BB6A, perChannelTolerance = 8)
+      assertTrue(
+        "override-applied render should be mostly green (granted branch); got" +
+          " ${"%.2f".format(grantedGreenPct * 100)}% green. If this dropped, the wire bag may" +
+          " no longer carry `permissions`, the planner may be skipping its always-on contract," +
+          " or the shadow tracker may be intercepting without forwarding to the real" +
+          " ShadowApplication grant state.",
+        grantedGreenPct >= 0.95,
+      )
+
+      // Override flipped back to DENIED → red again. Proves the round-trip is symmetric;
+      // a stuck "always grants" wiring would still produce green here and the test would fail.
+      val deniedPayload =
+        "previewId=permission-gated;overrides=" +
+          encodeOverridesBag(
+            PreviewOverrides(
+              permissions =
+                PermissionsOverride(
+                  grants =
+                    mapOf(
+                      "android.permission.CAMERA" to PermissionGrantStateOverride.DENIED
+                    )
+                )
+            )
+          )
+      val deniedAgain = renderAndDecode(host, deniedPayload, "denied-after-grant")
+      val deniedAgainRedPct =
+        pixelMatchPct(deniedAgain, expectedRgb = 0xEF5350, perChannelTolerance = 8)
+      assertTrue(
+        "explicit DENIED override should land on the red branch; got" +
+          " ${"%.2f".format(deniedAgainRedPct * 100)}% red",
+        deniedAgainRedPct >= 0.95,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
+   * Encodes a [PreviewOverrides] bag the way [JsonRpcServer.encodeRenderPayload] does — UTF-8 JSON
+   * → URL-safe base64 (no padding). The renderer's `decodePreviewOverrides` mirror in
+   * `RenderEngine.kt` reverses this; the round-trip is what production daemons use.
+   */
+  private fun encodeOverridesBag(bag: PreviewOverrides): String {
+    val bytes =
+      json.encodeToString(PreviewOverrides.serializer(), bag).toByteArray(Charsets.UTF_8)
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+  }
+
+  private fun renderAndDecode(
+    host: PreviewManifestRouter,
+    payload: String,
+    label: String,
+  ): java.awt.image.BufferedImage {
+    val request = RenderRequest.Render(payload = payload)
+    val result = host.submit(request, timeoutMs = 120_000)
+    assertNotNull("$label: pngPath must be populated", result.pngPath)
+    val pngFile = File(result.pngPath!!)
+    assertTrue("$label: rendered PNG must exist", pngFile.exists())
+    return ByteArrayInputStream(pngFile.readBytes()).use { ImageIO.read(it) }
+      ?: error("$label: PNG failed to decode")
+  }
+
+  /**
+   * Fraction of pixels matching [expectedRgb] within [perChannelTolerance] per channel. Mirrors
+   * the helper in [OverrideIntegrationTest] verbatim; kept private here rather than promoted so
+   * the two tests stay independent.
+   */
+  private fun pixelMatchPct(
+    img: java.awt.image.BufferedImage,
+    expectedRgb: Int,
+    perChannelTolerance: Int,
+  ): Double {
+    val expR = (expectedRgb shr 16) and 0xFF
+    val expG = (expectedRgb shr 8) and 0xFF
+    val expB = expectedRgb and 0xFF
+    var matches = 0L
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val rgb = img.getRGB(x, y)
+        val r = (rgb shr 16) and 0xFF
+        val g = (rgb shr 8) and 0xFF
+        val b = rgb and 0xFF
+        if (
+          abs(r - expR) <= perChannelTolerance &&
+            abs(g - expG) <= perChannelTolerance &&
+            abs(b - expB) <= perChannelTolerance
+        ) {
+          matches++
+        }
+      }
+    }
+    val total = img.width.toLong() * img.height.toLong()
+    return matches.toDouble() / total.toDouble()
+  }
+}

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -127,6 +127,30 @@ fun DarkAwareSquare() {
   Box(modifier = Modifier.fillMaxSize().background(bg))
 }
 
+/**
+ * Reads `Context.checkSelfPermission(android.permission.CAMERA)` through the platform path that
+ * `ContextCompat.checkSelfPermission(...)` ultimately delegates to (`ContextWrapper.checkPermission
+ * (String, int, int)`). Paints green when granted, red when denied. Used by
+ * `PermissionsOverrideIntegrationTest` to prove `renderNow.overrides.permissions` reaches
+ * `PermissionsPreviewOverrideExtension.plan(...)`, the around-composable seeds Robolectric's
+ * `ShadowApplication.grantPermissions`, the `ShadowContextWrapperPermissionTracker` shadow forwards
+ * to the real implementation, and the next `checkSelfPermission` read in the composition observes
+ * the requested value — the full chain the panel's permissions tab body drives.
+ *
+ * No connector-specific Compose API; the screen is the exact shape a consumer would author
+ * against the standard Android permission surface, mirroring `samples/android`'s
+ * `PermissionGatedPreview`.
+ */
+@Composable
+fun PermissionGatedSquare() {
+  val context = androidx.compose.ui.platform.LocalContext.current
+  val granted =
+    context.checkSelfPermission(android.Manifest.permission.CAMERA) ==
+      android.content.pm.PackageManager.PERMISSION_GRANTED
+  val color = if (granted) Color(0xFF66BB6A) else Color(0xFFEF5350)
+  Box(modifier = Modifier.fillMaxSize().background(color))
+}
+
 @Composable
 fun ResourceReadingPreview() {
   val label = stringResource(R.string.compose_ai_resource_used_label)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1006,9 +1006,22 @@ class JsonRpcServer(
       // Extension-driven overrides ride along as a single base64-encoded `PreviewOverrides`
       // bag — the renderer's [PreviewOverrideExtensions] hands the bag to every registered
       // planner. New override-driven fields don't need a new wire token; they ride this bag.
+      // `permissions` is included so the panel's permissions tab body (Inspection bundle)
+      // can push `renderNow.overrides.permissions` and reach
+      // `PermissionsPreviewOverrideExtension.plan(request)` end-to-end — without this the
+      // planner sees `request.permissions == null` and the around-composable's controller
+      // seed never lands.
       val extensionBag =
-        PreviewOverrides(material3Theme = overrides.material3Theme, wallpaper = overrides.wallpaper)
-      if (extensionBag.material3Theme != null || extensionBag.wallpaper != null) {
+        PreviewOverrides(
+          material3Theme = overrides.material3Theme,
+          wallpaper = overrides.wallpaper,
+          permissions = overrides.permissions,
+        )
+      if (
+        extensionBag.material3Theme != null ||
+          extensionBag.wallpaper != null ||
+          extensionBag.permissions != null
+      ) {
         if (isNotEmpty()) append(';')
         append("overrides=")
         append(

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsOverrideEncodingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsOverrideEncodingTest.kt
@@ -1,0 +1,270 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.Base64
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression test for the wire-side leg of issue #1400's permissions override pipeline.
+ *
+ * [JsonRpcServer.encodeRenderPayload] builds a base64-encoded [PreviewOverrides] bag for the
+ * extension-driven fields the renderer's planners consume (material3-theme, wallpaper, permissions,
+ * ...). Before this fix the encoder only included `material3Theme` + `wallpaper`, so a client that
+ * sent `renderNow.overrides.permissions = …` saw the field silently dropped: the planner read
+ * `request.permissions == null` and `PermissionsOverrideExtension` seeded the controller with
+ * `null`, leaving Robolectric's manifest baseline in place. The panel's `setPermissionsOverride` →
+ * host → daemon path would have looked like it worked end-to-end (pixels round-tripped, no error)
+ * but `ContextCompat.checkSelfPermission` would never have observed the requested grant.
+ *
+ * Drives a full JSON-RPC `initialize` → `renderNow` round-trip against a [PayloadCapturingHost] and
+ * asserts the encoded payload carries the permissions field inside the `overrides=<base64>` token.
+ * Sibling to [DeviceOverrideEncodingTest] — same plumbing, different override field.
+ */
+class PermissionsOverrideEncodingTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test(timeout = 30_000)
+  fun permissionsOverrideIsEncodedIntoTheExtensionBag() {
+    val captured =
+      renderAndCapturePayload(
+        overrides =
+          """{"permissions":{"grants":{
+                  "android.permission.CAMERA":"granted",
+                  "android.permission.RECORD_AUDIO":"denied"
+                }}}"""
+      )
+    val bag = decodeExtensionBag(captured)
+    assertNotNull("permissions bag must be present in the encoded payload", bag.permissions)
+    val grants = bag.permissions!!.grants
+    assertEquals(PermissionGrantStateOverride.GRANTED, grants["android.permission.CAMERA"])
+    assertEquals(PermissionGrantStateOverride.DENIED, grants["android.permission.RECORD_AUDIO"])
+  }
+
+  @Test(timeout = 30_000)
+  fun permissionsOverrideRidesAlongsideThemeAndWallpaperInTheSameBag() {
+    // Sanity: the three extension-driven fields share a single base64 bag; sending all three
+    // packs them into one token rather than one per field.
+    val captured =
+      renderAndCapturePayload(
+        overrides =
+          """{
+                "material3Theme":{"sourceColor":"#FF3366FF"},
+                "wallpaper":{"seedColor":"#FF884422"},
+                "permissions":{"grants":{"android.permission.CAMERA":"granted"}}
+              }"""
+      )
+    val bag = decodeExtensionBag(captured)
+    assertNotNull("material3Theme must round-trip", bag.material3Theme)
+    assertNotNull("wallpaper must round-trip", bag.wallpaper)
+    assertNotNull("permissions must round-trip", bag.permissions)
+  }
+
+  @Test(timeout = 30_000)
+  fun absentPermissionsOverrideOmitsTheBagWhenNoOtherExtensionFieldIsSet() {
+    // Mirror `DeviceOverrideEncodingTest.noDeviceOverrideLeavesDimensionsAlone` — the bag is
+    // only emitted when at least one extension-driven field is present, so a permissions-free
+    // payload that also lacks theme/wallpaper produces no `overrides=` token at all.
+    val captured = renderAndCapturePayload(overrides = """{"uiMode":"dark"}""")
+    assertTrue(
+      "overrides= bag must be omitted when no extension-driven field is set: '$captured'",
+      "overrides=" !in captured,
+    )
+  }
+
+  private fun decodeExtensionBag(payload: String): PreviewOverrides {
+    val token =
+      payload.split(';').firstOrNull { it.trim().startsWith("overrides=") }
+        ?: error("payload must carry an overrides= token: '$payload'")
+    val b64 = token.substringAfter('=').trim()
+    val raw = String(Base64.getUrlDecoder().decode(b64), Charsets.UTF_8)
+    return json.decodeFromString(PreviewOverrides.serializer(), raw)
+  }
+
+  /**
+   * Spins up a [JsonRpcServer] backed by a [PayloadCapturingHost] with a single-preview index, runs
+   * `initialize` → `renderNow` with the supplied overrides JSON, and returns the
+   * `RenderRequest.payload` string the host received. Mirrors
+   * [DeviceOverrideEncodingTest.renderAndCapturePayload] verbatim — kept here as a private helper
+   * rather than promoted to a shared utility because both tests are the only callers and the
+   * plumbing is mechanical.
+   */
+  private fun renderAndCapturePayload(overrides: String): String {
+    val sourceKt = java.nio.file.Files.createTempFile("permissions-override-test", ".kt")
+    java.nio.file.Files.writeString(sourceKt, "@Preview fun A() {}\n")
+    val previewDto =
+      PreviewInfoDto(
+        id = "preview-A",
+        className = "com.example.AKt",
+        methodName = "A",
+        sourceFile = sourceKt.toAbsolutePath().toString(),
+      )
+    val index = PreviewIndex.fromMap(path = sourceKt, byId = mapOf("preview-A" to previewDto))
+
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+
+    val host = PayloadCapturingPermissionsHost()
+    val exitLatch = CountDownLatch(1)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test",
+        previewIndex = index,
+        onExit = { _ -> exitLatch.countDown() },
+      )
+    val serverThread =
+      Thread({ server.run() }, "permissions-override-encoding-test").apply { isDaemon = true }
+    serverThread.start()
+
+    val reader = ContentLengthFramer(serverToClientIn)
+    val received = LinkedBlockingQueue<JsonObject>()
+    Thread(
+        {
+          try {
+            while (true) {
+              val frame = reader.readFrame() ?: break
+              val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+              received.put(obj)
+            }
+          } catch (_: Throwable) {}
+        },
+        "permissions-override-encoding-test-reader",
+      )
+      .apply { isDaemon = true }
+      .start()
+
+    try {
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+              "protocolVersion":2,"clientVersion":"test","workspaceRoot":"/tmp",
+              "moduleId":":t","moduleProjectDir":"/tmp",
+              "capabilities":{"visibility":true,"metrics":false}}}""",
+      )
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":2,"method":"renderNow","params":{
+              "previews":["preview-A"],"tier":"fast","overrides":$overrides}}""",
+      )
+      val finished =
+        pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+      assertNotNull("renderFinished must arrive within timeout", finished)
+
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","id":99,"method":"shutdown"}""")
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 99 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"exit"}""")
+      assertTrue(exitLatch.await(5, TimeUnit.SECONDS))
+      return host.lastPayload.get() ?: error("host never received a render request")
+    } finally {
+      try {
+        clientToServerOut.close()
+      } catch (_: Throwable) {}
+      try {
+        serverToClientIn.close()
+      } catch (_: Throwable) {}
+      try {
+        java.nio.file.Files.deleteIfExists(sourceKt)
+      } catch (_: Throwable) {}
+      serverThread.join(5_000)
+    }
+  }
+
+  private fun writeFrame(out: PipedOutputStream, jsonStr: String) {
+    val payload = jsonStr.toByteArray(Charsets.UTF_8)
+    out.write("Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII))
+    out.write(payload)
+    out.flush()
+  }
+
+  private fun pollUntil(
+    queue: LinkedBlockingQueue<JsonObject>,
+    timeoutMs: Long = 10_000,
+    matcher: (JsonObject) -> Boolean,
+  ): JsonObject? {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
+      val msg = queue.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
+      if (matcher(msg)) return msg
+    }
+    return null
+  }
+}
+
+/**
+ * Captures the [RenderRequest.Render.payload] string the daemon submits, then completes the render
+ * synchronously with a stub success result. Mirrors `DeviceOverrideEncodingTest`'s
+ * `PayloadCapturingHost` shape — separate file-local copy so the two tests don't take a cross-file
+ * dependency on a private helper.
+ */
+private class PayloadCapturingPermissionsHost : RenderHost {
+  val lastPayload: AtomicReference<String?> = AtomicReference(null)
+  private val queue = LinkedBlockingQueue<RenderRequest>()
+  private val results = LinkedBlockingQueue<RenderResult>()
+
+  @Volatile private var stopped = false
+
+  private val worker: Thread =
+    Thread(
+        {
+          while (!stopped) {
+            when (val req = queue.poll(50, TimeUnit.MILLISECONDS)) {
+              null -> continue
+              is RenderRequest.Render -> {
+                lastPayload.set(req.payload)
+                results.put(
+                  RenderResult(
+                    id = req.id,
+                    classLoaderHashCode = 0,
+                    classLoaderName = "permissions-override-encoding-test",
+                  )
+                )
+              }
+              RenderRequest.Shutdown -> return@Thread
+            }
+          }
+        },
+        "payload-capturing-permissions-host",
+      )
+      .apply { isDaemon = true }
+
+  override fun start() {
+    worker.start()
+  }
+
+  override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
+    require(request is RenderRequest.Render)
+    queue.put(request)
+    return results.poll(timeoutMs, TimeUnit.MILLISECONDS)
+      ?: error("PayloadCapturingPermissionsHost.submit timed out")
+  }
+
+  override fun shutdown(timeoutMs: Long) {
+    stopped = true
+    queue.put(RenderRequest.Shutdown)
+    worker.join(timeoutMs)
+  }
+}

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
@@ -50,11 +50,15 @@ import kotlinx.serialization.json.JsonElement
  *
  * Lifecycle:
  *
- * * On enter — [PermissionsController.set] is called with the seed (clears the map when null).
- *   `DisposableEffect(seed)` re-runs only when the override identity changes, so a subsequent
- *   `renderNow.overrides.permissions` with the same shape doesn't churn the controller.
- * * On dispose — clears the override (matches `KeyboardOverrideExtension`'s on-dispose
- *   semantics).
+ * * On construction (planner phase, before composition starts) — [PermissionsController.set]
+ *   is called with the seed (clears the map when null). The seed must land **before** the
+ *   first composition pass so that consumer code reading `Context.checkSelfPermission(...)` on
+ *   the very first composition observes the override; a previous shape applied the seed inside
+ *   a `DisposableEffect(seed)` whose block runs *after* composition, leaving the screen on the
+ *   pre-seed branch for one full render. See `PermissionsOverrideIntegrationTest` in
+ *   `:daemon:android` for the regression that pins this.
+ * * On dispose (composition leaves the tree) — clears the override (matches
+ *   `KeyboardOverrideExtension`'s on-dispose semantics).
  *
  * Runs in [DataExtensionPhase.OuterEnvironment] so the controller's Robolectric grant state is
  * primed before the user-environment phase reaches preview content — any `LaunchedEffect`-driven
@@ -69,12 +73,23 @@ class PermissionsOverrideExtension(private val seed: PermissionsOverride? = null
         provides = setOf(DataExtensionCapability(PermissionsDataProductRegistry.KIND)),
       ),
   ) {
+
+  init {
+    // Apply the seed eagerly so `Context.checkSelfPermission(...)` reads through the new
+    // `ShadowApplication` grant state on the very first composition. The planner constructs a
+    // fresh instance per render in the `OuterEnvironment` phase, which runs before user-environment
+    // composition starts, so this is the right hook for "seed before any consumer read".
+    //
+    // `seed = null` triggers `PermissionsController.set(null)` which clears the previous render's
+    // grant map and re-syncs `ShadowApplication` to a permission-free baseline — the always-on
+    // planner contract means every render that omits an override still gets a clean slate, not
+    // whatever the previous render left behind.
+    PermissionsController.set(seed)
+  }
+
   @Composable
   override fun AroundComposable(content: @Composable () -> Unit) {
-    DisposableEffect(seed) {
-      PermissionsController.set(seed)
-      onDispose { PermissionsController.set(null) }
-    }
+    DisposableEffect(seed) { onDispose { PermissionsController.set(null) } }
     content()
   }
 

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1211,6 +1211,64 @@ preview-app {
     color: var(--text-primary);
 }
 
+/* compose/permissions section — override-toggle UI in the inspection tab body. */
+.inspection-permissions-header {
+    align-items: baseline;
+    display: flex;
+    gap: 8px;
+    justify-content: space-between;
+    margin-bottom: 6px;
+}
+
+.inspection-permissions-add {
+    align-items: center;
+    display: flex;
+    gap: 6px;
+    margin: 4px 0 8px;
+}
+
+.inspection-permissions-add-input {
+    background: var(--vscode-input-background, transparent);
+    border: 1px solid var(--card-border);
+    border-radius: 3px;
+    color: var(--text-primary);
+    flex: 1 1 auto;
+    font-family: var(--vscode-editor-font-family, monospace);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    min-width: 120px;
+    padding: 2px 6px;
+}
+
+.inspection-permissions-actions-cell {
+    white-space: nowrap;
+}
+
+.inspection-permissions-action {
+    align-items: center;
+    background: transparent;
+    border: 1px solid color-mix(in srgb, var(--card-border) 70%, transparent);
+    border-radius: 3px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    display: inline-flex;
+    font-size: calc(var(--vscode-font-size) - 3px);
+    gap: 4px;
+    margin-right: 4px;
+    padding: 1px 6px;
+}
+
+.inspection-permissions-action:hover {
+    background: color-mix(in srgb, var(--card-border) 20%, transparent);
+    color: var(--text-primary);
+}
+
+/* The button reflecting the currently-applied grant reads as a pressed toggle. */
+.inspection-permissions-action--current {
+    background: color-mix(in srgb, var(--vscode-focusBorder) 18%, transparent);
+    border-color: var(--vscode-focusBorder);
+    color: var(--text-primary);
+}
+
 .inspection-source-link {
     background: transparent;
     border: none;

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -521,6 +521,19 @@ export interface PreviewOverrides {
      */
     remoteCompose?: RemoteComposeOverride;
     /**
+     * Android runtime-permissions override. Drives the connector-side
+     * `PermissionsOverrideExtension` (see `:data-permissions-connector`). Mirrors
+     * `PermissionsOverride` in `Messages.kt` — the around-composable seeds
+     * Robolectric's `ShadowApplication` grant state from {@link PermissionsOverride.grants}
+     * so consumer code reading the standard Android permission APIs
+     * (`ContextCompat.checkSelfPermission`, `Activity.checkSelfPermission`,
+     * `Context.checkPermission`, accompanist's `rememberPermissionState`) sees the
+     * requested value. The panel's permissions tab body builds this bag from the user's
+     * Grant / Deny / Clear button clicks and pushes a fresh `renderNow` so the held
+     * preview re-renders with the new grants. Android-only; desktop ignores.
+     */
+    permissions?: PermissionsOverride;
+    /**
      * Launcher-widget container-size override. Drives the connector-side
      * `LauncherWidgetExtension` (see `:data-launcher-widget-connector`) so a held preview can
      * be laid out at a specific whole-cell size on the host's launcher grid — `cells = (4, 2)`
@@ -621,6 +634,25 @@ export type LauncherResizeAxes = "none" | "horizontal" | "vertical" | "both";
 export interface KeyboardOverride {
     visible?: boolean;
     pressedKey?: string;
+}
+
+/**
+ * Wire spelling for `PermissionsOverride.grants` values. Mirrors `PermissionGrantStateOverride`
+ * in `Messages.kt` — the connector accepts a closed `granted | denied` sum so the daemon never
+ * has to disambiguate "unspecified" from "denied".
+ */
+export type PermissionGrantOverride = "granted" | "denied";
+
+/**
+ * Android runtime-permissions override for previews. See `PreviewOverrides.permissions`.
+ *
+ * `grants` is keyed by `Manifest.permission.*` constant string (e.g.
+ * `"android.permission.CAMERA"`). Permissions not listed keep whatever Robolectric's
+ * manifest baseline started them with — by default everything is denied. An empty `grants`
+ * map is the canonical "clear all panel-pinned overrides" payload.
+ */
+export interface PermissionsOverride {
+    grants: Record<string, PermissionGrantOverride>;
 }
 
 /**

--- a/vscode-extension/src/daemon/permissionsMerge.ts
+++ b/vscode-extension/src/daemon/permissionsMerge.ts
@@ -1,0 +1,56 @@
+// Pure (no DOM, no I/O) merge helper for the panel's permissions tab-body
+// edit pipeline. Lives in `daemon/` (host tsconfig) so the routing decision
+// is testable in plain mocha — `handleSetPermissionsOverride` in
+// `extension.ts` calls in here and forwards the merged bag to a
+// `renderNow.overrides.permissions` dispatch.
+//
+// Why a separate helper: the cumulative bag is the load-bearing invariant
+// of the edit pipeline ("user grants CAMERA, then denies RECORD_AUDIO,
+// then clears CAMERA — the next `renderNow` payload must reflect all three
+// edits in order"). Inline in `extension.ts` it's only reachable through a
+// full extension-host test fixture; here it's a one-call unit test per
+// behaviour.
+
+import type {
+    PermissionGrantOverride,
+    PermissionsOverride,
+} from "./daemonProtocol";
+import type { PermissionsChangeDetail } from "../types";
+
+/**
+ * Apply one panel-side [change] to [prior], returning the next cumulative
+ * permissions-override bag. Pure — neither argument is mutated; the result
+ * is a fresh object every call so callers can stash it without aliasing
+ * the prior snapshot.
+ *
+ * Semantics:
+ *  * `field: "setGrant"` — set the permission entry to the requested grant.
+ *    Overwrites an existing entry for the same name.
+ *  * `field: "clearGrant"` — remove the named permission from the bag (the
+ *    next render falls back to Robolectric's manifest baseline for it).
+ *  * `field: "clearAll"` — return an empty `PermissionsOverride()` so the
+ *    daemon strips every panel-pinned grant on the next render.
+ *
+ * `prior` may be `null` / `undefined` (first edit for a preview); the
+ * result then carries just the change. A `clearGrant` on a missing prior
+ * is a no-op that still returns an empty bag rather than `undefined`, so
+ * the caller can forward it as a normal override (clears any in-flight
+ * grants the daemon may have pinned in a previous session).
+ */
+export function mergePermissionsChange(
+    prior: PermissionsOverride | null | undefined,
+    change: PermissionsChangeDetail,
+): PermissionsOverride {
+    const baseGrants: Record<string, PermissionGrantOverride> = {
+        ...(prior?.grants ?? {}),
+    };
+    if (change.field === "clearAll") {
+        return { grants: {} };
+    }
+    if (change.field === "clearGrant") {
+        delete baseGrants[change.permission];
+        return { grants: baseGrants };
+    }
+    baseGrants[change.permission] = change.grant;
+    return { grants: baseGrants };
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -64,6 +64,7 @@ import {
 } from "./daemon/daemonScheduler";
 import { ContinuousCompileManager } from "./daemon/continuousCompileManager";
 import { mergeRemoteComposeChange } from "./daemon/remoteComposeMerge";
+import { mergePermissionsChange } from "./daemon/permissionsMerge";
 import {
     buildHistorySource,
     HistoryScope,
@@ -302,6 +303,20 @@ const latestRemoteComposeByPreview = new Map<
             import("./daemon/daemonProtocol").RemoteNamedValueWire
         >;
     }
+>();
+/**
+ * previewId → latest Android-permissions override the panel pushed. The permissions
+ * tab body posts `setPermissionsOverride` per Grant / Deny / Clear / Add click; we
+ * merge into this map and forward the cumulative `PermissionsOverride` on the next
+ * `renderNow` so the daemon's `PermissionsController.set(...)` applies the new state.
+ * Persists across renders for the activation lifetime, mirroring
+ * [remoteComposeOverridesByPreview]'s scope — a `clearAll` change resets the entry
+ * to `{ grants: {} }` rather than removing it, so the next dispatch still strips any
+ * grants the daemon previously pinned.
+ */
+const permissionsOverridesByPreview = new Map<
+    string,
+    import("./daemon/daemonProtocol").PermissionsOverride
 >();
 /** Last edited preview function name per Kotlin file, captured from in-memory edits and
  * consumed on save to prioritize that preview's refresh. */
@@ -5170,6 +5185,17 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 );
             }
             break;
+        case "setPermissionsOverride":
+            // Panel-side permissions tab body edit (Grant / Deny / Clear button
+            // or "Add permission" / "Clear overrides" action). Merges into the
+            // per-preview override bag and dispatches `renderNow.overrides.permissions`
+            // so the daemon's `PermissionsOverrideExtension` re-seeds Robolectric's
+            // grant state for the next composition. Gated on early features for the
+            // same reason as the Remote Compose edit path.
+            if (earlyFeaturesEnabled()) {
+                void handleSetPermissionsOverride(msg.previewId, msg.change);
+            }
+            break;
         case "openResourceFile":
             void openResourceFile(
                 {
@@ -5505,6 +5531,63 @@ async function handleSetRemoteComposeNamedValue(
         "remotecompose-edit",
         { remoteCompose: next },
     );
+}
+
+/**
+ * Apply one edit from the panel's permissions tab body. Merges the change into
+ * [permissionsOverridesByPreview] and dispatches `renderNow.overrides.permissions`
+ * so the daemon's `PermissionsOverrideExtension` re-seeds Robolectric's grant
+ * state on the next composition.
+ *
+ * No-op when the daemon scheduler isn't wired (Gradle-only mode) or the preview's
+ * owning module isn't yet known (panel rebuild race) — the webview keeps its
+ * optimistic button state; the next `updateDataProducts` payload reconciles.
+ *
+ * No live-session fast-path: unlike Remote Compose, permission changes propagate
+ * through Robolectric's `ShadowApplication` grant map, which is consulted on every
+ * `ContextWrapper.checkPermission` call as part of normal composition. A
+ * `renderNow` is the canonical way to surface the new value because the screen's
+ * `ContextCompat.checkSelfPermission(...)` read only re-fires on recomposition;
+ * mutating the controller without re-rendering would leave the visible UI on the
+ * pre-edit branch.
+ */
+async function handleSetPermissionsOverride(
+    previewId: string,
+    change: import("./types").PermissionsChangeDetail,
+): Promise<void> {
+    if (!daemonScheduler) {
+        return;
+    }
+    const moduleInfo = previewModuleIndex.get(previewId);
+    if (!moduleInfo) {
+        return;
+    }
+    const prior = permissionsOverridesByPreview.get(previewId);
+    const next = mergePermissionsChange(prior, change);
+    permissionsOverridesByPreview.set(previewId, next);
+    logInfo(
+        `[panel] permissions ${describePermissionsChange(change)} for ${previewId} via renderNow (bag size=${Object.keys(next.grants).length})`,
+    );
+    void daemonScheduler.renderNow(
+        moduleInfo,
+        [previewId],
+        "fast",
+        "permissions-edit",
+        { permissions: next },
+    );
+}
+
+function describePermissionsChange(
+    change: import("./types").PermissionsChangeDetail,
+): string {
+    switch (change.field) {
+        case "setGrant":
+            return `${change.permission}=${change.grant}`;
+        case "clearGrant":
+            return `clear ${change.permission}`;
+        case "clearAll":
+            return "clearAll";
+    }
 }
 
 /**

--- a/vscode-extension/src/test/inspectionPresenters.test.ts
+++ b/vscode-extension/src/test/inspectionPresenters.test.ts
@@ -248,3 +248,200 @@ describe("computeInspectionBundleData (cardBundleOverlay path)", () => {
         }
     });
 });
+
+// Override-toggle UI in the `compose/permissions` section. The presenter renders
+// per-row Grant / Deny / Clear buttons, an "Add permission" form, and a "Clear
+// overrides" action; each dispatches a bubbled `permissions-override-change`
+// CustomEvent ({@link PermissionsChangeDetail}). `main.ts` catches the event at
+// the inspection bundle wrapper and forwards it as the host's
+// `setPermissionsOverride` message; here we just pin the DOM-level contract.
+describe("computeInspectionBundleData compose/permissions override controls", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    type CapturedChange =
+        | { field: "setGrant"; permission: string; grant: "granted" | "denied" }
+        | { field: "clearGrant"; permission: string }
+        | { field: "clearAll" };
+
+    function mountSection(
+        payload: {
+            grants?: Record<string, "granted" | "denied">;
+            queried?: string[];
+        } | null,
+    ): { body: HTMLElement; events: CapturedChange[] } {
+        const data = computeInspectionBundleData(
+            (kind) => (kind === "compose/permissions" ? payload : undefined),
+            new Set<InspectionKind>(["compose/permissions"]),
+        );
+        assert.strictEqual(data.sections.length, 1);
+        assert.strictEqual(data.sections[0].kind, "compose/permissions");
+        // Mount the section into a wrapper that captures the bubbled events,
+        // mirroring the listener `main.ts` installs on the inspection bundle
+        // body wrapper.
+        const wrapper = document.createElement("div");
+        wrapper.appendChild(data.sections[0].data.body);
+        document.body.appendChild(wrapper);
+        const events: CapturedChange[] = [];
+        wrapper.addEventListener("permissions-override-change", (evt) => {
+            events.push((evt as CustomEvent<CapturedChange>).detail);
+        });
+        return { body: data.sections[0].data.body, events };
+    }
+
+    it("emits a setGrant=granted change when a queried-row Grant button is clicked", () => {
+        const { body, events } = mountSection({
+            grants: {},
+            queried: ["android.permission.CAMERA"],
+        });
+        const queriedTable = body.querySelector<HTMLElement>(
+            '[data-permission-table="queried"]',
+        );
+        assert.ok(queriedTable, "queried table missing");
+        const grantBtn = queriedTable!.querySelector<HTMLButtonElement>(
+            'button[data-permission-action="grant"][data-permission-name="android.permission.CAMERA"]',
+        );
+        assert.ok(grantBtn, "queried-row Grant button missing");
+        grantBtn!.click();
+        assert.deepStrictEqual(events, [
+            {
+                field: "setGrant",
+                permission: "android.permission.CAMERA",
+                grant: "granted",
+            },
+        ]);
+    });
+
+    it("emits a clearGrant change when a grant-table Clear button is clicked", () => {
+        const { body, events } = mountSection({
+            grants: { "android.permission.CAMERA": "granted" },
+            queried: [],
+        });
+        const grantsTable = body.querySelector<HTMLElement>(
+            '[data-permission-table="grants"]',
+        );
+        assert.ok(grantsTable, "grants table missing");
+        const clearBtn = grantsTable!.querySelector<HTMLButtonElement>(
+            'button[data-permission-action="clear"][data-permission-name="android.permission.CAMERA"]',
+        );
+        assert.ok(clearBtn, "grant-row Clear button missing");
+        clearBtn!.click();
+        assert.deepStrictEqual(events, [
+            {
+                field: "clearGrant",
+                permission: "android.permission.CAMERA",
+            },
+        ]);
+    });
+
+    it("marks the currently-applied grant button as aria-pressed", () => {
+        const { body } = mountSection({
+            grants: { "android.permission.CAMERA": "denied" },
+            queried: [],
+        });
+        const grantsTable = body.querySelector<HTMLElement>(
+            '[data-permission-table="grants"]',
+        );
+        const grantBtn = grantsTable!.querySelector<HTMLButtonElement>(
+            'button[data-permission-action="grant"][data-permission-name="android.permission.CAMERA"]',
+        );
+        const denyBtn = grantsTable!.querySelector<HTMLButtonElement>(
+            'button[data-permission-action="deny"][data-permission-name="android.permission.CAMERA"]',
+        );
+        assert.strictEqual(grantBtn?.getAttribute("aria-pressed"), null);
+        assert.strictEqual(denyBtn?.getAttribute("aria-pressed"), "true");
+    });
+
+    it("emits a clearAll change when the section's Clear overrides button is clicked", () => {
+        const { body, events } = mountSection({
+            grants: { "android.permission.CAMERA": "granted" },
+            queried: [],
+        });
+        const clearAllBtn = body.querySelector<HTMLButtonElement>(
+            'button[data-permission-action="clear-all"]',
+        );
+        assert.ok(clearAllBtn, "Clear overrides button missing");
+        clearAllBtn!.click();
+        assert.deepStrictEqual(events, [{ field: "clearAll" }]);
+    });
+
+    it("normalises bare short names from the add form and emits a fully-qualified setGrant", () => {
+        const { body, events } = mountSection({ grants: {}, queried: [] });
+        const form = body.querySelector<HTMLFormElement>(
+            '[data-permission-form="add"]',
+        );
+        assert.ok(form, "Add permission form missing");
+        const input = form!.querySelector<HTMLInputElement>(
+            ".inspection-permissions-add-input",
+        );
+        assert.ok(input, "Add permission input missing");
+        input!.value = "camera";
+        const grantBtn = form!.querySelector<HTMLButtonElement>(
+            'button[data-permission-action="add-grant"]',
+        );
+        grantBtn!.click();
+        form!.dispatchEvent(
+            new Event("submit", { bubbles: true, cancelable: true }),
+        );
+        assert.deepStrictEqual(events, [
+            {
+                field: "setGrant",
+                permission: "android.permission.CAMERA",
+                grant: "granted",
+            },
+        ]);
+        assert.strictEqual(
+            input!.value,
+            "",
+            "input should be cleared after submission",
+        );
+    });
+
+    it("passes through an already-qualified permission name from the add form unchanged", () => {
+        const { body, events } = mountSection({ grants: {}, queried: [] });
+        const form = body.querySelector<HTMLFormElement>(
+            '[data-permission-form="add"]',
+        );
+        const input = form!.querySelector<HTMLInputElement>(
+            ".inspection-permissions-add-input",
+        );
+        input!.value = "android.permission.FOREGROUND_SERVICE_LOCATION";
+        const denyBtn = form!.querySelector<HTMLButtonElement>(
+            'button[data-permission-action="add-deny"]',
+        );
+        denyBtn!.click();
+        form!.dispatchEvent(
+            new Event("submit", { bubbles: true, cancelable: true }),
+        );
+        assert.deepStrictEqual(events, [
+            {
+                field: "setGrant",
+                permission: "android.permission.FOREGROUND_SERVICE_LOCATION",
+                grant: "denied",
+            },
+        ]);
+    });
+
+    it("renders the add form and clear-all action even when the payload has no rows", () => {
+        const { body } = mountSection({ grants: {}, queried: [] });
+        assert.ok(
+            body.querySelector('[data-permission-form="add"]'),
+            "Add form should render with an empty payload so the user can pin a permission before the screen queries one",
+        );
+        assert.ok(
+            body.querySelector('button[data-permission-action="clear-all"]'),
+            "Clear overrides should render with an empty payload",
+        );
+        assert.strictEqual(
+            body.querySelector('[data-permission-table="grants"]'),
+            null,
+            "Grants table should be omitted when there are no rows",
+        );
+        assert.strictEqual(
+            body.querySelector('[data-permission-table="queried"]'),
+            null,
+            "Queried table should be omitted when there are no rows",
+        );
+    });
+});

--- a/vscode-extension/src/test/permissionsMerge.test.ts
+++ b/vscode-extension/src/test/permissionsMerge.test.ts
@@ -1,0 +1,101 @@
+import * as assert from "assert";
+import { mergePermissionsChange } from "../daemon/permissionsMerge";
+import type { PermissionsOverride } from "../daemon/daemonProtocol";
+
+describe("mergePermissionsChange", () => {
+    it("starts a single-grant bag from an undefined prior", () => {
+        const next = mergePermissionsChange(undefined, {
+            field: "setGrant",
+            permission: "android.permission.CAMERA",
+            grant: "granted",
+        });
+        assert.deepStrictEqual(next, {
+            grants: { "android.permission.CAMERA": "granted" },
+        });
+    });
+
+    it("treats null prior the same as undefined", () => {
+        const next = mergePermissionsChange(null, {
+            field: "setGrant",
+            permission: "android.permission.RECORD_AUDIO",
+            grant: "denied",
+        });
+        assert.deepStrictEqual(next, {
+            grants: { "android.permission.RECORD_AUDIO": "denied" },
+        });
+    });
+
+    it("merges a setGrant into a prior bag without aliasing", () => {
+        const prior: PermissionsOverride = {
+            grants: { "android.permission.CAMERA": "granted" },
+        };
+        const next = mergePermissionsChange(prior, {
+            field: "setGrant",
+            permission: "android.permission.RECORD_AUDIO",
+            grant: "denied",
+        });
+        assert.deepStrictEqual(next.grants, {
+            "android.permission.CAMERA": "granted",
+            "android.permission.RECORD_AUDIO": "denied",
+        });
+        // Prior must be untouched — host code stashes the prior bag and would
+        // otherwise see surprise mutations.
+        assert.deepStrictEqual(prior.grants, {
+            "android.permission.CAMERA": "granted",
+        });
+        assert.notStrictEqual(next.grants, prior.grants);
+    });
+
+    it("overwrites an existing grant on a setGrant for the same permission", () => {
+        const prior: PermissionsOverride = {
+            grants: {
+                "android.permission.CAMERA": "denied",
+                "android.permission.RECORD_AUDIO": "denied",
+            },
+        };
+        const next = mergePermissionsChange(prior, {
+            field: "setGrant",
+            permission: "android.permission.CAMERA",
+            grant: "granted",
+        });
+        assert.deepStrictEqual(next.grants, {
+            "android.permission.CAMERA": "granted",
+            "android.permission.RECORD_AUDIO": "denied",
+        });
+    });
+
+    it("drops the named permission on clearGrant", () => {
+        const prior: PermissionsOverride = {
+            grants: {
+                "android.permission.CAMERA": "granted",
+                "android.permission.RECORD_AUDIO": "denied",
+            },
+        };
+        const next = mergePermissionsChange(prior, {
+            field: "clearGrant",
+            permission: "android.permission.CAMERA",
+        });
+        assert.deepStrictEqual(next.grants, {
+            "android.permission.RECORD_AUDIO": "denied",
+        });
+    });
+
+    it("returns an empty bag (not undefined) on clearGrant against a missing prior", () => {
+        const next = mergePermissionsChange(undefined, {
+            field: "clearGrant",
+            permission: "android.permission.CAMERA",
+        });
+        assert.deepStrictEqual(next, { grants: {} });
+    });
+
+    it("replaces the bag with an empty grants map on clearAll", () => {
+        const prior: PermissionsOverride = {
+            grants: {
+                "android.permission.CAMERA": "granted",
+                "android.permission.RECORD_AUDIO": "denied",
+            },
+        };
+        const next = mergePermissionsChange(prior, { field: "clearAll" });
+        assert.deepStrictEqual(next, { grants: {} });
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -744,6 +744,28 @@ export type RemoteComposeChangeDetail =
     | { field: "profile"; value: RemoteComposeProfile | null }
     | { field: "namedValue"; name: string; value: RemoteNamedValue };
 
+/**
+ * Detail bag carried by `setPermissionsOverride`. Discriminated union so a single
+ * post-message channel covers every panel-side affordance on the permissions tab
+ * body — per-row Grant / Deny / Clear buttons, the "Add permission" form, and the
+ * "Clear all" action — without exploding into one message per shape.
+ *
+ *  * `field: "setGrant"` — pin `permission` to `granted` / `denied` in the cumulative
+ *    override bag the host maintains per preview.
+ *  * `field: "clearGrant"` — remove the named permission from the bag. The next render
+ *    falls back to whatever Robolectric's manifest baseline carries for it.
+ *  * `field: "clearAll"` — replace the cumulative bag with an empty `PermissionsOverride`,
+ *    so the next render strips every panel-pinned grant.
+ */
+export type PermissionsChangeDetail =
+    | {
+          field: "setGrant";
+          permission: string;
+          grant: "granted" | "denied";
+      }
+    | { field: "clearGrant"; permission: string }
+    | { field: "clearAll" };
+
 /** Messages from webview to extension */
 export type WebviewToExtension =
     /**
@@ -1112,6 +1134,22 @@ export type WebviewToExtension =
           command: "setRemoteComposeNamedValue";
           previewId: string;
           change: RemoteComposeChangeDetail;
+      }
+    /**
+     * Edit dispatched from the panel's permissions tab body (Inspection bundle,
+     * `compose/permissions` chip). The presenter's per-row Grant / Deny / Clear
+     * buttons, the "Add permission" input, and the "Clear overrides" action all
+     * bubble a `permissions-override-change` CustomEvent up to the bundle body
+     * wrapper, which re-emits it as this message. The extension host merges the
+     * change into its per-preview `PermissionsOverride` bag and dispatches a fresh
+     * `renderNow.overrides.permissions` so the daemon's
+     * `PermissionsOverrideExtension` re-seeds Robolectric's
+     * `ShadowApplication.grantPermissions/denyPermissions` for the next composition.
+     */
+    | {
+          command: "setPermissionsOverride";
+          previewId: string;
+          change: PermissionsChangeDetail;
       };
 
 /**

--- a/vscode-extension/src/webview/preview/inspectionPresenters.ts
+++ b/vscode-extension/src/webview/preview/inspectionPresenters.ts
@@ -496,15 +496,20 @@ function computeUiaHierarchyBundleData(
  * tables — grants and queried — under one `<section>`. The body sits in the
  * inspection bundle's host alongside the tree-tables; the bundle's merged
  * overlay stays empty for this kind.
+ *
+ * Each table row carries Grant / Deny / Clear buttons that bubble a
+ * `permissions-override-change` CustomEvent ({@link PermissionsChangeDetail})
+ * up to the inspection bundle body wrapper; `main.ts` catches it and posts
+ * `setPermissionsOverride` so the host can push a fresh
+ * `renderNow.overrides.permissions`. The section header also carries an
+ * "Add permission" form for pinning arbitrary `Manifest.permission.*` names
+ * even when the screen hasn't queried them, plus a "Clear overrides" action.
  */
 function computePermissionsInspectionData(
     payload: PermissionsPayload | undefined,
 ): InspectionKindData | null {
     if (!payload) return null;
     const data = computePermissionsBundleData(payload);
-    if (data.grantRows.length === 0 && data.queriedRows.length === 0) {
-        return null;
-    }
     const summary =
         data.allPermissions.length +
         " permission" +
@@ -513,14 +518,20 @@ function computePermissionsInspectionData(
     body.className = "inspection-permissions-section";
     const header = document.createElement("header");
     header.className = "inspection-permissions-header";
-    header.textContent = "Permissions · " + summary;
+    const headerTitle = document.createElement("span");
+    headerTitle.className = "inspection-permissions-title";
+    headerTitle.textContent = "Permissions · " + summary;
+    header.appendChild(headerTitle);
+    header.appendChild(buildClearOverridesButton());
     body.appendChild(header);
+    body.appendChild(buildAddPermissionForm());
     if (data.grantRows.length > 0) {
         body.appendChild(
             buildPermissionsTable("Effective grants", data.grantRows, [
                 "Permission",
                 "Grant",
                 "Queried?",
+                "Actions",
             ]),
         );
     }
@@ -529,6 +540,7 @@ function computePermissionsInspectionData(
             buildPermissionsTable("Queried", data.queriedRows, [
                 "Permission",
                 "Effective grant",
+                "Actions",
             ]),
         );
     }
@@ -542,6 +554,8 @@ function buildPermissionsTable(
 ): HTMLElement {
     const wrap = document.createElement("section");
     wrap.className = "inspection-permissions-table";
+    wrap.dataset.permissionTable =
+        title === "Effective grants" ? "grants" : "queried";
     const heading = document.createElement("h4");
     heading.textContent = title;
     wrap.appendChild(heading);
@@ -556,29 +570,197 @@ function buildPermissionsTable(
     thead.appendChild(headerRow);
     table.appendChild(thead);
     const tbody = document.createElement("tbody");
+    const isGrantsTable = headers.length === 4;
     for (const row of rows) {
         const tr = document.createElement("tr");
         tr.dataset.permissionLevel = row.level;
+        tr.dataset.permissionName = row.permission;
         const permCell = document.createElement("td");
         const code = document.createElement("code");
         code.textContent = row.shortLabel;
         permCell.appendChild(code);
         tr.appendChild(permCell);
         const grantCell = document.createElement("td");
-        grantCell.textContent =
-            row.grant ?? (headers.length === 3 ? "—" : "unknown");
+        grantCell.textContent = row.grant ?? (isGrantsTable ? "—" : "unknown");
         tr.appendChild(grantCell);
-        if (headers.length === 3) {
+        if (isGrantsTable) {
             const queriedCell = document.createElement("td");
             queriedCell.textContent = row.queried ? "yes" : "no";
             tr.appendChild(queriedCell);
         }
+        tr.appendChild(buildRowActionsCell(row, isGrantsTable));
         tbody.appendChild(tr);
     }
     table.appendChild(tbody);
     wrap.appendChild(table);
     return wrap;
 }
+
+/**
+ * Build the per-row override-action cell — Grant / Deny buttons, plus a Clear
+ * button on grant-table rows (queried-only rows have nothing to clear). The
+ * currently-applied grant's button is `aria-pressed` so the panel reads as a
+ * toggle, not a one-shot.
+ */
+function buildRowActionsCell(
+    row: PermissionRow,
+    isGrantsTable: boolean,
+): HTMLElement {
+    const cell = document.createElement("td");
+    cell.className = "inspection-permissions-actions-cell";
+    cell.appendChild(
+        buildGrantButton(row.permission, "granted", row.grant === "granted"),
+    );
+    cell.appendChild(
+        buildGrantButton(row.permission, "denied", row.grant === "denied"),
+    );
+    if (isGrantsTable) {
+        const clearBtn = document.createElement("button");
+        clearBtn.type = "button";
+        clearBtn.className = "inspection-permissions-action";
+        clearBtn.dataset.permissionAction = "clear";
+        clearBtn.dataset.permissionName = row.permission;
+        clearBtn.textContent = "Clear";
+        clearBtn.title = "Drop this permission's panel-pinned override";
+        clearBtn.addEventListener("click", () => {
+            emitPermissionsChange(clearBtn, {
+                field: "clearGrant",
+                permission: row.permission,
+            });
+        });
+        cell.appendChild(clearBtn);
+    }
+    return cell;
+}
+
+function buildGrantButton(
+    permission: string,
+    grant: "granted" | "denied",
+    isCurrent: boolean,
+): HTMLButtonElement {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "inspection-permissions-action";
+    btn.dataset.permissionAction = grant === "granted" ? "grant" : "deny";
+    btn.dataset.permissionName = permission;
+    btn.textContent = grant === "granted" ? "Grant" : "Deny";
+    btn.title =
+        grant === "granted"
+            ? "Pin this permission as granted for the next render"
+            : "Pin this permission as denied for the next render";
+    if (isCurrent) {
+        btn.setAttribute("aria-pressed", "true");
+        btn.classList.add("inspection-permissions-action--current");
+    }
+    btn.addEventListener("click", () => {
+        emitPermissionsChange(btn, {
+            field: "setGrant",
+            permission,
+            grant,
+        });
+    });
+    return btn;
+}
+
+function buildAddPermissionForm(): HTMLElement {
+    const form = document.createElement("form");
+    form.className = "inspection-permissions-add";
+    form.dataset.permissionForm = "add";
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = "inspection-permissions-add-input";
+    input.placeholder = "android.permission.CAMERA";
+    input.setAttribute(
+        "aria-label",
+        "Permission name to pin (e.g. android.permission.CAMERA)",
+    );
+    form.appendChild(input);
+    const grantBtn = document.createElement("button");
+    grantBtn.type = "submit";
+    grantBtn.className = "inspection-permissions-action";
+    grantBtn.dataset.permissionAction = "add-grant";
+    grantBtn.textContent = "Grant";
+    grantBtn.value = "granted";
+    form.appendChild(grantBtn);
+    const denyBtn = document.createElement("button");
+    denyBtn.type = "submit";
+    denyBtn.className = "inspection-permissions-action";
+    denyBtn.dataset.permissionAction = "add-deny";
+    denyBtn.textContent = "Deny";
+    denyBtn.value = "denied";
+    form.appendChild(denyBtn);
+    let pendingGrant: "granted" | "denied" = "granted";
+    grantBtn.addEventListener("click", () => {
+        pendingGrant = "granted";
+    });
+    denyBtn.addEventListener("click", () => {
+        pendingGrant = "denied";
+    });
+    form.addEventListener("submit", (evt) => {
+        evt.preventDefault();
+        const raw = input.value.trim();
+        if (!raw) return;
+        const permission = normalisePermissionInput(raw);
+        emitPermissionsChange(form, {
+            field: "setGrant",
+            permission,
+            grant: pendingGrant,
+        });
+        input.value = "";
+    });
+    return form;
+}
+
+function buildClearOverridesButton(): HTMLButtonElement {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className =
+        "inspection-permissions-action inspection-permissions-clear-all";
+    btn.dataset.permissionAction = "clear-all";
+    btn.textContent = "Clear overrides";
+    btn.title =
+        "Drop every panel-pinned permission override (the next render falls" +
+        " back to the manifest baseline).";
+    btn.addEventListener("click", () => {
+        emitPermissionsChange(btn, { field: "clearAll" });
+    });
+    return btn;
+}
+
+/**
+ * `CAMERA` → `android.permission.CAMERA` so the user can type the short
+ * label they see in the table without remembering the full prefix; an already-
+ * qualified input passes through unchanged. Whitespace-only input is caught by
+ * the form's submit handler before reaching this helper.
+ */
+function normalisePermissionInput(raw: string): string {
+    if (raw.includes(".")) return raw;
+    return "android.permission." + raw.toUpperCase();
+}
+
+function emitPermissionsChange(
+    source: HTMLElement,
+    detail: PermissionsChangeDetail,
+): void {
+    const evt = new CustomEvent<PermissionsChangeDetail>(
+        "permissions-override-change",
+        { detail, bubbles: true, composed: true },
+    );
+    source.dispatchEvent(evt);
+}
+
+/**
+ * Detail payload of the `permissions-override-change` CustomEvent the
+ * permissions section dispatches up to the inspection bundle body wrapper.
+ * Re-typed here (rather than imported from `../types`) because this module
+ * is the only webview-side producer and we don't want to drag the full host
+ * `WebviewToExtension` union into the presenter's type graph. `main.ts`
+ * forwards it verbatim as the `change` field of `setPermissionsOverride`.
+ */
+export type PermissionsChangeDetail =
+    | { field: "setGrant"; permission: string; grant: "granted" | "denied" }
+    | { field: "clearGrant"; permission: string }
+    | { field: "clearAll" };
 
 /** Namespace a node id with its kind so cross-kind dedupe stays clean. */
 function nsId(prefix: string, id: string): string {

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -142,6 +142,7 @@ import {
 import {
     computeInspectionBundleData,
     type InspectionKind,
+    type PermissionsChangeDetail,
 } from "./inspectionPresenters";
 import { FilterController } from "./filterController";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
@@ -2242,6 +2243,22 @@ export class PreviewApp extends LitElement {
             wrapper.appendChild(expander);
             wrapper.appendChild(host);
             wrapper.appendChild(rowDetail);
+            // Permissions section dispatches Grant / Deny / Clear / Add /
+            // Clear-overrides clicks as a single bubbled CustomEvent. Listen
+            // at the wrapper so the listener survives `host.replaceChildren()`
+            // on every refresh — the section element is re-built per refresh
+            // but the wrapper is cached for the panel lifetime.
+            wrapper.addEventListener("permissions-override-change", (evt) => {
+                const det = (evt as CustomEvent<PermissionsChangeDetail>)
+                    .detail;
+                const target = currentBundleTarget();
+                if (!target) return;
+                vscode.postMessage({
+                    command: "setPermissionsOverride",
+                    previewId: target,
+                    change: det,
+                });
+            });
             inspectionCachedBody = { wrapper, expander, host, rowDetail };
             return inspectionCachedBody;
         };


### PR DESCRIPTION
## Summary

Add interactive permission-override controls to the inspection panel's `compose/permissions` section, allowing users to grant/deny individual permissions and preview their effects in real-time without modifying the manifest.

## Key Changes

- **Permissions presenter UI** (`inspectionPresenters.ts`):
  - Render per-row Grant/Deny/Clear buttons in the permissions tables
  - Add "Add permission" form to pin arbitrary `Manifest.permission.*` names
  - Add "Clear overrides" button to reset all panel-pinned grants
  - Emit `permissions-override-change` CustomEvent for each user action
  - Normalize short permission names (e.g., `CAMERA` → `android.permission.CAMERA`)
  - Mark currently-applied grant button with `aria-pressed="true"` for accessibility
  - Always render the add form and clear button, even with empty payload

- **Permissions merge logic** (`daemon/permissionsMerge.ts`):
  - Pure function to apply panel edits to cumulative override bag
  - Handle three change types: `setGrant`, `clearGrant`, `clearAll`
  - Immutable updates (no aliasing of prior state)

- **Extension host integration** (`extension.ts`):
  - Track per-preview permissions overrides in `permissionsOverridesByPreview` map
  - Route `setPermissionsOverride` messages to merge handler
  - Dispatch `renderNow.overrides.permissions` to apply changes via daemon
  - Gated on early features flag (same as Remote Compose edits)

- **Webview message routing** (`main.ts`):
  - Listen for `permissions-override-change` events at inspection bundle wrapper
  - Forward to extension host as `setPermissionsOverride` message

- **Type definitions** (`types.ts`, `daemonProtocol.ts`):
  - Add `PermissionsChangeDetail` discriminated union for all edit types
  - Add `PermissionsOverride` and `PermissionGrantOverride` to daemon protocol
  - Document permissions override semantics in `PreviewOverrides`

- **Styling** (`preview.css`):
  - Style header layout with title and clear-all button
  - Style add-permission form with input and submit buttons
  - Style action buttons with hover states and current-grant highlighting

- **Test coverage** (`inspectionPresenters.test.ts`, `permissionsMerge.test.ts`):
  - DOM-level contract tests for all button interactions
  - Permission name normalization tests
  - Merge logic tests for all change types and edge cases

## Implementation Details

- Permission changes propagate through Robolectric's `ShadowApplication` grant map, which is consulted on every `ContextWrapper.checkPermission` call. A full `renderNow` is required (no fast-path) because the screen's `ContextCompat.checkSelfPermission()` only re-fires on recomposition.
- The cumulative override bag persists across renders for the activation lifetime, mirroring Remote Compose behavior. A `clearAll` resets to `{ grants: {} }` rather than removing the entry, ensuring the next dispatch strips any in-flight grants.
- The add form normalizes bare short names to the full `android.permission.*` prefix, allowing users to type what they see in the table without remembering the full constant name.

https://claude.ai/code/session_01MaJ3L2cyDfq9MudC1QFhD3