### PR TITLE
fix: detect transitive preview deps in unevaluated projects

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -259,7 +259,24 @@ internal object AndroidPreviewSupport {
           // the project isn't part of this build (composite builds, missing
           // `include(...)`) — treat that as "no signal" and continue.
           val sub = runCatching { project.rootProject.findProject(dep.path) }.getOrNull()
-          if (sub != null && hasPreviewDependencyDeep(sub, visited)) return true
+          if (sub != null) {
+            // Force the sub-project to evaluate before we inspect its
+            // configurations. Without this the walk races include-order:
+            // for `include(":androidApp")` before `include(":shared")`,
+            // `:shared`'s build script (including its KMP
+            // `commonMain.dependencies { implementation(...) }` block) has
+            // not run yet when AGP's `onVariants` fires for `:androidApp`,
+            // so `:shared.configurations["commonMainImplementation"]
+            // .allDependencies` is empty and the preview signal is missed —
+            // the exact shape that broke `joreilly/Confetti`'s `:androidApp`
+            // against `compose.components.uiToolingPreview` declared in
+            // `:shared`'s commonMain. `evaluationDependsOn` is safe here —
+            // it triggers configuration, not resolution (so doesn't tip the
+            // "Configuration was resolved during configuration time" warning)
+            // — and is no more cross-project than the `findProject` above.
+            runCatching { project.evaluationDependsOn(sub.path) }
+            if (hasPreviewDependencyDeep(sub, visited)) return true
+          }
         }
       }
     }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/HasPreviewDependencyTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/HasPreviewDependencyTest.kt
@@ -198,6 +198,52 @@ class HasPreviewDependencyTest {
   }
 
   @Test
+  fun `transitive preview signal added in dependent project's afterEvaluate is detected`() {
+    // Real-world shape: `:app` is included before `:shared` in `settings.gradle.kts`,
+    // so by the time AGP's `onVariants` fires on `:app` and our gate walks
+    // `:app -> :shared`, `:shared` hasn't been evaluated yet — its
+    // `commonMainImplementation` is empty even though the build script declares
+    // `implementation(compose.components.uiToolingPreview)` in its KMP commonMain
+    // block. `joreilly/Confetti`'s `:androidApp` hits this exactly: no direct
+    // preview-tooling dep, only a transitive `implementation(projects.shared)`,
+    // and `:shared`'s preview-tooling dec is in its commonMain DSL.
+    //
+    // ProjectBuilder doesn't model KMP source sets, but `afterEvaluate` is the
+    // same shape — a config-time hook that only populates configurations once
+    // the target project is told to evaluate. The fix calls
+    // `evaluationDependsOn` on the sub-project before walking its configurations,
+    // which triggers `afterEvaluate` and populates the configs the walk inspects.
+    val rootProject = ProjectBuilder.builder().withName("root").withProjectDir(tmp.root).build()
+    val lib =
+      ProjectBuilder.builder()
+        .withName("lib")
+        .withProjectDir(tmp.newFolder("lib"))
+        .withParent(rootProject)
+        .build()
+    val app =
+      ProjectBuilder.builder()
+        .withName("app")
+        .withProjectDir(tmp.newFolder("app"))
+        .withParent(rootProject)
+        .build()
+
+    lib.plugins.apply("java-library")
+    app.plugins.apply("java")
+
+    lib.afterEvaluate {
+      lib.dependencies.add(
+        "api",
+        "org.jetbrains.compose.components:components-ui-tooling-preview:1.7.5",
+      )
+    }
+
+    val implementation = app.configurations.getByName("implementation")
+    implementation.dependencies.add(app.dependencies.project(mapOf("path" to ":lib")))
+
+    assertThat(AndroidPreviewSupport.hasPreviewDependency(app, "debug")).isTrue()
+  }
+
+  @Test
   fun `project-dependency cycle does not stack-overflow`() {
     // The recursive walk has to bound itself by visited project paths — without it,
     // a `:a` -> `:b` -> `:a` cycle (legal in plain Gradle, exotic but possible) would


### PR DESCRIPTION
## Summary

Fixes a race condition where transitive Compose preview dependencies declared in a project's build script were not detected if that project hadn't been evaluated yet when the dependency walk occurred.

## Problem

When a project includes subprojects in a specific order (e.g., `:app` before `:shared` in `settings.gradle.kts`), AGP's `onVariants` callback fires on `:app` before `:shared` has been evaluated. This causes the dependency walk to inspect `:shared`'s configurations while they're still empty, missing preview dependencies declared in `afterEvaluate` blocks or KMP source set DSL blocks (like `commonMain.dependencies { implementation(...) }`).

This affected real-world projects like `joreilly/Confetti`, where `:androidApp` depends on `:shared`, and `:shared` declares `compose.components.uiToolingPreview` in its KMP commonMain block.

## Changes

- **AndroidPreviewSupport.kt**: Added `evaluationDependsOn()` call before inspecting a sub-project's configurations. This forces the sub-project to evaluate (triggering its build script and `afterEvaluate` blocks) without triggering configuration resolution, ensuring all declared dependencies are populated before the walk inspects them.

- **HasPreviewDependencyTest.kt**: Added test case `transitive preview signal added in dependent project's afterEvaluate is detected` that reproduces the race condition using ProjectBuilder and verifies the fix works correctly.

## Implementation Details

The fix uses `project.evaluationDependsOn(sub.path)` which is safe because:
- It triggers configuration-time evaluation, not resolution (no "resolved during configuration time" warnings)
- It's no more cross-project than the existing `findProject()` call
- It's wrapped in `runCatching` to handle edge cases gracefully

https://claude.ai/code/session_01YTYpLoWgzTsZVqKUd8yRxW