### PR TITLE
docs(daemon): document compose/permissions data product and overrides

### DIFF
--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -279,6 +279,7 @@ A `data/fetch` that needs a re-render:
 | `compose/semantics` | default | low | SemanticsNode projection — testTag, role, mergeMode, bounds. |
 | `compose/recomposition` | instrumented | medium | `[{nodeId, count, sinceFrameStreamId?}]`. Heat map. Snapshot or click-delta. |
 | `compose/theme` | default | medium | Resolved `MaterialTheme.*` values + which nodes consumed them. |
+| `compose/permissions` | default | low | Android runtime-permissions surface: `{ grants: { "android.permission.X" -> "granted" \| "denied" }, queried: ["android.permission.X", …] }`. Around-composable seeds `ShadowApplication.grantPermissions/denyPermissions` from `renderNow.overrides.permissions.grants` so `ContextCompat.checkSelfPermission(...)` / `Activity.checkSelfPermission(...)` return the requested value through the standard platform path; the matching shadow on `ContextWrapper.checkPermission(...)` records the queried permission for the panel's "queried but no grant pinned" surface. Android-only. |
 | `resources/used` | default | low | `R.*` references resolved during render. |
 | `text/strings` | default | low | Drawn text with locale, fontScale, fontSize, colors, bounds, plus per-entry `truncated` / `overflow` / `lineCount` / `maxLines` / `didOverflowWidth/Height` from the Compose `TextLayoutResult`. |
 | `i18n/translations` | default | low | Per-string locale coverage from `values*/strings.xml`. Android only. |
@@ -301,6 +302,7 @@ Which `kind` strings each backend's `extensions/list` advertises and serves thro
 | `test/failure` | ✅ | ✅ | Postmortem bundle on `renderFailed`. Renderer-agnostic. |
 | `compose/theme` | ✅ | ✅ | Material 3 theme tokens. Override-extension shape. |
 | `compose/wallpaper` | ✅ | ✅ | Wallpaper override shape. |
+| `compose/permissions` | ✅ | ❌ Android-only | Runtime-permissions surface — Robolectric `ShadowApplication` grant seed + `ContextWrapper.checkPermission` query tracker. Desktop has no Android permission model; CMP panel chip greys out on `serverCapabilities.backend == "desktop"`. |
 | `compose/recomposition` | ✅ stub | ✅ producer | The Compose-runtime observer install lands on desktop; Android exposes a `NotAvailable`-only stub until the in-sandbox install ships. |
 | `displayfilter/variants` | ✅ | ✅ | Both backends, gated on `composeai.displayfilter.filters`. Producer is pure `BufferedImage` post-capture. |
 | `fonts/used` | ✅ producer | 📁 registry-only | Android: `GoogleFontInterceptor` + Typeface accounting. Desktop: registry returns `NotAvailable` until a Skia-side font producer ports. |
@@ -381,6 +383,7 @@ Compose runtime, daemon, or AndroidX:
 | `compose/semantics` | `:data-layoutinspector-core` | `ComposeSemanticsPayload`, `ComposeSemanticsNode` |
 | `compose/theme` | `:data-theme-core` | `ThemePayload`, `ResolvedThemeTokens`, `TypographyToken` |
 | `compose/wallpaper` | `:data-wallpaper-core` | `WallpaperPayload` |
+| `compose/permissions` | `:data-permissions-core` | `PermissionsPayload`, `PermissionGrantWire` |
 | `fonts/used` | `:data-fonts-core` | `FontsUsedPayload`, `FontUsedEntry` |
 | `history/diff/regions` | `:data-history-core` | `HistoryDiffPayload`, `HistoryDiffRegion` |
 | `i18n/translations` | `:data-strings-core` | `I18nTranslationsPayload`, `I18nVisibleString` |

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -345,6 +345,10 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
     }>;
     shapes?: Record<string, number>; // Shape token name -> rounded corner size in dp.
   };
+  permissions?: {                    // Android runtime-permissions override. Android-only.
+    grants: Record<string,           // Manifest.permission.* constant string ->
+            "granted" | "denied">;   //   grant state to pin for this render.
+  };
 }
 
 // result
@@ -357,6 +361,8 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
 The result resolves as soon as the request is queued, **not** when rendering completes. Per-render progress arrives as `renderStarted` / `renderFinished` / `renderFailed` notifications keyed by ID.
 
 `overrides` are merged onto the discovery-time `RenderSpec` per-call. A subsequent `renderNow` for the same preview **without** `overrides` reverts to the discovery-time defaults — overrides are not sticky across calls. Backends that don't model a particular field ignore it (e.g. desktop `localeTag` requires a Compose UI runtime that exposes a providable locale list). `orientation` is supported on both backends: Android performs a full rotation via the resource qualifier; desktop reduces `landscape`/`portrait` to a `widthPx ↔ heightPx` swap before `ImageComposeScene` construction (issue #1208). The desktop hint is **idempotent** — it means "make it look like X", not "always flip": the swap only fires when the requested orientation conflicts with the current aspect ratio, so a landscape-shaped base plus `orientation = landscape` is a no-op (repeated calls stay stable). Explicit pixel/`device` overrides on the same call win over the orientation hint on desktop — pass `orientation` alone for the swap to fire. `inspectionMode` controls the `LocalInspectionMode` value for this one-shot render; absent/null preserves preview behaviour (`true`). `material3Theme` is applied in the renderer's normal Compose tree as a `MaterialTheme(...) { preview() }` wrapper, so it affects components that read Material 3 locals without requiring the preview source to declare its own theme.
+
+`permissions` drives the runtime-permissions surface (`compose/permissions`). Android-only — the desktop backend ignores it. The around-composable seeds Robolectric's `ShadowApplication.grantPermissions/denyPermissions` from `grants` **before composition starts**, so a screen reading `ContextCompat.checkSelfPermission(...)`, `Activity.checkSelfPermission(...)`, `PackageManager.checkPermission(...)`, accompanist's `rememberPermissionState`, or any standard Android check API observes the requested value on the very first composition — no connector-specific Compose API for the consumer to opt into. A subsequent `renderNow.overrides.permissions` re-renders with the new map (full replacement: permissions absent from the new map fall back to Robolectric's manifest baseline, not "previous grant"); to keep a previous grant on a follow-up render, send it again. The companion shadow on `ContextWrapper.checkPermission(...)` records every queried permission for the panel's "queried but no grant pinned" surface; that list is served back through `data/fetch?kind=compose/permissions`.
 
 **Coalescing.** When `overrides` is non-null and a prior override-bearing render is still in-flight for the same `previewId`, the new request is rejected with `reason = "coalesced: …"` rather than queued. The client (panel, MCP, etc.) is responsible for resubmitting on the next `renderFinished` if the latest override values still differ from what was rendered. Plain (no-overrides) `renderNow` is unaffected — the existing save-debounce loop continues to coalesce upstream.
 


### PR DESCRIPTION
Addresses Part 5 of #1400 in-repo. The override-toggle UI shipped in
#1540 plus the wire+composition fixes in the same PR all referenced
behaviour that wasn't actually documented anywhere agent-facing — the
panel surfaced `compose/permissions` rows the docs never mentioned and
clients sending `renderNow.overrides.permissions` had no spec to read.

DATA-PRODUCTS.md:
- Add `compose/permissions` row to the kinds table (payload shape,
  override behaviour, query-tracker behaviour, Android-only gate).
- Add a row to the per-backend support matrix (✅ Android, ❌ Desktop;
  CMP panel chip greys out on `serverCapabilities.backend == "desktop"`).
- Add a row to the schema source-of-truth table pointing at
  `:data-permissions-core`.

PROTOCOL.md:
- Add the `permissions?: { grants: Record<…, "granted" | "denied"> }`
  field to `PreviewOverrides` in the §5 `renderNow` schema.
- New paragraph explaining the seed-before-composition contract (after
  the connector fix from #1540 — earlier the seed lagged one render),
  the full-replacement semantics on resubmit (absent permissions fall
  back to the manifest baseline, not "previous grant"), and the
  companion query-tracker path that feeds `data/fetch?kind=compose/permissions`.

The external `yschimke/skills/skills/compose-preview/references/`
agent-facing how-to mentioned in the issue lives in a different repo;
I can't push to it from this session. The DATA-PRODUCTS + PROTOCOL
additions above are the in-repo half — readers of the skill can be
pointed at them from the skill's own reference once it lands.