### PR TITLE
fix(gradle-preview-driver): recover from Kotlin IC storage-already-registered (KT-59321)

### DIFF
--- a/gradle-preview-driver/build.gradle.kts
+++ b/gradle-preview-driver/build.gradle.kts
@@ -40,6 +40,18 @@ dependencies {
   testImplementation(kotlin("test"))
 }
 
+// Surface the running Gradle distribution's install dir to the test JVM so
+// `GradleConnectionRecoveryFunctionalTest` can point its synthetic-project `GradleConnection` at
+// a known installation rather than requiring the temp project to ship a wrapper. The test
+// self-skips when the property is absent (e.g. embedded Gradle invocations); see issue #1493.
+val gradleHomeForTests: String? = gradle.gradleHomeDir?.absolutePath
+
+tasks.named<Test>("test") {
+  if (gradleHomeForTests != null) {
+    systemProperty("composeai.test.gradleHome", gradleHomeForTests)
+  }
+}
+
 composeAiMavenPublishing {
   coordinates(
     artifactId = "gradle-preview-driver",

--- a/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -45,9 +45,23 @@ class GradleConnection(
    * manually wired it in their `build.gradle.kts`. See [autoInjectInitScriptArgs] for the source.
    */
   private val extraArguments: List<String> = emptyList(),
+  /**
+   * Optional Gradle installation directory passed to [GradleConnector.useInstallation]. Production
+   * callers leave this null so the Tooling API picks the wrapper version from the project tree;
+   * tests point it at a known distribution so they don't depend on a wrapper download. The Kotlin
+   * IC recovery path stays correct under either: it closes and re-opens its connection through the
+   * same [connector] instance, which preserves whichever distribution selection was made.
+   */
+  gradleInstallation: File? = null,
 ) : AutoCloseable {
-  private val connector = GradleConnector.newConnector().forProjectDirectory(projectDir)
-  private val connection = connector.connect()
+  private val connector: GradleConnector =
+    GradleConnector.newConnector().forProjectDirectory(projectDir).let { c ->
+      if (gradleInstallation != null) c.useInstallation(gradleInstallation) else c
+    }
+  // var so the Kotlin IC recovery pass can close + reconnect after wiping caches — the post-stop
+  // daemon is gone, so reusing the original ProjectConnection is undefined. See
+  // [recoverFromKotlinIcStorageFailure] (issue #1493).
+  private var connection: org.gradle.tooling.ProjectConnection = connector.connect()
   private var modelAccessFailure: GradleAccessFailure? = null
 
   val lastModelAccessFailure: GradleAccessFailure?
@@ -246,10 +260,11 @@ class GradleConnection(
    * registered"): the in-process Kotlin compiler retains a `FilePageCache` registration across
    * builds, the next build's re-registration throws, Kotlin falls back to non-incremental, and
    * Gradle reports SUCCESS — but the on-disk `caches-jvm` can be left inconsistent and a subsequent
-   * `compileKotlin UP-TO-DATE` then fails to reflect the user's edit. We stop the Gradle daemon
-   * (which restarts the Kotlin compile service with a clean cache registry), wipe each affected
-   * `caches-jvm` directory, and re-run the requested tasks once with `--rerun-tasks` so Gradle's
-   * up-to-date check doesn't skip the now-needed recompile.
+   * `compileKotlin UP-TO-DATE` then fails to reflect the user's edit. We close our own Tooling-API
+   * connection so the daemon goes idle, request a daemon stop (so the in-process Kotlin compile
+   * service is rebuilt from scratch on next connect), wipe each affected `caches-jvm` directory,
+   * reconnect, and re-run the requested tasks once with `--rerun-tasks` so Gradle's up-to-date
+   * check doesn't skip the now-needed recompile.
    *
    * One retry only: the recursion passes `allowKotlinIcRecovery = false` so a re-occurrence
    * propagates the failure to the caller instead of looping. See issue #1493.
@@ -265,6 +280,15 @@ class GradleConnection(
       "Kotlin incremental compiler reported 'Storage already registered' (KT-59321). " +
         "Stopping Gradle daemon, wiping ${detectedDirs.size} stale caches-jvm $dirWord, and retrying once..."
     )
+    // Release our hold on the daemon BEFORE asking it to stop — otherwise the stop request races
+    // the still-active ProjectConnection. The Kotlin in-process compile service lives in that
+    // daemon JVM, so cleanly killing it is the only way to drop the stale FilePageCache
+    // registration that's the root of KT-59321.
+    try {
+      connection.close()
+    } catch (_: Exception) {
+      // best-effort
+    }
     stopGradleDaemons()
     for (dir in detectedDirs) {
       if (!dir.exists()) continue
@@ -273,8 +297,16 @@ class GradleConnection(
         System.err.println("  warning: failed to wipe ${dir.absolutePath}")
       }
     }
+    connection = connector.connect()
     val retryArgs = if ("--rerun-tasks" in arguments) arguments else arguments + "--rerun-tasks"
-    return runTasksInternal(tasks, timeoutSeconds, retryArgs, allowKotlinIcRecovery = false)
+    val retryOk = runTasksInternal(tasks, timeoutSeconds, retryArgs, allowKotlinIcRecovery = false)
+    if (!retryOk) {
+      System.err.println(
+        "Kotlin IC recovery retry did not succeed. Manual workaround: `./gradlew --stop` then " +
+          "`rm -rf <module>/build/kotlin && ./gradlew <tasks>`. See issue #1493."
+      )
+    }
+    return retryOk
   }
 
   /**

--- a/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -68,6 +68,20 @@ class GradleConnection(
     vararg tasks: String,
     timeoutSeconds: Long = 300,
     arguments: List<String> = emptyList(),
+  ): Boolean =
+    runTasksInternal(tasks.toList(), timeoutSeconds, arguments, allowKotlinIcRecovery = true)
+
+  /**
+   * Internal entry point that drives the actual Tooling-API invocation. The public [runTasks]
+   * always calls in with [allowKotlinIcRecovery] = true; the recovery pass recurses once with it
+   * set to false so a re-occurrence of the marker doesn't loop forever — see
+   * [recoverFromKotlinIcStorageFailure] (issue #1493).
+   */
+  private fun runTasksInternal(
+    tasks: List<String>,
+    timeoutSeconds: Long,
+    arguments: List<String>,
+    allowKotlinIcRecovery: Boolean,
   ): Boolean {
     val tokenSource: CancellationTokenSource = GradleConnector.newCancellationTokenSource()
     val startTime = System.currentTimeMillis()
@@ -126,92 +140,166 @@ class GradleConnection(
 
     // Capture stderr for error reporting when not in verbose mode
     val errorCapture = ByteArrayOutputStream()
+    // Tee stdout/stderr through a Kotlin IC marker detector regardless of verbose mode — the
+    // "Storage for [...] is already registered" marker can appear on either stream depending on
+    // Kotlin's logger config, and the build typically still reports SUCCESS, so we need to scan
+    // live rather than only after a BuildException. See [recoverFromKotlinIcStorageFailure].
+    val stdoutDetector = KotlinIcStorageDetector(if (verbose) System.err else NullOutputStream)
+    val stderrDetector = KotlinIcStorageDetector(if (verbose) System.err else errorCapture)
 
-    return try {
-      val launcher =
-        connection.newBuild().forTasks(*tasks).withCancellationToken(tokenSource.token())
-      val combinedArguments = extraArguments + arguments
-      if (combinedArguments.isNotEmpty()) {
-        launcher.withArguments(combinedArguments)
-      }
+    val outcome: Boolean =
+      try {
+        val launcher =
+          connection
+            .newBuild()
+            .forTasks(*tasks.toTypedArray())
+            .withCancellationToken(tokenSource.token())
+        val combinedArguments = extraArguments + arguments
+        if (combinedArguments.isNotEmpty()) {
+          launcher.withArguments(combinedArguments)
+        }
 
-      if (verbose) {
-        launcher.setStandardOutput(System.err)
-        launcher.setStandardError(System.err)
-      } else {
-        launcher.setStandardOutput(NullOutputStream)
-        launcher.setStandardError(errorCapture)
-      }
+        launcher.setStandardOutput(stdoutDetector)
+        launcher.setStandardError(stderrDetector)
 
-      // TEST events are always on so we can capture failing-test details
-      // for `printBuildFailure`. Discriminate by descriptor type in the
-      // listener so test events don't pollute the task-progress counters
-      // or the heartbeat's "running:" list (a single render run can fire
-      // hundreds of test events).
-      val listenerTypes = setOf(OperationType.TASK, OperationType.TEST)
+        // TEST events are always on so we can capture failing-test details
+        // for `printBuildFailure`. Discriminate by descriptor type in the
+        // listener so test events don't pollute the task-progress counters
+        // or the heartbeat's "running:" list (a single render run can fire
+        // hundreds of test events).
+        val listenerTypes = setOf(OperationType.TASK, OperationType.TEST)
 
-      launcher.addProgressListener(
-        { event: ProgressEvent ->
-          val descriptor = event.descriptor
-          when {
-            descriptor is TaskOperationDescriptor -> {
-              val desc = descriptor.name
-              when (event) {
-                is StartEvent -> {
-                  taskCount++
-                  runningTasks.add(desc)
-                }
-                is FinishEvent -> {
-                  runningTasks.remove(desc)
-                  tasksFinished++
-                  if (taskCount > 0) {
-                    TerminalProgress.show((tasksFinished * 100) / taskCount)
+        launcher.addProgressListener(
+          { event: ProgressEvent ->
+            val descriptor = event.descriptor
+            when {
+              descriptor is TaskOperationDescriptor -> {
+                val desc = descriptor.name
+                when (event) {
+                  is StartEvent -> {
+                    taskCount++
+                    runningTasks.add(desc)
                   }
-                  if (
-                    progress &&
-                      !verbose &&
-                      (desc.contains("composePreviewDiscover") ||
-                        desc.contains("composePreviewRender") ||
-                        desc.contains("composePreviewRenderAll"))
-                  ) {
-                    val elapsed = (System.currentTimeMillis() - startTime) / 1000
-                    System.err.println("  [${elapsed}s] $desc")
+                  is FinishEvent -> {
+                    runningTasks.remove(desc)
+                    tasksFinished++
+                    if (taskCount > 0) {
+                      TerminalProgress.show((tasksFinished * 100) / taskCount)
+                    }
+                    if (
+                      progress &&
+                        !verbose &&
+                        (desc.contains("composePreviewDiscover") ||
+                          desc.contains("composePreviewRender") ||
+                          desc.contains("composePreviewRenderAll"))
+                    ) {
+                      val elapsed = (System.currentTimeMillis() - startTime) / 1000
+                      System.err.println("  [${elapsed}s] $desc")
+                    }
                   }
+                  else -> {}
                 }
-                else -> {}
+              }
+              descriptor is TestOperationDescriptor && event is FinishEvent -> {
+                val result = event.result
+                if (result is FailureResult) collectTestFailures(descriptor, result.failures)
               }
             }
-            descriptor is TestOperationDescriptor && event is FinishEvent -> {
-              val result = event.result
-              if (result is FailureResult) collectTestFailures(descriptor, result.failures)
-            }
-          }
-        },
-        listenerTypes,
-      )
+          },
+          listenerTypes,
+        )
 
-      launcher.run()
-      TerminalProgress.show(100)
-      true
-    } catch (e: org.gradle.tooling.BuildCancelledException) {
-      TerminalProgress.error()
-      System.err.println("Build cancelled.")
-      false
-    } catch (e: org.gradle.tooling.BuildException) {
-      TerminalProgress.error()
-      printBuildFailure(e, errorCapture)
-      false
-    } catch (e: org.gradle.tooling.GradleConnectionException) {
-      TerminalProgress.error()
-      System.err.println("Gradle connection failed: ${e.message}")
-      false
-    } finally {
-      timer.cancel()
-      tokenSource.cancel()
-      TerminalProgress.hide()
-      try {
-        Runtime.getRuntime().removeShutdownHook(shutdownHook)
-      } catch (_: IllegalStateException) {}
+        launcher.run()
+        TerminalProgress.show(100)
+        true
+      } catch (e: org.gradle.tooling.BuildCancelledException) {
+        TerminalProgress.error()
+        System.err.println("Build cancelled.")
+        false
+      } catch (e: org.gradle.tooling.BuildException) {
+        TerminalProgress.error()
+        printBuildFailure(e, errorCapture)
+        false
+      } catch (e: org.gradle.tooling.GradleConnectionException) {
+        TerminalProgress.error()
+        System.err.println("Gradle connection failed: ${e.message}")
+        false
+      } finally {
+        timer.cancel()
+        tokenSource.cancel()
+        TerminalProgress.hide()
+        try {
+          Runtime.getRuntime().removeShutdownHook(shutdownHook)
+        } catch (_: IllegalStateException) {}
+      }
+
+    val detectedIcDirs =
+      stdoutDetector.detectedCachesJvmDirs() + stderrDetector.detectedCachesJvmDirs()
+    if (allowKotlinIcRecovery && detectedIcDirs.isNotEmpty()) {
+      return recoverFromKotlinIcStorageFailure(detectedIcDirs, tasks, timeoutSeconds, arguments)
+    }
+    return outcome
+  }
+
+  /**
+   * Recovery for upstream Kotlin IC issue KT-59321 / KT-55435 ("Storage for [...] is already
+   * registered"): the in-process Kotlin compiler retains a `FilePageCache` registration across
+   * builds, the next build's re-registration throws, Kotlin falls back to non-incremental, and
+   * Gradle reports SUCCESS — but the on-disk `caches-jvm` can be left inconsistent and a subsequent
+   * `compileKotlin UP-TO-DATE` then fails to reflect the user's edit. We stop the Gradle daemon
+   * (which restarts the Kotlin compile service with a clean cache registry), wipe each affected
+   * `caches-jvm` directory, and re-run the requested tasks once with `--rerun-tasks` so Gradle's
+   * up-to-date check doesn't skip the now-needed recompile.
+   *
+   * One retry only: the recursion passes `allowKotlinIcRecovery = false` so a re-occurrence
+   * propagates the failure to the caller instead of looping. See issue #1493.
+   */
+  private fun recoverFromKotlinIcStorageFailure(
+    detectedDirs: Set<File>,
+    tasks: List<String>,
+    timeoutSeconds: Long,
+    arguments: List<String>,
+  ): Boolean {
+    val dirWord = if (detectedDirs.size == 1) "directory" else "directories"
+    System.err.println(
+      "Kotlin incremental compiler reported 'Storage already registered' (KT-59321). " +
+        "Stopping Gradle daemon, wiping ${detectedDirs.size} stale caches-jvm $dirWord, and retrying once..."
+    )
+    stopGradleDaemons()
+    for (dir in detectedDirs) {
+      if (!dir.exists()) continue
+      if (verbose) System.err.println("  wiping ${dir.absolutePath}")
+      if (!dir.deleteRecursively()) {
+        System.err.println("  warning: failed to wipe ${dir.absolutePath}")
+      }
+    }
+    val retryArgs = if ("--rerun-tasks" in arguments) arguments else arguments + "--rerun-tasks"
+    return runTasksInternal(tasks, timeoutSeconds, retryArgs, allowKotlinIcRecovery = false)
+  }
+
+  /**
+   * Best-effort `./gradlew --stop` to flush the daemon JVM (which is where the stale Kotlin
+   * compiler `FilePageCache` registration lives). Falls through silently if the wrapper script is
+   * missing or the subprocess fails — the cache wipe + `--rerun-tasks` retry still gives the
+   * recovery a fair shot at success on its own.
+   */
+  private fun stopGradleDaemons() {
+    val wrapperName =
+      if (System.getProperty("os.name").lowercase().contains("win")) "gradlew.bat" else "gradlew"
+    val wrapper = File(projectDir, wrapperName)
+    if (!wrapper.exists()) return
+    try {
+      val proc =
+        ProcessBuilder(wrapper.absolutePath, "--stop")
+          .directory(projectDir)
+          .redirectErrorStream(true)
+          .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+          .start()
+      if (!proc.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)) {
+        proc.destroyForcibly()
+      }
+    } catch (_: Exception) {
+      // best-effort
     }
   }
 

--- a/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/KotlinIcStorageDetector.kt
+++ b/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/KotlinIcStorageDetector.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.io.OutputStream
+import java.util.Collections
+
+/**
+ * Tees an [OutputStream] (Gradle stdout/stderr) and scans the byte stream for Kotlin's incremental
+ * compiler "Storage for [...] is already registered" failure. The marker is emitted by
+ * `FilePageCache.registerPagedFileStorage` when an in-process Kotlin compiler daemon retains a
+ * cache-file registration across builds (upstream KT-59321 / KT-55435).
+ *
+ * The Gradle build typically still reports BUILD SUCCESSFUL because Kotlin falls back to
+ * non-incremental, but the on-disk `caches-jvm` directory can be left inconsistent and subsequent
+ * `compileKotlin UP-TO-DATE` runs will not reflect the user's edit. [GradleConnection] uses the
+ * detected directories to drive a stop-daemon + wipe-cache + retry recovery pass — see issue #1493.
+ *
+ * Detection is path-based: the marker carries an absolute path ending in
+ * `caches-jvm/jvm/kotlin/source-to-classes.tab` (or a sibling `.tab` file). We walk parents until
+ * we hit a directory named `caches-jvm` and record that as the wipe target.
+ */
+class KotlinIcStorageDetector(private val delegate: OutputStream) : OutputStream() {
+  private val lineBuffer = StringBuilder()
+  private val detected = Collections.synchronizedSet(linkedSetOf<File>())
+
+  fun detectedCachesJvmDirs(): Set<File> = synchronized(detected) { detected.toSet() }
+
+  override fun write(b: Int) {
+    delegate.write(b)
+    handleByte(b.toByte())
+  }
+
+  override fun write(b: ByteArray) {
+    delegate.write(b)
+    for (byte in b) handleByte(byte)
+  }
+
+  override fun write(b: ByteArray, off: Int, len: Int) {
+    delegate.write(b, off, len)
+    for (i in off until off + len) handleByte(b[i])
+  }
+
+  override fun flush() {
+    delegate.flush()
+  }
+
+  override fun close() {
+    if (lineBuffer.isNotEmpty()) {
+      processLine(lineBuffer.toString())
+      lineBuffer.clear()
+    }
+    delegate.close()
+  }
+
+  private fun handleByte(b: Byte) {
+    val c = (b.toInt() and 0xFF).toChar()
+    if (c == '\n' || c == '\r') {
+      if (lineBuffer.isNotEmpty()) {
+        processLine(lineBuffer.toString())
+        lineBuffer.clear()
+      }
+    } else {
+      lineBuffer.append(c)
+      // Bound the buffer so a pathological no-newline stream can't OOM us. The
+      // marker line is < 1 KiB in practice; 16 KiB leaves ample headroom and
+      // matches a typical compiler diagnostic length.
+      if (lineBuffer.length > MAX_LINE_LENGTH) {
+        processLine(lineBuffer.toString())
+        lineBuffer.clear()
+      }
+    }
+  }
+
+  private fun processLine(line: String) {
+    val match = STORAGE_REGEX.find(line) ?: return
+    val dir = findCachesJvmAncestor(File(match.groupValues[1])) ?: return
+    detected.add(dir)
+  }
+
+  companion object {
+    private const val MAX_LINE_LENGTH = 16 * 1024
+    private val STORAGE_REGEX = Regex("""Storage for \[([^\]]+)] is already registered""")
+
+    /**
+     * Walks parents of [path] until a directory named `caches-jvm` is found. Returns null if no
+     * such ancestor exists — defensive against future Kotlin error-message refactors that change
+     * the cache layout.
+     */
+    fun findCachesJvmAncestor(path: File): File? {
+      var current: File? = path
+      while (current != null) {
+        if (current.name == "caches-jvm") return current
+        current = current.parentFile
+      }
+      return null
+    }
+  }
+}

--- a/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/GradleConnectionRecoveryFunctionalTest.kt
+++ b/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/GradleConnectionRecoveryFunctionalTest.kt
@@ -1,0 +1,153 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Assume.assumeTrue
+
+/**
+ * End-to-end coverage for the Kotlin IC "Storage already registered" recovery (issue #1493). Drives
+ * a synthetic Gradle project through [GradleConnection] using a real Gradle distribution; the
+ * synthetic project's `trigger` task emits the upstream marker line on its first invocation, then
+ * succeeds normally on subsequent invocations. Exercises the close-connection → stop-daemons →
+ * wipe-cache → reconnect → retry-with-rerun-tasks pipeline that [GradleConnection]'s recovery code
+ * is responsible for.
+ *
+ * The Gradle distribution path is provided by the parent build via the `composeai.test.gradleHome`
+ * system property (see `gradle-preview-driver/build.gradle.kts`). When the property is absent (e.g.
+ * running the test class directly from an IDE without that wiring), the test self-skips via
+ * `assumeTrue` so it doesn't false-fail.
+ *
+ * The synthetic project deliberately ships a fake `gradlew` shell stub instead of a real wrapper so
+ * the recovery's `./gradlew --stop` call (a) executes without trying to download Gradle and (b)
+ * cannot accidentally kill the daemon serving our own `./gradlew test` run. The stub touches a flag
+ * file we then assert on.
+ */
+class GradleConnectionRecoveryFunctionalTest {
+  private val gradleHome: File? =
+    (System.getProperty("composeai.test.gradleHome") ?: System.getenv("GRADLE_HOME"))?.let {
+      File(it).takeIf { dir -> dir.isDirectory }
+    }
+
+  private val tempDirs = mutableListOf<File>()
+
+  @BeforeTest
+  fun checkGradleAvailable() {
+    assumeTrue(
+      "GradleConnectionRecoveryFunctionalTest needs a Gradle install at " +
+        "-Dcomposeai.test.gradleHome=<path> or env GRADLE_HOME; got $gradleHome",
+      gradleHome != null,
+    )
+  }
+
+  @AfterTest
+  fun cleanup() {
+    tempDirs.forEach { runCatching { it.deleteRecursively() } }
+  }
+
+  private fun tempDir(prefix: String = "ic-recovery-"): File =
+    Files.createTempDirectory(prefix).toFile().also { tempDirs += it }
+
+  @Test
+  fun `wipes caches-jvm and retries with --rerun-tasks after Kotlin IC storage marker`() {
+    val projectDir = tempDir()
+    val stopFlag = projectDir.resolve("stop-called.flag")
+    writeFakeGradlewStub(projectDir, stopFlag)
+
+    val cacheDir = projectDir.resolve("build/kotlin/compileKotlin/cacheable/caches-jvm")
+    val counterFile = projectDir.resolve("build/invocations.txt")
+
+    projectDir.resolve("settings.gradle.kts").writeText("rootProject.name = \"ic-recovery\"\n")
+    projectDir.resolve("build.gradle.kts").writeText(triggerBuildScript())
+
+    val ok =
+      GradleConnection(projectDir = projectDir, verbose = false, gradleInstallation = gradleHome)
+        .use { it.runTasks("trigger", timeoutSeconds = 180) }
+
+    assertTrue(ok, "recovery retry should have succeeded; final outcome was false")
+    assertTrue(counterFile.exists(), "counter file should exist after both invocations")
+    assertEquals(
+      "2",
+      counterFile.readText().trim(),
+      "task should have run exactly twice (initial + recovery retry)",
+    )
+    assertFalse(
+      cacheDir.exists(),
+      "caches-jvm should have been wiped during recovery and not recreated on the retry pass " +
+        "(retry's counter==2 branch skips the cache-creation block)",
+    )
+    assertTrue(
+      stopFlag.exists(),
+      "fake gradlew stub should have been invoked by recovery's stopGradleDaemons()",
+    )
+  }
+
+  @Test
+  fun `does not loop when the marker re-occurs on the retry`() {
+    val projectDir = tempDir()
+    val stopFlag = projectDir.resolve("stop-called.flag")
+    writeFakeGradlewStub(projectDir, stopFlag)
+
+    val counterFile = projectDir.resolve("build/invocations.txt")
+
+    projectDir.resolve("settings.gradle.kts").writeText("rootProject.name = \"ic-recovery\"\n")
+    // ALWAYS-emit variant: the recovery retry will re-trigger detection, but the retry guard
+    // (allowKotlinIcRecovery=false on the recursive call) must prevent a second recovery pass.
+    projectDir.resolve("build.gradle.kts").writeText(triggerBuildScript(alwaysEmit = true))
+
+    val ok =
+      GradleConnection(projectDir = projectDir, verbose = false, gradleInstallation = gradleHome)
+        .use { it.runTasks("trigger", timeoutSeconds = 180) }
+
+    assertTrue(ok, "build itself still succeeds; the marker is only printed, not thrown")
+    assertEquals(
+      "2",
+      counterFile.readText().trim(),
+      "exactly two invocations: initial + one retry. A third would mean the recovery guard leaked.",
+    )
+  }
+
+  private fun writeFakeGradlewStub(projectDir: File, stopFlag: File) {
+    val script = projectDir.resolve("gradlew")
+    script.writeText(
+      """
+      #!/bin/sh
+      echo stopped > '${stopFlag.absolutePath}'
+      exit 0
+      """
+        .trimIndent() + "\n"
+    )
+    script.setExecutable(true)
+  }
+
+  private fun triggerBuildScript(alwaysEmit: Boolean = false): String {
+    val emitCondition = if (alwaysEmit) "true" else "count == 1"
+    return """
+      tasks.register("trigger") {
+        val cacheDir = file("build/kotlin/compileKotlin/cacheable/caches-jvm/jvm/kotlin")
+        val counterFile = file("build/invocations.txt")
+        outputs.upToDateWhen { false }
+        doLast {
+          val previous = if (counterFile.exists()) counterFile.readText().trim().toInt() else 0
+          val count = previous + 1
+          counterFile.parentFile.mkdirs()
+          counterFile.writeText(count.toString())
+          if ($emitCondition) {
+            cacheDir.mkdirs()
+            val tab = cacheDir.resolve("source-to-classes.tab")
+            tab.createNewFile()
+            // Mirror Kotlin's IC compiler logger format (KT-59321). The build still succeeds —
+            // upstream Kotlin falls back to non-incremental rather than failing the task.
+            println("e: Incremental compilation failed: Storage for [" + tab.absolutePath + "] is already registered")
+          }
+        }
+      }
+      """
+      .trimIndent()
+  }
+}

--- a/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/KotlinIcStorageDetectorTest.kt
+++ b/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/KotlinIcStorageDetectorTest.kt
@@ -1,0 +1,126 @@
+package ee.schimke.composeai.cli
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class KotlinIcStorageDetectorTest {
+  @Test
+  fun `passes bytes through to delegate verbatim`() {
+    val sink = ByteArrayOutputStream()
+    val detector = KotlinIcStorageDetector(sink)
+
+    detector.write("hello world\n".toByteArray())
+    detector.write("more\n".toByteArray())
+
+    assertEquals("hello world\nmore\n", sink.toString())
+    assertTrue(detector.detectedCachesJvmDirs().isEmpty())
+  }
+
+  @Test
+  fun `extracts caches-jvm dir from Kotlin storage already registered marker`() {
+    val sink = ByteArrayOutputStream()
+    val detector = KotlinIcStorageDetector(sink)
+
+    val msg =
+      "e: Incremental compilation failed: Storage for [/home/u/proj/samples/cmp/build/kotlin/" +
+        "compileKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab] is already registered\n"
+    detector.write(msg.toByteArray())
+
+    val expected = File("/home/u/proj/samples/cmp/build/kotlin/compileKotlin/cacheable/caches-jvm")
+    assertEquals(setOf(expected), detector.detectedCachesJvmDirs())
+  }
+
+  @Test
+  fun `detects marker streamed byte-by-byte across multiple writes`() {
+    val sink = ByteArrayOutputStream()
+    val detector = KotlinIcStorageDetector(sink)
+
+    val msg =
+      "Storage for [/x/build/kotlin/compileKotlin/cacheable/caches-jvm/jvm/kotlin/" +
+        "source-to-classes.tab] is already registered\n"
+    for (b in msg.toByteArray()) detector.write(b.toInt())
+
+    val expected = File("/x/build/kotlin/compileKotlin/cacheable/caches-jvm")
+    assertEquals(setOf(expected), detector.detectedCachesJvmDirs())
+  }
+
+  @Test
+  fun `dedups repeated markers for the same caches-jvm dir`() {
+    val sink = ByteArrayOutputStream()
+    val detector = KotlinIcStorageDetector(sink)
+
+    val line =
+      "Storage for [/p/build/kotlin/compileKotlin/cacheable/caches-jvm/jvm/kotlin/" +
+        "source-to-classes.tab] is already registered\n"
+    detector.write(line.toByteArray())
+    detector.write(line.toByteArray())
+
+    assertEquals(1, detector.detectedCachesJvmDirs().size)
+  }
+
+  @Test
+  fun `collects distinct caches-jvm dirs across modules`() {
+    val sink = ByteArrayOutputStream()
+    val detector = KotlinIcStorageDetector(sink)
+
+    detector.write(
+      ("Storage for [/p/a/build/kotlin/compileKotlin/cacheable/caches-jvm/jvm/kotlin/" +
+          "source-to-classes.tab] is already registered\n")
+        .toByteArray()
+    )
+    detector.write(
+      ("Storage for [/p/b/build/kotlin/compileKotlin/cacheable/caches-jvm/jvm/kotlin/" +
+          "java-to-kotlin.tab] is already registered\n")
+        .toByteArray()
+    )
+
+    assertEquals(
+      setOf(
+        File("/p/a/build/kotlin/compileKotlin/cacheable/caches-jvm"),
+        File("/p/b/build/kotlin/compileKotlin/cacheable/caches-jvm"),
+      ),
+      detector.detectedCachesJvmDirs(),
+    )
+  }
+
+  @Test
+  fun `ignores unrelated lines`() {
+    val sink = ByteArrayOutputStream()
+    val detector = KotlinIcStorageDetector(sink)
+
+    detector.write("> Task :app:compileKotlin\n".toByteArray())
+    detector.write("BUILD SUCCESSFUL in 3s\n".toByteArray())
+    detector.write("Storage for something else without brackets\n".toByteArray())
+
+    assertTrue(detector.detectedCachesJvmDirs().isEmpty())
+  }
+
+  @Test
+  fun `returns null when path has no caches-jvm ancestor`() {
+    assertNull(
+      KotlinIcStorageDetector.findCachesJvmAncestor(File("/some/other/path/source-to-classes.tab"))
+    )
+  }
+
+  @Test
+  fun `flushes trailing line on close even without newline`() {
+    val sink = ByteArrayOutputStream()
+    val detector = KotlinIcStorageDetector(sink)
+
+    detector.write(
+      ("Storage for [/p/build/kotlin/compileKotlin/cacheable/caches-jvm/jvm/kotlin/" +
+          "source-to-classes.tab] is already registered")
+        .toByteArray()
+    )
+    detector.close()
+
+    assertEquals(
+      setOf(File("/p/build/kotlin/compileKotlin/cacheable/caches-jvm")),
+      detector.detectedCachesJvmDirs(),
+    )
+  }
+}

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -20,6 +20,7 @@ import {
     KotlinCompileError,
     KotlinCompileErrorDetector,
 } from "./kotlinCompileErrorDetector";
+import { KotlinIcStorageDetector } from "./kotlinIcStorageDetector";
 import { LogFilter } from "./logFilter";
 import { ContinuousCompileWorker } from "./daemon/continuousCompileWorker";
 
@@ -1377,6 +1378,10 @@ export class GradleService {
         task: string,
         extraArgs: ReadonlyArray<string> = [],
         opts: TaskOptions = {},
+        // Internal parameter — first call always lets recovery fire; the recursive retry from
+        // [runKotlinIcStorageRecovery] passes `false` so a re-occurrence of the KT-59321
+        // marker on the retry pass propagates the failure to the caller instead of looping.
+        allowKotlinIcRecovery: boolean = true,
     ): Promise<void> {
         const cancellationKey = `compose-preview-${++this.taskCounter}|${task}`;
         this.activeKeys.add(cancellationKey);
@@ -1395,6 +1400,12 @@ export class GradleService {
         // cross-file gap that the LSP-driven gate (compileErrors.ts)
         // misses by design — that gate only inspects the active file.
         const kotlinDetector = new KotlinCompileErrorDetector();
+        // Detects the upstream Kotlin IC "Storage already registered" failure (KT-59321 /
+        // KT-55435 — see [KotlinIcStorageDetector]). The build usually still reports SUCCESS
+        // because Kotlin falls back to non-incremental, but the on-disk `caches-jvm` is then
+        // inconsistent and the next save's `compileKotlin UP-TO-DATE` doesn't reflect the
+        // user's edit — the "save isn't doing anything" symptom in issue #1493.
+        const icDetector = new KotlinIcStorageDetector();
 
         const timeoutPromise = new Promise<never>((_, reject) => {
             setTimeout(() => {
@@ -1434,6 +1445,7 @@ export class GradleService {
                         detector.consume(decoded);
                         classVersionDetector.consume(decoded);
                         kotlinDetector.consume(decoded);
+                        icDetector.consume(decoded);
                         const filtered =
                             this.logFilter.filterGradleChunk(decoded);
                         if (filtered.length > 0) {
@@ -1499,6 +1511,143 @@ export class GradleService {
                 this.activeKeys.delete(cancellationKey);
             });
 
-        return Promise.race([taskPromise, timeoutPromise]);
+        const racedPromise = Promise.race([taskPromise, timeoutPromise]);
+        // After the task settles (success, throw, or timeout), check whether the IC marker
+        // fired. Common case is BUILD SUCCESSFUL with a stale `caches-jvm` left behind, so the
+        // recovery has to run on the success path too — not just on errors.
+        return racedPromise.then(
+            async () => {
+                icDetector.end();
+                const dirs = icDetector.getDetectedCachesJvmDirs();
+                if (allowKotlinIcRecovery && dirs.length > 0) {
+                    await this.runKotlinIcStorageRecovery(
+                        dirs,
+                        task,
+                        extraArgs,
+                        opts,
+                    );
+                }
+            },
+            async (err) => {
+                icDetector.end();
+                const dirs = icDetector.getDetectedCachesJvmDirs();
+                // Don't try recovery on user-driven cancel (CANCELLED_RE / TaskCancelledError)
+                // — superseded refreshes are routine and the marker, if any, will fire again
+                // on the next attempt.
+                if (
+                    allowKotlinIcRecovery &&
+                    dirs.length > 0 &&
+                    !(err instanceof TaskCancelledError)
+                ) {
+                    // Returning normally from this onRejected handler swallows `err` and the
+                    // outer promise resolves — that's the intent when recovery succeeds.
+                    // If the retry itself throws, that error replaces `err`, which is the
+                    // most informative thing to surface.
+                    await this.runKotlinIcStorageRecovery(
+                        dirs,
+                        task,
+                        extraArgs,
+                        opts,
+                    );
+                    return;
+                }
+                throw err;
+            },
+        );
+    }
+
+    /**
+     * Recovery for the Kotlin IC "Storage already registered" failure (issue #1493). Stops the
+     * project's Gradle daemons via the local wrapper (so the in-process Kotlin compile service
+     * is rebuilt from scratch on the next invocation), wipes each detected `caches-jvm`
+     * directory, and re-runs the failed task once with `--rerun-tasks` so Gradle's
+     * up-to-date check doesn't skip the now-needed recompile. The recursive [runTask] call
+     * passes `allowKotlinIcRecovery=false` so a re-occurrence of the marker on the retry
+     * propagates instead of looping.
+     */
+    private async runKotlinIcStorageRecovery(
+        dirs: readonly string[],
+        task: string,
+        extraArgs: ReadonlyArray<string>,
+        opts: TaskOptions,
+    ): Promise<void> {
+        const dirWord = dirs.length === 1 ? "directory" : "directories";
+        this.logger.appendLine(
+            `> ${task}: Kotlin IC 'Storage already registered' (KT-59321) detected. ` +
+                `Stopping Gradle daemon, wiping ${dirs.length} stale caches-jvm ${dirWord}, ` +
+                `and retrying once with --rerun-tasks...`,
+        );
+        await this.stopGradleDaemonsForRecovery();
+        for (const dir of dirs) {
+            try {
+                await fs.promises.rm(dir, { recursive: true, force: true });
+            } catch (e) {
+                this.logger.appendLine(
+                    `  warning: failed to wipe ${dir}: ${(e as Error)?.message ?? e}`,
+                );
+            }
+        }
+        const retryArgs = extraArgs.includes("--rerun-tasks")
+            ? extraArgs
+            : [...extraArgs, "--rerun-tasks"];
+        try {
+            await this.runTask(
+                task,
+                retryArgs,
+                opts,
+                /*allowKotlinIcRecovery=*/ false,
+            );
+        } catch (err) {
+            this.logger.appendLine(
+                `> ${task}: Kotlin IC recovery retry did not succeed. Manual workaround: ` +
+                    "`./gradlew --stop` then `rm -rf <module>/build/kotlin && ./gradlew <task>`. " +
+                    "See issue #1493.",
+            );
+            throw err;
+        }
+    }
+
+    /**
+     * Best-effort `./gradlew --stop` from the workspace root — the daemon JVM is where the
+     * stale Kotlin `FilePageCache` registration lives, and stopping it is the only way to drop
+     * the registration. Resolves without throwing if the wrapper is missing or the subprocess
+     * fails: the cache wipe + `--rerun-tasks` retry still gives recovery a fair shot on its
+     * own. Times out at 30s so a stuck stop request doesn't pin save-to-preview latency.
+     */
+    private stopGradleDaemonsForRecovery(): Promise<void> {
+        const wrapperName =
+            process.platform === "win32" ? "gradlew.bat" : "gradlew";
+        const wrapper = path.join(this.workspaceRoot, wrapperName);
+        if (!fs.existsSync(wrapper)) {
+            return Promise.resolve();
+        }
+        return new Promise<void>((resolve) => {
+            // Lazy-require so the unit-test entry points that exercise everything around this
+            // method don't pull `child_process` into bundles where it's unneeded.
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const { spawn } =
+                require("child_process") as typeof import("child_process");
+            let resolved = false;
+            const done = () => {
+                if (resolved) return;
+                resolved = true;
+                clearTimeout(timer);
+                resolve();
+            };
+            const proc = spawn(wrapper, ["--stop"], {
+                cwd: this.workspaceRoot,
+                stdio: "ignore",
+            });
+            const timer = setTimeout(() => {
+                try {
+                    proc.kill("SIGKILL");
+                } catch {
+                    /* ignore */
+                }
+                done();
+            }, 30_000);
+            proc.once("exit", done);
+            proc.once("error", done);
+        });
     }
 }

--- a/vscode-extension/src/kotlinIcStorageDetector.ts
+++ b/vscode-extension/src/kotlinIcStorageDetector.ts
@@ -1,0 +1,88 @@
+/**
+ * Scans Gradle output for the Kotlin incremental-compiler "Storage already registered" failure
+ * (upstream KT-59321 / KT-55435). The in-process Kotlin compile service retains a
+ * `FilePageCache` registration across builds; a subsequent build's attempt to re-register the
+ * same `caches-jvm/.../source-to-classes.tab` path throws.
+ *
+ * Symptom path that brought us here (issue #1493): editing a file under VS Code triggers
+ * `gradleService.compileOnly` → daemon kicks `:<module>:composePreviewCompile`. Gradle reports
+ * BUILD SUCCESSFUL because Kotlin falls back to non-incremental, but the on-disk IC cache is
+ * left inconsistent, and the next save's `compileKotlin UP-TO-DATE` doesn't pick up the edit.
+ * From the user's side, "save isn't doing anything."
+ *
+ * Feed each `onOutput` chunk through {@link consume}; after the task completes call
+ * {@link end} and {@link getDetectedCachesJvmDirs}. A non-empty result is the signal to wipe
+ * those directories, stop the Gradle daemon (which restarts the in-process Kotlin compile
+ * service with a clean cache registry on next connect), and retry the build with
+ * `--rerun-tasks`. The Kotlin-side equivalent in `:gradle-preview-driver`
+ * (`KotlinIcStorageDetector.kt`) covers the CLI driver path; this module covers the
+ * VS Code → vscjava.vscode-gradle daemon-compile path that the issue title names.
+ */
+
+import * as path from "path";
+
+const STORAGE_RE = /Storage for \[([^\]]+)\] is already registered/;
+const MAX_BUFFER = 16 * 1024;
+
+/**
+ * Walks the parents of [filePath] until a directory named `caches-jvm` is found. Returns null
+ * if no such ancestor exists — defensive against future Kotlin error-message refactors that
+ * change the cache layout. Exported for test access.
+ */
+export function findCachesJvmAncestor(filePath: string): string | null {
+    let p = path.normalize(filePath);
+    while (true) {
+        const base = path.basename(p);
+        if (base === "caches-jvm") return p;
+        const parent = path.dirname(p);
+        if (parent === p) return null;
+        p = parent;
+    }
+}
+
+export class KotlinIcStorageDetector {
+    private buffer = "";
+    private readonly detected = new Set<string>();
+
+    /**
+     * Accept a chunk of decoded stdout/stderr. Safe to call with partial lines — bytes are
+     * buffered until a newline arrives. Unlike the single-finding detectors, this keeps
+     * scanning after a hit so multi-module builds report every affected directory in one pass.
+     */
+    consume(chunk: string): void {
+        this.buffer += chunk;
+        let nl = this.buffer.indexOf("\n");
+        while (nl !== -1) {
+            const line = this.buffer.slice(0, nl);
+            this.buffer = this.buffer.slice(nl + 1);
+            this.scanLine(line);
+            nl = this.buffer.indexOf("\n");
+        }
+        // Bound the buffer for pathological no-newline producers — 16 KiB dwarfs any single
+        // Kotlin diagnostic and matches JdkImageErrorDetector's policy for consistency.
+        if (this.buffer.length > MAX_BUFFER) {
+            this.scanLine(this.buffer);
+            this.buffer = "";
+        }
+    }
+
+    /** Flush the residual buffer. Call once after the stream ends. */
+    end(): void {
+        if (this.buffer.length > 0) {
+            this.scanLine(this.buffer);
+            this.buffer = "";
+        }
+    }
+
+    /** Distinct caches-jvm directories the recovery pass needs to wipe. */
+    getDetectedCachesJvmDirs(): string[] {
+        return Array.from(this.detected);
+    }
+
+    private scanLine(line: string): void {
+        const m = STORAGE_RE.exec(line);
+        if (!m) return;
+        const cachesJvm = findCachesJvmAncestor(m[1]);
+        if (cachesJvm) this.detected.add(cachesJvm);
+    }
+}

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -1603,6 +1603,183 @@ describe("GradleService", () => {
             }),
         );
     });
+
+    describe("Kotlin IC storage recovery (issue #1493)", () => {
+        // GradleApi stub that emits arbitrary output on a per-call basis. Used to drive the IC
+        // recovery flow: first invocation streams the KT-59321 marker, the retry streams nothing.
+        class QueuedOutputApi implements GradleApi {
+            public runCalls: Array<{
+                taskName: string;
+                args?: ReadonlyArray<string>;
+            }> = [];
+            constructor(
+                private readonly outputsPerCall: ReadonlyArray<string>,
+                // Optional hook that fires AFTER recording the call but BEFORE running onOutput,
+                // so the test can reconstitute on-disk state the marker line points at when the
+                // recovery just deleted it.
+                private readonly beforeOutput?: (callIdx: number) => void,
+            ) {}
+            async runTask(opts: {
+                projectFolder: string;
+                taskName: string;
+                args?: ReadonlyArray<string>;
+                onOutput?: (output: {
+                    getOutputBytes(): Uint8Array;
+                    getOutputType(): number;
+                }) => void;
+            }): Promise<void> {
+                const idx = this.runCalls.length;
+                this.runCalls.push({
+                    taskName: opts.taskName,
+                    args: opts.args,
+                });
+                this.beforeOutput?.(idx);
+                const out = this.outputsPerCall[idx] ?? "";
+                if (out && opts.onOutput) {
+                    opts.onOutput({
+                        getOutputBytes: () => new TextEncoder().encode(out),
+                        getOutputType: () => 0,
+                    });
+                }
+            }
+            async cancelRunTask(): Promise<void> {}
+        }
+
+        function writeFakeGradlewStub(dir: string, stopFlag?: string): void {
+            const wrapper = path.join(dir, "gradlew");
+            const cmd = stopFlag
+                ? `#!/bin/sh\necho stopped > '${stopFlag}'\nexit 0\n`
+                : `#!/bin/sh\nexit 0\n`;
+            fs.writeFileSync(wrapper, cmd);
+            fs.chmodSync(wrapper, 0o755);
+        }
+
+        it(
+            "wipes caches-jvm, stops daemon, and retries with --rerun-tasks",
+            withTempDir(async (dir) => {
+                const stopFlag = path.join(dir, "stop-called.flag");
+                writeFakeGradlewStub(dir, stopFlag);
+
+                const cacheDir = path.join(
+                    dir,
+                    "mod/build/kotlin/compileKotlin/cacheable/caches-jvm",
+                );
+                fs.mkdirSync(path.join(cacheDir, "jvm/kotlin"), {
+                    recursive: true,
+                });
+                const tabPath = path.join(
+                    cacheDir,
+                    "jvm/kotlin/source-to-classes.tab",
+                );
+                fs.writeFileSync(tabPath, "");
+
+                const marker =
+                    "e: Incremental compilation failed: " +
+                    `Storage for [${tabPath}] is already registered\n`;
+                const api = new QueuedOutputApi([marker, ""]);
+
+                const service = new GradleService(dir, api);
+                await service.compileOnly({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
+
+                assert.strictEqual(
+                    api.runCalls.length,
+                    2,
+                    "expected initial call + one recovery retry",
+                );
+                assert.strictEqual(
+                    api.runCalls[0].taskName,
+                    ":mod:composePreviewCompile",
+                );
+                assert.strictEqual(
+                    api.runCalls[1].taskName,
+                    ":mod:composePreviewCompile",
+                );
+                assert.ok(
+                    api.runCalls[1].args?.includes("--rerun-tasks"),
+                    `retry call should append --rerun-tasks; got ${JSON.stringify(api.runCalls[1].args)}`,
+                );
+                assert.ok(
+                    !fs.existsSync(cacheDir),
+                    "caches-jvm should have been wiped during recovery",
+                );
+                assert.ok(
+                    fs.existsSync(stopFlag),
+                    "fake gradlew --stop should have been invoked by recovery",
+                );
+            }),
+        );
+
+        it(
+            "does not loop when the marker re-occurs on the retry",
+            withTempDir(async (dir) => {
+                writeFakeGradlewStub(dir);
+
+                const cacheDir = path.join(
+                    dir,
+                    "mod/build/kotlin/compileKotlin/cacheable/caches-jvm",
+                );
+                const tabPath = path.join(
+                    cacheDir,
+                    "jvm/kotlin/source-to-classes.tab",
+                );
+
+                // ALWAYS-emit variant: the recovery retry will re-trigger detection. The retry
+                // guard inside runTask (allowKotlinIcRecovery=false on the recursive call) must
+                // prevent a second recovery pass.
+                const marker = `Storage for [${tabPath}] is already registered\n`;
+                const api = new QueuedOutputApi(
+                    [marker, marker],
+                    (_callIdx) => {
+                        // Reconstitute the directory before each call so the marker's path is
+                        // walkable to caches-jvm even after the recovery's wipe ran.
+                        fs.mkdirSync(path.join(cacheDir, "jvm/kotlin"), {
+                            recursive: true,
+                        });
+                        fs.writeFileSync(tabPath, "");
+                    },
+                );
+
+                const service = new GradleService(dir, api);
+                await service.compileOnly({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
+
+                assert.strictEqual(
+                    api.runCalls.length,
+                    2,
+                    "exactly two calls: initial + one retry. A third would mean the guard leaked.",
+                );
+            }),
+        );
+
+        it(
+            "skips recovery on a clean build",
+            withTempDir(async (dir) => {
+                writeFakeGradlewStub(dir);
+                const api = new QueuedOutputApi([
+                    "> Task :mod:compileKotlin\n",
+                ]);
+                const service = new GradleService(dir, api);
+                await service.compileOnly({
+                    projectDir: "mod",
+                    modulePath: ":mod",
+                });
+                assert.strictEqual(
+                    api.runCalls.length,
+                    1,
+                    "no marker, no retry",
+                );
+                assert.ok(
+                    !api.runCalls[0].args?.includes("--rerun-tasks"),
+                    "first call should not have --rerun-tasks",
+                );
+            }),
+        );
+    });
 });
 
 describe("encodeBundlePreviewId", () => {

--- a/vscode-extension/src/test/kotlinIcStorageDetector.test.ts
+++ b/vscode-extension/src/test/kotlinIcStorageDetector.test.ts
@@ -1,0 +1,94 @@
+import * as assert from "assert";
+import {
+    KotlinIcStorageDetector,
+    findCachesJvmAncestor,
+} from "../kotlinIcStorageDetector";
+
+describe("KotlinIcStorageDetector", () => {
+    it("extracts the caches-jvm dir from the upstream KT-59321 marker", () => {
+        const d = new KotlinIcStorageDetector();
+        d.consume(
+            "e: Incremental compilation failed: Storage for " +
+                "[/home/u/proj/samples/cmp/build/kotlin/compileKotlin/cacheable/" +
+                "caches-jvm/jvm/kotlin/source-to-classes.tab] is already registered\n",
+        );
+        d.end();
+        assert.deepStrictEqual(d.getDetectedCachesJvmDirs(), [
+            "/home/u/proj/samples/cmp/build/kotlin/compileKotlin/cacheable/caches-jvm",
+        ]);
+    });
+
+    it("collects distinct dirs across modules", () => {
+        const d = new KotlinIcStorageDetector();
+        d.consume(
+            "Storage for [/p/a/build/kotlin/compileKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab] is already registered\n",
+        );
+        d.consume(
+            "Storage for [/p/b/build/kotlin/compileKotlin/cacheable/caches-jvm/jvm/kotlin/java-to-kotlin.tab] is already registered\n",
+        );
+        d.end();
+        const got = d.getDetectedCachesJvmDirs().sort();
+        assert.deepStrictEqual(got, [
+            "/p/a/build/kotlin/compileKotlin/cacheable/caches-jvm",
+            "/p/b/build/kotlin/compileKotlin/cacheable/caches-jvm",
+        ]);
+    });
+
+    it("dedups repeated markers for the same dir", () => {
+        const d = new KotlinIcStorageDetector();
+        const line =
+            "Storage for [/p/build/kotlin/compileKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab] is already registered\n";
+        d.consume(line);
+        d.consume(line);
+        d.end();
+        assert.strictEqual(d.getDetectedCachesJvmDirs().length, 1);
+    });
+
+    it("reassembles a line split across chunks", () => {
+        const d = new KotlinIcStorageDetector();
+        d.consume(
+            "Storage for [/x/build/kotlin/compileKotlin/cacheable/caches-jvm/jvm/kotlin/",
+        );
+        d.consume("source-to-classes.tab] is already registered\n");
+        d.end();
+        assert.deepStrictEqual(d.getDetectedCachesJvmDirs(), [
+            "/x/build/kotlin/compileKotlin/cacheable/caches-jvm",
+        ]);
+    });
+
+    it("flushes a trailing line on end() even without a newline", () => {
+        const d = new KotlinIcStorageDetector();
+        d.consume(
+            "Storage for [/p/build/kotlin/compileKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab] is already registered",
+        );
+        d.end();
+        assert.deepStrictEqual(d.getDetectedCachesJvmDirs(), [
+            "/p/build/kotlin/compileKotlin/cacheable/caches-jvm",
+        ]);
+    });
+
+    it("ignores unrelated lines", () => {
+        const d = new KotlinIcStorageDetector();
+        d.consume("> Task :app:compileKotlin\n");
+        d.consume("BUILD SUCCESSFUL in 3s\n");
+        d.consume("Storage for something else without brackets\n");
+        d.end();
+        assert.deepStrictEqual(d.getDetectedCachesJvmDirs(), []);
+    });
+
+    it("findCachesJvmAncestor returns null when no caches-jvm in the path", () => {
+        assert.strictEqual(
+            findCachesJvmAncestor("/some/other/path/source-to-classes.tab"),
+            null,
+        );
+    });
+
+    it("findCachesJvmAncestor handles the caches-jvm dir itself", () => {
+        assert.strictEqual(
+            findCachesJvmAncestor(
+                "/p/build/kotlin/compileKotlin/cacheable/caches-jvm",
+            ),
+            "/p/build/kotlin/compileKotlin/cacheable/caches-jvm",
+        );
+    });
+});


### PR DESCRIPTION
Tee Gradle stdout/stderr through KotlinIcStorageDetector during runTasks. When
the upstream "Storage for [...] is already registered" marker appears, stop the
Gradle daemon, wipe the affected caches-jvm directories, and re-run the
requested tasks once with --rerun-tasks so Gradle's up-to-date check doesn't
skip the now-needed recompile. The retry guard (allowKotlinIcRecovery=false on
the recursive call) prevents loops if the marker re-occurs.

Build still typically reports SUCCESS in this case because Kotlin falls back to
non-incremental, but the on-disk IC caches can be left inconsistent — the next
`compileKotlin UP-TO-DATE` then fails to reflect the user's edit. Live scan
during the run handles both the success-with-marker and the rarer
BuildException paths.

Closes #1493