### PR TITLE
test(vscode-extension): preview-harness fixture for permissions override UI

### DIFF
--- a/vscode-extension/preview-harness/fixtures/permissions.gen.mjs
+++ b/vscode-extension/preview-harness/fixtures/permissions.gen.mjs
@@ -1,0 +1,124 @@
+// Generator for `permissions.json`. Run with:
+//   node preview-harness/fixtures/permissions.gen.mjs > preview-harness/fixtures/permissions.json
+//
+// Demonstrates the Inspection bundle's `compose/permissions` chip — the
+// runtime-permissions surface added in #1370 / #1374 / #1381 / #1395 with the
+// panel-side override-toggle UI from #1400 part 2.
+//
+// The fixture preloads a payload with one granted permission (CAMERA), one
+// denied permission (RECORD_AUDIO), and a queried-but-not-pinned permission
+// (ACCESS_FINE_LOCATION). It then activates the Inspection bundle and ticks
+// the `compose/permissions` checkbox in the Configure expander (default-OFF in
+// `bundleRegistry.ts`) so the tab body renders the two flat-table sections
+// plus the Add-permission form, the Clear-overrides action, and the per-row
+// Grant / Deny / Clear buttons.
+//
+// Payload shape mirrors `PermissionsPayload` in
+// `data/permissions/core/.../PermissionsModels.kt` — the same wire shape
+// `PermissionsDataProductRegistry` emits via `data/fetch?kind=compose/permissions`.
+
+import {
+    EARLY_FEATURES_DATASET,
+    activateBundleAction,
+    buildMobileMock,
+    buildPreviewPair,
+    expectSetDataExtension,
+    focusAction,
+    forbidSetDataExtensionEnabled,
+} from "./_utils.mjs";
+
+const mock = buildMobileMock();
+const { W, H, png } = mock;
+
+const focusId = "com.example.permissionsKt.CameraPermissionGrantedPreview";
+const { focused, sibling } = buildPreviewPair({
+    focusId,
+    width: W,
+    height: H,
+    fnName: "CameraPermissionGrantedPreview",
+    file: "PermissionGatedPreview.kt",
+});
+
+// `compose/permissions` payload — the real wire shape the daemon's
+// `PermissionsDataProductRegistry` emits. Mix of states so the panel
+// surfaces every cell variant in one snapshot:
+//
+//   - CAMERA       — granted + queried   → info row, Grant button reads as
+//                                          aria-pressed, queried column = "yes"
+//   - RECORD_AUDIO — denied + not queried → warning row, Deny aria-pressed
+//   - ACCESS_FINE_LOCATION — queried, no grant pinned → unknown row in
+//                                          the Queried table (the
+//                                          natural "give the user a
+//                                          one-click Grant/Deny here"
+//                                          target).
+const permissions = {
+    grants: {
+        "android.permission.CAMERA": "granted",
+        "android.permission.RECORD_AUDIO": "denied",
+    },
+    queried: [
+        "android.permission.CAMERA",
+        "android.permission.ACCESS_FINE_LOCATION",
+    ],
+};
+
+const setPreviews = {
+    command: "setPreviews",
+    moduleDir: "/workspace/sample-android",
+    heavyStaleIds: [],
+    previews: [focused, sibling],
+};
+
+const updateImage = {
+    command: "updateImage",
+    previewId: focusId,
+    captureIndex: 0,
+    imageData: png,
+};
+
+const updateDataProducts = {
+    command: "updateDataProducts",
+    previewId: focusId,
+    dataProducts: [{ kind: "compose/permissions", payload: permissions }],
+};
+
+const fixture = {
+    name: "permissions",
+    description:
+        "Focused card with a `compose/permissions` payload covering granted / denied / queried-unknown rows. Activates the Inspection bundle, opens the Configure expander, and ticks the Permissions checkbox so the tab body renders the Effective grants + Queried tables, the per-row Grant / Deny / Clear buttons (with `aria-pressed` on the currently-applied grant), the Add-permission form, and the Clear-overrides action — the surface the panel ships for #1400 part 2.",
+    dataset: EARLY_FEATURES_DATASET,
+    messages: [setPreviews, updateImage, updateDataProducts],
+    actions: [
+        focusAction(focusId),
+        activateBundleAction("inspection"),
+        // Open the Configure expander on the Inspection bundle's tab body
+        // and tick the `compose/permissions` checkbox — the kind is
+        // default-OFF in `bundleRegistry.ts`, so chip activation alone
+        // doesn't surface the section.
+        {
+            click: `[data-bundle="inspection"] bundle-expander details > summary`,
+        },
+        {
+            click: `[data-bundle="inspection"] bundle-expander input[data-kind="compose/permissions"]`,
+        },
+    ],
+    // Inspection bundle activation subscribes only its default-ON kind
+    // (`compose/semantics`); the Permissions checkbox click then posts a
+    // single-kind `setDataExtensionEnabled` for `compose/permissions`.
+    expectedPosts: [
+        expectSetDataExtension(focusId, "compose/semantics", true),
+        expectSetDataExtension(focusId, "compose/permissions", true),
+    ],
+    // The other default-OFF Inspection kinds must NOT be subscribed by
+    // chip activation or by ticking Permissions — same contract the
+    // `inspection-tree` fixture pins for `layout/inspector` and
+    // `uia/hierarchy`. `compose/launcher-widget` is also default-OFF and
+    // shouldn't ride along.
+    forbiddenPosts: [
+        forbidSetDataExtensionEnabled(focusId, "layout/inspector"),
+        forbidSetDataExtensionEnabled(focusId, "uia/hierarchy"),
+        forbidSetDataExtensionEnabled(focusId, "compose/launcher-widget"),
+    ],
+};
+
+process.stdout.write(JSON.stringify(fixture, null, 2) + "\n");

--- a/vscode-extension/preview-harness/fixtures/permissions.json
+++ b/vscode-extension/preview-harness/fixtures/permissions.json
@@ -1,0 +1,154 @@
+{
+  "name": "permissions",
+  "description": "Focused card with a `compose/permissions` payload covering granted / denied / queried-unknown rows. Activates the Inspection bundle, opens the Configure expander, and ticks the Permissions checkbox so the tab body renders the Effective grants + Queried tables, the per-row Grant / Deny / Clear buttons (with `aria-pressed` on the currently-applied grant), the Add-permission form, and the Clear-overrides action — the surface the panel ships for #1400 part 2.",
+  "dataset": {
+    "earlyFeatures": "true",
+    "minimalMode": "false"
+  },
+  "messages": [
+    {
+      "command": "setPreviews",
+      "moduleDir": "/workspace/sample-android",
+      "heavyStaleIds": [],
+      "previews": [
+        {
+          "id": "com.example.permissionsKt.CameraPermissionGrantedPreview",
+          "functionName": "CameraPermissionGrantedPreview",
+          "className": "PermissionGatedPreviewKt",
+          "sourceFile": "PermissionGatedPreview.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.permissionsKt.CameraPermissionGrantedPreview.png",
+              "label": ""
+            }
+          ]
+        },
+        {
+          "id": "com.example.permissionsKt.CameraPermissionGrantedPreviewSibling",
+          "functionName": "CameraPermissionGrantedPreviewSibling",
+          "className": "PermissionGatedPreviewKt",
+          "sourceFile": "PermissionGatedPreview.kt",
+          "params": {
+            "name": null,
+            "device": null,
+            "widthDp": 360,
+            "heightDp": 600,
+            "fontScale": 1,
+            "showSystemUi": false,
+            "showBackground": true,
+            "backgroundColor": 0,
+            "uiMode": 0,
+            "locale": null,
+            "group": null
+          },
+          "captures": [
+            {
+              "advanceTimeMillis": null,
+              "scroll": null,
+              "renderOutput": "renders/com.example.permissionsKt.CameraPermissionGrantedPreviewSibling.png",
+              "label": ""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "command": "updateImage",
+      "previewId": "com.example.permissionsKt.CameraPermissionGrantedPreview",
+      "captureIndex": 0,
+      "imageData": "iVBORw0KGgoAAAANSUhEUgAAAWgAAAJYCAIAAADAFeuyAAAH9UlEQVR4nO3UQQ2DUBRFwa+gilDSbW1VAFIQURuwYIWGs+GHdG5GwEtecsbyXgGSMf0C4HGEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8iEA8jGfpwAiXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAAmXAA2bRwvD5fbjDrvz+7ZcKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5QkHwmF5woFwWJ5wIByWJxwIh+UJB8JhecKBcFiecCAcliccCIflCQfCYXnCgXBYnnAgHJYnHAiH5f1dOIDnEg4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gEw4gG5uZWZxwmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFmecJhZnnCYWZ5wmFneBUZcMccpTkvCAAAAAElFTkSuQmCC"
+    },
+    {
+      "command": "updateDataProducts",
+      "previewId": "com.example.permissionsKt.CameraPermissionGrantedPreview",
+      "dataProducts": [
+        {
+          "kind": "compose/permissions",
+          "payload": {
+            "grants": {
+              "android.permission.CAMERA": "granted",
+              "android.permission.RECORD_AUDIO": "denied"
+            },
+            "queried": [
+              "android.permission.CAMERA",
+              "android.permission.ACCESS_FINE_LOCATION"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "click": ".preview-card[data-preview-id=\"com.example.permissionsKt.CameraPermissionGrantedPreview\"] .card-focus-btn"
+    },
+    {
+      "click": "bundle-chip-bar button[data-bundle=\"inspection\"]"
+    },
+    {
+      "click": "[data-bundle=\"inspection\"] bundle-expander details > summary"
+    },
+    {
+      "click": "[data-bundle=\"inspection\"] bundle-expander input[data-kind=\"compose/permissions\"]"
+    }
+  ],
+  "expectedPosts": [
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.permissionsKt.CameraPermissionGrantedPreview",
+      "kinds": {
+        "$includes": "compose/semantics"
+      },
+      "enabled": true
+    },
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.permissionsKt.CameraPermissionGrantedPreview",
+      "kinds": {
+        "$includes": "compose/permissions"
+      },
+      "enabled": true
+    }
+  ],
+  "forbiddenPosts": [
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.permissionsKt.CameraPermissionGrantedPreview",
+      "kinds": {
+        "$includes": "layout/inspector"
+      },
+      "enabled": true
+    },
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.permissionsKt.CameraPermissionGrantedPreview",
+      "kinds": {
+        "$includes": "uia/hierarchy"
+      },
+      "enabled": true
+    },
+    {
+      "command": "setDataExtensionEnabled",
+      "previewId": "com.example.permissionsKt.CameraPermissionGrantedPreview",
+      "kinds": {
+        "$includes": "compose/launcher-widget"
+      },
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the last in-repo deliverable of #1400 (Part 4 — preview-harness fixture + baselines). The override-toggle UI landed in #1540 and the data product was documented in #1543, but the preview-harness had no fixture covering the Permissions section under the Inspection bundle's Configure expander. Every other panel surface (`a11y-findings`, `theming`, `inspection-tree`, `remotecompose-state`, …) has one as the design contract per the `preview-harness/README.md` "agent workflow" rule.

## What the fixture covers

Preloads a `compose/permissions` payload covering all three row shapes the presenter has to handle:

- `CAMERA` → granted + queried → info row, Grant button `aria-pressed`, Queried column "yes".
- `RECORD_AUDIO` → denied + not queried → warning row, Deny `aria-pressed`.
- `ACCESS_FINE_LOCATION` → queried, no grant pinned → unknown row in the Queried table (the natural "give the user a one-click Grant/Deny here" target the override-toggle UI exists to serve).

Drives focus → bundle activation → opens the Configure expander → ticks the Permissions checkbox so the tab body renders the Effective grants + Queried tables, the Add-permission form, the Clear-overrides action, and the per-row Grant / Deny / Clear buttons.

## Contract

`expectedPosts` pins the wire contract: chip activation subscribes only `compose/semantics` (the Inspection bundle's lone default-ON kind), and ticking Permissions in the expander posts a single-kind `setDataExtensionEnabled` for `compose/permissions`. `forbiddenPosts` asserts the other default-OFF Inspection kinds (`layout/inspector`, `uia/hierarchy`, `compose/launcher-widget`) are never subscribed by these two actions, mirroring `inspection-tree`'s analogous contract.

## Verified

- `npm run harness:contract -- --fixture permissions` — 2 expected matched, 3 forbidden absent.
- `npm run harness:contract` — all 10 fixtures pass (no regression in sibling fixtures).
- `npm run harness:snapshot -- --fixture permissions` — dark + light PNGs render correctly; Permissions section appears with expected rows, buttons, and `aria-pressed` states.
- `npm test` — 1375 passing, unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaJ3L2cyDfq9MudC1QFhD3)_