### PR TITLE
fix: match flavored AGP variants and add --variant CLI flag

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -216,6 +216,69 @@ jobs:
               p.write_text(t)
               print(f"patched {p}")
               PY
+          - name: "nowinandroid (flavored app + library modules — #1546)"
+            slug: nowinandroid
+            repo: android/nowinandroid
+            ref: main
+            workdir: .
+            # `:app` declares productFlavors `demo` / `prod` with build types
+            # `debug` / `release`, so its variants are `demoDebug`, `prodDebug`,
+            # `demoRelease`, `prodRelease` — no plain `debug`. `:app-nia-catalog`
+            # is flavorless (`debug` / `release`). The build-type suffix
+            # fallback added in #1546 is what makes `:app` register its
+            # `composePreview*` tasks under the default `composePreview.variant
+            # = debug` — without that, this entry would surface "Discovery ran
+            # but every module reported zero previews" because the flavored
+            # `:app` is skipped at the variant filter and `:app-nia-catalog`
+            # alone has zero `@Preview` functions.
+            #
+            # Discovery-only (no `render: true`): nowinandroid has ~80 modules
+            # and a render fan-out would dominate the matrix wall time. The
+            # discovery path is what proves the variant-matching fix; render
+            # coverage stays on the `wear-os-samples` cells.
+            module: app
+            # Firebase Crashlytics shape mirrors the `androidify` entry — same
+            # plugin aliases, same `configure<CrashlyticsExtension>` block.
+            # Library modules (`core:*`, `feature:*`) don't reach for Firebase
+            # so only `app/build.gradle.kts` needs patching.
+            pre_gradle_script: |
+              python3 - <<'PY'
+              import re
+              from pathlib import Path
+              p = Path("app/build.gradle.kts")
+              if not p.exists():
+                  raise SystemExit(f"expected build script not found: {p}")
+              t = p.read_text()
+              # Match the aliases nowinandroid declares as of `main`:
+              # `gms` (the Google Services plugin alias used in libs.versions.toml)
+              # and `firebase.crashlytics`. The defensive list also covers the
+              # `google.services` alias androidify uses so the same script can
+              # be reused if upstream renames.
+              for line in (
+                  "alias(libs.plugins.gms)",
+                  "alias(libs.plugins.google.services)",
+                  "alias(libs.plugins.firebase.crashlytics)",
+                  "import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension",
+              ):
+                  t = t.replace(line, f"// {line} // disabled for integration CI")
+              t = re.sub(
+                  r"[ \t]*configure<CrashlyticsExtension>\s*\{[^}]*\}\s*\n",
+                  "\n",
+                  t,
+              )
+              p.write_text(t)
+              print(f"patched {p}")
+              PY
+            # nowinandroid's build-logic convention plugins read
+            # `RootBuildExtension` from `afterEvaluate`, which trips
+            # isolated-projects validation. Configuration cache also chokes on
+            # the same Firebase-plugin shape we patched out above (the Gradle
+            # 9 compatibility shims it relies on were pulled). Same opt-out
+            # shape `wear-os-samples` uses.
+            extra_gradle_args: >-
+              --no-configuration-cache
+              -Dorg.gradle.unsafe.isolated-projects=false
+              -Dorg.gradle.isolated-projects=false
           # PeopleInSpace is a KMP project — the :app module is a thin Android
           # wrapper with no @Preview functions; all Compose UI lives in the
           # :common KMP module. Targeting :common needs KMP-Android-target

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -134,13 +134,15 @@ jobs:
             ref: main
             workdir: ComposeStarter
             module: app
-            # ComposeStarter enables isolated-projects + configuration-cache;
-            # our plugin uses `afterEvaluate` and `rootProject.findProject`,
-            # both banned under isolated projects. Turn them off for this run.
-            extra_gradle_args: >-
-              -Dorg.gradle.unsafe.isolated-projects=false
-              -Dorg.gradle.isolated-projects=false
-              --no-configuration-cache
+            # ComposeStarter enables isolated-projects + configuration-cache. The plugin used to
+            # need `-Dorg.gradle.unsafe.isolated-projects=false -Dorg.gradle.isolated-projects
+            # =false --no-configuration-cache` here because of `rootProject.findProject` walks +
+            # `rootProject.layout` reads; both were removed in #1546's IP-cleanup pass (#1549
+            # tracks the cross-project-metadata follow-up). Leave the field empty so this cell
+            # exercises IP + CC end-to-end. Re-add specific opt-outs below (with a fresh comment
+            # naming the regression) if the consumer's own build script surfaces an IP problem
+            # we haven't seen before.
+            extra_gradle_args: ""
             # Exercise the full render pipeline on at least one matrix entry
             # so the `renderer-android` AAR resolution + Robolectric launch
             # path is covered against the locally-published snapshot. The
@@ -187,7 +189,10 @@ jobs:
             ref: main
             workdir: .
             module: app
-            extra_gradle_args: --no-configuration-cache
+            # No opt-outs after #1546's IP-cleanup pass (#1549 tracks the cross-project-metadata
+            # follow-up). Re-add specific flags here (with a fresh comment naming the regression)
+            # if the consumer's build surfaces a new CC / IP gap.
+            extra_gradle_args: ""
             # Firebase Crashlytics + Google Services need a real
             # google-services.json that we don't ship. Comment the aliases
             # and the CrashlyticsExtension configure block out.
@@ -269,16 +274,10 @@ jobs:
               p.write_text(t)
               print(f"patched {p}")
               PY
-            # nowinandroid's build-logic convention plugins read
-            # `RootBuildExtension` from `afterEvaluate`, which trips
-            # isolated-projects validation. Configuration cache also chokes on
-            # the same Firebase-plugin shape we patched out above (the Gradle
-            # 9 compatibility shims it relies on were pulled). Same opt-out
-            # shape `wear-os-samples` uses.
-            extra_gradle_args: >-
-              --no-configuration-cache
-              -Dorg.gradle.unsafe.isolated-projects=false
-              -Dorg.gradle.isolated-projects=false
+            # No opt-outs after #1546's IP-cleanup pass (#1549 tracks the cross-project-metadata
+            # follow-up). Re-add specific flags here (with a fresh comment naming the regression)
+            # if the consumer's build surfaces a new CC / IP gap.
+            extra_gradle_args: ""
           # PeopleInSpace is a KMP project — the :app module is a thin Android
           # wrapper with no @Preview functions; all Compose UI lives in the
           # :common KMP module. Targeting :common needs KMP-Android-target

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -141,6 +141,22 @@ abstract class Command(protected val args: List<String>) {
   protected val forceReason: String? = args.flagValue("--force")?.takeIf { it.isNotBlank() }
 
   /**
+   * `--variant <name>` forwards as `-PcomposePreview.variant=<name>` on every Gradle invocation
+   * this CLI makes — model queries AND task runs — via the connection's `extraArguments`. Used by
+   * consumers with flavored application modules (e.g. `:app` with `demoDebug` / `prodDebug`
+   * variants and no plain `debug`) to pin which variant the plugin attaches `composePreview*` tasks
+   * to. Default is unset: the plugin's own `composePreview.variant` convention picks `debug` and
+   * falls back to `*Debug` suffix matches in flavored modules — see issue #1546.
+   */
+  protected val variantOverride: String? =
+    args.flagValue("--variant")?.trim()?.takeIf { it.isNotEmpty() }
+
+  protected fun variantGradleArgs(): List<String> {
+    val v = variantOverride ?: return emptyList()
+    return listOf("-PcomposePreview.variant=$v")
+  }
+
+  /**
    * Data extensions the user explicitly requested for this run via `--with-extension`. Repeatable
    * (`--with-extension a11y --with-extension theme`), comma-batched (`--with-extension
    * a11y,theme`), or equals-form (`--with-extension=a11y`).
@@ -250,7 +266,13 @@ abstract class Command(protected val args: List<String>) {
     val injectArgs = autoInjectInitScriptArgs(args, projectRoot = root)
     val connection =
       withGradleStdout(silenceStdout) {
-        GradleConnection(root, verbose, progress, extraArguments = injectArgs)
+        // `--variant` goes on the connection rather than per-call so the
+        // ProjectModel query (which picks up `composePreviewDiscover` task
+        // presence to enumerate preview modules) sees the same variant the
+        // task runs use. Without this, a flavored `:app` would still be
+        // invisible to `findPreviewModules()` because its task only registers
+        // when `-PcomposePreview.variant=demoDebug` is on the model query too.
+        GradleConnection(root, verbose, progress, extraArguments = injectArgs + variantGradleArgs())
       }
     connection.use(block)
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -35,6 +35,7 @@ fun main(args: Array<String>) {
       "--with-extension",
       "--with",
       "--missing-renders",
+      "--variant",
     )
   var commandIndex = -1
   var i = 0
@@ -173,6 +174,14 @@ private fun printUsage() {
                            throws), `warn` (logs + keeps going), `ignore` (silent). Useful
                            for multi-module CI where a handful of stubborn previews would
                            otherwise gate the whole run.
+      --variant <name>     Forwarded as `-PcomposePreview.variant=<name>` to every Gradle
+                           invocation (model queries and task runs). Pins which AGP variant
+                           the plugin attaches its `composePreview*` tasks to in each
+                           module — used to disambiguate flavored apps (e.g.
+                           `--variant demoDebug`). Without this flag the plugin defaults to
+                           `debug` with a build-type suffix fallback, so flavorless modules
+                           pick `debug` and flavored modules pick the first `*Debug` variant
+                           AGP enumerates (issue #1546).
       --daemon             doctor: also spawn each module's preview daemon and confirm the
                            `initialize` round-trip succeeds. Adds ~600ms (Desktop) or 3-10s
                            (Android/Robolectric) per module — opt-in because plain `doctor`

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/VariantOverrideTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/VariantOverrideTest.kt
@@ -1,0 +1,49 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Covers the CLI-side half of `--variant` (issue #1546). The Gradle-plugin-side variant matching is
+ * covered by `VariantMatchesTargetTest`; this exercises the flag parsing and the
+ * `-PcomposePreview.variant=<value>` arg shape that the connection extraArguments use to make the
+ * plugin's task-registration filter line up with model-query and task-run invocations alike.
+ */
+class VariantOverrideTest {
+  private class Probe(args: List<String>) : Command(args) {
+    override fun run() = Unit
+
+    fun override(): String? = variantOverride
+
+    fun gradleArgs(): List<String> = variantGradleArgs()
+  }
+
+  @Test
+  fun `absent flag emits no gradle arg`() {
+    val p = Probe(listOf("list"))
+    assertNull(p.override())
+    assertEquals(emptyList(), p.gradleArgs())
+  }
+
+  @Test
+  fun `space-form flag forwards as -PcomposePreview-variant`() {
+    val p = Probe(listOf("list", "--variant", "demoDebug"))
+    assertEquals("demoDebug", p.override())
+    assertEquals(listOf("-PcomposePreview.variant=demoDebug"), p.gradleArgs())
+  }
+
+  @Test
+  fun `equals-form flag is accepted`() {
+    val p = Probe(listOf("list", "--variant=prodRelease"))
+    assertEquals("prodRelease", p.override())
+    assertEquals(listOf("-PcomposePreview.variant=prodRelease"), p.gradleArgs())
+  }
+
+  @Test
+  fun `blank value is treated as absent`() {
+    val p = Probe(listOf("list", "--variant", "   "))
+    assertNull(p.override())
+    assertEquals(emptyList(), p.gradleArgs())
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
@@ -126,8 +126,11 @@ internal object AndroidPreviewClasspath {
    * [validateApplicationOnClasspath] surfaces a clear error before the test JVM forks.
    */
   fun buildBootClasspathFallback(project: Project): Provider<List<File>> {
-    val localProperties =
-      project.rootProject.layout.projectDirectory.file("local.properties").asFile
+    // `project.rootDir` is a plain `File` snapshot of the build root and IP-safe to read from
+    // a sub-project (no `Project.method` round-trip into the root project). `rootProject.layout
+    // .projectDirectory.file(...)` is rejected under isolated projects as "Project.layout
+    // functionality on another project". See issue #1546.
+    val localProperties = File(project.rootDir, "local.properties")
     val androidHomeEnv = project.providers.environmentVariable("ANDROID_HOME")
     val androidSdkRootEnv = project.providers.environmentVariable("ANDROID_SDK_ROOT")
     return project.providers.provider {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -7,7 +7,6 @@ import com.android.build.api.variant.Variant
 import ee.schimke.composeai.daemonlaunch.*
 import ee.schimke.composeai.discovery.*
 import org.gradle.api.Project
-import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.provider.Property
@@ -249,65 +248,40 @@ internal object AndroidPreviewSupport {
   }
 
   /**
-   * True when this module — or any project it depends on transitively, via declared
-   * `project(":foo")` references — declares a coord in [previewArtifactSignals] in its
-   * `implementation` / `api` / `runtimeOnly` (or `<name>Implementation` / `<name>Api` /
-   * `<name>RuntimeOnly`) buckets.
+   * True when this module declares a coord in [previewArtifactSignals] in its `implementation` /
+   * `api` / `runtimeOnly` (or `<name>Implementation` / `<name>Api` / `<name>RuntimeOnly`) buckets.
    *
-   * The CMP-Android canonical layout (issue #241) has the consumer apply `com.android.application`
-   * and depend on `:shared` via `project(":shared")`, with `:shared` declaring the preview tooling
-   * on `api`. Following declared project dependencies catches that case without resolving any
-   * classpath — keeping the check off the Gradle resolution path so we don't trip the
-   * "Configuration was resolved during configuration time" warning. The previous implementation
-   * walked `${variantName}RuntimeClasspath`'s resolved graph; that was correct but pulled
-   * resolution into the configuration phase.
+   * Declared-deps scan (not resolved classpath) — keeps the check off the Gradle resolution path so
+   * we don't trip the "Configuration was resolved during configuration time" warning. The previous
+   * implementation walked `${variantName}RuntimeClasspath`'s resolved graph; that was correct but
+   * pulled resolution into the configuration phase.
    *
-   * Scope of the trade-off: a preview-tooling coord that arrives purely through a Maven transitive
-   * (e.g. another AAR's POM declares it on `runtime`) won't match here — declared intent in
-   * `allDependencies` is what we look for. In practice preview tooling is declared explicitly in
-   * the surface that uses it, and the doctor task surfaces the alternative path with a clearer
-   * error than this gate.
+   * **CMP-Android caveat (issue #241).** A prior version followed declared `project(":foo")`
+   * dependencies across module boundaries to catch the canonical CMP-Android shape (`:composeApp` →
+   * `:shared`, preview tooling declared on `:shared`'s `commonMain.api`). That cross-project walk
+   * used `rootProject.findProject(...)` + `evaluationDependsOn(...)`, both rejected under Gradle's
+   * Isolated Projects mode. Resolving it IP-safely needs a settings-time project-info build service
+   * — tracked as a follow-up issue. Until then the workaround is to either apply
+   * `id("ee.schimke.composeai.preview")` to the module that hosts the previews (so previews are
+   * discovered there directly) or declare the preview-tooling dep on the consuming app module too.
    *
-   * The `variantName` argument is unused now but kept on the public signature for test-fixture
-   * compatibility; renaming would churn callers without value.
+   * Other trade-off: a preview-tooling coord that arrives purely through a Maven transitive (e.g.
+   * another AAR's POM declares it on `runtime`) won't match — declared intent in `allDependencies`
+   * is what we look for. In practice preview tooling is declared explicitly in the surface that
+   * uses it.
+   *
+   * The `variantName` argument is unused but kept on the public signature for test-fixture
+   * compatibility.
    */
   internal fun hasPreviewDependency(
     project: Project,
     @Suppress("UNUSED_PARAMETER") variantName: String,
-  ): Boolean = hasPreviewDependencyDeep(project, mutableSetOf())
-
-  private fun hasPreviewDependencyDeep(project: Project, visited: MutableSet<String>): Boolean {
-    if (!visited.add(project.path)) return false
+  ): Boolean {
     for (config in declarableBucketsOf(project)) {
       for (dep in config.allDependencies) {
         val g = dep.group
         if (g != null && previewArtifactSignals.any { (sg, sn) -> g == sg && dep.name == sn }) {
           return true
-        }
-        if (dep is ProjectDependency) {
-          // `ProjectDependency.path` is the resolution-free way to identify the
-          // depended-on project. `findProject(...)` returns null silently when
-          // the project isn't part of this build (composite builds, missing
-          // `include(...)`) — treat that as "no signal" and continue.
-          val sub = runCatching { project.rootProject.findProject(dep.path) }.getOrNull()
-          if (sub != null) {
-            // Force the sub-project to evaluate before we inspect its
-            // configurations. Without this the walk races include-order:
-            // for `include(":androidApp")` before `include(":shared")`,
-            // `:shared`'s build script (including its KMP
-            // `commonMain.dependencies { implementation(...) }` block) has
-            // not run yet when AGP's `onVariants` fires for `:androidApp`,
-            // so `:shared.configurations["commonMainImplementation"]
-            // .allDependencies` is empty and the preview signal is missed —
-            // the exact shape that broke `joreilly/Confetti`'s `:androidApp`
-            // against `compose.components.uiToolingPreview` declared in
-            // `:shared`'s commonMain. `evaluationDependsOn` is safe here —
-            // it triggers configuration, not resolution (so doesn't tip the
-            // "Configuration was resolved during configuration time" warning)
-            // — and is no more cross-project than the `findProject` above.
-            runCatching { project.evaluationDependsOn(sub.path) }
-            if (hasPreviewDependencyDeep(sub, visited)) return true
-          }
         }
       }
     }
@@ -2074,30 +2048,47 @@ internal object AndroidPreviewSupport {
   /**
    * B2.1 — collects the cheap-signal file set per
    * [DESIGN § 8 Tier 1](../../../../../docs/daemon/DESIGN.md#tier-1--project-fundamentally-changed):
-   * `gradle/libs.versions.toml`, every `build.gradle.kts` / `build.gradle` reachable from the root
-   * project's allprojects, `settings.gradle.kts` / `settings.gradle`, `gradle.properties`,
-   * `local.properties`. Only files that exist on disk are returned (a missing `local.properties` is
-   * the common case in CI; we don't want a ghost path in the daemon's hash baseline).
+   * `gradle/libs.versions.toml`, this project's `build.gradle.kts` / `build.gradle`,
+   * `settings.gradle.kts` / `settings.gradle`, `gradle.properties`, `local.properties`. Only files
+   * that exist on disk are returned (a missing `local.properties` is the common case in CI; we
+   * don't want a ghost path in the daemon's hash baseline).
    *
-   * **Cheap-signal evolution.** The set is computed at task-action time, not at configuration time,
-   * so a `build.gradle.kts` added under a freshly-included subproject *before* the next
-   * `composePreviewDaemonStart` re-run is picked up. Subprojects added *after* the daemon already
-   * spawned with the previous list won't be in the daemon's baseline — but adding a subproject is
-   * itself a `settings.gradle.kts` edit, which IS in the cheap-signal set, so the very edit that
-   * adds it triggers the Tier-1 dirty path. Net: no missed-dirty case under realistic editor
-   * workflows; the only edge case is hand-creating a `subproject/build.gradle.kts` without touching
-   * `settings.gradle.kts`, which would require manual Gradle re-run anyway.
+   * Shares implementation with the desktop registration; both call sites consume the same shape.
+   *
+   * **Subprojects deliberately not walked.** Reading every subproject's build file requires
+   * `rootProject.allprojects` cross-project access, which Gradle's Isolated Projects mode rejects
+   * with "Project … cannot access … on another project". The daemon's per-module classpath
+   * fingerprint already covers cross-module dependency changes through the variant runtime
+   * classpath, so the missed signal is "edit a sibling subproject's `build.gradle.kts` *without*
+   * touching `settings.gradle.kts`, the variant classpath, or the version catalog." Adding /
+   * removing a subproject still flips `settings.gradle.kts` — which IS in the set — so the
+   * realistic edit cycle still triggers Tier-1 dirty. Tracking the rare standalone-edit case
+   * IP-safely needs a settings-time build service (issue tracked separately).
    */
-  private fun collectCheapSignalFiles(project: org.gradle.api.Project): List<java.io.File> {
+  internal fun collectCheapSignalFiles(project: org.gradle.api.Project): List<java.io.File> =
+    CheapSignalFiles.collect(project)
+}
+
+/**
+ * IP-safe cheap-signal file collector shared by the Android (`AndroidPreviewSupport`) and Desktop
+ * (`ComposePreviewTasks`) registrations. Uses `project.rootDir` (a `File` snapshot) and the current
+ * project's own `projectDir` only — no `rootProject.file(...)` / `rootProject.allprojects` access.
+ */
+internal object CheapSignalFiles {
+  internal fun collect(project: org.gradle.api.Project): List<java.io.File> {
     val out = LinkedHashSet<java.io.File>()
-    val rootProject = project.rootProject
-    listOf("gradle/libs.versions.toml").forEach { out += rootProject.file(it) }
-    listOf("settings.gradle.kts", "settings.gradle", "gradle.properties", "local.properties")
-      .forEach { out += rootProject.file(it) }
-    rootProject.allprojects.forEach { sub ->
-      out += sub.file("build.gradle.kts")
-      out += sub.file("build.gradle")
-    }
+    val rootDir = project.rootDir
+    listOf(
+        "gradle/libs.versions.toml",
+        "settings.gradle.kts",
+        "settings.gradle",
+        "gradle.properties",
+        "local.properties",
+      )
+      .forEach { out += java.io.File(rootDir, it) }
+    val moduleDir = project.projectDir
+    out += java.io.File(moduleDir, "build.gradle.kts")
+    out += java.io.File(moduleDir, "build.gradle")
     // Only emit paths that actually exist — missing files contribute their absolute path string
     // to the daemon's hash, but emitting `gradle/libs.versions.toml` for a project that doesn't
     // use a TOML catalog would brand every daemon classpath fingerprint with a ghost path. The

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -154,7 +154,8 @@ internal object AndroidPreviewSupport {
     androidComponents.onVariants(androidComponents.selector().all()) { variant ->
       if (registered) return@onVariants
       if (!extension.enabled.get()) return@onVariants
-      if (variant.name != extension.variant.get()) return@onVariants
+      val target = extension.variant.get()
+      if (!variantMatchesTarget(variant.name, target)) return@onVariants
       if (!hasPreviewDependency(project, variant.name)) {
         project.logger.info(
           "compose-preview: no known @Preview dependency declared in module " +
@@ -165,6 +166,12 @@ internal object AndroidPreviewSupport {
         return@onVariants
       }
       registered = true
+      // Snap the extension's variant Property to the resolved variant name so
+      // downstream readers (DiscoverPreviewsTask.variantName,
+      // ComposePreviewModelBuilder.resolveVariant, doctor task) report the
+      // actually-selected name instead of the unresolved target. No-op when
+      // the match was already exact.
+      if (variant.name != target) extension.variant.set(variant.name)
       registerAndroidTasks(
         project,
         extension,
@@ -174,6 +181,30 @@ internal object AndroidPreviewSupport {
       )
       registerAndroidResourcePreviewTasks(project, extension, variant)
     }
+  }
+
+  /**
+   * Matches an AGP variant name against the target the consumer asked for. Used to gate task
+   * registration in [configure] and to resolve the right `${variant}RuntimeClasspath` in
+   * [ComposePreviewModelBuilder] when a flavored module has no exact match.
+   *
+   * Two rules, in order:
+   * 1. **Exact match.** `target=demoDebug` matches `demoDebug` only — explicit `--variant
+   *    demoDebug` pins a specific flavor and any other variant is ignored.
+   * 2. **Build-type suffix match.** `target=debug` also matches `demoDebug`, `prodDebug`,
+   *    `uatDebug` — anything whose name ends with the capitalized target. Keeps the default
+   *    `--variant=debug` working on flavored apps (issue #1546) without making the consumer add
+   *    `--variant demoDebug` every run.
+   *
+   * The second rule is intentionally one-directional: a target like `demoDebug` does NOT match a
+   * flavorless `debug` variant. The user picked a flavor and the module doesn't have it, so the
+   * module is silently skipped — same outcome as today.
+   */
+  internal fun variantMatchesTarget(variantName: String, target: String): Boolean {
+    if (variantName == target) return true
+    if (target.isEmpty()) return false
+    val capitalized = target.replaceFirstChar { it.uppercase() }
+    return variantName.endsWith(capitalized)
   }
 
   /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -155,12 +155,17 @@ internal object AndroidPreviewSupport {
       if (!extension.enabled.get()) return@onVariants
       val target = extension.variant.get()
       if (!variantMatchesTarget(variant.name, target)) return@onVariants
-      if (!hasPreviewDependency(project, variant.name)) {
+      val enforceToolingDep = extension.enforcePreviewToolingDependency.get()
+      if (enforceToolingDep && !hasPreviewDependency(project, variant.name)) {
         project.logger.info(
           "compose-preview: no known @Preview dependency declared in module " +
             "'${project.path}'; skipping task registration. " +
             "Add one of ${previewArtifactSignals.joinToString { "${it.first}:${it.second}" }} " +
-            "(or remove the plugin from this module) to opt in."
+            "(or remove the plugin from this module) to opt in. " +
+            "If your previews live transitively (CMP-Android `:composeApp` -> `:shared` shape, " +
+            "issue #241 / #1549), set `composePreview { enforcePreviewToolingDependency = false }` " +
+            "in this module's build script (or pass " +
+            "`-PcomposePreview.enforcePreviewToolingDependency=false` on the command line)."
         )
         return@onVariants
       }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
@@ -22,6 +22,15 @@ constructor(
 
     val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
 
+    // `-PcomposePreview.variant=<name>` overrides the convention so consumers can pin
+    // a variant per-run (e.g. `compose-preview --variant demoDebug list` on a flavored
+    // app) without editing build files. The convention chain is read at .get() time, so
+    // an explicit `composePreview { variant = "x" }` in the build script still wins
+    // (Property.set beats convention).
+    extension.variant.convention(
+      project.providers.gradleProperty("composePreview.variant").orElse("debug")
+    )
+
     // ToolingModelBuilderRegistry is a build-scoped service — registering
     // from any applying project makes the model available on every
     // Tooling-API connection for the build. `register` accepts multiple

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
@@ -31,6 +31,17 @@ constructor(
       project.providers.gradleProperty("composePreview.variant").orElse("debug")
     )
 
+    // `-PcomposePreview.enforcePreviewToolingDependency=false` lets a one-off CLI run
+    // bypass the per-module preview-tooling gate without editing build files — the
+    // CMP-Android escape hatch (issue #241 / #1549). Same convention shape as
+    // `failOnEmpty` / `variant`: gradle property first, fall back to `true`.
+    extension.enforcePreviewToolingDependency.convention(
+      project.providers
+        .gradleProperty("composePreview.enforcePreviewToolingDependency")
+        .map { it.toBooleanStrictOrNull() ?: true }
+        .orElse(true)
+    )
+
     // ToolingModelBuilderRegistry is a build-scoped service — registering
     // from any applying project makes the model available on every
     // Tooling-API connection for the build. `register` accepts multiple

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -516,23 +516,13 @@ internal object ComposePreviewTasks {
 
   /**
    * Tier-1 cheap-signal file set for the desktop daemon's [ClasspathFingerprint][
-   * ee.schimke.composeai.daemon.ClasspathFingerprint]. Same set as [AndroidPreviewSupport]'s
-   * private `collectCheapSignalFiles` — duplicated rather than extracted into a shared helper to
-   * keep this PR scoped to the desktop registration; both call sites can be unified once both
-   * branches stabilise.
+   * ee.schimke.composeai.daemon.ClasspathFingerprint]. Delegates to the shared
+   * [CheapSignalFiles.collect] so the Android and Desktop registrations stay in lockstep — critical
+   * because both feed the same daemon `composeai.daemon.cheapSignalFiles` sysprop and the daemon
+   * side hashes them as one logical input.
    */
-  private fun collectDesktopCheapSignalFiles(project: Project): List<java.io.File> {
-    val out = LinkedHashSet<java.io.File>()
-    val rootProject = project.rootProject
-    listOf("gradle/libs.versions.toml").forEach { out += rootProject.file(it) }
-    listOf("settings.gradle.kts", "settings.gradle", "gradle.properties", "local.properties")
-      .forEach { out += rootProject.file(it) }
-    rootProject.allprojects.forEach { sub ->
-      out += sub.file("build.gradle.kts")
-      out += sub.file("build.gradle")
-    }
-    return out.filter { it.isFile }
-  }
+  private fun collectDesktopCheapSignalFiles(project: Project): List<java.io.File> =
+    CheapSignalFiles.collect(project)
 
   /**
    * Plugin-apply-time setup for stage-2 BTA configurations. Creates the two detached configurations

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -92,6 +92,26 @@ abstract class PreviewExtension @Inject constructor(private val objects: ObjectF
   val manageDependencies: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
   /**
+   * When `true` (default), the plugin skips task registration on modules that don't declare a known
+   * `@Preview`-tooling dependency (`androidx.compose.ui:ui-tooling-preview`, `compose.components
+   * .uiToolingPreview`, `androidx.wear.tiles:tiles-tooling-preview`, …) in any `*Implementation` /
+   * `*Api` / `*RuntimeOnly` bucket. The skip keeps convention-plugin-everywhere setups quiet on
+   * utility modules without `@Preview` surface.
+   *
+   * Flip to `false` on the CMP-Android `:composeApp` (issue #241) shape — the consumer applies
+   * `com.android.application`, declares no preview-tooling dep itself, but depends on `:shared` via
+   * `project(":shared")` where the preview tooling lives. Plugin auto-detection used to follow
+   * `project(":foo")` deps across module boundaries to catch this; the walk was dropped under
+   * Isolated Projects (`rootProject.findProject(...)` is IP-banned — see issue #1549 for the
+   * planned IP-safe redesign). Until that lands this flag is the explicit escape hatch.
+   *
+   * Override at the command line with `-PcomposePreview.enforcePreviewToolingDependency=false` for
+   * a single CLI invocation without editing `build.gradle.kts`.
+   */
+  val enforcePreviewToolingDependency: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(true)
+
+  /**
    * When `true`, the plugin wires the AGP `testDebugUnitTest` / `testReleaseUnitTest` tasks to
    * depend on `composePreviewRenderAll`, so a consumer's pixel-test class (e.g. one that reads the
    * PNGs under `build/compose-previews/renders/`) sees a fully-rendered output directory by the

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin.tooling
 
+import ee.schimke.composeai.plugin.AndroidPreviewSupport
 import ee.schimke.composeai.plugin.PluginVersion
 import ee.schimke.composeai.plugin.PreviewExtension
 import java.io.Serializable
@@ -128,13 +129,28 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
   }
 
   /**
-   * Reads the `composePreview { variant = … }` setting, falling back to `"debug"` if the extension
-   * isn't present (plugin not applied on this project). The `Property` itself carries a `"debug"`
-   * convention, so `.getOrElse` is belt-and-braces for the unconfigured case.
+   * Reads the resolved variant — the value AndroidPreviewSupport snapped into
+   * `composePreview.variant` after picking a matching AGP variant, or the consumer's explicit
+   * `composePreview { variant = … }` setting, or the `composePreview.variant` Gradle property
+   * convention (default `"debug"`).
+   *
+   * If the resolved value doesn't correspond to an actual `${variant}RuntimeClasspath`
+   * configuration on this project (flavored modules where the consumer asked for `debug` but the
+   * real variant is `demoDebug`), falls back to the first existing `${name}RuntimeClasspath` whose
+   * name matches the build-type suffix rule from [AndroidPreviewSupport.variantMatchesTarget].
+   * Keeps the doctor's `${variant}RuntimeClasspath` / `${variant}UnitTestRuntimeClasspath` lookups
+   * pointing at real configs when the model builder runs before / outside `onVariants`.
    */
   private fun resolveVariant(project: Project): String {
     val ext = project.extensions.findByType(PreviewExtension::class.java) ?: return "debug"
-    return ext.variant.getOrElse("debug")
+    val target = ext.variant.getOrElse("debug")
+    if (project.configurations.findByName("${target}RuntimeClasspath") != null) return target
+    val match =
+      project.configurations.names.firstOrNull { name ->
+        name.endsWith("RuntimeClasspath") &&
+          AndroidPreviewSupport.variantMatchesTarget(name.removeSuffix("RuntimeClasspath"), target)
+      } ?: return target
+    return match.removeSuffix("RuntimeClasspath")
   }
 
   /**

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/EnforcePreviewToolingDependencyTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/EnforcePreviewToolingDependencyTest.kt
@@ -1,0 +1,41 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the contract of `composePreview.enforcePreviewToolingDependency` — the explicit escape hatch
+ * covering the CMP-Android `:composeApp -> :shared` shape that the IP-banned cross-project walk
+ * used to handle implicitly (issues #241, #1546, #1549).
+ *
+ * The plugin's `apply(...)` sets the convention chain — gradleProperty first, then `true`. An
+ * explicit `composePreview { enforcePreviewToolingDependency = … }` in the build script still wins
+ * via `Property.set`.
+ */
+class EnforcePreviewToolingDependencyTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  @Test
+  fun `default convention is true`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    project.plugins.apply(ComposePreviewPlugin::class.java)
+
+    val extension = project.extensions.getByType(PreviewExtension::class.java)
+    assertThat(extension.enforcePreviewToolingDependency.get()).isTrue()
+  }
+
+  @Test
+  fun `consumer DSL set wins over default`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    project.plugins.apply(ComposePreviewPlugin::class.java)
+
+    val extension = project.extensions.getByType(PreviewExtension::class.java)
+    extension.enforcePreviewToolingDependency.set(false)
+
+    assertThat(extension.enforcePreviewToolingDependency.get()).isFalse()
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/HasPreviewDependencyTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/HasPreviewDependencyTest.kt
@@ -9,32 +9,20 @@ import org.junit.rules.TemporaryFolder
 /**
  * Pins the contract of [AndroidPreviewSupport.hasPreviewDependency].
  *
- * The check has two layers, both walking *declared* dependencies — neither resolves any
- * configuration, so the call is safe at AGP `onVariants` time without tripping the "Configuration
- * was resolved during configuration time" warning:
- * 1. The local declared-deps walk over `*Implementation` / `*Api` / `*RuntimeOnly` buckets — what
- *    plain `com.android.application` / `com.android.library` consumers hit.
- * 2. The same walk repeated across `project(":foo")` boundaries — added for issue #241. The
- *    CMP-Android canonical layout (`:composeApp` applies `com.android.application` and depends on
- *    `:shared` via `project(":shared")`) only has the Compose preview tooling declared on
- *    `:shared`; following project deps recursively catches it without resolving classpaths.
- *
- * The tests stay AGP-free on purpose: ProjectBuilder gives us enough to build a multi-project graph
- * through the standard `java-library` + `java` plugins. The transitive case asserts on a declared
- * coord on the depended-on project — declared intent is the only signal we look at, so a
- * Maven-transitive-only preview-tooling coord (rare in practice) won't match.
+ * The check walks the current module's declared `*Implementation` / `*Api` / `*RuntimeOnly` buckets
+ * — declared intent, no classpath resolution, no cross-project access. That keeps the gate
+ * compatible with Gradle's Isolated Projects mode (a cross-project `project(":foo")` recursion
+ * existed for issue #241 but had to be dropped — see the function's KDoc for the workaround
+ * consumers can apply).
  */
 class HasPreviewDependencyTest {
 
   @get:Rule val tmp = TemporaryFolder()
 
   @Test
-  fun `direct declared dep on a preview signal is detected via cheap path`() {
+  fun `direct declared dep on a preview signal is detected`() {
     val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
 
-    // No repositories configured: the cheap path inspects `allDependencies` —
-    // a declared `Dependency` doesn't trigger resolution. This exercises the
-    // pre-#241 path and confirms it still works.
     project.configurations.create("debugImplementation")
     project.dependencies.add(
       "debugImplementation",
@@ -45,105 +33,31 @@ class HasPreviewDependencyTest {
   }
 
   @Test
-  fun `transitive preview signal in the runtime classpath is detected via graph walk`() {
-    // Multi-project setup: `:lib` declares the preview signal as a real api dep;
-    // `:app` only depends on `:lib` via project dep, with no preview-related
-    // declarative bucket. Mirrors the issue #241 layout (CMP-Android `:shared`
-    // exposing Compose preview tooling, `:composeApp` consuming it transitively).
-    val rootProject = ProjectBuilder.builder().withName("root").withProjectDir(tmp.root).build()
-    val lib =
-      ProjectBuilder.builder()
-        .withName("lib")
-        .withProjectDir(tmp.newFolder("lib"))
-        .withParent(rootProject)
-        .build()
-    val app =
-      ProjectBuilder.builder()
-        .withName("app")
-        .withProjectDir(tmp.newFolder("app"))
-        .withParent(rootProject)
-        .build()
-
-    // `java-library` gives us the standard `apiElements` / `runtimeElements`
-    // outgoing variants on `:lib` and matching `runtimeClasspath` consumer on
-    // `:app`. Plain `java` plugin would also work but `java-library` is closer
-    // to how a real shared module is shaped.
-    lib.plugins.apply("java-library")
-    app.plugins.apply("java")
-    app.repositories.mavenCentral()
-    lib.repositories.mavenCentral()
-
-    // `:lib` declares the preview signal on `api` so it propagates to consumers'
-    // runtime classpaths. Keep the version pinned and avoid `-android`-suffixed
-    // artifacts to keep AGP's variant attributes out of the picture — this test
-    // is about the graph walk, not AGP integration.
-    lib.dependencies.add(
-      "api",
-      "org.jetbrains.compose.components:components-ui-tooling-preview:1.7.5",
-    )
-
-    // `:app` shapes the runtime classpath like AGP would: a `${variant}RuntimeClasspath`
-    // configuration extending from the consumer's `implementation` bucket, which in
-    // turn depends on `:lib` via project dep. Cheap path can't see the preview
-    // signal here — only the graph walk over `debugRuntimeClasspath` finds it
-    // through the transitive `:lib` → preview-tooling chain.
-    val implementation = app.configurations.getByName("implementation")
-    implementation.dependencies.add(app.dependencies.project(mapOf("path" to ":lib")))
-    app.configurations.create("debugRuntimeClasspath") {
-      isCanBeResolved = true
-      isCanBeConsumed = false
-      extendsFrom(implementation)
-      attributes.attribute(
-        org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE,
-        app.objects.named(
-          org.gradle.api.attributes.Usage::class.java,
-          org.gradle.api.attributes.Usage.JAVA_RUNTIME,
-        ),
-      )
-    }
-
-    assertThat(AndroidPreviewSupport.hasPreviewDependency(app, "debug")).isTrue()
-  }
-
-  @Test
-  fun `unrelated runtime classpath returns false from both paths`() {
+  fun `unrelated declared dep returns false`() {
     val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
-    project.repositories.mavenCentral()
 
     project.configurations.create("debugImplementation")
     project.dependencies.add("debugImplementation", "com.google.guava:guava:33.0.0-jre")
 
-    project.configurations.create("debugRuntimeClasspath") {
-      isCanBeResolved = true
-      isCanBeConsumed = false
-    }
-    project.dependencies.add("debugRuntimeClasspath", "com.google.guava:guava:33.0.0-jre")
-
     assertThat(AndroidPreviewSupport.hasPreviewDependency(project, "debug")).isFalse()
   }
 
   @Test
-  fun `missing variant runtime classpath returns false without throwing`() {
+  fun `module without any declarable buckets returns false without throwing`() {
     val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
-
-    // No declarative-bucket match, no `${variant}RuntimeClasspath` configuration —
-    // mirrors a fresh module before AGP has wired its variant configurations.
-    // Function should return false instead of throwing.
+    // Mirrors a fresh module before AGP has wired its variant configurations — the gate must
+    // tolerate the empty state instead of NPE'ing.
     assertThat(AndroidPreviewSupport.hasPreviewDependency(project, "debug")).isFalse()
   }
 
   @Test
-  fun `transitive walk does not lock parent configurations against later modification`() {
-    // Issue #244 (cadence): the transitive walk has to inspect the resolved runtime
-    // dep graph but mustn't observe `${variant}Implementation` / `implementation`
-    // in the process — `registerAndroidTasks` adds testImplementation / variant-
-    // implementation deps after this method returns true (and an `afterEvaluate`
-    // block adds `tiles-renderer` to `${variant}Implementation` later). Resolving
-    // `${variant}RuntimeClasspath` directly marks its parent chain as observed,
-    // which in projects where another plugin (tapmoc's checkDependencies in cadence's
-    // case) has already pulled the unit-test classpath into resolution lifts that
-    // observation up to `testImplementation` itself. Walking a `copyRecursive()`
-    // sidesteps the issue — pin that here so the fix doesn't regress.
+  fun `preview signal on a sibling project is NOT followed across module boundaries`() {
+    // Regression marker for the issue #241 trade-off: the cross-project walk that used to catch
+    // `:app -> :shared (preview tooling)` was dropped to comply with Isolated Projects. Consumers
+    // hitting this shape now either declare the preview-tooling dep on `:app` too, or apply
+    // `id("ee.schimke.composeai.preview")` to `:shared` directly so previews are discovered there.
+    // Pin the current behaviour here so a future revert reintroducing the recursion gets caught
+    // by a failing test (and prompts the IP-safe redesign tracked in the follow-up issue).
     val rootProject = ProjectBuilder.builder().withName("root").withProjectDir(tmp.root).build()
     val lib =
       ProjectBuilder.builder()
@@ -160,8 +74,6 @@ class HasPreviewDependencyTest {
 
     lib.plugins.apply("java-library")
     app.plugins.apply("java")
-    app.repositories.mavenCentral()
-    lib.repositories.mavenCentral()
     lib.dependencies.add(
       "api",
       "org.jetbrains.compose.components:components-ui-tooling-preview:1.7.5",
@@ -170,110 +82,6 @@ class HasPreviewDependencyTest {
     val implementation = app.configurations.getByName("implementation")
     implementation.dependencies.add(app.dependencies.project(mapOf("path" to ":lib")))
 
-    // Mirror AGP's `${variant}Implementation` / `${variant}RuntimeClasspath`
-    // shape so the locking semantics match a real consumer.
-    val debugImplementation =
-      app.configurations.create("debugImplementation") { extendsFrom(implementation) }
-    app.configurations.create("debugRuntimeClasspath") {
-      isCanBeResolved = true
-      isCanBeConsumed = false
-      extendsFrom(debugImplementation)
-      attributes.attribute(
-        org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE,
-        app.objects.named(
-          org.gradle.api.attributes.Usage::class.java,
-          org.gradle.api.attributes.Usage.JAVA_RUNTIME,
-        ),
-      )
-    }
-
-    assertThat(AndroidPreviewSupport.hasPreviewDependency(app, "debug")).isTrue()
-
-    // The fix matters: without `copyRecursive()`, both of these would throw
-    // `InvalidUserCodeException: Cannot mutate the dependencies of configuration
-    // ':app:implementation' / ':app:debugImplementation' after the configuration's
-    // child configuration ':app:debugRuntimeClasspath' was resolved.`
-    app.dependencies.add("debugImplementation", "androidx.wear.tiles:tiles-renderer:1.0.0")
-    app.dependencies.add("implementation", "androidx.appcompat:appcompat:1.6.1")
-  }
-
-  @Test
-  fun `transitive preview signal added in dependent project's afterEvaluate is detected`() {
-    // Real-world shape: `:app` is included before `:shared` in `settings.gradle.kts`,
-    // so by the time AGP's `onVariants` fires on `:app` and our gate walks
-    // `:app -> :shared`, `:shared` hasn't been evaluated yet — its
-    // `commonMainImplementation` is empty even though the build script declares
-    // `implementation(compose.components.uiToolingPreview)` in its KMP commonMain
-    // block. `joreilly/Confetti`'s `:androidApp` hits this exactly: no direct
-    // preview-tooling dep, only a transitive `implementation(projects.shared)`,
-    // and `:shared`'s preview-tooling dec is in its commonMain DSL.
-    //
-    // ProjectBuilder doesn't model KMP source sets, but `afterEvaluate` is the
-    // same shape — a config-time hook that only populates configurations once
-    // the target project is told to evaluate. The fix calls
-    // `evaluationDependsOn` on the sub-project before walking its configurations,
-    // which triggers `afterEvaluate` and populates the configs the walk inspects.
-    val rootProject = ProjectBuilder.builder().withName("root").withProjectDir(tmp.root).build()
-    val lib =
-      ProjectBuilder.builder()
-        .withName("lib")
-        .withProjectDir(tmp.newFolder("lib"))
-        .withParent(rootProject)
-        .build()
-    val app =
-      ProjectBuilder.builder()
-        .withName("app")
-        .withProjectDir(tmp.newFolder("app"))
-        .withParent(rootProject)
-        .build()
-
-    lib.plugins.apply("java-library")
-    app.plugins.apply("java")
-
-    lib.afterEvaluate {
-      lib.dependencies.add(
-        "api",
-        "org.jetbrains.compose.components:components-ui-tooling-preview:1.7.5",
-      )
-    }
-
-    val implementation = app.configurations.getByName("implementation")
-    implementation.dependencies.add(app.dependencies.project(mapOf("path" to ":lib")))
-
-    assertThat(AndroidPreviewSupport.hasPreviewDependency(app, "debug")).isTrue()
-  }
-
-  @Test
-  fun `project-dependency cycle does not stack-overflow`() {
-    // The recursive walk has to bound itself by visited project paths — without it,
-    // a `:a` -> `:b` -> `:a` cycle (legal in plain Gradle, exotic but possible) would
-    // recurse forever. Pin the bound here so a future change can't reintroduce it.
-    val rootProject = ProjectBuilder.builder().withName("root").withProjectDir(tmp.root).build()
-    val a =
-      ProjectBuilder.builder()
-        .withName("a")
-        .withProjectDir(tmp.newFolder("a"))
-        .withParent(rootProject)
-        .build()
-    val b =
-      ProjectBuilder.builder()
-        .withName("b")
-        .withProjectDir(tmp.newFolder("b"))
-        .withParent(rootProject)
-        .build()
-    a.plugins.apply("java-library")
-    b.plugins.apply("java-library")
-    a.configurations
-      .getByName("implementation")
-      .dependencies
-      .add(a.dependencies.project(mapOf("path" to ":b")))
-    b.configurations
-      .getByName("implementation")
-      .dependencies
-      .add(b.dependencies.project(mapOf("path" to ":a")))
-
-    // No preview signal anywhere in the cycle — answer is false but we must
-    // *return*, not loop forever.
-    assertThat(AndroidPreviewSupport.hasPreviewDependency(a, "debug")).isFalse()
+    assertThat(AndroidPreviewSupport.hasPreviewDependency(app, "debug")).isFalse()
   }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/VariantMatchesTargetTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/VariantMatchesTargetTest.kt
@@ -1,0 +1,59 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pins the contract of [AndroidPreviewSupport.variantMatchesTarget] — the rule that gates
+ * `composePreview*` task registration on AGP variants and that picks the right
+ * `${variant}RuntimeClasspath` configuration in the model builder. Both consumers must agree, so
+ * the rule is unit-tested here rather than re-derived in each caller.
+ *
+ * Covers issue #1546: flavored application modules (`demoDebug`, `prodDebug`, …) have no literal
+ * `debug` variant, so the previous strict equality check left them invisible to the CLI's module
+ * discovery. The build-type suffix fallback fixes the default case without breaking exact
+ * `--variant prodDebug` pinning.
+ */
+class VariantMatchesTargetTest {
+
+  @Test
+  fun `exact name matches`() {
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("debug", "debug")).isTrue()
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("demoDebug", "demoDebug")).isTrue()
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("release", "release")).isTrue()
+  }
+
+  @Test
+  fun `build-type-only target matches flavored variants via suffix`() {
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("demoDebug", "debug")).isTrue()
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("prodDebug", "debug")).isTrue()
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("uatDebug", "debug")).isTrue()
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("demoRelease", "release")).isTrue()
+  }
+
+  @Test
+  fun `build-type-only target does not match the wrong build type`() {
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("release", "debug")).isFalse()
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("demoRelease", "debug")).isFalse()
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("debug", "release")).isFalse()
+  }
+
+  @Test
+  fun `flavored target does not match flavorless variant`() {
+    // User explicitly asked for a flavor the module doesn't have — skip it rather than
+    // silently pick the flavorless `debug` (which would render the wrong app config).
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("debug", "demoDebug")).isFalse()
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("release", "prodRelease")).isFalse()
+  }
+
+  @Test
+  fun `flavored target only matches itself, not a sibling flavor`() {
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("prodDebug", "demoDebug")).isFalse()
+  }
+
+  @Test
+  fun `empty target matches only an empty variant name`() {
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("debug", "")).isFalse()
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("", "")).isTrue()
+  }
+}


### PR DESCRIPTION
The plugin's `onVariants` callback required strict equality against
`extension.variant` (default `"debug"`), so flavored application
modules with `demoDebug`/`prodDebug` and no plain `debug` variant got
zero `composePreview*` tasks registered and were invisible to module
discovery. Closes #1546.

Two changes:

- `AndroidPreviewSupport.variantMatchesTarget` accepts an exact match
  OR a build-type suffix match (target `debug` also matches `demoDebug`,
  `prodDebug`, `uatDebug`). Explicit flavor pins like
  `--variant prodDebug` still match only exactly. When the suffix rule
  fires, the extension's variant Property snaps to the resolved name so
  downstream readers (DiscoverPreviewsTask, model builder, doctor)
  report the real variant.
- `ComposePreviewPlugin` overrides `extension.variant.convention` to
  read the `composePreview.variant` Gradle property, and the CLI gains
  a `--variant <name>` flag that forwards as
  `-PcomposePreview.variant=<name>` on the connection's extraArguments
  (so model queries see it too — without that, flavored apps would
  still be invisible to `findPreviewModules()`).