### PR TITLE
docs: list namespaced record_preview event ids and hint at the prefix

### DIFF
--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -150,9 +150,9 @@ Typical agent flow:
   "fps": 12,
   "format": "apng",
   "events": [
-    { "tMs": 0, "kind": "click", "pixelX": 120, "pixelY": 80 },
+    { "tMs": 0, "kind": "input.click", "pixelX": 120, "pixelY": 80 },
     { "tMs": 400, "kind": "recording.probe", "label": "after-first-click" },
-    { "tMs": 600, "kind": "click", "pixelX": 120, "pixelY": 80 }
+    { "tMs": 600, "kind": "input.click", "pixelX": 120, "pixelY": 80 }
   ]
 }
 ```
@@ -160,14 +160,35 @@ Typical agent flow:
 Events sharing a `tMs` are treated as one script step. Control markers in the
 step are applied before the frame for that timestamp is captured.
 
-`record_preview` accepts two kinds of events:
+Every `kind` is a namespaced id advertised by the daemon's
+`capabilities.dataExtensions[].recordingScriptEvents[]` — there are no bare /
+un-namespaced kinds. Call `list_data_products` (or read
+`InitializeResult.capabilities.dataExtensions`) for the authoritative list on
+the active daemon; the catalogue below is the current cross-host roster:
 
-1. **Built-in input kinds** — `click`, `pointerDown`, `pointerMove`, `pointerUp`,
-   `rotaryScroll`, `keyDown`, `keyUp`. Sourced from `InteractiveInputKind`.
-2. **Namespaced data-extension events** — advertised by the daemon via
-   `capabilities.dataExtensions[].recordingScriptEvents[]`. Only entries with
-   `supported = true` are accepted. Today the only supported extension event
-   is `recording.probe`.
+| Namespace | Event ids | Hosts |
+|-----------|-----------|-------|
+| `input.touch` | `input.click`, `input.pointerDown`, `input.pointerMove`, `input.pointerUp` | desktop + Android |
+| `input.keyboard` | `input.keyDown`, `input.keyUp` | desktop + Android |
+| `input.rsb` | `input.rotaryScroll` | Android (Wear) |
+| `recording` | `recording.probe` | desktop + Android |
+| `uiautomator` | `uia.click`, `uia.longClick`, `uia.scrollForward`, `uia.scrollBackward`, `uia.requestFocus`, `uia.expand`, `uia.collapse`, `uia.dismiss`, `uia.inputText` (each needs a `selector`) | Android |
+| `navigation` | `navigation.deepLink`, `navigation.back`, `navigation.predictiveBackStarted`, `navigation.predictiveBackProgressed`, `navigation.predictiveBackCommitted`, `navigation.predictiveBackCancelled` | Android |
+| `lifecycle` | `lifecycle.pause`, `lifecycle.resume`, `lifecycle.stop` | Android |
+| `preview.reload` | `preview.reload` | Android |
+| `state` | `state.recreate`, `state.save`, `state.restore` | Android |
+| `a11y` | `a11y.action.<name>` (e.g. `a11y.action.click`, `a11y.action.scrollForward`) | Android, when the `a11y` extension is enabled |
+
+The `uiautomator` extension is wired unconditionally on Android daemons — no
+Gradle DSL opt-in is needed to use `uia.*` events. The `composePreview {
+previewExtensions { … } }` block gates Gradle-task render extensions only; it
+does not change what the daemon advertises here.
+
+The deprecated names listed in `InteractiveInputKind` (`click`, `pointerDown`,
+`pointerMove`, `pointerUp`, `rotaryScroll`, `keyDown`, `keyUp`) are the
+interactive-session payload variants and are **not** valid `record_preview`
+event ids — agents that send `{ "kind": "click" }` get rejected with
+`kind 'click' is not advertised by this daemon`. Prefix with `input.` instead.
 
 On success the tool returns an inline media block plus a JSON metadata text
 block containing `recordingId`, `videoPath`, `mimeType`, `sizeBytes`,

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -3243,11 +3243,25 @@ class DaemonMcpServer(
         event.kind in advertisedButUnsupported ->
           "event[$index] script event '${event.kind}' is advertised by this daemon but not yet " +
             "implemented (supported=false); list_data_products to inspect the roadmap"
-        else ->
+        else -> {
+          val hint = suggestionFor(event.kind, supportedEventIds)
           "event[$index] kind '${event.kind}' is not advertised by this daemon. Call " +
-            "list_data_products to see the available script-event ids."
+            "list_data_products to see the available script-event ids." +
+            if (hint != null) " Did you mean '$hint'?" else ""
+        }
       }
     }
+  }
+
+  /**
+   * Catch the common "agent followed stale docs and dropped the namespace" mistake — e.g. `{
+   * "kind": "click" }` instead of `{ "kind": "input.click" }`. When the unrecognised name matches a
+   * supported id's tail past the dot, return that id; otherwise no hint (avoid misleading
+   * suggestions for genuinely unknown kinds).
+   */
+  private fun suggestionFor(unknown: String, supported: Set<String>): String? {
+    if (unknown.contains('.')) return null
+    return supported.firstOrNull { it.substringAfter('.', "") == unknown }
   }
 
   private fun nameOf(code: Int): String =

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -1419,6 +1419,51 @@ class DaemonMcpServerTest {
   }
 
   @Test
+  fun `record_preview rejection hints at the namespaced id when the unprefixed name was sent`() {
+    // Issue #1550 — older docs (and the InteractiveInputKind enum) list bare names like `click`,
+    // `pointerDown`. The record_preview event ids are namespaced: `input.click`, etc. When an
+    // agent sends the unprefixed form, point them at the namespaced id so they don't have to
+    // round-trip through `list_data_products`.
+    factory.daemonConfigurer = { d ->
+      d.advertisedDataExtensions =
+        listOf(ee.schimke.composeai.daemon.InputTouchRecordingScriptEvents.descriptor)
+    }
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "record_preview",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonArray("events") {
+            add(
+              buildJsonObject {
+                put("tMs", 0)
+                put("kind", "click")
+                put("pixelX", 10)
+                put("pixelY", 10)
+              }
+            )
+          }
+        },
+      )
+
+    assertThat(resp.isError()).isTrue()
+    val msg = resp.firstTextContent()
+    assertThat(msg).contains("kind 'click' is not advertised by this daemon")
+    assertThat(msg).contains("Did you mean 'input.click'?")
+    assertThat(daemon.recordingStarts).isEmpty()
+  }
+
+  @Test
   fun `record_preview rejects extension events advertised but not yet implemented`() {
     // The daemon advertises a script event in `dataExtensions[].recordingScriptEvents` with
     // `supported = false` to signal a planned-but-unwired roadmap item. MCP rejects up front so the


### PR DESCRIPTION
The MCP.md example showed `kind: "click"` and described the built-in input
kinds as bare names (`click`, `pointerDown`, …) sourced from
`InteractiveInputKind`. The daemon actually advertises them under the
`input.touch` / `input.keyboard` / `input.rsb` extensions as `input.click`,
`input.pointerDown`, etc., and `validateRecordingScriptKinds` rejects the
unprefixed form with "kind 'click' is not advertised by this daemon" —
exactly the mismatch reported in #1550.

Refresh the doc with a full catalogue of namespaced event ids per host
(input.touch / input.keyboard / input.rsb / uiautomator / navigation /
lifecycle / preview.reload / state / a11y), note that the daemon advertises
`uiautomator` unconditionally on Android (no Gradle DSL opt-in needed),
and call out the `InteractiveInputKind` name shadowing so agents don't
get re-routed by the enum.

Also hint at the namespaced id from the rejection diagnostic: when the
unrecognised kind has no dot and matches a supported id's tail, append
"Did you mean 'input.click'?" so the agent can recover without an extra
`list_data_products` round trip.