### PR TITLE
feat(doctor): surface module.preview-tooling-not-declared finding

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -498,6 +498,11 @@ internal object AndroidPreviewSupport {
     val injectedDependencies =
       mutableListOf<ee.schimke.composeai.plugin.tooling.InjectedDependency>()
     val injectedDependencyJson = kotlinx.serialization.json.Json { encodeDefaults = true }
+    // Captured at registration time so the doctor task's `@Input Boolean` is a plain serializable
+    // value (no `Project` capture in the Provider chain). We're already inside `onVariants` here,
+    // so the consumer's `dependencies { }` block has finished evaluating and
+    // `hasPreviewDependency` sees the full declared graph.
+    val previewToolingDeclaredAtRegistration = hasPreviewDependency(project, variantName)
     project.tasks.register(
       "composePreviewDoctor",
       ee.schimke.composeai.plugin.tooling.ComposePreviewDoctorTask::class.java,
@@ -510,6 +515,8 @@ internal object AndroidPreviewSupport {
       this.outputFile.set(previewOutputDir.map { it.file("doctor.json") })
       mainRuntimeRoot?.let { this.mainRuntimeRoot.set(it) }
       testRuntimeRoot?.let { this.testRuntimeRoot.set(it) }
+      this.previewToolingDeclared.set(previewToolingDeclaredAtRegistration)
+      this.enforcePreviewToolingDependency.set(extension.enforcePreviewToolingDependency)
       this.injectedDependenciesJson.set(
         project.provider {
           injectedDependencyJson.encodeToString(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
@@ -63,11 +63,26 @@ internal object CompatRules {
   /**
    * Runs every rule against the given dep snapshot and returns findings ordered by severity. Pure —
    * safe to call from tests and from the serialisation path.
+   *
+   * [previewToolingDeclared] and [enforcePreviewToolingDependency] are the per-module signals the
+   * Android registration captures at `onVariants` time:
+   * - `previewToolingDeclared` — `AndroidPreviewSupport.hasPreviewDependency(project, variant)`,
+   *   i.e. is one of the known `@Preview` tooling coords declared in this module's
+   *   `*Implementation` / `*Api` / `*RuntimeOnly` buckets?
+   * - `enforcePreviewToolingDependency` — `composePreview.enforcePreviewToolingDependency`, the
+   *   escape hatch added for the CMP-Android `:composeApp -> :shared` shape (issue #241 / #1549).
+   *
+   * When both are non-null (i.e. the caller passes meaningful Android signals) and the escape hatch
+   * is in use without a direct dep, [checkUndeclaredPreviewTooling] fires a warning telling the
+   * consumer to declare the dep directly too. CMP / Desktop callers pass `null` for both, and the
+   * check is skipped.
    */
   fun evaluate(
     main: Map<String, String>,
     test: Map<String, String>,
     gradleVersion: String? = null,
+    previewToolingDeclared: Boolean? = null,
+    enforcePreviewToolingDependency: Boolean? = null,
   ): List<ModuleFindingData> {
     val findings = mutableListOf<ModuleFindingData>()
     val mainV = parseVersions(main)
@@ -79,8 +94,65 @@ internal object CompatRules {
     checkComposeBom(main)?.let(findings::add)
     checkHamcrestSkew(test)?.let(findings::add)
     checkKmpAndroidSiblingMismatch(test)?.let(findings::add)
+    checkUndeclaredPreviewTooling(previewToolingDeclared, enforcePreviewToolingDependency)
+      ?.let(findings::add)
     findings += checkOldDeps(mainV, testV, main, test)
     return findings
+  }
+
+  /**
+   * Fires when the consumer is leaning on `composePreview.enforcePreviewToolingDependency = false`
+   * (the IP-safe escape hatch for the CMP-Android `:composeApp -> :shared` shape) AND no
+   * preview-tooling coord is declared directly in this module's `*Implementation` / `*Api` /
+   * `*RuntimeOnly` buckets.
+   *
+   * The escape hatch makes task registration work, but a sibling module's preview tooling is
+   * conceptually a *transitive* dep — pinned by the sibling's version policy. Restating the dep
+   * directly on this module:
+   * - locks the version in this module's view of the graph, so a sibling-only upgrade can't
+   *   silently shift the renderer's expected compose-tooling version,
+   * - makes the dep visible to `compose-preview doctor`'s version-skew checks (the renderer-vs-
+   *   `ui-tooling-preview` version compat rules walk this module's declared graph, not the
+   *   sibling's),
+   * - documents intent for the next maintainer who reads `:composeApp`'s build file looking for
+   *   "why does compose-preview see previews here?".
+   *
+   * Strongly suggested — emitted as a `warning` not an `error` because the escape hatch itself is
+   * an opt-in design choice. Returns `null` (no finding) when either signal is unset (Desktop / CMP
+   * callers) or when the consumer has already declared the dep directly.
+   */
+  private fun checkUndeclaredPreviewTooling(
+    previewToolingDeclared: Boolean?,
+    enforcePreviewToolingDependency: Boolean?,
+  ): ModuleFindingData? {
+    if (previewToolingDeclared == null || enforcePreviewToolingDependency == null) return null
+    if (previewToolingDeclared) return null
+    if (enforcePreviewToolingDependency) return null
+    return ModuleFindingData(
+      id = "module.preview-tooling-not-declared",
+      severity = "warning",
+      message =
+        "composePreview.enforcePreviewToolingDependency = false but no @Preview tooling coord is " +
+          "declared directly in this module",
+      detail =
+        "The escape hatch (#241 / #1549) lets task registration succeed when the preview tooling " +
+          "arrives transitively (e.g. via project(\":shared\")). Declaring the dep here too pins " +
+          "the version in this module's view of the graph, surfaces it to compose-preview " +
+          "doctor's version-skew checks, and documents intent for future readers. Pick whichever " +
+          "tooling coord matches your stack: androidx.compose.ui:ui-tooling-preview (AGP-only), " +
+          "or org.jetbrains.compose.components:components-ui-tooling-preview (CMP / KMP).",
+      remediationSummary =
+        "Declare the preview-tooling dep directly so it's pinned and visible to doctor",
+      remediationCommands =
+        listOf(
+          "dependencies {",
+          "  implementation(\"androidx.compose.ui:ui-tooling-preview\")",
+          "  // or, for Compose Multiplatform consumers:",
+          "  // implementation(compose.components.uiToolingPreview)",
+          "}",
+        ),
+      docsUrl = null,
+    )
   }
 
   /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
@@ -64,6 +64,23 @@ abstract class ComposePreviewDoctorTask : DefaultTask() {
    */
   @get:Input abstract val injectedDependenciesJson: Property<String>
 
+  /**
+   * True when this module declared a known `@Preview` tooling coord directly. Captured at
+   * `onVariants` time inside `AndroidPreviewSupport.registerAndroidTasks` — at that point
+   * `AndroidPreviewSupport.hasPreviewDependency(project, variant)` has the consumer's full
+   * `dependencies { }` block to inspect. Feeds `CompatRules.checkUndeclaredPreviewTooling`. Default
+   * `true` so the check stays silent when the input isn't wired (e.g. an older plugin version's
+   * doctor task running against a newer model).
+   */
+  @get:Input abstract val previewToolingDeclared: Property<Boolean>
+
+  /**
+   * Value of `composePreview.enforcePreviewToolingDependency` at registration time — wired through
+   * the Property so an `-PcomposePreview.enforcePreviewToolingDependency=false` override flows into
+   * the finding. Default `true` for the same parity reason as [previewToolingDeclared].
+   */
+  @get:Input abstract val enforcePreviewToolingDependency: Property<Boolean>
+
   @get:OutputFile abstract val outputFile: RegularFileProperty
 
   @TaskAction
@@ -71,7 +88,14 @@ abstract class ComposePreviewDoctorTask : DefaultTask() {
     val variantName = variant.get()
     val main = collectModuleVersions(mainRuntimeRoot.orNull)
     val test = collectModuleVersions(testRuntimeRoot.orNull)
-    val findings = CompatRules.evaluate(main, test, gradleVersion.orNull)
+    val findings =
+      CompatRules.evaluate(
+        main,
+        test,
+        gradleVersion.orNull,
+        previewToolingDeclared = previewToolingDeclared.getOrElse(true),
+        enforcePreviewToolingDependency = enforcePreviewToolingDependency.getOrElse(true),
+      )
     val injections = decodeInjectedDependencys(injectedDependenciesJson.getOrElse("[]"))
     val report =
       DoctorModuleReport(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
@@ -37,7 +37,15 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
     val main = resolveConfiguration(project, "${variant}RuntimeClasspath")
     val test = resolveConfiguration(project, "${variant}UnitTestRuntimeClasspath")
     val gradleVersion = org.gradle.util.GradleVersion.current().version
-    val findings: List<ModuleFinding> = CompatRules.evaluate(main, test, gradleVersion)
+    val (toolingDeclared, enforceTooling) = androidPreviewToolingSignals(project, variant)
+    val findings: List<ModuleFinding> =
+      CompatRules.evaluate(
+        main,
+        test,
+        gradleVersion,
+        previewToolingDeclared = toolingDeclared,
+        enforcePreviewToolingDependency = enforceTooling,
+      )
     val info: ModuleInfo =
       ModuleInfoData(
         variant = variant,
@@ -151,6 +159,28 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
           AndroidPreviewSupport.variantMatchesTarget(name.removeSuffix("RuntimeClasspath"), target)
       } ?: return target
     return match.removeSuffix("RuntimeClasspath")
+  }
+
+  /**
+   * Returns the per-module Android signals feeding [CompatRules.checkUndeclaredPreviewTooling], or
+   * `(null, null)` for non-Android modules (CMP Desktop / KMP-Desktop). Android-ness is detected by
+   * the presence of a `${variant}RuntimeClasspath` configuration matching [resolveVariant]'s output
+   * — AGP's variant-specific configurations only exist when `com.android.application` /
+   * `com.android.library` is applied. CMP / Desktop projects expose `runtimeClasspath` /
+   * `desktopRuntimeClasspath` instead, so the check stays silent on them.
+   */
+  private fun androidPreviewToolingSignals(
+    project: Project,
+    variant: String,
+  ): Pair<Boolean?, Boolean?> {
+    val isAndroid = project.configurations.findByName("${variant}RuntimeClasspath") != null
+    if (!isAndroid) return null to null
+    val ext = project.extensions.findByType(PreviewExtension::class.java) ?: return null to null
+    val declared =
+      runCatching { AndroidPreviewSupport.hasPreviewDependency(project, variant) }.getOrNull()
+        ?: return null to null
+    val enforce = ext.enforcePreviewToolingDependency.getOrElse(true)
+    return declared to enforce
   }
 
   /**

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
@@ -290,6 +290,57 @@ class CompatRulesTest {
     assertNotNull(Semver.parseOrNull("1.13.0-alpha01"))
   }
 
+  @Test
+  fun `undeclared preview tooling with escape hatch on fires warning`() {
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        testWithoutUiTestManifest(),
+        previewToolingDeclared = false,
+        enforcePreviewToolingDependency = false,
+      )
+    val f = findings.single { it.id == "module.preview-tooling-not-declared" }
+    assertEquals("warning", f.severity)
+    assertTrue(f.remediationCommands.any { "ui-tooling-preview" in it })
+  }
+
+  @Test
+  fun `declared preview tooling stays quiet even with escape hatch on`() {
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        testWithoutUiTestManifest(),
+        previewToolingDeclared = true,
+        enforcePreviewToolingDependency = false,
+      )
+    assertNull(findings.firstOrNull { it.id == "module.preview-tooling-not-declared" })
+  }
+
+  @Test
+  fun `enforce-on path does not fire the escape-hatch finding`() {
+    // When the gate is enforced and tooling is declared, the check is a no-op. (When the gate is
+    // enforced and tooling is NOT declared, the plugin's `onVariants` filter skips registration
+    // entirely so doctor never runs — but `CompatRules.evaluate` itself stays silent on the
+    // input, which is the contract pinned here.)
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        testWithoutUiTestManifest(),
+        previewToolingDeclared = false,
+        enforcePreviewToolingDependency = true,
+      )
+    assertNull(findings.firstOrNull { it.id == "module.preview-tooling-not-declared" })
+  }
+
+  @Test
+  fun `null signals skip the check entirely (CMP Desktop path)`() {
+    // CMP / Desktop callers pass null/null because the per-module Android signals aren't
+    // meaningful for them. Asserts the check stays silent rather than emitting a spurious warning
+    // on non-Android modules.
+    val findings = CompatRules.evaluate(mainWithBom(), testWithoutUiTestManifest())
+    assertNull(findings.firstOrNull { it.id == "module.preview-tooling-not-declared" })
+  }
+
   // --- Fixtures ----------------------------------------------------------
 
   private fun mainWithBom(): Map<String, String> =


### PR DESCRIPTION
## Summary

Follow-up to #1551 (which landed variant matching + IP cleanup + the
`enforcePreviewToolingDependency` escape hatch). This adds the doctor
guardrail flagged in #1549 so consumers using the escape hatch get a
strong recommendation to restate the preview-tooling dep on their app
module too.

When `composePreview.enforcePreviewToolingDependency = false` is set
(the IP-safe escape hatch for the CMP-Android `:composeApp -> :shared`
shape — issue #241 / #1549) AND no `@Preview`-tooling coord is declared
directly in the module's `*Implementation` / `*Api` / `*RuntimeOnly`
buckets, doctor now emits a `warning`-level finding:
`module.preview-tooling-not-declared`. The remediation message
explains why restating the dep matters:

- pins the version in this module's view of the graph so a sibling-only
  upgrade can't silently shift the renderer's expected tooling version,
- makes the dep visible to doctor's other version-skew checks (the
  renderer-vs-`ui-tooling-preview` rules walk this module's declared
  graph, not the sibling's),
- documents intent for future readers of `:composeApp`'s build file.

## Wiring

- `CompatRules.evaluate` grows two optional `Boolean?` parameters
  (`previewToolingDeclared`, `enforcePreviewToolingDependency`).
  Existing CMP / Desktop callers pass nothing and the new check stays
  silent on non-Android modules.
- `ComposePreviewModelBuilder` (Tooling-API path, drives
  `compose-preview doctor`) detects Android-ness by looking for a
  `${variant}RuntimeClasspath` configuration, then sources
  `AndroidPreviewSupport.hasPreviewDependency` +
  `extension.enforcePreviewToolingDependency` at `buildAll` time.
- `ComposePreviewDoctorTask` (Gradle-task path, drives the VS Code
  extension's `doctor.json`) gains two `@Input Boolean` properties
  wired at `onVariants` registration time. `hasPreviewDependency` is
  captured eagerly there — we're already inside `onVariants` where the
  consumer's `dependencies { }` has finished evaluating, and a plain
  `Boolean` is trivially CC-serialisable.
- Four new `CompatRulesTest` cases pin the fire-vs-quiet contract.

The proper IP-safe auto-detection (settings-time `BuildService`) is
still tracked in #1549; this warning remains useful as a soft
recommendation even after auto-detection comes back (pin the version
locally + doctor's other rules see the coord).

## Test plan

- [x] `./gradlew :gradle-plugin:test :cli:test` — green locally.
- [x] `./gradlew ktfmtCheckAll` — green locally.
- [ ] CI integration matrix passes against `wear-os-samples (ComposeStarter)`, `WearTilesKotlin`, `androidify`, `nowinandroid` with full IP + CC.
- [ ] Manual smoke: run `compose-preview doctor --json` against a CMP-Android sample with `enforcePreviewToolingDependency = false` and no direct tooling dep; assert `module.preview-tooling-not-declared` appears in the findings.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QGcjt247uavuKgR9YsHbVd)_