### PR TITLE
fix(daemon): stub Application by default, plumb useConsumerApplication

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1305,6 +1305,15 @@ open class RobolectricHost(
    * the daemon module doesn't generate that file (the consumer module does
    * for the existing JUnit path).
    *
+   * **`application` deliberately omitted.** The Application override (default
+   * `android.app.Application`, opt-out via `composePreview.useConsumerApplication = true`)
+   * is supplied at runtime by [SandboxHoldingRunner.buildGlobalConfig] so the daemon mirrors
+   * the Gradle `composePreviewRender` path's behaviour without baking the choice into bytecode.
+   * Without that override, Robolectric would resolve the manifest-declared Application and run
+   * its `onCreate()` on every sandbox worker — fine on worker 0, but any process-global side
+   * effect (e.g. `URL.setURLStreamHandlerFactory`, which only accepts one call per JVM) throws
+   * on worker 1+ and takes down the whole sandbox pool.
+   *
    * `@GraphicsMode(NATIVE)` is required by B1.4's real render body — Roborazzi's
    * `captureRoboImage` walks `HardwareRenderer` to materialise the bitmap, which
    * is only available under NATIVE graphics mode. The B1.3-era stub render

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon
 
 import org.junit.runners.model.FrameworkMethod
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import org.robolectric.internal.bytecode.InstrumentationConfiguration
 
 /**
@@ -32,7 +33,7 @@ import org.robolectric.internal.bytecode.InstrumentationConfiguration
  * single cached sandbox (the cache key would be identical) and concurrent renders queue on one
  * single-thread executor.
  */
-class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(testClass) {
+open class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(testClass) {
 
   /**
    * Snapshot of the worker-index hint at construction time. The ThreadLocal is set on the pool
@@ -48,6 +49,44 @@ class SandboxHoldingRunner(testClass: Class<*>) : RobolectricTestRunner(testClas
    * across runs.
    */
   private val poolWorkerIndex: Int? = SandboxHoldingHints.workerIndex.get()
+
+  /**
+   * Mirrors the `application=android.app.Application` line that
+   * [ee.schimke.composeai.plugin.GenerateRobolectricPropertiesTask] writes to the consumer's
+   * `ee/schimke/composeai/renderer/robolectric.properties` for the Gradle `composePreviewRender`
+   * path. That properties file is package-scoped — Robolectric only finds it for tests under
+   * `ee.schimke.composeai.renderer`, so the daemon's [RobolectricHost.SandboxRunner] (package
+   * `ee.schimke.composeai.daemon`) never picks it up. Without an explicit override here, Robolectric
+   * falls back to the consumer's `AndroidManifest.xml` and invokes the production `Application`
+   * subclass, defeating the renderer's "previews shouldn't run app-lifecycle init" contract.
+   *
+   * Setting the global config's `application` field is equivalent to the properties-file line: it
+   * supplies the default that gets merged with `@Config` on the test class. The host loads
+   * `android.app.Application` via the daemon-classpath's `android.jar`; the sandbox re-resolves it
+   * by FQN through its instrumenting loader, same as Robolectric's own internals.
+   *
+   * `composeai.daemon.useConsumerApplication=true` (sourced from `composePreview.useConsumerApplication`
+   * via [ee.schimke.composeai.plugin.daemon.DaemonBootstrapTask]) restores the historical "Robolectric
+   * reads the manifest" behaviour for previews that genuinely depend on consumer-Application init
+   * (Koin/Hilt seeded in `onCreate`, etc.). Consumers opting in are responsible for making their
+   * `Application.onCreate` Robolectric-safe — multiple sandbox workers run in the same JVM, so any
+   * process-global side effect (`URL.setURLStreamHandlerFactory`, static `init {}` blocks that throw
+   * on second invocation) must be idempotent.
+   *
+   * `buildGlobalConfig` is `@Deprecated` in Robolectric 4.16 in favour of a `Configurer` extension,
+   * but it remains the documented seam for "default for tests in this runner" overrides and is still
+   * invoked by `RobolectricTestRunner.getConfig`. Migrating to a `Configurer` would require
+   * registering it via `META-INF/services` and rebuilding the merge ordering by hand; the deprecated
+   * hook does exactly what the consumer-side `robolectric.properties` line does without that churn.
+   */
+  @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+  override fun buildGlobalConfig(): Config {
+    val parent = super.buildGlobalConfig()
+    val useConsumerApp =
+      System.getProperty("composeai.daemon.useConsumerApplication", "false").toBoolean()
+    if (useConsumerApp) return parent
+    return Config.Builder(parent).setApplication(android.app.Application::class.java).build()
+  }
 
   override fun createClassLoaderConfig(method: org.junit.runners.model.FrameworkMethod):
     InstrumentationConfiguration {

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunnerApplicationOverrideTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunnerApplicationOverrideTest.kt
@@ -1,0 +1,76 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Locks the daemon's [SandboxHoldingRunner.buildGlobalConfig] override that mirrors the
+ * `application=android.app.Application` line [ee.schimke.composeai.plugin.GenerateRobolectricPropertiesTask]
+ * writes for the consumer's `composePreviewRender` Test path. Without this override the daemon
+ * sandbox falls back to the manifest-declared `Application`, whose `onCreate` runs once per
+ * sandbox worker — and any process-global side effect (e.g. `URL.setURLStreamHandlerFactory`)
+ * throws on worker 1+, taking the pool down.
+ *
+ * The dummy test class supplies the `RobolectricTestRunner(Class)` constructor with a valid
+ * test class; we read the resolved [Config] back via the protected `buildGlobalConfig` exposer.
+ */
+class SandboxHoldingRunnerApplicationOverrideTest {
+
+  @After
+  fun clearSysprop() {
+    System.clearProperty("composeai.daemon.useConsumerApplication")
+  }
+
+  @Test
+  fun defaultPinsAndroidAppApplication() {
+    System.clearProperty("composeai.daemon.useConsumerApplication")
+    val runner = ExposedRunner(DummyTest::class.java)
+    // FQN comparison (not class-identity) because the runner is constructed under Robolectric's
+    // shadow-aware classloader chain; `android.app.Application::class.java` resolved here and the
+    // class the runner installs into the Config may originate from different `Class<?>` instances
+    // even though they refer to the same type. The renderer cares about the FQN match — that's
+    // what Robolectric's manifest-vs-explicit dispatch compares.
+    assertEquals(
+      "Default daemon config should pin android.app.Application so consumer onCreate is skipped",
+      "android.app.Application",
+      runner.exposedGlobalConfig().application.java.name,
+    )
+  }
+
+  @Test
+  fun useConsumerApplicationFalseStillPinsStub() {
+    System.setProperty("composeai.daemon.useConsumerApplication", "false")
+    val runner = ExposedRunner(DummyTest::class.java)
+    assertEquals("android.app.Application", runner.exposedGlobalConfig().application.java.name)
+  }
+
+  @Test
+  fun useConsumerApplicationTrueRestoresParentDefault() {
+    System.setProperty("composeai.daemon.useConsumerApplication", "true")
+    val runner = ExposedRunner(DummyTest::class.java)
+    // Opt-in must NOT pin android.app.Application — the consumer's manifest Application wins.
+    // Robolectric's sentinel default ("look at manifest") is its own class
+    // (`org.robolectric.DefaultTestLifecycle$$DefaultApplication$$` family), not
+    // `android.app.Application`, so checking the FQN is enough to lock the opt-in path.
+    assertNotEquals(
+      "useConsumerApplication=true must not pin the stub Application",
+      "android.app.Application",
+      runner.exposedGlobalConfig().application.java.name,
+    )
+  }
+
+  /** Exposes the `protected` [RobolectricTestRunner.buildGlobalConfig] for the assertions above. */
+  private class ExposedRunner(testClass: Class<*>) : SandboxHoldingRunner(testClass) {
+    fun exposedGlobalConfig(): Config = buildGlobalConfig()
+  }
+
+  @RunWith(SandboxHoldingRunner::class)
+  class DummyTest {
+    @Test fun stub() = Unit
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1735,6 +1735,15 @@ internal object AndroidPreviewSupport {
         "composeai.daemon.warmSpare",
         extension.daemon.warmSpare.map { it.toString() },
       )
+      // Mirrors the `application=android.app.Application` line
+      // GenerateRobolectricPropertiesTask writes for the composePreviewRender Test path.
+      // SandboxHoldingRunner.buildGlobalConfig reads this and supplies the Application
+      // default. Without it, the daemon falls back to the consumer's manifest-declared
+      // Application — see RobolectricHost.SandboxRunner KDoc for the URL factory cascade.
+      this.systemProperties.put(
+        "composeai.daemon.useConsumerApplication",
+        extension.useConsumerApplication.map { it.toString() },
+      )
       this.systemProperties.put(
         "composeai.daemon.perfettoTrace",
         resolveComposeAiTraceEnabled(project, extension).map { it.toString() },


### PR DESCRIPTION
The Gradle composePreviewRender path has long pinned
application=android.app.Application via the generated
ee/schimke/composeai/renderer/robolectric.properties so consumer-side
init (DI containers, Firebase, WorkManager, URL stream handler
factories, …) does not run during preview rendering. That properties
file is package-scoped, so the daemon's SandboxRunner — package
ee.schimke.composeai.daemon — never picked it up and Robolectric fell
back to the manifest-declared Application. On a single-sandbox host
the first onCreate succeeds, but the sandbox pool brings up worker
1+ in the same JVM and any process-global side effect throws there
(e.g. java.net.URL.setURLStreamHandlerFactory: factory already
defined), taking down the pool.

Override RobolectricTestRunner.buildGlobalConfig in
SandboxHoldingRunner to install android.app.Application as the
default, mirroring the consumer-side properties file. Honour the
existing composePreview.useConsumerApplication flag by reading
composeai.daemon.useConsumerApplication at sandbox bootstrap, plumbed
through the daemon-launch descriptor's systemProperties map by
AndroidPreviewSupport. Opt-in callers (Koin/Hilt seeded in onCreate)
keep the manifest Application and are on the hook for making
onCreate idempotent across sandbox workers.