### PR TITLE
fix(vscode-extension): recover from partial render failures, break drift loop

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7,6 +7,7 @@ import {
     GradleApi,
     ModuleInfo,
     TaskCancelledError,
+    TaskOptions,
 } from "./gradleService";
 import { JdkImageError } from "./jdkImageErrorDetector";
 import { ClassVersionError } from "./classVersionErrorDetector";
@@ -33,6 +34,7 @@ import {
     AccessibilityNode,
     HEAVY_COST_THRESHOLD,
     PreviewInfo,
+    PreviewManifest,
     WebviewToExtension,
 } from "./types";
 import { formatRenderErrorMessage } from "./renderError";
@@ -4179,6 +4181,56 @@ function refreshStrength(
     return 1;
 }
 
+/**
+ * Runs `composePreviewRender` but recovers when the task itself exits non-zero with a generic
+ * build failure (e.g. `composePreviewRenderAll: render produced no output file for N
+ * preview(s)`). The earlier discover step has already written `previews.json`, and the
+ * renderer typically writes a `.error.json` sidecar next to each preview that threw — so the
+ * panel can usefully paint: full PNG cards for the previews that rendered, structured error
+ * messages for the ones that threw. Without this recovery the catch handler at the end of
+ * `refresh` clears the whole panel on the first preview-throw and the user sees nothing despite
+ * 100+ valid PNGs sitting on disk.
+ *
+ * Structured errors that callers handle specially — `TaskCancelledError`, `JdkImageError`,
+ * `ClassVersionError`, `KotlinCompileError` — still propagate so the toplevel catch surfaces
+ * their dedicated remediations.
+ */
+async function renderWithDiskFallback(
+    mod: ModuleInfo,
+    tier: "fast" | "full",
+    taskOpts: TaskOptions,
+): Promise<{ manifest: PreviewManifest | null; partialFailure: Error | null }> {
+    if (!gradleService) {
+        throw new Error(
+            "renderWithDiskFallback called before gradleService initialised",
+        );
+    }
+    try {
+        const manifest = await gradleService.composePreviewRender(
+            mod,
+            tier,
+            taskOpts,
+            [],
+        );
+        return { manifest, partialFailure: null };
+    } catch (err) {
+        if (
+            err instanceof TaskCancelledError ||
+            err instanceof JdkImageError ||
+            err instanceof ClassVersionError ||
+            err instanceof KotlinCompileError
+        ) {
+            throw err;
+        }
+        const cached = gradleService.readManifest(mod);
+        if (!cached) {
+            throw err;
+        }
+        const wrapped = err instanceof Error ? err : new Error(String(err));
+        return { manifest: cached, partialFailure: wrapped };
+    }
+}
+
 async function refresh(
     forceRender: boolean,
     forFilePath?: string,
@@ -4466,6 +4518,15 @@ async function refresh(
         // from preload → discover in their public phase state.
         opts.onPhase?.("discover");
 
+        // Collected by `renderWithDiskFallback` whenever composePreviewRender
+        // exits non-zero but a usable manifest sits on disk. Surfaced as a
+        // single non-blocking notice after the panel paints so the user sees
+        // their PNGs AND the underlying "the render task failed" diagnosis.
+        const partialRenderFailures: Array<{
+            module: ModuleInfo;
+            error: Error;
+        }> = [];
+
         for (const mod of modules) {
             if (abort.signal.aborted) {
                 return "cancelled";
@@ -4502,19 +4563,27 @@ async function refresh(
             // `handleSetDataExtensionEnabled` opts the module into a11y via the daemon's
             // subscription API; the daemon attaches the post-capture walk on the next render
             // and stamps the on-disk data products itself.
-            manifest =
-                manifest ??
-                (forceRender
-                    ? await gradleService.composePreviewRender(
-                          mod,
-                          tier,
-                          taskOpts,
-                          [],
-                      )
-                    : await gradleService.composePreviewDiscover(
-                          mod,
-                          taskOpts,
-                      ));
+            if (!manifest) {
+                if (forceRender) {
+                    const result = await renderWithDiskFallback(
+                        mod,
+                        tier,
+                        taskOpts,
+                    );
+                    manifest = result.manifest;
+                    if (result.partialFailure) {
+                        partialRenderFailures.push({
+                            module: mod,
+                            error: result.partialFailure,
+                        });
+                    }
+                } else {
+                    manifest = await gradleService.composePreviewDiscover(
+                        mod,
+                        taskOpts,
+                    );
+                }
+            }
 
             // Drift escalation. `forceRender=false` only runs `composePreviewDiscover`, so a
             // cached manifest whose filenames don't match what's on disk (sanitiser bump,
@@ -4537,12 +4606,18 @@ async function refresh(
                     `disk drift for ${mod.modulePath} — manifest references PNG(s) missing on disk; escalating to render`,
                 );
                 escalatedFromDrift = true;
-                manifest = await gradleService.composePreviewRender(
+                const result = await renderWithDiskFallback(
                     mod,
                     tier,
                     taskOpts,
-                    [],
                 );
+                manifest = result.manifest;
+                if (result.partialFailure) {
+                    partialRenderFailures.push({
+                        module: mod,
+                        error: result.partialFailure,
+                    });
+                }
             }
 
             // Track tier so the webview can mark heavy cards as stale after a
@@ -4791,6 +4866,19 @@ async function refresh(
                 }
             }
             await Promise.all(imageJobs);
+        }
+        // Surface render-task failures that the fallback recovered from. Cards
+        // for previews that DID render are already on screen; this line just
+        // tells the user "the build itself failed too — broken cards are where
+        // to look". Logging once per refresh (vs throwing) keeps the panel
+        // useful instead of going dark on the first preview-throw.
+        if (partialRenderFailures.length > 0) {
+            const first = partialRenderFailures[0];
+            const summary =
+                partialRenderFailures.length === 1
+                    ? `composePreviewRender failed for ${first.module.modulePath} — showing partial results from disk (${first.error.message.slice(0, 200)})`
+                    : `composePreviewRender failed for ${partialRenderFailures.length} module(s) — showing partial results from disk. First: ${first.module.modulePath}: ${first.error.message.slice(0, 200)}`;
+            logLine(summary);
         }
         // RefreshOrchestrator sub-phase: image bytes have streamed to the panel
         // (or were skipped because the source was newer than the on-disk PNGs).

--- a/vscode-extension/src/previewConsistency.ts
+++ b/vscode-extension/src/previewConsistency.ts
@@ -99,6 +99,15 @@ export interface VerifyResult {
  * missing. Short-circuits so the cost is one `existsSync` per file at most, and zero when the
  * manifest's first output is present and complete.
  *
+ * A per-preview `.error.json` sidecar counts as satisfaction even when the PNG itself is absent.
+ * The sidecar is the renderer's structured "I tried and the preview threw" record; the panel
+ * surfaces it as a per-card error message and the refresh loop must NOT keep escalating to
+ * `composePreviewRender` on every focus event when the source file hasn't changed. Without this
+ * carve-out, a single broken preview pins the whole module into a render-fails-immediately loop
+ * — `manifestExpectedFilesMissing` returns `true` → escalate → render fails → manifest still
+ * references the missing PNG → next focus sees drift again. A source edit invalidates the
+ * per-file freshness stamp (`hasFreshRenderStamp`) and reopens the retry window naturally.
+ *
  * Used to detect render/manifest drift after `composePreviewDiscover` returns FROM-CACHE with
  * filenames that no `composePreviewRender` has ever written under (sanitiser bumps, wiped
  * `build/`, branch switches, half-finished renders). When this returns `true` the refresh path
@@ -117,14 +126,21 @@ export function manifestExpectedFilesMissing(
         "build",
         "compose-previews",
     );
+    const hasOutputOrSidecar = (rel: string): boolean => {
+        const png = path.join(root, rel);
+        if (fileExists(png)) return true;
+        // Sidecar = renderer's structured failure record; counts as "we tried, don't retry
+        // until the source moves" rather than "render never happened".
+        return fileExists(`${png}.error.json`);
+    };
     for (const preview of manifest.previews) {
         for (const capture of preview.captures) {
             if (!capture.renderOutput) continue;
-            if (!fileExists(path.join(root, capture.renderOutput))) return true;
+            if (!hasOutputOrSidecar(capture.renderOutput)) return true;
         }
         for (const product of preview.dataProducts ?? []) {
             if (!product.output) continue;
-            if (!fileExists(path.join(root, product.output))) return true;
+            if (!hasOutputOrSidecar(product.output)) return true;
         }
     }
     return false;

--- a/vscode-extension/src/test/previewConsistency.test.ts
+++ b/vscode-extension/src/test/previewConsistency.test.ts
@@ -575,9 +575,11 @@ describe("manifestExpectedFilesMissing", () => {
         );
     });
 
-    it("short-circuits on the first missing file", () => {
+    it("short-circuits on the first preview that has neither PNG nor sidecar", () => {
         // The check fires on every refresh, so the cheap case (everything present) must stay
         // O(1) and the expensive case (drift) must not pay for files beyond the first miss.
+        // After the sidecar carve-out a missing entry costs two probes (PNG + sidecar) before
+        // we declare drift, but the rest of the manifest is still skipped.
         const previews = Array.from({ length: 100 }, (_, i) =>
             preview(`com.example.P${i}`, `renders/P${i}.png`),
         );
@@ -591,6 +593,45 @@ describe("manifestExpectedFilesMissing", () => {
                 return false;
             },
         );
-        assert.strictEqual(calls, 1);
+        assert.strictEqual(calls, 2);
+    });
+
+    it("treats `<png>.error.json` sidecar as satisfaction so a broken preview doesn't loop", () => {
+        // Repro of the wedge the Confetti :wearApp report hit: 5 ThemePreviews threw inside
+        // their composables, the renderer wrote .error.json sidecars and skipped the PNGs.
+        // Without this carve-out, every focus event sees "manifest references PNG missing on
+        // disk" → escalates to composePreviewRender → render fails the same way → infinite
+        // retry loop. The sidecar means "we tried, this preview is in a known bad state until
+        // its source moves" — the per-file freshness stamp opens the retry window again when
+        // the user edits the file.
+        const p1 = preview("com.example.RedPreview", "renders/Red.png");
+        const p2 = preview("com.example.BluePreview", "renders/Blue.png");
+        const manifest = { previews: [p1, p2] } as PreviewManifest;
+        const disk = new Set([
+            "/ws/app/build/compose-previews/renders/Red.png",
+            // Blue.png absent, but the renderer left a structured error sidecar:
+            "/ws/app/build/compose-previews/renders/Blue.png.error.json",
+        ]);
+        assert.strictEqual(
+            manifestExpectedFilesMissing("/ws", module, manifest, (p) =>
+                disk.has(p),
+            ),
+            false,
+        );
+    });
+
+    it("still reports drift when neither PNG nor sidecar is on disk", () => {
+        // Guard against the carve-out swallowing the "discover-only, never rendered" case.
+        // That's the original drift signal — wiped `build/`, branch switch, sanitiser bump —
+        // and we still want to escalate to render there.
+        const p = preview("com.example.RedPreview", "renders/Red.png");
+        const manifest = { previews: [p] } as PreviewManifest;
+        const disk = new Set<string>(); // nothing on disk
+        assert.strictEqual(
+            manifestExpectedFilesMissing("/ws", module, manifest, (path) =>
+                disk.has(path),
+            ),
+            true,
+        );
     });
 });


### PR DESCRIPTION
## Summary

Stops two related "terminal bad state" symptoms in the refresh path. Triaged from a Confetti `:wearApp` report where 5 `ThemePreviews` throw inside the renderer, leaving the panel showing all-placeholder cards and re-triggering a doomed render on every focus event.

### 1. Drift-detection sidecar carve-out (`previewConsistency.ts`)

`manifestExpectedFilesMissing` previously returned `true` when a manifest entry's PNG wasn't on disk, which made the refresh path escalate `composePreviewDiscover` to `composePreviewRender`. For a deterministically-broken preview the renderer writes a `.error.json` sidecar (its structured "I tried, this preview threw" record) but no PNG — so the next focus event sees drift again, escalates again, fails the same way. Infinite loop until the user edits the source.

Treat a sidecar at `<png>.error.json` as satisfaction. Source edits invalidate `hasFreshRenderStamp` and reopen the retry window naturally, so a real fix attempt still triggers a re-render.

### 2. Partial-success recovery (`extension.ts`)

When `composePreviewRender` exited non-zero with a generic build failure (e.g. `composePreviewRenderAll: render produced no output file for N preview(s)`), the top-level catch in `refresh()` cleared progress, posted a "FAILED" toast, and returned — dropping the ~100 PNGs the renderer DID produce on the floor.

New `renderWithDiskFallback` helper wraps both `composePreviewRender` call sites (initial render + drift escalation). On a generic build failure it re-reads `previews.json` from disk and returns it alongside the captured error. The existing image-load loop then paints what's loadable: full cards for previews that rendered, structured per-card errors (via the existing `setImageError` path) for previews with sidecars. Single output-channel log line per refresh summarises the failure — broken cards already carry their own per-card errors, so no global "FAILED" wipe.

Structured errors with dedicated remediations (`TaskCancelledError`, `JdkImageError`, `ClassVersionError`, `KotlinCompileError`) still propagate untouched.

## Test plan

- [x] `npm test` — 1386 tests pass; three new `manifestExpectedFilesMissing` cases (sidecar satisfaction, neither-on-disk drift signal, short-circuit semantics with sidecar carve-out)
- [x] `tsc -p . --noEmit` — clean
- [x] `npm run format` — clean
- [ ] Manual: focus a Kotlin file in a module with at least one broken preview; verify the panel paints valid PNGs alongside per-card error messages for broken previews, and no `composePreviewRender` loop fires on subsequent focus events

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaUM37xuivv7tc7kAHuGa5)_