### PR TITLE
feat(samples): add :samples:xr-glimmer for Jetpack Compose Glimmer (Android XR)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,11 @@ wear-compose = "1.6.1"
 wear-tiles = "1.6.0"
 wear-protolayout = "1.4.0"
 wear-tooling-preview = "1.0.0"
+# Jetpack Compose Glimmer — the Compose UI toolkit for Android XR display AI
+# glasses (`androidx.xr.glimmer`). Alpha10+ requires AGP 9.2+ and
+# `compileSdk = 37` (matched by `:samples:xr-glimmer`'s `compileSdk` and our
+# `agp = 9.2.x` toolchain). Alpha13 was published 2026-05-19.
+xr-glimmer = "1.0.0-alpha13"
 # `androidx.wear:wear` carries `androidx.wear.ambient.AmbientLifecycleObserver` —
 # the AOSP entry point both horologist's `AmbientAware` and direct subscribers
 # wrap. Used only by `:data-ambient-connector` (the Robolectric shadow + state
@@ -161,6 +166,8 @@ wear-tiles = { module = "androidx.wear.tiles:tiles", version.ref = "wear-tiles" 
 wear-tiles-renderer = { module = "androidx.wear.tiles:tiles-renderer", version.ref = "wear-tiles" }
 wear-tiles-tooling = { module = "androidx.wear.tiles:tiles-tooling", version.ref = "wear-tiles" }
 wear-tiles-tooling-preview = { module = "androidx.wear.tiles:tiles-tooling-preview", version.ref = "wear-tiles" }
+xr-glimmer = { module = "androidx.xr.glimmer:glimmer", version.ref = "xr-glimmer" }
+xr-glimmer-google-fonts = { module = "androidx.xr.glimmer:glimmer-google-fonts", version.ref = "xr-glimmer" }
 wear-tooling-preview = { module = "androidx.wear:wear-tooling-preview", version.ref = "wear-tooling-preview" }
 wear = { module = "androidx.wear:wear", version.ref = "wear" }
 horologist-compose-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }

--- a/samples/xr-glimmer/build.gradle.kts
+++ b/samples/xr-glimmer/build.gradle.kts
@@ -1,0 +1,68 @@
+plugins {
+  id("composeai.android-conventions")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
+  id("ee.schimke.composeai.preview")
+}
+
+// `:samples:xr-glimmer` — Jetpack Compose Glimmer previews for Android XR display
+// AI glasses. Glimmer (`androidx.xr.glimmer:glimmer`) is a separate Compose UI
+// toolkit (not Material 3): components carry their own theme, additive-display
+// colour tokens, depth effects, and focus model. The sample mirrors the per-env
+// naming the design in `docs/design/GLIMMER_PREVIEW.md` proposes so the
+// captures land at predictable filenames (`Glimmer_·_Light` etc.) and slot in
+// when the `@GlimmerPreview*` meta-annotations from `:glimmer-preview-runtime`
+// arrive — until they do, plain `@Preview(name = "Glimmer · ...")` is enough
+// to produce the same discovery shape.
+
+composePreview {
+  // Pin Robolectric to SDK 35. Glimmer's published metadata raises
+  // `minCompileSdk = 37` (so the module compiles against 37 below), but
+  // Robolectric 4.16.1 only ships shadows up to API 36 and requires JDK 21+
+  // for that — and the rest of the repo (and our CI toolchain) stays on JDK
+  // 17. The Glimmer composables we exercise here don't reach for any API-36+
+  // platform symbol at render time, so capturing them under SDK 35 works:
+  // pure Compose drawing + the Glimmer additive colour tokens. If a future
+  // Glimmer release wires in a platform-version-gated path that 35 doesn't
+  // satisfy, bump this together with the JDK toolchain.
+  sdkVersion.set(35)
+
+  // `GlimmerCaptureAdditivePixelTest` reads PNGs under
+  // `build/compose-previews/renders/`; opt the unit-test tasks into a
+  // `dependsOn(composePreviewRenderAll)` chain so `:samples:xr-glimmer:check`
+  // renders before asserting.
+  renderBeforeUnitTests.set(true)
+}
+
+android {
+  namespace = "com.example.samplexrglimmer"
+  // Glimmer's alpha10+ metadata declares `minCompileSdk = 37` and the
+  // AGP 9.2.x line is required to honour that — both are in place here
+  // (see `agp = "9.2.x"` in [gradle/libs.versions.toml] and the
+  // `platforms;android-37.0` install). Same pattern as `:samples:android-alpha`
+  // and `:samples:remotecompose`; this module diverges from the rest of
+  // the repo (still on 36) for the same metadata-gating reason.
+  compileSdk = 37
+
+  buildFeatures { compose = true }
+}
+
+dependencies {
+  // `compose-bom-stable` (2026.05.x — Compose 1.10.x) aligns with what
+  // Glimmer alpha13's POM resolves to (`androidx.compose.foundation:1.10.0`),
+  // so no manual `compose-ui` pin needed. The BOM also brings tooling /
+  // preview alongside Compose itself.
+  implementation(platform(libs.compose.bom.stable))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation)
+  implementation(libs.compose.ui.tooling.preview)
+  implementation(libs.activity.compose)
+  debugImplementation("androidx.compose.ui:ui-tooling")
+
+  // Glimmer itself. Pulls `androidx.compose.foundation:1.10.0` and
+  // `androidx.compose.ui:1.10.0` transitively per the alpha13 POM.
+  implementation(libs.xr.glimmer)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+}

--- a/samples/xr-glimmer/src/main/AndroidManifest.xml
+++ b/samples/xr-glimmer/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerPreviews.kt
+++ b/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerPreviews.kt
@@ -1,0 +1,143 @@
+package com.example.samplexrglimmer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.xr.glimmer.Card
+import androidx.xr.glimmer.GlimmerTheme
+import androidx.xr.glimmer.ListItem
+import androidx.xr.glimmer.Text
+import androidx.xr.glimmer.TitleChip
+
+/**
+ * Sample Glimmer composables exercised by `:samples:xr-glimmer:composePreviewRenderAll`.
+ *
+ * Glimmer (`androidx.xr.glimmer:glimmer`) renders for additive display AI glasses — pure black
+ * pixels render as 100% transparent on-device, so the SKILL.md mandates a `Color.Black`
+ * background on the root projected-activity container. Captures here mirror that intent:
+ * `showBackground = true, backgroundColor = 0xFF000000` so the rendered PNG is opaque RGB
+ * (Encoding B in `docs/design/GLIMMER_PREVIEW.md`) with `RGB == (0, 0, 0)` everywhere the
+ * Glimmer UI didn't paint — that's the additive-zero baseline an env compositor would later
+ * `ADD`-blend onto a Light / Dark / Busy / Venice-canal-cats backdrop.
+ *
+ * Preview `name` values track the per-env family proposed by the design doc
+ * (`Glimmer · Light`, `Glimmer · Dark`, `Glimmer · Busy`, `Glimmer · VeniceCanalCats`,
+ * `Glimmer · Input`) so when the `@GlimmerPreview*` meta-annotations from
+ * `:glimmer-preview-runtime` land, this file's previews fold in as a drop-in replacement. The
+ * four card variants produce identical captures today — they will diverge once
+ * `:data-glimmer-environment-connector` wires the env compositor in.
+ */
+
+// Wraps content in `GlimmerTheme` against an additive-zero `Color.Black` base. Standalone helper
+// inside the sample so we don't have to depend on a `:glimmer-preview-runtime` that doesn't exist
+// yet; the eventual published `GlimmerSurface` from that module is intentionally the same shape.
+@Composable
+private fun GlimmerSurface(content: @Composable () -> Unit) {
+  Box(Modifier.fillMaxSize().background(Color.Black).padding(24.dp)) {
+    GlimmerTheme(content = content)
+  }
+}
+
+@Preview(
+  name = "Glimmer · Light",
+  device = AI_GLASSES_DEVICE_SPEC,
+  showBackground = true,
+  backgroundColor = ADDITIVE_ZERO_BACKGROUND,
+)
+@Preview(
+  name = "Glimmer · Dark",
+  device = AI_GLASSES_DEVICE_SPEC,
+  showBackground = true,
+  backgroundColor = ADDITIVE_ZERO_BACKGROUND,
+)
+@Preview(
+  name = "Glimmer · Busy",
+  device = AI_GLASSES_DEVICE_SPEC,
+  showBackground = true,
+  backgroundColor = ADDITIVE_ZERO_BACKGROUND,
+)
+@Preview(
+  name = "Glimmer · VeniceCanalCats",
+  device = AI_GLASSES_DEVICE_SPEC,
+  showBackground = true,
+  backgroundColor = ADDITIVE_ZERO_BACKGROUND,
+)
+@Composable
+fun NowPlayingCard() {
+  GlimmerSurface {
+    // Standalone TitleChip sitting above a Card — SKILL.md § Title Chips: "Pill-shaped
+    // specialized labeling component sitting above Card or content groups." 8.dp is the
+    // documented `TitleChipDefaults.AssociatedContentSpacing` between a standalone chip
+    // and its associated card; hard-coded as a literal here to avoid pulling the composable
+    // accessor (it's a @Composable getter that can't be inlined from a regular `val`) and
+    // to keep the sample's dependency list to Glimmer + Compose foundation only.
+    Column(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      TitleChip { Text("NOW PLAYING") }
+      Spacer(Modifier.height(8.dp))
+      Card(
+        onClick = {},
+        title = { Text("Lake of Fire") },
+        subtitle = { Text("Nirvana — MTV Unplugged in New York") },
+      ) {
+        // Empty body content slot — the title / subtitle cover the visible layout. A
+        // non-null content lambda is required by the Card API.
+      }
+    }
+  }
+}
+
+/**
+ * Focusable-menu scenario. Drawn as three `ListItem`s stacked vertically (not a
+ * `GlimmerLazyColumn` — the lazy container plays games with focus delegation that the static
+ * `@Preview` clock can't drive deterministically; the design's `@GlimmerPreviewInput` overlay
+ * is the right surface for that). Same additive-zero encoding as [NowPlayingCard]; SKILL.md's
+ * documented `verticalArrangement = Arrangement.spacedBy(20.dp)` for `VerticalList` is the
+ * source of the 20-dp gap here.
+ */
+@Preview(
+  name = "Glimmer · Input",
+  device = AI_GLASSES_DEVICE_SPEC,
+  showBackground = true,
+  backgroundColor = ADDITIVE_ZERO_BACKGROUND,
+)
+@Composable
+fun FocusableMenu() {
+  GlimmerSurface {
+    Column(
+      modifier = Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+      ListItem(onClick = {}) { Text("Next track") }
+      ListItem(onClick = {}) { Text("Add to favourites") }
+      ListItem(onClick = {}) { Text("Send to phone") }
+    }
+  }
+}
+
+// Studio's AI-Glasses preview-pane device preset (4:3 at 240dpi). Values are expressed in dp
+// without a suffix — the discovery-side `DeviceSpec.resolve(...)` reads `width=` / `height=`
+// as bare integers (`spec:width=…px` silently falls back to the 400×800dp default) and
+// applies `dpi/160` as the density. Kept as a named const so the previews above all share
+// one source of truth — bump in lockstep when the eventual `@GlimmerPreview` meta-annotation
+// adopts a different spec.
+private const val AI_GLASSES_DEVICE_SPEC: String = "spec:width=640,height=480,dpi=240"
+
+// Opaque pure black — additive-zero base per the SKILL.md mandate. Drawn by the renderer's
+// background-fill path so the captured PNG carries `RGB == (0, 0, 0)` in every pixel the
+// Glimmer UI didn't paint, ready for an `ADD`-blend env compositor.
+private const val ADDITIVE_ZERO_BACKGROUND: Long = 0xFF000000L

--- a/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerCaptureAdditivePixelTest.kt
+++ b/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerCaptureAdditivePixelTest.kt
@@ -1,0 +1,89 @@
+package com.example.samplexrglimmer
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Test
+
+/**
+ * Asserts the additive-RGB capture contract that `:samples:xr-glimmer:composePreviewRenderAll`
+ * is supposed to deliver — the renderer mirror of
+ * `:samples:android`'s `TransparentBackgroundPreviewPixelTest`, on the other channel.
+ *
+ * Glimmer's display model is additive: pure black pixels render as 100% transparent on-device,
+ * so the design (`docs/design/GLIMMER_PREVIEW.md` § "Capture encoding") picks Encoding B —
+ * opaque RGB on a `Color.Black` background, then `ADD`-blend onto an environment image to
+ * recover what a wearer sees. The contract this test guards:
+ *
+ *  - The captured PNG carries an alpha plane (i.e. it's loaded as RGBA, not RGB-flattened).
+ *  - Alpha is fully opaque in every pixel (`0xFF`) — Encoding B is NOT a transparent capture.
+ *  - The four outer corners read `RGB == (0, 0, 0)` — additive-zero. These pixels sit well
+ *    outside the centred title chip / card, so any drift away from black would mean either
+ *    (a) the background-fill path lost the explicit `backgroundColor = 0xFF000000` from
+ *    `@Preview`, or (b) a future env compositor mutated the original capture in place
+ *    (it must write a sibling file instead).
+ *
+ * Without this test, Encoding-B drift slips through silently: an opaque-grey background still
+ * looks "fine" in a manual review, but breaks the eventual `ADD`-blend env compositor because
+ * grey + scene > 0 everywhere and the scene gets washed out across every pixel.
+ */
+class GlimmerCaptureAdditivePixelTest {
+
+  private val rendersDir = File("build/compose-previews/renders")
+
+  // Captures discovered for `NowPlayingCard` — one per `@Preview` env name. Filenames are
+  // the renderer's sanitised form: the middle dot in `Glimmer · Light` lands outside the
+  // `[A-Za-z0-9._-]` allowlist defined by `docs/RENDER_FILENAMES.md` and gets stripped,
+  // with the surrounding spaces compacted to a single underscore, so the on-disk file is
+  // `NowPlayingCard_Glimmer_Light.png` (not `_·_`).
+  private val nowPlayingCaptures =
+    listOf(
+      "NowPlayingCard_Glimmer_Light.png",
+      "NowPlayingCard_Glimmer_Dark.png",
+      "NowPlayingCard_Glimmer_Busy.png",
+      "NowPlayingCard_Glimmer_VeniceCanalCats.png",
+    )
+
+  private val focusableMenuCapture = "FocusableMenu_Glimmer_Input.png"
+
+  @Test
+  fun `every Glimmer capture is opaque RGB with additive-zero corners`() {
+    val files = (nowPlayingCaptures + focusableMenuCapture).map { File(rendersDir, it) }
+    files.forEach { file ->
+      assertThat(file.exists()).isTrue()
+      val img = ImageIO.read(file)
+      assertThat(img.colorModel.hasAlpha()).isTrue()
+      assertThat(img.width).isAtLeast(40)
+      assertThat(img.height).isAtLeast(40)
+
+      val (w, h) = img.width to img.height
+      // The card and chip sit centred in a 640×480 canvas with 24-dp insets from the
+      // background `Box`, so the four absolute corner pixels are well outside any
+      // composable that could paint over the background-fill layer.
+      listOf(0 to 0, w - 1 to 0, 0 to h - 1, w - 1 to h - 1).forEach { (x, y) ->
+        val argb = img.getRGB(x, y)
+        val alpha = (argb ushr 24) and 0xff
+        val r = (argb ushr 16) and 0xff
+        val g = (argb ushr 8) and 0xff
+        val b = argb and 0xff
+        assertThat(alpha).isEqualTo(0xff)
+        assertThat(Triple(r, g, b)).isEqualTo(Triple(0, 0, 0))
+      }
+    }
+  }
+
+  /**
+   * The four `NowPlayingCard` captures are pixel-identical today — Encoding B doesn't see
+   * the env name at render time; the future `:data-glimmer-environment-connector` is what
+   * differentiates them by writing a sibling composited PNG. If a regression starts varying
+   * the captures across env names (e.g. the renderer accidentally reads `Preview.name` and
+   * synthesises something env-specific in-process), this test catches it.
+   */
+  @Test
+  fun `four NowPlayingCard env variants land at pixel-identical captures`() {
+    val files = nowPlayingCaptures.map { File(rendersDir, it) }
+    files.forEach { assertThat(it.exists()).isTrue() }
+    val hashes = files.map { it.readBytes().contentHashCode() }.toSet()
+    assertThat(hashes).hasSize(1)
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -99,6 +99,8 @@ include(":samples:sdk-matrix")
 
 include(":samples:wear")
 
+include(":samples:xr-glimmer")
+
 include(":samples:cmp")
 
 include(":samples:cmp-shared")


### PR DESCRIPTION
## Summary

End-to-end sample exercising Jetpack Compose Glimmer (`androidx.xr.glimmer:glimmer`) — the Compose UI toolkit for Android XR display AI glasses — through this repo's `@Preview` pipeline. Follows the design in [`docs/design/GLIMMER_PREVIEW.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/GLIMMER_PREVIEW.md) (merged in #1560).

- **`:samples:xr-glimmer`** — Android library module, `compileSdk = 37` (Glimmer alpha10+ raises `minCompileSdk`; AGP 9.2.x in the catalog satisfies the AGP floor). Robolectric pinned to SDK 35 to stay on JDK 17 — same dance as `:samples:android-alpha` and `:samples:remotecompose`.
- **`NowPlayingCard`** — a standalone `TitleChip { Text("NOW PLAYING") }` above a `Card` with `title` / `subtitle` slots, wrapped in `GlimmerTheme` against an additive-zero `Color.Black` background per the SKILL.md mandate.
- **`FocusableMenu`** — three stacked Glimmer `ListItem`s for the input-overlay scenario.
- **Five `@Preview` entries** with the distinct per-env names from the design doc (`Glimmer · Light`, `… · Dark`, `… · Busy`, `… · VeniceCanalCats`, `… · Input`) so discovery generates one `PreviewInfo.id` per env — when `:glimmer-preview-runtime`'s `@GlimmerPreviewLight / Dark / …` meta-annotations land, this file folds in as a drop-in replacement. All five use `showBackground = true, backgroundColor = 0xFF000000` — Encoding B per the design's "Capture encoding" section.
- **`GlimmerCaptureAdditivePixelTest`** — asserts every capture is opaque (`alpha == 0xFF`) and the four outer corners read `RGB == (0, 0, 0)`. Mirror of `:samples:android`'s `TransparentBackgroundPreviewPixelTest`, on the other channel. Also asserts the four `NowPlayingCard` env variants are byte-identical today (the env compositor that will differentiate them is a future module).
- Catalog entries: `xr-glimmer = "1.0.0-alpha13"` plus `xr-glimmer-google-fonts`.

Two minor surprises along the way, documented in code comments:

- The discovery's `DeviceSpec.resolve(...)` parser doesn't accept the `px` suffix Studio shows in its device picker — bare integers (`spec:width=640,height=480,dpi=240`) are required, otherwise it silently falls back to a 400×800dp default.
- `TitleChipDefaults.AssociatedContentSpacing` is a `@Composable` getter (not a `val`), so passing it to `Spacer(Modifier.height(…))` from a non-composable scope doesn't resolve — hard-coded the `8.dp` literal per SKILL.md instead.

## Test plan

- [x] `./gradlew :samples:xr-glimmer:check` — compiles, renders, tests pass, lint clean
- [x] `./gradlew :samples:xr-glimmer:composePreviewDiscover` — discovers all 5 previews with distinct names (`Glimmer · Light` / `Dark` / `Busy` / `VeniceCanalCats` / `Input`)
- [x] `./gradlew :samples:xr-glimmer:composePreviewRenderAll` — produces 960×720 RGBA captures at the AI Glasses 4:3 / 240dpi spec
- [x] `./gradlew :samples:xr-glimmer:ktfmtCheck` — clean
- [ ] CI green across the full matrix