### PR TITLE
Would you be open to support private previews? Private previews PoC

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -210,14 +210,6 @@ object PreviewDiscovery {
       ClassGraph()
         .enableMethodInfo()
         .enableAnnotationInfo()
-        // Surface JVM-private methods so the loop below can actively warn
-        // when a `private fun` is annotated with @Preview (the renderer's
-        // `getDeclaredComposableMethod` fails on private composables, so
-        // we drop them — see the `method.isPrivate` branch). Without this
-        // flag ClassGraph's default visibility filter would drop them
-        // silently and the user would never learn why their preview
-        // disappeared. `internal fun` compiles to JVM `public` (with the
-        // `name$module` mangle) and passes the default filter regardless.
         .ignoreMethodVisibility()
         .overrideClasspath(classpath.map { it.absolutePath })
         .ignoreParentClassLoaders()
@@ -253,36 +245,6 @@ object PreviewDiscovery {
               if (annotations.isNotEmpty()) scanMethodsWithAnnotations++
               for (ann in annotations) {
                 annotationFqnCounts.merge(ann.name, 1, Int::plus)
-              }
-              // Kotlin `private fun` compiles to a JVM `private` method.
-              // `ComposableMethod` resolution at render time fails on those
-              // (NoSuchMethodException from `getDeclaredComposableMethod`, see
-              // RenderEngine), so the renderer cannot invoke private @Preview
-              // composables. Discover into a probe list first, and if anything
-              // came out, drop it with a clear warning instead of letting it
-              // surface and fail downstream. `internal fun` compiles to JVM
-              // `public` (with the `name$module` mangle) and is unaffected.
-              if (method.isPrivate) {
-                val probe = mutableListOf<PreviewInfo>()
-                discoverFromMethod(
-                  classInfo,
-                  method,
-                  annotations.toList(),
-                  scanResult,
-                  projectClassFqns,
-                  probe,
-                  input,
-                  warnings,
-                )
-                if (probe.isNotEmpty()) {
-                  warnings.add(
-                    "composePreview: skipping private @Preview " +
-                      "'${classInfo.name}.${method.name}' — private composables cannot be " +
-                      "reflectively invoked by the renderer; make it `internal` or `public` " +
-                      "to surface this preview."
-                  )
-                }
-                continue
               }
               discoverFromMethod(
                 classInfo,

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -53,7 +53,7 @@ private object ComposePreviewStrategy : PreviewRenderStrategy {
             clazz.getDeclaredComposableMethod(preview.functionName)
         } else {
             findComposableMethodWithArgs(clazz, preview.functionName, previewArgs)
-        }
+        }.also { it.asMethod().isAccessible = true }
         // Top-level `@Preview` functions compile into static methods on the
         // file's synthetic `FooKt` class, so `receiver = null` works. Google's
         // `com.android.compose.screenshot` tool (and Paparazzi-style tests)

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/Previews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/Previews.kt
@@ -34,7 +34,7 @@ fun Greeting(name: String, modifier: Modifier = Modifier) {
 
 @Preview(name = "Red Box", showBackground = true, backgroundColor = 0xFFFF0000)
 @Composable
-fun RedBoxPreview() {
+private fun RedBoxPreview() {
     Box(
         modifier = Modifier.size(100.dp).background(Color.Red),
         contentAlignment = Alignment.Center,
@@ -45,7 +45,7 @@ fun RedBoxPreview() {
 
 @Preview(name = "Blue Box", showBackground = true, backgroundColor = 0xFF0000FF)
 @Composable
-fun BlueBoxPreview() {
+private fun BlueBoxPreview() {
     Box(
         modifier = Modifier.size(100.dp).background(Color.Blue),
         contentAlignment = Alignment.Center,
@@ -56,7 +56,7 @@ fun BlueBoxPreview() {
 
 @Preview(name = "Green Box", showBackground = true, backgroundColor = 0xFF00FF00)
 @Composable
-fun GreenBoxPreview() {
+private fun GreenBoxPreview() {
     Box(
         modifier = Modifier.size(100.dp).background(Color.Green),
         contentAlignment = Alignment.Center,


### PR DESCRIPTION
## Rationale

Disclosure: This is written by a human, but AI was used for the minimal code example.

We have all private preview functions in our big codebase, and reluctant to change this. I created this proof of concept (with the help of AI), and it worked very well for our repo. This is not meant to be merged as is, just as a proof that its possible, and check if you are interested. Without private preview support we are forced to either fork, or rename thousands of previews -- both doable, but not desired :)

If you want to support it -- I imagine you would rather do the code yourself. But let me know if you want help

Very cool and welcome project btw, previously I relied on a (bad) Paparazzi hack to render previews

## Result

Three boxes were flipped to private fun in this PR's diff — discovery and render pick them up unchanged

Render log [link](https://github.com/joakimtall/compose-ai-tools/blob/private-preview-render-proof/docs/private-preview-render-proof/composePreviewRenderAll.log)

```
Task :samples:android:composePreviewDiscover
Discovered 79 preview(s) in module 'android':
  ...
  com.example.sampleandroid.PreviewsKt.RedBoxPreview  [Red Box]
  com.example.sampleandroid.PreviewsKt.BlueBoxPreview  [Blue Box]
  com.example.sampleandroid.PreviewsKt.GreenBoxPreview  [Green Box]
  ...
Task :samples:android:composePreviewRender
Task :samples:android:composePreviewRenderAll
BUILD SUCCESSFUL in 27s
230 actionable tasks: 230 executed
```

Json output [link](https://github.com/joakimtall/compose-ai-tools/blob/private-preview-render-proof/docs/private-preview-render-proof/previews.json)

```
{
  "id": "com.example.sampleandroid.PreviewsKt.RedBoxPreview_Red Box",
  "functionName": "RedBoxPreview",
  "className": "com.example.sampleandroid.PreviewsKt",
  "sourceFile": "src/main/kotlin/com/example/sampleandroid/Previews.kt",
  "params": { "name": "Red Box", "kind": "COMPOSE", ... },
  "captures": [ { "renderOutput": "renders/RedBoxPreview_Red_Box.png", "cost": 1.0 } ]
}
```

| `private fun RedBoxPreview` | `private fun BlueBoxPreview` | `private fun GreenBoxPreview` |
|:---:|:---:|:---:|
| ![Red](https://raw.githubusercontent.com/joakimtall/compose-ai-tools/private-preview-render-proof/docs/private-preview-render-proof/RedBoxPreview_Red_Box.png) | ![Blue](https://raw.githubusercontent.com/joakimtall/compose-ai-tools/private-preview-render-proof/docs/private-preview-render-proof/BlueBoxPreview_Blue_Box.png) | ![Green](https://raw.githubusercontent.com/joakimtall/compose-ai-tools/private-preview-render-proof/docs/private-preview-render-proof/GreenBoxPreview_Green_Box.png) |
