### PR TITLE
fix(vscode-extension): clear stale previews when last editor closes

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -29,6 +29,7 @@ import { PreviewA11yDiagnostics } from "./previewA11yDiagnostics";
 import { PreviewDoctorDiagnostics } from "./previewDoctorDiagnostics";
 import { moduleRelativeSourcePath, previewSourceMatches } from "./sourcePath";
 import { visiblePreviewsForFile } from "./previewScope";
+import { anyPreviewSourceTabOpen } from "./previewTabs";
 import {
     AccessibilityFinding,
     AccessibilityNode,
@@ -2576,6 +2577,21 @@ function isFileOpenInTextDocument(filePath: string): boolean {
     );
 }
 
+/**
+ * True iff some preview-source `.kt` file is still open in a tab — visible,
+ * covered, or in a background group. Distinguishes "focus drifted off the
+ * editor" (webview/output pane gets focus during a daemon spawn) from "the
+ * last preview editor was closed" for the refresh() no-module guard. See
+ * [anyPreviewSourceTabOpen] for why tab state, not `textDocuments`, is the
+ * authoritative signal here.
+ */
+function isAnyPreviewSourceTabOpen(): boolean {
+    return anyPreviewSourceTabOpen(
+        vscode.window.tabGroups.all,
+        isPreviewSourceFile,
+    );
+}
+
 function isAntigravityHost(): boolean {
     const bundleId = process.env.__CFBundleIdentifier?.toLowerCase() ?? "";
     return (
@@ -4309,10 +4325,13 @@ async function refresh(
         }
         // When the panel already has previews painted (preload or a prior render put cards
         // on screen), focus drifting to the webview / output pane / no-editor-at-all is NOT
-        // a reason to clearAll. Stale cached images are explicitly OK — the daemon's next
-        // render will replace them. Wiping here is what causes the "panel goes back to
-        // placeholders during the 15-25s daemon spawn" bug the verify command surfaces.
-        if (hasPreviewsLoaded) {
+        // a reason to clearAll *as long as a preview source is still open somewhere*. Stale
+        // cached images are explicitly OK while the daemon's next render is coming — wiping
+        // here is what causes the "panel goes back to placeholders during the 15-25s daemon
+        // spawn" bug the verify command surfaces. But once the last preview editor is closed
+        // there's no source left to render, so holding the cards strands the user on stale
+        // previews (issue #1566) — fall through to the empty-state clear below.
+        if (hasPreviewsLoaded && isAnyPreviewSourceTabOpen()) {
             logLine(
                 `no module — activeFile=${activeFile ?? "<none>"} (${scopeSource}); keeping ${lastLoadedModules.length} loaded module(s) on screen`,
             );

--- a/vscode-extension/src/previewTabs.ts
+++ b/vscode-extension/src/previewTabs.ts
@@ -1,0 +1,64 @@
+/**
+ * Open-tab inspection for the refresh() "keep stale previews?" decision.
+ *
+ * When focus drifts off a preview source — onto the webview panel, the output
+ * pane, or no editor at all — the panel must not blank while the daemon is
+ * mid-spawn: the already-painted cards stay up because the next render replaces
+ * them (issue #145). But that only holds while a preview source is still
+ * *open*. Once the user closes the last preview editor there is nothing left to
+ * render into the panel, so leaving the cards up strands them on stale previews
+ * (issue #1566). The discriminator is "is any preview source still open in a
+ * tab?", which is what this module answers.
+ *
+ * This module deliberately avoids importing `vscode`: it operates on a
+ * structural subset of `vscode.window.tabGroups` so the open-tab scan can be
+ * unit-tested without a live editor. The extension adapts the real tab groups
+ * to [TabGroupLike] at the call site. Tab state is the right signal here
+ * because it updates synchronously on close, unlike `workspace.textDocuments`,
+ * which VS Code keeps cached for a while after the editor is gone.
+ */
+
+/** Subset of `vscode.Tab` we read — the tab's `input` may expose a `uri`. */
+export interface TabLike {
+    readonly input?: unknown;
+}
+
+/** Subset of `vscode.TabGroup`. */
+export interface TabGroupLike {
+    readonly tabs: ReadonlyArray<TabLike>;
+}
+
+/**
+ * Collect the filesystem paths of every text-backed tab across [groups].
+ * `TabInputText` and the modified side of `TabInputTextDiff` both expose a
+ * `uri` with an `fsPath`; non-text tabs (webviews, terminals, notebooks) carry
+ * a differently-shaped `input` and are skipped.
+ */
+export function openTabFsPaths(groups: ReadonlyArray<TabGroupLike>): string[] {
+    const paths: string[] = [];
+    for (const group of groups) {
+        for (const tab of group.tabs) {
+            const input = tab.input;
+            if (input && typeof input === "object" && "uri" in input) {
+                const uri = (input as { uri?: { fsPath?: unknown } }).uri;
+                const fsPath = uri?.fsPath;
+                if (typeof fsPath === "string") {
+                    paths.push(fsPath);
+                }
+            }
+        }
+    }
+    return paths;
+}
+
+/**
+ * True iff at least one open tab is a preview source file, per the supplied
+ * [isPreviewSource] predicate. Drives the refresh() no-module guard: retain
+ * stale cards only while this holds.
+ */
+export function anyPreviewSourceTabOpen(
+    groups: ReadonlyArray<TabGroupLike>,
+    isPreviewSource: (fsPath: string) => boolean,
+): boolean {
+    return openTabFsPaths(groups).some(isPreviewSource);
+}

--- a/vscode-extension/src/test/previewTabs.test.ts
+++ b/vscode-extension/src/test/previewTabs.test.ts
@@ -1,0 +1,91 @@
+import * as assert from "assert";
+import {
+    TabGroupLike,
+    anyPreviewSourceTabOpen,
+    openTabFsPaths,
+} from "../previewTabs";
+
+/** Mirror of the extension's preview-source predicate, kept simple here. */
+function isPreviewSource(fsPath: string): boolean {
+    return fsPath.endsWith(".kt") && !fsPath.endsWith(".gradle.kts");
+}
+
+/** Build a text-document tab (TabInputText shape). */
+function textTab(fsPath: string): { input: { uri: { fsPath: string } } } {
+    return { input: { uri: { fsPath } } };
+}
+
+/** Build a non-text tab (webview/terminal shape — no `uri`). */
+function webviewTab(viewType: string): { input: { viewType: string } } {
+    return { input: { viewType } };
+}
+
+function groups(...tabs: TabGroupLike["tabs"][number][][]): TabGroupLike[] {
+    return tabs.map((groupTabs) => ({ tabs: groupTabs }));
+}
+
+describe("openTabFsPaths", () => {
+    it("collects fsPaths from text-document tabs across groups", () => {
+        const g = groups(
+            [textTab("/a/Foo.kt"), webviewTab("compose.preview")],
+            [textTab("/b/Bar.kt")],
+        );
+        assert.deepStrictEqual(openTabFsPaths(g), ["/a/Foo.kt", "/b/Bar.kt"]);
+    });
+
+    it("skips tabs whose input has no uri (webviews, terminals)", () => {
+        const g = groups([webviewTab("terminal"), webviewTab("output")]);
+        assert.deepStrictEqual(openTabFsPaths(g), []);
+    });
+
+    it("tolerates undefined / malformed inputs", () => {
+        const g: TabGroupLike[] = [
+            { tabs: [{ input: undefined }, { input: null as unknown }] },
+            { tabs: [{ input: { uri: {} } }] }, // uri without fsPath
+        ];
+        assert.deepStrictEqual(openTabFsPaths(g), []);
+    });
+
+    it("returns empty for no groups", () => {
+        assert.deepStrictEqual(openTabFsPaths([]), []);
+    });
+});
+
+describe("anyPreviewSourceTabOpen", () => {
+    it("is true when a covered (non-visible) preview tab is still open", () => {
+        // Focus-drift / daemon-spawn case: the .kt is open in a background
+        // group while the webview holds focus. Stale cards must stay up.
+        const g = groups(
+            [webviewTab("compose.preview")],
+            [textTab("/app/Screen.kt")],
+        );
+        assert.strictEqual(anyPreviewSourceTabOpen(g, isPreviewSource), true);
+    });
+
+    it("is false once the last preview editor is closed (issue #1566)", () => {
+        // Only a webview tab remains — nothing left to render, so the guard
+        // should let the panel clear to the empty state.
+        const g = groups([webviewTab("compose.preview")]);
+        assert.strictEqual(anyPreviewSourceTabOpen(g, isPreviewSource), false);
+    });
+
+    it("is false when no tabs are open at all", () => {
+        assert.strictEqual(anyPreviewSourceTabOpen([], isPreviewSource), false);
+    });
+
+    it("ignores non-preview source tabs (build scripts, markdown)", () => {
+        const g = groups([
+            textTab("/app/build.gradle.kts"),
+            textTab("/README.md"),
+        ]);
+        assert.strictEqual(anyPreviewSourceTabOpen(g, isPreviewSource), false);
+    });
+
+    it("is true when at least one preview tab sits among non-preview tabs", () => {
+        const g = groups([
+            textTab("/app/build.gradle.kts"),
+            textTab("/app/Screen.kt"),
+        ]);
+        assert.strictEqual(anyPreviewSourceTabOpen(g, isPreviewSource), true);
+    });
+});


### PR DESCRIPTION
The refresh() no-module guard kept already-painted cards on screen
whenever focus left a preview source, to survive the focus drift onto
the webview/output pane during a 15-25s daemon spawn (issue #145). But
it couldn't distinguish a covered-but-still-open editor from a genuinely
closed one, so closing the last preview editor left the user staring at
stale previews with no source backing them (issue #1566).

Gate the keep-cards branch on a preview-source file still being open in
a tab. Tab state (not workspace.textDocuments, which VS Code keeps
cached after close) is the authoritative signal and updates synchronously
on close. When nothing is open, fall through to the existing empty-state
clear. The tab scan lives in a vscode-free previewTabs module so it is
unit-tested.