### PR TITLE
fix(vscode-extension): scope bundle overlays to the focused preview

### DIFF
--- a/vscode-extension/src/test/cardBundleOverlay.test.ts
+++ b/vscode-extension/src/test/cardBundleOverlay.test.ts
@@ -17,6 +17,7 @@ import {
     getVisiblePreviewIds,
     paintBundleBoxes,
     paintBundleBoxesEverywhere,
+    paintBundleBoxesForFocus,
 } from "../webview/preview/cardBundleOverlay";
 import { sanitizeId } from "../webview/preview/cardData";
 // Import for side-effect: registers `<box-overlay>` with
@@ -458,6 +459,87 @@ describe("cardBundleOverlay", () => {
                 document.querySelectorAll("box-overlay[data-bundle='history']")
                     .length,
                 0,
+            );
+        });
+    });
+
+    // Production paint path: bundles scope to the focused preview only,
+    // so the overlay must never leak onto a grid card the user later
+    // browses to (#1567). `paintOverlaysForBundle` in `main.ts`
+    // delegates here, passing the focused card in focus layout and
+    // `null` in grid/flow/column layout.
+    describe("paintBundleBoxesForFocus", () => {
+        it("paints the focused card's own boxes", () => {
+            const card = buildCard("p:a");
+            paintBundleBoxesForFocus("a11y", card, () => [box("a-0")]);
+            const layer = card.querySelector<BoxOverlay>(
+                "box-overlay[data-bundle='a11y']",
+            );
+            assert.ok(layer, "focused card should host an a11y layer");
+        });
+
+        it("computes boxes only for the focused card's previewId", () => {
+            const card = buildCard("p:a");
+            const seen: string[] = [];
+            paintBundleBoxesForFocus("a11y", card, (previewId) => {
+                seen.push(previewId);
+                return [box("a-0")];
+            });
+            assert.deepStrictEqual(seen, ["p:a"]);
+        });
+
+        it("clears every layer when there is no focused card (grid layout)", () => {
+            // A box painted while the card was focused...
+            const card = buildCard("p:a");
+            paintBundleBoxesForFocus("a11y", card, () => [box("a-0")]);
+            assert.strictEqual(
+                document.querySelectorAll("box-overlay[data-bundle='a11y']")
+                    .length,
+                1,
+            );
+            // ...must be torn down when the user drops to grid layout —
+            // `null` focused card. This is the #1567 leak guard.
+            let computed = false;
+            paintBundleBoxesForFocus("a11y", null, () => {
+                computed = true;
+                return [box("a-0")];
+            });
+            assert.strictEqual(
+                document.querySelectorAll("box-overlay[data-bundle='a11y']")
+                    .length,
+                0,
+                "a11y overlay must not survive into grid layout",
+            );
+            assert.strictEqual(
+                computed,
+                false,
+                "no overlay is computed when there is no focused card",
+            );
+        });
+
+        it("treats a card without a previewId like no focus — clears, never paints", () => {
+            const card = buildCard("p:a");
+            paintBundleBoxesForFocus("a11y", card, () => [box("a-0")]);
+            delete card.dataset.previewId;
+            paintBundleBoxesForFocus("a11y", card, () => [box("a-0")]);
+            assert.strictEqual(
+                document.querySelectorAll("box-overlay[data-bundle='a11y']")
+                    .length,
+                0,
+            );
+        });
+
+        it("only touches its own bundle's layer, leaving siblings intact", () => {
+            const card = buildCard("p:a");
+            paintBundleBoxes(card, "history", [box("h-0")]);
+            // Switching to grid clears a11y but must not disturb the
+            // history layer (each bundle owns its own teardown).
+            paintBundleBoxesForFocus("a11y", null, () => [box("a-0")]);
+            assert.strictEqual(
+                card.querySelectorAll("box-overlay[data-bundle='history']")
+                    .length,
+                1,
+                "sibling bundle layer is untouched",
             );
         });
     });

--- a/vscode-extension/src/test/chipTabOverlayChain.test.ts
+++ b/vscode-extension/src/test/chipTabOverlayChain.test.ts
@@ -1,9 +1,15 @@
 // Bundle chip ↔ tab ↔ overlay integration smoke. Wires
 // `BundleController` to the three visual surfaces (chip-bar's active
-// set, `<data-tabs>` tab strip, per-card `<box-overlay>` layers) the
-// same way `main.ts`'s `reflectBundleState` + `setTabBody` plumbing
-// does, then drives the chip on / `×`-close round-trip and asserts
-// the full chain.
+// set, `<data-tabs>` tab strip, per-card `<box-overlay>` layers),
+// then drives the chip on / `×`-close round-trip and asserts the full
+// chain.
+//
+// The overlay wiring here paints every card via
+// `paintBundleBoxesEverywhere` to exercise the chip → multi-layer
+// paint/clear mechanics. Production `main.ts` instead scopes overlays
+// to the focused preview (`paintBundleBoxesForFocus`, #1567); this
+// suite covers the chip/tab/overlay state-sync, not the focus
+// scoping.
 //
 // Complementary to the existing leaf-component tests
 // (`bundleChipBar.test.ts`, `dataTabs.test.ts`,

--- a/vscode-extension/src/test/gridOverlayPaintSmoke.test.ts
+++ b/vscode-extension/src/test/gridOverlayPaintSmoke.test.ts
@@ -2,9 +2,18 @@
 // round-trip via the production `BundleController`. The existing
 // `cardBundleOverlay.test.ts` covers the helper functions
 // (`paintBundleBoxesEverywhere`, `clearBundleBoxes`) in isolation;
-// this suite wires them through the controller the way `main.ts`
-// does so a regression in the `onChange` → paint/clear plumbing
-// surfaces here instead of waiting for an electron run.
+// this suite wires them through the controller so a regression in the
+// `onChange` → paint/clear plumbing surfaces here instead of waiting
+// for an electron run.
+//
+// Note: production `main.ts` scopes bundle overlays to the focused
+// preview only (`paintBundleBoxesForFocus`) — it does NOT paint every
+// grid card, since the chip bar / data tabs are hidden outside focus
+// layout (#1567, settled "Open question 1" in
+// `docs/design/EXTENSION_DATA_EXPOSURE.md`). This suite drives the
+// `paintBundleBoxesEverywhere` primitive directly via a test-local
+// `wireBundleToOverlay` helper to pin the multi-card paint/clear
+// mechanics of the primitive itself.
 
 import * as assert from "assert";
 import { BundleController } from "../webview/preview/bundleController";
@@ -43,12 +52,15 @@ function box(id: string): OverlayBox {
 }
 
 /**
- * Mirror of the chip → paint plumbing in `main.ts`'s
- * `reflectBundleState`: when [bundleId] is in `activeBundles` we
- * paint every card with its own data; when it leaves, we clear the
- * bundle's `<box-overlay>` layer from every card. The closure is
- * the smallest piece of `reflectBundleState` we can exercise
- * without spinning up the full panel.
+ * Test-local chip → paint plumbing that drives the
+ * `paintBundleBoxesEverywhere` primitive: when [bundleId] is in
+ * `activeBundles` we paint every card with its own data; when it
+ * leaves, we clear the bundle's `<box-overlay>` layer from every card.
+ *
+ * This is intentionally NOT how `main.ts` wires overlays — production
+ * scopes to the focused preview via `paintBundleBoxesForFocus` (#1567).
+ * It exists only to exercise the every-card primitive end-to-end with
+ * the real `BundleController` state machine.
  */
 function wireBundleToOverlay(
     controller: BundleController,

--- a/vscode-extension/src/webview/preview/cardBundleOverlay.ts
+++ b/vscode-extension/src/webview/preview/cardBundleOverlay.ts
@@ -222,6 +222,35 @@ export function paintBundleBoxesEverywhere(
     }
 }
 
+/**
+ * Paint [bundleId]'s boxes on the focused card only, or tear the layer
+ * down when there is no focused card. This is the production paint path
+ * for bundle overlays: bundles scope to the focused preview, and
+ * `bundleChipBar` / `<data-tabs>` are hidden outside focus layout, so a
+ * bundle must never paint an overlay on an ambient grid selection
+ * (settled "Open question 1 — Multi-preview selection" in
+ * `docs/design/EXTENSION_DATA_EXPOSURE.md`).
+ *
+ * Passing `null` (grid/flow/column layout, or focus mode with no card
+ * selected) clears every layer the bundle previously stamped — without
+ * this, a layer painted while a card was focused would linger on that
+ * card after the user dropped back to the grid (#1567). Passing a card
+ * with no `data-preview-id` is treated the same as `null` since there's
+ * no preview to compute boxes for.
+ */
+export function paintBundleBoxesForFocus(
+    bundleId: string,
+    focusedCard: HTMLElement | null,
+    computeOverlay: (previewId: string) => readonly OverlayBox[],
+): void {
+    const previewId = focusedCard?.dataset.previewId;
+    if (!focusedCard || !previewId) {
+        clearBundleBoxes(null, bundleId);
+        return;
+    }
+    paintBundleBoxes(focusedCard, bundleId, computeOverlay(previewId));
+}
+
 function isCardHidden(card: HTMLElement): boolean {
     if (card.hasAttribute("hidden")) return true;
     // happy-dom doesn't run CSS layout so `getComputedStyle` only

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -70,6 +70,15 @@ export interface FocusControllerConfig {
      *  without it, activating a11y in focus mode and then exiting
      *  leaves the legend rendering next to the preview grid. */
     refreshBundleLegend(): void;
+    /** Re-run the chip → card-overlay paint/clear decision. Bundles
+     *  scope to the focused preview, so card overlay layers painted in
+     *  focus mode must be torn down when the user drops back to a
+     *  grid/flow/column layout. Wired from main to `reflectBundleState`
+     *  so layout transitions re-evaluate every active bundle's overlay
+     *  the same way a chip toggle does — without it, an a11y (or other
+     *  bundle) overlay painted while focused leaks onto the grid card
+     *  (#1567). */
+    refreshBundleState(): void;
     focusToolbar: FocusToolbarController;
     /** Repaint the focus inspector for the given card, or clear it
      *  when `null` (no card focused / exiting focus layout). */
@@ -350,6 +359,11 @@ export class FocusController {
         this.applyFocusedToggleButtonStates();
         this.applyEarlyFeatureVisibility();
         this.config.refreshBundleLegend();
+        // Re-evaluate every active bundle's card overlay for the new
+        // layout. Entering focus repaints the focused card; dropping to
+        // a grid/flow/column layout clears any layer painted while
+        // focused, so the overlay never leaks onto a grid card (#1567).
+        this.config.refreshBundleState();
     }
 
     /**

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -58,9 +58,8 @@ import type {
 import { findLegendTarget } from "./bundleLegendTarget";
 import {
     clearBundleBoxes,
-    getVisiblePreviewIds,
     paintBundleBoxes,
-    paintBundleBoxesEverywhere,
+    paintBundleBoxesForFocus,
 } from "./cardBundleOverlay";
 import type { OverlayBox } from "./components/BoxOverlay";
 import { BundleController, type BundleSnapshot } from "./bundleController";
@@ -928,30 +927,27 @@ export class PreviewApp extends LitElement {
             return visible?.dataset.previewId ?? null;
         };
         /**
-         * Paint [bundleId]'s overlay boxes onto either the focused
-         * card (focus mode) or every visible card (grid mode), using
+         * Paint [bundleId]'s overlay boxes on the focused card, using
          * [computeOverlay] to derive that card's `OverlayBox[]` from
-         * its own data caches. Centralises the focused-vs-grid
-         * switch the design doc promises (see
-         * `docs/design/EXTENSION_DATA_EXPOSURE.md` § "Open question
-         * 1 — Multi-preview selection") so each bundle refresh
-         * function only has to supply the per-preview compute.
+         * its own data caches.
+         *
+         * Bundles scope to the focused preview only — `bundleChipBar`
+         * and `<data-tabs>` are hidden outside focus layout, so the
+         * bundles never act on an ambient grid selection (settled
+         * "Open question 1 — Multi-preview selection" in
+         * `docs/design/EXTENSION_DATA_EXPOSURE.md`). Outside focus mode
+         * we therefore tear the layer down rather than paint: a box
+         * stamped while a card was focused must not leak onto the grid
+         * card the user later browses to (#1567).
          */
         const paintOverlaysForBundle = (
             bundleId: string,
             computeOverlay: (previewId: string) => readonly OverlayBox[],
         ): void => {
-            if (focusController?.inFocus?.()) {
-                const focused = focusController.focusedCard();
-                const previewId = focused?.dataset.previewId;
-                if (!focused || !previewId) return;
-                paintBundleBoxes(focused, bundleId, computeOverlay(previewId));
-                return;
-            }
-            const ids = getVisiblePreviewIds();
-            const perCard = new Map<string, readonly OverlayBox[]>();
-            for (const id of ids) perCard.set(id, computeOverlay(id));
-            paintBundleBoxesEverywhere(bundleId, perCard);
+            const focused = focusController?.inFocus?.()
+                ? focusController.focusedCard()
+                : null;
+            paintBundleBoxesForFocus(bundleId, focused, computeOverlay);
         };
         // Per-bundle tab bodies. Each entry holds the wrapper element
         // we attach to `<data-tabs>` plus the `<bundle-expander>` /
@@ -2779,6 +2775,7 @@ export class PreviewApp extends LitElement {
             bundleChipBar,
             dataTabs,
             refreshBundleLegend: () => reflectLegendActiveTab(),
+            refreshBundleState: () => reflectBundleState(),
             focusToolbar,
             inspectorRender: renderFocusInspector,
             liveState,


### PR DESCRIPTION
The A11y overlay (and any bundle overlay) painted on a card in focus
mode leaked onto that card after the user switched to a grid/flow/
column layout. `paintOverlaysForBundle` still carried the unsettled
"Open question 1" fallback that painted every visible grid card, and
nothing tore the layer down on the focus→grid transition.

Per the settled design (docs/design/EXTENSION_DATA_EXPOSURE.md), bundles
scope to the focused preview only — the chip bar and data tabs are
hidden outside focus layout, so a bundle must never act on an ambient
grid selection. Extract the focus-scoped paint/clear decision into a
testable `paintBundleBoxesForFocus` helper (paints the focused card,
clears every layer when there is no focused card) and route
`paintOverlaysForBundle` through it. Wire `applyLayout` to re-run the
overlay paint/clear on every layout transition via `reflectBundleState`
so a layer stamped while focused is cleared the moment the user drops
back to the grid.

Fixes #1567.