### PR TITLE
ci(compose-preview): run a11y baseline across all Android sample modules

### DIFF
--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -42,5 +42,13 @@ jobs:
           # that change the previews.json schema don't render against a
           # stale released CLI. External consumers omit this input.
           cli-version: source
-          a11y-module: 'samples:wear'
+          # Empty = auto-detect every module the CLI knows about, so the a11y
+          # baseline covers the whole Android sample suite (overlays + legends
+          # on each preview) instead of just one module. Desktop / Compose-
+          # Multiplatform modules are skipped below: their daemon doesn't
+          # advertise `a11y/atf` (ATF is Android-only), so including them would
+          # stamp `atf-unavailable` and surface a misleading "renders not
+          # accessibility-checked" banner over the whole report.
+          a11y-module: ''
+          a11y-skip-modules: 'samples:cmp,samples:cmp-shared,samples:desktop-daemon-bench'
           notifications-module: 'samples:android'


### PR DESCRIPTION
The a11y baseline job scoped ATF to `samples:wear` only. The preview
baseline still renders every module, and copy-annotated folds them all
into the report — so every non-wear preview showed its plain render with
a misleading "_No findings._" and no overlay/legend, even though the
daemon a11y path produces overlays for them (verified locally: e.g.
:samples:android yields 73 overlays / 79 previews, ActionsPreview flags
2 findings).

Switch a11y-module to '' (auto-detect every module) so the baseline
covers the whole Android sample suite. Skip the Compose-Multiplatform /
desktop modules (cmp, cmp-shared, desktop-daemon-bench): their daemon
doesn't advertise a11y/atf (ATF is Android-only), and including them
would stamp atf-unavailable and raise the global "renders not
accessibility-checked" banner over the entire report.