### PR TITLE
feat: surface private @Preview methods via reflection

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -210,14 +210,6 @@ object PreviewDiscovery {
       ClassGraph()
         .enableMethodInfo()
         .enableAnnotationInfo()
-        // Surface JVM-private methods so the loop below can actively warn
-        // when a `private fun` is annotated with @Preview (the renderer's
-        // `getDeclaredComposableMethod` fails on private composables, so
-        // we drop them — see the `method.isPrivate` branch). Without this
-        // flag ClassGraph's default visibility filter would drop them
-        // silently and the user would never learn why their preview
-        // disappeared. `internal fun` compiles to JVM `public` (with the
-        // `name$module` mangle) and passes the default filter regardless.
         .ignoreMethodVisibility()
         .overrideClasspath(classpath.map { it.absolutePath })
         .ignoreParentClassLoaders()
@@ -253,36 +245,6 @@ object PreviewDiscovery {
               if (annotations.isNotEmpty()) scanMethodsWithAnnotations++
               for (ann in annotations) {
                 annotationFqnCounts.merge(ann.name, 1, Int::plus)
-              }
-              // Kotlin `private fun` compiles to a JVM `private` method.
-              // `ComposableMethod` resolution at render time fails on those
-              // (NoSuchMethodException from `getDeclaredComposableMethod`, see
-              // RenderEngine), so the renderer cannot invoke private @Preview
-              // composables. Discover into a probe list first, and if anything
-              // came out, drop it with a clear warning instead of letting it
-              // surface and fail downstream. `internal fun` compiles to JVM
-              // `public` (with the `name$module` mangle) and is unaffected.
-              if (method.isPrivate) {
-                val probe = mutableListOf<PreviewInfo>()
-                discoverFromMethod(
-                  classInfo,
-                  method,
-                  annotations.toList(),
-                  scanResult,
-                  projectClassFqns,
-                  probe,
-                  input,
-                  warnings,
-                )
-                if (probe.isNotEmpty()) {
-                  warnings.add(
-                    "composePreview: skipping private @Preview " +
-                      "'${classInfo.name}.${method.name}' — private composables cannot be " +
-                      "reflectively invoked by the renderer; make it `internal` or `public` " +
-                      "to surface this preview."
-                  )
-                }
-                continue
               }
               discoverFromMethod(
                 classInfo,

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
@@ -60,7 +60,7 @@ public object PreviewDiscoveryCli {
       }
       is PreviewDiscovery.Outcome.Failure -> {
         // Mirror the success branch's WARN emission so the failure path doesn't drop per-method
-        // skip reasons (private @Preview, unsupported parameters) — they're the most actionable
+        // skip reasons (e.g. unsupported parameters) — they're the most actionable
         // signal when failOnEmpty filtered the run to zero previews.
         outcome.warnings.forEach { System.err.println("WARN: $it") }
         outcome.diagnostics.forEach { System.err.println(it) }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryFailureWarningsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryFailureWarningsTest.kt
@@ -12,14 +12,15 @@ import org.objectweb.asm.Opcodes
 /**
  * Regression coverage for [PreviewDiscovery.Outcome.Failure] carrying per-method `warnings`
  * symmetrically with [PreviewDiscovery.Outcome.Success]. The historical bug: when
- * `failOnEmpty=true` and every candidate method got filtered out (private `@Preview`, unsupported
- * parameter shapes), discovery returned `Failure` with `diagnostics` only — the skip reasons
- * collected during the scan were silently dropped, leaving the consumer with no actionable signal
- * for "why didn't my preview show up". See issue #1364.
+ * `failOnEmpty=true` and every candidate method got filtered out (unsupported parameter shapes,
+ * etc.), discovery returned `Failure` with `diagnostics` only — the skip reasons collected during
+ * the scan were silently dropped, leaving the consumer with no actionable signal for "why didn't my
+ * preview show up". See issue #1364.
  *
  * Hand-rolls a `.class` file via ASM so the test exercises the real ClassGraph scan against a
- * private-method-with-`@Preview`-annotation candidate, without round-tripping through Kotlin
- * compilation.
+ * skipped `@Preview` candidate, without round-tripping through Kotlin compilation. We use an
+ * unsupported-parameter method (one non-`@PreviewParameter` arg) as the skip trigger — `private`
+ * previews are no longer dropped, they're surfaced and invoked with `setAccessible(true)`.
  */
 class PreviewDiscoveryFailureWarningsTest {
 
@@ -28,7 +29,11 @@ class PreviewDiscoveryFailureWarningsTest {
   @Test
   fun `failure path carries per-method skip-reason warnings`() {
     val classDir = tempDir.newFolder("classes")
-    writePrivatePreviewClass(classDir, internalName = "test/PrivatePreviewKt", methodName = "Hidden")
+    writeUnsupportedParamPreviewClass(
+      classDir,
+      internalName = "test/UnsupportedParamPreviewKt",
+      methodName = "Hidden",
+    )
 
     val outcome =
       PreviewDiscovery.discover(
@@ -48,8 +53,8 @@ class PreviewDiscoveryFailureWarningsTest {
     assertThat(failure.warnings).isNotEmpty()
     // The actionable signal: name the method and explain WHY it was skipped.
     val joined = failure.warnings.joinToString("\n")
-    assertThat(joined).contains("test.PrivatePreviewKt.Hidden")
-    assertThat(joined).contains("private")
+    assertThat(joined).contains("test.UnsupportedParamPreviewKt.Hidden")
+    assertThat(joined).contains("@PreviewParameter")
   }
 
   @Test
@@ -61,13 +66,18 @@ class PreviewDiscoveryFailureWarningsTest {
   }
 
   /**
-   * Writes a minimal `.class` file containing one private static method annotated with
-   * `androidx.compose.ui.tooling.preview.Preview`. Mirrors the JVM shape Kotlin's compiler
-   * produces for a top-level `private fun @Preview Hidden()` — file-class with a private static
-   * method, single annotation entry. The method body is a no-op (`RETURN`); discovery only
-   * inspects the annotation + visibility, never invokes the method.
+   * Writes a minimal `.class` file containing one public static method annotated with
+   * `androidx.compose.ui.tooling.preview.Preview` that takes a single `int` parameter with no
+   * `@PreviewParameter` wiring. Mirrors the JVM shape Kotlin's compiler produces for a top-level
+   * `@Preview fun Hidden(x: Int)` — discovery flags it as an unsupported-parameter preview and
+   * skips it with a warning. The method body is a no-op (`RETURN`); discovery only inspects the
+   * annotation + signature, never invokes the method.
    */
-  private fun writePrivatePreviewClass(outDir: File, internalName: String, methodName: String) {
+  private fun writeUnsupportedParamPreviewClass(
+    outDir: File,
+    internalName: String,
+    methodName: String,
+  ) {
     val cw = ClassWriter(0)
     cw.visit(
       Opcodes.V17,
@@ -79,9 +89,9 @@ class PreviewDiscoveryFailureWarningsTest {
     )
     val mv =
       cw.visitMethod(
-        Opcodes.ACC_PRIVATE or Opcodes.ACC_STATIC,
+        Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC,
         methodName,
-        "()V",
+        "(I)V",
         null,
         null,
       )

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -804,7 +804,7 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
-  fun `composePreviewDiscover skips private preview methods`() {
+  fun `composePreviewDiscover discovers private preview methods`() {
     val projectDir = createCmpTestProject()
 
     File(projectDir, "src/main/kotlin/test/Previews.kt")
@@ -843,12 +843,16 @@ class DiscoveryFunctionalTest {
         .withPluginClasspath()
         .build()
 
-    assertThat(result.output).contains("skipping private @Preview")
+    // Private previews are surfaced by ClassGraph's `ignoreMethodVisibility()`
+    // and invoked through reflection with `setAccessible(true)` at render time,
+    // so they no longer get dropped with a "skipping private @Preview" warning.
+    assertThat(result.output).doesNotContain("skipping private @Preview")
     val manifest =
       json.decodeFromString<PreviewManifest>(
         File(projectDir, "build/compose-previews/previews.json").readText()
       )
-    assertThat(manifest.previews.map { it.functionName }).containsExactly("PublicPreview")
+    assertThat(manifest.previews.map { it.functionName })
+      .containsExactly("PrivatePreview", "PublicPreview")
   }
 
   @Test
@@ -1221,13 +1225,14 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
-  fun `composePreviewDiscover finds internal previews and skips private previews`() {
+  fun `composePreviewDiscover finds public, internal, and private previews`() {
     // Teams that don't want @Preview functions to leak into their public
     // API mark them `private` (or `internal`). Kotlin compiles `private
-    // fun` to JVM `private` and ClassGraph's default visibility filter
-    // drops them; `internal fun` compiles to JVM `public` (with the
-    // `name$module` mangle) so it has always been visible. Asserting both
-    // shapes so the visibility regression doesn't return on either axis.
+    // fun` to JVM `private` and `internal fun` to JVM `public` (with the
+    // `name$module` mangle); ClassGraph's `ignoreMethodVisibility()` surfaces
+    // both, and the renderer's `setAccessible(true)` lets the private one be
+    // invoked. Asserting all three shapes so the visibility regression doesn't
+    // return on any axis.
     val projectDir = createCmpTestProject()
 
     val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
@@ -1273,7 +1278,7 @@ class DiscoveryFunctionalTest {
         .build()
 
     assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-    assertThat(result.output).contains("skipping private @Preview")
+    assertThat(result.output).doesNotContain("skipping private @Preview")
 
     val manifest =
       json.decodeFromString<PreviewManifest>(
@@ -1284,7 +1289,8 @@ class DiscoveryFunctionalTest {
     val names = manifest.previews.map { it.functionName }
     assertThat(names).contains("PublicPreview")
     assertThat(names.any { it.startsWith("InternalPreview") }).isTrue()
-    assertThat(manifest.previews).hasSize(2)
+    assertThat(names).contains("PrivatePreview")
+    assertThat(manifest.previews).hasSize(3)
   }
 
   @Test

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -92,7 +92,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         outcome.infoMessages.forEach { logger.lifecycle(it) }
       }
       is PreviewDiscovery.Outcome.Failure -> {
-        // Surface per-method skip reasons (private @Preview, unsupported parameters) before the
+        // Surface per-method skip reasons (e.g. unsupported parameters) before the
         // diagnostics dump so users can see WHY a method was filtered out — when failOnEmpty=true
         // and every candidate was skipped, these warnings are the most actionable signal. Mirrors
         // the Success branch's warning emission so the failure path doesn't drop them.

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -53,7 +53,7 @@ private object ComposePreviewStrategy : PreviewRenderStrategy {
             clazz.getDeclaredComposableMethod(preview.functionName)
         } else {
             findComposableMethodWithArgs(clazz, preview.functionName, previewArgs)
-        }
+        }.also { it.asMethod().isAccessible = true }
         // Top-level `@Preview` functions compile into static methods on the
         // file's synthetic `FooKt` class, so `receiver = null` works. Google's
         // `com.android.compose.screenshot` tool (and Paparazzi-style tests)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -53,7 +53,17 @@ private object ComposePreviewStrategy : PreviewRenderStrategy {
             clazz.getDeclaredComposableMethod(preview.functionName)
         } else {
             findComposableMethodWithArgs(clazz, preview.functionName, previewArgs)
-        }.also { it.asMethod().isAccessible = true }
+        }
+        // Kotlin `private fun` previews compile to JVM-private methods.
+        // `getDeclaredComposableMethod` still resolves them (it scans
+        // `declaredMethods`), but the reflective `invoke` below would throw
+        // IllegalAccessException, so open the method up first — the same trick
+        // `resolvePreviewReceiver` uses for private/internal receiver classes.
+        // Guarded with `runCatching`: a SecurityManager or strong module
+        // encapsulation can refuse, in which case we still attempt the invoke
+        // (which succeeds for public/internal previews) rather than fail
+        // resolution outright.
+        runCatching { composableMethod.asMethod().isAccessible = true }
         // Top-level `@Preview` functions compile into static methods on the
         // file's synthetic `FooKt` class, so `receiver = null` works. Google's
         // `com.android.compose.screenshot` tool (and Paparazzi-style tests)

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/Previews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/Previews.kt
@@ -32,6 +32,9 @@ fun Greeting(name: String, modifier: Modifier = Modifier) {
     Text(text = "Hello $name!", modifier = modifier)
 }
 
+// Kept `private` on purpose: exercises the private-@Preview render path
+// (ClassGraph `ignoreMethodVisibility()` + reflective `setAccessible(true)`)
+// end-to-end in the sample. The other boxes stay public to cover both shapes.
 @Preview(name = "Red Box", showBackground = true, backgroundColor = 0xFFFF0000)
 @Composable
 private fun RedBoxPreview() {
@@ -45,7 +48,7 @@ private fun RedBoxPreview() {
 
 @Preview(name = "Blue Box", showBackground = true, backgroundColor = 0xFF0000FF)
 @Composable
-private fun BlueBoxPreview() {
+fun BlueBoxPreview() {
     Box(
         modifier = Modifier.size(100.dp).background(Color.Blue),
         contentAlignment = Alignment.Center,
@@ -56,7 +59,7 @@ private fun BlueBoxPreview() {
 
 @Preview(name = "Green Box", showBackground = true, backgroundColor = 0xFF00FF00)
 @Composable
-private fun GreenBoxPreview() {
+fun GreenBoxPreview() {
     Box(
         modifier = Modifier.size(100.dp).background(Color.Green),
         contentAlignment = Alignment.Center,

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/Previews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/Previews.kt
@@ -34,7 +34,7 @@ fun Greeting(name: String, modifier: Modifier = Modifier) {
 
 @Preview(name = "Red Box", showBackground = true, backgroundColor = 0xFFFF0000)
 @Composable
-fun RedBoxPreview() {
+private fun RedBoxPreview() {
     Box(
         modifier = Modifier.size(100.dp).background(Color.Red),
         contentAlignment = Alignment.Center,
@@ -45,7 +45,7 @@ fun RedBoxPreview() {
 
 @Preview(name = "Blue Box", showBackground = true, backgroundColor = 0xFF0000FF)
 @Composable
-fun BlueBoxPreview() {
+private fun BlueBoxPreview() {
     Box(
         modifier = Modifier.size(100.dp).background(Color.Blue),
         contentAlignment = Alignment.Center,
@@ -56,7 +56,7 @@ fun BlueBoxPreview() {
 
 @Preview(name = "Green Box", showBackground = true, backgroundColor = 0xFF00FF00)
 @Composable
-fun GreenBoxPreview() {
+private fun GreenBoxPreview() {
     Box(
         modifier = Modifier.size(100.dp).background(Color.Green),
         contentAlignment = Alignment.Center,


### PR DESCRIPTION
## Summary

Enable discovery and rendering of `private` @Preview methods by leveraging ClassGraph's `ignoreMethodVisibility()` and reflective `setAccessible(true)` at render time. Previously, private previews were actively filtered out with a warning; they are now surfaced and invoked like any other preview.

## Changes

- **PreviewDiscovery.kt**: Remove the explicit `method.isPrivate` check that was dropping private @Preview methods. The `ignoreMethodVisibility()` flag on ClassGraph now surfaces them, and they flow through the normal discovery pipeline.

- **PreviewRenderStrategy.kt**: Add `setAccessible(true)` call on resolved composable methods before invocation to handle JVM-private methods. This mirrors the technique already used for private/internal receiver classes. The call is guarded with `runCatching` to gracefully handle SecurityManager or module encapsulation restrictions.

- **Test updates**: 
  - `PreviewDiscoveryFailureWarningsTest`: Refactor to test unsupported-parameter skipping (the actual regression case) instead of private-method skipping, since private methods are no longer dropped.
  - `DiscoveryFunctionalTest`: Update two test cases to expect private previews in the manifest and remove assertions for the "skipping private @Preview" warning.

- **Sample & documentation**: Mark `RedBoxPreview()` as private in the sample to exercise the private-preview render path end-to-end. Update comments in CLI and task code to reflect that private previews are no longer a skip reason.

## Implementation Details

The change unifies visibility handling: ClassGraph's `ignoreMethodVisibility()` was already enabled to surface private methods for warning purposes; now we simply let them through and handle the JVM access restriction at render time via reflection's `setAccessible(true)`. This is consistent with how the renderer already handles private/internal receiver classes and avoids the need for special-case filtering logic in discovery.

https://claude.ai/code/session_01JosJLNdx1ftBHthRnASNnt