### PR TITLE
fix: allow private @Preview Glance composables to be invoked

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/GlanceAppWidgetPreviewRenderer.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/GlanceAppWidgetPreviewRenderer.kt
@@ -117,6 +117,11 @@ private class SyntheticGlanceAppWidget(
                     classLoader ?: Thread.currentThread().contextClassLoader,
                 )
             val method = cls.getDeclaredComposableMethod(functionName)
+            // Private `@Preview` Glance composables resolve fine but would throw
+            // IllegalAccessException on invoke — open them up, same as the
+            // COMPOSE strategy and the tile/notification paths. Guarded so a
+            // SecurityManager / strong encapsulation can't break public ones.
+            runCatching { method.asMethod().isAccessible = true }
             val receiver = resolvePreviewReceiver(cls)
             method.invoke(currentComposer, receiver)
         }


### PR DESCRIPTION
## Summary
Enable invocation of private `@Preview` annotated Glance composables by making them accessible via reflection, matching the behavior of the COMPOSE strategy and other preview paths.

## Changes
- Added `runCatching { method.asMethod().isAccessible = true }` to allow reflection-based invocation of private preview methods
- Guarded with `runCatching` to prevent SecurityManager or strong encapsulation from breaking public method access
- Includes explanatory comment documenting the rationale and safety considerations

## Details
Private `@Preview` Glance composables were previously failing with `IllegalAccessException` during preview rendering. This fix aligns the Glance widget preview renderer with existing patterns used in the COMPOSE strategy and tile/notification preview paths by explicitly enabling accessibility for private methods before invocation.

https://claude.ai/code/session_01JosJLNdx1ftBHthRnASNnt