### PR TITLE
docs: strengthen PR state check guidance before pushing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,4 +4,4 @@ See [docs/AGENTS.md](docs/AGENTS.md) for project context, architecture, commands
 
 - **No `Co-Authored-By` trailers** in commit messages or PR bodies. Commits are attributed solely to the committer — do not add a Claude/AI co-author line, even by default.
 - **Use conventional commits for PR titles and commit subjects** (`fix:`, `feat:`, `docs:`, `test:`, etc.) so squash merges feed release-please correctly.
-- **Before adding commits to an existing PR branch, check whether the PR has already landed.** Fetch `origin` and inspect the PR state or compare against `origin/main` first. If the PR has merged, create a fresh branch from `origin/main` for follow-up work instead of stacking commits onto the merged branch.
+- **Re-check PR state immediately before EVERY push, not just the first commit of a session.** A PR can merge between turns, so a check at the start is not enough. Right before pushing, `git fetch origin main` and confirm the branch head isn't already in `origin/main` (or read the PR's `state`/`merged`). If the PR has landed, STOP: do not stack commits onto the merged branch — create a fresh branch from `origin/main` for the follow-up and tell the user.


### PR DESCRIPTION
## Summary
Updated the Git conventions documentation to emphasize the importance of checking PR state immediately before every push, not just at the start of a session. This prevents accidental commits from being stacked onto already-merged branches.

## Changes
- Clarified that PR state checks must occur **before every push**, not just before the first commit of a session
- Added explicit instructions to run `git fetch origin main` and verify the branch head isn't already in `origin/main` (or check the PR's `state`/`merged` field)
- Emphasized that if a PR has merged between turns, the developer should stop and create a fresh branch from `origin/main` for follow-up work, then notify the user

## Rationale
The original guidance only recommended checking PR state before adding commits to an existing branch, which could miss cases where a PR merges between turns in a multi-turn session. This update ensures developers catch merged PRs at push time, preventing wasted work and confusing commit histories.

https://claude.ai/code/session_01JosJLNdx1ftBHthRnASNnt