### PR TITLE
docs: add PR workflow guidelines for agent automation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,10 @@ See [docs/AGENTS.md](docs/AGENTS.md) for project context, architecture, commands
 - **No `Co-Authored-By` trailers** in commit messages or PR bodies. Commits are attributed solely to the committer — do not add a Claude/AI co-author line, even by default.
 - **Use conventional commits for PR titles and commit subjects** (`fix:`, `feat:`, `docs:`, `test:`, etc.) so squash merges feed release-please correctly.
 - **Re-check PR state immediately before EVERY push, not just the first commit of a session.** A PR can merge between turns, so a check at the start is not enough. Right before pushing, `git fetch origin main` and confirm the branch head isn't already in `origin/main` (or read the PR's `state`/`merged`). If the PR has landed, STOP: do not stack commits onto the merged branch — create a fresh branch from `origin/main` for the follow-up and tell the user.
+
+## PR workflow (must follow)
+
+- **Open a PR automatically when finishing a coding task.** Once the change is committed and pushed to its branch, open a PR against `main` without waiting for the user to ask. Use a conventional-commit title and a short summary + test plan body. The only exceptions are pure-exploration sessions where the user explicitly said "don't open a PR" or "just investigate".
+- **Always track PRs you've opened.** After creating a PR, subscribe to its activity (via `subscribe_pr_activity`) so CI failures, review comments, and review submissions wake the session. Do not ask the user whether to subscribe — subscribe by default and mention it in the turn that opens the PR.
+- **Respond to PR review comments automatically.** When a `<github-webhook-activity>` event arrives for a tracked PR, investigate it and act per the harness rules: push a fix if the change is clear and in-scope, ask via `AskUserQuestion` if ambiguous, or skip silently if no action is warranted. For CI failures on tracked PRs, re-diagnose and push fixes until green or until you're genuinely stuck — don't go quiet mid-loop.
+- **Stop tracking when asked.** If the user says to stop watching/babysitting/auto-fixing a PR, call `unsubscribe_pr_activity` for it and don't push further changes to that branch.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -117,6 +117,20 @@ The seams are deliberately split per concern; a new feature usually maps to exte
 - **Before adding commits to an existing PR branch, check whether the PR has already landed.** Fetch `origin` and inspect the PR state or compare `origin/main` first. If the PR is merged, start a fresh branch from `origin/main` for follow-up work instead of stacking new commits onto the merged branch.
 - **Run the formatter before committing.** CI's `format` job runs `./gradlew ktfmtCheckAll` and it's a hard gate — `ktfmtCheck` aborts on the first unformatted file. Before each commit that touches `*.kt`/`*.kts`, run `./gradlew ktfmtFormat` (or `./gradlew :<module>:ktfmtFormatMain :<module>:ktfmtFormatTest` for the touched modules) and stage the result. For VS Code extension TypeScript changes, run `npm --prefix vscode-extension run format`. Don't push without re-running these — the fix-up round-trip costs more than running the formatter locally.
 
+## PR workflow
+
+These rules also live in [CLAUDE.md](../CLAUDE.md#pr-workflow-must-follow); detail and rationale below.
+
+- **Open PRs automatically.** When a coding task is finished, committed, and pushed, open a PR against `main` without prompting. Conventional-commit title, short summary, test-plan checklist — same shape as the `gh pr create` heredoc template the harness ships with. Skip this only when the user explicitly said "no PR" or framed the task as pure exploration. Always check first whether the branch already has an open PR (`list_pull_requests` or `search_pull_requests` filtered by head); if so, push to it instead of opening a duplicate.
+- **Subscribe to every PR you open.** Call `subscribe_pr_activity` for the PR's number on the same turn you open it. Don't ask the user whether to track — tracking is the default. Mention it in the reply so the user knows the session is now listening (e.g. "Opened PR #N and subscribed to its activity").
+- **Respond to PR review comments and CI events automatically.** `<github-webhook-activity>` events on tracked PRs are not no-ops. For each event:
+  - If the requested change is clear, in-scope, and not architecturally significant — push the fix, update the status checklist on the PR, and don't narrate each round in chat.
+  - If the comment is ambiguous or touches something significant — use `AskUserQuestion` with enough context that the user can answer without scrolling back.
+  - For CI failures on a PR the user asked you to babysit — re-diagnose and re-kick (rebase, re-run, push fix) until green. After several rounds with no progress, reply with the diagnosis and where you're stuck instead of going silent.
+  - When everything is green, reply with the green status. That IS the deliverable.
+- **Stop on request.** "Stop watching", "unsubscribe", "leave it alone" — call `unsubscribe_pr_activity` for that PR and stop pushing.
+- **Don't auto-merge.** Opening, tracking, and fix-up commits are automatic; merging is the user's call. Don't enable auto-merge unless the user explicitly asks.
+
 ## VS Code panel UI changes
 
 Edits under `vscode-extension/src/webview/` or `vscode-extension/media/preview*.css` need a visual record. Capture a baseline + post-change PNG via the preview-harness and send both to the user before reporting the task done — the harness boots the real `<preview-app>` bundle headlessly against fixture JSON and is the panel's equivalent of a Compose `@Preview`. Loop and fixture authoring are documented in [`vscode-extension/preview-harness/README.md`](../vscode-extension/preview-harness/README.md#agent-workflow); seed fixtures are `grid-default` (multi-card grid) and `a11y-findings` (focus mode + Accessibility bundle). Use it for shape, layout, and theming — not as a substitute for `npm test` / `test:electron`, which still own behavioural correctness.


### PR DESCRIPTION
## Summary

Adds comprehensive PR workflow documentation for agent-driven development, establishing clear rules for automatic PR creation, tracking, and response to review feedback and CI events.

## Changes

- **CLAUDE.md**: Added "PR workflow (must follow)" section with four core rules:
  - Automatically open PRs when coding tasks are complete
  - Subscribe to PR activity by default without user prompting
  - Respond to review comments and CI failures automatically per harness rules
  - Stop tracking when explicitly requested by the user

- **docs/AGENTS.md**: Added "PR workflow" section with detailed rationale and implementation guidance:
  - Expanded rules from CLAUDE.md with specific examples and decision trees
  - Clarified when to push fixes vs. ask for clarification on review comments
  - Documented CI failure handling (re-diagnose and re-kick until green or stuck)
  - Emphasized that merging remains a user decision (no auto-merge)
  - Cross-referenced CLAUDE.md for the normative rules

## Implementation Details

The workflow establishes a clear contract: agents handle the mechanical aspects of PR lifecycle (creation, tracking, fix-up commits) while users retain control over merge decisions. The distinction between "clear and in-scope" changes (auto-fix) and "ambiguous or significant" changes (ask user) prevents over-automation while keeping the feedback loop tight.

https://claude.ai/code/session_01KQ8K7VugUuzAF9hwF7CDX4