### PR TITLE
feat(daemon): produce @ScrollingPreview artefacts via data/fetch

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -130,6 +130,13 @@ dependencies {
   // `PseudolocalePreviewOverrideExtension` planner mapped to `localeTag` in {en-XA, ar-XB}. No
   // build-time `pseudoLocalesEnabled` / `resConfigs` requirement on the consumer.
   implementation(project(":data-pseudolocale-connector"))
+  // Scroll data-product connector — advertises render/scroll/long and render/scroll/gif as
+  // requiresRerender=true kinds. RenderEngine.kt branches into the renderer's scroll scenario
+  // handlers (handleLongCapture / handleGifCapture) when `RenderSpec.renderMode` is
+  // `"scroll-long"` / `"scroll-gif"`. Writes to the same on-disk paths Gradle's
+  // `composePreviewRenderAll` writes, so the host's `gradleService.readPreviewImage` reads the
+  // same file either way. See issue #1528.
+  implementation(project(":data-scroll-connector"))
   // UIAutomator-shaped Selector + UiObject — RobolectricHost.performUiAutomatorAction decodes
   // selector JSON via decodeSelectorJson and walks the SemanticsNode tree via
   // UiAutomator.findObject(rule, selector, useUnmergedTree).

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -529,6 +529,27 @@ fun main(args: Array<String>) {
                 ),
             )
           }
+          // Issue #1528 — daemon-side scroll artefact production. The registry advertises
+          // `render/scroll/long` and `render/scroll/gif` as `requiresRerender = true`, so a
+          // missing scroll artefact returns `Outcome.RequiresRerender("scroll-long"|"scroll-gif")`
+          // and the dispatcher queues a per-preview re-render in the right scenario instead of
+          // the host falling back to a module-wide Gradle `composePreviewRenderAll`. Writes to
+          // the same `<modulePreviewsDir>/data/render-scroll-{long,gif}/<id>.{png,gif}` paths
+          // Gradle does, so the host's `gradleService.readPreviewImage` reads the same file
+          // either way. Descriptors are also advertised here so MCP /
+          // `previewExtensions/list` clients see the scroll extension surface.
+          tryAdd("scroll") {
+            Extension(
+              id = "scroll",
+              displayName = "Scrolling preview artifacts",
+              dataProductRegistry = ScrollDataProductRegistry(rootDir = dataRoot),
+              previewExtensionDescriptors =
+                listOf(
+                  ee.schimke.composeai.scroll.ScrollPreviewExtension.longScrollDescriptor,
+                  ee.schimke.composeai.scroll.ScrollPreviewExtension.gifScrollDescriptor,
+                ),
+            )
+          }
           // UIAutomator-shaped script events (`uia.click`, `uia.inputText`, etc.) plus the
           // `uia/hierarchy` data product (#874). Always wired on the Android backend — the
           // dispatch path lives in RobolectricHost and the hierarchy producer ride along on

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -179,6 +179,24 @@ class RenderEngine(
      */
     runAccessibility: Boolean? = null,
   ): RenderResult {
+    // Issue #1528 Stage 1 — the scroll registry advertises `render/scroll/long` /
+    // `render/scroll/gif` as `requiresRerender = true` so `data/fetch` queues a re-render in
+    // `scroll-long` / `scroll-gif` mode, but the renderer-side scroll-scenario dispatch
+    // (`handleLongCapture` / `handleGifCapture` over in `:renderer-android`) isn't wired into
+    // this engine yet. Decline the render before any Compose work so:
+    //   (a) the baseline END-capture PNG at `<outputDir>/<outputBaseName>.png` is not
+    //       overwritten by an unrelated render that the dispatcher will discard anyway, and
+    //   (b) `JsonRpcServer.handleDataFetchWithRerender` sees `RerenderOutcome.Failed(...)` and
+    //       emits `ERR_DATA_PRODUCT_FETCH_FAILED` with a useful message instead of looping back
+    //       through `RequiresRerender` a second time.
+    // The Stage 2 follow-up replaces this guard with the actual scroll-scenario dispatch.
+    if (spec.renderMode == SCROLL_LONG_RENDER_MODE || spec.renderMode == SCROLL_GIF_RENDER_MODE) {
+      throw IllegalStateException(
+        "scroll render mode '${spec.renderMode}' is advertised by the daemon's scroll registry " +
+          "but the renderer-side scenario dispatch is not yet wired (issue #1528, Stage 2). " +
+          "Host should fall back to the Gradle `composePreviewRenderAll` path for now."
+      )
+    }
     val effectiveRunAccessibility =
       runAccessibility ?: (spec.renderMode == A11Y_RENDER_MODE)
     // Roborazzi defaults to "compare" mode — `captureRoboImage` reads the existing baseline at
@@ -826,6 +844,24 @@ class RenderEngine(
      * `LocalInspectionMode = false` and writes ATF + hierarchy artefacts to `dataDir`.
      */
     const val A11Y_RENDER_MODE: String = "a11y"
+
+    /**
+     * Issue #1528 — scroll scenarios the daemon's `data/fetch` re-render path can request. The
+     * registry in `:data-scroll-connector` advertises `render/scroll/long` / `render/scroll/gif`
+     * as `requiresRerender = true`, so a missing scroll artefact returns
+     * `Outcome.RequiresRerender("scroll-long" | "scroll-gif")` and the dispatcher submits a render
+     * with `spec.renderMode` set to one of these constants.
+     *
+     * **Stage 2 follow-up.** The actual scroll-scenario dispatch (calling
+     * `handleLongCapture` / `handleGifCapture` from the renderer) lands in a follow-up — this
+     * constant pair is here so the early-return guard below has a single named place to live.
+     * Until the wiring is complete the engine declines scroll renders with a structured failure
+     * sidecar so the dispatcher emits `ERR_DATA_PRODUCT_FETCH_FAILED` cleanly instead of running
+     * a normal render whose PNG would overwrite the baseline.
+     */
+    const val SCROLL_LONG_RENDER_MODE: String = "scroll-long"
+
+    const val SCROLL_GIF_RENDER_MODE: String = "scroll-gif"
 
     /**
      * `RenderSpec.kind` value flagging a tile preview (non-composable function returning

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -179,23 +179,19 @@ class RenderEngine(
      */
     runAccessibility: Boolean? = null,
   ): RenderResult {
-    // Issue #1528 Stage 1 — the scroll registry advertises `render/scroll/long` /
-    // `render/scroll/gif` as `requiresRerender = true` so `data/fetch` queues a re-render in
-    // `scroll-long` / `scroll-gif` mode, but the renderer-side scroll-scenario dispatch
-    // (`handleLongCapture` / `handleGifCapture` over in `:renderer-android`) isn't wired into
-    // this engine yet. Decline the render before any Compose work so:
-    //   (a) the baseline END-capture PNG at `<outputDir>/<outputBaseName>.png` is not
-    //       overwritten by an unrelated render that the dispatcher will discard anyway, and
-    //   (b) `JsonRpcServer.handleDataFetchWithRerender` sees `RerenderOutcome.Failed(...)` and
-    //       emits `ERR_DATA_PRODUCT_FETCH_FAILED` with a useful message instead of looping back
-    //       through `RequiresRerender` a second time.
-    // The Stage 2 follow-up replaces this guard with the actual scroll-scenario dispatch.
+    // Issue #1528 — scroll-scenario dispatch. When the dispatcher's `data/fetch` re-render path
+    // queues `mode=scroll-long` / `scroll-gif`, route into the renderer's scroll handlers
+    // (`renderer.handleLongCapture` / `renderer.handleGifCapture`) instead of the default
+    // single-frame Compose path. The handlers write to the on-disk path the scroll registry
+    // (`ScrollDataProductRegistry.fileFor`) reads back, so the second registry fetch sees the
+    // file and emits `Ok(path)`. Looks up `ScrollCaptureDto` via the daemon's PreviewIndex
+    // (`scrollCaptureFor`) — the previews.json path is loaded lazily via
+    // `PreviewIndex.loadFromFile` against the `composeai.daemon.previewsJsonPath` system property
+    // so the engine doesn't need a constructor-time previewIndex injection. The DTO carries
+    // `axis` / `maxScrollPx` / `frameIntervalMs` straight from the annotation through the
+    // gradle plugin's `dataProducts[].scroll` field.
     if (spec.renderMode == SCROLL_LONG_RENDER_MODE || spec.renderMode == SCROLL_GIF_RENDER_MODE) {
-      throw IllegalStateException(
-        "scroll render mode '${spec.renderMode}' is advertised by the daemon's scroll registry " +
-          "but the renderer-side scenario dispatch is not yet wired (issue #1528, Stage 2). " +
-          "Host should fall back to the Gradle `composePreviewRenderAll` path for now."
-      )
+      return runScrollScenario(spec = spec, requestId = requestId, classLoader = classLoader)
     }
     val effectiveRunAccessibility =
       runAccessibility ?: (spec.renderMode == A11Y_RENDER_MODE)
@@ -753,6 +749,179 @@ class RenderEngine(
     )
   }
 
+  /**
+   * Issue #1528 — dispatch for `scroll-long` / `scroll-gif` render modes. Builds the held
+   * `AndroidComposeTestRule`, paints the preview's `@Composable` body via
+   * [setHeldComposableContentForScroll], then calls the renderer's public scroll handlers to
+   * write the final stitched PNG / animated GIF under `<dataRoot>/render-scroll-{long,gif}/`.
+   *
+   * Returns a [RenderResult] with `pngPath` pointing at the produced scroll artefact so the
+   * dispatcher's second-fetch picks up the file. Throws [IllegalStateException] when the preview
+   * has no `dataProducts[].scroll` metadata (the dispatcher surfaces this as
+   * `ERR_DATA_PRODUCT_FETCH_FAILED` with the message body), or when the renderer's scroll handler
+   * returns `false` (no scrollable on the requested axis — the dispatcher surfaces the same
+   * error code so the host can fall back to its Gradle path or paint a "no scrollable" hint).
+   *
+   * Looks up the scroll intent by lazily loading the daemon's `previews.json`
+   * ([PreviewIndex.PREVIEWS_JSON_PATH_PROP]) per render. The cost is one ~kB file read per
+   * `data/fetch` re-render, which is dwarfed by the render itself.
+   */
+  @OptIn(ExperimentalRoborazziApi::class)
+  private fun runScrollScenario(
+    spec: RenderSpec,
+    requestId: Long,
+    classLoader: ClassLoader,
+  ): RenderResult {
+    val previewId =
+      spec.previewId
+        ?: error(
+          "RenderEngine: scroll mode '${spec.renderMode}' requires a previewId on the RenderSpec " +
+            "so the scroll metadata can be resolved from the previews.json index"
+        )
+    val previewIndex = loadPreviewIndexLazily()
+    val scroll =
+      previewIndex.scrollCaptureFor(previewId, spec.renderMode!!)
+        ?: error(
+          "RenderEngine: scroll mode '${spec.renderMode}' requested for previewId '$previewId' " +
+            "but the preview has no matching dataProducts[].scroll entry in previews.json — " +
+            "the host should fall back to the Gradle composePreviewRenderAll path"
+        )
+    val scenarioDataDir =
+      dataDir
+        ?: error(
+          "RenderEngine: scroll mode '${spec.renderMode}' needs a non-null dataDir to write " +
+            "<dataDir>/render-scroll-{long,gif}/<previewId>.{png,gif}"
+        )
+    val (subdir, ext) =
+      when (spec.renderMode) {
+        SCROLL_LONG_RENDER_MODE -> "render-scroll-long" to "png"
+        SCROLL_GIF_RENDER_MODE -> "render-scroll-gif" to "gif"
+        else -> error("RenderEngine: unreachable scroll mode '${spec.renderMode}'")
+      }
+    val outputFile = scenarioDataDir.resolve(subdir).resolve("$previewId.$ext")
+    outputFile.parentFile?.mkdirs()
+
+    val isRound = isRoundDevice(spec.device)
+    applyPreviewQualifiers(
+      widthDp = pxToDp(spec.widthPx, spec.density),
+      heightDp = pxToDp(spec.heightPx, spec.density),
+      density = spec.density,
+      isRound = isRound,
+      localeTag = spec.localeTag,
+      uiMode = spec.uiMode,
+      orientation = spec.orientation,
+    )
+    org.robolectric.RuntimeEnvironment.setFontScale(spec.fontScale ?: 1.0f)
+
+    val appContext: android.app.Application =
+      androidx.test.core.app.ApplicationProvider.getApplicationContext()
+    org.robolectric.Shadows.shadowOf(appContext.packageManager)
+      .addActivityIfNotPresent(
+        android.content.ComponentName(appContext.packageName, ComponentActivity::class.java.name)
+      )
+
+    @Suppress("DEPRECATION") val rule = createAndroidComposeRule<ComponentActivity>()
+    val description =
+      org.junit.runner.Description.createTestDescription(
+        RenderEngine::class.java,
+        "scroll_${spec.outputBaseName}",
+      )
+    val startNs = System.nanoTime()
+    var handled = false
+    val statement =
+      object : org.junit.runners.model.Statement() {
+        override fun evaluate() {
+          rule.mainClock.autoAdvance = false
+          val clazz = Class.forName(spec.className, true, classLoader)
+          val composableMethod = clazz.getDeclaredComposableMethod(spec.functionName)
+          val bgArgb = resolveBackgroundColor(spec).toArgb()
+          val heightDp = pxToDp(spec.heightPx, spec.density)
+          rule.setContent {
+            CompositionLocalProvider(LocalInspectionMode provides false) {
+              Box(modifier = Modifier.fillMaxSize().background(Color(bgArgb))) {
+                InvokeComposable(composableMethod)
+              }
+            }
+          }
+          rule.mainClock.advanceTimeBy(spec.captureAdvanceMs ?: CAPTURE_ADVANCE_MS)
+          handled =
+            when (spec.renderMode) {
+              SCROLL_LONG_RENDER_MODE ->
+                ee.schimke.composeai.renderer.handleLongCapture(
+                  rule = rule,
+                  scroll = scroll.toRendererScrollCapture(),
+                  previewId = previewId,
+                  heightDp = heightDp,
+                  isRound = isRound,
+                  outputFile = outputFile,
+                )
+              SCROLL_GIF_RENDER_MODE ->
+                ee.schimke.composeai.renderer.handleGifCapture(
+                  rule = rule,
+                  scroll = scroll.toRendererScrollCapture(),
+                  previewId = previewId,
+                  heightDp = heightDp,
+                  isRound = isRound,
+                  outputFile = outputFile,
+                )
+              else -> false
+            }
+        }
+      }
+    rule.apply(statement, description).evaluate()
+
+    if (!handled) {
+      error(
+        "RenderEngine: scroll mode '${spec.renderMode}' returned false (no scrollable on " +
+          "scroll.axis=${scroll.axis} for previewId '$previewId')"
+      )
+    }
+    val tookMs = (System.nanoTime() - startNs) / 1_000_000L
+    return RenderResult(
+      id = requestId,
+      classLoaderHashCode = System.identityHashCode(classLoader),
+      classLoaderName = classLoader.javaClass.name,
+      pngPath = outputFile.absolutePath,
+      metrics = mapOf("tookMs" to tookMs),
+    )
+  }
+
+  /**
+   * Lazily reads the daemon's `previews.json` via [PreviewIndex.loadFromFile] using the
+   * `composeai.daemon.previewsJsonPath` system property the gradle plugin populates. Falls back to
+   * [PreviewIndex.empty] when the property is unset (harness / fake-mode tests) — callers that
+   * need a real index check for an empty result and emit a structured error.
+   */
+  private fun loadPreviewIndexLazily(): PreviewIndex {
+    val path = System.getProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP)
+    return if (path.isNullOrBlank()) {
+      PreviewIndex.empty()
+    } else {
+      PreviewIndex.loadFromFile(java.nio.file.Paths.get(path))
+    }
+  }
+
+  private fun ScrollCaptureDto.toRendererScrollCapture():
+    ee.schimke.composeai.renderer.ScrollCapture =
+    ee.schimke.composeai.renderer.ScrollCapture(
+      mode =
+        when (mode.uppercase()) {
+          "LONG" -> ee.schimke.composeai.renderer.ScrollMode.LONG
+          "GIF" -> ee.schimke.composeai.renderer.ScrollMode.GIF
+          "END" -> ee.schimke.composeai.renderer.ScrollMode.END
+          "TOP" -> ee.schimke.composeai.renderer.ScrollMode.TOP
+          else -> error("ScrollCaptureDto: unknown mode '$mode'")
+        },
+      axis =
+        when (axis.uppercase()) {
+          "HORIZONTAL" -> ee.schimke.composeai.renderer.ScrollAxis.HORIZONTAL
+          else -> ee.schimke.composeai.renderer.ScrollAxis.VERTICAL
+        },
+      maxScrollPx = maxScrollPx,
+      reduceMotion = reduceMotion,
+      frameIntervalMs = frameIntervalMs,
+    )
+
   private fun resolveBackgroundColor(spec: RenderSpec): Color =
     when {
       spec.backgroundColor != 0L -> Color(spec.backgroundColor.toInt())
@@ -850,14 +1019,9 @@ class RenderEngine(
      * registry in `:data-scroll-connector` advertises `render/scroll/long` / `render/scroll/gif`
      * as `requiresRerender = true`, so a missing scroll artefact returns
      * `Outcome.RequiresRerender("scroll-long" | "scroll-gif")` and the dispatcher submits a render
-     * with `spec.renderMode` set to one of these constants.
-     *
-     * **Stage 2 follow-up.** The actual scroll-scenario dispatch (calling
-     * `handleLongCapture` / `handleGifCapture` from the renderer) lands in a follow-up — this
-     * constant pair is here so the early-return guard below has a single named place to live.
-     * Until the wiring is complete the engine declines scroll renders with a structured failure
-     * sidecar so the dispatcher emits `ERR_DATA_PRODUCT_FETCH_FAILED` cleanly instead of running
-     * a normal render whose PNG would overwrite the baseline.
+     * with `spec.renderMode` set to one of these constants. [render] routes scroll-mode requests
+     * into [runScrollScenario], which delegates to the renderer's public
+     * [ee.schimke.composeai.renderer.handleLongCapture] / [handleGifCapture] entry points.
      */
     const val SCROLL_LONG_RENDER_MODE: String = "scroll-long"
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -72,6 +72,64 @@ data class PreviewInfoDto(
    * incremental rescan.
    */
   val params: PreviewParamsDto? = null,
+  /**
+   * Annotation-sourced data products this preview exposes (e.g. `render/scroll/long` from
+   * `@ScrollingPreview(modes = [LONG])`). Optional — fixtures predating issue #1528 omit the field
+   * entirely, and the daemon only reads the subset it needs (currently the `scroll` sub-shape, used
+   * by the daemon's scroll-scenario dispatch to look up axis / maxScrollPx / frameIntervalMs for a
+   * given `(previewId, render/scroll/long|gif)` pair).
+   */
+  val dataProducts: List<PreviewDataProductDto> = emptyList(),
+)
+
+/**
+ * Daemon-side mirror of the gradle plugin's `PreviewDataProduct`
+ * (`:gradle-plugin:preview-discovery`'s `PreviewData.kt`). Only carries the fields the daemon needs
+ * — `kind` so the daemon can match `render/scroll/long` / `render/scroll/gif`, and `scroll` so the
+ * renderer can replay the annotation's axis / maxScrollPx / frameIntervalMs intent. Other
+ * plugin-side fields (`extensionId`, `usageMode`, `displayName`, `output`, `cost`, …) are
+ * deliberately ignored on parse — the daemon routes the on-disk path via
+ * [ScrollDataProductRegistry.fileFor] off the kind alone, so the plugin-supplied `output` would be
+ * redundant and brittle (path layout changes would have to land in both places). [Json] is
+ * configured with `ignoreUnknownKeys = true` so adding plugin-side fields doesn't require a
+ * daemon-side change.
+ */
+@Serializable
+data class PreviewDataProductDto(val kind: String, val scroll: ScrollCaptureDto? = null)
+
+/**
+ * Daemon-side mirror of the gradle plugin's `ScrollCapture`. Carries only the intent fields the
+ * renderer needs to drive the scrolling — outcome fields (`atEnd`, `reachedPx`) the plugin records
+ * post-render are skipped because the daemon writes its own fresh artefact rather than reading the
+ * plugin's recorded state.
+ */
+@Serializable
+data class ScrollCaptureDto(
+  /**
+   * Mirrors the gradle plugin's `ScrollMode` (`END` / `LONG` / `GIF`). String-typed so the daemon
+   * doesn't depend on the plugin's enum.
+   */
+  val mode: String,
+  /**
+   * Mirrors `ScrollAxis` (`VERTICAL` / `HORIZONTAL`). String-typed for the same reason as [mode].
+   * Defaults to `VERTICAL` matching the annotation default.
+   */
+  val axis: String = "VERTICAL",
+  /**
+   * Annotation-set cap (`@ScrollingPreview(maxScrollPx = N)`). `0` means "no cap — exhaust the
+   * scrollable".
+   */
+  val maxScrollPx: Int = 0,
+  /**
+   * `@ScrollingPreview(reduceMotion = …)`. Carried for wire parity; the renderer reads it via the
+   * same field after population from this DTO.
+   */
+  val reduceMotion: Boolean = true,
+  /**
+   * `@ScrollingPreview(frameIntervalMs = N)` for `GIF` mode. `0` means "renderer default
+   * (`ScrollGifEncoder.DEFAULT_FRAME_DELAY_MS`)".
+   */
+  val frameIntervalMs: Int = 0,
 )
 
 /**
@@ -225,6 +283,25 @@ internal constructor(
 
   /** Lookup by `PreviewInfo.id`. `null` if the id is unknown. */
   fun byId(id: String): PreviewInfoDto? = lock.read { byId[id] }
+
+  /**
+   * Issue #1528 — resolves the [ScrollCaptureDto] for a given `(previewId, renderMode)` pair so the
+   * daemon's `RenderEngine` can drive the scrolling scenario the plugin annotated. `mode` is the
+   * daemon's render-mode tag (`scroll-long` / `scroll-gif`) — the matching kind is
+   * `render/scroll/long` / `render/scroll/gif`. Returns `null` when no preview matches or the
+   * preview has no `dataProducts` entry of that kind (typical for previews without
+   * `@ScrollingPreview`).
+   */
+  fun scrollCaptureFor(previewId: String, mode: String): ScrollCaptureDto? {
+    val kind =
+      when (mode) {
+        "scroll-long" -> "render/scroll/long"
+        "scroll-gif" -> "render/scroll/gif"
+        else -> return null
+      }
+    val info = byId(previewId) ?: return null
+    return info.dataProducts.firstOrNull { it.kind == kind }?.scroll
+  }
 
   /** All known preview ids. Phase 2 will diff a fresh scan against this set. */
   fun ids(): Set<String> = lock.read { byId.keys.toSet() }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexTest.kt
@@ -242,4 +242,111 @@ class PreviewIndexTest {
     assertTrue(empty.ids().isEmpty())
     assertNull(empty.byId("anything"))
   }
+
+  @Test
+  fun `scrollCaptureFor resolves dataProducts scroll metadata per (previewId mode) pair`() {
+    val tmp = Files.createTempFile("previews-scroll", ".json")
+    Files.writeString(
+      tmp,
+      """
+      {
+        "previews": [
+          {
+            "id": "ScrollPreview_1",
+            "className": "com.example.ScrollPreviewsKt",
+            "functionName": "MyScrollPreview",
+            "dataProducts": [
+              {
+                "kind": "render/scroll/long",
+                "scroll": {
+                  "mode": "LONG",
+                  "axis": "VERTICAL",
+                  "maxScrollPx": 4000,
+                  "frameIntervalMs": 0
+                }
+              },
+              {
+                "kind": "render/scroll/gif",
+                "scroll": {
+                  "mode": "GIF",
+                  "axis": "VERTICAL",
+                  "maxScrollPx": 0,
+                  "frameIntervalMs": 33
+                }
+              }
+            ]
+          },
+          {
+            "id": "NoScrollPreview_1",
+            "className": "com.example.PreviewsKt",
+            "functionName": "Other"
+          }
+        ]
+      }
+      """
+        .trimIndent(),
+    )
+    try {
+      val index = PreviewIndex.loadFromFile(tmp)
+      val longScroll = index.scrollCaptureFor("ScrollPreview_1", "scroll-long")
+      assertNotNull(
+        "scroll-long should resolve when render/scroll/long is in dataProducts",
+        longScroll,
+      )
+      assertEquals("LONG", longScroll!!.mode)
+      assertEquals(4000, longScroll.maxScrollPx)
+
+      val gifScroll = index.scrollCaptureFor("ScrollPreview_1", "scroll-gif")
+      assertNotNull(gifScroll)
+      assertEquals(33, gifScroll!!.frameIntervalMs)
+
+      // Unknown mode → null (the kind isn't reachable from the mode tag).
+      assertNull(index.scrollCaptureFor("ScrollPreview_1", "a11y"))
+      // Preview that doesn't carry the kind → null.
+      assertNull(index.scrollCaptureFor("NoScrollPreview_1", "scroll-long"))
+      // Unknown previewId → null.
+      assertNull(index.scrollCaptureFor("DoesNotExist", "scroll-long"))
+    } finally {
+      Files.deleteIfExists(tmp)
+    }
+  }
+
+  @Test
+  fun `loadFromFile ignores unknown dataProducts fields so plugin-side schema additions don't break`() {
+    val tmp = Files.createTempFile("previews-scroll-extra", ".json")
+    Files.writeString(
+      tmp,
+      """
+      {
+        "previews": [
+          {
+            "id": "P_1",
+            "className": "com.example.PreviewsKt",
+            "functionName": "P",
+            "dataProducts": [
+              {
+                "kind": "render/scroll/long",
+                "extensionId": "scroll-long",
+                "displayName": "Long scroll",
+                "output": "data/render-scroll-long/P_1.png",
+                "cost": 7.5,
+                "scroll": { "mode": "LONG" }
+              }
+            ]
+          }
+        ]
+      }
+      """
+        .trimIndent(),
+    )
+    try {
+      val index = PreviewIndex.loadFromFile(tmp)
+      val scroll = index.scrollCaptureFor("P_1", "scroll-long")
+      assertNotNull(scroll)
+      assertEquals("LONG", scroll!!.mode)
+      // Plugin-side fields are silently dropped — no parse exception.
+    } finally {
+      Files.deleteIfExists(tmp)
+    }
+  }
 }

--- a/data/scroll/connector/build.gradle.kts
+++ b/data/scroll/connector/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  api(project(":data-scroll-core"))
+  api(project(":daemon:core"))
+  testImplementation(libs.junit)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-scroll-connector",
+    displayName = "Compose Preview - Scroll Data Product Connector",
+    description =
+      "Daemon-side scroll data-product connector: advertises render/scroll/long and " +
+        "render/scroll/gif kinds as requiresRerender=true producers so a missing scroll " +
+        "artefact triggers a per-preview re-render via data/fetch instead of a module-wide " +
+        "Gradle round-trip.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/scroll/connector/src/main/kotlin/ee/schimke/composeai/daemon/ScrollDataProductRegistry.kt
+++ b/data/scroll/connector/src/main/kotlin/ee/schimke/composeai/daemon/ScrollDataProductRegistry.kt
@@ -1,0 +1,97 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductFacet
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
+import ee.schimke.composeai.scroll.ScrollPreviewExtension
+import java.io.File
+
+/**
+ * Daemon-side registry that advertises `render/scroll/long` and `render/scroll/gif` so a missing
+ * scroll artefact triggers a per-preview re-render via `data/fetch` instead of the module-wide
+ * `composePreviewRenderAll` round-trip the host used to fall back to (see issue #1528).
+ *
+ * **On-disk layout** matches what the gradle plugin's discovery writes (and what
+ * `gradleService.readPreviewImage` reads on the host):
+ * - `<modulePreviewsDir>/data/render-scroll-long/<previewId>.png`
+ * - `<modulePreviewsDir>/data/render-scroll-gif/<previewId>.gif`
+ *
+ * The Gradle path is intentionally unchanged — the daemon writes to the same files Gradle would, so
+ * the host's existing PNG/GIF read path keeps working on either producer.
+ *
+ * **Re-render contract** mirrors [AccessibilityDataProductRegistry]: both kinds are
+ * `requiresRerender = true`, and a missing artefact returns
+ * [DataProductRegistry.Outcome.RequiresRerender] with the matching `scroll-long` / `scroll-gif`
+ * render mode so the dispatcher queues a per-preview re-render in the right scenario. Binary
+ * artefacts (PNG / animated GIF) — never parse the file as JSON, so [allowInlineUpgrade] is
+ * overridden to `false`.
+ *
+ * **Why per-kind subdirectories, not per-preview.** Unlike most file-backed registries (which use
+ * the [FileBackedDataProductRegistry] default `<rootDir>/<previewId>/<file>` layout), scroll's
+ * on-disk shape is per-kind (`render-scroll-long/<id>.png`). The [fileFor] override below pins that
+ * layout so `gradleService.readPreviewImage` and `data/fetch` resolve to the exact same file.
+ */
+class ScrollDataProductRegistry(private val rootDir: File) :
+  FileBackedDataProductRegistry(
+    capabilities =
+      listOf(
+        DataProductCapability(
+          kind = ScrollPreviewExtension.KIND_LONG,
+          schemaVersion = 1,
+          transport = DataProductTransport.PATH,
+          attachable = true,
+          fetchable = true,
+          requiresRerender = true,
+          displayName = "Long scroll capture",
+          facets = listOf(DataProductFacet.ARTIFACT, DataProductFacet.IMAGE),
+          mediaTypes = listOf("image/png"),
+          sampling = SamplingPolicy.End,
+        ),
+        DataProductCapability(
+          kind = ScrollPreviewExtension.KIND_GIF,
+          schemaVersion = 1,
+          transport = DataProductTransport.PATH,
+          attachable = true,
+          fetchable = true,
+          requiresRerender = true,
+          displayName = "Scroll GIF capture",
+          facets = listOf(DataProductFacet.ARTIFACT, DataProductFacet.ANIMATION),
+          mediaTypes = listOf("image/gif"),
+          sampling = SamplingPolicy.End,
+        ),
+      )
+  ) {
+
+  override fun fileFor(previewId: String, kind: String): File? {
+    val (subdir, ext) =
+      when (kind) {
+        ScrollPreviewExtension.KIND_LONG -> SCROLL_LONG_SUBDIR to "png"
+        ScrollPreviewExtension.KIND_GIF -> SCROLL_GIF_SUBDIR to "gif"
+        else -> return null
+      }
+    return rootDir.resolve(subdir).resolve("$previewId.$ext")
+  }
+
+  override fun missingOutcome(previewId: String, kind: String): DataProductRegistry.Outcome =
+    when (kind) {
+      ScrollPreviewExtension.KIND_LONG ->
+        DataProductRegistry.Outcome.RequiresRerender("scroll-long")
+      ScrollPreviewExtension.KIND_GIF -> DataProductRegistry.Outcome.RequiresRerender("scroll-gif")
+      else -> DataProductRegistry.Outcome.Unknown
+    }
+
+  override fun renderModeFor(kind: String): String? =
+    when (kind) {
+      ScrollPreviewExtension.KIND_LONG -> "scroll-long"
+      ScrollPreviewExtension.KIND_GIF -> "scroll-gif"
+      else -> null
+    }
+
+  override fun allowInlineUpgrade(kind: String): Boolean = false
+
+  companion object {
+    const val SCROLL_LONG_SUBDIR: String = "render-scroll-long"
+    const val SCROLL_GIF_SUBDIR: String = "render-scroll-gif"
+  }
+}

--- a/data/scroll/connector/src/main/kotlin/ee/schimke/composeai/daemon/ScrollDataProductRegistry.kt
+++ b/data/scroll/connector/src/main/kotlin/ee/schimke/composeai/daemon/ScrollDataProductRegistry.kt
@@ -23,9 +23,13 @@ import java.io.File
  * **Re-render contract** mirrors [AccessibilityDataProductRegistry]: both kinds are
  * `requiresRerender = true`, and a missing artefact returns
  * [DataProductRegistry.Outcome.RequiresRerender] with the matching `scroll-long` / `scroll-gif`
- * render mode so the dispatcher queues a per-preview re-render in the right scenario. Binary
- * artefacts (PNG / animated GIF) — never parse the file as JSON, so [allowInlineUpgrade] is
- * overridden to `false`.
+ * render mode so the dispatcher queues a per-preview re-render in the right scenario.
+ * `RenderEngine.runScrollScenario` on the daemon-android side picks up the mode, resolves the
+ * annotation intent (axis, maxScrollPx, frameIntervalMs) via `PreviewIndex.scrollCaptureFor`
+ * (populated from the gradle plugin's `dataProducts[].scroll` field in `previews.json`), and
+ * dispatches into the renderer's `handleLongCapture` / `handleGifCapture` to write the artefact at
+ * the path [fileFor] resolves to. Binary artefacts (PNG / animated GIF) — never parse the file as
+ * JSON, so [allowInlineUpgrade] is overridden to `false`.
  *
  * **Why per-kind subdirectories, not per-preview.** Unlike most file-backed registries (which use
  * the [FileBackedDataProductRegistry] default `<rootDir>/<previewId>/<file>` layout), scroll's

--- a/data/scroll/connector/src/test/kotlin/ee/schimke/composeai/daemon/ScrollDataProductRegistryTest.kt
+++ b/data/scroll/connector/src/test/kotlin/ee/schimke/composeai/daemon/ScrollDataProductRegistryTest.kt
@@ -1,0 +1,175 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.scroll.ScrollPreviewExtension
+import java.io.File
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins the daemon's `render/scroll/long` / `render/scroll/gif` registry contract: both kinds are
+ * `requiresRerender = true`, missing files surface as
+ * [DataProductRegistry.Outcome.RequiresRerender] with the matching `scroll-long` / `scroll-gif`
+ * mode, and on-disk artefacts live at `<rootDir>/render-scroll-{long,gif}/<previewId>.{png,gif}` —
+ * the same paths the gradle plugin's `composePreviewRenderAll` writes, so the host's
+ * `gradleService.readPreviewImage` reads the same files either way.
+ */
+class ScrollDataProductRegistryTest {
+
+  private lateinit var rootDir: File
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("scroll-data-product-test").toFile()
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+  }
+
+  @Test
+  fun `capabilities advertise scroll long and scroll gif as path-transport requiresRerender kinds`() {
+    val registry = ScrollDataProductRegistry(rootDir)
+    val byKind = registry.capabilities.associateBy { it.kind }
+    assertEquals(
+      setOf(ScrollPreviewExtension.KIND_LONG, ScrollPreviewExtension.KIND_GIF),
+      byKind.keys,
+    )
+    for (cap in registry.capabilities) {
+      assertEquals(DataProductTransport.PATH, cap.transport)
+      assertTrue("${cap.kind}: attachable", cap.attachable)
+      assertTrue("${cap.kind}: fetchable", cap.fetchable)
+      assertTrue("${cap.kind}: requiresRerender", cap.requiresRerender)
+    }
+    assertEquals(listOf("image/png"), byKind.getValue(ScrollPreviewExtension.KIND_LONG).mediaTypes)
+    assertEquals(listOf("image/gif"), byKind.getValue(ScrollPreviewExtension.KIND_GIF).mediaTypes)
+  }
+
+  @Test
+  fun `missing scroll artefact fetches as RequiresRerender with the matching mode`() {
+    val registry = ScrollDataProductRegistry(rootDir)
+
+    val longOutcome =
+      registry.fetch(
+        previewId = "com.example.HomeKt#LongScroll",
+        kind = ScrollPreviewExtension.KIND_LONG,
+        params = null,
+        inline = false,
+      )
+    assertEquals(DataProductRegistry.Outcome.RequiresRerender("scroll-long"), longOutcome)
+
+    val gifOutcome =
+      registry.fetch(
+        previewId = "com.example.HomeKt#GifScroll",
+        kind = ScrollPreviewExtension.KIND_GIF,
+        params = null,
+        inline = false,
+      )
+    assertEquals(DataProductRegistry.Outcome.RequiresRerender("scroll-gif"), gifOutcome)
+  }
+
+  @Test
+  fun `fetch returns Ok with the on-disk path when the artefact exists`() {
+    val previewId = "com.example.HomeKt#LongScroll"
+    val longFile =
+      rootDir.resolve(ScrollDataProductRegistry.SCROLL_LONG_SUBDIR).resolve("$previewId.png")
+    longFile.parentFile.mkdirs()
+    longFile.writeBytes(
+      byteArrayOf(0x89.toByte(), 'P'.code.toByte(), 'N'.code.toByte(), 'G'.code.toByte())
+    )
+
+    val outcome =
+      ScrollDataProductRegistry(rootDir)
+        .fetch(
+          previewId = previewId,
+          kind = ScrollPreviewExtension.KIND_LONG,
+          params = null,
+          inline = false,
+        )
+    val ok = outcome as DataProductRegistry.Outcome.Ok
+    assertEquals(ScrollPreviewExtension.KIND_LONG, ok.result.kind)
+    assertEquals(longFile.absolutePath, ok.result.path)
+    assertNull("PATH transport must not also carry an inline payload", ok.result.payload)
+  }
+
+  @Test
+  fun `inline upgrade is rejected for scroll kinds so binary PNG bytes never get parsed as JSON`() {
+    // Binary artefacts: `allowInlineUpgrade = false`. Even when the caller asks for inline,
+    // fetch still serves the path (matching the a11y overlay's PNG behaviour). Without this,
+    // `data/fetch(inline=true)` on `render/scroll/long` would read the PNG and crash the JSON
+    // parser with `FetchFailed`.
+    val previewId = "com.example.HomeKt#LongScroll"
+    val longFile =
+      rootDir.resolve(ScrollDataProductRegistry.SCROLL_LONG_SUBDIR).resolve("$previewId.png")
+    longFile.parentFile.mkdirs()
+    // Real PNG signature plus 4 bytes of garbage — definitely not JSON.
+    longFile.writeBytes(
+      byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x01, 0x02, 0x03)
+    )
+
+    val outcome =
+      ScrollDataProductRegistry(rootDir)
+        .fetch(
+          previewId = previewId,
+          kind = ScrollPreviewExtension.KIND_LONG,
+          params = null,
+          inline = true,
+        )
+    val ok = outcome as DataProductRegistry.Outcome.Ok
+    assertNotNull(ok.result.path)
+    assertNull("inline=true must not promote a binary kind to inline", ok.result.payload)
+  }
+
+  @Test
+  fun `renderModeFor returns the per-kind scroll mode so the dispatcher routes the right scenario`() {
+    val registry = ScrollDataProductRegistry(rootDir)
+    assertEquals("scroll-long", registry.renderModeFor(ScrollPreviewExtension.KIND_LONG))
+    assertEquals("scroll-gif", registry.renderModeFor(ScrollPreviewExtension.KIND_GIF))
+    assertNull(registry.renderModeFor("a11y/atf"))
+  }
+
+  @Test
+  fun `attachmentsFor surfaces an existing scroll PNG as a path attachment`() {
+    val previewId = "com.example.HomeKt#LongScroll"
+    val gifFile =
+      rootDir.resolve(ScrollDataProductRegistry.SCROLL_GIF_SUBDIR).resolve("$previewId.gif")
+    gifFile.parentFile.mkdirs()
+    gifFile.writeBytes(byteArrayOf('G'.code.toByte(), 'I'.code.toByte(), 'F'.code.toByte()))
+
+    val attachments =
+      ScrollDataProductRegistry(rootDir)
+        .attachmentsFor(
+          previewId = previewId,
+          kinds = setOf(ScrollPreviewExtension.KIND_LONG, ScrollPreviewExtension.KIND_GIF),
+        )
+    // LONG file is absent — only GIF appears.
+    assertEquals(1, attachments.size)
+    val gif = attachments.single()
+    assertEquals(ScrollPreviewExtension.KIND_GIF, gif.kind)
+    assertEquals(gifFile.absolutePath, gif.path)
+    assertNull(gif.payload)
+  }
+
+  @Test
+  fun `unknown kinds route through the base class to Outcome Unknown`() {
+    val outcome =
+      ScrollDataProductRegistry(rootDir)
+        .fetch(
+          previewId = "com.example.HomeKt#LongScroll",
+          kind = "a11y/atf",
+          params = null,
+          inline = false,
+        )
+    assertEquals(DataProductRegistry.Outcome.Unknown, outcome)
+    // No spurious file lookups for unknown kinds.
+    assertFalse(rootDir.resolve(ScrollDataProductRegistry.SCROLL_LONG_SUBDIR).exists())
+  }
+}

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtension.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtension.kt
@@ -10,11 +10,15 @@ import ee.schimke.composeai.data.render.pipeline.PreviewPipelineStep
 /**
  * Pipeline metadata for the scroll preview extension.
  *
- * Unlike most `data/<feature>/`, scroll has only a `core/` module — there is no
- * `data-scroll-connector`. Scroll produces image artifacts (long PNG, GIF) via the renderer's
- * pipeline-step seam, not a JSON payload exposed on `data/fetch`. It never appears on
- * `initialize.capabilities.dataProducts`. See `docs/daemon/DATA-PRODUCTS.md` § "`data/scroll` is
- * renderer-side only".
+ * Scroll has both a `core/` module (the scenario primitives — `ScrollDriver`, `ScrollGifEncoder`,
+ * the LONG / GIF frame-driver extensions) and a `connector/` module (`ScrollDataProductRegistry`)
+ * that advertises [KIND_LONG] / [KIND_GIF] on `initialize.capabilities.dataProducts` as
+ * `requiresRerender = true` producers (issue #1528). A missing scroll artefact resolves through the
+ * daemon's `data/fetch` re-render path — `RenderEngine.runScrollScenario` looks up the annotation
+ * intent via `PreviewIndex.scrollCaptureFor` and dispatches into `renderer.handleLongCapture` /
+ * `renderer.handleGifCapture`, writing the same `<modulePreviewsDir>/data/render-scroll-*` file
+ * paths the gradle plugin's `composePreviewRenderAll` writes. See `docs/daemon/DATA-PRODUCTS.md` §
+ * "`data/scroll` is daemon-produced via `data/fetch`".
  */
 object ScrollPreviewExtension {
   const val ID: String = "scroll"

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -397,13 +397,42 @@ Each `core` module advertises its kind identity and schemaVersion via a
 `Material3ThemeProduct.SCHEMA_VERSION`, etc.). Connectors and consumers
 both refer to those constants — never inline the string literals.
 
-### `data/scroll` is renderer-side only
+### `data/scroll` is daemon-produced via `data/fetch` (issue #1528)
 
-`data/scroll/core` carries scroll-scenario drivers (`ScrollDriver`,
-`ScrollGifEncoder`, `ScrollPreviewExtension`) that the renderer
-composes through the regular extension pipeline. There is no
-`data-scroll-connector` because scroll is not a daemon-side data
-product — it produces image artifacts (GIFs, long PNGs), not a JSON
-payload, so it has no `kind` and never appears on the
-`initialize.capabilities.dataProducts` list. The renderer drives it
-directly via the `PreviewPipelineStep` / scenario-driver hooks.
+`data/scroll/core` carries the scroll-scenario primitives — `ScrollDriver`,
+`ScrollGifEncoder`, the LONG / GIF frame-driver extensions — that the renderer
+composes when `@ScrollingPreview(modes = [LONG | GIF])` runs. `data/scroll/connector`
+wires those primitives into the daemon's data-product surface: it advertises
+`render/scroll/long` (PNG) and `render/scroll/gif` (GIF) on
+`initialize.capabilities.dataProducts` as `requiresRerender = true` producers, so
+a missing scroll artefact returns `Outcome.RequiresRerender("scroll-long" |
+"scroll-gif")` and `JsonRpcServer.handleDataFetchWithRerender` queues a
+per-preview re-render in the right scenario via
+`RenderEngine.runScrollScenario`. The engine resolves the annotation's intent
+(axis, maxScrollPx, frameIntervalMs) from `PreviewIndex.scrollCaptureFor` —
+populated from the gradle plugin's `dataProducts[].scroll` field in
+`previews.json` — and delegates the heavy lifting to the renderer's public
+`renderer.handleLongCapture` / `renderer.handleGifCapture` entry points.
+
+**On-disk layout is intentionally identical to the Gradle path.** The daemon
+writes to `<modulePreviewsDir>/data/render-scroll-long/<previewId>.png` and
+`<modulePreviewsDir>/data/render-scroll-gif/<previewId>.gif` — the same files
+`composePreviewRenderAll` writes — so `gradleService.readPreviewImage` and
+`data/fetch` resolve to the exact same path regardless of which side produced
+it. Binary artefacts (PNG / animated GIF) override `allowInlineUpgrade` to
+`false` so an `inline = true` fetch still returns the path (matching the
+a11y overlay PNG's existing behaviour).
+
+| Kind | Transport | Source | Notes |
+| --- | --- | --- | --- |
+| `render/scroll/long` | `PATH` | `data/scroll/connector` + `RenderEngine.runScrollScenario` | One stitched PNG per `@ScrollingPreview(modes = [LONG])`. `requiresRerender = true`. |
+| `render/scroll/gif` | `PATH` | same as above | One animated GIF per `@ScrollingPreview(modes = [GIF])`. `requiresRerender = true`. |
+
+**Host backfill.** The VS Code extension's viewport-driven backfill
+(`triggerViewportScrollBackfill` in `extension.ts`) calls
+`daemonScheduler.fetchScrollDataProduct` per-`(module, previewId, kind)` against
+the daemon; on daemon-side failure it falls back to the historical
+`composePreviewRender('full')` Gradle round-trip so older daemons that don't
+advertise the kinds still work. The fallback gate lives at the
+fetch-result boundary rather than `initialize.capabilities.dataProducts` so an
+in-flight rollout doesn't need a daemon version bump in the host.

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1287,8 +1287,49 @@ private fun cropPngTopLeft(
  * Returns `true` when [outputFile] was written; `false` to let the caller
  * fall through to END-style single capture (e.g. when no scrollable matched).
  */
+/**
+ * Public so the daemon-android `RenderEngine` can dispatch into the same scroll-scenario logic
+ * the in-process Robolectric harness uses for the `:samples` end-to-end runs — see issue #1528
+ * and [ScrollScenarioHandlers] for the wider scope-and-rationale doc. Wraps the original private
+ * `handleLongCapture` so the harness code path stays unchanged.
+ *
+ * `rule` is the held `AndroidComposeTestRule<*, ComponentActivity>` (`createAndroidComposeRule`)
+ * whose `setContent` has already painted the preview; `scroll` carries the annotation's intent
+ * (axis / maxScrollPx); `previewId` is logged into the structured error messages; `heightDp` is
+ * the viewport height in dp matching the device qualifier; `isRound` triggers the Wear pill clip;
+ * `outputFile` is the final stitched PNG.
+ *
+ * Returns `true` when [outputFile] was written. Returns `false` when there was no scrollable on
+ * `scroll.axis` (caller can fall through to a single-frame capture / structured failure sidecar
+ * — see issue #1528 § "NoScrollable failure shape on the wire").
+ */
 @OptIn(ExperimentalRoborazziApi::class)
-private fun handleLongCapture(
+public fun handleLongCapture(
+    rule: AndroidComposeTestRule<*, ComponentActivity>,
+    scroll: ScrollCapture,
+    previewId: String,
+    heightDp: Int,
+    isRound: Boolean,
+    outputFile: File,
+): Boolean = handleLongCaptureInternal(rule, scroll, previewId, heightDp, isRound, outputFile)
+
+/**
+ * Public sibling of [handleLongCapture] for `@ScrollingPreview(modes = [GIF])`. Same arguments
+ * — see that doc for semantics. Writes [outputFile] as an animated GIF rather than a stitched
+ * still PNG.
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+public fun handleGifCapture(
+    rule: AndroidComposeTestRule<*, ComponentActivity>,
+    scroll: ScrollCapture,
+    previewId: String,
+    heightDp: Int,
+    isRound: Boolean,
+    outputFile: File,
+): Boolean = handleGifCaptureInternal(rule, scroll, previewId, heightDp, isRound, outputFile)
+
+@OptIn(ExperimentalRoborazziApi::class)
+private fun handleLongCaptureInternal(
     rule: AndroidComposeTestRule<*, ComponentActivity>,
     scroll: ScrollCapture,
     previewId: String,
@@ -1452,7 +1493,7 @@ private const val POST_SCROLL_SETTLE_MS = 1000L
  * when the encoder declines).
  */
 @OptIn(ExperimentalRoborazziApi::class)
-private fun handleGifCapture(
+private fun handleGifCaptureInternal(
     rule: AndroidComposeTestRule<*, ComponentActivity>,
     scroll: ScrollCapture,
     previewId: String,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -173,6 +173,10 @@ include(":data-scroll-android")
 
 project(":data-scroll-android").projectDir = file("data/scroll/android")
 
+include(":data-scroll-connector")
+
+project(":data-scroll-connector").projectDir = file("data/scroll/connector")
+
 include(":data-history-core")
 
 project(":data-history-core").projectDir = file("data/history/core")

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -207,6 +207,24 @@ export interface DaemonScheduler {
         reason?: string,
         overrides?: PreviewOverrides,
     ): Promise<boolean>;
+    /**
+     * Issue #1528 — pulls a single `render/scroll/long` / `render/scroll/gif` artefact through
+     * the daemon's `data/fetch` re-render path. `kind` is inferred from the missing entry's
+     * `renderOutput` extension (`.png` → `render/scroll/long`, `.gif` → `render/scroll/gif`).
+     * Returns the absolute on-disk path the daemon wrote (typically equal to
+     * `missing.absolutePath` since the daemon writes to the same `<module>/build/compose-previews/`
+     * location Gradle does), or `null` when the daemon isn't ready, doesn't advertise the kind,
+     * or the fetch fails. Callers post `updateImage` against the returned path.
+     */
+    fetchScrollDataProduct(
+        module: ModuleInfo,
+        missing: {
+            previewId: string;
+            captureIndex: number;
+            renderOutput: string;
+            absolutePath: string;
+        },
+    ): Promise<string | null>;
     daemonEvents(moduleId: string): DaemonClientEvents;
 }
 
@@ -741,8 +759,53 @@ export class LiveDaemonScheduler implements DaemonScheduler {
      * the same events bag when issuing one-off `historyList` /
      * `historyRead` / `historyDiff` calls — the gate's daemon registry
      * keys on identity equivalence of the events bag, so reusing the
-     * same one keeps a single live registration.
+     * Issue #1528 — pull a scroll artefact (`render/scroll/long` / `render/scroll/gif`) through
+     * `data/fetch`. The daemon registry's `requiresRerender = true` semantics mean a missing
+     * artefact returns `Outcome.RequiresRerender`, which the dispatcher converts into a
+     * `mode=scroll-long|gif` re-render via `RenderEngine.runScrollScenario`. Returns the
+     * on-disk path the daemon wrote (matches the `missing.absolutePath` the host already
+     * computed off the manifest); `null` on any failure so callers can keep their Gradle
+     * fallback behind the same code path.
      */
+    async fetchScrollDataProduct(
+        module: ModuleInfo,
+        missing: {
+            previewId: string;
+            captureIndex: number;
+            renderOutput: string;
+            absolutePath: string;
+        },
+    ): Promise<string | null> {
+        const client = await this.gate.getOrSpawn(
+            module,
+            this.daemonEvents(module.modulePath),
+        );
+        if (!client) return null;
+        const lower = missing.renderOutput.toLowerCase();
+        const kind = lower.endsWith(".gif")
+            ? "render/scroll/gif"
+            : lower.endsWith(".png")
+              ? "render/scroll/long"
+              : null;
+        if (!kind) return null;
+        try {
+            const result = await client.dataFetch({
+                previewId: missing.previewId,
+                kind,
+                inline: false,
+            });
+            return result.path ?? missing.absolutePath;
+        } catch (err) {
+            // FetchFailed / Unknown / BudgetExceeded all surface as throws from the
+            // protocol client. Logged at the caller via the `null` return so the host
+            // can fall back to its Gradle path on older daemons that don't advertise
+            // the kinds. The thrown reason isn't logged here because the caller already
+            // has the (previewId, kind) context that makes the error meaningful.
+            void err;
+            return null;
+        }
+    }
+
     daemonEvents(moduleId: string) {
         return {
             onRenderFinished: (params: RenderFinishedParams) => {
@@ -954,6 +1017,19 @@ export class GradleOnlyDaemonScheduler implements DaemonScheduler {
         _reason?: string,
     ): Promise<boolean> {
         return false;
+    }
+
+    async fetchScrollDataProduct(
+        _module: ModuleInfo,
+        _missing: {
+            previewId: string;
+            captureIndex: number;
+            renderOutput: string;
+            absolutePath: string;
+        },
+    ): Promise<string | null> {
+        /* no-op: minimal mode has no daemon; caller falls back to Gradle */
+        return null;
     }
 
     daemonEvents(_moduleId: string): DaemonClientEvents {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7243,21 +7243,81 @@ function triggerViewportScrollBackfill(
         pendingScrollBackfill,
         visible,
         predicted,
-        scrollBackfillRequested,
+        // Module-wide Gradle dedup intentionally NOT passed here — the per-
+        // `(module, previewId, kind)` dedup below replaces it (issue #1528).
+        // Keeping the module-level set as a separate Gradle-fallback gate.
+        new Set<string>(),
     );
     for (const candidate of candidates) {
-        scrollBackfillRequested.add(candidate.modulePath);
         const owningModule = previewModuleIndex.get(
             candidate.missing[0].previewId,
         );
         if (!owningModule) continue;
+        // Issue #1528 — per-(module, previewId, kind) dedup. The daemon's
+        // `data/fetch` path takes one preview at a time (vs. Gradle's
+        // module-wide rebuild), so dedup needs to be at the same granularity
+        // or we'd re-issue the same fetch on every viewport tick.
+        const freshlyRequested: MissingImageDataProduct[] = [];
+        for (const m of candidate.missing) {
+            const kind = m.renderOutput.toLowerCase().endsWith(".gif")
+                ? "render/scroll/gif"
+                : "render/scroll/long";
+            const dedupKey = `${candidate.modulePath}::${m.previewId}::${kind}`;
+            if (scrollBackfillRequested.has(dedupKey)) continue;
+            scrollBackfillRequested.add(dedupKey);
+            freshlyRequested.push(m);
+        }
+        if (freshlyRequested.length === 0) continue;
         logLine(
-            `scroll backfill: ${candidate.modulePath} has ${candidate.missing.length} missing image data product(s) in viewport; kicking composePreviewRender('full')`,
+            `scroll backfill: ${candidate.modulePath} has ${freshlyRequested.length} missing image data product(s) in viewport; trying daemon data/fetch per preview`,
         );
-        // Fire-and-forget. After Gradle resolves, the helper re-reads the produced
-        // PNGs and posts `updateImage` for each captureIndex; the panel paints the
-        // previously-placeholdered scroll cards in place.
-        void backfillScrollDataProducts(owningModule, candidate.missing);
+        for (const m of freshlyRequested) {
+            // Fire-and-forget. Daemon path returns the on-disk path the
+            // dispatcher's `RenderEngine.runScrollScenario` wrote (same file
+            // Gradle would write to). On any daemon-side failure the per-kind
+            // dedup is rolled back and the module-wide Gradle path takes over.
+            void (async () => {
+                if (!daemonScheduler) return;
+                const path = await daemonScheduler.fetchScrollDataProduct(
+                    owningModule,
+                    m,
+                );
+                if (path && gradleService) {
+                    const imageData = await gradleService.readPreviewImage(
+                        owningModule,
+                        m.renderOutput,
+                    );
+                    if (imageData && panel) {
+                        panel.postMessage({
+                            command: "updateImage",
+                            previewId: m.previewId,
+                            captureIndex: m.captureIndex,
+                            imageData,
+                        });
+                    }
+                    return;
+                }
+                // Daemon path failed — fall back to the historical Gradle
+                // round-trip for this module. Drop the per-kind dedup entries
+                // we just added so a subsequent viewport tick can retry
+                // through the daemon once it advertises the kinds.
+                const kind = m.renderOutput.toLowerCase().endsWith(".gif")
+                    ? "render/scroll/gif"
+                    : "render/scroll/long";
+                scrollBackfillRequested.delete(
+                    `${candidate.modulePath}::${m.previewId}::${kind}`,
+                );
+                if (scrollBackfillRequested.has(candidate.modulePath)) return;
+                scrollBackfillRequested.add(candidate.modulePath);
+                logLine(
+                    `scroll backfill: daemon data/fetch failed for ${m.previewId}; falling back to composePreviewRender('full') for ${candidate.modulePath}`,
+                );
+                void backfillScrollDataProducts(
+                    owningModule,
+                    candidate.missing,
+                );
+            })();
+        }
     }
 }
 


### PR DESCRIPTION
Closes #1528.

## Summary

Implements all stages of the comment plan: the daemon advertises `render/scroll/long` / `render/scroll/gif`, produces them on demand through `data/fetch`, and the VS Code extension's viewport backfill switches from the per-module Gradle round-trip to a per-card daemon fetch (with Gradle as the fallback for older daemons).

## What changed

**Daemon side (`:daemon:core`, `:daemon:android`, `:data-scroll-connector`):**

- New `:data-scroll-connector` module with `ScrollDataProductRegistry` extending `FileBackedDataProductRegistry`. Advertises both kinds as `requiresRerender = true`, `transport = PATH`, with per-kind `renderModeFor` returning `"scroll-long"` / `"scroll-gif"`. Binary kinds override `allowInlineUpgrade` to `false` so `inline = true` never tries to parse PNG/GIF bytes as JSON.
- `PreviewInfoDto` gains a `dataProducts: List<PreviewDataProductDto>` field (and `ScrollCaptureDto` carrying `mode` / `axis` / `maxScrollPx` / `frameIntervalMs`). The gradle plugin was already writing this into `previews.json`; the daemon's parse path now reads what it needs without depending on `:gradle-plugin:preview-discovery`.
- `PreviewIndex.scrollCaptureFor(previewId, mode)` resolves the annotation intent for a `(previewId, render/scroll/long|gif)` pair.
- `RenderEngine.runScrollScenario` handles the dispatcher's `mode = scroll-long` / `scroll-gif` re-renders: paints the preview, then delegates to the renderer's public scroll handlers and writes the result under `<dataDir>/render-scroll-{long,gif}/<previewId>.{png,gif}` — the same path Gradle's `composePreviewRenderAll` writes to, so `gradleService.readPreviewImage` and `data/fetch` resolve to the same file regardless of producer.

**Renderer side (`:renderer-android`):**

- Promote `handleLongCapture` / `handleGifCapture` to `public` via thin wrappers around the existing private implementations. The historic in-file callers keep their semantics unchanged; only the entry points cross the module boundary. Helpers (`emitTailFlings`, `settlePostScrollAnimations`, `cropPngTopLeft`, …) stay file-private.

**Host side (`vscode-extension`):**

- `DaemonScheduler.fetchScrollDataProduct(module, missing)` issues a `data/fetch` for one preview, inferring kind from the `.png` / `.gif` extension. Returns the path the daemon wrote, or `null` on any failure so the caller can fall back to Gradle.
- `triggerViewportScrollBackfill` switches from per-module Gradle `composePreviewRender('full')` to per-`(module, previewId, kind)` `data/fetch`. On daemon-side failure, the per-kind dedup is rolled back and the historic Gradle round-trip takes over once per module, so older daemons that don't advertise the scroll kinds keep working unchanged. Dedup granularity moves from per-module to per-card to match the daemon path's per-preview cost.

**Docs:**

- `docs/daemon/DATA-PRODUCTS.md` § "data/scroll is renderer-side only" is rewritten as § "data/scroll is daemon-produced via data/fetch", with the kind table and host-backfill story brought up to date.
- `ScrollPreviewExtension.kt` opening comment now points at the connector + RenderEngine dispatch path.

## Test plan

- [x] `:data-scroll-connector:test` — new `ScrollDataProductRegistryTest` (7 cases): kind advertisement, `requiresRerender` + PATH transport + media types, `RequiresRerender(mode)` on missing files, `Ok(path)` on present files, `inline=true` not promoting binary kinds, per-kind `renderModeFor`, attachment paths, unknown-kind routing through `Outcome.Unknown`.
- [x] `:daemon:core:test --tests PreviewIndexTest` — added two cases pinning `scrollCaptureFor` per-(previewId, mode) resolution and plugin-side schema additions (`extensionId`, `displayName`, `output`, `cost`) parsing without breaking. Existing 18 cases still pass.
- [x] `:daemon:android:compileReleaseKotlin` — full daemon-android compile with the registry register-site, `RenderEngine.runScrollScenario`, and `RenderEngine` constants.
- [x] `:renderer-android:compileReleaseKotlin` — the public-wrapper extraction.
- [x] `vscode-extension` tests — full suite (1400 tests) green after `DaemonScheduler.fetchScrollDataProduct` + `triggerViewportScrollBackfill` rewrite.
- [ ] CI will re-run `:gradle-plugin:test` / `:samples:android:composePreviewRenderAll` for the end-to-end Gradle path (untouched here).

## Notes

- One pre-existing flaky `:daemon:core:test --tests InteractiveCoalescingTest.burst_inputs_during_in_flight_render_coalesce_into_one_followup_render` shows up locally; reproduced from a clean tree before any of the changes in this PR, so unrelated.
- The plan's open question #1 — does `PreviewInfoDto` already carry `dataProducts[].scroll`? — turned out to be a real gap. The DTO extension above resolves it; the plugin had been writing the data all along.
- The plan's open question #3 — `NoScrollable` failure shape — is surfaced via `RenderEngine.runScrollScenario`'s `error()` when the handler returns `false`, which the dispatcher converts into `ERR_DATA_PRODUCT_FETCH_FAILED` with a structured message. Host falls back to Gradle on that path, matching the plan's "host should fall back" guidance.
