### PR TITLE
feat(permissions): cross-classloader data/fetch readback for compose/permissions queries

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/SandboxPermissionsBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/SandboxPermissionsBridge.kt
@@ -1,0 +1,77 @@
+package ee.schimke.composeai.daemon.bridge
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Cross-classloader handoff for the runtime-permissions query tracker (issue #1400).
+ *
+ * **Why a sibling of [DaemonHostBridge].** `PermissionsController.recordQuery(...)` fires from
+ * inside the Robolectric sandbox — `ShadowContextWrapperPermissionTracker` intercepts
+ * `ContextWrapper.checkPermission(...)` for every consumer `ContextCompat.checkSelfPermission(...)`
+ * read, and the shadow runs in sandbox-instrumented code. The sandbox classloader acquires the
+ * `ee.schimke.composeai.daemon` package by default, so the controller's static state is loaded
+ * fresh per-sandbox and the daemon-host `PermissionsDataProductRegistry` (constructed once on the
+ * host thread, in the host classloader) sees an empty `queried` list when it reads
+ * `PermissionsController.queried.value` for the `compose/permissions` data product. The grants
+ * leg works because the host-side planner sets the host-CL controller directly; queries have no
+ * such host-side write path.
+ *
+ * This bridge is registered as a do-not-acquire package on [SandboxHoldingRunner], so the same
+ * single instance is visible from both sides of the sandbox boundary. The shadow's controller
+ * call pushes to [recordQuery] here; the host registry drains via [snapshot] / [reset].
+ *
+ * **Strict bridge-package rules.** Only `java.util.concurrent.*` types and primitives. No
+ * Compose, no Robolectric, no `ee.schimke.composeai.*` imports — those would drag the bridge
+ * back into the instrumented graph and break the single-instance invariant.
+ *
+ * **State shape.** A single concurrent map per JVM keyed by permission name, valued by a
+ * monotonic arrival counter so [snapshot] can return the unique permissions in insertion order
+ * (the same shape `PermissionsController.queriedSet` produces in-process). Cumulative across
+ * renders within the active interactive session; [reset] is the per-session cleanup hook that
+ * `PermissionsController.resetForNewSession` calls.
+ */
+object SandboxPermissionsBridge {
+
+  private val arrivalCounter: AtomicLong = AtomicLong(0L)
+
+  /** Permission name -> arrival counter. ConcurrentHashMap so writes from any sandbox thread race-free. */
+  private val queries: ConcurrentHashMap<String, Long> = ConcurrentHashMap()
+
+  /**
+   * Sandbox-side: record that the screen queried [permission]. Idempotent — the first call for
+   * a given permission stamps an arrival counter; subsequent calls are no-ops so the snapshot
+   * preserves the original insertion order. Mirrors `PermissionsController.recordQuery`'s
+   * de-duplication semantics so the bridge and the in-CL controller agree on the queried set.
+   */
+  @JvmStatic
+  fun recordQuery(permission: String) {
+    queries.computeIfAbsent(permission) { arrivalCounter.incrementAndGet() }
+  }
+
+  /**
+   * Host-side: snapshot the queried permissions in insertion order without clearing. Repeated
+   * reads — e.g. the panel re-fetching `compose/permissions` between renders — see the cumulative
+   * set, matching the in-CL controller's "session-lifetime" semantics.
+   *
+   * Returns a primitive `String[]` so the cross-loader transport stays in JLS types only —
+   * neither side reinterprets a `kotlin.collections.List` from the other's classloader. Mirrors
+   * the `arrayOf(String[], long[])` shape `SandboxRecompositionBridge.drainCounters` uses.
+   */
+  @JvmStatic
+  fun snapshot(): Array<String> {
+    if (queries.isEmpty()) return emptyArray()
+    val entries = queries.entries.toList().sortedBy { it.value }
+    return Array(entries.size) { entries[it].key }
+  }
+
+  /**
+   * Both sides: drop every recorded query. Called by `PermissionsController.resetForNewSession`
+   * (per-session cleanup) and by [DaemonHostBridge]-style host restart paths so a fresh sandbox
+   * doesn't see the previous session's queries.
+   */
+  @JvmStatic
+  fun reset() {
+    queries.clear()
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsDataFetchE2ETest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsDataFetchE2ETest.kt
@@ -1,0 +1,198 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.bridge.SandboxPermissionsBridge
+import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
+import ee.schimke.composeai.daemon.protocol.PermissionsOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.Base64
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end verification that a render driven through the sandbox surfaces the
+ * `ContextCompat.checkSelfPermission(...)` queries the screen issued into the
+ * `compose/permissions` data product the panel reads via `data/fetch`. Closes issue #1400 Part 3
+ * step 3.
+ *
+ * The pixel-flip leg ([PermissionsOverrideIntegrationTest]) already pins the grant-write side of
+ * `renderNow.overrides.permissions` end-to-end — a granted override produces the green branch on
+ * the first composition. The previously-missing leg is the read-back: a render that fires
+ * `ContextCompat.checkSelfPermission(CAMERA)` inside the sandbox must land CAMERA in the host-side
+ * [PermissionsDataProductRegistry]'s `data/fetch` payload.
+ *
+ * **Why a cross-classloader bridge.** [PermissionsController] is loaded by the Robolectric
+ * sandbox classloader (the `ee.schimke.composeai.daemon` package is acquired). The host-side
+ * [PermissionsDataProductRegistry] is loaded by the daemon classloader. Each classloader has its
+ * own static `PermissionsController` instance, so the shadow's sandbox-side `recordQuery(...)`
+ * writes are invisible to the host-CL registry. [SandboxPermissionsBridge] sits in the
+ * `ee.schimke.composeai.daemon.bridge` package (registered as `doNotAcquirePackage` on
+ * [SandboxHoldingRunner]), so it's a single instance shared across the boundary — the controller
+ * forwards `recordQuery` to it reflectively, and the registry reads it back the same way.
+ *
+ * **Out of scope.** This test does NOT go through `JsonRpcServer.handleDataFetch` — the JSON-RPC
+ * envelope leg is already covered by `:daemon:core`'s `DataFetchRerenderTest` and the registry
+ * dispatch shape doesn't change here. We exercise the registry directly to keep the test focused
+ * on the cross-classloader path that #1400 calls out, and use the same render-result wire shape
+ * the JSON-RPC server would feed to `extensions.activeDataProducts().onRender(...)`.
+ */
+class PermissionsDataFetchE2ETest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+  }
+
+  @After
+  fun resetBridge() {
+    // Bridge is a JVM-wide singleton; previous test methods or sibling test classes that
+    // exercised the sandbox can leak queries into ours. Reset the bridge here AND between every
+    // render submission below so each assertion sees only the queries from the render it gated.
+    SandboxPermissionsBridge.reset()
+  }
+
+  @Test
+  fun `dataFetch returns the permissions the rendered screen queried`() {
+    val outputDir = tempFolder.newFolder("renders-permissions-fetch")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val previewId = "permission-gated-fetch"
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = previewId,
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "PermissionGatedSquare",
+              widthPx = 32,
+              heightPx = 32,
+              density = 1.0f,
+              outputBaseName = previewId,
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    val registry = PermissionsDataProductRegistry()
+    host.start()
+    try {
+      // Push CAMERA = GRANTED through the same wire shape the panel produces. The around-composable
+      // primes ShadowApplication grants pre-composition (the seed path proven by
+      // `PermissionsOverrideIntegrationTest`), and the `ContextCompat.checkSelfPermission(CAMERA)`
+      // read in `PermissionGatedSquare` flows through `ShadowContextWrapperPermissionTracker`,
+      // which records CAMERA against the sandbox-CL controller AND the cross-CL bridge.
+      val overrideBag =
+        PreviewOverrides(
+          permissions =
+            PermissionsOverride(
+              grants =
+                mapOf("android.permission.CAMERA" to PermissionGrantStateOverride.GRANTED)
+            )
+        )
+      val payload =
+        "previewId=$previewId;overrides=${encodeOverridesBag(overrideBag)}"
+      SandboxPermissionsBridge.reset()
+      val result = host.submit(RenderRequest.Render(payload = payload), timeoutMs = 120_000)
+
+      // Pixel correctness — sanity check that the override actually drove the granted branch.
+      // If this drops, the failure isn't the data-fetch path; it's the override-application path
+      // (see `PermissionsOverrideIntegrationTest` for the dedicated regression).
+      assertNotNull("pngPath must be populated", result.pngPath)
+      val img =
+        ByteArrayInputStream(File(result.pngPath!!).readBytes()).use { ImageIO.read(it) }
+          ?: error("PNG failed to decode")
+      val greenPct = pixelMatchPct(img, expectedRgb = 0x66BB6A, perChannelTolerance = 8)
+      assertTrue(
+        "render should land on the granted (green) branch; got ${"%.2f".format(greenPct * 100)}% green",
+        greenPct >= 0.95,
+      )
+
+      // Hand the rendered result to the registry the same way `JsonRpcServer.handleRenderFinished`
+      // does. The registry's `onRender` reads the bridge's snapshot (host-CL read of the
+      // cross-classloader queries the sandbox-CL shadow wrote) and captures the payload for the
+      // preview id.
+      registry.onRender(previewId, result, overrideBag, previewContext = result.previewContext)
+
+      val outcome = registry.fetch(previewId, "compose/permissions", params = null, inline = true)
+      val ok = outcome as DataProductRegistry.Outcome.Ok
+      val obj = ok.result.payload!!.jsonObject
+
+      // Queried — the assertion #1400 part 3 step 3 calls out. CAMERA must appear because the
+      // shadow caught it. If this drops, either:
+      //  - `ShadowContextWrapperPermissionTracker` isn't wired (check `SandboxHoldingRunner
+      //    .getExtraShadows`),
+      //  - the controller's bridge forward stopped running (check `PermissionsController
+      //    .recordQuery`'s `bridgeForwarder?.recordQuery` call),
+      //  - or the registry's bridge read regressed (check `PermissionsDataProductRegistry
+      //    .readQueriedAcrossClassloaders`).
+      val queried = obj["queried"]!!.jsonArray.map { it.jsonPrimitive.content }
+      assertEquals(
+        "data/fetch?kind=compose/permissions should report CAMERA as queried",
+        listOf("android.permission.CAMERA"),
+        queried,
+      )
+
+      // Grants leg — the host-side planner already seeds `PermissionsController.grants.value` in
+      // the host CL (it constructs `PermissionsOverrideExtension(seed=…)` whose `init {
+      // PermissionsController.set(seed) }` block runs host-side), so the registry's
+      // `overrides?.permissions?.grants + controller.grants.value` returns the override regardless
+      // of the cross-classloader bridge. Asserted here so a future refactor that moves the seed
+      // to sandbox-side construction doesn't silently break the grants leg too.
+      val grants = obj["grants"]!!.jsonObject
+      assertEquals(
+        "granted",
+        grants["android.permission.CAMERA"]?.jsonPrimitive?.content,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  private fun encodeOverridesBag(bag: PreviewOverrides): String {
+    val bytes =
+      json.encodeToString(PreviewOverrides.serializer(), bag).toByteArray(Charsets.UTF_8)
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+  }
+
+  private fun pixelMatchPct(
+    img: java.awt.image.BufferedImage,
+    expectedRgb: Int,
+    perChannelTolerance: Int,
+  ): Double {
+    val expR = (expectedRgb shr 16) and 0xFF
+    val expG = (expectedRgb shr 8) and 0xFF
+    val expB = expectedRgb and 0xFF
+    var matches = 0L
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val rgb = img.getRGB(x, y)
+        val r = (rgb shr 16) and 0xFF
+        val g = (rgb shr 8) and 0xFF
+        val b = rgb and 0xFF
+        if (
+          abs(r - expR) <= perChannelTolerance &&
+            abs(g - expG) <= perChannelTolerance &&
+            abs(b - expB) <= perChannelTolerance
+        ) {
+          matches++
+        }
+      }
+    }
+    val total = img.width.toLong() * img.height.toLong()
+    return matches.toDouble() / total.toDouble()
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsOverrideIntegrationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsOverrideIntegrationTest.kt
@@ -39,13 +39,11 @@ import org.junit.rules.TemporaryFolder
  * leg is covered separately by [PermissionsOverrideEncodingTest] in `:daemon:core`. Together
  * the two tests pin the full panel → daemon → renderer → shadow chain.
  *
- * Out of scope here: asserting `data/fetch?kind=compose/permissions` returns the queried
- * list — that capture happens inside the sandbox's [PermissionsController] static state, and
- * the daemon-side `PermissionsDataProductRegistry` reads it from there. Cross-classloader
- * read-out from the JUnit runner would need a dedicated surfacing channel; the unit-level
- * `PermissionsDataProductTest.onRender captures override grants plus controller queries`
- * pins the registry's behaviour for now. Pixel correctness is the strongest single E2E
- * signal: it can only succeed if every rung worked.
+ * The data-fetch read-back leg — proving that the queries the shadow caught surface through
+ * `data/fetch?kind=compose/permissions` — lives in [PermissionsDataFetchE2ETest]; it uses the
+ * cross-classloader [bridge.SandboxPermissionsBridge][ee.schimke.composeai.daemon.bridge.SandboxPermissionsBridge]
+ * seam the host-side registry reads. Pixel correctness here remains the strongest single signal
+ * that the override-application chain works: it can only succeed if every rung wired up.
  */
 class PermissionsOverrideIntegrationTest {
 

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -128,25 +128,41 @@ fun DarkAwareSquare() {
 }
 
 /**
- * Reads `Context.checkSelfPermission(android.permission.CAMERA)` through the platform path that
- * `ContextCompat.checkSelfPermission(...)` ultimately delegates to (`ContextWrapper.checkPermission
- * (String, int, int)`). Paints green when granted, red when denied. Used by
- * `PermissionsOverrideIntegrationTest` to prove `renderNow.overrides.permissions` reaches
- * `PermissionsPreviewOverrideExtension.plan(...)`, the around-composable seeds Robolectric's
- * `ShadowApplication.grantPermissions`, the `ShadowContextWrapperPermissionTracker` shadow forwards
- * to the real implementation, and the next `checkSelfPermission` read in the composition observes
- * the requested value — the full chain the panel's permissions tab body drives.
+ * Reads `ContextCompat.checkSelfPermission(...)` for `android.permission.CAMERA` — the exact call
+ * shape `samples/android`'s `PermissionGatedPreview` uses and the path the panel's permission UI
+ * targets. Paints green when granted, red when denied. Used by `PermissionsOverrideIntegrationTest`
+ * to prove `renderNow.overrides.permissions` reaches `PermissionsPreviewOverrideExtension.plan(...)`,
+ * the around-composable seeds Robolectric's `ShadowApplication.grantPermissions`, and by
+ * `PermissionsDataFetchE2ETest` to prove the `ShadowContextWrapperPermissionTracker` shadow
+ * intercepts the call and records the query into the cross-classloader bridge the registry reads.
  *
- * No connector-specific Compose API; the screen is the exact shape a consumer would author
- * against the standard Android permission surface, mirroring `samples/android`'s
- * `PermissionGatedPreview`.
+ * **Why `ContextCompat.checkSelfPermission` and not `context.checkSelfPermission`.** They look
+ * interchangeable but route differently inside the Android framework: `Context.checkSelfPermission
+ * (String)` is implemented in `ContextImpl` as a direct `PermissionManager.checkPermission(...)`
+ * call that bypasses `ContextWrapper.checkPermission(String, int, int)`, where the shadow lives.
+ * `ContextCompat.checkSelfPermission(context, perm)` instead calls `context.checkPermission(perm,
+ * Process.myPid(), Process.myUid())` — which on any `ContextWrapper`-rooted context (every
+ * Activity) dispatches into `ContextWrapper.checkPermission`, the path
+ * `ShadowContextWrapperPermissionTracker` intercepts. Pixel correctness held either way because
+ * `ShadowApplication`'s grant state is consulted by both code paths; the query-tracking surface
+ * only sees the `ContextCompat` path.
  */
 @Composable
 fun PermissionGatedSquare() {
   val context = androidx.compose.ui.platform.LocalContext.current
+  // Inlines what `androidx.core.content.ContextCompat.checkSelfPermission(context, perm)` does:
+  // a virtual `context.checkPermission(perm, Process.myPid(), Process.myUid())` dispatch. On any
+  // `ContextWrapper`-rooted context (every Activity) that lands in `ContextWrapper.checkPermission
+  // (String, int, int)` — the method `ShadowContextWrapperPermissionTracker` shadows. Using the
+  // raw call avoids adding `androidx.core:core` to the test-fixtures source set just to import
+  // the static helper; the production sample (`samples/android/.../PermissionGatedPreview.kt`)
+  // imports `ContextCompat` because it's already on the consumer's classpath.
   val granted =
-    context.checkSelfPermission(android.Manifest.permission.CAMERA) ==
-      android.content.pm.PackageManager.PERMISSION_GRANTED
+    context.checkPermission(
+      android.Manifest.permission.CAMERA,
+      android.os.Process.myPid(),
+      android.os.Process.myUid(),
+    ) == android.content.pm.PackageManager.PERMISSION_GRANTED
   val color = if (granted) Color(0xFF66BB6A) else Color(0xFFEF5350)
   Box(modifier = Modifier.fillMaxSize().background(color))
 }

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsController.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsController.kt
@@ -85,11 +85,21 @@ object PermissionsController {
    * Record a query against [permission]. Idempotent — duplicate queries don't re-append. The
    * insertion-ordered list is what the data-product payload surfaces, so the panel can display
    * queries in roughly the sequence the composition issued them.
+   *
+   * Also forwards to the cross-classloader [SandboxPermissionsBridge][bridgeForwarder] so the
+   * daemon-side `PermissionsDataProductRegistry`, which lives in the host classloader, can read
+   * out the sandbox-side queries. Without the forward, the host registry's
+   * `PermissionsController.queried.value` read returns the host-CL controller's (empty) state and
+   * `data/fetch?kind=compose/permissions` reports no queries even though
+   * `ShadowContextWrapperPermissionTracker` caught them. The bridge is loaded reflectively so the
+   * connector keeps its no-`:daemon:android` dependency shape — the same pattern
+   * [syncRobolectricGrants] uses for Robolectric.
    */
   fun recordQuery(permission: String) {
     if (queriedSeen.add(permission)) {
       synchronized(lock) { queriedSet.value = queriedSet.value + permission }
     }
+    bridgeForwarder?.recordQuery(permission)
   }
 
   /** Register a callback fired on every [set] transition. Returns an unregister handle. */
@@ -110,6 +120,7 @@ object PermissionsController {
       queriedSeen.clear()
       syncRobolectricGrants(emptyMap())
     }
+    bridgeForwarder?.reset()
   }
 
   /**
@@ -157,6 +168,65 @@ object PermissionsController {
     } catch (_: ReflectiveOperationException) {
       // Underlying invocation failure (e.g. application not yet initialised). Drop silently — the
       // controller's snapshot state still reflects the requested grants for the data product.
+    }
+  }
+
+  /**
+   * Resolved once per JVM, cached even on failure. `null` means the bridge class isn't on the
+   * classpath (connector-module unit tests; consumers that depend on the connector without the
+   * `:daemon:android` artefact) — every forward call no-ops in that case.
+   */
+  private val bridgeForwarder: BridgeForwarder? by lazy { BridgeForwarder.tryLoad() }
+
+  /**
+   * Reflective handle to [bridge.SandboxPermissionsBridge][ee.schimke.composeai.daemon.bridge.SandboxPermissionsBridge].
+   * The bridge lives in `:daemon:android` (a downstream module the connector does NOT depend on),
+   * so the connector reaches it through `Class.forName` — same shape as [syncRobolectricGrants]'s
+   * reach into Robolectric. Connector-only consumers (no daemon-android on the classpath) see
+   * `tryLoad() == null` and the connector still serves the in-CL controller state.
+   *
+   * `Class.forName(..., javaClass.classLoader)`: in the production daemon, the controller is
+   * sandbox-loaded so `javaClass.classLoader` is the Robolectric sandbox CL; the bridge package
+   * (`ee.schimke.composeai.daemon.bridge`) is registered as do-not-acquire on that CL, so the
+   * sandbox delegates loading to the daemon CL parent — both sides observe the same single bridge
+   * instance and writes here are readable from the host registry.
+   */
+  private class BridgeForwarder(
+    private val recordQueryMethod: java.lang.reflect.Method,
+    private val resetMethod: java.lang.reflect.Method,
+  ) {
+    fun recordQuery(permission: String) {
+      try {
+        recordQueryMethod.invoke(null, permission)
+      } catch (_: ReflectiveOperationException) {
+        // Bridge invocation failed (unexpected — the class loaded but the call failed). Drop —
+        // controller's in-CL state still serves the same-CL fast path.
+      }
+    }
+
+    fun reset() {
+      try {
+        resetMethod.invoke(null)
+      } catch (_: ReflectiveOperationException) {
+        // Same defensive drop as recordQuery; the controller's in-CL state already cleared above.
+      }
+    }
+
+    companion object {
+      private const val BRIDGE_FQN: String = "ee.schimke.composeai.daemon.bridge.SandboxPermissionsBridge"
+
+      fun tryLoad(): BridgeForwarder? =
+        try {
+          val cls = Class.forName(BRIDGE_FQN, true, PermissionsController::class.java.classLoader)
+          BridgeForwarder(
+            recordQueryMethod = cls.getMethod("recordQuery", String::class.java),
+            resetMethod = cls.getMethod("reset"),
+          )
+        } catch (_: ClassNotFoundException) {
+          null
+        } catch (_: NoSuchMethodException) {
+          null
+        }
     }
   }
 }

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
@@ -198,12 +198,89 @@ class PermissionsDataProductRegistry : DataProductRegistry {
     // through the controller without a seed, and the panel still wants to surface that. An empty
     // payload (no grants, no queries) is filtered out so we don't masquerade `NotAvailable`.
     val grants = overrides?.permissions?.grants.orEmpty() + PermissionsController.grants.value
-    val queried = PermissionsController.queried.value
+    val queried = readQueriedAcrossClassloaders()
     if (grants.isEmpty() && queried.isEmpty()) {
       clear(previewId)
       return
     }
     capture(previewId, payloadFor(grants, queried))
+  }
+
+  /**
+   * Read the queried-permission list with cross-classloader awareness. In production, the daemon's
+   * registry runs in the host classloader, while
+   * [ShadowContextWrapperPermissionTracker]-driven `recordQuery` writes land in the sandbox
+   * classloader's [PermissionsController] static state — different `static` per classloader, so the
+   * host-CL controller's `queried.value` is empty even though queries fired. The
+   * [bridge.SandboxPermissionsBridge][ee.schimke.composeai.daemon.bridge.SandboxPermissionsBridge]
+   * is a do-not-acquire singleton shared across the boundary, so we prefer it when reachable.
+   *
+   * Fallback to [PermissionsController.queried] keeps connector-only unit tests
+   * (`PermissionsDataProductTest`) working unchanged — they exercise both sides from a single
+   * classloader where the controller's in-CL state IS the source of truth.
+   */
+  private fun readQueriedAcrossClassloaders(): List<String> {
+    val bridge = SandboxPermissionsBridgeReader.tryLoad()
+    val controllerQueried = PermissionsController.queried.value
+    if (bridge == null) return controllerQueried
+    val bridgeQueried = bridge.snapshot()
+    // Union of bridge and same-CL controller views, preserving bridge insertion order first and
+    // appending controller-only entries (the rare same-CL `:daemon:android` test path where a
+    // direct controller call wrote to in-CL state but the bridge was the loaded singleton).
+    if (bridgeQueried.isEmpty()) return controllerQueried
+    if (controllerQueried.isEmpty()) return bridgeQueried
+    val seen = LinkedHashSet(bridgeQueried)
+    seen.addAll(controllerQueried)
+    return seen.toList()
+  }
+
+  /**
+   * Reflective lookup of [bridge.SandboxPermissionsBridge][ee.schimke.composeai.daemon.bridge.SandboxPermissionsBridge].
+   * Cached per JVM (object init). `null` means the bridge isn't on the classpath (connector-only
+   * unit tests; non-daemon consumers) — the registry falls back to the in-CL controller state.
+   */
+  private class SandboxPermissionsBridgeReader(
+    private val snapshotMethod: java.lang.reflect.Method,
+  ) {
+    fun snapshot(): List<String> =
+      try {
+        @Suppress("UNCHECKED_CAST")
+        (snapshotMethod.invoke(null) as Array<String>).toList()
+      } catch (_: ReflectiveOperationException) {
+        emptyList()
+      }
+
+    companion object {
+      private const val BRIDGE_FQN: String =
+        "ee.schimke.composeai.daemon.bridge.SandboxPermissionsBridge"
+
+      @Volatile private var resolved: SandboxPermissionsBridgeReader? = null
+      @Volatile private var resolutionAttempted: Boolean = false
+
+      fun tryLoad(): SandboxPermissionsBridgeReader? {
+        if (resolutionAttempted) return resolved
+        synchronized(this) {
+          if (resolutionAttempted) return resolved
+          val r =
+            try {
+              val cls =
+                Class.forName(
+                  BRIDGE_FQN,
+                  true,
+                  PermissionsDataProductRegistry::class.java.classLoader,
+                )
+              SandboxPermissionsBridgeReader(snapshotMethod = cls.getMethod("snapshot"))
+            } catch (_: ClassNotFoundException) {
+              null
+            } catch (_: NoSuchMethodException) {
+              null
+            }
+          resolved = r
+          resolutionAttempted = true
+          return r
+        }
+      }
+    }
   }
 
   private fun payloadFor(

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/ShadowContextWrapperPermissionTracker.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/ShadowContextWrapperPermissionTracker.kt
@@ -2,36 +2,53 @@ package ee.schimke.composeai.daemon
 
 import android.content.ContextWrapper
 import android.content.pm.PackageManager
+import ee.schimke.composeai.daemon.protocol.PermissionGrantStateOverride
 import org.robolectric.annotation.Implementation
 import org.robolectric.annotation.Implements
 import org.robolectric.annotation.RealObject
-import org.robolectric.shadow.api.Shadow
 
 /**
  * Robolectric shadow on `android.content.ContextWrapper.checkPermission(String, int, int)`.
  *
- * Purpose: every Android permission check eventually flows through either
- * `Context.checkSelfPermission(String)` (which under the hood calls `checkPermission(perm,
- * Process.myPid(), Process.myUid())` on the bound `Context`) or `ContextCompat.checkSelfPermission
- * (context, perm)` (which calls the same `checkPermission(...)` triple). Both paths terminate at
- * `ContextWrapper.checkPermission` for any non-trivial context (the base `Activity`,
- * `Application`, or any wrapper around them) — shadowing the wrapper catches every consumer-side
- * path without needing per-context shadows.
+ * Purpose: every Android permission check that goes through the `checkPermission(perm, pid, uid)`
+ * triple (`ContextCompat.checkSelfPermission(context, perm)`,
+ * `accompanist`'s `rememberPermissionState`, or any direct
+ * `Context.checkPermission(perm, Process.myPid(), Process.myUid())` call) terminates at
+ * `ContextWrapper.checkPermission` for any non-trivial context (an `Activity`, `Application`, or
+ * any wrapper around them). Shadowing the wrapper catches every consumer-side path that uses
+ * that call shape without needing per-context shadows.
  *
- * Behaviour: forwards to the real implementation (so Robolectric's `ShadowApplication`-grant state
- * still drives the actual return value), then records the queried permission in
- * `PermissionsController.recordQuery(...)` for the data-product payload. Idempotent — duplicate
- * queries for the same permission don't grow the list, only the first hit lands.
+ * **Path coverage.** `Context.checkSelfPermission(String)` is implemented directly in
+ * `ContextImpl` against `PermissionManager.checkPermission(...)` and bypasses
+ * `ContextWrapper.checkPermission` — this shadow does NOT intercept the
+ * `context.checkSelfPermission(perm)` form. The production sample
+ * (`samples/android/.../PermissionGatedPreview.kt`) uses `ContextCompat.checkSelfPermission`, the
+ * recommended AndroidX shape, which goes through the wrapper path this shadow covers.
  *
- * The shadow targets `android.content.ContextWrapper` rather than `ContextImpl` because the
- * platform's `ContextImpl` is a hidden class (Robolectric maps it in but consumers shouldn't
- * touch). `Activity` extends `ContextThemeWrapper` extends `ContextWrapper`, and so does every
- * `View`-derived context — so this single shadow covers every preview's Compose root.
+ * **Why no `Shadow.directlyOn` forward.** Robolectric ships `ShadowActivity` which is a more
+ * specific shadow than this one for any `Activity` instance — the common case for preview
+ * compositions (`LocalContext.current` is the Activity hosting the `ComposeView`). Calling
+ * `Shadow.directlyOn(realWrapper, ContextWrapper::class.java, "checkPermission", …)` re-enters
+ * the bytecode-instrumented `ContextWrapper.checkPermission` from the `ReflectionHelpers
+ * .callInstanceMethod` side. Robolectric's intercept then resolves the runtime shadow for the
+ * `Activity` instance, gets `ShadowActivity`, and tries to cast it to this shadow's type — which
+ * fails with `ClassCastException`. The integration regression is pinned by
+ * `PermissionsDataFetchE2ETest`.
  *
- * **Registration**: this shadow is registered conditionally on the consumer's classpath shape via
- * `SandboxHoldingRunner.getExtraShadows(...)` in `:daemon:android`. The Robolectric sandbox loads
- * the shadow class, sees the `@Implements` annotation, and from then on every
- * `ContextWrapper.checkPermission` call routes through here.
+ * Instead this shadow resolves the result by consulting Robolectric's `ShadowApplication` grant
+ * state directly (the same data structure `PermissionsController.syncRobolectricGrants` writes
+ * the override into via reflection). `ShadowApplication`'s public API is the documented authority
+ * for permission state under Robolectric, so reading from it returns the same value the real
+ * `ContextImpl.checkPermission` would, without crossing the broken shadow-cast path.
+ *
+ * Behaviour: consult [PermissionsController]'s grant state (which mirrors `ShadowApplication`'s)
+ * and record the queried permission in `PermissionsController.recordQuery(...)` for the
+ * data-product payload. Idempotent — duplicate queries for the same permission don't grow the
+ * list, only the first hit lands.
+ *
+ * **Registration**: this shadow is registered via `SandboxHoldingRunner.getExtraShadows(...)` in
+ * `:daemon:android`. The Robolectric sandbox loads the shadow class, sees the `@Implements`
+ * annotation, and from then on every `ContextWrapper.checkPermission` call routes through here.
  */
 @Implements(ContextWrapper::class)
 class ShadowContextWrapperPermissionTracker {
@@ -40,28 +57,21 @@ class ShadowContextWrapperPermissionTracker {
 
   @Implementation
   fun checkPermission(permission: String?, pid: Int, uid: Int): Int {
-    // Forward to the real `ContextWrapper.checkPermission` so Robolectric's `ShadowApplication`
-    // grant state still drives the actual return value. `Shadow.directlyOn` re-enters the
-    // unwrapped method without going back through this shadow.
-    val result: Int =
-      Shadow.directlyOn<Int, ContextWrapper>(
-        realWrapper,
-        ContextWrapper::class.java,
-        "checkPermission",
-        org.robolectric.util.ReflectionHelpers.ClassParameter.from(String::class.java, permission),
-        org.robolectric.util.ReflectionHelpers.ClassParameter.from(
-          Int::class.javaPrimitiveType,
-          pid,
-        ),
-        org.robolectric.util.ReflectionHelpers.ClassParameter.from(
-          Int::class.javaPrimitiveType,
-          uid,
-        ),
-      ) ?: PackageManager.PERMISSION_DENIED
     if (permission != null) {
       PermissionsController.recordQuery(permission)
     }
-    return result
+    // Consult [PermissionsController]'s grant state directly. The around-composable seeds it from
+    // `renderNow.overrides.permissions` before the first composition runs (via
+    // `PermissionsOverrideExtension.init`); the controller also mirrors the seed into
+    // `ShadowApplication.grantPermissions/denyPermissions` via reflection so the
+    // `context.checkSelfPermission(perm)` path (which goes through `ContextImpl` and consults
+    // `ShadowApplication` directly, bypassing this shadow) returns the same value. Permissions
+    // not pinned in the override fall back to denied — matching Robolectric's default for a
+    // preview-rendered Application that hasn't declared the permission in its manifest.
+    return when (PermissionsController.grantFor(permission ?: return PackageManager.PERMISSION_DENIED)) {
+      PermissionGrantStateOverride.GRANTED -> PackageManager.PERMISSION_GRANTED
+      PermissionGrantStateOverride.DENIED, null -> PackageManager.PERMISSION_DENIED
+    }
   }
 
   companion object {


### PR DESCRIPTION
Closes the last in-repo deliverable of #1400 (Part 3 step 3): asserting
`data/fetch?kind=compose/permissions` returns the queried permission list
end-to-end through the sandbox. The pixel-flip leg shipped in earlier PRs;
the read-back leg never worked because of two issues:

- `ShadowContextWrapperPermissionTracker.checkPermission` called
  `Shadow.directlyOn(realWrapper, ContextWrapper, …)` to forward to the
  real implementation. For Activity-rooted contexts (every preview),
  Robolectric resolves `ShadowActivity` as the more specific shadow and
  the cast to this shadow's type fails with ClassCastException — the
  existing pixel test never hit it because the fixture used
  `context.checkSelfPermission(perm)`, which is implemented in
  ContextImpl as a direct `PermissionManager.checkPermission(...)` call
  and bypasses `ContextWrapper.checkPermission` entirely.

- The shadow's `recordQuery(...)` writes land in the Robolectric sandbox
  classloader's `PermissionsController` static state. The host-side
  `PermissionsDataProductRegistry` reads from the host-CL controller,
  which is a different static. Grants worked because the host-side
  planner sets the host-CL controller directly; queries had no such
  host-side write path, so `data/fetch?kind=compose/permissions`
  reported an empty `queried` list even when the shadow had caught the
  query.

Fixes:

- Replace the `Shadow.directlyOn` forward in the shadow with a direct
  read of `PermissionsController.grantFor(...)`. The override seed has
  already mirrored grants into ShadowApplication via reflection, so the
  controller's grant state is the same authority Robolectric's
  ContextImpl path consults; reading it skips the broken cast and still
  returns the correct grant for the override (CAMERA = GRANTED → PERMISSION_GRANTED).

- Add `SandboxPermissionsBridge` in `daemon/android/.../bridge/` — a
  do-not-acquire singleton shared across the boundary, same shape as
  `SandboxRecompositionBridge`. The controller forwards `recordQuery`
  and `resetForNewSession` to the bridge reflectively (the connector
  module has no compile-time dep on `:daemon:android`); the registry's
  `onRender` reads the bridge's snapshot in preference to the in-CL
  controller's `queried.value`. Connector-only unit tests stay unchanged
  — bridge class isn't on their classpath, so `tryLoad()` returns null
  and the fallback to controller state covers them.

- Update `PermissionGatedSquare` fixture to use the
  `context.checkPermission(perm, pid, uid)` call shape (what
  `ContextCompat.checkSelfPermission` does internally), which is the
  path the shadow actually intercepts. Matches the samples/android
  preview's call shape.

- Add `PermissionsDataFetchE2ETest`: drives a `renderNow.overrides
  .permissions = { CAMERA = GRANTED }` render through `PreviewManifestRouter`,
  asserts the pixel landed on the granted branch, then asserts
  `registry.fetch("preview", "compose/permissions", …)` returns
  `queried = [android.permission.CAMERA]` and `grants[CAMERA] = "granted"`.
  Pins the full panel → daemon → renderer → shadow → bridge → registry chain.