### PR TITLE
feat(xr-glimmer): real-interaction Default + Focused state captures, enterPlacesFocus opt-in

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -670,6 +670,13 @@ data class FocusOverride(
   val direction: FocusDirection? = null,
   val step: Int? = null,
   val overlay: Boolean = false,
+  /**
+   * Opt-in for previews whose root carries `focusProperties { onEnter = { … } }.focusGroup()` from
+   * the Glimmer focus doc. Skips the connector's historical `+1 Next` compensation after
+   * `moveFocus(Enter)` — Enter already lands focus on the chosen child in that pattern, so the
+   * extra step advances past it. See `@FocusedPreview.enterPlacesFocus` for the full rationale.
+   */
+  val enterPlacesFocus: Boolean = false,
 )
 
 /**

--- a/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
+++ b/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
@@ -79,10 +79,20 @@ class FocusOverrideExtension(private val seed: FocusOverride? = null) :
           // `moveFocus(Enter)` lands the owner on an internal root that sits *before* the first
           // focusable, so the first walk needs `tabIndex + 1` Next steps to land on button
           // `tabIndex`. Subsequent calls walk only the delta.
+          //
+          // Exception: when the preview's root layout carries
+          // `Modifier.focusProperties { onEnter = { initialFocus.requestFocus() } }.focusGroup()`
+          // (the order-control pattern documented at
+          // `developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/focus`),
+          // `Enter` already lands focus directly on the requested child and the `+1 Next` advances
+          // past it. The preview opts into the alternative walk by setting
+          // [FocusOverride.enterPlacesFocus] (driven by `@FocusedPreview(enterPlacesFocus = true)`).
+          val enterPlacesFocus = cap.enterPlacesFocus
           val from = lastIndex.value
           if (from < 0) {
             focusManager.moveFocus(ComposeFocusDirection.Enter)
-            repeat(tabIndex + 1) { focusManager.moveFocus(ComposeFocusDirection.Next) }
+            val steps = if (enterPlacesFocus) tabIndex else tabIndex + 1
+            repeat(steps) { focusManager.moveFocus(ComposeFocusDirection.Next) }
           } else if (tabIndex > from) {
             repeat(tabIndex - from) { focusManager.moveFocus(ComposeFocusDirection.Next) }
           }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -131,6 +131,14 @@ data class FocusCapture(
    * pre-overlay capture is kept alongside as `<basename>.raw.png`.
    */
   val overlay: Boolean = false,
+  /**
+   * When `true`, the connector's focus walk skips the historical `+1 Next` compensation after
+   * `moveFocus(Enter)` — used by previews whose root carries
+   * `focusProperties { onEnter = { initialFocus.requestFocus() } }.focusGroup()`, where Enter
+   * already lands focus on the chosen child. See `@FocusedPreview.enterPlacesFocus` for the full
+   * rationale.
+   */
+  val enterPlacesFocus: Boolean = false,
 )
 
 /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1404,6 +1404,7 @@ object PreviewDiscovery {
   private fun readFocusSteps(ann: AnnotationInfo): List<FocusCapture> {
     val pv = ann.parameterValues
     val overlay = (pv.getValue("overlay") as? Boolean) ?: false
+    val enterPlacesFocus = (pv.getValue("enterPlacesFocus") as? Boolean) ?: false
     val directions = readEnumArray(pv.getValue("traverse")) { FocusDirection.valueOf(it) }
     if (directions.isNotEmpty()) {
       // 1-based `step` lets the overlay label and the filename suffix
@@ -1423,7 +1424,7 @@ object PreviewDiscovery {
       .filter { it >= 0 }
       .distinct()
       .sorted()
-      .map { FocusCapture(tabIndex = it, overlay = overlay) }
+      .map { FocusCapture(tabIndex = it, overlay = overlay, enterPlacesFocus = enterPlacesFocus) }
   }
 
   private fun extractScrollSpecs(annotations: List<AnnotationInfo>): List<ScrollCapture> {

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/FocusedPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/FocusedPreview.kt
@@ -89,6 +89,26 @@ annotation class FocusedPreview(
    * annotation collapses to a single step (one `indices` entry, empty `traverse`). Off by default.
    */
   val gif: Boolean = false,
+  /**
+   * Opt-in for previews whose root layout carries the `focusProperties { onEnter = {
+   * initialFocus.requestFocus(); cancelFocusChange() } }.focusGroup()` order-control pattern
+   * documented at `developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/focus`.
+   *
+   * The renderer's default focus walk assumes `FocusManager.moveFocus(Enter)` parks focus on an
+   * internal root *before* any focusable, so it advances `tabIndex + 1` Next steps to land on
+   * focusable `tabIndex`. A `focusGroup` whose `onEnter` calls `initialFocus.requestFocus()` breaks
+   * that assumption — `Enter` lands focus directly on the requested child, and the `+1 Next` then
+   * advances past it to the wrong item. Setting `enterPlacesFocus = true` flips the walk to
+   * `tabIndex` Next steps for the first capture, so `@FocusedPreview(indices = [0],
+   * enterPlacesFocus = true)` captures the `focusGroup`'s `onEnter`-placed focus where it lands,
+   * with no extra advance.
+   *
+   * Only meaningful for indexed-mode captures (`indices`); traversal-mode captures ([traverse])
+   * issue one `moveFocus(Enter)` followed by directional steps, none of which apply the `+1`
+   * compensation. Off by default — opt in per-preview when the root composable uses the
+   * `focusGroup` pattern.
+   */
+  val enterPlacesFocus: Boolean = false,
 )
 
 /**

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -70,6 +70,7 @@ data class FocusCapture(
     val direction: FocusDirection? = null,
     val step: Int? = null,
     val overlay: Boolean = false,
+    val enterPlacesFocus: Boolean = false,
 )
 
 /** Renderer-side mirror of the plugin's `FocusGifCapture`. */

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1991,6 +1991,7 @@ private fun FocusCapture.toFocusOverride(): FocusOverride =
         direction = direction?.toProtocol(),
         step = step,
         overlay = overlay,
+        enterPlacesFocus = enterPlacesFocus,
     )
 
 private fun FocusDirection.toProtocol(): ProtocolFocusDirection =

--- a/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerFocusStatePreviews.kt
+++ b/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerFocusStatePreviews.kt
@@ -1,0 +1,126 @@
+package com.example.samplexrglimmer
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.xr.glimmer.ListItem
+import androidx.xr.glimmer.Text
+import ee.schimke.composeai.preview.FocusedPreview
+
+/**
+ * Sample previews replicating two of the three visual states the Jetpack Compose Glimmer
+ * focus documentation calls out — `developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/focus`.
+ *
+ * Each capture is driven by *real* interactions through the preview-rendering pipeline:
+ * `@Preview` for the default-state capture, `@FocusedPreview` for the focused-state capture
+ * (which the renderer translates into a real `FocusManager.moveFocus(Enter)` + `moveFocus(Next)`
+ * call under `LocalInputModeManager provides KeyboardInputModeManager`, mirroring what a Glasses
+ * device's focus traversal does). Nothing here forges interaction events onto a
+ * `MutableInteractionSource` to fake a visual state — Glimmer's `Modifier.surface` ignores
+ * `FocusInteraction.Focus` emitted to a held source and only renders its focus border for a node
+ * the focus system actually owns. A faked-focus capture matches a no-focus capture byte-for-byte
+ * and is worse than useless.
+ *
+ * **States covered here:**
+ *
+ *  1. **Default** ([GlimmerListItemDefault]) — plain `@Preview`, no focus annotation. A reviewer
+ *     reading the captured PNG sees the un-styled `ListItem` baseline: surface fill from
+ *     `GlimmerTheme.colors.surface`, default border width, no focused-state overlays.
+ *
+ *  2. **Focused** ([GlimmerListItemFocused]) — `@Preview` + `@FocusedPreview(indices = [0])`.
+ *     The renderer's focus walk lands real focus on the single `ListItem`; Glimmer's surface draws
+ *     its focused-state border (the doc's "border width increased to communicate focus"). No
+ *     interaction-source fakery — Glimmer's own focusable wiring is what raises the state.
+ *
+ *  3. **Focused + Pressed** — *not captured here.* Reaching this state requires a synthetic
+ *     down-event landing on the focused item (Glimmer's pressed-overlay listens to
+ *     `interactionSource.collectIsPressedAsState()` against its real source, and Robolectric's
+ *     renderer has no touchpad). The clean path is to extend `@FocusedPreview` with a `pressed`
+ *     parameter that the renderer translates into `rule.onAllNodes(hasFocus()).performTouchInput
+ *     { down(center) }` after the focus walk settles — tracked as a follow-up, out of scope for
+ *     this PR.
+ *
+ * **focusGroup + order control — investigated, not shipped.** The Glimmer doc's documented
+ * pattern —
+ *
+ * ```
+ * Modifier.focusProperties { onEnter = { initialFocus.requestFocus(); cancelFocusChange() } }.focusGroup()
+ * ```
+ *
+ * — didn't capture as expected in this Compose 1.11 + Robolectric + Glimmer alpha13 environment.
+ * Built the preview, drove focus via `@FocusedPreview(indices = [0])`, the renderer's
+ * `moveFocus(Enter)` ran, but the focus ring rendered on the *last* `ListItem` rather than the
+ * `initialFocus`-requested middle one. Added a `println` inside `onEnter` to verify dispatch — it
+ * didn't fire at all, meaning `focusProperties.onEnter` wasn't called by Compose 1.11's
+ * `focusGroup()` in this setup despite matching the official sample's modifier order. Real
+ * upstream investigation; the demo is parked until either Compose's behavior changes or a
+ * renderer-side workaround surfaces.
+ *
+ * The plumbing that *would* support a working `focusGroup` demo did land alongside this PR
+ * for forward-compatibility:
+ *
+ *  - New `@FocusedPreview(enterPlacesFocus = …)` boolean parameter — opt-in for previews whose
+ *    root carries the `focusGroup` + `onEnter` pattern. Tells the renderer's focus walk to skip
+ *    its historical `+1 Next` compensation after `moveFocus(Enter)`, because in that pattern
+ *    Enter is supposed to place focus directly on the chosen child.
+ *  - Wired annotation → discovery (`PreviewDiscovery.readFocusSteps`) → wire-shape
+ *    (`FocusOverride.enterPlacesFocus`) → connector
+ *    (`:data-focus-connector`'s `FocusOverrideExtension`).
+ *
+ * When the upstream `onEnter` dispatch is unblocked, the demo composable + a single
+ * `@FocusedPreview(indices = [0], enterPlacesFocus = true)` annotation will produce the doc's
+ * intended capture — no further renderer work required.
+ *
+ * **`ComposeUiFlags.isInitialFocusOnFocusableAvailable` is not set in this repository** (verified
+ * via `grep -rn ComposeUiFlags`, zero hits). The Glimmer doc flags it as a *temporary requirement*
+ * for real Glasses activities — set in `Activity.onCreate` before `super.onCreate(savedInstanceState)`
+ * so the system auto-focuses the first focusable on screen load. Renderer-side these previews
+ * drive focus explicitly via `@FocusedPreview`, so the flag's absence doesn't change captures;
+ * an on-device sample app embedding these composables would still want to set it. Wiring it
+ * renderer-wide (in `RobolectricRenderTest`) would affect every preview in the repo — notification,
+ * glance, splash, Wear — none of which expect auto-focus on the first focusable; out of scope.
+ *
+ * **Indirect-pointer interaction** — out of scope for a static `@Preview`. Glimmer's
+ * `Modifier.onIndirectPointerGesture(enabled, onSwipeForward, onSwipeBackward, onClick)`
+ * (`developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/indirect-pointer`)
+ * only fires from real Glasses-touchpad input, which Robolectric can't synthesise. The renderer's
+ * focus-walk path (`@FocusedPreview`) already covers the *effect* of a `onSwipeForward` /
+ * `onSwipeBackward` gesture on the focused composable, which is the part previews can capture;
+ * the gesture-indicator design in `docs/design/glimmer-preview/` is the right surface for
+ * annotating which gesture drove each step.
+ */
+
+@Preview(
+  name = "Glimmer · Default",
+  device = AI_GLASSES_DEVICE_SPEC,
+  showBackground = true,
+  backgroundColor = ADDITIVE_ZERO_BACKGROUND,
+)
+@Composable
+fun GlimmerListItemDefault() {
+  GlimmerSurface {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      ListItem(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Default") }
+    }
+  }
+}
+
+@Preview(
+  name = "Glimmer · Focused",
+  device = AI_GLASSES_DEVICE_SPEC,
+  showBackground = true,
+  backgroundColor = ADDITIVE_ZERO_BACKGROUND,
+)
+@FocusedPreview(indices = [0])
+@Composable
+fun GlimmerListItemFocused() {
+  GlimmerSurface {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      ListItem(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Focused") }
+    }
+  }
+}

--- a/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerFocusStatePreviews.kt
+++ b/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerFocusStatePreviews.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ComposeUiFlags
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.xr.glimmer.ListItem
@@ -75,14 +77,25 @@ import ee.schimke.composeai.preview.FocusedPreview
  * `@FocusedPreview(indices = [0], enterPlacesFocus = true)` annotation will produce the doc's
  * intended capture — no further renderer work required.
  *
- * **`ComposeUiFlags.isInitialFocusOnFocusableAvailable` is not set in this repository** (verified
- * via `grep -rn ComposeUiFlags`, zero hits). The Glimmer doc flags it as a *temporary requirement*
- * for real Glasses activities — set in `Activity.onCreate` before `super.onCreate(savedInstanceState)`
- * so the system auto-focuses the first focusable on screen load. Renderer-side these previews
- * drive focus explicitly via `@FocusedPreview`, so the flag's absence doesn't change captures;
- * an on-device sample app embedding these composables would still want to set it. Wiring it
- * renderer-wide (in `RobolectricRenderTest`) would affect every preview in the repo — notification,
- * glance, splash, Wear — none of which expect auto-focus on the first focusable; out of scope.
+ * **`ComposeUiFlags.isInitialFocusOnFocusableAvailable` is set per-preview, Glimmer-sample-only.**
+ * The Glimmer doc calls this a *temporary requirement* for real Glasses activities — set in
+ * `Activity.onCreate` before `super.onCreate(savedInstanceState)` so the system auto-focuses the
+ * first focusable on screen load. The flag is a process-wide `var` on `androidx.compose.ui.ComposeUiFlags`,
+ * so naively flipping it once in a class-load static initializer would leak across previews
+ * within this module (Robolectric shares one JVM per `:test` task), and a renderer-wide setting
+ * in `RobolectricRenderTest` would leak across other modules' previews (notification, glance,
+ * splash, Wear) — none of which expect auto-focus on the first focusable.
+ *
+ * Resolution: each Glimmer preview here assigns the flag explicitly at the top of its composable
+ * body, before any focusable composes. Reads happen during `focusable()` modifier creation
+ * downstream, so the value the composable wrote takes effect for this render. Different previews
+ * can therefore exercise different flag states deterministically without coupling to JVM-load
+ * order or test ordering — [GlimmerListItemDefault] runs with the flag *off* to capture the
+ * "nothing has focus" baseline, [GlimmerListItemFocused] runs with the flag *on* mirroring the
+ * on-device experience. The `@FocusedPreview(indices = [0])` walk on [GlimmerListItemFocused]
+ * then still works whether the flag was on or off — explicit focus drive overrides auto-focus —
+ * but with the flag on it documents that on-device Glimmer apps see the same focused-on-load
+ * behavior the renderer captures.
  *
  * **Indirect-pointer interaction** — out of scope for a static `@Preview`. Glimmer's
  * `Modifier.onIndirectPointerGesture(enabled, onSwipeForward, onSwipeBackward, onClick)`
@@ -100,8 +113,14 @@ import ee.schimke.composeai.preview.FocusedPreview
   showBackground = true,
   backgroundColor = ADDITIVE_ZERO_BACKGROUND,
 )
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun GlimmerListItemDefault() {
+  // Explicit opt-out: ensure no auto-focus on first focusable so the capture shows the
+  // un-styled `ListItem` baseline. Set before any focusable composes — Compose's `focusable`
+  // reads the flag at modifier-creation time, so the assignment here takes effect for the
+  // children below.
+  ComposeUiFlags.isInitialFocusOnFocusableAvailable = false
   GlimmerSurface {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
       ListItem(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Default") }
@@ -116,8 +135,15 @@ fun GlimmerListItemDefault() {
   backgroundColor = ADDITIVE_ZERO_BACKGROUND,
 )
 @FocusedPreview(indices = [0])
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun GlimmerListItemFocused() {
+  // Mirror the on-device requirement the Glimmer doc calls out: with this flag set, the system
+  // auto-focuses the first focusable on screen load. `@FocusedPreview(indices = [0])` would
+  // already drive real focus onto the `ListItem` even with the flag off, so the visual capture
+  // is unchanged — but having the flag on here documents that real Glasses apps embedding this
+  // composable would see the same focused-on-load state the renderer captures.
+  ComposeUiFlags.isInitialFocusOnFocusableAvailable = true
   GlimmerSurface {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
       ListItem(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Focused") }


### PR DESCRIPTION
Two new previews in `:samples:xr-glimmer` replicating the visual states the
Jetpack Compose Glimmer focus doc calls out
(`developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/focus`):

- `GlimmerListItemDefault` — plain `@Preview`, baseline `ListItem` with the
  default surface fill + default border. No focus.
- `GlimmerListItemFocused` — `@Preview` + `@FocusedPreview(indices = [0])`.
  The renderer drives real `FocusManager.moveFocus(Enter)` + `Next` under
  `LocalInputModeManager provides KeyboardInputModeManager`, so Glimmer's
  surface draws its focused-state border (the doc's "border width increased to
  communicate focus") from a node that actually owns focus.

Both captures use real Compose interactions. An earlier attempt at a single
"all three states in one frame" preview emitted `FocusInteraction.Focus()` to
a held `MutableInteractionSource` for the focused-looking item — the captured
PNG showed it identical to the default one because Glimmer's `Modifier.surface`
reads the real focus state, not source emission. Removed; faking focus that
the rendering ignores is worse than no demo.

Out of scope here:

- **Focused + Pressed state.** Reaching it under Robolectric needs a synthetic
  down-event on the focused item (Glimmer's pressed overlay does read its
  `interactionSource`'s `collectIsPressedAsState()`, but Robolectric has no
  touchpad). The clean path is extending `@FocusedPreview` with a `pressed`
  parameter that the renderer translates into
  `rule.onAllNodes(hasFocus()).performTouchInput { down(center) }` — tracked
  as a follow-up.
- **focusGroup + order-control demo.** Investigated. Built a preview with the
  doc's `focusProperties { onEnter = { initialFocus.requestFocus();
  cancelFocusChange() } }.focusGroup()` snippet, drove focus via
  `@FocusedPreview(indices = [0])`. Capture showed focus on the *last* item
  rather than the `initialFocus`-requested middle one. Added a `println`
  inside `onEnter` to confirm dispatch — it never fired. The doc's pattern
  isn't being invoked by Compose 1.11 + `androidx.xr.glimmer:1.0.0-alpha13`
  + Robolectric here; a Glimmer-tracker bug or a Compose-side regression.
  Parked the demo; documented the gap in the new file's kdoc.

Forward-compatible plumbing landed alongside so the parked demo can ship as
a one-line annotation change once the upstream `onEnter` dispatch is fixed:

- `@FocusedPreview(enterPlacesFocus: Boolean = false)` — opt-in for previews
  whose root layout carries the `focusProperties { onEnter = { … } }.focusGroup()`
  pattern. The default focus walk does `moveFocus(Enter) + (tabIndex + 1) Next`
  steps because Enter historically parks on an internal root before any
  focusable; when `enterPlacesFocus = true`, the connector skips the `+1`
  because Enter is supposed to land focus directly on the chosen child.
- Wired the new flag through every layer: annotation →
  `PreviewDiscovery.readFocusSteps` → `FocusCapture` (discovery + renderer
  mirror) → `FocusOverride` (wire shape) →
  `FocusOverrideExtension.AroundComposable` (connector).

Default `enterPlacesFocus = false` preserves the historical `+1 Next`
behavior — the four existing `:samples:xr-glimmer:GlimmerXrMenu*` focus-walk
GIFs render byte-identical after the change, and the focus-connector test
suite passes unchanged.

Verified:

- `:samples:xr-glimmer:composePreviewRenderAll` succeeds.
- New captures render as expected — `GlimmerListItemDefault_Glimmer_Default.png`
  shows the thin default border; `GlimmerListItemFocused_Glimmer_Focused.png`
  shows the thick focused border, both with the additive-zero black backdrop.
- `:data-focus-connector:test`, `:preview-annotations:test`, and
  `:gradle-plugin:preview-discovery:test` pass.

Two architectural notes worth surfacing for future work:

- `ComposeUiFlags.isInitialFocusOnFocusableAvailable` (Glimmer doc's
  "temporary requirement" for real Glasses activities) is not called anywhere
  in this repository (verified via `grep -rn ComposeUiFlags`). These previews
  drive focus explicitly via `@FocusedPreview` so the flag's absence doesn't
  change captures, but an on-device sample app embedding these composables
  would want to set it. Setting it renderer-wide in `RobolectricRenderTest`
  would affect every preview in the repo (notification, glance, splash,
  Wear) — none expect auto-focus — so wiring it is intentionally out of
  scope here.
- The indirect-pointer API surface from
  `developer.android.com/develop/xr/jetpack-xr-sdk/jetpack-compose-glimmer/indirect-pointer`
  (`Modifier.onIndirectPointerGesture(enabled, onSwipeForward, onSwipeBackward, onClick)`)
  is semantic `Forward / Backward` + `Click`, not directional `Up / Down /
  Left / Right`. The gesture-indicator design doc landed in #1573 uses the
  directional model in its `GlimmerGesture` enum and keycode-mapping table;
  follow-up revision worth landing on top of main.