### PR TITLE
feat(preview): @FocusedPreview(pressed = true) dispatches indirect-pointer Press

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -677,6 +677,14 @@ data class FocusOverride(
    * extra step advances past it. See `@FocusedPreview.enterPlacesFocus` for the full rationale.
    */
   val enterPlacesFocus: Boolean = false,
+  /**
+   * When `true`, the connector dispatches an indirect-pointer Press event onto the focused
+   * composable after the focus walk lands. Drives `AndroidComposeView.sendIndirectPointerEvent`
+   * directly — the same dispatch path XR Glasses touchpads route through — so the captured pixels
+   * show the *pressed* visual state on the focused element. See `@FocusedPreview.pressed` for the
+   * full rationale and platform context.
+   */
+  val pressed: Boolean = false,
 )
 
 /**

--- a/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
+++ b/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
@@ -1,5 +1,9 @@
 package ee.schimke.composeai.daemon
 
+import android.os.SystemClock
+import android.view.InputDevice
+import android.view.MotionEvent
+import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -8,10 +12,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalIndirectPointerApi
 import androidx.compose.ui.focus.FocusDirection as ComposeFocusDirection
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.input.indirect.IndirectPointerEvent
+import androidx.compose.ui.input.indirect.IndirectPointerEventPrimaryDirectionalMotionAxis
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
+import androidx.compose.ui.platform.LocalView
 import ee.schimke.composeai.daemon.protocol.FocusOverride
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.focus.Material3FocusProduct
@@ -62,6 +70,7 @@ class FocusOverrideExtension(private val seed: FocusOverride? = null) :
     }
     CompositionLocalProvider(LocalInputModeManager provides KeyboardInputModeManager) {
       val focusManager = LocalFocusManager.current
+      val view = LocalView.current
       val active by FocusController.activeFocus
       val lastIndex = remember { mutableIntStateOf(-1) }
       val entered = remember { mutableStateOf(false) }
@@ -98,6 +107,15 @@ class FocusOverrideExtension(private val seed: FocusOverride? = null) :
           }
           lastIndex.value = tabIndex
         }
+        // `@FocusedPreview(pressed = true)` — after the focus walk lands, dispatch an
+        // indirect-pointer Press onto the focused composable so its `PressInteraction.Press` fires
+        // before the renderer captures pixels. Glimmer's `Modifier.onIndirectPointerGesture`
+        // observes this event on the focused-target path and emits the pressed-state interaction;
+        // Material's `Modifier.clickable` does the same through its indirect-pointer fallback. See
+        // [dispatchIndirectPress] for the platform rationale.
+        if (cap.pressed) {
+          view.dispatchIndirectPress()
+        }
       }
       content()
     }
@@ -124,4 +142,60 @@ fun FocusManager.applyFocusOverride(override: FocusOverride?) {
   // Renderer-side helper kept here so it can evolve alongside the connector's walk semantics
   // without the renderer reaching into controller internals.
   FocusController.set(override)
+}
+
+/**
+ * Dispatches a single indirect-pointer Press event onto the focused composable through Compose UI's
+ * `AndroidComposeView.sendIndirectPointerEvent` — the same dispatch path real XR Glasses touchpads
+ * route through. The composable's `IndirectPointerInputModifierNode`s (Glimmer's
+ * `onIndirectPointerGesture`, Material `clickable`'s indirect-pointer fallback) observe the event
+ * on the focused-target path and emit `PressInteraction.Press` to their `InteractionSource` — the
+ * focused element's pressed visual then renders before the renderer's per-capture clock advance
+ * elapses.
+ *
+ * Press is dispatched without a matching Release. That holds the composable in its pressed state
+ * for the capture window — the same shape a real "finger held on the touchpad" produces — and
+ * deliberately doesn't fire the `onClick` lambda (a tap = Press+Release). The JVM is recycled
+ * after capture so no manual cleanup is needed.
+ *
+ * Reflection rather than a direct call: `AndroidComposeView` is `internal` at the Kotlin source
+ * level (compiles to `public final class` at the JVM level — `internal` is module-scoped in the
+ * Kotlin compiler only), so a direct `as AndroidComposeView` cast would fail to compile from
+ * outside `androidx.compose.ui`. The bytecode-public `sendIndirectPointerEvent` is callable via
+ * reflection without taking a compile-time dep on the internal class — same pattern the renderer's
+ * focus-overlay reflection uses to read `AndroidComposeView` internals for the post-capture
+ * stroke. We identify the view by class name rather than `isAssignableFrom` checks so the resolver
+ * stays focused on the concrete platform class — wrappers and test stand-ins skip the dispatch
+ * cleanly.
+ *
+ * The motion event sets `source = SOURCE_TOUCHPAD` to match what real Glasses input carries;
+ * coordinates are `(0, 0)` because indirect-pointer events have no screen position (the consumer
+ * routes by focused target, not by hit-test). Axis is `X` — matches Glimmer's primary swipe axis
+ * — but no axis is read for a Press with no motion, so the value is documentation more than
+ * mechanism. We don't recycle the `MotionEvent` because Compose retains it as
+ * `IndirectPointerEvent.nativeEvent` for the event lifetime, and recycling would null out fields
+ * the consumer may still read.
+ */
+@OptIn(ExperimentalIndirectPointerApi::class)
+private fun View.dispatchIndirectPress() {
+  if (javaClass.name != "androidx.compose.ui.platform.AndroidComposeView") return
+  val now = SystemClock.uptimeMillis()
+  val motionEvent =
+    MotionEvent.obtain(
+      /* downTime = */ now,
+      /* eventTime = */ now,
+      /* action = */ MotionEvent.ACTION_DOWN,
+      /* x = */ 0f,
+      /* y = */ 0f,
+      /* metaState = */ 0,
+    )
+  motionEvent.source = InputDevice.SOURCE_TOUCHPAD
+  val event =
+    IndirectPointerEvent(
+      motionEvent = motionEvent,
+      primaryDirectionalMotionAxis = IndirectPointerEventPrimaryDirectionalMotionAxis.X,
+      previousMotionEvent = null,
+    )
+  val send = javaClass.getMethod("sendIndirectPointerEvent", IndirectPointerEvent::class.java)
+  send.invoke(this, event)
 }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -139,6 +139,15 @@ data class FocusCapture(
    * rationale.
    */
   val enterPlacesFocus: Boolean = false,
+  /**
+   * When `true`, the renderer dispatches an indirect-pointer Press event onto the focused
+   * composable after the focus walk settles, before capturing pixels — captures the *pressed*
+   * visual state on top of the focused state. Drives Compose UI's
+   * `AndroidComposeView.sendIndirectPointerEvent` (the same entry point real XR Glasses touchpads
+   * route through); see `@FocusedPreview.pressed` for the rationale. Only meaningful for
+   * indexed-mode captures (`tabIndex`); traversal-mode skips it.
+   */
+  val pressed: Boolean = false,
 )
 
 /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1405,10 +1405,13 @@ object PreviewDiscovery {
     val pv = ann.parameterValues
     val overlay = (pv.getValue("overlay") as? Boolean) ?: false
     val enterPlacesFocus = (pv.getValue("enterPlacesFocus") as? Boolean) ?: false
+    val pressed = (pv.getValue("pressed") as? Boolean) ?: false
     val directions = readEnumArray(pv.getValue("traverse")) { FocusDirection.valueOf(it) }
     if (directions.isNotEmpty()) {
       // 1-based `step` lets the overlay label and the filename suffix
-      // disambiguate repeated directions (e.g. `Next, Next, Previous`).
+      // disambiguate repeated directions (e.g. `Next, Next, Previous`). `pressed` is
+      // indexed-mode only — traversal-mode walks across focusables without a "settle and press"
+      // point, so it's intentionally not carried here.
       return directions.mapIndexed { i, dir ->
         FocusCapture(direction = dir, step = i + 1, overlay = overlay)
       }
@@ -1424,7 +1427,14 @@ object PreviewDiscovery {
       .filter { it >= 0 }
       .distinct()
       .sorted()
-      .map { FocusCapture(tabIndex = it, overlay = overlay, enterPlacesFocus = enterPlacesFocus) }
+      .map {
+        FocusCapture(
+          tabIndex = it,
+          overlay = overlay,
+          enterPlacesFocus = enterPlacesFocus,
+          pressed = pressed,
+        )
+      }
   }
 
   private fun extractScrollSpecs(annotations: List<AnnotationInfo>): List<ScrollCapture> {

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/FocusedPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/FocusedPreview.kt
@@ -109,6 +109,29 @@ annotation class FocusedPreview(
    * `focusGroup` pattern.
    */
   val enterPlacesFocus: Boolean = false,
+  /**
+   * When `true`, the renderer dispatches an indirect-pointer Press event onto the focused
+   * composable after the focus walk lands, before capturing pixels. The composable renders in its
+   * pressed visual state — `Modifier.clickable`'s `PressInteraction.Press` is emitted to the
+   * focused element's interaction source, so material ripples / Glimmer's brighter pressed surface
+   * appear in the PNG.
+   *
+   * Indirect-pointer dispatch (rather than synthetic `MotionEvent.ACTION_DOWN` on the View) is
+   * required for **XR Glasses**: the display has no touchscreen, so input arrives from the
+   * temple-mounted touchpad as `IndirectPointerEvent`s through Compose UI's
+   * `AndroidComposeView.sendIndirectPointerEvent`. Glimmer's `Modifier.onIndirectPointerGesture` is
+   * the only consumer that routes those events into per-modifier `onClick` / `onSwipeForward` /
+   * `onSwipeBackward` lambdas, and it always targets the currently-focused composable — so this
+   * flag pairs naturally with `indices` (focus the n-th focusable, then press it). For plain
+   * touch-screen surfaces (`Modifier.clickable` on a phone-style preview) the same Press still
+   * dispatches via the focus-targeted indirect-pointer path: `Modifier.clickable` registers a
+   * fallback indirect-pointer handler, so the visual still arrives.
+   *
+   * Only meaningful for indexed-mode captures (`indices`) — traversal-mode (`traverse`) doesn't
+   * carry a "settle and press" point. Off by default; opt in per-preview when you want the
+   * pressed-state capture in addition to (or instead of) the focused-state capture.
+   */
+  val pressed: Boolean = false,
 )
 
 /**

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -71,6 +71,7 @@ data class FocusCapture(
     val step: Int? = null,
     val overlay: Boolean = false,
     val enterPlacesFocus: Boolean = false,
+    val pressed: Boolean = false,
 )
 
 /** Renderer-side mirror of the plugin's `FocusGifCapture`. */

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1992,6 +1992,7 @@ private fun FocusCapture.toFocusOverride(): FocusOverride =
         step = step,
         overlay = overlay,
         enterPlacesFocus = enterPlacesFocus,
+        pressed = pressed,
     )
 
 private fun FocusDirection.toProtocol(): ProtocolFocusDirection =

--- a/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerFocusStatePreviews.kt
+++ b/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerFocusStatePreviews.kt
@@ -150,3 +150,26 @@ fun GlimmerListItemFocused() {
     }
   }
 }
+
+@Preview(
+  name = "Glimmer · Pressed",
+  device = AI_GLASSES_DEVICE_SPEC,
+  showBackground = true,
+  backgroundColor = ADDITIVE_ZERO_BACKGROUND,
+)
+@FocusedPreview(indices = [0], pressed = true)
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun GlimmerListItemPressed() {
+  // `pressed = true` opts in to the indirect-pointer Press dispatch the connector fires after the
+  // focus walk lands. On XR Glasses the temple touchpad routes through
+  // `AndroidComposeView.sendIndirectPointerEvent`; Glimmer's `surface()` (under `ListItem`) reads
+  // those events through `Modifier.onIndirectPointerGesture` and emits `PressInteraction.Press`
+  // onto its interaction source — the focused item's pressed visual then renders before capture.
+  ComposeUiFlags.isInitialFocusOnFocusableAvailable = true
+  GlimmerSurface {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      ListItem(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Pressed") }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

XR Glasses have no touchscreen — input arrives from the temple touchpad as `IndirectPointerEvent`s through `AndroidComposeView.sendIndirectPointerEvent`. That's also the only path Glimmer's `Modifier.onIndirectPointerGesture` consumes, which means the *pressed* visual state on a Glimmer surface (brighter fill + thicker focus ring) is unreachable from a synthetic `MotionEvent.ACTION_DOWN` on the View — that's a phone-style touch input Glimmer's modifier doesn't route through.

Add an opt-in `pressed = true` field to `@FocusedPreview` that drives the indirect-pointer dispatch end-to-end:

- **`preview-annotations`** — `@FocusedPreview(pressed: Boolean = false)`, indexed-mode only.
- **`gradle-plugin/preview-discovery`** — extract `pressed` in `readFocusSteps`, carry on `FocusCapture`.
- **`renderer-android`** — wire `pressed` through `FocusCapture.toFocusOverride()` so the connector reads it via `FocusController.activeFocus`. Mirror on the renderer-side `FocusCapture`.
- **`daemon/core`** protocol — same field on `FocusOverride` so the daemon-driven `renderNow.overrides.focus` path can request the pressed-state capture too.
- **`data/focus/connector`** — after the existing `LaunchedEffect`-driven focus walk completes, dispatch a single `IndirectPointerEvent(Press)` via reflection on `AndroidComposeView.sendIndirectPointerEvent` (`@ExperimentalIndirectPointerApi`). Reflection rather than a direct call because `AndroidComposeView` is Kotlin-`internal` at the source level but bytecode-public — same pattern the renderer's focus-overlay reflection uses to read its internals. Press is sent without a matching Release so the composable stays in its pressed state for the capture window and doesn't fire `onClick`.

The MotionEvent carries `source = SOURCE_TOUCHPAD` and axis = `X` to match real Glasses input; coordinates are `(0, 0)` because indirect-pointer events have no screen position (the consumer routes by focused target). The MotionEvent isn't recycled because Compose retains it as `IndirectPointerEvent.nativeEvent`.

Off by default — existing `@FocusedPreview(indices = [...])` previews keep their byte-identical capture. `pressed` only takes effect on indexed-mode captures; traversal-mode (`traverse = [...]`) ignores it because each step walks focus without a "settle and press" point.

## Test plan

- [x] `:data-focus-connector:test` passes.
- [x] `:samples:xr-glimmer:composePreviewRenderAll` renders the new `Glimmer · Pressed` capture (`samples/xr-glimmer/build/compose-previews/renders/GlimmerListItemPressed_Glimmer_Pressed.png`). Compare against `Glimmer · Focused`:
  - **Focused** — dark fill, bright focus ring.
  - **Pressed** — *lighter* fill (`surface()`'s `collectIsPressedAsState` emits via Glimmer's `onIndirectPointerGesture`), thicker brighter focus ring.
- [x] Existing `Glimmer · Default` and `Glimmer · Focused` captures unchanged from `main` (no regression in the default `pressed = false` path).
- [ ] CI green on the rest of the matrix (no other modules touched besides the schema mirrors).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8rwpN4xdDv8rTeHXnH9JX)_