### PR TITLE
feat(daemon): complete stage-2 in-process compile (BTA) behind experimental flag

### DIFF
--- a/daemon/bta-host/build.gradle.kts
+++ b/daemon/bta-host/build.gradle.kts
@@ -1,10 +1,12 @@
-// Stage-2 spike for the kotlinc-in-daemon investigation. Standalone proof-of-concept
-// that the Kotlin Build Tools API (BTA) can compile a `@Composable` source file with
-// the Compose compiler plugin loaded, in-process, with no Gradle.
+// Standalone Kotlin Build Tools API (BTA) parity/soak harness. Began as the stage-2 spike
+// proving BTA can compile a `@Composable` source file with the Compose compiler plugin loaded,
+// in-process, with no Gradle — that work has SHIPPED in `:daemon:core` (bta/BtaCompileSession,
+// the `compileSources` JSON-RPC method) behind `composePreview.daemon.compileInProcess`.
 //
-// NOT published. NOT wired into the daemon. The only artifact this module produces
-// today is a test report demonstrating BTA + Compose-plugin viability against Kotlin
-// 2.3.21. See docs/daemon/BTA-SPIKE.md for goals + exit criteria + what to do next.
+// NOT published. Nothing in production depends on this module; it's retained for its BTA-impl
+// parity, incremental-compile, and classloader-leak soak tests against Kotlin 2.3.21. See
+// docs/daemon/BTA-SPIKE.md for the checkpoints and docs/daemon/COMPILE-IN-PROCESS.md for the
+// production design these tests guard.
 
 plugins { alias(libs.plugins.kotlin.jvm) }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/DefaultBtaCompileService.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/DefaultBtaCompileService.kt
@@ -7,6 +7,7 @@ import java.nio.file.Path
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPlugin
+import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPluginOption
 
 /**
  * Production [BtaCompileService] adapter. Constructed once per daemon JVM at startup if (and only
@@ -28,14 +29,14 @@ import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPlugin
  *    become `SourcesChanges.Known`; null becomes `SourcesChanges.ToBeCalculated` (BTA inspects file
  *    timestamps against its IC cache). Same shape KGP uses.
  *
- * 3. **Exception → Fallback mapping.** Any throw from [backend] is treated as a transient runtime
- *    failure (typically: BTA bootstrap fault, missing JAR, file system error) and downgraded to
- *    [BtaCompileService.Outcome.Fallback]. The daemon's stage-1 `gradle --continuous` worker picks
- *    up the save instead. Diagnostic-bearing compile failures (Kotlin source errors) are not yet
- *    surfaced as [BtaCompileService.Outcome.CompileError] from here — that requires a
- *    `KotlinLogger`-backed diagnostic collector wired through the session, tracked as a follow-up.
- *    Until then, a compile-error save falls through to stage 1 which still surfaces the diagnostics
- *    via `KotlinCompileErrorDetector`. Lossy but not silent.
+ * 3. **Exception → outcome mapping.** [forSession]'s backend routes BTA's diagnostic stream through
+ *    a [DiagnosticCollector]; on a `COMPILATION_ERROR` it re-throws the collected diagnostics as a
+ *    typed [BtaCompileDiagnosticException], which this adapter maps to
+ *    [BtaCompileService.Outcome.CompileError] so the editor's existing compile-error banner renders
+ *    the Kotlin source errors directly from stage 2. Any *other* throw (BTA bootstrap fault,
+ *    missing JAR, file system error, or a `COMPILATION_ERROR` with no diagnostics captured) is
+ *    treated as a transient runtime failure and downgraded to [BtaCompileService.Outcome.Fallback]
+ *    so the daemon's stage-1 `gradle --continuous` worker picks up the save instead.
  *
  * The split between [backend] (a function reference) and [forSession] (the production factory
  * wrapping a [BtaCompileSession]) lets unit tests stub the compile behaviour without dragging in a
@@ -182,17 +183,7 @@ class DefaultBtaCompileService(
       val compileClasspath = sysprops(SYSPROP_COMPILE_CLASSPATH).toPathList()
       val pluginJars = sysprops(SYSPROP_COMPILER_PLUGINS).toPathList()
       val ineligibilityReason = sysprops(SYSPROP_INELIGIBILITY_REASON)?.takeIf { it.isNotEmpty() }
-      val compilerPlugins =
-        if (pluginJars.isEmpty()) emptyList()
-        else
-          listOf(
-            CompilerPlugin(
-              "androidx.compose.compiler.plugins.kotlin",
-              pluginJars,
-              emptyList(),
-              emptySet(),
-            )
-          )
+      val compilerPlugins = composeCompilerPlugins(pluginJars)
       val session =
         BtaCompileSession(
           implClasspath = implClasspath,
@@ -207,6 +198,30 @@ class DefaultBtaCompileService(
         ineligibilityReason = ineligibilityReason,
       )
     }
+
+    /**
+     * Compose compiler plugin config for the in-process BTA compile. Mirrors what KGP's Compose
+     * plugin hands to `compileKotlin`: the plugin id, the embeddable plugin JARs, and the
+     * `sourceInformation=true` option.
+     *
+     * The option is load-bearing, not cosmetic. KGP enables `sourceInformation` by default and the
+     * markers it emits (`~236 byte` delta measured in BTA-SPIKE.md §4) are read by Compose
+     * Inspector / Live Literals / recomposition tooling. Without it, stage-2-emitted classes drift
+     * from the Gradle-emitted classes the daemon's hot-swap diffs against — see
+     * COMPILE-IN-PROCESS.md § "Compose plugin option drift". Returns an empty list when no plugin
+     * JARs were resolved (plain Kotlin/JVM module with no Compose plugin on the classpath).
+     */
+    internal fun composeCompilerPlugins(pluginJars: List<Path>): List<CompilerPlugin> =
+      if (pluginJars.isEmpty()) emptyList()
+      else
+        listOf(
+          CompilerPlugin(
+            "androidx.compose.compiler.plugins.kotlin",
+            pluginJars,
+            listOf(CompilerPluginOption("sourceInformation", "true")),
+            emptySet(),
+          )
+        )
 
     private fun String?.toPathList(): List<Path> =
       if (this.isNullOrEmpty()) emptyList()

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/bta/DefaultBtaCompileServiceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/bta/DefaultBtaCompileServiceTest.kt
@@ -25,11 +25,10 @@ import org.junit.Test
  *   etc.). The exception message is folded into the Fallback reason for diagnostic surfacing in the
  *   panel log.
  *
- * The fourth outcome ([BtaCompileService.Outcome.CompileError]) isn't reachable from
- * [DefaultBtaCompileService] yet — that lands when the `KotlinLogger`-backed diagnostic collector
- * is wired through [BtaCompileSession]. Until then, diagnostic-bearing compile failures fall
- * through to stage 1's `KotlinCompileErrorDetector` via the editor's Fallback retry path. Tracked
- * in COMPILE-IN-PROCESS.md follow-ups.
+ * - **CompileError** → [forSession]'s backend routes BTA's diagnostics through a
+ *   [DiagnosticCollector] and re-throws a [BtaCompileDiagnosticException] on `COMPILATION_ERROR`;
+ *   the service maps that to [BtaCompileService.Outcome.CompileError] so the editor's diagnostic
+ *   banner renders the Kotlin source errors from stage 2 directly.
  */
 class DefaultBtaCompileServiceTest {
 
@@ -205,6 +204,27 @@ class DefaultBtaCompileServiceTest {
       outcome is BtaCompileService.Outcome.CompileError,
     )
     assertEquals(errors, (outcome as BtaCompileService.Outcome.CompileError).errors)
+  }
+
+  @Test
+  fun `composeCompilerPlugins passes sourceInformation=true to the Compose plugin`() {
+    val jars = listOf(Path.of("/abs/kotlin-compose-compiler-plugin-embeddable.jar"))
+    val plugins = DefaultBtaCompileService.composeCompilerPlugins(jars)
+    assertEquals(1, plugins.size)
+    val plugin = plugins.single()
+    assertEquals("androidx.compose.compiler.plugins.kotlin", plugin.pluginId)
+    assertEquals(jars, plugin.classpath)
+    val sourceInformation = plugin.rawArguments.single { it.key == "sourceInformation" }
+    assertEquals(
+      "sourceInformation must be true so BTA bytecode stays byte-parity with Gradle's output",
+      "true",
+      sourceInformation.value,
+    )
+  }
+
+  @Test
+  fun `composeCompilerPlugins is empty when no plugin JARs were resolved`() {
+    assertTrue(DefaultBtaCompileService.composeCompilerPlugins(emptyList()).isEmpty())
   }
 
   @Test

--- a/docs/daemon/BTA-SPIKE.md
+++ b/docs/daemon/BTA-SPIKE.md
@@ -1,8 +1,13 @@
 # Kotlin Build Tools API — stage 2 spike
 
-**Status:** all five checkpoints green ✅. Not wired into the daemon. Not
-user-facing. Lives in `:daemon:bta-host` (+ companion `:daemon:bta-host-fixture`)
-and produces six test reports under `./gradlew :daemon:bta-host:test` against
+**Status:** all five checkpoints green ✅, and the production wire-up has since
+SHIPPED — in-process compile lives in `:daemon:core` (`bta/BtaCompileSession`,
+`bta/DefaultBtaCompileService`, the `compileSources` JSON-RPC method) behind the
+experimental, off-by-default workspace flag `composePreview.daemon.compileInProcess`
+(see [COMPILE-IN-PROCESS.md](COMPILE-IN-PROCESS.md)). This module
+(`:daemon:bta-host`, + companion `:daemon:bta-host-fixture`) is retained as the
+standalone parity/soak harness guarding that path; nothing in production depends on
+it. It produces six test reports under `./gradlew :daemon:bta-host:test` against
 Kotlin 2.3.21 + Compose compiler plugin 2.3.21 + JDK 17:
 
   - `compiles @Composable source with Compose plugin loaded` (✅ decisive)
@@ -15,9 +20,14 @@ Kotlin 2.3.21 + Compose compiler plugin 2.3.21 + JDK 17:
   - `BTA compiles a @Composable that references a synthetic Android R class`
     (✅ checkpoint #5, Android-distilled)
 
-The stage-2 design proposal is unblocked; remaining work is the production
-wire-up (JSON-RPC `compileSources` endpoint, classpath assembly per
-variant, fallback strategy for KSP/KAPT modules).
+The stage-2 design proposal was unblocked by these checkpoints and the
+production wire-up has since landed: the JSON-RPC `compileSources` endpoint,
+per-variant classpath assembly (gradle plugin → `composeai.daemon.bta.*`
+sysprops → `DefaultBtaCompileService.fromSysprops`), and the stage-1
+fallback for KSP/KAPT/`annotationProcessor`/KMP modules
+(`ComposePreviewTasks.detectStageTwoIneligibility`). What remains is the
+latency-measurement + promote/demote evaluation, tracked in
+[#1586](https://github.com/yschimke/compose-ai-tools/issues/1586).
 
 [CONTINUOUS-COMPILE.md](CONTINUOUS-COMPILE.md) describes the stage-1 path
 (long-running `gradle --continuous` worker per module). This spike asks the

--- a/docs/daemon/COMPILE-IN-PROCESS.md
+++ b/docs/daemon/COMPILE-IN-PROCESS.md
@@ -1,10 +1,24 @@
 # In-process compile — stage-2 production design
 
-**Status:** design proposal. Not yet implemented. Builds on the
+**Status:** implemented and shipping behind the experimental, off-by-default
+workspace flag `composePreview.daemon.compileInProcess`. Builds on the
 spike findings in [BTA-SPIKE.md](BTA-SPIKE.md) (all five checkpoints
 green) and on the stage-1 baseline in
 [CONTINUOUS-COMPILE.md](CONTINUOUS-COMPILE.md) (`gradle --continuous`
 worker, already shipping behind `composePreview.daemon.continuousCompile`).
+
+> **As-built note.** The sections below are the original design. What
+> actually landed differs from the "Module layout" sketch in two ways:
+> the per-module session is `daemon/core/.../bta/BtaCompileSession.kt`
+> (a new class, not a moved `BtaCompiler.kt`), and the spike modules
+> `:daemon:bta-host` / `:daemon:bta-host-fixture` were **kept** as
+> standalone parity/soak test harnesses rather than removed — nothing in
+> production depends on them. The eligibility predicate
+> ([`ComposePreviewTasks.detectStageTwoIneligibility`](../../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt))
+> short-circuits KSP, KAPT, `annotationProcessor` dependencies, and KMP
+> modules to stage 1. The bench-harness measurement work in § "What we
+> expect to measure" is tracked in
+> [#1586](https://github.com/yschimke/compose-ai-tools/issues/1586).
 
 This doc describes the next layer: a JSON-RPC `compileSources` endpoint
 on `:daemon:core` that hosts the Kotlin compiler in-process via the

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -685,16 +685,23 @@ internal object ComposePreviewTasks {
     setupBtaConfigurations(project, extension)
 
   /**
-   * Daemon-warm-time KSP/KAPT detection. Returns a human-readable string when the consumer's module
-   * is NOT eligible for stage 2; `null` when eligible.
+   * Daemon-warm-time stage-2 eligibility predicate. Returns a human-readable string when the
+   * consumer's module is NOT eligible for in-process compile; `null` when eligible. Mirrors
+   * `docs/daemon/COMPILE-IN-PROCESS.md` § "Eligibility" — keep the two in sync.
    *
-   * - KSP-using modules need their generated sources recompiled on every save. BTA doesn't drive
-   *   KSP; stage 1's `gradle --continuous` covers KSP because Gradle drives KSP for it.
-   * - KAPT is the legacy variant of the same problem.
-   * - Plain `annotationProcessor` configurations (javac APs) similarly aren't BTA-driven.
+   * - **KSP** modules need their generated sources recompiled on every save. BTA doesn't drive KSP;
+   *   stage 1's `gradle --continuous` covers it because Gradle drives KSP for it.
+   * - **KAPT** is the legacy variant of the same problem.
+   * - **Plain `annotationProcessor` dependencies** (javac APs) similarly aren't BTA-driven — a save
+   *   in an AP-processed source would render with stale generated code.
+   * - **KMP** modules: the spike covered a single JVM source set only; the stage-2 wiring uses the
+   *   plain Kotlin/JVM module-name + `classes/kotlin/main` output dir, which doesn't model KMP's
+   *   per-target source-set layout. Re-evaluate when KMP support is explicitly added.
    *
-   * Listed by plugin id rather than dependency probing because the ids are stable across KGP
-   * versions and don't require resolving the consumer's classpath at config time.
+   * Plugins are matched by id (stable across KGP versions, no classpath resolution). The
+   * annotationProcessor check reads declared dependencies on the AP configurations by name —
+   * `configurations.names` doesn't realize the container, and only the matching configs are
+   * realized — so it stays configuration-cache-safe.
    */
   private fun detectStageTwoIneligibility(project: Project): String? =
     when {
@@ -703,8 +710,28 @@ internal object ComposePreviewTasks {
           "docs/daemon/COMPILE-IN-PROCESS.md § Eligibility)"
       project.plugins.hasPlugin("org.jetbrains.kotlin.kapt") ->
         "org.jetbrains.kotlin.kapt plugin applied (stage 2 doesn't drive KAPT yet)"
+      project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") ->
+        "org.jetbrains.kotlin.multiplatform plugin applied (stage 2 covers single-source-set " +
+          "JVM/Android modules only; KMP source-set wiring stays on stage 1 — see " +
+          "docs/daemon/COMPILE-IN-PROCESS.md § Eligibility)"
+      hasAnnotationProcessorDependencies(project) ->
+        "annotationProcessor dependencies declared (javac annotation processors aren't BTA-driven " +
+          "— see docs/daemon/COMPILE-IN-PROCESS.md § Eligibility)"
       else -> null
     }
+
+  /**
+   * True when the consumer declares any dependency on an `annotationProcessor`-shaped configuration
+   * (`annotationProcessor`, `testAnnotationProcessor`, AGP's per-variant
+   * `<variant>AnnotationProcessor`, …). Reads `configurations.names` (which does not force the
+   * container to realize) and only realizes the configurations whose name matches, reading their
+   * *declared* dependencies — no classpath resolution — so the check is configuration-cache-safe at
+   * config time.
+   */
+  private fun hasAnnotationProcessorDependencies(project: Project): Boolean =
+    project.configurations.names
+      .filter { it.contains("annotationProcessor", ignoreCase = true) }
+      .any { name -> project.configurations.getByName(name).dependencies.isNotEmpty() }
 
   /**
    * Reads the consumer's Kotlin version from their `libs.versions.toml` `kotlin` entry — the

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/StageTwoEligibilityTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/StageTwoEligibilityTest.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the contract of [ComposePreviewTasks.detectStageTwoIneligibilityFor] — the daemon-warm-time
+ * predicate that keeps modules off in-process compile (stage 2,
+ * `composePreview.daemon.compileInProcess`) when BTA can't safely drive their build. Mirrors
+ * `docs/daemon/COMPILE-IN-PROCESS.md` § "Eligibility".
+ *
+ * The KSP / KAPT / KMP branches are plain `hasPlugin(<id>)` string checks — exercised end-to-end by
+ * the functional tests where the real plugins are on the TestKit classpath. These unit tests cover
+ * the branch with actual logic: the `annotationProcessor`-dependency probe, which must read
+ * declared dependencies (not mere configuration existence) and stay configuration-cache-safe.
+ */
+class StageTwoEligibilityTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  @Test
+  fun `plain module with no processors is eligible`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    assertThat(ComposePreviewTasks.detectStageTwoIneligibilityFor(project)).isNull()
+  }
+
+  @Test
+  fun `an empty annotationProcessor configuration does not disqualify`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    // The config exists (java/AGP create it) but carries no declared deps — the module isn't
+    // actually annotation-processed, so it stays eligible.
+    project.configurations.create("annotationProcessor")
+    assertThat(ComposePreviewTasks.detectStageTwoIneligibilityFor(project)).isNull()
+  }
+
+  @Test
+  fun `a declared annotationProcessor dependency falls back to stage 1`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    project.configurations.create("annotationProcessor")
+    project.dependencies.add("annotationProcessor", "com.example:some-processor:1.0")
+
+    val reason = ComposePreviewTasks.detectStageTwoIneligibilityFor(project)
+    assertThat(reason).isNotNull()
+    assertThat(reason).contains("annotationProcessor")
+  }
+
+  @Test
+  fun `a per-variant annotationProcessor bucket is matched case-insensitively`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    // AGP creates `<variant>AnnotationProcessor` buckets; the probe matches the substring
+    // regardless of the camelCase prefix.
+    project.configurations.create("debugAnnotationProcessor")
+    project.dependencies.add("debugAnnotationProcessor", "com.example:some-processor:1.0")
+
+    assertThat(ComposePreviewTasks.detectStageTwoIneligibilityFor(project)).isNotNull()
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -338,15 +338,18 @@ include(":daemon:desktop")
 
 include(":daemon:harness")
 
-// Stage-2 spike for the kotlinc-in-daemon investigation (#1332 → follow-up). Standalone
-// proof-of-concept that the Kotlin Build Tools API can compile a `@Composable` source file
-// with the Compose compiler plugin loaded, in-process, with no Gradle. NOT wired into the
-// daemon yet — see docs/daemon/BTA-SPIKE.md. Remove this module if the spike abandons.
+// Standalone Kotlin Build Tools API parity/soak harness (#1332). The stage-2 spike it began as
+// has SHIPPED: in-process compile is wired into `:daemon:core` (`bta/BtaCompileSession`,
+// `bta/DefaultBtaCompileService`, the `compileSources` JSON-RPC method) behind the experimental
+// workspace flag `composePreview.daemon.compileInProcess` — see docs/daemon/COMPILE-IN-PROCESS.md.
+// Nothing in production depends on this module; it's retained only for its BTA-impl parity, IC,
+// and classloader-leak soak tests (`./gradlew :daemon:bta-host:test`, see
+// docs/daemon/BTA-SPIKE.md).
 include(":daemon:bta-host")
 
 // Companion fixture for `:daemon:bta-host` — same Kotlin source compiled through Gradle's
-// standard `compileKotlin`, so the BTA spike's Gradle-parity test has a reference artefact
-// to diff against. Same lifecycle as `:daemon:bta-host`; remove together with it.
+// standard `compileKotlin`, so the BTA parity test has a reference artefact to diff against.
+// Same lifecycle as `:daemon:bta-host`; remove together with it.
 include(":daemon:bta-host-fixture")
 
 include(":mcp")


### PR DESCRIPTION
## Summary

In-process compile via the Kotlin Build Tools API (BTA) ships behind the off-by-default workspace flag `composePreview.daemon.compileInProcess`. The plumbing (gradle-plugin sysprops → `DefaultBtaCompileService.fromSysprops` → `JsonRpcServer.compileSources`, VS Code dispatch gate) was already in place; this closes the remaining gaps relative to `docs/daemon/COMPILE-IN-PROCESS.md` so the feature is actually complete behind the flag.

- **Compose `sourceInformation=true`.** Pass the option to the Compose compiler plugin so stage-2 bytecode stays byte-parity with Gradle's `compileKotlin` output — the source-information markers Compose Inspector / Live Literals / recomposition tooling read, and that the daemon's classloader hot-swap diffs against. Previously passed as `emptyList()`, contradicting the doc's "Compose plugin option drift" mitigation. Extracted as a testable `DefaultBtaCompileService.composeCompilerPlugins(...)`.
- **Eligibility predicate.** Extend `ComposePreviewTasks.detectStageTwoIneligibility` to fall back to stage 1 for modules that declare `annotationProcessor` dependencies or apply the Kotlin Multiplatform plugin, alongside the existing KSP/KAPT checks (per the doc's § "Eligibility" — KMP source-set wiring and javac APs aren't BTA-driven). The annotationProcessor probe reads declared deps via `configurations.names` so it doesn't realize the whole configuration container and stays configuration-cache-safe.
- **Docs/comments refresh.** The wire-up had already landed but several places still described it as a spike: `COMPILE-IN-PROCESS.md` / `BTA-SPIKE.md` "not yet implemented / not wired in" status, the `settings.gradle.kts` + `daemon/bta-host/build.gradle.kts` "spike, remove if abandoned" notes (the bta-host modules are now standalone parity/soak harnesses nothing in production depends on), and the `DefaultBtaCompileService` KDoc that claimed `CompileError` wasn't surfaced yet (it is — `DiagnosticCollector` → `BtaCompileDiagnosticException` → `Outcome.CompileError`, and the existing test covers it).

The bench-harness latency measurement that feeds the stage-2 promote/demote decision is tracked separately in #1586.

## Test plan

- [x] `./gradlew :daemon:core:test --tests "*DefaultBtaCompileServiceTest*" --tests "*CompileSourcesTest*" --tests "*DiagnosticCollectorTest*"` — green, including new `sourceInformation` assertions.
- [x] `./gradlew :gradle-plugin:test --tests "*StageTwoEligibilityTest*"` — green (new test: declared AP dep disqualifies, empty AP config does not, per-variant bucket matched case-insensitively, plain module eligible).
- [x] `./gradlew :daemon:core:test :gradle-plugin:test` — green apart from `InteractiveCoalescingTest`, a pre-existing wall-clock timing flake confirmed failing on the untouched tree (no relation to changed code).
- [x] `ktfmtFormat` / `ktfmtCheckScripts` clean.

> Note: the KSP/KAPT/KMP branches of the eligibility predicate are plain `hasPlugin(<id>)` string checks; they're exercised end-to-end by the functional tests where the real plugins are on the TestKit classpath. The new unit test covers the `annotationProcessor` branch, which is the one with actual logic.

---
_Generated by [Claude Code](https://claude.ai/code/session_0161zj8Hc1G52XECYKWjdXE5)_