### PR TITLE
fix(focus-connector): release indirect-pointer Press across multi-index captures

### DIFF
--- a/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
+++ b/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
@@ -74,8 +74,18 @@ class FocusOverrideExtension(private val seed: FocusOverride? = null) :
       val active by FocusController.activeFocus
       val lastIndex = remember { mutableIntStateOf(-1) }
       val entered = remember { mutableStateOf(false) }
+      val pressHeld = remember { mutableStateOf(false) }
       LaunchedEffect(active) {
         val cap = active ?: return@LaunchedEffect
+        // Release any indirect-pointer Press from the prior capture *before* walking focus to the
+        // new target. Indirect-pointer events route to the focused composable, so a Release
+        // dispatched after the focus walk would land on the new target and leave the previous
+        // target's `PressInteraction.Press` active — surfacing as two simultaneously-pressed items
+        // in a multi-index capture (`@FocusedPreview(indices = [0, 1], pressed = true)`).
+        if (pressHeld.value) {
+          view.dispatchIndirectRelease()
+          pressHeld.value = false
+        }
         val direction = cap.direction
         val tabIndex = cap.tabIndex
         if (direction != null) {
@@ -112,9 +122,12 @@ class FocusOverrideExtension(private val seed: FocusOverride? = null) :
         // before the renderer captures pixels. Glimmer's `Modifier.onIndirectPointerGesture`
         // observes this event on the focused-target path and emits the pressed-state interaction;
         // Material's `Modifier.clickable` does the same through its indirect-pointer fallback. See
-        // [dispatchIndirectPress] for the platform rationale.
+        // [dispatchIndirectPress] for the platform rationale. The matching Release is held off
+        // until the NEXT capture's LaunchedEffect runs (above) — held-press across the capture
+        // window is exactly the "finger held on touchpad" shape we want pixels to show.
         if (cap.pressed) {
           view.dispatchIndirectPress()
+          pressHeld.value = true
         }
       }
       content()
@@ -153,10 +166,15 @@ fun FocusManager.applyFocusOverride(override: FocusOverride?) {
  * focused element's pressed visual then renders before the renderer's per-capture clock advance
  * elapses.
  *
- * Press is dispatched without a matching Release. That holds the composable in its pressed state
- * for the capture window — the same shape a real "finger held on the touchpad" produces — and
- * deliberately doesn't fire the `onClick` lambda (a tap = Press+Release). The JVM is recycled
- * after capture so no manual cleanup is needed.
+ * The matching Release isn't sent here — it's deferred to the next capture's `LaunchedEffect`
+ * pass (via the `pressHeld` flag) so the composable stays in its pressed state for *this*
+ * capture window (the "finger held on the touchpad" shape) and deliberately doesn't fire the
+ * `onClick` lambda (a tap = Press+Release). The next capture, if any, dispatches
+ * [dispatchIndirectRelease] before walking focus, clearing the prior target's
+ * `PressInteraction.Press` while focus is still on it — without that step, a multi-index pressed
+ * walk (`@FocusedPreview(indices = [0, 1], pressed = true)`) would leave item 0 still visually
+ * pressed in the index-1 capture. After the final capture the JVM is recycled, so no terminal
+ * Release is needed.
  *
  * Reflection rather than a direct call: `AndroidComposeView` is `internal` at the Kotlin source
  * level (compiles to `public final class` at the JVM level — `internal` is module-scoped in the
@@ -178,13 +196,30 @@ fun FocusManager.applyFocusOverride(override: FocusOverride?) {
  */
 @OptIn(ExperimentalIndirectPointerApi::class)
 private fun View.dispatchIndirectPress() {
+  sendIndirectPointer(MotionEvent.ACTION_DOWN)
+}
+
+/**
+ * Matching Release for [dispatchIndirectPress] — clears the held `PressInteraction.Press` on the
+ * focused composable so a subsequent capture (next focus walk) doesn't leave the prior target
+ * visually pressed. Must dispatch *before* `FocusManager.moveFocus(...)` walks focus to the next
+ * target: indirect-pointer events route to whatever's currently focused, so a Release after the
+ * walk would land on the new target and leave the previous target's interaction source dangling.
+ */
+@OptIn(ExperimentalIndirectPointerApi::class)
+private fun View.dispatchIndirectRelease() {
+  sendIndirectPointer(MotionEvent.ACTION_UP)
+}
+
+@OptIn(ExperimentalIndirectPointerApi::class)
+private fun View.sendIndirectPointer(action: Int) {
   if (javaClass.name != "androidx.compose.ui.platform.AndroidComposeView") return
   val now = SystemClock.uptimeMillis()
   val motionEvent =
     MotionEvent.obtain(
       /* downTime = */ now,
       /* eventTime = */ now,
-      /* action = */ MotionEvent.ACTION_DOWN,
+      /* action = */ action,
       /* x = */ 0f,
       /* y = */ 0f,
       /* metaState = */ 0,

--- a/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerFocusStatePreviews.kt
+++ b/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerFocusStatePreviews.kt
@@ -1,6 +1,8 @@
 package com.example.samplexrglimmer
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
@@ -9,6 +11,7 @@ import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.xr.glimmer.ListItem
 import androidx.xr.glimmer.Text
 import ee.schimke.composeai.preview.FocusedPreview
@@ -147,6 +150,33 @@ fun GlimmerListItemFocused() {
   GlimmerSurface {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
       ListItem(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Focused") }
+    }
+  }
+}
+
+@Preview(
+  name = "Glimmer · Pressed Walk",
+  device = AI_GLASSES_DEVICE_SPEC,
+  showBackground = true,
+  backgroundColor = ADDITIVE_ZERO_BACKGROUND,
+)
+@FocusedPreview(indices = [0, 1], pressed = true)
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun GlimmerListPressedWalk() {
+  // Two-item walk that exercises the cross-capture Press/Release pairing in the focus connector.
+  // Capture 0 lands focus on item 0 and presses it (item 0 visually pressed, item 1 neutral);
+  // capture 1 must release item 0's held press before walking focus to item 1 — otherwise both
+  // items would render in their pressed visual state. Visually verifies the connector's
+  // `pressHeld`-tracked Release on the prior target.
+  ComposeUiFlags.isInitialFocusOnFocusableAvailable = true
+  GlimmerSurface {
+    Column(
+      modifier = Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+    ) {
+      ListItem(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Item 0") }
+      ListItem(onClick = {}, modifier = Modifier.fillMaxWidth()) { Text("Item 1") }
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1585.

`@FocusedPreview(pressed = true)` previously dispatched a Press without a matching Release. For single-index captures (`indices = [0]`) that was intentional — the held press is what makes pixels show the pressed state during the capture window. But for **multi-index captures** (`indices = [0, 1]`), the connector reuses the composition across capture jobs and only advances `FocusController` between them: item 0's `PressInteraction.Press` stayed live on its `InteractionSource` while focus walked to item 1, so the second PNG rendered both items in their pressed visual state instead of just item 1.

Fix in `:data-focus-connector`'s `LaunchedEffect(active)`: track whether a Press is currently held (`pressHeld: MutableState<Boolean>`), and on each re-entry dispatch a Release **before** walking focus to the new target. Indirect-pointer events route to whatever's currently focused, so the Release must dispatch while focus is still on the previous target — releasing after the focus walk would clear the wrong InteractionSource and leave the previous target visually pressed anyway. After the final capture the JVM is recycled, so no terminal Release is needed.

The Release path uses the same `sendIndirectPointerEvent` reflection as Press, just with `ACTION_UP` instead of `ACTION_DOWN`; both are factored through a shared `sendIndirectPointer(action)` helper.

## Test plan

- [x] New `Glimmer · Pressed Walk` preview: `@FocusedPreview(indices = [0, 1], pressed = true)` on a `Column` of two `ListItem`s.
  - **Capture 0** (`FOCUS_0`): item 0 pressed (bright ring + lighter fill), item 1 neutral.
  - **Capture 1** (`FOCUS_1`): item 0 **neutral** (Release landed), item 1 pressed.
  - Without the fix, capture 1 would show both items in pressed state.
- [x] Single-index `Glimmer · Pressed` (from #1585) — byte-identical, no regression in the no-walk case.
- [ ] CI green on the rest of the matrix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8rwpN4xdDv8rTeHXnH9JX)_