### PR TITLE
fix(a11y): surface only changed previews in PR comment

### DIFF
--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -22,7 +22,10 @@ readme
 
 comment
     Render ``findings.json`` to a PR-comment Markdown body with the
-    ``<!-- a11y-report -->`` marker the action upserts on.
+    ``<!-- a11y-report -->`` marker the action upserts on. Diffs against the
+    baseline ``findings.json`` and surfaces only the previews whose findings
+    changed (collapsing the rest into a roster); stays silent when nothing
+    a reviewer cares about changed.
 """
 
 from __future__ import annotations
@@ -427,37 +430,59 @@ def cmd_readme(args: argparse.Namespace) -> int:
 # comment
 # ---------------------------------------------------------------------------
 
+def _finding_tuple(f: dict) -> tuple:
+    """Hash-stable representation of a single finding for change detection.
+
+    Filenames are deliberately excluded elsewhere; here we capture only the
+    fields a reviewer reacts to (level, rule type, message, element, bounds).
+    """
+    return (
+        f.get("level"),
+        f.get("type"),
+        f.get("message"),
+        f.get("viewDescription"),
+        f.get("boundsInScreen"),
+    )
+
+
+def _entry_findings_key(entry: dict) -> tuple:
+    """Order-insensitive key for one preview's findings.
+
+    Returns the empty tuple for a preview with no findings, so an
+    absent-from-baseline preview (default ``()``) and a clean preview compare
+    equal — the surface rule in [cmd_comment] treats "clean" and "not present"
+    as the same neutral state.
+    """
+    return tuple(sorted(_finding_tuple(f) for f in entry.get("findings", [])))
+
+
 def _findings_fingerprint(entries: list[dict], status: str | None = None) -> tuple:
-    """Stable representation of (status, preview, findings) used for change detection.
+    """Stable representation of (status, previews-with-findings) for change detection.
 
     Compares only the data a reviewer would care about — top-level status,
     plus per-entry module, previewId, and findings list. Filenames
     (`cleanBasename`, `annotatedBasename`) are excluded because identical
     findings can move around between files when the renderer renames variants,
-    and we don't want to wake the PR comment for that. Findings are
-    tuple-ified so the comparison is hash-stable and order-insensitive
-    (sorted below).
+    and we don't want to wake the PR comment for that.
+
+    Previews with **no** findings are excluded entirely: adding or removing a
+    clean preview is not an accessibility change, so it must neither break the
+    comment's silence nor surface a near-empty "nothing to see" comment. Only
+    previews that carry findings participate, which mirrors the per-preview
+    surface rule in [cmd_comment] (an absent/clean preview has the empty
+    findings key).
 
     ``status`` is included so the fingerprint diverges when the daemon goes
     from "ran cleanly" to "atf-unavailable" or vice versa — without this, a
     daemon crash would match a clean baseline and the workflow would stay
     silent on the very condition the comment needs to surface.
     """
-    def finding_tuple(f: dict) -> tuple:
-        return (
-            f.get("level"),
-            f.get("type"),
-            f.get("message"),
-            f.get("viewDescription"),
-            f.get("boundsInScreen"),
-        )
     return (status,) + tuple(
-        (
-            e["module"],
-            e["previewId"],
-            tuple(sorted(finding_tuple(f) for f in e.get("findings", []))),
+        (e["module"], e["previewId"], _entry_findings_key(e))
+        for e in sorted(
+            (e for e in entries if e.get("findings")),
+            key=lambda e: (e["module"], e["previewId"]),
         )
-        for e in sorted(entries, key=lambda e: (e["module"], e["previewId"]))
     )
 
 
@@ -477,6 +502,8 @@ def cmd_comment(args: argparse.Namespace) -> int:
     # this side never matches a clean-run baseline — that flips on the
     # comment so reviewers see the daemon failure rather than the misleading
     # "no findings" the bug in #1453 produced.
+    baseline_entries: list[dict] = []
+    baseline_status: str | None = None
     if args.baseline:
         baseline_path = Path(args.baseline)
         if baseline_path.exists():
@@ -492,12 +519,40 @@ def cmd_comment(args: argparse.Namespace) -> int:
             ):
                 return 0  # silent
 
+    # Per-preview diff against the baseline. The comment used to re-post every
+    # preview's findings on every PR that tripped the fingerprint (#1585);
+    # instead, surface only the previews whose findings actually changed and
+    # collapse the rest. A preview's findings key defaults to `()` when it's
+    # absent from the baseline, so a brand-new *clean* preview compares equal
+    # to its (empty) baseline and is treated as unchanged — only new or
+    # changed findings get a full block.
+    baseline_by_key: dict[tuple[str, str], tuple] = {
+        (e["module"], e["previewId"]): _entry_findings_key(e)
+        for e in baseline_entries
+    }
+    current_keys = {(e["module"], e["previewId"]) for e in entries}
+
+    changed: list[dict] = []
+    unchanged: list[dict] = []
+    for entry in entries:
+        key = (entry["module"], entry["previewId"])
+        if _entry_findings_key(entry) != baseline_by_key.get(key, ()):
+            changed.append(entry)
+        else:
+            unchanged.append(entry)
+
+    # Previews that carried findings on the baseline but are gone now — the
+    # underlying issue is no longer reachable. A clean baseline preview that
+    # disappears isn't an accessibility change, so those are ignored.
+    resolved = [
+        e
+        for e in baseline_entries
+        if (e["module"], e["previewId"]) not in current_keys
+        and _entry_findings_key(e)
+    ]
+
     err, warn, info = _level_counts(entries)
     findings_count = err + warn + info
-
-    by_module: dict[str, list[dict]] = {}
-    for entry in entries:
-        by_module.setdefault(entry["module"], []).append(entry)
 
     marker = "<!-- a11y-report -->"
     lines = [
@@ -528,30 +583,36 @@ def cmd_comment(args: argparse.Namespace) -> int:
     if findings_count == 0:
         lines.append("No accessibility findings.")
         lines.append("")
-        # Still link the gallery thumbnails so reviewers can spot-check
-        # what was actually rendered — same data the readme would show,
-        # without the table.
-        for module, module_entries in sorted(by_module.items()):
-            lines.append(f"### {module}")
-            lines.append("")
-            for entry in sorted(module_entries, key=lambda e: e["functionName"]):
-                image = entry["annotatedBasename"] or entry["cleanBasename"]
-                if not image:
-                    continue
-                url = _image_url(args.repo, args.head_ref, module, image)
-                lines.append(
-                    f"- `{entry['functionName']}` "
-                    f'<img src="{url}" width="120" />'
-                )
-            lines.append("")
-        sys.stdout.write("\n".join(lines).rstrip() + "\n")
-        return 0
 
-    for module, module_entries in sorted(by_module.items()):
+    # Changed / new previews, grouped by module — these get the full block.
+    changed_by_module: dict[str, list[dict]] = {}
+    for entry in changed:
+        changed_by_module.setdefault(entry["module"], []).append(entry)
+    for module, module_entries in sorted(changed_by_module.items()):
         lines.append(f"### {module}")
         lines.append("")
         for entry in sorted(module_entries, key=lambda e: e["functionName"]):
             lines.extend(_entry_block(entry, args.head_ref, args.repo, image_width=240))
+
+    if resolved:
+        lines.append(f"### Resolved ({len(resolved)} preview(s) no longer present)")
+        lines.append("")
+        for entry in sorted(resolved, key=lambda e: (e["module"], e["functionName"])):
+            lines.append(f"- `{entry['functionName']}` ({entry['module']})")
+        lines.append("")
+
+    if unchanged:
+        # Collapse everything that didn't change into a names-only roster so
+        # reviewers can still confirm the tool covered the full preview set
+        # without scrolling past 100+ unchanged tables.
+        lines.append("<details>")
+        lines.append(f"<summary>Unchanged ({len(unchanged)} preview(s))</summary>")
+        lines.append("")
+        for entry in sorted(unchanged, key=lambda e: (e["module"], e["functionName"])):
+            lines.append(f"- `{entry['functionName']}`")
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
 
     sys.stdout.write("\n".join(lines).rstrip() + "\n")
     return 0

--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -580,6 +580,16 @@ def cmd_comment(args: argparse.Namespace) -> int:
         "",
     ])
 
+    if status == ATF_UNAVAILABLE:
+        # ATF returned no data, so every current entry has empty findings —
+        # not because the issues were fixed but because nothing was checked.
+        # Diffing those empties against a baseline would render prior findings
+        # as "resolved" / "_No findings._", making a daemon failure look like
+        # a clean run. Surface only the warning + counts; the per-preview diff
+        # is meaningless until ATF data comes back.
+        sys.stdout.write("\n".join(lines).rstrip() + "\n")
+        return 0
+
     if findings_count == 0:
         lines.append("No accessibility findings.")
         lines.append("")

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -574,6 +574,25 @@ class CommentTest(unittest.TestCase):
         body = self._run_comment([existing, new_clean], baseline_entries=[existing])
         self.assertEqual(body, "")
 
+    def test_atf_unavailable_does_not_render_findings_as_resolved(self):
+        # When ATF fails, copy-annotated still emits the manifest previews
+        # with empty findings. Diffing those against a baseline that had
+        # findings must NOT render them as changed-to-empty/"No findings" or
+        # "Resolved" — that would make a daemon failure look like the issues
+        # were fixed. Only the warning + counts should appear.
+        baseline = self._entry(
+            function="Bad", preview_id="x.Bad", findings=[_finding(level="ERROR")]
+        )
+        current = self._entry(function="Bad", preview_id="x.Bad", findings=[])
+        body = self._run_comment(
+            [current], baseline_entries=[baseline], status="atf-unavailable"
+        )
+        self.assertIn("ATF data unavailable", body)
+        self.assertNotIn("_No findings._", body)
+        self.assertNotIn("### `Bad`", body)
+        self.assertNotIn("Resolved", body)
+        self.assertNotIn("No accessibility findings", body)
+
     def test_resolved_preview_listed_when_removed(self):
         # A preview that carried a finding on the baseline but is gone now
         # should be called out as resolved.

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -416,15 +416,22 @@ class CommentTest(unittest.TestCase):
         self.tmp = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, self.tmp)
 
-    def _entry(self, *, findings: list[dict] | None = None) -> dict:
+    def _entry(
+        self,
+        *,
+        findings: list[dict] | None = None,
+        function: str = "Bad",
+        preview_id: str = "x.Bad_small_round",
+        module: str = "sample-wear",
+    ) -> dict:
         return {
-            "module": "sample-wear",
-            "functionName": "Bad",
+            "module": module,
+            "functionName": function,
             "sourceFile": "Previews.kt",
-            "previewId": "x.Bad_small_round",
+            "previewId": preview_id,
             "variant": "small_round",
-            "cleanBasename": "Bad.png",
-            "annotatedBasename": "Bad.a11y.png" if findings else "",
+            "cleanBasename": f"{function}.png",
+            "annotatedBasename": f"{function}.a11y.png" if findings else "",
             "findings": findings or [],
         }
 
@@ -533,6 +540,52 @@ class CommentTest(unittest.TestCase):
         )
         self.assertNotEqual(body, "")
         self.assertIn("No accessibility findings", body)
+
+    def test_only_changed_preview_gets_a_block_others_collapsed(self):
+        # Two previews exist; only one gains a finding vs the baseline. The
+        # changed one gets a full findings table, the unchanged-but-flagged
+        # one is collapsed to a name in the <details> roster rather than
+        # re-posting its table (#1585).
+        kept = self._entry(
+            function="Kept", preview_id="x.Kept", findings=[_finding(level="ERROR")]
+        )
+        added = self._entry(
+            function="Added", preview_id="x.Added", findings=[_finding(level="WARNING")]
+        )
+        baseline_kept = self._entry(
+            function="Kept", preview_id="x.Kept", findings=[_finding(level="ERROR")]
+        )
+        baseline_added = self._entry(function="Added", preview_id="x.Added", findings=[])
+        body = self._run_comment(
+            [kept, added], baseline_entries=[baseline_kept, baseline_added]
+        )
+        # The changed preview gets its own h3 block + table.
+        self.assertIn("### `Added`", body)
+        # The unchanged preview is only listed as a name inside <details>.
+        self.assertIn("<summary>Unchanged (1 preview(s))</summary>", body)
+        self.assertIn("- `Kept`", body)
+        self.assertNotIn("### `Kept`", body)
+
+    def test_new_clean_preview_stays_silent(self):
+        # Adding a brand-new preview that has no findings is not an a11y
+        # change — it must not break silence with a near-empty comment.
+        existing = self._entry(function="A", preview_id="x.A", findings=[])
+        new_clean = self._entry(function="B", preview_id="x.B", findings=[])
+        body = self._run_comment([existing, new_clean], baseline_entries=[existing])
+        self.assertEqual(body, "")
+
+    def test_resolved_preview_listed_when_removed(self):
+        # A preview that carried a finding on the baseline but is gone now
+        # should be called out as resolved.
+        baseline = self._entry(
+            function="Gone", preview_id="x.Gone", findings=[_finding(level="ERROR")]
+        )
+        survivor = self._entry(
+            function="Stay", preview_id="x.Stay", findings=[_finding(level="WARNING")]
+        )
+        body = self._run_comment([survivor], baseline_entries=[baseline, survivor])
+        self.assertIn("Resolved", body)
+        self.assertIn("`Gone`", body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The accessibility PR comment (`a11y-report.py comment`) used a single global fingerprint as an all-or-nothing gate: when *anything* diverged from the baseline it re-emitted the **entire** gallery — every module and every preview — re-posting 100+ unchanged findings tables on PRs that barely touched a11y (see #1585).

This makes the comment behave like the preview-diff comment: it now diffs each preview's findings against the baseline and surfaces a full block only for previews whose findings actually changed.

### Changes
- Added `_finding_tuple` / `_entry_findings_key` helpers (shared by the fingerprint and the per-preview diff).
- `_findings_fingerprint` now ignores previews with **no** findings, so adding/removing a clean preview no longer breaks silence (it previously fired a near-empty comment).
- `cmd_comment` now:
  - emits a full findings block only for **changed / newly-flagged** previews, grouped by module;
  - collapses everything unchanged into a names-only `<details>` roster (so reviewers can still confirm full coverage);
  - lists previews whose findings were **resolved** (had findings on the baseline, gone now);
  - treats a clean preview and an absent-from-baseline preview as the same neutral empty state.

Net effect on #1585-style PRs (one new clean preview, no findings changed): the comment stays silent instead of dumping all 114 previews.

## Test plan
- `python3 -m unittest test_a11y_report` (run from `.github/actions/lib`) — 27 tests pass.
- New tests cover: only-changed-preview gets a block while others collapse; a new clean preview stays silent; resolved previews are listed.
- Manual smoke test of the `comment` subcommand against a hand-built baseline confirms only the changed preview renders a table; unchanged + clean-new previews appear only in the collapsed roster.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTBdKS5tnPyk9k1huRZYnD)_