### PR TITLE
fix(notifications): distinguish failed renders from removals in PR comment

### DIFF
--- a/.github/actions/lib/notification-previews.py
+++ b/.github/actions/lib/notification-previews.py
@@ -20,7 +20,9 @@ stage
     ``*.notification.json`` sidecar under
     ``samples/android/build/compose-previews/data/notifications/`` into a
     staging dir, and write ``findings.json`` summarising what was staged
-    (one entry per preview: id, png filename, sidecar filename, sha256).
+    (one entry per preview: id, png filename, sidecar filename, sha256) plus
+    ``declaredPreviewIds`` — every notification previewId the manifests
+    declared, so the comment can tell a removal from a failed render.
 
 readme
     Render ``findings.json`` to a browsable Markdown gallery with inline
@@ -28,9 +30,12 @@ readme
 
 comment
     Render ``findings.json`` plus a baseline ``findings.json`` to a
-    PR-comment Markdown body listing added / changed / removed entries.
-    Emits empty stdout (the action treats that as "skip") when the diff
-    against the baseline is empty.
+    PR-comment Markdown body listing added / changed / removed entries. A
+    baseline preview missing from the head render is only reported as
+    *removed* when the head manifest no longer declares it; one that's still
+    declared but didn't render is surfaced under a *not rendered* warning
+    instead of a false removal. Emits empty stdout (the action treats that as
+    "skip") when the diff against the baseline is empty.
 """
 
 from __future__ import annotations
@@ -40,6 +45,7 @@ import hashlib
 import json
 import shutil
 import sys
+from fnmatch import fnmatch
 from pathlib import Path
 
 
@@ -83,6 +89,35 @@ def _sanitize_preview_id(preview_id: str) -> str:
     return "".join("_" if c in _SANITIZE_REPLACE else c for c in preview_id)
 
 
+def _declared_notification_ids(build_dir: Path) -> set[str]:
+    """Notification previewIds the module *declares*, read from previews.json.
+
+    Mirrors the staging glob: a manifest preview counts as a notification
+    preview when any of its capture render outputs is a ``*Notification*.png``.
+    The id is derived from the PNG basename (its stem) rather than the manifest
+    ``id`` so it matches the previewId [_preview_id_from_png] assigns to the
+    staged render — including ``@Preview`` gallery variants whose render
+    basename carries a ``_<name>`` suffix the manifest id lacks.
+
+    Used by the comment subcommand to tell a *removed* preview (gone from the
+    manifest) apart from one that's declared but failed to render this run.
+    """
+    previews_json = build_dir / "previews.json"
+    if not previews_json.exists():
+        return set()
+    try:
+        manifest = json.loads(previews_json.read_text())
+    except json.JSONDecodeError:
+        return set()
+    declared: set[str] = set()
+    for preview in manifest.get("previews", []):
+        for capture in preview.get("captures", []):
+            name = Path(capture.get("renderOutput") or "").name
+            if fnmatch(name, _PNG_GLOB):
+                declared.add(Path(name).stem)
+    return declared
+
+
 def cmd_stage(args: argparse.Namespace) -> int:
     # ``--build-dir`` is repeatable so one `stage` invocation can fold every
     # module that registers ``composePreviewRenderAll`` into a single flat
@@ -103,6 +138,7 @@ def cmd_stage(args: argparse.Namespace) -> int:
     seen_basenames: dict[str, str] = {}
     total_pngs = 0
     modules_seen: list[str] = []
+    declared_ids: set[str] = set()
 
     for raw_build_dir in build_dirs:
         build_dir = Path(raw_build_dir)
@@ -114,6 +150,10 @@ def cmd_stage(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
+
+        # Record what the manifest declares even when a render is missing, so
+        # the comment can distinguish a failed render from a real removal.
+        declared_ids |= _declared_notification_ids(build_dir)
 
         pngs = sorted(renders_dir.glob(_PNG_GLOB))
         if not pngs:
@@ -188,7 +228,12 @@ def cmd_stage(args: argparse.Namespace) -> int:
 
     entries.sort(key=lambda e: (e["module"], e["previewId"]))
     (out_dir / "findings.json").write_text(
-        json.dumps({"entries": entries}, indent=2, sort_keys=True) + "\n"
+        json.dumps(
+            {"entries": entries, "declaredPreviewIds": sorted(declared_ids)},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
     )
     print(
         f"Staged {total_pngs} notification preview(s) across "
@@ -216,6 +261,16 @@ def _load_entries(path: Path) -> list[dict]:
         return json.loads(path.read_text()).get("entries", [])
     except json.JSONDecodeError:
         return []
+
+
+def _load_declared(path: Path) -> set[str]:
+    """Set of notification previewIds the head manifest declared (see stage)."""
+    if not path.exists():
+        return set()
+    try:
+        return set(json.loads(path.read_text()).get("declaredPreviewIds", []))
+    except json.JSONDecodeError:
+        return set()
 
 
 def _by_id(entries: list[dict]) -> dict[str, dict]:
@@ -301,21 +356,43 @@ def _diff(
 
 def cmd_comment(args: argparse.Namespace) -> int:
     head = _load_entries(Path(args.findings))
+    declared = _load_declared(Path(args.findings))
     baseline = _load_entries(Path(args.baseline)) if args.baseline else []
 
     added, changed, removed = _diff(head, baseline)
-    if not added and not changed and not removed:
+
+    # Split the baseline previews that are missing from the head render into
+    # genuine removals vs render failures. A preview the head still *declares*
+    # in its manifest but that produced no PNG this run wasn't deleted — its
+    # render (or its module's build) failed. Reporting it as "Removed" turns a
+    # CI breakage into a false "someone deleted this" alarm (#1588). Only call a
+    # missing preview removed when the head no longer declares it; when there's
+    # no manifest coverage at all (empty `declared`) we can't be sure, so we
+    # err toward "not rendered" rather than asserting a removal.
+    not_rendered: list[dict] = []
+    truly_removed: list[dict] = []
+    for entry in removed:
+        if not declared or entry["previewId"] in declared:
+            not_rendered.append(entry)
+        else:
+            truly_removed.append(entry)
+    removed = truly_removed
+
+    if not added and not changed and not removed and not not_rendered:
         # Empty stdout signals the workflow to skip the push + upsert. PRs
         # that don't touch notifications shouldn't generate noise.
         return 0
 
     marker = "<!-- notification-previews -->"
+    summary = f"{len(added)} added · {len(changed)} changed · {len(removed)} removed"
+    if not_rendered:
+        summary += f" · {len(not_rendered)} not rendered"
+    summary += f" vs `{args.baseline_branch}`."
     lines = [
         marker,
         "## Notification Previews",
         "",
-        f"{len(added)} added · {len(changed)} changed · {len(removed)} removed "
-        f"vs `{args.baseline_branch}`.",
+        summary,
         "",
     ]
 
@@ -357,6 +434,28 @@ def cmd_comment(args: argparse.Namespace) -> int:
         lines.append("| Preview | Last baseline image |")
         lines.append("|---|---|")
         for entry in removed:
+            url = _image_url(
+                args.repo, args.baseline_branch, entry["pngBasename"]
+            )
+            lines.append(
+                f"| `{entry['previewId']}` "
+                f'| <img src="{url}" width="240" /> |'
+            )
+        lines.append("")
+
+    if not_rendered:
+        lines.append("### ⚠️ Not rendered")
+        lines.append("")
+        lines.append("> [!WARNING]")
+        lines.append(
+            "> These previews are still declared in the head manifest but "
+            "produced no render this run — a render or build failure, **not** a "
+            "removal. Images below are the last known baseline renders."
+        )
+        lines.append("")
+        lines.append("| Preview | Last baseline image |")
+        lines.append("|---|---|")
+        for entry in sorted(not_rendered, key=lambda e: e["previewId"]):
             url = _image_url(
                 args.repo, args.baseline_branch, entry["pngBasename"]
             )

--- a/.github/actions/lib/test_notification_previews.py
+++ b/.github/actions/lib/test_notification_previews.py
@@ -25,12 +25,27 @@ np = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(np)  # type: ignore[union-attr]
 
 
-def _make_module(root: Path, module: str, png_names: list[str]) -> Path:
+def _make_module(
+    root: Path,
+    module: str,
+    png_names: list[str],
+    declared: list[str] | None = None,
+) -> Path:
     build = root / module.replace(":", "/") / "build" / "compose-previews"
     (build / "renders").mkdir(parents=True)
     for name in png_names:
         (build / "renders" / name).write_bytes(f"png-{name}".encode())
-    (build / "previews.json").write_text(json.dumps({"module": module}))
+    manifest: dict = {"module": module}
+    if declared is not None:
+        # Declare each render output in the manifest so the stage step can
+        # record `declaredPreviewIds` — including names with no PNG on disk
+        # (a render that failed), which is the case the comment diff cares
+        # about.
+        manifest["previews"] = [
+            {"id": Path(n).stem, "captures": [{"renderOutput": f"renders/{n}"}]}
+            for n in declared
+        ]
+    (build / "previews.json").write_text(json.dumps(manifest))
     return build
 
 
@@ -110,6 +125,125 @@ class StageTest(unittest.TestCase):
             output_dir=str(out),
         ))
         self.assertEqual(rc, 1)
+
+    def test_stage_records_declared_ids_including_unrendered(self):
+        # The manifest declares two notification previews but only one
+        # rendered a PNG. `declaredPreviewIds` must carry both so the comment
+        # can tell the unrendered one apart from a real removal.
+        build = _make_module(
+            self.tmp,
+            "samples:android",
+            ["FooNotification.png"],
+            declared=["FooNotification.png", "GoneNotification.png"],
+        )
+        out = self.tmp / "out"
+        rc = np.cmd_stage(argparse.Namespace(
+            build_dir=str(build),
+            output_dir=str(out),
+        ))
+        self.assertEqual(rc, 0)
+        findings = json.loads((out / "findings.json").read_text())
+        self.assertEqual(
+            findings["declaredPreviewIds"],
+            ["FooNotification", "GoneNotification"],
+        )
+
+
+class CommentTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    @staticmethod
+    def _entry(pid: str, sha: str = "a") -> dict:
+        return {
+            "module": "samples:android",
+            "previewId": pid,
+            "pngBasename": f"{pid}.png",
+            "sidecarBasename": "",
+            "sha256": sha,
+        }
+
+    def _run_comment(self, head, baseline, declared=None) -> str:
+        import contextlib
+        import io
+
+        head_path = self.tmp / "head.json"
+        payload: dict = {"entries": head}
+        if declared is not None:
+            payload["declaredPreviewIds"] = declared
+        head_path.write_text(json.dumps(payload))
+        base_path = self.tmp / "base.json"
+        base_path.write_text(json.dumps({"entries": baseline}))
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            np.cmd_comment(argparse.Namespace(
+                findings=str(head_path),
+                repo="o/r",
+                head_ref="headsha",
+                baseline=str(base_path),
+                baseline_branch="compose-preview/notifications/main",
+            ))
+        return buf.getvalue()
+
+    def test_missing_but_still_declared_is_not_rendered_not_removed(self):
+        # The head still declares Foo (its module built) but no PNG came out
+        # this run — a render failure, not a deletion. Must surface under the
+        # "Not rendered" warning, never "Removed". Regression for #1588.
+        body = self._run_comment(
+            head=[],
+            baseline=[self._entry("x.Foo")],
+            declared=["x.Foo"],
+        )
+        self.assertIn("Not rendered", body)
+        self.assertIn("[!WARNING]", body)
+        self.assertIn("`x.Foo`", body)
+        self.assertNotIn("### Removed", body)
+        self.assertIn("0 added · 0 changed · 0 removed · 1 not rendered", body)
+
+    def test_missing_and_undeclared_is_removed(self):
+        # Head declares something else but not Foo → Foo was genuinely removed
+        # from source. Real removal still reported as such.
+        body = self._run_comment(
+            head=[self._entry("x.Bar")],
+            baseline=[self._entry("x.Foo"), self._entry("x.Bar")],
+            declared=["x.Bar"],
+        )
+        self.assertIn("### Removed", body)
+        self.assertIn("`x.Foo`", body)
+        self.assertNotIn("Not rendered", body)
+
+    def test_no_manifest_coverage_errs_toward_not_rendered(self):
+        # Without any declared ids we can't prove a removal, so a missing
+        # baseline preview is treated as not-rendered rather than asserting a
+        # deletion.
+        body = self._run_comment(
+            head=[],
+            baseline=[self._entry("x.Foo")],
+            declared=[],
+        )
+        self.assertIn("Not rendered", body)
+        self.assertNotIn("### Removed", body)
+
+    def test_added_and_changed_still_reported(self):
+        body = self._run_comment(
+            head=[self._entry("x.New"), self._entry("x.Same", sha="b")],
+            baseline=[self._entry("x.Same", sha="a")],
+            declared=["x.New", "x.Same"],
+        )
+        self.assertIn("### Added", body)
+        self.assertIn("`x.New`", body)
+        self.assertIn("### Changed", body)
+        self.assertIn("`x.Same`", body)
+
+    def test_silent_when_no_diff(self):
+        body = self._run_comment(
+            head=[self._entry("x.Same", sha="a")],
+            baseline=[self._entry("x.Same", sha="a")],
+            declared=["x.Same"],
+        )
+        self.assertEqual(body, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The notification PR comment (`notification-previews.py`) diffed head renders against the baseline purely by previewId set membership: any baseline preview missing from the head render was bucketed as **Removed**. When a build/render failure drops previews — e.g. the "22 removed" on the Isolated Projects PR #1588 — this turned a CI breakage into a false "someone deleted this" alarm.

### Fix
- **Stage** now records `declaredPreviewIds` in `findings.json` — every notification previewId the module `previews.json` manifests declare (matched the same way the staging glob picks up renders: a capture whose `renderOutput` basename matches `*Notification*.png`). Crucially this includes previews whose **render failed** (declared in the manifest, no PNG on disk).
- **Comment** uses it to split the baseline previews missing from the head render:
  - still declared but unrendered → a **⚠️ Not rendered** warning section ("render or build failure, not a removal", with the last baseline image), and
  - only previews the head no longer declares → **Removed**.
  - With no manifest coverage at all, it errs toward "not rendered" rather than asserting a removal.
- Summary line gains a `· N not rendered` segment when applicable.

Net effect on a #1588-style PR: the affected previews show under "Not rendered" with a clear failure warning instead of a misleading "22 removed."

## Test plan
- `python3 -m unittest test_notification_previews` (from `.github/actions/lib`) — 11 tests pass.
- New coverage: stage records declared-but-unrendered ids; missing-but-declared → not-rendered (not removed); missing-and-undeclared → removed; no-manifest-coverage → not-rendered; added/changed still reported; silent on no diff.
- Existing `test_a11y_report` / `test_compare_previews` still green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTBdKS5tnPyk9k1huRZYnD)_