### PR TITLE
fix(notifications): render @NotificationPreview at 400dp wide, not a 320 square

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -365,6 +365,10 @@ class RenderEngine(
                             // the PNG for daemon-driven renders (same path used by the standalone
                             // `composePreviewRender` Test task).
                             previewId = spec.previewId,
+                            // Exact surface width = the resolved canvas width (400dp for FQN-
+                            // discovered notifications), so the shade isn't cropped to its ~320dp
+                            // intrinsic square. Mirrors the Glance branch's dp conversion.
+                            widthDp = pxToDp(spec.widthPx, spec.density),
                           )
                         } else if (isGlanceAppWidget) {
                           // `@androidx.glance.preview.Preview` — mirrors the standalone

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1665,11 +1665,19 @@ object PreviewDiscovery {
   ): PreviewParams {
     // `@NotificationPreview` has no parameters, so the rest of this function — which
     // dereferences `device` / `widthDp` / `fontScale` / etc. from `ann.parameterValues` — would
-    // throw `NoSuchElementException`. Return a minimal params object up-front; the renderer
-    // applies its own default qualifiers when rendering RemoteViews. Width/height parameters
-    // will be added when the variants matrix from #1249 lands.
+    // throw `NoSuchElementException`. Return a minimal params object up-front.
+    //
+    // Pin `widthDp` to the sandbox width (400dp) rather than leaving it null: without it the
+    // router falls back to its 320dp square default and the AOSP notification shade inflates to
+    // its ~320dp intrinsic width, producing the cramped ~320×320 PNG from #1249. 400dp matches
+    // the canvas the `@Preview` + `NotificationContent` gallery path renders at (its
+    // `DEFAULT_NOTIFICATION_WIDTH_DP`), so FQN-discovered notifications share the wider shade
+    // footprint. Height stays on the renderer default.
     if (ann.name == NOTIFICATION_PREVIEW_FQN) {
-      return PreviewParams(kind = PreviewKind.NOTIFICATION)
+      return PreviewParams(
+        kind = PreviewKind.NOTIFICATION,
+        widthDp = DeviceDimensions.SANDBOX_WIDTH_DP,
+      )
     }
     // Glance's own `androidx.glance.preview.Preview(widthDp, heightDp)`. The annotation's params
     // started life as `()` in 1.0.x, gained `widthDp` / `heightDp` in 1.1.0-rc01. Read both

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -1612,6 +1612,9 @@ class DiscoveryFunctionalTest {
       .containsExactly("SimpleNotificationPreview", "NoArgNotificationPreview")
     assertThat(notificationPreviews.map { it.params.kind }.toSet())
       .containsExactly(PreviewKind.NOTIFICATION)
+    // `widthDp` is pinned to the 400dp sandbox width so the shade renders at its wide footprint
+    // rather than the router's 320dp square default (#1249). Height is left to the renderer.
+    assertThat(notificationPreviews.map { it.params.widthDp }.toSet()).containsExactly(400)
     // Each notification preview produces exactly one capture (no scroll / time / focus / ambient
     // fan-out — `buildOutputPlan` treats NOTIFICATION the same as TILE for dimensional axes).
     assertThat(notificationPreviews.map { it.captures.size }).containsExactly(1, 1)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/NotificationPreviewRenderer.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/NotificationPreviewRenderer.kt
@@ -6,13 +6,23 @@ import android.content.res.Configuration
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import java.lang.reflect.Method
+
+/**
+ * Fallback notification surface width when a caller doesn't pass [NotificationPreviewComposable]'s
+ * `widthDp`. Mirrors the discovery / gallery sandbox width
+ * (`DeviceDimensions.SANDBOX_WIDTH_DP` / `DEFAULT_NOTIFICATION_WIDTH_DP`, both 400dp) so a
+ * directly-invoked render still gets the wide shade footprint rather than the ~320dp intrinsic
+ * square from #1249.
+ */
+const val NOTIFICATION_PREVIEW_DEFAULT_WIDTH_DP: Int = 400
 
 /**
  * Renders a `@NotificationPreview` function — `(Context) -> Notification` — into the surrounding
@@ -44,10 +54,19 @@ fun NotificationPreviewComposable(
      * use today pass the manifest's preview id.
      */
     previewId: String? = null,
+    /**
+     * Width of the notification surface in dp — the render canvas width the caller laid out for.
+     * Set as an exact width rather than `fillMaxWidth()`: under the renderer's wrap-to-content
+     * measure path the `AndroidView` is handed `minWidth = 0`, and the inflated RemoteViews tree's
+     * ~320dp AOSP intrinsic width is what comes back, cropping the PNG to a square (#1249). Pinning
+     * the width gives the inflater the full canvas, matching the `NotificationContent` gallery fix
+     * (#1576). Defaults to [NOTIFICATION_PREVIEW_DEFAULT_WIDTH_DP] for direct callers.
+     */
+    widthDp: Int = NOTIFICATION_PREVIEW_DEFAULT_WIDTH_DP,
 ) {
     val context = LocalContext.current
     AndroidView(
-        modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+        modifier = Modifier.width(widthDp.dp).wrapContentHeight(),
         factory = { ctx ->
             val parent = FrameLayout(ctx).apply {
                 layoutParams = ViewGroup.LayoutParams(

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -183,6 +183,7 @@ private object NotificationPreviewStrategy : PreviewRenderStrategy {
             className = preview.className,
             functionName = preview.functionName,
             previewId = preview.id,
+            widthDp = widthDp,
         )
     }
 }


### PR DESCRIPTION
## Summary

FQN-discovered `@NotificationPreview` previews (e.g. `simpleNotificationPreview`, `bigTextNotificationPreview`) render as a cramped **~320×320 square** instead of a wide notification shade. The earlier fix #1576 only covered the `@Preview` + `NotificationContent` gallery path; the discovery path was left with a known TODO (`PreviewDiscovery` returned `PreviewParams(kind = NOTIFICATION)` with no `widthDp`), so the router fell back to its 320dp square default and the AOSP shade inflated to its ~320dp intrinsic width (#1249).

### Changes
- **Discovery** (`PreviewDiscovery`): pin `@NotificationPreview` `widthDp` to the 400dp sandbox width (`DeviceDimensions.SANDBOX_WIDTH_DP`) — same canvas the gallery path uses. In the standalone renderer this also flips `wrapWidth` off so the PNG is pinned to 400 wide (height still wraps to content → a wide shade row, not a square).
- **Renderer** (`NotificationPreviewComposable`): host the inflated `RemoteViews` at an explicit `Modifier.width(widthDp.dp)` instead of `fillMaxWidth()`, which collapses to the ~320dp intrinsic under the wrap-to-content measure path (the exact lesson from #1576). `widthDp` is plumbed through both the standalone `NotificationPreviewStrategy` and the daemon `RenderEngine` (mirroring the Glance branch's `pxToDp`).

## Test plan
- `DiscoveryFunctionalTest` notification case now asserts `widthDp == 400`.
- ⚠️ **Visual confirmation needs a baseline re-render.** I can't rasterize Robolectric/Android renders in this environment, so the resulting PNG shape relies on CI's real-renderer harness + the `compose-preview/notifications/main` baseline being re-rendered (note: the current baseline is stale — it predates #1576 — so even the gallery images there are still square). Happy to iterate once a fresh render exists.

## Notes
- ktfmt was hand-verified for line length (the pre-commit hook can't provision a JDK toolchain in the agent sandbox); CI's ktfmt job is the gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTBdKS5tnPyk9k1huRZYnD)_