### PR TITLE
fix(notifications): treat @PreviewParameter fan-out variants as declared

### DIFF
--- a/.github/actions/lib/notification-previews.py
+++ b/.github/actions/lib/notification-previews.py
@@ -22,7 +22,10 @@ stage
     staging dir, and write ``findings.json`` summarising what was staged
     (one entry per preview: id, png filename, sidecar filename, sha256) plus
     ``declaredPreviewIds`` — every notification previewId the manifests
-    declared, so the comment can tell a removal from a failed render.
+    declared — and ``declaredFanoutBases`` — the unsuffixed stems of any
+    ``@PreviewParameter`` previews, whose rendered ids gain a ``_<label>``
+    suffix the manifest stem lacks. The comment uses both to tell a removal
+    from a failed render.
 
 readme
     Render ``findings.json`` to a browsable Markdown gallery with inline
@@ -89,33 +92,51 @@ def _sanitize_preview_id(preview_id: str) -> str:
     return "".join("_" if c in _SANITIZE_REPLACE else c for c in preview_id)
 
 
-def _declared_notification_ids(build_dir: Path) -> set[str]:
+def _declared_notification_ids(build_dir: Path) -> tuple[set[str], set[str]]:
     """Notification previewIds the module *declares*, read from previews.json.
 
-    Mirrors the staging glob: a manifest preview counts as a notification
-    preview when any of its capture render outputs is a ``*Notification*.png``.
-    The id is derived from the PNG basename (its stem) rather than the manifest
-    ``id`` so it matches the previewId [_preview_id_from_png] assigns to the
-    staged render — including ``@Preview`` gallery variants whose render
-    basename carries a ``_<name>`` suffix the manifest id lacks.
+    Returns ``(declared, fanout_bases)``.
+
+    ``declared`` mirrors the staging glob: a manifest preview counts as a
+    notification preview when any of its capture render outputs is a
+    ``*Notification*.png``. The id is derived from the PNG basename (its stem)
+    rather than the manifest ``id`` so it matches the previewId
+    [_preview_id_from_png] assigns to the staged render — including
+    ``@Preview`` gallery variants whose render basename carries a ``_<name>``
+    suffix the manifest id lacks.
+
+    ``fanout_bases`` holds the stems of previews that carry a
+    ``@PreviewParameter`` provider. The renderer expands those *after* loading
+    the manifest, appending a ``_<label>`` / ``_PARAM_<idx>`` suffix to each
+    capture's renderOutput (see ``RobolectricRenderTest.expandParameterProvider``),
+    so the actual rendered (and baseline) previewIds are ``<stem>_<suffix>`` —
+    ids the unsuffixed manifest stem never matches. The comment subcommand
+    prefix-matches missing baseline ids against these bases so a parameterized
+    notification preview that fails to render is still classed as *not
+    rendered* rather than *removed*.
 
     Used by the comment subcommand to tell a *removed* preview (gone from the
     manifest) apart from one that's declared but failed to render this run.
     """
     previews_json = build_dir / "previews.json"
     if not previews_json.exists():
-        return set()
+        return set(), set()
     try:
         manifest = json.loads(previews_json.read_text())
     except json.JSONDecodeError:
-        return set()
+        return set(), set()
     declared: set[str] = set()
+    fanout_bases: set[str] = set()
     for preview in manifest.get("previews", []):
+        has_provider = bool((preview.get("params") or {}).get("previewParameterProviderClassName"))
         for capture in preview.get("captures", []):
             name = Path(capture.get("renderOutput") or "").name
             if fnmatch(name, _PNG_GLOB):
-                declared.add(Path(name).stem)
-    return declared
+                stem = Path(name).stem
+                declared.add(stem)
+                if has_provider:
+                    fanout_bases.add(stem)
+    return declared, fanout_bases
 
 
 def cmd_stage(args: argparse.Namespace) -> int:
@@ -139,6 +160,7 @@ def cmd_stage(args: argparse.Namespace) -> int:
     total_pngs = 0
     modules_seen: list[str] = []
     declared_ids: set[str] = set()
+    fanout_bases: set[str] = set()
 
     for raw_build_dir in build_dirs:
         build_dir = Path(raw_build_dir)
@@ -153,7 +175,9 @@ def cmd_stage(args: argparse.Namespace) -> int:
 
         # Record what the manifest declares even when a render is missing, so
         # the comment can distinguish a failed render from a real removal.
-        declared_ids |= _declared_notification_ids(build_dir)
+        module_declared, module_fanout = _declared_notification_ids(build_dir)
+        declared_ids |= module_declared
+        fanout_bases |= module_fanout
 
         pngs = sorted(renders_dir.glob(_PNG_GLOB))
         if not pngs:
@@ -229,7 +253,11 @@ def cmd_stage(args: argparse.Namespace) -> int:
     entries.sort(key=lambda e: (e["module"], e["previewId"]))
     (out_dir / "findings.json").write_text(
         json.dumps(
-            {"entries": entries, "declaredPreviewIds": sorted(declared_ids)},
+            {
+                "entries": entries,
+                "declaredPreviewIds": sorted(declared_ids),
+                "declaredFanoutBases": sorted(fanout_bases),
+            },
             indent=2,
             sort_keys=True,
         )
@@ -263,14 +291,34 @@ def _load_entries(path: Path) -> list[dict]:
         return []
 
 
-def _load_declared(path: Path) -> set[str]:
-    """Set of notification previewIds the head manifest declared (see stage)."""
+def _load_declared(path: Path) -> tuple[set[str], set[str]]:
+    """``(declaredPreviewIds, declaredFanoutBases)`` from a findings.json (see stage)."""
     if not path.exists():
-        return set()
+        return set(), set()
     try:
-        return set(json.loads(path.read_text()).get("declaredPreviewIds", []))
+        payload = json.loads(path.read_text())
     except json.JSONDecodeError:
-        return set()
+        return set(), set()
+    return (
+        set(payload.get("declaredPreviewIds", [])),
+        set(payload.get("declaredFanoutBases", [])),
+    )
+
+
+def _is_declared(preview_id: str, declared: set[str], fanout_bases: set[str]) -> bool:
+    """Whether the head manifest declared ``preview_id``.
+
+    Exact match covers static previews and multi-``@Preview`` variants (the
+    manifest carries their suffixed renderOutput verbatim). The prefix check
+    covers ``@PreviewParameter`` fan-out, whose rendered ids are
+    ``<base>_<label>`` / ``<base>_PARAM_<idx>`` — the manifest only has the
+    unsuffixed ``<base>`` (the renderer appends the suffix post-load), so a
+    baseline id beginning with a declared fan-out base + ``_`` is still
+    declared.
+    """
+    if preview_id in declared:
+        return True
+    return any(preview_id.startswith(f"{base}_") for base in fanout_bases)
 
 
 def _by_id(entries: list[dict]) -> dict[str, dict]:
@@ -356,7 +404,7 @@ def _diff(
 
 def cmd_comment(args: argparse.Namespace) -> int:
     head = _load_entries(Path(args.findings))
-    declared = _load_declared(Path(args.findings))
+    declared, fanout_bases = _load_declared(Path(args.findings))
     baseline = _load_entries(Path(args.baseline)) if args.baseline else []
 
     added, changed, removed = _diff(head, baseline)
@@ -369,10 +417,11 @@ def cmd_comment(args: argparse.Namespace) -> int:
     # missing preview removed when the head no longer declares it; when there's
     # no manifest coverage at all (empty `declared`) we can't be sure, so we
     # err toward "not rendered" rather than asserting a removal.
+    has_coverage = bool(declared or fanout_bases)
     not_rendered: list[dict] = []
     truly_removed: list[dict] = []
     for entry in removed:
-        if not declared or entry["previewId"] in declared:
+        if not has_coverage or _is_declared(entry["previewId"], declared, fanout_bases):
             not_rendered.append(entry)
         else:
             truly_removed.append(entry)

--- a/.github/actions/lib/test_notification_previews.py
+++ b/.github/actions/lib/test_notification_previews.py
@@ -30,21 +30,37 @@ def _make_module(
     module: str,
     png_names: list[str],
     declared: list[str] | None = None,
+    fanout: list[str] | None = None,
 ) -> Path:
     build = root / module.replace(":", "/") / "build" / "compose-previews"
     (build / "renders").mkdir(parents=True)
     for name in png_names:
         (build / "renders" / name).write_bytes(f"png-{name}".encode())
     manifest: dict = {"module": module}
+    previews: list[dict] = []
     if declared is not None:
         # Declare each render output in the manifest so the stage step can
         # record `declaredPreviewIds` — including names with no PNG on disk
         # (a render that failed), which is the case the comment diff cares
         # about.
-        manifest["previews"] = [
+        previews += [
             {"id": Path(n).stem, "captures": [{"renderOutput": f"renders/{n}"}]}
             for n in declared
         ]
+    if fanout is not None:
+        # `@PreviewParameter` previews: the manifest carries the unsuffixed
+        # base renderOutput plus a provider class; the renderer fans the base
+        # out into `<base>_<label>` ids post-load.
+        previews += [
+            {
+                "id": Path(n).stem,
+                "params": {"previewParameterProviderClassName": "test.FakeProvider"},
+                "captures": [{"renderOutput": f"renders/{n}"}],
+            }
+            for n in fanout
+        ]
+    if declared is not None or fanout is not None:
+        manifest["previews"] = previews
     (build / "previews.json").write_text(json.dumps(manifest))
     return build
 
@@ -148,6 +164,28 @@ class StageTest(unittest.TestCase):
             ["FooNotification", "GoneNotification"],
         )
 
+    def test_stage_records_fanout_bases(self):
+        # A `@PreviewParameter` notification preview declares only the base
+        # stem in the manifest; record it in `declaredFanoutBases` so the
+        # comment can prefix-match its rendered `<base>_<label>` variants.
+        build = _make_module(
+            self.tmp,
+            "samples:android",
+            ["StaticNotification.png"],
+            declared=["StaticNotification.png"],
+            fanout=["ParamNotification.png"],
+        )
+        out = self.tmp / "out"
+        rc = np.cmd_stage(argparse.Namespace(
+            build_dir=str(build),
+            output_dir=str(out),
+        ))
+        self.assertEqual(rc, 0)
+        findings = json.loads((out / "findings.json").read_text())
+        self.assertEqual(findings["declaredFanoutBases"], ["ParamNotification"])
+        # The base also lands in declaredPreviewIds (it's a notification stem).
+        self.assertIn("ParamNotification", findings["declaredPreviewIds"])
+
 
 class CommentTest(unittest.TestCase):
     def setUp(self):
@@ -164,7 +202,7 @@ class CommentTest(unittest.TestCase):
             "sha256": sha,
         }
 
-    def _run_comment(self, head, baseline, declared=None) -> str:
+    def _run_comment(self, head, baseline, declared=None, fanout=None) -> str:
         import contextlib
         import io
 
@@ -172,6 +210,8 @@ class CommentTest(unittest.TestCase):
         payload: dict = {"entries": head}
         if declared is not None:
             payload["declaredPreviewIds"] = declared
+        if fanout is not None:
+            payload["declaredFanoutBases"] = fanout
         head_path.write_text(json.dumps(payload))
         base_path = self.tmp / "base.json"
         base_path.write_text(json.dumps({"entries": baseline}))
@@ -244,6 +284,36 @@ class CommentTest(unittest.TestCase):
             declared=["x.Same"],
         )
         self.assertEqual(body, "")
+
+    def test_fanout_variant_failed_render_is_not_rendered_not_removed(self):
+        # A `@PreviewParameter` notification preview: the baseline has the
+        # rendered `x.Param_busy` variant, but the head failed to render it.
+        # The head manifest only declares the unsuffixed base `x.Param`, so
+        # exact matching alone would mis-class the variant as Removed. The
+        # fan-out base must prefix-match it into Not rendered.
+        body = self._run_comment(
+            head=[],
+            baseline=[self._entry("x.Param_busy")],
+            declared=["x.Param"],
+            fanout=["x.Param"],
+        )
+        self.assertIn("Not rendered", body)
+        self.assertIn("`x.Param_busy`", body)
+        self.assertNotIn("### Removed", body)
+
+    def test_fanout_base_does_not_swallow_sibling_removal(self):
+        # Prefix matching must respect the `_` boundary: declaring base `x.Foo`
+        # should not absorb a genuinely-removed sibling `x.FooBar` (no
+        # underscore right after the base), which stays Removed.
+        body = self._run_comment(
+            head=[self._entry("x.Foo_a")],
+            baseline=[self._entry("x.Foo_a"), self._entry("x.FooBar")],
+            declared=["x.Foo"],
+            fanout=["x.Foo"],
+        )
+        self.assertIn("### Removed", body)
+        self.assertIn("`x.FooBar`", body)
+        self.assertNotIn("Not rendered", body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up to #1591, closing a gap raised in review. The declared-set check from #1591 recorded only the **unsuffixed** manifest `renderOutput` stem. A `@PreviewParameter` preview is expanded by the renderer *after* manifest load — `RobolectricRenderTest.expandParameterProvider` appends a `_<label>` / `_PARAM_<idx>` suffix to each capture's renderOutput. So the actual rendered (and baseline) ids are `<base>_<suffix>`, which the unsuffixed manifest stem never matches.

Result: a parameterized notification preview (a `@Preview` gallery composable the `*Notification*` glob catches) that **fails to render** would have its baseline variants (`FooNotification_Loading`, …) miss the declared set and fall back to **Removed** — exactly the false-removal #1591 set out to fix.

> Latent today (no current sample uses `@PreviewParameter` on a notification-glob preview), but the manifest already serializes the provider class, so it's a real forward-looking gap.

### Fix
- **Stage** now also records `declaredFanoutBases` — the unsuffixed stems of previews carrying a `previewParameterProviderClassName`.
- **Comment** prefix-matches a missing baseline id against those bases (`id == base` or `id.startswith(base + "_")`), respecting the `_` boundary so a sibling like `FooBar` isn't swallowed by base `Foo`. Fan-out variants that didn't render are classed as **Not rendered** instead of **Removed**.
- The "no manifest coverage → err toward not-rendered" fallback now considers both sets.

## Test plan
- `python3 -m unittest test_notification_previews` (from `.github/actions/lib`) — 14 tests pass.
- New: stage records `declaredFanoutBases`; a failed fan-out variant → Not rendered; the `_`-boundary guard keeps a genuinely-removed sibling as Removed.

## Notes
- ktfmt/Gradle hook can't run in the agent sandbox (no JDK toolchain); this PR is Python-only and unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTBdKS5tnPyk9k1huRZYnD)_