### PR TITLE
fix(vscode-extension): address codex follow-ups on preview-tab + focus refresh

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -4319,8 +4319,15 @@ async function refresh(
         // When the preview panel steals keyboard focus, activeTextEditor
         // becomes undefined and scopeSource is "none". Don't abort a
         // valid in-flight discover just because the user glanced at the
-        // panel — it will paint the cards when it finishes.
-        if (scopeSource === "none" && pendingRefreshKey) {
+        // panel — it will paint the cards when it finishes. But if the
+        // user closes the last preview source tab while that discover is
+        // running, the no-source empty-state clear below still has to
+        // run (issue #1566) — otherwise stale cards persist.
+        if (
+            scopeSource === "none" &&
+            pendingRefreshKey &&
+            isAnyPreviewSourceTabOpen()
+        ) {
             return "no-module";
         }
         // When the panel already has previews painted (preload or a prior render put cards

--- a/vscode-extension/src/previewTabs.ts
+++ b/vscode-extension/src/previewTabs.ts
@@ -30,17 +30,32 @@ export interface TabGroupLike {
 
 /**
  * Collect the filesystem paths of every text-backed tab across [groups].
- * `TabInputText` and the modified side of `TabInputTextDiff` both expose a
- * `uri` with an `fsPath`; non-text tabs (webviews, terminals, notebooks) carry
- * a differently-shaped `input` and are skipped.
+ * `TabInputText` exposes `uri`; `TabInputTextDiff` exposes `modified` and
+ * `original` (no plain `uri`) — both sides count as the source being open in
+ * a tab, so we read both. Non-text tabs (webviews, terminals, notebooks)
+ * carry a differently-shaped `input` and are skipped.
  */
 export function openTabFsPaths(groups: ReadonlyArray<TabGroupLike>): string[] {
     const paths: string[] = [];
     for (const group of groups) {
         for (const tab of group.tabs) {
             const input = tab.input;
-            if (input && typeof input === "object" && "uri" in input) {
-                const uri = (input as { uri?: { fsPath?: unknown } }).uri;
+            if (!input || typeof input !== "object") continue;
+            const candidates: Array<{ fsPath?: unknown } | undefined> = [];
+            if ("uri" in input) {
+                candidates.push((input as { uri?: { fsPath?: unknown } }).uri);
+            }
+            if ("modified" in input) {
+                candidates.push(
+                    (input as { modified?: { fsPath?: unknown } }).modified,
+                );
+            }
+            if ("original" in input) {
+                candidates.push(
+                    (input as { original?: { fsPath?: unknown } }).original,
+                );
+            }
+            for (const uri of candidates) {
                 const fsPath = uri?.fsPath;
                 if (typeof fsPath === "string") {
                     paths.push(fsPath);

--- a/vscode-extension/src/test/previewTabs.test.ts
+++ b/vscode-extension/src/test/previewTabs.test.ts
@@ -20,6 +20,19 @@ function webviewTab(viewType: string): { input: { viewType: string } } {
     return { input: { viewType } };
 }
 
+/** Build a diff-editor tab (TabInputTextDiff shape: `modified` + `original`). */
+function diffTab(
+    modifiedFsPath: string,
+    originalFsPath: string,
+): { input: { modified: { fsPath: string }; original: { fsPath: string } } } {
+    return {
+        input: {
+            modified: { fsPath: modifiedFsPath },
+            original: { fsPath: originalFsPath },
+        },
+    };
+}
+
 function groups(...tabs: TabGroupLike["tabs"][number][][]): TabGroupLike[] {
     return tabs.map((groupTabs) => ({ tabs: groupTabs }));
 }
@@ -48,6 +61,14 @@ describe("openTabFsPaths", () => {
 
     it("returns empty for no groups", () => {
         assert.deepStrictEqual(openTabFsPaths([]), []);
+    });
+
+    it("collects fsPaths from diff-editor tabs (TabInputTextDiff)", () => {
+        const g = groups([diffTab("/a/Foo.kt", "/a/.git/Foo.kt")]);
+        assert.deepStrictEqual(openTabFsPaths(g), [
+            "/a/Foo.kt",
+            "/a/.git/Foo.kt",
+        ]);
     });
 });
 
@@ -86,6 +107,11 @@ describe("anyPreviewSourceTabOpen", () => {
             textTab("/app/build.gradle.kts"),
             textTab("/app/Screen.kt"),
         ]);
+        assert.strictEqual(anyPreviewSourceTabOpen(g, isPreviewSource), true);
+    });
+
+    it("is true when only a diff editor on the .kt is open", () => {
+        const g = groups([diffTab("/app/Screen.kt", "/app/.git/Screen.kt")]);
         assert.strictEqual(anyPreviewSourceTabOpen(g, isPreviewSource), true);
     });
 });

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -306,6 +306,9 @@ export class FocusController {
                 this.config.inspectorRender(null);
                 this.publishScopedPreview();
                 this.config.refreshBundleLegend();
+                // Filter zeroed out the focused set; clear any bundle
+                // overlay still painted on a now-hidden card (#1567).
+                this.config.refreshBundleState();
                 return;
             }
             let focusIndex = this.config.getFocusIndex();


### PR DESCRIPTION
Three codex review findings from #1568, #1568, and #1570 that were left unaddressed at merge — clustered together because they all touch the vscode-extension preview-source / focus-mode plumbing.

## Summary

- **`previewTabs.openTabFsPaths`**: `TabInputTextDiff` doesn't expose `uri` — it has `modified` and `original`. The `"uri" in input` check silently skipped diff editors, so opening the .kt source in a diff view didn't count as "preview source still open" (codex on #1568). Now reads both diff sides; added tests for the diff-tab shape.
- **`extension.ts` refresh()**: the pending-refresh focus-drift guard returned early on `scopeSource === "none"` without checking whether any preview source tab was actually still open. If the user closed the last preview editor while a refresh was in flight, the empty-state clear below never ran and stale cards persisted — the exact case #1568 was meant to handle (codex on #1568).
- **`focusController.applyLayout`**: the `visible.length === 0` early return skipped `refreshBundleState()`, so a bundle overlay painted on a card that subsequently got filtered out stayed on screen (codex on #1570; regression vs. the #1567 fix).

## Test plan

- [x] `npm run compile:host` (vscode-extension)
- [x] `npm test` — 1402 passing, including new `TabInputTextDiff` cases in `previewTabs.test.ts`
- [ ] Manual: open a .kt in a diff view, close the regular editor, confirm preview cards stay up while diff tab is open; close diff, confirm cards clear
- [ ] Manual: filter previews to zero in focus mode, confirm bundle overlay clears

---
_Generated by [Claude Code](https://claude.ai/code/session_017rcB2a7Ka1rfZbKJj86m7Y)_