### PR TITLE
fix(cli,gradle-plugin): tighten --variant matching and propagate to doctor

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -71,6 +71,21 @@ class DoctorCommand(private val args: List<String>) {
   private val recommendedPluginVersion = args.flagValue("--plugin-version") ?: BUNDLE_VERSION
 
   /**
+   * `--variant <name>` forwarded as `-PcomposePreview.variant=<name>` on the Gradle connection,
+   * mirroring [BaseCommand.variantOverride]. Without this the model query (and any subsequent
+   * daemon spawn through `--with-daemon`) defaults to whatever the plugin's
+   * `composePreview.variant` convention picks, so `doctor --variant prodRelease` would silently
+   * report on `debug` instead.
+   */
+  private val variantOverride: String? =
+    args.flagValue("--variant")?.trim()?.takeIf { it.isNotEmpty() }
+
+  private fun variantGradleArgs(): List<String> {
+    val v = variantOverride ?: return emptyList()
+    return listOf("-PcomposePreview.variant=$v")
+  }
+
+  /**
    * Plugin version actually applied to the project, read from the Tooling model after
    * [runProjectChecks] fetches it. Null when no project was detected or no module applies the
    * plugin. Surfaced in the report header and as an explicit `project.plugin-version` check so
@@ -309,15 +324,20 @@ class DoctorCommand(private val args: List<String>) {
     val injectArgs = autoInjectInitScriptArgs(args, projectRoot = projectDir)
     val model =
       try {
-        GradleConnection(projectDir, verbose = verbose, extraArguments = injectArgs).use { gc ->
-          // Daemon-JVM + Gradle-version snapshot. Runs first so other
-          // project-scope checks can compare against the daemon's JDK
-          // (e.g. flagging test worker mismatch in #142).
-          checkGradleDaemon(gc)
-          gc.runBuildAction(GatherComposePreviewModelAction()).also {
-            gradleAccessFailure = gc.lastModelAccessFailure
+        GradleConnection(
+            projectDir,
+            verbose = verbose,
+            extraArguments = injectArgs + variantGradleArgs(),
+          )
+          .use { gc ->
+            // Daemon-JVM + Gradle-version snapshot. Runs first so other
+            // project-scope checks can compare against the daemon's JDK
+            // (e.g. flagging test worker mismatch in #142).
+            checkGradleDaemon(gc)
+            gc.runBuildAction(GatherComposePreviewModelAction()).also {
+              gradleAccessFailure = gc.lastModelAccessFailure
+            }
           }
-        }
       } catch (e: Exception) {
         addCheck(
           DoctorCheck(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -192,19 +192,28 @@ internal object AndroidPreviewSupport {
    *
    * Two rules, in order:
    * 1. **Exact match.** `target=demoDebug` matches `demoDebug` only — explicit `--variant
-   *    demoDebug` pins a specific flavor and any other variant is ignored.
-   * 2. **Build-type suffix match.** `target=debug` also matches `demoDebug`, `prodDebug`,
-   *    `uatDebug` — anything whose name ends with the capitalized target. Keeps the default
-   *    `--variant=debug` working on flavored apps (issue #1546) without making the consumer add
-   *    `--variant demoDebug` every run.
+   *    demoDebug` pins a specific flavor and any other variant is ignored. Suffix matching is
+   *    skipped for flavored targets so `--variant paidDebug` does NOT silently match
+   *    `minApi23PaidDebug` on a multi-dimension flavored module.
+   * 2. **Build-type suffix match.** A bare build-type target (`debug`, `release`) also matches
+   *    `demoDebug`, `prodDebug`, `uatDebug` — anything whose name ends with the capitalized target.
+   *    Keeps the default `--variant=debug` working on flavored apps (issue #1546) without making
+   *    the consumer add `--variant demoDebug` every run.
    *
-   * The second rule is intentionally one-directional: a target like `demoDebug` does NOT match a
-   * flavorless `debug` variant. The user picked a flavor and the module doesn't have it, so the
-   * module is silently skipped — same outcome as today.
+   * "Bare build-type" is detected as a target containing no uppercase characters — matches AGP's
+   * convention that build types are lowercase identifiers while combined variant names carry an
+   * uppercased segment (`paidDebug`, `minApi23PaidDebug`). If the target itself has an internal
+   * uppercase, it's a flavored variant name and rule 2 is bypassed.
+   *
+   * Rule 2 is intentionally one-directional: a target like `demoDebug` does NOT match a flavorless
+   * `debug` variant. The user picked a flavor and the module doesn't have it, so the module is
+   * silently skipped — same outcome as today.
    */
   internal fun variantMatchesTarget(variantName: String, target: String): Boolean {
     if (variantName == target) return true
     if (target.isEmpty()) return false
+    val isBareBuildType = target.none { it.isUpperCase() }
+    if (!isBareBuildType) return false
     val capitalized = target.replaceFirstChar { it.uppercase() }
     return variantName.endsWith(capitalized)
   }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/VariantMatchesTargetTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/VariantMatchesTargetTest.kt
@@ -52,6 +52,15 @@ class VariantMatchesTargetTest {
   }
 
   @Test
+  fun `flavored target does not suffix-match a multi-dimension variant`() {
+    // Regression: --variant paidDebug must not silently match minApi23PaidDebug on a
+    // multi-dimension flavored module. Only bare build-type targets get suffix matching.
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("minApi23PaidDebug", "paidDebug"))
+      .isFalse()
+    assertThat(AndroidPreviewSupport.variantMatchesTarget("freePaidDebug", "paidDebug")).isFalse()
+  }
+
+  @Test
   fun `empty target matches only an empty variant name`() {
     assertThat(AndroidPreviewSupport.variantMatchesTarget("debug", "")).isFalse()
     assertThat(AndroidPreviewSupport.variantMatchesTarget("", "")).isTrue()


### PR DESCRIPTION
Two codex review findings on #1551 that were left unaddressed at merge — both about `--variant` correctness, so clustered into one PR.

## Summary

- **`AndroidPreviewSupport.variantMatchesTarget`**: the build-type suffix fallback fired for any target, so `--variant paidDebug` silently matched `minApi23PaidDebug` on a multi-dimension flavored module. The docstring already described suffix matching as build-type-only; the code now enforces it — flavored targets (anything with an internal uppercase character) require exact match.
- **`DoctorCommand`**: constructs its own `GradleConnection` and so missed the `--variant` propagation that `BaseCommand` does via `variantGradleArgs()`. `doctor --variant prodRelease` was running the model query against `debug` and reporting on the wrong variant. Mirror `BaseCommand`'s flag parsing and pass `-PcomposePreview.variant=` through.

## Test plan

- [x] `./gradlew :gradle-plugin:test --tests "*VariantMatchesTargetTest*"` — added regression case for `paidDebug` vs `minApi23PaidDebug`
- [x] `./gradlew :cli:compileKotlin`
- [ ] Manual: `compose-preview doctor --variant prodRelease` on a flavored project reports on `prodRelease`, not `debug`

---
_Generated by [Claude Code](https://claude.ai/code/session_017rcB2a7Ka1rfZbKJj86m7Y)_