### PR TITLE
fix(daemon): truthful supportedOverrides + drop stale Android-only docstrings

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -344,6 +344,12 @@ open class RobolectricHost(
       "material3Theme",
       "wallpaper",
       "ambient",
+      "focus",
+      "keyboard",
+      "touchOverlay",
+      "launcherWidget",
+      "permissions",
+      "remoteCompose",
     )
 
   /** PROTOCOL.md § 3 — android backend identifier surfaced via `capabilities.backend`. */

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -108,9 +108,10 @@ interface RenderHost {
    *
    * The default empty set is the safe pre-feature value — clients treat absent and `[]` identically
    * and assume any field they pass might be ignored. Real backends override: `RobolectricHost`
-   * advertises all fields; `DesktopHost` omits `orientation` (no rotation concept on
-   * `ImageComposeScene`), Android-only timing knobs, and `localeTag` unless the Compose UI runtime
-   * exposes a providable locale list.
+   * advertises all fields; `DesktopHost` omits Android-only timing knobs (`captureAdvanceMs` —
+   * `ImageComposeScene` has no paused-clock concept) and `localeTag` unless the Compose UI runtime
+   * exposes a providable locale list. `orientation` IS advertised on desktop — reduced to a
+   * `widthPx ↔ heightPx` swap by `DesktopHost` (issue #1208).
    */
   val supportedOverrides: Set<String>
     get() = emptySet()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -187,9 +187,10 @@ data class ServerCapabilities(
    * fields the backend would silently ignore. Empty list = pre-feature daemon (clients treat absent
    * and `[]` identically and assume any field they pass might be ignored).
    *
-   * Today: `RobolectricHost` advertises every field; `DesktopHost` omits `orientation` (no rotation
-   * concept on `ImageComposeScene`), Android-only timing knobs, and `localeTag` unless the Compose
-   * UI runtime exposes a providable locale list.
+   * Today: `RobolectricHost` advertises every field; `DesktopHost` omits Android-only timing knobs
+   * (`captureAdvanceMs` — `ImageComposeScene` has no paused-clock concept) and `localeTag` unless
+   * the Compose UI runtime exposes a providable locale list. `orientation` IS advertised on desktop
+   * — reduced to a `widthPx ↔ heightPx` swap by `DesktopHost` (issue #1208).
    */
   val supportedOverrides: List<String> = emptyList(),
   /**
@@ -465,9 +466,17 @@ data class PreviewOverrides(
   val localeTag: String? = null,
   /** Font scale multiplier (1.0 = system default, 1.3 = "large", 2.0 = max accessibility). */
   val fontScale: Float? = null,
-  /** Light/dark mode override. Android-only today. */
+  /**
+   * Light/dark mode override. Android applies via `Configuration.uiMode`; desktop applies via
+   * `LocalSystemTheme` on `ImageComposeScene`.
+   */
   val uiMode: UiMode? = null,
-  /** Portrait/landscape override. Android-only today. */
+  /**
+   * Portrait/landscape override. Android applies via the corresponding qualifier; desktop reduces
+   * the hint to a `widthPx ↔ heightPx` swap when neither an explicit pixel dimension nor a `device`
+   * token is supplied AND the requested orientation conflicts with the current aspect ratio
+   * (issue #1208) — `ImageComposeScene` has no display-rotation concept of its own.
+   */
   val orientation: Orientation? = null,
   /**
    * `@Preview(device = ...)` string — `id:pixel_5`, `id:wearos_small_round`, `id:tv_1080p`, or a

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -631,13 +631,14 @@ internal fun buildDesktopExtensions(
     // `DesktopHost.acquireRecordingSession`. The around-composable observes pointer events via
     // `Modifier.pointerInput` on the Initial pass without consuming them, so the inner preview's
     // gesture detectors (`Modifier.transformable`, `Modifier.clickable`, …) keep working
-    // unchanged. Lives in `:daemon:desktop` for now since this is the first backend with live
-    // mode; a future `data/touch-overlay/connector/` module will host the planner so Android picks
-    // it up automatically when live mode lands on Robolectric.
+    // unchanged. The planner lives in the shared `:data-touch-overlay-connector` module so both
+    // backends register the same `TouchOverlayPreviewOverrideExtension` — Android wires it from
+    // `RobolectricHost.previewOverrideExtensions` and advertises the extension descriptor from
+    // `:daemon:android`'s `DaemonMain`.
     //
     // [dataExtensionDescriptors] advertises `TouchOverlayExtension.ID` so the panel / MCP can
     // discover the extension via `initialize.capabilities.dataExtensions` and gate the per-card
-    // "touch overlay" toggle on the daemon actually shipping it (today: desktop only).
+    // "touch overlay" toggle on the daemon actually shipping it.
     Extension(
       id = "data/touch-overlay",
       displayName = "Touch event overlay",

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -209,6 +209,12 @@ open class DesktopHost(
     // `data/focus` (`FocusPreviewOverrideExtension`), which installs the around-composable that
     // flips `LocalInputModeManager` to keyboard mode and drives `FocusManager.moveFocus(...)`.
     add("focus")
+    // Other override-driven extensions whose planners are registered in `buildDesktopExtensions`.
+    // Advertising them matches the actual behaviour: a `renderNow.overrides.<field>` IS applied,
+    // not silently ignored. Pseudolocale is driven by `localeTag` (no separate field).
+    add("keyboard")
+    add("touchOverlay")
+    add("launcherWidget")
   }
 
   /** PROTOCOL.md § 3 — desktop backend identifier surfaced via `capabilities.backend`. */


### PR DESCRIPTION
## Summary

Audit of "what's missing in Android vs CMP" surfaced several small inconsistencies that the daemon/MCP capability surface was lying about. Fixes:

- **`RobolectricHost.supportedOverrides` was understating accepted fields.** Added `focus`, `keyboard`, `touchOverlay`, `launcherWidget`, `permissions`, `remoteCompose` — all six have planners wired into `previewOverrideExtensions` already, the capability bag just wasn't telling clients. MCP's `validate_overrides` was incorrectly poised to warn agents off fields that actually work.
- **`DesktopHost.supportedOverrides` had the same hole.** Added `keyboard`, `touchOverlay`, `launcherWidget` (already advertised: `focus`). Pseudolocale is driven by `localeTag` so it needs no separate field.
- **Stale "Android-only today" docstrings** in `PreviewOverrides.uiMode`, `PreviewOverrides.orientation`, and `RenderHost.supportedOverrides`. Desktop has applied `uiMode` via `LocalSystemTheme` and `orientation` via a `widthPx ↔ heightPx` swap since issue #1208.
- **Stale comment in desktop `DaemonMain.kt`** on the touch-overlay extension claiming "Lives in `:daemon:desktop` for now since this is the first backend with live mode" — both halves are now untrue: `:data-touch-overlay-connector` is a shared CMP module, Android wires the planner from `RobolectricHost.kt:1445`, and live mode (`AndroidRecordingSession`) exists on Android.

No protocol breaks — `supportedOverrides` is documented as additive on the wire (`Messages.kt:189`: "clients treat absent and `[]` identically and assume any field they pass might be ignored").

## Test plan

- [x] `./gradlew :daemon:core:ktfmtCheck :daemon:android:ktfmtCheck :daemon:desktop:ktfmtCheck`
- [x] `./gradlew :daemon:desktop:test --tests "*DesktopHostTest*" --tests "*BuildDesktopExtensionsTest*"`
- [x] `./gradlew :mcp:test --tests "*DaemonMcpServerTest*" --tests "*DaemonMcpLiveCapabilityTest*"`
- [x] `./gradlew :daemon:android:compileReleaseKotlin :daemon:desktop:compileKotlin`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdzfeJ1bkbsdfGV3K8M56K)_