### PR TITLE
fix(a11y): preserve baseline findings on ATF-unavailable runs

### DIFF
--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -560,35 +560,58 @@ def cmd_comment(args: argparse.Namespace) -> int:
         "## Accessibility Report",
         "",
     ]
+
     if status == ATF_UNAVAILABLE:
-        # Header replaces the usual finding-counts line when ATF didn't run
-        # — the counts would be misleadingly zero. The link to the CI logs
-        # is left abstract on purpose; the workflow's failure step already
-        # surfaces a direct link, and we don't want to embed the job URL
-        # here (the python helper doesn't know it).
+        # ATF returned no data this run, so every *current* entry has empty
+        # findings — not because the issues were fixed but because nothing
+        # was checked. Diffing those empties against the baseline would render
+        # prior findings as "resolved" / "_No findings._" (#1595), making a
+        # daemon failure look like a clean run and silently masking real prior
+        # a11y issues.
+        #
+        # Skip the per-preview comparison entirely. Re-surface the baseline's
+        # findings verbatim, marked as carried-over, behind a banner that
+        # explains no comparison was produced. Counts come from the baseline
+        # so the numbers stay consistent with the prior known state instead of
+        # collapsing to a misleading zero. The CI-log link is left abstract on
+        # purpose; the workflow's failure step already surfaces a direct link
+        # and the python helper doesn't know the job URL.
+        preserved = sorted(
+            (e for e in baseline_entries if _entry_findings_key(e)),
+            key=lambda e: (e["module"], e["functionName"]),
+        )
+        b_err, b_warn, b_info = _level_counts(baseline_entries)
         lines.extend([
             "> [!WARNING]",
-            "> ATF data unavailable — the preview daemon did not return "
-            "accessibility findings for this run. The renders below are "
-            "**not** accessibility-checked; see the CI logs for the daemon "
+            "> ATF data unavailable this run — the preview daemon did not "
+            "return accessibility findings. Baseline findings are preserved "
+            "below **unchanged**; no comparison was performed, so nothing here "
+            "reflects this PR's changes. See the CI logs for the daemon "
             "failure.",
             "",
+            f"{b_err} error(s) · {b_warn} warning(s) · {b_info} info "
+            f"across {len(preserved)} baseline preview(s) — carried over, "
+            f"not re-checked.",
+            "",
         ])
+        for entry in preserved:
+            variant = entry.get("variant")
+            header_suffix = f" · `{variant}`" if variant else ""
+            lines.append(
+                f"### `{entry['functionName']}`{header_suffix} "
+                f"({entry['module']})"
+            )
+            lines.append("")
+            lines.extend(_findings_table(entry["findings"]))
+            lines.append("")
+        sys.stdout.write("\n".join(lines).rstrip() + "\n")
+        return 0
+
     lines.extend([
         f"{err} error(s) · {warn} warning(s) · {info} info "
         f"across {len(entries)} preview(s).",
         "",
     ])
-
-    if status == ATF_UNAVAILABLE:
-        # ATF returned no data, so every current entry has empty findings —
-        # not because the issues were fixed but because nothing was checked.
-        # Diffing those empties against a baseline would render prior findings
-        # as "resolved" / "_No findings._", making a daemon failure look like
-        # a clean run. Surface only the warning + counts; the per-preview diff
-        # is meaningless until ATF data comes back.
-        sys.stdout.write("\n".join(lines).rstrip() + "\n")
-        return 0
 
     if findings_count == 0:
         lines.append("No accessibility findings.")

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -541,6 +541,52 @@ class CommentTest(unittest.TestCase):
         self.assertNotEqual(body, "")
         self.assertIn("No accessibility findings", body)
 
+    def test_atf_unavailable_preserves_baseline_findings_not_resolved(self):
+        # Regression for #1595: when the current run is atf-unavailable its
+        # entries are empty, but the baseline had real findings. Those must be
+        # preserved as carried-over — NOT diffed away into a "Resolved" block,
+        # which would falsely signal the issues were fixed when in fact nothing
+        # was checked.
+        baseline_entry = self._entry(
+            function="Bad", findings=[_finding(level="ERROR", message="Contrast.")]
+        )
+        body = self._run_comment(
+            [],  # daemon down: no current entries
+            baseline_entries=[baseline_entry],
+            status="atf-unavailable",
+        )
+        # The prior finding is re-surfaced, not dropped or marked resolved.
+        self.assertIn("`Bad`", body)
+        self.assertIn("Contrast.", body)
+        self.assertNotIn("Resolved", body)
+        self.assertNotIn("_No findings._", body)
+        # Banner explains no comparison was produced.
+        self.assertIn("[!WARNING]", body)
+        self.assertIn("no comparison was performed", body)
+        self.assertIn("preserved", body)
+
+    def test_atf_unavailable_counts_track_baseline_not_zero(self):
+        # Regression for #1595: the summary counters must reflect the baseline
+        # findings being preserved, not collapse to a misleading zero from the
+        # empty current entries.
+        baseline_entries = [
+            self._entry(
+                function="A", preview_id="x.A",
+                findings=[_finding(level="ERROR"), _finding(level="WARNING")],
+            ),
+            self._entry(
+                function="B", preview_id="x.B", findings=[_finding(level="INFO")]
+            ),
+            self._entry(function="Clean", preview_id="x.Clean", findings=[]),
+        ]
+        body = self._run_comment(
+            [], baseline_entries=baseline_entries, status="atf-unavailable"
+        )
+        self.assertIn("1 error(s) · 1 warning(s) · 1 info", body)
+        # Only the two previews carrying findings are counted; the clean one
+        # is not surfaced.
+        self.assertIn("across 2 baseline preview(s)", body)
+
     def test_only_changed_preview_gets_a_block_others_collapsed(self):
         # Two previews exist; only one gains a finding vs the baseline. The
         # changed one gets a full findings table, the unchanged-but-flagged
@@ -579,7 +625,8 @@ class CommentTest(unittest.TestCase):
         # with empty findings. Diffing those against a baseline that had
         # findings must NOT render them as changed-to-empty/"No findings" or
         # "Resolved" — that would make a daemon failure look like the issues
-        # were fixed. Only the warning + counts should appear.
+        # were fixed (#1595). Instead the baseline finding is preserved
+        # verbatim under the carried-over banner.
         baseline = self._entry(
             function="Bad", preview_id="x.Bad", findings=[_finding(level="ERROR")]
         )
@@ -589,9 +636,10 @@ class CommentTest(unittest.TestCase):
         )
         self.assertIn("ATF data unavailable", body)
         self.assertNotIn("_No findings._", body)
-        self.assertNotIn("### `Bad`", body)
         self.assertNotIn("Resolved", body)
         self.assertNotIn("No accessibility findings", body)
+        # The prior finding is preserved, not silently dropped.
+        self.assertIn("### `Bad`", body)
 
     def test_resolved_preview_listed_when_removed(self):
         # A preview that carried a finding on the baseline but is gone now


### PR DESCRIPTION
Closes #1595.

## Problem

When the preview daemon fails to return ATF data, the current run's entries come back empty. The per-preview comment diff in `cmd_comment` compared those empties against a baseline that had findings and treated them as **resolved** / "_No findings._", making a daemon failure look like a clean run and silently masking real prior accessibility issues.

The prior partial fix (#1590) short-circuited the diff but *dropped* the baseline findings entirely and reported a misleading `0 error(s)` summary.

## Fix

When `status == "atf-unavailable"`, skip the per-preview comparison entirely and instead:

- Re-surface the baseline's findings verbatim, marked as **carried over, not re-checked** (preserved, never "resolved").
- Show a banner explaining that no comparison was produced: _"ATF data unavailable this run … Baseline findings are preserved below unchanged; no comparison was performed."_
- Drive the summary counters from the **baseline** so the numbers stay consistent with the prior known state instead of collapsing to zero.

## Test plan

- `python3 -m unittest test_a11y_report` — all 30 tests pass.
- Updated `test_atf_unavailable_does_not_render_findings_as_resolved` to assert the baseline finding is now preserved (not dropped) while still never rendered as resolved / "No findings".
- Added `test_atf_unavailable_preserves_baseline_findings_not_resolved` and `test_atf_unavailable_counts_track_baseline_not_zero` regression tests covering the acceptance criteria.
- Manually rendered a sample ATF-unavailable comment to confirm the banner, baseline-consistent counts, and preserved findings table.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvuEEmHi6Ryqzw1go9HSWT)_