### PR TITLE
feat(daemon): wire desktop scroll scenario runner (render/scroll/long + gif)

### DIFF
--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -109,6 +109,20 @@ dependencies {
   // Android-only, so findings are always empty here — no dependency on `:data-a11y-core` (an
   // android-library). See `DesktopAccessibility*`.
   implementation(project(":preview-data-api"))
+  // Scroll data-product connector — issue #1604. Advertises render/scroll/long and
+  // render/scroll/gif as requiresRerender=true kinds, and carries `ScrollDataProductRegistry`
+  // plus the `ScrollPreviewExtension.KIND_*` / descriptor constants. Pure-JVM module — mirrors the
+  // Android side's `implementation(project(":data-scroll-connector"))`. `RenderEngine` branches
+  // into the scroll scenario when the dispatcher's `data/fetch` re-render path queues
+  // `mode=scroll-long` / `scroll-gif`, writing to the same on-disk paths the registry reads back.
+  implementation(project(":data-scroll-connector"))
+  // Renderer-desktop — the `runComposeUiTest`-driven scroll capture (`renderScrollPreview`) that
+  // drives `SemanticsActions.ScrollBy`, stitches LONG slices, and encodes the GIF. Mirrors
+  // `:daemon:android`'s `implementation(project(":renderer-android"))` dependency for the scroll
+  // handlers; the daemon's `RenderEngine.runScrollScenario` delegates to it per re-render. The
+  // function's `compose.uiTest` machinery stays internal to `:renderer-desktop` (that module's
+  // `implementation` dep) and rides along on the runtime classpath transitively.
+  implementation(project(":renderer-desktop"))
 
   // Compose runtime / foundation / ui — the B-desktop.1.4 RenderEngine body
   // imports `ImageComposeScene`, `@Composable`, `currentComposer`,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -737,6 +737,30 @@ internal fun buildDesktopExtensions(
         dataProductRegistry = NavigationDataProductRegistry(rootDir = dataRoot),
       )
     }
+    // Issue #1604 — daemon-side scroll artefact production on CMP-desktop. Unlike the registries
+    // above (whose producers are still Android-bound), scroll is fully portable: the registry
+    // lives in the pure-JVM `:data-scroll-connector`, and `:renderer-desktop` already carries the
+    // `runComposeUiTest`-driven capture. The registry advertises `render/scroll/long` /
+    // `render/scroll/gif` as `requiresRerender = true`, so a missing scroll artefact returns
+    // `Outcome.RequiresRerender("scroll-long"|"scroll-gif")` and the dispatcher queues a
+    // per-preview re-render that `RenderEngine.runScrollScenario` routes into
+    // `renderScrollPreview`, writing to the same
+    // `<dataRoot>/render-scroll-{long,gif}/<id>.{png,gif}`
+    // paths Gradle does so the host's `gradleService.readPreviewImage` reads the same file either
+    // way. Descriptors are advertised too so MCP / `previewExtensions/list` clients see the scroll
+    // surface — exactly mirroring `:daemon:android`'s `DaemonMain`.
+    tryAdd("scroll") {
+      Extension(
+        id = "scroll",
+        displayName = "Scrolling preview artifacts",
+        dataProductRegistry = ScrollDataProductRegistry(rootDir = dataRoot),
+        previewExtensionDescriptors =
+          listOf(
+            ee.schimke.composeai.scroll.ScrollPreviewExtension.longScrollDescriptor,
+            ee.schimke.composeai.scroll.ScrollPreviewExtension.gifScrollDescriptor,
+          ),
+      )
+    }
     // Accessibility (desktop, overlay-only). Unlike Android — where the producer runs ATF over the
     // Robolectric View tree — the desktop path extracts Compose semantics from the scene's
     // `semanticsOwners` and draws the Paparazzi-style overlay + legend with AWT (see

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -123,6 +123,16 @@ class RenderEngine(
      */
     sandboxStats: SandboxLifecycleStats = SandboxLifecycleStats(),
   ): RenderResult {
+    // Issue #1604 — scroll-scenario dispatch. When the dispatcher's `data/fetch` re-render path
+    // queues `mode=scroll-long` / `scroll-gif` (because the `ScrollDataProductRegistry` advertised
+    // the kind as `requiresRerender = true` and the artefact was missing), leave the single-frame
+    // `ImageComposeScene` path and drive `:renderer-desktop`'s `renderScrollPreview` instead. It
+    // writes the stitched PNG (LONG) / animated GIF (GIF) to the same on-disk path the registry
+    // (`ScrollDataProductRegistry.fileFor`) reads back, so the dispatcher's second fetch sees the
+    // file and emits `Ok(path)`. Mirrors `:daemon:android`'s `RenderEngine.runScrollScenario`.
+    if (spec.renderMode == SCROLL_LONG_RENDER_MODE || spec.renderMode == SCROLL_GIF_RENDER_MODE) {
+      return runScrollScenario(spec = spec, requestId = requestId, classLoader = classLoader)
+    }
     val trace = PerfettoTraceDataProducer.recorder(spec.outputBaseName, backend = "desktop")
     val state =
       trace.section("compose:setUp") {
@@ -499,6 +509,116 @@ class RenderEngine(
     }
   }
 
+  /**
+   * Issue #1604 — dispatch for `scroll-long` / `scroll-gif` render modes on CMP-desktop. Resolves
+   * the `@ScrollingPreview` intent (axis / maxScrollPx / frameIntervalMs) from the daemon's
+   * `previews.json` index via [PreviewIndex.scrollCaptureFor], then delegates to
+   * `:renderer-desktop`'s [ee.schimke.composeai.renderer.renderScrollPreview] (a `runComposeUiTest`
+   * capture that drives `SemanticsActions.ScrollBy`, stitches the LONG slices, or encodes the GIF).
+   * The artefact lands at `<dataDir>/render-scroll-{long,gif}/<previewId>.{png,gif}` — the exact
+   * path [ScrollDataProductRegistry.fileFor] resolves to — so the dispatcher's second fetch reads
+   * it back. Returns a [RenderResult] whose `pngPath` points at the produced artefact.
+   *
+   * Throws [IllegalStateException] when the spec carries no `previewId`, when the preview has no
+   * matching `dataProducts[].scroll` entry in `previews.json`, or when the renderer reports "no
+   * scrollable on the requested axis" (returns `false`). The dispatcher surfaces each as
+   * `ERR_DATA_PRODUCT_FETCH_FAILED` so the host can fall back to its Gradle path. Mirrors the
+   * Android side's `runScrollScenario` one-to-one (same lookup, same on-disk layout, same error
+   * contract) so consumer code stays platform-agnostic.
+   */
+  private fun runScrollScenario(
+    spec: RenderSpec,
+    requestId: Long,
+    classLoader: ClassLoader,
+  ): RenderResult {
+    val previewId =
+      spec.previewId
+        ?: error(
+          "RenderEngine: scroll mode '${spec.renderMode}' requires a previewId on the RenderSpec " +
+            "so the scroll metadata can be resolved from the previews.json index"
+        )
+    val previewIndex = loadPreviewIndexLazily()
+    val scroll =
+      previewIndex.scrollCaptureFor(previewId, spec.renderMode!!)
+        ?: error(
+          "RenderEngine: scroll mode '${spec.renderMode}' requested for previewId '$previewId' " +
+            "but the preview has no matching dataProducts[].scroll entry in previews.json — " +
+            "the host should fall back to the Gradle composePreviewRenderAll path"
+        )
+    val (subdir, ext) =
+      when (spec.renderMode) {
+        SCROLL_LONG_RENDER_MODE -> ScrollDataProductRegistry.SCROLL_LONG_SUBDIR to "png"
+        SCROLL_GIF_RENDER_MODE -> ScrollDataProductRegistry.SCROLL_GIF_SUBDIR to "gif"
+        else -> error("RenderEngine: unreachable scroll mode '${spec.renderMode}'")
+      }
+    val outputFile = dataDir.resolve(subdir).resolve("$previewId.$ext")
+    outputFile.parentFile?.mkdirs()
+
+    val scrollMode =
+      when (spec.renderMode) {
+        SCROLL_LONG_RENDER_MODE -> ee.schimke.composeai.renderer.DesktopScrollMode.LONG
+        else -> ee.schimke.composeai.renderer.DesktopScrollMode.GIF
+      }
+    val axis =
+      when (scroll.axis.uppercase()) {
+        "HORIZONTAL" -> ee.schimke.composeai.scroll.ScrollAxis.HORIZONTAL
+        else -> ee.schimke.composeai.scroll.ScrollAxis.VERTICAL
+      }
+
+    val startNs = System.nanoTime()
+    val handled =
+      ee.schimke.composeai.renderer.renderScrollPreview(
+        className = spec.className,
+        functionName = spec.functionName,
+        widthPx = spec.widthPx,
+        heightPx = spec.heightPx,
+        density = spec.density,
+        showBackground = spec.showBackground,
+        backgroundColor = spec.backgroundColor,
+        outputFile = outputFile,
+        wrapperClassName = spec.wrapperClassName,
+        // v1 daemon renders the parameterless `@Preview` overload only — `@PreviewParameter`
+        // fan-out stays behind the standalone renderer (see this file's class doc).
+        previewArgs = emptyList(),
+        localeTag = spec.localeTag,
+        scrollMode = scrollMode,
+        axis = axis,
+        maxScrollPx = scroll.maxScrollPx,
+        frameIntervalMs = scroll.frameIntervalMs,
+        classLoader = classLoader,
+      )
+    if (!handled) {
+      error(
+        "RenderEngine: scroll mode '${spec.renderMode}' returned false (no scrollable on " +
+          "scroll.axis=${scroll.axis} for previewId '$previewId')"
+      )
+    }
+    val tookMs = (System.nanoTime() - startNs) / 1_000_000L
+    return RenderResult(
+      id = requestId,
+      classLoaderHashCode = System.identityHashCode(classLoader),
+      classLoaderName = classLoader.javaClass.name,
+      pngPath = outputFile.absolutePath,
+      metrics = mapOf("tookMs" to tookMs),
+    )
+  }
+
+  /**
+   * Lazily reads the daemon's `previews.json` via [PreviewIndex.loadFromFile] using the
+   * `composeai.daemon.previewsJsonPath` system property the gradle plugin populates. Falls back to
+   * [PreviewIndex.empty] when the property is unset (harness / fake-mode tests) —
+   * [runScrollScenario] then surfaces a structured "no scroll metadata" error. Mirrors the Android
+   * engine's helper of the same name so the two backends resolve scroll intent identically.
+   */
+  private fun loadPreviewIndexLazily(): PreviewIndex {
+    val path = System.getProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP)
+    return if (path.isNullOrBlank()) {
+      PreviewIndex.empty()
+    } else {
+      PreviewIndex.loadFromFile(java.nio.file.Paths.get(path))
+    }
+  }
+
   interface PreviewContextCapture {
     fun shouldCapture(previewId: String?, renderMode: String?): Boolean
   }
@@ -509,6 +629,19 @@ class RenderEngine(
      * side uses; the gradle plugin's daemon launch descriptor sets it once at JVM start.
      */
     const val OUTPUT_DIR_PROP: String = "composeai.render.outputDir"
+
+    /**
+     * Issue #1604 — scroll scenarios the daemon's `data/fetch` re-render path can request. The
+     * registry in `:data-scroll-connector` advertises `render/scroll/long` / `render/scroll/gif` as
+     * `requiresRerender = true`, so a missing scroll artefact returns
+     * `Outcome.RequiresRerender("scroll-long" | "scroll-gif")` and the dispatcher submits a render
+     * with `spec.renderMode` set to one of these constants. [render] routes scroll-mode requests
+     * into [runScrollScenario]. Values match `:daemon:android`'s `RenderEngine` constants byte for
+     * byte so a single payload drives both backends.
+     */
+    const val SCROLL_LONG_RENDER_MODE: String = "scroll-long"
+
+    const val SCROLL_GIF_RENDER_MODE: String = "scroll-gif"
 
     fun supportsLocaleTagOverride(): Boolean = localProvidableLocaleListOrNull() != null
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/BuildDesktopExtensionsTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/BuildDesktopExtensionsTest.kt
@@ -119,6 +119,51 @@ class BuildDesktopExtensionsTest {
   }
 
   @Test
+  fun scroll_advertised_when_data_root_set() {
+    // Issue #1604 — scroll is the first #1201 gap closed end-to-end on desktop: the registry lives
+    // in the pure-JVM `:data-scroll-connector` and `:renderer-desktop` already carries the capture,
+    // so `render/scroll/long` / `render/scroll/gif` are produced on demand rather than tripping
+    // `-32020 kind not advertised`. The extension gates on `dataRoot` like the other file-backed
+    // registries (the artefacts land under `<dataRoot>/render-scroll-{long,gif}/`).
+    assertFalse("scroll" in build(dataRoot = null))
+    val ids = build(dataRoot = tempFolder.newFolder("scroll-data"))
+    assertTrue("scroll" in ids)
+  }
+
+  @Test
+  fun scroll_extension_advertises_long_and_gif_descriptors() {
+    // The scroll extension carries the LONG / GIF preview-extension descriptors so MCP /
+    // `previewExtensions/list` clients discover the scroll surface — mirroring `:daemon:android`'s
+    // `DaemonMain`. Without the descriptors the panel would see an advertised data-product kind it
+    // can't attribute to an extension.
+    val extensions =
+      buildDesktopExtensions(
+        previewIndex = PreviewIndex.empty(),
+        recompositionRegistry = RecompositionDataProductRegistry(),
+        themeRegistry = ThemeDataProductRegistry(),
+        wallpaperRegistry = WallpaperDataProductRegistry(),
+        launcherWidgetRegistry = LauncherWidgetDataProductRegistry(),
+        historyManager = null,
+        dataRoot = tempFolder.newFolder("scroll-desc-data"),
+        composeTraceEnabled = false,
+        displayFilterEnabled = false,
+      )
+    val scroll = extensions.single { it.id == "scroll" }
+    val kinds = scroll.dataProductCapabilities.map { it.kind }.toSet()
+    assertTrue(
+      "scroll registry must advertise render/scroll/long + render/scroll/gif; got $kinds",
+      ee.schimke.composeai.scroll.ScrollPreviewExtension.KIND_LONG in kinds &&
+        ee.schimke.composeai.scroll.ScrollPreviewExtension.KIND_GIF in kinds,
+    )
+    val descriptorIds = scroll.previewExtensionDescriptors.map { it.id }.toSet()
+    assertTrue(
+      "scroll extension must advertise its LONG + GIF descriptors; got $descriptorIds",
+      ee.schimke.composeai.scroll.ScrollPreviewExtension.longScrollDescriptor.id in descriptorIds &&
+        ee.schimke.composeai.scroll.ScrollPreviewExtension.gifScrollDescriptor.id in descriptorIds,
+    )
+  }
+
+  @Test
   fun touch_overlay_and_keyboard_band_advertise_data_extension_descriptors() {
     // The override-driven extensions (`data/touch-overlay` + `data/keyboard`) carry a
     // `DataExtensionDescriptor` so GUI clients (panel, MCP) can discover them via

--- a/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopScrollRenderer.kt
+++ b/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopScrollRenderer.kt
@@ -86,8 +86,20 @@ fun renderScrollPreview(
   axis: ScrollAxis,
   maxScrollPx: Int,
   frameIntervalMs: Int,
+  /**
+   * Classloader used to resolve [className] (and any `@PreviewWrapper` provider). B2.0 — the daemon
+   * (`:daemon:desktop`'s `RenderEngine.runScrollScenario`) loads user previews from a disposable
+   * child classloader (CLASSLOADER.md), not the app classpath, so a bare `Class.forName(className)`
+   * — which resolves against this module's own loader — would miss the freshly-recompiled preview
+   * class. When non-null it's used for the reflective class lookup and threaded into the wrapper
+   * resolution below. The standalone CLI / Gradle path (`DesktopRendererMain`) passes null and
+   * keeps the app-classloader behaviour.
+   */
+  classLoader: ClassLoader? = null,
 ): Boolean {
-  val clazz = Class.forName(className)
+  val clazz =
+    if (classLoader != null) Class.forName(className, true, classLoader)
+    else Class.forName(className)
   val composableMethod =
     if (previewArgs.isEmpty()) clazz.getDeclaredComposableMethod(functionName)
     else findComposableMethodForScroll(clazz, functionName, previewArgs)
@@ -136,7 +148,7 @@ fun renderScrollPreview(
           }
         }
         if (wrapperClassName != null) {
-          InvokeScrollWrappedComposable(wrapperClassName, body)
+          InvokeScrollWrappedComposable(wrapperClassName, classLoader, body)
         } else {
           body()
         }
@@ -479,10 +491,16 @@ private fun InvokeScrollComposable(
 }
 
 @Composable
-private fun InvokeScrollWrappedComposable(wrapperFqn: String, body: @Composable () -> Unit) {
+private fun InvokeScrollWrappedComposable(
+  wrapperFqn: String,
+  classLoader: ClassLoader?,
+  body: @Composable () -> Unit,
+) {
   val resolved =
-    androidx.compose.runtime.remember(wrapperFqn) {
-      val cls = Class.forName(wrapperFqn)
+    androidx.compose.runtime.remember(wrapperFqn, classLoader) {
+      val cls =
+        if (classLoader != null) Class.forName(wrapperFqn, true, classLoader)
+        else Class.forName(wrapperFqn)
       val instance = cls.getDeclaredConstructor().apply { isAccessible = true }.newInstance()
       val method = cls.getDeclaredComposableMethod("Wrap", Function2::class.java)
       method to instance


### PR DESCRIPTION
## Summary

`render/scroll/long` and `render/scroll/gif` only fired on Android because the desktop daemon neither advertised the scroll extension nor had a scenario runner to route `data/fetch` re-renders into. On CMP-desktop the symptom was `-32020 kind not advertised`.

As #1604 notes, scroll is the cheapest #1201 gap to close: the registry (`ScrollDataProductRegistry`) already lives in the pure-JVM `:data-scroll-connector`, and `:renderer-desktop` already carries the `runComposeUiTest`-driven capture (`renderScrollPreview`). So this is a wire-up, not a new producer.

### Changes
- **`:daemon:desktop` build** — added `:data-scroll-connector` + `:renderer-desktop` dependencies (mirroring `:daemon:android`).
- **`DaemonMain.buildDesktopExtensions`** — registers the `scroll` extension (`ScrollDataProductRegistry` + LONG/GIF preview-extension descriptors), gated on `dataRoot != null` like the other file-backed registries.
- **`RenderEngine`** — `render()` dispatches `scroll-long` / `scroll-gif` render modes into a new `runScrollScenario`, which resolves the `@ScrollingPreview` intent (axis / maxScrollPx / frameIntervalMs) from `previews.json` via `PreviewIndex.scrollCaptureFor` and delegates to `renderScrollPreview`. Artefacts land at the same `render-scroll-{long,gif}/<id>.{png,gif}` paths the Android side and Gradle write, so the host's read path stays platform-agnostic. Added `SCROLL_LONG/GIF_RENDER_MODE` constants matching the Android engine.
- **`renderScrollPreview`** — gained an optional `classLoader` so the daemon's disposable child loader (CLASSLOADER.md / B2.0) resolves freshly-recompiled previews; the standalone CLI / Gradle path passes `null` and keeps app-classloader behaviour.

The existing desktop sample (`samples/cmp/.../ScrollingPreviews.kt`) already exercises a scrollable column, and the registry behaviour is identical across backends so the existing `ScrollDataProductRegistryTest` in `:data-scroll-connector` already covers it.

## Test plan
- `./gradlew :renderer-desktop:compileKotlin :daemon:desktop:test --tests "ee.schimke.composeai.daemon.BuildDesktopExtensionsTest"` — **BUILD SUCCESSFUL**.
- New `BuildDesktopExtensionsTest` assertions: `scroll` is advertised only when `dataRoot` is set, and the extension carries `render/scroll/long` + `render/scroll/gif` kinds plus the LONG/GIF descriptors.

Closes #1604

---
_Generated by [Claude Code](https://claude.ai/code/session_01QruMCKEjKBLKovk6ebjZbu)_