### PR TITLE
fix(permissions): scope sandbox query bridge by previewId

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/SandboxPermissionsBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/SandboxPermissionsBridge.kt
@@ -25,53 +25,92 @@ import java.util.concurrent.atomic.AtomicLong
  * Compose, no Robolectric, no `ee.schimke.composeai.*` imports — those would drag the bridge
  * back into the instrumented graph and break the single-instance invariant.
  *
- * **State shape.** A single concurrent map per JVM keyed by permission name, valued by a
+ * **Per-preview scoping (issue #1593).** A naive single JVM-wide map keyed by permission name
+ * leaks across concurrent previews: when `sandboxCount > 1`, preview A's sandbox and preview B's
+ * sandbox both write into the same shared singleton, and the host's `compose/permissions` readback
+ * for A returns answers that belong to B. The same flat map also accumulates across re-uses of a
+ * single slot for different previews. To fix it the bridge mirrors
+ * [SandboxRecompositionBridge]'s `(previewId)` keying: state is an outer map keyed by previewId,
+ * each holding the permission -> arrival-counter inner map. Writers stamp their active previewId
+ * (the controller forwards it from the around-composable's `ExtensionComposeContext.previewId`);
+ * the host reads back by the same previewId. A render with no previewId (legacy stub payloads)
+ * scopes under [NO_PREVIEW_SCOPE].
+ *
+ * **State shape.** Per previewId, a concurrent map keyed by permission name and valued by a
  * monotonic arrival counter so [snapshot] can return the unique permissions in insertion order
- * (the same shape `PermissionsController.queriedSet` produces in-process). Cumulative across
- * renders within the active interactive session; [reset] is the per-session cleanup hook that
- * `PermissionsController.resetForNewSession` calls.
+ * (the same shape `PermissionsController.queriedSet` produces in-process). The arrival counter is
+ * a single JVM-wide sequence — ordering only matters within a previewId's snapshot, and a global
+ * counter keeps cross-preview comparisons meaningless without extra per-preview bookkeeping.
+ * Cumulative across renders within the active interactive session; [reset] is the per-preview
+ * cleanup hook that `PermissionsController.resetForNewSession` calls and [resetAll] the JVM-wide
+ * one for host restart / test isolation.
  */
 object SandboxPermissionsBridge {
 
+  /** Scope key used when a render carries no previewId (legacy stub-render payloads). */
+  const val NO_PREVIEW_SCOPE: String = ""
+
   private val arrivalCounter: AtomicLong = AtomicLong(0L)
 
-  /** Permission name -> arrival counter. ConcurrentHashMap so writes from any sandbox thread race-free. */
-  private val queries: ConcurrentHashMap<String, Long> = ConcurrentHashMap()
+  /**
+   * previewId -> (permission name -> arrival counter). Outer and inner maps are both
+   * [ConcurrentHashMap] so writes from any sandbox thread race-free, and concurrent previews each
+   * own a private inner map — preview A's queries can never surface in preview B's [snapshot].
+   */
+  private val queriesByPreview: ConcurrentHashMap<String, ConcurrentHashMap<String, Long>> =
+    ConcurrentHashMap()
 
   /**
-   * Sandbox-side: record that the screen queried [permission]. Idempotent — the first call for
-   * a given permission stamps an arrival counter; subsequent calls are no-ops so the snapshot
-   * preserves the original insertion order. Mirrors `PermissionsController.recordQuery`'s
-   * de-duplication semantics so the bridge and the in-CL controller agree on the queried set.
+   * Sandbox-side: record that [previewId]'s screen queried [permission]. Idempotent within a
+   * preview — the first call for a given (previewId, permission) stamps an arrival counter;
+   * subsequent calls are no-ops so the snapshot preserves the original insertion order. Mirrors
+   * `PermissionsController.recordQuery`'s de-duplication semantics so the bridge and the in-CL
+   * controller agree on the queried set.
    */
   @JvmStatic
-  fun recordQuery(permission: String) {
-    queries.computeIfAbsent(permission) { arrivalCounter.incrementAndGet() }
+  fun recordQuery(previewId: String, permission: String) {
+    queriesByPreview
+      .computeIfAbsent(previewId) { ConcurrentHashMap() }
+      .computeIfAbsent(permission) { arrivalCounter.incrementAndGet() }
   }
 
   /**
-   * Host-side: snapshot the queried permissions in insertion order without clearing. Repeated
-   * reads — e.g. the panel re-fetching `compose/permissions` between renders — see the cumulative
-   * set, matching the in-CL controller's "session-lifetime" semantics.
+   * Host-side: snapshot [previewId]'s queried permissions in insertion order without clearing.
+   * Repeated reads — e.g. the panel re-fetching `compose/permissions` between renders — see the
+   * cumulative set for that preview, matching the in-CL controller's "session-lifetime" semantics.
+   * A previewId the bridge never saw returns an empty array (the registry treats that as "no
+   * queries", i.e. `NotAvailable` when grants are empty too).
    *
    * Returns a primitive `String[]` so the cross-loader transport stays in JLS types only —
    * neither side reinterprets a `kotlin.collections.List` from the other's classloader. Mirrors
    * the `arrayOf(String[], long[])` shape `SandboxRecompositionBridge.drainCounters` uses.
    */
   @JvmStatic
-  fun snapshot(): Array<String> {
+  fun snapshot(previewId: String): Array<String> {
+    val queries = queriesByPreview[previewId] ?: return emptyArray()
     if (queries.isEmpty()) return emptyArray()
     val entries = queries.entries.toList().sortedBy { it.value }
     return Array(entries.size) { entries[it].key }
   }
 
   /**
-   * Both sides: drop every recorded query. Called by `PermissionsController.resetForNewSession`
-   * (per-session cleanup) and by [DaemonHostBridge]-style host restart paths so a fresh sandbox
-   * doesn't see the previous session's queries.
+   * Both sides: drop the recorded queries for [previewId] only. Called by
+   * `PermissionsController.resetForNewSession` (per-session cleanup) so closing preview A's session
+   * doesn't wipe a concurrently-held preview B's queries — the bug a JVM-wide `clear()` would
+   * reintroduce.
    */
   @JvmStatic
-  fun reset() {
-    queries.clear()
+  fun reset(previewId: String) {
+    queriesByPreview.remove(previewId)
+  }
+
+  /**
+   * Both sides: drop every recorded query across all previews. Used by host-restart paths and test
+   * isolation where a full wipe is the intent. Per-session cleanup must use [reset] instead so it
+   * stays scoped to the closing preview.
+   */
+  @JvmStatic
+  fun resetAll() {
+    queriesByPreview.clear()
   }
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsDataFetchE2ETest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PermissionsDataFetchE2ETest.kt
@@ -60,9 +60,9 @@ class PermissionsDataFetchE2ETest {
   @After
   fun resetBridge() {
     // Bridge is a JVM-wide singleton; previous test methods or sibling test classes that
-    // exercised the sandbox can leak queries into ours. Reset the bridge here AND between every
-    // render submission below so each assertion sees only the queries from the render it gated.
-    SandboxPermissionsBridge.reset()
+    // exercised the sandbox can leak queries into ours. Reset every preview scope here AND between
+    // render submissions below so each assertion sees only the queries from the render it gated.
+    SandboxPermissionsBridge.resetAll()
   }
 
   @Test
@@ -105,7 +105,7 @@ class PermissionsDataFetchE2ETest {
         )
       val payload =
         "previewId=$previewId;overrides=${encodeOverridesBag(overrideBag)}"
-      SandboxPermissionsBridge.reset()
+      SandboxPermissionsBridge.resetAll()
       val result = host.submit(RenderRequest.Render(payload = payload), timeoutMs = 120_000)
 
       // Pixel correctness — sanity check that the override actually drove the granted branch.

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/SandboxPermissionsBridgeTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/SandboxPermissionsBridgeTest.kt
@@ -1,0 +1,105 @@
+package ee.schimke.composeai.daemon.bridge
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Per-preview scoping coverage for [SandboxPermissionsBridge] (issue #1593).
+ *
+ * The bridge is a single JVM-wide singleton shared across every Robolectric sandbox (it lives in
+ * the do-not-acquire `ee.schimke.composeai.daemon.bridge` package). Before the fix it keyed its
+ * query map by permission name alone, so two concurrent previews — each in its own sandbox, each
+ * writing into the same singleton — cross-polluted: the host's `compose/permissions` readback for
+ * preview A could surface a permission preview B queried. These tests pin that each previewId owns
+ * an isolated query set, mirroring `SandboxRecompositionBridge`'s `(previewId)` keying.
+ *
+ * Plain JUnit (no `@RunWith(SandboxHoldingRunner::class)`) — the bridge is plain host-side state;
+ * its cross-classloader visibility is exercised end-to-end by `PermissionsDataFetchE2ETest`.
+ */
+class SandboxPermissionsBridgeTest {
+
+  @After fun tearDown() = SandboxPermissionsBridge.resetAll()
+
+  @Test
+  fun `two concurrent previews see only their own queries`() {
+    SandboxPermissionsBridge.recordQuery("preview-a", "android.permission.CAMERA")
+    SandboxPermissionsBridge.recordQuery("preview-b", "android.permission.ACCESS_FINE_LOCATION")
+    SandboxPermissionsBridge.recordQuery("preview-a", "android.permission.RECORD_AUDIO")
+
+    assertEquals(
+      "preview-a must see only its own queries",
+      listOf("android.permission.CAMERA", "android.permission.RECORD_AUDIO"),
+      SandboxPermissionsBridge.snapshot("preview-a").toList(),
+    )
+    assertEquals(
+      "preview-b must see only its own queries",
+      listOf("android.permission.ACCESS_FINE_LOCATION"),
+      SandboxPermissionsBridge.snapshot("preview-b").toList(),
+    )
+  }
+
+  @Test
+  fun `snapshot preserves insertion order and de-duplicates within a preview`() {
+    SandboxPermissionsBridge.recordQuery("preview-a", "android.permission.CAMERA")
+    SandboxPermissionsBridge.recordQuery("preview-a", "android.permission.RECORD_AUDIO")
+    SandboxPermissionsBridge.recordQuery("preview-a", "android.permission.CAMERA") // duplicate
+
+    assertEquals(
+      listOf("android.permission.CAMERA", "android.permission.RECORD_AUDIO"),
+      SandboxPermissionsBridge.snapshot("preview-a").toList(),
+    )
+  }
+
+  @Test
+  fun `snapshot of an unseen preview is empty`() {
+    SandboxPermissionsBridge.recordQuery("preview-a", "android.permission.CAMERA")
+
+    assertEquals(emptyList<String>(), SandboxPermissionsBridge.snapshot("never-rendered").toList())
+  }
+
+  @Test
+  fun `reset clears only the named preview, leaving concurrent previews intact`() {
+    SandboxPermissionsBridge.recordQuery("preview-a", "android.permission.CAMERA")
+    SandboxPermissionsBridge.recordQuery("preview-b", "android.permission.ACCESS_FINE_LOCATION")
+
+    SandboxPermissionsBridge.reset("preview-a")
+
+    assertEquals(
+      "preview-a's scope is cleared",
+      emptyList<String>(),
+      SandboxPermissionsBridge.snapshot("preview-a").toList(),
+    )
+    assertEquals(
+      "closing preview-a's session must not wipe a concurrently-held preview-b",
+      listOf("android.permission.ACCESS_FINE_LOCATION"),
+      SandboxPermissionsBridge.snapshot("preview-b").toList(),
+    )
+  }
+
+  @Test
+  fun `resetAll clears every preview scope`() {
+    SandboxPermissionsBridge.recordQuery("preview-a", "android.permission.CAMERA")
+    SandboxPermissionsBridge.recordQuery("preview-b", "android.permission.ACCESS_FINE_LOCATION")
+
+    SandboxPermissionsBridge.resetAll()
+
+    assertEquals(emptyList<String>(), SandboxPermissionsBridge.snapshot("preview-a").toList())
+    assertEquals(emptyList<String>(), SandboxPermissionsBridge.snapshot("preview-b").toList())
+  }
+
+  @Test
+  fun `no-preview renders share the dedicated sentinel scope`() {
+    SandboxPermissionsBridge.recordQuery(
+      SandboxPermissionsBridge.NO_PREVIEW_SCOPE,
+      "android.permission.CAMERA",
+    )
+
+    assertEquals(
+      listOf("android.permission.CAMERA"),
+      SandboxPermissionsBridge.snapshot(SandboxPermissionsBridge.NO_PREVIEW_SCOPE).toList(),
+    )
+    // A real previewId must not pick up the sentinel scope's queries.
+    assertEquals(emptyList<String>(), SandboxPermissionsBridge.snapshot("preview-a").toList())
+  }
+}

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsController.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsController.kt
@@ -35,6 +35,13 @@ import java.util.concurrent.CopyOnWriteArrayList
  */
 object PermissionsController {
 
+  /**
+   * Bridge scope key for a render with no previewId. Must equal
+   * `SandboxPermissionsBridge.NO_PREVIEW_SCOPE`; duplicated as a literal here because the
+   * controller reaches the bridge reflectively (no compile-time dependency on `:daemon:android`).
+   */
+  private const val NO_PREVIEW_SCOPE: String = ""
+
   private val lock = Any()
 
   /** Effective grant map. Persisted across renders so a session that flips a grant mid-flight is observable. */
@@ -49,6 +56,19 @@ object PermissionsController {
 
   /** Cache of unique queried permissions for O(1) duplicate suppression in [recordQuery]. */
   private val queriedSeen: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+  /**
+   * previewId of the render whose composition is currently driving this controller, or `null` for
+   * a render with no previewId. Set by [PermissionsOverrideExtension]'s around-composable from
+   * `ExtensionComposeContext.previewId` before the preview content composes, so the shadow-driven
+   * [recordQuery] can stamp the cross-classloader bridge with the right scope (issue #1593).
+   *
+   * `@Volatile`, not mutex-guarded: composition for a given sandbox is single-threaded, so the only
+   * cross-thread reader is a defensive one; a plain volatile is enough to publish the write made on
+   * the composition thread. The controller is loaded fresh per sandbox, so this never holds two
+   * concurrent previews' ids — those live in separate classloaders, each with their own static.
+   */
+  @Volatile private var activePreviewId: String? = null
 
   val grants: State<Map<String, PermissionGrantStateOverride>>
     get() = grantsState
@@ -99,8 +119,21 @@ object PermissionsController {
     if (queriedSeen.add(permission)) {
       synchronized(lock) { queriedSet.value = queriedSet.value + permission }
     }
-    bridgeForwarder?.recordQuery(permission)
+    bridgeForwarder?.recordQuery(bridgeScope(), permission)
   }
+
+  /**
+   * Sandbox-side: stamp the previewId whose composition is about to read permissions, so the
+   * subsequent shadow-driven [recordQuery] forwards land in that preview's bridge scope. Called by
+   * [PermissionsOverrideExtension]'s around-composable before the preview content composes. `null`
+   * (a render with no previewId) maps to the bridge's no-preview scope.
+   */
+  fun beginRender(previewId: String?) {
+    activePreviewId = previewId
+  }
+
+  /** Bridge scope key for the active render — the bridge's no-preview sentinel when unset. */
+  private fun bridgeScope(): String = activePreviewId ?: NO_PREVIEW_SCOPE
 
   /** Register a callback fired on every [set] transition. Returns an unregister handle. */
   fun addChangeListener(listener: () -> Unit): () -> Unit {
@@ -114,13 +147,17 @@ object PermissionsController {
    * `KeyboardController.resetForNewSession` / `AmbientStateController.resetForNewSession`.
    */
   fun resetForNewSession() {
+    val scope = bridgeScope()
     synchronized(lock) {
       grantsState.value = emptyMap()
       queriedSet.value = emptyList()
       queriedSeen.clear()
+      activePreviewId = null
       syncRobolectricGrants(emptyMap())
     }
-    bridgeForwarder?.reset()
+    // Scope the bridge reset to the closing preview so a concurrent preview's queries survive —
+    // a JVM-wide clear here would reintroduce the cross-preview leak the per-preview keying fixes.
+    bridgeForwarder?.reset(scope)
   }
 
   /**
@@ -195,18 +232,18 @@ object PermissionsController {
     private val recordQueryMethod: java.lang.reflect.Method,
     private val resetMethod: java.lang.reflect.Method,
   ) {
-    fun recordQuery(permission: String) {
+    fun recordQuery(previewId: String, permission: String) {
       try {
-        recordQueryMethod.invoke(null, permission)
+        recordQueryMethod.invoke(null, previewId, permission)
       } catch (_: ReflectiveOperationException) {
         // Bridge invocation failed (unexpected — the class loaded but the call failed). Drop —
         // controller's in-CL state still serves the same-CL fast path.
       }
     }
 
-    fun reset() {
+    fun reset(previewId: String) {
       try {
-        resetMethod.invoke(null)
+        resetMethod.invoke(null, previewId)
       } catch (_: ReflectiveOperationException) {
         // Same defensive drop as recordQuery; the controller's in-CL state already cleared above.
       }
@@ -219,8 +256,9 @@ object PermissionsController {
         try {
           val cls = Class.forName(BRIDGE_FQN, true, PermissionsController::class.java.classLoader)
           BridgeForwarder(
-            recordQueryMethod = cls.getMethod("recordQuery", String::class.java),
-            resetMethod = cls.getMethod("reset"),
+            recordQueryMethod =
+              cls.getMethod("recordQuery", String::class.java, String::class.java),
+            resetMethod = cls.getMethod("reset", String::class.java),
           )
         } catch (_: ClassNotFoundException) {
           null

--- a/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
+++ b/data/permissions/connector/src/main/kotlin/ee/schimke/composeai/daemon/PermissionsDataProduct.kt
@@ -16,10 +16,12 @@ import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtension
 import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
 import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
-import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionComposeContext
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -65,14 +67,17 @@ import kotlinx.serialization.json.JsonElement
  * permission check composed in user code sees the override.
  */
 class PermissionsOverrideExtension(private val seed: PermissionsOverride? = null) :
-  AroundComposableExtension(
-    id = ID,
-    constraints =
-      DataExtensionConstraints(
-        phase = DataExtensionPhase.OuterEnvironment,
-        provides = setOf(DataExtensionCapability(PermissionsDataProductRegistry.KIND)),
-      ),
-  ) {
+  AroundComposableHook {
+
+  override val id: DataExtensionId = ID
+
+  override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.AroundComposable)
+
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(
+      phase = DataExtensionPhase.OuterEnvironment,
+      provides = setOf(DataExtensionCapability(PermissionsDataProductRegistry.KIND)),
+    )
 
   init {
     // Apply the seed eagerly so `Context.checkSelfPermission(...)` reads through the new
@@ -88,7 +93,12 @@ class PermissionsOverrideExtension(private val seed: PermissionsOverride? = null
   }
 
   @Composable
-  override fun AroundComposable(content: @Composable () -> Unit) {
+  override fun Around(context: ExtensionComposeContext, content: @Composable () -> Unit) {
+    // Stamp the active previewId before the preview content composes so the shadow-driven
+    // `recordQuery` lands in this preview's bridge scope, not a concurrent preview's (issue #1593).
+    // Plain call (not a SideEffect) so it runs during composition, ahead of any
+    // `ContextCompat.checkSelfPermission(...)` read in `content()`.
+    PermissionsController.beginRender(context.previewId)
     DisposableEffect(seed) { onDispose { PermissionsController.set(null) } }
     content()
   }
@@ -198,7 +208,12 @@ class PermissionsDataProductRegistry : DataProductRegistry {
     // through the controller without a seed, and the panel still wants to surface that. An empty
     // payload (no grants, no queries) is filtered out so we don't masquerade `NotAvailable`.
     val grants = overrides?.permissions?.grants.orEmpty() + PermissionsController.grants.value
-    val queried = readQueriedAcrossClassloaders()
+    // Read the bridge by the previewId the sandbox stamped its queries under. Prefer the render's
+    // own `previewContext.previewId` (literally `spec.previewId`, the exact key the sandbox-side
+    // controller used) and fall back to the registry's `previewId` argument when no context is
+    // attached (connector-only tests, where the bridge is absent and the in-CL controller answers).
+    val scope = previewContext?.previewId ?: previewId
+    val queried = readQueriedAcrossClassloaders(scope)
     if (grants.isEmpty() && queried.isEmpty()) {
       clear(previewId)
       return
@@ -219,11 +234,11 @@ class PermissionsDataProductRegistry : DataProductRegistry {
    * (`PermissionsDataProductTest`) working unchanged — they exercise both sides from a single
    * classloader where the controller's in-CL state IS the source of truth.
    */
-  private fun readQueriedAcrossClassloaders(): List<String> {
+  private fun readQueriedAcrossClassloaders(scope: String): List<String> {
     val bridge = SandboxPermissionsBridgeReader.tryLoad()
     val controllerQueried = PermissionsController.queried.value
     if (bridge == null) return controllerQueried
-    val bridgeQueried = bridge.snapshot()
+    val bridgeQueried = bridge.snapshot(scope)
     // Union of bridge and same-CL controller views, preserving bridge insertion order first and
     // appending controller-only entries (the rare same-CL `:daemon:android` test path where a
     // direct controller call wrote to in-CL state but the bridge was the loaded singleton).
@@ -242,10 +257,10 @@ class PermissionsDataProductRegistry : DataProductRegistry {
   private class SandboxPermissionsBridgeReader(
     private val snapshotMethod: java.lang.reflect.Method,
   ) {
-    fun snapshot(): List<String> =
+    fun snapshot(scope: String): List<String> =
       try {
         @Suppress("UNCHECKED_CAST")
-        (snapshotMethod.invoke(null) as Array<String>).toList()
+        (snapshotMethod.invoke(null, scope) as Array<String>).toList()
       } catch (_: ReflectiveOperationException) {
         emptyList()
       }
@@ -269,7 +284,9 @@ class PermissionsDataProductRegistry : DataProductRegistry {
                   true,
                   PermissionsDataProductRegistry::class.java.classLoader,
                 )
-              SandboxPermissionsBridgeReader(snapshotMethod = cls.getMethod("snapshot"))
+              SandboxPermissionsBridgeReader(
+                snapshotMethod = cls.getMethod("snapshot", String::class.java)
+              )
             } catch (_: ClassNotFoundException) {
               null
             } catch (_: NoSuchMethodException) {


### PR DESCRIPTION
## Summary

`SandboxPermissionsBridge` kept a single JVM-wide map keyed only by permission name. Because the bridge is a do-not-acquire singleton shared across every Robolectric sandbox, with `sandboxCount > 1` two concurrent previews wrote into the same map — so the host's `compose/permissions` readback for preview A could surface a permission that preview B queried. The same flat map also accumulated across slot re-use for different previews. This is a correctness bug, not a perf nit.

The fix mirrors `SandboxRecompositionBridge`'s per-`previewId` keying:

- **Bridge** state becomes `previewId -> (permission -> arrival counter)`. `recordQuery`/`snapshot`/`reset` now take a `previewId`, plus a `resetAll` for full wipes (host restart / test isolation). A render with no previewId scopes under a dedicated sentinel.
- **PermissionsController** stamps the active previewId (`beginRender`) and forwards it to the bridge. `resetForNewSession` scopes its bridge reset to the closing preview, so a concurrently-held preview's queries survive (a JVM-wide `clear()` here would just reintroduce the leak in the other direction).
- **PermissionsOverrideExtension** now implements `AroundComposableHook` directly so it can read `ExtensionComposeContext.previewId` and call `beginRender` before the preview content composes — ahead of any `ContextCompat.checkSelfPermission(...)` read.
- **Host readback** filters by `previewContext.previewId` (the exact key the sandbox stamped), falling back to the registry `previewId` argument when no context is attached (connector-only tests).

Closes #1593.

## Test plan

- New `SandboxPermissionsBridgeTest` (6 tests) pins the per-preview scoping contract: two concurrent previews see only their own queries, `reset(previewId)` clears only the named preview while a concurrent one survives, `resetAll` wipes everything, insertion-order/de-dup within a preview, and the no-preview sentinel scope.
- `PermissionsDataFetchE2ETest` (drives the real Robolectric sandbox, cross-classloader bridge path) — passes, confirming no regression in the single-sandbox path.
- `PermissionsOverrideIntegrationTest` — passes.
- `:data-permissions-connector:test` (controller + data-product unit tests) — passes.

```
:daemon:android  SandboxPermissionsBridgeTest        6 tests, 0 failures
:daemon:android  PermissionsDataFetchE2ETest         1 test,  0 failures
:daemon:android  PermissionsOverrideIntegrationTest  1 test,  0 failures
:data-permissions-connector:test                     all green
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9vZsc5E8fyD8uzbwP6Yvg)_