### PR TITLE
feat(recomposition): v2 schema with per-scope invalidation reason

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecompositionDataProductRegistry.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecompositionDataProductRegistry.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.recomposition.InvalidationReason
 import ee.schimke.composeai.data.recomposition.RecompositionNode
 import ee.schimke.composeai.data.recomposition.RecompositionPayload
 import ee.schimke.composeai.data.recomposition.RecompositionProduct
@@ -329,9 +330,30 @@ open class AndroidRecompositionDataProductRegistry : DataProductRegistry {
     @Suppress("UNCHECKED_CAST")
     val ids = drained[0] as Array<String>
     val counts = drained[1] as LongArray
+    val invalidations = drained[2] as LongArray
     if (ids.isEmpty()) return emptyList()
-    return List(ids.size) { i -> RecompositionNode(nodeId = ids[i], count = counts[i].toInt()) }
+    return List(ids.size) { i ->
+      val count = counts[i].toInt()
+      RecompositionNode(
+        nodeId = ids[i],
+        count = count,
+        reason = reasonFor(count = count, invalidations = invalidations[i].toInt()),
+      )
+    }
   }
+
+  /**
+   * Attribute a scope's recomposition from its recomposition count vs how many times the runtime
+   * invalidated it with a snapshot value this window — same derivation as the desktop producer.
+   * v2 (#1605). See [InvalidationReason].
+   */
+  private fun reasonFor(count: Int, invalidations: Int): InvalidationReason =
+    when {
+      count <= 0 -> InvalidationReason.UNKNOWN
+      invalidations <= 0 -> InvalidationReason.PARAMETER_CHANGE
+      invalidations >= count -> InvalidationReason.STATE_READ
+      else -> InvalidationReason.BOTH
+    }
 
   private fun parseParams(params: JsonElement?): SubscribeParamsView? {
     if (params == null) return null

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -2414,7 +2414,19 @@ open class RobolectricHost(
           override fun onScopeInvalidated(
             scope: androidx.compose.runtime.RecomposeScope,
             value: Any?,
-          ) {}
+          ) {
+            // v2 (#1605): a non-null [value] is the snapshot object that invalidated the scope —
+            // the STATE_READ signal. The host derives each node's InvalidationReason by comparing
+            // these against the recomposition counts. A null value (unconditional invalidate)
+            // carries no state attribution, so we ignore it.
+            if (value != null) {
+              ee.schimke.composeai.daemon.bridge.SandboxRecompositionBridge.markInvalidated(
+                previewId,
+                streamId,
+                System.identityHashCode(scope),
+              )
+            }
+          }
 
           override fun onScopeDisposed(scope: androidx.compose.runtime.RecomposeScope) {
             ee.schimke.composeai.daemon.bridge.SandboxRecompositionBridge.markDisposed(

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/SandboxPermissionsBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/SandboxPermissionsBridge.kt
@@ -56,7 +56,7 @@ object SandboxPermissionsBridge {
    *
    * Returns a primitive `String[]` so the cross-loader transport stays in JLS types only —
    * neither side reinterprets a `kotlin.collections.List` from the other's classloader. Mirrors
-   * the `arrayOf(String[], long[])` shape `SandboxRecompositionBridge.drainCounters` uses.
+   * the parallel-primitive-arrays shape `SandboxRecompositionBridge.drainCounters` uses.
    */
   @JvmStatic
   fun snapshot(): Array<String> {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/SandboxRecompositionBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/SandboxRecompositionBridge.kt
@@ -24,11 +24,13 @@ import java.util.concurrent.ConcurrentHashMap
  * snapshots and clears the entries so each subsequent call carries only the delta since the previous
  * drain.
  *
- * **Wire shape across the bridge.** [drainCounters] returns `arrayOf(String[], long[])`: the first
- * element holds the base-16 scope ids (sorted), the second holds the matching counts. Mirrors the
- * parallel-primitive-arrays convention `DaemonHostBridge` already uses (and what the issue brief
- * spells out as the prescribed seam shape) — keeps the cross-loader transport in pure JLS types so
- * neither side reinterprets the other's `Map<*,*>` or `Pair<*,*>`.
+ * **Wire shape across the bridge.** [drainCounters] returns `arrayOf(String[], long[], long[])`:
+ * the first element holds the base-16 scope ids (sorted), the second the matching recomposition
+ * counts, and the third (v2, #1605) the matching snapshot-invalidation counts the host side uses to
+ * attribute each scope's `InvalidationReason`. Mirrors the parallel-primitive-arrays convention
+ * `DaemonHostBridge` already uses (and what the issue brief spells out as the prescribed seam
+ * shape) — keeps the cross-loader transport in pure JLS types so neither side reinterprets the
+ * other's `Map<*,*>` or `Pair<*,*>`.
  */
 object SandboxRecompositionBridge {
 
@@ -40,6 +42,13 @@ object SandboxRecompositionBridge {
    *  ("thread-safe ConcurrentHashMap per (previewId, frameStreamId)"). */
   private val counters: ConcurrentHashMap<String, ConcurrentHashMap<Int, Int>> = ConcurrentHashMap()
 
+  /** Per-stream snapshot-invalidation maps (v2, #1605), keyed by `System.identityHashCode(scope)`.
+   *  Parallel to [counters]: bumped by [markInvalidated] when the runtime invalidates a scope with a
+   *  snapshot value, drained alongside the counts so the host can attribute STATE_READ vs
+   *  PARAMETER_CHANGE. */
+  private val invalidations: ConcurrentHashMap<String, ConcurrentHashMap<Int, Int>> =
+    ConcurrentHashMap()
+
   /**
    * Sandbox-side: open a counter slot for [previewId] + [streamId]. Idempotent — re-calling on a
    * live slot is a no-op (returns the same inner map). The host-side registry calls into this via
@@ -48,6 +57,7 @@ object SandboxRecompositionBridge {
   @JvmStatic
   fun open(previewId: String, streamId: String) {
     counters.computeIfAbsent(key(previewId, streamId)) { ConcurrentHashMap() }
+    invalidations.computeIfAbsent(key(previewId, streamId)) { ConcurrentHashMap() }
   }
 
   /**
@@ -57,6 +67,7 @@ object SandboxRecompositionBridge {
   @JvmStatic
   fun close(previewId: String, streamId: String) {
     counters.remove(key(previewId, streamId))
+    invalidations.remove(key(previewId, streamId))
   }
 
   /**
@@ -71,41 +82,65 @@ object SandboxRecompositionBridge {
   }
 
   /**
+   * Sandbox-side (v2, #1605): bump the snapshot-invalidation counter for [scopeHash]. Called from
+   * the `CompositionObserver.onScopeInvalidated` callback when the runtime invalidates a scope with
+   * a non-null snapshot value — the STATE_READ signal. Silently dropped if the slot has been closed.
+   */
+  @JvmStatic
+  fun markInvalidated(previewId: String, streamId: String, scopeHash: Int) {
+    val map = invalidations[key(previewId, streamId)] ?: return
+    map.merge(scopeHash, 1, Int::plus)
+  }
+
+  /**
    * Sandbox-side: drop the counter for [scopeHash] when the recompose scope is disposed. Keeps the
    * map from leaking entries across a long-running session.
    */
   @JvmStatic
   fun markDisposed(previewId: String, streamId: String, scopeHash: Int) {
-    val map = counters[key(previewId, streamId)] ?: return
-    map.remove(scopeHash)
+    counters[key(previewId, streamId)]?.remove(scopeHash)
+    invalidations[key(previewId, streamId)]?.remove(scopeHash)
   }
 
   /**
    * Host-side: snapshot + reset the per-scope counters for [previewId] + [streamId].
    *
-   * Wire shape: `arrayOf(String[] ids, long[] counts)` where `ids[i]` is `Integer.toHexString(hash)`
-   * for the i-th entry (sorted ascending by id for deterministic payloads) and `counts[i]` is the
-   * delta count since the previous drain. Returns `arrayOf(String[0], long[0])` when no observer
-   * is active for the slot — the caller treats that the same as a live-but-quiet slot, i.e. an
-   * empty `nodes: []` attachment.
+   * Wire shape: `arrayOf(String[] ids, long[] counts, long[] invalidationCounts)` where `ids[i]` is
+   * `Integer.toHexString(hash)` for the i-th entry (sorted ascending by id for deterministic
+   * payloads), `counts[i]` is the recomposition delta count since the previous drain, and
+   * `invalidationCounts[i]` (v2, #1605) is how many times that scope was invalidated with a snapshot
+   * value over the same window — the host derives each scope's `InvalidationReason` from the two.
+   * Returns `arrayOf(String[0], long[0], long[0])` when no observer is active for the slot — the
+   * caller treats that the same as a live-but-quiet slot, i.e. an empty `nodes: []` attachment.
    *
    * Reset is per-entry (`ConcurrentHashMap.remove`) so concurrent observer increments don't lose
-   * a count between snapshot and reset — same atomic pattern the desktop producer uses.
+   * a count between snapshot and reset — same atomic pattern the desktop producer uses. The
+   * invalidation map is keyed on the recomposed ids and any invalidate-but-didn't-recompose
+   * leftovers are cleared so they don't mis-attribute a later structural recomposition.
    */
   @JvmStatic
   fun drainCounters(previewId: String, streamId: String): Array<Any> {
-    val map = counters[key(previewId, streamId)] ?: return arrayOf(emptyArray<String>(), LongArray(0))
-    if (map.isEmpty()) return arrayOf(emptyArray<String>(), LongArray(0))
+    val empty = arrayOf<Any>(emptyArray<String>(), LongArray(0), LongArray(0))
+    val map = counters[key(previewId, streamId)] ?: return empty
+    val invMap = invalidations[key(previewId, streamId)]
+    if (map.isEmpty()) {
+      invMap?.clear()
+      return empty
+    }
     val keys = map.keys.toList()
-    val pairs = ArrayList<Pair<String, Long>>(keys.size)
+    val rows = ArrayList<Triple<String, Long, Long>>(keys.size)
     for (k in keys) {
       val v = map.remove(k) ?: continue
-      pairs.add(Integer.toHexString(k) to v.toLong())
+      val inv = invMap?.remove(k) ?: 0
+      rows.add(Triple(Integer.toHexString(k), v.toLong(), inv.toLong()))
     }
-    pairs.sortBy { it.first }
-    val ids = Array(pairs.size) { pairs[it].first }
-    val counts = LongArray(pairs.size) { pairs[it].second }
-    return arrayOf(ids, counts)
+    // Drop invalidate-but-didn't-recompose leftovers so the next window starts clean.
+    invMap?.clear()
+    rows.sortBy { it.first }
+    val ids = Array(rows.size) { rows[it].first }
+    val countsOut = LongArray(rows.size) { rows[it].second }
+    val invCountsOut = LongArray(rows.size) { rows[it].third }
+    return arrayOf(ids, countsOut, invCountsOut)
   }
 
   /**
@@ -116,5 +151,6 @@ object SandboxRecompositionBridge {
   @JvmStatic
   fun resetAll() {
     counters.clear()
+    invalidations.clear()
   }
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecompositionDataProductRegistryTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecompositionDataProductRegistryTest.kt
@@ -33,7 +33,7 @@ class AndroidRecompositionDataProductRegistryTest {
     assertEquals(setOf("compose/recomposition"), byKind.keys)
     val cap = byKind.getValue("compose/recomposition")
     assertEquals(DataProductTransport.INLINE, cap.transport)
-    assertEquals(1, cap.schemaVersion)
+    assertEquals(2, cap.schemaVersion)
     assertTrue("compose/recomposition must be attachable", cap.attachable)
     assertTrue("compose/recomposition must be fetchable", cap.fetchable)
     assertTrue(
@@ -155,6 +155,19 @@ class AndroidRecompositionDataProductRegistryTest {
         assertTrue(
           "post-click delta must carry at least one recomposed scope (got '$nodes')",
           nodes!!.size >= 1,
+        )
+
+        // v2 (#1605): the reason field rides the bridge symmetrically with desktop. The toggle
+        // fixture reads its `clicked` state in composition, so the click invalidates that scope
+        // via a snapshot write — STATE_READ must surface, and every node must carry a reason.
+        val reasons = nodes.map { it.jsonObject["reason"]?.jsonPrimitive?.content }
+        assertTrue(
+          "every v2 node must carry a non-null reason (got '$reasons')",
+          reasons.all { it != null },
+        )
+        assertTrue(
+          "a state-read click must surface at least one STATE_READ scope (got '$reasons')",
+          reasons.contains("STATE_READ"),
         )
 
         // Quiet flush — no further input, so the next drain ships an empty nodes list.

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionAuditTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionAuditTest.kt
@@ -41,11 +41,13 @@ import org.junit.rules.TemporaryFolder
  *    further input drains to `nodes: []`, confirming the producer reset counters between flushes
  *    (not "the fix masked the producer").
  *
- * ## Data shape gap — what visualisation needs that the v1 payload does not expose
+ * ## Data shape — what the v2 payload exposes (and what is still deferred)
  *
- * The test uses the existing [ee.schimke.composeai.data.recomposition.RecompositionPayload] which
- * carries `{nodeId: hexhash, count: int}` per recomposed scope. That's enough for "did N scopes
- * recompose?" assertions like this test makes, but a *user-facing* visualisation needs more:
+ * The test uses [ee.schimke.composeai.data.recomposition.RecompositionPayload], which in v2 (#1605)
+ * carries `{nodeId, count, reason, …}` per recomposed scope. The `reason` field is what this test
+ * now asserts on: the bad fixture's parent shows up as `STATE_READ` and its forwarded-parameter
+ * children as `PARAMETER_CHANGE`, and the fix collapses that parameter-change cascade. A
+ * *user-facing* visualisation still wants more, deferred per the issue's Risk section:
  *
  * - **PNG heat-map overlay.** Needs per-scope screen bounds (x, y, width, height in the rendered
  *   image's pixel space) so a colour-shaded region can be drawn over the captured PNG. The current
@@ -57,17 +59,16 @@ import org.junit.rules.TemporaryFolder
  *   bytecode; the same path Layout Inspector reads. A v2 producer would parse those markers off the
  *   scope's anchor in the slot table — the same `(file:line:column)` key the producer KDoc already
  *   flags as a v2 followup for stable cross-session ids.
- * - **Investigate-the-fix diagnostic.** Needs a reason field per scope: parameter-change vs
- *   snapshot-state read vs both. [androidx.compose.runtime.tooling.CompositionObserver] surfaces
- *   `onScopeInvalidated(scope, value)` carrying the value that triggered invalidation; the v1
- *   producer ignores it. DejaVu's `$dirty`-bit reflection is the next rung up: it can flag a
- *   parameter as dirty-but-equal, which is exactly the surprising-recomposition signal.
+ * - **Investigate-the-fix diagnostic.** *Shipped in v2.* Each node now carries
+ *   [ee.schimke.composeai.data.recomposition.InvalidationReason] derived from
+ *   [androidx.compose.runtime.tooling.CompositionObserver]'s `onScopeInvalidated(scope, value)` (a
+ *   non-null value being the snapshot object that triggered it) compared against the recompose
+ *   count. DejaVu's `$dirty`-bit reflection is the next rung up — it can flag a parameter as
+ *   dirty-but-equal — but stays optional and out of scope here, falling back to `UNKNOWN`.
  *
- * Without those fields the audit *test* still works — it asserts on a count of distinct opaque ids
- * — but a human or agent reading the JSON payload sees `[{"nodeId": "1a2b3c4d", "count": 1}, …]`
- * with no way to tell which composable each entry is. The fix path is the v2 schema bump outlined
- * in [RecompositionDataProductRegistry]'s KDoc; this test exists in part to make that gap concrete
- * and testable.
+ * The `bounds` and source-marker fields exist on the v2 wire (nullable) but stay unpopulated until
+ * the post-layout bounds join and slot-table reflection land — both flagged risky in the issue's
+ * Risk section. The `reason` field is the non-risky core, and this test asserts on it directly.
  */
 class RecompositionAuditTest {
 
@@ -75,12 +76,46 @@ class RecompositionAuditTest {
 
   @Test
   fun bad_fixture_invalidates_whole_subtree_then_fix_narrows_invalidation_footprint() {
-    val nodeCountsBad = clickAndCaptureDeltaNodeIds(FIXTURES.first)
-    val nodeCountsBetter = clickAndCaptureDeltaNodeIds(FIXTURES.second)
+    val nodesBad = clickAndCaptureDeltaNodes(FIXTURES.first)
+    val nodesBetter = clickAndCaptureDeltaNodes(FIXTURES.second)
+    val nodeCountsBad = nodesBad.associate { it.nodeId to it.count }
+    val nodeCountsBetter = nodesBetter.associate { it.nodeId to it.count }
 
     assertTrue(
-      "Bad fixture: parent + 3 children should each invalidate (got '$nodeCountsBad')",
+      "Bad fixture: parent + 3 children should each invalidate (got '$nodesBad')",
       nodeCountsBad.size >= 3,
+    )
+
+    // v2 (#1605) — the audit now reads per-scope invalidation reasons instead of opaque ids. The
+    // bad fixture's defining shape: the parent reads `clicks` (STATE_READ) and forwards it as an
+    // `Int` parameter to three children, each of which re-runs because its argument changed
+    // (PARAMETER_CHANGE) without itself reading any state. That STATE_READ-cascades-into-
+    // PARAMETER_CHANGE mix is exactly what a reviewer wants to see surfaced.
+    val reasonsBad = nodesBad.map { it.reason }
+    assertTrue(
+      "Bad fixture: the parent's snapshot read must surface as STATE_READ (got '$nodesBad')",
+      reasonsBad.contains("STATE_READ"),
+    )
+    assertTrue(
+      "Bad fixture: the forwarded-parameter children must surface as PARAMETER_CHANGE " +
+        "(got '$nodesBad')",
+      reasonsBad.contains("PARAMETER_CHANGE"),
+    )
+
+    // The fix hoists the state into a holder whose reference is passed down, so the parent no
+    // longer reads `.value` during composition and the children take no changing parameter. The
+    // parameter-change cascade collapses — strictly fewer PARAMETER_CHANGE scopes than the bad
+    // case — while the one legitimate consumer still shows up as STATE_READ.
+    val paramChangeBad = reasonsBad.count { it == "PARAMETER_CHANGE" }
+    val paramChangeBetter = nodesBetter.count { it.reason == "PARAMETER_CHANGE" }
+    assertTrue(
+      "Better fixture: a state read must still be attributed (got '$nodesBetter')",
+      nodesBetter.any { it.reason == "STATE_READ" },
+    )
+    assertTrue(
+      "Better fixture: the fix must collapse the parameter-change cascade " +
+        "(bad PARAMETER_CHANGE=$paramChangeBad, better=$paramChangeBetter)",
+      paramChangeBetter < paramChangeBad,
     )
 
     // The audit's "fix worked" signal: a narrow invalidation footprint, not necessarily exactly
@@ -109,7 +144,7 @@ class RecompositionAuditTest {
     )
   }
 
-  private fun clickAndCaptureDeltaNodeIds(fixture: Fixture): Map<String, Int> {
+  private fun clickAndCaptureDeltaNodes(fixture: Fixture): List<DeltaNode> {
     val outputDir = tempFolder.newFolder("renders-${fixture.previewId}")
     val engine = RenderEngine(outputDir = outputDir)
     val registry = RecompositionDataProductRegistry()
@@ -166,9 +201,13 @@ class RecompositionAuditTest {
           registry.attachmentsFor(fixture.previewId, setOf("compose/recomposition")).single()
         val payload = postClick.payload!!.jsonObject
         val nodes = payload["nodes"]!!.jsonArray
-        val counts = nodes.associate { node ->
+        val captured = nodes.map { node ->
           val obj = node.jsonObject
-          obj["nodeId"]!!.jsonPrimitive.content to obj["count"]!!.jsonPrimitive.content.toInt()
+          DeltaNode(
+            nodeId = obj["nodeId"]!!.jsonPrimitive.content,
+            count = obj["count"]!!.jsonPrimitive.content.toInt(),
+            reason = obj["reason"]!!.jsonPrimitive.content,
+          )
         }
 
         // The "confirm a fix" rung needs the producer to actually reset between flushes — render
@@ -184,7 +223,7 @@ class RecompositionAuditTest {
           idleNodes.size,
         )
 
-        return counts
+        return captured
       } finally {
         registry.onUnsubscribe(fixture.previewId, "compose/recomposition")
         session.close()
@@ -195,6 +234,11 @@ class RecompositionAuditTest {
   }
 
   private data class Fixture(val previewId: String, val functionName: String, val streamId: String)
+
+  /**
+   * One recomposed scope from a delta payload: opaque id, exit count, and v2 invalidation reason.
+   */
+  private data class DeltaNode(val nodeId: String, val count: Int, val reason: String)
 
   companion object {
     private val FIXTURES =

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionDataProductRegistryTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionDataProductRegistryTest.kt
@@ -54,7 +54,7 @@ class RecompositionDataProductRegistryTest {
     assertEquals(setOf("compose/recomposition"), byKind.keys)
     val cap = byKind.getValue("compose/recomposition")
     assertEquals(DataProductTransport.INLINE, cap.transport)
-    assertEquals(1, cap.schemaVersion)
+    assertEquals(2, cap.schemaVersion)
     assertTrue("compose/recomposition must be attachable", cap.attachable)
     assertTrue("compose/recomposition must be fetchable", cap.fetchable)
     assertTrue(
@@ -133,7 +133,7 @@ class RecompositionDataProductRegistryTest {
         assertEquals(1, postClickAttachments.size)
         val postClick = postClickAttachments[0]
         assertEquals("compose/recomposition", postClick.kind)
-        assertEquals(1, postClick.schemaVersion)
+        assertEquals(2, postClick.schemaVersion)
         assertNotNull("delta payload must travel inline", postClick.payload)
         assertNull("compose/recomposition is INLINE-only; path must be null", postClick.path)
         val payload = postClick.payload!!.jsonObject
@@ -151,6 +151,19 @@ class RecompositionDataProductRegistryTest {
         assertTrue(
           "post-click delta must carry at least one recomposed scope (got '$nodes')",
           nodes!!.size >= 1,
+        )
+
+        // v2 (#1605): every node carries a reason; ClickRecomposingSquare's inner `key(clicks)`
+        // scope reads the clicks state, so the click invalidates it via a snapshot write — the
+        // STATE_READ signal must surface in the delta.
+        val reasons = nodes.map { it.jsonObject["reason"]?.jsonPrimitive?.content }
+        assertTrue(
+          "every v2 node must carry a non-null reason (got '$reasons')",
+          reasons.all { it != null },
+        )
+        assertTrue(
+          "a state-read click must surface at least one STATE_READ scope (got '$reasons')",
+          reasons.contains("STATE_READ"),
         )
 
         // 4. Without a second click, the next flush carries an empty nodes list — the post-
@@ -252,6 +265,7 @@ class RecompositionDataProductRegistryTest {
         override fun installObserver(
           scene: androidx.compose.ui.ImageComposeScene,
           onScopeRecomposed: (androidx.compose.runtime.RecomposeScope) -> Unit,
+          onScopeInvalidatedByState: (androidx.compose.runtime.RecomposeScope) -> Unit,
           onScopeDisposed: (androidx.compose.runtime.RecomposeScope) -> Unit,
         ): androidx.compose.runtime.tooling.CompositionObserverHandle {
           throw NoSuchMethodError(

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/RecompositionAttachmentsAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/RecompositionAttachmentsAndroidRealModeTest.kt
@@ -157,7 +157,7 @@ class RecompositionAttachmentsAndroidRealModeTest {
                 "attachment; got kinds=" +
                 attachments.map { it.jsonObject["kind"]?.jsonPrimitive?.contentOrNull }
             )
-        assertEquals(1, recomp["schemaVersion"]?.jsonPrimitive?.long?.toInt())
+        assertEquals(2, recomp["schemaVersion"]?.jsonPrimitive?.long?.toInt())
         assertEquals(
           "compose/recomposition is INLINE — path must be absent on the wire",
           null,

--- a/data/recomposition/connector/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
+++ b/data/recomposition/connector/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
@@ -16,6 +16,7 @@ import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.recomposition.InvalidationReason
 import ee.schimke.composeai.data.recomposition.RecompositionNode
 import ee.schimke.composeai.data.recomposition.RecompositionPayload
 import ee.schimke.composeai.data.recomposition.RecompositionProduct
@@ -42,12 +43,14 @@ import kotlinx.serialization.json.contentOrNull
  * "Recomposition + interactive mode" for the wire contract this implements.
  *
  * **What it does.**
- * - Advertises a single kind, `compose/recomposition`, schemaVersion=1, transport=INLINE,
+ * - Advertises a single kind, `compose/recomposition`, schemaVersion=2, transport=INLINE,
  *   attachable=true, fetchable=true, requiresRerender=true.
  * - On `data/subscribe` with `params: { frameStreamId, mode: "delta" }` against a live
  *   [DesktopInteractiveSession]: looks up the live scene via [liveScenes], reaches the held scene's
  *   [androidx.compose.runtime.Recomposer] reflectively, and installs a [CompositionObserver] that
- *   increments per-[RecomposeScope] counters on each `onScopeExit`.
+ *   increments per-[RecomposeScope] counters on each `onScopeExit` and records snapshot-driven
+ *   invalidations on `onScopeInvalidated` so each emitted node carries an [InvalidationReason]
+ *   (v2, #1605).
  * - On each `interactive/input` cycle the daemon's render watcher emits `renderFinished` and calls
  *   [attachmentsFor]; we snapshot the current counter map, attach it as a [RecompositionPayload],
  *   then reset counters to zero so the next input's payload is the delta *since the previous
@@ -130,6 +133,14 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
      * while [attachmentsFor] runs from JsonRpcServer's render watcher.
      */
     val counters: ConcurrentHashMap<Int, Int> = ConcurrentHashMap(),
+    /**
+     * Map of identity-hashcode-of-RecomposeScope → how many times the runtime invalidated it with a
+     * snapshot value this delta window (`onScopeInvalidated(scope, value != null)`). Compared
+     * against [counters] in [snapshotAndReset] to attribute each scope's [InvalidationReason]: an
+     * entry here means a state read drove (at least one of) the scope's recompositions; its absence
+     * means the scope re-ran because its caller did — a parameter change. v2 (#1605).
+     */
+    val invalidations: ConcurrentHashMap<Int, Int> = ConcurrentHashMap(),
   )
 
   /** Keyed by previewId. One subscription per (previewId, kind=compose/recomposition). */
@@ -185,7 +196,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
               mode = MODE_DELTA,
               sinceFrameStreamId = state.frameStreamId,
               inputSeq = state.inputSeq,
-              nodes = state.counters.snapshot(),
+              nodes = state.snapshot(),
             )
           }
         DataProductRegistry.Outcome.Ok(
@@ -223,7 +234,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     // post-input renderFinished in the interactive path (the dispatcher calls attachmentsFor
     // once per render). Snapshot the counter map *before* incrementing so the payload reads
     // monotonically from the client's perspective: the n-th attachment carries inputSeq=n.
-    val nodes = state.counters.snapshotAndReset()
+    val nodes = state.snapshotAndReset()
     state.inputSeq += 1L
     val payload =
       RecompositionPayload(
@@ -329,7 +340,15 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
             val key = System.identityHashCode(scope)
             state.counters.merge(key, 1, Int::plus)
           },
-          onScopeDisposed = { scope -> state.counters.remove(System.identityHashCode(scope)) },
+          onScopeInvalidatedByState = { scope ->
+            val key = System.identityHashCode(scope)
+            state.invalidations.merge(key, 1, Int::plus)
+          },
+          onScopeDisposed = { scope ->
+            val key = System.identityHashCode(scope)
+            state.counters.remove(key)
+            state.invalidations.remove(key)
+          },
         )
       } catch (t: Throwable) {
         // The brief mandates LinkageError / NoSuchMethodError specifically; we widen to any
@@ -367,6 +386,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
   protected open fun installObserver(
     scene: ImageComposeScene,
     onScopeRecomposed: (RecomposeScope) -> Unit,
+    onScopeInvalidatedByState: (RecomposeScope) -> Unit,
     onScopeDisposed: (RecomposeScope) -> Unit,
   ): CompositionObserverHandle {
     val recomposer = reflectRecomposer(scene)
@@ -399,9 +419,13 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
         }
 
         override fun onScopeInvalidated(scope: RecomposeScope, value: Any?) {
-          // Compose calls this when a Snapshot write invalidates [scope]. We could surface "n
-          // invalidations since last flush" alongside counts, but the brief asks only for the
-          // recomposition count; defer.
+          // v2 (#1605): Compose calls this when a Snapshot write invalidates [scope]. A non-null
+          // [value] is the snapshot object that triggered it — i.e. this scope read state that was
+          // then written, the STATE_READ signal. A null value means an unconditional invalidate
+          // (e.g. a direct RecomposeScope.invalidate()), which carries no state attribution, so we
+          // ignore it. Scopes that recompose without ever landing here re-ran because their caller
+          // did — that's the PARAMETER_CHANGE signal, derived by absence in snapshotAndReset.
+          if (value != null) onScopeInvalidatedByState(scope)
         }
 
         override fun onScopeDisposed(scope: RecomposeScope) {
@@ -456,22 +480,57 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     return SubscribeParamsView(frameStreamId = frameStreamId, mode = mode)
   }
 
-  private fun ConcurrentHashMap<Int, Int>.snapshot(): List<RecompositionNode> =
-    map { (k, v) -> RecompositionNode(nodeId = Integer.toHexString(k), count = v) }
+  /**
+   * Non-destructive snapshot (used by `fetch(mode=delta)`): reads counts + invalidations, leaves
+   * both maps intact so the next `attachmentsFor` flush still drains them.
+   */
+  private fun SubscriptionState.snapshot(): List<RecompositionNode> =
+    counters
+      .map { (k, v) ->
+        RecompositionNode(
+          nodeId = Integer.toHexString(k),
+          count = v,
+          reason = reasonFor(count = v, invalidations = invalidations[k] ?: 0),
+        )
+      }
       .sortedBy { it.nodeId }
 
-  private fun ConcurrentHashMap<Int, Int>.snapshotAndReset(): List<RecompositionNode> {
+  private fun SubscriptionState.snapshotAndReset(): List<RecompositionNode> {
     val out = mutableListOf<RecompositionNode>()
-    val keys = keys.toList()
+    val keys = counters.keys.toList()
     for (k in keys) {
       // Atomic per-key read+remove; Compose's observer thread may be incrementing concurrently,
       // so a `get()`-then-`remove()` sequence could lose a count between the two. `remove()`
       // returns the prior value atomically.
-      val v = remove(k) ?: continue
-      out.add(RecompositionNode(nodeId = Integer.toHexString(k), count = v))
+      val v = counters.remove(k) ?: continue
+      val inv = invalidations.remove(k) ?: 0
+      out.add(
+        RecompositionNode(
+          nodeId = Integer.toHexString(k),
+          count = v,
+          reason = reasonFor(count = v, invalidations = inv),
+        )
+      )
     }
+    // Drop invalidation signals for scopes that were invalidated this window but never recomposed
+    // (no matching counter entry). Keeping them would mis-attribute a *later* structural
+    // recomposition as STATE_READ. Safe to clear here: this runs after the synchronous render
+    // settles, with no recomposition cycle in flight.
+    invalidations.clear()
     return out.sortedBy { it.nodeId }
   }
+
+  /**
+   * Attribute a scope's recomposition from how its exit count relates to how many times the runtime
+   * invalidated it with a snapshot value this window. See [InvalidationReason].
+   */
+  private fun reasonFor(count: Int, invalidations: Int): InvalidationReason =
+    when {
+      count <= 0 -> InvalidationReason.UNKNOWN
+      invalidations <= 0 -> InvalidationReason.PARAMETER_CHANGE
+      invalidations >= count -> InvalidationReason.STATE_READ
+      else -> InvalidationReason.BOTH
+    }
 
   private fun SubscriptionState.disposeObserver() {
     val handle = observerHandle ?: return

--- a/data/recomposition/connector/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSceneRecomposerTest.kt
+++ b/data/recomposition/connector/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSceneRecomposerTest.kt
@@ -76,6 +76,7 @@ class DesktopSceneRecomposerTest {
         override fun installObserver(
           scene: ImageComposeScene,
           onScopeRecomposed: (RecomposeScope) -> Unit,
+          onScopeInvalidatedByState: (RecomposeScope) -> Unit,
           onScopeDisposed: (RecomposeScope) -> Unit,
         ): CompositionObserverHandle {
           installAttempts++

--- a/data/recomposition/core/src/main/kotlin/ee/schimke/composeai/data/recomposition/RecompositionModels.kt
+++ b/data/recomposition/core/src/main/kotlin/ee/schimke/composeai/data/recomposition/RecompositionModels.kt
@@ -10,7 +10,15 @@ import kotlinx.serialization.Serializable
  */
 object RecompositionProduct {
   const val KIND: String = "compose/recomposition"
-  const val SCHEMA_VERSION: Int = 1
+
+  /**
+   * v2 (#1605) — adds a per-scope [RecompositionNode.reason] diagnostic plus the nullable
+   * [RecompositionNode.bounds] / source-marker carriers. The new fields all default (reason to
+   * [InvalidationReason.UNKNOWN], the rest to `null`) so a v2 payload decoded by a v1-shaped reader
+   * still parses — the wire stays additive. See `docs/daemon/DATA-PRODUCTS.md` § "Recomposition +
+   * interactive mode".
+   */
+  const val SCHEMA_VERSION: Int = 2
 
   /** Subscribe-time mode: per-input deltas, requires a live interactive session. */
   const val MODE_DELTA: String = "delta"
@@ -18,6 +26,39 @@ object RecompositionProduct {
   /** Subscribe-time mode: one-shot snapshot of initial-composition counts. */
   const val MODE_SNAPSHOT: String = "snapshot"
 }
+
+/**
+ * Why a recomposed scope re-ran, as far as the
+ * [androidx.compose.runtime.tooling.CompositionObserver] signals can tell. Derived per delta-window
+ * from the relationship between how many times a scope exited composition
+ * ([RecompositionNode.count]) and how many times the runtime *invalidated* it with a snapshot
+ * value:
+ *
+ * - [STATE_READ] — the scope subscribed to a snapshot state it read, and a write to that state
+ *   invalidated it. Every recomposition this window was state-driven.
+ * - [PARAMETER_CHANGE] — the scope re-ran without being directly invalidated, i.e. its caller
+ *   recomposed and re-invoked it (typically with changed arguments). This is the "surprising" audit
+ *   signal: a child dragged along by its parent rather than its own state.
+ * - [BOTH] — the scope was invalidated by state *and* re-ran more times than it was invalidated, so
+ *   at least one of its recompositions came from a parameter change too.
+ * - [UNKNOWN] — instrumentation couldn't attribute the recomposition (e.g. a backend that doesn't
+ *   surface invalidation signals yet, or a Compose runtime where the callback didn't fire).
+ */
+enum class InvalidationReason {
+  PARAMETER_CHANGE,
+  STATE_READ,
+  BOTH,
+  UNKNOWN,
+}
+
+/**
+ * Per-scope screen bounds in the rendered image's pixel space, for the PNG heat-map overlay.
+ * Carried nullable on [RecompositionNode] because the layout join that populates it (matching a
+ * scope id to its post-layout [androidx.compose.ui.layout.LayoutCoordinates]) is a v2 increment
+ * that producers may ship without. See issue #1605.
+ */
+@Serializable
+data class RecompositionBounds(val x: Int, val y: Int, val width: Int, val height: Int)
 
 /**
  * Wire shape for `compose/recomposition` payloads. Mirrors the JSON the VS Code panel's heat-map
@@ -44,4 +85,25 @@ data class RecompositionNode(
    */
   val nodeId: String,
   val count: Int,
+  /**
+   * v2 (#1605) — why this scope recomposed, as attributed from the runtime's invalidation signals.
+   * Defaults to [InvalidationReason.UNKNOWN] so a producer that can't attribute (or a v1 reader) is
+   * never wrong, just uninformative.
+   */
+  val reason: InvalidationReason = InvalidationReason.UNKNOWN,
+  /**
+   * v2 (#1605) — per-scope screen bounds for the heat-map overlay, or `null` until the post-layout
+   * bounds join lands (see issue #1605, deferred per its Risk section).
+   */
+  val bounds: RecompositionBounds? = null,
+  /**
+   * v2 (#1605) — source-marker fields for the VS Code source overlay, parsed from the compiler's
+   * `sourceInformation()` markers off the scope's slot-table anchor. Nullable: the slot-table
+   * reflection is private API and is a deferred v2 increment (issue #1605 Risk section), so
+   * producers ship `null` until that path is wired and version-probed.
+   */
+  val sourceFile: String? = null,
+  val sourceLine: Int? = null,
+  val sourceColumn: Int? = null,
+  val functionName: String? = null,
 )

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -277,7 +277,7 @@ A `data/fetch` that needs a re-render:
 | `a11y/touchTargets` | a11y | low | 48dp + overlap detection. |
 | `layout/inspector` | default | low | Compose layout/component hierarchy with bounds, constraints, modifiers, source refs. |
 | `compose/semantics` | default | low | SemanticsNode projection — testTag, role, mergeMode, bounds. |
-| `compose/recomposition` | instrumented | medium | `[{nodeId, count, sinceFrameStreamId?}]`. Heat map. Snapshot or click-delta. |
+| `compose/recomposition` | instrumented | medium | schemaVersion 2: `[{nodeId, count, reason, bounds?, sourceFile?…}]` + `sinceFrameStreamId`/`inputSeq`. `reason` (PARAMETER_CHANGE/STATE_READ/BOTH/UNKNOWN) attributes each scope; `bounds`/source markers nullable until their joins land (#1605). Heat map. Snapshot or click-delta. |
 | `compose/theme` | default | medium | Resolved `MaterialTheme.*` values + which nodes consumed them. |
 | `compose/permissions` | default | low | Android runtime-permissions surface: `{ grants: { "android.permission.X" -> "granted" \| "denied" }, queried: ["android.permission.X", …] }`. Around-composable seeds `ShadowApplication.grantPermissions/denyPermissions` from `renderNow.overrides.permissions.grants` so `ContextCompat.checkSelfPermission(...)` / `Activity.checkSelfPermission(...)` return the requested value through the standard platform path; the matching shadow on `ContextWrapper.checkPermission(...)` records the queried permission for the panel's "queried but no grant pinned" surface. Android-only. |
 | `resources/used` | default | low | `R.*` references resolved during render. |
@@ -303,7 +303,7 @@ Which `kind` strings each backend's `extensions/list` advertises and serves thro
 | `compose/theme` | ✅ | ✅ | Material 3 theme tokens. Override-extension shape. |
 | `compose/wallpaper` | ✅ | ✅ | Wallpaper override shape. |
 | `compose/permissions` | ✅ | ❌ Android-only | Runtime-permissions surface — Robolectric `ShadowApplication` grant seed + `ContextWrapper.checkPermission` query tracker. Desktop has no Android permission model; CMP panel chip greys out on `serverCapabilities.backend == "desktop"`. |
-| `compose/recomposition` | ✅ stub | ✅ producer | The Compose-runtime observer install lands on desktop; Android exposes a `NotAvailable`-only stub until the in-sandbox install ships. |
+| `compose/recomposition` | ✅ producer | ✅ producer | Compose-runtime observer install on both backends (desktop in-process; Android via the in-sandbox bridge). schemaVersion 2 adds the per-scope `reason` (#1605), derived symmetrically from `onScopeInvalidated`. |
 | `displayfilter/variants` | ✅ | ✅ | Both backends, gated on `composeai.displayfilter.filters`. Producer is pure `BufferedImage` post-capture. |
 | `fonts/used` | ✅ producer | 📁 registry-only | Android: `GoogleFontInterceptor` + Typeface accounting. Desktop: registry returns `NotAvailable` until a Skia-side font producer ports. |
 | `compose/semantics` / `layout/inspector` | ✅ producer | 📁 registry-only | Android producer reads the Robolectric semantics tree. Desktop registry serves the file once a CMP-portable producer driving `LocalView` / `SemanticsOwner` lands. |

--- a/site/reference/recomposition.md
+++ b/site/reference/recomposition.md
@@ -16,7 +16,7 @@ recomposed N times for one click" reviews.
 | | |
 |---|---|
 | Kind | `compose/recomposition` |
-| Schema version | 1 |
+| Schema version | 2 |
 | Modules | `:data-recomposition-core` (published) · `:data-recomposition-connector` |
 | Render mode | instrumented |
 | Cost | medium |
@@ -53,18 +53,34 @@ Two modes:
 [`:data-recomposition-core`](https://github.com/yschimke/compose-ai-tools/tree/main/data/recomposition/core).
 
 ```jsonc
-// compose/recomposition
+// compose/recomposition (schemaVersion 2)
 {
-  "mode": "snapshot",         // or "clickDelta"
-  "frameStreamId": "f-7a1c",  // when click-delta
+  "mode": "delta",                  // or "snapshot"
+  "sinceFrameStreamId": "f-7a1c",   // populated in delta mode
+  "inputSeq": 2,                    // monotonic per flushed delta
   "nodes": [
-    { "nodeId": 12, "name": "Row", "count": 3,
-      "boundsInScreen": "0,80,1080,160" },
-    { "nodeId": 14, "name": "Text", "count": 12,
-      "boundsInScreen": "16,96,1064,144" }
+    // reason: PARAMETER_CHANGE | STATE_READ | BOTH | UNKNOWN
+    { "nodeId": "1a2b3c4d", "count": 1, "reason": "STATE_READ" },
+    { "nodeId": "5e6f7a8b", "count": 1, "reason": "PARAMETER_CHANGE" }
   ]
 }
 ```
+
+Each node's `reason` is attributed from the Compose runtime's
+`onScopeInvalidated(scope, value)` signal compared against the recompose
+count: a scope invalidated by a snapshot write it subscribed to reads
+`STATE_READ`, one that re-ran only because its caller did reads
+`PARAMETER_CHANGE`, and a mix reads `BOTH`. This is the
+"why did this recompose?" signal — a parent reading state and forwarding
+it as parameters shows up as one `STATE_READ` dragging a fan of
+`PARAMETER_CHANGE` children.
+
+Nodes also carry nullable `bounds` (`{x, y, width, height}`) and
+source-marker fields (`sourceFile` / `sourceLine` / `sourceColumn` /
+`functionName`) for the heat-map and source-overlay surfaces. These are
+present on the v2 wire but not yet populated — the post-layout bounds
+join and slot-table reflection that fill them are deferred increments
+(see [issue #1605](https://github.com/yschimke/compose-ai-tools/issues/1605)).
 
 ## Enabling
 


### PR DESCRIPTION
## Summary

Bumps the `compose/recomposition` data product to **schemaVersion 2** (#1605). Each `RecompositionNode` now carries:

- **`reason`** — `PARAMETER_CHANGE` / `STATE_READ` / `BOTH` / `UNKNOWN`. The "why did this recompose?" signal.
- **`bounds`** (`{x, y, width, height}`) and **source markers** (`sourceFile` / `sourceLine` / `sourceColumn` / `functionName`) — present on the wire, nullable, **unpopulated for now**.

All new fields default (`reason` → `UNKNOWN`, the rest → `null`), so the wire stays additive — a v1-shaped reader still parses a v2 payload.

### What's implemented

The `reason` field is the non-risky core of the issue's plan (steps 1 + 4) and lands **symmetrically on both backends**. It's derived from the Compose runtime's `CompositionObserver.onScopeInvalidated(scope, value)` signal (a non-null `value` being the snapshot object that triggered the invalidation) compared against the scope's recompose count:

- invalidations `== 0` → `PARAMETER_CHANGE` (re-ran because its caller did)
- invalidations `>= count` → `STATE_READ` (every recomposition was state-driven)
- in between → `BOTH`

Desktop tracks invalidations in-process. Android plumbs a parallel invalidation array through `SandboxRecompositionBridge.drainCounters` (wire shape `arrayOf(String[] ids, long[] counts, long[] invalidations)`) and wires `RobolectricHost`'s sandbox observer's `onScopeInvalidated`.

The headline payoff: a parent that reads state and forwards it as parameters now surfaces as **one `STATE_READ` dragging a fan of `PARAMETER_CHANGE` children** — and the audit test asserts exactly that, plus that the "fixed" fixture collapses the parameter-change cascade.

### What's deferred (per the issue's Risk section)

- **`bounds`** — needs the post-layout `LayoutCoordinates` join.
- **source markers** — need private slot-table reflection (`sourceInformation()` parsing), which the issue flags as version-fragile.
- **DejaVu `$dirty`-bit** attribution and the heat-map PNG renderer.

These stay `null` / `UNKNOWN` rather than risking the private-API reflection the issue warns about. The schema carries the fields so populating them later is a non-breaking increment.

## Test plan

- `RecompositionAuditTest` (desktop, real Compose runtime) — now asserts the bad fixture surfaces both `STATE_READ` and `PARAMETER_CHANGE`, the better fixture still attributes a `STATE_READ`, and the fix has strictly fewer `PARAMETER_CHANGE` scopes. ✅
- `RecompositionDataProductRegistryTest` (desktop) — schemaVersion `2`, every node carries a reason, a state-read click surfaces `STATE_READ`. ✅
- `AndroidRecompositionDataProductRegistryTest` (Robolectric, real sandbox + bridge) — schemaVersion `2`, reason rides the bridge, `STATE_READ` surfaces. ✅
- `DesktopSceneRecomposerTest` — updated for the new `installObserver` callback. ✅
- `ktfmtCheck` clean across all changed modules. ✅
- Docs updated: `site/reference/recomposition.md`, `docs/daemon/DATA-PRODUCTS.md`.

Closes #1605

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4ppU3A6o6DYpYJCc95uH6)_