### PR TITLE
fix(tui-cli): refresh preview index on live discovery updates

### DIFF
--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Discovery.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Discovery.kt
@@ -59,7 +59,7 @@ class PreviewIndex(
   initialFilter: String? = null,
   initialExactId: String? = null,
 ) {
-  private val all: List<PreviewRow> = initialRows
+  private var all: List<PreviewRow> = initialRows
   private var filterText: String? = initialFilter
   private var exactId: String? = initialExactId
   private var cursor: Int = 0
@@ -90,6 +90,25 @@ class PreviewIndex(
   fun selectById(id: String) {
     val idx = rows().indexOfFirst { it.id == id }
     if (idx >= 0) cursor = idx
+  }
+
+  /**
+   * Swap in a freshly-discovered row set (the daemon's file watcher rewrote `previews.json` because
+   * a `@Preview` was added, removed, or renamed) without losing the user's place. The active filter
+   * is preserved and re-applied against the new rows.
+   *
+   * Selection handling mirrors [setFilter] but clamps rather than resetting: if the row that was
+   * selected still exists after the update, the cursor follows it to its new position; otherwise it
+   * clamps to the nearest valid index so an unrelated add/remove doesn't yank the user to the top
+   * of the list.
+   */
+  fun refresh(newRows: List<PreviewRow>) {
+    val previousId = current()?.id
+    all = newRows
+    val n = rows().size
+    cursor =
+      previousId?.let { id -> rows().indexOfFirst { it.id == id } }?.takeIf { it >= 0 }
+        ?: cursor.coerceIn(0, (n - 1).coerceAtLeast(0))
   }
 
   private fun applyFilter(filterText: String?, exactId: String?): List<PreviewRow> {

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/DiscoveryWatcher.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/DiscoveryWatcher.kt
@@ -1,0 +1,122 @@
+package ee.schimke.composeai.tui
+
+import ee.schimke.composeai.cli.PreviewModule
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardWatchEventKinds.ENTRY_CREATE
+import java.nio.file.StandardWatchEventKinds.ENTRY_DELETE
+import java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY
+import java.nio.file.WatchKey
+import java.nio.file.WatchService
+import kotlin.concurrent.thread
+
+/**
+ * Watches each module's `build/compose-previews/previews.json` and fires a single coalesced signal
+ * whenever the discovered preview set changes — a `@Preview` was added, removed, or renamed and the
+ * Gradle discovery pass (or the daemon's file watcher) rewrote the manifest.
+ *
+ * ## Why a separate watcher from [FileWatcher]
+ *
+ * [FileWatcher] watches the module's *source* tree to drive live re-renders, and only runs while
+ * live mode is on. Discovery refresh has to work regardless of live mode — you can add a preview
+ * with the TUI sitting idle — and it cares about exactly one generated file per module rather than
+ * the whole source tree. Keeping it separate keeps both watchers small and single-purpose.
+ *
+ * ## Late directory creation
+ *
+ * `build/compose-previews/` (and even `build/`) may not exist yet when the TUI launches against a
+ * module that hasn't rendered. A [WatchService] can only watch directories that exist, so we
+ * register the deepest ancestor that *does* exist and walk down as the missing links are created:
+ * watching the project dir catches `build/` appearing, watching `build/` catches
+ * `compose-previews/` appearing, and watching `compose-previews/` catches `previews.json` itself.
+ * This also survives a `gradle clean` that deletes `build/` out from under us and a later rebuild
+ * that recreates it.
+ */
+class DiscoveryWatcher(
+  private val modules: List<PreviewModule>,
+  private val debounceMillis: Long = 250,
+) : AutoCloseable {
+  private val watchService: WatchService = FileSystems.getDefault().newWatchService()
+  private val keysToDir = mutableMapOf<WatchKey, Path>()
+
+  @Volatile private var stopped = false
+  private var thread: Thread? = null
+  private var lastFire = 0L
+
+  /** Directory names on the path from a project dir down to the manifest's parent. */
+  private val chainDirs = setOf("build", "compose-previews")
+
+  fun start(onChange: () -> Unit) {
+    for (module in modules) {
+      var dir = module.projectDir
+      // Register the project dir and each existing link of build/compose-previews so we pick up
+      // the manifest however deep the tree currently goes.
+      register(dir.toPath())
+      dir = dir.resolve("build")
+      register(dir.toPath())
+      dir = dir.resolve("compose-previews")
+      register(dir.toPath())
+    }
+    if (keysToDir.isEmpty()) return // No watchable ancestor for any module — nothing to do.
+
+    thread =
+      thread(name = "compose-preview-tui-discovery", isDaemon = true) {
+        while (!stopped) {
+          val key =
+            try {
+              watchService.take()
+            } catch (_: InterruptedException) {
+              break
+            } catch (_: java.nio.file.ClosedWatchServiceException) {
+              break
+            }
+          val dir = keysToDir[key] ?: continue
+          var relevant = false
+          for (event in key.pollEvents()) {
+            val ctx = event.context() as? Path ?: continue
+            val name = ctx.fileName?.toString() ?: continue
+            val absolute = dir.resolve(ctx)
+            // A newly-created link in the build/compose-previews chain — register it so the next
+            // level down (ultimately previews.json) becomes observable.
+            if (event.kind() == ENTRY_CREATE && name in chainDirs && Files.isDirectory(absolute)) {
+              register(absolute)
+              relevant = true
+            }
+            if (name == "previews.json") relevant = true
+          }
+          if (relevant) {
+            val now = System.currentTimeMillis()
+            if (now - lastFire >= debounceMillis) {
+              lastFire = now
+              try {
+                onChange()
+              } catch (_: Throwable) {
+                // Isolate listener faults from the watcher loop, as FileWatcher does.
+              }
+            }
+          }
+          if (!key.reset()) {
+            keysToDir.remove(key)
+            // Don't break when the map empties: a `gradle clean` can invalidate the build/
+            // and compose-previews keys, but the project-dir key survives and will re-register
+            // them when the rebuild recreates the chain.
+          }
+        }
+      }
+  }
+
+  override fun close() {
+    stopped = true
+    runCatching { watchService.close() }
+    thread?.interrupt()
+    thread = null
+  }
+
+  private fun register(dir: Path) {
+    if (!Files.isDirectory(dir)) return
+    if (keysToDir.values.any { it == dir }) return // already watching
+    val key = dir.register(watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE)
+    keysToDir[key] = dir
+  }
+}

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/App.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/App.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.tui.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -17,11 +18,15 @@ import com.jakewharton.mosaic.modifier.Modifier
 import com.jakewharton.mosaic.ui.Column
 import com.jakewharton.mosaic.ui.Spacer
 import ee.schimke.composeai.cli.PreviewModule
+import ee.schimke.composeai.tui.DiscoveryWatcher
 import ee.schimke.composeai.tui.LiveSession
 import ee.schimke.composeai.tui.PreviewIndex
 import ee.schimke.composeai.tui.TuiArgs
 import ee.schimke.composeai.tui.terminal.TerminalSize
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Top-level TUI composition. Holds the [PreviewIndex] (filtered, navigable rows) and the
@@ -61,6 +66,29 @@ fun App(modules: List<PreviewModule>, args: TuiArgs) {
   var filterDraft by remember { mutableStateOf(args.filter ?: "") }
   var exitRequested by remember { mutableStateOf(false) }
   var cursorTick by remember { mutableIntStateOf(0) }
+
+  // Discovery refresh: a filesystem watcher rooted at each module's build/compose-previews bumps
+  // this counter whenever `previews.json` is rewritten (a @Preview added / removed / renamed). The
+  // watcher fires from a background thread, so it writes through a StateFlow — collectAsState
+  // marshals
+  // the value back onto the composition thread safely. Single writer (the watcher thread) means the
+  // read-modify-write below is race-free.
+  val discoverySignal = remember { MutableStateFlow(0L) }
+  DisposableEffect(modules) {
+    val watcher = DiscoveryWatcher(modules)
+    watcher.start { discoverySignal.value = discoverySignal.value + 1 }
+    onDispose { watcher.close() }
+  }
+  val discoveryTick by discoverySignal.collectAsState()
+  LaunchedEffect(discoveryTick) {
+    if (discoveryTick == 0L) return@LaunchedEffect
+    val newRows = withContext(Dispatchers.IO) { PreviewIndex.loadRows(modules) }
+    index.refresh(newRows)
+    // Bump the navigation tick so the panes re-read index.rows() and the live-session re-target
+    // effect runs — if the previously-selected preview was removed, the cursor clamped to a new
+    // current and the visible-set needs to follow.
+    cursorTick++
+  }
 
   // Sticky live mode: when the user toggles live on, this effect opens the session against the
   // current preview's module. Toggling off disables. Navigation between previews is handled by

--- a/tui-cli/src/test/kotlin/ee/schimke/composeai/tui/DiscoveryWatcherTest.kt
+++ b/tui-cli/src/test/kotlin/ee/schimke/composeai/tui/DiscoveryWatcherTest.kt
@@ -1,0 +1,86 @@
+package ee.schimke.composeai.tui
+
+import ee.schimke.composeai.cli.PreviewModule
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Filesystem-watch coverage for [DiscoveryWatcher]. These tests drive the real JDK [java.nio.file]
+ * watch service, so they assert with a generous timeout — watch latency varies by platform — rather
+ * than a tight sleep.
+ */
+class DiscoveryWatcherTest {
+  private fun previewsJson(moduleDir: File): File =
+    File(moduleDir, "build/compose-previews/previews.json")
+
+  private fun writeManifest(file: File, vararg ids: String) {
+    file.parentFile.mkdirs()
+    val entries =
+      ids.joinToString(",\n") { """    { "id": "$it", "functionName": "$it", "className": "C" }""" }
+    file.writeText(
+      """
+      { "module": ":sample", "variant": "debug", "previews": [
+      $entries
+      ] }
+      """
+        .trimIndent()
+    )
+  }
+
+  @Test
+  fun firesWhenManifestIsRewritten(@TempDir tmp: File) {
+    val moduleDir = File(tmp, "sample")
+    val manifest = previewsJson(moduleDir)
+    writeManifest(manifest, "A", "B") // exists before the watcher starts
+
+    val module = PreviewModule(gradlePath = ":sample", projectDir = moduleDir)
+    val latch = CountDownLatch(1)
+    val fires = AtomicInteger(0)
+    val watcher = DiscoveryWatcher(listOf(module), debounceMillis = 50)
+    try {
+      watcher.start {
+        fires.incrementAndGet()
+        latch.countDown()
+      }
+      // Give the watch thread a beat to register, then rewrite the manifest (a @Preview renamed).
+      Thread.sleep(300)
+      writeManifest(manifest, "A", "B", "C")
+
+      assertTrue(
+        latch.await(15, TimeUnit.SECONDS),
+        "DiscoveryWatcher did not fire after previews.json was rewritten",
+      )
+    } finally {
+      watcher.close()
+    }
+  }
+
+  @Test
+  fun firesWhenManifestAppearsLater(@TempDir tmp: File) {
+    // Module has rendered nothing yet: build/ doesn't exist when the watcher starts. The watcher
+    // should still pick up previews.json once the chain is created.
+    val moduleDir = File(tmp, "sample").apply { mkdirs() }
+    val module = PreviewModule(gradlePath = ":sample", projectDir = moduleDir)
+    val latch = CountDownLatch(1)
+    val watcher = DiscoveryWatcher(listOf(module), debounceMillis = 50)
+    try {
+      watcher.start { latch.countDown() }
+      Thread.sleep(300)
+      // Create build/, then compose-previews/, then the manifest — each level should be registered
+      // as it appears so the leaf write is observed.
+      writeManifest(previewsJson(moduleDir), "A")
+
+      assertTrue(
+        latch.await(15, TimeUnit.SECONDS),
+        "DiscoveryWatcher did not fire when previews.json was created late",
+      )
+    } finally {
+      watcher.close()
+    }
+  }
+}

--- a/tui-cli/src/test/kotlin/ee/schimke/composeai/tui/PreviewIndexTest.kt
+++ b/tui-cli/src/test/kotlin/ee/schimke/composeai/tui/PreviewIndexTest.kt
@@ -1,0 +1,79 @@
+package ee.schimke.composeai.tui
+
+import ee.schimke.composeai.cli.PreviewInfo
+import ee.schimke.composeai.cli.PreviewModule
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Unit coverage for [PreviewIndex.refresh] — the selection-preserving swap that backs live
+ * discovery updates (issue #1594). The watcher plumbing is exercised separately in
+ * [DiscoveryWatcherTest]; here we pin the cursor semantics that make a refresh non-destructive.
+ */
+class PreviewIndexTest {
+  private val module = PreviewModule(gradlePath = ":sample", projectDir = File("/tmp/sample"))
+
+  private fun rows(vararg ids: String): List<PreviewRow> = ids.map { id ->
+    PreviewRow(module = module, info = PreviewInfo(id = id, functionName = id, className = "C"))
+  }
+
+  @Test
+  fun refreshKeepsCursorOnSamePreviewWhenItStillExists() {
+    val index = PreviewIndex(rows("A", "B", "C"))
+    index.moveCursor(1) // select B
+    assertEquals("B", index.current()?.id)
+
+    // A new preview is inserted ahead of B; B's index shifts but selection should follow it.
+    index.refresh(rows("A", "A2", "B", "C"))
+
+    assertEquals("B", index.current()?.id)
+    assertEquals(2, index.cursorIndex())
+  }
+
+  @Test
+  fun refreshClampsWhenSelectedPreviewWasRemoved() {
+    val index = PreviewIndex(rows("A", "B", "C"))
+    index.moveCursor(2) // select C (index 2)
+    assertEquals("C", index.current()?.id)
+
+    // C is deleted. Cursor can't follow it, so it clamps to the new last index rather than
+    // resetting to the top.
+    index.refresh(rows("A", "B"))
+
+    assertEquals(1, index.cursorIndex())
+    assertEquals("B", index.current()?.id)
+  }
+
+  @Test
+  fun refreshSurvivesEmptyResultAndRepopulation() {
+    val index = PreviewIndex(rows("A", "B"))
+    index.moveCursor(1)
+
+    index.refresh(emptyList())
+    assertEquals(0, index.size())
+    assertNull(index.current())
+    assertEquals(0, index.cursorIndex())
+
+    index.refresh(rows("X", "Y"))
+    assertEquals(2, index.size())
+    // No prior id to restore (list was empty), cursor stays clamped at 0.
+    assertEquals("X", index.current()?.id)
+  }
+
+  @Test
+  fun refreshReappliesActiveFilter() {
+    val index = PreviewIndex(rows("ButtonPreview", "CardPreview", "DialogPreview"))
+    index.setFilter("Card")
+    assertEquals(1, index.size())
+    assertEquals("CardPreview", index.current()?.id)
+
+    // Discovery adds another "Card*" preview; the filter must apply to the fresh rows.
+    index.refresh(rows("ButtonPreview", "CardPreview", "CardHeaderPreview", "DialogPreview"))
+
+    assertEquals(2, index.size())
+    // Selection stays on CardPreview (still present), now at filtered index 0.
+    assertEquals("CardPreview", index.current()?.id)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #1594. The TUI built its `PreviewIndex` once inside `remember(modules)`, so adding, removing, or renaming a `@Preview` while it was open left a stale list until the process was restarted.

- **`DiscoveryWatcher`** — a small `WatchService`-based watcher (separate from the live-mode `FileWatcher`) that watches each module's `build/compose-previews/previews.json` and fires a single coalesced signal when the manifest changes. It registers the `build` → `compose-previews` chain as those directories appear, so a module that hasn't rendered yet (and a `gradle clean` that deletes `build/`) are both handled. Runs regardless of live mode.
- **`PreviewIndex.refresh(newRows)`** — swaps in freshly-loaded rows while preserving selection: the cursor follows the selected preview to its new position when it still exists, and clamps to the nearest valid index when it was removed. The active filter is re-applied across the refresh.
- **`App`** — collects the watcher signal through a `StateFlow` (so the background watch thread hands the value back to the composition safely), reloads rows off the IO dispatcher, and bumps the navigation tick so the panes re-read and the live-session re-target effect runs.

### Why this targets `agent/mosaic-tui-preview` instead of `main`

The `tui-cli` module only exists in PR #1518 (still open), so this stacks on that branch and lands with it.

## Test plan

- `PreviewIndexTest` — selection follows the preview on insert, clamps on removal, survives empty→repopulate, and re-applies the active filter across a refresh.
- `DiscoveryWatcherTest` — the watcher fires when `previews.json` is rewritten and when it is created late (no `build/` at start).
- Acceptance: adding/removing/renaming a `@Preview` while the TUI is open updates the list without restart; selection survives unrelated updates.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAQC4y7zMHotfWSEKybPfy)_