### PR TITLE
feat(daemon-bench): drive stage-1/stage-2 compile legs + CI smoke (#1586)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,17 @@ jobs:
       # `composePreviewDiscover` alone would pass even when broken.
       - name: Render Android screenshot-test sample previews
         run: ./gradlew :samples:android-screenshot-test:composePreviewRenderAll
+      # Daemon-bench smoke (issue #1586). The full latency benches
+      # (benchPreviewLatency / benchCompileStages) are deliberately slow and run on the
+      # reference machine — see .github/workflows/daemon-bench.yml. Here we only render
+      # the five trivial previews in each bench module so they can't bit-rot: a cheap
+      # proof the modules build, discovery wires up, and the renderer path is intact on
+      # both the Android (Robolectric) and desktop (Compose-Desktop) targets.
+      - name: Render daemon-bench samples (smoke)
+        run: |
+          ./gradlew \
+            :samples:android-daemon-bench:composePreviewRender \
+            :samples:desktop-daemon-bench:composePreviewRender
       # samples/wear's pixel-scan tests (`LongScrollPreviewPixelTest`) gate
       # the stitched Wear long-preview output against known flake
       # signatures — ghost peek-pill rows, scaled-card seam ghosts,

--- a/.github/workflows/daemon-bench.yml
+++ b/.github/workflows/daemon-bench.yml
@@ -1,0 +1,75 @@
+name: Daemon Latency Bench
+
+# Scheduled, NON-BLOCKING latency bench for the preview daemon — issue #1586.
+#
+# These harnesses (`:samples:android-daemon-bench`, `:samples:desktop-daemon-bench`)
+# are deliberately slow (~10-15 min Android, ~5-10 min desktop) and measure
+# wall-clock latency, so they must NOT gate PRs — the per-PR critical path only runs
+# the cheap `composePreviewRender` smoke in ci.yml's build-samples job.
+#
+# This workflow runs weekly (and on demand) and publishes the measured CSV + the
+# stage-2 graduation verdict as artifacts. It feeds the "should stage 2 graduate from
+# experimental?" decision (COMPILE-IN-PROCESS.md § "Promote / demote criteria"); it
+# does not change any default. Numbers from a shared CI runner are noisier than the
+# reference machine in docs/daemon/baseline-latency.md — treat them as trend, not gospel.
+#
+# Each job runs `benchPreviewLatency` first (stage 0 + the render baseline the verdict
+# reuses) then `benchCompileStages` (stage 1 + stage 2 + verdict).
+
+on:
+  schedule:
+    # Mondays 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  desktop-bench:
+    name: Daemon Bench (desktop)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Run desktop latency bench (stage 0 + render baseline)
+        run: ./gradlew :samples:desktop-daemon-bench:benchPreviewLatency
+      - name: Run desktop compile-stage bench (stage 1 + stage 2 + verdict)
+        run: ./gradlew :samples:desktop-daemon-bench:benchCompileStages
+      - name: Upload desktop baseline CSV + verdict
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: daemon-bench-desktop
+          path: |
+            docs/daemon/baseline-latency.csv
+            docs/daemon/stage-2-verdict-desktop.md
+
+  android-bench:
+    name: Daemon Bench (android)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Run android latency bench (stage 0 + render baseline)
+        run: ./gradlew :samples:android-daemon-bench:benchPreviewLatency
+      - name: Run android compile-stage bench (stage 1 + stage 2 + verdict)
+        run: ./gradlew :samples:android-daemon-bench:benchCompileStages
+      - name: Upload android baseline CSV + verdict
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: daemon-bench-android
+          path: |
+            docs/daemon/baseline-latency.csv
+            docs/daemon/stage-2-verdict-android.md

--- a/.github/workflows/daemon-bench.yml
+++ b/.github/workflows/daemon-bench.yml
@@ -39,6 +39,12 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+      # Start from an empty CSV so this run's artifact + verdict reflect only this
+      # run. The committed CSV holds reference-machine history (kept in git); the
+      # desktop benchPreviewLatency APPENDS, so without this it would mix CI rows
+      # with the checked-in rows and skew the render-baseline median the verdict reads.
+      - name: Reset baseline CSV (CI runs start clean)
+        run: rm -f docs/daemon/baseline-latency.csv
       - name: Run desktop latency bench (stage 0 + render baseline)
         run: ./gradlew :samples:desktop-daemon-bench:benchPreviewLatency
       - name: Run desktop compile-stage bench (stage 1 + stage 2 + verdict)
@@ -61,6 +67,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
+      # Start from an empty CSV so this run's artifact + verdict reflect only this
+      # run (see the desktop job for the rationale).
+      - name: Reset baseline CSV (CI runs start clean)
+        run: rm -f docs/daemon/baseline-latency.csv
       - name: Run android latency bench (stage 0 + render baseline)
         run: ./gradlew :samples:android-daemon-bench:benchPreviewLatency
       - name: Run android compile-stage bench (stage 1 + stage 2 + verdict)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaBenchMain.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaBenchMain.kt
@@ -1,0 +1,225 @@
+@file:OptIn(org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi::class)
+@file:JvmName("BtaBenchMain")
+
+package ee.schimke.composeai.daemon.bta
+
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Path
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.SourcesChanges
+
+/**
+ * Stage-2 measurement driver for `:samples:*-daemon-bench:benchCompileStages` — tracked in
+ * [#1586](https://github.com/yschimke/compose-ai-tools/issues/1586). See
+ * [docs/daemon/COMPILE-IN-PROCESS.md](../../../../../../docs/daemon/COMPILE-IN-PROCESS.md)
+ * § "What we expect to measure".
+ *
+ * This is a thin, standalone `main` so the bench Gradle task can `javaexec` it on `:daemon:core`'s
+ * runtime classpath, feeding it the exact `btaCompile` block the daemon would consume at startup
+ * (via the same `composeai.daemon.bta.*` system properties [DefaultBtaCompileService.fromSysprops]
+ * reads). It drives the *real* production [BtaCompileSession.compileIncremental] — the same code
+ * path the daemon's `compileSources` handler runs — so the numbers it emits are the stage-2 compile
+ * leg, not an approximation.
+ *
+ * It deliberately does NOT spawn a daemon or speak JSON-RPC: the only stage-2 surface the bench
+ * needs to time is `compileIncremental` (compile leg) and the child-classloader rotation that
+ * follows a successful compile (`classloader-swap`). The render leg is unchanged from stage 0 (the
+ * daemon's hot-swap reuses the same renderer), so the bench reuses its stage-0 render number rather
+ * than re-measuring it here.
+ *
+ * Output protocol — one tab-separated record per line on stdout, parsed by the bench task:
+ * - `BENCHROW\t<phase>\t<scenario>\t<run>\t<milliseconds>\t<notes>` — a measured CSV row.
+ * - `BENCHMEM\t<usedHeapMb>` — resident used-heap after warm-up, for the memory-delta criterion.
+ * - `BENCHNOTE\t<message>` — stage 2 unavailable / ineligible / failed; bench records it verbatim
+ *   and keeps going (a missing stage-2 number is informational, not a hard failure).
+ *
+ * The driver mutates the edit file in place (the `warm-after-1-line-edit` scenario) and always
+ * restores it in a `finally`, so a crash mid-run can't leave the working tree dirty.
+ */
+fun main() {
+  val sysprops: (String) -> String? = System::getProperty
+  val config = BenchConfig.fromSysprops(sysprops)
+  if (config == null) {
+    emit(note("stage-2 unavailable: launch descriptor carried no btaCompile block"))
+    return
+  }
+  val ineligibility =
+    sysprops(DefaultBtaCompileService.SYSPROP_INELIGIBILITY_REASON)?.ifEmpty { null }
+  if (ineligibility != null) {
+    emit(note("stage-2 ineligible for this module: $ineligibility"))
+    return
+  }
+
+  val editFile = config.editFile.toFile()
+  val original = if (editFile.exists()) editFile.readText() else null
+  try {
+    runBench(config)
+  } catch (t: Throwable) {
+    // A BTA bootstrap / compile fault is informational for the bench — surface it and exit 0 so a
+    // scheduled job stays green and a human reads the note. (The cheap composePreviewRender smoke
+    // is the real green-gate; this task only produces measurement rows.)
+    emit(note("stage-2 driver failed: ${t.javaClass.simpleName}: ${t.message}"))
+  } finally {
+    if (original != null) editFile.writeText(original)
+  }
+}
+
+private const val COLD_NOTE = "BTA impl bootstrap + first compileIncremental()"
+private const val WARM_NOTE = "BtaCompileSession.compileIncremental()"
+private const val SWAP_NOTE =
+  "URLClassLoader rotation over output classes dir (same shape as UserClassLoaderHolder)"
+
+private fun runBench(config: BenchConfig) {
+  val session =
+    BtaCompileSession(
+      implClasspath = config.implClasspath,
+      icWorkingDir = config.icWorkingDir,
+      moduleName = config.moduleName,
+    )
+  val plugins = DefaultBtaCompileService.composeCompilerPlugins(config.compilerPlugins)
+
+  fun compileFull(changes: SourcesChanges) =
+    session.compileIncremental(
+      sources = config.sources,
+      compileClasspath = config.compileClasspath,
+      outputDir = config.outputDir,
+      compilerPlugins = plugins,
+      sourcesChanges = changes,
+    )
+
+  // Cold first save: pays the BTA impl-classloader bootstrap (~5 s in the spike). One tax per
+  // daemon JVM; recorded so the README's stage table stays honest about it.
+  val coldMs = timeMillis { compileFull(SourcesChanges.ToBeCalculated) }
+  emit(row("compile", "stage-2-cold-first-save", 1, coldMs, COLD_NOTE))
+
+  // Warm the frontend + IC cache so the recorded warm runs don't absorb first-touch cost.
+  repeat(config.warmups) { compileFull(SourcesChanges.ToBeCalculated) }
+
+  val editFile = config.editFile.toFile()
+  val pristine = editFile.readText()
+  check(config.editMarker in pristine) {
+    "${config.editFile} no longer contains ${config.editMarker} — update the bench marker"
+  }
+
+  // Rotate a child classloader the same way UserClassLoaderHolder does after a swap: a parent over
+  // the compile classpath, a short-lived child over the freshly-written output classes dir.
+  val parentUrls = config.compileClasspath.map { it.toUri().toURL() }.toTypedArray()
+  val parent = URLClassLoader(parentUrls, BtaBenchClassLoaderMarker::class.java.classLoader)
+  val outputUrl = config.outputDir.toUri().toURL()
+  var child: URLClassLoader? = null
+
+  try {
+    for (run in 1..config.runs) {
+      editFile.writeText(mutateMarker(pristine, config.editMarker))
+      try {
+        // Editor knows the dirty file → SourcesChanges.Known, exactly what the daemon forwards.
+        val changes = SourcesChanges.Known(listOf(editFile), emptyList())
+        val compileMs = timeMillis { compileFull(changes) }
+        emit(row("compile", "stage-2-warm-after-1-line-edit", run, compileMs, WARM_NOTE))
+
+        val swapMs = timeMillis {
+          val next = URLClassLoader(arrayOf(outputUrl), parent)
+          child?.close()
+          child = next
+        }
+        emit(row("classloader-swap", "stage-2-warm", run, swapMs, SWAP_NOTE))
+      } finally {
+        editFile.writeText(pristine)
+      }
+    }
+  } finally {
+    child?.close()
+    parent.close()
+  }
+
+  System.gc()
+  val runtime = Runtime.getRuntime()
+  val usedMb = (runtime.totalMemory() - runtime.freeMemory()) / (1024 * 1024)
+  emit("BENCHMEM\t$usedMb")
+  emit(note("stage-2 resident used-heap after warm-up: $usedMb MB (BTA frontend loaded)"))
+}
+
+/** Marker type whose classloader roots the bench's parent loader. */
+private class BtaBenchClassLoaderMarker
+
+// --- Pure helpers (unit-tested in BtaBenchMainTest) -------------------------------------------
+
+/** Bench JVM-side config, assembled from the daemon `btaCompile` sysprops plus `composeai.bench.*`. */
+internal data class BenchConfig(
+  val implClasspath: List<Path>,
+  val compileClasspath: List<Path>,
+  val compilerPlugins: List<Path>,
+  val moduleName: String,
+  val outputDir: Path,
+  val icWorkingDir: Path,
+  val sources: List<Path>,
+  val editFile: Path,
+  val editMarker: String,
+  val warmups: Int,
+  val runs: Int,
+) {
+  companion object {
+    const val SYSPROP_SOURCES = "composeai.bench.sources"
+    const val SYSPROP_EDIT_FILE = "composeai.bench.editFile"
+    const val SYSPROP_EDIT_MARKER = "composeai.bench.editMarker"
+    const val SYSPROP_WARMUPS = "composeai.bench.warmups"
+    const val SYSPROP_RUNS = "composeai.bench.runs"
+
+    /** Returns null when the daemon `btaCompile` block (or the bench inputs) are absent. */
+    fun fromSysprops(sysprops: (String) -> String?): BenchConfig? {
+      val impl = parsePathList(sysprops(DefaultBtaCompileService.SYSPROP_IMPL_CLASSPATH))
+      val compile = parsePathList(sysprops(DefaultBtaCompileService.SYSPROP_COMPILE_CLASSPATH))
+      val plugins = parsePathList(sysprops(DefaultBtaCompileService.SYSPROP_COMPILER_PLUGINS))
+      val moduleName = sysprops(DefaultBtaCompileService.SYSPROP_MODULE_NAME)?.ifEmpty { null }
+      val outputDir = sysprops(DefaultBtaCompileService.SYSPROP_OUTPUT_DIR)?.ifEmpty { null }
+      val icDir = sysprops(DefaultBtaCompileService.SYSPROP_IC_WORKING_DIR)?.ifEmpty { null }
+      val sources = parsePathList(sysprops(SYSPROP_SOURCES))
+      val editFile = sysprops(SYSPROP_EDIT_FILE)?.ifEmpty { null }
+      if (impl.isEmpty() || moduleName == null || outputDir == null || icDir == null) return null
+      if (sources.isEmpty() || editFile == null) return null
+      return BenchConfig(
+        implClasspath = impl,
+        compileClasspath = compile,
+        compilerPlugins = plugins,
+        moduleName = moduleName,
+        outputDir = Path.of(outputDir),
+        icWorkingDir = Path.of(icDir),
+        sources = sources,
+        editFile = Path.of(editFile),
+        editMarker = sysprops(SYSPROP_EDIT_MARKER)?.ifEmpty { null } ?: "\"three\"",
+        warmups = sysprops(SYSPROP_WARMUPS)?.toIntOrNull() ?: 2,
+        runs = sysprops(SYSPROP_RUNS)?.toIntOrNull() ?: 5,
+      )
+    }
+  }
+}
+
+internal fun parsePathList(value: String?): List<Path> =
+  if (value.isNullOrEmpty()) emptyList()
+  else value.split(File.pathSeparator).filter { it.isNotEmpty() }.map { Path.of(it) }
+
+/**
+ * Swap the [marker] string literal for a unique one so the recompile produces genuinely different
+ * bytecode (kotlinc strips comments, so a comment-only edit would leave the `.class` files — and
+ * therefore the IC pass — UP-TO-DATE). Mirrors the existing `benchPreviewLatency` edit.
+ */
+internal fun mutateMarker(text: String, marker: String): String =
+  text.replaceFirst(marker, marker.dropLast(1) + "-${System.nanoTime() % 1_000_000}\"")
+
+internal fun row(phase: String, scenario: String, run: Int, ms: Long, notes: String): String =
+  "BENCHROW\t$phase\t$scenario\t$run\t$ms\t${notes.replace("\t", " ")}"
+
+internal fun note(message: String): String = "BENCHNOTE\t${message.replace("\t", " ")}"
+
+private inline fun timeMillis(block: () -> Unit): Long {
+  val start = System.nanoTime()
+  block()
+  return (System.nanoTime() - start) / 1_000_000
+}
+
+private fun emit(line: String) {
+  // The daemon swaps System.out to stderr at startup; the bench main keeps stdout clean for its
+  // tab-separated protocol and lets BTA's own logging go to stderr.
+  println(line)
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaBenchMain.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaBenchMain.kt
@@ -12,8 +12,8 @@ import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 /**
  * Stage-2 measurement driver for `:samples:*-daemon-bench:benchCompileStages` — tracked in
  * [#1586](https://github.com/yschimke/compose-ai-tools/issues/1586). See
- * [docs/daemon/COMPILE-IN-PROCESS.md](../../../../../../docs/daemon/COMPILE-IN-PROCESS.md)
- * § "What we expect to measure".
+ * [docs/daemon/COMPILE-IN-PROCESS.md](../../../../../../docs/daemon/COMPILE-IN-PROCESS.md) § "What
+ * we expect to measure".
  *
  * This is a thin, standalone `main` so the bench Gradle task can `javaexec` it on `:daemon:core`'s
  * runtime classpath, feeding it the exact `btaCompile` block the daemon would consume at startup
@@ -145,7 +145,9 @@ private class BtaBenchClassLoaderMarker
 
 // --- Pure helpers (unit-tested in BtaBenchMainTest) -------------------------------------------
 
-/** Bench JVM-side config, assembled from the daemon `btaCompile` sysprops plus `composeai.bench.*`. */
+/**
+ * Bench JVM-side config, assembled from the daemon `btaCompile` sysprops plus `composeai.bench.*`.
+ */
 internal data class BenchConfig(
   val implClasspath: List<Path>,
   val compileClasspath: List<Path>,

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/bta/BtaBenchMainTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/bta/BtaBenchMainTest.kt
@@ -1,0 +1,109 @@
+@file:OptIn(org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi::class)
+
+package ee.schimke.composeai.daemon.bta
+
+import java.io.File
+import java.nio.file.Path
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the pure helpers in [BtaBenchMain] — the sysprop → [BenchConfig] parse, the output
+ * record formatting (the tab-separated protocol the bench Gradle task parses), and the marker-swap
+ * edit. The actual `compileIncremental` drive needs the BTA impl JARs + a real module, so it lives
+ * on the reference machine via `benchCompileStages`, not in this unit test.
+ */
+class BtaBenchMainTest {
+
+  private fun props(map: Map<String, String>): (String) -> String? = { map[it] }
+
+  private val complete =
+    mapOf(
+      DefaultBtaCompileService.SYSPROP_IMPL_CLASSPATH to "/a.jar${File.pathSeparator}/b.jar",
+      DefaultBtaCompileService.SYSPROP_COMPILE_CLASSPATH to "/c.jar",
+      DefaultBtaCompileService.SYSPROP_COMPILER_PLUGINS to "/compose.jar",
+      DefaultBtaCompileService.SYSPROP_MODULE_NAME to "desktop-daemon-bench",
+      DefaultBtaCompileService.SYSPROP_OUTPUT_DIR to "/out",
+      DefaultBtaCompileService.SYSPROP_IC_WORKING_DIR to "/ic",
+      BenchConfig.SYSPROP_SOURCES to "/src/BenchPreviews.kt",
+      BenchConfig.SYSPROP_EDIT_FILE to "/src/BenchPreviews.kt",
+    )
+
+  @Test
+  fun `fromSysprops parses a complete btaCompile block`() {
+    val cfg = BenchConfig.fromSysprops(props(complete))!!
+    assertEquals(listOf(Path.of("/a.jar"), Path.of("/b.jar")), cfg.implClasspath)
+    assertEquals(listOf(Path.of("/c.jar")), cfg.compileClasspath)
+    assertEquals(listOf(Path.of("/compose.jar")), cfg.compilerPlugins)
+    assertEquals("desktop-daemon-bench", cfg.moduleName)
+    assertEquals(Path.of("/out"), cfg.outputDir)
+    assertEquals(Path.of("/ic"), cfg.icWorkingDir)
+    assertEquals(listOf(Path.of("/src/BenchPreviews.kt")), cfg.sources)
+    // Defaults.
+    assertEquals("\"three\"", cfg.editMarker)
+    assertEquals(2, cfg.warmups)
+    assertEquals(5, cfg.runs)
+  }
+
+  @Test
+  fun `fromSysprops returns null when the btaCompile block is incomplete`() {
+    val required =
+      listOf(
+        DefaultBtaCompileService.SYSPROP_IMPL_CLASSPATH,
+        DefaultBtaCompileService.SYSPROP_MODULE_NAME,
+        DefaultBtaCompileService.SYSPROP_OUTPUT_DIR,
+        DefaultBtaCompileService.SYSPROP_IC_WORKING_DIR,
+        BenchConfig.SYSPROP_SOURCES,
+        BenchConfig.SYSPROP_EDIT_FILE,
+      )
+    for (missing in required) {
+      val cfg = BenchConfig.fromSysprops(props(complete - missing))
+      assertNull("missing $missing should yield null", cfg)
+    }
+  }
+
+  @Test
+  fun `fromSysprops honours overridden warmups and runs`() {
+    val overrides =
+      complete + mapOf(BenchConfig.SYSPROP_WARMUPS to "0", BenchConfig.SYSPROP_RUNS to "9")
+    val cfg = BenchConfig.fromSysprops(props(overrides))!!
+    assertEquals(0, cfg.warmups)
+    assertEquals(9, cfg.runs)
+  }
+
+  @Test
+  fun `parsePathList ignores empty entries and a null input`() {
+    val sep = File.pathSeparator
+    assertEquals(emptyList<Path>(), parsePathList(null))
+    assertEquals(emptyList<Path>(), parsePathList(""))
+    assertEquals(listOf(Path.of("/x")), parsePathList("$sep/x$sep"))
+  }
+
+  @Test
+  fun `mutateMarker swaps the first literal for a unique one and stays a string literal`() {
+    val src = """Text("three")"""
+    val edited = mutateMarker(src, "\"three\"")
+    assertNotEquals(src, edited)
+    assertTrue("edit keeps it a quoted literal: $edited", edited.contains(Regex("\"three-\\d+\"")))
+  }
+
+  @Test
+  fun `row and note follow the tab-separated wire protocol`() {
+    assertEquals(
+      "BENCHROW\tcompile\tstage-2-warm-after-1-line-edit\t3\t312\tBtaCompileSession.compileIncremental()",
+      row(
+        "compile",
+        "stage-2-warm-after-1-line-edit",
+        3,
+        312,
+        "BtaCompileSession.compileIncremental()",
+      ),
+    )
+    // Tabs inside notes would corrupt the parse — they're flattened to spaces.
+    assertEquals("BENCHNOTE\ta b", note("a\tb"))
+  }
+}

--- a/docs/daemon/COMPILE-IN-PROCESS.md
+++ b/docs/daemon/COMPILE-IN-PROCESS.md
@@ -17,8 +17,12 @@ worker, already shipping behind `composePreview.daemon.continuousCompile`).
 > ([`ComposePreviewTasks.detectStageTwoIneligibility`](../../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt))
 > short-circuits KSP, KAPT, `annotationProcessor` dependencies, and KMP
 > modules to stage 1. The bench-harness measurement work in § "What we
-> expect to measure" is tracked in
-> [#1586](https://github.com/yschimke/compose-ai-tools/issues/1586).
+> expect to measure" landed in
+> [#1586](https://github.com/yschimke/compose-ai-tools/issues/1586): the
+> `:samples:*-daemon-bench:benchCompileStages` task drives the stage-1 and
+> stage-2 legs and writes the graduation verdict
+> (`docs/daemon/stage-2-verdict-<target>.md`) against § "Promote / demote
+> criteria" below.
 
 This doc describes the next layer: a JSON-RPC `compileSources` endpoint
 on `:daemon:core` that hosts the Kotlin compiler in-process via the
@@ -221,8 +225,10 @@ Gradle invocation) stays as the floor when the workspace flag is off
 
 ## What we expect to measure
 
-Reuse the harness from `samples/desktop-daemon-bench` and
-`samples/android-daemon-bench`, same baseline methodology as
+Implemented by `:samples:{android,desktop}-daemon-bench:benchCompileStages`
+(#1586) — it `javaexec`s `:daemon:core`'s `BtaBenchMain`, which drives the
+production `BtaCompileSession.compileIncremental()` using the `btaCompile`
+block from the module's `daemon-launch.json`. Same baseline methodology as
 [`baseline-latency.csv`](baseline-latency.csv). New columns:
 
 ```

--- a/docs/daemon/baseline-latency.md
+++ b/docs/daemon/baseline-latency.md
@@ -36,6 +36,29 @@ render rows compare like-for-like across targets.
 
 Total render set per run: **5 captures**.
 
+## Stages (CSV column `scenario` prefix)
+
+The CSV started as a stage-0 baseline (per-save `./gradlew`). Issue #1586 added
+the two faster save loops that shipped behind experimental flags, driven by the
+sibling `benchCompileStages` task:
+
+| Stage | Save loop | `scenario` values | Source |
+| ----- | --------- | ----------------- | ------ |
+| 0 | per-save `./gradlew` | `cold`, `warm-no-edit`, `warm-after-1-line-edit` | `benchPreviewLatency` |
+| 1 | resident `gradle --continuous` (`composePreview.daemon.continuousCompile`) | `stage-1-warm-after-1-line-edit` | `benchCompileStages` |
+| 2 | in-process BTA (`composePreview.daemon.compileInProcess`) | `stage-2-cold-first-save`, `stage-2-warm-after-1-line-edit`, `stage-2-warm` | `benchCompileStages` |
+
+Stage 1 rows carry `phase=compile` — the wall of one resident-Gradle rebuild,
+parsed from `BUILD SUCCESSFUL in N` exactly as `ContinuousCompileWorker` does.
+Stage 2 rows carry `phase=compile` (the real
+`BtaCompileSession.compileIncremental()` driven via `:daemon:core`'s
+`BtaBenchMain`) and `phase=classloader-swap` (the child-loader rotation that
+follows a successful compile). The stage-2 `render` leg is unchanged from stage
+0, so it is not re-measured — `benchCompileStages` reuses the stage-0
+`render,warm-after-1-line-edit` median when it evaluates the graduation verdict
+(`docs/daemon/stage-2-verdict-<target>.md`) against
+[COMPILE-IN-PROCESS.md](COMPILE-IN-PROCESS.md) § "Promote / demote criteria".
+
 ## Phases (CSV column `phase`)
 
 `config`, `compile`, and `discovery` match across targets (Gradle
@@ -109,12 +132,21 @@ on both targets because it absorbs first-time classloader/runtime init.
 ## Running it
 
 ```sh
-# Android — see :samples:android-daemon-bench/README.md
-./gradlew :samples:android-daemon-bench:benchPreviewLatency
+# Stage 0 (+ render baseline the stage-2 verdict reuses).
+./gradlew :samples:android-daemon-bench:benchPreviewLatency   # Android
+./gradlew :samples:desktop-daemon-bench:benchPreviewLatency   # Desktop
 
-# Desktop — see :samples:desktop-daemon-bench/README.md
-./gradlew :samples:desktop-daemon-bench:benchPreviewLatency
+# Stage 1 + stage 2 + graduation verdict. Run after benchPreviewLatency.
+./gradlew :samples:android-daemon-bench:benchCompileStages    # Android
+./gradlew :samples:desktop-daemon-bench:benchCompileStages    # Desktop
 ```
+
+Both also run weekly (and on demand) via
+[`.github/workflows/daemon-bench.yml`](../../.github/workflows/daemon-bench.yml),
+which uploads the CSV + per-target verdict as artifacts. That workflow is
+**non-blocking** — the per-PR critical path only runs the cheap
+`composePreviewRender` smoke (`ci.yml` build-samples job). Shared-runner numbers
+are noisier than the reference machine above; treat them as trend, not gospel.
 
 Wall time on the reference machine: **~85 s** (android), **~170 s**
 (desktop — desktop's per-preview forks dominate). Both tasks do ~36

--- a/samples/android-daemon-bench/README.md
+++ b/samples/android-daemon-bench/README.md
@@ -20,11 +20,46 @@ that would re-introduce the same problem.
 
 - `./gradlew :samples:android-daemon-bench:composePreviewRender` — renders all
   five previews to `build/compose-previews/renders/`. Smoke test that the
-  module builds and discovery wires up.
+  module builds and discovery wires up. **This is the cheap CI smoke** (wired
+  into `check` and run per-PR in `ci.yml`'s build-samples job) so the module
+  can't bit-rot without paying the full bench wall time.
 - `./gradlew :samples:android-daemon-bench:benchPreviewLatency` — runs the
-  full bench matrix (3 scenarios × 3 reps × 5 phases = 45 measurements) and
-  writes [`docs/daemon/baseline-latency.csv`](../../docs/daemon/baseline-latency.csv).
+  **stage-0** bench matrix (3 scenarios × 3 reps × 5 phases = 45 measurements)
+  and writes [`docs/daemon/baseline-latency.csv`](../../docs/daemon/baseline-latency.csv).
   Plan for ~10–15 min wall time.
+- `./gradlew :samples:android-daemon-bench:benchCompileStages` — drives the
+  **stage-1** (`gradle --continuous`) and **stage-2** (in-process Build Tools API)
+  compile legs, appends their rows to the same CSV, and writes a stage-2
+  graduation verdict to `docs/daemon/stage-2-verdict-android.md`. Run
+  `benchPreviewLatency` first — the verdict reuses its stage-0
+  `render,warm-after-1-line-edit` median as the render baseline.
+
+Both bench tasks run weekly (and on demand) via
+[`.github/workflows/daemon-bench.yml`](../../.github/workflows/daemon-bench.yml),
+which uploads the CSV + verdict as artifacts. That job is **non-blocking** — it
+never gates a PR.
+
+## Stages measured
+
+| Stage | Save loop | Driven by | Rows |
+| ----- | --------- | --------- | ---- |
+| 0 | per-save `./gradlew` | `benchPreviewLatency` | `config` / `compile` / `discovery` / `forkAndInit` / `render` × cold / warm-no-edit / warm-after-1-line-edit |
+| 1 | resident `gradle --continuous` (`composePreview.daemon.continuousCompile`) | `benchCompileStages` | `compile,stage-1-warm-after-1-line-edit` |
+| 2 | in-process BTA (`composePreview.daemon.compileInProcess`) | `benchCompileStages` | `compile,stage-2-cold-first-save`, `compile,stage-2-warm-after-1-line-edit`, `classloader-swap,stage-2-warm` |
+
+The stage-2 `render` leg is unchanged from stage 0 (the daemon hot-swaps into
+the same renderer), so the verdict reuses the stage-0 `render` median rather
+than re-measuring it. Stage 2 is driven by `javaexec`-ing `:daemon:core`'s
+`BtaBenchMain`, which calls the production `BtaCompileSession.compileIncremental()`
+— the same code path the daemon's `compileSources` handler runs — using the
+`btaCompile` block from this module's `daemon-launch.json`.
+
+The verdict evaluates the
+[COMPILE-IN-PROCESS.md](../../docs/daemon/COMPILE-IN-PROCESS.md) §
+"Promote / demote criteria" thresholds (< 2 s warm save→pixel on Android;
+warm-path advantage over stage 1) and prints `PROMOTE CANDIDATE` /
+`DO NOT PROMOTE` / `INCONCLUSIVE`. The memory-delta criterion is reported
+informationally (the harness can't observe the stage-1 daemon's resident set).
 
 ## Phases measured
 
@@ -62,3 +97,7 @@ we measure Gradle's reaction to "input changed" without confounding it with
   (Java 17, Kotlin 2.3.x, AGP 9.1+ — currently 9.2).
 - Don't add animations, scrolls, Wear, or `@PreviewParameter` here. Add
   them to `:samples:android` if you need a heavier workload.
+- Keep this module shape-for-shape with
+  [`:samples:desktop-daemon-bench`](../desktop-daemon-bench): any preview-set
+  change, and any change to the `BenchCompileStagesTask` body, must be mirrored
+  in both modules in the same commit.

--- a/samples/android-daemon-bench/build.gradle.kts
+++ b/samples/android-daemon-bench/build.gradle.kts
@@ -13,8 +13,11 @@
 // scenario definitions.
 @file:Suppress("UnstableApiUsage")
 
+import java.io.File
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 import org.w3c.dom.Element
 
 plugins {
@@ -356,3 +359,445 @@ tasks.register<BenchPreviewLatencyTask>("benchPreviewLatency") {
   )
   outputs.upToDateWhen { false }
 }
+
+// --- Stage-1 + stage-2 compile-leg bench (issue #1586) --------------------------------------
+//
+// Android counterpart to :samples:desktop-daemon-bench's BenchCompileStagesTask — kept in lockstep
+// (same scenarios, same output protocol, same verdict). `benchPreviewLatency` (above) measures
+// stage 0 (per-save `./gradlew`); this sibling drives the two faster save loops that shipped behind
+// experimental flags and emits the rows COMPILE-IN-PROCESS.md § "What we expect to measure" asks
+// for, then evaluates the promote/demote thresholds (< 2 s save→pixel on Android) and prints a
+// verdict:
+//
+//   * stage 1 (`composePreview.daemon.continuousCompile`): a resident `gradle --continuous`
+//     invocation; we prime its warm-up build then time edit→`BUILD SUCCESSFUL in N` per rep.
+//   * stage 2 (`composePreview.daemon.compileInProcess`): the in-process Build Tools API compile;
+//     we read the `btaCompile` block from `daemon-launch.json` and `javaexec` `:daemon:core`'s
+//     `BtaBenchMain`, driving the real `BtaCompileSession.compileIncremental()`.
+//
+// The render leg is unchanged from stage 0, so the verdict reuses the stage-0
+// `render,warm-after-1-line-edit` median already in the CSV — run `benchPreviewLatency` first.
+
+abstract class BenchCompileStagesTask : DefaultTask() {
+
+  @get:Internal
+  val rootProjectDir: org.gradle.api.file.DirectoryProperty =
+    project.objects.directoryProperty().convention(project.layout.settingsDirectory)
+
+  @get:Input
+  val benchModulePath: org.gradle.api.provider.Property<String> =
+    project.objects.property(String::class.java).convention(":samples:android-daemon-bench")
+
+  @get:Input
+  val target: org.gradle.api.provider.Property<String> =
+    project.objects.property(String::class.java).convention("android")
+
+  @get:Internal
+  val previewSourceFile: org.gradle.api.file.RegularFileProperty =
+    project.objects
+      .fileProperty()
+      .convention(
+        project.layout.projectDirectory.file(
+          "src/main/kotlin/com/example/daemonbench/BenchPreviews.kt"
+        )
+      )
+
+  @get:Internal
+  val sourceDir: org.gradle.api.file.DirectoryProperty =
+    project.objects
+      .directoryProperty()
+      .convention(project.layout.projectDirectory.dir("src/main/kotlin"))
+
+  @get:Internal
+  val outputCsv: org.gradle.api.file.RegularFileProperty =
+    project.objects
+      .fileProperty()
+      .convention(project.layout.settingsDirectory.file("docs/daemon/baseline-latency.csv"))
+
+  @get:Internal
+  val daemonLaunchJson: org.gradle.api.file.RegularFileProperty =
+    project.objects
+      .fileProperty()
+      .convention(project.layout.buildDirectory.file("compose-previews/daemon-launch.json"))
+
+  @get:Internal abstract val daemonCoreClasspath: org.gradle.api.file.ConfigurableFileCollection
+
+  @get:Internal
+  val javaLauncher: org.gradle.api.provider.Property<String> =
+    project.objects
+      .property(String::class.java)
+      .convention(project.providers.systemProperty("java.home").map { "$it/bin/java" })
+
+  @get:Input
+  val runsPerScenario: org.gradle.api.provider.Property<Int> =
+    project.objects.property(Int::class.java).convention(5)
+
+  @TaskAction
+  fun run() {
+    val csv = outputCsv.get().asFile
+    csv.parentFile.mkdirs()
+    val rootDir = rootProjectDir.get().asFile
+    val benchPath = benchModulePath.get()
+    val tgt = target.get()
+    val previewFile = previewSourceFile.get().asFile
+    val gradlew = rootDir.resolve("gradlew").also { check(it.exists()) { "missing $it" } }
+    val runs = runsPerScenario.get()
+    val marker = "\"three\""
+
+    val rows = mutableListOf<StageRow>()
+    val notes = mutableListOf<String>()
+    var stage2UsedMb: Long? = null
+
+    fun gradle(vararg args: String): Int {
+      val cmd = mutableListOf(gradlew.absolutePath) + args
+      logger.lifecycle("bench> {}", cmd.joinToString(" "))
+      val proc = ProcessBuilder(cmd).directory(rootDir).redirectErrorStream(true).start()
+      val output = proc.inputStream.bufferedReader().readText()
+      val rc = proc.waitFor()
+      if (rc != 0) logger.error(output)
+      return rc
+    }
+
+    gradle("$benchPath:composePreviewCompile")
+    gradle("$benchPath:composePreviewDaemonStart")
+
+    // --- Stage 1: gradle --continuous resident recompile ------------------------------------
+    run {
+      val cmd =
+        listOf(
+          gradlew.absolutePath,
+          "--continuous",
+          "--console=plain",
+          "$benchPath:composePreviewCompile",
+        )
+      logger.lifecycle("bench> {}", cmd.joinToString(" "))
+      val proc = ProcessBuilder(cmd).directory(rootDir).redirectErrorStream(true).start()
+      val builds = LinkedBlockingQueue<Long>()
+      Thread {
+          proc.inputStream.bufferedReader().forEachLine { line ->
+            val ms = parseBuildSuccessful(line)
+            when {
+              ms != null -> builds.offer(ms)
+              line.contains("BUILD FAILED") -> builds.offer(-1L)
+            }
+          }
+        }
+        .apply {
+          isDaemon = true
+          start()
+        }
+      try {
+        val warm = builds.poll(180, TimeUnit.SECONDS)
+        if (warm == null) {
+          notes += "stage-1: `gradle --continuous` warm-up build never completed within 180s"
+        } else {
+          for (run in 1..runs) {
+            // Drain rebuilds a previous revert may have triggered: poll until the watcher
+            // goes quiet for 2 s, so the next poll observes only this rep's edit build.
+            while (builds.poll(2, TimeUnit.SECONDS) != null) {
+              /* discard stale build */
+            }
+            val original = previewFile.readText()
+            check(marker in original) {
+              "${previewFile.name} no longer contains $marker — update the bench marker"
+            }
+            previewFile.writeText(
+              original.replace(marker, "\"three-${System.nanoTime() % 1_000_000}\"")
+            )
+            try {
+              val ms = builds.poll(120, TimeUnit.SECONDS)
+              when {
+                ms == null ->
+                  notes +=
+                    "stage-1 run $run: no rebuild within 120s (Gradle's file watcher missed the save?)"
+                ms < 0 -> notes += "stage-1 run $run: BUILD FAILED"
+                else ->
+                  rows +=
+                    StageRow(
+                      "compile",
+                      "stage-1-warm-after-1-line-edit",
+                      run,
+                      ms,
+                      "gradle --continuous resident rebuild (BUILD SUCCESSFUL in N)",
+                    )
+              }
+            } finally {
+              previewFile.writeText(original)
+            }
+          }
+        }
+      } finally {
+        proc.destroy()
+        if (!proc.waitFor(10, TimeUnit.SECONDS)) proc.destroyForcibly()
+      }
+    }
+
+    // --- Stage 2: in-process BTA compile via :daemon:core BtaBenchMain ----------------------
+    run {
+      val descriptor = daemonLaunchJson.get().asFile
+      val bta =
+        if (!descriptor.exists()) null
+        else (groovy.json.JsonSlurper().parse(descriptor) as Map<*, *>)["btaCompile"] as? Map<*, *>
+      if (bta == null) {
+        notes +=
+          "stage-2: daemon-launch.json carried no btaCompile block (BTA classpath not resolved for $benchPath)"
+      } else {
+        fun joined(key: String) =
+          (bta[key] as? List<*>).orEmpty().joinToString(File.pathSeparator) { it.toString() }
+        val sources =
+          sourceDir
+            .get()
+            .asFile
+            .walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .map { it.absolutePath }
+            .toList()
+            .joinToString(File.pathSeparator)
+        val cp = daemonCoreClasspath.files.joinToString(File.pathSeparator) { it.absolutePath }
+        val cmd = mutableListOf(javaLauncher.get())
+        cmd += "-Dcomposeai.daemon.bta.implClasspath=${joined("implClasspath")}"
+        cmd += "-Dcomposeai.daemon.bta.compileClasspath=${joined("compileClasspath")}"
+        cmd += "-Dcomposeai.daemon.bta.compilerPlugins=${joined("compilerPlugins")}"
+        cmd += "-Dcomposeai.daemon.bta.moduleName=${bta["moduleName"]}"
+        cmd += "-Dcomposeai.daemon.bta.outputDir=${bta["outputDir"]}"
+        cmd += "-Dcomposeai.daemon.bta.icWorkingDir=${bta["icWorkingDir"]}"
+        (bta["ineligibilityReason"] as? String)?.takeIf { it.isNotEmpty() }?.let {
+          cmd += "-Dcomposeai.daemon.bta.ineligibilityReason=$it"
+        }
+        cmd += "-Dcomposeai.bench.sources=$sources"
+        cmd += "-Dcomposeai.bench.editFile=${previewFile.absolutePath}"
+        cmd += "-Dcomposeai.bench.runs=$runs"
+        cmd += listOf("-cp", cp, "ee.schimke.composeai.daemon.bta.BtaBenchMain")
+        logger.lifecycle("bench> java … ee.schimke.composeai.daemon.bta.BtaBenchMain")
+        val proc =
+          ProcessBuilder(cmd)
+            .directory(rootDir)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .start()
+        val out = proc.inputStream.bufferedReader().readText()
+        val rc = proc.waitFor()
+        out.lineSequence().forEach { line ->
+          val p = line.split("\t")
+          when (p.getOrNull(0)) {
+            "BENCHROW" ->
+              if (p.size >= 6)
+                rows +=
+                  StageRow(p[1], p[2], p[3].toIntOrNull() ?: 0, p[4].toLongOrNull() ?: 0L, p[5])
+            "BENCHMEM" -> stage2UsedMb = p.getOrNull(1)?.toLongOrNull()
+            "BENCHNOTE" -> notes += p.getOrNull(1).orEmpty()
+          }
+        }
+        if (rc != 0) notes += "stage-2: BtaBenchMain exited $rc"
+      }
+    }
+
+    appendCsv(csv, rows, tgt)
+    writeVerdict(csv, rows, notes, tgt, stage2UsedMb)
+    logger.lifecycle("bench: wrote ${rows.size} stage-1/stage-2 rows for {} to {}", tgt, csv)
+  }
+
+  private fun writeVerdict(
+    csv: java.io.File,
+    rows: List<StageRow>,
+    notes: List<String>,
+    target: String,
+    stage2UsedMb: Long?,
+  ) {
+    fun median(xs: List<Long>): Long? = if (xs.isEmpty()) null else xs.sorted()[xs.size / 2]
+    fun medianFor(phase: String, scenario: String) =
+      median(rows.filter { it.phase == phase && it.scenario == scenario && it.ms >= 0 }.map { it.ms })
+
+    val s1 = medianFor("compile", "stage-1-warm-after-1-line-edit")
+    val s2compile = medianFor("compile", "stage-2-warm-after-1-line-edit")
+    val s2swap = medianFor("classloader-swap", "stage-2-warm")
+    val renderBaseline = readRenderBaseline(csv, target)
+    val budget = if (target == "desktop") 1000L else 2000L
+
+    fun fmt(v: Long?) = v?.let { "$it ms" } ?: "—"
+    fun verdict(ok: Boolean?) = if (ok == null) "UNKNOWN" else if (ok) "PASS" else "FAIL"
+
+    val s2SavePixel =
+      if (s2compile != null && s2swap != null && renderBaseline != null)
+        s2compile + s2swap + renderBaseline
+      else null
+    val s1SavePixel = if (s1 != null && renderBaseline != null) s1 + renderBaseline else null
+    val latencyOk = s2SavePixel?.let { it < budget }
+    val advantage = if (s1 != null && s2compile != null) s1 - s2compile else null
+    val demoteSignal = if (target == "desktop" && advantage != null) advantage < 200 else false
+
+    val sb = StringBuilder()
+    sb.appendLine("# Stage-2 graduation verdict — $target")
+    sb.appendLine()
+    sb.appendLine(
+      "Generated by `:${benchModulePath.get().removePrefix(":")}:benchCompileStages`. " +
+        "Thresholds from [COMPILE-IN-PROCESS.md](COMPILE-IN-PROCESS.md) § \"Promote / demote criteria\"."
+    )
+    sb.appendLine()
+    sb.appendLine("## Measured medians")
+    sb.appendLine()
+    sb.appendLine("| Leg | Stage 1 | Stage 2 |")
+    sb.appendLine("| --- | --- | --- |")
+    sb.appendLine("| compile (warm, 1-line edit) | ${fmt(s1)} | ${fmt(s2compile)} |")
+    sb.appendLine("| classloader-swap | — | ${fmt(s2swap)} |")
+    sb.appendLine("| render (warm, from stage-0 baseline) | ${fmt(renderBaseline)} | ${fmt(renderBaseline)} |")
+    sb.appendLine("| **save → pixel total** | **${fmt(s1SavePixel)}** | **${fmt(s2SavePixel)}** |")
+    sb.appendLine()
+    sb.appendLine("## Promote criteria")
+    sb.appendLine()
+    sb.appendLine(
+      "- ${verdict(latencyOk)} — save→pixel < ${budget} ms ($target): measured ${fmt(s2SavePixel)}."
+    )
+    sb.appendLine(
+      "- INFORMATIONAL — memory delta vs stage 1 < +250 MB: stage-2 BTA-frontend used heap " +
+        "= ${stage2UsedMb?.let { "$it MB" } ?: "—"} (compare manually to a stage-1 daemon on the same workspace; this harness can't observe the stage-1 daemon's resident set)."
+    )
+    sb.appendLine(
+      "- OUT OF SCOPE (manual) — sustained 10 min editing without wedging; a real KSP module exercises the fallback predicate cleanly."
+    )
+    sb.appendLine()
+    sb.appendLine("## Demote signal")
+    sb.appendLine()
+    sb.appendLine(
+      "- Warm-path advantage over stage 1: ${fmt(advantage)} " +
+        "(< 200 ms on desktop ⇒ BTA's win has collapsed)." +
+        if (demoteSignal) " ⚠️ DEMOTE SIGNAL TRIPPED." else ""
+    )
+    sb.appendLine()
+    val overall =
+      when {
+        latencyOk == true && demoteSignal != true ->
+          "PROMOTE CANDIDATE — latency threshold met; confirm the manual criteria before flipping the default."
+        latencyOk == false || demoteSignal == true -> "DO NOT PROMOTE — see failed criteria above."
+        else -> "INCONCLUSIVE — missing measurements (did `benchPreviewLatency` run first for the render baseline?)."
+      }
+    sb.appendLine("## Verdict: $overall")
+    if (notes.isNotEmpty()) {
+      sb.appendLine()
+      sb.appendLine("## Notes")
+      sb.appendLine()
+      notes.forEach { sb.appendLine("- $it") }
+    }
+
+    val verdictFile = csv.parentFile.resolve("stage-2-verdict-$target.md")
+    verdictFile.writeText(sb.toString())
+    logger.lifecycle("bench: stage-2 verdict ({}) -> {}", target, verdictFile)
+    logger.lifecycle("bench: {}", overall)
+    notes.forEach { logger.warn("bench note: {}", it) }
+  }
+
+  private fun readRenderBaseline(csv: java.io.File, target: String): Long? {
+    if (!csv.exists()) return null
+    val times =
+      csv
+        .readLines()
+        .filterNot { it.startsWith("#") || it.isBlank() }
+        .mapNotNull { line ->
+          val c = line.split(",")
+          if (
+            c.size >= 5 &&
+              c[0] == target &&
+              c[1] == "render" &&
+              c[2] == "warm-after-1-line-edit"
+          )
+            c[4].toLongOrNull()
+          else null
+        }
+        .filter { it > 0 }
+    return if (times.isEmpty()) null else times.sorted()[times.size / 2]
+  }
+
+  private fun parseBuildSuccessful(line: String): Long? {
+    val idx = line.indexOf("BUILD SUCCESSFUL in ")
+    if (idx < 0) return null
+    return parseGradleDuration(line.substring(idx + "BUILD SUCCESSFUL in ".length))
+  }
+
+  private fun parseGradleDuration(s: String): Long {
+    var total = 0L
+    for (tok in s.trim().split(Regex("\\s+"))) {
+      val m = Regex("([0-9.]+)(ms|h|m|s)").find(tok) ?: continue
+      val v = m.groupValues[1].toDoubleOrNull() ?: continue
+      total +=
+        when (m.groupValues[2]) {
+          "h" -> (v * 3_600_000).toLong()
+          "m" -> (v * 60_000).toLong()
+          "s" -> (v * 1000).toLong()
+          "ms" -> v.toLong()
+          else -> 0L
+        }
+    }
+    return total
+  }
+
+  private fun appendCsv(csv: java.io.File, rows: List<StageRow>, target: String) {
+    val newHeader = "target,phase,scenario,run,milliseconds,notes"
+    val existing = if (csv.exists()) csv.readText() else ""
+    val sb = StringBuilder()
+    if (existing.isBlank()) {
+      sb.appendLine("# baseline-latency.csv — captured by the daemon-bench :benchPreviewLatency and")
+      sb.appendLine("# :benchCompileStages tasks. See docs/daemon/baseline-latency.md for methodology.")
+      sb.appendLine(newHeader)
+    } else {
+      val lines = existing.lineSequence().toList()
+      val headerIdx = lines.indexOfFirst { !it.startsWith("#") && it.isNotBlank() }
+      check(headerIdx >= 0) { "baseline-latency.csv has no header row" }
+      val header = lines[headerIdx].trim()
+      when (header) {
+        newHeader -> {
+          sb.append(existing)
+          if (!existing.endsWith("\n")) sb.appendLine()
+        }
+        "phase,scenario,run,milliseconds,notes" ->
+          for ((i, line) in lines.withIndex()) {
+            when {
+              line.startsWith("#") -> sb.appendLine(line)
+              i == headerIdx -> sb.appendLine(newHeader)
+              line.isBlank() -> {}
+              else -> sb.appendLine("android,$line")
+            }
+          }
+        else -> error("baseline-latency.csv has an unexpected header: '$header'")
+      }
+    }
+    for (r in rows) {
+      sb.appendLine("$target,${r.phase},${r.scenario},${r.run},${r.ms},${r.notes.replace(",", ";")}")
+    }
+    csv.writeText(sb.toString())
+  }
+
+  private data class StageRow(
+    val phase: String,
+    val scenario: String,
+    val run: Int,
+    val ms: Long,
+    val notes: String,
+  )
+}
+
+// `:daemon:core` runtime (BtaBenchMain + BtaCompileSession + kotlin-build-tools-api). Isolated in
+// its own resolvable configuration so it never leaks onto the module's real compile/runtime path.
+configurations.create("daemonBench") {
+  isCanBeResolved = true
+  isCanBeConsumed = false
+}
+
+dependencies { add("daemonBench", project(":daemon:core")) }
+
+tasks.register<BenchCompileStagesTask>("benchCompileStages") {
+  group = "verification"
+  description =
+    "Drives the stage-1 (gradle --continuous) and stage-2 (in-process BTA) compile legs, appends " +
+      "their rows to docs/daemon/baseline-latency.csv, and writes a stage-2 graduation verdict."
+  daemonCoreClasspath.from(configurations.named("daemonBench"))
+  dependsOn("composePreviewDaemonStart")
+  notCompatibleWithConfigurationCache(
+    "BenchCompileStagesTask shells out to nested ./gradlew + a daemon JVM"
+  )
+  outputs.upToDateWhen { false }
+}
+
+// --- CI smoke (issue #1586) -----------------------------------------------------------------
+// The full benches are deliberately slow (run on the reference machine, not per-PR). To keep this
+// module from bit-rotting, `check` renders the five trivial previews — a cheap proof the module
+// builds, discovery wires up, and the renderer path is intact.
+tasks.named("check") { dependsOn("composePreviewRender") }

--- a/samples/android-daemon-bench/build.gradle.kts
+++ b/samples/android-daemon-bench/build.gradle.kts
@@ -561,9 +561,9 @@ abstract class BenchCompileStagesTask : DefaultTask() {
         cmd += "-Dcomposeai.daemon.bta.moduleName=${bta["moduleName"]}"
         cmd += "-Dcomposeai.daemon.bta.outputDir=${bta["outputDir"]}"
         cmd += "-Dcomposeai.daemon.bta.icWorkingDir=${bta["icWorkingDir"]}"
-        (bta["ineligibilityReason"] as? String)?.takeIf { it.isNotEmpty() }?.let {
-          cmd += "-Dcomposeai.daemon.bta.ineligibilityReason=$it"
-        }
+        (bta["ineligibilityReason"] as? String)
+          ?.takeIf { it.isNotEmpty() }
+          ?.let { cmd += "-Dcomposeai.daemon.bta.ineligibilityReason=$it" }
         cmd += "-Dcomposeai.bench.sources=$sources"
         cmd += "-Dcomposeai.bench.editFile=${previewFile.absolutePath}"
         cmd += "-Dcomposeai.bench.runs=$runs"
@@ -605,7 +605,9 @@ abstract class BenchCompileStagesTask : DefaultTask() {
   ) {
     fun median(xs: List<Long>): Long? = if (xs.isEmpty()) null else xs.sorted()[xs.size / 2]
     fun medianFor(phase: String, scenario: String) =
-      median(rows.filter { it.phase == phase && it.scenario == scenario && it.ms >= 0 }.map { it.ms })
+      median(
+        rows.filter { it.phase == phase && it.scenario == scenario && it.ms >= 0 }.map { it.ms }
+      )
 
     val s1 = medianFor("compile", "stage-1-warm-after-1-line-edit")
     val s2compile = medianFor("compile", "stage-2-warm-after-1-line-edit")
@@ -639,7 +641,9 @@ abstract class BenchCompileStagesTask : DefaultTask() {
     sb.appendLine("| --- | --- | --- |")
     sb.appendLine("| compile (warm, 1-line edit) | ${fmt(s1)} | ${fmt(s2compile)} |")
     sb.appendLine("| classloader-swap | — | ${fmt(s2swap)} |")
-    sb.appendLine("| render (warm, from stage-0 baseline) | ${fmt(renderBaseline)} | ${fmt(renderBaseline)} |")
+    sb.appendLine(
+      "| render (warm, from stage-0 baseline) | ${fmt(renderBaseline)} | ${fmt(renderBaseline)} |"
+    )
     sb.appendLine("| **save → pixel total** | **${fmt(s1SavePixel)}** | **${fmt(s2SavePixel)}** |")
     sb.appendLine()
     sb.appendLine("## Promote criteria")
@@ -668,7 +672,8 @@ abstract class BenchCompileStagesTask : DefaultTask() {
         latencyOk == true && demoteSignal != true ->
           "PROMOTE CANDIDATE — latency threshold met; confirm the manual criteria before flipping the default."
         latencyOk == false || demoteSignal == true -> "DO NOT PROMOTE — see failed criteria above."
-        else -> "INCONCLUSIVE — missing measurements (did `benchPreviewLatency` run first for the render baseline?)."
+        else ->
+          "INCONCLUSIVE — missing measurements (did `benchPreviewLatency` run first for the render baseline?)."
       }
     sb.appendLine("## Verdict: $overall")
     if (notes.isNotEmpty()) {
@@ -693,12 +698,7 @@ abstract class BenchCompileStagesTask : DefaultTask() {
         .filterNot { it.startsWith("#") || it.isBlank() }
         .mapNotNull { line ->
           val c = line.split(",")
-          if (
-            c.size >= 5 &&
-              c[0] == target &&
-              c[1] == "render" &&
-              c[2] == "warm-after-1-line-edit"
-          )
+          if (c.size >= 5 && c[0] == target && c[1] == "render" && c[2] == "warm-after-1-line-edit")
             c[4].toLongOrNull()
           else null
         }
@@ -734,8 +734,12 @@ abstract class BenchCompileStagesTask : DefaultTask() {
     val existing = if (csv.exists()) csv.readText() else ""
     val sb = StringBuilder()
     if (existing.isBlank()) {
-      sb.appendLine("# baseline-latency.csv — captured by the daemon-bench :benchPreviewLatency and")
-      sb.appendLine("# :benchCompileStages tasks. See docs/daemon/baseline-latency.md for methodology.")
+      sb.appendLine(
+        "# baseline-latency.csv — captured by the daemon-bench :benchPreviewLatency and"
+      )
+      sb.appendLine(
+        "# :benchCompileStages tasks. See docs/daemon/baseline-latency.md for methodology."
+      )
       sb.appendLine(newHeader)
     } else {
       val lines = existing.lineSequence().toList()
@@ -760,7 +764,9 @@ abstract class BenchCompileStagesTask : DefaultTask() {
       }
     }
     for (r in rows) {
-      sb.appendLine("$target,${r.phase},${r.scenario},${r.run},${r.ms},${r.notes.replace(",", ";")}")
+      sb.appendLine(
+        "$target,${r.phase},${r.scenario},${r.run},${r.ms},${r.notes.replace(",", ";")}"
+      )
     }
     csv.writeText(sb.toString())
   }

--- a/samples/desktop-daemon-bench/README.md
+++ b/samples/desktop-daemon-bench/README.md
@@ -17,14 +17,49 @@ two CSVs compare like-for-like.
 
 - `./gradlew :samples:desktop-daemon-bench:composePreviewRender` — renders all
   five previews to `build/compose-previews/renders/`. Smoke test that the
-  module builds and the desktop renderer (`renderer-desktop`) wires up.
+  module builds and the desktop renderer (`renderer-desktop`) wires up. **This
+  is the cheap CI smoke** (wired into `check` and run per-PR in `ci.yml`'s
+  build-samples job) so the module can't bit-rot without paying the full bench.
 - `./gradlew :samples:desktop-daemon-bench:benchPreviewLatency` — runs the
-  full bench matrix (3 scenarios × 3 reps × 5 phases = 45 measurements) and
-  appends desktop rows to
+  **stage-0** bench matrix (3 scenarios × 3 reps × 5 phases = 45 measurements)
+  and appends desktop rows to
   [`docs/daemon/baseline-latency.csv`](../../docs/daemon/baseline-latency.csv).
   The first time it sees the CSV in the legacy P0.1 layout (no `target`
   column) it migrates existing rows by prepending `android,`. Plan for
   ~5–10 min wall time on the reference machine.
+- `./gradlew :samples:desktop-daemon-bench:benchCompileStages` — drives the
+  **stage-1** (`gradle --continuous`) and **stage-2** (in-process Build Tools API)
+  compile legs, appends their rows to the same CSV, and writes a stage-2
+  graduation verdict to `docs/daemon/stage-2-verdict-desktop.md`. Run
+  `benchPreviewLatency` first — the verdict reuses its stage-0
+  `render,warm-after-1-line-edit` median as the render baseline.
+
+Both bench tasks run weekly (and on demand) via
+[`.github/workflows/daemon-bench.yml`](../../.github/workflows/daemon-bench.yml),
+which uploads the CSV + verdict as artifacts. That job is **non-blocking** — it
+never gates a PR.
+
+## Stages measured
+
+| Stage | Save loop | Driven by | Rows |
+| ----- | --------- | --------- | ---- |
+| 0 | per-save `./gradlew` | `benchPreviewLatency` | `config` / `compile` / `discovery` / `forkAndInit` / `render` × cold / warm-no-edit / warm-after-1-line-edit |
+| 1 | resident `gradle --continuous` (`composePreview.daemon.continuousCompile`) | `benchCompileStages` | `compile,stage-1-warm-after-1-line-edit` |
+| 2 | in-process BTA (`composePreview.daemon.compileInProcess`) | `benchCompileStages` | `compile,stage-2-cold-first-save`, `compile,stage-2-warm-after-1-line-edit`, `classloader-swap,stage-2-warm` |
+
+The stage-2 `render` leg is unchanged from stage 0 (the daemon hot-swaps into
+the same renderer), so the verdict reuses the stage-0 `render` median rather
+than re-measuring it. Stage 2 is driven by `javaexec`-ing `:daemon:core`'s
+`BtaBenchMain`, which calls the production `BtaCompileSession.compileIncremental()`
+— the same code path the daemon's `compileSources` handler runs — using the
+`btaCompile` block from this module's `daemon-launch.json`.
+
+The verdict evaluates the
+[COMPILE-IN-PROCESS.md](../../docs/daemon/COMPILE-IN-PROCESS.md) §
+"Promote / demote criteria" thresholds (< 1 s warm save→pixel on desktop;
+warm-path advantage over stage 1 ≥ 200 ms) and prints `PROMOTE CANDIDATE` /
+`DO NOT PROMOTE` / `INCONCLUSIVE`. The memory-delta criterion is reported
+informationally (the harness can't observe the stage-1 daemon's resident set).
 
 ## Phases measured
 
@@ -83,8 +118,9 @@ stay UP-TO-DATE.
 
 ## Constraints
 
-- Mirror the Android bench shape-for-shape. If you grow the preview set,
-  grow `:samples:android-daemon-bench` to match in the same commit.
+- Mirror the Android bench shape-for-shape. If you grow the preview set — or
+  change the `BenchCompileStagesTask` body — grow/update
+  `:samples:android-daemon-bench` to match in the same commit.
 - No animations, no scrolls, no `@PreviewParameter` here.
 - The bench appends to a shared CSV — running both Android and desktop
   benches back-to-back is fine; order doesn't matter.

--- a/samples/desktop-daemon-bench/build.gradle.kts
+++ b/samples/desktop-daemon-bench/build.gradle.kts
@@ -701,9 +701,9 @@ abstract class BenchCompileStagesTask : DefaultTask() {
         cmd += "-Dcomposeai.daemon.bta.moduleName=${bta["moduleName"]}"
         cmd += "-Dcomposeai.daemon.bta.outputDir=${bta["outputDir"]}"
         cmd += "-Dcomposeai.daemon.bta.icWorkingDir=${bta["icWorkingDir"]}"
-        (bta["ineligibilityReason"] as? String)?.takeIf { it.isNotEmpty() }?.let {
-          cmd += "-Dcomposeai.daemon.bta.ineligibilityReason=$it"
-        }
+        (bta["ineligibilityReason"] as? String)
+          ?.takeIf { it.isNotEmpty() }
+          ?.let { cmd += "-Dcomposeai.daemon.bta.ineligibilityReason=$it" }
         cmd += "-Dcomposeai.bench.sources=$sources"
         cmd += "-Dcomposeai.bench.editFile=${previewFile.absolutePath}"
         cmd += "-Dcomposeai.bench.runs=$runs"
@@ -747,7 +747,9 @@ abstract class BenchCompileStagesTask : DefaultTask() {
   ) {
     fun median(xs: List<Long>): Long? = if (xs.isEmpty()) null else xs.sorted()[xs.size / 2]
     fun medianFor(phase: String, scenario: String) =
-      median(rows.filter { it.phase == phase && it.scenario == scenario && it.ms >= 0 }.map { it.ms })
+      median(
+        rows.filter { it.phase == phase && it.scenario == scenario && it.ms >= 0 }.map { it.ms }
+      )
 
     val s1 = medianFor("compile", "stage-1-warm-after-1-line-edit")
     val s2compile = medianFor("compile", "stage-2-warm-after-1-line-edit")
@@ -781,7 +783,9 @@ abstract class BenchCompileStagesTask : DefaultTask() {
     sb.appendLine("| --- | --- | --- |")
     sb.appendLine("| compile (warm, 1-line edit) | ${fmt(s1)} | ${fmt(s2compile)} |")
     sb.appendLine("| classloader-swap | — | ${fmt(s2swap)} |")
-    sb.appendLine("| render (warm, from stage-0 baseline) | ${fmt(renderBaseline)} | ${fmt(renderBaseline)} |")
+    sb.appendLine(
+      "| render (warm, from stage-0 baseline) | ${fmt(renderBaseline)} | ${fmt(renderBaseline)} |"
+    )
     sb.appendLine("| **save → pixel total** | **${fmt(s1SavePixel)}** | **${fmt(s2SavePixel)}** |")
     sb.appendLine()
     sb.appendLine("## Promote criteria")
@@ -810,7 +814,8 @@ abstract class BenchCompileStagesTask : DefaultTask() {
         latencyOk == true && demoteSignal != true ->
           "PROMOTE CANDIDATE — latency threshold met; confirm the manual criteria before flipping the default."
         latencyOk == false || demoteSignal == true -> "DO NOT PROMOTE — see failed criteria above."
-        else -> "INCONCLUSIVE — missing measurements (did `benchPreviewLatency` run first for the render baseline?)."
+        else ->
+          "INCONCLUSIVE — missing measurements (did `benchPreviewLatency` run first for the render baseline?)."
       }
     sb.appendLine("## Verdict: $overall")
     if (notes.isNotEmpty()) {
@@ -835,12 +840,7 @@ abstract class BenchCompileStagesTask : DefaultTask() {
         .filterNot { it.startsWith("#") || it.isBlank() }
         .mapNotNull { line ->
           val c = line.split(",")
-          if (
-            c.size >= 5 &&
-              c[0] == target &&
-              c[1] == "render" &&
-              c[2] == "warm-after-1-line-edit"
-          )
+          if (c.size >= 5 && c[0] == target && c[1] == "render" && c[2] == "warm-after-1-line-edit")
             c[4].toLongOrNull()
           else null
         }
@@ -881,8 +881,12 @@ abstract class BenchCompileStagesTask : DefaultTask() {
     val existing = if (csv.exists()) csv.readText() else ""
     val sb = StringBuilder()
     if (existing.isBlank()) {
-      sb.appendLine("# baseline-latency.csv — captured by the daemon-bench :benchPreviewLatency and")
-      sb.appendLine("# :benchCompileStages tasks. See docs/daemon/baseline-latency.md for methodology.")
+      sb.appendLine(
+        "# baseline-latency.csv — captured by the daemon-bench :benchPreviewLatency and"
+      )
+      sb.appendLine(
+        "# :benchCompileStages tasks. See docs/daemon/baseline-latency.md for methodology."
+      )
       sb.appendLine(newHeader)
     } else {
       val lines = existing.lineSequence().toList()
@@ -907,7 +911,9 @@ abstract class BenchCompileStagesTask : DefaultTask() {
       }
     }
     for (r in rows) {
-      sb.appendLine("$target,${r.phase},${r.scenario},${r.run},${r.ms},${r.notes.replace(",", ";")}")
+      sb.appendLine(
+        "$target,${r.phase},${r.scenario},${r.run},${r.ms},${r.notes.replace(",", ";")}"
+      )
     }
     csv.writeText(sb.toString())
   }

--- a/samples/desktop-daemon-bench/build.gradle.kts
+++ b/samples/desktop-daemon-bench/build.gradle.kts
@@ -17,6 +17,8 @@
 import java.io.File
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 
 plugins {
   id("composeai.base-conventions")
@@ -491,3 +493,458 @@ tasks.register<BenchPreviewLatencyTask>("benchPreviewLatency") {
   )
   outputs.upToDateWhen { false }
 }
+
+// --- Stage-1 + stage-2 compile-leg bench (issue #1586) --------------------------------------
+//
+// `benchPreviewLatency` (above) measures stage 0 — the per-save `./gradlew` invocation. This
+// sibling task drives the two faster save loops that shipped behind experimental flags and emits
+// the rows COMPILE-IN-PROCESS.md § "What we expect to measure" calls for, then evaluates the
+// promote/demote thresholds and prints a verdict:
+//
+//   * stage 1 (`composePreview.daemon.continuousCompile`): a resident `gradle --continuous`
+//     invocation. We launch one, prime its warm-up build, then time edit→`BUILD SUCCESSFUL in N`
+//     for each rep — exactly the leg `ContinuousCompileWorker.waitForNextBuild()` resolves on.
+//   * stage 2 (`composePreview.daemon.compileInProcess`): the in-process Build Tools API compile.
+//     We read the `btaCompile` block the daemon would consume from `daemon-launch.json` and
+//     `javaexec` `:daemon:core`'s `BtaBenchMain`, which drives the real
+//     `BtaCompileSession.compileIncremental()` — the same call the daemon's `compileSources`
+//     handler runs — plus the child-classloader rotation that follows it.
+//
+// The render leg is unchanged from stage 0 (the daemon hot-swaps into the same renderer), so the
+// verdict reuses the stage-0 `render,warm-after-1-line-edit` median already in the CSV rather than
+// re-measuring it here — run `benchPreviewLatency` first so that baseline exists.
+
+abstract class BenchCompileStagesTask : DefaultTask() {
+
+  @get:Internal
+  val rootProjectDir: org.gradle.api.file.DirectoryProperty =
+    project.objects.directoryProperty().convention(project.layout.settingsDirectory)
+
+  @get:Input
+  val benchModulePath: org.gradle.api.provider.Property<String> =
+    project.objects.property(String::class.java).convention(":samples:desktop-daemon-bench")
+
+  @get:Input
+  val target: org.gradle.api.provider.Property<String> =
+    project.objects.property(String::class.java).convention("desktop")
+
+  @get:Internal
+  val previewSourceFile: org.gradle.api.file.RegularFileProperty =
+    project.objects
+      .fileProperty()
+      .convention(
+        project.layout.projectDirectory.file(
+          "src/main/kotlin/com/example/desktopdaemonbench/BenchPreviews.kt"
+        )
+      )
+
+  @get:Internal
+  val sourceDir: org.gradle.api.file.DirectoryProperty =
+    project.objects
+      .directoryProperty()
+      .convention(project.layout.projectDirectory.dir("src/main/kotlin"))
+
+  @get:Internal
+  val outputCsv: org.gradle.api.file.RegularFileProperty =
+    project.objects
+      .fileProperty()
+      .convention(project.layout.settingsDirectory.file("docs/daemon/baseline-latency.csv"))
+
+  @get:Internal
+  val daemonLaunchJson: org.gradle.api.file.RegularFileProperty =
+    project.objects
+      .fileProperty()
+      .convention(project.layout.buildDirectory.file("compose-previews/daemon-launch.json"))
+
+  // `:daemon:core`'s runtime classpath — carries `BtaBenchMain`, `BtaCompileSession`, and the
+  // kotlin-build-tools-api the driver links against. Resolved at config time; see the
+  // `daemonBench` configuration below.
+  @get:Internal abstract val daemonCoreClasspath: org.gradle.api.file.ConfigurableFileCollection
+
+  @get:Internal
+  val javaLauncher: org.gradle.api.provider.Property<String> =
+    project.objects
+      .property(String::class.java)
+      .convention(project.providers.systemProperty("java.home").map { "$it/bin/java" })
+
+  @get:Input
+  val runsPerScenario: org.gradle.api.provider.Property<Int> =
+    project.objects.property(Int::class.java).convention(5)
+
+  @TaskAction
+  fun run() {
+    val csv = outputCsv.get().asFile
+    csv.parentFile.mkdirs()
+    val rootDir = rootProjectDir.get().asFile
+    val benchPath = benchModulePath.get()
+    val tgt = target.get()
+    val previewFile = previewSourceFile.get().asFile
+    val gradlew = rootDir.resolve("gradlew").also { check(it.exists()) { "missing $it" } }
+    val runs = runsPerScenario.get()
+    val marker = "\"three\""
+
+    val rows = mutableListOf<StageRow>()
+    val notes = mutableListOf<String>()
+    var stage2UsedMb: Long? = null
+
+    fun gradle(vararg args: String): Int {
+      val cmd = mutableListOf(gradlew.absolutePath) + args
+      logger.lifecycle("bench> {}", cmd.joinToString(" "))
+      val proc = ProcessBuilder(cmd).directory(rootDir).redirectErrorStream(true).start()
+      val output = proc.inputStream.bufferedReader().readText()
+      val rc = proc.waitFor()
+      if (rc != 0) logger.error(output)
+      return rc
+    }
+
+    // Prime warm state + the launch descriptor before measuring.
+    gradle("$benchPath:composePreviewCompile")
+    gradle("$benchPath:composePreviewDaemonStart")
+
+    // --- Stage 1: gradle --continuous resident recompile ------------------------------------
+    run {
+      val cmd =
+        listOf(
+          gradlew.absolutePath,
+          "--continuous",
+          "--console=plain",
+          "$benchPath:composePreviewCompile",
+        )
+      logger.lifecycle("bench> {}", cmd.joinToString(" "))
+      val proc = ProcessBuilder(cmd).directory(rootDir).redirectErrorStream(true).start()
+      val builds = LinkedBlockingQueue<Long>()
+      Thread {
+          proc.inputStream.bufferedReader().forEachLine { line ->
+            val ms = parseBuildSuccessful(line)
+            when {
+              ms != null -> builds.offer(ms)
+              line.contains("BUILD FAILED") -> builds.offer(-1L)
+            }
+          }
+        }
+        .apply {
+          isDaemon = true
+          start()
+        }
+      try {
+        val warm = builds.poll(180, TimeUnit.SECONDS)
+        if (warm == null) {
+          notes += "stage-1: `gradle --continuous` warm-up build never completed within 180s"
+        } else {
+          for (run in 1..runs) {
+            // Drain rebuilds a previous revert may have triggered: poll until the watcher
+            // goes quiet for 2 s, so the next poll observes only this rep's edit build.
+            while (builds.poll(2, TimeUnit.SECONDS) != null) {
+              /* discard stale build */
+            }
+            val original = previewFile.readText()
+            check(marker in original) {
+              "${previewFile.name} no longer contains $marker — update the bench marker"
+            }
+            previewFile.writeText(
+              original.replace(marker, "\"three-${System.nanoTime() % 1_000_000}\"")
+            )
+            try {
+              val ms = builds.poll(120, TimeUnit.SECONDS)
+              when {
+                ms == null ->
+                  notes +=
+                    "stage-1 run $run: no rebuild within 120s (Gradle's file watcher missed the save?)"
+                ms < 0 -> notes += "stage-1 run $run: BUILD FAILED"
+                else ->
+                  rows +=
+                    StageRow(
+                      "compile",
+                      "stage-1-warm-after-1-line-edit",
+                      run,
+                      ms,
+                      "gradle --continuous resident rebuild (BUILD SUCCESSFUL in N)",
+                    )
+              }
+            } finally {
+              previewFile.writeText(original)
+            }
+          }
+        }
+      } finally {
+        proc.destroy()
+        if (!proc.waitFor(10, TimeUnit.SECONDS)) proc.destroyForcibly()
+      }
+    }
+
+    // --- Stage 2: in-process BTA compile via :daemon:core BtaBenchMain ----------------------
+    run {
+      val descriptor = daemonLaunchJson.get().asFile
+      val bta =
+        if (!descriptor.exists()) null
+        else (groovy.json.JsonSlurper().parse(descriptor) as Map<*, *>)["btaCompile"] as? Map<*, *>
+      if (bta == null) {
+        notes +=
+          "stage-2: daemon-launch.json carried no btaCompile block (BTA classpath not resolved for $benchPath)"
+      } else {
+        fun joined(key: String) =
+          (bta[key] as? List<*>).orEmpty().joinToString(File.pathSeparator) { it.toString() }
+        val sources =
+          sourceDir
+            .get()
+            .asFile
+            .walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .map { it.absolutePath }
+            .toList()
+            .joinToString(File.pathSeparator)
+        val cp = daemonCoreClasspath.files.joinToString(File.pathSeparator) { it.absolutePath }
+        val cmd = mutableListOf(javaLauncher.get())
+        cmd += "-Dcomposeai.daemon.bta.implClasspath=${joined("implClasspath")}"
+        cmd += "-Dcomposeai.daemon.bta.compileClasspath=${joined("compileClasspath")}"
+        cmd += "-Dcomposeai.daemon.bta.compilerPlugins=${joined("compilerPlugins")}"
+        cmd += "-Dcomposeai.daemon.bta.moduleName=${bta["moduleName"]}"
+        cmd += "-Dcomposeai.daemon.bta.outputDir=${bta["outputDir"]}"
+        cmd += "-Dcomposeai.daemon.bta.icWorkingDir=${bta["icWorkingDir"]}"
+        (bta["ineligibilityReason"] as? String)?.takeIf { it.isNotEmpty() }?.let {
+          cmd += "-Dcomposeai.daemon.bta.ineligibilityReason=$it"
+        }
+        cmd += "-Dcomposeai.bench.sources=$sources"
+        cmd += "-Dcomposeai.bench.editFile=${previewFile.absolutePath}"
+        cmd += "-Dcomposeai.bench.runs=$runs"
+        cmd += listOf("-cp", cp, "ee.schimke.composeai.daemon.bta.BtaBenchMain")
+        logger.lifecycle("bench> java … ee.schimke.composeai.daemon.bta.BtaBenchMain")
+        val proc =
+          ProcessBuilder(cmd)
+            .directory(rootDir)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .start()
+        val out = proc.inputStream.bufferedReader().readText()
+        val rc = proc.waitFor()
+        out.lineSequence().forEach { line ->
+          val p = line.split("\t")
+          when (p.getOrNull(0)) {
+            "BENCHROW" ->
+              if (p.size >= 6)
+                rows +=
+                  StageRow(p[1], p[2], p[3].toIntOrNull() ?: 0, p[4].toLongOrNull() ?: 0L, p[5])
+            "BENCHMEM" -> stage2UsedMb = p.getOrNull(1)?.toLongOrNull()
+            "BENCHNOTE" -> notes += p.getOrNull(1).orEmpty()
+          }
+        }
+        if (rc != 0) notes += "stage-2: BtaBenchMain exited $rc"
+      }
+    }
+
+    appendCsv(csv, rows, tgt)
+    writeVerdict(csv, rows, notes, tgt, stage2UsedMb)
+    logger.lifecycle("bench: wrote ${rows.size} stage-1/stage-2 rows for {} to {}", tgt, csv)
+  }
+
+  // --- Stage-graduation verdict ------------------------------------------------------------
+
+  private fun writeVerdict(
+    csv: java.io.File,
+    rows: List<StageRow>,
+    notes: List<String>,
+    target: String,
+    stage2UsedMb: Long?,
+  ) {
+    fun median(xs: List<Long>): Long? = if (xs.isEmpty()) null else xs.sorted()[xs.size / 2]
+    fun medianFor(phase: String, scenario: String) =
+      median(rows.filter { it.phase == phase && it.scenario == scenario && it.ms >= 0 }.map { it.ms })
+
+    val s1 = medianFor("compile", "stage-1-warm-after-1-line-edit")
+    val s2compile = medianFor("compile", "stage-2-warm-after-1-line-edit")
+    val s2swap = medianFor("classloader-swap", "stage-2-warm")
+    val renderBaseline = readRenderBaseline(csv, target)
+    val budget = if (target == "desktop") 1000L else 2000L
+
+    fun fmt(v: Long?) = v?.let { "$it ms" } ?: "—"
+    fun verdict(ok: Boolean?) = if (ok == null) "UNKNOWN" else if (ok) "PASS" else "FAIL"
+
+    val s2SavePixel =
+      if (s2compile != null && s2swap != null && renderBaseline != null)
+        s2compile + s2swap + renderBaseline
+      else null
+    val s1SavePixel = if (s1 != null && renderBaseline != null) s1 + renderBaseline else null
+    val latencyOk = s2SavePixel?.let { it < budget }
+    val advantage = if (s1 != null && s2compile != null) s1 - s2compile else null
+    val demoteSignal = if (target == "desktop" && advantage != null) advantage < 200 else false
+
+    val sb = StringBuilder()
+    sb.appendLine("# Stage-2 graduation verdict — $target")
+    sb.appendLine()
+    sb.appendLine(
+      "Generated by `:${benchModulePath.get().removePrefix(":")}:benchCompileStages`. " +
+        "Thresholds from [COMPILE-IN-PROCESS.md](COMPILE-IN-PROCESS.md) § \"Promote / demote criteria\"."
+    )
+    sb.appendLine()
+    sb.appendLine("## Measured medians")
+    sb.appendLine()
+    sb.appendLine("| Leg | Stage 1 | Stage 2 |")
+    sb.appendLine("| --- | --- | --- |")
+    sb.appendLine("| compile (warm, 1-line edit) | ${fmt(s1)} | ${fmt(s2compile)} |")
+    sb.appendLine("| classloader-swap | — | ${fmt(s2swap)} |")
+    sb.appendLine("| render (warm, from stage-0 baseline) | ${fmt(renderBaseline)} | ${fmt(renderBaseline)} |")
+    sb.appendLine("| **save → pixel total** | **${fmt(s1SavePixel)}** | **${fmt(s2SavePixel)}** |")
+    sb.appendLine()
+    sb.appendLine("## Promote criteria")
+    sb.appendLine()
+    sb.appendLine(
+      "- ${verdict(latencyOk)} — save→pixel < ${budget} ms ($target): measured ${fmt(s2SavePixel)}."
+    )
+    sb.appendLine(
+      "- INFORMATIONAL — memory delta vs stage 1 < +250 MB: stage-2 BTA-frontend used heap " +
+        "= ${stage2UsedMb?.let { "$it MB" } ?: "—"} (compare manually to a stage-1 daemon on the same workspace; this harness can't observe the stage-1 daemon's resident set)."
+    )
+    sb.appendLine(
+      "- OUT OF SCOPE (manual) — sustained 10 min editing without wedging; a real KSP module exercises the fallback predicate cleanly."
+    )
+    sb.appendLine()
+    sb.appendLine("## Demote signal")
+    sb.appendLine()
+    sb.appendLine(
+      "- Warm-path advantage over stage 1: ${fmt(advantage)} " +
+        "(< 200 ms on desktop ⇒ BTA's win has collapsed)." +
+        if (demoteSignal) " ⚠️ DEMOTE SIGNAL TRIPPED." else ""
+    )
+    sb.appendLine()
+    val overall =
+      when {
+        latencyOk == true && demoteSignal != true ->
+          "PROMOTE CANDIDATE — latency threshold met; confirm the manual criteria before flipping the default."
+        latencyOk == false || demoteSignal == true -> "DO NOT PROMOTE — see failed criteria above."
+        else -> "INCONCLUSIVE — missing measurements (did `benchPreviewLatency` run first for the render baseline?)."
+      }
+    sb.appendLine("## Verdict: $overall")
+    if (notes.isNotEmpty()) {
+      sb.appendLine()
+      sb.appendLine("## Notes")
+      sb.appendLine()
+      notes.forEach { sb.appendLine("- $it") }
+    }
+
+    val verdictFile = csv.parentFile.resolve("stage-2-verdict-$target.md")
+    verdictFile.writeText(sb.toString())
+    logger.lifecycle("bench: stage-2 verdict ({}) -> {}", target, verdictFile)
+    logger.lifecycle("bench: {}", overall)
+    notes.forEach { logger.warn("bench note: {}", it) }
+  }
+
+  private fun readRenderBaseline(csv: java.io.File, target: String): Long? {
+    if (!csv.exists()) return null
+    val times =
+      csv
+        .readLines()
+        .filterNot { it.startsWith("#") || it.isBlank() }
+        .mapNotNull { line ->
+          val c = line.split(",")
+          if (
+            c.size >= 5 &&
+              c[0] == target &&
+              c[1] == "render" &&
+              c[2] == "warm-after-1-line-edit"
+          )
+            c[4].toLongOrNull()
+          else null
+        }
+        .filter { it > 0 }
+    return if (times.isEmpty()) null else times.sorted()[times.size / 2]
+  }
+
+  private fun parseBuildSuccessful(line: String): Long? {
+    val idx = line.indexOf("BUILD SUCCESSFUL in ")
+    if (idx < 0) return null
+    return parseGradleDuration(line.substring(idx + "BUILD SUCCESSFUL in ".length))
+  }
+
+  // Gradle prints "BUILD SUCCESSFUL in 420ms" / "in 2s" / "in 1m 3s". Sum the tokens to ms.
+  private fun parseGradleDuration(s: String): Long {
+    var total = 0L
+    for (tok in s.trim().split(Regex("\\s+"))) {
+      val m = Regex("([0-9.]+)(ms|h|m|s)").find(tok) ?: continue
+      val v = m.groupValues[1].toDoubleOrNull() ?: continue
+      total +=
+        when (m.groupValues[2]) {
+          "h" -> (v * 3_600_000).toLong()
+          "m" -> (v * 60_000).toLong()
+          "s" -> (v * 1000).toLong()
+          "ms" -> v.toLong()
+          else -> 0L
+        }
+    }
+    return total
+  }
+
+  /**
+   * Append rows to the shared CSV, migrating the legacy P0.1 layout (no `target` column) on first
+   * sight. Same logic as [BenchPreviewLatencyTask.appendCsv] so the two tasks interleave cleanly.
+   */
+  private fun appendCsv(csv: java.io.File, rows: List<StageRow>, target: String) {
+    val newHeader = "target,phase,scenario,run,milliseconds,notes"
+    val existing = if (csv.exists()) csv.readText() else ""
+    val sb = StringBuilder()
+    if (existing.isBlank()) {
+      sb.appendLine("# baseline-latency.csv — captured by the daemon-bench :benchPreviewLatency and")
+      sb.appendLine("# :benchCompileStages tasks. See docs/daemon/baseline-latency.md for methodology.")
+      sb.appendLine(newHeader)
+    } else {
+      val lines = existing.lineSequence().toList()
+      val headerIdx = lines.indexOfFirst { !it.startsWith("#") && it.isNotBlank() }
+      check(headerIdx >= 0) { "baseline-latency.csv has no header row" }
+      val header = lines[headerIdx].trim()
+      when (header) {
+        newHeader -> {
+          sb.append(existing)
+          if (!existing.endsWith("\n")) sb.appendLine()
+        }
+        "phase,scenario,run,milliseconds,notes" ->
+          for ((i, line) in lines.withIndex()) {
+            when {
+              line.startsWith("#") -> sb.appendLine(line)
+              i == headerIdx -> sb.appendLine(newHeader)
+              line.isBlank() -> {}
+              else -> sb.appendLine("android,$line")
+            }
+          }
+        else -> error("baseline-latency.csv has an unexpected header: '$header'")
+      }
+    }
+    for (r in rows) {
+      sb.appendLine("$target,${r.phase},${r.scenario},${r.run},${r.ms},${r.notes.replace(",", ";")}")
+    }
+    csv.writeText(sb.toString())
+  }
+
+  private data class StageRow(
+    val phase: String,
+    val scenario: String,
+    val run: Int,
+    val ms: Long,
+    val notes: String,
+  )
+}
+
+// `:daemon:core` runtime (BtaBenchMain + BtaCompileSession + kotlin-build-tools-api). Isolated in
+// its own resolvable configuration so it never leaks onto the module's real compile/runtime path.
+configurations.create("daemonBench") {
+  isCanBeResolved = true
+  isCanBeConsumed = false
+}
+
+dependencies { add("daemonBench", project(":daemon:core")) }
+
+tasks.register<BenchCompileStagesTask>("benchCompileStages") {
+  group = "verification"
+  description =
+    "Drives the stage-1 (gradle --continuous) and stage-2 (in-process BTA) compile legs, appends " +
+      "their rows to docs/daemon/baseline-latency.csv, and writes a stage-2 graduation verdict."
+  daemonCoreClasspath.from(configurations.named("daemonBench"))
+  dependsOn("composePreviewDaemonStart")
+  notCompatibleWithConfigurationCache(
+    "BenchCompileStagesTask shells out to nested ./gradlew + a daemon JVM"
+  )
+  outputs.upToDateWhen { false }
+}
+
+// --- CI smoke (issue #1586) -----------------------------------------------------------------
+// The full benches are deliberately slow (run on the reference machine, not per-PR). To keep this
+// module from bit-rotting, `check` renders the five trivial previews — a cheap proof the module
+// builds, discovery wires up, and the renderer path is intact.
+tasks.named("check") { dependsOn("composePreviewRender") }


### PR DESCRIPTION
Completes and utilises the `:samples:android-daemon-bench` / `:samples:desktop-daemon-bench` harnesses (#1586). They previously only measured stage 0 and weren't exercised in CI.

## What's here

**Stage-2 driver — `:daemon:core` `BtaBenchMain`**
A standalone `main` the bench `javaexec`s on `:daemon:core`'s runtime classpath. It reads the `btaCompile` block from the module's `daemon-launch.json` (the same `composeai.daemon.bta.*` sysprops `DefaultBtaCompileService.fromSysprops` consumes) and drives the **real** `BtaCompileSession.compileIncremental()` — the exact code path the daemon's `compileSources` handler runs — plus the child-classloader rotation that follows a compile. No daemon spawn / JSON-RPC; the render leg is unchanged from stage 0 so it isn't re-measured.

**`benchCompileStages` task (both modules, in lockstep)**
- **Stage 1** (`composePreview.daemon.continuousCompile`): launches a resident `gradle --continuous :module:composePreviewCompile`, primes the warm-up build, then times edit→`BUILD SUCCESSFUL in N` per rep — the leg `ContinuousCompileWorker.waitForNextBuild()` resolves on.
- **Stage 2** (`composePreview.daemon.compileInProcess`): javaexecs `BtaBenchMain`.
- Appends `compile,stage-1-warm-after-1-line-edit`, `compile,stage-2-cold-first-save`, `compile,stage-2-warm-after-1-line-edit`, and `classloader-swap,stage-2-warm` rows to `baseline-latency.csv` (documented column shape).
- Writes a **graduation verdict** (`docs/daemon/stage-2-verdict-<target>.md`) evaluating COMPILE-IN-PROCESS.md's promote/demote thresholds (< 1 s desktop / < 2 s Android save→pixel; warm-path advantage over stage 1) and prints `PROMOTE CANDIDATE` / `DO NOT PROMOTE` / `INCONCLUSIVE`. The memory-delta criterion is reported informationally.

**CI**
- Per-PR **smoke**: `ci.yml` build-samples now renders the five trivial previews of both modules; `check` also depends on `composePreviewRender`. Cheap, keeps the modules from bit-rotting.
- New **scheduled, non-blocking** `daemon-bench.yml` (weekly + manual) runs the full benches and uploads the CSV + verdict as artifacts — deliberately off the per-PR critical path.

**Docs**: both READMEs, `baseline-latency.md`, and `COMPILE-IN-PROCESS.md` updated for the new stages, verdict, and CI.

## Test plan
- `:daemon:core` `BtaBenchMainTest` covers the sysprop→config parse, the tab-separated output protocol, and the marker-swap edit.
- Full benches run on the reference machine / scheduled CI; the per-PR smoke renders both modules.

## Notes for review
- **Could not build/format locally**: this environment only has JDK 21 (the project pins a JDK 17 toolchain) and no network, so I couldn't run `ktfmtCheckAll`, the unit test, or the heavy benches here — consistent with the issue's reference-machine premise. The `src/` files were hand-formatted to Google ktfmt style; if CI's ktfmt gate flags anything I'll fix it.
- Stage 2 relies on the descriptor's `btaCompile` block being populated (BTA classpath resolved + module eligible). If it's absent/ineligible the driver emits a clear note rather than failing.
- Branch name is `claude/issue-1586-W6JSY` as required by the harness (your global preference is `agent/...` — flagging it; happy to rename if you'd rather, though it may disturb harness PR tracking).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JY5cbPq9UC3HZSsGZ3tfrj)_