### PR TITLE
fix: discover preview modules without realizing the whole task graph

### DIFF
--- a/api/gradle-preview-driver/build.gradle.kts
+++ b/api/gradle-preview-driver/build.gradle.kts
@@ -41,6 +41,15 @@ dependencies {
   testImplementation(kotlin("test"))
 }
 
+tasks.withType<Test>().configureEach {
+  // The unpacked Gradle distribution this build runs from. `DiscoverPreviewModulesIntegrationTest`
+  // points a real Tooling-API connection at it via `useInstallation(...)` so it reuses the
+  // already-present distribution instead of downloading one (the test `assumeTrue`s out when this
+  // is absent — e.g. a bare IDE run). Read at configuration time so the configuration cache
+  // captures it.
+  systemProperty("composeai.test.gradleHome", gradle.gradleHomeDir?.absolutePath ?: "")
+}
+
 composeAiMavenPublishing {
   coordinates(
     artifactId = "gradle-preview-driver",

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesAction.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesAction.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.plugin.tooling.ComposePreviewModel
+import java.io.Serializable
+import org.gradle.tooling.BuildAction
+import org.gradle.tooling.BuildController
+import org.gradle.tooling.model.gradle.GradleBuild
+
+/**
+ * Discovers every subproject that applies `ee.schimke.composeai.preview`, *without* realizing the
+ * build's task graph.
+ *
+ * Why this exists (issue #1620): the previous discovery path fetched the Tooling-API
+ * `GradleProject` model and read `project.tasks` to spot the `composePreviewDiscover` task.
+ * Building `GradleProject` eagerly realizes **every task provider in every project** — so any
+ * configuration-time side effect in an unrelated module (a `nativeCompile` task pinning a Java
+ * toolchain, say) fired during preview discovery, forcing an expensive/failing toolchain provision
+ * just to *list* previews.
+ *
+ * This action instead walks the lightweight [GradleBuild] model — whose `BasicGradleProject`s carry
+ * only `path` + `projectDirectory`, no tasks — and asks each project for the [ComposePreviewModel].
+ * That model's builder detects the plugin with a single targeted
+ * `tasks.findByName("composePreviewDiscover")`, which realizes only that one named task (returning
+ * `null` for projects that don't have it) rather than the whole graph. Unrelated modules' eager
+ * tasks are never realized.
+ *
+ * Runs inside the Gradle daemon (serialised by the Tooling API). Mirrors the per-project
+ * `findModel` walk in [GatherComposePreviewModelAction]; aggregating here is cross-project-safe
+ * under Isolated Projects, where a single root-scoped builder couldn't poke at subprojects.
+ *
+ * Per-project failure isolation: each `findModel` is wrapped so a configuration failure in a module
+ * that contributes no previews is skipped, not propagated — discovery still returns the modules
+ * that did resolve.
+ */
+class DiscoverPreviewModulesAction : BuildAction<ArrayList<PreviewModule>>, Serializable {
+  override fun execute(controller: BuildController): ArrayList<PreviewModule> {
+    val build = controller.getModel(GradleBuild::class.java)
+    val modules = ArrayList<PreviewModule>()
+    for (project in build.projects) {
+      val model =
+        try {
+          controller.findModel(project, ComposePreviewModel::class.java)
+        } catch (_: Throwable) {
+          // A configuration failure in an unrelated module (or a Gradle version whose model
+          // proxy can't be built) shouldn't sink the whole discovery — drop this project and
+          // keep going. See issue #1620's "isolate failures per module" point.
+          null
+        } ?: continue
+      // The model builder keys `modules` by the project path only when the plugin is applied to
+      // *that* project, so presence of this project's path is the plugin-applied signal.
+      if (model.modules.containsKey(project.path)) {
+        val path = project.path.removePrefix(":")
+        if (path.isNotEmpty()) {
+          modules.add(PreviewModule(gradlePath = path, projectDir = project.projectDirectory))
+        }
+      }
+    }
+    return modules
+  }
+}

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -26,7 +26,7 @@ import org.gradle.tooling.events.test.TestOperationDescriptor
  * Tooling API. Using it instead of `projectRoot/$gradlePath` is what makes nested subprojects
  * (`:foo:bar`) and any custom `project.projectDir` override work correctly — see issue #157.
  */
-data class PreviewModule(val gradlePath: String, val projectDir: File)
+data class PreviewModule(val gradlePath: String, val projectDir: File) : java.io.Serializable
 
 data class GradleAccessFailure(
   val operation: String,
@@ -366,44 +366,30 @@ class GradleConnection(
   }
 
   /**
-   * Find all subprojects that have a `composePreviewDiscover` task — these have the
-   * compose-ai-tools plugin applied.
+   * Find all subprojects that apply the compose-ai-tools plugin (detected by the presence of a
+   * `composePreviewDiscover` task).
    *
    * Each entry carries both the Gradle path (used to build task specs like
    * `:foo:bar:composePreviewRenderAll`) and the resolved filesystem `projectDir`. Nested
    * subprojects (`:foo:bar`) have directory layouts like `foo/bar/`, so substituting `:` for `/`
    * doesn't always work — and even for standard layouts a user can point `project.projectDir`
-   * anywhere. Reading it from the Tooling API's [GradleProject.projectDirectory] is the only
+   * anywhere. Reading it from the Tooling API's `BasicGradleProject.projectDirectory` is the only
    * reliable way to resolve manifests / PNGs on disk without replicating Gradle's own
    * project-layout logic.
+   *
+   * Implemented via [DiscoverPreviewModulesAction] rather than the `GradleProject` model: fetching
+   * `GradleProject` realizes every task in every module, which runs unrelated modules'
+   * configuration-time side effects (e.g. a `nativeCompile` task provisioning a Java toolchain)
+   * during mere discovery (issue #1620). The build action queries the lightweight `GradleBuild` +
+   * per-project `ComposePreviewModel` instead, which never realizes the full task graph.
+   *
+   * On a tooling-API failure the action returns `null`; we fold that into an empty list and leave
+   * [lastModelAccessFailure] populated so callers can tell "no preview modules" from "couldn't talk
+   * to Gradle." A generous timeout matches the old un-timed model query — discovery configures each
+   * project, which can be slow on a cold daemon.
    */
-  fun findPreviewModules(): List<PreviewModule> {
-    return try {
-      val model =
-        connection
-          .model(org.gradle.tooling.model.GradleProject::class.java)
-          .apply { if (extraArguments.isNotEmpty()) withArguments(extraArguments) }
-          .get()
-      modelAccessFailure = null
-      val modules = mutableListOf<PreviewModule>()
-      fun visit(project: org.gradle.tooling.model.GradleProject) {
-        val hasPreviewTask = project.tasks.any { it.name == "composePreviewDiscover" }
-        if (hasPreviewTask) {
-          val path = project.path.removePrefix(":")
-          if (path.isNotEmpty()) {
-            modules.add(PreviewModule(gradlePath = path, projectDir = project.projectDirectory))
-          }
-        }
-        for (child in project.children) visit(child)
-      }
-      visit(model)
-      modules
-    } catch (e: Exception) {
-      recordModelAccessFailure("GradleProject", e)
-      if (verbose) System.err.println("Could not query project model: ${e.message}")
-      emptyList()
-    }
-  }
+  fun findPreviewModules(): List<PreviewModule> =
+    runBuildAction(DiscoverPreviewModulesAction(), timeoutSeconds = 300) ?: emptyList()
 
   /**
    * Resolve a single module by its Gradle path (colon-separated, with or without the leading `:`).

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradlePreviewDriver.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/GradlePreviewDriver.kt
@@ -48,9 +48,12 @@ class GradlePreviewDriver(projectRoot: File, private val options: DriverOptions 
     get() = connection.lastModelAccessFailure
 
   /**
-   * Find every subproject that applies the `ee.schimke.composeai.preview` plugin. Detection is by
-   * task-name presence (`composePreviewDiscover`) so it works against any consumer plugin version
-   * that ships the discovery task.
+   * Find every subproject that applies the `ee.schimke.composeai.preview` plugin. Detection is via
+   * the plugin's `ComposePreviewModel` Tooling-API model (see [DiscoverPreviewModulesAction])
+   * rather than a task-graph scan, so it avoids realizing unrelated modules' tasks during discovery
+   * (issue #1620). This requires the plugin to register that model — present since 0.11.13. The
+   * CLI's default auto-inject path always supplies a current plugin, so this only matters for
+   * projects that manually pin an older plugin version *and* disable auto-inject.
    */
   fun discoverModules(): List<PreviewModule> = connection.findPreviewModules()
 

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
@@ -1,11 +1,16 @@
 package ee.schimke.composeai.plugin.tooling
 
 /**
- * CLI-side copy of the plugin's Tooling API model. MUST stay at the same fully-qualified name and
- * method signatures as the plugin-side interface — Gradle's Tooling API uses reflective proxies to
- * bridge the two across the daemon boundary, so drift silently produces `null` returns. See the
+ * Driver-side copy of the plugin's Tooling API model. MUST stay at the same fully-qualified name
+ * and method signatures as the plugin-side interface — Gradle's Tooling API uses reflective proxies
+ * to bridge the two across the daemon boundary, so drift silently produces `null` returns. See the
  * plugin-side source for the canonical docstrings:
  * `gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt`.
+ *
+ * Lives in `:gradle-preview-driver` (not `:cli`) so the driver's
+ * [ee.schimke.composeai.cli .DiscoverPreviewModulesAction] can reference it directly; `:cli` keeps
+ * seeing it through its transitive `api` dependency on this module, so existing
+ * `ee.schimke.composeai.plugin.tooling` imports in `:cli` resolve unchanged.
  */
 interface ComposePreviewModel {
   val pluginVersion: String

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesActionTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesActionTest.kt
@@ -1,0 +1,171 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.plugin.tooling.ComposePreviewModel
+import ee.schimke.composeai.plugin.tooling.ModuleInfo
+import java.io.File
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.tooling.BuildController
+import org.gradle.tooling.model.GradleProject
+import org.gradle.tooling.model.gradle.BasicGradleProject
+import org.gradle.tooling.model.gradle.GradleBuild
+
+/**
+ * Verifies [DiscoverPreviewModulesAction] discovers plugin modules through the lightweight
+ * `GradleBuild` + per-project `ComposePreviewModel` path, isolates per-module failures, and — the
+ * crux of issue #1620 — never requests the heavyweight `GradleProject` model (which would realize
+ * the whole task graph and trigger unrelated modules' configuration-time side effects).
+ */
+class DiscoverPreviewModulesActionTest {
+
+  /** A `BasicGradleProject` answering only the two getters the action reads. */
+  private fun project(path: String, dir: File): BasicGradleProject =
+    Proxy.newProxyInstance(javaClass.classLoader, arrayOf(BasicGradleProject::class.java)) {
+      _,
+      method,
+      _ ->
+      when (method.name) {
+        "getPath" -> path
+        "getProjectDirectory" -> dir
+        "toString" -> "BasicGradleProject($path)"
+        "hashCode" -> path.hashCode()
+        else -> error("unexpected BasicGradleProject.${method.name}")
+      }
+    } as BasicGradleProject
+
+  /** A `GradleBuild` whose `projects` iterates [projects]. */
+  private fun build(projects: List<BasicGradleProject>): GradleBuild =
+    Proxy.newProxyInstance(javaClass.classLoader, arrayOf(GradleBuild::class.java)) { _, method, _
+      ->
+      when (method.name) {
+        "getProjects" ->
+          Proxy.newProxyInstance(
+            javaClass.classLoader,
+            arrayOf(org.gradle.tooling.model.DomainObjectSet::class.java),
+          ) { _, m, _ ->
+            when (m.name) {
+              "iterator" -> projects.iterator()
+              "size" -> projects.size
+              "isEmpty" -> projects.isEmpty()
+              else -> error("unexpected DomainObjectSet.${m.name}")
+            }
+          }
+        else -> error("unexpected GradleBuild.${method.name}")
+      }
+    } as GradleBuild
+
+  /** Build a [ComposePreviewModel] whose `modules` is keyed by [appliedPath] (plugin-applied). */
+  private fun model(appliedPath: String?): ComposePreviewModel =
+    object : ComposePreviewModel {
+      override val pluginVersion = "test"
+      override val modules: Map<String, ModuleInfo> =
+        if (appliedPath == null) emptyMap() else mapOf(appliedPath to dummyModuleInfo())
+    }
+
+  private fun dummyModuleInfo(): ModuleInfo =
+    object : ModuleInfo {
+      override val variant = "debug"
+      override val mainRuntimeDependencies = emptyMap<String, String>()
+      override val testRuntimeDependencies = emptyMap<String, String>()
+      override val findings = emptyList<ee.schimke.composeai.plugin.tooling.ModuleFinding>()
+      override val agpVersion: String? = null
+      override val kotlinVersion: String? = null
+      override val renderPreviewsTask: ee.schimke.composeai.plugin.tooling.RenderPreviewsTaskInfo? =
+        null
+    }
+
+  /**
+   * Reflective [BuildController] that serves [GradleBuild] from [buildModel] and per-project
+   * [ComposePreviewModel] via [findModelFor]. Fails loudly if anyone asks for [GradleProject] — the
+   * regression guard for #1620.
+   */
+  private fun controller(
+    buildModel: GradleBuild,
+    findModelFor: (BasicGradleProject) -> ComposePreviewModel?,
+  ): BuildController {
+    val handler = InvocationHandler { _: Any, method: Method, args: Array<Any?>? ->
+      when (method.name) {
+        "getModel" -> {
+          val type = args?.lastOrNull()
+          assertFalse(
+            type == GradleProject::class.java,
+            "must not query GradleProject — that realizes the whole task graph (#1620)",
+          )
+          if (type == GradleBuild::class.java) buildModel else error("unexpected getModel($type)")
+        }
+        "findModel" -> {
+          val type = args?.getOrNull(1)
+          assertFalse(
+            type == GradleProject::class.java,
+            "must not query GradleProject — that realizes the whole task graph (#1620)",
+          )
+          if (type == ComposePreviewModel::class.java) {
+            findModelFor(args!![0] as BasicGradleProject)
+          } else error("unexpected findModel($type)")
+        }
+        "toString" -> "FakeBuildController"
+        "hashCode" -> 0
+        else -> error("unexpected BuildController.${method.name}")
+      }
+    }
+    return Proxy.newProxyInstance(
+      javaClass.classLoader,
+      arrayOf(BuildController::class.java),
+      handler,
+    ) as BuildController
+  }
+
+  @Test
+  fun `discovers only plugin-applied modules and resolves their project dirs`() {
+    val root = project(":", File("/tmp/root"))
+    val ui = project(":ui", File("/tmp/root/ui"))
+    val cli = project(":cli", File("/tmp/root/cli"))
+    val controller =
+      controller(build(listOf(root, ui, cli))) { p ->
+        // Only :ui applies the plugin; :cli is the unrelated native-image module.
+        when (p.path) {
+          ":ui" -> model(":ui")
+          else -> model(null)
+        }
+      }
+
+    val modules = DiscoverPreviewModulesAction().execute(controller)
+
+    assertEquals(listOf("ui"), modules.map { it.gradlePath })
+    assertEquals(File("/tmp/root/ui"), modules.single().projectDir)
+  }
+
+  @Test
+  fun `a module whose findModel throws is skipped, not fatal`() {
+    val ui = project(":ui", File("/tmp/root/ui"))
+    val poison = project(":native-cli", File("/tmp/root/native-cli"))
+    val controller =
+      controller(build(listOf(ui, poison))) { p ->
+        when (p.path) {
+          ":ui" -> model(":ui")
+          // Simulates an unrelated module that blows up during configuration (e.g. failed
+          // toolchain provisioning). It must not sink discovery of :ui.
+          else -> throw RuntimeException("toolchain download blocked")
+        }
+      }
+
+    val modules = DiscoverPreviewModulesAction().execute(controller)
+
+    assertEquals(listOf("ui"), modules.map { it.gradlePath })
+  }
+
+  @Test
+  fun `the root project is never emitted even if it reports applied`() {
+    val root = project(":", File("/tmp/root"))
+    val controller = controller(build(listOf(root))) { model(":") }
+
+    val modules = DiscoverPreviewModulesAction().execute(controller)
+
+    assertTrue(modules.isEmpty())
+  }
+}

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesIntegrationTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesIntegrationTest.kt
@@ -1,0 +1,100 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.gradle.tooling.BuildException
+import org.gradle.tooling.GradleConnector
+import org.gradle.tooling.model.GradleProject
+import org.junit.Assume.assumeTrue
+
+/**
+ * End-to-end regression for issue #1620 against a real Gradle build: preview discovery must not
+ * realize the whole task graph.
+ *
+ * The synthetic build's `:native` module registers a task whose **configuration action** throws —
+ * standing in for a real `org.graalvm.buildtools.native` `nativeCompile` task that provisions a
+ * Java toolchain (expensive, network-dependent, frequently failing) when it's realized.
+ *
+ * Both queries run against the same Tooling-API connection:
+ * 1. [DiscoverPreviewModulesAction] — the new discovery path. Walks `GradleBuild` + per-project
+ *    `ComposePreviewModel` and never realizes `:native`'s task, so it completes. (No plugin is
+ *    applied, so the result is empty — the point is that it does *not* throw.)
+ * 2. The `GradleProject` model — the old discovery path. Building it realizes every task in every
+ *    project, runs `:native`'s poison configuration, and fails the whole query. Asserting this
+ *    keeps the repro honest: it's the exact failure #1620 removes.
+ */
+class DiscoverPreviewModulesIntegrationTest {
+
+  private val gradleHome: String = System.getProperty("composeai.test.gradleHome", "")
+  private val workspace: File =
+    File.createTempFile("task-graph-repro", "").let {
+      it.delete()
+      it.mkdirs()
+      it
+    }
+
+  @AfterTest
+  fun cleanup() {
+    workspace.deleteRecursively()
+  }
+
+  private fun seedBuild() {
+    File(workspace, "settings.gradle.kts")
+      .writeText(
+        """
+        rootProject.name = "task-graph-repro"
+        include(":ui")
+        include(":native")
+        """
+          .trimIndent()
+      )
+    File(workspace, "build.gradle.kts").writeText("")
+
+    File(workspace, "ui").mkdirs()
+    File(workspace, "ui/build.gradle.kts").writeText("")
+
+    File(workspace, "native").mkdirs()
+    // The lambda is the task's configuration action, which Gradle runs only when the task is
+    // *realized*. Lazy registration means merely configuring the project (what a model query does)
+    // is fine — realizing the task is what trips it. That's exactly the distinction under test.
+    File(workspace, "native/build.gradle.kts")
+      .writeText(
+        """
+        tasks.register("nativeCompile") {
+            throw GradleException("config-time toolchain provisioning blocked")
+        }
+        """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `discovery completes while GradleProject blows up on the poison module`() {
+    assumeTrue(
+      "Gradle installation dir not surfaced via composeai.test.gradleHome — skipping",
+      gradleHome.isNotEmpty() && File(gradleHome).isDirectory,
+    )
+    seedBuild()
+
+    GradleConnector.newConnector()
+      .useInstallation(File(gradleHome))
+      .forProjectDirectory(workspace)
+      .connect()
+      .use { connection ->
+        // The fix: completes without realizing :native's poison task.
+        val discovered = connection.action(DiscoverPreviewModulesAction()).run()
+        assertEquals(emptyList(), discovered.map { it.gradlePath })
+
+        // Control: the old `GradleProject` discovery path realizes the task graph and dies.
+        val failure =
+          runCatching { connection.model(GradleProject::class.java).get() }.exceptionOrNull()
+        assertTrue(
+          failure is BuildException,
+          "expected GradleProject query to fail by realizing :native's task, got $failure",
+        )
+      }
+  }
+}


### PR DESCRIPTION
## Summary

`compose-preview` preview discovery fetched the Tooling-API `GradleProject` model and read `project.tasks` to detect the `composePreviewDiscover` task. Building `GradleProject` **eagerly realizes every task provider in every module**, so configuration-time side effects in unrelated modules fire during mere discovery. Concretely, a module applying `org.graalvm.buildtools.native` with a `nativeCompile` task that pins a Java toolchain gets that toolchain provisioned every time you list previews:

- **Offline / restricted networks** (CI sandboxes, cloud agent environments): provisioning fails, the model query dies, and `show --json` emits nothing → the downstream `_previews.json is empty` symptom (upstream cause of #292).
- **Online**: a large, pointless JDK/GraalVM download just to *list* previews.

## What changed

- New `DiscoverPreviewModulesAction` (`:gradle-preview-driver`) walks the lightweight `GradleBuild` model — whose `BasicGradleProject`s carry only `path` + `projectDirectory`, no tasks — and asks each project for the existing `ComposePreviewModel`. The model builder detects the plugin via a single targeted `findByName("composePreviewDiscover")`, which realizes only that one named task rather than the whole graph. Unrelated modules' eager tasks are never realized.
- Per-project `findModel` calls are isolated, so a configuration failure in a module that contributes **no** previews is skipped, not fatal — discovery returns the modules that did resolve (issue's "isolate failures per module" point).
- `findPreviewModules()` now runs the build action instead of the `GradleProject` query.
- `ComposePreviewModel` moves from `:cli` into `:gradle-preview-driver` so the driver's build action can reference it directly; `:cli` keeps seeing it through its transitive `api` dependency, so existing `ee.schimke.composeai.plugin.tooling` imports resolve unchanged.

No plugin-side change required — this reuses the model the plugin already registers (and that `doctor` already consumes), so it works against already-published plugin versions.

## Test plan

- [x] `DiscoverPreviewModulesActionTest` (unit) — fake `BuildController`; asserts only plugin-applied modules are returned, the root project is never emitted, a throwing `findModel` is skipped not fatal, and the `GradleProject` model is **never** queried.
- [x] `DiscoverPreviewModulesIntegrationTest` (real Tooling-API connection) — synthetic build whose `:native` module registers a task that **throws during configuration**. Asserts `DiscoverPreviewModulesAction` completes while the old `GradleProject` query fails on that poison task. Ran (not skipped): passes.
- [x] `:gradle-preview-driver:test`, `:cli:compileTestKotlin`, ktfmt checks on touched modules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLJ2gZ1XnWaA75KqYApkW2)_