### PR TITLE
feat(plugin): make ValidatePreviewToolingPresent opt-in

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -603,10 +603,17 @@ internal object AndroidPreviewSupport {
     // with a remediation-oriented error instead of hitting Robolectric with a missing-class
     // explosion. When the direct check already passed we know the coord is on the classpath and
     // skip registering the validator entirely — saves a resolution at execution time.
+    //
+    // Opt-in by default: gated on `composePreview.failOnMissingPreviewTooling`. The hard fail is
+    // useful for CI fast-fail but actively hurts multi-module apps that have an aggregator module
+    // (e.g. a `:demo-app` that pulls together cards from sibling modules without hosting any
+    // `@Preview` itself). Those modules pass the tier-2 over-approximation but legitimately don't
+    // host previews — letting `composePreviewDiscover` find zero and silently no-op is the right
+    // outcome for them.
     val validatePreviewToolingPresentTask =
       if (
         !previewToolingDeclaredAtRegistration &&
-          extension.enforcePreviewToolingDependency.get() &&
+          extension.failOnMissingPreviewTooling.get() &&
           mainRuntimeRoot != null
       ) {
         project.tasks.register(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -613,6 +613,7 @@ internal object AndroidPreviewSupport {
     val validatePreviewToolingPresentTask =
       if (
         !previewToolingDeclaredAtRegistration &&
+          extension.enforcePreviewToolingDependency.get() &&
           extension.failOnMissingPreviewTooling.get() &&
           mainRuntimeRoot != null
       ) {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
@@ -42,6 +42,18 @@ constructor(
         .orElse(true)
     )
 
+    // `-PcomposePreview.failOnMissingPreviewTooling=true` opts a single CLI run into the
+    // task-time validator that hard-fails `composePreviewRender` when the resolved runtime
+    // classpath has no preview-tooling coord. Default `false` — aggregator modules that pass
+    // the tier-2 over-approximation but legitimately host no `@Preview` shouldn't fail the
+    // build; let `composePreviewDiscover` find zero and no-op instead.
+    extension.failOnMissingPreviewTooling.convention(
+      project.providers
+        .gradleProperty("composePreview.failOnMissingPreviewTooling")
+        .map { it.toBooleanStrictOrNull() ?: false }
+        .orElse(false)
+    )
+
     // ToolingModelBuilderRegistry is a build-scoped service — registering
     // from any applying project makes the model available on every
     // Tooling-API connection for the build. `register` accepts multiple

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -112,6 +112,26 @@ abstract class PreviewExtension @Inject constructor(private val objects: ObjectF
     objects.property(Boolean::class.java).convention(true)
 
   /**
+   * When `true`, `composePreviewRender` depends on [ValidatePreviewToolingPresentTask], which walks
+   * the resolved `${variant}RuntimeClasspath` and fails the build (with a remediation message) if
+   * no known `@Preview` tooling coord is reachable. Only meaningful on modules that passed the
+   * config-time gate via the tier-2 over-approximation (Compose plugin + `project(":...")` deps but
+   * no directly-declared tooling coord) — when the consumer declared a tooling coord directly, the
+   * validator isn't registered regardless.
+   *
+   * Default: `false` — render proceeds and surfaces whatever the actual failure mode is (often
+   * "discovery found zero previews", since the discovery task walks the classpath for
+   * annotation-bearing classes). Flip to `true` for fast-fail in CI when a missing-tooling
+   * regression on a multi-module app should stop the build at the gate with a coordinate to add,
+   * rather than at render time with a less-direct error.
+   *
+   * Override at the command line with `-PcomposePreview.failOnMissingPreviewTooling=true` for a
+   * single CLI invocation without editing `build.gradle.kts`.
+   */
+  val failOnMissingPreviewTooling: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(false)
+
+  /**
    * When `true`, the plugin wires the AGP `testDebugUnitTest` / `testReleaseUnitTest` tasks to
    * depend on `composePreviewRenderAll`, so a consumer's pixel-test class (e.g. one that reads the
    * PNGs under `build/compose-previews/renders/`) sees a fully-rendered output directory by the

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ValidatePreviewToolingPresentTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ValidatePreviewToolingPresentTask.kt
@@ -12,11 +12,17 @@ import org.gradle.work.DisableCachingByDefault
 
 /**
  * Fails the render path when a module's runtime classpath doesn't transitively reach any of the
- * supported `@Preview` tooling coords. Used as a fast-fail gate registered as a `dependsOn` of
- * `composePreviewRender` for AGP modules where the **direct** declared-deps scan didn't find
- * preview tooling but the module still applies the plugin (typically because a sibling
- * `project(":...")` dep is expected to contribute it — the CMP-Android `:composeApp -> :shared`
- * shape from issue #241 / #1549).
+ * supported `@Preview` tooling coords. Registered as a `dependsOn` of `composePreviewRender` only
+ * when the consumer opts in via `composePreview.failOnMissingPreviewTooling = true` AND the
+ * **direct** declared-deps scan didn't find preview tooling on this module (typically because a
+ * sibling `project(":...")` dep is expected to contribute it — the CMP-Android `:composeApp ->
+ * :shared` shape from issue #241 / #1549).
+ *
+ * **Opt-in by default.** Aggregator modules that pass the tier-2 over-approximation (Compose
+ * plugin + project deps) without actually hosting `@Preview` functions don't need the hard fail;
+ * `composePreviewDiscover` finding zero previews on them is the correct outcome. CI pipelines that
+ * want fast-fail when a missing-tooling regression slips in on a multi-module app turn this on
+ * explicitly via the DSL or `-PcomposePreview.failOnMissingPreviewTooling=true`.
  *
  * **Why a task-time check.** Resolving `${variant}RuntimeClasspath` at *configuration time* trips
  * the "Configuration was resolved during configuration time" CC warning (and the older
@@ -27,11 +33,13 @@ import org.gradle.work.DisableCachingByDefault
  * task runs, and the configuration-cache-stored task graph references the Provider, not the
  * resolved snapshot itself.
  *
- * On no-tooling, throws with a remediation message pointing at the two ways out:
+ * On no-tooling, throws with a remediation message pointing at the ways out:
  * 1. declare a preview-tooling coord directly on this module's `*Implementation` / `*Api` /
- *    `*RuntimeOnly` buckets, or
- * 2. set `composePreview.enforcePreviewToolingDependency = false` (the manual escape hatch) and
- *    rely on the sibling's transitive contribution at runtime.
+ *    `*RuntimeOnly` buckets,
+ * 2. drop `composePreview.failOnMissingPreviewTooling` (or set it back to `false`) to let the
+ *    render task proceed and surface whatever the actual failure mode is, or
+ * 3. set `composePreview.enforcePreviewToolingDependency = false` to bypass the per-module tooling
+ *    gate entirely (the issue #241 / #1549 escape hatch).
  */
 @DisableCachingByDefault(
   because =
@@ -79,11 +87,15 @@ abstract class ValidatePreviewToolingPresentTask : DefaultTask() {
           "      // implementation(\"org.jetbrains.compose.components:components-ui-tooling-preview\")"
         )
         appendLine(
-          "  - or setting `composePreview { enforcePreviewToolingDependency = false }` to bypass"
+          "  - dropping `composePreview { failOnMissingPreviewTooling = true }` so render no"
         )
         appendLine(
-          "    this check (issue #241 / #1549 escape hatch — leans on a sibling module's tooling)."
+          "    longer hard-fails when this module's classpath lacks tooling (the default)."
         )
+        appendLine(
+          "  - or setting `composePreview { enforcePreviewToolingDependency = false }` to bypass"
+        )
+        appendLine("    the per-module gate entirely (issue #241 / #1549 escape hatch).")
       }
     )
   }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/FailOnMissingPreviewToolingTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/FailOnMissingPreviewToolingTest.kt
@@ -1,0 +1,41 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the contract of `composePreview.failOnMissingPreviewTooling` — the opt-in for the task-time
+ * validator that hard-fails `composePreviewRender` when the resolved runtime classpath has no
+ * preview-tooling coord. Default is `false` so aggregator modules (the `:demo-app` shape from
+ * yschimke/homeassistant-remotecompose) pass through; a CLI override via
+ * `-PcomposePreview.failOnMissingPreviewTooling=true` flips a single run; an explicit
+ * `composePreview { failOnMissingPreviewTooling = … }` in the build script still wins via
+ * `Property.set`.
+ */
+class FailOnMissingPreviewToolingTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  @Test
+  fun `default convention is false`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    project.plugins.apply(ComposePreviewPlugin::class.java)
+
+    val extension = project.extensions.getByType(PreviewExtension::class.java)
+    assertThat(extension.failOnMissingPreviewTooling.get()).isFalse()
+  }
+
+  @Test
+  fun `consumer DSL set wins over default`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    project.plugins.apply(ComposePreviewPlugin::class.java)
+
+    val extension = project.extensions.getByType(PreviewExtension::class.java)
+    extension.failOnMissingPreviewTooling.set(true)
+
+    assertThat(extension.failOnMissingPreviewTooling.get()).isTrue()
+  }
+}


### PR DESCRIPTION
## Summary

- Make `ValidatePreviewToolingPresentTask` opt-in via a new `composePreview.failOnMissingPreviewTooling` flag (default `false`).
- Aggregator modules that pass the tier-2 over-approximation (Compose plugin + `project(":...")` deps but no directly-declared tooling coord) and legitimately host no `@Preview` functions of their own no longer fail the build — `composePreviewDiscover` finding zero is the correct outcome for them. This unblocks the `:demo-app` shape in `yschimke/homeassistant-remotecompose`.
- Existing `enforcePreviewToolingDependency` flag is unchanged — flipping its default would also bypass the Compose-dep-injection gate on utility modules in auto-inject setups, which its KDoc explicitly warns against.
- Validator's remediation message and KDoc updated to reference both the new flag and the existing escape hatch.
- Override via `-PcomposePreview.failOnMissingPreviewTooling=true` for a single CLI run.

## Test plan

- [x] `:gradle-plugin:test --tests FailOnMissingPreviewToolingTest` (new) — pins default `false` + `Property.set` override.
- [x] `:gradle-plugin:test --tests EnforcePreviewToolingDependencyTest` — existing flag's default `true` and override still hold.
- [x] `:gradle-plugin:test --tests ValidatePreviewToolingPresentTaskTest` — resolved-graph walk untouched.
- [x] `:gradle-plugin:test --tests HasPreviewDependencyTest` — config-time gate's tier semantics untouched.
- [x] `:gradle-plugin:test --tests tooling.CompatRulesTest` — doctor's per-finding rules untouched.
- [x] `:gradle-plugin:ktfmtCheck`
- [ ] Re-run the failing pipeline on `yschimke/homeassistant-remotecompose#331` against this branch's plugin build to confirm `:demo-app` passes without changes on the consumer side.

---
_Generated by [Claude Code](https://claude.ai/code/session_017uiFasCREyxoPyxPMYRPGE)_