### PR TITLE
fix(daemon): pass classpath via @argfile to avoid spawn E2BIG

### DIFF
--- a/vscode-extension/src/daemon/daemonProcess.ts
+++ b/vscode-extension/src/daemon/daemonProcess.ts
@@ -1,5 +1,6 @@
 import { ChildProcess, spawn } from "child_process";
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 import {
     DaemonClient,
@@ -183,11 +184,18 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
     const sysProps = Object.entries(descriptor.systemProperties).map(
         ([k, v]) => `-D${k}=${v}`,
     );
+    // A large module classpath joined into a single `-cp` argument overflows
+    // the OS argument limits — Linux caps a single argv entry at
+    // MAX_ARG_STRLEN (128 KB) — so `spawn` fails with E2BIG before the JVM
+    // even starts. Hand the classpath to `java` through an `@argfile` instead:
+    // the launcher reads it from disk, so the argv stays tiny regardless of
+    // how many jars the consumer's classpath carries. Supported since Java 9,
+    // which the daemon already requires.
+    const argfilePath = writeClasspathArgfile(descriptor.classpath);
     const args = [
         ...descriptor.jvmArgs,
         ...sysProps,
-        "-cp",
-        descriptor.classpath.join(path.delimiter),
+        `@${argfilePath}`,
         descriptor.mainClass,
     ];
 
@@ -272,6 +280,20 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
             logger?.appendLine(`[daemon] process exited with code=${code}`);
             resolve(code);
         });
+    });
+    // `java` reads the @argfile during launch, so it's safe to remove once the
+    // process exits — whether that's a clean shutdown, a crash, or the SIGTERM
+    // from a failed initialize handshake below. Best-effort: a leaked temp file
+    // is harmless and the OS reclaims it eventually.
+    void exited.then(() => {
+        try {
+            fs.rmSync(path.dirname(argfilePath), {
+                recursive: true,
+                force: true,
+            });
+        } catch {
+            /* best-effort cleanup */
+        }
     });
 
     const client = new DaemonClient(child.stdin, child.stdout, events, logger);
@@ -358,6 +380,33 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
     }
 
     return { client, process: child, initializeResult, exited };
+}
+
+/**
+ * Builds the contents of a Java `@argfile` carrying the daemon classpath.
+ * Exported for unit coverage; callers go through [spawnDaemon].
+ *
+ * The joined classpath is wrapped in double quotes so entries containing
+ * spaces (e.g. `C:\Program Files\...`) survive the JDK argfile tokenizer, and
+ * backslashes are rewritten to forward slashes: the tokenizer treats `\` as an
+ * escape character, so a raw Windows path would be silently mangled, while
+ * `java` accepts `/` separators in classpath entries on every platform.
+ */
+export function formatClasspathArgfileContent(classpath: string[]): string {
+    const joined = classpath.join(path.delimiter).replace(/\\/g, "/");
+    return `-cp "${joined}"\n`;
+}
+
+/**
+ * Writes the classpath `@argfile` to a private temp directory and returns its
+ * path. The directory (not just the file) is removed once the daemon exits;
+ * see the cleanup hook in [spawnDaemon].
+ */
+function writeClasspathArgfile(classpath: string[]): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "compose-preview-cp-"));
+    const file = path.join(dir, "daemon-classpath.argfile");
+    fs.writeFileSync(file, formatClasspathArgfileContent(classpath), "utf-8");
+    return file;
 }
 
 /**

--- a/vscode-extension/src/test/daemonProcess.test.ts
+++ b/vscode-extension/src/test/daemonProcess.test.ts
@@ -4,6 +4,7 @@ import * as os from "os";
 import * as path from "path";
 import {
     ChunkLineSplitter,
+    formatClasspathArgfileContent,
     formatDaemonSpawnFailure,
     readLaunchDescriptor,
     spawnDaemon,
@@ -373,5 +374,44 @@ describe("formatDaemonSpawnFailure (issue #1326)", () => {
         assert.strictEqual(split[1], "[daemon stderr tail for :samples:wear]");
         assert.strictEqual(split[2], "line-150");
         assert.strictEqual(split[51], "line-199");
+    });
+});
+
+describe("formatClasspathArgfileContent", () => {
+    it("emits a single -cp option with the entries quoted", () => {
+        const content = formatClasspathArgfileContent([
+            "/a/one.jar",
+            "/a/two.jar",
+        ]);
+        assert.strictEqual(
+            content,
+            `-cp "/a/one.jar${path.delimiter}/a/two.jar"\n`,
+        );
+    });
+
+    it("keeps the whole classpath in one argv token regardless of size", () => {
+        // The E2BIG regression: a huge classpath used to become one giant
+        // `-cp` argv entry. Routed through the argfile it never reaches argv,
+        // so the only argv token the caller adds is the small `@file` ref.
+        const entries = Array.from(
+            { length: 5000 },
+            (_, i) => `/very/long/gradle/cache/path/to/dependency-${i}.jar`,
+        );
+        const content = formatClasspathArgfileContent(entries);
+        assert.ok(content.length > 128 * 1024, "fixture should exceed 128 KB");
+        // Exactly one option (`-cp`) and one value token on a single line.
+        assert.strictEqual(content.split("\n").filter(Boolean).length, 1);
+        assert.ok(content.startsWith('-cp "'));
+        assert.ok(content.includes("dependency-4999.jar"));
+    });
+
+    it("rewrites Windows backslashes to forward slashes", () => {
+        const content = formatClasspathArgfileContent([
+            "C:\\Program Files\\app\\lib.jar",
+        ]);
+        // No backslashes survive (the JDK argfile tokenizer would eat them),
+        // and the space-bearing path stays inside the quotes.
+        assert.ok(!content.includes("\\"));
+        assert.strictEqual(content, '-cp "C:/Program Files/app/lib.jar"\n');
     });
 });


### PR DESCRIPTION
## Summary

The VS Code e2e tests (`test:e2e` and `test:e2e-external`) were failing during daemon warm-up with:

```
[daemon] spawn failed for :androidApp: spawn E2BIG
```

`spawnDaemon` joined the entire module classpath into a single `-cp` argv entry. On Linux a single argv string is capped at `MAX_ARG_STRLEN` (128 KB), so for a large Android/Compose classpath `child_process.spawn` rejects with `E2BIG` before the JVM ever starts — aborting the warm path and failing the e2e suite (the `:samples:cmp` interactive failures were downstream of the daemon never coming up).

## Fix

Hand the classpath to `java` through a temporary `@argfile` instead of an inline `-cp`. The launcher reads the file from disk, so argv stays tiny regardless of classpath size. `@argfile` support has been in the JDK since Java 9, which the daemon already requires.

- Classpath entries are joined and written as `-cp "<entries>"` into a per-spawn temp dir.
- Paths are wrapped in quotes and backslashes rewritten to `/` so the JDK argfile tokenizer doesn't choke on spaces or mangle Windows paths (the tokenizer treats `\` as an escape char; `java` accepts `/` separators on every platform).
- The temp dir is removed once the daemon process exits (clean shutdown, crash, or the SIGTERM from a failed `initialize`).

## Test plan

- New unit tests for `formatClasspathArgfileContent`: single quoted `-cp` option, a 5000-entry classpath that exceeds 128 KB staying in one token, and Windows backslash rewriting.
- `npm test` — 1455 passing.
- `npx eslint` clean on both changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wMRzBNZjSm9m1ac3vZBJi)_