### PR TITLE
feat(tui-cli): open a bundle PNG straight into a live image-only view

### DIFF
--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Args.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Args.kt
@@ -21,6 +21,13 @@ data class TuiArgs(
   val liveOnStart: Boolean = false,
   /** Project root override. Defaults to walking up from cwd looking for `gradlew`. */
   val projectRoot: File? = null,
+  /**
+   * A bundle PNG to open directly. When set, the TUI skips Gradle discovery and the browser UI
+   * entirely and renders just this preview's image — full-screen, no chrome — seeding the first
+   * frame from the PNG and (if it carries provenance) attaching the daemon for live re-renders.
+   * Captured from a lone existing `*.png` positional argument.
+   */
+  val bundlePng: File? = null,
   val verbose: Boolean = false,
   val timeoutSeconds: Long = 300,
   /**
@@ -43,6 +50,7 @@ data class TuiArgs(
       var projectRoot: File? = null
       var timeoutSeconds = 300L
       var noDiscovery = false
+      val positionals = mutableListOf<String>()
 
       val valuedFlags =
         setOf("--module", "--filter", "--id", "--timeout", "--project-root", "--with-extension")
@@ -79,10 +87,19 @@ data class TuiArgs(
           else ->
             if (name.startsWith("-")) {
               System.err.println("warning: ignoring unknown flag '$name'")
+            } else {
+              positionals += arg
             }
         }
         i += 1
       }
+
+      // A lone existing `*.png` positional opens straight into the image-only bundle view.
+      val bundlePng =
+        positionals
+          .firstOrNull()
+          ?.let(::File)
+          ?.takeIf { it.isFile && it.name.endsWith(".png", ignoreCase = true) }
 
       return TuiArgs(
         module = module,
@@ -91,6 +108,7 @@ data class TuiArgs(
         extensions = extensions,
         liveOnStart = live,
         projectRoot = projectRoot,
+        bundlePng = bundlePng,
         verbose = verbose,
         timeoutSeconds = timeoutSeconds,
         noDiscovery = noDiscovery,
@@ -102,7 +120,10 @@ data class TuiArgs(
         """
         compose-preview-tui — interactive Mosaic-based Compose Preview browser
 
-        Usage: compose-preview-tui [options]
+        Usage:
+          compose-preview-tui [options]          Browse a project's previews
+          compose-preview-tui <bundle.png>       Open a bundle PNG full-screen (image only,
+                                                 live if the PNG carries provenance)
 
         Options:
           --module <path>        Gradle path (e.g. :samples:android). Default: prompt

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/BundlePngMetadata.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/BundlePngMetadata.kt
@@ -1,0 +1,67 @@
+package ee.schimke.composeai.tui
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipInputStream
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Just enough of a `compose-preview` bundle's `bundle.json` for the image-only TUI to drive a live
+ * session: which Gradle module produced it and which preview is the cover. A bundle is a PNG+ZIP
+ * polyglot — a valid PNG up front (the cover render) with a standard zip appended. We read only the
+ * `bundle.json` entry and ignore everything else (`classes/app.jar`, `previews.json`, `report.json`).
+ *
+ * The polyglot-extraction routine is duplicated here rather than shared with `:cli`'s `BundleReader`
+ * or `:bundle-viewer`'s loader — both deliberately keep their own copy so neither module drags the
+ * other onto its classpath, and the routine is tiny and stable. See `cli/BundleCommand.kt`.
+ */
+@Serializable
+data class BundlePngMetadata(val modulePath: String = "", val coverPreviewId: String? = null) {
+  companion object {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Returns the parsed `bundle.json`, or null if [file] isn't a readable bundle polyglot. */
+    fun readOrNull(file: File): BundlePngMetadata? =
+      try {
+        val zipBytes = extractZipBytes(file) ?: return null
+        var result: BundlePngMetadata? = null
+        ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+          while (true) {
+            val entry = zin.nextEntry ?: break
+            if (entry.name == "bundle.json") {
+              result =
+                json.decodeFromString(serializer(), zin.readBytes().toString(Charsets.UTF_8))
+              break
+            }
+            zin.closeEntry()
+          }
+        }
+        result?.takeIf { it.modulePath.isNotEmpty() }
+      } catch (_: Throwable) {
+        null
+      }
+
+    /** The trailing zip of a PNG+ZIP polyglot, the whole file for a bare zip, or null otherwise. */
+    private fun extractZipBytes(file: File): ByteArray? {
+      val bytes = file.readBytes()
+      if (bytes.size < PNG_SIG.size) return null
+      if (bytes[0] == 0x50.toByte() && bytes[1] == 0x4B.toByte()) return bytes // bare zip "PK"
+      for (i in PNG_SIG.indices) if (bytes[i] != PNG_SIG[i]) return null
+      var offset = PNG_SIG.size
+      while (offset + 8 <= bytes.size) {
+        val length =
+          ((bytes[offset].toInt() and 0xff) shl 24) or
+            ((bytes[offset + 1].toInt() and 0xff) shl 16) or
+            ((bytes[offset + 2].toInt() and 0xff) shl 8) or
+            (bytes[offset + 3].toInt() and 0xff)
+        val type = String(bytes, offset + 4, 4, Charsets.US_ASCII)
+        offset += 4 + 4 + length + 4
+        if (type == "IEND") return if (offset <= bytes.size) bytes.copyOfRange(offset, bytes.size) else null
+      }
+      return null
+    }
+
+    private val PNG_SIG = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
+  }
+}

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Main.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Main.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.cli.DriverOptions
 import ee.schimke.composeai.cli.GradlePreviewDriver
 import ee.schimke.composeai.cli.PreviewModule
 import ee.schimke.composeai.tui.ui.App
+import ee.schimke.composeai.tui.ui.runBundle
 import java.io.File
 import java.io.FileOutputStream
 import java.io.PrintStream
@@ -13,6 +14,19 @@ import kotlin.system.exitProcess
 
 fun main(argv: Array<String>) {
   val args = TuiArgs.parse(argv)
+
+  // Bundle-PNG mode: skip discovery and the browser entirely and open straight into the
+  // image-only live view. Live re-render needs the source project, so resolve a project root the
+  // same way normal mode does (override, else walk up for gradlew) — but unlike normal mode its
+  // absence isn't fatal: with no project we just show the bundle's baked-in image statically. The
+  // log lives under the project root (or next to the PNG) so daemon stderr can't corrupt the screen.
+  val bundlePng = args.bundlePng
+  if (bundlePng != null) {
+    val projectRoot = args.projectRoot?.absoluteFile ?: findProjectRoot()
+    redirectStderrToLogFile(projectRoot ?: bundlePng.absoluteFile.parentFile ?: File("."))
+    runBundle(bundlePng, projectRoot, args)
+    return
+  }
 
   val projectRoot =
     args.projectRoot?.absoluteFile

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/BundleView.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/BundleView.kt
@@ -1,0 +1,155 @@
+package ee.schimke.composeai.tui.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import com.jakewharton.mosaic.LocalTerminalState
+import com.jakewharton.mosaic.layout.onKeyEvent
+import com.jakewharton.mosaic.modifier.Modifier
+import com.jakewharton.mosaic.runMosaicMain
+import com.jakewharton.mosaic.ui.Bitmap
+import com.jakewharton.mosaic.ui.Column
+import com.jakewharton.mosaic.ui.Image
+import com.jakewharton.mosaic.ui.Text
+import com.jakewharton.mosaic.ui.TextStyle
+import ee.schimke.composeai.cli.PreviewModule
+import ee.schimke.composeai.tui.BundlePngMetadata
+import ee.schimke.composeai.tui.LiveSession
+import ee.schimke.composeai.tui.TuiArgs
+import ee.schimke.composeai.tui.image.Bitmaps
+import ee.schimke.composeai.tui.terminal.TerminalSize
+import java.io.File
+import kotlinx.coroutines.launch
+
+/**
+ * Bundle-PNG entry point. Renders ONE preview full-screen with no list / tab / status chrome — just
+ * the image. The PNG handed on the command line is decoded and shown immediately as the first frame
+ * (ImageIO reads the leading PNG of a PNG+ZIP polyglot bundle, ignoring the appended zip); then, if
+ * the bundle names a module and we're inside its project on disk, the daemon is attached and later
+ * renders replace the seed live as the source is edited. A plain PNG (or a bundle opened outside its
+ * project) is shown as a static image.
+ *
+ * `q` / `Esc` quits; `r` forces a re-render (no-op without a live session).
+ */
+fun runBundle(png: File, projectRoot: File?, args: TuiArgs) {
+  // Decode the bundle's own image up front so the very first composed frame already shows it — no
+  // "rendering…" flash before the daemon attaches.
+  val seed = Bitmaps.readPng(png)
+
+  // `bundle.json` tells us which module + cover preview produced this PNG. Live re-render also needs
+  // the source project on disk: without a project root (we're not inside a Gradle checkout) there's
+  // no daemon to attach, so we fall back to the static seed.
+  val metadata = BundlePngMetadata.readOrNull(png)
+  val previewId = metadata?.coverPreviewId
+  val module =
+    if (projectRoot != null && metadata != null) {
+      // Mirror the synthetic module Main builds for `--no-discovery`: <projectRoot>/<path-as-dirs>.
+      val relative = metadata.modulePath.trimStart(':').replace(':', '/').ifEmpty { "." }
+      PreviewModule(gradlePath = metadata.modulePath, projectDir = File(projectRoot, relative))
+    } else {
+      null
+    }
+
+  runMosaicMain {
+    BundleApp(
+      seed = seed,
+      pngName = png.name,
+      module = module,
+      previewId = previewId,
+      extensions = args.extensions,
+    )
+  }
+}
+
+/**
+ * The whole bundle-mode UI: a single full-terminal image. Holds an optional [LiveSession] and swaps
+ * the seed for the daemon's freshest render of [previewId] whenever a notification ticks.
+ */
+@Composable
+private fun BundleApp(
+  seed: Bitmap?,
+  pngName: String,
+  module: PreviewModule?,
+  previewId: String?,
+  extensions: Set<String>,
+) {
+  val initialSize = remember { TerminalSize.probe() }
+  val terminalState = LocalTerminalState.current
+  val cols = terminalState.size.columns.takeIf { it > 0 } ?: initialSize.cols
+  val rows = terminalState.size.rows.takeIf { it > 0 } ?: initialSize.rows
+
+  val scope = rememberCoroutineScope()
+  val liveSession = remember { LiveSession(scope) }
+  val liveState by liveSession.state.collectAsState()
+  var exitRequested by remember { mutableStateOf(false) }
+
+  // Attach the daemon once, if the bundle named a module. The session is sticky for the run.
+  LaunchedEffect(module) { if (module != null) liveSession.enable(module, extensions) }
+  // Mark the preview visible once the session is READY so the daemon pushes its re-renders.
+  LaunchedEffect(liveState.status, previewId) {
+    if (previewId != null && liveState.status == LiveSession.Status.READY) {
+      liveSession.setVisible(previewId)
+    }
+  }
+
+  if (exitRequested) {
+    LaunchedEffect(Unit) { kotlin.system.exitProcess(0) }
+    return
+  }
+
+  // Prefer the daemon's freshest render of this preview; fall back to the seed PNG until (or unless)
+  // one exists. Re-resolved on every daemon tick.
+  val liveFrame: Bitmap? =
+    if (module != null && previewId != null) {
+      remember(liveState.tick) { resolveRenderedPng(module, previewId)?.let(Bitmaps::readPng) }
+    } else {
+      null
+    }
+  val bitmap = liveFrame ?: seed
+
+  Column(
+    modifier =
+      Modifier.onKeyEvent { event ->
+        when (event.key) {
+          "q",
+          "Q",
+          "Escape" -> {
+            liveSession.disable()
+            exitRequested = true
+            true
+          }
+          "r" -> {
+            if (previewId != null) scope.launch { liveSession.forceRender(previewId) }
+            true
+          }
+          else -> false
+        }
+      }
+  ) {
+    if (bitmap == null) {
+      Text("(failed to decode $pngName)".take(cols), textStyle = TextStyle.Dim)
+    } else {
+      Image(bitmap = bitmap, cellWidth = cols, cellHeight = rows)
+    }
+  }
+}
+
+/**
+ * The daemon's most recent render of [previewId] for [module], or null if it hasn't rendered yet.
+ * Mirrors `PreviewRow.resolvePng` — the renderer writes `build/compose-previews/<id>.png`, with
+ * multi-capture previews landing as `<id>--<dimension>.png` (we take the first sibling).
+ */
+private fun resolveRenderedPng(module: PreviewModule, previewId: String): File? {
+  val direct = module.projectDir.resolve("build/compose-previews/$previewId.png")
+  if (direct.isFile) return direct
+  val dir = direct.parentFile?.takeIf { it.isDirectory } ?: return null
+  val prefix = "$previewId--"
+  return dir
+    .listFiles { f -> f.isFile && f.name.startsWith(prefix) && f.name.endsWith(".png") }
+    ?.minByOrNull { it.name }
+}


### PR DESCRIPTION
## Summary

`compose-preview-tui <bundle.png>` (a lone existing `*.png` positional, no subcommand) now opens the PNG directly instead of treating it as a project directory to browse:

1. The image is decoded and shown **full-screen immediately** — no list / tabs / status chrome, just the image. ImageIO reads the leading PNG of a PNG+ZIP polyglot bundle, so the first frame appears with no "rendering…" flash.
2. If the bundle names a module (`bundle.json` → `modulePath` + `coverPreviewId`) and we're inside that project's Gradle checkout, the daemon is attached via the existing `LiveSession` and **live re-renders replace the seed** as the source is edited.
3. A plain PNG, an unreadable bundle, or a bundle opened outside its project is shown as a **static image**.

`q` / `Esc` quits; `r` forces a re-render (no-op without a live session).

### Changes
- **`Args.kt`** — captures a lone existing `*.png` positional as `bundlePng` (other positionals still ignored).
- **`Main.kt`** — `bundlePng` short-circuits Gradle discovery and the browser into the image-only view; resolves a project root the same way normal mode does (override, else walk up for `gradlew`), but its absence is non-fatal (static image). stderr is redirected to a log so daemon output can't corrupt the screen.
- **`BundlePngMetadata.kt`** (new) — small reader for a bundle's `bundle.json` (`modulePath` + `coverPreviewId`) from the PNG+ZIP polyglot. The polyglot-extraction routine is duplicated here, matching the existing deliberate duplication in `:cli`'s `BundleReader` and `:bundle-viewer`'s loader.
- **`BundleView.kt`** (new) — minimal `runMosaicMain` composition rendering only the image, reusing `LiveSession` for the daemon and resolving live frames from `build/compose-previews/<id>.png` (mirrors `PreviewRow.resolvePng`). The owning `PreviewModule` is synthesised from the project root + the bundle's `modulePath`.

Includes a companion docs commit correcting `tui-cli/MOSAIC-FORK.md`: the published Sonatype snapshot **does** ship the JNI native libs (verified — see test plan), so the "no native libs / UnsatisfiedLinkError" warning was reframed as a caveat of the sandbox-patched local `publishToMavenLocal` path only.

No change to `build.gradle.kts` (no new module dependency). The TUI remains opt-in behind `tui.enabled=true` in `local.properties`.

### Design note
A bundle PNG is portable and records the Gradle `modulePath` + cover preview id, but **not** an absolute project root — so live mode uses the current Gradle checkout (override or walk-up) as the root. Opened outside a project, it shows the static image only.

## Test plan
- [x] `./gradlew :tui-cli:compileKotlin` (with `tui.enabled=true`) — green.
- [x] `./gradlew :tui-cli:test` — green (the kitty e2e self-skips without the X/kitty binaries).
- [x] `./gradlew :tui-cli:installDist` + `compose-preview-tui --help` — green; native `libmosaic.so` loads (the Sonatype snapshot bundles it for linux amd64/aarch64/riscv64).
- [x] **Smoke run** under a PTY against a plain test PNG: image renders (half-block tier — a bare PTY doesn't advertise Kitty graphics), ~73 KB drawn, **no `UnsatisfiedLinkError`, no exception**, clean quit on `q`. Confirms the image-only path and native-lib loading end-to-end.
- [ ] Manual (not done here): live re-render against a real bundle + running daemon on a Kitty/ghostty terminal — exercises the daemon-attach path and the Kitty-graphics tier, neither reachable from a bare PTY.
- [ ] CI green.