### PR TITLE
feat(bundle): bake every preview into the bundle + TUI ASCII dump

### DIFF
--- a/.github/workflows/preview-bundle-ascii.yml
+++ b/.github/workflows/preview-bundle-ascii.yml
@@ -1,0 +1,108 @@
+name: Preview Bundle ASCII
+
+# Smoke-tests the detached preview-bundle path end to end:
+#   1. render a single sample's previews,
+#   2. pack them into ONE portable bundle (PNG + ZIP polyglot, schema v2 — every
+#      preview baked under previews/<id>.png so the bundle stands alone),
+#   3. drive the Mosaic TUI in its headless --dump mode to print each baked
+#      preview to the terminal as ASCII / half-block text.
+#
+# The dump runs with a plain piped stdout (no PTY), so it leans on the Image
+# composable's lowest-fidelity fallback tier — it won't look great in the log,
+# but it proves the whole "open a bundle with no project, see every preview"
+# pipeline works. The TUI is opt-in (Mosaic fork snapshot), so this is the only
+# workflow that sets `tui.enabled=true`; the rest of CI never resolves it.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'gradle-plugin/**'
+      - 'tui-cli/**'
+      - 'samples/cmp/**'
+      - '.github/workflows/preview-bundle-ascii.yml'
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'gradle-plugin/**'
+      - 'tui-cli/**'
+      - 'samples/cmp/**'
+      - '.github/workflows/preview-bundle-ascii.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-bundle-ascii-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dump:
+    name: Pack + dump sample bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+
+      # The TUI module and its Mosaic fork snapshot are gated behind this flag
+      # (settings.gradle.kts). local.properties is gitignored, so writing it here
+      # is local to the runner.
+      - name: Enable the TUI build
+        run: echo "tui.enabled=true" >> local.properties
+
+      # Render FIRST, in its own invocation. composePreviewBundle deliberately
+      # doesn't depend on composePreviewRender (packing without a render is a
+      # valid flow), and its renders dir is an @Internal input — so the renders
+      # have to already exist on disk before the bundle task's first execution
+      # for them to be baked in. A clean CI checkout packs exactly once, after
+      # this step, so every preview lands in previews/<id>.png.
+      - name: Render the CMP sample previews
+        run: ./gradlew :samples:cmp:composePreviewRenderAll --stacktrace
+
+      # --rerun-tasks forces a fresh pack: composePreviewBundle's renders dir is an
+      # @Internal input (not tracked for up-to-date / cache keying), so a build-cache
+      # hit from a previous run could otherwise restore a bundle packed before the
+      # renders above existed. The render outputs are on disk either way (a cache hit
+      # restores them), so the fresh pack always sees them.
+      - name: Pack the bundle (all previews, schema v2)
+        run: |
+          ./gradlew :samples:cmp:composePreviewBundle \
+            -PbundleOutput="$PWD/build/preview-bundle.png" --rerun-tasks --stacktrace
+
+      # Compiles main + test and runs the TUI unit suite (BundleContentsTest et al).
+      # The kitty-under-Xvfb e2e self-skips without its binaries. `:tui-cli:test`
+      # depends on installDist, so this also builds the launcher the dump uses.
+      - name: Build + unit-test the TUI
+        run: ./gradlew :tui-cli:test :tui-cli:installDist --stacktrace
+
+      # Headless dump: no PTY, fixed terminal geometry via COLUMNS/LINES so the
+      # output is deterministic. `--dump` renders each baked preview through
+      # Mosaic's one-shot renderMosaic + Image (ASCII / half-block fallback) and
+      # exits — no daemon, no raw-mode terminal I/O.
+      - name: Dump each preview to the terminal (ASCII fallback)
+        env:
+          TERM: dumb
+          COLUMNS: '100'
+          LINES: '40'
+        run: |
+          BUNDLE="$PWD/build/preview-bundle.png"
+          TUI=tui-cli/build/install/compose-preview-tui/bin/compose-preview-tui
+          echo "::group::compose-preview-tui --dump $BUNDLE"
+          "$TUI" --dump "$BUNDLE" | tee build/preview-ascii.txt
+          echo "::endgroup::"
+          # Fail loudly if the dump produced nothing — that means the bundle had
+          # no baked previews (schema/render regression) rather than a layout nit.
+          test -s build/preview-ascii.txt
+
+      - name: Upload bundle + ASCII dump
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preview-bundle
+          path: |
+            build/preview-bundle.png
+            build/preview-ascii.txt

--- a/.github/workflows/preview-bundle-ascii.yml
+++ b/.github/workflows/preview-bundle-ascii.yml
@@ -71,16 +71,19 @@ jobs:
           ./gradlew :samples:cmp:composePreviewBundle \
             -PbundleOutput="$PWD/build/preview-bundle.png" --stacktrace
 
-      # Compiles main + test and runs the TUI unit suite (BundleContentsTest et al).
-      # The kitty-under-Xvfb e2e self-skips without its binaries. `:tui-cli:test`
-      # depends on installDist, so this also builds the launcher the dump uses.
+      # Build the launcher FIRST (so the dump can run even if a unit test is flaky),
+      # then run the TUI unit suite (BundleContentsTest et al). The kitty-under-Xvfb
+      # e2e self-skips without its binaries.
       - name: Build + unit-test the TUI
-        run: ./gradlew :tui-cli:test :tui-cli:installDist --stacktrace
+        run: ./gradlew :tui-cli:installDist :tui-cli:test --stacktrace
 
       # Headless dump: no PTY, fixed terminal geometry via COLUMNS/LINES so the
       # output is deterministic. `--dump` renders each baked preview through
       # Mosaic's one-shot renderMosaic + Image (ASCII / half-block fallback) and
-      # exits — no daemon, no raw-mode terminal I/O.
+      # exits — no daemon, no raw-mode terminal I/O. We capture stdout and stderr
+      # separately and echo both (plus the exit code) into the step log so any
+      # failure — a render exception, a missing native lib, an empty dump — is
+      # diagnosable inline instead of needing the raw run log.
       - name: Dump each preview to the terminal (ASCII fallback)
         env:
           TERM: dumb
@@ -89,11 +92,22 @@ jobs:
         run: |
           BUNDLE="$PWD/build/preview-bundle.png"
           TUI=tui-cli/build/install/compose-preview-tui/bin/compose-preview-tui
-          echo "::group::compose-preview-tui --dump $BUNDLE"
-          "$TUI" --dump "$BUNDLE" | tee build/preview-ascii.txt
+          set +e
+          "$TUI" --dump "$BUNDLE" >build/preview-ascii.txt 2>build/preview-dump-stderr.txt
+          code=$?
+          set -e
+          echo "::group::compose-preview-tui --dump (exit=$code)"
+          cat build/preview-ascii.txt
           echo "::endgroup::"
-          # Fail loudly if the dump produced nothing — that means the bundle had
-          # no baked previews (schema/render regression) rather than a layout nit.
+          if [ -s build/preview-dump-stderr.txt ]; then
+            echo "::group::compose-preview-tui --dump stderr"
+            cat build/preview-dump-stderr.txt
+            echo "::endgroup::"
+          fi
+          # The dump must exit cleanly AND print something — an empty stdout means
+          # the bundle had no baked previews (schema/render regression) or the TUI
+          # crashed before printing.
+          test "$code" -eq 0
           test -s build/preview-ascii.txt
 
       - name: Upload bundle + ASCII dump
@@ -104,3 +118,4 @@ jobs:
           path: |
             build/preview-bundle.png
             build/preview-ascii.txt
+            build/preview-dump-stderr.txt

--- a/.github/workflows/preview-bundle-ascii.yml
+++ b/.github/workflows/preview-bundle-ascii.yml
@@ -63,15 +63,13 @@ jobs:
       - name: Render the CMP sample previews
         run: ./gradlew :samples:cmp:composePreviewRenderAll --stacktrace
 
-      # --rerun-tasks forces a fresh pack: composePreviewBundle's renders dir is an
-      # @Internal input (not tracked for up-to-date / cache keying), so a build-cache
-      # hit from a previous run could otherwise restore a bundle packed before the
-      # renders above existed. The render outputs are on disk either way (a cache hit
-      # restores them), so the fresh pack always sees them.
+      # composePreviewBundle tracks the render PNGs as inputs (renderFiles), so a
+      # cached render-less bundle won't be restored over the fresh renders above —
+      # no --rerun-tasks needed.
       - name: Pack the bundle (all previews, schema v2)
         run: |
           ./gradlew :samples:cmp:composePreviewBundle \
-            -PbundleOutput="$PWD/build/preview-bundle.png" --rerun-tasks --stacktrace
+            -PbundleOutput="$PWD/build/preview-bundle.png" --stacktrace
 
       # Compiles main + test and runs the TUI unit suite (BundleContentsTest et al).
       # The kitty-under-Xvfb e2e self-skips without its binaries. `:tui-cli:test`

--- a/.github/workflows/preview-bundle-ascii.yml
+++ b/.github/workflows/preview-bundle-ascii.yml
@@ -74,8 +74,13 @@ jobs:
       # Build the launcher FIRST (so the dump can run even if a unit test is flaky),
       # then run the TUI unit suite (BundleContentsTest et al). The kitty-under-Xvfb
       # e2e self-skips without its binaries.
+      #
+      # --refresh-dependencies: `:tui-cli` depends on the Mosaic fork's 0.19.0-SNAPSHOT.
+      # Because the snapshot version string is fixed, Gradle's cached copy (restored by
+      # setup-gradle) would otherwise mask a republished snapshot — force a re-resolve so a
+      # freshly published fork (e.g. a new renderMosaic) is actually picked up.
       - name: Build + unit-test the TUI
-        run: ./gradlew :tui-cli:installDist :tui-cli:test --stacktrace
+        run: ./gradlew :tui-cli:installDist :tui-cli:test --refresh-dependencies --stacktrace
 
       # Headless dump: no PTY, fixed terminal geometry via COLUMNS/LINES so the
       # output is deterministic. `--dump` renders the cover preview (default; --id /

--- a/.github/workflows/preview-bundle-ascii.yml
+++ b/.github/workflows/preview-bundle-ascii.yml
@@ -78,13 +78,14 @@ jobs:
         run: ./gradlew :tui-cli:installDist :tui-cli:test --stacktrace
 
       # Headless dump: no PTY, fixed terminal geometry via COLUMNS/LINES so the
-      # output is deterministic. `--dump` renders each baked preview through
-      # Mosaic's one-shot renderMosaic + Image (ASCII / half-block fallback) and
+      # output is deterministic. `--dump` renders the cover preview (default; --id /
+      # --filter pick others) through Mosaic's one-shot renderMosaic + Image
+      # (ASCII / half-block fallback) and
       # exits — no daemon, no raw-mode terminal I/O. We capture stdout and stderr
       # separately and echo both (plus the exit code) into the step log so any
       # failure — a render exception, a missing native lib, an empty dump — is
       # diagnosable inline instead of needing the raw run log.
-      - name: Dump each preview to the terminal (ASCII fallback)
+      - name: Dump the cover preview to the terminal (ASCII fallback)
         env:
           TERM: dumb
           COLUMNS: '100'

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -242,6 +242,47 @@ class BundleFunctionalTest {
     assertThat(leadingPng.toList()).isEqualTo(coverEntry.toList())
   }
 
+  @Test
+  fun `composePreviewBundle re-packs when renders appear after a render-less pack`() {
+    val projectDir = createTestProject()
+    val redId = "test.RedKt.RedBoxPreview"
+
+    fun pack(): TaskOutcome? =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewBundle", "-PbundlePreviewIds=$redId", "--build-cache")
+        .withPluginClasspath()
+        .build()
+        .task(":composePreviewBundle")
+        ?.outcome
+
+    // Pack once with no renders on disk: bundle is well-formed but bakes nothing.
+    assertThat(pack()).isEqualTo(TaskOutcome.SUCCESS)
+    var bundle = File(projectDir, "build/compose-previews/bundle.png")
+    assertThat(listEntries(bundle).none { it.startsWith("previews/") }).isTrue()
+
+    // Discover (for the renderOutput path), then seed a render and re-pack. Because the render PNGs
+    // are tracked inputs (renderFiles), the task must NOT be UP-TO-DATE — it re-packs and bakes the
+    // now-present PNG, rather than restoring the stale render-less bundle.
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover")
+      .withPluginClasspath()
+      .build()
+    val manifest =
+      json.decodeFromString(
+        PreviewManifest.serializer(),
+        File(projectDir, "build/compose-previews/previews.json").readText(),
+      )
+    val redOutput = manifest.previews.first { it.id == redId }.captures.first().renderOutput
+    val rendersDir = File(projectDir, "build/compose-previews/renders").apply { mkdirs() }
+    File(rendersDir, redOutput.substringAfterLast('/')).writeBytes(solidPng(0x336699))
+
+    assertThat(pack()).isEqualTo(TaskOutcome.SUCCESS)
+    bundle = File(projectDir, "build/compose-previews/bundle.png")
+    assertThat(listEntries(bundle)).contains("previews/$redId.png")
+  }
+
   /** A tiny solid-colour PNG, distinct per [rgb], for seeding fake renders. */
   private fun solidPng(rgb: Int): ByteArray {
     val img = java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_INT_RGB)

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -182,6 +182,76 @@ class BundleFunctionalTest {
   }
 
   @Test
+  fun `composePreviewBundle bakes a PNG per selected preview into previews dir`() {
+    val projectDir = createTestProject()
+    val redId = "test.RedKt.RedBoxPreview"
+    val blueId = "test.BlueKt.BlueBoxPreview"
+
+    // Phase 1 — discover so previews.json exists; that's where each capture's module-relative
+    // renderOutput path comes from.
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewDiscover")
+      .withPluginClasspath()
+      .build()
+
+    val previewsJson = File(projectDir, "build/compose-previews/previews.json")
+    assertThat(previewsJson.exists()).isTrue()
+    val manifest = json.decodeFromString(PreviewManifest.serializer(), previewsJson.readText())
+
+    // Phase 2 — seed a distinct dummy rendered PNG for each preview's primary capture, mimicking a
+    // prior composePreviewRender. This exercises the baking path without needing the published
+    // renderer-desktop artifact (composePreviewRender resolves it from Maven; unavailable here).
+    val rendersDir = File(projectDir, "build/compose-previews/renders").apply { mkdirs() }
+    val seeded = mutableMapOf<String, ByteArray>()
+    var tint = 0
+    for (preview in manifest.previews) {
+      val name =
+        preview.captures.first().renderOutput.substringAfterLast('/').ifEmpty {
+          "${preview.id}.png"
+        }
+      val bytes = solidPng(0x202020 + (tint++ * 0x303030))
+      File(rendersDir, name).writeBytes(bytes)
+      seeded[preview.id] = bytes
+    }
+
+    // Phase 3 — pack both previews (red is the cover).
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewBundle", "-PbundlePreviewIds=$redId,$blueId", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+    assertThat(result.task(":composePreviewBundle")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    val entries = listEntries(bundle)
+    // Every selected preview is baked under the well-known previews/ directory, keyed by id.
+    assertThat(entries).containsAtLeast("previews/$redId.png", "previews/$blueId.png")
+
+    val coverEntry = readZipEntry(bundle, "previews/$redId.png")
+    assertThat(coverEntry).isNotNull()
+    assertThat(coverEntry!!.toList()).isEqualTo(seeded[redId]!!.toList())
+    assertThat(readZipEntry(bundle, "previews/$blueId.png")!!.toList())
+      .isEqualTo(seeded[blueId]!!.toList())
+
+    // The polyglot's leading PNG (everything before the appended zip) is byte-identical to the
+    // cover preview's baked entry — the front image is just a mirror of previews/<coverId>.png.
+    val allBytes = bundle.readBytes()
+    val leadingPng = allBytes.copyOfRange(0, allBytes.size - extractZipBytes(bundle).size)
+    assertThat(leadingPng.toList()).isEqualTo(coverEntry.toList())
+  }
+
+  /** A tiny solid-colour PNG, distinct per [rgb], for seeding fake renders. */
+  private fun solidPng(rgb: Int): ByteArray {
+    val img = java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_INT_RGB)
+    for (y in 0 until 2) for (x in 0 until 2) img.setRGB(x, y, rgb and 0xFFFFFF)
+    val baos = java.io.ByteArrayOutputStream()
+    javax.imageio.ImageIO.write(img, "png", baos)
+    return baos.toByteArray()
+  }
+
+  @Test
   fun `composePreviewBundle filters previews_json to selected ids`() {
     val projectDir = createTestProject()
     val redId = "test.RedKt.RedBoxPreview"

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -247,17 +247,21 @@ class BundleFunctionalTest {
     val projectDir = createTestProject()
     val redId = "test.RedKt.RedBoxPreview"
 
-    fun pack(): TaskOutcome? =
+    // `--build-cache` so the test asserts the *cache-correctness* property the renderFiles input
+    // exists for, not just up-to-date checks. We assert on bundle CONTENT rather than task outcome:
+    // outcome flips between SUCCESS / FROM_CACHE depending on whether a prior suite run warmed the
+    // cache, but the regression (renders untracked) would leave the second pack UP_TO_DATE and the
+    // bundle render-less — which the content assertions below catch deterministically either way.
+    fun pack() {
       GradleRunner.create()
         .withProjectDir(projectDir)
         .withArguments("composePreviewBundle", "-PbundlePreviewIds=$redId", "--build-cache")
         .withPluginClasspath()
         .build()
-        .task(":composePreviewBundle")
-        ?.outcome
+    }
 
     // Pack once with no renders on disk: bundle is well-formed but bakes nothing.
-    assertThat(pack()).isEqualTo(TaskOutcome.SUCCESS)
+    pack()
     var bundle = File(projectDir, "build/compose-previews/bundle.png")
     assertThat(listEntries(bundle).none { it.startsWith("previews/") }).isTrue()
 
@@ -278,7 +282,7 @@ class BundleFunctionalTest {
     val rendersDir = File(projectDir, "build/compose-previews/renders").apply { mkdirs() }
     File(rendersDir, redOutput.substringAfterLast('/')).writeBytes(solidPng(0x336699))
 
-    assertThat(pack()).isEqualTo(TaskOutcome.SUCCESS)
+    pack()
     bundle = File(projectDir, "build/compose-previews/bundle.png")
     assertThat(listEntries(bundle)).contains("previews/$redId.png")
   }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -180,6 +180,14 @@ abstract class BundlePreviewTask : DefaultTask() {
         producedBy = producedBy.get(),
       )
 
+    // Bake one PNG per selected preview into `previews/<id>.png` so the bundle renders detached
+    // from its project (see [PreviewBundleFormat]). Previews whose render is missing on disk are
+    // simply omitted — the reader treats an absent entry as "not rendered yet".
+    val previewPngs = LinkedHashMap<String, ByteArray>()
+    for (preview in selected) {
+      resolvePreviewPng(preview)?.let { previewPngs[preview.id] = it }
+    }
+
     val filteredManifest = manifest.copy(previews = selected)
     val zipBytes =
       buildZip(
@@ -188,9 +196,13 @@ abstract class BundlePreviewTask : DefaultTask() {
         appJar = appJarBytes,
         inlinedProjectJars = inlinedProjectJars,
         report = JSON.encodeToString(MinimizationReport.serializer(), report),
+        previewPngs = previewPngs,
       )
 
-    val coverPng = resolveCoverPng(selected.first())
+    // The cover (first selected preview) forms the polyglot's leading bytes. Reuse its baked PNG
+    // when present so the front image and `previews/<coverId>.png` are byte-identical; otherwise a
+    // stub gray placeholder keeps the file a well-formed PNG.
+    val coverPng = previewPngs[coverId] ?: STUB_GRAY_PNG
     val outFile = output.get().asFile
     writePngZipPolyglot(coverPng, zipBytes, outFile)
 
@@ -199,6 +211,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     val depsDropped = depDecisions.count { !it.kept }
     logger.lifecycle(
       "composePreviewBundle — wrote ${outFile.name} (${outFile.length()} bytes)\n" +
+        "  previews baked:       ${previewPngs.size} / ${selected.size} (cover=$coverId)\n" +
         "  entry classes:        ${report.entryClassFqns.size}\n" +
         "  reachable classes:    ${report.reachableClassCount} / ${report.totalScannedClassCount}\n" +
         "  module classes kept:  ${report.moduleClasses.reachableClasses} / ${report.moduleClasses.totalClasses}\n" +
@@ -227,21 +240,38 @@ abstract class BundlePreviewTask : DefaultTask() {
     return resolved
   }
 
-  private fun resolveCoverPng(cover: PreviewInfo): ByteArray {
-    val rendersRoot = rendersDir.orNull?.asFile
-    if (rendersRoot != null) {
-      val candidate =
-        cover.captures.firstOrNull()?.renderOutput?.let { rel ->
-          // `renderOutput` is module-relative under `build/compose-previews/`, e.g.
-          // `renders/<id>.png`. The rendersDir input points at the `renders/` dir itself.
-          val name = rel.substringAfterLast('/')
-          File(rendersRoot, name)
-        }
-      if (candidate != null && candidate.isFile && candidate.length() > 0) {
-        return candidate.readBytes()
+  /**
+   * The rendered PNG bytes for [preview]'s primary capture, or null when no render exists on disk
+   * (bundling without a prior `composePreviewRender`, or a preview that failed to render). Used
+   * both for the cover (first selected) and to bake every selected preview into
+   * `previews/<id>.png`.
+   */
+  private fun resolvePreviewPng(preview: PreviewInfo): ByteArray? {
+    val rendersRoot = rendersDir.orNull?.asFile ?: return null
+    // `renderOutput` is module-relative under `build/compose-previews/`, e.g. `renders/<id>.png`.
+    // The rendersDir input points at the `renders/` dir itself.
+    val rel =
+      preview.captures.firstOrNull()?.renderOutput?.takeIf { it.isNotEmpty() } ?: return null
+    val name = rel.substringAfterLast('/')
+
+    val exact = File(rendersRoot, name)
+    if (exact.isFile && exact.length() > 0) return exact.readBytes()
+
+    // No file at the primary capture's exact path: @PreviewParameter / multi-variant previews fan
+    // out into siblings (`<base>_<param>.png`, `<base>--<dimension>.png`). Bake the first sibling
+    // as
+    // a representative cover so the preview isn't silently dropped from the bundle.
+    if (!rendersRoot.isDirectory) return null
+    val base = name.removeSuffix(".png")
+    return rendersRoot
+      .listFiles { f ->
+        f.isFile &&
+          f.length() > 0 &&
+          f.name.endsWith(".png") &&
+          (f.name.startsWith("${base}_") || f.name.startsWith("$base--"))
       }
-    }
-    return STUB_GRAY_PNG
+      ?.minByOrNull { it.name }
+      ?.readBytes()
   }
 
   private fun packModuleClasses(
@@ -372,11 +402,14 @@ abstract class BundlePreviewTask : DefaultTask() {
     appJar: ByteArray,
     inlinedProjectJars: Map<String, File>,
     report: String,
+    previewPngs: Map<String, ByteArray>,
   ): ByteArray {
     val baos = ByteArrayOutputStream()
     ZipOutputStream(baos).use { zip ->
       zip.writeFile("bundle.json", bundleJson.toByteArray(Charsets.UTF_8))
       zip.writeFile("previews.json", previewsJson.toByteArray(Charsets.UTF_8))
+      // One baked PNG per selected preview under the well-known `previews/` directory.
+      previewPngs.forEach { (id, bytes) -> zip.writeFile("$BUNDLE_PREVIEWS_DIR/$id.png", bytes) }
       zip.writeFile("classes/app.jar", appJar)
       inlinedProjectJars.forEach { (path, file) -> zip.writeFile(path, file.readBytes()) }
       zip.writeFile("report.json", report.toByteArray(Charsets.UTF_8))

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
@@ -102,16 +103,34 @@ abstract class BundlePreviewTask : DefaultTask() {
   @get:Input abstract val dependencyCoordinates: MapProperty<String, String>
 
   /**
-   * Renders directory from the preceding `composePreviewRender` task. The cover preview's PNG is
-   * read from here and prepended to the polyglot; when missing or empty, the task emits a stub gray
-   * PNG so the bundle is still well-formed (and `file(1)` still reports PNG).
+   * Renders directory from the preceding `composePreviewRender` task. Each selected preview's PNG
+   * is read from here: the cover is prepended to the polyglot, and every selected preview is baked
+   * into `previews/<id>.png`. When missing or empty, the cover falls back to a stub gray PNG so the
+   * bundle is still well-formed (and `file(1)` still reports PNG).
    *
-   * Marked `@Internal` because the dir may legitimately not exist (bundling without a prior render
-   * is a supported v1 flow). Tracking it as an `@InputDirectory @Optional` errors out when Gradle
-   * resolves the property to a path on disk that doesn't yet exist. The bundle is still re-packed
-   * whenever the upstream `composePreviewDiscover` output or the classpath change.
+   * Marked `@Internal` because this is the *root* used for path resolution in the action, and the
+   * dir may legitimately not exist (bundling without a prior render is a supported flow); tracking
+   * it as an `@InputDirectory @Optional` errors out when Gradle resolves the property to a path on
+   * disk that doesn't yet exist. The render *contents* are tracked separately via [renderFiles] so
+   * the task's up-to-date / cache keys do change when the PNGs appear or change.
    */
   @get:Internal abstract val rendersDir: DirectoryProperty
+
+  /**
+   * The render PNGs under [rendersDir], tracked as a proper input so up-to-date checks and the
+   * build cache key reflect them. Without this, the bundle could be skipped/restored stale: someone
+   * packs before rendering (or restores such a cached bundle), then renders and re-packs with the
+   * same manifest/classes, and `composePreviewBundle` would otherwise see unchanged inputs and keep
+   * the render-less bundle despite fresh PNGs on disk (Codex review, PR #1627).
+   *
+   * Modelled as an `@InputFiles` collection rather than `@InputDirectory` precisely so an absent
+   * `renders/` dir snapshots as empty instead of failing the build — the reason [rendersDir] itself
+   * had to stay `@Internal`.
+   */
+  @get:InputFiles
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val renderFiles: ConfigurableFileCollection
 
   /**
    * Preview ids to include. First entry is the cover. Empty means "all previews in the manifest";

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -294,9 +294,13 @@ internal object ComposePreviewTasks {
       output.set(project.layout.file(resolvedOutput))
       group = "compose preview"
       description = "Pack selected previews + minimal classpath into a portable PNG+ZIP polyglot."
-      // No dependsOn composePreviewRender — bundle without a render is valid (stub cover). Callers
-      // wire
-      // explicitly when they want a real cover.
+      // No dependsOn composePreviewRender — bundle without a render is valid (stub cover). But
+      // `renderFiles` declares the renders dir (composePreviewRender's output) as an input, so when
+      // BOTH tasks are in the graph (the common `composePreviewRender composePreviewBundle` pack
+      // flow, e.g. `compose-preview bundle pack`) Gradle requires a declared ordering to avoid the
+      // implicit-dependency validation error. `mustRunAfter` supplies it WITHOUT pulling render in
+      // when only bundle is requested — render still doesn't run unless the caller asks for it.
+      mustRunAfter("composePreviewRender")
       dependsOn(discoverTaskName)
     }
   }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -280,8 +280,13 @@ internal object ComposePreviewTasks {
       depJarFiles?.let { dependencyJars.from(it) }
       dependencyCoordinates.set(coordMapProvider)
       // Renders dir is wired conditionally — when composePreviewRender has run, the dir exists and
-      // contains PNGs. Use orNull semantics: missing dir = stub cover.
+      // contains PNGs. Use orNull semantics: missing dir = stub cover. `rendersDir` is the
+      // @Internal
+      // resolution root; `renderFiles` tracks the PNG contents as a real input so the task re-packs
+      // (and the cache key changes) when renders appear/change rather than restoring a stale
+      // bundle.
       rendersDir.set(previewOutputDir.map { it.dir("renders") })
+      renderFiles.from(previewOutputDir.map { it.dir("renders") })
       previewIds.set(previewIdsProperty.orElse(emptyList()))
       modulePath.set(project.path)
       backend.set("desktop")

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -13,7 +13,8 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  * The bundle is a **PNG + ZIP polyglot**:
  * 1. Bytes `0..n` are a valid PNG (the cover image — the first selected preview's rendered output,
  *    or a stub gray placeholder). Finder, Preview.app, browsers, GitHub, Slack — every PNG viewer
- *    renders the leading image.
+ *    renders the leading image. This is the bundle's **default** preview: the one thing every plain
+ *    image viewer shows.
  * 2. Bytes `n+1..EOF` are a standard ZIP archive. ZIP parsers scan backwards from EOF for the
  *    End-Of-Central-Directory signature (`PK\x05\x06`), so the leading PNG bytes are invisible to
  *    them. `unzip foo.png` works.
@@ -26,10 +27,23 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  * ```
  * bundle.json              — manifest (this file's [BundleManifest])
  * previews.json            — filtered to selected preview ids; same shape as the original
+ * previews/<id>.png        — the rendered PNG for EACH selected preview (see [BUNDLE_PREVIEWS_DIR]).
+ *                            The cover's leading-bytes PNG is mirrored here under its own id so
+ *                            iterating the well-known directory yields every preview uniformly.
+ *                            A preview with no render on disk is simply absent from this directory.
  * classes/app.jar          — consumer module bytecode, MINIMIZED to classes reachable from the
  *                            selected previews (plus all module resources)
  * report.json              — [MinimizationReport]: which deps contributed reachable classes
  * ```
+ *
+ * # Multiple previews, detached from a project
+ *
+ * The leading PNG is a *single* default image, but a bundle can carry many previews. Their rendered
+ * PNGs are baked into the well-known [BUNDLE_PREVIEWS_DIR] directory so a reader can show every
+ * preview **without re-rendering and without the originating Gradle project on disk** — the bundle
+ * is fully self-describing when opened from `~/Downloads`, a chat attachment, or a gist. The
+ * `classes/app.jar` + classpath are still present for tooling that wants a *live* re-render (the VS
+ * Code panel, the desktop daemon), but they are no longer required just to look at the images.
  *
  * **Notably absent:** there is no `libs/` directory. Maven / Google-resolvable dependencies are
  * recorded as coordinates in [BundleManifest.classpath]; the player (`compose-preview bundle open`,
@@ -108,7 +122,24 @@ sealed interface ClasspathEntry {
   ) : ClasspathEntry
 }
 
-const val BUNDLE_SCHEMA_VERSION: Int = 1
+/**
+ * Schema version stamped into [BundleManifest.schemaVersion].
+ * - v1 — `bundle.json` + `previews.json` + `classes/app.jar` + `report.json`, cover PNG as the
+ *   polyglot's leading bytes only.
+ * - v2 — adds the [BUNDLE_PREVIEWS_DIR] directory: a baked PNG per selected preview so the bundle
+ *   renders detached from its project. Readers gate on `>= 2` before looking for
+ *   `previews/<id>.png` (v1 bundles simply have no such directory); the additive zip entries are
+ *   otherwise ignored by `ignoreUnknownKeys` readers, so a v1 reader opening a v2 bundle still
+ *   works.
+ */
+const val BUNDLE_SCHEMA_VERSION: Int = 2
+
+/**
+ * Well-known directory inside the bundle zip holding one rendered PNG per selected preview, keyed
+ * by preview id: `previews/<previewId>.png`. The cover (the polyglot's leading bytes) is mirrored
+ * here under its own id so a reader can iterate this single directory to enumerate every preview.
+ */
+const val BUNDLE_PREVIEWS_DIR: String = "previews"
 
 /**
  * Diagnostic record describing how aggressive the minimization was. Always written into the bundle

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Args.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Args.kt
@@ -28,6 +28,13 @@ data class TuiArgs(
    * Captured from a lone existing `*.png` positional argument.
    */
   val bundlePng: File? = null,
+  /**
+   * Non-interactive dump mode (`--dump` / `--ascii`). Requires a bundle PNG positional: render every
+   * baked preview to stdout as text (half-block / ASCII fallback via Mosaic's one-shot
+   * [com.jakewharton.mosaic.renderMosaic]) and exit, instead of taking over the terminal. Built for
+   * CI / piped stdout where there's no PTY.
+   */
+  val dump: Boolean = false,
   val verbose: Boolean = false,
   val timeoutSeconds: Long = 300,
   /**
@@ -50,6 +57,7 @@ data class TuiArgs(
       var projectRoot: File? = null
       var timeoutSeconds = 300L
       var noDiscovery = false
+      var dump = false
       val positionals = mutableListOf<String>()
 
       val valuedFlags =
@@ -77,6 +85,8 @@ data class TuiArgs(
           "--project-root" -> projectRoot = nextValue()?.let(::File)
           "--live" -> live = true
           "--no-discovery" -> noDiscovery = true
+          "--dump",
+          "--ascii" -> dump = true
           "--verbose",
           "-v" -> verbose = true
           "--help",
@@ -109,6 +119,7 @@ data class TuiArgs(
         liveOnStart = live,
         projectRoot = projectRoot,
         bundlePng = bundlePng,
+        dump = dump,
         verbose = verbose,
         timeoutSeconds = timeoutSeconds,
         noDiscovery = noDiscovery,
@@ -124,8 +135,14 @@ data class TuiArgs(
           compose-preview-tui [options]          Browse a project's previews
           compose-preview-tui <bundle.png>       Open a bundle PNG full-screen (image only,
                                                  live if the PNG carries provenance)
+          compose-preview-tui --dump <bundle.png>
+                                                 Print every baked preview to stdout as text
+                                                 (half-block / ASCII) and exit. No PTY needed —
+                                                 for CI / piped output.
 
         Options:
+          --dump, --ascii        Non-interactive: dump each baked preview in a bundle to
+                                 stdout (ASCII fallback) and exit. Requires a bundle PNG.
           --module <path>        Gradle path (e.g. :samples:android). Default: prompt
                                  / pick first discovered.
           --filter <pattern>     Case-insensitive substring filter on preview id.

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Args.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Args.kt
@@ -29,10 +29,11 @@ data class TuiArgs(
    */
   val bundlePng: File? = null,
   /**
-   * Non-interactive dump mode (`--dump` / `--ascii`). Requires a bundle PNG positional: render every
+   * Non-interactive dump mode (`--dump` / `--ascii`). Requires a bundle PNG positional: render a
    * baked preview to stdout as text (half-block / ASCII fallback via Mosaic's one-shot
-   * [com.jakewharton.mosaic.renderMosaic]) and exit, instead of taking over the terminal. Built for
-   * CI / piped stdout where there's no PTY.
+   * [com.jakewharton.mosaic.renderMosaic]) and exit, instead of taking over the terminal. Dumps the
+   * cover preview by default; `--id` pins an exact preview and `--filter` dumps a matching slice.
+   * Built for CI / piped stdout where there's no PTY.
    */
   val dump: Boolean = false,
   val verbose: Boolean = false,
@@ -136,13 +137,15 @@ data class TuiArgs(
           compose-preview-tui <bundle.png>       Open a bundle PNG full-screen (image only,
                                                  live if the PNG carries provenance)
           compose-preview-tui --dump <bundle.png>
-                                                 Print every baked preview to stdout as text
-                                                 (half-block / ASCII) and exit. No PTY needed —
-                                                 for CI / piped output.
+                                                 Print a baked preview to stdout as text
+                                                 (half-block / ASCII) and exit — the cover by
+                                                 default, or pick with --id / --filter. No PTY
+                                                 needed — for CI / piped output.
 
         Options:
-          --dump, --ascii        Non-interactive: dump each baked preview in a bundle to
-                                 stdout (ASCII fallback) and exit. Requires a bundle PNG.
+          --dump, --ascii        Non-interactive: dump a baked preview in a bundle to stdout
+                                 (ASCII fallback) and exit. The cover preview by default;
+                                 use --id / --filter to choose. Requires a bundle PNG.
           --module <path>        Gradle path (e.g. :samples:android). Default: prompt
                                  / pick first discovered.
           --filter <pattern>     Case-insensitive substring filter on preview id.

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/BundlePngMetadata.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/BundlePngMetadata.kt
@@ -9,8 +9,13 @@ import kotlinx.serialization.json.Json
 /**
  * Just enough of a `compose-preview` bundle's `bundle.json` for the image-only TUI to drive a live
  * session: which Gradle module produced it and which preview is the cover. A bundle is a PNG+ZIP
- * polyglot — a valid PNG up front (the cover render) with a standard zip appended. We read only the
- * `bundle.json` entry and ignore everything else (`classes/app.jar`, `previews.json`, `report.json`).
+ * polyglot — a valid PNG up front (the cover render) with a standard zip appended.
+ *
+ * Since bundle schema v2 the zip also carries one baked PNG per selected preview under the
+ * well-known `previews/<previewId>.png` directory (see `gradle-plugin/PreviewBundleFormat.kt`), so
+ * the TUI can page through every preview **without the originating project on disk** — opening a
+ * bundle straight from `~/Downloads` shows all its images, not just the cover. [BundleContents]
+ * exposes both the metadata and those baked PNGs from a single zip pass.
  *
  * The polyglot-extraction routine is duplicated here rather than shared with `:cli`'s `BundleReader`
  * or `:bundle-viewer`'s loader — both deliberately keep their own copy so neither module drags the
@@ -42,6 +47,45 @@ data class BundlePngMetadata(val modulePath: String = "", val coverPreviewId: St
         null
       }
 
+    /**
+     * Reads the bundle's metadata **and** every baked preview PNG (`previews/<id>.png`) in one zip
+     * pass. The returned [BundleContents.previews] is ordered cover-first (per
+     * [BundlePngMetadata.coverPreviewId]) then the rest by id, so a viewer can page through them in
+     * a stable order. Returns an empty [BundleContents] when [file] isn't a readable polyglot, so
+     * callers can render a "couldn't read this file" hint without a try/catch.
+     */
+    fun readContents(file: File): BundleContents {
+      val zipBytes = extractZipBytes(file) ?: return BundleContents(null, emptyList())
+      var metadata: BundlePngMetadata? = null
+      val pngs = LinkedHashMap<String, ByteArray>()
+      try {
+        ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+          while (true) {
+            val entry = zin.nextEntry ?: break
+            val name = entry.name
+            when {
+              name == "bundle.json" ->
+                metadata =
+                  json.decodeFromString(serializer(), zin.readBytes().toString(Charsets.UTF_8))
+              !entry.isDirectory && name.startsWith("previews/") && name.endsWith(".png") -> {
+                val id = name.removePrefix("previews/").removeSuffix(".png")
+                if (id.isNotEmpty()) pngs[id] = zin.readBytes()
+              }
+            }
+            zin.closeEntry()
+          }
+        }
+      } catch (_: Throwable) {
+        return BundleContents(metadata, emptyList())
+      }
+      val cover = metadata?.coverPreviewId
+      val ordered =
+        pngs.entries
+          .sortedWith(compareBy({ it.key != cover }, { it.key }))
+          .map { BundlePreview(id = it.key, pngBytes = it.value) }
+      return BundleContents(metadata = metadata, previews = ordered)
+    }
+
     /** The trailing zip of a PNG+ZIP polyglot, the whole file for a bare zip, or null otherwise. */
     private fun extractZipBytes(file: File): ByteArray? {
       val bytes = file.readBytes()
@@ -57,7 +101,8 @@ data class BundlePngMetadata(val modulePath: String = "", val coverPreviewId: St
             (bytes[offset + 3].toInt() and 0xff)
         val type = String(bytes, offset + 4, 4, Charsets.US_ASCII)
         offset += 4 + 4 + length + 4
-        if (type == "IEND") return if (offset <= bytes.size) bytes.copyOfRange(offset, bytes.size) else null
+        if (type == "IEND")
+          return if (offset <= bytes.size) bytes.copyOfRange(offset, bytes.size) else null
       }
       return null
     }
@@ -65,3 +110,20 @@ data class BundlePngMetadata(val modulePath: String = "", val coverPreviewId: St
     private val PNG_SIG = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
   }
 }
+
+/** A single baked preview pulled out of a bundle: its id and raw PNG bytes. */
+data class BundlePreview(val id: String, val pngBytes: ByteArray) {
+  // ByteArray breaks data-class equality/hashCode by identity; override so list comparisons in
+  // tests behave structurally.
+  override fun equals(other: Any?): Boolean =
+    this === other ||
+      (other is BundlePreview && id == other.id && pngBytes.contentEquals(other.pngBytes))
+
+  override fun hashCode(): Int = 31 * id.hashCode() + pngBytes.contentHashCode()
+}
+
+/** Everything the TUI needs to render a bundle detached from its project: metadata + baked PNGs. */
+data class BundleContents(
+  val metadata: BundlePngMetadata?,
+  val previews: List<BundlePreview>,
+)

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Main.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Main.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.cli.DriverOptions
 import ee.schimke.composeai.cli.GradlePreviewDriver
 import ee.schimke.composeai.cli.PreviewModule
 import ee.schimke.composeai.tui.ui.App
+import ee.schimke.composeai.tui.ui.dumpBundle
 import ee.schimke.composeai.tui.ui.runBundle
 import java.io.File
 import java.io.FileOutputStream
@@ -21,6 +22,18 @@ fun main(argv: Array<String>) {
   // absence isn't fatal: with no project we just show the bundle's baked-in image statically. The
   // log lives under the project root (or next to the PNG) so daemon stderr can't corrupt the screen.
   val bundlePng = args.bundlePng
+
+  // Dump mode is headless: print each baked preview to stdout and exit. No terminal takeover, no
+  // daemon — safe under a piped stdout (CI). Requires a bundle PNG positional.
+  if (args.dump) {
+    if (bundlePng == null) {
+      System.err.println("error: --dump requires a bundle PNG argument")
+      exitProcess(2)
+    }
+    dumpBundle(bundlePng)
+    return
+  }
+
   if (bundlePng != null) {
     val projectRoot = args.projectRoot?.absoluteFile ?: findProjectRoot()
     redirectStderrToLogFile(projectRoot ?: bundlePng.absoluteFile.parentFile ?: File("."))

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Main.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Main.kt
@@ -30,7 +30,7 @@ fun main(argv: Array<String>) {
       System.err.println("error: --dump requires a bundle PNG argument")
       exitProcess(2)
     }
-    dumpBundle(bundlePng)
+    dumpBundle(bundlePng, exactId = args.exactId, filter = args.filter)
     return
   }
 

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/image/Bitmaps.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/image/Bitmaps.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.tui.image
 
 import com.jakewharton.mosaic.ui.Bitmap
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
 
@@ -14,13 +16,23 @@ import javax.imageio.ImageIO
  * a try/catch.
  */
 object Bitmaps {
-  fun readPng(file: File): Bitmap? {
-    val img =
-      try {
-        ImageIO.read(file) ?: return null
-      } catch (_: Throwable) {
-        return null
-      }
+  fun readPng(file: File): Bitmap? =
+    try {
+      toBitmap(ImageIO.read(file))
+    } catch (_: Throwable) {
+      null
+    }
+
+  /** Decode raw PNG/JPEG/etc. bytes (e.g. a baked `previews/<id>.png` bundle entry) into a Bitmap. */
+  fun decode(bytes: ByteArray): Bitmap? =
+    try {
+      toBitmap(ByteArrayInputStream(bytes).use { ImageIO.read(it) })
+    } catch (_: Throwable) {
+      null
+    }
+
+  private fun toBitmap(img: BufferedImage?): Bitmap? {
+    if (img == null) return null
     val w = img.width
     val h = img.height
     if (w <= 0 || h <= 0) return null

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/BundleDump.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/BundleDump.kt
@@ -3,7 +3,6 @@ package ee.schimke.composeai.tui.ui
 import com.jakewharton.mosaic.renderMosaic
 import com.jakewharton.mosaic.ui.Column
 import com.jakewharton.mosaic.ui.Image
-import com.jakewharton.mosaic.ui.Text
 import ee.schimke.composeai.tui.BundlePngMetadata
 import ee.schimke.composeai.tui.image.Bitmaps
 import ee.schimke.composeai.tui.terminal.TerminalSize

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/BundleDump.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/BundleDump.kt
@@ -1,0 +1,63 @@
+package ee.schimke.composeai.tui.ui
+
+import com.jakewharton.mosaic.renderMosaic
+import com.jakewharton.mosaic.ui.Column
+import com.jakewharton.mosaic.ui.Image
+import com.jakewharton.mosaic.ui.Text
+import ee.schimke.composeai.tui.BundlePngMetadata
+import ee.schimke.composeai.tui.image.Bitmaps
+import ee.schimke.composeai.tui.terminal.TerminalSize
+import java.io.File
+
+/**
+ * Non-interactive bundle dump: render every baked preview in [png] to stdout as text and return.
+ *
+ * This is the headless counterpart of [runBundle]. Where the interactive view takes over the
+ * terminal (raw mode, alternate screen, a render loop), the dump uses Mosaic's one-shot
+ * [renderMosaic] to turn each preview's `Image` into a static string and prints it — no PTY, no raw
+ * mode, no daemon. That's what makes it usable from a CI step whose stdout is a plain pipe: the
+ * `Image` composable picks its lowest-fidelity tier (half-block / ASCII) when no Kitty-graphics
+ * capability is advertised, so the result "won't look great but technically works" in a build log.
+ *
+ * Reads the bundle's baked `previews/<id>.png` entries (schema v2+), so it works fully detached from
+ * the originating project. Prints a short notice and returns cleanly when the file carries no baked
+ * previews (e.g. an older v1 bundle, or one packed with `--no-render`).
+ */
+fun dumpBundle(png: File, cols: Int? = null, rowsPerPreview: Int = DEFAULT_DUMP_ROWS) {
+  val contents = BundlePngMetadata.readContents(png)
+  val width = (cols ?: TerminalSize.probe().cols).coerceIn(MIN_DUMP_COLS, MAX_DUMP_COLS)
+
+  if (contents.previews.isEmpty()) {
+    println("${png.name}: no baked previews found (needs a schema v2 bundle packed after a render).")
+    return
+  }
+
+  val total = contents.previews.size
+  println("${png.name}: $total preview(s)")
+  contents.previews.forEachIndexed { index, preview ->
+    println()
+    println("=== ${preview.id} (${index + 1}/$total) ===")
+    val bitmap = Bitmaps.decode(preview.pngBytes)
+    if (bitmap == null) {
+      println("(failed to decode previews/${preview.id}.png)")
+      return@forEachIndexed
+    }
+    // renderMosaic composes a single frame and returns it as a string; the Image composable owns
+    // the resample + tier selection (half-block / ASCII fallback when no graphics protocol). Guard
+    // per-preview so a single render hiccup prints a note instead of aborting the whole dump.
+    val frame =
+      try {
+        renderMosaic {
+          Column { Image(bitmap = bitmap, cellWidth = width, cellHeight = rowsPerPreview) }
+        }
+      } catch (t: Throwable) {
+        "(could not render ${preview.id}: ${t.javaClass.simpleName}: ${t.message})\n"
+      }
+    print(frame)
+    if (!frame.endsWith("\n")) println()
+  }
+}
+
+private const val DEFAULT_DUMP_ROWS = 20
+private const val MIN_DUMP_COLS = 20
+private const val MAX_DUMP_COLS = 120

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/BundleDump.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/BundleDump.kt
@@ -10,7 +10,12 @@ import ee.schimke.composeai.tui.terminal.TerminalSize
 import java.io.File
 
 /**
- * Non-interactive bundle dump: render every baked preview in [png] to stdout as text and return.
+ * Non-interactive bundle dump: render a baked preview in [png] to stdout as text and return.
+ *
+ * By default this dumps a **single** preview — the cover ([BundleContents.previews] is ordered
+ * cover-first), since a bundle is usually viewed one preview at a time. Pass [exactId] to pin a
+ * specific preview, or [filter] to dump a slice (every preview whose id contains the substring,
+ * case-insensitively).
  *
  * This is the headless counterpart of [runBundle]. Where the interactive view takes over the
  * terminal (raw mode, alternate screen, a render loop), the dump uses Mosaic's one-shot
@@ -21,9 +26,16 @@ import java.io.File
  *
  * Reads the bundle's baked `previews/<id>.png` entries (schema v2+), so it works fully detached from
  * the originating project. Prints a short notice and returns cleanly when the file carries no baked
- * previews (e.g. an older v1 bundle, or one packed with `--no-render`).
+ * previews (e.g. an older v1 bundle, or one packed with `--no-render`) or when the id/filter matches
+ * nothing.
  */
-fun dumpBundle(png: File, cols: Int? = null, rowsPerPreview: Int = DEFAULT_DUMP_ROWS) {
+fun dumpBundle(
+  png: File,
+  exactId: String? = null,
+  filter: String? = null,
+  cols: Int? = null,
+  rowsPerPreview: Int = DEFAULT_DUMP_ROWS,
+) {
   val contents = BundlePngMetadata.readContents(png)
   val width = (cols ?: TerminalSize.probe().cols).coerceIn(MIN_DUMP_COLS, MAX_DUMP_COLS)
 
@@ -32,9 +44,24 @@ fun dumpBundle(png: File, cols: Int? = null, rowsPerPreview: Int = DEFAULT_DUMP_
     return
   }
 
-  val total = contents.previews.size
-  println("${png.name}: $total preview(s)")
-  contents.previews.forEachIndexed { index, preview ->
+  // Default to the single cover preview; `--id` pins one exactly, `--filter` selects a slice.
+  val selected =
+    when {
+      exactId != null -> contents.previews.filter { it.id == exactId }
+      filter != null -> contents.previews.filter { it.id.contains(filter, ignoreCase = true) }
+      else -> listOf(contents.previews.first())
+    }
+
+  if (selected.isEmpty()) {
+    val which = exactId?.let { "id '$it'" } ?: "filter '$filter'"
+    println("${png.name}: no baked preview matches $which (${contents.previews.size} available).")
+    return
+  }
+
+  val total = selected.size
+  val suffix = if (total < contents.previews.size) " of ${contents.previews.size}" else ""
+  println("${png.name}: $total preview(s)$suffix")
+  selected.forEachIndexed { index, preview ->
     println()
     println("=== ${preview.id} (${index + 1}/$total) ===")
     val bitmap = Bitmaps.decode(preview.pngBytes)

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/BundleView.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/BundleView.kt
@@ -26,28 +26,42 @@ import ee.schimke.composeai.tui.terminal.TerminalSize
 import java.io.File
 import kotlinx.coroutines.launch
 
+/** One paged preview in the bundle view: its id (may be null for a bare PNG) and decoded image. */
+private data class BundlePage(val id: String?, val bitmap: Bitmap?)
+
 /**
- * Bundle-PNG entry point. Renders ONE preview full-screen with no list / tab / status chrome — just
- * the image. The PNG handed on the command line is decoded and shown immediately as the first frame
- * (ImageIO reads the leading PNG of a PNG+ZIP polyglot bundle, ignoring the appended zip); then, if
- * the bundle names a module and we're inside its project on disk, the daemon is attached and later
- * renders replace the seed live as the source is edited. A plain PNG (or a bundle opened outside its
- * project) is shown as a static image.
+ * Bundle-PNG entry point. Renders the bundle's previews full-screen with minimal chrome (the image
+ * plus a one-line footer when there's more than one preview).
  *
- * `q` / `Esc` quits; `r` forces a re-render (no-op without a live session).
+ * Since bundle schema v2 the zip carries a baked PNG per preview under `previews/<id>.png`, so this
+ * works **fully detached from the originating project** — opening a bundle from `~/Downloads` lets
+ * you page through every preview with the arrow keys, no Gradle checkout required. When the bundle
+ * does name a module and we're inside its project on disk, the daemon is additionally attached and
+ * later renders of the *current* preview replace the baked image live as the source is edited. An
+ * older v1 bundle (or a `--no-render` pack) falls back to the single cover image decoded from the
+ * polyglot's leading bytes.
+ *
+ * `q` / `Esc` quits; `←/→` (also `h/l`, `p/n`, `↑/↓`, `j/k`) page between previews; `r` forces a
+ * re-render of the current preview (no-op without a live session).
  */
 fun runBundle(png: File, projectRoot: File?, args: TuiArgs) {
-  // Decode the bundle's own image up front so the very first composed frame already shows it — no
-  // "rendering…" flash before the daemon attaches.
-  val seed = Bitmaps.readPng(png)
+  val contents = BundlePngMetadata.readContents(png)
+  val metadata = contents.metadata
 
-  // `bundle.json` tells us which module + cover preview produced this PNG. Live re-render also needs
-  // the source project on disk: without a project root (we're not inside a Gradle checkout) there's
-  // no daemon to attach, so we fall back to the static seed.
-  val metadata = BundlePngMetadata.readOrNull(png)
-  val previewId = metadata?.coverPreviewId
+  // Prefer the baked per-preview PNGs (v2). Fall back to the single cover image decoded from the
+  // polyglot's leading bytes for v1 bundles / bare PNGs so old artefacts still open.
+  val pages =
+    if (contents.previews.isNotEmpty()) {
+      contents.previews.map { BundlePage(id = it.id, bitmap = Bitmaps.decode(it.pngBytes)) }
+    } else {
+      listOf(BundlePage(id = metadata?.coverPreviewId, bitmap = Bitmaps.readPng(png)))
+    }
+
+  // `bundle.json` tells us which module produced this PNG. Live re-render also needs the source
+  // project on disk: without a project root (we're not inside a Gradle checkout) there's no daemon
+  // to attach, so we just page through the baked images statically.
   val module =
-    if (projectRoot != null && metadata != null) {
+    if (projectRoot != null && metadata != null && metadata.modulePath.isNotEmpty()) {
       // Mirror the synthetic module Main builds for `--no-discovery`: <projectRoot>/<path-as-dirs>.
       val relative = metadata.modulePath.trimStart(':').replace(':', '/').ifEmpty { "." }
       PreviewModule(gradlePath = metadata.modulePath, projectDir = File(projectRoot, relative))
@@ -56,26 +70,20 @@ fun runBundle(png: File, projectRoot: File?, args: TuiArgs) {
     }
 
   runMosaicMain {
-    BundleApp(
-      seed = seed,
-      pngName = png.name,
-      module = module,
-      previewId = previewId,
-      extensions = args.extensions,
-    )
+    BundleApp(pages = pages, pngName = png.name, module = module, extensions = args.extensions)
   }
 }
 
 /**
- * The whole bundle-mode UI: a single full-terminal image. Holds an optional [LiveSession] and swaps
- * the seed for the daemon's freshest render of [previewId] whenever a notification ticks.
+ * The whole bundle-mode UI: a single full-terminal image with an optional one-line footer. Holds an
+ * optional [LiveSession] and swaps the current page's baked image for the daemon's freshest render
+ * of the selected preview whenever a notification ticks.
  */
 @Composable
 private fun BundleApp(
-  seed: Bitmap?,
+  pages: List<BundlePage>,
   pngName: String,
   module: PreviewModule?,
-  previewId: String?,
   extensions: Set<String>,
 ) {
   val initialSize = remember { TerminalSize.probe() }
@@ -87,13 +95,17 @@ private fun BundleApp(
   val liveSession = remember { LiveSession(scope) }
   val liveState by liveSession.state.collectAsState()
   var exitRequested by remember { mutableStateOf(false) }
+  var index by remember { mutableStateOf(0) }
+
+  val current = pages.getOrElse(index) { pages.first() }
+  val currentId = current.id
 
   // Attach the daemon once, if the bundle named a module. The session is sticky for the run.
   LaunchedEffect(module) { if (module != null) liveSession.enable(module, extensions) }
-  // Mark the preview visible once the session is READY so the daemon pushes its re-renders.
-  LaunchedEffect(liveState.status, previewId) {
-    if (previewId != null && liveState.status == LiveSession.Status.READY) {
-      liveSession.setVisible(previewId)
+  // Mark the current preview visible once the session is READY so the daemon pushes its re-renders.
+  LaunchedEffect(liveState.status, currentId) {
+    if (currentId != null && liveState.status == LiveSession.Status.READY) {
+      liveSession.setVisible(currentId)
     }
   }
 
@@ -102,15 +114,20 @@ private fun BundleApp(
     return
   }
 
-  // Prefer the daemon's freshest render of this preview; fall back to the seed PNG until (or unless)
-  // one exists. Re-resolved on every daemon tick.
+  // Prefer the daemon's freshest render of the current preview; fall back to the baked image until
+  // (or unless) one exists. Re-resolved on every daemon tick / page change.
   val liveFrame: Bitmap? =
-    if (module != null && previewId != null) {
-      remember(liveState.tick) { resolveRenderedPng(module, previewId)?.let(Bitmaps::readPng) }
+    if (module != null && currentId != null) {
+      remember(liveState.tick, currentId) {
+        resolveRenderedPng(module, currentId)?.let(Bitmaps::readPng)
+      }
     } else {
       null
     }
-  val bitmap = liveFrame ?: seed
+  val bitmap = liveFrame ?: current.bitmap
+
+  val multi = pages.size > 1
+  val imageRows = if (multi) (rows - 1).coerceAtLeast(1) else rows
 
   Column(
     modifier =
@@ -124,7 +141,23 @@ private fun BundleApp(
             true
           }
           "r" -> {
-            if (previewId != null) scope.launch { liveSession.forceRender(previewId) }
+            if (currentId != null) scope.launch { liveSession.forceRender(currentId) }
+            true
+          }
+          "Right",
+          "l",
+          "n",
+          "Down",
+          "j" -> {
+            if (multi) index = (index + 1) % pages.size
+            true
+          }
+          "Left",
+          "h",
+          "p",
+          "Up",
+          "k" -> {
+            if (multi) index = (index - 1 + pages.size) % pages.size
             true
           }
           else -> false
@@ -132,9 +165,15 @@ private fun BundleApp(
       }
   ) {
     if (bitmap == null) {
-      Text("(failed to decode $pngName)".take(cols), textStyle = TextStyle.Dim)
+      val label = currentId ?: pngName
+      Text("(failed to decode $label)".take(cols), textStyle = TextStyle.Dim)
     } else {
-      Image(bitmap = bitmap, cellWidth = cols, cellHeight = rows)
+      Image(bitmap = bitmap, cellWidth = cols, cellHeight = imageRows)
+    }
+    if (multi) {
+      val name = currentId ?: pngName
+      val footer = "  $name  (${index + 1}/${pages.size})   ←/→ page · q quit"
+      Text(footer.take(cols).padEnd(cols), textStyle = TextStyle.Dim)
     }
   }
 }

--- a/tui-cli/src/test/kotlin/ee/schimke/composeai/tui/BundleContentsTest.kt
+++ b/tui-cli/src/test/kotlin/ee/schimke/composeai/tui/BundleContentsTest.kt
@@ -54,7 +54,7 @@ class BundleContentsTest {
     assertTrue(contents.previews.isEmpty())
   }
 
-  /** Builds a PNG+ZIP polyglot: a tiny PNG cover, then a zip with bundle.json + previews/*.png. */
+  /** Builds a PNG+ZIP polyglot: a tiny PNG cover, then a zip with bundle.json + per-preview PNGs. */
   private fun writeBundle(
     cover: String,
     modulePath: String,

--- a/tui-cli/src/test/kotlin/ee/schimke/composeai/tui/BundleContentsTest.kt
+++ b/tui-cli/src/test/kotlin/ee/schimke/composeai/tui/BundleContentsTest.kt
@@ -1,0 +1,94 @@
+package ee.schimke.composeai.tui
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Unit coverage for [BundlePngMetadata.readContents] — the detached-bundle reader that pulls every
+ * baked `previews/<id>.png` (schema v2) out of a PNG+ZIP polyglot so the TUI can page through a
+ * bundle with no project on disk.
+ */
+class BundleContentsTest {
+
+  @TempDir lateinit var tempDir: File
+
+  @Test
+  fun `reads baked previews cover-first`() {
+    val bundle =
+      writeBundle(
+        cover = "pkg.Foo",
+        modulePath = ":sample",
+        previewPngs = linkedMapOf("pkg.Baz" to png(0x111111), "pkg.Foo" to png(0x222222)),
+      )
+
+    val contents = BundlePngMetadata.readContents(bundle)
+
+    assertEquals(":sample", contents.metadata?.modulePath)
+    // Cover (pkg.Foo) sorts first; the rest follow by id.
+    assertEquals(listOf("pkg.Foo", "pkg.Baz"), contents.previews.map { it.id })
+    assertTrue(contents.previews.all { it.pngBytes.isNotEmpty() })
+  }
+
+  @Test
+  fun `non-bundle file yields empty contents`() {
+    val notABundle = File(tempDir, "random.bin").apply { writeBytes(byteArrayOf(1, 2, 3, 4)) }
+    val contents = BundlePngMetadata.readContents(notABundle)
+    assertNull(contents.metadata)
+    assertTrue(contents.previews.isEmpty())
+  }
+
+  @Test
+  fun `v1-shaped bundle with no previews dir reads zero previews`() {
+    val bundle = writeBundle(cover = "pkg.Foo", modulePath = ":sample", previewPngs = linkedMapOf())
+    val contents = BundlePngMetadata.readContents(bundle)
+    assertEquals(":sample", contents.metadata?.modulePath)
+    assertTrue(contents.previews.isEmpty())
+  }
+
+  /** Builds a PNG+ZIP polyglot: a tiny PNG cover, then a zip with bundle.json + previews/*.png. */
+  private fun writeBundle(
+    cover: String,
+    modulePath: String,
+    previewPngs: Map<String, ByteArray>,
+  ): File {
+    val coverPng = previewPngs[cover] ?: png(0x808080)
+    val zip = ByteArrayOutputStream()
+    ZipOutputStream(zip).use { zos ->
+      val bundleJson =
+        """{"schemaVersion":2,"backend":"desktop","previewIds":${
+          previewPngs.keys.joinToString(prefix = "[", postfix = "]") { "\"$it\"" }
+        },"coverPreviewId":"$cover","classpath":[],"modulePath":"$modulePath","producedBy":"test"}"""
+      zos.putNextEntry(ZipEntry("bundle.json"))
+      zos.write(bundleJson.toByteArray())
+      zos.closeEntry()
+      previewPngs.forEach { (id, bytes) ->
+        zos.putNextEntry(ZipEntry("previews/$id.png"))
+        zos.write(bytes)
+        zos.closeEntry()
+      }
+    }
+    val out = File(tempDir, "bundle.png")
+    out.outputStream().use {
+      it.write(coverPng)
+      it.write(zip.toByteArray())
+    }
+    return out
+  }
+
+  private fun png(rgb: Int): ByteArray {
+    val img = BufferedImage(2, 2, BufferedImage.TYPE_INT_RGB)
+    for (y in 0 until 2) for (x in 0 until 2) img.setRGB(x, y, rgb and 0xFFFFFF)
+    val baos = ByteArrayOutputStream()
+    ImageIO.write(img, "png", baos)
+    return baos.toByteArray()
+  }
+}

--- a/tui-cli/src/test/kotlin/ee/schimke/composeai/tui/BundleContentsTest.kt
+++ b/tui-cli/src/test/kotlin/ee/schimke/composeai/tui/BundleContentsTest.kt
@@ -63,10 +63,9 @@ class BundleContentsTest {
     val coverPng = previewPngs[cover] ?: png(0x808080)
     val zip = ByteArrayOutputStream()
     ZipOutputStream(zip).use { zos ->
+      val previewIds = previewPngs.keys.joinToString(prefix = "[", postfix = "]") { "\"$it\"" }
       val bundleJson =
-        """{"schemaVersion":2,"backend":"desktop","previewIds":${
-          previewPngs.keys.joinToString(prefix = "[", postfix = "]") { "\"$it\"" }
-        },"coverPreviewId":"$cover","classpath":[],"modulePath":"$modulePath","producedBy":"test"}"""
+        "{\"schemaVersion\":2,\"backend\":\"desktop\",\"previewIds\":$previewIds,\"coverPreviewId\":\"$cover\",\"classpath\":[],\"modulePath\":\"$modulePath\",\"producedBy\":\"test\"}"
       zos.putNextEntry(ZipEntry("bundle.json"))
       zos.write(bundleJson.toByteArray())
       zos.closeEntry()


### PR DESCRIPTION
## Summary

Make preview bundles self-describing so they work **detached from a project** (e.g. opened from `~/Downloads`), carry **multiple previews** (one default + the rest in a well-known location), and add a CI workflow that dumps each preview to the terminal through the TUI's ASCII fallback.

### Bundle format — schema v2
- `composePreviewBundle` now bakes the rendered PNG of **every selected preview** into a well-known `previews/<id>.png` directory inside the zip, alongside the cover that forms the polyglot's leading bytes (the single *default* image every viewer shows).
- A bundle no longer needs the originating Gradle project (or a re-render) just to view its previews — `classes/app.jar` + classpath stay for *live* re-render, but are no longer required to look at the images.
- `@PreviewParameter` / multi-variant previews fall back to a representative sibling render (`<base>_<param>.png` / `<base>--<dim>.png`) instead of being dropped.
- Schema bumped `1 → 2`; additive zip entries, so v1 readers (`ignoreUnknownKeys`) still open v2 bundles.

### TUI
- The bundle view reads the baked previews and pages through all of them (`←/→`, `h/l`, `j/k`, `n/p`) **fully detached from a project**; when the project *is* present, the live daemon still overrides the current preview.
- New headless `--dump` / `--ascii` mode renders each baked preview to stdout via Mosaic's one-shot `renderMosaic` + `Image` (half-block / ASCII fallback) — no PTY, no daemon — usable from a plain piped stdout.

### CI
- New `preview-bundle-ascii.yml`: renders the CMP sample, packs one multi-preview bundle, and drives `compose-preview-tui --dump` to print each preview to the build log. It's the only workflow that opts the Mosaic-fork TUI in (`tui.enabled=true`).

## Test plan
- [x] `:gradle-plugin:functionalTest --tests BundleFunctionalTest` — new test seeds dummy renders, packs, asserts `previews/<id>.png` per preview + cover-front mirrors `previews/<coverId>.png`. All bundle tests green.
- [x] Local end-to-end: `:samples:cmp:composePreviewRenderAll` then `composePreviewBundle` → 11/12 previews baked (the 12th is a scroll data-product with no primary capture), schema v2, cover-front byte-identical to the baked cover.
- [x] `:gradle-plugin:test`, `:bundle-viewer:test`, `:cli` compile green.
- [ ] **`:tui-cli` is verified only by this PR's `preview-bundle-ascii` CI run** — the Mosaic fork snapshot (`central.sonatype.com`) returns 403 in the authoring sandbox, so the TUI couldn't be compiled locally. In particular the `--dump` path's use of `renderMosaic` is confirmed by that workflow. The new `BundleContentsTest` (`:tui-cli:test`) and `installDist` both run there.

> Note: the working branch was renamed `claude/preview-png-bundles-S4mbU` → `agent/preview-png-bundles-S4mbU` per my standing branch-naming convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pkfwxdoh2qrkS44z8pdFJs)_