### PR TITLE
feat(tui-cli): view a bundle with no project context

### DIFF
--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -13,6 +13,8 @@ import ee.schimke.composeai.render.session.RenderSessionConfig
 import ee.schimke.composeai.render.session.RenderSessionException
 import ee.schimke.composeai.render.session.RenderSessionFactory
 import java.io.File
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * [RenderSessionFactory] singleton for the daemon-subprocess backend. Open a session via
@@ -56,17 +58,94 @@ object SubprocessRenderSessions : RenderSessionFactory {
     val workspaceRoot = config.workspaceRoot
     val canonicalRoot =
       runCatching { workspaceRoot.canonicalFile }.getOrDefault(workspaceRoot.absoluteFile)
+    return spawnAndInitialize(
+      descriptor = effectiveDescriptor,
+      workspaceName = config.workspaceName,
+      canonicalRoot = canonicalRoot,
+      initializeTimeout = config.initializeTimeout,
+      factory = factory,
+    )
+  }
+
+  /**
+   * Open a session against a self-contained preview bundle — no Gradle project on disk.
+   *
+   * Where [open] reads a `daemon-launch.json` the gradle plugin wrote into a module's `build/`
+   * directory, this overload synthesizes the [DaemonLaunchDescriptor] in-process from the inputs a
+   * bundle already carries: the desktop daemon main class, a [daemonClasspath] assembled from the
+   * shipped sidecar jars (`lib-daemon-desktop/jars` + `lib-renderer/jars`), and the bundle's
+   * extracted user classes ([classesDir]) + discovery manifest ([previewsJson]). The daemon reads
+   * those two via the same `composeai.daemon.userClassDirs` / `composeai.daemon.previewsJsonPath`
+   * system properties the `compose-preview bundle daemon` CLI command uses, so the spawn +
+   * initialize + notification wiring is identical to [open] from there on.
+   *
+   * Keeping descriptor construction here (rather than in a consumer like `:tui-cli`) means the
+   * schema version and field names stay owned by the module that owns [DaemonLaunchDescriptor].
+   *
+   * @param daemonClasspath absolute paths of every jar on the daemon subprocess classpath.
+   * @param classesDir directory holding the bundle's extracted `classes/app.jar` contents.
+   * @param previewsJson the bundle's extracted `previews.json` discovery manifest.
+   * @param workspaceRoot a scratch directory used as the daemon's working directory + workspace id.
+   * @param modulePath informational module label surfaced in diagnostics (defaults to the bundle).
+   */
+  fun openBundleDaemon(
+    daemonClasspath: List<String>,
+    classesDir: File,
+    previewsJson: File,
+    workspaceRoot: File,
+    modulePath: String = ":bundle",
+    initializeTimeout: Duration = 60.seconds,
+    factory: DaemonClientFactory = SubprocessDaemonClientFactory(),
+  ): RenderSession {
+    require(daemonClasspath.isNotEmpty()) { "daemonClasspath must not be empty" }
+    val canonicalRoot =
+      runCatching { workspaceRoot.canonicalFile }.getOrDefault(workspaceRoot.absoluteFile)
+    val descriptor =
+      DaemonLaunchDescriptor(
+        schemaVersion = DAEMON_DESCRIPTOR_SCHEMA_VERSION,
+        modulePath = modulePath,
+        variant = "",
+        enabled = true,
+        mainClass = DESKTOP_DAEMON_MAIN_CLASS,
+        javaLauncher = null,
+        classpath = daemonClasspath,
+        jvmArgs = listOf("--enable-native-access=ALL-UNNAMED"),
+        systemProperties =
+          mapOf(
+            "composeai.daemon.userClassDirs" to classesDir.absolutePath,
+            "composeai.daemon.previewsJsonPath" to previewsJson.absolutePath,
+          ),
+        workingDirectory = canonicalRoot.absolutePath,
+        manifestPath = previewsJson.absolutePath,
+      )
+    return spawnAndInitialize(
+      descriptor = descriptor,
+      workspaceName = canonicalRoot.name.ifBlank { "bundle" },
+      canonicalRoot = canonicalRoot,
+      initializeTimeout = initializeTimeout,
+      factory = factory,
+    )
+  }
+
+  /** Shared spawn + JSON-RPC initialize + session-wrap path for [open] and [openBundleDaemon]. */
+  private fun spawnAndInitialize(
+    descriptor: DaemonLaunchDescriptor,
+    workspaceName: String,
+    canonicalRoot: File,
+    initializeTimeout: Duration,
+    factory: DaemonClientFactory,
+  ): RenderSession {
     val project =
       RegisteredProject(
-        workspaceId = WorkspaceId.derive(config.workspaceName, canonicalRoot),
-        rootProjectName = config.workspaceName,
+        workspaceId = WorkspaceId.derive(workspaceName, canonicalRoot),
+        rootProjectName = workspaceName,
         path = canonicalRoot,
         knownModules = mutableListOf(),
       )
 
     val spawn =
       try {
-        factory.spawn(project, effectiveDescriptor)
+        factory.spawn(project, descriptor)
       } catch (e: Exception) {
         throw RenderSessionException(
           "Failed to spawn daemon subprocess for ${descriptor.modulePath}: " +
@@ -86,9 +165,9 @@ object SubprocessRenderSessions : RenderSessionFactory {
       try {
         client.initialize(
           workspaceRoot = canonicalRoot.absolutePath,
-          moduleId = effectiveDescriptor.modulePath,
-          moduleProjectDir = effectiveDescriptor.workingDirectory,
-          timeout = config.initializeTimeout,
+          moduleId = descriptor.modulePath,
+          moduleProjectDir = descriptor.workingDirectory,
+          timeout = initializeTimeout,
         )
       } catch (e: Exception) {
         runCatching { spawn.shutdown() }
@@ -101,7 +180,7 @@ object SubprocessRenderSessions : RenderSessionFactory {
 
     return DaemonClientRenderSession(
       workspaceRoot = canonicalRoot.absolutePath,
-      modulePath = effectiveDescriptor.modulePath,
+      modulePath = descriptor.modulePath,
       initializeResult = initializeResult,
       backendKind = RenderSessionBackend.Subprocess,
       client = client,
@@ -112,6 +191,14 @@ object SubprocessRenderSessions : RenderSessionFactory {
       },
     )
   }
+
+  /** `ee.schimke.composeai.daemon.DaemonMain` — the desktop daemon entrypoint a bundle spawns. */
+  private const val DESKTOP_DAEMON_MAIN_CLASS = "ee.schimke.composeai.daemon.DaemonMain"
+
+  /**
+   * Descriptor schema version the daemon launch path speaks; mirrors the gradle plugin's writer.
+   */
+  private const val DAEMON_DESCRIPTOR_SCHEMA_VERSION = 2
 
   /**
    * Resolve a module's daemon launch descriptor under [projectDir] / [modulePath] using the

--- a/tui-cli/build.gradle.kts
+++ b/tui-cli/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
+
 plugins {
   id("composeai.jvm-conventions")
   alias(libs.plugins.kotlin.jvm)
@@ -40,6 +43,24 @@ tasks.named<Tar>("distTar") {
   compression = Compression.GZIP
 }
 
+// Sidecar configurations carrying the desktop renderer + daemon and their Compose Multiplatform
+// runtime. Project-less bundle mode (`compose-preview-tui <bundle.png>` outside a Gradle checkout)
+// spawns the desktop daemon straight from the bundle's embedded classes, and the daemon needs these
+// jars on its subprocess classpath. Same isolation story as `:cli`'s sidecars: never on the
+// launcher's own classpath — only loaded by the spawned daemon JVM — so there's no version-skew
+// risk against anything the launcher links. Resolved into `lib-renderer/` and `lib-daemon-desktop/`
+// in the dist and located at runtime via `APP_HOME` (see `BundleSidecars`).
+val composePreviewRenderer =
+  configurations.create("composePreviewRenderer") {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+  }
+val composePreviewDaemonDesktop =
+  configurations.create("composePreviewDaemonDesktop") {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+  }
+
 dependencies {
   implementation(project(":preview-data-api"))
   implementation(project(":gradle-preview-driver"))
@@ -50,6 +71,13 @@ dependencies {
 
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.json)
+
+  // Subprocess-only sidecars shipped in the dist for project-less bundle mode. The daemon's
+  // subprocess classpath joins `lib-daemon-desktop/jars` + `lib-renderer/jars` at launch; the renderer
+  // sidecar carries the per-OS Compose Multiplatform stack (incl. Skiko) so it isn't duplicated
+  // in the daemon sidecar. Mirrors `:cli`'s `bundle daemon` / `bundle render` wiring.
+  add("composePreviewRenderer", project(":renderer-desktop"))
+  add("composePreviewDaemonDesktop", project(":daemon:desktop"))
 
   testImplementation(kotlin("test"))
   // JUnit 5 — used directly for `@TempDir`, `Assumptions.assumeTrue`, `@DisplayName`
@@ -73,4 +101,43 @@ tasks.withType<Test>().configureEach {
   // The e2e test is gated on `Xvfb`/`kitty`/`xdotool`/`import` being on PATH (it self-skips
   // when any of them is missing). On a CI runner without those binaries the test is a fast
   // no-op; locally with `apt install kitty xdotool imagemagick xvfb` it runs end-to-end.
+}
+
+// Multiple JetBrains Compose Multiplatform `components-*-desktop` artifacts ship as
+// `library-desktop-<version>.jar`, so a flat copy into `lib-daemon-desktop/` collides on filename.
+// Stage the resolved artifacts first, disambiguating colliding filenames by `module-version.jar`,
+// so both end up on the daemon's classpath. Copied verbatim from `:cli`'s `stageDaemonDesktopLibs`.
+val stageDaemonDesktopLibs =
+  tasks.register<Sync>("stageDaemonDesktopLibs") {
+    description = "Stages :daemon:desktop runtime artifacts, renaming filename collisions."
+    destinationDir = layout.buildDirectory.dir("staged-daemon-desktop-libs").get().asFile
+    val artifactsProvider = composePreviewDaemonDesktop.incoming.artifacts.resolvedArtifacts
+    from(artifactsProvider.map { it.map(ResolvedArtifactResult::getFile) })
+    val nameByPath =
+      artifactsProvider.map { resolved ->
+        val counts = resolved.groupingBy { it.file.name }.eachCount()
+        resolved.associate { artifact ->
+          val original = artifact.file.name
+          val mapped =
+            if (counts.getValue(original) > 1) {
+              val id = artifact.id.componentIdentifier
+              if (id is ModuleComponentIdentifier) "${id.module}-${id.version}.jar" else original
+            } else original
+          artifact.file.absolutePath to mapped
+        }
+      }
+    inputs.property("nameByPath", nameByPath)
+    eachFile {
+      val mapped = nameByPath.get()[file.absolutePath]
+      if (mapped != null) name = mapped
+    }
+  }
+
+distributions {
+  named("main") {
+    contents {
+      into("lib-renderer") { from(composePreviewRenderer) }
+      into("lib-daemon-desktop") { from(stageDaemonDesktopLibs) }
+    }
+  }
 }

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/BundleExtractor.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/BundleExtractor.kt
@@ -1,0 +1,97 @@
+package ee.schimke.composeai.tui
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.util.zip.ZipInputStream
+
+/**
+ * Extracts the two products a self-contained preview bundle needs to drive its own daemon — the
+ * user `classes/app.jar` (unpacked into a `classes/` dir) and the `previews.json` discovery manifest
+ * — out of the PNG+ZIP polyglot, with no Gradle project involved.
+ *
+ * The polyglot zip-slice routine is shared with [BundlePngMetadata.extractZipBytes] rather than
+ * re-implemented; the per-entry unpack mirrors `cli`'s `BundleDaemonCommand.expandJarBytesSafely`,
+ * including its Zip-Slip guard (a hostile entry name resolving outside the target dir is rejected).
+ */
+object BundleExtractor {
+
+  /** The on-disk products of [extract]: where the daemon reads classes + the discovery manifest. */
+  data class Extracted(val workDir: File, val classesDir: File, val previewsJson: File)
+
+  /**
+   * Extract [bundle] into a fresh temp [workDir]. Returns null when [bundle] is not a readable
+   * polyglot or is missing `classes/app.jar` / `previews.json` (i.e. a plain PNG, not a bundle) —
+   * callers fall back to showing the static seed image.
+   *
+   * The caller owns [Extracted.workDir]; delete it when the session closes.
+   */
+  fun extract(bundle: File): Extracted? {
+    val zipBytes = BundlePngMetadata.extractZipBytes(bundle) ?: return null
+
+    val workDir = File.createTempFile("compose-preview-tui-bundle-", "").let { tmp ->
+      tmp.delete()
+      tmp.mkdirs()
+      tmp
+    }
+    val classesDir = File(workDir, "classes").apply { mkdirs() }
+    val previewsJson = File(workDir, "previews.json")
+
+    var sawAppJar = false
+    var sawPreviews = false
+    try {
+      ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+        while (true) {
+          val entry = zin.nextEntry ?: break
+          when (entry.name) {
+            "previews.json" -> {
+              previewsJson.writeBytes(zin.readBytes())
+              sawPreviews = true
+            }
+            "classes/app.jar" -> {
+              expandJarSafely(zin.readBytes(), classesDir)
+              sawAppJar = true
+            }
+          }
+          zin.closeEntry()
+        }
+      }
+    } catch (_: Throwable) {
+      workDir.deleteRecursively()
+      return null
+    }
+
+    if (!sawAppJar || !sawPreviews) {
+      workDir.deleteRecursively()
+      return null
+    }
+    return Extracted(workDir = workDir, classesDir = classesDir, previewsJson = previewsJson)
+  }
+
+  /**
+   * Unpack [appJarBytes] into [targetDir], rejecting Zip-Slip (an entry whose resolved path escapes
+   * [targetDir]). Same shape as `BundleDaemonCommand.expandJarBytesSafely`; duplicated rather than
+   * shared to keep `:tui-cli` off `:cli`'s classpath.
+   */
+  private fun expandJarSafely(appJarBytes: ByteArray, targetDir: File) {
+    val canonicalTarget = targetDir.canonicalFile
+    ZipInputStream(ByteArrayInputStream(appJarBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        val candidate = File(targetDir, entry.name).canonicalFile
+        if (
+          candidate != canonicalTarget &&
+            !candidate.path.startsWith(canonicalTarget.path + File.separator)
+        ) {
+          throw SecurityException("bundle app jar entry escapes target dir: ${entry.name}")
+        }
+        if (entry.isDirectory) {
+          candidate.mkdirs()
+        } else {
+          candidate.parentFile?.mkdirs()
+          candidate.outputStream().use { sink -> zin.copyTo(sink) }
+        }
+        zin.closeEntry()
+      }
+    }
+  }
+}

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/BundlePngMetadata.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/BundlePngMetadata.kt
@@ -42,8 +42,11 @@ data class BundlePngMetadata(val modulePath: String = "", val coverPreviewId: St
         null
       }
 
-    /** The trailing zip of a PNG+ZIP polyglot, the whole file for a bare zip, or null otherwise. */
-    private fun extractZipBytes(file: File): ByteArray? {
+    /**
+     * The trailing zip of a PNG+ZIP polyglot, the whole file for a bare zip, or null otherwise.
+     * `internal` so [BundleExtractor] reuses the same polyglot scan instead of re-implementing it.
+     */
+    internal fun extractZipBytes(file: File): ByteArray? {
       val bytes = file.readBytes()
       if (bytes.size < PNG_SIG.size) return null
       if (bytes[0] == 0x50.toByte() && bytes[1] == 0x4B.toByte()) return bytes // bare zip "PK"

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/BundleSidecars.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/BundleSidecars.kt
@@ -1,0 +1,57 @@
+package ee.schimke.composeai.tui
+
+import java.io.File
+
+/**
+ * Locates the daemon + renderer sidecar jar directories shipped in the `compose-preview-tui`
+ * distribution (`$APP_HOME/lib-daemon-desktop/` and `$APP_HOME/lib-renderer/`). Project-less bundle
+ * mode joins both onto the daemon subprocess classpath.
+ *
+ * Resolution order mirrors `cli`'s `BundleDaemonCommand.locateSidecarJars`:
+ * 1. an explicit `-Dcomposeai.tui.libDaemonDesktopDir` / `-Dcomposeai.tui.libRendererDir` override,
+ * 2. `$APP_HOME/<name>` (the env var the generated launcher script exports),
+ * 3. `<first-classpath-jar>/../../<name>` (IDE / `JavaExec` runs against the install layout).
+ *
+ * [locate] returns null when either directory is absent — e.g. running from source without
+ * `installDist` — so the caller can fall back to the static seed image instead of failing.
+ */
+object BundleSidecars {
+
+  /** Absolute paths of every jar across both sidecar dirs, ready for the daemon classpath. */
+  data class Sidecars(val daemonDesktopDir: File, val rendererDir: File) {
+    fun classpath(): List<String> =
+      (jarsIn(daemonDesktopDir) + jarsIn(rendererDir)).map { it.absolutePath }
+
+    private fun jarsIn(dir: File): List<File> =
+      dir.listFiles { f -> f.isFile && f.name.endsWith(".jar") }?.sortedBy { it.name }.orEmpty()
+  }
+
+  fun locate(): Sidecars? {
+    val daemon = locateDir("lib-daemon-desktop", "composeai.tui.libDaemonDesktopDir") ?: return null
+    val renderer = locateDir("lib-renderer", "composeai.tui.libRendererDir") ?: return null
+    val sidecars = Sidecars(daemonDesktopDir = daemon, rendererDir = renderer)
+    // Both dirs must actually carry jars; an empty sidecar dir is as useless as a missing one.
+    return sidecars.takeIf { it.classpath().isNotEmpty() }
+  }
+
+  private fun locateDir(name: String, sysprop: String): File? {
+    val candidates =
+      listOfNotNull(
+        System.getProperty(sysprop)?.let(::File),
+        (System.getProperty("composeai.cli.appHome") ?: System.getenv("APP_HOME"))?.let {
+          File(it, name)
+        },
+        inferFromClasspath(name),
+      )
+    return candidates.firstOrNull { it.isDirectory }
+  }
+
+  /** `<install-root>/<name>` inferred from the first jar on the launcher's own classpath (`lib/`). */
+  private fun inferFromClasspath(name: String): File? {
+    val cp = System.getProperty("java.class.path") ?: return null
+    val firstJar = cp.split(File.pathSeparator).firstOrNull { it.endsWith(".jar") } ?: return null
+    val libDir = File(firstJar).parentFile ?: return null
+    val installRoot = libDir.parentFile ?: return null
+    return File(installRoot, name).takeIf { it.isDirectory }
+  }
+}

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/LiveSession.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/LiveSession.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
 /**
  * Live-mode controller. Owns the optional [RenderSession] subscription that turns external file
@@ -49,6 +51,13 @@ class LiveSession(private val scope: CoroutineScope) {
     val lastError: String? = null,
     /** Monotonic counter incremented on every daemon notification — drives recompose tick. */
     val tick: Long = 0,
+    /**
+     * Latest rendered PNG path per preview id, harvested from `renderFinished` notifications. This
+     * is how a consumer finds the freshest frame **without assuming any on-disk project layout** —
+     * the daemon reports exactly where it wrote each render (project mode and project-less bundle
+     * mode alike).
+     */
+    val lastPng: Map<String, String> = emptyMap(),
   )
 
   private val _state = MutableStateFlow(State())
@@ -115,45 +124,111 @@ class LiveSession(private val scope: CoroutineScope) {
             return@launch
           }
 
-        sessionRef.set(session)
-
-        if (extensions.isNotEmpty()) {
-          try {
-            session.enableExtensions(extensions.toList())
-          } catch (_: RenderSessionException) {
-            // Best-effort — a missing extension shouldn't kill live mode; the UI will show
-            // a "no findings" state for that pane.
-          }
-        }
-
-        // Tick on every notification so Compose recomposes and the UI re-reads disk. We don't
-        // care about the params payload — the daemon already wrote the PNG / sidecar before
-        // the notification went out.
-        val ticker = session.onNotification { _, _ ->
-          _state.update { it.copy(tick = it.tick + 1) }
-        }
-
-        // Start a filesystem watcher rooted at the module's project directory. When source
-        // edits land, forward them as `fileChanged` so the daemon invalidates and re-renders.
-        val watcher = FileWatcher(module.projectDir.resolve("src"))
-        watcherRef.set(watcher)
-        watcher.start { changedPath ->
-          val s = sessionRef.get() ?: return@start
-          try {
-            s.fileChanged(changedPath.toAbsolutePath().toString(), kind = FileKind.SOURCE)
-          } catch (_: RenderSessionException) {
-            // Transport went away (daemon died, etc.); the next user action will surface
-            // the FAILED status when the listener's next call throws.
-          }
-        }
-
-        _state.value =
-          State(status = Status.READY, modulePath = module.gradlePath, tick = current.tick + 1)
-
-        // Keep the listener registered for the lifetime of the session. `ticker` is closed in
-        // [closeQuietly]; the AutoCloseable is parked here.
-        sessionListenerHandle.set(ticker)
+        // Project mode: a filesystem watcher rooted at the module's `src/` forwards edits as
+        // `fileChanged` so the daemon invalidates and re-renders.
+        attachSession(
+          session = session,
+          modulePath = module.gradlePath,
+          extensions = extensions,
+          watchDir = module.projectDir.resolve("src"),
+          priorTick = current.tick,
+        )
       }
+  }
+
+  /**
+   * Project-less live mode for a self-contained bundle. [opener] spawns a daemon straight from the
+   * bundle (no `daemon-launch.json`, no source tree); the returned session is wired identically to
+   * [enable] **except there is no file watcher** — there is no source to watch, so "live" here means
+   * the daemon is held open for `r`-driven re-renders. [modulePath] is informational only.
+   */
+  fun enableBundle(modulePath: String, extensions: Set<String>, opener: () -> RenderSession) {
+    closeQuietly()
+    val priorTick = _state.value.tick
+    _state.value = State(status = Status.OPENING, modulePath = modulePath, lastError = null)
+
+    openJob =
+      scope.launch(Dispatchers.IO) {
+        val session: RenderSession =
+          try {
+            opener()
+          } catch (e: Exception) {
+            _state.value =
+              State(
+                status = Status.FAILED,
+                modulePath = modulePath,
+                lastError = e.message ?: e.javaClass.simpleName,
+              )
+            return@launch
+          }
+        attachSession(
+          session = session,
+          modulePath = modulePath,
+          extensions = extensions,
+          watchDir = null,
+          priorTick = priorTick,
+        )
+      }
+  }
+
+  /**
+   * Shared post-open wiring for [enable] and [enableBundle]: register the session, enable
+   * extensions, install the notification listener (which harvests `renderFinished.pngPath` into
+   * [State.lastPng]), optionally start a [FileWatcher] over [watchDir], and flip the state to READY.
+   */
+  private fun attachSession(
+    session: RenderSession,
+    modulePath: String,
+    extensions: Set<String>,
+    watchDir: File?,
+    priorTick: Long,
+  ) {
+    sessionRef.set(session)
+
+    if (extensions.isNotEmpty()) {
+      try {
+        session.enableExtensions(extensions.toList())
+      } catch (_: RenderSessionException) {
+        // Best-effort — a missing extension shouldn't kill live mode; the UI will show
+        // a "no findings" state for that pane.
+      }
+    }
+
+    // Tick on every notification so Compose recomposes. `renderFinished` additionally carries the
+    // path the daemon wrote the frame to (`id` + `pngPath`); record it so consumers read the
+    // freshest frame from the daemon's own report rather than guessing an on-disk project layout.
+    val ticker =
+      session.onNotification { method, params ->
+        if (method == "renderFinished" && params != null) {
+          val id = (params["id"] as? JsonPrimitive)?.contentOrNull
+          val png = (params["pngPath"] as? JsonPrimitive)?.contentOrNull
+          if (id != null && png != null) {
+            _state.update { it.copy(tick = it.tick + 1, lastPng = it.lastPng + (id to png)) }
+            return@onNotification
+          }
+        }
+        _state.update { it.copy(tick = it.tick + 1) }
+      }
+
+    if (watchDir != null) {
+      val watcher = FileWatcher(watchDir)
+      watcherRef.set(watcher)
+      watcher.start { changedPath ->
+        val s = sessionRef.get() ?: return@start
+        try {
+          s.fileChanged(changedPath.toAbsolutePath().toString(), kind = FileKind.SOURCE)
+        } catch (_: RenderSessionException) {
+          // Transport went away (daemon died, etc.); the next user action will surface
+          // the FAILED status when the listener's next call throws.
+        }
+      }
+    }
+
+    _state.value = State(status = Status.READY, modulePath = modulePath, tick = priorTick + 1)
+
+    // Keep the listener registered for the lifetime of the session. `ticker` is closed in
+    // [closeQuietly]; the AutoCloseable is parked here.
+    sessionListenerHandle.set(ticker)
   }
 
   /** Drop the session and the file watcher. Idempotent. */

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Main.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Main.kt
@@ -15,16 +15,18 @@ import kotlin.system.exitProcess
 fun main(argv: Array<String>) {
   val args = TuiArgs.parse(argv)
 
-  // Bundle-PNG mode: skip discovery and the browser entirely and open straight into the
-  // image-only live view. Live re-render needs the source project, so resolve a project root the
-  // same way normal mode does (override, else walk up for gradlew) — but unlike normal mode its
-  // absence isn't fatal: with no project we just show the bundle's baked-in image statically. The
-  // log lives under the project root (or next to the PNG) so daemon stderr can't corrupt the screen.
+  // Bundle-PNG mode: skip discovery and the browser entirely and open straight into the image-only
+  // live view. A bundle is self-contained, so this path assumes NO project context — it spawns the
+  // bundle's own daemon from its embedded classes (see `runBundle`). The stderr log lands next to
+  // the PNG (or under a project root if we happen to be in one) so daemon stderr can't corrupt the
+  // live screen.
   val bundlePng = args.bundlePng
   if (bundlePng != null) {
-    val projectRoot = args.projectRoot?.absoluteFile ?: findProjectRoot()
-    redirectStderrToLogFile(projectRoot ?: bundlePng.absoluteFile.parentFile ?: File("."))
-    runBundle(bundlePng, projectRoot, args)
+    val logRoot =
+      args.projectRoot?.absoluteFile ?: findProjectRoot() ?: bundlePng.absoluteFile.parentFile
+        ?: File(".")
+    redirectStderrToLogFile(logRoot)
+    runBundle(bundlePng, args)
     return
   }
 

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/BundleView.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/ui/BundleView.kt
@@ -17,8 +17,11 @@ import com.jakewharton.mosaic.ui.Column
 import com.jakewharton.mosaic.ui.Image
 import com.jakewharton.mosaic.ui.Text
 import com.jakewharton.mosaic.ui.TextStyle
-import ee.schimke.composeai.cli.PreviewModule
+import ee.schimke.composeai.render.session.RenderSession
+import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
+import ee.schimke.composeai.tui.BundleExtractor
 import ee.schimke.composeai.tui.BundlePngMetadata
+import ee.schimke.composeai.tui.BundleSidecars
 import ee.schimke.composeai.tui.LiveSession
 import ee.schimke.composeai.tui.TuiArgs
 import ee.schimke.composeai.tui.image.Bitmaps
@@ -28,30 +31,50 @@ import kotlinx.coroutines.launch
 
 /**
  * Bundle-PNG entry point. Renders ONE preview full-screen with no list / tab / status chrome — just
- * the image. The PNG handed on the command line is decoded and shown immediately as the first frame
- * (ImageIO reads the leading PNG of a PNG+ZIP polyglot bundle, ignoring the appended zip); then, if
- * the bundle names a module and we're inside its project on disk, the daemon is attached and later
- * renders replace the seed live as the source is edited. A plain PNG (or a bundle opened outside its
- * project) is shown as a static image.
+ * the image — and **assumes no project context**: a bundle is self-contained, so showing it must not
+ * depend on a surrounding Gradle checkout.
+ *
+ * The PNG handed on the command line is decoded and shown immediately as the first frame (ImageIO
+ * reads the leading PNG of the PNG+ZIP polyglot, ignoring the appended zip). Then, if this is a real
+ * bundle (carries `classes/app.jar` + `previews.json`) and the daemon/renderer sidecars ship in this
+ * install, the bundle's **own daemon** is spawned from those embedded classes and the live frame
+ * replaces the seed. There is no source tree to watch project-less, so "live" here means the daemon
+ * is held open for `r`-driven re-renders (paused-clock animations step, deterministic re-render).
+ *
+ * Falls back to the static seed image when: the file is a plain PNG (no provenance), the sidecars
+ * aren't present (e.g. run from source without `installDist`), or the daemon fails to start.
  *
  * `q` / `Esc` quits; `r` forces a re-render (no-op without a live session).
  */
-fun runBundle(png: File, projectRoot: File?, args: TuiArgs) {
+fun runBundle(png: File, args: TuiArgs) {
   // Decode the bundle's own image up front so the very first composed frame already shows it — no
   // "rendering…" flash before the daemon attaches.
   val seed = Bitmaps.readPng(png)
 
-  // `bundle.json` tells us which module + cover preview produced this PNG. Live re-render also needs
-  // the source project on disk: without a project root (we're not inside a Gradle checkout) there's
-  // no daemon to attach, so we fall back to the static seed.
-  val metadata = BundlePngMetadata.readOrNull(png)
-  val previewId = metadata?.coverPreviewId
-  val module =
-    if (projectRoot != null && metadata != null) {
-      // Mirror the synthetic module Main builds for `--no-discovery`: <projectRoot>/<path-as-dirs>.
-      val relative = metadata.modulePath.trimStart(':').replace(':', '/').ifEmpty { "." }
-      PreviewModule(gradlePath = metadata.modulePath, projectDir = File(projectRoot, relative))
+  val coverPreviewId = BundlePngMetadata.readOrNull(png)?.coverPreviewId
+  val modulePath = BundlePngMetadata.readOrNull(png)?.modulePath ?: ":bundle"
+
+  // Build a project-less opener iff this is a real bundle AND the sidecars are on disk. Extraction
+  // happens here (once) so the temp dir's lifetime spans the whole session; a shutdown hook cleans
+  // it up. `opener` is null → static seed only.
+  val extracted = BundleExtractor.extract(png)
+  val sidecars = BundleSidecars.locate()
+  val opener: (() -> RenderSession)? =
+    if (extracted != null && sidecars != null && coverPreviewId != null) {
+      Runtime.getRuntime()
+        .addShutdownHook(Thread { runCatching { extracted.workDir.deleteRecursively() } })
+      val open: () -> RenderSession = {
+        SubprocessRenderSessions.openBundleDaemon(
+          daemonClasspath = sidecars.classpath(),
+          classesDir = extracted.classesDir,
+          previewsJson = extracted.previewsJson,
+          workspaceRoot = extracted.workDir,
+          modulePath = modulePath,
+        )
+      }
+      open
     } else {
+      extracted?.workDir?.deleteRecursively()
       null
     }
 
@@ -59,24 +82,28 @@ fun runBundle(png: File, projectRoot: File?, args: TuiArgs) {
     BundleApp(
       seed = seed,
       pngName = png.name,
-      module = module,
-      previewId = previewId,
+      previewId = coverPreviewId,
+      modulePath = modulePath,
       extensions = args.extensions,
+      opener = opener,
     )
   }
 }
 
 /**
- * The whole bundle-mode UI: a single full-terminal image. Holds an optional [LiveSession] and swaps
- * the seed for the daemon's freshest render of [previewId] whenever a notification ticks.
+ * The whole bundle-mode UI: a single full-terminal image. When [opener] is non-null it attaches the
+ * bundle's daemon via [LiveSession.enableBundle] and shows the daemon's freshest render of
+ * [previewId] (read from the path the daemon reports, never an assumed project layout); otherwise it
+ * shows the static [seed].
  */
 @Composable
 private fun BundleApp(
   seed: Bitmap?,
   pngName: String,
-  module: PreviewModule?,
   previewId: String?,
+  modulePath: String,
   extensions: Set<String>,
+  opener: (() -> RenderSession)?,
 ) {
   val initialSize = remember { TerminalSize.probe() }
   val terminalState = LocalTerminalState.current
@@ -88,12 +115,16 @@ private fun BundleApp(
   val liveState by liveSession.state.collectAsState()
   var exitRequested by remember { mutableStateOf(false) }
 
-  // Attach the daemon once, if the bundle named a module. The session is sticky for the run.
-  LaunchedEffect(module) { if (module != null) liveSession.enable(module, extensions) }
-  // Mark the preview visible once the session is READY so the daemon pushes its re-renders.
+  // Attach the bundle's own daemon once, if we have an opener. Sticky for the run.
+  LaunchedEffect(opener) {
+    if (opener != null) liveSession.enableBundle(modulePath, extensions, opener)
+  }
+  // Once READY, mark the preview visible and kick one render so the daemon frame replaces the seed
+  // without the user pressing `r`.
   LaunchedEffect(liveState.status, previewId) {
     if (previewId != null && liveState.status == LiveSession.Status.READY) {
       liveSession.setVisible(previewId)
+      liveSession.forceRender(previewId)
     }
   }
 
@@ -102,14 +133,11 @@ private fun BundleApp(
     return
   }
 
-  // Prefer the daemon's freshest render of this preview; fall back to the seed PNG until (or unless)
-  // one exists. Re-resolved on every daemon tick.
-  val liveFrame: Bitmap? =
-    if (module != null && previewId != null) {
-      remember(liveState.tick) { resolveRenderedPng(module, previewId)?.let(Bitmaps::readPng) }
-    } else {
-      null
-    }
+  // Prefer the daemon's freshest render of this preview, read from the path it reported on the last
+  // `renderFinished`; fall back to the seed PNG until one exists. Re-decoded only when the path
+  // changes.
+  val livePngPath = previewId?.let { liveState.lastPng[it] }
+  val liveFrame: Bitmap? = remember(livePngPath) { livePngPath?.let { Bitmaps.readPng(File(it)) } }
   val bitmap = liveFrame ?: seed
 
   Column(
@@ -137,19 +165,4 @@ private fun BundleApp(
       Image(bitmap = bitmap, cellWidth = cols, cellHeight = rows)
     }
   }
-}
-
-/**
- * The daemon's most recent render of [previewId] for [module], or null if it hasn't rendered yet.
- * Mirrors `PreviewRow.resolvePng` — the renderer writes `build/compose-previews/<id>.png`, with
- * multi-capture previews landing as `<id>--<dimension>.png` (we take the first sibling).
- */
-private fun resolveRenderedPng(module: PreviewModule, previewId: String): File? {
-  val direct = module.projectDir.resolve("build/compose-previews/$previewId.png")
-  if (direct.isFile) return direct
-  val dir = direct.parentFile?.takeIf { it.isDirectory } ?: return null
-  val prefix = "$previewId--"
-  return dir
-    .listFiles { f -> f.isFile && f.name.startsWith(prefix) && f.name.endsWith(".png") }
-    ?.minByOrNull { it.name }
 }


### PR DESCRIPTION
## Summary

`compose-preview-tui <bundle.png>` (the bundle-PNG mode from #1622) no longer **assumes a Gradle project**. A bundle is self-contained — it embeds `classes/app.jar` + `previews.json` — so the TUI now spawns the bundle's **own** desktop daemon from those embedded classes and renders live, anywhere, not just inside the source checkout.

Before, live mode only worked when launched inside the bundle's project (it looked for `<projectDir>/build/compose-previews/daemon-launch.json` and read frames from `<projectDir>/build/compose-previews/<id>.png`). Now there is no project assumption at all.

### Changes
- **`tui-cli/build.gradle.kts`** — ship the desktop daemon + renderer sidecars in the dist (`lib-daemon-desktop/`, `lib-renderer/`), mirroring `:cli`'s `bundle daemon`/`bundle render` wiring. Subprocess-only; never on the launcher's own classpath.
- **`render-session-subprocess`** — add `SubprocessRenderSessions.openBundleDaemon(...)`: synthesizes a `DaemonLaunchDescriptor` in-process (no on-disk `daemon-launch.json`) and shares a new `spawnAndInitialize` path with the existing `open()`. Descriptor schema/field ownership stays in the module that owns the type, not in `:tui-cli`.
- **`BundleExtractor.kt`** (new) — unpacks the polyglot's `classes/app.jar` + `previews.json` to a temp dir (Zip-Slip-guarded; reuses `BundlePngMetadata`'s polyglot scan).
- **`BundleSidecars.kt`** (new) — locates the shipped sidecar dirs relative to the install (`APP_HOME` / classpath inference / sysprop override), mirroring `BundleDaemonCommand.locateSidecarJars`.
- **`LiveSession.kt`** — harvest `renderFinished.pngPath` into state (frames now come from the path the daemon *reports*, not an assumed `build/` layout — benefits project mode too), and add a project-less `enableBundle` attach path that skips the `FileWatcher` (no source tree to watch off-project).
- **`BundleView.kt` / `Main.kt`** — drop the `projectRoot`-derived `PreviewModule`; spawn the bundle daemon when sidecars are present, else fall back to the static seed image.

Project-less "live" = image shown immediately + the daemon held open for `r`-driven re-renders (deterministic re-render / paused-clock animation step); there is no file-watching because there is no source on disk. Still opt-in behind `tui.enabled=true`.

### Scope
TUI only. No changes to `:cli`'s `BundleDaemonCommand`, the bundle format, or `:bundle-viewer`.

## Test plan
- [x] `./gradlew :render-session-subprocess:compileKotlin :tui-cli:compileKotlin` (with `tui.enabled=true`) — green.
- [x] `./gradlew :render-session-subprocess:ktfmtFormat :ktfmtCheck` — green. (`:tui-cli` applies `jvm-conventions` only — no ktfmt gate; new files hand-written in googleStyle.)
- [x] `./gradlew :render-session-subprocess:test :tui-cli:test` — green.
- [x] `./gradlew :tui-cli:installDist` — `lib-daemon-desktop/` (93 jars) + `lib-renderer/` (74 jars) populated; launcher present, native `libmosaic.so` shipped.
- [x] **Project-less e2e**: packed a `:samples:cmp` bundle, copied to `/tmp/noproj/bundle.png` (no `gradlew` anywhere up the tree), ran the **installed** launcher under a PTY from there. Session log shows the bundle's own daemon: spawned → `UserClassLoaderHolder active` over the extracted classes → bundle `PreviewIndex loaded` (off the embedded `previews.json`) → `initialize received` → `renderNow` → `renderFinished`, **0 exceptions**; image rendered (104 KB captured, 2240 half-block glyphs). Full project-less round-trip from the TUI.
- [ ] Manual: `compose-preview-tui <bundle.png>` in kitty/ghostty from outside any checkout — image immediately, `r` re-renders via the bundle's daemon (Kitty-graphics tier needs a real terminal; a bare PTY falls back to half-block).
- [ ] CI green.

Note: Kotlin block comments nest, so KDoc referencing `lib-…/`+glob avoids a literal `/`+`*` sequence (it would open a nested comment) — caught and fixed during impl.