### PR TITLE
fix(daemon): tolerate missing previews.json on first warm

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -127,10 +127,25 @@ fun main(args: Array<String>) {
   // a few hundred lines down so `data/subscribe` / `attachmentsFor` reach the same bookkeeping.
   val recompositionRegistry = AndroidRecompositionDataProductRegistry()
 
+  // `composeai.harness.previewsManifest` is set unconditionally by the gradle plugin for production
+  // Android daemons (the "harness" prefix is historical) — see AndroidPreviewSupport.kt wire-up.
+  // The file may not exist on the very first warm: VS Code runs `composePreviewDaemonStart` (which
+  // writes only the launch descriptor) and spawns this JVM *before* `composePreviewDiscover` writes
+  // `previews.json`. Treat a missing file as "no router yet" and fall through to the same
+  // previewIndex-backed RobolectricHost the no-sysprop path uses; the next warm after discover
+  // lands picks up the populated manifest and re-enters the router branch.
   val manifestPath = System.getProperty("composeai.harness.previewsManifest")
+  val manifestFile = manifestPath?.takeIf { it.isNotBlank() }?.let(::File)
+  if (manifestFile != null && !manifestFile.isFile) {
+    System.err.println(
+      "compose-ai-tools daemon: composeai.harness.previewsManifest set to '$manifestPath' but " +
+        "file does not exist; falling back to PreviewIndex-backed RobolectricHost until " +
+        "composePreviewDiscover writes the manifest"
+    )
+  }
   val host: RenderHost =
-    if (manifestPath != null && manifestPath.isNotBlank()) {
-      val manifest = PreviewManifestRouter.loadManifest(File(manifestPath))
+    if (manifestFile != null && manifestFile.isFile) {
+      val manifest = PreviewManifestRouter.loadManifest(manifestFile)
       System.err.println(
         "compose-ai-tools daemon: PreviewManifestRouter active " +
           "(manifest=$manifestPath, previews=${manifest.previews.map { it.id }})"

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -258,10 +258,25 @@ fun runDaemon(
       previewOverrideExtensions = extensions.activeOverrideExtensions(),
     )
 
+  // `composeai.harness.previewsManifest` is set unconditionally by the gradle plugin for production
+  // CMP / desktop daemons (the "harness" prefix is historical) — see ComposePreviewTasks.kt's
+  // wire-up. The file may not exist on the very first warm: VS Code runs
+  // `composePreviewDaemonStart` (which writes only the launch descriptor) and spawns this JVM
+  // *before* `composePreviewDiscover` writes `previews.json`. Treat a missing file as "no router
+  // yet" and fall through to the same previewIndex-backed DesktopHost the no-sysprop path uses; the
+  // next warm after discover lands picks up the populated manifest and re-enters the router branch.
   val manifestPath = System.getProperty("composeai.harness.previewsManifest")
+  val manifestFile = manifestPath?.takeIf { it.isNotBlank() }?.let(::File)
+  if (manifestFile != null && !manifestFile.isFile) {
+    System.err.println(
+      "compose-ai-tools desktop daemon: composeai.harness.previewsManifest set to " +
+        "'$manifestPath' but file does not exist; falling back to PreviewIndex-backed " +
+        "DesktopHost until composePreviewDiscover writes the manifest"
+    )
+  }
   val host: RenderHost =
-    if (manifestPath != null && manifestPath.isNotBlank()) {
-      val manifest = PreviewManifestRouter.loadManifest(File(manifestPath))
+    if (manifestFile != null && manifestFile.isFile) {
+      val manifest = PreviewManifestRouter.loadManifest(manifestFile)
       System.err.println(
         "compose-ai-tools desktop daemon: PreviewManifestRouter active " +
           "(manifest=$manifestPath, previews=${manifest.previews.map { it.id }})"


### PR DESCRIPTION
## Summary

The Gradle plugin sets `composeai.harness.previewsManifest` unconditionally for production Android and CMP/desktop daemons (the "harness" prefix is historical — see `AndroidPreviewSupport.kt` / `ComposePreviewTasks.kt` wire-up). On the very first warm of a fresh module, VS Code runs `composePreviewDaemonStart` (writes only the launch descriptor) and spawns the daemon JVM *before* `composePreviewDiscover` writes `previews.json`. `PreviewManifestRouter.loadManifest`'s `require(file.isFile)` then crashes the daemon with:

```
Exception in thread "main" java.lang.IllegalArgumentException: PreviewManifestRouter: manifest '…/previews.json' does not exist
    at ee.schimke.composeai.daemon.PreviewManifestRouter$Companion.loadManifest(PreviewManifestRouter.kt:172)
    at ee.schimke.composeai.daemon.DaemonMain.main(DaemonMain.kt:133)
```

That surfaces in the external-consumer e2e (Confetti, [run 26683819803](https://github.com/yschimke/compose-ai-tools/actions/runs/26683819803/job/78648548804)) as `Daemon channel closed (JVM exit code=1)` after the stderr stack trace.

Fix: check `manifestFile.isFile` in both `DaemonMain` entry points (Android + Desktop) before invoking the router. When the file isn't there, log a stderr line and fall through to the same `previewIndex`-backed `RobolectricHost` / `DesktopHost` the no-sysprop production path already uses. The next warm after discover lands picks up the populated manifest and re-enters the router branch.

## Test plan

- [ ] `vscode-extension-e2e-external.yml` job ("VS Code Extension E2E (Confetti, published plugin)") reaches the `composePreviewRenderAll` round-trip and asserts >= 1 preview rendered from `:androidApp`.
- [ ] In-repo `vscode-extension-e2e.yml` still passes (refresh-first flow already wrote `previews.json` before spawn, so the router branch is unchanged for that path).
- [ ] Daemon stderr shows the new fallback log line on the first warm and `PreviewManifestRouter active` on the second.

---
_Generated by [Claude Code](https://claude.ai/code/session_018kWkKBUAmdnUTq16bsNWhX)_