### PR TITLE
feat(bundle): schema v3 — Embedded classpath kind + producer/resolution fields

### DIFF
--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/BundleLoader.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/BundleLoader.kt
@@ -16,10 +16,19 @@ import kotlinx.serialization.json.Json
  * # Classloading
  *
  * The bundle's inlined `classes/app.jar` is written to a temp file (URLClassLoader needs a URL, and
- * a `file:` URL is simpler than a `jar:` polyglot URL). A child [URLClassLoader] loads it with the
- * viewer's own classloader as parent — every `androidx.compose.*` symbol the bundle's code
- * references resolves against the viewer's bundled Compose runtime, so the composer state is shared
- * and `@Composable` invocation works across the loader boundary.
+ * a `file:` URL is simpler than a `jar:` polyglot URL). Any jars the bundle carries under `libs/` —
+ * the schema-v3 `resolution = "embedded"` / `"mixed"` mode, where reachable third-party (and
+ * project-local) deps are packed inside the bundle rather than referenced by Maven coordinate — are
+ * extracted alongside it and added to the same child [URLClassLoader]. That loader uses the
+ * viewer's own classloader as parent, so every `androidx.compose.*` symbol still resolves against
+ * the viewer's bundled Compose runtime (shared composer state, cross-loader `@Composable`
+ * invocation), while a preview's *own* third-party dependencies (an icon pack, Coil, a
+ * `:design-system` jar, …) resolve from the embedded `libs/` jars instead of blowing up with
+ * `NoClassDefFoundError`.
+ *
+ * A `coordinates`-mode bundle carries no `libs/`; the loader simply finds none and behaves exactly
+ * as before (Compose-only previews work; previews needing un-bundled third-party deps still won't,
+ * which is what `--embed-deps` is for).
  *
  * # Lifecycle
  *
@@ -70,15 +79,27 @@ fun loadBundle(bundleFile: File): LoadedBundle {
   val zipBytes = extractZipBytes(bundleFile)
   val workDir = Files.createTempDirectory("compose-preview-viewer-").toFile()
   val appJarFile = File(workDir, "app.jar")
+  // Embedded dep jars, keyed by their posix `libs/<name>.jar` path so order is deterministic and
+  // dedupe-safe even if the zip lists them oddly. Extracted under workDir/libs/.
+  val libJarFiles = sortedMapOf<String, File>()
   var bundleJson: String? = null
   var previewsJson: String? = null
   ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
     while (true) {
       val entry = zin.nextEntry ?: break
-      when (entry.name) {
-        "bundle.json" -> bundleJson = zin.readBytes().toString(Charsets.UTF_8)
-        "previews.json" -> previewsJson = zin.readBytes().toString(Charsets.UTF_8)
-        "classes/app.jar" -> appJarFile.outputStream().use { sink -> zin.copyTo(sink) }
+      val name = entry.name
+      when {
+        name == "bundle.json" -> bundleJson = zin.readBytes().toString(Charsets.UTF_8)
+        name == "previews.json" -> previewsJson = zin.readBytes().toString(Charsets.UTF_8)
+        name == "classes/app.jar" -> appJarFile.outputStream().use { sink -> zin.copyTo(sink) }
+        !entry.isDirectory && name.startsWith("libs/") && name.endsWith(".jar") -> {
+          // Flatten to a safe basename under workDir/libs/; `libs/` paths in our own bundles never
+          // contain `..` or nested dirs, but guard against a hostile bundle escaping workDir.
+          val safe = File(workDir, "libs/" + File(name).name)
+          safe.parentFile?.mkdirs()
+          safe.outputStream().use { sink -> zin.copyTo(sink) }
+          libJarFiles[name] = safe
+        }
       }
       zin.closeEntry()
     }
@@ -96,7 +117,13 @@ fun loadBundle(bundleFile: File): LoadedBundle {
   }
 
   val parentLoader = LoadedBundle::class.java.classLoader
-  val classLoader = URLClassLoader(arrayOf(appJarFile.toURI().toURL()), parentLoader)
+  // app.jar first, then every embedded lib jar (path-sorted). The viewer's bundled Compose still
+  // wins
+  // on shared symbols because it sits on the parent loader; the embedded jars only supply classes
+  // the
+  // parent doesn't have (the preview's own third-party deps).
+  val classpathUrls = (listOf(appJarFile) + libJarFiles.values).map { it.toURI().toURL() }
+  val classLoader = URLClassLoader(classpathUrls.toTypedArray(), parentLoader)
 
   val loadedPreviews = previewManifest.previews.map { info -> resolvePreview(info, classLoader) }
   val cover =

--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
@@ -20,6 +20,14 @@ data class BundleManifest(
   val classpath: List<ClasspathEntry>,
   val modulePath: String,
   val producedBy: String,
+  /**
+   * v3+: producing build system (`gradle`|`amper`|`bazel`). Defaults to `gradle` for v2 bundles.
+   */
+  val producer: String = "gradle",
+  /**
+   * v3+: classpath assembly strategy (`coordinates`|`embedded`|`mixed`). Defaults for v2 bundles.
+   */
+  val resolution: String = "coordinates",
 )
 
 @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
@@ -38,6 +46,11 @@ sealed interface ClasspathEntry {
   @Serializable
   @kotlinx.serialization.SerialName("project")
   data class Project(val path: String, val inlinedAs: String) : ClasspathEntry
+
+  /** v3+: a third-party jar carried inside the bundle's `libs/` — no coordinate, no resolution. */
+  @Serializable
+  @kotlinx.serialization.SerialName("embedded")
+  data class Embedded(val inlinedAs: String) : ClasspathEntry
 }
 
 @Serializable

--- a/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/BundleLoaderTest.kt
+++ b/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/BundleLoaderTest.kt
@@ -56,19 +56,107 @@ class BundleLoaderTest {
     assertThat(ex).isInstanceOf(IllegalArgumentException::class.java)
   }
 
+  @Test
+  fun `loadBundle puts embedded libs jars on the bundle classloader`() {
+    // A v3 embedded bundle: an extra jar under libs/ carrying a class that is NOT on the viewer's
+    // own classpath. The loader must extract it and add it to the child URLClassLoader so the
+    // preview's third-party deps resolve (the whole point of --embed-deps / resolution=embedded).
+    //
+    // The preview's owner class `test.PreviewsKt` is itself placed in classes/app.jar so that
+    // `loadBundle` resolves it via the bundle's URLClassLoader (rather than the placeholder it
+    // falls
+    // back to when the class is missing) — giving us a handle on the *actual* bundle loader to
+    // prove
+    // the embedded jar landed on the same classpath.
+    val embeddedClassFqn = "com.example.embedded.Widget"
+    val bundle =
+      writeMinimalBundle(
+        includeAppClass = true,
+        resolution = "embedded",
+        extraClasspath = listOf(ClasspathEntry.Embedded(inlinedAs = "libs/embedded.jar")),
+        libs = mapOf("libs/embedded.jar" to singleClassJar(embeddedClassFqn)),
+      )
+
+    val loaded = loadBundle(bundle)
+    try {
+      assertThat(loaded.bundleManifest.resolution).isEqualTo("embedded")
+      // `test.PreviewsKt` resolved → ownerClass is the real class loaded by the bundle's loader.
+      val bundleLoader = loaded.coverPreview.ownerClass.classLoader!!
+      assertThat(loaded.coverPreview.ownerClass.name).isEqualTo("test.PreviewsKt")
+      // The embedded class is absent from the viewer's own classloader…
+      assertThat(runCatching { Class.forName(embeddedClassFqn) }.isFailure).isTrue()
+      // …but loads via the bundle's loader because libs/embedded.jar is on its classpath.
+      val resolved = Class.forName(embeddedClassFqn, false, bundleLoader)
+      assertThat(resolved.name).isEqualTo(embeddedClassFqn)
+    } finally {
+      loaded.close()
+    }
+  }
+
+  /** A jar carrying a single trivial public class [fqn] (see [minimalClassBytes]). */
+  private fun singleClassJar(fqn: String): ByteArray {
+    val classBytes = minimalClassBytes(fqn)
+    val baos = ByteArrayOutputStream()
+    ZipOutputStream(baos).use { zip ->
+      zip.putNextEntry(ZipEntry(fqn.replace('.', '/') + ".class"))
+      zip.write(classBytes)
+      zip.closeEntry()
+    }
+    return baos.toByteArray()
+  }
+
+  /**
+   * Emit a minimal but verifiable `public class <fqn> extends Object` with no fields/methods/
+   * interfaces. Loadable via `Class.forName(fqn, initialize = false, loader)` — that path needs no
+   * constructor and doesn't run `<clinit>`, so an empty class body is enough to prove the embedded
+   * jar made it onto the classloader. Avoids pulling ASM onto the viewer's test classpath.
+   */
+  private fun minimalClassBytes(fqn: String): ByteArray {
+    val internalName = fqn.replace('.', '/')
+    val baos = ByteArrayOutputStream()
+    java.io.DataOutputStream(baos).use { out ->
+      out.writeInt(-0x35014542) // 0xCAFEBABE magic
+      out.writeShort(0) // minor version
+      out.writeShort(52) // major version = Java 8
+      // Constant pool: count = 5 (entries 1..4).
+      out.writeShort(5)
+      out.writeByte(1) // #1 Utf8
+      out.writeUTF(internalName)
+      out.writeByte(7) // #2 Class → #1
+      out.writeShort(1)
+      out.writeByte(1) // #3 Utf8
+      out.writeUTF("java/lang/Object")
+      out.writeByte(7) // #4 Class → #3
+      out.writeShort(3)
+      out.writeShort(0x0021) // access flags: ACC_PUBLIC | ACC_SUPER
+      out.writeShort(2) // this_class = #2
+      out.writeShort(4) // super_class = #4
+      out.writeShort(0) // interfaces_count
+      out.writeShort(0) // fields_count
+      out.writeShort(0) // methods_count
+      out.writeShort(0) // attributes_count
+    }
+    return baos.toByteArray()
+  }
+
   /**
    * Build a tiny but well-formed PNG+ZIP polyglot. The PNG is just a sanity 1×1 cover; the zip
    * carries the manifests + an empty `classes/app.jar` so resolution exercises the
    * "class-not-found" branch deterministically.
    */
-  private fun writeMinimalBundle(includeAppClass: Boolean): File {
+  private fun writeMinimalBundle(
+    includeAppClass: Boolean = false,
+    resolution: String = "coordinates",
+    extraClasspath: List<ClasspathEntry> = emptyList(),
+    libs: Map<String, ByteArray> = emptyMap(),
+  ): File {
     val zipBytes = ByteArrayOutputStream()
     ZipOutputStream(zipBytes).use { zip ->
       val bundleJson =
         Json.encodeToString(
           BundleManifest.serializer(),
           BundleManifest(
-            schemaVersion = 1,
+            schemaVersion = if (resolution == "coordinates") 1 else 3,
             backend = "desktop",
             previewIds = listOf("test.PreviewsKt.MissingPreview"),
             coverPreviewId = "test.PreviewsKt.MissingPreview",
@@ -81,9 +169,10 @@ class BundleLoaderTest {
                   version = "1.10.3",
                   type = "jar",
                 ),
-              ),
+              ) + extraClasspath,
             modulePath = ":test",
             producedBy = "test-suite",
+            resolution = resolution,
           ),
         )
       zip.putNextEntry(ZipEntry("bundle.json"))
@@ -110,12 +199,26 @@ class BundleLoaderTest {
       zip.write(previewsJson.toByteArray(Charsets.UTF_8))
       zip.closeEntry()
 
-      // Empty jar — just enough to satisfy the "classes/app.jar must be present" precondition.
-      val emptyJarBytes = ByteArrayOutputStream()
-      ZipOutputStream(emptyJarBytes).use { /* no entries */ }
+      // classes/app.jar: empty by default (exercises the class-not-found branch). When
+      // [includeAppClass] is set, carry the preview's owner class so resolution succeeds and the
+      // owner class is loaded by the bundle's own URLClassLoader.
+      val appJarBytes = ByteArrayOutputStream()
+      ZipOutputStream(appJarBytes).use { appJar ->
+        if (includeAppClass) {
+          appJar.putNextEntry(ZipEntry("test/PreviewsKt.class"))
+          appJar.write(minimalClassBytes("test.PreviewsKt"))
+          appJar.closeEntry()
+        }
+      }
       zip.putNextEntry(ZipEntry("classes/app.jar"))
-      zip.write(emptyJarBytes.toByteArray())
+      zip.write(appJarBytes.toByteArray())
       zip.closeEntry()
+
+      for ((path, bytes) in libs) {
+        zip.putNextEntry(ZipEntry(path))
+        zip.write(bytes)
+        zip.closeEntry()
+      }
     }
 
     // Synthesise a 1×1 PNG header so the polyglot is recognised by `extractZipBytes`. Same byte

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -473,4 +473,36 @@ internal object BundleReader {
     }
     throw IllegalArgumentException("truncated PNG: IEND not found before EOF")
   }
+
+  /**
+   * Extract every embedded jar under `libs/` from a bundle's [zipBytes] into [libsDir], returning
+   * the written jar files sorted by name (stable classpath order). Embedded-mode bundles (schema-v3
+   * `resolution = "embedded"`) carry their reachable third-party deps here; coordinate bundles
+   * carry none, so this returns an empty list.
+   *
+   * Each entry is flattened to its basename under [libsDir] and the resolved path is verified to
+   * live inside [libsDir] — defeats Zip Slip (`../` traversal) on a hostile bundle. Nested paths
+   * and directory entries are ignored. Shared by [BundleRenderer] and [BundleDaemonCommand] so the
+   * two player paths extract identically.
+   */
+  fun extractEmbeddedLibs(zipBytes: ByteArray, libsDir: File): List<File> {
+    libsDir.mkdirs()
+    val canonicalLibs = libsDir.canonicalFile
+    val written = mutableListOf<File>()
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        val name = entry.name
+        if (!entry.isDirectory && name.startsWith("libs/") && name.endsWith(".jar")) {
+          val dest = File(libsDir, File(name).name).canonicalFile
+          if (dest.path.startsWith(canonicalLibs.path + File.separator)) {
+            dest.outputStream().use { sink -> zin.copyTo(sink) }
+            written += dest
+          }
+        }
+        zin.closeEntry()
+      }
+    }
+    return written.sortedBy { it.name }
+  }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -162,14 +162,19 @@ private class PackSubcommand(private val args: List<String>) {
 
   private fun printPackSummary(file: File, meta: BundleReader.Metadata) {
     println("wrote ${file.path} (${file.length()} bytes)")
-    println("  schema:        v${meta.manifest.schemaVersion}, backend=${meta.manifest.backend}")
+    println(
+      "  schema:        v${meta.manifest.schemaVersion}, backend=${meta.manifest.backend}, " +
+        "producer=${meta.manifest.producer}, resolution=${meta.manifest.resolution}"
+    )
     println(
       "  previews:      ${meta.manifest.previewIds.size} (cover=${meta.manifest.coverPreviewId})"
     )
     val mavenCount = meta.manifest.classpath.count { it is BundleReader.ClasspathEntry.Maven }
     val projectCount = meta.manifest.classpath.count { it is BundleReader.ClasspathEntry.Project }
+    val embeddedCount = meta.manifest.classpath.count { it is BundleReader.ClasspathEntry.Embedded }
     println(
-      "  classpath:     ${meta.manifest.classpath.size} entries (Maven=$mavenCount, inlined=$projectCount)"
+      "  classpath:     ${meta.manifest.classpath.size} entries " +
+        "(Maven=$mavenCount, embedded=$embeddedCount, inlined=$projectCount)"
     )
     val r = meta.report
     if (r != null) {
@@ -336,6 +341,10 @@ internal object BundleReader {
     val classpath: List<ClasspathEntry>,
     val modulePath: String,
     val producedBy: String,
+    /** v3+: producing build system (`gradle`|`amper`|`bazel`). Defaults for v2 bundles. */
+    val producer: String = "gradle",
+    /** v3+: classpath assembly strategy (`coordinates`|`embedded`|`mixed`). Defaults for v2. */
+    val resolution: String = "coordinates",
   )
 
   @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
@@ -358,6 +367,13 @@ internal object BundleReader {
     @Serializable
     @kotlinx.serialization.SerialName("project")
     data class Project(val path: String, val inlinedAs: String) : ClasspathEntry
+
+    /**
+     * v3+: a third-party jar carried inside the bundle's `libs/` — no coordinate, no resolution.
+     */
+    @Serializable
+    @kotlinx.serialization.SerialName("embedded")
+    data class Embedded(val inlinedAs: String) : ClasspathEntry
   }
 
   @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -76,6 +76,9 @@ class BundleCommand(args: List<String>) : Command(args) {
         --id <preview-id>   Preview to include. Repeatable. First is the cover. Default: all.
         -o, --output <file> Output file path. Default: <module>/build/compose-previews/bundle.png.
         --no-render         Skip composePreviewRender — pack with a stub gray cover.
+        --embed-deps        Carry reachable third-party jars inside the bundle (libs/) instead of
+                            referencing Maven coordinates. Bigger file, but renders with no network
+                            and no build system on the other end (resolution=embedded).
 
       Inspect / extract / render flags:
         -o, --output <dir>  Directory to extract / render into. Default: alongside the bundle.
@@ -89,6 +92,7 @@ private class PackSubcommand(private val args: List<String>) {
   private val module: String? = args.flagValue("--module")
   private val output: String? = args.flagValue("--output") ?: args.flagValue("-o")
   private val noRender: Boolean = "--no-render" in args
+  private val embedDeps: Boolean = "--embed-deps" in args
   private val verbose: Boolean = "--verbose" in args || "-v" in args
   private val ids: List<String> =
     args
@@ -123,6 +127,7 @@ private class PackSubcommand(private val args: List<String>) {
 
             val gradleArgs = buildList {
               if (ids.isNotEmpty()) add("-PbundlePreviewIds=${ids.joinToString(",")}")
+              if (embedDeps) add("-PbundleEmbedDeps=true")
               add("-PbundleOutput=${resolvedOutput.absolutePath}")
             }
             val tasks =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -14,11 +14,12 @@ import kotlin.system.exitProcess
  * # Layout
  *
  * The packed bundle is a PNG+ZIP polyglot whose zip portion contains `classes/app.jar` (consumer
- * module + inlined project deps) plus `previews.json` (discovery output). We extract both to a temp
- * working directory, then launch a Java subprocess whose classpath joins
- * `$APP_HOME/lib-daemon-desktop/` (daemon + data-extension connectors) with
- * `$APP_HOME/lib-renderer/` (Compose Multiplatform + Skiko). The consumer's bytecode is exposed to
- * the daemon via `-Dcomposeai.daemon.userClassDirs=<extracted-jar>`, and the discovery manifest via
+ * module + inlined project deps), optionally embedded third-party jars under `libs/`, plus
+ * `previews.json` (discovery output). We extract them to a temp working directory, then launch a
+ * Java subprocess whose classpath joins `$APP_HOME/lib-daemon-desktop/` (daemon + data-extension
+ * connectors) with `$APP_HOME/lib-renderer/` (Compose Multiplatform + Skiko). The consumer's
+ * bytecode — the extracted app classes plus any embedded `libs/` jars — is exposed to the daemon
+ * via `-Dcomposeai.daemon.userClassDirs=<paths>`, and the discovery manifest via
  * `-Dcomposeai.daemon.previewsJsonPath=<extracted-previews-json>` — the same sysprops the Gradle
  * daemon launch path uses.
  *
@@ -26,12 +27,14 @@ import kotlin.system.exitProcess
  * additional plumbing. We don't wait on it from this command — `daemon` is `exec`-style: we print
  * one ready line on stderr and replace this process via `ProcessBuilder.inheritIO`.
  *
- * # Maven coordinates intentionally not resolved
+ * # Dependency resolution
  *
- * `bundle.json`'s `classpath[]` entries record Maven coordinates for every dependency that
- * contributed reachable classes to the rendered previews. v1 ignores them — the renderer's bundled
- * Compose stack supplies every API call the bundle's classes resolve against, and a full resolver
- * pass (download Maven, hash-verify, layer-on) is its own milestone. Same trade-off `bundle render`
+ * Embedded-mode bundles (schema-v3 `resolution = "embedded"`) carry their reachable third-party
+ * deps under `libs/`; those are extracted and joined onto the daemon's `userClassDirs` so a
+ * preview's own deps resolve with no network. For coordinate-mode bundles, `bundle.json`'s
+ * `ClasspathEntry.Maven` entries are still *not* resolved here — the renderer's bundled Compose
+ * stack supplies the common API surface, and a full coordinate-resolver pass (download Maven,
+ * hash-verify, layer-on) is its own milestone (#1632, Tier 3). Same trade-off `bundle render`
  * makes.
  */
 class BundleDaemonCommand(args: List<String>) : Command(args) {
@@ -51,9 +54,17 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     val verbose = "--verbose" in args || "-v" in args
     val workDir = createTempWorkDir()
     val classesDir = workDir.resolve("classes").apply { mkdirs() }
+    val libsDir = workDir.resolve("libs").apply { mkdirs() }
     val previewsJson = workDir.resolve("previews.json")
     val zipBytes = BundleReader.extractZipBytes(file)
-    expandAppJarAndManifest(zipBytes, classesDir, previewsJson, file)
+    expandAppJarAndManifest(zipBytes, classesDir, libsDir, previewsJson, file)
+    // Embedded-mode bundles (schema-v3 `resolution = "embedded"`) carry the preview's reachable
+    // third-party deps under `libs/`. They're consumer classes, so they ride the daemon's
+    // `userClassDirs` holder (dirs-before-jars ordered, see UserClassLoaderHolder) alongside the
+    // extracted app classes — NOT the daemon/renderer `-cp`. Empty for coordinate bundles.
+    val libJars = libsDir.listFiles { f -> f.isFile && f.name.endsWith(".jar") }?.sorted().orEmpty()
+    val userClassPath =
+      (listOf(classesDir) + libJars).joinToString(File.pathSeparator) { it.absolutePath }
 
     val daemonJars = locateSidecarJars("lib-daemon-desktop")
     if (daemonJars.isEmpty()) {
@@ -81,7 +92,7 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       add("--enable-native-access=ALL-UNNAMED")
       // PROTOCOL.md § 3a — the daemon advertises capabilities lazily; the client
       // (BundleViewerPanel's DaemonClient) does the `initialize` round-trip on stdin.
-      add("-D${USER_CLASS_DIRS_PROP}=${classesDir.absolutePath}")
+      add("-D${USER_CLASS_DIRS_PROP}=$userClassPath")
       add("-D${PREVIEWS_JSON_PATH_PROP}=${previewsJson.absolutePath}")
       // Tag the temp dir on the daemon so logs / debug dumps make it discoverable.
       add("-Dcomposeai.daemon.bundleSource=${file.absolutePath}")
@@ -93,6 +104,7 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     if (verbose) {
       System.err.println("[bundle-daemon] working dir: ${workDir.absolutePath}")
       System.err.println("[bundle-daemon] classes dir: ${classesDir.absolutePath}")
+      System.err.println("[bundle-daemon] embedded lib jars: ${libJars.size}")
       System.err.println("[bundle-daemon] previews.json: ${previewsJson.absolutePath}")
       System.err.println("[bundle-daemon] daemon jars: ${daemonJars.size}")
       System.err.println("[bundle-daemon] renderer jars: ${rendererJars.size}")
@@ -147,30 +159,41 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
   }
 
   /**
-   * Extract `classes/app.jar` into [classesDir] and `previews.json` into [previewsJson]. Throws if
-   * either entry is missing — both are required for the daemon to come up against a usable preview
-   * index.
+   * Extract `classes/app.jar` into [classesDir], any embedded jars under `libs/` into [libsDir],
+   * and `previews.json` into [previewsJson]. Throws if app.jar or previews.json is missing — both
+   * are required for the daemon to come up against a usable preview index. The `libs/` directory is
+   * optional (only embedded-mode bundles carry it).
    */
   private fun expandAppJarAndManifest(
     zipBytes: ByteArray,
     classesDir: File,
+    libsDir: File,
     previewsJson: File,
     bundleFile: File,
   ) {
     var sawAppJar = false
     var sawPreviewsJson = false
+    val canonicalLibs = libsDir.canonicalFile
     ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
       while (true) {
         val entry = zin.nextEntry ?: break
-        when (entry.name) {
-          "previews.json" -> {
+        val name = entry.name
+        when {
+          name == "previews.json" -> {
             previewsJson.writeBytes(zin.readBytes())
             sawPreviewsJson = true
           }
-          "classes/app.jar" -> {
+          name == "classes/app.jar" -> {
             val appJarBytes = zin.readBytes()
             expandJarBytesSafely(appJarBytes, classesDir)
             sawAppJar = true
+          }
+          !entry.isDirectory && name.startsWith("libs/") && name.endsWith(".jar") -> {
+            // Flatten to a safe basename under libsDir; guard against Zip Slip on a hostile bundle.
+            val dest = File(libsDir, File(name).name).canonicalFile
+            if (dest.path.startsWith(canonicalLibs.path + File.separator)) {
+              dest.writeBytes(zin.readBytes())
+            }
           }
         }
         zin.closeEntry()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -57,12 +57,11 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     val libsDir = workDir.resolve("libs").apply { mkdirs() }
     val previewsJson = workDir.resolve("previews.json")
     val zipBytes = BundleReader.extractZipBytes(file)
-    expandAppJarAndManifest(zipBytes, classesDir, libsDir, previewsJson, file)
-    // Embedded-mode bundles (schema-v3 `resolution = "embedded"`) carry the preview's reachable
-    // third-party deps under `libs/`. They're consumer classes, so they ride the daemon's
-    // `userClassDirs` holder (dirs-before-jars ordered, see UserClassLoaderHolder) alongside the
-    // extracted app classes — NOT the daemon/renderer `-cp`. Empty for coordinate bundles.
-    val libJars = libsDir.listFiles { f -> f.isFile && f.name.endsWith(".jar") }?.sorted().orEmpty()
+    expandAppJarAndManifest(zipBytes, classesDir, previewsJson, file)
+    // Embedded `libs/` jars are consumer classes, so they ride the daemon's `userClassDirs` holder
+    // (dirs-before-jars ordered, see UserClassLoaderHolder) alongside the extracted app classes —
+    // NOT the daemon/renderer `-cp`. Empty for coordinate bundles.
+    val libJars = BundleReader.extractEmbeddedLibs(zipBytes, libsDir)
     val userClassPath =
       (listOf(classesDir) + libJars).joinToString(File.pathSeparator) { it.absolutePath }
 
@@ -159,41 +158,30 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
   }
 
   /**
-   * Extract `classes/app.jar` into [classesDir], any embedded jars under `libs/` into [libsDir],
-   * and `previews.json` into [previewsJson]. Throws if app.jar or previews.json is missing — both
-   * are required for the daemon to come up against a usable preview index. The `libs/` directory is
-   * optional (only embedded-mode bundles carry it).
+   * Extract `classes/app.jar` into [classesDir] and `previews.json` into [previewsJson]. Throws if
+   * either is missing — both are required for the daemon to come up against a usable preview index.
+   * Embedded `libs/` jars are extracted separately via [BundleReader.extractEmbeddedLibs].
    */
   private fun expandAppJarAndManifest(
     zipBytes: ByteArray,
     classesDir: File,
-    libsDir: File,
     previewsJson: File,
     bundleFile: File,
   ) {
     var sawAppJar = false
     var sawPreviewsJson = false
-    val canonicalLibs = libsDir.canonicalFile
     ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
       while (true) {
         val entry = zin.nextEntry ?: break
-        val name = entry.name
-        when {
-          name == "previews.json" -> {
+        when (entry.name) {
+          "previews.json" -> {
             previewsJson.writeBytes(zin.readBytes())
             sawPreviewsJson = true
           }
-          name == "classes/app.jar" -> {
+          "classes/app.jar" -> {
             val appJarBytes = zin.readBytes()
             expandJarBytesSafely(appJarBytes, classesDir)
             sawAppJar = true
-          }
-          !entry.isDirectory && name.startsWith("libs/") && name.endsWith(".jar") -> {
-            // Flatten to a safe basename under libsDir; guard against Zip Slip on a hostile bundle.
-            val dest = File(libsDir, File(name).name).canonicalFile
-            if (dest.path.startsWith(canonicalLibs.path + File.separator)) {
-              dest.writeBytes(zin.readBytes())
-            }
           }
         }
         zin.closeEntry()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -22,13 +22,17 @@ import kotlinx.serialization.json.Json
  *
  * # Classpath
  *
- * The subprocess JVM's classpath = extracted `classes/app.jar` directory + every jar in
- * `<APP_HOME>/lib-renderer/`. The bundled renderer's transitive Compose Multiplatform graph
- * supplies every Compose API the app classes resolve against. The bundle's recorded Maven
- * coordinates are NOT downloaded for v1 — the renderer's own Compose version wins, relying on
- * Compose's binary-compatibility story across point releases. A bundle compiled against compose
- * 1.10.x renders fine against the CLI's bundled 1.10.x; future major-version skew will need a
- * resolver pass.
+ * The subprocess JVM's classpath = extracted `classes/app.jar` directory + any embedded `libs/`
+ * jars
+ * + every jar in `<APP_HOME>/lib-renderer/`, in that order. Embedded-mode bundles (schema-v3
+ *   `resolution = "embedded"`) carry their reachable third-party deps under `libs/`, so a preview's
+ *   own deps resolve from there; the bundled renderer's transitive Compose Multiplatform graph
+ *   still supplies the Compose API surface and wins on shared symbols (it sits after the consumer
+ *   classes). For coordinate-mode bundles there are no `libs/` jars and the recorded Maven
+ *   coordinates are NOT downloaded for v1 — the renderer's own Compose version wins, relying on
+ *   Compose's binary-compatibility story across point releases. A bundle compiled against compose
+ *   1.10.x renders fine against the CLI's bundled 1.10.x; full coordinate resolution is a later
+ *   milestone (#1632, Tier 3).
  *
  * # Renderer / Java location
  *
@@ -64,8 +68,10 @@ class BundleRenderer(
     }
     val workDir = createTempWorkDir()
     val classesDir = workDir.resolve("classes").apply { mkdirs() }
+    val libsDir = workDir.resolve("libs").apply { mkdirs() }
     val zipBytes = BundleReader.extractZipBytes(bundleFile)
-    val (bundleJsonBytes, previewsJsonBytes) = expandAppJarAndReadManifests(zipBytes, classesDir)
+    val (bundleJsonBytes, previewsJsonBytes) =
+      expandAppJarAndReadManifests(zipBytes, classesDir, libsDir)
 
     val manifest = BUNDLE_JSON.decodeFromString(BundleReader.Manifest.serializer(), bundleJsonBytes)
     val previews = MANIFEST_JSON.decodeFromString(PreviewManifest.serializer(), previewsJsonBytes)
@@ -83,8 +89,17 @@ class BundleRenderer(
           "either build the CLI via `./gradlew :cli:installDist` or set `-Dcomposeai.cli.appHome=<install-root>`."
       )
     }
+    // Embedded-mode bundles (schema-v3 `resolution = "embedded"`) carry their reachable third-party
+    // deps under `libs/`; put them between the consumer classes and the renderer's own Compose
+    // stack
+    // so a preview's own deps resolve while the renderer's bundled Compose still wins on shared
+    // symbols (same layering the desktop viewer's URLClassLoader uses). Coordinate bundles have no
+    // `libs/`, so this is empty and the classpath is unchanged.
+    val libJars = libsDir.listFiles { f -> f.isFile && f.name.endsWith(".jar") }?.sorted().orEmpty()
     val classpathString =
-      (listOf(classesDir) + rendererJars).joinToString(File.pathSeparator) { it.absolutePath }
+      (listOf(classesDir) + libJars + rendererJars).joinToString(File.pathSeparator) {
+        it.absolutePath
+      }
 
     outputDir.mkdirs()
     val succeeded = mutableListOf<RenderedPreview>()
@@ -107,17 +122,27 @@ class BundleRenderer(
   private fun expandAppJarAndReadManifests(
     zipBytes: ByteArray,
     classesDir: File,
+    libsDir: File,
   ): Pair<String, String> {
     var bundleJson: String? = null
     var previewsJson: String? = null
     var appJarBytes: ByteArray? = null
+    val canonicalLibs = libsDir.canonicalFile
     ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
       while (true) {
         val entry = zin.nextEntry ?: break
-        when (entry.name) {
-          "bundle.json" -> bundleJson = zin.readBytes().toString(Charsets.UTF_8)
-          "previews.json" -> previewsJson = zin.readBytes().toString(Charsets.UTF_8)
-          "classes/app.jar" -> appJarBytes = zin.readBytes()
+        val name = entry.name
+        when {
+          name == "bundle.json" -> bundleJson = zin.readBytes().toString(Charsets.UTF_8)
+          name == "previews.json" -> previewsJson = zin.readBytes().toString(Charsets.UTF_8)
+          name == "classes/app.jar" -> appJarBytes = zin.readBytes()
+          !entry.isDirectory && name.startsWith("libs/") && name.endsWith(".jar") -> {
+            // Flatten to a safe basename under libsDir; guard against Zip Slip on a hostile bundle.
+            val dest = File(libsDir, File(name).name).canonicalFile
+            if (dest.path.startsWith(canonicalLibs.path + File.separator)) {
+              dest.outputStream().use { sink -> zin.copyTo(sink) }
+            }
+          }
         }
         zin.closeEntry()
       }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -70,8 +70,8 @@ class BundleRenderer(
     val classesDir = workDir.resolve("classes").apply { mkdirs() }
     val libsDir = workDir.resolve("libs").apply { mkdirs() }
     val zipBytes = BundleReader.extractZipBytes(bundleFile)
-    val (bundleJsonBytes, previewsJsonBytes) =
-      expandAppJarAndReadManifests(zipBytes, classesDir, libsDir)
+    val (bundleJsonBytes, previewsJsonBytes) = expandAppJarAndReadManifests(zipBytes, classesDir)
+    val libJars = BundleReader.extractEmbeddedLibs(zipBytes, libsDir)
 
     val manifest = BUNDLE_JSON.decodeFromString(BundleReader.Manifest.serializer(), bundleJsonBytes)
     val previews = MANIFEST_JSON.decodeFromString(PreviewManifest.serializer(), previewsJsonBytes)
@@ -89,13 +89,10 @@ class BundleRenderer(
           "either build the CLI via `./gradlew :cli:installDist` or set `-Dcomposeai.cli.appHome=<install-root>`."
       )
     }
-    // Embedded-mode bundles (schema-v3 `resolution = "embedded"`) carry their reachable third-party
-    // deps under `libs/`; put them between the consumer classes and the renderer's own Compose
-    // stack
-    // so a preview's own deps resolve while the renderer's bundled Compose still wins on shared
-    // symbols (same layering the desktop viewer's URLClassLoader uses). Coordinate bundles have no
-    // `libs/`, so this is empty and the classpath is unchanged.
-    val libJars = libsDir.listFiles { f -> f.isFile && f.name.endsWith(".jar") }?.sorted().orEmpty()
+    // Embedded `libs/` jars go between the consumer classes and the renderer's own Compose stack so
+    // a preview's own deps resolve while the renderer's bundled Compose still wins on shared
+    // symbols
+    // (same layering the desktop viewer's URLClassLoader uses). Empty for coordinate bundles.
     val classpathString =
       (listOf(classesDir) + libJars + rendererJars).joinToString(File.pathSeparator) {
         it.absolutePath
@@ -122,27 +119,17 @@ class BundleRenderer(
   private fun expandAppJarAndReadManifests(
     zipBytes: ByteArray,
     classesDir: File,
-    libsDir: File,
   ): Pair<String, String> {
     var bundleJson: String? = null
     var previewsJson: String? = null
     var appJarBytes: ByteArray? = null
-    val canonicalLibs = libsDir.canonicalFile
     ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
       while (true) {
         val entry = zin.nextEntry ?: break
-        val name = entry.name
-        when {
-          name == "bundle.json" -> bundleJson = zin.readBytes().toString(Charsets.UTF_8)
-          name == "previews.json" -> previewsJson = zin.readBytes().toString(Charsets.UTF_8)
-          name == "classes/app.jar" -> appJarBytes = zin.readBytes()
-          !entry.isDirectory && name.startsWith("libs/") && name.endsWith(".jar") -> {
-            // Flatten to a safe basename under libsDir; guard against Zip Slip on a hostile bundle.
-            val dest = File(libsDir, File(name).name).canonicalFile
-            if (dest.path.startsWith(canonicalLibs.path + File.separator)) {
-              dest.outputStream().use { sink -> zin.copyTo(sink) }
-            }
-          }
+        when (entry.name) {
+          "bundle.json" -> bundleJson = zin.readBytes().toString(Charsets.UTF_8)
+          "previews.json" -> previewsJson = zin.readBytes().toString(Charsets.UTF_8)
+          "classes/app.jar" -> appJarBytes = zin.readBytes()
         }
         zin.closeEntry()
       }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ExtractEmbeddedLibsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ExtractEmbeddedLibsTest.kt
@@ -1,0 +1,112 @@
+package ee.schimke.composeai.cli
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit coverage for [BundleReader.extractEmbeddedLibs] — the shared `libs/` extractor both
+ * [BundleRenderer] and [BundleDaemonCommand] use to put an embedded-mode bundle's third-party jars
+ * on the consumer classpath. Operates on raw zip bytes (the player passes the polyglot's appended
+ * zip), so these tests build a plain zip in memory.
+ */
+class ExtractEmbeddedLibsTest {
+
+  private val workRoot = Files.createTempDirectory("extract-libs-test-").toFile()
+
+  @AfterTest
+  fun cleanup() {
+    workRoot.deleteRecursively()
+  }
+
+  private fun libsDir(name: String) = File(workRoot, name).apply { mkdirs() }
+
+  private fun zipOf(entries: Map<String, ByteArray>): ByteArray {
+    val baos = ByteArrayOutputStream()
+    ZipOutputStream(baos).use { zip ->
+      for ((path, bytes) in entries) {
+        zip.putNextEntry(ZipEntry(path))
+        zip.write(bytes)
+        zip.closeEntry()
+      }
+    }
+    return baos.toByteArray()
+  }
+
+  @Test
+  fun `extracts every libs jar sorted by name`() {
+    val zip =
+      zipOf(
+        linkedMapOf(
+          "bundle.json" to "{}".toByteArray(),
+          "classes/app.jar" to byteArrayOf(1, 2, 3),
+          // Intentionally out of order to prove the result is name-sorted.
+          "libs/zebra.jar" to byteArrayOf(9),
+          "libs/alpha.jar" to byteArrayOf(7),
+        )
+      )
+
+    val out = BundleReader.extractEmbeddedLibs(zip, libsDir("a"))
+
+    assertEquals(listOf("alpha.jar", "zebra.jar"), out.map { it.name })
+    assertTrue(out.all { it.isFile })
+    assertEquals(listOf<Byte>(7), out[0].readBytes().toList())
+  }
+
+  @Test
+  fun `coordinate bundle with no libs yields empty list`() {
+    val zip =
+      zipOf(
+        linkedMapOf(
+          "bundle.json" to "{}".toByteArray(),
+          "classes/app.jar" to byteArrayOf(1),
+          "previews.json" to "{}".toByteArray(),
+        )
+      )
+
+    assertTrue(BundleReader.extractEmbeddedLibs(zip, libsDir("b")).isEmpty())
+  }
+
+  @Test
+  fun `ignores non-jar libs entries and flattens nested jars to basenames`() {
+    val zip =
+      zipOf(
+        linkedMapOf(
+          "libs/keep.jar" to byteArrayOf(1),
+          "libs/notes.txt" to byteArrayOf(2), // not a .jar — skipped
+          "libs/nested/deep.jar" to byteArrayOf(3), // nested — taken, flattened to basename
+        )
+      )
+
+    val out = BundleReader.extractEmbeddedLibs(zip, libsDir("c"))
+
+    // The .txt is skipped; both jars are kept, the nested one flattened to its basename. Every
+    // extracted file lives directly under libsDir.
+    assertEquals(listOf("deep.jar", "keep.jar"), out.map { it.name })
+    assertTrue(out.all { it.parentFile.name == "c" })
+  }
+
+  @Test
+  fun `zip-slip traversal cannot escape the libs dir`() {
+    val libs = libsDir("d")
+    val zip = zipOf(linkedMapOf("libs/../../evil.jar" to byteArrayOf(66)))
+
+    val out = BundleReader.extractEmbeddedLibs(zip, libs)
+
+    // Flattening to the basename neutralises the `../` traversal: the entry is written safely as
+    // libsDir/evil.jar, and crucially NOT at the parent dir it tried to escape to.
+    assertEquals(listOf("evil.jar"), out.map { it.name })
+    assertTrue(out.single().canonicalFile.parentFile == libs.canonicalFile)
+    assertFalse(
+      File(libs.parentFile, "evil.jar").exists(),
+      "traversal entry must not land outside libsDir",
+    )
+  }
+}

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -408,6 +408,69 @@ class BundleFunctionalTest {
     assertThat(first["type"]!!.jsonPrimitive.content).isEqualTo("jar")
   }
 
+  @Test
+  fun `embed-deps pack carries reachable jars in libs and marks resolution embedded`() {
+    val projectDir = createTestProject()
+    val redId = "test.RedKt.RedBoxPreview"
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewBundle", "-PbundlePreviewIds=$redId", "-PbundleEmbedDeps=true")
+      .withPluginClasspath()
+      .build()
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    val entries = listEntries(bundle)
+    // Embedded mode carries the reachable third-party jars inside the bundle's `libs/`.
+    val libsEntries = entries.filter { it.startsWith("libs/") && it.endsWith(".jar") }
+    assertThat(libsEntries).isNotEmpty()
+
+    val manifest =
+      json
+        .parseToJsonElement(readZipEntry(bundle, "bundle.json")!!.toString(Charsets.UTF_8))
+        .jsonObject
+    assertThat(manifest["schemaVersion"]!!.jsonPrimitive.content).isEqualTo("3")
+    assertThat(manifest["resolution"]!!.jsonPrimitive.content).isEqualTo("embedded")
+    assertThat(manifest["producer"]!!.jsonPrimitive.content).isEqualTo("gradle")
+
+    val kinds =
+      manifest["classpath"]!!.jsonArray.map { it.jsonObject["kind"]!!.jsonPrimitive.content }
+    // First entry is still the inlined consumer module; the third-party deps are now `embedded`,
+    // not `maven` — that's the whole point of the mode.
+    assertThat(kinds.first()).isEqualTo("module")
+    assertThat(kinds).contains("embedded")
+    assertThat(kinds).doesNotContain("maven")
+
+    // Every `embedded` entry's `inlinedAs` must point at a real `libs/` zip entry.
+    val embeddedPaths =
+      manifest["classpath"]!!
+        .jsonArray
+        .filter { it.jsonObject["kind"]!!.jsonPrimitive.content == "embedded" }
+        .map { it.jsonObject["inlinedAs"]!!.jsonPrimitive.content }
+    assertThat(embeddedPaths).isNotEmpty()
+    assertThat(entries).containsAtLeastElementsIn(embeddedPaths)
+  }
+
+  @Test
+  fun `default pack stays coordinates with no libs directory`() {
+    val projectDir = createTestProject()
+    val redId = "test.RedKt.RedBoxPreview"
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewBundle", "-PbundlePreviewIds=$redId")
+      .withPluginClasspath()
+      .build()
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    val manifest =
+      json
+        .parseToJsonElement(readZipEntry(bundle, "bundle.json")!!.toString(Charsets.UTF_8))
+        .jsonObject
+    assertThat(manifest["resolution"]!!.jsonPrimitive.content).isEqualTo("coordinates")
+    assertThat(listEntries(bundle).filter { it.startsWith("libs/") }).isEmpty()
+  }
+
   private fun listEntries(file: File): Set<String> = listEntries(extractZipBytes(file))
 
   private fun listEntries(zipBytes: ByteArray): Set<String> {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -38,12 +38,18 @@ import org.gradle.api.tasks.TaskAction
  * # Dependency strategy
  *
  * Only consumer-module bytecode is inlined into the bundle (`classes/app.jar`, minimized to classes
- * reachable from the selected previews). Every Maven-resolved runtime dependency is recorded as a
- * `ClasspathEntry.Maven` coordinate — not bundled — so the bundle stays small enough to share over
- * chat / paste into a gist. The player resolves the coordinates from the consumer's normal Gradle
- * repos at open time. Project deps that have no Maven coordinate (transitive `:my-lib` references
- * inside the consumer's build) fall back to being inlined as `ClasspathEntry.Project(inlinedAs =
- * "libs/<name>.jar")` so the bundle is still self-contained for offline use.
+ * reachable from the selected previews). In the default `resolution = "coordinates"` mode every
+ * Maven-resolved runtime dependency is recorded as a `ClasspathEntry.Maven` coordinate — not
+ * bundled — so the bundle stays small enough to share over chat / paste into a gist, and the player
+ * resolves the coordinates from the consumer's normal Gradle repos at open time. Project deps that
+ * have no Maven coordinate (transitive `:my-lib` references inside the consumer's build) fall back
+ * to being inlined as `ClasspathEntry.Project(inlinedAs = "libs/<name>.jar")` so the bundle is
+ * still self-contained for offline use.
+ *
+ * With [embedDeps] (`-PbundleEmbedDeps=true`, schema-v3 `resolution = "embedded"`) the kept
+ * Maven-resolved deps are instead carried inside the bundle's `libs/` as `ClasspathEntry.Embedded`,
+ * producing a larger but fully self-contained artefact that a player can render with no network and
+ * no consumer build system — the "pass it to a colleague" mode.
  *
  * # Closure walk
  *
@@ -147,6 +153,17 @@ abstract class BundlePreviewTask : DefaultTask() {
   /** Backend identifier. v1 = "desktop". */
   @get:Input abstract val backend: Property<String>
 
+  /**
+   * Embed-deps mode (`-PbundleEmbedDeps=true`, schema-v3 `resolution = "embedded"`). When true,
+   * every *kept* third-party dependency jar is carried **inside** the bundle under `libs/` as a
+   * [ClasspathEntry.Embedded] entry instead of being referenced by Maven coordinate. The result is
+   * a larger but fully self-contained bundle that a player can render with no network and no
+   * consumer build system — the "pass it to a colleague" mode. Project-local deps (no coordinate)
+   * are inlined regardless; this flag only changes how Maven-resolved deps are carried. Defaults to
+   * false so the normal pack stays small and `resolution = "coordinates"`.
+   */
+  @get:Input @get:Optional abstract val embedDeps: Property<Boolean>
+
   /** Output `.png` polyglot file. */
   @get:OutputFile abstract val output: RegularFileProperty
 
@@ -171,8 +188,9 @@ abstract class BundlePreviewTask : DefaultTask() {
 
     val coordMap = dependencyCoordinates.getOrElse(emptyMap())
     val depDecisions = buildDepDecisions(jarsList, closure.perElement, coordMap)
-    val classpathEntries = buildClasspathEntries(depDecisions)
-    val inlinedProjectJars = inlinedProjectJars(jarsList, depDecisions)
+    val classpath = assembleClasspath(jarsList, depDecisions, embed = embedDeps.getOrElse(false))
+    val classpathEntries = classpath.entries
+    val inlinedJars = classpath.inlinedJars
 
     val report =
       MinimizationReport(
@@ -197,6 +215,8 @@ abstract class BundlePreviewTask : DefaultTask() {
         classpath = classpathEntries,
         modulePath = modulePath.get(),
         producedBy = producedBy.get(),
+        producer = PRODUCER_GRADLE,
+        resolution = classpath.resolution,
       )
 
     // Bake one PNG per selected preview into `previews/<id>.png` so the bundle renders detached
@@ -213,7 +233,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         bundleJson = JSON.encodeToString(BundleManifest.serializer(), bundle),
         previewsJson = JSON.encodeToString(PreviewManifest.serializer(), filteredManifest),
         appJar = appJarBytes,
-        inlinedProjectJars = inlinedProjectJars,
+        inlinedProjectJars = inlinedJars,
         report = JSON.encodeToString(MinimizationReport.serializer(), report),
         previewPngs = previewPngs,
       )
@@ -226,15 +246,18 @@ abstract class BundlePreviewTask : DefaultTask() {
     writePngZipPolyglot(coverPng, zipBytes, outFile)
 
     val mavenKept = classpathEntries.count { it is ClasspathEntry.Maven }
+    val embeddedKept = classpathEntries.count { it is ClasspathEntry.Embedded }
     val projectInlined = classpathEntries.count { it is ClasspathEntry.Project }
     val depsDropped = depDecisions.count { !it.kept }
     logger.lifecycle(
       "composePreviewBundle — wrote ${outFile.name} (${outFile.length()} bytes)\n" +
+        "  resolution:           ${classpath.resolution}\n" +
         "  previews baked:       ${previewPngs.size} / ${selected.size} (cover=$coverId)\n" +
         "  entry classes:        ${report.entryClassFqns.size}\n" +
         "  reachable classes:    ${report.reachableClassCount} / ${report.totalScannedClassCount}\n" +
         "  module classes kept:  ${report.moduleClasses.reachableClasses} / ${report.moduleClasses.totalClasses}\n" +
         "  Maven deps listed:    $mavenKept\n" +
+        "  Embedded deps:        $embeddedKept (carried in libs/)\n" +
         "  Project deps inlined: $projectInlined\n" +
         "  deps dropped:         $depsDropped (no reachable classes)"
     )
@@ -349,37 +372,76 @@ abstract class BundlePreviewTask : DefaultTask() {
     )
   }
 
-  private fun buildClasspathEntries(deps: List<DependencyDecision>): List<ClasspathEntry> {
-    val result = mutableListOf<ClasspathEntry>(ClasspathEntry.Module(path = "classes/app.jar"))
+  /** The classpath manifest entries, the jars to inline under `libs/`, and the resolution mode. */
+  private data class AssembledClasspath(
+    val entries: List<ClasspathEntry>,
+    val inlinedJars: Map<String, File>,
+    val resolution: String,
+  )
+
+  /**
+   * Build the manifest classpath from the kept dependency decisions.
+   * - Project-local deps (no Maven coordinate) are always inlined under `libs/` as
+   *   [ClasspathEntry.Project] — they can't be re-resolved.
+   * - Maven-resolved deps are referenced by [ClasspathEntry.Maven] coordinate (the small default),
+   *   OR, when [embed] is true, inlined under `libs/` as [ClasspathEntry.Embedded] so the bundle
+   *   needs no resolver at open time.
+   *
+   * `resolution` is derived honestly from the result: `embedded` when every kept Maven dep was
+   * carried in `libs/`, `mixed` when some Maven deps are embedded and others referenced (it isn't
+   * today, but the field stays accurate if that changes), else `coordinates`.
+   */
+  private fun assembleClasspath(
+    jars: List<File>,
+    deps: List<DependencyDecision>,
+    embed: Boolean,
+  ): AssembledClasspath {
+    val byPath = jars.associateBy { it.absolutePath }
+    val entries = mutableListOf<ClasspathEntry>(ClasspathEntry.Module(path = "classes/app.jar"))
+    val inlinedJars = LinkedHashMap<String, File>()
+    var mavenReferenced = 0
+    var mavenEmbedded = 0
+    seenJarNames.clear()
     for (dep in deps) {
       if (!dep.kept) continue
       val coord = dep.coordinate
-      if (coord != null) {
-        result += parseMavenCoord(coord)
-      } else {
-        val inlined = "libs/${dedupeJarName(File(dep.sourcePath).name)}"
-        result += ClasspathEntry.Project(path = dep.projectPath ?: ":anon", inlinedAs = inlined)
+      val src = byPath[dep.sourcePath]
+      when {
+        // Maven-resolved dep, default mode: reference by coordinate, carry nothing.
+        coord != null && !embed -> {
+          entries += parseMavenCoord(coord)
+          mavenReferenced++
+        }
+        // Maven-resolved dep, embed mode: carry the jar in `libs/` (skip if its file is missing).
+        coord != null -> {
+          if (src != null) {
+            val inlined = "libs/${dedupeJarName(src.name)}"
+            inlinedJars[inlined] = src
+            entries += ClasspathEntry.Embedded(inlinedAs = inlined)
+            mavenEmbedded++
+          } else {
+            // No file to embed — fall back to a coordinate reference rather than dropping the dep.
+            entries += parseMavenCoord(coord)
+            mavenReferenced++
+          }
+        }
+        // Project-local dep (no coordinate): always inline.
+        else -> {
+          val name = src?.name ?: File(dep.sourcePath).name
+          val inlined = "libs/${dedupeJarName(name)}"
+          if (src != null) inlinedJars[inlined] = src
+          entries += ClasspathEntry.Project(path = dep.projectPath ?: ":anon", inlinedAs = inlined)
+        }
       }
     }
-    return result
-  }
-
-  private fun inlinedProjectJars(
-    jars: List<File>,
-    deps: List<DependencyDecision>,
-  ): Map<String, File> {
-    val byPath = jars.associateBy { it.absolutePath }
-    val result = LinkedHashMap<String, File>()
     seenJarNames.clear()
-    for (dep in deps) {
-      if (!dep.kept) continue
-      if (dep.coordinate != null) continue
-      val src = byPath[dep.sourcePath] ?: continue
-      val inlined = "libs/${dedupeJarName(src.name)}"
-      result[inlined] = src
-    }
-    seenJarNames.clear()
-    return result
+    val resolution =
+      when {
+        mavenEmbedded > 0 && mavenReferenced > 0 -> RESOLUTION_MIXED
+        mavenEmbedded > 0 -> RESOLUTION_EMBEDDED
+        else -> RESOLUTION_COORDINATES
+      }
+    return AssembledClasspath(entries = entries, inlinedJars = inlinedJars, resolution = resolution)
   }
 
   /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -219,6 +219,11 @@ internal object ComposePreviewTasks {
         BundlePreviewIds.parse(raw)
       }
     val outputProperty: Provider<String> = project.providers.gradleProperty("bundleOutput")
+    // `-PbundleEmbedDeps=true` → schema-v3 `resolution = "embedded"`: carry reachable third-party
+    // jars inside the bundle's `libs/` instead of referencing Maven coordinates. Larger file, but
+    // renders with no network / no consumer build system.
+    val embedDepsProperty: Provider<Boolean> =
+      project.providers.gradleProperty("bundleEmbedDeps").map { it.toBoolean() }
     val pluginVersionProperty = PluginVersion.value
 
     val artifactTypeAttr = Attribute.of("artifactType", String::class.java)
@@ -288,6 +293,7 @@ internal object ComposePreviewTasks {
       rendersDir.set(previewOutputDir.map { it.dir("renders") })
       renderFiles.from(previewOutputDir.map { it.dir("renders") })
       previewIds.set(previewIdsProperty.orElse(emptyList()))
+      embedDeps.set(embedDepsProperty.orElse(false))
       modulePath.set(project.path)
       backend.set("desktop")
       producedBy.set("compose-preview $pluginVersionProperty")

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -33,6 +33,10 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  *                            A preview with no render on disk is simply absent from this directory.
  * classes/app.jar          — consumer module bytecode, MINIMIZED to classes reachable from the
  *                            selected previews (plus all module resources)
+ * libs/<name>.jar          — third-party / project jars carried IN the bundle. Present only for
+ *                            [ClasspathEntry.Project] fallbacks and, since v3, [ClasspathEntry.Embedded]
+ *                            entries (`resolution = "embedded"` / `"mixed"`). Absent for a pure
+ *                            `coordinates` pack.
  * report.json              — [MinimizationReport]: which deps contributed reachable classes
  * ```
  *
@@ -45,10 +49,14 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  * `classes/app.jar` + classpath are still present for tooling that wants a *live* re-render (the VS
  * Code panel, the desktop daemon), but they are no longer required just to look at the images.
  *
- * **Notably absent:** there is no `libs/` directory. Maven / Google-resolvable dependencies are
- * recorded as coordinates in [BundleManifest.classpath]; the player (`compose-preview bundle open`,
- * VS Code extension) re-resolves them from the consumer's normal Gradle / Maven repos at open time.
- * That keeps a one-preview bundle ~100 KB instead of dragging the whole Compose graph in.
+ * **Dependency carriage.** In the default `resolution = "coordinates"` pack there is no `libs/`
+ * directory: Maven / Google-resolvable dependencies are recorded as coordinates in
+ * [BundleManifest.classpath] and the player (`compose-preview bundle open`, VS Code extension)
+ * re-resolves them from the consumer's normal Gradle / Maven repos at open time. That keeps a
+ * one-preview bundle ~100 KB instead of dragging the whole Compose graph in. A `resolution =
+ * "embedded"` pack (and non-Gradle producers that can't emit coordinates) instead carries the
+ * reachable jars in `libs/` as [ClasspathEntry.Embedded] so the bundle renders with no network and
+ * no consumer build system — trading size for portability.
  *
  * For Android backends, [ClasspathEntry.Maven.type] = `"aar"` records that the player must resolve
  * the **unprocessed** AAR (not the extracted classes.jar) so AGP's artifact transforms run as they
@@ -65,15 +73,35 @@ data class BundleManifest(
   val coverPreviewId: String?,
   /**
    * Classpath in load order. First entry is always [ClasspathEntry.Module] for the inlined
-   * `classes/app.jar`; remaining entries are typically [ClasspathEntry.Maven] coordinates the
-   * player resolves at open time. [ClasspathEntry.Project] is the escape hatch for local /
-   * unresolvable artifacts that had to be inlined alongside the app jar.
+   * `classes/app.jar`; remaining entries are [ClasspathEntry.Maven] coordinates the player resolves
+   * at open time, [ClasspathEntry.Embedded] jars carried inside the bundle's `libs/` (no resolution
+   * needed), or [ClasspathEntry.Project] fallbacks for local artifacts that had to be inlined
+   * alongside the app jar.
    */
   val classpath: List<ClasspathEntry>,
   /** Source Gradle path that produced the bundle, e.g. `:samples:cmp`. */
   val modulePath: String,
   /** `BUNDLE_VERSION`-shaped identifier of the producer for diagnostics. */
   val producedBy: String,
+  /**
+   * Build system that produced the bundle: `"gradle"` (this plugin), `"amper"`, or `"bazel"` (the
+   * contrib drivers). Informational — lets a player report provenance and pick heuristics without
+   * sniffing the classpath. Defaults to `"gradle"` so a v2 bundle (which omits the field) decodes
+   * as Gradle-produced.
+   */
+  val producer: String = PRODUCER_GRADLE,
+  /**
+   * How the player is expected to assemble the third-party classpath:
+   * - [RESOLUTION_COORDINATES] — resolve [ClasspathEntry.Maven] entries from the consumer's repos
+   *   (small bundle; the Gradle default, and the only mode a v2 bundle could express).
+   * - [RESOLUTION_EMBEDDED] — everything reachable is carried in `libs/` as
+   *   [ClasspathEntry.Embedded] (larger bundle, but renders with no network / no consumer build
+   *   system — the portable hand-off mode).
+   * - [RESOLUTION_MIXED] — coordinate-less deps embedded, the rest referenced by coordinate.
+   *
+   * Defaults to [RESOLUTION_COORDINATES] for v2 back-compat.
+   */
+  val resolution: String = RESOLUTION_COORDINATES,
 )
 
 /** Discriminator field `kind`, values: `module`, `maven`, `project`. */
@@ -120,7 +148,31 @@ sealed interface ClasspathEntry {
     /** Posix relative path inside the bundle zip, e.g. `libs/my-lib.jar`. */
     val inlinedAs: String,
   ) : ClasspathEntry
+
+  /**
+   * A third-party dependency carried **inside** the bundle's `libs/` directory rather than
+   * referenced by coordinate — no resolution, no network, no consumer build system needed to put it
+   * on the classpath. Emitted by `--embed-deps` / `resolution = "embedded"` packs and by non-Gradle
+   * producers that can't (or don't want to) express resolvable Maven coordinates. Unlike [Project],
+   * an embedded entry carries no Gradle path — it's just "this jar, here".
+   */
+  @Serializable
+  @kotlinx.serialization.SerialName("embedded")
+  data class Embedded(
+    /** Posix relative path inside the bundle zip, e.g. `libs/coil-compose-2.6.0.jar`. */
+    val inlinedAs: String
+  ) : ClasspathEntry
 }
+
+/** [BundleManifest.producer] values. */
+const val PRODUCER_GRADLE: String = "gradle"
+
+/** [BundleManifest.resolution] values. */
+const val RESOLUTION_COORDINATES: String = "coordinates"
+
+const val RESOLUTION_EMBEDDED: String = "embedded"
+
+const val RESOLUTION_MIXED: String = "mixed"
 
 /**
  * Schema version stamped into [BundleManifest.schemaVersion].
@@ -131,8 +183,14 @@ sealed interface ClasspathEntry {
  *   `previews/<id>.png` (v1 bundles simply have no such directory); the additive zip entries are
  *   otherwise ignored by `ignoreUnknownKeys` readers, so a v1 reader opening a v2 bundle still
  *   works.
+ * - v3 — adds [BundleManifest.producer] / [BundleManifest.resolution] and the
+ *   [ClasspathEntry.Embedded] kind for `libs/`-carried third-party deps (the `--embed-deps` /
+ *   `resolution = "embedded"` portable-hand-off mode and non-Gradle producers). Both new manifest
+ *   fields default, and `ignoreUnknownKeys` readers skip the `embedded` discriminator they don't
+ *   recognise, so a v2 reader opening a v3 *coordinate* bundle still works; only the embedded jars
+ *   need a v3-aware player.
  */
-const val BUNDLE_SCHEMA_VERSION: Int = 2
+const val BUNDLE_SCHEMA_VERSION: Int = 3
 
 /**
  * Well-known directory inside the bundle zip holding one rendered PNG per selected preview, keyed

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
@@ -1,0 +1,134 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+/**
+ * Schema v3 round-trip + back-compat coverage for [BundleManifest] / [ClasspathEntry]. v3 adds the
+ * [ClasspathEntry.Embedded] kind and the [BundleManifest.producer] / [BundleManifest.resolution]
+ * fields; both manifest fields default so a v2 `bundle.json` (which omits them) still decodes.
+ */
+class PreviewBundleFormatTest {
+
+  // `classDiscriminator = "kind"` mirrors the producer's writer (BundlePreviewTask.JSON) and every
+  // reader (cli BundleReader, :bundle-viewer). `ignoreUnknownKeys` is what makes a v2 reader
+  // tolerate
+  // a v3 bundle's extra entries.
+  private val json = Json {
+    classDiscriminator = "kind"
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+  }
+
+  @Test
+  fun `current schema version is 3`() {
+    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(3)
+  }
+
+  @Test
+  fun `embedded entry round-trips through the kind discriminator`() {
+    val original =
+      BundleManifest(
+        schemaVersion = BUNDLE_SCHEMA_VERSION,
+        backend = "desktop",
+        previewIds = listOf("pkg.Foo"),
+        coverPreviewId = "pkg.Foo",
+        classpath =
+          listOf(
+            ClasspathEntry.Module(path = "classes/app.jar"),
+            ClasspathEntry.Maven("g", "a", "1.0", "jar"),
+            ClasspathEntry.Embedded(inlinedAs = "libs/coil-2.6.0.jar"),
+            ClasspathEntry.Project(path = ":lib", inlinedAs = "libs/lib.jar"),
+          ),
+        modulePath = ":sample",
+        producedBy = "test",
+        producer = PRODUCER_GRADLE,
+        resolution = RESOLUTION_MIXED,
+      )
+
+    val decoded =
+      json.decodeFromString(
+        BundleManifest.serializer(),
+        json.encodeToString(BundleManifest.serializer(), original),
+      )
+
+    assertThat(decoded).isEqualTo(original)
+    val embedded = decoded.classpath.filterIsInstance<ClasspathEntry.Embedded>().single()
+    assertThat(embedded.inlinedAs).isEqualTo("libs/coil-2.6.0.jar")
+  }
+
+  @Test
+  fun `embedded entry serialises with kind=embedded`() {
+    val encoded =
+      json.encodeToString(
+        ClasspathEntry.serializer(),
+        ClasspathEntry.Embedded(inlinedAs = "libs/x.jar"),
+      )
+    assertThat(encoded).contains("\"kind\":\"embedded\"")
+    assertThat(encoded).contains("\"inlinedAs\":\"libs/x.jar\"")
+  }
+
+  @Test
+  fun `v2 manifest without producer or resolution decodes with gradle coordinates defaults`() {
+    // A literal v2 bundle.json: no `producer`, no `resolution`, classpath has only the kinds v2
+    // knew.
+    val v2 =
+      """
+      {
+        "schemaVersion": 2,
+        "backend": "desktop",
+        "previewIds": ["pkg.Foo"],
+        "coverPreviewId": "pkg.Foo",
+        "classpath": [
+          { "kind": "module", "path": "classes/app.jar" },
+          { "kind": "maven", "group": "g", "artifact": "a", "version": "1.0", "type": "jar" }
+        ],
+        "modulePath": ":sample",
+        "producedBy": "test"
+      }
+      """
+        .trimIndent()
+
+    val decoded = json.decodeFromString(BundleManifest.serializer(), v2)
+
+    assertThat(decoded.schemaVersion).isEqualTo(2)
+    assertThat(decoded.producer).isEqualTo(PRODUCER_GRADLE)
+    assertThat(decoded.resolution).isEqualTo(RESOLUTION_COORDINATES)
+    assertThat(decoded.classpath).hasSize(2)
+  }
+
+  @Test
+  fun `v2 reader tolerates an embedded entry it does not recognise`() {
+    // Simulate a v2 reader (no Embedded kind) by decoding a v3 bundle into a model that only lists
+    // module/maven/project. `ignoreUnknownKeys` doesn't cover polymorphic discriminators, so the
+    // realistic v2-tolerance story is: a coordinate-only v3 bundle decodes fine for old readers,
+    // and
+    // an embedded entry simply requires a v3-aware player. Here we assert the v3 reader keeps the
+    // embedded entry rather than silently dropping it.
+    val v3 =
+      """
+      {
+        "schemaVersion": 3,
+        "backend": "desktop",
+        "previewIds": ["pkg.Foo"],
+        "coverPreviewId": "pkg.Foo",
+        "classpath": [
+          { "kind": "module", "path": "classes/app.jar" },
+          { "kind": "embedded", "inlinedAs": "libs/x.jar" }
+        ],
+        "modulePath": ":sample",
+        "producedBy": "test",
+        "producer": "bazel",
+        "resolution": "embedded"
+      }
+      """
+        .trimIndent()
+
+    val decoded = json.decodeFromString(BundleManifest.serializer(), v3)
+
+    assertThat(decoded.producer).isEqualTo("bazel")
+    assertThat(decoded.resolution).isEqualTo(RESOLUTION_EMBEDDED)
+    assertThat(decoded.classpath.filterIsInstance<ClasspathEntry.Embedded>()).hasSize(1)
+  }
+}


### PR DESCRIPTION
Additive, backward-compatible bump toward cross-build-system portable bundles
(#1632). Adds:
- `ClasspathEntry.Embedded(inlinedAs)` — a third-party jar carried inside the
  bundle's `libs/` (no coordinate, no resolution) for `--embed-deps` /
  non-Gradle producers.
- `BundleManifest.producer` ("gradle"|"amper"|"bazel") and `resolution`
  ("coordinates"|"embedded"|"mixed"), both defaulted so a v2 bundle decodes
  unchanged.
- bumps BUNDLE_SCHEMA_VERSION 2 → 3.

Mirrored across all three schema copies (plugin PreviewBundleFormat, cli
BundleReader, :bundle-viewer Schema). The Gradle producer keeps emitting
coordinate bundles via the new defaults — no behavior change yet; Tier 1
(--embed-deps) and the player-side libs/ loader land in follow-ups. `inspect`
now reports producer/resolution and an embedded count.

Adds PreviewBundleFormatTest covering the v3 round-trip, the embedded
discriminator, and v2→v3 default decode.