### PR TITLE
feat(bundle): schema v4 — content-hashed detached dependencies

### DIFF
--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
@@ -40,8 +40,14 @@ sealed interface ClasspathEntry {
 
   @Serializable
   @kotlinx.serialization.SerialName("maven")
-  data class Maven(val group: String, val artifact: String, val version: String, val type: String) :
-    ClasspathEntry
+  data class Maven(
+    val group: String,
+    val artifact: String,
+    val version: String,
+    val type: String,
+    /** v4+: hex SHA-256 of the artifact bytes; verify after re-resolving. Null = unverifiable. */
+    val sha256: String? = null,
+  ) : ClasspathEntry
 
   @Serializable
   @kotlinx.serialization.SerialName("project")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -367,6 +367,8 @@ internal object BundleReader {
       val artifact: String,
       val version: String,
       val type: String,
+      /** v4+: hex SHA-256 of the artifact bytes; verify after re-resolving. Null = unverifiable. */
+      val sha256: String? = null,
     ) : ClasspathEntry
 
     @Serializable

--- a/docs/portable-bundles.md
+++ b/docs/portable-bundles.md
@@ -233,14 +233,21 @@ The player already exists (`compose-preview-viewer`, §2b) — the work is small
 ### Tier 3 — the coordinate resolver (the default play path, not a fallback)
 
 Give the player an embedded resolver (e.g. **Coursier**) so `ClasspathEntry.Maven`
-entries can be fetched without a Gradle install, then **verify each fetched
-artifact against its v4 `sha256`** before putting it on the classpath. With this in
-place, detached coordinate bundles — the small default — render anywhere with
-network access (a Bazel/Amper user re-rendering a Gradle-produced bundle, a
-colleague who only has the `.png`). This is the "resolve from any source,
-hash-verify, layer on" pass; the hash plumbing now exists (v4), so this tier is
-just the resolver + verification, and it becomes the *primary* path with embedding
-reserved for offline.
+entries can be fetched without a Gradle install, then **check each fetched
+artifact against its v4 `sha256`**. With this in place, detached coordinate
+bundles — the small default — render anywhere with network access (a Bazel/Amper
+user re-rendering a Gradle-produced bundle, a colleague who only has the `.png`).
+This is the "resolve from any source, hash-check, layer on" pass; the hash
+plumbing now exists (v4), so this tier is just the resolver + check, and it becomes
+the *primary* path with embedding reserved for offline.
+
+**Mismatch policy: warn, never fail.** A hash mismatch (or a missing hash) is a
+loud warning — name the coordinate and expected-vs-actual hash — and the player
+renders anyway with the resolved bytes. A different artifact for the same
+coordinate is usually *almost* compatible (point-release skew, a
+repackaged-but-equivalent jar), and a slightly-off preview beats no preview. The
+hash is a fidelity signal, not a gate; there is no strict mode that refuses to
+render.
 
 ### Sequencing
 

--- a/docs/portable-bundles.md
+++ b/docs/portable-bundles.md
@@ -181,22 +181,40 @@ extra work.
 > Note: live Compose-only re-render also already ships via `compose-preview-viewer`
 > (§2b) — but it breaks on third-party deps, which is what Tier 1 fixes.
 
-### Tier 1 — portable live re-render via embedded deps (the core fix)
+### Design principle — deps stay *detached*, embedding is the fallback
 
-Add an **`--embed-deps` pack mode** → `resolution = "embedded"`, available to
-the Gradle plugin *and* contrib producers:
+The load-bearing mechanism is **not** stuffing jars into the bundle. A bundle
+should stay small and *reference* its third-party deps, leaving the bytes
+detached; a player **re-attaches** them at play time from wherever they happen to
+live — Maven Central, the colleague's local Gradle/Coursier cache, an internal
+mirror, or a future content-addressable store. The source is interchangeable.
 
-1. Producer writes the *reachable* third-party jars (it already computes the set
-   via the ClassGraph closure — only `kept` deps) into `libs/`, recording each as
-   `ClasspathEntry.Embedded`.
-2. Player builds its classpath entirely from inside the zip: `classes/app.jar` +
-   every `libs/*.jar` + its own bundled renderer.
-3. No Maven resolution, no network, no consumer build system. **The file is the
-   environment** — exactly the "send it to a colleague" case.
+What makes that safe across interchangeable sources is **content addressing**:
+schema v4 records a `sha256` on every `ClasspathEntry.Maven`, so a player resolves
+the coordinate however it can and then verifies the fetched bytes hash to what the
+bundle was built against before trusting them. Coordinate + hash = "find it
+anywhere, but prove it's the right bytes."
 
-Trade-off: size (a one-preview Compose bundle goes ~100 KB → a few MB). Keep
-`coordinates` as the small-file default for Gradle→Gradle; `embedded` is the
-"portable hand-off" switch.
+Embedding (`--embed-deps` / `resolution = "embedded"`, `ClasspathEntry.Embedded`)
+is therefore an **offline fallback**, not the default — for air-gapped hand-off or
+non-Gradle producers that can't emit resolvable coordinates. Don't design players
+to assume the jars are in the zip.
+
+### Tier 1 — detached deps with verifiable hashes (the core)
+
+Default `resolution = "coordinates"`, available to the Gradle plugin *and* contrib
+producers:
+
+1. Producer records each *reachable* third-party dep (ClassGraph closure, `kept`
+   only) as a `ClasspathEntry.Maven` coordinate **plus its `sha256`** — no bytes in
+   the bundle. *(Done for Gradle: schema v4.)*
+2. Player resolves each coordinate from any source it has, verifies the bytes
+   against `sha256`, then puts them on the classpath (Tier 3 is the resolver
+   itself).
+3. **`--embed-deps` remains** as the offline fallback: writes the reachable jars
+   into `libs/` as `ClasspathEntry.Embedded` and a player builds its classpath
+   straight from the zip. Trade-off: size (~100 KB → a few MB). Use it only when
+   the recipient can't resolve coordinates.
 
 ### Tier 2 — teach the existing player to read `libs/`, ship it runnable
 
@@ -212,13 +230,17 @@ The player already exists (`compose-preview-viewer`, §2b) — the work is small
    `jpackage`/`jlink` native app per OS so a non-Java colleague needs nothing
    installed at all.
 
-### Tier 3 — coordinate resolver fallback (for small Gradle-shaped bundles)
+### Tier 3 — the coordinate resolver (the default play path, not a fallback)
 
 Give the player an embedded resolver (e.g. **Coursier**) so `ClasspathEntry.Maven`
-entries can be fetched without a Gradle install — letting a Bazel/Amper user
-re-render a small Gradle-produced bundle, given network. This is precisely the
-"download Maven, hash-verify, layer on" pass the code currently defers
-(`BundleDaemonCommand`).
+entries can be fetched without a Gradle install, then **verify each fetched
+artifact against its v4 `sha256`** before putting it on the classpath. With this in
+place, detached coordinate bundles — the small default — render anywhere with
+network access (a Bazel/Amper user re-rendering a Gradle-produced bundle, a
+colleague who only has the `.png`). This is the "resolve from any source,
+hash-verify, layer on" pass; the hash plumbing now exists (v4), so this tier is
+just the resolver + verification, and it becomes the *primary* path with embedding
+reserved for offline.
 
 ### Sequencing
 

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -406,6 +406,10 @@ class BundleFunctionalTest {
     assertThat(first["artifact"]!!.jsonPrimitive.content).isNotEmpty()
     assertThat(first["version"]!!.jsonPrimitive.content).isNotEmpty()
     assertThat(first["type"]!!.jsonPrimitive.content).isEqualTo("jar")
+    // v4: every referenced (detached) coordinate carries a content hash so a player can verify the
+    // bytes after re-resolving from any source. 64 lowercase hex chars = SHA-256.
+    val sha = first["sha256"]!!.jsonPrimitive.content
+    assertThat(sha).matches("[0-9a-f]{64}")
   }
 
   @Test

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.zip.ZipInputStream
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -433,7 +434,10 @@ class BundleFunctionalTest {
       json
         .parseToJsonElement(readZipEntry(bundle, "bundle.json")!!.toString(Charsets.UTF_8))
         .jsonObject
-    assertThat(manifest["schemaVersion"]!!.jsonPrimitive.content).isEqualTo("3")
+    // Assert against the current schema constant rather than a hardcoded number so a future bump
+    // doesn't make this stale (it did when v3 → v4 landed sha256). The embedded carriage + manifest
+    // fields below are the behaviour this test actually pins.
+    assertThat(manifest["schemaVersion"]!!.jsonPrimitive.int).isEqualTo(BUNDLE_SCHEMA_VERSION)
     assertThat(manifest["resolution"]!!.jsonPrimitive.content).isEqualTo("embedded")
     assertThat(manifest["producer"]!!.jsonPrimitive.content).isEqualTo("gradle")
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -407,9 +407,10 @@ abstract class BundlePreviewTask : DefaultTask() {
       val coord = dep.coordinate
       val src = byPath[dep.sourcePath]
       when {
-        // Maven-resolved dep, default mode: reference by coordinate, carry nothing.
+        // Maven-resolved dep, default mode: reference by coordinate (with a content hash so the
+        // detached bytes can be re-attached and verified from any source).
         coord != null && !embed -> {
-          entries += parseMavenCoord(coord)
+          entries += parseMavenCoord(coord, src)
           mavenReferenced++
         }
         // Maven-resolved dep, embed mode: carry the jar in `libs/` (skip if its file is missing).
@@ -421,7 +422,7 @@ abstract class BundlePreviewTask : DefaultTask() {
             mavenEmbedded++
           } else {
             // No file to embed — fall back to a coordinate reference rather than dropping the dep.
-            entries += parseMavenCoord(coord)
+            entries += parseMavenCoord(coord, src = null)
             mavenReferenced++
           }
         }
@@ -447,9 +448,11 @@ abstract class BundlePreviewTask : DefaultTask() {
   /**
    * Parse `"<group>:<artifact>:<version>:<type>"` (the post-prefix shape produced by the plugin
    * registration's `ResolvedArtifactResult` → coord encoder). Falls back to `type = "jar"` when the
-   * coordinate omits the trailing packaging.
+   * coordinate omits the trailing packaging. When [src] (the resolved jar on disk) is provided, its
+   * SHA-256 is recorded so a player can verify the bytes after re-resolving the coordinate from any
+   * source; [src] = null leaves the entry resolvable-but-unverifiable.
    */
-  private fun parseMavenCoord(coord: String): ClasspathEntry.Maven {
+  private fun parseMavenCoord(coord: String, src: File?): ClasspathEntry.Maven {
     val parts = coord.split(':')
     require(parts.size >= 3) { "composePreviewBundle: malformed Maven coordinate: $coord" }
     return ClasspathEntry.Maven(
@@ -457,7 +460,24 @@ abstract class BundlePreviewTask : DefaultTask() {
       artifact = parts[1],
       version = parts[2],
       type = parts.getOrNull(3) ?: "jar",
+      sha256 = src?.let { sha256Hex(it) },
     )
+  }
+
+  /**
+   * Lowercase hex SHA-256 of [file]'s bytes, streamed so large jars don't load fully into memory.
+   */
+  private fun sha256Hex(file: File): String {
+    val digest = java.security.MessageDigest.getInstance("SHA-256")
+    file.inputStream().use { input ->
+      val buf = ByteArray(64 * 1024)
+      while (true) {
+        val n = input.read(buf)
+        if (n < 0) break
+        digest.update(buf, 0, n)
+      }
+    }
+    return digest.digest().joinToString("") { "%02x".format(it) }
   }
 
   private fun buildJar(classes: Map<String, ByteArray>, resourcesDir: File?): ByteArray {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -261,6 +261,21 @@ abstract class BundlePreviewTask : DefaultTask() {
         "  Project deps inlined: $projectInlined\n" +
         "  deps dropped:         $depsDropped (no reachable classes)"
     )
+
+    // Bundles are meant to be small and shareable — a detached `coordinates` pack is typically
+    // ~100 KB. Embedding (`--embed-deps`) trades that for offline self-containment, but a fat
+    // bundle
+    // defeats the "paste it into a chat" point. Warn past a soft threshold so embedding stays a
+    // deliberate, rare choice rather than an accidental 50 MB artefact.
+    val sizeBytes = outFile.length()
+    if (sizeBytes > EMBED_SIZE_WARN_BYTES && embeddedKept > 0) {
+      logger.warn(
+        "composePreviewBundle: ${outFile.name} is ${sizeBytes / 1_000_000}MB with $embeddedKept " +
+          "embedded dep(s). Embedding is an offline fallback — prefer the default detached " +
+          "`coordinates` pack (drop `--embed-deps` / `-PbundleEmbedDeps`) so the bundle stays small " +
+          "and resolves its deps at open time."
+      )
+    }
   }
 
   private fun resolveSelection(manifest: PreviewManifest, ids: List<String>): List<PreviewInfo> {
@@ -609,6 +624,13 @@ abstract class BundlePreviewTask : DefaultTask() {
       encodeDefaults = true
       classDiscriminator = "kind"
     }
+
+    /**
+     * Soft size ceiling above which an embed-deps pack warns. 25 MB is comfortably above a normal
+     * embedded Compose graph (a few MB) but well under the "nobody pastes this into a chat" range —
+     * enough to flag an accidental fat bundle without failing the build.
+     */
+    const val EMBED_SIZE_WARN_BYTES: Long = 25_000_000L
 
     /**
      * Fixed timestamp stamped onto every ZIP entry produced by [writeFile]. 1980-01-01T00:00:00

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -141,12 +141,17 @@ sealed interface ClasspathEntry {
     val type: String,
     /**
      * Lowercase hex SHA-256 of the resolved artifact's bytes at pack time, or null when the
-     * producer couldn't compute it (older bundles, non-Gradle producers). This is what makes a
-     * *detached* dep safe to re-attach from **any** source: a player resolves the coordinate from
-     * whatever repository / cache it has, then verifies the fetched bytes hash to [sha256] before
-     * putting them on the classpath — so the source is interchangeable but the bytes are pinned. A
-     * coordinate without a hash is resolvable but unverifiable; players may warn or refuse in
-     * strict mode.
+     * producer couldn't compute it (older bundles, non-Gradle producers). Lets a player that
+     * re-attaches a *detached* dep from **any** source (Maven, a local cache, a mirror, a CAS)
+     * check the fetched bytes against the bytes the bundle was built with.
+     *
+     * **Mismatch policy: warn, never fail.** A player MUST NOT refuse to render on a hash mismatch.
+     * A different artifact for the same coordinate is usually *almost* compatible — a point-release
+     * skew, a repackaged-but-equivalent jar, a stripped vs. full variant — and a preview that
+     * renders slightly off is far more useful than no preview at all. So a mismatch (or a
+     * missing/unverifiable hash) is a **noisy warning**: surface it loudly (which coordinate,
+     * expected vs. actual hash) and proceed with the resolved bytes. There is no strict mode that
+     * hard-fails. Verification is a fidelity signal, not a gate.
      */
     val sha256: String? = null,
   ) : ClasspathEntry

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -118,9 +118,14 @@ sealed interface ClasspathEntry {
   ) : ClasspathEntry
 
   /**
-   * A Maven (or Google Maven, JitPack, …) coordinate the player resolves at open time. Encoded as
-   * separate fields rather than a `group:artifact:version` string so consumers can pick a subset
-   * (e.g. only allow certain groups) without re-parsing.
+   * A Maven (or Google Maven, JitPack, …) coordinate the player resolves at open time. This is the
+   * **canonical** way a bundle carries a third-party dependency: the bytes stay *detached* and the
+   * player re-attaches them from wherever they live (Maven Central, the colleague's local Gradle /
+   * Coursier cache, an internal mirror, a future content-addressable store). Embedding
+   * ([ClasspathEntry.Embedded]) is only an offline fallback.
+   *
+   * Encoded as separate fields rather than a `group:artifact:version` string so consumers can pick
+   * a subset (e.g. only allow certain groups) without re-parsing.
    */
   @Serializable
   @kotlinx.serialization.SerialName("maven")
@@ -134,6 +139,16 @@ sealed interface ClasspathEntry {
      * artifact-transform pipeline.
      */
     val type: String,
+    /**
+     * Lowercase hex SHA-256 of the resolved artifact's bytes at pack time, or null when the
+     * producer couldn't compute it (older bundles, non-Gradle producers). This is what makes a
+     * *detached* dep safe to re-attach from **any** source: a player resolves the coordinate from
+     * whatever repository / cache it has, then verifies the fetched bytes hash to [sha256] before
+     * putting them on the classpath — so the source is interchangeable but the bytes are pinned. A
+     * coordinate without a hash is resolvable but unverifiable; players may warn or refuse in
+     * strict mode.
+     */
+    val sha256: String? = null,
   ) : ClasspathEntry
 
   /**
@@ -189,8 +204,13 @@ const val RESOLUTION_MIXED: String = "mixed"
  *   fields default, and `ignoreUnknownKeys` readers skip the `embedded` discriminator they don't
  *   recognise, so a v2 reader opening a v3 *coordinate* bundle still works; only the embedded jars
  *   need a v3-aware player.
+ * - v4 — adds [ClasspathEntry.Maven.sha256], the content hash that makes a *detached* coordinate
+ *   safe to re-attach from any source (Maven, a local cache, a mirror, a CAS): the player resolves
+ *   the coordinate however it can, then verifies the bytes against the hash. Purely additive —
+ *   `sha256` defaults to null, so a v3 reader opening a v4 bundle just ignores it and an older
+ *   bundle reads as "unverifiable coordinate".
  */
-const val BUNDLE_SCHEMA_VERSION: Int = 3
+const val BUNDLE_SCHEMA_VERSION: Int = 4
 
 /**
  * Well-known directory inside the bundle zip holding one rendered PNG per selected preview, keyed

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
@@ -22,8 +22,8 @@ class PreviewBundleFormatTest {
   }
 
   @Test
-  fun `current schema version is 3`() {
-    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(3)
+  fun `current schema version is 4`() {
+    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(4)
   }
 
   @Test
@@ -37,7 +37,7 @@ class PreviewBundleFormatTest {
         classpath =
           listOf(
             ClasspathEntry.Module(path = "classes/app.jar"),
-            ClasspathEntry.Maven("g", "a", "1.0", "jar"),
+            ClasspathEntry.Maven("g", "a", "1.0", "jar", sha256 = "a".repeat(64)),
             ClasspathEntry.Embedded(inlinedAs = "libs/coil-2.6.0.jar"),
             ClasspathEntry.Project(path = ":lib", inlinedAs = "libs/lib.jar"),
           ),
@@ -56,6 +56,22 @@ class PreviewBundleFormatTest {
     assertThat(decoded).isEqualTo(original)
     val embedded = decoded.classpath.filterIsInstance<ClasspathEntry.Embedded>().single()
     assertThat(embedded.inlinedAs).isEqualTo("libs/coil-2.6.0.jar")
+  }
+
+  @Test
+  fun `maven sha256 round-trips and defaults to null for v3-shaped entries`() {
+    val withHash = ClasspathEntry.Maven("g", "a", "1.0", "jar", sha256 = "b".repeat(64))
+    val decoded =
+      json.decodeFromString(
+        ClasspathEntry.serializer(),
+        json.encodeToString(ClasspathEntry.serializer(), withHash),
+      ) as ClasspathEntry.Maven
+    assertThat(decoded.sha256).isEqualTo("b".repeat(64))
+
+    // A v3-shaped maven entry (no sha256 key) decodes with sha256 = null — unverifiable but valid.
+    val v3 = """{"kind":"maven","group":"g","artifact":"a","version":"1.0","type":"jar"}"""
+    val legacy = json.decodeFromString(ClasspathEntry.serializer(), v3) as ClasspathEntry.Maven
+    assertThat(legacy.sha256).isNull()
   }
 
   @Test


### PR DESCRIPTION
## Summary

Part of #1632. Establishes the design principle that a bundle's third-party deps stay **detached** — referenced, not embedded — and a player re-attaches them at play time from whatever source it has (Maven Central, a local Gradle/Coursier cache, a mirror, a future CAS). Embedding stays available but is the rare offline fallback, explicitly guarded against bloat.

What makes "resolve from any source" safe is **content addressing**, so this adds a content hash to every referenced coordinate:

- **Schema v4** (`PreviewBundleFormat.kt`): `ClasspathEntry.Maven.sha256` — hex SHA-256 of the artifact bytes at pack time. Nullable, defaults null → purely additive; a v3 reader opening a v4 bundle ignores it, and an older bundle reads as "unverifiable coordinate". Bumps `BUNDLE_SCHEMA_VERSION` 3 → 4. `Maven` is reworded as the **canonical** carriage; embedding demoted to offline fallback in the docs.
- **Producer** (`BundlePreviewTask.kt`): stream-hashes each resolved jar into its coordinate entry.
- **Size guardrail**: an `--embed-deps` pack warns (never fails) past a 25 MB soft ceiling, pointing back at the default detached pack — so embedding stays a deliberate, rare choice and we don't get 50 MB bundles.
- **Mirrors** `sha256` into the read-side schema copies (`cli` `BundleReader`, `:bundle-viewer`).
- **Docs** (`docs/portable-bundles.md`): adds the "deps stay detached, embedding is the fallback" principle; Tier 1 is coordinates+hash, Tier 3 (resolver + hash-verify) is reframed as the *primary* play path.

This is the foundation for the Tier 3 resolver (fetch a coordinate from any source, verify bytes against `sha256`, layer on) — deferred to its own PR since it's a network-fetching component.

## Test plan

- `PreviewBundleFormatTest` (unit): v4 round-trip incl. `sha256`, and a v3-shaped Maven entry (no `sha256` key) decodes with `sha256 = null`. ✅ offline
- `BundleFunctionalTest` "Maven coordinates not inlined jars": asserts every referenced coordinate carries a 64-hex-char SHA-256. ✅ against Maven Central
- `:bundle-viewer:test`, `:cli` `ExtractEmbeddedLibsTest`: ✅ (schema mirrors still decode)
- compile + ktfmt clean across `:gradle-plugin`, `:cli`, `:bundle-viewer`

Note: `:tui-cli` isn't built locally (Mosaic snapshot host blocked in this env); it's unaffected — its reader only pulls `modulePath`/`coverPreviewId` with `ignoreUnknownKeys`, so v4 is transparent. CI covers it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pkfwxdoh2qrkS44z8pdFJs)_