### PR TITLE
feat(cli): resolve detached maven coordinates from local repos (Tier 3)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -22,17 +22,18 @@ import kotlinx.serialization.json.Json
  *
  * # Classpath
  *
- * The subprocess JVM's classpath = extracted `classes/app.jar` directory + any embedded `libs/`
- * jars
- * + every jar in `<APP_HOME>/lib-renderer/`, in that order. Embedded-mode bundles (schema-v3
- *   `resolution = "embedded"`) carry their reachable third-party deps under `libs/`, so a preview's
- *   own deps resolve from there; the bundled renderer's transitive Compose Multiplatform graph
- *   still supplies the Compose API surface and wins on shared symbols (it sits after the consumer
- *   classes). For coordinate-mode bundles there are no `libs/` jars and the recorded Maven
- *   coordinates are NOT downloaded for v1 — the renderer's own Compose version wins, relying on
- *   Compose's binary-compatibility story across point releases. A bundle compiled against compose
- *   1.10.x renders fine against the CLI's bundled 1.10.x; full coordinate resolution is a later
- *   milestone (#1632, Tier 3).
+ * The subprocess JVM's classpath, in order: extracted `classes/app.jar` directory, any embedded
+ * `libs/` jars, any `maven` coordinates resolved from local repositories ([CoordinateResolver]),
+ * then every jar in `<APP_HOME>/lib-renderer/`. The consumer's deps sit ahead of the renderer's own
+ * Compose Multiplatform graph, so a preview's own deps resolve while the bundled Compose still wins
+ * on shared symbols (same layering the desktop viewer's URLClassLoader uses).
+ *
+ * Embedded-mode bundles (schema-v3 `resolution = "embedded"`) carry their reachable deps in
+ * `libs/`. Coordinate-mode bundles (the default) carry only references; [CoordinateResolver]
+ * re-attaches them from the machine's local Maven / Gradle caches (Tier 3) and hash-checks against
+ * the v4 `sha256` — a miss or mismatch warns but never fails, since the renderer's bundled Compose
+ * covers the common surface and an almost-compatible jar still renders. Network resolution is a
+ * later increment behind the same seam.
  *
  * # Renderer / Java location
  *
@@ -89,12 +90,20 @@ class BundleRenderer(
           "either build the CLI via `./gradlew :cli:installDist` or set `-Dcomposeai.cli.appHome=<install-root>`."
       )
     }
-    // Embedded `libs/` jars go between the consumer classes and the renderer's own Compose stack so
-    // a preview's own deps resolve while the renderer's bundled Compose still wins on shared
-    // symbols
-    // (same layering the desktop viewer's URLClassLoader uses). Empty for coordinate bundles.
+    // Resolve the bundle's detached `maven` coordinates from local repositories (Tier 3). Misses
+    // and hash mismatches warn but never fail — see CoordinateResolver. Embedded `libs/` jars and
+    // resolved coordinate jars both sit between the consumer classes and the renderer's own Compose
+    // stack, so a preview's own deps resolve while the renderer's bundled Compose still wins on
+    // shared symbols (same layering the desktop viewer's URLClassLoader uses).
+    val mavenCoords = manifest.classpath.filterIsInstance<BundleReader.ClasspathEntry.Maven>()
+    val resolvedJars =
+      CoordinateResolver(warn = { logSink("compose-preview: $it") })
+        .resolveAll(mavenCoords)
+        .mapNotNull { it.file }
     val classpathString =
-      (listOf(classesDir) + libJars + rendererJars).joinToString(File.pathSeparator) {
+      (listOf(classesDir) + libJars + resolvedJars + rendererJars).joinToString(
+        File.pathSeparator
+      ) {
         it.absolutePath
       }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
@@ -1,0 +1,146 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Resolves a bundle's detached `maven` coordinates (#1632, Tier 3) into local jar files so a player
+ * can put them on the classpath. This is the consumer side of schema v4's content-addressing: a
+ * coordinate names *what* dependency the bundle needs, and the resolver finds the bytes from
+ * whatever the machine already has.
+ *
+ * # Sources
+ *
+ * v1 resolves from **local repositories only** — no network. Two layouts are searched, in order:
+ * 1. A Maven local repo (`~/.m2/repository`, standard `group/as/path/artifact/version/...` layout).
+ * 2. The Gradle module cache (`~/.gradle/caches/modules-2/files-2.1`, which fans the file out under
+ *    a per-sha1 subdirectory — we glob for the jar by name rather than guess the hash dir).
+ *
+ * Both roots are overridable via [repositoryRoots] (tests pass a temp dir; a future network fetcher
+ * is just another root that populates a cache then resolves from it). A colleague who has built any
+ * project using the same deps will already have them in one of these caches, so the common "someone
+ * sent me a bundle" path works offline.
+ *
+ * # Verification — warn, never fail
+ *
+ * When a coordinate carries a v4 `sha256`, the resolved jar's bytes are hashed and compared. A
+ * **mismatch is a loud warning, not an error**: a different artifact for the same coordinate is
+ * usually almost compatible (point-release skew, a repackaged-but-equivalent jar), and a
+ * slightly-off preview beats no preview. The resolver still returns the jar. A missing hash
+ * (older/non-Gradle bundles) resolves silently as unverifiable. This mirrors the contract pinned on
+ * [ee.schimke.composeai.cli.BundleReader.ClasspathEntry.Maven] / `PreviewBundleFormat`.
+ *
+ * The resolver itself never throws on a missing artifact either — it returns null and warns, so the
+ * caller decides whether to proceed with a partial classpath (it should: the bundled renderer's
+ * Compose stack covers the common surface).
+ */
+internal class CoordinateResolver(
+  private val repositoryRoots: List<File> = defaultRepositoryRoots(),
+  private val warn: (String) -> Unit = { System.err.println("compose-preview: $it") },
+) {
+
+  /** Outcome of resolving one coordinate. [file] is null when nothing was found locally. */
+  data class Resolution(
+    val coordinate: BundleReader.ClasspathEntry.Maven,
+    val file: File?,
+    val verified: Boolean,
+    val mismatch: Boolean,
+  )
+
+  /**
+   * Resolve [coords] to local jars, warning (never throwing) on misses and hash mismatches. Returns
+   * one [Resolution] per input coordinate in order; callers typically take `mapNotNull { it.file }`
+   * for the classpath and surface the misses to the user.
+   */
+  fun resolveAll(coords: List<BundleReader.ClasspathEntry.Maven>): List<Resolution> = coords.map {
+    resolve(it)
+  }
+
+  fun resolve(coord: BundleReader.ClasspathEntry.Maven): Resolution {
+    val jar = locate(coord)
+    if (jar == null) {
+      warn(
+        "could not resolve ${coord.group}:${coord.artifact}:${coord.version} from any local " +
+          "repository (looked in ${repositoryRoots.joinToString { it.path }}); the preview may " +
+          "fail to render if it needs this dependency. Re-pack with --embed-deps for an offline bundle."
+      )
+      return Resolution(coord, file = null, verified = false, mismatch = false)
+    }
+    val expected = coord.sha256
+    if (expected == null) {
+      return Resolution(coord, file = jar, verified = false, mismatch = false)
+    }
+    val actual = sha256Hex(jar)
+    if (!actual.equals(expected, ignoreCase = true)) {
+      // Warn, do NOT fail — the bytes are probably almost compatible. See the verification
+      // contract.
+      warn(
+        "hash mismatch for ${coord.group}:${coord.artifact}:${coord.version} — bundle expected " +
+          "$expected but ${jar.name} hashes to $actual. Rendering with the local copy anyway; the " +
+          "preview may differ slightly from the original."
+      )
+      return Resolution(coord, file = jar, verified = false, mismatch = true)
+    }
+    return Resolution(coord, file = jar, verified = true, mismatch = false)
+  }
+
+  /** First matching jar across [repositoryRoots], or null. */
+  private fun locate(coord: BundleReader.ClasspathEntry.Maven): File? {
+    val jarName = "${coord.artifact}-${coord.version}.jar"
+    for (root in repositoryRoots) {
+      if (!root.isDirectory) continue
+      // Maven layout: <root>/<group as path>/<artifact>/<version>/<artifact>-<version>.jar
+      val mavenPath =
+        File(root, coord.group.replace('.', '/') + "/${coord.artifact}/${coord.version}/$jarName")
+      if (mavenPath.isFile) return mavenPath
+      // Gradle modules-2 layout fans the jar under a per-hash dir; glob for it by exact name under
+      // <root>/<group>/<artifact>/<version>/<hash>/<jarName>. Bounded walk (depth-limited) so a
+      // huge
+      // cache root doesn't turn this into a full filesystem scan.
+      val gradleVersionDir = File(root, "${coord.group}/${coord.artifact}/${coord.version}")
+      if (gradleVersionDir.isDirectory) {
+        gradleVersionDir
+          .listFiles()
+          ?.asSequence()
+          ?.filter { it.isDirectory }
+          ?.mapNotNull { hashDir -> File(hashDir, jarName).takeIf { it.isFile } }
+          ?.firstOrNull()
+          ?.let {
+            return it
+          }
+      }
+    }
+    return null
+  }
+
+  private fun sha256Hex(file: File): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    file.inputStream().use { input ->
+      val buf = ByteArray(64 * 1024)
+      while (true) {
+        val n = input.read(buf)
+        if (n < 0) break
+        digest.update(buf, 0, n)
+      }
+    }
+    return digest.digest().joinToString("") { "%02x".format(it) }
+  }
+
+  companion object {
+    /**
+     * Default local repositories searched when a caller doesn't pass its own. Honours the standard
+     * `maven.repo.local` override and `GRADLE_USER_HOME`; falls back to the conventional `~/.m2`
+     * and `~/.gradle` locations. Non-existent roots are simply skipped at lookup time.
+     */
+    fun defaultRepositoryRoots(): List<File> {
+      val home = System.getProperty("user.home")?.let(::File)
+      val roots = mutableListOf<File>()
+      System.getProperty("maven.repo.local")?.let { roots += File(it) }
+      if (home != null) roots += File(home, ".m2/repository")
+      val gradleHome =
+        System.getenv("GRADLE_USER_HOME")?.let(::File) ?: home?.let { File(it, ".gradle") }
+      if (gradleHome != null) roots += File(gradleHome, "caches/modules-2/files-2.1")
+      return roots
+    }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
@@ -57,8 +57,8 @@ internal class CoordinateResolver(
   }
 
   fun resolve(coord: BundleReader.ClasspathEntry.Maven): Resolution {
-    val jar = locate(coord)
-    if (jar == null) {
+    val candidates = locate(coord)
+    if (candidates.isEmpty()) {
       warn(
         "could not resolve ${coord.group}:${coord.artifact}:${coord.version} from any local " +
           "repository (looked in ${repositoryRoots.joinToString { it.path }}); the preview may " +
@@ -68,34 +68,45 @@ internal class CoordinateResolver(
     }
     val expected = coord.sha256
     if (expected == null) {
-      return Resolution(coord, file = jar, verified = false, mismatch = false)
+      // No hash to disambiguate with — first candidate, unverifiable.
+      return Resolution(coord, file = candidates.first(), verified = false, mismatch = false)
     }
-    val actual = sha256Hex(jar)
-    if (!actual.equals(expected, ignoreCase = true)) {
-      // Warn, do NOT fail — the bytes are probably almost compatible. See the verification
-      // contract.
-      warn(
-        "hash mismatch for ${coord.group}:${coord.artifact}:${coord.version} — bundle expected " +
-          "$expected but ${jar.name} hashes to $actual. Rendering with the local copy anyway; the " +
-          "preview may differ slightly from the original."
-      )
-      return Resolution(coord, file = jar, verified = false, mismatch = true)
-    }
-    return Resolution(coord, file = jar, verified = true, mismatch = false)
+    // The hash exists precisely to pick the *right* copy when a GAV resolves to several local files
+    // (a stale ~/.m2 copy + a Gradle cache entry, multiple Gradle hash dirs for a republished
+    // module, …). Prefer a candidate whose bytes match before settling for a mismatch.
+    candidates
+      .firstOrNull { sha256Hex(it).equals(expected, ignoreCase = true) }
+      ?.let {
+        return Resolution(coord, file = it, verified = true, mismatch = false)
+      }
+    // Nothing matched. Warn, do NOT fail — the bytes are probably almost compatible (see the
+    // verification contract). Fall back to the first candidate so the preview still renders.
+    val fallback = candidates.first()
+    warn(
+      "hash mismatch for ${coord.group}:${coord.artifact}:${coord.version} — bundle expected " +
+        "$expected but none of ${candidates.size} local copy(ies) matched (using ${fallback.name}, " +
+        "${sha256Hex(fallback)}). Rendering with the local copy anyway; the preview may differ " +
+        "slightly from the original."
+    )
+    return Resolution(coord, file = fallback, verified = false, mismatch = true)
   }
 
-  /** First matching jar across [repositoryRoots], or null. */
-  private fun locate(coord: BundleReader.ClasspathEntry.Maven): File? {
+  /**
+   * All candidate jars for [coord] across [repositoryRoots], in search order (Maven layout before
+   * Gradle layout, roots in declared order). May hold more than one when the same GAV is present in
+   * several caches or Gradle hash dirs — [resolve] uses the hash to pick among them.
+   */
+  private fun locate(coord: BundleReader.ClasspathEntry.Maven): List<File> {
     val jarName = "${coord.artifact}-${coord.version}.jar"
+    val found = mutableListOf<File>()
     for (root in repositoryRoots) {
       if (!root.isDirectory) continue
       // Maven layout: <root>/<group as path>/<artifact>/<version>/<artifact>-<version>.jar
       val mavenPath =
         File(root, coord.group.replace('.', '/') + "/${coord.artifact}/${coord.version}/$jarName")
-      if (mavenPath.isFile) return mavenPath
-      // Gradle modules-2 layout fans the jar under a per-hash dir; glob for it by exact name under
-      // <root>/<group>/<artifact>/<version>/<hash>/<jarName>. Bounded walk (depth-limited) so a
-      // huge
+      if (mavenPath.isFile) found += mavenPath
+      // Gradle modules-2 layout fans the jar under per-hash dirs; collect every match under
+      // <root>/<group>/<artifact>/<version>/<hash>/<jarName>. One directory level only, so a huge
       // cache root doesn't turn this into a full filesystem scan.
       val gradleVersionDir = File(root, "${coord.group}/${coord.artifact}/${coord.version}")
       if (gradleVersionDir.isDirectory) {
@@ -104,13 +115,10 @@ internal class CoordinateResolver(
           ?.asSequence()
           ?.filter { it.isDirectory }
           ?.mapNotNull { hashDir -> File(hashDir, jarName).takeIf { it.isFile } }
-          ?.firstOrNull()
-          ?.let {
-            return it
-          }
+          ?.let { found += it }
       }
     }
-    return null
+    return found
   }
 
   private fun sha256Hex(file: File): String {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
@@ -107,6 +107,22 @@ class CoordinateResolverTest {
   }
 
   @Test
+  fun `prefers a hash-matching candidate over an earlier mismatch`() {
+    // A stale Maven-layout copy (wrong bytes) plus a Gradle-cache copy with the bundle's exact
+    // bytes. The resolver must skip the first-found mismatch and pick the matching one.
+    val wanted = byteArrayOf(4, 4, 4, 4)
+    writeMavenJar(byteArrayOf(0, 0, 0)) // stale, found first
+    val good = writeGradleJar(wanted) // exact match, found later
+
+    val r = resolver.resolve(maven(sha = sha256(wanted)))
+
+    assertEquals(good.canonicalFile, r.file?.canonicalFile)
+    assertTrue(r.verified)
+    assertFalse(r.mismatch)
+    assertTrue(warnings.isEmpty(), "picking the matching candidate must not warn: $warnings")
+  }
+
+  @Test
   fun `null hash resolves as unverifiable without warning`() {
     writeMavenJar(byteArrayOf(5, 5, 5))
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
@@ -1,0 +1,123 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import java.security.MessageDigest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Offline coverage for [CoordinateResolver] — the Tier 3 (#1632) consumer of schema-v4 detached
+ * coordinates. Exercises both local-repo layouts, the warn-not-fail miss path, and the
+ * warn-but-return hash-mismatch contract, all against a temp repo dir (no network).
+ */
+class CoordinateResolverTest {
+
+  private val root = Files.createTempDirectory("coord-resolver-test-").toFile()
+  private val warnings = mutableListOf<String>()
+  private val resolver =
+    CoordinateResolver(repositoryRoots = listOf(root), warn = { warnings += it })
+
+  @AfterTest
+  fun cleanup() {
+    root.deleteRecursively()
+  }
+
+  private fun maven(sha: String? = null) =
+    BundleReader.ClasspathEntry.Maven(
+      group = "com.example.foo",
+      artifact = "widgets",
+      version = "1.2.3",
+      type = "jar",
+      sha256 = sha,
+    )
+
+  /**
+   * Write `<root>/<group as path>/<artifact>/<version>/<artifact>-<version>.jar` (Maven layout).
+   */
+  private fun writeMavenJar(bytes: ByteArray): File {
+    val f = File(root, "com/example/foo/widgets/1.2.3/widgets-1.2.3.jar")
+    f.parentFile.mkdirs()
+    f.writeBytes(bytes)
+    return f
+  }
+
+  /** Write the Gradle modules-2 layout: `<group>/<artifact>/<version>/<hash>/<jar>`. */
+  private fun writeGradleJar(bytes: ByteArray): File {
+    val f = File(root, "com.example.foo/widgets/1.2.3/abcdef0123/widgets-1.2.3.jar")
+    f.parentFile.mkdirs()
+    f.writeBytes(bytes)
+    return f
+  }
+
+  private fun sha256(bytes: ByteArray): String =
+    MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+  @Test
+  fun `resolves from maven local layout and verifies a matching hash`() {
+    val bytes = byteArrayOf(1, 2, 3, 4)
+    val jar = writeMavenJar(bytes)
+
+    val r = resolver.resolve(maven(sha = sha256(bytes)))
+
+    assertEquals(jar.canonicalFile, r.file?.canonicalFile)
+    assertTrue(r.verified)
+    assertFalse(r.mismatch)
+    assertTrue(warnings.isEmpty(), "a verified resolution must not warn: $warnings")
+  }
+
+  @Test
+  fun `resolves from gradle modules-2 layout`() {
+    val bytes = byteArrayOf(9, 8, 7)
+    val jar = writeGradleJar(bytes)
+
+    val r = resolver.resolve(maven(sha = sha256(bytes)))
+
+    assertEquals(jar.canonicalFile, r.file?.canonicalFile)
+    assertTrue(r.verified)
+  }
+
+  @Test
+  fun `missing artifact returns null and warns, never throws`() {
+    val r = resolver.resolve(maven(sha = "a".repeat(64)))
+
+    assertNull(r.file)
+    assertFalse(r.verified)
+    assertTrue(warnings.any { it.contains("could not resolve") })
+  }
+
+  @Test
+  fun `hash mismatch still returns the jar but warns`() {
+    writeMavenJar(byteArrayOf(1, 2, 3, 4))
+
+    // Coordinate claims a different hash than the bytes on disk.
+    val r = resolver.resolve(maven(sha = "b".repeat(64)))
+
+    assertNotNullFile(r.file)
+    assertFalse(r.verified)
+    assertTrue(r.mismatch)
+    assertTrue(
+      warnings.any { it.contains("hash mismatch") },
+      "expected a mismatch warning: $warnings",
+    )
+  }
+
+  @Test
+  fun `null hash resolves as unverifiable without warning`() {
+    writeMavenJar(byteArrayOf(5, 5, 5))
+
+    val r = resolver.resolve(maven(sha = null))
+
+    assertNotNullFile(r.file)
+    assertFalse(r.verified)
+    assertFalse(r.mismatch)
+    assertTrue(warnings.isEmpty(), "an unverifiable (no-hash) resolution must not warn: $warnings")
+  }
+
+  private fun assertNotNullFile(f: File?) =
+    assertTrue(f != null && f.isFile, "expected a resolved jar")
+}


### PR DESCRIPTION
## Summary

First increment of Tier 3 (#1632) — the **consumer** side of schema v4's content-addressed detached deps. Until now players *recorded* `maven` coordinates (+ `sha256`) but ignored them at play time; `bundle render` now actually resolves them.

- **`CoordinateResolver`** (new): locates each coordinate's jar in **local repositories** — `~/.m2/repository` (Maven layout) and `~/.gradle/.../modules-2` (Gradle cache), with roots overridable via `maven.repo.local` / `GRADLE_USER_HOME` (and injectable for tests). Then **hash-checks** against the v4 `sha256`.
  - **Warn, never fail** (per the merged contract): a mismatch *or* a miss is a loud warning and the resolver still returns the local jar / proceeds — an almost-compatible artifact beats no preview, and the renderer's bundled Compose covers the common surface. Never throws.
  - **No network in v1.** A fetcher is a future source behind the same `locate()` seam (resolve from a populated cache).
- **`BundleRenderer`**: resolved coordinate jars join the subprocess classpath between embedded `libs/` and the renderer's bundled Compose, so consumer deps win for their own classes while Compose stays shared.

This makes the small default *coordinate* bundle render for a colleague who already has the deps in a local cache — the common "someone sent me a `.png`" case — with no embedding and no network.

## Test plan

- **`CoordinateResolverTest`** (offline, temp repo dir): Maven-layout hit + verified hash; Gradle modules-2 layout hit; miss → null + warn (no throw); hash mismatch → warns but returns the jar; null hash → unverifiable, no warn. ✅
- compile + ktfmt clean; full `:cli:test` green.

## Follow-ups (not in this PR)
- Wire the same resolver into `BundleDaemonCommand` and the desktop viewer (`BundleLoader`).
- Add a network source (download + populate cache, then resolve) behind the existing seam.

Note: `:tui-cli` unaffected (its reader ignores classpath entries); not built locally (Mosaic snapshot host blocked in this env) — CI covers it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pkfwxdoh2qrkS44z8pdFJs)_