### PR TITLE
feat(bundle): open bundles from a URL, not just a local path

### DIFF
--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Main.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Main.kt
@@ -59,7 +59,10 @@ import java.io.File
  * same shape `@Preview` viewers in Android Studio show.
  */
 fun main(args: Array<String>) {
-  val initial = args.firstOrNull()?.let { File(it) }?.takeIf { it.isFile }
+  // The bundle arg may be a local path or an http(s)/file URL — resolve (download) it to a local
+  // file before loading. Null when no arg, an unreadable path, or a failed download (the window
+  // still opens so the user can drop a bundle).
+  val initial = args.firstOrNull()?.let { resolveBundleArg(it) }
   application {
     var loadedBundle by remember { mutableStateOf<LoadedBundle?>(null) }
     var loadError by remember { mutableStateOf<String?>(null) }
@@ -241,3 +244,37 @@ private fun previewSize(preview: LoadedPreview): DpSize {
 
 private val INITIAL_WIDTH = 480.dp
 private val INITIAL_HEIGHT = 720.dp
+
+/**
+ * Resolve a bundle CLI arg — a local path or an http(s)/file URL — to a readable local file, or
+ * null when it can't be opened (missing path, failed download). URLs are downloaded to a temp file
+ * (delete-on-exit). Kept self-contained here rather than depending on `:cli`'s BundleSource so the
+ * viewer's module graph stays minimal (same convention as the duplicated `extractZipBytes`).
+ */
+private fun resolveBundleArg(arg: String): File? {
+  val scheme = arg.substringBefore(':', missingDelimiterValue = "").lowercase()
+  val isUrl = scheme == "http" || scheme == "https" || scheme == "file"
+  if (!isUrl) return File(arg).takeIf { it.isFile }
+  return try {
+    val uri = java.net.URI(arg)
+    if (uri.scheme.equals("file", ignoreCase = true)) return File(uri).takeIf { it.isFile }
+    val temp = java.nio.file.Files.createTempFile("compose-preview-bundle-", ".png").toFile()
+    temp.deleteOnExit()
+    val client =
+      java.net.http.HttpClient.newBuilder()
+        .followRedirects(java.net.http.HttpClient.Redirect.NORMAL)
+        .build()
+    val response =
+      client.send(
+        java.net.http.HttpRequest.newBuilder(uri).GET().build(),
+        java.net.http.HttpResponse.BodyHandlers.ofFile(temp.toPath()),
+      )
+    if (response.statusCode() in 200..299 && temp.length() > 0) temp
+    else {
+      temp.delete()
+      null
+    }
+  } catch (_: Exception) {
+    null
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -65,12 +65,14 @@ class BundleCommand(args: List<String>) : Command(args) {
       """
       compose-preview bundle — portable preview bundles (PNG+ZIP polyglot)
 
+      A <bundle> below is a local path OR an http(s)/file URL — URLs are downloaded first.
+
       Usage:
         compose-preview bundle pack [--module <name>] [--id <preview>...] [-o <file.png>] [--no-render]
-        compose-preview bundle inspect <bundle.png>
-        compose-preview bundle extract <bundle.png> [-o <dir>]
-        compose-preview bundle render  <bundle.png> [-o <dir>]   (v1: stub — prints what would render)
-        compose-preview bundle daemon  <bundle.png> [-v]         (spawn the desktop daemon over stdio)
+        compose-preview bundle inspect <bundle.png | URL>
+        compose-preview bundle extract <bundle.png | URL> [-o <dir>]
+        compose-preview bundle render  <bundle.png | URL> [-o <dir>]   (v1: stub — prints what would render)
+        compose-preview bundle daemon  <bundle.png | URL> [-v]         (spawn the desktop daemon over stdio)
 
       Pack flags:
         --id <preview-id>   Preview to include. Repeatable. First is the cover. Default: all.
@@ -200,14 +202,16 @@ private class InspectSubcommand(private val args: List<String>) {
   fun run() {
     val path = args.firstOrNull { !it.startsWith("-") }
     if (path == null) {
-      System.err.println("Usage: compose-preview bundle inspect <bundle.png>")
+      System.err.println("Usage: compose-preview bundle inspect <bundle.png | URL>")
       exitProcess(64)
     }
-    val file = File(path)
-    if (!file.isFile) {
-      System.err.println("Not a file: $path")
-      exitProcess(1)
-    }
+    val file =
+      try {
+        BundleSource.resolveToFile(path)
+      } catch (e: IllegalArgumentException) {
+        System.err.println(e.message)
+        exitProcess(1)
+      }
     val meta = BundleReader.readMetadata(file)
     val pretty = Json {
       prettyPrint = true
@@ -229,14 +233,16 @@ private class ExtractSubcommand(private val args: List<String>) {
     val path = args.firstOrNull { !it.startsWith("-") }
     val outDir = args.flagValue("--output") ?: args.flagValue("-o")
     if (path == null) {
-      System.err.println("Usage: compose-preview bundle extract <bundle.png> [-o <dir>]")
+      System.err.println("Usage: compose-preview bundle extract <bundle.png | URL> [-o <dir>]")
       exitProcess(64)
     }
-    val file = File(path)
-    if (!file.isFile) {
-      System.err.println("Not a file: $path")
-      exitProcess(1)
-    }
+    val file =
+      try {
+        BundleSource.resolveToFile(path)
+      } catch (e: IllegalArgumentException) {
+        System.err.println(e.message)
+        exitProcess(1)
+      }
     val target =
       File(
           outDir
@@ -257,14 +263,16 @@ private class RenderSubcommand(private val args: List<String>) {
     val path = args.firstOrNull { !it.startsWith("-") }
     val outDir = args.flagValue("--output") ?: args.flagValue("-o")
     if (path == null) {
-      System.err.println("Usage: compose-preview bundle render <bundle.png> [-o <dir>]")
+      System.err.println("Usage: compose-preview bundle render <bundle.png | URL> [-o <dir>]")
       exitProcess(64)
     }
-    val file = File(path)
-    if (!file.isFile) {
-      System.err.println("Not a file: $path")
-      exitProcess(1)
-    }
+    val file =
+      try {
+        BundleSource.resolveToFile(path)
+      } catch (e: IllegalArgumentException) {
+        System.err.println(e.message)
+        exitProcess(1)
+      }
     val target =
       File(outDir ?: (file.absoluteFile.parent.toString() + "/${file.nameWithoutExtension}-render"))
         .absoluteFile

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -46,11 +46,13 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       if (sub == null) exitProcess(64)
       return
     }
-    val file = File(sub)
-    if (!file.isFile) {
-      System.err.println("bundle daemon: not a file: ${file.path}")
-      exitProcess(1)
-    }
+    val file =
+      try {
+        BundleSource.resolveToFile(sub)
+      } catch (e: IllegalArgumentException) {
+        System.err.println("bundle daemon: ${e.message}")
+        exitProcess(1)
+      }
     val verbose = "--verbose" in args || "-v" in args
     val workDir = createTempWorkDir()
     val classesDir = workDir.resolve("classes").apply { mkdirs() }
@@ -143,7 +145,9 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       compose-preview bundle daemon — start the desktop daemon against a packed bundle
 
       Usage:
-        compose-preview bundle daemon <bundle.png> [-v]
+        compose-preview bundle daemon <bundle.png | URL> [-v]
+
+      <bundle> is a local path or an http(s)/file URL (downloaded first).
 
       Inherits stdio: the spawned daemon JVM speaks JSON-RPC over stdin/stdout and writes log
       lines to stderr, the same protocol `composePreviewDaemonStart` uses in a Gradle module.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSource.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSource.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+
+/**
+ * Resolves a bundle argument — a local path **or** a URL — to a local [File] every bundle-open
+ * command can operate on. A bundle is a PNG+ZIP polyglot, so once it's on disk the rest of the
+ * pipeline ([BundleReader], [BundleRenderer], `bundle daemon`, the viewer) is unchanged.
+ *
+ * - `http(s)://…` — downloaded to a temp file (follows redirects; fails loudly on a non-2xx).
+ * - `file://…` — the referenced local file.
+ * - anything else — treated as a local filesystem path.
+ *
+ * Downloaded temp files are marked delete-on-exit; callers that want eager cleanup can delete the
+ * returned file themselves once done. The `.png` suffix is preserved so downstream name-derivation
+ * (`<name>-render`, `<name>-extracted`, the daemon's `bundleSource` tag) stays sensible.
+ */
+object BundleSource {
+
+  /**
+   * True when [arg] is an http/https/file URL we should resolve as a URL rather than a raw path.
+   * Matches a `<scheme>:` prefix (so `file:/x`, `file:///x`, and `https://…` all count) while
+   * leaving Windows drive letters (`C:\…`) and bare paths alone.
+   */
+  fun looksLikeUrl(arg: String): Boolean {
+    val scheme = arg.substringBefore(':', missingDelimiterValue = "").lowercase()
+    return scheme == "http" || scheme == "https" || scheme == "file"
+  }
+
+  /**
+   * Resolve [arg] to a readable local file, downloading if it's a URL. Throws
+   * [IllegalArgumentException] when a path doesn't exist or a download fails — callers map that to
+   * their usual "not a file" exit.
+   */
+  fun resolveToFile(arg: String): File {
+    if (!looksLikeUrl(arg)) {
+      val f = File(arg)
+      require(f.isFile) { "not a file: $arg" }
+      return f
+    }
+    val uri =
+      try {
+        URI(arg)
+      } catch (e: Exception) {
+        throw IllegalArgumentException("not a valid URL: $arg (${e.message})")
+      }
+    if (uri.scheme.equals("file", ignoreCase = true)) {
+      val f = File(uri)
+      require(f.isFile) { "not a file: $arg" }
+      return f
+    }
+    return download(uri, arg)
+  }
+
+  private fun download(uri: URI, arg: String): File {
+    // Bundles are always PNG+ZIP polyglots, so a `.png` temp suffix keeps downstream
+    // name-derivation (`<name>-render`, the daemon's bundleSource tag) sensible.
+    val temp = Files.createTempFile("compose-preview-bundle-", ".png").toFile()
+    temp.deleteOnExit()
+    val client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()
+    val request = HttpRequest.newBuilder(uri).GET().build()
+    val response =
+      try {
+        client.send(request, HttpResponse.BodyHandlers.ofFile(temp.toPath()))
+      } catch (e: Exception) {
+        temp.delete()
+        throw IllegalArgumentException("could not download bundle from $arg: ${e.message}")
+      }
+    if (response.statusCode() !in 200..299) {
+      temp.delete()
+      throw IllegalArgumentException(
+        "could not download bundle from $arg: HTTP ${response.statusCode()}"
+      )
+    }
+    require(temp.length() > 0) { "downloaded an empty bundle from $arg" }
+    return temp
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSourceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSourceTest.kt
@@ -1,0 +1,88 @@
+package ee.schimke.composeai.cli
+
+import com.sun.net.httpserver.HttpServer
+import java.io.File
+import java.net.InetSocketAddress
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [BundleSource.resolveToFile] — the local-path-or-URL resolver every bundle-open
+ * command shares. URL cases use a throwaway loopback [HttpServer] so no real network is touched.
+ */
+class BundleSourceTest {
+
+  private val tmp = Files.createTempDirectory("bundle-source-test-").toFile()
+  private var server: HttpServer? = null
+
+  @AfterTest
+  fun cleanup() {
+    server?.stop(0)
+    tmp.deleteRecursively()
+  }
+
+  private fun startServer(handler: (path: String) -> Pair<Int, ByteArray>): String {
+    val s = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    s.createContext("/") { exchange ->
+      val (code, body) = handler(exchange.requestURI.path)
+      exchange.sendResponseHeaders(code, if (body.isEmpty()) -1L else body.size.toLong())
+      exchange.responseBody.use { if (body.isNotEmpty()) it.write(body) }
+    }
+    s.start()
+    server = s
+    return "http://127.0.0.1:${s.address.port}"
+  }
+
+  @Test
+  fun `local path resolves to the file`() {
+    val f = File(tmp, "bundle.png").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+    assertEquals(f.canonicalFile, BundleSource.resolveToFile(f.path).canonicalFile)
+  }
+
+  @Test
+  fun `missing local path throws`() {
+    val ex =
+      assertFailsWith<IllegalArgumentException> { BundleSource.resolveToFile("/no/such.png") }
+    assertTrue(ex.message!!.contains("not a file"))
+  }
+
+  @Test
+  fun `file URL resolves to the referenced file`() {
+    val f = File(tmp, "via-url.png").apply { writeBytes(byteArrayOf(4, 5)) }
+    val resolved = BundleSource.resolveToFile(f.toURI().toString())
+    assertEquals(f.canonicalFile, resolved.canonicalFile)
+  }
+
+  @Test
+  fun `http URL downloads to a temp file`() {
+    val payload = byteArrayOf(9, 8, 7, 6)
+    val base = startServer { _ -> 200 to payload }
+
+    val resolved = BundleSource.resolveToFile("$base/some/bundle.png")
+
+    assertTrue(resolved.isFile)
+    assertEquals(payload.toList(), resolved.readBytes().toList())
+    assertTrue(resolved.name.endsWith(".png"))
+  }
+
+  @Test
+  fun `http error status throws`() {
+    val base = startServer { _ -> 404 to ByteArray(0) }
+    val ex =
+      assertFailsWith<IllegalArgumentException> { BundleSource.resolveToFile("$base/missing.png") }
+    assertTrue(ex.message!!.contains("HTTP 404"), "expected HTTP status in message: ${ex.message}")
+  }
+
+  @Test
+  fun `looksLikeUrl recognises schemes`() {
+    assertTrue(BundleSource.looksLikeUrl("https://example.com/x.png"))
+    assertTrue(BundleSource.looksLikeUrl("HTTP://example.com/x.png"))
+    assertTrue(BundleSource.looksLikeUrl("file:///tmp/x.png"))
+    assertTrue(!BundleSource.looksLikeUrl("/tmp/x.png"))
+    assertTrue(!BundleSource.looksLikeUrl("bundle.png"))
+  }
+}

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Args.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Args.kt
@@ -105,12 +105,9 @@ data class TuiArgs(
         i += 1
       }
 
-      // A lone existing `*.png` positional opens straight into the image-only bundle view.
-      val bundlePng =
-        positionals
-          .firstOrNull()
-          ?.let(::File)
-          ?.takeIf { it.isFile && it.name.endsWith(".png", ignoreCase = true) }
+      // A lone `*.png` positional — a local path OR an http(s)/file URL — opens straight into the
+      // image-only bundle view. URLs are downloaded to a temp file first.
+      val bundlePng = positionals.firstOrNull()?.let(::resolveBundleArg)
 
       return TuiArgs(
         module = module,
@@ -134,9 +131,9 @@ data class TuiArgs(
 
         Usage:
           compose-preview-tui [options]          Browse a project's previews
-          compose-preview-tui <bundle.png>       Open a bundle PNG full-screen (image only,
-                                                 live if the PNG carries provenance)
-          compose-preview-tui --dump <bundle.png>
+          compose-preview-tui <bundle.png | URL>  Open a bundle full-screen (image only, live if it
+                                                 carries provenance). A URL is downloaded first.
+          compose-preview-tui --dump <bundle.png | URL>
                                                  Print a baked preview to stdout as text
                                                  (half-block / ASCII) and exit — the cover by
                                                  default, or pick with --id / --filter. No PTY
@@ -178,5 +175,43 @@ data class TuiArgs(
           .trimIndent()
       )
     }
+  }
+}
+
+/**
+ * Resolve a bundle positional — a local `*.png` path or an http(s)/file URL — to a readable local
+ * file, or null when it isn't an openable bundle (missing path, non-png, failed download). URLs are
+ * downloaded to a temp file (delete-on-exit). Self-contained here rather than depending on `:cli` so
+ * the opt-in TUI module's graph stays minimal.
+ */
+private fun resolveBundleArg(arg: String): File? {
+  val scheme = arg.substringBefore(':', missingDelimiterValue = "").lowercase()
+  val isUrl = scheme == "http" || scheme == "https" || scheme == "file"
+  if (!isUrl) {
+    return File(arg).takeIf { it.isFile && it.name.endsWith(".png", ignoreCase = true) }
+  }
+  return try {
+    val uri = java.net.URI(arg)
+    if (uri.scheme.equals("file", ignoreCase = true)) {
+      return File(uri).takeIf { it.isFile && it.name.endsWith(".png", ignoreCase = true) }
+    }
+    val temp = java.nio.file.Files.createTempFile("compose-preview-tui-bundle-", ".png").toFile()
+    temp.deleteOnExit()
+    val client =
+      java.net.http.HttpClient.newBuilder()
+        .followRedirects(java.net.http.HttpClient.Redirect.NORMAL)
+        .build()
+    val response =
+      client.send(
+        java.net.http.HttpRequest.newBuilder(uri).GET().build(),
+        java.net.http.HttpResponse.BodyHandlers.ofFile(temp.toPath()),
+      )
+    if (response.statusCode() in 200..299 && temp.length() > 0) temp
+    else {
+      temp.delete()
+      null
+    }
+  } catch (_: Exception) {
+    null
   }
 }


### PR DESCRIPTION
## Summary

Every command/entry point that opens a bundle now accepts an **http(s)/file URL** in addition to a local path. A URL is downloaded to a temp file (delete-on-exit, follows redirects, fails loudly on non-2xx) and the rest of the pipeline ([BundleReader], [BundleRenderer], the daemon, the viewer) is unchanged — so "someone sent me a link to a `.png`" works end to end.

Covered entry points:
- **`compose-preview bundle inspect | extract | render | daemon`** — new shared `BundleSource.resolveToFile(path-or-url)`; help/usage updated to `<bundle.png | URL>`.
- **`compose-preview-viewer`** (desktop GUI) — `main` resolves its arg via a small self-contained URL helper.
- **`compose-preview-tui <bundle.png | URL>`** — the lone positional now also accepts a URL.

The viewer and tui keep their own tiny copy of the resolver rather than depending on `:cli` — same deliberate convention as the duplicated `extractZipBytes` (keeps those module graphs minimal).

URL detection matches a real `<scheme>:` prefix (so `file:/x`, `file:///x`, and `https://…` all resolve as URLs) while leaving Windows drive letters (`C:\…`) and bare paths alone.

## Test plan

- **`BundleSourceTest`**: local path → file; missing path → throws "not a file"; `file://` URL → referenced file; `http://` URL → downloads to temp `.png` with the right bytes; HTTP 404 → throws with status; `looksLikeUrl` scheme matrix. URL cases use a throwaway loopback `HttpServer` — no real network. ✅
- compile + ktfmt clean for `:cli` and `:bundle-viewer`; full `:cli:test` green.

Note: `:tui-cli` not built locally (Mosaic snapshot host blocked in this env). Its change mirrors the verified cli/viewer logic and is structurally sound (balanced/format-checked by hand); CI covers it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pkfwxdoh2qrkS44z8pdFJs)_