### PR TITLE
refactor(bundle): use Ktor client + OkHttp engine for URL downloads

### DIFF
--- a/bundle-viewer/build.gradle.kts
+++ b/bundle-viewer/build.gradle.kts
@@ -64,6 +64,10 @@ dependencies {
 
   implementation(libs.kotlinx.serialization.json)
 
+  // Ktor client (OkHttp engine) for opening a bundle from a URL.
+  implementation(libs.ktor.client.core)
+  implementation(libs.ktor.client.okhttp)
+
   testImplementation(libs.junit)
   testImplementation(libs.truth)
 }

--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Main.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Main.kt
@@ -30,6 +30,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.copyTo
 import java.awt.datatransfer.DataFlavor
 import java.awt.dnd.DnDConstants
 import java.awt.dnd.DropTarget
@@ -260,16 +264,22 @@ private fun resolveBundleArg(arg: String): File? {
     if (uri.scheme.equals("file", ignoreCase = true)) return File(uri).takeIf { it.isFile }
     val temp = java.nio.file.Files.createTempFile("compose-preview-bundle-", ".png").toFile()
     temp.deleteOnExit()
-    val client =
-      java.net.http.HttpClient.newBuilder()
-        .followRedirects(java.net.http.HttpClient.Redirect.NORMAL)
-        .build()
-    val response =
-      client.send(
-        java.net.http.HttpRequest.newBuilder(uri).GET().build(),
-        java.net.http.HttpResponse.BodyHandlers.ofFile(temp.toPath()),
-      )
-    if (response.statusCode() in 200..299 && temp.length() > 0) temp
+    // Ktor client over the OkHttp engine; stream the body to disk on a 2xx. runBlocking is fine at
+    // this one-shot startup call.
+    val ok =
+      io.ktor.client.HttpClient(io.ktor.client.engine.okhttp.OkHttp).use { client ->
+        kotlinx.coroutines.runBlocking {
+          client.prepareGet(uri.toString()).execute { response ->
+            if (response.status.isSuccess()) {
+              temp.outputStream().use { out -> response.bodyAsChannel().copyTo(out) }
+              true
+            } else {
+              false
+            }
+          }
+        }
+      }
+    if (ok && temp.length() > 0) temp
     else {
       temp.delete()
       null

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -93,6 +93,10 @@ dependencies {
 
   implementation(libs.kotlinx.serialization.json)
 
+  // Ktor client (OkHttp engine) for downloading a bundle when the open arg is a URL.
+  implementation(libs.ktor.client.core)
+  implementation(libs.ktor.client.okhttp)
+
   // Bundle the MCP server so `compose-preview mcp serve` can invoke it in-process —
   // the consumer install story stays a single tarball + a single launcher.
   implementation(project(":mcp"))

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSource.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSource.kt
@@ -1,11 +1,15 @@
 package ee.schimke.composeai.cli
 
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.copyTo
 import java.io.File
 import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
 import java.nio.file.Files
+import kotlinx.coroutines.runBlocking
 
 /**
  * Resolves a bundle argument — a local path **or** a URL — to a local [File] every bundle-open
@@ -62,20 +66,29 @@ object BundleSource {
     // name-derivation (`<name>-render`, the daemon's bundleSource tag) sensible.
     val temp = Files.createTempFile("compose-preview-bundle-", ".png").toFile()
     temp.deleteOnExit()
-    val client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()
-    val request = HttpRequest.newBuilder(uri).GET().build()
-    val response =
-      try {
-        client.send(request, HttpResponse.BodyHandlers.ofFile(temp.toPath()))
-      } catch (e: Exception) {
-        temp.delete()
-        throw IllegalArgumentException("could not download bundle from $arg: ${e.message}")
+    // Ktor client over the OkHttp engine. OkHttp follows redirects by default; we stream the body
+    // to
+    // disk and only keep the file on a 2xx. `runBlocking` is fine here — this is a one-shot CLI /
+    // startup call, not a hot path.
+    try {
+      HttpClient(OkHttp).use { client ->
+        runBlocking {
+          client.prepareGet(uri.toString()).execute { response ->
+            if (!response.status.isSuccess()) {
+              throw IllegalArgumentException(
+                "could not download bundle from $arg: HTTP ${response.status.value}"
+              )
+            }
+            temp.outputStream().use { out -> response.bodyAsChannel().copyTo(out) }
+          }
+        }
       }
-    if (response.statusCode() !in 200..299) {
+    } catch (e: IllegalArgumentException) {
       temp.delete()
-      throw IllegalArgumentException(
-        "could not download bundle from $arg: HTTP ${response.statusCode()}"
-      )
+      throw e
+    } catch (e: Exception) {
+      temp.delete()
+      throw IllegalArgumentException("could not download bundle from $arg: ${e.message}")
     }
     require(temp.length() > 0) { "downloaded an empty bundle from $arg" }
     return temp

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -149,8 +149,15 @@ metro = "1.1.1"
 # `settings.gradle.kts`). The Kotlin compose-compiler plugin pulled in via our toolchain is
 # what compiles the @Composable functions, so no separate Mosaic gradle plugin is needed.
 mosaic = "0.19.0-SNAPSHOT"
+# Ktor HTTP client (+ OkHttp engine) for downloading bundles given a URL. Ktor 3.x is current and
+# compatible with Kotlin 2.3 / coroutines 1.11; OkHttp 4.12 is the stable engine backing it.
+ktor = "3.0.3"
+okhttp = "4.12.0"
 
 [libraries]
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 compose-bom-stable = { module = "androidx.compose:compose-bom", version.ref = "compose-bom-stable" }

--- a/tui-cli/build.gradle.kts
+++ b/tui-cli/build.gradle.kts
@@ -72,6 +72,10 @@ dependencies {
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.json)
 
+  // Ktor client (OkHttp engine) for opening a bundle from a URL.
+  implementation(libs.ktor.client.core)
+  implementation(libs.ktor.client.okhttp)
+
   // Subprocess-only sidecars shipped in the dist for project-less bundle mode. The daemon's
   // subprocess classpath joins `lib-daemon-desktop/jars` + `lib-renderer/jars` at launch; the renderer
   // sidecar carries the per-OS Compose Multiplatform stack (incl. Skiko) so it isn't duplicated

--- a/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Args.kt
+++ b/tui-cli/src/main/kotlin/ee/schimke/composeai/tui/Args.kt
@@ -1,5 +1,9 @@
 package ee.schimke.composeai.tui
 
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.copyTo
 import java.io.File
 
 /**
@@ -197,16 +201,22 @@ private fun resolveBundleArg(arg: String): File? {
     }
     val temp = java.nio.file.Files.createTempFile("compose-preview-tui-bundle-", ".png").toFile()
     temp.deleteOnExit()
-    val client =
-      java.net.http.HttpClient.newBuilder()
-        .followRedirects(java.net.http.HttpClient.Redirect.NORMAL)
-        .build()
-    val response =
-      client.send(
-        java.net.http.HttpRequest.newBuilder(uri).GET().build(),
-        java.net.http.HttpResponse.BodyHandlers.ofFile(temp.toPath()),
-      )
-    if (response.statusCode() in 200..299 && temp.length() > 0) temp
+    // Ktor client over the OkHttp engine; stream the body to disk on a 2xx. runBlocking is fine at
+    // this one-shot startup parse.
+    val ok =
+      io.ktor.client.HttpClient(io.ktor.client.engine.okhttp.OkHttp).use { client ->
+        kotlinx.coroutines.runBlocking {
+          client.prepareGet(uri.toString()).execute { response ->
+            if (response.status.isSuccess()) {
+              temp.outputStream().use { out -> response.bodyAsChannel().copyTo(out) }
+              true
+            } else {
+              false
+            }
+          }
+        }
+      }
+    if (ok && temp.length() > 0) temp
     else {
       temp.delete()
       null


### PR DESCRIPTION
## Summary

Swaps the JDK `java.net.http.HttpClient` used for bundle URL downloads over to the **Ktor client on the OkHttp engine**, as requested.

Behaviour is unchanged: a URL bundle arg streams its body to a temp `.png` on a 2xx (OkHttp follows redirects by default), keeps the file only on success, deletes on failure. `runBlocking` wraps Ktor's suspend API at these one-shot CLI/startup call sites.

- **Version catalog**: `ktor = 3.0.3` (`ktor-client-core` + `ktor-client-okhttp`), `okhttp = 4.12.0`.
- **All three URL-download paths converted**, deps added to each module:
  - `cli` `BundleSource` (shared by `bundle inspect|extract|render|daemon`)
  - `bundle-viewer` `Main`
  - `tui-cli` `Args`

## Test plan

- `BundleSourceTest` — local path / missing path / `file://` URL / `http://` download / HTTP-error / `looksLikeUrl`, the download case via a loopback `HttpServer`. ✅
- `:cli:test` green; `:cli` + `:bundle-viewer` compile + ktfmt clean.
- Ktor/OkHttp resolution verified (`:cli:dependencies`).

## Notes
- `DoctorCommand`'s `HttpURLConnection` (update check + connectivity probe) is **left as-is** — unrelated to bundle opening, out of scope here. Happy to convert it in a follow-up if you want the whole CLI on Ktor.
- `:tui-cli` not built locally (Mosaic snapshot host blocked in this env); its change uses the exact same Ktor API/imports as the compiled `:cli` path and is structurally verified. CI covers it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pkfwxdoh2qrkS44z8pdFJs)_