### PR TITLE
feat(bundle): resolve maven coordinates in the daemon + desktop viewer

### DIFF
--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/BundleLoader.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/BundleLoader.kt
@@ -116,13 +116,19 @@ fun loadBundle(bundleFile: File): LoadedBundle {
     throw IllegalStateException("bundle has no previews: ${bundleFile.path}")
   }
 
+  // Default (coordinate-mode) bundles reference their deps by `maven` coordinate rather than
+  // carrying them; resolve those from the machine's local Maven / Gradle caches (warn-not-fail) so
+  // the preview's own third-party deps are available the same way embedded `libs/` jars are.
+  val resolvedCoordJars =
+    CoordinateResolver.resolve(bundleManifest.classpath.filterIsInstance<ClasspathEntry.Maven>())
+
   val parentLoader = LoadedBundle::class.java.classLoader
-  // app.jar first, then every embedded lib jar (path-sorted). The viewer's bundled Compose still
-  // wins
-  // on shared symbols because it sits on the parent loader; the embedded jars only supply classes
-  // the
-  // parent doesn't have (the preview's own third-party deps).
-  val classpathUrls = (listOf(appJarFile) + libJarFiles.values).map { it.toURI().toURL() }
+  // app.jar first, then embedded lib jars (path-sorted), then resolved coordinate jars. The
+  // viewer's
+  // bundled Compose still wins on shared symbols because it sits on the parent loader; these jars
+  // only supply classes the parent doesn't have (the preview's own third-party deps).
+  val classpathUrls =
+    (listOf(appJarFile) + libJarFiles.values + resolvedCoordJars).map { it.toURI().toURL() }
   val classLoader = URLClassLoader(classpathUrls.toTypedArray(), parentLoader)
 
   val loadedPreviews = previewManifest.previews.map { info -> resolvePreview(info, classLoader) }

--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/CoordinateResolver.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/CoordinateResolver.kt
@@ -1,0 +1,100 @@
+package ee.schimke.composeai.viewer
+
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Resolves a bundle's detached `maven` coordinates ([ClasspathEntry.Maven]) to local jar files so
+ * the viewer can add them to a bundle's child classloader. Consumer side of schema v4's
+ * content-addressing: a coordinate names *what* dependency a preview needs, and this finds the
+ * bytes from whatever the machine already has.
+ *
+ * Mirrors `:cli`'s `CoordinateResolver` (duplicated rather than depended on, same convention as the
+ * viewer's copy of `extractZipBytes`, so the viewer's module graph stays minimal):
+ * - Local repos only — `~/.m2/repository` (Maven layout) and `~/.gradle/.../modules-2` (Gradle
+ *   cache), overridable via `maven.repo.local` / `GRADLE_USER_HOME`. No network.
+ * - When several local copies exist for one GAV, the v4 `sha256` picks the matching one.
+ * - **Warn, never fail**: a miss or hash mismatch logs and still returns the best local jar (or
+ *   none), so a preview renders with an almost-compatible dep rather than not at all.
+ */
+internal object CoordinateResolver {
+
+  /** Resolve [coords] to local jars (name-sorted, misses dropped), warning on misses/mismatches. */
+  fun resolve(
+    coords: List<ClasspathEntry.Maven>,
+    warn: (String) -> Unit = { System.err.println("compose-preview-viewer: $it") },
+    repositoryRoots: List<File> = defaultRepositoryRoots(),
+  ): List<File> = coords.mapNotNull { resolveOne(it, warn, repositoryRoots) }
+
+  private fun resolveOne(
+    coord: ClasspathEntry.Maven,
+    warn: (String) -> Unit,
+    roots: List<File>,
+  ): File? {
+    val candidates = locate(coord, roots)
+    if (candidates.isEmpty()) {
+      warn(
+        "could not resolve ${coord.group}:${coord.artifact}:${coord.version} from a local " +
+          "repository; the preview may fail if it needs this dependency."
+      )
+      return null
+    }
+    val expected = coord.sha256 ?: return candidates.first()
+    candidates
+      .firstOrNull { sha256Hex(it).equals(expected, ignoreCase = true) }
+      ?.let {
+        return it
+      }
+    val fallback = candidates.first()
+    warn(
+      "hash mismatch for ${coord.group}:${coord.artifact}:${coord.version} — using ${fallback.name} " +
+        "anyway; the preview may differ slightly from the original."
+    )
+    return fallback
+  }
+
+  private fun locate(coord: ClasspathEntry.Maven, roots: List<File>): List<File> {
+    val jarName = "${coord.artifact}-${coord.version}.jar"
+    val found = mutableListOf<File>()
+    for (root in roots) {
+      if (!root.isDirectory) continue
+      val mavenPath =
+        File(root, coord.group.replace('.', '/') + "/${coord.artifact}/${coord.version}/$jarName")
+      if (mavenPath.isFile) found += mavenPath
+      val gradleVersionDir = File(root, "${coord.group}/${coord.artifact}/${coord.version}")
+      if (gradleVersionDir.isDirectory) {
+        gradleVersionDir
+          .listFiles()
+          ?.asSequence()
+          ?.filter { it.isDirectory }
+          ?.mapNotNull { hashDir -> File(hashDir, jarName).takeIf { it.isFile } }
+          ?.let { found += it }
+      }
+    }
+    return found
+  }
+
+  private fun sha256Hex(file: File): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    file.inputStream().use { input ->
+      val buf = ByteArray(64 * 1024)
+      while (true) {
+        val n = input.read(buf)
+        if (n < 0) break
+        digest.update(buf, 0, n)
+      }
+    }
+    return digest.digest().joinToString("") { "%02x".format(it) }
+  }
+
+  private fun defaultRepositoryRoots(): List<File> {
+    val home = System.getProperty("user.home")?.let(::File)
+    val roots = mutableListOf<File>()
+    System.getProperty("maven.repo.local")?.let { roots += File(it) }
+    if (home != null) roots += File(home, ".m2/repository")
+    val gradleHome =
+      System.getenv("GRADLE_USER_HOME")?.let(::File) ?: home?.let { File(it, ".gradle") }
+    if (gradleHome != null) roots += File(gradleHome, "caches/modules-2/files-2.1")
+    return roots
+  }
+}

--- a/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/CoordinateResolverTest.kt
+++ b/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/CoordinateResolverTest.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.viewer
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import java.nio.file.Files
+import java.security.MessageDigest
+import org.junit.After
+import org.junit.Test
+
+/**
+ * Offline coverage for the viewer's [CoordinateResolver] — resolves a bundle's detached `maven`
+ * coordinates to local jars against a temp repo dir (no network), exercising the
+ * pick-matching-candidate and warn-not-fail behaviour the cli resolver also guarantees.
+ */
+class CoordinateResolverTest {
+
+  private val root = Files.createTempDirectory("viewer-coord-test-").toFile()
+  private val warnings = mutableListOf<String>()
+
+  @After
+  fun cleanup() {
+    root.deleteRecursively()
+  }
+
+  private fun maven(sha: String? = null) =
+    ClasspathEntry.Maven(
+      group = "com.example.foo",
+      artifact = "widgets",
+      version = "1.2.3",
+      type = "jar",
+      sha256 = sha,
+    )
+
+  private fun writeMavenJar(bytes: ByteArray): File {
+    val f = File(root, "com/example/foo/widgets/1.2.3/widgets-1.2.3.jar")
+    f.parentFile.mkdirs()
+    f.writeBytes(bytes)
+    return f
+  }
+
+  private fun writeGradleJar(bytes: ByteArray): File {
+    val f = File(root, "com.example.foo/widgets/1.2.3/deadbeef/widgets-1.2.3.jar")
+    f.parentFile.mkdirs()
+    f.writeBytes(bytes)
+    return f
+  }
+
+  private fun sha256(bytes: ByteArray): String =
+    MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+  private fun resolve(vararg coords: ClasspathEntry.Maven): List<File> =
+    CoordinateResolver.resolve(
+      coords.toList(),
+      warn = { warnings += it },
+      repositoryRoots = listOf(root),
+    )
+
+  @Test
+  fun `resolves and verifies a matching hash`() {
+    val bytes = byteArrayOf(1, 2, 3, 4)
+    val jar = writeMavenJar(bytes)
+
+    val out = resolve(maven(sha = sha256(bytes)))
+
+    assertThat(out.map { it.canonicalFile }).containsExactly(jar.canonicalFile)
+    assertThat(warnings).isEmpty()
+  }
+
+  @Test
+  fun `prefers a hash-matching candidate over an earlier mismatch`() {
+    val wanted = byteArrayOf(4, 4, 4, 4)
+    writeMavenJar(byteArrayOf(0, 0, 0)) // stale, found first
+    val good = writeGradleJar(wanted) // exact match, found later
+
+    val out = resolve(maven(sha = sha256(wanted)))
+
+    assertThat(out.map { it.canonicalFile }).containsExactly(good.canonicalFile)
+    assertThat(warnings).isEmpty()
+  }
+
+  @Test
+  fun `missing artifact is dropped with a warning`() {
+    val out = resolve(maven(sha = "a".repeat(64)))
+
+    assertThat(out).isEmpty()
+    assertThat(warnings.any { it.contains("could not resolve") }).isTrue()
+  }
+
+  @Test
+  fun `hash mismatch still returns the jar but warns`() {
+    val jar = writeMavenJar(byteArrayOf(1, 2, 3, 4))
+
+    val out = resolve(maven(sha = "b".repeat(64)))
+
+    assertThat(out.map { it.canonicalFile }).containsExactly(jar.canonicalFile)
+    assertThat(warnings.any { it.contains("hash mismatch") }).isTrue()
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -29,13 +29,14 @@ import kotlin.system.exitProcess
  *
  * # Dependency resolution
  *
- * Embedded-mode bundles (schema-v3 `resolution = "embedded"`) carry their reachable third-party
- * deps under `libs/`; those are extracted and joined onto the daemon's `userClassDirs` so a
- * preview's own deps resolve with no network. For coordinate-mode bundles, `bundle.json`'s
- * `ClasspathEntry.Maven` entries are still *not* resolved here — the renderer's bundled Compose
- * stack supplies the common API surface, and a full coordinate-resolver pass (download Maven,
- * hash-verify, layer-on) is its own milestone (#1632, Tier 3). Same trade-off `bundle render`
- * makes.
+ * The bundle's third-party deps are joined onto the daemon's `userClassDirs` from two sources, the
+ * same way `bundle render` builds its classpath:
+ * - Embedded-mode bundles (schema-v3 `resolution = "embedded"`) carry their reachable deps under
+ *   `libs/`; those are extracted and added directly.
+ * - Default coordinate bundles record `ClasspathEntry.Maven` entries; [CoordinateResolver] resolves
+ *   each from the machine's local Maven / Gradle caches and hash-checks against the v4 `sha256`. A
+ *   miss or mismatch warns but never fails — the renderer's bundled Compose still covers the common
+ *   API surface, and an almost-compatible jar renders. A network source is a later increment.
  */
 class BundleDaemonCommand(args: List<String>) : Command(args) {
 
@@ -60,12 +61,26 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     val previewsJson = workDir.resolve("previews.json")
     val zipBytes = BundleReader.extractZipBytes(file)
     expandAppJarAndManifest(zipBytes, classesDir, previewsJson, file)
-    // Embedded `libs/` jars are consumer classes, so they ride the daemon's `userClassDirs` holder
-    // (dirs-before-jars ordered, see UserClassLoaderHolder) alongside the extracted app classes —
-    // NOT the daemon/renderer `-cp`. Empty for coordinate bundles.
+    // Consumer classpath for the daemon's `userClassDirs` holder (dirs-before-jars ordered, see
+    // UserClassLoaderHolder) — the extracted app classes plus the bundle's third-party deps. NOT
+    // the
+    // daemon/renderer `-cp`. Deps come from two sources: embedded `libs/` jars (embedded-mode
+    // bundles) and `maven` coordinates resolved from local repos (the default detached bundles). A
+    // resolver miss or hash mismatch warns but never fails — same contract as `bundle render`.
     val libJars = BundleReader.extractEmbeddedLibs(zipBytes, libsDir)
+    val mavenCoords =
+      BundleReader.readMetadata(file)
+        .manifest
+        .classpath
+        .filterIsInstance<BundleReader.ClasspathEntry.Maven>()
+    val resolvedJars =
+      CoordinateResolver(warn = { System.err.println("[bundle-daemon] $it") })
+        .resolveAll(mavenCoords)
+        .mapNotNull { it.file }
     val userClassPath =
-      (listOf(classesDir) + libJars).joinToString(File.pathSeparator) { it.absolutePath }
+      (listOf(classesDir) + libJars + resolvedJars).joinToString(File.pathSeparator) {
+        it.absolutePath
+      }
 
     val daemonJars = locateSidecarJars("lib-daemon-desktop")
     if (daemonJars.isEmpty()) {
@@ -106,6 +121,9 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       System.err.println("[bundle-daemon] working dir: ${workDir.absolutePath}")
       System.err.println("[bundle-daemon] classes dir: ${classesDir.absolutePath}")
       System.err.println("[bundle-daemon] embedded lib jars: ${libJars.size}")
+      System.err.println(
+        "[bundle-daemon] resolved coordinate jars: ${resolvedJars.size} / ${mavenCoords.size}"
+      )
       System.err.println("[bundle-daemon] previews.json: ${previewsJson.absolutePath}")
       System.err.println("[bundle-daemon] daemon jars: ${daemonJars.size}")
       System.err.println("[bundle-daemon] renderer jars: ${rendererJars.size}")


### PR DESCRIPTION
## Summary

Coordinate-resolver parity (#1632). Until now only `bundle render` resolved a detached *coordinate* bundle's deps from local caches; `bundle daemon` and the desktop viewer still ignored `maven` entries. This brings both onto the same path so **all three players render a default coordinate bundle consistently**.

- **`BundleDaemonCommand`**: reads the manifest's `ClasspathEntry.Maven` entries, resolves them via `CoordinateResolver` (local Maven/Gradle caches, v4 `sha256` hash-checked), and joins the resolved jars onto the daemon's `userClassDirs` alongside the extracted app classes + embedded `libs/`. Verbose log + KDoc updated.
- **`bundle-viewer` `BundleLoader`**: resolves the manifest's `maven` coordinates and adds the jars to the bundle's child `URLClassLoader` after `app.jar` + embedded `libs/`. Adds a viewer-local `CoordinateResolver` (mirrors `:cli`'s — duplicated to keep the viewer module graph minimal, same convention as its `extractZipBytes` copy).

**Warn-not-fail throughout** (the merged contract): a resolver miss or hash mismatch logs and proceeds — an almost-compatible jar renders, and the renderer's bundled Compose covers the common surface.

## Test plan
- New `:bundle-viewer` `CoordinateResolverTest`: verified match, prefer-matching-candidate, miss→dropped+warn, mismatch→returns+warn (offline, temp repo dir). ✅
- `:cli:test` + `:bundle-viewer:test` green; both compile + ktfmt clean.

Note: `:tui-cli`'s bundle view drives the daemon via `bundle daemon`, so it inherits resolution through that path — no separate change. Not built locally (Mosaic host blocked); CI covers it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pkfwxdoh2qrkS44z8pdFJs)_