### PR TITLE
feat(cli): resolver downloads missing coordinates from remote repos

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -34,9 +34,10 @@ import kotlin.system.exitProcess
  * - Embedded-mode bundles (schema-v3 `resolution = "embedded"`) carry their reachable deps under
  *   `libs/`; those are extracted and added directly.
  * - Default coordinate bundles record `ClasspathEntry.Maven` entries; [CoordinateResolver] resolves
- *   each from the machine's local Maven / Gradle caches and hash-checks against the v4 `sha256`. A
- *   miss or mismatch warns but never fails — the renderer's bundled Compose still covers the common
- *   API surface, and an almost-compatible jar renders. A network source is a later increment.
+ *   each from the machine's local Maven / Gradle caches and, on a miss, downloads from Maven
+ *   Central / Google Maven, hash-checking against the v4 `sha256`. A miss or mismatch warns but
+ *   never fails — the renderer's bundled Compose still covers the common API surface, and an
+ *   almost-compatible jar renders.
  */
 class BundleDaemonCommand(args: List<String>) : Command(args) {
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -30,10 +30,10 @@ import kotlinx.serialization.json.Json
  *
  * Embedded-mode bundles (schema-v3 `resolution = "embedded"`) carry their reachable deps in
  * `libs/`. Coordinate-mode bundles (the default) carry only references; [CoordinateResolver]
- * re-attaches them from the machine's local Maven / Gradle caches (Tier 3) and hash-checks against
- * the v4 `sha256` — a miss or mismatch warns but never fails, since the renderer's bundled Compose
- * covers the common surface and an almost-compatible jar still renders. Network resolution is a
- * later increment behind the same seam.
+ * re-attaches them from the machine's local Maven / Gradle caches and, on a miss, downloads from
+ * Maven Central / Google Maven (Tier 3), hash-checking against the v4 `sha256` — a miss or mismatch
+ * warns but never fails, since the renderer's bundled Compose covers the common surface and an
+ * almost-compatible jar still renders.
  *
  * # Renderer / Java location
  *
@@ -90,8 +90,9 @@ class BundleRenderer(
           "either build the CLI via `./gradlew :cli:installDist` or set `-Dcomposeai.cli.appHome=<install-root>`."
       )
     }
-    // Resolve the bundle's detached `maven` coordinates from local repositories (Tier 3). Misses
-    // and hash mismatches warn but never fail — see CoordinateResolver. Embedded `libs/` jars and
+    // Resolve the bundle's detached `maven` coordinates from local repos, downloading on a miss
+    // (Tier 3). Misses and hash mismatches warn but never fail — see CoordinateResolver. Embedded
+    // `libs/` jars and
     // resolved coordinate jars both sit between the consumer classes and the renderer's own Compose
     // stack, so a preview's own deps resolve while the renderer's bundled Compose still wins on
     // shared symbols (same layering the desktop viewer's URLClassLoader uses).

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
@@ -1,56 +1,69 @@
 package ee.schimke.composeai.cli
 
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.copyTo
 import java.io.File
 import java.security.MessageDigest
+import kotlinx.coroutines.runBlocking
 
 /**
  * Resolves a bundle's detached `maven` coordinates (#1632, Tier 3) into local jar files so a player
  * can put them on the classpath. This is the consumer side of schema v4's content-addressing: a
  * coordinate names *what* dependency the bundle needs, and the resolver finds the bytes from
- * whatever the machine already has.
+ * whatever the machine already has — or, failing that, downloads them.
  *
- * # Sources
+ * # Sources, in order
  *
- * v1 resolves from **local repositories only** — no network. Two layouts are searched, in order:
- * 1. A Maven local repo (`~/.m2/repository`, standard `group/as/path/artifact/version/...` layout).
- * 2. The Gradle module cache (`~/.gradle/caches/modules-2/files-2.1`, which fans the file out under
- *    a per-sha1 subdirectory — we glob for the jar by name rather than guess the hash dir).
- *
- * Both roots are overridable via [repositoryRoots] (tests pass a temp dir; a future network fetcher
- * is just another root that populates a cache then resolves from it). A colleague who has built any
- * project using the same deps will already have them in one of these caches, so the common "someone
- * sent me a bundle" path works offline.
+ * 1. **Local repositories** — a Maven local repo (`~/.m2/repository`, standard
+ *    `group/as/path/artifact/version/...` layout) and the Gradle module cache
+ *    (`~/.gradle/caches/modules-2/files-2.1`, jar fanned under per-sha1 dirs). A colleague who has
+ *    built any project using the same deps already has them here, so the common "someone sent me a
+ *    bundle" path stays offline.
+ * 2. **Remote repositories** (when [networkEnabled]) — Maven Central + Google Maven by default,
+ *    overridable via [remoteRepositories]. Hit only when the local repos can't satisfy the
+ *    coordinate (nothing found, or a v4 hash that no local copy matched). A downloaded jar is
+ *    cached under [downloadCacheDir] in Maven layout, so a second resolve — or a later local-only
+ *    run — finds it without the network.
  *
  * # Verification — warn, never fail
  *
- * When a coordinate carries a v4 `sha256`, the resolved jar's bytes are hashed and compared. A
+ * When a coordinate carries a v4 `sha256`, a resolved jar's bytes are hashed and compared. A
  * **mismatch is a loud warning, not an error**: a different artifact for the same coordinate is
  * usually almost compatible (point-release skew, a repackaged-but-equivalent jar), and a
  * slightly-off preview beats no preview. The resolver still returns the jar. A missing hash
- * (older/non-Gradle bundles) resolves silently as unverifiable. This mirrors the contract pinned on
- * [ee.schimke.composeai.cli.BundleReader.ClasspathEntry.Maven] / `PreviewBundleFormat`.
+ * (older/non-Gradle bundles) resolves silently as unverifiable. Mirrors the contract pinned on
+ * [BundleReader.ClasspathEntry.Maven] / `PreviewBundleFormat`.
  *
- * The resolver itself never throws on a missing artifact either — it returns null and warns, so the
- * caller decides whether to proceed with a partial classpath (it should: the bundled renderer's
- * Compose stack covers the common surface).
+ * The resolver never throws on a missing artifact or a failed download — it returns null and warns,
+ * so the caller proceeds with a partial classpath (the bundled renderer's Compose stack covers the
+ * common surface).
  */
 internal class CoordinateResolver(
   private val repositoryRoots: List<File> = defaultRepositoryRoots(),
   private val warn: (String) -> Unit = { System.err.println("compose-preview: $it") },
+  private val networkEnabled: Boolean = defaultNetworkEnabled(),
+  private val remoteRepositories: List<String> = DEFAULT_REMOTE_REPOSITORIES,
+  private val downloadCacheDir: File = defaultDownloadCacheDir(),
 ) {
 
-  /** Outcome of resolving one coordinate. [file] is null when nothing was found locally. */
+  /** Outcome of resolving one coordinate. [file] is null when nothing was found or downloaded. */
   data class Resolution(
     val coordinate: BundleReader.ClasspathEntry.Maven,
     val file: File?,
     val verified: Boolean,
     val mismatch: Boolean,
+    /** True when [file] came from a remote repository rather than a pre-existing local one. */
+    val downloaded: Boolean = false,
   )
 
   /**
-   * Resolve [coords] to local jars, warning (never throwing) on misses and hash mismatches. Returns
-   * one [Resolution] per input coordinate in order; callers typically take `mapNotNull { it.file }`
-   * for the classpath and surface the misses to the user.
+   * Resolve [coords] to jars, warning (never throwing) on misses and hash mismatches. Returns one
+   * [Resolution] per input coordinate in order; callers typically take `mapNotNull { it.file }` for
+   * the classpath and surface the misses to the user.
    */
   fun resolveAll(coords: List<BundleReader.ClasspathEntry.Maven>): List<Resolution> = coords.map {
     resolve(it)
@@ -58,37 +71,69 @@ internal class CoordinateResolver(
 
   fun resolve(coord: BundleReader.ClasspathEntry.Maven): Resolution {
     val candidates = locate(coord)
-    if (candidates.isEmpty()) {
-      warn(
-        "could not resolve ${coord.group}:${coord.artifact}:${coord.version} from any local " +
-          "repository (looked in ${repositoryRoots.joinToString { it.path }}); the preview may " +
-          "fail to render if it needs this dependency. Re-pack with --embed-deps for an offline bundle."
-      )
-      return Resolution(coord, file = null, verified = false, mismatch = false)
-    }
     val expected = coord.sha256
-    if (expected == null) {
-      // No hash to disambiguate with — first candidate, unverifiable.
+
+    // A local copy whose bytes match the recorded hash is the ideal outcome — done.
+    if (expected != null) {
+      candidates
+        .firstOrNull { sha256Hex(it).equals(expected, ignoreCase = true) }
+        ?.let {
+          return Resolution(coord, file = it, verified = true, mismatch = false)
+        }
+    } else if (candidates.isNotEmpty()) {
+      // No hash to disambiguate with — first local candidate, unverifiable.
       return Resolution(coord, file = candidates.first(), verified = false, mismatch = false)
     }
-    // The hash exists precisely to pick the *right* copy when a GAV resolves to several local files
-    // (a stale ~/.m2 copy + a Gradle cache entry, multiple Gradle hash dirs for a republished
-    // module, …). Prefer a candidate whose bytes match before settling for a mismatch.
-    candidates
-      .firstOrNull { sha256Hex(it).equals(expected, ignoreCase = true) }
-      ?.let {
-        return Resolution(coord, file = it, verified = true, mismatch = false)
+
+    // Local repos couldn't satisfy it (nothing found, or a hash that no local copy matched). Try
+    // the
+    // network before settling — the whole point of carrying a coordinate is that the bytes can be
+    // re-fetched from any source.
+    if (networkEnabled) {
+      val fetched = download(coord)
+      if (fetched != null) {
+        if (expected == null || sha256Hex(fetched).equals(expected, ignoreCase = true)) {
+          return Resolution(
+            coord,
+            file = fetched,
+            verified = expected != null,
+            mismatch = false,
+            downloaded = true,
+          )
+        }
+        // Downloaded bytes don't match either — warn but keep them (almost-compatible beats
+        // nothing).
+        warn(
+          "hash mismatch for ${coord.group}:${coord.artifact}:${coord.version} — downloaded copy " +
+            "(${sha256Hex(fetched)}) does not match the bundle's $expected. Rendering with it anyway."
+        )
+        return Resolution(
+          coord,
+          file = fetched,
+          verified = false,
+          mismatch = true,
+          downloaded = true,
+        )
       }
-    // Nothing matched. Warn, do NOT fail — the bytes are probably almost compatible (see the
-    // verification contract). Fall back to the first candidate so the preview still renders.
-    val fallback = candidates.first()
+    }
+
+    // Nothing usable from the network. Fall back to a local mismatch if we have one, else give up.
+    if (candidates.isNotEmpty()) {
+      val fallback = candidates.first()
+      warn(
+        "hash mismatch for ${coord.group}:${coord.artifact}:${coord.version} — bundle expected " +
+          "$expected but no local or remote copy matched (using ${fallback.name}, " +
+          "${sha256Hex(fallback)}). Rendering with the local copy anyway; the preview may differ " +
+          "slightly from the original."
+      )
+      return Resolution(coord, file = fallback, verified = false, mismatch = true)
+    }
     warn(
-      "hash mismatch for ${coord.group}:${coord.artifact}:${coord.version} — bundle expected " +
-        "$expected but none of ${candidates.size} local copy(ies) matched (using ${fallback.name}, " +
-        "${sha256Hex(fallback)}). Rendering with the local copy anyway; the preview may differ " +
-        "slightly from the original."
+      "could not resolve ${coord.group}:${coord.artifact}:${coord.version} from any local " +
+        "repository${if (networkEnabled) " or remote repository" else ""}; the preview may fail to " +
+        "render if it needs this dependency. Re-pack with --embed-deps for an offline bundle."
     )
-    return Resolution(coord, file = fallback, verified = false, mismatch = true)
+    return Resolution(coord, file = null, verified = false, mismatch = false)
   }
 
   /**
@@ -102,8 +147,7 @@ internal class CoordinateResolver(
     for (root in repositoryRoots) {
       if (!root.isDirectory) continue
       // Maven layout: <root>/<group as path>/<artifact>/<version>/<artifact>-<version>.jar
-      val mavenPath =
-        File(root, coord.group.replace('.', '/') + "/${coord.artifact}/${coord.version}/$jarName")
+      val mavenPath = File(root, mavenRelativePath(coord))
       if (mavenPath.isFile) found += mavenPath
       // Gradle modules-2 layout fans the jar under per-hash dirs; collect every match under
       // <root>/<group>/<artifact>/<version>/<hash>/<jarName>. One directory level only, so a huge
@@ -121,6 +165,51 @@ internal class CoordinateResolver(
     return found
   }
 
+  /**
+   * Download [coord]'s jar from the first [remoteRepositories] base URL that serves it, into
+   * [downloadCacheDir] (Maven layout), and return the cached file. Returns null — never throws — on
+   * a total miss or any transport error, so resolution degrades to a warning. If the cache already
+   * holds the file (a prior download), it's returned without a network hit.
+   */
+  private fun download(coord: BundleReader.ClasspathEntry.Maven): File? {
+    val rel = mavenRelativePath(coord)
+    val cached = File(downloadCacheDir, rel)
+    if (cached.isFile && cached.length() > 0) return cached
+    for (base in remoteRepositories) {
+      val url = base.trimEnd('/') + "/" + rel
+      if (fetchTo(url, cached)) return cached
+    }
+    return null
+  }
+
+  /** GET [url] → [dest] (parent dirs created); true only on a 2xx with a non-empty body. */
+  private fun fetchTo(url: String, dest: File): Boolean =
+    try {
+      dest.parentFile?.mkdirs()
+      val ok =
+        HttpClient(OkHttp).use { client ->
+          runBlocking {
+            client.prepareGet(url).execute { response ->
+              if (response.status.isSuccess()) {
+                dest.outputStream().use { out -> response.bodyAsChannel().copyTo(out) }
+                true
+              } else {
+                false
+              }
+            }
+          }
+        }
+      if (ok && dest.length() > 0) {
+        true
+      } else {
+        dest.delete()
+        false
+      }
+    } catch (_: Exception) {
+      dest.delete()
+      false
+    }
+
   private fun sha256Hex(file: File): String {
     val digest = MessageDigest.getInstance("SHA-256")
     file.inputStream().use { input ->
@@ -135,6 +224,15 @@ internal class CoordinateResolver(
   }
 
   companion object {
+    /** Maven Central + Google Maven, the two repos that serve almost every Compose/AndroidX dep. */
+    val DEFAULT_REMOTE_REPOSITORIES: List<String> =
+      listOf("https://repo1.maven.org/maven2", "https://dl.google.com/dl/android/maven2")
+
+    /** `<group as path>/<artifact>/<version>/<artifact>-<version>.jar`. */
+    private fun mavenRelativePath(coord: BundleReader.ClasspathEntry.Maven): String =
+      coord.group.replace('.', '/') +
+        "/${coord.artifact}/${coord.version}/${coord.artifact}-${coord.version}.jar"
+
     /**
      * Default local repositories searched when a caller doesn't pass its own. Honours the standard
      * `maven.repo.local` override and `GRADLE_USER_HOME`; falls back to the conventional `~/.m2`
@@ -149,6 +247,26 @@ internal class CoordinateResolver(
         System.getenv("GRADLE_USER_HOME")?.let(::File) ?: home?.let { File(it, ".gradle") }
       if (gradleHome != null) roots += File(gradleHome, "caches/modules-2/files-2.1")
       return roots
+    }
+
+    /**
+     * Network resolution is on unless `composeai.bundle.offline=true` (sysprop) or
+     * `COMPOSE_PREVIEW_OFFLINE=1` (env) — an escape hatch for sandboxes / air-gapped machines that
+     * want strictly-local resolution.
+     */
+    fun defaultNetworkEnabled(): Boolean {
+      if (System.getProperty("composeai.bundle.offline").toBoolean()) return false
+      if (System.getenv("COMPOSE_PREVIEW_OFFLINE") == "1") return false
+      return true
+    }
+
+    /** Where downloaded coordinate jars are cached (Maven layout). Override-able for tests. */
+    fun defaultDownloadCacheDir(): File {
+      System.getProperty("composeai.bundle.cacheDir")?.let {
+        return File(it)
+      }
+      val home = System.getProperty("user.home")?.let(::File) ?: File(".")
+      return File(home, ".cache/compose-preview/bundle-deps")
     }
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
@@ -142,7 +142,7 @@ internal class CoordinateResolver(
    * several caches or Gradle hash dirs — [resolve] uses the hash to pick among them.
    */
   private fun locate(coord: BundleReader.ClasspathEntry.Maven): List<File> {
-    val jarName = "${coord.artifact}-${coord.version}.jar"
+    val jarName = artifactFileName(coord)
     val found = mutableListOf<File>()
     for (root in repositoryRoots) {
       if (!root.isDirectory) continue
@@ -228,10 +228,14 @@ internal class CoordinateResolver(
     val DEFAULT_REMOTE_REPOSITORIES: List<String> =
       listOf("https://repo1.maven.org/maven2", "https://dl.google.com/dl/android/maven2")
 
-    /** `<group as path>/<artifact>/<version>/<artifact>-<version>.jar`. */
+    /** `<artifact>-<version>.<type>` — `type` is `jar` (desktop) or `aar` (Android). */
+    private fun artifactFileName(coord: BundleReader.ClasspathEntry.Maven): String =
+      "${coord.artifact}-${coord.version}.${coord.type.ifBlank { "jar" }}"
+
+    /** `<group as path>/<artifact>/<version>/<artifact>-<version>.<type>`. */
     private fun mavenRelativePath(coord: BundleReader.ClasspathEntry.Maven): String =
       coord.group.replace('.', '/') +
-        "/${coord.artifact}/${coord.version}/${coord.artifact}-${coord.version}.jar"
+        "/${coord.artifact}/${coord.version}/${artifactFileName(coord)}"
 
     /**
      * Default local repositories searched when a caller doesn't pass its own. Honours the standard

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
@@ -144,7 +144,10 @@ internal class CoordinateResolver(
   private fun locate(coord: BundleReader.ClasspathEntry.Maven): List<File> {
     val jarName = artifactFileName(coord)
     val found = mutableListOf<File>()
-    for (root in repositoryRoots) {
+    // Search the user's local repos AND our own download cache — a jar fetched during an earlier
+    // online run lives in [downloadCacheDir] (Maven layout) and must resolve offline too, since the
+    // network gate only governs *new* fetches, not reading what we already have.
+    for (root in repositoryRoots + downloadCacheDir) {
       if (!root.isDirectory) continue
       // Maven layout: <root>/<group as path>/<artifact>/<version>/<artifact>-<version>.jar
       val mavenPath = File(root, mavenRelativePath(coord))
@@ -166,18 +169,20 @@ internal class CoordinateResolver(
   }
 
   /**
-   * Download [coord]'s jar from the first [remoteRepositories] base URL that serves it, into
+   * Download [coord]'s artifact from the first [remoteRepositories] base URL that serves it, into
    * [downloadCacheDir] (Maven layout), and return the cached file. Returns null — never throws — on
-   * a total miss or any transport error, so resolution degrades to a warning. If the cache already
-   * holds the file (a prior download), it's returned without a network hit.
+   * a total miss or any transport error, so resolution degrades to a warning.
+   *
+   * A previously-cached download is *not* short-circuited here: [locate] already searches
+   * [downloadCacheDir], so reaching this method means either nothing was cached, or the cached
+   * bytes didn't match the bundle's hash and we want fresh bytes (which overwrite the stale copy).
    */
   private fun download(coord: BundleReader.ClasspathEntry.Maven): File? {
     val rel = mavenRelativePath(coord)
-    val cached = File(downloadCacheDir, rel)
-    if (cached.isFile && cached.length() > 0) return cached
+    val dest = File(downloadCacheDir, rel)
     for (base in remoteRepositories) {
       val url = base.trimEnd('/') + "/" + rel
-      if (fetchTo(url, cached)) return cached
+      if (fetchTo(url, dest)) return dest
     }
     return null
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
@@ -203,6 +203,31 @@ class CoordinateResolverTest {
   }
 
   @Test
+  fun `a prior download is read offline from the cache`() {
+    // Simulates a later offline run: a jar cached by an earlier online fetch must resolve even with
+    // the network disabled, since the cache is read independently of the network gate.
+    val bytes = byteArrayOf(8, 8, 8)
+    File(cacheDir, "com/example/foo/widgets/1.2.3/widgets-1.2.3.jar").apply {
+      parentFile.mkdirs()
+      writeBytes(bytes)
+    }
+    val offline =
+      CoordinateResolver(
+        repositoryRoots = listOf(root),
+        warn = { warnings += it },
+        networkEnabled = false,
+        downloadCacheDir = cacheDir,
+      )
+
+    val r = offline.resolve(maven(sha = sha256(bytes)))
+
+    assertNotNullFile(r.file)
+    assertTrue(r.verified)
+    assertFalse(r.downloaded, "came from the cache, not a fresh download")
+    assertTrue(warnings.isEmpty(), "a cached offline hit must not warn: $warnings")
+  }
+
+  @Test
   fun `remote 404 returns null and warns, never throws`() {
     val base = startRepo(status = 404)
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.cli
 
+import com.sun.net.httpserver.HttpServer
 import java.io.File
+import java.net.InetSocketAddress
 import java.nio.file.Files
 import java.security.MessageDigest
 import kotlin.test.AfterTest
@@ -11,21 +13,54 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * Offline coverage for [CoordinateResolver] — the Tier 3 (#1632) consumer of schema-v4 detached
- * coordinates. Exercises both local-repo layouts, the warn-not-fail miss path, and the
- * warn-but-return hash-mismatch contract, all against a temp repo dir (no network).
+ * Coverage for [CoordinateResolver] — the Tier 3 (#1632) consumer of schema-v4 detached
+ * coordinates. The local-repo cases run with network disabled (hermetic, temp repo dir); the
+ * network cases use a throwaway loopback [HttpServer] as a fake remote Maven repo — no real
+ * network.
  */
 class CoordinateResolverTest {
 
   private val root = Files.createTempDirectory("coord-resolver-test-").toFile()
+  private val cacheDir = Files.createTempDirectory("coord-resolver-cache-").toFile()
   private val warnings = mutableListOf<String>()
+  // Local-only resolver for the offline cases: network off so a miss doesn't reach out.
   private val resolver =
-    CoordinateResolver(repositoryRoots = listOf(root), warn = { warnings += it })
+    CoordinateResolver(
+      repositoryRoots = listOf(root),
+      warn = { warnings += it },
+      networkEnabled = false,
+    )
+  private var server: HttpServer? = null
 
   @AfterTest
   fun cleanup() {
+    server?.stop(0)
     root.deleteRecursively()
+    cacheDir.deleteRecursively()
   }
+
+  /** A loopback Maven repo that serves [body] for any request path; returns its base URL. */
+  private fun startRepo(status: Int = 200, body: ByteArray = byteArrayOf(1)): String {
+    val s = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    s.createContext("/") { exchange ->
+      val len = if (body.isEmpty() || status >= 400) -1L else body.size.toLong()
+      exchange.sendResponseHeaders(status, len)
+      exchange.responseBody.use { if (status < 400 && body.isNotEmpty()) it.write(body) }
+    }
+    s.start()
+    server = s
+    return "http://127.0.0.1:${s.address.port}"
+  }
+
+  /** A network-enabled resolver pointed only at [base] (no real repos), caching into [cacheDir]. */
+  private fun networkResolver(base: String) =
+    CoordinateResolver(
+      repositoryRoots = listOf(root),
+      warn = { warnings += it },
+      networkEnabled = true,
+      remoteRepositories = listOf(base),
+      downloadCacheDir = cacheDir,
+    )
 
   private fun maven(sha: String? = null) =
     BundleReader.ClasspathEntry.Maven(
@@ -132,6 +167,64 @@ class CoordinateResolverTest {
     assertFalse(r.verified)
     assertFalse(r.mismatch)
     assertTrue(warnings.isEmpty(), "an unverifiable (no-hash) resolution must not warn: $warnings")
+  }
+
+  @Test
+  fun `downloads from a remote repo when local misses, and caches it`() {
+    val bytes = byteArrayOf(7, 7, 7, 7)
+    val base = startRepo(body = bytes)
+
+    val r = networkResolver(base).resolve(maven(sha = sha256(bytes)))
+
+    assertNotNullFile(r.file)
+    assertTrue(r.downloaded, "should have come from the remote repo")
+    assertTrue(r.verified)
+    assertFalse(r.mismatch)
+    // Cached in Maven layout for next time.
+    val cached = File(cacheDir, "com/example/foo/widgets/1.2.3/widgets-1.2.3.jar")
+    assertTrue(cached.isFile)
+    assertEquals(bytes.toList(), cached.readBytes().toList())
+  }
+
+  @Test
+  fun `served cache is reused without re-downloading`() {
+    // Pre-seed the cache; point the resolver at a server that would 404 if hit.
+    val bytes = byteArrayOf(3, 1, 4)
+    File(cacheDir, "com/example/foo/widgets/1.2.3/widgets-1.2.3.jar").apply {
+      parentFile.mkdirs()
+      writeBytes(bytes)
+    }
+    val base = startRepo(status = 404)
+
+    val r = networkResolver(base).resolve(maven(sha = sha256(bytes)))
+
+    assertNotNullFile(r.file)
+    assertTrue(r.verified)
+  }
+
+  @Test
+  fun `remote 404 returns null and warns, never throws`() {
+    val base = startRepo(status = 404)
+
+    val r = networkResolver(base).resolve(maven(sha = "a".repeat(64)))
+
+    assertNull(r.file)
+    assertTrue(warnings.any { it.contains("could not resolve") && it.contains("remote") })
+  }
+
+  @Test
+  fun `local hash-match wins without any network call`() {
+    // A local match exists; the server would 404 if the resolver wrongly reached for the network.
+    val bytes = byteArrayOf(2, 2, 2)
+    val jar = writeMavenJar(bytes)
+    val base = startRepo(status = 404)
+
+    val r = networkResolver(base).resolve(maven(sha = sha256(bytes)))
+
+    assertEquals(jar.canonicalFile, r.file?.canonicalFile)
+    assertFalse(r.downloaded)
+    assertTrue(r.verified)
+    assertTrue(warnings.isEmpty(), "a local hash-match must not warn or hit the network: $warnings")
   }
 
   private fun assertNotNullFile(f: File?) =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
@@ -227,6 +227,51 @@ class CoordinateResolverTest {
     assertTrue(warnings.isEmpty(), "a local hash-match must not warn or hit the network: $warnings")
   }
 
+  @Test
+  fun `aar coordinate resolves by its type extension, not jar`() {
+    // An Android coordinate (type=aar) must be looked up / downloaded as
+    // `<artifact>-<version>.aar`.
+    val bytes = byteArrayOf(5, 0, 5)
+    val aar = File(root, "com/example/foo/widgets/1.2.3/widgets-1.2.3.aar")
+    aar.parentFile.mkdirs()
+    aar.writeBytes(bytes)
+
+    val coord =
+      BundleReader.ClasspathEntry.Maven(
+        group = "com.example.foo",
+        artifact = "widgets",
+        version = "1.2.3",
+        type = "aar",
+        sha256 = sha256(bytes),
+      )
+    val r = resolver.resolve(coord)
+
+    assertEquals(aar.canonicalFile, r.file?.canonicalFile)
+    assertTrue(r.verified)
+  }
+
+  @Test
+  fun `aar coordinate downloads with the aar extension`() {
+    val bytes = byteArrayOf(1, 0, 0, 1)
+    val base = startRepo(body = bytes)
+
+    val coord =
+      BundleReader.ClasspathEntry.Maven(
+        group = "com.example.foo",
+        artifact = "widgets",
+        version = "1.2.3",
+        type = "aar",
+        sha256 = sha256(bytes),
+      )
+    val r = networkResolver(base).resolve(coord)
+
+    assertNotNullFile(r.file)
+    assertTrue(r.downloaded)
+    // Cached under the aar filename, not jar.
+    val cached = File(cacheDir, "com/example/foo/widgets/1.2.3/widgets-1.2.3.aar")
+    assertTrue(cached.isFile)
+  }
+
   private fun assertNotNullFile(f: File?) =
     assertTrue(f != null && f.isFile, "expected a resolved jar")
 }


### PR DESCRIPTION
## Summary

Network source for the Tier 3 resolver (#1632) — completes the detached-deps story. When a bundle's `maven` coordinate isn't in any **local** repo (or no local copy matches the v4 `sha256`), `CoordinateResolver` now **downloads** it from Maven Central / Google Maven and caches it, so a colleague who only has the `.png` can render a default coordinate bundle with nothing pre-cached.

- **`CoordinateResolver`**: adds
  - `networkEnabled` (default on; off via `-Dcomposeai.bundle.offline=true` or `COMPOSE_PREVIEW_OFFLINE=1` for sandboxes/air-gapped),
  - `remoteRepositories` (Maven Central + Google Maven),
  - `downloadCacheDir` (`~/.cache/compose-preview/bundle-deps`, override `-Dcomposeai.bundle.cacheDir`).
  - Order: local hash-match wins with **no network call**; on a local miss it downloads, then hash-checks the downloaded bytes too. A previously downloaded jar is reused from the cache without a second fetch. **Warn-never-fail** throughout. Uses the Ktor/OkHttp client already on the `:cli` classpath.
- **`BundleRenderer` / `BundleDaemonCommand`**: KDocs updated (local + remote; no longer "later increment").

## Test plan
- `CoordinateResolverTest`: 6 local cases (pinned `networkEnabled=false`) + 4 network cases via a throwaway loopback `HttpServer` fake repo — download+cache, served-cache reuse (no re-download), remote 404 → null+warn, local-match-wins-without-network. All offline. ✅
- `:cli:test` green; compile + ktfmt clean.

## Follow-up
Mirror the network source into the viewer's `CoordinateResolver` (currently local-only). Kept out of this PR to stay focused.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pkfwxdoh2qrkS44z8pdFJs)_