### PR TITLE
feat(cli): add opt-in --bundle flag to render

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -854,15 +854,33 @@ class ListCommand(args: List<String>) : Command(args) {
 class RenderCommand(args: List<String>) : Command(args) {
   private val output: String? = args.flagValue("--output")
 
+  /**
+   * `--bundle` opt-in: after rendering, also pack each module's previews into a portable PNG+ZIP
+   * bundle (`<module>/build/compose-previews/bundle.png`) via the `composePreviewBundle` task — one
+   * bundle per module, containing all of that module's previews. Off by default: the bundle step
+   * adds a classpath closure walk + jar minimization on top of the render, which is wasted work on
+   * the fast iterate loop where you only want PNGs. Reach for it when you want a shareable artifact
+   * (see `compose-preview bundle` for inspect/extract/render of the result).
+   */
+  private val bundle: Boolean = "--bundle" in args
+
+  /**
+   * `--embed-deps` (only meaningful with `--bundle`): carry reachable third-party jars inside the
+   * bundle instead of referencing Maven coordinates. Bigger file, but renders offline with no build
+   * system on the other end. Forwarded as `-PbundleEmbedDeps=true`.
+   */
+  private val embedDeps: Boolean = "--embed-deps" in args
+
   override fun run() {
     withGradle { gradle ->
       val modules = resolveModules(gradle)
-      val tasks = modules.map { ":${it.gradlePath}:composePreviewRenderAll" }.toTypedArray()
-
-      if (!runGradle(gradle, *tasks, arguments = gradleArgsWithForce())) {
+      val tasks = previewTasksFor(modules.map { it.gradlePath }).toTypedArray()
+      if (!runGradle(gradle, *tasks, arguments = gradleArgsWithForce(bundleGradleArgs()))) {
         reportRenderFailures(gradle)
         exitProcess(2)
       }
+
+      if (bundle) reportBundles(modules)
 
       val manifests = readAllManifests(modules)
       val all = buildResults(manifests)
@@ -909,6 +927,52 @@ class RenderCommand(args: List<String>) : Command(args) {
           if (shouldFailOnMissingRenders()) exitProcess(2)
         }
       }
+    }
+  }
+
+  /**
+   * Gradle task list for this render run, one entry per module. With `--bundle` set, each module's
+   * `composePreviewBundle` is appended right after its `composePreviewRenderAll` so both run in a
+   * single Gradle invocation: `composePreviewRenderAll` depends on `composePreviewRender`, and the
+   * bundle task declares `mustRunAfter("composePreviewRender")`, so the bundle packs the PNGs this
+   * run just produced.
+   */
+  internal fun previewTasksFor(modulePaths: List<String>): List<String> = buildList {
+    for (path in modulePaths) {
+      add(":$path:composePreviewRenderAll")
+      if (bundle) add(":$path:composePreviewBundle")
+    }
+  }
+
+  /**
+   * Extra Gradle properties for the bundle step. Empty unless `--bundle` is set; `--embed-deps`
+   * (only meaningful alongside `--bundle`) adds `-PbundleEmbedDeps=true` so reachable third-party
+   * jars are carried inside the bundle rather than referenced by Maven coordinate.
+   */
+  internal fun bundleGradleArgs(): List<String> =
+    if (bundle && embedDeps) listOf("-PbundleEmbedDeps=true") else emptyList()
+
+  /**
+   * Print one line per module's freshly-packed bundle. Reuses [BundleReader] to read back the
+   * polyglot we just wrote so the summary reflects what actually landed on disk (preview count,
+   * resolution mode) rather than what we asked for. A missing file is a warning, not a hard fail —
+   * the render itself already succeeded by the time we get here.
+   */
+  private fun reportBundles(modules: List<PreviewModule>) {
+    for (m in modules) {
+      val file = m.projectDir.resolve("build/compose-previews/bundle.png")
+      if (!file.isFile) {
+        System.err.println("Bundle expected but missing for ${m.gradlePath}: ${file.path}")
+        continue
+      }
+      val summary =
+        try {
+          val meta = BundleReader.readMetadata(file)
+          "${meta.manifest.previewIds.size} preview(s), resolution=${meta.manifest.resolution}"
+        } catch (e: Exception) {
+          "unreadable: ${e.message}"
+        }
+      println("Bundled ${file.path} (${file.length()} bytes; $summary)")
     }
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -106,7 +106,9 @@ private fun printUsage() {
                        command, separate from `show` because the workflows are disjoint —
                        see also `compose-preview-show-resources/v1` JSON envelope.
       list             List discovered previews
-      render           Render previews; with --output copies a single match to disk
+      render           Render previews; with --output copies a single match to disk.
+                       --bundle additionally packs each module's previews into a
+                       portable PNG+ZIP bundle (off by default).
       a11y             Render previews with the a11y data extension on and
                        print ATF findings (thin wrapper over `--with-extension a11y`)
       extensions       Introspect registered data extensions (`extensions list`)
@@ -141,6 +143,11 @@ private fun printUsage() {
       --brief              JSON only: drop functionName/className/sourceFile/params
       --changed-only       JSON only (show, a11y): drop previews with no changed capture
       --output <path>      Copy matched preview PNG to this path (render)
+      --bundle             render: after rendering, pack each module's previews into a portable
+                           PNG+ZIP bundle at <module>/build/compose-previews/bundle.png. Opt-in —
+                           adds a classpath closure walk + jar minimization on top of the render.
+      --embed-deps         render (with --bundle): embed reachable third-party jars in the bundle
+                           instead of referencing Maven coordinates. Bigger file, renders offline.
       --images[=<mode>]    show: emit rendered PNGs inline using the terminal's image protocol.
                            Default `auto` — on by default in an interactive TTY when a
                            kitty-graphics-capable terminal is detected (`KITTY_WINDOW_ID`,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/RenderBundleFlagTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/RenderBundleFlagTest.kt
@@ -1,0 +1,55 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Covers the opt-in `--bundle` flag on `compose-preview render`: it must append each module's
+ * `composePreviewBundle` task after its `composePreviewRenderAll` (so both run in one Gradle build)
+ * and forward `-PbundleEmbedDeps=true` only when `--embed-deps` is also present. Default (no flag)
+ * must stay render-only so the fast iterate loop pays no bundling cost.
+ */
+class RenderBundleFlagTest {
+  private val twoModules = listOf("app", "feature:home")
+
+  @Test
+  fun `default render emits only renderAll tasks`() {
+    val cmd = RenderCommand(listOf("render"))
+    assertEquals(
+      listOf(":app:composePreviewRenderAll", ":feature:home:composePreviewRenderAll"),
+      cmd.previewTasksFor(twoModules),
+    )
+    assertEquals(emptyList(), cmd.bundleGradleArgs())
+  }
+
+  @Test
+  fun `--bundle appends composePreviewBundle per module after its renderAll`() {
+    val cmd = RenderCommand(listOf("render", "--bundle"))
+    assertEquals(
+      listOf(
+        ":app:composePreviewRenderAll",
+        ":app:composePreviewBundle",
+        ":feature:home:composePreviewRenderAll",
+        ":feature:home:composePreviewBundle",
+      ),
+      cmd.previewTasksFor(twoModules),
+    )
+    // --bundle alone keeps the default coordinates resolution (no embed property).
+    assertEquals(emptyList(), cmd.bundleGradleArgs())
+  }
+
+  @Test
+  fun `--embed-deps forwards only when --bundle is set`() {
+    // --embed-deps without --bundle is a no-op: no bundle tasks, no embed property.
+    val embedOnly = RenderCommand(listOf("render", "--embed-deps"))
+    assertEquals(listOf(":app:composePreviewRenderAll"), embedOnly.previewTasksFor(listOf("app")))
+    assertEquals(emptyList(), embedOnly.bundleGradleArgs())
+
+    val both = RenderCommand(listOf("render", "--bundle", "--embed-deps"))
+    assertEquals(
+      listOf(":app:composePreviewRenderAll", ":app:composePreviewBundle"),
+      both.previewTasksFor(listOf("app")),
+    )
+    assertEquals(listOf("-PbundleEmbedDeps=true"), both.bundleGradleArgs())
+  }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `--bundle` flag to `compose-preview render`. By default `render` keeps producing plain PNGs; with `--bundle` it additionally packs each module's previews into a portable PNG+ZIP bundle at `<module>/build/compose-previews/bundle.png` by appending `composePreviewBundle` to the same Gradle invocation (one bundle per module, containing all of that module's previews).

This came out of a "what if every preview were a bundle?" discussion. The conclusion was that bundling shouldn't be the default — the bundle step adds a classpath closure walk + jar minimization on top of the render, which is a fixed per-invocation cost that's wasted work on the fast iterate loop where you only want PNGs. So this lands it as an explicit opt-in instead.

### What's included
- `--bundle` on `render`: appends `:<module>:composePreviewBundle` after each `:<module>:composePreviewRenderAll`. `composePreviewRenderAll` depends on `composePreviewRender`, and the bundle task already declares `mustRunAfter("composePreviewRender")`, so the bundle packs the PNGs this run just produced — no extra Gradle round-trip.
- `--embed-deps` (only meaningful with `--bundle`): forwards `-PbundleEmbedDeps=true` so reachable third-party jars are carried inside the bundle instead of referenced by Maven coordinate.
- Per-module summary printed via the existing `BundleReader` (preview count + resolution mode), read back from the file actually written.
- Help text updated in `Main.kt`.

Default behaviour (no flag) is unchanged — render-only, no bundling cost.

## Test plan
- New `RenderBundleFlagTest` (`:cli:test`) covers the task-list construction:
  - default render emits only `composePreviewRenderAll` tasks, no embed property;
  - `--bundle` appends `composePreviewBundle` per module after its `renderAll`;
  - `--embed-deps` adds `-PbundleEmbedDeps=true` only when `--bundle` is also set (no-op otherwise).
- `./gradlew :cli:test --tests "*.RenderBundleFlagTest"` → BUILD SUCCESSFUL.
- `./gradlew :cli:ktfmtFormat` clean.

https://claude.ai/code/session_01GsJZfW6xT9JDJuvmHsUeA1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsJZfW6xT9JDJuvmHsUeA1)_