### PR TITLE
test(vscode): fix interactive e2e render-path resolution

### DIFF
--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -144,13 +144,23 @@ function nonEmptyForModule(
         msg.previews.length > 0 && msg.moduleDir.includes(moduleDirNeedle);
 }
 
-function fullRenderPath(moduleDir: string, output: string): string {
+function fullRenderPath(
+    repoRoot: string,
+    moduleDir: string,
+    output: string,
+): string {
     if (path.isAbsolute(output)) return output;
-    // `moduleDir` for a single-module switch is the module's projectDir.
-    // For multi-module aggregations it's a comma-joined list; the test never
-    // hits that path because we trigger refreshes against a single file.
+    // `moduleDir` (the `setPreviews.moduleDir` field) is the module's
+    // `projectDir` — a path *relative to the workspace root*, e.g.
+    // `samples/cmp`. For multi-module aggregations it's a comma-joined list;
+    // the test never hits that path because we trigger refreshes against a
+    // single file.
     const first = moduleDir.split(",")[0] ?? moduleDir;
-    return path.join(first, output);
+    // `capture.renderOutput` is relative to the module's
+    // `build/compose-previews/` dir (e.g. `renders/Foo.png`). Resolve it the
+    // same way the extension does in `GradleService.readPreviewImage`:
+    // `<workspaceRoot>/<projectDir>/build/compose-previews/<renderOutput>`.
+    return path.join(repoRoot, first, "build", "compose-previews", output);
 }
 
 function dumpTranscript(
@@ -341,6 +351,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         for (const p of androidFirst.previews) {
             for (const c of p.captures ?? []) {
                 const resolved = fullRenderPath(
+                    repoRoot,
                     androidFirst.moduleDir,
                     c.renderOutput,
                 );
@@ -478,6 +489,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                 );
                 for (const c of captures) {
                     const resolved = fullRenderPath(
+                        repoRoot,
                         afterAdd.moduleDir,
                         c.renderOutput,
                     );
@@ -566,6 +578,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         for (const p of settled.previews) {
             for (const c of p.captures ?? []) {
                 const resolved = fullRenderPath(
+                    repoRoot,
                     settled.moduleDir,
                     c.renderOutput,
                 );
@@ -617,6 +630,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         for (const p of settled.previews) {
             for (const c of p.captures ?? []) {
                 const resolved = fullRenderPath(
+                    repoRoot,
                     settled.moduleDir,
                     c.renderOutput,
                 );


### PR DESCRIPTION
## Summary

The `VS Code Extension E2E (real Gradle)` job has been red — all four interactive scenarios fail with assertions like:

```
captures pointing at missing PNGs after rapid burst:
  ...RedBoxPreview_Red Box → samples/cmp/renders/RedBoxPreview_Red_Box.png
```

Root cause is in the test, not the extension. `fullRenderPath` in `e2eInteractive.test.ts` resolved capture PNGs as `<projectDir>/<renderOutput>` — a path relative to the test process cwd, missing **both** the workspace root and the `build/compose-previews` segment.

The `setPreviews.moduleDir` field carries the module's `projectDir`, which is *relative to the workspace root* (e.g. `samples/cmp`), and `capture.renderOutput` is relative to the module's `build/compose-previews/` dir (e.g. `renders/Foo.png`). The extension resolves these to `<workspaceRoot>/<projectDir>/build/compose-previews/<renderOutput>` (see `GradleService.readPreviewImage`, and the smoke `e2e.test.ts`). Because the test's resolver produced a relative path missing `build/compose-previews`, every `fs.existsSync` check failed — so scenarios A (A3), B (B1), C (C1), and D all reported their on-disk PNGs as missing.

Fix: thread `repoRoot` through `fullRenderPath` and resolve render outputs the same way the production code does.

## Test plan

- `npm run compile` is clean (host + webview).
- The fix mirrors the path layout already asserted by the passing `e2e.test.ts` smoke (`<repoRoot>/samples/cmp/build/compose-previews/renders/`), so the four interactive scenarios now check the same on-disk paths the renderer actually writes.
- Full validation is the `VS Code Extension E2E (real Gradle)` workflow itself (push-to-main / `workflow_dispatch`), which drives real Gradle.

## Note on the external-consumer e2e

The `VS Code Extension E2E (external consumer)` job (Confetti) is a separate suite (`e2eExternal.test.ts`) that does **not** share this path-resolution helper and is untouched here. Its failure log was truncated (no mocha output before the host exit), so I couldn't pin a root cause from it — the fast exit points at the `before()` workspace-shape assertions (Confetti clone / catalog rewrite / upstream layout drift) rather than a code bug in this repo. Happy to dig in if you can share the full job log.

https://claude.ai/code/session_01T915Erk22RSgbLEGHhB9bS

---
_Generated by [Claude Code](https://claude.ai/code/session_01T915Erk22RSgbLEGHhB9bS)_