### PR TITLE
feat(bundle-viewer): network coordinate resolution at viewer parity

### DIFF
--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/CoordinateResolver.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/CoordinateResolver.kt
@@ -7,6 +7,8 @@ import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.jvm.javaio.copyTo
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
 import kotlinx.coroutines.runBlocking
 
@@ -134,15 +136,23 @@ internal object CoordinateResolver {
     return null
   }
 
-  private fun fetchTo(url: String, dest: File): Boolean =
-    try {
-      dest.parentFile?.mkdirs()
+  /**
+   * GET [url] into [dest] (parent dirs created); true only on a 2xx with a non-empty body. The
+   * bytes land in a sibling `.part` temp file first and are moved into [dest] only on success, so a
+   * failed or empty fetch never clobbers an existing cached copy — which may be the
+   * stale-but-usable jar that [resolveOne]'s warn-never-fail fallback then returns.
+   */
+  private fun fetchTo(url: String, dest: File): Boolean {
+    val parent = dest.parentFile
+    parent?.mkdirs()
+    val tmp = File.createTempFile(dest.name, ".part", parent)
+    return try {
       val ok =
         HttpClient(OkHttp).use { client ->
           runBlocking {
             client.prepareGet(url).execute { response ->
               if (response.status.isSuccess()) {
-                dest.outputStream().use { out -> response.bodyAsChannel().copyTo(out) }
+                tmp.outputStream().use { out -> response.bodyAsChannel().copyTo(out) }
                 true
               } else {
                 false
@@ -150,16 +160,18 @@ internal object CoordinateResolver {
             }
           }
         }
-      if (ok && dest.length() > 0) {
+      if (ok && tmp.length() > 0) {
+        Files.move(tmp.toPath(), dest.toPath(), StandardCopyOption.REPLACE_EXISTING)
         true
       } else {
-        dest.delete()
         false
       }
     } catch (_: Exception) {
-      dest.delete()
       false
+    } finally {
+      tmp.delete()
     }
+  }
 
   private fun sha256Hex(file: File): String {
     val digest = MessageDigest.getInstance("SHA-256")

--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/CoordinateResolver.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/CoordinateResolver.kt
@@ -1,65 +1,106 @@
 package ee.schimke.composeai.viewer
 
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.copyTo
 import java.io.File
 import java.security.MessageDigest
+import kotlinx.coroutines.runBlocking
 
 /**
- * Resolves a bundle's detached `maven` coordinates ([ClasspathEntry.Maven]) to local jar files so
- * the viewer can add them to a bundle's child classloader. Consumer side of schema v4's
+ * Resolves a bundle's detached `maven` coordinates ([ClasspathEntry.Maven]) to jar files so the
+ * viewer can add them to a bundle's child classloader. Consumer side of schema v4's
  * content-addressing: a coordinate names *what* dependency a preview needs, and this finds the
- * bytes from whatever the machine already has.
+ * bytes from whatever the machine already has — or, failing that, downloads them.
  *
  * Mirrors `:cli`'s `CoordinateResolver` (duplicated rather than depended on, same convention as the
  * viewer's copy of `extractZipBytes`, so the viewer's module graph stays minimal):
- * - Local repos only — `~/.m2/repository` (Maven layout) and `~/.gradle/.../modules-2` (Gradle
- *   cache), overridable via `maven.repo.local` / `GRADLE_USER_HOME`. No network.
- * - When several local copies exist for one GAV, the v4 `sha256` picks the matching one.
- * - **Warn, never fail**: a miss or hash mismatch logs and still returns the best local jar (or
- *   none), so a preview renders with an almost-compatible dep rather than not at all.
+ * - **Local repos + download cache** — `~/.m2/repository` (Maven layout), `~/.gradle/.../modules-2`
+ *   (Gradle cache), and our own download cache, overridable via `maven.repo.local` /
+ *   `GRADLE_USER_HOME` / `composeai.bundle.cacheDir`. When several local copies exist for one GAV,
+ *   the v4 `sha256` picks the matching one. The cache is read regardless of the network flag.
+ * - **Remote repos** (when [networkEnabled]) — Maven Central + Google Maven by default; hit only on
+ *   a local miss, and a download is cached for next time. Off via `composeai.bundle.offline=true` /
+ *   `COMPOSE_PREVIEW_OFFLINE=1`.
+ * - **Warn, never fail**: a miss or hash mismatch logs and still returns the best jar (or none), so
+ *   a preview renders with an almost-compatible dep rather than not at all.
  */
 internal object CoordinateResolver {
 
-  /** Resolve [coords] to local jars (name-sorted, misses dropped), warning on misses/mismatches. */
+  /** Resolve [coords] to jars (misses dropped), warning on misses/mismatches. */
   fun resolve(
     coords: List<ClasspathEntry.Maven>,
     warn: (String) -> Unit = { System.err.println("compose-preview-viewer: $it") },
     repositoryRoots: List<File> = defaultRepositoryRoots(),
-  ): List<File> = coords.mapNotNull { resolveOne(it, warn, repositoryRoots) }
+    networkEnabled: Boolean = defaultNetworkEnabled(),
+    remoteRepositories: List<String> = DEFAULT_REMOTE_REPOSITORIES,
+    downloadCacheDir: File = defaultDownloadCacheDir(),
+  ): List<File> = coords.mapNotNull {
+    resolveOne(it, warn, repositoryRoots, networkEnabled, remoteRepositories, downloadCacheDir)
+  }
 
   private fun resolveOne(
     coord: ClasspathEntry.Maven,
     warn: (String) -> Unit,
     roots: List<File>,
+    networkEnabled: Boolean,
+    remoteRepositories: List<String>,
+    downloadCacheDir: File,
   ): File? {
-    val candidates = locate(coord, roots)
-    if (candidates.isEmpty()) {
-      warn(
-        "could not resolve ${coord.group}:${coord.artifact}:${coord.version} from a local " +
-          "repository; the preview may fail if it needs this dependency."
-      )
-      return null
+    // Local repos AND our download cache — a jar fetched in an earlier online run must resolve
+    // offline too (the network gate only governs *new* fetches, not reading what we already have).
+    val candidates = locate(coord, roots + downloadCacheDir)
+    val expected = coord.sha256
+
+    if (expected != null) {
+      candidates
+        .firstOrNull { sha256Hex(it).equals(expected, ignoreCase = true) }
+        ?.let {
+          return it
+        }
+    } else if (candidates.isNotEmpty()) {
+      return candidates.first()
     }
-    val expected = coord.sha256 ?: return candidates.first()
-    candidates
-      .firstOrNull { sha256Hex(it).equals(expected, ignoreCase = true) }
-      ?.let {
-        return it
+
+    // Local couldn't satisfy it; try the network before settling.
+    if (networkEnabled) {
+      val fetched = download(coord, remoteRepositories, downloadCacheDir)
+      if (fetched != null) {
+        if (expected == null || sha256Hex(fetched).equals(expected, ignoreCase = true))
+          return fetched
+        warn(
+          "hash mismatch for ${coord.group}:${coord.artifact}:${coord.version} — downloaded copy " +
+            "does not match the bundle's $expected; using it anyway."
+        )
+        return fetched
       }
-    val fallback = candidates.first()
+    }
+
+    if (candidates.isNotEmpty()) {
+      val fallback = candidates.first()
+      warn(
+        "hash mismatch for ${coord.group}:${coord.artifact}:${coord.version} — no local or remote " +
+          "copy matched; using ${fallback.name} anyway, the preview may differ slightly."
+      )
+      return fallback
+    }
     warn(
-      "hash mismatch for ${coord.group}:${coord.artifact}:${coord.version} — using ${fallback.name} " +
-        "anyway; the preview may differ slightly from the original."
+      "could not resolve ${coord.group}:${coord.artifact}:${coord.version}" +
+        "${if (networkEnabled) " from any local or remote repository" else " from a local repository"};" +
+        " the preview may fail if it needs this dependency."
     )
-    return fallback
+    return null
   }
 
   private fun locate(coord: ClasspathEntry.Maven, roots: List<File>): List<File> {
-    val jarName = "${coord.artifact}-${coord.version}.jar"
+    val jarName = artifactFileName(coord)
     val found = mutableListOf<File>()
     for (root in roots) {
       if (!root.isDirectory) continue
-      val mavenPath =
-        File(root, coord.group.replace('.', '/') + "/${coord.artifact}/${coord.version}/$jarName")
+      val mavenPath = File(root, mavenRelativePath(coord))
       if (mavenPath.isFile) found += mavenPath
       val gradleVersionDir = File(root, "${coord.group}/${coord.artifact}/${coord.version}")
       if (gradleVersionDir.isDirectory) {
@@ -74,6 +115,52 @@ internal object CoordinateResolver {
     return found
   }
 
+  /**
+   * Download [coord]'s artifact from the first [remoteRepositories] base that serves it, into
+   * [downloadCacheDir] (Maven layout); return the cached file or null (never throws). A cached copy
+   * isn't short-circuited here — [locate] already searches the cache, so reaching this means we
+   * want fresh bytes.
+   */
+  private fun download(
+    coord: ClasspathEntry.Maven,
+    remoteRepositories: List<String>,
+    downloadCacheDir: File,
+  ): File? {
+    val rel = mavenRelativePath(coord)
+    val dest = File(downloadCacheDir, rel)
+    for (base in remoteRepositories) {
+      if (fetchTo(base.trimEnd('/') + "/" + rel, dest)) return dest
+    }
+    return null
+  }
+
+  private fun fetchTo(url: String, dest: File): Boolean =
+    try {
+      dest.parentFile?.mkdirs()
+      val ok =
+        HttpClient(OkHttp).use { client ->
+          runBlocking {
+            client.prepareGet(url).execute { response ->
+              if (response.status.isSuccess()) {
+                dest.outputStream().use { out -> response.bodyAsChannel().copyTo(out) }
+                true
+              } else {
+                false
+              }
+            }
+          }
+        }
+      if (ok && dest.length() > 0) {
+        true
+      } else {
+        dest.delete()
+        false
+      }
+    } catch (_: Exception) {
+      dest.delete()
+      false
+    }
+
   private fun sha256Hex(file: File): String {
     val digest = MessageDigest.getInstance("SHA-256")
     file.inputStream().use { input ->
@@ -87,6 +174,18 @@ internal object CoordinateResolver {
     return digest.digest().joinToString("") { "%02x".format(it) }
   }
 
+  /** Maven Central + Google Maven, the two repos that serve almost every Compose/AndroidX dep. */
+  val DEFAULT_REMOTE_REPOSITORIES: List<String> =
+    listOf("https://repo1.maven.org/maven2", "https://dl.google.com/dl/android/maven2")
+
+  /** `<artifact>-<version>.<type>` — `type` is `jar` (desktop) or `aar` (Android). */
+  private fun artifactFileName(coord: ClasspathEntry.Maven): String =
+    "${coord.artifact}-${coord.version}.${coord.type.ifBlank { "jar" }}"
+
+  /** `<group as path>/<artifact>/<version>/<artifact>-<version>.<type>`. */
+  private fun mavenRelativePath(coord: ClasspathEntry.Maven): String =
+    coord.group.replace('.', '/') + "/${coord.artifact}/${coord.version}/${artifactFileName(coord)}"
+
   private fun defaultRepositoryRoots(): List<File> {
     val home = System.getProperty("user.home")?.let(::File)
     val roots = mutableListOf<File>()
@@ -96,5 +195,19 @@ internal object CoordinateResolver {
       System.getenv("GRADLE_USER_HOME")?.let(::File) ?: home?.let { File(it, ".gradle") }
     if (gradleHome != null) roots += File(gradleHome, "caches/modules-2/files-2.1")
     return roots
+  }
+
+  private fun defaultNetworkEnabled(): Boolean {
+    if (System.getProperty("composeai.bundle.offline").toBoolean()) return false
+    if (System.getenv("COMPOSE_PREVIEW_OFFLINE") == "1") return false
+    return true
+  }
+
+  private fun defaultDownloadCacheDir(): File {
+    System.getProperty("composeai.bundle.cacheDir")?.let {
+      return File(it)
+    }
+    val home = System.getProperty("user.home")?.let(::File) ?: File(".")
+    return File(home, ".cache/compose-preview/bundle-deps")
   }
 }

--- a/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/CoordinateResolverTest.kt
+++ b/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/CoordinateResolverTest.kt
@@ -181,6 +181,24 @@ class CoordinateResolverTest {
   }
 
   @Test
+  fun `a failed download keeps a stale cached jar for the fallback`() {
+    // The cache holds a copy whose bytes don't match the bundle's hash, and the remote 404s. The
+    // failed fetch must not delete the cached file: warn-never-fail returns it as the best jar.
+    val cached =
+      File(cacheDir, "com/example/foo/widgets/1.2.3/widgets-1.2.3.jar").apply {
+        parentFile.mkdirs()
+        writeBytes(byteArrayOf(9, 9, 9))
+      }
+    val base = startRepo(status = 404)
+
+    val out = resolveNetwork(base, maven(sha = "c".repeat(64)))
+
+    assertThat(out.map { it.canonicalFile }).containsExactly(cached.canonicalFile)
+    assertThat(cached.isFile).isTrue()
+    assertThat(warnings.any { it.contains("hash mismatch") }).isTrue()
+  }
+
+  @Test
   fun `remote 404 is dropped with a warning, never throws`() {
     val base = startRepo(status = 404)
 

--- a/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/CoordinateResolverTest.kt
+++ b/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/CoordinateResolverTest.kt
@@ -1,25 +1,46 @@
 package ee.schimke.composeai.viewer
 
 import com.google.common.truth.Truth.assertThat
+import com.sun.net.httpserver.HttpServer
 import java.io.File
+import java.net.InetSocketAddress
 import java.nio.file.Files
 import java.security.MessageDigest
 import org.junit.After
 import org.junit.Test
 
 /**
- * Offline coverage for the viewer's [CoordinateResolver] — resolves a bundle's detached `maven`
- * coordinates to local jars against a temp repo dir (no network), exercising the
- * pick-matching-candidate and warn-not-fail behaviour the cli resolver also guarantees.
+ * Coverage for the viewer's [CoordinateResolver]. Local-repo cases run with network disabled
+ * (hermetic, temp repo dir); the network cases use a throwaway loopback [HttpServer] as a fake
+ * remote Maven repo — no real network. Mirrors the cli resolver's behaviour:
+ * pick-matching-candidate, download-on-miss + cache, offline cache read, jar/aar by type,
+ * warn-not-fail.
  */
 class CoordinateResolverTest {
 
   private val root = Files.createTempDirectory("viewer-coord-test-").toFile()
+  private val cacheDir = Files.createTempDirectory("viewer-coord-cache-").toFile()
   private val warnings = mutableListOf<String>()
+  private var server: HttpServer? = null
 
   @After
   fun cleanup() {
+    server?.stop(0)
     root.deleteRecursively()
+    cacheDir.deleteRecursively()
+  }
+
+  /** A loopback Maven repo that serves [body] for any path; returns its base URL. */
+  private fun startRepo(status: Int = 200, body: ByteArray = byteArrayOf(1)): String {
+    val s = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    s.createContext("/") { exchange ->
+      val len = if (body.isEmpty() || status >= 400) -1L else body.size.toLong()
+      exchange.sendResponseHeaders(status, len)
+      exchange.responseBody.use { if (status < 400 && body.isNotEmpty()) it.write(body) }
+    }
+    s.start()
+    server = s
+    return "http://127.0.0.1:${s.address.port}"
   }
 
   private fun maven(sha: String? = null) =
@@ -48,11 +69,25 @@ class CoordinateResolverTest {
   private fun sha256(bytes: ByteArray): String =
     MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
 
+  /** Local-only resolve: network off so a miss stays hermetic. */
   private fun resolve(vararg coords: ClasspathEntry.Maven): List<File> =
     CoordinateResolver.resolve(
       coords.toList(),
       warn = { warnings += it },
       repositoryRoots = listOf(root),
+      networkEnabled = false,
+      downloadCacheDir = cacheDir,
+    )
+
+  /** Network-enabled resolve pointed only at [base], caching into [cacheDir]. */
+  private fun resolveNetwork(base: String, vararg coords: ClasspathEntry.Maven): List<File> =
+    CoordinateResolver.resolve(
+      coords.toList(),
+      warn = { warnings += it },
+      repositoryRoots = listOf(root),
+      networkEnabled = true,
+      remoteRepositories = listOf(base),
+      downloadCacheDir = cacheDir,
     )
 
   @Test
@@ -94,5 +129,64 @@ class CoordinateResolverTest {
 
     assertThat(out.map { it.canonicalFile }).containsExactly(jar.canonicalFile)
     assertThat(warnings.any { it.contains("hash mismatch") }).isTrue()
+  }
+
+  @Test
+  fun `downloads from a remote repo on a local miss, and caches it`() {
+    val bytes = byteArrayOf(7, 7, 7, 7)
+    val base = startRepo(body = bytes)
+
+    val out = resolveNetwork(base, maven(sha = sha256(bytes)))
+
+    val cached = File(cacheDir, "com/example/foo/widgets/1.2.3/widgets-1.2.3.jar")
+    assertThat(out.map { it.canonicalFile }).containsExactly(cached.canonicalFile)
+    assertThat(cached.readBytes().toList()).isEqualTo(bytes.toList())
+    assertThat(warnings).isEmpty()
+  }
+
+  @Test
+  fun `a prior download is read offline from the cache`() {
+    val bytes = byteArrayOf(8, 8, 8)
+    File(cacheDir, "com/example/foo/widgets/1.2.3/widgets-1.2.3.jar").apply {
+      parentFile.mkdirs()
+      writeBytes(bytes)
+    }
+
+    // Network off — must still resolve from the cache populated by an earlier online run.
+    val out = resolve(maven(sha = sha256(bytes)))
+
+    assertThat(out).hasSize(1)
+    assertThat(warnings).isEmpty()
+  }
+
+  @Test
+  fun `aar coordinate resolves by its type extension`() {
+    val bytes = byteArrayOf(5, 0, 5)
+    val aar = File(root, "com/example/foo/widgets/1.2.3/widgets-1.2.3.aar")
+    aar.parentFile.mkdirs()
+    aar.writeBytes(bytes)
+
+    val coord =
+      ClasspathEntry.Maven(
+        group = "com.example.foo",
+        artifact = "widgets",
+        version = "1.2.3",
+        type = "aar",
+        sha256 = sha256(bytes),
+      )
+    val out = resolve(coord)
+
+    assertThat(out.map { it.canonicalFile }).containsExactly(aar.canonicalFile)
+    assertThat(warnings).isEmpty()
+  }
+
+  @Test
+  fun `remote 404 is dropped with a warning, never throws`() {
+    val base = startRepo(status = 404)
+
+    val out = resolveNetwork(base, maven(sha = "a".repeat(64)))
+
+    assertThat(out).isEmpty()
+    assertThat(warnings.any { it.contains("could not resolve") }).isTrue()
   }
 }


### PR DESCRIPTION
## Summary

Brings the **viewer's** `CoordinateResolver` to parity with `:cli`'s (#1632 follow-up). It was local-only, so the desktop viewer (`compose-preview-viewer`) couldn't render a default coordinate bundle whose deps weren't already in `~/.m2` / the Gradle cache — unlike `bundle render` / `bundle daemon`, which got the network source + hardening in earlier PRs.

Ports the cli resolver's full behaviour into the viewer's copy (still duplicated, not depended on — same convention as its `extractZipBytes`):
- **Network source**: on a local miss, download from Maven Central / Google Maven and cache (Maven layout). Off via `composeai.bundle.offline=true` / `COMPOSE_PREVIEW_OFFLINE=1`.
- **Offline cache read**: the download cache is searched regardless of the network flag, so a jar fetched online resolves on a later offline run.
- **Type extension**: resolve `<artifact>-<version>.<type>` (jar/aar), not a hardcoded `.jar`.
- **Warn-never-fail** throughout; a local hash-match still wins with no network call.

`BundleLoader` KDoc updated (local + remote). Uses the Ktor/OkHttp client already on the viewer classpath.

## Test plan
- `CoordinateResolverTest`: existing local cases (now pinned `networkEnabled=false`) + new download+cache, offline-cache-read, aar-by-type, and remote-404 cases via a loopback `HttpServer`. All offline. ✅
- `:bundle-viewer` compile + ktfmt clean; `:bundle-viewer:test` green.

This finishes "all three players resolve coordinates identically" — render, daemon, and the GUI viewer now share the same local→remote→verify→offline-reuse behaviour.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pkfwxdoh2qrkS44z8pdFJs)_