### PR TITLE
feat(bundle): register composePreviewBundle on the Android path

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1688,10 +1688,12 @@ internal object AndroidPreviewSupport {
     // sees real bytecode. `backendId = "android"` is recorded in bundle.json so players know the
     // bundle was packed for the Robolectric/Android renderer.
     //
-    // Limitations carried for now (desktop parity / future work): Maven coordinates are recorded
-    // with type `jar` even for AAR-backed deps, and Android-merged resources aren't packed — both
-    // only matter for coordinate-mode re-rendering on an Android player, which isn't built yet.
-    // `--embed-deps` sidesteps the coordinate-type concern entirely by inlining the resolved jars.
+    // AAR-backed Maven deps are recorded as real `ClasspathEntry.Maven` coordinates (not inlined):
+    // registerBundleTask keys the coordinate map off the same `artifactType=jar` view, so the
+    // transformed classes.jar paths match what the closure walk sees. Limitation carried for now
+    // (only matters for coordinate-mode re-rendering on an Android player, which isn't built yet):
+    // the coordinate type is recorded as `jar` even for AAR-published deps, and Android-merged
+    // resources aren't packed. `--embed-deps` sidesteps the type concern by inlining resolved jars.
     ComposePreviewTasks.registerBundleTask(
       project = project,
       extension = extension,

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1680,6 +1680,28 @@ internal object AndroidPreviewSupport {
 
     ComposePreviewTasks.registerRenderAllPreviews(project, extension, renderTask, previewOutputDir)
 
+    // Register the portable-bundle task on the Android path too. `composePreviewBundle` was
+    // previously desktop/JVM-only, so `compose-preview render --bundle` against a project with
+    // Android modules failed task-not-found before rendering anything. Wire it with the same
+    // variant class dirs and `${variant}RuntimeClasspath` the render path consumes — the bundle's
+    // `artifactType=jar` view already transforms AARs to extracted classes.jar, so the closure walk
+    // sees real bytecode. `backendId = "android"` is recorded in bundle.json so players know the
+    // bundle was packed for the Robolectric/Android renderer.
+    //
+    // Limitations carried for now (desktop parity / future work): Maven coordinates are recorded
+    // with type `jar` even for AAR-backed deps, and Android-merged resources aren't packed — both
+    // only matter for coordinate-mode re-rendering on an Android player, which isn't built yet.
+    // `--embed-deps` sidesteps the coordinate-type concern entirely by inlining the resolved jars.
+    ComposePreviewTasks.registerBundleTask(
+      project = project,
+      extension = extension,
+      previewOutputDir = previewOutputDir,
+      sourceClassDirs = sourceClassDirs,
+      resolveDependencyConfigName = { dependencyConfigName },
+      discoverTaskName = "composePreviewDiscover",
+      backendId = "android",
+    )
+
     // Phase 1, Stream A — preview daemon bootstrap descriptor. Registered
     // unconditionally so the VS Code extension can sniff the output file
     // even when `daemon.enabled = false` (it then refuses to

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -232,11 +232,18 @@ internal object ComposePreviewTasks {
 
     val artifactTypeAttr = Attribute.of("artifactType", String::class.java)
     val depConfig = project.configurations.findByName(resolveDependencyConfigName())
-    val depJarFiles = depConfig?.let { config ->
-      // `artifactType=jar` view: AAR consumers transform to extracted classes.jar; pure JVM
-      // consumers pass through. Either way we get real jars on the closure walk.
-      config.incoming.artifactView { attributes.attribute(artifactTypeAttr, "jar") }.files
-    }
+    // `artifactType=jar` view: AAR consumers transform to extracted classes.jar; pure JVM consumers
+    // pass through. Either way we get real jars on the closure walk. The coordinate map below MUST
+    // be built from THIS SAME view's resolvedArtifacts, not the configuration's untransformed
+    // artifacts — otherwise an AAR dep's transformed classes.jar path (what `dependencyJars` and
+    // the
+    // closure walk see) wouldn't match the coordinate-map key (the untransformed `.aar` path), so
+    // the task would treat the Maven dep as an anonymous/project jar and inline it instead of
+    // recording a `ClasspathEntry.Maven`. On JVM this view is a passthrough, so desktop is
+    // unchanged; on Android it's what makes coordinate-mode bundles stay small + re-resolvable.
+    val depJarView =
+      depConfig?.incoming?.artifactView { attributes.attribute(artifactTypeAttr, "jar") }
+    val depJarFiles = depJarView?.files
     // Map each resolved dependency jar to a coordinate string the task action can fold into
     // `bundle.json`'s `classpath`:
     // - `maven:<group>:<artifact>:<version>:jar` for Maven-resolved deps (the player resolves at
@@ -244,9 +251,11 @@ internal object ComposePreviewTasks {
     // - `project:<gradle path>` for project-local deps (the task inlines those into the bundle
     //   since they can't be re-resolved from Maven).
     //
-    // Resolution happens via `Provider` transformations, so this stays config-cache-safe.
+    // Resolution happens via `Provider` transformations, so this stays config-cache-safe. The
+    // transformed artifact keeps its original `componentIdentifier` (the Maven module / project),
+    // so coordinates resolve correctly even though `.file` points at the extracted classes.jar.
     val coordMapProvider: Provider<Map<String, String>> =
-      depConfig?.incoming?.artifacts?.resolvedArtifacts?.map { artifacts ->
+      depJarView?.artifacts?.resolvedArtifacts?.map { artifacts ->
         artifacts.associate { artifact ->
           val id = artifact.id.componentIdentifier
           val value =

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -206,13 +206,17 @@ internal object ComposePreviewTasks {
    * `composePreviewRender` first (the CLI shells through `composePreviewRender
    * composePreviewBundle` as a single Gradle invocation).
    */
-  private fun registerBundleTask(
+  internal fun registerBundleTask(
     project: Project,
     extension: PreviewExtension,
     previewOutputDir: Provider<Directory>,
     sourceClassDirs: FileCollection,
     resolveDependencyConfigName: () -> String,
     discoverTaskName: String,
+    // Recorded into `bundle.json`'s `backend` field. "desktop" for the CMP/JVM path; the Android
+    // path (AndroidPreviewSupport) passes "android" so players know which renderer the bundle was
+    // packed for. Packing itself is backend-agnostic — the closure walk only sees JVM bytecode.
+    backendId: String = "desktop",
   ) {
     val previewIdsProperty: Provider<List<String>> =
       project.providers.gradleProperty("bundlePreviewIds").map { raw ->
@@ -295,7 +299,7 @@ internal object ComposePreviewTasks {
       previewIds.set(previewIdsProperty.orElse(emptyList()))
       embedDeps.set(embedDepsProperty.orElse(false))
       modulePath.set(project.path)
-      backend.set("desktop")
+      backend.set(backendId)
       producedBy.set("compose-preview $pluginVersionProperty")
       output.set(project.layout.file(resolvedOutput))
       group = "compose preview"

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RegisterBundleTaskBackendTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RegisterBundleTaskBackendTest.kt
@@ -1,0 +1,73 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the backend wiring of [ComposePreviewTasks.registerBundleTask] without standing up AGP/KGP.
+ *
+ * `composePreviewBundle` was originally registered only on the desktop/JVM path, so
+ * `compose-preview render --bundle` against a project containing Android modules failed
+ * task-not-found before rendering anything. The Android path now calls the same shared registration
+ * with `backendId = "android"`; this test exercises that registration directly via a synthetic
+ * project and asserts the resulting task records the right `backend` for `bundle.json`.
+ */
+class RegisterBundleTaskBackendTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  private fun registerBundle(backendId: String): BundlePreviewTask {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    ComposePreviewTasks.registerBundleTask(
+      project = project,
+      extension = extension,
+      previewOutputDir = project.layout.buildDirectory.dir("compose-previews"),
+      sourceClassDirs = project.files("build/classes/kotlin/main"),
+      resolveDependencyConfigName = { "runtimeClasspath" },
+      discoverTaskName = "composePreviewDiscover",
+      backendId = backendId,
+    )
+    return project.tasks.getByName("composePreviewBundle") as BundlePreviewTask
+  }
+
+  @Test
+  fun `android registration records the android backend`() {
+    assertThat(registerBundle("android").backend.get()).isEqualTo("android")
+  }
+
+  @Test
+  fun `backend defaults to desktop`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    // No backendId argument — the default must stay "desktop" so the CMP/JVM path is unchanged.
+    ComposePreviewTasks.registerBundleTask(
+      project = project,
+      extension = extension,
+      previewOutputDir = project.layout.buildDirectory.dir("compose-previews"),
+      sourceClassDirs = project.files("build/classes/kotlin/main"),
+      resolveDependencyConfigName = { "runtimeClasspath" },
+      discoverTaskName = "composePreviewDiscover",
+    )
+    val task = project.tasks.getByName("composePreviewBundle") as BundlePreviewTask
+    assertThat(task.backend.get()).isEqualTo("desktop")
+  }
+
+  @Test
+  fun `desktop task registration still wires the bundle task with the desktop backend`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    project.configurations.create("desktopRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+
+    ComposePreviewTasks.registerDesktopTasks(project, extension)
+
+    val task = project.tasks.getByName("composePreviewBundle") as BundlePreviewTask
+    assertThat(task.backend.get()).isEqualTo("desktop")
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #1641. Codex correctly flagged that `composePreviewBundle` is registered only on the desktop/JVM path (`ComposePreviewTasks.registerDesktopTasks`), while classic Android modules (`com.android.application`/`library`) go through `AndroidPreviewSupport.registerAndroidTasks` and register `composePreviewRenderAll` but **not** the bundle task. So `compose-preview render --bundle` against any project containing Android modules failed with a task-not-found error before rendering anything.

Per the chosen direction ("also support Android bundles"), this registers the bundle task on the Android path so Android modules are bundle-capable — which also removes the crash.

### Changes
- `registerBundleTask` is now `internal` and takes a `backendId: String = "desktop"` parameter (recorded in `bundle.json`'s `backend` field). Desktop behaviour is unchanged by default.
- `AndroidPreviewSupport.registerAndroidTasks` calls `registerBundleTask(...)` with the variant class dirs and `${variant}RuntimeClasspath` the render path already consumes, and `backendId = "android"`. The bundle's `artifactType=jar` artifact view already transforms AARs to extracted `classes.jar`, and the ClassGraph closure walk is pure-bytecode, so packing works unchanged.

### Known follow-ups (documented inline)
These only affect coordinate-mode **re-rendering** on an Android player, which isn't built yet:
- Maven coordinates are recorded with type `jar` even for AAR-backed deps (desktop parity).
- Android-merged resources aren't packed.
- `--embed-deps` sidesteps the coordinate-type gap entirely by inlining the resolved jars.

## Test plan
- New `RegisterBundleTaskBackendTest` (`:gradle-plugin:test`, ProjectBuilder-based, no Android SDK needed):
  - Android registration records `backend == "android"`;
  - default `backendId` stays `"desktop"`;
  - `registerDesktopTasks` still wires `composePreviewBundle` with `backend == "desktop"`.
- `./gradlew :gradle-plugin:test --tests "*.RegisterBundleTaskBackendTest" --tests "*.KmpAndroidDesktopRoutingTest"` → BUILD SUCCESSFUL.
- `:gradle-plugin:ktfmtFormat` clean.
- Full Android E2E (bundling a real `com.android.library` module) is exercised by the SDK-gated `functionalTestWithAndroid` chain in CI; not runnable in SDK-less dev environments.

https://claude.ai/code/session_01GsJZfW6xT9JDJuvmHsUeA1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsJZfW6xT9JDJuvmHsUeA1)_