### PR TITLE
refactor(cli): doctor HEAD probes use the Ktor/OkHttp client

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -1,10 +1,14 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.plugin.tooling.ModuleInfo
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.head
+import io.ktor.client.request.header
 import java.io.File
-import java.net.HttpURLConnection
-import java.net.URI
 import kotlin.system.exitProcess
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -1024,19 +1028,13 @@ class DoctorCommand(private val args: List<String>) {
     val latestUrl = "https://github.com/$REPO/releases/latest"
     val resolved =
       try {
-        val conn =
-          (URI(latestUrl).toURL().openConnection() as HttpURLConnection).apply {
-            requestMethod = "HEAD"
-            connectTimeout = 3_000
-            readTimeout = 3_000
-            instanceFollowRedirects = true
-            setRequestProperty("User-Agent", "compose-preview-doctor")
+        httpProbeClient().use { client ->
+          runBlocking {
+            // HEAD with redirects followed (Ktor follows for HEAD by default); the final request
+            // URL is the `…/releases/tag/v<version>` the `releases/latest` 302 lands on.
+            val response = client.head(latestUrl) { header("User-Agent", USER_AGENT) }
+            response.call.request.url.toString()
           }
-        try {
-          conn.responseCode // force the request
-          conn.url.toString()
-        } finally {
-          conn.disconnect()
         }
       } catch (e: Exception) {
         addCheck(
@@ -1140,26 +1138,37 @@ class DoctorCommand(private val args: List<String>) {
     }
   }
 
-  private fun headPlain(url: String): Pair<Int, Map<String, String>> {
-    val conn =
-      (URI(url).toURL().openConnection() as HttpURLConnection).apply {
-        requestMethod = "HEAD"
-        connectTimeout = 3_000
-        readTimeout = 3_000
-        instanceFollowRedirects = true
-        setRequestProperty("User-Agent", "compose-preview-doctor")
+  /**
+   * HEAD [url] and return its status code + response headers, or `-1 to {error}` when the host is
+   * unreachable (never throws). A non-2xx is still a real response — its code comes back unchanged
+   * so [checkNetworkReach] reports "reachable (HTTP 404)" rather than a failure.
+   */
+  internal fun headPlain(url: String): Pair<Int, Map<String, String>> =
+    try {
+      httpProbeClient().use { client ->
+        runBlocking {
+          val response = client.head(url) { header("User-Agent", USER_AGENT) }
+          val headers = response.headers.entries().associate { (k, v) -> k to v.joinToString(", ") }
+          response.status.value to headers
+        }
       }
-    return try {
-      val code = conn.responseCode
-      val headers =
-        conn.headerFields.filterKeys { it != null }.mapValues { it.value.joinToString(", ") }
-      code to headers
     } catch (e: Exception) {
       -1 to mapOf("error" to (e.message ?: e.javaClass.simpleName))
-    } finally {
-      conn.disconnect()
     }
-  }
+
+  /**
+   * A Ktor/OkHttp client tuned for doctor's one-shot HEAD probes: 3s connect + request timeouts,
+   * redirects followed (the engine default for HEAD). One client per probe — doctor isn't a hot
+   * path, and `use {}` tears the connection pool down immediately. Mirrors the Ktor/OkHttp client
+   * the rest of the CLI already uses (see [BundleSource]).
+   */
+  private fun httpProbeClient(): HttpClient =
+    HttpClient(OkHttp) {
+      install(HttpTimeout) {
+        connectTimeoutMillis = 3_000
+        requestTimeoutMillis = 3_000
+      }
+    }
 
   /**
    * Sanitise a module path (e.g. `:app` → `app`, `:samples:wear` → `samples:wear`) for use in check
@@ -1235,6 +1244,9 @@ class DoctorCommand(private val args: List<String>) {
      */
     private const val MIN_BOM_YEAR = 2025
     private const val MIN_BOM_MONTH = 1
+
+    /** User-Agent for doctor's HEAD probes — matches the string `scripts/install.sh` sends. */
+    private const val USER_AGENT = "compose-preview-doctor"
 
     /**
      * Highest JDK we trust to drive AGP without surfacing the issue-1544-class footguns

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DoctorNetworkProbeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DoctorNetworkProbeTest.kt
@@ -1,0 +1,66 @@
+package ee.schimke.composeai.cli
+
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [DoctorCommand.headPlain] after its move to the Ktor/OkHttp client. A throwaway
+ * loopback [HttpServer] stands in for a remote host — no real network. Asserts the behaviour
+ * [checkNetworkReach] depends on: a real response (any status) reports its code, an unreachable
+ * host folds to `-1 to {error}` without throwing.
+ */
+class DoctorNetworkProbeTest {
+  private var server: HttpServer? = null
+
+  @AfterTest
+  fun cleanup() {
+    server?.stop(0)
+  }
+
+  private fun startServer(status: Int): String {
+    val s = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    s.createContext("/") { exchange ->
+      exchange.responseHeaders.add("X-Probe", "yes")
+      exchange.sendResponseHeaders(status, -1)
+      exchange.close()
+    }
+    s.start()
+    server = s
+    return "http://127.0.0.1:${s.address.port}/"
+  }
+
+  @Test
+  fun `reachable host returns its status code and headers`() {
+    val url = startServer(200)
+
+    val (code, headers) = DoctorCommand(emptyList()).headPlain(url)
+
+    assertEquals(200, code)
+    assertTrue(
+      headers.keys.any { it.equals("X-Probe", ignoreCase = true) },
+      "expected the probe header to round-trip: $headers",
+    )
+  }
+
+  @Test
+  fun `a non-2xx is still a reachable response, not an error`() {
+    val url = startServer(404)
+
+    val (code, _) = DoctorCommand(emptyList()).headPlain(url)
+
+    assertEquals(404, code)
+  }
+
+  @Test
+  fun `an unreachable host returns -1 and an error, never throws`() {
+    // Nothing is listening on port 1 — the connection is refused fast, well inside the 3s timeout.
+    val (code, headers) = DoctorCommand(emptyList()).headPlain("http://127.0.0.1:1/")
+
+    assertEquals(-1, code)
+    assertTrue(headers.containsKey("error"), "expected an error entry: $headers")
+  }
+}


### PR DESCRIPTION
## Summary

`DoctorCommand` was the last `java.net.HttpURLConnection` user in the CLI. This moves its two HEAD probes — the `releases/latest` update check (`checkBundleVersion`) and the Google-host network-reach probes (`headPlain` / `checkNetworkReach`) — onto the same Ktor client (OkHttp engine) the rest of the CLI already uses (`BundleSource`, the coordinate resolver). #1632 follow-up: one HTTP client across the codebase.

- New `httpProbeClient()` builder: `HttpClient(OkHttp)` with a 3s connect + request `HttpTimeout` (matching the old `connectTimeout`/`readTimeout`).
- Behaviour preserved:
  - HEAD with redirects followed (Ktor's default for HEAD), so the update check still reads the final `…/releases/tag/v<version>` URL off `response.call.request.url`.
  - A non-2xx is still a *reachable* response — its code comes back unchanged (`reachable (HTTP 404)`), not an error.
  - An unreachable host folds to `-1 to {error}` without throwing.
- `headPlain` is now `internal` so it can be tested directly.
- Drops the `java.net.HttpURLConnection` / `java.net.URI` imports; centralizes the `User-Agent` string as a `USER_AGENT` const.

No public output change — the `compose-preview-doctor/v1` report schema and all check ids/messages are untouched.

## Test plan
- New `DoctorNetworkProbeTest` (`:cli:test`) drives `headPlain` against a loopback `HttpServer`:
  - reachable host → status code + headers round-trip;
  - 404 → still reports `404` (reachable, not an error);
  - refused connection → `-1` + an `error` entry, never throws.
- `./gradlew :cli:compileKotlin :cli:ktfmtCheck :cli:test --tests "*.DoctorNetworkProbeTest" --tests "*.DoctorReportSerializationTest" --tests "*.McpDoctorTest"` → BUILD SUCCESSFUL (run on JDK 17).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pkfwxdoh2qrkS44z8pdFJs)_