### PR TITLE
feat(bundle-viewer): ship the viewer as a runnable Compose uber jar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
           ./gradlew \
             :cli:distZip :cli:distTar \
             :mcp:distZip :mcp:distTar \
-            :bundle-viewer:distZip :bundle-viewer:distTar
+            :bundle-viewer:packageUberJarForCurrentOS
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cli-dist
@@ -159,15 +159,17 @@ jobs:
             mcp/build/distributions/compose-preview-mcp-*.zip
             mcp/build/distributions/compose-preview-mcp-*.tar.gz
           retention-days: 1
-      # Viewer ships its full Compose Multiplatform Desktop + Skiko runtime in `lib/`, so the
-      # tarball is ~37 MB on Linux. Same single-artifact / single-parent path shape as the CLI
-      # and MCP uploads so the `release` job's flat `artifacts/*.{zip,tar.gz}` glob picks it up.
+      # The viewer ships as a single self-contained Compose Desktop uber jar
+      # (`compose-preview-viewer-<os>-<arch>-<ver>.jar`, ~40 MB — it carries its own Compose
+      # Multiplatform + Skiko runtime), built by Compose's `packageUberJarForCurrentOS`. A colleague
+      # `java -jar`s it on bundle.png with nothing unpacked (portable-bundles.md Tier 2.2). This
+      # runner is Linux, so the jar carries the linux-x64 Skiko native — it's the per-OS artefact for
+      # Linux recipients. Single-parent path (`bundle-viewer/build/compose/jars/`) so the artifact's
+      # LCA stays flat and the `release` job's `artifacts/*.jar` glob picks it up.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: bundle-viewer-dist
-          path: |
-            bundle-viewer/build/distributions/compose-preview-viewer-*.zip
-            bundle-viewer/build/distributions/compose-preview-viewer-*.tar.gz
+          name: bundle-viewer-uberjar
+          path: bundle-viewer/build/compose/jars/compose-preview-viewer-*.jar
           retention-days: 1
 
   build-vscode-extension:
@@ -302,6 +304,7 @@ jobs:
               --clobber \
               artifacts/*.zip \
               artifacts/*.tar.gz \
+              artifacts/*.jar \
               artifacts/*.vsix
           else
             echo "Release $TAG_NAME does not exist — creating."
@@ -310,5 +313,6 @@ jobs:
               --generate-notes \
               artifacts/*.zip \
               artifacts/*.tar.gz \
+              artifacts/*.jar \
               artifacts/*.vsix
           fi

--- a/bundle-viewer/build.gradle.kts
+++ b/bundle-viewer/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 plugins {
   id("composeai.base-conventions")
   id("composeai.jvm-conventions")
@@ -7,7 +5,6 @@ plugins {
   alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.compose.multiplatform)
   alias(libs.plugins.compose.compiler)
-  application
 }
 
 // Version derivation mirrors `:cli/build.gradle.kts` — CI sets `PLUGIN_VERSION` from the git
@@ -24,28 +21,31 @@ version =
       "$major.$minor.${patch + 1}-SNAPSHOT"
     }
 
-// `archivesName` drives the distZip / distTar file name (`<archivesName>-<version>.<ext>`) AND
-// the root directory inside the archive. Pinning here gives us `compose-preview-viewer-<ver>.zip`
-// / `compose-preview-viewer-<ver>.tar.gz` on disk and a matching root dir inside — same shape
-// the CLI uses and what the `gh release upload` glob in `.github/workflows/release.yml` expects.
 base { archivesName.set("compose-preview-viewer") }
 
-application {
-  applicationName = "compose-preview-viewer"
-  mainClass.set("ee.schimke.composeai.viewer.MainKt")
-  // Compose Multiplatform Desktop's Skiko loader uses `System.load` for native libs. JDK 24+
-  // would otherwise print a 4-line warning on every launch; pre-declaring native access for the
-  // unnamed module silences it.
-  applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")
-}
-
-// Match the CLI's archive-extension trick. `archiveExtension = "tar.gz"` lets Gradle compute
-// the file name as `<archivesName>-<version>.tar.gz` while keeping the extracted-archive root
-// dir at `<archivesName>-<version>/`. Setting `archiveFileName` directly would leak the
-// `.tar.gz` suffix into the extracted folder name — see the warning in `:cli/build.gradle.kts`.
-tasks.named<Tar>("distTar") {
-  archiveExtension.set("tar.gz")
-  compression = Compression.GZIP
+// The viewer is a Compose Desktop application, configured through Compose Multiplatform's own
+// `compose.desktop.application` DSL rather than the JVM `application` plugin. The DSL's
+// `packageUberJarForCurrentOS` is what makes the viewer portable: a single self-contained
+// `compose-preview-viewer-<os>-<arch>-<ver>.jar` (the current OS's Compose Desktop + Skiko runtime
+// flattened in), so a colleague can `java -jar compose-preview-viewer-linux-x64-<ver>.jar foo.png`
+// with nothing unpacked (portable-bundles.md Tier 2.2). It bundles Skiko's native libs and merges
+// Compose's service files correctly, and stays Isolated-Projects-clean — unlike the GradleUp Shadow
+// plugin, whose optional-property lookup walks to the parent project and trips this repo's
+// `isolated-projects=true` + `configuration-cache.problems=fail` gate.
+//
+// We drop the JVM `application` plugin entirely (its slim `distZip`/`distTar` is superseded by the
+// drag-around uber jar, and keeping both registers two colliding `run` tasks). The DSL still offers
+// `createDistributable` (an unpacked app dir) and `packageDeb`/`packageDmg`/`packageMsi` for the
+// native-installer follow-up, if those are ever wanted.
+compose.desktop {
+  application {
+    mainClass = "ee.schimke.composeai.viewer.MainKt"
+    // Compose Multiplatform Desktop's Skiko loader uses `System.load` for native libs. JDK 24+
+    // would otherwise print a 4-line warning on every launch; pre-declaring native access for the
+    // unnamed module silences it (parity with the old applicationDefaultJvmArgs).
+    jvmArgs += "--enable-native-access=ALL-UNNAMED"
+    nativeDistributions { packageName = "compose-preview-viewer" }
+  }
 }
 
 dependencies {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -47,10 +47,10 @@ Both fallbacks share the same concurrency group as the primary path, so they can
    - **Data product connectors** — `ee.schimke.composeai:data-*-connector` artifacts used by daemon modules, including recomposition
 
    Maven Central is the only Maven coordinate source — we no longer mirror jars onto GitHub Packages. Consumers point Gradle at `mavenCentral()` and resolve every module from there.
-2. Builds the **CLI**, the standalone **MCP server**, and the **bundle viewer** as `.zip` and `.tar.gz` distributions:
+2. Builds the **CLI** and the standalone **MCP server** as `.zip` / `.tar.gz` distributions, and the **bundle viewer** as a single runnable uber jar:
    - `compose-preview-<ver>.{zip,tar.gz}` — the CLI; tarball already implementation-bundles `:mcp` and the desktop renderer.
    - `compose-preview-mcp-<ver>.{zip,tar.gz}` — the MCP server standalone for consumers who want to wire it into an MCP client without dragging the CLI in.
-   - `compose-preview-viewer-<ver>.{zip,tar.gz}` — single-window Compose Desktop app (`compose-preview-viewer <bundle.png>` or drag-and-drop) that opens a packed bundle and renders its `@Preview` composable live. Bigger than the CLI archive (~37 MB on Linux) because it ships its own Compose Multiplatform + Skiko runtime.
+   - `compose-preview-viewer-<os>-<arch>-<ver>.jar` — single-window Compose Desktop app, built by Compose's `packageUberJarForCurrentOS`, that opens a packed bundle and renders its `@Preview` composable live (`java -jar compose-preview-viewer-<os>-<arch>-<ver>.jar <bundle.png>`, or drag-and-drop). One self-contained file — no unpacking — but **per-OS** (it carries that OS's Compose Multiplatform + Skiko runtime, ~40 MB). The release runner is Linux, so today's published jar is `linux-x64`; macOS/Windows recipients build it locally with `./gradlew :bundle-viewer:packageUberJarForCurrentOS`.
 3. Packages the **VS Code extension** as a `.vsix` file and publishes it to the **VS Code Marketplace** and **Open VSX** (runs alongside the Release upload, so a marketplace outage can't block the GitHub Release).
 4. Uploads the CLI, MCP, viewer, and VS Code extension artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).
 

--- a/docs/portable-bundles.md
+++ b/docs/portable-bundles.md
@@ -85,8 +85,8 @@ whoever produced the bundle (Gradle, Amper, Bazel), the baked PNGs read the same
 ### 2b. Live re-render — already works, *Compose-only*
 
 This repo already ships a **player application**: `:bundle-viewer`
-(`compose-preview-viewer`, a Compose Desktop `application` with a `distZip`/
-`distTar` launcher). `BundleLoader.loadBundle` does the real thing:
+(`compose-preview-viewer`, a Compose Desktop app distributed as a single runnable
+uber jar — see Tier 2.2). `BundleLoader.loadBundle` does the real thing:
 
 ```kotlin
 // BundleLoader.kt — child loader over the inlined app.jar, parent = viewer's own Compose
@@ -224,10 +224,19 @@ The player already exists (`compose-preview-viewer`, §2b) — the work is small
    `URLClassLoader(arrayOf(appJarFile))`; extend it to also extract and append
    every `ClasspathEntry.Embedded` jar. ~10 lines; makes third-party deps resolve
    without touching the parent Compose stack.
-2. **Distribute it runnable.** It ships as a `distZip`/`distTar` today (slim, needs
-   the launcher script). For drag-around use, add a fat/`shadow` jar so
-   `java -jar compose-preview-viewer.jar foo.png` works, and/or a
-   `jpackage`/`jlink` native app per OS so a non-Java colleague needs nothing
+2. **Distribute it runnable.** *Done* — the viewer ships as a single self-contained
+   uber jar built by Compose Multiplatform's own
+   `:bundle-viewer:packageUberJarForCurrentOS`
+   (`compose-preview-viewer-<os>-<arch>-<ver>.jar`), so
+   `java -jar compose-preview-viewer-<os>-<arch>-<ver>.jar foo.png` works as a
+   single drag-around file with nothing unpacked. It carries the current OS's
+   Compose Desktop + Skiko runtime (so it's per-OS, ~40 MB). The module uses
+   Compose's `compose.desktop.application` DSL rather than the JVM `application`
+   plugin (the uber jar supersedes the slim `distZip`/`distTar`) and rather than the
+   Shadow plugin (whose parent-project property lookup breaks this repo's Isolated
+   Projects gate). The same DSL also exposes `createDistributable` (unpacked app
+   dir) and `packageDeb`/`packageDmg`/`packageMsi` — the still-open follow-up is to
+   wire those native installers per OS so a non-Java colleague needs nothing
    installed at all.
 
 ### Tier 3 — the coordinate resolver (the default play path, not a fallback)
@@ -262,7 +271,7 @@ render.
 |---|---|
 | 0 | Open a v2 bundle in Preview.app / `tui-cli --dump` with no project (already in this repo's CI). |
 | 1 | Pack with `--embed-deps`; `unzip -l` shows `libs/*.jar`; render on a box with **no Gradle/Maven and no network**. |
-| 2 | `java -jar compose-preview-viewer.jar sample.png` on a clean JDK. |
+| 2 | `java -jar compose-preview-viewer-<os>-<arch>-<ver>.jar sample.png` on a clean JDK. (Headless smoke: the launch reaches Compose's composition + AWT `EventQueue` and stops only at `HeadlessException` — no `NoClassDefFoundError`, proving the runtime classpath is complete.) |
 | 3 | Open a `coordinates` bundle on a Bazel-only box; resolver fetches deps. |
 
 ## 5. Questions to confirm against `compose-ai-contrib`


### PR DESCRIPTION
## Summary

Makes the desktop bundle viewer a **single drag-around file** — portable-bundles.md Tier 2.2:

```
java -jar compose-preview-viewer-<os>-<arch>-<ver>.jar bundle.png
```

with nothing unpacked. Until now the viewer only shipped as a `distZip`/`distTar` that needs its `bin/` launcher + an unpacked `lib/` — not itself portable.

### Approach: Compose's own uber jar (not a hand-rolled / shadow jar)
The viewer **is** a Compose Desktop application, so it's now configured through Compose Multiplatform's `compose.desktop.application` DSL instead of the JVM `application` plugin, and the artefact is built by the DSL's **`packageUberJarForCurrentOS`** — the idiomatic, first-party way to package a Compose Desktop app as one self-contained jar (the current OS's Compose Desktop + Skiko runtime flattened in; per-OS, ~40 MB).

Why this over the alternatives:
- **GradleUp Shadow** — its optional-property lookup walks to the parent project, which this repo's `isolated-projects=true` + `configuration-cache.problems=fail` gate **rejects** (verified: config-cache store fails). The Compose DSL stays IP-clean.
- **A hand-rolled `Jar` task** (this PR's first revision) works, but reimplements service-file/native handling that Compose's DSL already does correctly.
- The DSL's `run`-task collision that made me reach for those was only there because the module *also* applied the JVM `application` plugin. Dropping that plugin removes the collision — and the slim `distZip`/`distTar` it produced had no consumer besides the release, which this jar supersedes.

Bonus: the same DSL unlocks `createDistributable` and `packageDeb`/`packageDmg`/`packageMsi` for the later native-installer (jpackage) follow-up, and the now-unneeded `@file:Suppress("DEPRECATION")` is dropped.

### Release wiring
`release.yml`'s `build-applications` job runs `:bundle-viewer:packageUberJarForCurrentOS`, uploads it as a `bundle-viewer-uberjar` artifact, and the `release` job's asset globs gain `artifacts/*.jar`. The viewer `.zip`/`.tar.gz` assets are replaced by the jar. The release runner is Linux, so the published jar is `compose-preview-viewer-linux-x64-<ver>.jar` — macOS/Windows recipients build their own with `./gradlew :bundle-viewer:packageUberJarForCurrentOS`. `RELEASING.md` updated accordingly.

## Test plan
- `./gradlew :bundle-viewer:packageUberJarForCurrentOS :bundle-viewer:ktfmtCheck :bundle-viewer:test` → BUILD SUCCESSFUL, config-cache stored clean (Isolated-Projects-safe), on JDK 17.
- Output: `bundle-viewer/build/compose/jars/compose-preview-viewer-linux-x64-<ver>.jar` (~40 MB); manifest `Main-Class: ee.schimke.composeai.viewer.MainKt`; `MainKt` + `libskiko-linux-x64.so` present.
- **Headless launch smoke**: `java -jar …jar` reaches Compose's composition pipeline + AWT `EventQueue` dispatch and stops only at `java.awt.HeadlessException` (no display) — **no `NoClassDefFoundError`**, proving the runtime classpath is complete.
- Native installers (`packageDeb`/`packageDmg`/`packageMsi`) are out of scope — noted as the jpackage follow-up in `portable-bundles.md`.