### PR TITLE
fix(a11y-report): tolerate boundsInScreen jitter in PR-comment diff

### DIFF
--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -486,17 +486,57 @@ def _bounds_close(a: str | None, b: str | None, tol: int) -> bool:
     return all(abs(x - y) <= tol for x, y in zip(pa, pb))
 
 
+def _has_perfect_matching(
+    left: list[str | None], right: list[str | None], tol: int
+) -> bool:
+    """True when ``left`` and ``right`` rects pair off 1:1 within ``tol``.
+
+    A current rect "matches" a baseline rect when [_bounds_close]; this finds
+    a maximum bipartite matching (Kuhn's augmenting paths) and reports whether
+    every rect is paired. Greedy pairing is wrong here: when tolerance windows
+    overlap, an early rect can grab the only partner a later rect needs even
+    though a complete pairing exists by a different assignment (e.g. baselines
+    `0,0,40,40`/`8,0,48,40` vs currents `4,0,44,40`/`0,0,40,40`). The augmenting
+    search reassigns around that, so overlapping jitter on dense duplicate
+    findings (repeated unlabeled rows) doesn't reintroduce false "changed".
+
+    Per-preview finding counts are tiny, so the O(V·E) search is cheap.
+    """
+    if len(left) != len(right):
+        return False
+    adj: list[list[int]] = [
+        [j for j, rb in enumerate(right) if _bounds_close(lb, rb, tol)]
+        for lb in left
+    ]
+    match_right: list[int] = [-1] * len(right)
+
+    def augment(u: int, seen: list[bool]) -> bool:
+        for v in adj[u]:
+            if seen[v]:
+                continue
+            seen[v] = True
+            if match_right[v] == -1 or augment(match_right[v], seen):
+                match_right[v] = u
+                return True
+        return False
+
+    for u in range(len(left)):
+        if not augment(u, [False] * len(right)):
+            return False
+    return True
+
+
 def _findings_equivalent(
     current: list[dict], baseline: list[dict], tol: int = BOUNDS_TOLERANCE_PX
 ) -> bool:
     """True when two findings lists describe the same a11y state.
 
     Findings are grouped by their bounds-free [_finding_signature]; within a
-    signature each current rect must pair off (greedily, 1:1) with a distinct
-    baseline rect that's [_bounds_close]. So a clean preview matches an
-    absent/clean baseline (both empty → equivalent), pixel jitter on an
-    existing finding is absorbed, but an added/removed finding or one that
-    moved beyond ``tol`` makes the lists diverge.
+    signature the current and baseline rects must pair off 1:1 within ``tol``
+    via [_has_perfect_matching]. So a clean preview matches an absent/clean
+    baseline (both empty → equivalent), pixel jitter on an existing finding is
+    absorbed, but an added/removed finding or one that moved beyond ``tol``
+    makes the lists diverge.
 
     Multiple findings sharing a signature (e.g. several unlabeled rows) keep
     their own rects, so two genuinely distinct items more than ``tol`` apart
@@ -511,18 +551,10 @@ def _findings_equivalent(
 
     if by_sig_cur.keys() != by_sig_base.keys():
         return False
-    for sig, cur_bounds in by_sig_cur.items():
-        remaining = list(by_sig_base[sig])
-        if len(cur_bounds) != len(remaining):
-            return False
-        for cb in cur_bounds:
-            for i, bb in enumerate(remaining):
-                if _bounds_close(cb, bb, tol):
-                    remaining.pop(i)
-                    break
-            else:
-                return False
-    return True
+    return all(
+        _has_perfect_matching(cur_bounds, by_sig_base[sig], tol)
+        for sig, cur_bounds in by_sig_cur.items()
+    )
 
 
 def cmd_comment(args: argparse.Namespace) -> int:

--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -430,60 +430,99 @@ def cmd_readme(args: argparse.Namespace) -> int:
 # comment
 # ---------------------------------------------------------------------------
 
-def _finding_tuple(f: dict) -> tuple:
-    """Hash-stable representation of a single finding for change detection.
+# Per-coordinate tolerance (in screen pixels) applied to `boundsInScreen`
+# when deciding whether a finding is "the same" as one on the baseline.
+#
+# ATF reports each finding's rect as an absolute pixel box
+# ("x1,y1,x2,y2"). Those coordinates jitter by a pixel or two between
+# renders — anti-aliasing, density rounding, an unrelated layout nudge
+# elsewhere on the screen — without the underlying accessibility issue
+# changing at all. Including the raw rect in the change-detection key made
+# every such jitter read as a brand-new finding, so a PR that shifted
+# layout re-posted the full findings table for every preview instead of
+# collapsing the unchanged ones (the "full output" / "not detecting
+# duplicates" report). We treat two findings as the same when their rule,
+# element, and message match AND every bounds coordinate is within this
+# many pixels; a genuine relocation past the tolerance still surfaces.
+BOUNDS_TOLERANCE_PX: int = 4
 
-    Filenames are deliberately excluded elsewhere; here we capture only the
-    fields a reviewer reacts to (level, rule type, message, element, bounds).
+
+def _finding_signature(f: dict) -> tuple:
+    """Bounds-free identity of a finding: the fields a reviewer reacts to.
+
+    Excludes ``boundsInScreen`` on purpose — position is compared separately
+    with [_bounds_close] so pixel jitter doesn't count as a new finding.
     """
     return (
         f.get("level"),
         f.get("type"),
         f.get("message"),
         f.get("viewDescription"),
-        f.get("boundsInScreen"),
     )
 
 
-def _entry_findings_key(entry: dict) -> tuple:
-    """Order-insensitive key for one preview's findings.
+def _parse_bounds(value: str | None) -> tuple[int, ...] | None:
+    """Parse ``"x1,y1,x2,y2"`` into a 4-int tuple; ``None`` if unparseable."""
+    if not value:
+        return None
+    try:
+        parts = tuple(int(p) for p in value.split(","))
+    except ValueError:
+        return None
+    return parts if len(parts) == 4 else None
 
-    Returns the empty tuple for a preview with no findings, so an
-    absent-from-baseline preview (default ``()``) and a clean preview compare
-    equal — the surface rule in [cmd_comment] treats "clean" and "not present"
-    as the same neutral state.
+
+def _bounds_close(a: str | None, b: str | None, tol: int) -> bool:
+    """True when two bounds rects match within ``tol`` pixels per coordinate.
+
+    Falls back to exact string equality when either rect can't be parsed, so
+    a malformed/absent bounds value never silently matches a different one.
     """
-    return tuple(sorted(_finding_tuple(f) for f in entry.get("findings", [])))
+    if a == b:
+        return True
+    pa, pb = _parse_bounds(a), _parse_bounds(b)
+    if pa is None or pb is None:
+        return False
+    return all(abs(x - y) <= tol for x, y in zip(pa, pb))
 
 
-def _findings_fingerprint(entries: list[dict], status: str | None = None) -> tuple:
-    """Stable representation of (status, previews-with-findings) for change detection.
+def _findings_equivalent(
+    current: list[dict], baseline: list[dict], tol: int = BOUNDS_TOLERANCE_PX
+) -> bool:
+    """True when two findings lists describe the same a11y state.
 
-    Compares only the data a reviewer would care about — top-level status,
-    plus per-entry module, previewId, and findings list. Filenames
-    (`cleanBasename`, `annotatedBasename`) are excluded because identical
-    findings can move around between files when the renderer renames variants,
-    and we don't want to wake the PR comment for that.
+    Findings are grouped by their bounds-free [_finding_signature]; within a
+    signature each current rect must pair off (greedily, 1:1) with a distinct
+    baseline rect that's [_bounds_close]. So a clean preview matches an
+    absent/clean baseline (both empty → equivalent), pixel jitter on an
+    existing finding is absorbed, but an added/removed finding or one that
+    moved beyond ``tol`` makes the lists diverge.
 
-    Previews with **no** findings are excluded entirely: adding or removing a
-    clean preview is not an accessibility change, so it must neither break the
-    comment's silence nor surface a near-empty "nothing to see" comment. Only
-    previews that carry findings participate, which mirrors the per-preview
-    surface rule in [cmd_comment] (an absent/clean preview has the empty
-    findings key).
-
-    ``status`` is included so the fingerprint diverges when the daemon goes
-    from "ran cleanly" to "atf-unavailable" or vice versa — without this, a
-    daemon crash would match a clean baseline and the workflow would stay
-    silent on the very condition the comment needs to surface.
+    Multiple findings sharing a signature (e.g. several unlabeled rows) keep
+    their own rects, so two genuinely distinct items more than ``tol`` apart
+    won't collapse into one match.
     """
-    return (status,) + tuple(
-        (e["module"], e["previewId"], _entry_findings_key(e))
-        for e in sorted(
-            (e for e in entries if e.get("findings")),
-            key=lambda e: (e["module"], e["previewId"]),
-        )
-    )
+    by_sig_cur: dict[tuple, list[str | None]] = {}
+    by_sig_base: dict[tuple, list[str | None]] = {}
+    for f in current:
+        by_sig_cur.setdefault(_finding_signature(f), []).append(f.get("boundsInScreen"))
+    for f in baseline:
+        by_sig_base.setdefault(_finding_signature(f), []).append(f.get("boundsInScreen"))
+
+    if by_sig_cur.keys() != by_sig_base.keys():
+        return False
+    for sig, cur_bounds in by_sig_cur.items():
+        remaining = list(by_sig_base[sig])
+        if len(cur_bounds) != len(remaining):
+            return False
+        for cb in cur_bounds:
+            for i, bb in enumerate(remaining):
+                if _bounds_close(cb, bb, tol):
+                    remaining.pop(i)
+                    break
+            else:
+                return False
+    return True
 
 
 def cmd_comment(args: argparse.Namespace) -> int:
@@ -492,18 +531,13 @@ def cmd_comment(args: argparse.Namespace) -> int:
     entries: list[dict] = payload.get("entries", [])
     status: str | None = payload.get("status")
 
-    # When a baseline (the on-`compose-preview/a11y/main` findings.json) is provided, stay
-    # silent if nothing has changed — the workflow runs on every PR and a
-    # comment that says "no findings" on PRs that don't touch a11y was
-    # noted as distracting in user feedback. Empty stdout signals the
-    # action to skip both the push and the upsert.
-    #
-    # `status` participates in the fingerprint so an atf-unavailable run on
-    # this side never matches a clean-run baseline — that flips on the
-    # comment so reviewers see the daemon failure rather than the misleading
-    # "no findings" the bug in #1453 produced.
+    # Load the baseline (the on-`compose-preview/a11y/main` findings.json) when
+    # one is provided. `baseline_loaded` tracks whether we actually have a
+    # baseline to diff against — only then do we exercise the silent-skip
+    # below.
     baseline_entries: list[dict] = []
     baseline_status: str | None = None
+    baseline_loaded = False
     if args.baseline:
         baseline_path = Path(args.baseline)
         if baseline_path.exists():
@@ -513,33 +547,30 @@ def cmd_comment(args: argparse.Namespace) -> int:
                 baseline_payload = {"entries": []}
             baseline_entries = baseline_payload.get("entries", [])
             baseline_status = baseline_payload.get("status")
-            if (
-                _findings_fingerprint(entries, status)
-                == _findings_fingerprint(baseline_entries, baseline_status)
-            ):
-                return 0  # silent
+            baseline_loaded = True
 
     # Per-preview diff against the baseline. The comment used to re-post every
-    # preview's findings on every PR that tripped the fingerprint (#1585);
+    # preview's findings on every PR that tripped a hash mismatch (#1585);
     # instead, surface only the previews whose findings actually changed and
-    # collapse the rest. A preview's findings key defaults to `()` when it's
-    # absent from the baseline, so a brand-new *clean* preview compares equal
-    # to its (empty) baseline and is treated as unchanged — only new or
-    # changed findings get a full block.
-    baseline_by_key: dict[tuple[str, str], tuple] = {
-        (e["module"], e["previewId"]): _entry_findings_key(e)
-        for e in baseline_entries
+    # collapse the rest. [_findings_equivalent] treats an absent baseline
+    # preview as empty, so a brand-new *clean* preview compares equal and is
+    # unchanged; it also absorbs pixel jitter in `boundsInScreen` so a layout
+    # shift no longer flips every preview to "changed" — only new, removed, or
+    # genuinely relocated findings get a full block.
+    baseline_by_key: dict[tuple[str, str], dict] = {
+        (e["module"], e["previewId"]): e for e in baseline_entries
     }
     current_keys = {(e["module"], e["previewId"]) for e in entries}
 
     changed: list[dict] = []
     unchanged: list[dict] = []
     for entry in entries:
-        key = (entry["module"], entry["previewId"])
-        if _entry_findings_key(entry) != baseline_by_key.get(key, ()):
-            changed.append(entry)
-        else:
+        base = baseline_by_key.get((entry["module"], entry["previewId"]))
+        base_findings = base.get("findings", []) if base else []
+        if _findings_equivalent(entry.get("findings", []), base_findings):
             unchanged.append(entry)
+        else:
+            changed.append(entry)
 
     # Previews that carried findings on the baseline but are gone now — the
     # underlying issue is no longer reachable. A clean baseline preview that
@@ -548,8 +579,19 @@ def cmd_comment(args: argparse.Namespace) -> int:
         e
         for e in baseline_entries
         if (e["module"], e["previewId"]) not in current_keys
-        and _entry_findings_key(e)
+        and e.get("findings")
     ]
+
+    # Stay silent when a baseline was available and nothing a reviewer cares
+    # about moved — no changed previews, none resolved, and the same top-level
+    # status. The workflow runs on every PR; a "no findings" comment on PRs
+    # that don't touch a11y was noted as distracting (empty stdout tells the
+    # action to skip the push + upsert). The `status` guard keeps an
+    # atf-unavailable run from matching a clean-run baseline (#1453); the
+    # atf-unavailable side is handled by its own branch below before we get
+    # here, so this only fires for clean-vs-clean comparisons.
+    if baseline_loaded and not changed and not resolved and status == baseline_status:
+        return 0
 
     err, warn, info = _level_counts(entries)
     findings_count = err + warn + info
@@ -577,7 +619,7 @@ def cmd_comment(args: argparse.Namespace) -> int:
         # purpose; the workflow's failure step already surfaces a direct link
         # and the python helper doesn't know the job URL.
         preserved = sorted(
-            (e for e in baseline_entries if _entry_findings_key(e)),
+            (e for e in baseline_entries if e.get("findings")),
             key=lambda e: (e["module"], e["functionName"]),
         )
         b_err, b_warn, b_info = _level_counts(baseline_entries)

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -681,6 +681,21 @@ class CommentTest(unittest.TestCase):
         body = self._run_comment([current], baseline_entries=[baseline])
         self.assertIn("<!-- a11y-report -->", body)
 
+    def test_overlapping_tolerance_windows_still_match(self):
+        # Same-signature findings whose tolerance windows overlap must pair off
+        # via a complete assignment, not a greedy first-come grab. With tol=4,
+        # baselines 0,0,40,40 / 8,0,48,40 and currents 4,0,44,40 / 0,0,40,40
+        # only match 1:1 if the matcher reassigns (4,..→8,.. ; 0,..→0,..).
+        def at(bounds):
+            f = dict(_finding(level="ERROR"))
+            f["boundsInScreen"] = bounds
+            return f
+
+        baseline = self._entry(findings=[at("0,0,40,40"), at("8,0,48,40")])
+        current = self._entry(findings=[at("4,0,44,40"), at("0,0,40,40")])
+        body = self._run_comment([current], baseline_entries=[baseline])
+        self.assertEqual(body, "")
+
     def test_resolved_preview_listed_when_removed(self):
         # A preview that carried a finding on the baseline but is gone now
         # should be called out as resolved.

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -641,6 +641,46 @@ class CommentTest(unittest.TestCase):
         # The prior finding is preserved, not silently dropped.
         self.assertIn("### `Bad`", body)
 
+    def test_silent_when_bounds_jitter_within_tolerance(self):
+        # Regression for the "full output / not detecting duplicates" report:
+        # ATF rects jitter by a pixel or two between renders without the
+        # underlying issue changing. A finding that only moved within
+        # BOUNDS_TOLERANCE_PX must read as unchanged, so the comment stays
+        # silent rather than re-posting the whole table.
+        baseline = self._entry(
+            findings=[_finding(level="ERROR")]  # bounds "0,0,40,40"
+        )
+        jittered = dict(_finding(level="ERROR"))
+        jittered["boundsInScreen"] = "1,1,41,41"  # +1px on every coordinate
+        current = self._entry(findings=[jittered])
+        body = self._run_comment([current], baseline_entries=[baseline])
+        self.assertEqual(body, "")
+
+    def test_emits_when_bounds_move_beyond_tolerance(self):
+        # A relocation past the tolerance is a real change and must surface —
+        # the tolerance only absorbs jitter, it doesn't blind the diff.
+        baseline = self._entry(findings=[_finding(level="ERROR")])  # "0,0,40,40"
+        moved = dict(_finding(level="ERROR"))
+        moved["boundsInScreen"] = "200,200,240,240"
+        current = self._entry(findings=[moved])
+        body = self._run_comment([current], baseline_entries=[baseline])
+        self.assertIn("<!-- a11y-report -->", body)
+        self.assertIn("### `Bad`", body)
+
+    def test_distinct_same_signature_findings_not_collapsed(self):
+        # Two findings that share rule/element/message but sit far apart (e.g.
+        # several unlabeled rows) must each keep their own rect — a removed one
+        # still counts as a change rather than matching the surviving twin.
+        def at(bounds):
+            f = dict(_finding(level="ERROR"))
+            f["boundsInScreen"] = bounds
+            return f
+
+        baseline = self._entry(findings=[at("0,0,40,40"), at("0,500,40,540")])
+        current = self._entry(findings=[at("0,0,40,40")])  # one removed
+        body = self._run_comment([current], baseline_entries=[baseline])
+        self.assertIn("<!-- a11y-report -->", body)
+
     def test_resolved_preview_listed_when_removed(self):
         # A preview that carried a finding on the baseline but is gone now
         # should be called out as resolved.


### PR DESCRIPTION
## Summary

A11y PR comments were dumping the full findings table for every preview instead of collapsing unchanged ones — the "not detecting duplicates" symptom seen on downstream PRs (e.g. `homeassistant-remotecompose#366`: *1020 error(s) … across 265 preview(s)*, no `Unchanged`/`Resolved` collapsing).

Root cause: the comment subcommand keyed each finding's change-detection identity on its raw `boundsInScreen` rect. ATF reports those as absolute pixel boxes that jitter by a pixel or two between renders (anti-aliasing, density rounding, an unrelated layout nudge elsewhere on the screen). Any jitter made an otherwise-identical finding read as new, so a PR that shifted layout flipped *every* preview to "changed".

Reproduced against the live baseline vs PR `findings.json` (265 entries each, 227 with findings): with the raw-bounds key the diff classified previews as changed purely on sub-pixel rect shifts (e.g. `500,1378,603,1564` → `499,1378,602,1564`); all 1041 findings had an identical `(level, type, message, element)` already on the baseline.

## Change

- Compare findings by a **bounds-free signature** `(level, type, message, viewDescription)` plus a **per-coordinate pixel tolerance** (`BOUNDS_TOLERANCE_PX = 4`). A finding that only moved within tolerance is unchanged; an added/removed finding or a relocation past the tolerance still surfaces. Multiple same-signature findings are matched 1:1 so genuinely distinct items aren't collapsed.
- Replace the exact-hash fingerprint silent-skip with a post-diff decision (silent when nothing changed/resolved and top-level status is unchanged), so the silence path uses the same tolerant comparison instead of a parallel hash.

With the 4px tolerance the real PR data goes from 265 full tables to **0 changed / 265 collapsed**.

## Test plan

- `cd .github/actions/lib && python3 -m unittest test_a11y_report` — 33 tests pass.
- New cases: jitter within tolerance stays silent; movement beyond tolerance surfaces; distinct same-signature findings aren't collapsed.
- Existing ATF-unavailable / resolved / changed-collapse behaviour unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVGX81p35Sec3KtBy623Ap)_