### PR TITLE
feat(bundle): replay remote-compose & protolayout previews from a captured IR (schema v5)

### DIFF
--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
@@ -28,6 +28,21 @@ data class BundleManifest(
    * v3+: classpath assembly strategy (`coordinates`|`embedded`|`mixed`). Defaults for v2 bundles.
    */
   val resolution: String = "coordinates",
+  /**
+   * v5+: previews replayed from a captured intermediate representation (`ir/<id>.<ext>`) instead of
+   * by re-running their consumer bytecode. Empty for a classic all-classes bundle.
+   */
+  val intermediateRepresentations: List<BundleIr> = emptyList(),
+)
+
+/** v5+ mirror of `BundleIr` in `PreviewBundleFormat.kt`. */
+@Serializable
+data class BundleIr(
+  val previewId: String,
+  /** `remotecompose` (RC doc) or `protolayout` (Wear tile Layout proto). */
+  val format: String,
+  val path: String,
+  val resourcesPath: String? = null,
 )
 
 @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -128,7 +128,8 @@ private class PackSubcommand(private val args: List<String>) {
             resolvedOutput.parentFile?.mkdirs()
 
             val gradleArgs = buildList {
-              if (ids.isNotEmpty()) add("-PbundlePreviewIds=${ids.joinToString(",")}")
+              if (ids.isNotEmpty())
+                add("-PbundlePreviewIds=${ids.joinToString(",") { encodePreviewId(it) }}")
               if (embedDeps) add("-PbundleEmbedDeps=true")
               add("-PbundleOutput=${resolvedOutput.absolutePath}")
             }
@@ -301,6 +302,21 @@ private class RenderSubcommand(private val args: List<String>) {
       }
     }
     if (!result.allOk) exitProcess(1)
+  }
+}
+
+/**
+ * Escape a preview id for the `-PbundlePreviewIds=` Gradle property: `,` and `\` are
+ * backslash-escaped so an id carrying a `@Preview(name = "Phone, dark")` suffix survives the
+ * comma-separated transport (an unescaped comma would otherwise split into two ids and the bundle
+ * task would fail with "preview id not found"). Mirrors `BundlePreviewIds.encode` in `:gradle-plugin`
+ * — the CLI can't depend on that module, same reason [BundleReader] mirrors the on-disk schema. The
+ * plugin-side `BundlePreviewIds.parse` is the matching decoder.
+ */
+private fun encodePreviewId(id: String): String = buildString(id.length) {
+  for (c in id) {
+    if (c == '\\' || c == ',') append('\\')
+    append(c)
   }
 }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -309,16 +309,17 @@ private class RenderSubcommand(private val args: List<String>) {
  * Escape a preview id for the `-PbundlePreviewIds=` Gradle property: `,` and `\` are
  * backslash-escaped so an id carrying a `@Preview(name = "Phone, dark")` suffix survives the
  * comma-separated transport (an unescaped comma would otherwise split into two ids and the bundle
- * task would fail with "preview id not found"). Mirrors `BundlePreviewIds.encode` in `:gradle-plugin`
- * — the CLI can't depend on that module, same reason [BundleReader] mirrors the on-disk schema. The
- * plugin-side `BundlePreviewIds.parse` is the matching decoder.
+ * task would fail with "preview id not found"). Mirrors `BundlePreviewIds.encode` in
+ * `:gradle-plugin` — the CLI can't depend on that module, same reason [BundleReader] mirrors the
+ * on-disk schema. The plugin-side `BundlePreviewIds.parse` is the matching decoder.
  */
-private fun encodePreviewId(id: String): String = buildString(id.length) {
-  for (c in id) {
-    if (c == '\\' || c == ',') append('\\')
-    append(c)
+private fun encodePreviewId(id: String): String =
+  buildString(id.length) {
+    for (c in id) {
+      if (c == '\\' || c == ',') append('\\')
+      append(c)
+    }
   }
-}
 
 /**
  * Extracts a zip safely — every entry's resolved target path is verified to live inside [target].

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -358,6 +358,21 @@ internal object BundleReader {
     val producer: String = "gradle",
     /** v3+: classpath assembly strategy (`coordinates`|`embedded`|`mixed`). Defaults for v2. */
     val resolution: String = "coordinates",
+    /**
+     * v5+: previews replayed from a captured intermediate representation (`ir/<id>.<ext>`) rather
+     * than by re-running their consumer bytecode. Empty for a classic all-classes bundle.
+     */
+    val intermediateRepresentations: List<BundleIr> = emptyList(),
+  )
+
+  /** v5+ mirror of `BundleIr` in `PreviewBundleFormat.kt`. */
+  @Serializable
+  data class BundleIr(
+    val previewId: String,
+    /** `remotecompose` (RC doc) or `protolayout` (Wear tile Layout proto). */
+    val format: String,
+    val path: String,
+    val resourcesPath: String? = null,
   )
 
   @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -112,7 +112,8 @@ class BundleRenderer(
     // class in `classes/app.jar` — their bytecode was intentionally dropped at pack time. They are
     // replayed through the Remote Compose / ProtoLayout runtime by the Android daemon
     // (`compose-preview bundle daemon`), not by the desktop subprocess renderer, which can't drive
-    // those Android-only libraries. Skip them here rather than spawn `DesktopRendererMain` against a
+    // those Android-only libraries. Skip them here rather than spawn `DesktopRendererMain` against
+    // a
     // class that isn't present (which would fail every IR preview with a ClassNotFoundException).
     val irById = manifest.intermediateRepresentations.associateBy { it.previewId }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -108,10 +108,26 @@ class BundleRenderer(
         it.absolutePath
       }
 
+    // Previews replayed from a captured intermediate representation (schema v5) have NO consumer
+    // class in `classes/app.jar` — their bytecode was intentionally dropped at pack time. They are
+    // replayed through the Remote Compose / ProtoLayout runtime by the Android daemon
+    // (`compose-preview bundle daemon`), not by the desktop subprocess renderer, which can't drive
+    // those Android-only libraries. Skip them here rather than spawn `DesktopRendererMain` against a
+    // class that isn't present (which would fail every IR preview with a ClassNotFoundException).
+    val irById = manifest.intermediateRepresentations.associateBy { it.previewId }
+
     outputDir.mkdirs()
     val succeeded = mutableListOf<RenderedPreview>()
     val failed = mutableListOf<FailedPreview>()
     for (preview in previews.previews) {
+      val ir = irById[preview.id]
+      if (ir != null) {
+        logSink(
+          "compose-preview: skipping ${preview.id} — IR replay (format=${ir.format}) runs in the " +
+            "Android daemon (compose-preview bundle daemon), not the desktop renderer"
+        )
+        continue
+      }
       val outFile = outputDir.resolve(safeFilename(preview.id) + ".png")
       val (exitCode, tail) = spawnRenderer(classpathString, preview, outFile)
       if (exitCode == 0 && outFile.isFile && outFile.length() > 0) {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -173,7 +173,18 @@ abstract class BundlePreviewTask : DefaultTask() {
     val manifest = JSON.decodeFromString(PreviewManifest.serializer(), manifestFile.readText())
     val selected = resolveSelection(manifest, previewIds.get())
     val coverId = selected.first().id
-    val entryClassFqns = selected.map { it.className }.toSet()
+
+    // Previews whose flavour emitted a serialisable intermediate representation (Remote Compose doc
+    // / Wear protolayout proto) during the render step are replayed from that IR, not by re-running
+    // their composable. We therefore (a) carry the IR bytes in the bundle and (b) DROP their
+    // enclosing class from the closure seed below, so the consumer bytecode that produced them isn't
+    // packed at all — the whole point of the v5 format. A preview with no IR sidecar stays on the
+    // classic class-minimisation path.
+    val irByPreview: Map<String, ResolvedIr> =
+      selected.mapNotNull { p -> resolvePreviewIr(p)?.let { p.id to it } }.toMap()
+
+    // Seed the minimisation closure only from previews that still need their bytecode replayed.
+    val entryClassFqns = selected.filter { it.id !in irByPreview }.map { it.className }.toSet()
 
     val classDirsList = moduleClassDirs.files.filter { it.exists() && it.isDirectory }
     val jarsList = dependencyJars.files.filter { it.isFile && it.name.endsWith(".jar") }
@@ -206,6 +217,29 @@ abstract class BundlePreviewTask : DefaultTask() {
         dependencies = depDecisions,
       )
 
+    // Lay out the IR artefacts under `ir/<id>.<ext>` and record a manifest entry per IR-backed
+    // preview. The companion resources proto (protolayout) lands beside the layout proto.
+    val irEntries = mutableListOf<BundleIr>()
+    val irZipFiles = LinkedHashMap<String, ByteArray>()
+    for (preview in selected) {
+      val ir = irByPreview[preview.id] ?: continue
+      val irPath = "$BUNDLE_IR_DIR/${preview.id}.${ir.ext}"
+      irZipFiles[irPath] = ir.bytes
+      val resourcesPath =
+        ir.resourcesBytes?.let { rb ->
+          val rp = "$BUNDLE_IR_DIR/${preview.id}.${ir.resourcesExt}"
+          irZipFiles[rp] = rb
+          rp
+        }
+      irEntries +=
+        BundleIr(
+          previewId = preview.id,
+          format = ir.format,
+          path = irPath,
+          resourcesPath = resourcesPath,
+        )
+    }
+
     val bundle =
       BundleManifest(
         schemaVersion = BUNDLE_SCHEMA_VERSION,
@@ -217,6 +251,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         producedBy = producedBy.get(),
         producer = PRODUCER_GRADLE,
         resolution = classpath.resolution,
+        intermediateRepresentations = irEntries,
       )
 
     // Bake one PNG per selected preview into `previews/<id>.png` so the bundle renders detached
@@ -236,6 +271,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         inlinedProjectJars = inlinedJars,
         report = JSON.encodeToString(MinimizationReport.serializer(), report),
         previewPngs = previewPngs,
+        irFiles = irZipFiles,
       )
 
     // The cover (first selected preview) forms the polyglot's leading bytes. Reuse its baked PNG
@@ -253,6 +289,7 @@ abstract class BundlePreviewTask : DefaultTask() {
       "composePreviewBundle — wrote ${outFile.name} (${outFile.length()} bytes)\n" +
         "  resolution:           ${classpath.resolution}\n" +
         "  previews baked:       ${previewPngs.size} / ${selected.size} (cover=$coverId)\n" +
+        "  IR-backed previews:   ${irEntries.size} (replayed from ir/, classes dropped)\n" +
         "  entry classes:        ${report.entryClassFqns.size}\n" +
         "  reachable classes:    ${report.reachableClassCount} / ${report.totalScannedClassCount}\n" +
         "  module classes kept:  ${report.moduleClasses.reachableClasses} / ${report.moduleClasses.totalClasses}\n" +
@@ -329,6 +366,53 @@ abstract class BundlePreviewTask : DefaultTask() {
       }
       ?.minByOrNull { it.name }
       ?.readBytes()
+  }
+
+  /** A captured intermediate representation resolved off disk for one preview. */
+  private data class ResolvedIr(
+    val format: String,
+    val ext: String,
+    val bytes: ByteArray,
+    val resourcesExt: String? = null,
+    val resourcesBytes: ByteArray? = null,
+  )
+
+  /**
+   * Look for a captured IR sidecar emitted by the render step next to [preview]'s PNG. The render
+   * path writes the IR alongside the rendered image using the same stem: `<stem>.rcdoc` for a
+   * Remote Compose document, or `<stem>.tilelayout` (+ optional `<stem>.tileresources`) for a Wear
+   * protolayout proto. Returns `null` when the preview's flavour has no IR (the common case — every
+   * plain `@Composable @Preview`), in which case the preview stays on the class-minimisation path.
+   *
+   * Resolution mirrors [resolvePreviewPng]: the stem comes from the primary capture's
+   * `renderOutput`, and the file lives under [rendersDir]. IR sidecars are NOT fanned out across
+   * `@PreviewParameter` variants (a tile / remote document is a single artefact), so unlike the PNG
+   * path there's no sibling search.
+   */
+  private fun resolvePreviewIr(preview: PreviewInfo): ResolvedIr? {
+    val rendersRoot = rendersDir.orNull?.asFile ?: return null
+    val rel =
+      preview.captures.firstOrNull()?.renderOutput?.takeIf { it.isNotEmpty() } ?: return null
+    val stem = rel.substringAfterLast('/').removeSuffix(".png")
+
+    fun read(ext: String): ByteArray? {
+      val f = File(rendersRoot, "$stem.$ext")
+      return if (f.isFile && f.length() > 0) f.readBytes() else null
+    }
+
+    read(IR_EXT_REMOTECOMPOSE)?.let {
+      return ResolvedIr(format = IR_FORMAT_REMOTECOMPOSE, ext = IR_EXT_REMOTECOMPOSE, bytes = it)
+    }
+    read(IR_EXT_PROTOLAYOUT_LAYOUT)?.let { layout ->
+      return ResolvedIr(
+        format = IR_FORMAT_PROTOLAYOUT,
+        ext = IR_EXT_PROTOLAYOUT_LAYOUT,
+        bytes = layout,
+        resourcesExt = IR_EXT_PROTOLAYOUT_RESOURCES,
+        resourcesBytes = read(IR_EXT_PROTOLAYOUT_RESOURCES),
+      )
+    }
+    return null
   }
 
   private fun packModuleClasses(
@@ -519,6 +603,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     inlinedProjectJars: Map<String, File>,
     report: String,
     previewPngs: Map<String, ByteArray>,
+    irFiles: Map<String, ByteArray>,
   ): ByteArray {
     val baos = ByteArrayOutputStream()
     ZipOutputStream(baos).use { zip ->
@@ -526,6 +611,8 @@ abstract class BundlePreviewTask : DefaultTask() {
       zip.writeFile("previews.json", previewsJson.toByteArray(Charsets.UTF_8))
       // One baked PNG per selected preview under the well-known `previews/` directory.
       previewPngs.forEach { (id, bytes) -> zip.writeFile("$BUNDLE_PREVIEWS_DIR/$id.png", bytes) }
+      // Captured IR bytes (Remote Compose doc / protolayout proto) under `ir/`.
+      irFiles.forEach { (path, bytes) -> zip.writeFile(path, bytes) }
       zip.writeFile("classes/app.jar", appJar)
       inlinedProjectJars.forEach { (path, file) -> zip.writeFile(path, file.readBytes()) }
       zip.writeFile("report.json", report.toByteArray(Charsets.UTF_8))

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -337,8 +337,14 @@ abstract class BundlePreviewTask : DefaultTask() {
   /**
    * The rendered PNG bytes for [preview]'s primary capture, or null when no render exists on disk
    * (bundling without a prior `composePreviewRender`, or a preview that failed to render). Used
-   * both for the cover (first selected) and to bake every selected preview into
-   * `previews/<id>.png`.
+   * both for the cover (first selected) and to bake every selected preview into `previews/<id>.png`.
+   *
+   * Only **PNG** bytes are ever returned: the result is used verbatim as the polyglot's leading
+   * cover and as `previews/<id>.png`, and [extractZipBytes] rejects a file whose leading signature
+   * is neither PNG nor ZIP. A preview whose primary capture is a GIF (`@AnimatedPreview`,
+   * `@FocusedPreview(gif = true)`) therefore must NOT have its `.gif` bytes read as the cover — that
+   * would produce an unreadable bundle. Such a preview falls through to the PNG-sibling search and,
+   * failing that, to the stub gray cover.
    */
   private fun resolvePreviewPng(preview: PreviewInfo): ByteArray? {
     val rendersRoot = rendersDir.orNull?.asFile ?: return null
@@ -347,16 +353,21 @@ abstract class BundlePreviewTask : DefaultTask() {
     val rel =
       preview.captures.firstOrNull()?.renderOutput?.takeIf { it.isNotEmpty() } ?: return null
     val name = rel.substringAfterLast('/')
+    val base = name.substringBeforeLast('.')
 
-    val exact = File(rendersRoot, name)
-    if (exact.isFile && exact.length() > 0) return exact.readBytes()
+    // Only read the primary-capture file directly when it's a PNG. A GIF (or any non-PNG) primary
+    // capture is skipped here so its bytes never become the cover; the sibling search below is
+    // already PNG-filtered.
+    if (name.endsWith(".png")) {
+      val exact = File(rendersRoot, name)
+      if (exact.isFile && exact.length() > 0) return exact.readBytes()
+    }
 
-    // No file at the primary capture's exact path: @PreviewParameter / multi-variant previews fan
+    // No usable PNG at the primary capture's path: @PreviewParameter / multi-variant previews fan
     // out into siblings (`<base>_<param>.png`, `<base>--<dimension>.png`). Bake the first sibling
     // as
     // a representative cover so the preview isn't silently dropped from the bundle.
     if (!rendersRoot.isDirectory) return null
-    val base = name.removeSuffix(".png")
     return rendersRoot
       .listFiles { f ->
         f.isFile &&

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -177,7 +177,8 @@ abstract class BundlePreviewTask : DefaultTask() {
     // Previews whose flavour emitted a serialisable intermediate representation (Remote Compose doc
     // / Wear protolayout proto) during the render step are replayed from that IR, not by re-running
     // their composable. We therefore (a) carry the IR bytes in the bundle and (b) DROP their
-    // enclosing class from the closure seed below, so the consumer bytecode that produced them isn't
+    // enclosing class from the closure seed below, so the consumer bytecode that produced them
+    // isn't
     // packed at all — the whole point of the v5 format. A preview with no IR sidecar stays on the
     // classic class-minimisation path.
     val irByPreview: Map<String, ResolvedIr> =
@@ -337,14 +338,15 @@ abstract class BundlePreviewTask : DefaultTask() {
   /**
    * The rendered PNG bytes for [preview]'s primary capture, or null when no render exists on disk
    * (bundling without a prior `composePreviewRender`, or a preview that failed to render). Used
-   * both for the cover (first selected) and to bake every selected preview into `previews/<id>.png`.
+   * both for the cover (first selected) and to bake every selected preview into
+   * `previews/<id>.png`.
    *
    * Only **PNG** bytes are ever returned: the result is used verbatim as the polyglot's leading
    * cover and as `previews/<id>.png`, and [extractZipBytes] rejects a file whose leading signature
    * is neither PNG nor ZIP. A preview whose primary capture is a GIF (`@AnimatedPreview`,
-   * `@FocusedPreview(gif = true)`) therefore must NOT have its `.gif` bytes read as the cover — that
-   * would produce an unreadable bundle. Such a preview falls through to the PNG-sibling search and,
-   * failing that, to the stub gray cover.
+   * `@FocusedPreview(gif = true)`) therefore must NOT have its `.gif` bytes read as the cover —
+   * that would produce an unreadable bundle. Such a preview falls through to the PNG-sibling search
+   * and, failing that, to the stub gray cover.
    */
   private fun resolvePreviewPng(preview: PreviewInfo): ByteArray? {
     val rendersRoot = rendersDir.orNull?.asFile ?: return null

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -74,8 +74,8 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  *
  * # Intermediate-representation previews (v5)
  *
- * Some preview flavours don't need their producing code re-executed to render again — they declare a
- * serialisable **intermediate representation** that a small runtime can replay on its own:
+ * Some preview flavours don't need their producing code re-executed to render again — they declare
+ * a serialisable **intermediate representation** that a small runtime can replay on its own:
  * - **Remote Compose** (`@PreviewWrapper(RemotePreviewWrapper::class)` composables) captures a
  *   `RemoteDocument` byte stream — the "RC doc". A `RemoteDocumentPlayer` paints it back with no
  *   reference to the Kotlin that authored it.
@@ -86,11 +86,12 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  *
  * For such previews the bundle carries the IR bytes under `ir/<id>.<ext>` and records a [BundleIr]
  * in [BundleManifest.intermediateRepresentations]; the enclosing class is dropped from the
- * minimisation closure seed, so the consumer bytecode that produced it is **not** packed. The player
- * dispatches on the recorded [BundleIr.format] and replays through the Remote Compose / ProtoLayout
- * library instead of loading consumer classes. A bundle can mix IR-backed and classpath-backed
- * previews; each preview is independently either listed in `intermediateRepresentations` (replayed
- * from IR) or seeded into `classes/app.jar` (replayed by re-running its composable).
+ * minimisation closure seed, so the consumer bytecode that produced it is **not** packed. The
+ * player dispatches on the recorded [BundleIr.format] and replays through the Remote Compose /
+ * ProtoLayout library instead of loading consumer classes. A bundle can mix IR-backed and
+ * classpath-backed previews; each preview is independently either listed in
+ * `intermediateRepresentations` (replayed from IR) or seeded into `classes/app.jar` (replayed by
+ * re-running its composable).
  */
 @Serializable
 data class BundleManifest(
@@ -135,8 +136,8 @@ data class BundleManifest(
   /**
    * (v5) Per-preview intermediate-representation records. Each entry names a preview that is
    * replayed from a captured IR ([BundleIr.format] = [IR_FORMAT_REMOTECOMPOSE] /
-   * [IR_FORMAT_PROTOLAYOUT]) rather than by re-running its composable. A preview appears here OR has
-   * its enclosing class in `classes/app.jar`, never both. Empty (the default) on a classic
+   * [IR_FORMAT_PROTOLAYOUT]) rather than by re-running its composable. A preview appears here OR
+   * has its enclosing class in `classes/app.jar`, never both. Empty (the default) on a classic
    * all-classes bundle, so a v4 reader that ignores this field still decodes a v5 classpath bundle
    * correctly. See the "Intermediate-representation previews" section above.
    */
@@ -295,8 +296,8 @@ const val IR_EXT_PROTOLAYOUT_RESOURCES: String = "tileresources"
  *   serialisable IR (Remote Compose doc, Wear protolayout proto) are replayed from the IR via the
  *   matching runtime library instead of by re-running their consumer bytecode, which is then
  *   dropped from `classes/app.jar`. Additive — the field defaults to empty and `ignoreUnknownKeys`
- *   readers skip the `ir/` entries, so a v4 reader opening a v5 *classpath* bundle still works; only
- *   the IR previews need a v5-aware player.
+ *   readers skip the `ir/` entries, so a v4 reader opening a v5 *classpath* bundle still works;
+ *   only the IR previews need a v5-aware player.
  */
 const val BUNDLE_SCHEMA_VERSION: Int = 5
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -32,11 +32,21 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  *                            iterating the well-known directory yields every preview uniformly.
  *                            A preview with no render on disk is simply absent from this directory.
  * classes/app.jar          — consumer module bytecode, MINIMIZED to classes reachable from the
- *                            selected previews (plus all module resources)
+ *                            selected previews (plus all module resources). For an IR-backed
+ *                            preview (see below) the enclosing class is NOT a closure seed, so its
+ *                            bytecode is omitted unless some other preview reaches it.
  * libs/<name>.jar          — third-party / project jars carried IN the bundle. Present only for
  *                            [ClasspathEntry.Project] fallbacks and, since v3, [ClasspathEntry.Embedded]
  *                            entries (`resolution = "embedded"` / `"mixed"`). Absent for a pure
  *                            `coordinates` pack.
+ * ir/<id>.<ext>            — (v5) the captured **intermediate representation** for a preview whose
+ *                            flavour has one: a Remote Compose document byte stream
+ *                            (`<id>.rcdoc`) or a Wear protolayout `Layout` proto (`<id>.tilelayout`,
+ *                            with the companion resources proto as `<id>.tileresources`). A player
+ *                            replays the IR directly through the Remote Compose / ProtoLayout
+ *                            runtime — it needs neither the consumer's `@Preview` bytecode nor the
+ *                            full Compose graph that produced it. See [BundleIr] and
+ *                            [BundleManifest.intermediateRepresentations].
  * report.json              — [MinimizationReport]: which deps contributed reachable classes
  * ```
  *
@@ -61,6 +71,26 @@ import kotlinx.serialization.json.JsonClassDiscriminator
  * For Android backends, [ClasspathEntry.Maven.type] = `"aar"` records that the player must resolve
  * the **unprocessed** AAR (not the extracted classes.jar) so AGP's artifact transforms run as they
  * would in a normal build.
+ *
+ * # Intermediate-representation previews (v5)
+ *
+ * Some preview flavours don't need their producing code re-executed to render again — they declare a
+ * serialisable **intermediate representation** that a small runtime can replay on its own:
+ * - **Remote Compose** (`@PreviewWrapper(RemotePreviewWrapper::class)` composables) captures a
+ *   `RemoteDocument` byte stream — the "RC doc". A `RemoteDocumentPlayer` paints it back with no
+ *   reference to the Kotlin that authored it.
+ * - **Wear Tiles / ProtoLayout** (`@androidx.wear.tiles.tooling.preview.Preview`) produces a
+ *   `LayoutElementBuilders.Layout` protobuf plus a `ResourceBuilders.Resources` proto. A
+ *   `TileRenderer` inflates the proto with no reference to the `fun foo(): TilePreviewData` that
+ *   built it.
+ *
+ * For such previews the bundle carries the IR bytes under `ir/<id>.<ext>` and records a [BundleIr]
+ * in [BundleManifest.intermediateRepresentations]; the enclosing class is dropped from the
+ * minimisation closure seed, so the consumer bytecode that produced it is **not** packed. The player
+ * dispatches on the recorded [BundleIr.format] and replays through the Remote Compose / ProtoLayout
+ * library instead of loading consumer classes. A bundle can mix IR-backed and classpath-backed
+ * previews; each preview is independently either listed in `intermediateRepresentations` (replayed
+ * from IR) or seeded into `classes/app.jar` (replayed by re-running its composable).
  */
 @Serializable
 data class BundleManifest(
@@ -102,6 +132,36 @@ data class BundleManifest(
    * Defaults to [RESOLUTION_COORDINATES] for v2 back-compat.
    */
   val resolution: String = RESOLUTION_COORDINATES,
+  /**
+   * (v5) Per-preview intermediate-representation records. Each entry names a preview that is
+   * replayed from a captured IR ([BundleIr.format] = [IR_FORMAT_REMOTECOMPOSE] /
+   * [IR_FORMAT_PROTOLAYOUT]) rather than by re-running its composable. A preview appears here OR has
+   * its enclosing class in `classes/app.jar`, never both. Empty (the default) on a classic
+   * all-classes bundle, so a v4 reader that ignores this field still decodes a v5 classpath bundle
+   * correctly. See the "Intermediate-representation previews" section above.
+   */
+  val intermediateRepresentations: List<BundleIr> = emptyList(),
+)
+
+/**
+ * One preview replayed from a captured intermediate representation rather than from its consumer
+ * bytecode. The player keys on [format] to pick the replay library and reads the IR bytes from
+ * [path] (and [resourcesPath] for protolayout).
+ */
+@Serializable
+data class BundleIr(
+  /** Preview id this IR renders; matches an entry in [BundleManifest.previewIds]. */
+  val previewId: String,
+  /** IR flavour: [IR_FORMAT_REMOTECOMPOSE] or [IR_FORMAT_PROTOLAYOUT]. */
+  val format: String,
+  /** Posix zip path of the IR bytes, e.g. `ir/<id>.rcdoc` or `ir/<id>.tilelayout`. */
+  val path: String,
+  /**
+   * Posix zip path of a companion artefact the format needs, e.g. the protolayout
+   * `ResourceBuilders.Resources` proto (`ir/<id>.tileresources`). `null` for formats that carry
+   * everything in [path] (Remote Compose).
+   */
+  val resourcesPath: String? = null,
 )
 
 /** Discriminator field `kind`, values: `module`, `maven`, `project`. */
@@ -194,6 +254,23 @@ const val RESOLUTION_EMBEDDED: String = "embedded"
 
 const val RESOLUTION_MIXED: String = "mixed"
 
+/** [BundleIr.format] values. */
+const val IR_FORMAT_REMOTECOMPOSE: String = "remotecompose"
+
+const val IR_FORMAT_PROTOLAYOUT: String = "protolayout"
+
+/** Well-known directory inside the bundle zip holding per-preview IR bytes (`ir/<id>.<ext>`). */
+const val BUNDLE_IR_DIR: String = "ir"
+
+/** File extension for a captured Remote Compose document byte stream. */
+const val IR_EXT_REMOTECOMPOSE: String = "rcdoc"
+
+/** File extension for a captured Wear protolayout `Layout` proto. */
+const val IR_EXT_PROTOLAYOUT_LAYOUT: String = "tilelayout"
+
+/** File extension for the companion protolayout `Resources` proto. */
+const val IR_EXT_PROTOLAYOUT_RESOURCES: String = "tileresources"
+
 /**
  * Schema version stamped into [BundleManifest.schemaVersion].
  * - v1 — `bundle.json` + `previews.json` + `classes/app.jar` + `report.json`, cover PNG as the
@@ -214,8 +291,14 @@ const val RESOLUTION_MIXED: String = "mixed"
  *   the coordinate however it can, then verifies the bytes against the hash. Purely additive —
  *   `sha256` defaults to null, so a v3 reader opening a v4 bundle just ignores it and an older
  *   bundle reads as "unverifiable coordinate".
+ * - v5 — adds [BundleManifest.intermediateRepresentations] and the `ir/` directory: previews with a
+ *   serialisable IR (Remote Compose doc, Wear protolayout proto) are replayed from the IR via the
+ *   matching runtime library instead of by re-running their consumer bytecode, which is then
+ *   dropped from `classes/app.jar`. Additive — the field defaults to empty and `ignoreUnknownKeys`
+ *   readers skip the `ir/` entries, so a v4 reader opening a v5 *classpath* bundle still works; only
+ *   the IR previews need a v5-aware player.
  */
-const val BUNDLE_SCHEMA_VERSION: Int = 4
+const val BUNDLE_SCHEMA_VERSION: Int = 5
 
 /**
  * Well-known directory inside the bundle zip holding one rendered PNG per selected preview, keyed

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
@@ -7,8 +7,8 @@ import org.junit.Test
 /**
  * Schema round-trip + back-compat coverage for [BundleManifest] / [ClasspathEntry] / [BundleIr].
  * Covers the v3 [ClasspathEntry.Embedded] kind, the v4 [ClasspathEntry.Maven.sha256], and the v5
- * [BundleManifest.intermediateRepresentations]; every added field defaults so an older `bundle.json`
- * (which omits it) still decodes.
+ * [BundleManifest.intermediateRepresentations]; every added field defaults so an older
+ * `bundle.json` (which omits it) still decodes.
  */
 class PreviewBundleFormatTest {
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
@@ -5,9 +5,10 @@ import kotlinx.serialization.json.Json
 import org.junit.Test
 
 /**
- * Schema v3 round-trip + back-compat coverage for [BundleManifest] / [ClasspathEntry]. v3 adds the
- * [ClasspathEntry.Embedded] kind and the [BundleManifest.producer] / [BundleManifest.resolution]
- * fields; both manifest fields default so a v2 `bundle.json` (which omits them) still decodes.
+ * Schema round-trip + back-compat coverage for [BundleManifest] / [ClasspathEntry] / [BundleIr].
+ * Covers the v3 [ClasspathEntry.Embedded] kind, the v4 [ClasspathEntry.Maven.sha256], and the v5
+ * [BundleManifest.intermediateRepresentations]; every added field defaults so an older `bundle.json`
+ * (which omits it) still decodes.
  */
 class PreviewBundleFormatTest {
 
@@ -22,8 +23,67 @@ class PreviewBundleFormatTest {
   }
 
   @Test
-  fun `current schema version is 4`() {
-    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(4)
+  fun `current schema version is 5`() {
+    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(5)
+  }
+
+  @Test
+  fun `intermediate representations round-trip`() {
+    val original =
+      BundleManifest(
+        schemaVersion = BUNDLE_SCHEMA_VERSION,
+        backend = "android",
+        previewIds = listOf("pkg.Rc", "pkg.Tile"),
+        coverPreviewId = "pkg.Rc",
+        classpath = listOf(ClasspathEntry.Module(path = "classes/app.jar")),
+        modulePath = ":sample",
+        producedBy = "test",
+        intermediateRepresentations =
+          listOf(
+            BundleIr(
+              previewId = "pkg.Rc",
+              format = IR_FORMAT_REMOTECOMPOSE,
+              path = "ir/pkg.Rc.rcdoc",
+            ),
+            BundleIr(
+              previewId = "pkg.Tile",
+              format = IR_FORMAT_PROTOLAYOUT,
+              path = "ir/pkg.Tile.tilelayout",
+              resourcesPath = "ir/pkg.Tile.tileresources",
+            ),
+          ),
+      )
+
+    val decoded =
+      json.decodeFromString(
+        BundleManifest.serializer(),
+        json.encodeToString(BundleManifest.serializer(), original),
+      )
+
+    assertThat(decoded).isEqualTo(original)
+    val tile = decoded.intermediateRepresentations.single { it.format == IR_FORMAT_PROTOLAYOUT }
+    assertThat(tile.resourcesPath).isEqualTo("ir/pkg.Tile.tileresources")
+  }
+
+  @Test
+  fun `v4 manifest without intermediateRepresentations decodes with an empty list`() {
+    val v4 =
+      """
+      {
+        "schemaVersion": 4,
+        "backend": "desktop",
+        "previewIds": ["pkg.Foo"],
+        "coverPreviewId": "pkg.Foo",
+        "classpath": [ { "kind": "module", "path": "classes/app.jar" } ],
+        "modulePath": ":sample",
+        "producedBy": "test"
+      }
+      """
+        .trimIndent()
+
+    val decoded = json.decodeFromString(BundleManifest.serializer(), v4)
+
+    assertThat(decoded.intermediateRepresentations).isEmpty()
   }
 
   @Test


### PR DESCRIPTION
## Goal

Make executable PNG/ZIP bundles render Remote Compose and Wear Tiles/ProtoLayout previews **from their intermediate representation** instead of by re-running the consumer's `@Preview` bytecode. Both flavours already produce a serialisable IR during a render:

- **Remote Compose** → a `RemoteDocument` byte stream ("RC doc"), replayable by `RemoteDocumentPlayer` with no reference to the authoring Kotlin.
- **Wear Tiles / ProtoLayout** → a `LayoutElementBuilders.Layout` proto (+ `ResourceBuilders.Resources`), replayable by `TileRenderer` with no reference to the `fun foo(): TilePreviewData` that built it.

So for these previews the bundle should carry the IR, signal its type in the metadata, drop the now-unneeded class files, and replay through the runtime library.

## What this PR lands (the format + production + metadata half — unit-tested)

**Metadata signalling the type (`PreviewBundleFormat.kt`, schema v5)**
- New `BundleManifest.intermediateRepresentations: List<BundleIr>`; each `BundleIr` records `previewId`, `format` (`remotecompose` | `protolayout`), the zip `path` of the IR bytes, and an optional `resourcesPath` (protolayout resources proto).
- New `ir/<id>.<ext>` zip directory (`.rcdoc`, `.tilelayout`, `.tileresources`); `BUNDLE_SCHEMA_VERSION` → 5. All new fields default, so a v4 reader decodes a v5 *classpath* bundle unchanged.

**Production (`BundlePreviewTask`)**
- Resolves an IR sidecar emitted by the render step next to each preview's PNG (`<stem>.rcdoc` / `<stem>.tilelayout` / `<stem>.tileresources`), embeds it under `ir/`, and records a `BundleIr`.
- **Drops IR-backed previews from the minimisation closure seed**, so their consumer bytecode is no longer packed into `classes/app.jar` — a bundle whose previews are all IR-backed carries an (effectively empty) app jar.

**Replay metadata-awareness**
- CLI `BundleReader` and `bundle-viewer` `Schema` mirror the new fields so v5 bundles decode everywhere.
- The desktop CLI `BundleRenderer` now **skips** IR-backed previews (their class was intentionally dropped, so `DesktopRendererMain` would `ClassNotFoundException`) and points at the Android daemon replay path, instead of failing them.

**Tests:** `PreviewBundleFormatTest` covers v5 round-trip and v4→v5 back-compat.

> ⚠️ **Verification note.** I could not compile or run anything in the cloud sandbox for this session: Gradle 9.5.1 fails to resolve its own `kotlin-dsl` plugin here (a network-policy quirk — the artifact is reachable via `curl` but Gradle's resolution fails fast), and JDK 17 had to be hand-installed. The changes above are pure-JVM/data and reasoned carefully, but **please run `./gradlew :gradle-plugin:test ktfmtFormatAll` on a working build** — in particular re-run the formatter, since I couldn't run ktfmt and matched its style by hand.

## What remains (the emission + execution half — needs a working Android build)

These two pieces are **Android/Robolectric + alpha `androidx.compose.remote.*` only**, which the sandbox can't build or execute, so I deliberately did not push unverifiable renderer code. The seams are:

1. **Emit the IR sidecars during render** so production has something to embed:
   - *ProtoLayout:* in `renderers/android/.../TilePreviewRenderer.kt`, after the `layout` / `resources` are built (around `renderTileInto`), serialise them (`Layout.toByteArray()` / `Resources.toByteArray()`) and write `<stem>.tilelayout` / `<stem>.tileresources` next to the PNG. The output stem is known to the harness (`RobolectricRenderTest` / the daemon `RenderEngine`), so the bytes need routing out via a small process-static holder, mirroring the `NotificationSidecar` pattern.
   - *Remote Compose:* in `data/remotecompose/connector/.../RemoteOverridablePreview.kt` the `RemoteDocument(...).bytes` already exist; surface them through `RemoteComposeController` (like the host-action buffer) so the harness writes `<stem>.rcdoc`.

2. **Replay the IR via the libraries** in the Android daemon (`:daemon:android` `RenderEngine`, reached by `compose-preview bundle daemon`): when a preview is listed in `intermediateRepresentations`, inflate the IR directly — `TileRenderer.inflateAsync(Layout.fromByteArray(...), Resources.fromByteArray(...))` for protolayout, `RemoteDocumentPlayer(RemoteDocument(bytes))` for remote compose — instead of reflecting the (absent) consumer function. The protolayout-renderer / compose-remote-player libraries replace the consumer classes on the replay classpath.

Happy to follow up with those on a build where I can compile and run `:samples:remotecompose` / `:samples:wear` end-to-end, or split them into their own PRs — let me know your preference.

## Test plan

- [ ] `./gradlew :gradle-plugin:test --tests "*PreviewBundleFormatTest"`
- [ ] `./gradlew ktfmtFormatAll` (re-run formatter; I couldn't run it here)
- [ ] `./gradlew check`
- [ ] Manual: pack a classpath bundle and confirm it's byte-identical behaviourally to v4 (v5 with empty `intermediateRepresentations`).

https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt)_