### PR TITLE
fix(bundle): skip IR-backed previews in renderAndroid (parity with renderDesktop)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -5,6 +5,12 @@ import java.io.File
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Re-renders a packed `.png` (PNG+ZIP polyglot bundle) outside of any Gradle project: extract the
@@ -202,9 +208,17 @@ class BundleRenderer(
         .resolveAll(mavenCoords)
         .mapNotNull { it.file }
 
-    // previews.json drives the batch — write the bundle's copy verbatim where the renderer reads
-    // it.
-    val previewsJsonFile = workDir.resolve("previews.json").apply { writeText(previewsJsonRaw) }
+    // IR-backed previews (schema v5) are replayed by the Android daemon (`compose-preview bundle
+    // daemon`), not this one-shot renderer: their consumer class was dropped from the bundle at
+    // pack
+    // time, so handing them to AndroidRendererMain (which reflects the enclosing class) would fail.
+    // Strip them from the manifest the renderer sees — parity with renderDesktop's per-preview IR
+    // skip — and report them as skipped rather than failed.
+    val irIds = manifest.intermediateRepresentations.map { it.previewId }.toSet()
+    val rendererPreviewsJson =
+      if (irIds.isEmpty()) previewsJsonRaw else filterPreviewsJson(previewsJsonRaw, irIds)
+    val previewsJsonFile =
+      workDir.resolve("previews.json").apply { writeText(rendererPreviewsJson) }
 
     // Synthesized robolectric.properties wins first; then consumer classes + deps; then the Android
     // renderer's own runtime; android.jar last (discovery-only stub — Robolectric's android-all
@@ -224,6 +238,13 @@ class BundleRenderer(
     val succeeded = mutableListOf<RenderedPreview>()
     val failed = mutableListOf<FailedPreview>()
     for (preview in previews.previews) {
+      if (preview.id in irIds) {
+        logSink(
+          "compose-preview: skipping ${preview.id} — IR replay runs in the Android daemon " +
+            "(compose-preview bundle daemon), not the one-shot renderer"
+        )
+        continue
+      }
       val outFile = outputDir.resolve(androidOutputLeaf(preview))
       if (outFile.isFile && outFile.length() > 0) {
         succeeded += RenderedPreview(preview.id, outFile)
@@ -512,6 +533,24 @@ class BundleRenderer(
      * from the preview id — is what keeps a successful Android render from being mis-reported as a
      * failure. Fan-out captures write additional files; the primary capture is the render signal.
      */
+    /**
+     * Return [raw] (a `previews.json` body) with every preview whose `id` is in [drop] removed from
+     * the top-level `previews` array, preserving all other fields verbatim (operates on the JSON
+     * tree, not the lossy `ignoreUnknownKeys` model). Used to hide IR-backed previews from the
+     * batch Android renderer, whose consumer classes were dropped from the bundle at pack time.
+     */
+    internal fun filterPreviewsJson(raw: String, drop: Set<String>): String {
+      val root = Json.parseToJsonElement(raw).jsonObject
+      val previews = root["previews"]?.jsonArray ?: return raw
+      val kept = previews.filter { el ->
+        el.jsonObject["id"]?.jsonPrimitive?.contentOrNull !in drop
+      }
+      return Json.encodeToString(
+        JsonObject.serializer(),
+        JsonObject(root + ("previews" to JsonArray(kept))),
+      )
+    }
+
     internal fun androidOutputLeaf(preview: PreviewInfo): String {
       val leaf = preview.captures.firstOrNull()?.renderOutput?.substringAfterLast('/')
       return if (leaf.isNullOrEmpty()) "${preview.id}.png" else leaf

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -181,6 +181,30 @@ class BundleRenderer(
     previews: PreviewManifest,
     previewsJsonRaw: String,
   ): Result {
+    // IR-backed previews (schema v5) are replayed by the Android daemon (`compose-preview bundle
+    // daemon`), not this one-shot renderer: their consumer class was dropped from the bundle at
+    // pack
+    // time, so handing them to AndroidRendererMain (which reflects the enclosing class) would fail.
+    // Compute the IR/non-IR split FIRST and report IR previews as skipped — parity with
+    // renderDesktop's per-preview IR skip. An all-IR bundle has nothing for this renderer to do, so
+    // return before requiring the Android sidecar/SDK (which Phase 1 doesn't package), rather than
+    // throwing on prerequisites we don't actually need.
+    val irIds = manifest.intermediateRepresentations.map { it.previewId }.toSet()
+    for (preview in previews.previews.filter { it.id in irIds }) {
+      logSink(
+        "compose-preview: skipping ${preview.id} — IR replay runs in the Android daemon " +
+          "(compose-preview bundle daemon), not the one-shot renderer"
+      )
+    }
+    val renderable = previews.previews.filter { it.id !in irIds }
+    if (renderable.isEmpty()) {
+      return Result(
+        previewCount = previews.previews.size,
+        succeeded = emptyList(),
+        failed = emptyList(),
+      )
+    }
+
     val rendererJars = locateAndroidRendererClasspath()
     if (rendererJars.isEmpty()) {
       throw IllegalStateException(
@@ -208,13 +232,8 @@ class BundleRenderer(
         .resolveAll(mavenCoords)
         .mapNotNull { it.file }
 
-    // IR-backed previews (schema v5) are replayed by the Android daemon (`compose-preview bundle
-    // daemon`), not this one-shot renderer: their consumer class was dropped from the bundle at
-    // pack
-    // time, so handing them to AndroidRendererMain (which reflects the enclosing class) would fail.
-    // Strip them from the manifest the renderer sees — parity with renderDesktop's per-preview IR
-    // skip — and report them as skipped rather than failed.
-    val irIds = manifest.intermediateRepresentations.map { it.previewId }.toSet()
+    // Strip the IR previews from the manifest the renderer sees so AndroidRendererMain never
+    // attempts the classless preview (it renders the whole previews.json in one batch).
     val rendererPreviewsJson =
       if (irIds.isEmpty()) previewsJsonRaw else filterPreviewsJson(previewsJsonRaw, irIds)
     val previewsJsonFile =
@@ -237,14 +256,7 @@ class BundleRenderer(
     // file and falsely fail the preview).
     val succeeded = mutableListOf<RenderedPreview>()
     val failed = mutableListOf<FailedPreview>()
-    for (preview in previews.previews) {
-      if (preview.id in irIds) {
-        logSink(
-          "compose-preview: skipping ${preview.id} — IR replay runs in the Android daemon " +
-            "(compose-preview bundle daemon), not the one-shot renderer"
-        )
-        continue
-      }
+    for (preview in renderable) {
       val outFile = outputDir.resolve(androidOutputLeaf(preview))
       if (outFile.isFile && outFile.length() > 0) {
         succeeded += RenderedPreview(preview.id, outFile)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRendererAndroidOutputTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRendererAndroidOutputTest.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.cli
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Pins how the Android bundle render path reconciles produced PNGs back to previews: by the
@@ -43,5 +45,32 @@ class BundleRendererAndroidOutputTest {
         captures = emptyList(),
       )
     assertEquals("Lonely.png", BundleRenderer.androidOutputLeaf(p))
+  }
+
+  @Test
+  fun `filterPreviewsJson drops IR-backed previews and preserves other fields`() {
+    val raw =
+      """
+      {"module":":app","previews":[
+        {"id":"a.Foo","functionName":"Foo","className":"a.Kt"},
+        {"id":"a.TilePreview","functionName":"TilePreview","className":"a.TileKt"}
+      ]}
+      """
+        .trimIndent()
+
+    val filtered = BundleRenderer.filterPreviewsJson(raw, drop = setOf("a.TilePreview"))
+
+    // The IR-backed preview is gone; the classpath preview and top-level `module` survive.
+    assertTrue(filtered.contains("\"a.Foo\""))
+    assertFalse(filtered.contains("a.TilePreview"))
+    assertTrue(filtered.contains("\":app\""))
+  }
+
+  @Test
+  fun `filterPreviewsJson with an empty drop set keeps every preview`() {
+    val raw = """{"module":":app","previews":[{"id":"a.Foo"},{"id":"a.Bar"}]}"""
+    val filtered = BundleRenderer.filterPreviewsJson(raw, drop = emptySet())
+    assertTrue(filtered.contains("a.Foo"))
+    assertTrue(filtered.contains("a.Bar"))
   }
 }


### PR DESCRIPTION
## Summary

Closes a gap between `renderDesktop` and `renderAndroid` in `BundleRenderer`. `renderDesktop` already skips schema-v5 IR-backed previews (their consumer class is dropped from the bundle at pack time; replay is the Android daemon's job). `renderAndroid` — added in #1651, after the "BundleRenderer is desktop-only" assumption — did **not**. So once IR emission lands, `compose-preview bundle render` against an android bundle would hand IR previews to `AndroidRendererMain` (which reflects the absent enclosing class) and fail them.

`renderAndroid` is a single batch subprocess (unlike desktop's per-preview spawn), so the fix strips IR previews from the `previews.json` the renderer sees — via `filterPreviewsJson`, a lossless JSON-tree edit (preserves fields the `ignoreUnknownKeys` model would drop) — and reports them as skipped, never attempting the classless preview.

This is purely additive to the IR work in flight (the IR emission/execution handoff): it ensures the one-shot `bundle render` android path stays correct when IR bundles start being produced. IR *replay* remains the daemon's responsibility.

## Test plan
- `BundleRendererAndroidOutputTest` gains coverage for `filterPreviewsJson`: drops the IR-backed preview while preserving the classpath preview and top-level fields; empty drop-set is a no-op.
- `./gradlew :cli:test --tests "*.BundleRendererAndroidOutputTest" --tests "*.AndroidBundleLaunchTest"` → BUILD SUCCESSFUL.
- `:cli:ktfmtFormat` clean.

https://claude.ai/code/session_01GsJZfW6xT9JDJuvmHsUeA1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsJZfW6xT9JDJuvmHsUeA1)_