### PR TITLE
feat(bundle): emit Remote Compose IR sidecar at render time (Piece A)

### DIFF
--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
+import ee.schimke.composeai.data.render.IrSidecarChannel
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -23,8 +24,8 @@ import kotlinx.coroutines.runBlocking
  * running `RemoteComposePlayer`'s `StateUpdater`. Applied as `@PreviewWrapper(
  * RemoteOverridablePreviewWrapper::class)` on a `@Preview`-annotated composable so the body stays
  * authoring-shaped (`Container { MyRemoteComponent() }`) — no `RemoteOverridablePreview(...)` /
- * `RemotePreview(...)` call inside the body. This is the canonical shape: preview authors swap
- * one annotation, not the function body.
+ * `RemotePreview(...)` call inside the body. This is the canonical shape: preview authors swap one
+ * annotation, not the function body.
  *
  * Hard-codes [RcPlatformProfiles.ANDROIDX] for symmetry with the local `RemotePreviewWrapper` the
  * sample shipped before this connector existed. Consumers that want a different profile subclass
@@ -54,11 +55,11 @@ open class RemoteOverridablePreviewWrapper : PreviewWrapperProvider {
  *
  * The "USER:" domain prefix that `rememberNamedRemoteString` (and the rest of the `rememberNamed*`
  * family) uses on the writer side is the same prefix `StateUpdater.setUserLocal*` consumes, so a
- * binding declared with `rememberNamedRemoteString("label", "Tap me")` is reachable by passing
- * the bare `"label"` (no manual prefix) into the override map.
+ * binding declared with `rememberNamedRemoteString("label", "Tap me")` is reachable by passing the
+ * bare `"label"` (no manual prefix) into the override map.
  *
- * `RemoteNamedValue.BooleanValue` has no `setUserLocalBoolean` counterpart in alpha010; we
- * collapse it to `setUserLocalInt(name, 0 | 1)` so consumer code that bound the same name to a
+ * `RemoteNamedValue.BooleanValue` has no `setUserLocalBoolean` counterpart in alpha010; we collapse
+ * it to `setUserLocalInt(name, 0 | 1)` so consumer code that bound the same name to a
  * `rememberNamedRemoteInt` sees the toggled value. `RemoteNamedValue.DpValue` maps to
  * `setUserLocalFloat` (dp units are densitised float values once they reach the player).
  *
@@ -87,7 +88,14 @@ fun RemoteOverridablePreview(
   val remoteDocument =
     remember(profile, content) {
       runBlocking {
-        RemoteDocument(captureSingleRemoteDocument(context, displayInfo, profile, content).bytes)
+        val bytes = captureSingleRemoteDocument(context, displayInfo, profile, content).bytes
+        // Offer the captured RC doc so a bundle can carry + replay it without this composable's
+        // bytecode; the render harness drains it into the `renders/<stem>.rcdoc` sidecar that
+        // `BundlePreviewTask.resolvePreviewIr` packs. No-op outside a daemon/test render (no
+        // current
+        // preview id). Best-effort — never fail the render over IR capture. See IrSidecarChannel.
+        runCatching { IrSidecarChannel.offer(IrSidecarChannel.FORMAT_REMOTECOMPOSE, bytes) }
+        RemoteDocument(bytes)
       }
     }
 
@@ -107,9 +115,9 @@ fun RemoteOverridablePreview(
 }
 
 /**
- * Pushes every entry of [overrides] through [updater] using the matching `setUserLocal*` setter
- * for the `RemoteNamedValue` variant. Internal but visible for tests; ordinary callers reach this
- * via [RemoteOverridablePreview] / [RemoteOverridablePreviewWrapper].
+ * Pushes every entry of [overrides] through [updater] using the matching `setUserLocal*` setter for
+ * the `RemoteNamedValue` variant. Internal but visible for tests; ordinary callers reach this via
+ * [RemoteOverridablePreview] / [RemoteOverridablePreviewWrapper].
  */
 internal fun applyConnectorOverrides(
   updater: StateUpdater,
@@ -132,4 +140,3 @@ internal fun applyConnectorOverrides(
     }
   }
 }
-

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/IrSidecarChannel.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/IrSidecarChannel.kt
@@ -1,0 +1,86 @@
+package ee.schimke.composeai.data.render
+
+/**
+ * Process-static hand-off for a preview's captured **intermediate representation** (IR): the Remote
+ * Compose document byte stream, or the Wear protolayout `Layout` (+ `Resources`) protos.
+ *
+ * Mirrors `LauncherWidgetMetadataChannel`'s shape — a `ThreadLocal` "current preview id" the render
+ * harness sets/clears around each composition, plus a `ConcurrentHashMap` the producer offers into
+ * and the harness drains post-render. The producer side lives where the IR is built
+ * (`TilePreviewComposable` for protolayout, `RemoteOverridablePreview` for Remote Compose); the
+ * consumer side is the render harness (`RobolectricRenderTest` / the daemon), which writes the
+ * bytes next to the rendered PNG as the `renders/<stem>.<ext>` sidecar that
+ * `BundlePreviewTask.resolvePreviewIr` picks up.
+ *
+ * Keeping only raw `ByteArray`s here means this module needs no protolayout / alpha
+ * `compose-remote` types on its classpath — the producers serialise to bytes before offering.
+ * Best-effort: an offer outside a render (no current preview id) is a no-op, matching the
+ * launcher-widget channel.
+ */
+object IrSidecarChannel {
+
+  /**
+   * [format] values — kept in lockstep with `IR_FORMAT_*` in `:gradle-plugin`'s
+   * `PreviewBundleFormat`.
+   */
+  const val FORMAT_REMOTECOMPOSE: String = "remotecompose"
+
+  const val FORMAT_PROTOLAYOUT: String = "protolayout"
+
+  /**
+   * One captured IR. [resourcesBytes] is non-null only for [FORMAT_PROTOLAYOUT] (the tile
+   * `Resources` proto, written as the companion `.tileresources` sidecar); Remote Compose carries
+   * everything in [bytes].
+   */
+  data class IrCapture(
+    val format: String,
+    val bytes: ByteArray,
+    val resourcesBytes: ByteArray? = null,
+  ) {
+    // ByteArray needs structural equals/hashCode for data-class semantics to be meaningful.
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (other !is IrCapture) return false
+      return format == other.format &&
+        bytes.contentEquals(other.bytes) &&
+        (resourcesBytes?.contentEquals(other.resourcesBytes ?: ByteArray(0))
+          ?: (other.resourcesBytes == null))
+    }
+
+    override fun hashCode(): Int {
+      var result = format.hashCode()
+      result = 31 * result + bytes.contentHashCode()
+      result = 31 * result + (resourcesBytes?.contentHashCode() ?: 0)
+      return result
+    }
+  }
+
+  private val pending = java.util.concurrent.ConcurrentHashMap<String, IrCapture>()
+  private val currentPreviewIdHolder = ThreadLocal<String?>()
+
+  /**
+   * Render-side: set the preview id for the current render thread before invoking the preview's
+   * composition; clear in a `finally`. Producers read it via [offer] so they don't need an explicit
+   * `previewId` parameter.
+   */
+  fun setCurrentPreviewId(previewId: String?) {
+    if (previewId == null) currentPreviewIdHolder.remove()
+    else currentPreviewIdHolder.set(previewId)
+  }
+
+  /** Current render thread's preview id, or `null` outside a render. */
+  fun currentPreviewId(): String? = currentPreviewIdHolder.get()
+
+  /**
+   * Producer-side: stash the captured IR for the current render's preview. No-op when no current
+   * preview id is set (running outside a daemon/test render — bare unit tests, IDE preview pane). A
+   * later offer within the same render replaces the previous entry.
+   */
+  fun offer(format: String, bytes: ByteArray, resourcesBytes: ByteArray? = null) {
+    val previewId = currentPreviewIdHolder.get() ?: return
+    pending[previewId] = IrCapture(format, bytes, resourcesBytes)
+  }
+
+  /** Drain (read + remove) the IR captured for [previewId] during the just-finished render. */
+  fun consume(previewId: String): IrCapture? = pending.remove(previewId)
+}

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -438,6 +438,12 @@ abstract class RobolectricRenderTestBase(
         val pngFile = preview.captures.firstOrNull()?.let { outputFileFor(it, outputDir) }
             ?: outputFileFor(preview.dataProducts.first(), outputDir)
         RenderErrorSidecar.deleteStale(pngFile)
+        // Drop any IR sidecar from a prior run before rendering. The renders dir is reused, and
+        // `BundlePreviewTask.resolvePreviewIr` treats any non-empty sidecar as authoritative — so a
+        // preview that stops producing IR (RC wrapper removed, tile serialization fails, kind
+        // changed) would otherwise leave stale `<stem>.{rcdoc,tilelayout,tileresources}` that a later
+        // bundle embeds while dropping the now-classpath-backed preview's classes, breaking replay.
+        deleteStaleIrSidecars(pngFile)
 
         // Catch Throwable per preview. Today, a throw inside the preview
         // function fails the JUnit test, fails the Test task, and the
@@ -457,6 +463,9 @@ abstract class RobolectricRenderTestBase(
         // the offered entry post-render via the same id. Cleared in `finally` so the next
         // preview's render doesn't accidentally carry this one's id.
         ee.schimke.composeai.daemon.LauncherWidgetMetadataChannel.setCurrentPreviewId(preview.id)
+        // Arm the IR channel for this preview so a Remote Compose / protolayout producer can offer
+        // its captured intermediate representation during composition; drained post-render below.
+        ee.schimke.composeai.data.render.IrSidecarChannel.setCurrentPreviewId(preview.id)
         try {
             renderDefault(
                 params = params,
@@ -469,6 +478,9 @@ abstract class RobolectricRenderTestBase(
                 composeOptions = composeOptions,
                 inspectionMode = inspectionMode,
             )
+            // Render succeeded: if the preview's flavour captured an IR, write it beside the PNG as
+            // the `renders/<stem>.<ext>` sidecar `BundlePreviewTask.resolvePreviewIr` packs.
+            writeIrSidecar(pngFile, preview.id)
         } catch (e: Throwable) {
             System.err.println(
                 "Render failed for ${preview.className}.${preview.functionName}: ${e.message}"
@@ -482,6 +494,47 @@ abstract class RobolectricRenderTestBase(
             // exception detail on the failing card.
         } finally {
             ee.schimke.composeai.daemon.LauncherWidgetMetadataChannel.setCurrentPreviewId(null)
+            // Clear the IR channel id and drop any capture this preview left behind (e.g. on a
+            // render that threw after offering) so it can't leak onto the next preview.
+            ee.schimke.composeai.data.render.IrSidecarChannel.consume(preview.id)
+            ee.schimke.composeai.data.render.IrSidecarChannel.setCurrentPreviewId(null)
+        }
+    }
+
+    /**
+     * Write the IR captured during the just-finished render (if any) as a sidecar next to [pngFile],
+     * keyed by the PNG stem so it matches the `renders/<stem>.<ext>` contract
+     * `BundlePreviewTask.resolvePreviewIr` reads: `.rcdoc` for a Remote Compose document, or
+     * `.tilelayout` (+ `.tileresources`) for a Wear protolayout proto. Best-effort — a write failure
+     * must not derail the PNG render path.
+     */
+    private fun deleteStaleIrSidecars(pngFile: File) {
+        val dir = pngFile.parentFile ?: return
+        val stem = pngFile.nameWithoutExtension
+        for (ext in listOf("rcdoc", "tilelayout", "tileresources")) {
+            val f = File(dir, "$stem.$ext")
+            if (f.isFile && !f.delete()) {
+                System.err.println("Failed to delete stale IR sidecar: ${f.absolutePath}")
+            }
+        }
+    }
+
+    private fun writeIrSidecar(pngFile: File, previewId: String) {
+        val capture =
+            ee.schimke.composeai.data.render.IrSidecarChannel.consume(previewId) ?: return
+        try {
+            val dir = pngFile.parentFile ?: return
+            val stem = pngFile.nameWithoutExtension
+            when (capture.format) {
+                ee.schimke.composeai.data.render.IrSidecarChannel.FORMAT_REMOTECOMPOSE ->
+                    File(dir, "$stem.rcdoc").writeBytes(capture.bytes)
+                ee.schimke.composeai.data.render.IrSidecarChannel.FORMAT_PROTOLAYOUT -> {
+                    File(dir, "$stem.tilelayout").writeBytes(capture.bytes)
+                    capture.resourcesBytes?.let { File(dir, "$stem.tileresources").writeBytes(it) }
+                }
+            }
+        } catch (e: Throwable) {
+            System.err.println("Failed to write IR sidecar for $previewId: ${e.message}")
         }
     }
 


### PR DESCRIPTION
## Goal

**Piece A (emission)** of IR-backed bundle replay, continuing the v5 format from #1654. The render step now *produces* a Remote Compose preview's intermediate representation as a sidecar next to its PNG, so the v5 machinery already shipped — `BundlePreviewTask.resolvePreviewIr` embedding `ir/<id>.<ext>` and dropping the preview's classes — finally has something to find. Before this PR the IR path was inert (no producer ever wrote a sidecar).

## What this does

- **New `IrSidecarChannel` in `:data-render-core`** — a process-static, raw-`ByteArray` hand-off mirroring `LauncherWidgetMetadataChannel` (a `ThreadLocal` "current preview id" the harness arms/clears, plus a per-id pending map the producer offers into and the harness drains post-render). Raw bytes + a format string only, so this shared module needs **no** protolayout / alpha `compose-remote` types. It's the common main-classpath module of both the renderer (`implementation`) and the RC connector (`api`).
- **Remote Compose producer** — `RemoteOverridablePreview` offers the already-captured `RemoteDocument` bytes.
- **Consumer** — `RobolectricRenderTest` arms the channel per preview, **deletes any stale IR sidecar up front** (so a preview that stops producing IR can't leave an authoritative-but-stale `<stem>.rcdoc` that a later bundle would embed while dropping the now-classpath-backed preview's classes — thanks Codex), and on a successful render drains the channel to `renders/<stem>.rcdoc`. Best-effort throughout — IR capture never fails the PNG render.

## ProtoLayout (tiles) emission is deferred — and why

The first draft also serialised the tile `Layout`/`Resources` protos, but CI surfaced the problem: `LayoutElementBuilders.Layout` has a clean `toByteArray()`, but **`ResourceBuilders.Resources` has no byte serializer** — only `toProto()`, whose return type lives in `protolayout-proto`, a **`runtime`-scope** dependency that isn't on `:renderer-android`'s compile classpath. Serialising it needs a deliberate compile-classpath addition (`protolayout-proto` + the shaded `protolayout-external-protobuf`) to the renderer, which the renderer-vs-consumer alignment doc warns about and which I can't validate in this no-Android sandbox. So tile emission is split out to be done + verified on a real Android build. The harness writer already has the `protolayout` branch ready for when that producer lands.

## This is still Piece A only — replay needs Piece B

Once this lands, packing a Remote Compose bundle carries the RC doc and **drops the preview's classes** (the #1654 production behaviour). **Executing** it on replay — `RemoteDocumentPlayer(RemoteDocument(bytes))` in the `:daemon:android` `RenderEngine` via an `IrReplayStrategy`, plus `BundleDaemonCommand` `ir/`-wiring and player-library carriage — is **Piece B**, not here. Until Piece B, both render paths already **skip** IR-backed previews (#1654/#1657), so an RC preview on replay shows its **baked cover PNG**. No crash, no non-IR regression.

> ⚠️ **Verification note (same sandbox limits as #1654).** No Android SDK / alpha `compose-remote` runtime / working Gradle here, so I can't compile-check. I hand-ran ktfmt 0.62 on the googleStyle files and matched the renderer file's 4-space style. The earlier protolayout compile break (caught by CI) is removed; the remaining surface is small and low-risk (raw bytes, no proto). Please confirm `:data-render-core` is on the main classpath of `:renderer-android` (`implementation`) and `:data-remotecompose-connector` (`api`) — it is per their `build.gradle.kts`.

## Test plan

- [ ] `./gradlew :renderer-android:compileReleaseKotlin :data-remotecompose-connector:assemble`
- [ ] `:samples:remotecompose`: render → assert `build/compose-previews/renders/<stem>.rcdoc` appears → pack → assert `ir/` populated and the preview's class absent from `classes/app.jar`.
- [ ] `./gradlew check`

https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt