### PR TITLE
test(vscode): kill orphaned gradlew on cancel; bound+retry preload prime

### DIFF
--- a/vscode-extension/src/test/electron/realGradleApi.ts
+++ b/vscode-extension/src/test/electron/realGradleApi.ts
@@ -1,6 +1,14 @@
-import { spawn } from "child_process";
+import { spawn, type ChildProcess } from "child_process";
 import * as path from "path";
 import type { GradleApi } from "../../gradleService";
+
+/**
+ * Grace period between SIGTERM and SIGKILL when cancelling a hung gradlew.
+ * SIGTERM lets the Gradle client disconnect cleanly (which signals its
+ * daemon to cancel the in-flight build and release the build lock); the
+ * SIGKILL fallback covers a wedged JVM that ignores the term.
+ */
+const KILL_GRACE_MS = 5_000;
 
 /**
  * Real {@link GradleApi} that shells out to the repo's `./gradlew` wrapper.
@@ -26,6 +34,18 @@ export class RealGradleApi implements GradleApi {
         private readonly onLog: (line: string) => void = () => {},
         private readonly extraArgs: ReadonlyArray<string> = [],
     ) {}
+
+    /**
+     * Live gradlew child processes keyed by `cancellationKey`. Tracked so
+     * {@link cancelRunTask} can actually terminate a hung/superseded build
+     * — the original no-op left orphaned gradlew clients running, holding
+     * the project's Gradle build lock. Across a long serial e2e session
+     * (multiple render + daemon suites) those orphans accumulate and a
+     * later module render blocks forever on the lock, surfacing only as a
+     * 20-minute mocha hook timeout with no Gradle output. See
+     * `e2eCachedPreloadOnSwitch.test.ts`.
+     */
+    private readonly liveChildren = new Map<string, ChildProcess>();
 
     runTask(opts: {
         projectFolder: string;
@@ -68,6 +88,22 @@ export class RealGradleApi implements GradleApi {
                 env: { ...process.env },
                 stdio: ["ignore", "pipe", "pipe"],
             });
+            // Register under the cancellation key so a later
+            // `cancelRunTask` (fired by gradleService's 5-minute task
+            // timeout or a refresh supersession) can terminate this exact
+            // process instead of leaving it orphaned on the build lock.
+            if (opts.cancellationKey) {
+                this.liveChildren.set(opts.cancellationKey, child);
+            }
+            const forget = () => {
+                if (opts.cancellationKey) {
+                    // Only drop the entry if it still points at *this* child;
+                    // a re-run under the same key would have replaced it.
+                    if (this.liveChildren.get(opts.cancellationKey) === child) {
+                        this.liveChildren.delete(opts.cancellationKey);
+                    }
+                }
+            };
             child.stdout.on("data", (chunk: Buffer) => {
                 if (diagE2e) {
                     const text = chunk.toString("utf-8");
@@ -92,19 +128,29 @@ export class RealGradleApi implements GradleApi {
                     getOutputType: () => 1,
                 });
             });
-            child.once("error", reject);
-            child.once("close", (code) => {
+            child.once("error", (err) => {
+                forget();
+                reject(err);
+            });
+            child.once("close", (code, signal) => {
+                forget();
                 if (diagE2e) {
                     console.log(
-                        `[gradle exit] code=${code} args=${gradleArgs.join(" ")}`,
+                        `[gradle exit] code=${code} signal=${signal ?? "none"} args=${gradleArgs.join(" ")}`,
                     );
                 }
                 if (code === 0) {
                     resolve();
                 } else {
+                    // A cancelled build exits via signal (SIGTERM/SIGKILL)
+                    // with a null code. Surface it as a distinct, matchable
+                    // message so callers can tell "I cancelled this" apart
+                    // from a genuine build failure.
                     reject(
                         new Error(
-                            `gradlew ${gradleArgs.join(" ")} exited with ${code}`,
+                            signal
+                                ? `gradlew ${gradleArgs.join(" ")} cancelled (signal ${signal})`
+                                : `gradlew ${gradleArgs.join(" ")} exited with ${code}`,
                         ),
                     );
                 }
@@ -112,9 +158,53 @@ export class RealGradleApi implements GradleApi {
         });
     }
 
-    async cancelRunTask(): Promise<void> {
-        // The e2e suite runs each gradle invocation to completion; the
-        // extension never cancels mid-run in this harness. If we ever want
-        // to exercise cancellation we'd track the live child here.
+    async cancelRunTask(opts: {
+        projectFolder: string;
+        taskName: string;
+        cancellationKey?: string;
+    }): Promise<void> {
+        // Match the production `vscode-gradle` contract: cancellation is
+        // keyed by `cancellationKey`. Without a key there's nothing
+        // specific to cancel (gradleService always supplies one).
+        const key = opts.cancellationKey;
+        const child = key ? this.liveChildren.get(key) : undefined;
+        if (!child || child.pid === undefined || child.exitCode !== null) {
+            return;
+        }
+        this.onLog(
+            `[realGradleApi] cancel ${opts.taskName} (key=${key}) — terminating gradlew pid ${child.pid}`,
+        );
+        // SIGTERM first so the Gradle client disconnects gracefully and its
+        // daemon cancels the build (releasing the build lock); escalate to
+        // SIGKILL if the process is still alive after the grace period.
+        try {
+            child.kill("SIGTERM");
+        } catch {
+            /* already gone */
+        }
+        const killTimer = setTimeout(() => {
+            if (child.exitCode === null && child.signalCode === null) {
+                try {
+                    child.kill("SIGKILL");
+                } catch {
+                    /* already gone */
+                }
+            }
+        }, KILL_GRACE_MS);
+        // Don't keep the test host's event loop alive on the grace timer.
+        killTimer.unref?.();
+        // Resolve once the child has actually exited so callers serialise
+        // their retry *after* the build lock is released, not before.
+        await new Promise<void>((resolve) => {
+            if (child.exitCode !== null || child.signalCode !== null) {
+                clearTimeout(killTimer);
+                resolve();
+                return;
+            }
+            child.once("close", () => {
+                clearTimeout(killTimer);
+                resolve();
+            });
+        });
     }
 }

--- a/vscode-extension/src/test/electron/suite/e2eCachedPreloadOnSwitch.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eCachedPreloadOnSwitch.test.ts
@@ -81,13 +81,88 @@ function listPngs(renderDir: string): string[] {
     return fs.readdirSync(renderDir).filter((n) => n.endsWith(".png"));
 }
 
+function firstNonEmptySetPreviews(
+    api: ComposePreviewTestApi,
+): PostedMessage | undefined {
+    const msgs = api.getPostedMessages();
+    for (let i = msgs.length - 1; i >= 0; i--) {
+        const m = msgs[i] as PostedMessage;
+        if (m.command !== "setPreviews") continue;
+        const previews = m.previews as Array<unknown> | undefined;
+        if (previews && previews.length > 0) return m;
+    }
+    return undefined;
+}
+
+/**
+ * Force a full render of `file` and wait for the resulting non-empty
+ * `setPreviews`, leaving ≥2 PNGs in `renderDir` for the module-switch test
+ * to preload.
+ *
+ * Bounded + retried on purpose. Each render runs through `gradleService`,
+ * which caps a Gradle task at 5 minutes (`TASK_TIMEOUT_MS`) and fires
+ * `cancelRunTask` on expiry; `RealGradleApi` now honours that cancel by
+ * killing the gradlew client, so a wedged render is terminated at ~5min
+ * and its build lock released. We budget the wait just past that cap so a
+ * hung render surfaces as a fast, attributable failure (not the 20-minute
+ * hook cap), then retry once on the freed lock. A render that's genuinely
+ * progressing always completes inside the 5-minute task cap, so the budget
+ * never truncates a healthy-but-slow cold render. On failure we dump the
+ * Compose Preview output channel — the underlying render rejection is
+ * otherwise swallowed by the refresh scheduler, leaving only a bare
+ * "timed out" with no Gradle context.
+ */
+async function primeModule(
+    api: ComposePreviewTestApi,
+    label: string,
+    file: string,
+    renderDir: string,
+): Promise<void> {
+    const ATTEMPT_BUDGET_MS = 6 * 60_000;
+    const MAX_ATTEMPTS = 2;
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        console.log(
+            `[preload-e2e] priming ${label} (attempt ${attempt}/${MAX_ATTEMPTS})`,
+        );
+        api.resetMessages();
+        try {
+            await api.triggerRefresh(file, /* force */ true, "full");
+            await waitFor(
+                `non-empty setPreviews for ${label} prime`,
+                ATTEMPT_BUDGET_MS,
+                500,
+                () => firstNonEmptySetPreviews(api),
+            );
+            assert.ok(
+                listPngs(renderDir).length >= 2,
+                `${label} prime produced no PNGs in ${renderDir}`,
+            );
+            return;
+        } catch (err) {
+            lastErr = err;
+            console.log(
+                `[preload-e2e] ${label} prime attempt ${attempt}/${MAX_ATTEMPTS} failed: ${
+                    (err as Error)?.message ?? String(err)
+                }`,
+            );
+            for (const line of api.getOutputChannelTail(80)) {
+                console.log(`[preload-e2e]   [out] ${line}`);
+            }
+        }
+    }
+    throw lastErr;
+}
+
 describeE2E("Compose Preview cached preload on module switch", function () {
     // Cold paths for `:samples:cmp` + `:samples:wear` both run inside
     // this suite (sibling e2e* suites may share the Gradle cache but we
     // can't rely on it — the wear cold daemon spawn alone is ~10s on a
     // warm host, multi-minute on a fresh CI runner). 20 minutes matches
     // the combined ceiling of the cmp + wear e2e suites and leaves head
-    // room under the workflow's 60m cap.
+    // room under the workflow's 60m cap. `primeModule` bounds + retries
+    // each render well inside this cap, so a hung render fails fast with
+    // diagnostics rather than burning the whole budget on one stuck task.
     this.timeout(20 * 60_000);
 
     let api: ComposePreviewTestApi;
@@ -200,51 +275,8 @@ describeE2E("Compose Preview cached preload on module switch", function () {
         // `showTextDocument` path because the prime phase wants to
         // *force* the render-all (no force flag on the activation
         // path), and the message log doesn't need to be tidy yet.
-        console.log("[preload-e2e] priming :samples:cmp");
-        api.resetMessages();
-        await api.triggerRefresh(cmpKotlinFile, /* force */ true, "full");
-        await waitFor(
-            "non-empty setPreviews for samples/cmp prime",
-            this.timeout(),
-            500,
-            () => {
-                const msgs = api.getPostedMessages();
-                for (let i = msgs.length - 1; i >= 0; i--) {
-                    const m = msgs[i] as PostedMessage;
-                    if (m.command !== "setPreviews") continue;
-                    const previews = m.previews as Array<unknown> | undefined;
-                    if (previews && previews.length > 0) return m;
-                }
-                return undefined;
-            },
-        );
-        assert.ok(
-            listPngs(cmpRenderDir).length >= 2,
-            `cmp prime produced no PNGs in ${cmpRenderDir}`,
-        );
-
-        console.log("[preload-e2e] priming :samples:wear");
-        api.resetMessages();
-        await api.triggerRefresh(wearKotlinFile, /* force */ true, "full");
-        await waitFor(
-            "non-empty setPreviews for samples/wear prime",
-            this.timeout(),
-            500,
-            () => {
-                const msgs = api.getPostedMessages();
-                for (let i = msgs.length - 1; i >= 0; i--) {
-                    const m = msgs[i] as PostedMessage;
-                    if (m.command !== "setPreviews") continue;
-                    const previews = m.previews as Array<unknown> | undefined;
-                    if (previews && previews.length > 0) return m;
-                }
-                return undefined;
-            },
-        );
-        assert.ok(
-            listPngs(wearRenderDir).length >= 2,
-            `wear prime produced no PNGs in ${wearRenderDir}`,
-        );
+        await primeModule(api, ":samples:cmp", cmpKotlinFile, cmpRenderDir);
+        await primeModule(api, ":samples:wear", wearKotlinFile, wearRenderDir);
     });
 
     it("paints cached PNGs from disk when switching to a previously-rendered module", async () => {


### PR DESCRIPTION
The VS Code E2E (real Gradle) job hung for the full 20-minute hook cap in
the 'cached preload on module switch' before-hook: the :samples:wear prime
render wedged and never posted setPreviews, producing only a bare mocha
'Timeout of 1200000ms exceeded' with no Gradle context.

Root cause: RealGradleApi.cancelRunTask was a no-op. gradleService already
caps every Gradle task at 5 minutes (TASK_TIMEOUT_MS) and fires
cancelRunTask on expiry, and every refresh() calls gradleService.cancel()
to drop superseded work -- but in the e2e harness those cancels did
nothing, so timed-out/superseded gradlew clients kept running and held the
project's Gradle build lock. Across a long serial e2e session those orphans
accumulate until a later module render blocks forever on the lock.

- RealGradleApi now tracks live children by cancellationKey and
  cancelRunTask terminates the matching gradlew (SIGTERM, then SIGKILL
  after a grace period), waiting for exit so the build lock is released
  before any retry. This matches production vscode-gradle cancellation
  semantics, which the e2e suites are meant to exercise.
- The preload prime is bounded per attempt (6m, just past the 5m task cap)
  and retried once on a freed lock, and dumps the Compose Preview output
  channel on failure -- so a future hang fails fast and diagnosably instead
  of burning the 20-minute hook budget on one stuck task.