### PR TITLE
test(vscode): size preload suite timeout to outlast prime retries

### DIFF
--- a/vscode-extension/src/test/electron/suite/e2eCachedPreloadOnSwitch.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eCachedPreloadOnSwitch.test.ts
@@ -95,12 +95,14 @@ function firstNonEmptySetPreviews(
 }
 
 /**
- * Per-attempt wait budget for a single prime render. A render runs through
- * `gradleService`, which caps each Gradle task at 5 minutes
- * (`TASK_TIMEOUT_MS`) and fires `cancelRunTask` on expiry. Budget the wait
- * just past that cap so a render completing near the cap still posts its
- * `setPreviews`, while a wedged one is observed as "no setPreviews"
- * shortly after the cap kills it.
+ * Wall-clock ceiling for one whole prime attempt — the awaited Gradle
+ * render *and* the subsequent wait for its `setPreviews`, together (see
+ * `primeModule`). A render runs through `gradleService`, which caps each
+ * Gradle task at 5 minutes (`TASK_TIMEOUT_MS`) and fires `cancelRunTask`
+ * on expiry; budget just past that cap so a render completing near it
+ * still posts its `setPreviews`, while a wedged one is abandoned shortly
+ * after the cap kills it. Because this bounds the *entire* attempt (not
+ * just the wait), `SUITE_TIMEOUT_MS` below can be derived from it directly.
  */
 const PRIME_ATTEMPT_BUDGET_MS = 6 * 60_000;
 /** Prime attempts per module (one retry on a freed build lock). */
@@ -130,18 +132,24 @@ const SUITE_TIMEOUT_MS =
  * `setPreviews`, leaving ≥2 PNGs in `renderDir` for the module-switch test
  * to preload.
  *
- * Bounded + retried on purpose. Each render is killed by gradleService's
- * 5-minute task cap on expiry, and `RealGradleApi` honours that cancel by
- * terminating the gradlew client and releasing its build lock — so we
- * budget the wait just past that cap (see `PRIME_ATTEMPT_BUDGET_MS`) and
- * retry once on the freed lock. A render that's genuinely progressing
- * always completes inside the 5-minute task cap, so the budget never
- * truncates a healthy-but-slow cold render. The suite timeout
- * (`SUITE_TIMEOUT_MS`) is sized to outlast every attempt for both modules
- * so this throws an attributable error rather than tripping the hook cap.
- * On failure we dump the Compose Preview output channel — the underlying
- * render rejection is otherwise swallowed by the refresh scheduler,
- * leaving only a bare "timed out" with no Gradle context.
+ * Bounded + retried on purpose. `triggerRefresh` *awaits* the Gradle
+ * render (gradleService caps it at the 5-minute `TASK_TIMEOUT_MS` and, via
+ * `RealGradleApi`, kills the gradlew client + releases its build lock on
+ * expiry); on a render that times out without producing a manifest the
+ * refresh resolves *without* posting `setPreviews`. So the render's
+ * blocking time and the subsequent `setPreviews` wait must share a single
+ * budget — otherwise a slow-failing attempt costs ~5m (render) +
+ * `PRIME_ATTEMPT_BUDGET_MS` (wait) and the suite timeout, derived from
+ * attempts × budget alone, fires before this reaches its diagnostic throw.
+ * We therefore race the whole attempt (refresh + wait) against one
+ * `PRIME_ATTEMPT_BUDGET_MS` deadline, then retry once on the freed lock
+ * (the retry's refresh cancels any render still in flight from the
+ * abandoned attempt). A healthy render always completes inside the
+ * 5-minute task cap and posts `setPreviews` before the refresh resolves,
+ * so the budget never truncates a healthy-but-slow cold render. On failure
+ * we dump the Compose Preview output channel — the underlying render
+ * rejection is otherwise swallowed by the refresh scheduler, leaving only
+ * a bare "timed out" with no Gradle context.
  */
 async function primeModule(
     api: ComposePreviewTestApi,
@@ -155,7 +163,24 @@ async function primeModule(
             `[preload-e2e] priming ${label} (attempt ${attempt}/${PRIME_MAX_ATTEMPTS})`,
         );
         api.resetMessages();
-        try {
+        // One deadline covering refresh + wait, so a render that blocks up
+        // to its task cap before failing can't push the attempt past the
+        // budget the suite timeout is sized against.
+        let budgetTimer: ReturnType<typeof setTimeout> | undefined;
+        const budget = new Promise<never>((_, reject) => {
+            budgetTimer = setTimeout(
+                () =>
+                    reject(
+                        new Error(
+                            `${label} prime attempt ${attempt} exceeded ${
+                                PRIME_ATTEMPT_BUDGET_MS / 1000
+                            }s budget`,
+                        ),
+                    ),
+                PRIME_ATTEMPT_BUDGET_MS,
+            );
+        });
+        const work = (async () => {
             await api.triggerRefresh(file, /* force */ true, "full");
             await waitFor(
                 `non-empty setPreviews for ${label} prime`,
@@ -163,6 +188,9 @@ async function primeModule(
                 500,
                 () => firstNonEmptySetPreviews(api),
             );
+        })();
+        try {
+            await Promise.race([work, budget]);
             assert.ok(
                 listPngs(renderDir).length >= 2,
                 `${label} prime produced no PNGs in ${renderDir}`,
@@ -178,6 +206,13 @@ async function primeModule(
             for (const line of api.getOutputChannelTail(80)) {
                 console.log(`[preload-e2e]   [out] ${line}`);
             }
+        } finally {
+            if (budgetTimer) clearTimeout(budgetTimer);
+            // If the budget won the race the `work` promise is still live;
+            // swallow its eventual rejection so it doesn't surface as an
+            // unhandled rejection (the next attempt's refresh cancels the
+            // render it left in flight).
+            void work.catch(() => {});
         }
     }
     throw lastErr;

--- a/vscode-extension/src/test/electron/suite/e2eCachedPreloadOnSwitch.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eCachedPreloadOnSwitch.test.ts
@@ -95,22 +95,53 @@ function firstNonEmptySetPreviews(
 }
 
 /**
+ * Per-attempt wait budget for a single prime render. A render runs through
+ * `gradleService`, which caps each Gradle task at 5 minutes
+ * (`TASK_TIMEOUT_MS`) and fires `cancelRunTask` on expiry. Budget the wait
+ * just past that cap so a render completing near the cap still posts its
+ * `setPreviews`, while a wedged one is observed as "no setPreviews"
+ * shortly after the cap kills it.
+ */
+const PRIME_ATTEMPT_BUDGET_MS = 6 * 60_000;
+/** Prime attempts per module (one retry on a freed build lock). */
+const PRIME_MAX_ATTEMPTS = 2;
+/** Modules primed by the before-hook: `:samples:cmp` + `:samples:wear`. */
+const PRIME_MODULE_COUNT = 2;
+/**
+ * Non-render before-hook work (extension activation, the 30s webviewReady
+ * wait, render-dir cleans) plus a safety margin, on top of the worst-case
+ * prime time below.
+ */
+const PRIME_OVERHEAD_MS = 4 * 60_000;
+/**
+ * Suite/hook timeout. Derived from the prime budget so it always outlasts
+ * the worst case — every attempt for both modules exhausting its budget —
+ * and `primeModule` reaches its attributable `throw lastErr` instead of
+ * degrading into a bare Mocha "hook timeout" with no Gradle context. With
+ * the values above this is 28 minutes, comfortably under the workflow's
+ * 60m job cap.
+ */
+const SUITE_TIMEOUT_MS =
+    PRIME_MODULE_COUNT * PRIME_MAX_ATTEMPTS * PRIME_ATTEMPT_BUDGET_MS +
+    PRIME_OVERHEAD_MS;
+
+/**
  * Force a full render of `file` and wait for the resulting non-empty
  * `setPreviews`, leaving ≥2 PNGs in `renderDir` for the module-switch test
  * to preload.
  *
- * Bounded + retried on purpose. Each render runs through `gradleService`,
- * which caps a Gradle task at 5 minutes (`TASK_TIMEOUT_MS`) and fires
- * `cancelRunTask` on expiry; `RealGradleApi` now honours that cancel by
- * killing the gradlew client, so a wedged render is terminated at ~5min
- * and its build lock released. We budget the wait just past that cap so a
- * hung render surfaces as a fast, attributable failure (not the 20-minute
- * hook cap), then retry once on the freed lock. A render that's genuinely
- * progressing always completes inside the 5-minute task cap, so the budget
- * never truncates a healthy-but-slow cold render. On failure we dump the
- * Compose Preview output channel — the underlying render rejection is
- * otherwise swallowed by the refresh scheduler, leaving only a bare
- * "timed out" with no Gradle context.
+ * Bounded + retried on purpose. Each render is killed by gradleService's
+ * 5-minute task cap on expiry, and `RealGradleApi` honours that cancel by
+ * terminating the gradlew client and releasing its build lock — so we
+ * budget the wait just past that cap (see `PRIME_ATTEMPT_BUDGET_MS`) and
+ * retry once on the freed lock. A render that's genuinely progressing
+ * always completes inside the 5-minute task cap, so the budget never
+ * truncates a healthy-but-slow cold render. The suite timeout
+ * (`SUITE_TIMEOUT_MS`) is sized to outlast every attempt for both modules
+ * so this throws an attributable error rather than tripping the hook cap.
+ * On failure we dump the Compose Preview output channel — the underlying
+ * render rejection is otherwise swallowed by the refresh scheduler,
+ * leaving only a bare "timed out" with no Gradle context.
  */
 async function primeModule(
     api: ComposePreviewTestApi,
@@ -118,19 +149,17 @@ async function primeModule(
     file: string,
     renderDir: string,
 ): Promise<void> {
-    const ATTEMPT_BUDGET_MS = 6 * 60_000;
-    const MAX_ATTEMPTS = 2;
     let lastErr: unknown;
-    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    for (let attempt = 1; attempt <= PRIME_MAX_ATTEMPTS; attempt++) {
         console.log(
-            `[preload-e2e] priming ${label} (attempt ${attempt}/${MAX_ATTEMPTS})`,
+            `[preload-e2e] priming ${label} (attempt ${attempt}/${PRIME_MAX_ATTEMPTS})`,
         );
         api.resetMessages();
         try {
             await api.triggerRefresh(file, /* force */ true, "full");
             await waitFor(
                 `non-empty setPreviews for ${label} prime`,
-                ATTEMPT_BUDGET_MS,
+                PRIME_ATTEMPT_BUDGET_MS,
                 500,
                 () => firstNonEmptySetPreviews(api),
             );
@@ -142,7 +171,7 @@ async function primeModule(
         } catch (err) {
             lastErr = err;
             console.log(
-                `[preload-e2e] ${label} prime attempt ${attempt}/${MAX_ATTEMPTS} failed: ${
+                `[preload-e2e] ${label} prime attempt ${attempt}/${PRIME_MAX_ATTEMPTS} failed: ${
                     (err as Error)?.message ?? String(err)
                 }`,
             );
@@ -155,15 +184,14 @@ async function primeModule(
 }
 
 describeE2E("Compose Preview cached preload on module switch", function () {
-    // Cold paths for `:samples:cmp` + `:samples:wear` both run inside
-    // this suite (sibling e2e* suites may share the Gradle cache but we
-    // can't rely on it — the wear cold daemon spawn alone is ~10s on a
-    // warm host, multi-minute on a fresh CI runner). 20 minutes matches
-    // the combined ceiling of the cmp + wear e2e suites and leaves head
-    // room under the workflow's 60m cap. `primeModule` bounds + retries
-    // each render well inside this cap, so a hung render fails fast with
-    // diagnostics rather than burning the whole budget on one stuck task.
-    this.timeout(20 * 60_000);
+    // Cold paths for `:samples:cmp` + `:samples:wear` both run inside this
+    // suite (sibling e2e* suites may share the Gradle cache but we can't
+    // rely on it — the wear cold daemon spawn alone is ~10s on a warm
+    // host, multi-minute on a fresh CI runner). The timeout is derived
+    // from the prime budget (`SUITE_TIMEOUT_MS`) so it always outlasts the
+    // worst-case retry path for both modules: a hung render then fails
+    // fast with diagnostics instead of degrading into a bare hook timeout.
+    this.timeout(SUITE_TIMEOUT_MS);
 
     let api: ComposePreviewTestApi;
     let repoRoot: string;


### PR DESCRIPTION
## Summary

Follow-up to the `cached preload on module switch` hardening. A review flagged that the retry/diagnostic path could still degrade into a bare Mocha hook timeout:

- `primeModule` can spend up to `PRIME_MAX_ATTEMPTS * PRIME_ATTEMPT_BUDGET_MS` (2 × 6m = 12m) per module, and the before-hook primes **both** `:samples:cmp` and `:samples:wear` — worst case ~24m of wait.
- The hook timeout was a fixed 20 minutes, so in the exact scenario the helper exists to diagnose (a render that returns but never posts a non-empty `setPreviews`, or repeated slow failures), Mocha could fire its generic `hook timeout` **before** `primeModule` reached `throw lastErr`. That collapsed the attributable failure (with the dumped Compose Preview output channel) back into the opaque timeout the change was meant to replace.

Fix: hoist the prime budget into module-level constants and derive the suite timeout from them, so the hook always outlasts the worst-case retry path for both modules.

```
SUITE_TIMEOUT_MS = PRIME_MODULE_COUNT * PRIME_MAX_ATTEMPTS * PRIME_ATTEMPT_BUDGET_MS + PRIME_OVERHEAD_MS
                 = 2 * 2 * 6m + 4m = 28m
```

Still comfortably under the workflow's 60m job cap. The per-attempt budget (6m, just past the 5m `TASK_TIMEOUT_MS` task cap) is unchanged, so a healthy-but-slow cold render is never truncated.

## Test plan

- `npm run compile` — clean
- `npm test` (fast suite) — 1414 passing (unchanged; this only touches the e2e-gated suite's constants)
- `prettier --check` — clean
- The real-Gradle e2e job (`COMPOSE_PREVIEW_E2E=1`) only runs on push to `main`; this change is verified by compilation + the derivation being self-consistent (the timeout is now computed from the same constants `primeModule` uses).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rx32i9Ea7p2XCXBmxVEuv6)_