### PR TITLE
feat(bundle): emit protolayout IR sidecar at render time (Piece A, tiles)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -203,6 +203,14 @@ compose-ui-tooling-prerelease = { module = "androidx.compose.ui:ui-tooling", ver
 wear-protolayout = { module = "androidx.wear.protolayout:protolayout", version.ref = "wear-protolayout" }
 wear-protolayout-material3 = { module = "androidx.wear.protolayout:protolayout-material3", version.ref = "wear-protolayout" }
 wear-protolayout-expression = { module = "androidx.wear.protolayout:protolayout-expression", version.ref = "wear-protolayout" }
+# protolayout-proto carries the generated `androidx.wear.protolayout.proto.*` messages that
+# `Layout.toProto()` / `Resources.toProto()` return; protolayout-external-protobuf carries the
+# shaded `androidx.wear.protolayout.protobuf.*` runtime (GeneratedMessageLite, with the inherited
+# `toByteArray()` / `parseFrom(byte[])`). Both are `runtime`-scope transitives of `protolayout`, so
+# the renderer takes them `compileOnly` to serialise the tile IR for a bundle without dragging them
+# onto a consumer's classpath (the consumer already brings them at runtime via protolayout).
+wear-protolayout-proto = { module = "androidx.wear.protolayout:protolayout-proto", version.ref = "wear-protolayout" }
+wear-protolayout-external-protobuf = { module = "androidx.wear.protolayout:protolayout-external-protobuf", version.ref = "wear-protolayout" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 mcp-kotlin-sdk-server = { module = "io.modelcontextprotocol:kotlin-sdk-server", version.ref = "mcp-kotlin-sdk" }

--- a/renderers/android/build.gradle.kts
+++ b/renderers/android/build.gradle.kts
@@ -212,6 +212,12 @@ dependencies {
   compileOnly(libs.wear.tiles.tooling.preview)
   compileOnly(libs.wear.protolayout)
   compileOnly(libs.wear.protolayout.expression)
+  // Tile IR capture: `Layout.toProto()` / `Resources.toProto()` return generated messages from
+  // protolayout-proto, whose inherited `toByteArray()` lives in the shaded protobuf runtime
+  // (protolayout-external-protobuf). compileOnly so neither reaches a consumer's classpath — the
+  // consumer's own protolayout pulls them at runtime under Robolectric. See TilePreviewRenderer.
+  compileOnly(libs.wear.protolayout.proto)
+  compileOnly(libs.wear.protolayout.external.protobuf)
 }
 
 mavenPublishing {

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
@@ -16,6 +16,7 @@ import androidx.wear.tiles.RequestBuilders
 import androidx.wear.tiles.TileBuilders
 import androidx.wear.tiles.renderer.TileRenderer
 import androidx.wear.tiles.tooling.preview.TilePreviewData
+import ee.schimke.composeai.data.render.IrSidecarChannel
 import java.lang.reflect.Method
 import java.util.concurrent.TimeUnit
 
@@ -104,6 +105,21 @@ private fun renderTileInto(
         ?.firstOrNull()
         ?.layout
         ?: error("TilePreview '$functionName' produced no layout (empty timeline)")
+
+    // Capture the protolayout IR (the Layout + Resources protos) so a bundle can carry and replay
+    // it via TileRenderer without this tile function's bytecode. Serialised here through the
+    // generated protos — `toProto().toByteArray()` — so the :data-render-core channel stays
+    // protolayout-free; the render harness drains the channel and writes the
+    // renders/<stem>.tilelayout / .tileresources sidecars BundlePreviewTask.resolvePreviewIr packs.
+    // `Resources` has no direct byte serializer (only toProto), so both go through the proto for
+    // symmetry. Best-effort — an IR-capture hiccup must never fail the render.
+    runCatching {
+        IrSidecarChannel.offer(
+            format = IrSidecarChannel.FORMAT_PROTOLAYOUT,
+            bytes = layout.toProto().toByteArray(),
+            resourcesBytes = resources.toProto().toByteArray(),
+        )
+    }
 
     // Inline executor — Robolectric has the main looper paused, so posting
     // to a background thread and awaiting back on main would deadlock. Inflating


### PR DESCRIPTION
## Goal

The deferred **tile / protolayout half of Piece A (emission)**, following the Remote Compose half in #1659. `TilePreviewRenderer` now captures a tile preview's protolayout intermediate representation as a sidecar next to its PNG, so the v5 machinery from #1654 (`BundlePreviewTask.resolvePreviewIr`) embeds it under `ir/` and drops the tile function's classes.

## What this does

- **Serialise the tile IR** — once the tile's `Layout` and `Resources` are built, offer `Layout.toProto().toByteArray()` + `Resources.toProto().toByteArray()` to `IrSidecarChannel` (#1659). The harness already writes `renders/<stem>.tilelayout` / `.tileresources` and clears stale sidecars before each render, so this PR is just the producer + its deps.
- **Two `compileOnly` deps on `:renderer-android`** — `protolayout-proto` (the generated `androidx.wear.protolayout.proto.*` messages `toProto()` returns) and `protolayout-external-protobuf` (the shaded `androidx.wear.protolayout.protobuf.*` runtime whose `GeneratedMessageLite`/`AbstractMessageLite` supplies the inherited `toByteArray()`). Both are `runtime`-scope transitives of `protolayout`, so `compileOnly` keeps them off a consumer's classpath while the consumer's own protolayout supplies them at runtime under Robolectric — matching the renderer-vs-consumer alignment rule.

## Why this shape (learning from #1659's CI break)

#1659's first draft used `Resources.toByteArray()`, which **doesn't exist** — that's what broke CI. This time I pinned every call against the actual `protolayout 1.4.0` artifacts before pushing:
- `ResourceBuilders.Resources` has **no** byte serializer — only `toProto()` → `ResourceProto.Resources`, which extends the shaded `GeneratedMessageLite` (so `.toByteArray()` / `parseFrom(byte[])` are inherited). `protolayout-proto.jar` carries the messages but **not** the protobuf base — hence the second dep.
- I use `toProto()` (a `@RestrictTo` API → **lint** concern, not a compile error) rather than `Layout.toByteArray()` (which is `@ProtoLayoutExperimental` → a Kotlin opt-in **compile** error). The renderer already calls restricted/deprecated tile APIs (`TileRenderer.inflateAsync(layout, resources, …)`) with green CI, so `RestrictedApi` lint isn't a hard gate for this module; I kept the change minimal (no lint block).

> ⚠️ **Verification note** (same sandbox limits — no Android SDK / working Gradle here). Every API is pinned via `javap` against the published 1.4.0 jars, and the kts/toml edits are ktfmt-clean, but I can't compile. Two things to confirm on a real build: (1) `androidx.wear.protolayout:protolayout-proto` and `:protolayout-external-protobuf` resolve at 1.4.0 (they're published — I downloaded both); (2) `RestrictedApi` lint doesn't abort `:renderer-android` (if it does, add `lint { disable += "RestrictedApi" }` to its `android {}` block, as the RC connector does).

## Still emission only — replay is Piece B

Packing a tile bundle now carries the protolayout IR and drops the tile's classes. **Executing** it — `TileRenderer.inflateAsync(Layout.fromProto(LayoutElementProto.Layout.parseFrom(bytes)), Resources.fromProto(ResourceProto.Resources.parseFrom(bytes)))` in the `:daemon:android` `RenderEngine` via an `IrReplayStrategy` — is Piece B. Until then both render paths skip IR-backed previews (#1654/#1657), so a tile preview on replay shows its baked cover PNG.

## Test plan

- [ ] `./gradlew :renderer-android:compileReleaseKotlin` — confirm the `toProto().toByteArray()` calls resolve with the two new deps.
- [ ] `:samples:wear`: render → assert `build/compose-previews/renders/<stem>.tilelayout` + `.tileresources` appear → pack → assert `ir/` populated and the tile function's class absent from `classes/app.jar`.
- [ ] `./gradlew check`

https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt)_