### PR TITLE
feat(daemon): clarify in-process compile (BTA) startup logging

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -628,8 +628,14 @@ fun main(args: Array<String>) {
   val btaCompileService = ee.schimke.composeai.daemon.bta.DefaultBtaCompileService.fromSysprops()
   if (btaCompileService != null) {
     System.err.println(
-      "compose-ai-tools daemon-android: BtaCompileService active — `compileSources` JSON-RPC " +
-        "will dispatch through the in-process Kotlin Build Tools compiler"
+      "compose-ai-tools daemon-android: in-process compile available (Kotlin Build Tools API " +
+        "loaded) — engaged only when the editor sets composePreview.daemon.compileInProcess=true; " +
+        "otherwise compiles run via Gradle"
+    )
+  } else {
+    System.err.println(
+      "compose-ai-tools daemon-android: in-process compile unavailable (Build Tools API not " +
+        "configured for this module) — compiles run via Gradle"
     )
   }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -315,8 +315,14 @@ fun runDaemon(
   val btaCompileService = ee.schimke.composeai.daemon.bta.DefaultBtaCompileService.fromSysprops()
   if (btaCompileService != null) {
     System.err.println(
-      "compose-ai-tools desktop daemon: BtaCompileService active — `compileSources` JSON-RPC " +
-        "will dispatch through the in-process Kotlin Build Tools compiler"
+      "compose-ai-tools desktop daemon: in-process compile available (Kotlin Build Tools API " +
+        "loaded) — engaged only when the editor sets composePreview.daemon.compileInProcess=true; " +
+        "otherwise compiles run via Gradle"
+    )
+  } else {
+    System.err.println(
+      "compose-ai-tools desktop daemon: in-process compile unavailable (Build Tools API not " +
+        "configured for this module) — compiles run via Gradle"
     )
   }
 


### PR DESCRIPTION
## Summary

The daemon startup banner read `BtaCompileService active — compileSources JSON-RPC will dispatch through the in-process Kotlin Build Tools compiler`. That phrasing implies BTA is *handling* compiles, but at boot the service is only **loaded/available** — whether it's actually used is gated by the editor setting `composePreview.daemon.compileInProcess` (default `false`). This caused real confusion: the "active" line showed up even though in-process compile was switched off, making it look like the setting was being ignored.

Changes to both the desktop and android `DaemonMain.kt` banners:

- Reword to distinguish **loaded/available** from **engaged**, and explicitly name the controlling setting (`composePreview.daemon.compileInProcess`).
- Note the Gradle fallback so it's clear what happens when BTA isn't used.
- Add an `else` branch that logs the **unavailable** case, so investigators (human or agent) can tell "BTA not wired for this module" apart from "available but switched off" — previously the absence of any line was ambiguous.

New messages:

- Available: `in-process compile available (Kotlin Build Tools API loaded) — engaged only when the editor sets composePreview.daemon.compileInProcess=true; otherwise compiles run via Gradle`
- Unavailable: `in-process compile unavailable (Build Tools API not configured for this module) — compiles run via Gradle`

## Test plan

- Pure log-string change; no behavior change to compile dispatch.
- Could not run `./gradlew ktfmtCheckAll` / compile locally — this environment only has JDK 21 and the build requires a JDK 17 toolchain it can't download. The edits keep the exact indentation/operator-placement of the pre-existing (ktfmt-passing) block, so CI ktfmt is expected to pass. Will fix if CI flags anything.

---
_Generated by [Claude Code](https://claude.ai/code/session_017YXMTrsTyUi34ehn2V9R6C)_