### PR TITLE
feat(bundle): carry IR-preview deps + pass ir/ to the daemon (Piece B foundation)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -85,6 +85,17 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
         it.absolutePath
       }
 
+    // v5 IR replay: when the bundle carries intermediate representations, extract the `ir/` bytes
+    // and the bundle.json so the daemon (Piece B) can replay those previews through the protolayout
+    // / Remote Compose runtime instead of reflecting their (dropped) consumer classes. Skipped
+    // entirely for a classic all-classes bundle.
+    val hasIr = manifest.intermediateRepresentations.isNotEmpty()
+    val irDir = if (hasIr) workDir.resolve("ir").apply { mkdirs() } else null
+    val bundleManifestFile = if (hasIr) workDir.resolve("bundle.json") else null
+    if (hasIr) {
+      extractIrArtifacts(zipBytes, irDir!!, bundleManifestFile!!, file)
+    }
+
     // Branch on the bundle's backend, exactly as `bundle render` does: a desktop bundle launches
     // the CMP/Skiko daemon (lib-daemon-desktop + lib-renderer); an android bundle launches the
     // Robolectric daemon (lib-daemon-android + android.jar), reusing the Phase 1
@@ -111,6 +122,9 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       // (BundleViewerPanel's DaemonClient) does the `initialize` round-trip on stdin.
       add("-D${USER_CLASS_DIRS_PROP}=$userClassPath")
       add("-D${PREVIEWS_JSON_PATH_PROP}=${previewsJson.absolutePath}")
+      // IR replay inputs (Piece B); present only for a bundle that carries IR.
+      irDir?.let { add("-D${IR_DIR_PROP}=${it.absolutePath}") }
+      bundleManifestFile?.let { add("-D${BUNDLE_MANIFEST_PATH_PROP}=${it.absolutePath}") }
       // Tag the temp dir on the daemon so logs / debug dumps make it discoverable.
       add("-Dcomposeai.daemon.bundleSource=${file.absolutePath}")
       for (prop in launch.sysProps) add(prop)
@@ -128,6 +142,11 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
         "[bundle-daemon] resolved coordinate jars: ${resolvedJars.size} / ${mavenCoords.size}"
       )
       System.err.println("[bundle-daemon] previews.json: ${previewsJson.absolutePath}")
+      if (hasIr) {
+        System.err.println(
+          "[bundle-daemon] IR previews: ${manifest.intermediateRepresentations.size} → ${irDir?.absolutePath}"
+        )
+      }
       System.err.println("[bundle-daemon] launching: ${command.joinToString(" ")}")
     }
 
@@ -287,6 +306,45 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
    * either is missing — both are required for the daemon to come up against a usable preview index.
    * Embedded `libs/` jars are extracted separately via [BundleReader.extractEmbeddedLibs].
    */
+  /**
+   * Extract the v5 IR artefacts from [zipBytes]: every `ir/<leaf>` entry into [irDir] (flattened to
+   * its basename, since `BundleIr.path` is `ir/<previewId>.<ext>` and the daemon resolves by leaf),
+   * plus `bundle.json` into [manifestFile] so the daemon can read `intermediateRepresentations`.
+   * Each `ir/` destination is verified to live inside [irDir] — defeats Zip Slip on a hostile
+   * bundle, same guard as [extractEmbeddedLibs] / [expandJarBytesSafely].
+   */
+  private fun extractIrArtifacts(
+    zipBytes: ByteArray,
+    irDir: File,
+    manifestFile: File,
+    bundleFile: File,
+  ) {
+    val canonicalIr = irDir.canonicalFile
+    var sawManifest = false
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        val name = entry.name
+        when {
+          name == "bundle.json" -> {
+            manifestFile.writeBytes(zin.readBytes())
+            sawManifest = true
+          }
+          !entry.isDirectory && name.startsWith("ir/") -> {
+            val dest = File(irDir, File(name).name).canonicalFile
+            if (dest.path.startsWith(canonicalIr.path + File.separator)) {
+              dest.outputStream().use { sink -> zin.copyTo(sink) }
+            }
+          }
+        }
+        zin.closeEntry()
+      }
+    }
+    require(sawManifest) {
+      "bundle daemon: bundle.json missing in ${bundleFile.path} — cannot resolve IR descriptors"
+    }
+  }
+
   private fun expandAppJarAndManifest(
     zipBytes: ByteArray,
     classesDir: File,
@@ -430,5 +488,12 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     // need an extra :daemon:core dependency just for the constants.
     private const val USER_CLASS_DIRS_PROP = "composeai.daemon.userClassDirs"
     private const val PREVIEWS_JSON_PATH_PROP = "composeai.daemon.previewsJsonPath"
+    // v5 IR replay (consumed by the Android daemon — Piece B). `irDir` holds the extracted
+    // `ir/<id>.<ext>` bytes; `bundleManifestPath` points at the bundle.json whose
+    // `intermediateRepresentations` tell the daemon which previews replay from IR and in what
+    // format. Passed only when the bundle actually carries IR; harmless to an older daemon that
+    // doesn't read them.
+    private const val IR_DIR_PROP = "composeai.daemon.irDir"
+    private const val BUNDLE_MANIFEST_PATH_PROP = "composeai.daemon.bundleManifestPath"
   }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -176,25 +176,30 @@ abstract class BundlePreviewTask : DefaultTask() {
 
     // Previews whose flavour emitted a serialisable intermediate representation (Remote Compose doc
     // / Wear protolayout proto) during the render step are replayed from that IR, not by re-running
-    // their composable. We therefore (a) carry the IR bytes in the bundle and (b) DROP their
-    // enclosing class from the closure seed below, so the consumer bytecode that produced them
-    // isn't
-    // packed at all — the whole point of the v5 format. A preview with no IR sidecar stays on the
-    // classic class-minimisation path.
+    // their composable, so their consumer *bytecode* must not be packed. But the player still needs
+    // their third-party dependencies on the replay classpath (the Compose / protolayout / Remote
+    // Compose runtime the IR inflates against). So the minimisation runs two closures from one
+    // scan:
+    //  - the DEP closure seeds from every selected preview, so deps reachable from an IR preview
+    // are
+    //    still recorded as Maven coordinates (carriage — the bundle stays replayable);
+    //  - the PACK closure seeds only from non-IR previews, so only their module classes land in
+    //    `classes/app.jar`. An IR preview contributes no module bytecode.
+    // With no IR previews the two seeds are identical and this is byte-for-byte the old behaviour.
     val irByPreview: Map<String, ResolvedIr> =
       selected.mapNotNull { p -> resolvePreviewIr(p)?.let { p.id to it } }.toMap()
 
-    // Seed the minimisation closure only from previews that still need their bytecode replayed.
-    val entryClassFqns = selected.filter { it.id !in irByPreview }.map { it.className }.toSet()
+    val depSeedFqns = selected.map { it.className }.toSet()
+    val packSeedFqns = selected.filter { it.id !in irByPreview }.map { it.className }.toSet()
 
     val classDirsList = moduleClassDirs.files.filter { it.exists() && it.isDirectory }
     val jarsList = dependencyJars.files.filter { it.isFile && it.name.endsWith(".jar") }
     val scanPaths = (classDirsList + jarsList).map { it.absolutePath }
 
-    val closure = closureWalk(scanPaths, entryClassFqns)
+    val closure = closureWalk(scanPaths, depSeed = depSeedFqns, packSeed = packSeedFqns)
 
     val moduleClassFqns = collectClassFqns(classDirsList)
-    val reachableModuleClasses = moduleClassFqns intersect closure.reachable
+    val reachableModuleClasses = moduleClassFqns intersect closure.packReachable
     val keptModuleClassFiles = packModuleClasses(classDirsList, reachableModuleClasses)
     val appJarBytes = buildJar(keptModuleClassFiles, moduleResourcesDir.orNull?.asFile)
 
@@ -206,8 +211,8 @@ abstract class BundlePreviewTask : DefaultTask() {
 
     val report =
       MinimizationReport(
-        entryClassFqns = entryClassFqns.sorted(),
-        reachableClassCount = closure.reachable.size,
+        entryClassFqns = depSeedFqns.sorted(),
+        reachableClassCount = closure.depReachable.size,
         totalScannedClassCount = closure.totalScanned,
         moduleClasses =
           ModuleClassesStats(
@@ -663,14 +668,26 @@ abstract class BundlePreviewTask : DefaultTask() {
   private data class PerElementCount(val reachable: Int, val total: Int)
 
   private data class Closure(
-    val reachable: Set<String>,
+    /** Classes reachable from the dep seed (every preview) — drives which deps are kept. */
+    val depReachable: Set<String>,
+    /** Classes reachable from the pack seed (non-IR previews) — drives module-class packing. */
+    val packReachable: Set<String>,
     val perElement: Map<String, PerElementCount>,
     val totalScanned: Int,
   )
 
-  private fun closureWalk(scanPaths: List<String>, entries: Set<String>): Closure {
+  private fun closureWalk(
+    scanPaths: List<String>,
+    depSeed: Set<String>,
+    packSeed: Set<String>,
+  ): Closure {
     if (scanPaths.isEmpty()) {
-      return Closure(reachable = entries.toSet(), perElement = emptyMap(), totalScanned = 0)
+      return Closure(
+        depReachable = depSeed.toSet(),
+        packReachable = packSeed.toSet(),
+        perElement = emptyMap(),
+        totalScanned = 0,
+      )
     }
     ClassGraph()
       .enableAllInfo()
@@ -679,43 +696,57 @@ abstract class BundlePreviewTask : DefaultTask() {
       .ignoreParentClassLoaders()
       .scan()
       .use { scan ->
-        val depMap = scan.classDependencyMap
-        val all = scan.allClasses
-        val visited = mutableSetOf<String>()
-        val queue = ArrayDeque<String>()
-        // Seed with every class in the enclosing FQN's compilation unit — Kotlin top-level
-        // functions live on `FooKt` and their generated companions (`ComposableSingletons$FooKt`,
-        // `FooKt$lambda-1`, …) share the prefix. Adding them all up front means we don't depend on
-        // ClassGraph having an edge from the FooKt class to its lambda inner classes (it usually
-        // does, but the seed is cheap insurance).
-        for (entry in entries) {
-          for (ci in all) {
-            if (ci.name == entry || ci.name.startsWith("$entry$")) {
-              if (visited.add(ci.name)) queue += ci.name
-            }
-          }
-        }
-        while (queue.isNotEmpty()) {
-          val current = queue.removeFirst()
-          val ci = scan.getClassInfo(current) ?: continue
-          val deps = depMap[ci] ?: continue
-          for (dep in deps) {
-            if (visited.add(dep.name)) queue += dep.name
-          }
-        }
+        val depReachable = bfsReachable(scan, depSeed)
+        val packReachable = bfsReachable(scan, packSeed)
+        // Dependency reachability (which jars contributed a reachable class) is computed against
+        // the
+        // dep closure so an IR preview's third-party deps are still recorded — see the carriage
+        // note
+        // in `pack`.
         val perElementReachable = HashMap<String, IntArray>() // [reachable, total]
-        for (ci in all) {
+        for (ci in scan.allClasses) {
           val file = ci.classpathElementFile?.absolutePath ?: continue
           val counts = perElementReachable.getOrPut(file) { IntArray(2) }
           counts[1]++
-          if (ci.name in visited) counts[0]++
+          if (ci.name in depReachable) counts[0]++
         }
         return Closure(
-          reachable = visited,
+          depReachable = depReachable,
+          packReachable = packReachable,
           perElement = perElementReachable.mapValues { (_, c) -> PerElementCount(c[0], c[1]) },
-          totalScanned = all.size,
+          totalScanned = scan.allClasses.size,
         )
       }
+  }
+
+  /**
+   * BFS over ClassGraph's inter-class dependency map from [seed]'s compilation units. Kotlin
+   * top-level functions live on `FooKt` and their generated companions
+   * (`ComposableSingletons$FooKt`, `FooKt$lambda-1`, …) share the prefix, so we seed every class
+   * whose name equals or is `$`-prefixed by an entry FQN — cheap insurance against a missing
+   * inner-class edge. Returns every reachable class name.
+   */
+  private fun bfsReachable(scan: io.github.classgraph.ScanResult, seed: Set<String>): Set<String> {
+    if (seed.isEmpty()) return emptySet()
+    val depMap = scan.classDependencyMap
+    val visited = mutableSetOf<String>()
+    val queue = ArrayDeque<String>()
+    for (entry in seed) {
+      for (ci in scan.allClasses) {
+        if (ci.name == entry || ci.name.startsWith("$entry$")) {
+          if (visited.add(ci.name)) queue += ci.name
+        }
+      }
+    }
+    while (queue.isNotEmpty()) {
+      val current = queue.removeFirst()
+      val ci = scan.getClassInfo(current) ?: continue
+      val deps = depMap[ci] ?: continue
+      for (dep in deps) {
+        if (visited.add(dep.name)) queue += dep.name
+      }
+    }
+    return visited
   }
 
   private companion object {


### PR DESCRIPTION
## Goal

The verifiable **plugin/CLI foundation for Piece B (IR execution)** — the daemon-side inflate-from-bytes is the follow-up PR. This makes a bundle that carries IR self-sufficient for replay and threads the IR inputs to the daemon, without yet changing how the daemon renders.

## What this does

**`BundlePreviewTask` — carriage via two closures from one scan**
Emission (#1659/#1662) means an IR-backed preview's *classes* are dropped, but the player still needs that preview's *third-party dependencies* (the Compose / protolayout / Remote Compose runtime the IR inflates against). So the minimization now runs two BFS closures over a single ClassGraph scan:
- **dep closure** seeds from *every* selected preview → deps reachable from an IR preview stay recorded as `ClasspathEntry.Maven` coordinates (the carriage);
- **pack closure** seeds only from *non-IR* previews → only their module classes land in `classes/app.jar`.

With no IR previews the two seeds are identical, so this is **byte-for-byte the existing behaviour** for classic bundles (the existing `BundleFunctionalTest` should be unaffected).

**`BundleDaemonCommand` — IR inputs to the daemon**
When the bundle carries IR, extract the `ir/<id>.<ext>` bytes and `bundle.json` into the daemon work dir and pass `-Dcomposeai.daemon.irDir` + `-Dcomposeai.daemon.bundleManifestPath` (zip-slip-guarded extraction, mirroring `extractEmbeddedLibs`). These are **harmless to the current daemon**, which doesn't read them yet — Piece B's `RenderEngine` will consume them to replay via `TileRenderer` / `RemoteDocumentPlayer`.

## Known limitation (for Piece B)

The carriage keeps deps **reachable from an IR preview's bytecode**. The renderer-side player libraries — `tiles-renderer`, `protolayout-renderer`, `compose-remote-player` — may not be reachable from consumer code (they're invoked by *our* renderer, which takes them `compileOnly`). Piece B will stand up the actual replay and confirm what the daemon classpath is missing, then add it (explicit carriage coords, or ship them with the daemon). I left that decision to the point where it can be validated rather than guessing now.

> ⚠️ **Verification note** — same sandbox limits (no working Gradle here). The two-closure refactor is pure logic reasoned carefully; the back-compat path (no IR → identical behaviour) is by construction. The CLI extraction mirrors existing guarded code. The kts/kt edits are ktfmt-clean. Please run `:gradle-plugin:test`, `:gradle-plugin:functionalTest` (esp. `*BundleFunctionalTest`), and `:cli:test` on a real build.

## Test plan

- [ ] `./gradlew :gradle-plugin:test :gradle-plugin:functionalTest` — confirm classic (non-IR) bundles are unchanged.
- [ ] `:cli:test` — `BundleDaemonCommand` still launches correctly; IR props appear only for IR bundles.
- [ ] Manual: pack an IR bundle (`:samples:wear` / `:samples:remotecompose`) → confirm `report.json` shows the IR preview's deps kept while its module class is absent from `classes/app.jar`, and `bundle daemon -v` logs the IR previews + `irDir`.

https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt)_