### PR TITLE
feat(bundle): replay protolayout IR in the Android daemon (Piece B, tiles)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -214,7 +214,16 @@ class RenderEngine(
     val isTile = spec.kind.equals(TILE_KIND, ignoreCase = true)
     val isNotification = spec.kind.equals(NOTIFICATION_KIND, ignoreCase = true)
     val isGlanceAppWidget = spec.kind.equals(GLANCE_APPWIDGET_KIND, ignoreCase = true)
-    val clazz = trace.section("classloader:loadPreviewClass") { Class.forName(spec.className, true, classLoader) }
+    // v5 IR replay: a bundle may carry this preview's intermediate representation, in which case its
+    // consumer class was dropped at pack time. We then inflate the IR via the matching runtime in
+    // the setContent body below instead of reflecting the (absent) class. This handles protolayout;
+    // a Remote Compose IR preview falls through to the normal path (its class is still absent, so it
+    // errors as it did before, until its replay path lands).
+    val irReplay = BundleIrReplayStore.lookup(spec.previewId)
+    val isProtolayoutIr = irReplay?.format == BundleIrReplayStore.FORMAT_PROTOLAYOUT
+    val clazz =
+      if (isProtolayoutIr) null
+      else trace.section("classloader:loadPreviewClass") { Class.forName(spec.className, true, classLoader) }
     // Tile / notification previews are non-composable top-level functions returning
     // `TilePreviewData` / `android.app.Notification`; routing them through
     // `getDeclaredComposableMethod` would throw `NoSuchMethodException` (the Compose-method
@@ -226,10 +235,10 @@ class RenderEngine(
     // body that fails the moment a Glance composable touches the GlanceComposition applier. The
     // dedicated branches skip top-level composable resolution and paint the result through the
     // matching renderer helper in the setContent body below.
-    val nonComposableInvocation = isTile || isNotification || isGlanceAppWidget
+    val nonComposableInvocation = isTile || isNotification || isGlanceAppWidget || isProtolayoutIr
     val composableMethod: ComposableMethod? =
       if (nonComposableInvocation) null
-      else trace.section("compose:resolveComposable") { clazz.getDeclaredComposableMethod(spec.functionName) }
+      else trace.section("compose:resolveComposable") { clazz!!.getDeclaredComposableMethod(spec.functionName) }
 
     // Self-diagnostic — surfaces in the VS Code extension's output channel as `[daemon stderr] …`.
     // Pairs with `[classloader] swap requested` / `allocate child loader` lines from
@@ -334,7 +343,18 @@ class RenderEngine(
                       sink = RecordingExtensionCompositionSink(),
                     ) {
                       Box(modifier = Modifier.fillMaxSize()) {
-                        if (isTile) {
+                        if (isProtolayoutIr) {
+                          // v5 IR replay — inflate the captured protolayout `Layout` + `Resources`
+                          // protos through `TileRenderer`, with no reference to the tile function
+                          // that produced them (its class was dropped at pack time). Same
+                          // AndroidView-hosted shape as the live tile branch, so captureRoboImage
+                          // walks an identical Compose tree.
+                          ee.schimke.composeai.renderer.TileIrReplayComposable(
+                            layoutBytes = irReplay!!.bytes,
+                            resourcesBytes = irReplay.resourcesBytes ?: ByteArray(0),
+                            label = "IR replay ${spec.previewId ?: spec.outputBaseName}",
+                          )
+                        } else if (isTile) {
                           // Non-composable @Preview from `androidx.wear.tiles.tooling.preview` —
                           // mirrors the standalone renderer's `TilePreviewStrategy`. The
                           // inflated tile View lands inside the `Box` via `AndroidView`, so

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/BundleIrReplayStore.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/BundleIrReplayStore.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Process-static lookup of a bundle's captured **intermediate representations** for IR replay
+ * (schema v5). When `compose-preview bundle daemon` launches against a bundle that carries IR, the
+ * CLI extracts the `ir/<id>.<ext>` bytes and the `bundle.json`, then passes:
+ * - `composeai.daemon.bundleManifestPath` — the bundle.json whose `intermediateRepresentations` say
+ *   which previews replay from IR and in what format;
+ * - `composeai.daemon.irDir` — the directory holding the extracted IR bytes (flattened to leaf
+ *   names, e.g. `<previewId>.tilelayout`).
+ *
+ * The render engine consults [lookup] by `previewId` before reflecting the preview's class: an
+ * IR-backed preview has had its consumer bytecode dropped at pack time, so it is rendered by
+ * inflating the IR via the matching runtime (`TileRenderer` for protolayout) instead.
+ *
+ * Loaded once, lazily, mirroring `PreviewIndex`'s sysprop-driven load — the engine needs no
+ * constructor-time injection. Absent sysprops (every non-bundle daemon session) yield an empty map,
+ * so [lookup] is always a cheap no-op there. Format strings are kept in lockstep with `IR_FORMAT_*`
+ * in `:gradle-plugin` / `IrSidecarChannel` in `:data-render-core`.
+ */
+object BundleIrReplayStore {
+
+  const val FORMAT_REMOTECOMPOSE: String = "remotecompose"
+
+  const val FORMAT_PROTOLAYOUT: String = "protolayout"
+
+  /** One preview's resolved IR. [resourcesBytes] is non-null only for protolayout. */
+  class Entry(val format: String, val bytes: ByteArray, val resourcesBytes: ByteArray?)
+
+  const val BUNDLE_MANIFEST_PATH_PROP: String = "composeai.daemon.bundleManifestPath"
+
+  const val IR_DIR_PROP: String = "composeai.daemon.irDir"
+
+  @Volatile private var cached: Map<String, Entry>? = null
+
+  /** The resolved IR for [previewId], or `null` when this preview isn't IR-backed. */
+  fun lookup(previewId: String?): Entry? {
+    if (previewId == null) return null
+    return entries()[previewId]
+  }
+
+  private fun entries(): Map<String, Entry> = cached ?: load().also { cached = it }
+
+  /** Visible for tests — load from explicit paths instead of the system properties. */
+  fun loadFrom(bundleManifestFile: File, irDir: File): Map<String, Entry> {
+    val descriptors =
+      runCatching {
+          JSON.decodeFromString(BundleManifestLite.serializer(), bundleManifestFile.readText())
+            .intermediateRepresentations
+        }
+        .getOrElse { emptyList() }
+    val out = LinkedHashMap<String, Entry>()
+    for (ir in descriptors) {
+      val bytesFile = File(irDir, ir.path.substringAfterLast('/'))
+      if (!bytesFile.isFile) continue
+      val resourcesBytes =
+        ir.resourcesPath
+          ?.let { File(irDir, it.substringAfterLast('/')) }
+          ?.takeIf { it.isFile }
+          ?.readBytes()
+      out[ir.previewId] = Entry(ir.format, bytesFile.readBytes(), resourcesBytes)
+    }
+    return out
+  }
+
+  /** Test seam — drop the cached map so a follow-up [lookup] reloads from the (new) sysprops. */
+  fun resetForTest() {
+    cached = null
+  }
+
+  private fun load(): Map<String, Entry> {
+    val manifestPath = System.getProperty(BUNDLE_MANIFEST_PATH_PROP) ?: return emptyMap()
+    val irDirPath = System.getProperty(IR_DIR_PROP) ?: return emptyMap()
+    val manifestFile = File(manifestPath)
+    val irDir = File(irDirPath)
+    if (!manifestFile.isFile || !irDir.isDirectory) return emptyMap()
+    return loadFrom(manifestFile, irDir)
+  }
+
+  private val JSON = Json { ignoreUnknownKeys = true }
+
+  @Serializable
+  private data class BundleManifestLite(
+    val intermediateRepresentations: List<BundleIrLite> = emptyList()
+  )
+
+  @Serializable
+  private data class BundleIrLite(
+    val previewId: String,
+    val format: String,
+    val path: String,
+    val resourcesPath: String? = null,
+  )
+}

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
@@ -12,6 +12,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.wear.protolayout.DeviceParametersBuilders
 import androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters
+import androidx.wear.protolayout.LayoutElementBuilders
+import androidx.wear.protolayout.ResourceBuilders
+import androidx.wear.protolayout.proto.LayoutElementProto
+import androidx.wear.protolayout.proto.ResourceProto
 import androidx.wear.tiles.RequestBuilders
 import androidx.wear.tiles.TileBuilders
 import androidx.wear.tiles.renderer.TileRenderer
@@ -121,6 +125,22 @@ private fun renderTileInto(
         )
     }
 
+    inflateLayoutInto(context, layout, resources, parent, "preview '$functionName'")
+}
+
+/**
+ * Inflate a protolayout [layout] + [resources] into [parent] via [TileRenderer]. Shared by the
+ * live tile path ([renderTileInto], which builds the protos by invoking the tile function) and the
+ * bundle IR-replay path ([TileIrReplayComposable], which deserializes them from bytes) so both
+ * drive the renderer identically. [label] only flavours the error message.
+ */
+private fun inflateLayoutInto(
+    context: Context,
+    layout: LayoutElementBuilders.Layout,
+    resources: ResourceBuilders.Resources,
+    parent: FrameLayout,
+    label: String,
+) {
     // Inline executor — Robolectric has the main looper paused, so posting
     // to a background thread and awaiting back on main would deadlock. Inflating
     // on the caller thread completes before the future leaves the method.
@@ -136,7 +156,7 @@ private fun renderTileInto(
     val renderer = TileRenderer(context, Runnable::run) { _ -> /* no-op loader */ }
     val view = renderer.inflateAsync(layout, resources, parent)
         .get(10, TimeUnit.SECONDS)
-        ?: error("TileRenderer returned no view for preview '$functionName'")
+        ?: error("TileRenderer returned no view for $label")
 
     // Tile inflation defaults to WRAP_CONTENT, which collapses against an
     // AndroidView that's still measuring. Mirror `TileServiceViewAdapter`:
@@ -146,6 +166,38 @@ private fun renderTileInto(
         height = ViewGroup.LayoutParams.MATCH_PARENT
         gravity = Gravity.CENTER
     }
+}
+
+/**
+ * Replays a Wear Tiles preview from a bundle's captured protolayout IR (schema v5): the serialized
+ * `Layout` ([layoutBytes]) and `Resources` ([resourcesBytes]) protos written by [TilePreviewComposable]'s
+ * capture path. Deserializes both and drives [TileRenderer] through the same [inflateLayoutInto]
+ * the live path uses — so a bundle renders the tile with **no** reference to the `fun foo():
+ * TilePreviewData` that produced it (its class was dropped at pack time). Bytes are the
+ * `toProto().toByteArray()` form the capture side emits; we reverse with `parseFrom` + `fromProto`.
+ */
+@Composable
+fun TileIrReplayComposable(layoutBytes: ByteArray, resourcesBytes: ByteArray, label: String) {
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = { ctx ->
+            val parent = FrameLayout(ctx).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+                setBackgroundColor(Color.BLACK)
+            }
+            val layout = LayoutElementBuilders.Layout.fromProto(
+                LayoutElementProto.Layout.parseFrom(layoutBytes),
+            )
+            val resources = ResourceBuilders.Resources.fromProto(
+                ResourceProto.Resources.parseFrom(resourcesBytes),
+            )
+            inflateLayoutInto(ctx, layout, resources, parent, label)
+            parent
+        },
+    )
 }
 
 private fun invokeTilePreviewFunction(


### PR DESCRIPTION
## Goal

**Piece B — execution, for tiles/protolayout.** The Android daemon now *renders* an IR-backed tile preview from its captured protolayout IR, instead of reflecting the consumer class that emission (#1662) + carriage (#1665) deliberately dropped. This is the first half that makes IR bundles actually replay; Remote Compose execution is the remaining follow-up (see below).

## What this does

- **`BundleIrReplayStore` (`:daemon:core`)** — lazily loads the IR descriptors from the `bundle.json` + `ir/` dir the CLI already passes (`composeai.daemon.bundleManifestPath` / `composeai.daemon.irDir`, #1665), keyed by `previewId`. Mirrors `PreviewIndex`'s sysprop-driven lazy load; empty for every non-bundle session, so `lookup` is a cheap no-op there.
- **`TilePreviewRenderer` (`:renderer-android`)** — factor the `TileRenderer` inflate + layout-params fixup into `inflateLayoutInto()`, shared by the live tile path and a new **`TileIrReplayComposable(layoutBytes, resourcesBytes, label)`** that deserializes the `Layout` / `Resources` protos (`…Proto.parseFrom(bytes)` → `…Builders.fromProto(...)`, reversing the capture side's `toProto().toByteArray()` from #1662) and inflates them — no tile function involved.
- **`RenderEngine` (`:daemon:android`)** — when `BundleIrReplayStore.lookup(spec.previewId)` is a protolayout entry, **skip `Class.forName(spec.className)`** (the class is gone) and route the `setContent` body to `TileIrReplayComposable`. Same `AndroidView`-hosted shape as the live tile branch, so `captureRoboImage` walks an identical tree.

## Remote Compose IR replay — deferred (next PR)

`RemoteDocumentPlayer` lives in the `compileSdk-37` alpha `:data-remotecompose-connector`, which the `compileSdk-36` `:daemon:android` can't compile-depend on directly. So RC replay needs a reflective/service seam (or a connector-provided strategy registered like the other alpha connectors), which is its own change. Until then a RC-IR preview falls through to the normal path and errors as it did before (its class is absent) — no regression vs. today, where it already doesn't replay.

## Player-library carriage check (the #1665 open question)

Tile replay needs `tiles-renderer`/`protolayout-renderer` on the daemon's replay classpath. The #1665 carriage keeps deps **reachable from the tile preview's bytecode** as coords; whether that includes the *renderer* libs (vs. just the `protolayout` builders the preview references) is exactly what this PR's end-to-end run on `:samples:wear` will reveal. If `TileRenderer` resolution fails at replay, the fix is an explicit carriage entry in `BundlePreviewTask` — a small fast-follow.

> ⚠️ **Verification note** — unverifiable in this sandbox (no Android SDK / Robolectric / working Gradle). Every protolayout API is pinned via `javap` against `protolayout 1.4.0` (`Layout.fromProto`, `LayoutElementProto.Layout.parseFrom`, `Resources.fromProto`, `ResourceProto.Resources.parseFrom`). The new `:daemon:core` file is ktfmt-clean; the daemon/renderer edits match those files' hand-maintained style (they're not standalone-ktfmt-clean, so I matched surroundings rather than reformatting). The `clazz` gate is null-safe by construction (`isProtolayoutIr ⟹ nonComposableInvocation`, so `clazz!!` is only reached when non-null).

## Test plan

- [ ] `:daemon:android` + `:renderer-android` compile (the proto `parseFrom`/`fromProto` calls resolve via the #1662 `protolayout-proto` dep).
- [ ] Add a `BundleIrReplayStore` unit test (load from a temp `bundle.json` + `ir/` dir).
- [ ] End-to-end: pack a `:samples:wear` tile bundle → `compose-preview bundle daemon` → render the tile preview → confirm it inflates from IR (not ClassNotFoundException) and the PNG matches the live render. **This is where the carriage question gets answered.**
- [ ] `./gradlew check`

https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt)_