### PR TITLE
fix(daemon): render non-composable previews in live mode instead of blanking

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -945,6 +945,11 @@ open class RobolectricHost(
         // get threaded across the sandbox boundary (see the field's doc on
         // `InteractiveCommand.Start`).
         touchOverlay = spec.overrides?.touchOverlay,
+        // Preview flavour — lets the held-rule loop route tile / notification / Glance previews
+        // through their non-composable strategies instead of `getDeclaredComposableMethod`, which
+        // those previews never satisfy. Without it the start reply errors and live mode blanks the
+        // preview (the tile-preview-goes-blank bug).
+        kind = spec.kind,
       )
     )
     if (!replyLatch.await(INTERACTIVE_START_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
@@ -1785,16 +1790,32 @@ open class RobolectricHost(
         slot.childLoaderRef.get()
           ?: Thread.currentThread().contextClassLoader
           ?: RenderEngine::class.java.classLoader
+      // Branch on the preview flavour exactly like `RenderEngine.render` (see `RenderEngine.kt`
+      // around the `isTile` / `isNotification` / `isGlanceAppWidget` checks). Tile, notification,
+      // and Glance previews are non-composable top-level functions returning `TilePreviewData` /
+      // `android.app.Notification` / a Glance widget — they never synthesise the `(Composer, Int)`
+      // method `getDeclaredComposableMethod` looks for, so resolving one throws and (pre-fix) blanked
+      // the preview the instant live mode was enabled. Skip resolution for those and render them
+      // through their dedicated strategies in the held `setContent` below instead.
+      val isTile = start.kind.equals(RenderEngine.TILE_KIND, ignoreCase = true)
+      val isNotification = start.kind.equals(RenderEngine.NOTIFICATION_KIND, ignoreCase = true)
+      val isGlanceAppWidget =
+        start.kind.equals(RenderEngine.GLANCE_APPWIDGET_KIND, ignoreCase = true)
+      val nonComposableInvocation = isTile || isNotification || isGlanceAppWidget
       val composableMethod =
-        try {
-          val clazz = Class.forName(start.previewClassName, true, classLoader)
-          clazz.getDeclaredComposableMethod(start.previewFunctionName)
-        } catch (t: Throwable) {
-          // Resolution failure (class missing / method missing / signature mismatch) — surface
-          // immediately on the start reply so the host doesn't wait out the 30s timeout.
-          start.replyError.set(unwrapInvocationTarget(t))
-          start.replyLatch.countDown()
-          return
+        if (nonComposableInvocation) {
+          null
+        } else {
+          try {
+            val clazz = Class.forName(start.previewClassName, true, classLoader)
+            clazz.getDeclaredComposableMethod(start.previewFunctionName)
+          } catch (t: Throwable) {
+            // Resolution failure (class missing / method missing / signature mismatch) — surface
+            // immediately on the start reply so the host doesn't wait out the 30s timeout.
+            start.replyError.set(unwrapInvocationTarget(t))
+            start.replyLatch.countDown()
+            return
+          }
         }
 
       // Activity registration — same idempotent shape RenderEngine.render uses. Robolectric
@@ -1973,7 +1994,42 @@ open class RobolectricHost(
                           renderMode = null,
                           sink = RecordingExtensionCompositionSink(),
                         ) {
-                          InvokeHeldComposable(composableMethod)
+                          // Mirror `RenderEngine.render`'s kind dispatch so live mode renders the
+                          // same way a one-shot capture does. Non-composable previews (tile /
+                          // notification / Glance) go through their `*PreviewComposable` strategy;
+                          // everything else invokes the resolved held composable. Pointer / key
+                          // dispatch against a tile or notification simply finds no Compose targets
+                          // (they're inflated Views inside an `AndroidView`), so live input no-ops
+                          // gracefully while the frame still renders instead of going blank.
+                          // `widthDp` / `heightDp` are the held session's resolved canvas dimensions
+                          // (computed above for the qualifier string), reused here verbatim.
+                          if (isTile) {
+                            ee.schimke.composeai.renderer.TilePreviewComposable(
+                              className = start.previewClassName,
+                              functionName = start.previewFunctionName,
+                              widthDp = widthDp,
+                              heightDp = heightDp,
+                              device = start.device,
+                              classLoader = classLoader,
+                            )
+                          } else if (isNotification) {
+                            ee.schimke.composeai.renderer.NotificationPreviewComposable(
+                              className = start.previewClassName,
+                              functionName = start.previewFunctionName,
+                              classLoader = classLoader,
+                              widthDp = widthDp,
+                            )
+                          } else if (isGlanceAppWidget) {
+                            ee.schimke.composeai.renderer.GlanceAppWidgetPreviewComposable(
+                              className = start.previewClassName,
+                              functionName = start.previewFunctionName,
+                              widthDp = widthDp,
+                              heightDp = heightDp,
+                              classLoader = classLoader,
+                            )
+                          } else {
+                            InvokeHeldComposable(composableMethod!!)
+                          }
                         }
                       }
                     }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -417,6 +417,17 @@ sealed interface InteractiveCommand {
      * material3Theme, …) can be added the same way when their interactive use cases need them.
      */
     val touchOverlay: Boolean? = null,
+    /**
+     * `RenderSpec.kind` value (`"TILE"` / `"NOTIFICATION"` / `"GLANCE_APPWIDGET"` / `"COMPOSE"` /
+     * `null`). The held-rule loop branches on it exactly like `RenderEngine.render` does so a live
+     * session renders non-composable previews (tiles, notifications, Glance widgets) through their
+     * dedicated `*PreviewComposable` strategies instead of trying to resolve a `@Composable` method
+     * that those previews never synthesise — without this a tile preview goes blank the moment live
+     * mode is enabled (the resolution throws `NoSuchMethodException` and the start reply errors out).
+     * Threaded as the raw `java.lang.String` for the same do-not-acquire bridge reason as the other
+     * `spec.*` fields above.
+     */
+    val kind: String? = null,
   ) : InteractiveCommand
 
   /**

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
@@ -495,6 +495,53 @@ class AndroidInteractiveSessionTest {
   }
 
   @Test
+  fun nonComposableNotificationKindRendersInHeldSessionInsteadOfErroring() {
+    // Regression: "TilePreview goes blank on enabled live mode". The held-rule loop used to call
+    // `getDeclaredComposableMethod` unconditionally, which throws for non-composable preview kinds
+    // (tile / notification / Glance return `TilePreviewData` / `android.app.Notification` / a Glance
+    // widget — they never synthesise the `(Composer, Int)` method). The exception failed the
+    // `interactive/start` reply, so enabling live mode blanked the preview. The fix branches on
+    // `RenderSpec.kind` exactly like the one-shot `RenderEngine.render` path and routes these
+    // through their dedicated `*PreviewComposable` strategies.
+    //
+    // Notification stands in for the whole non-composable family: it exercises the identical
+    // "skip composable resolution + render via strategy in the held setContent" path the tile
+    // branch uses, but needs no wear-tiles test dependencies / merged-resource AAR in this module.
+    System.setProperty(
+      RenderEngine.OUTPUT_DIR_PROP,
+      tempFolder.newFolder("interactive-notification").absolutePath,
+    )
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost(sandboxCount = 2, previewSpecResolver = previewSpecResolver())
+    host.start()
+    try {
+      // Pre-fix this `acquire` threw (the start reply carried the NoSuchMethodException) — getting a
+      // live session at all is the core of the regression.
+      val session =
+        host.acquireInteractiveSession(
+          previewId = NOTIFICATION_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+      try {
+        val result = session.render(requestId = RenderHost.nextRequestId())
+        val pngPath = result.pngPath
+        assertNotNull(
+          "held notification render must produce a PNG instead of blanking the preview",
+          pngPath,
+        )
+        // Decoding asserts the capture is a real, non-empty image — the notification surface
+        // rendered rather than the held composition coming up empty.
+        val img = decode(File(pngPath!!))
+        assertTrue("rendered notification frame must have pixels", img.width > 0 && img.height > 0)
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
   fun acquireWithoutResolverThrowsUnsupported() {
     val host = RobolectricHost(sandboxCount = 2)
     assertFalse(
@@ -893,6 +940,19 @@ class AndroidInteractiveSessionTest {
           showBackground = true,
           outputBaseName = "interactive-rsb",
         )
+      NOTIFICATION_PREVIEW_ID ->
+        RenderSpec(
+          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+          functionName = "RedNotification",
+          widthPx = INTERACTIVE_WIDTH_PX,
+          heightPx = INTERACTIVE_HEIGHT_PX,
+          density = 1.0f,
+          showBackground = true,
+          outputBaseName = "interactive-notification",
+          // The whole point of the regression: a non-composable preview kind must route through its
+          // dedicated strategy in the held loop instead of `getDeclaredComposableMethod`.
+          kind = RenderEngine.NOTIFICATION_KIND,
+        )
       else -> null
     }
   }
@@ -939,6 +999,7 @@ class AndroidInteractiveSessionTest {
     private const val SCROLL_PREVIEW_ID = "interactive-scroll"
     private const val RELEASE_POSITION_PREVIEW_ID = "interactive-release-position"
     private const val ROTARY_PREVIEW_ID = "interactive-rsb"
+    private const val NOTIFICATION_PREVIEW_ID = "interactive-notification"
     private const val INTERACTIVE_WIDTH_PX = 96
     private const val INTERACTIVE_HEIGHT_PX = 96
     private const val RED_RGB = 0xEF5350

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -273,3 +273,39 @@ fun RotaryToggleSquare() {
         .background(color)
   )
 }
+
+/**
+ * Non-composable `@NotificationPreview`-shaped fixture: a top-level `fun(Context): Notification`
+ * exactly like the ones the gradle plugin discovers and tags `kind = "NOTIFICATION"`. Used by
+ * [AndroidInteractiveSessionTest.nonComposableNotificationKindRendersInHeldSessionInsteadOfErroring]
+ * to lock in the held-interactive-session fix: previously the held-rule loop called
+ * `getDeclaredComposableMethod` unconditionally, which throws `NoSuchMethodException` on a function
+ * that returns `android.app.Notification` (no synthesised `(Composer, Int)` method) and blanked the
+ * preview the moment live mode was enabled. Notification stands in for the whole non-composable
+ * family (tiles / notifications / Glance) because it needs no extra build dependencies — wear-tiles
+ * fixtures would pull `protolayout` + a merged-resource AAR into this module's test classpath.
+ */
+fun RedNotification(context: android.content.Context): android.app.Notification {
+  val channelId = "red-fixture-channel"
+  if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+    val manager = context.getSystemService(android.app.NotificationManager::class.java)
+    manager?.createNotificationChannel(
+      android.app.NotificationChannel(
+        channelId,
+        "Red fixture",
+        android.app.NotificationManager.IMPORTANCE_DEFAULT,
+      )
+    )
+    return android.app.Notification.Builder(context, channelId)
+      .setSmallIcon(android.R.drawable.ic_dialog_info)
+      .setContentTitle("Held notification")
+      .setContentText("rendered inside a live session")
+      .build()
+  }
+  @Suppress("DEPRECATION")
+  return android.app.Notification.Builder(context)
+    .setSmallIcon(android.R.drawable.ic_dialog_info)
+    .setContentTitle("Held notification")
+    .setContentText("rendered inside a live session")
+    .build()
+}


### PR DESCRIPTION
The Android held interactive session resolved a @Composable method via
getDeclaredComposableMethod before entering live mode. Tile, notification,
and Glance previews are non-composable top-level functions (returning
TilePreviewData / android.app.Notification / a Glance widget) that never
synthesise the (Composer, Int) method, so resolution threw
NoSuchMethodException, failed the interactive/start reply, and blanked the
preview the instant live mode was enabled.

Thread RenderSpec.kind through InteractiveCommand.Start and branch on it in
the held-rule loop exactly like the one-shot RenderEngine.render path: skip
composable resolution for non-composable kinds and route them through their
dedicated *PreviewComposable strategies. Live input no-ops against the
inflated View while the frame still renders.

Add a regression test driving a notification-kind preview through a held
session; notification stands in for the non-composable family without
pulling wear-tiles deps into the module's test classpath.