### PR TITLE
feat(vscode): declutter focus-mode preview toolbar

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -1522,15 +1522,17 @@ preview-app {
     );
 }
 
+/* In focus mode the focus-controls live button doubles as the stop control
+ * (it flips to a stop glyph while live), so the on-image corner stop on the
+ * focused card is redundant — hide it. The corner stop stays in grid/flow/
+ * column layouts, where it's the per-card stop for multi-stream live previews. */
+.preview-grid.layout-focus .preview-card.focused .card-live-stop-btn {
+    display: none;
+}
+
 /* Toggle button "live-on" state: red glyph matching the live card outline. */
 .icon-button.live-on {
     color: var(--vscode-errorForeground, #f55);
-}
-
-/* D2 — a11y-overlay toggle pressed state. Blue glyph echoes the hierarchy
- * overlay's box border colour so the toolbar tells you which layer is on. */
-.icon-button.a11y-overlay-on {
-    color: rgba(80, 160, 255, 1);
 }
 
 /* Diff overlay — covers the focused image with a side-by-side comparison
@@ -2099,10 +2101,11 @@ preview-app {
     outline: 1px solid var(--vscode-focusBorder);
     outline-offset: 1px;
 }
-/* In focus mode the icon flips to "exit focus" — same hot zone, opposite verb. */
+/* In focus mode the per-card focus button is redundant — the focus-controls
+ * bar already has an "exit focus" (×) button — so hide it rather than flip it
+ * to a second exit affordance. */
 .preview-grid.layout-focus .preview-card.focused .card-focus-btn {
-    color: var(--vscode-foreground);
-    opacity: 1;
+    display: none;
 }
 
 /* Level → colour. Used as a fallback chain for `.overlay-box` /

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -238,10 +238,14 @@ export class FocusController {
             // The cell-size picker only makes sense for launcher / app-widget
             // previews, so gate on the focused preview actually surfacing a
             // `compose/launcher-widget` data product rather than on any module
-            // in the panel advertising the extension.
+            // in the panel advertising the extension. Also keep the button
+            // visible when a cell-size override is already set (e.g. restored
+            // from persisted state on a webview reload before the payload is
+            // re-cached) so the user can still reset / change it.
             advertised:
                 previewId !== null &&
-                this.config.launcherWidgetAvailable(previewId),
+                (this.config.launcherWidgetAvailable(previewId) ||
+                    live.launcherWidgetCellsForPreview(previewId) !== null),
             enabled:
                 previewId !== null &&
                 live.launcherWidgetCellsForPreview(previewId) !== null,

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -2,7 +2,7 @@
 //
 // Lifted verbatim from `behavior.ts`'s `applyLayout` / `publishScopedPreview`
 // / `focusOnCard` / `exitFocus` / `requestFocusedDiff` /
-// `requestLaunchOnDevice` / `toggleA11yOverlay` cluster, plus the four
+// `requestLaunchOnDevice` cluster, plus the
 // `applyXxxButtonState` hooks that drive the focus-mode toolbar. After
 // this lift `behavior.ts` is mostly setup + message-event wiring; the
 // focus-mode behaviour lives here.
@@ -100,6 +100,11 @@ export interface FocusControllerConfig {
     bundleDaemonReady?(): boolean;
     getA11yOverlayId(): string | null;
     setA11yOverlayId(id: string | null): void;
+    /** True when [previewId] is a launcher-widget / app-widget preview — i.e.
+     *  it has surfaced a `compose/launcher-widget` data product. Gates the
+     *  launcher-widget cell-size button so it only appears on widget previews
+     *  rather than every preview in a module that ships the extension. */
+    launcherWidgetAvailable(previewId: string): boolean;
     getFocusIndex(): number;
     setFocusIndex(idx: number): void;
     getPreviousLayout(): "grid" | "flow" | "column";
@@ -182,19 +187,6 @@ export class FocusController {
         });
     }
 
-    applyA11yOverlayButtonState(): void {
-        const inFocus = this.inFocus();
-        const card = inFocus
-            ? this.getVisibleCards()[this.config.getFocusIndex()]
-            : null;
-        this.config.focusToolbar.applyA11yOverlayButtonState({
-            inFocus,
-            earlyFeatures: this.config.earlyFeatures(),
-            focusedPreviewId: card?.dataset.previewId ?? null,
-            a11yOverlayId: this.config.getA11yOverlayId(),
-        });
-    }
-
     /**
      * Push the touch-overlay / keyboard-band / controls toggle state for the
      * focused preview onto the focus-toolbar buttons. These were previously
@@ -232,13 +224,24 @@ export class FocusController {
         this.config.focusToolbar.applyControlsButtonState({
             inFocus,
             focusedPreviewId: previewId,
-            advertised: live.isControlsAdvertised(),
+            // Keyboard input is meaningless on Wear OS surfaces (no software
+            // keyboard), so hide the controls toggle on round-watch previews —
+            // same `data-wear-preview` gate the keyboard-band button uses.
+            advertised:
+                live.isControlsAdvertised() &&
+                card?.dataset.wearPreview !== "1",
             enabled: previewId !== null && live.isControlsEnabled(previewId),
         });
         this.config.focusToolbar.applyLauncherWidgetButtonState({
             inFocus,
             focusedPreviewId: previewId,
-            advertised: live.isLauncherWidgetAdvertised(),
+            // The cell-size picker only makes sense for launcher / app-widget
+            // previews, so gate on the focused preview actually surfacing a
+            // `compose/launcher-widget` data product rather than on any module
+            // in the panel advertising the extension.
+            advertised:
+                previewId !== null &&
+                this.config.launcherWidgetAvailable(previewId),
             enabled:
                 previewId !== null &&
                 live.launcherWidgetCellsForPreview(previewId) !== null,
@@ -252,34 +255,6 @@ export class FocusController {
      * than waiting for a next render. When turning ON for a different
      * preview, first turn the previous one off so the wire stays clean.
      */
-    toggleA11yOverlay(): void {
-        // a11y is the graduated bundle — no early-features gate (the chip bar
-        // and the focus-toolbar button are both visible in basic mode, the
-        // host's `setA11yOverlay` handler also drops its gate). Other entry
-        // points (`launch-on-device`, `record`, `export-bundle`) keep theirs.
-        if (!this.inFocus()) return;
-        const card = this.getVisibleCards()[this.config.getFocusIndex()];
-        const previewId = card ? card.dataset.previewId : null;
-        if (!previewId) return;
-        const currentId = this.config.getA11yOverlayId();
-        const turningOn = previewId !== currentId;
-        if (currentId && currentId !== previewId) {
-            this.config.vscode.postMessage({
-                command: "setA11yOverlay",
-                previewId: currentId,
-                enabled: false,
-            });
-        }
-        this.config.setA11yOverlayId(turningOn ? previewId : null);
-        this.config.vscode.postMessage({
-            command: "setA11yOverlay",
-            previewId,
-            enabled: turningOn,
-        });
-        this.applyA11yOverlayButtonState();
-        this.config.inspectorRender(card);
-    }
-
     applyLayout(): void {
         const mode = this.config.filterToolbar.getLayoutValue();
         const inFocus = mode === "focus";
@@ -358,7 +333,6 @@ export class FocusController {
         }
         this.applyInteractiveButtonState();
         this.applyRecordingButtonState();
-        this.applyA11yOverlayButtonState();
         this.applyFocusedToggleButtonStates();
         this.applyEarlyFeatureVisibility();
         this.config.refreshBundleLegend();

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -26,7 +26,6 @@ export interface FocusToolbarElements {
     btnDiffHead: HTMLButtonElement;
     btnDiffMain: HTMLButtonElement;
     btnLaunchDevice: HTMLButtonElement;
-    btnA11yOverlay: HTMLButtonElement;
     btnInteractive: HTMLButtonElement;
     btnStopInteractive: HTMLButtonElement;
     btnRecording: HTMLButtonElement;
@@ -84,15 +83,6 @@ export interface RecordingButtonState {
     isRecording: boolean;
 }
 
-export interface A11yOverlayButtonState {
-    inFocus: boolean;
-    earlyFeatures: boolean;
-    focusedPreviewId: string | null;
-    /** `previewId` whose accessibility-overlay subscription is on, or
-     *  `null` when no overlay is active. */
-    a11yOverlayId: string | null;
-}
-
 /**
  * Common shape for the three preview-override / interactive-input toggles that
  * follow the focused card (touch overlay, soft-keyboard band, #1203 controls).
@@ -125,12 +115,10 @@ export class FocusToolbarController {
         // sidebar panels gate daemon-readiness per-button via the
         // individual `applyXxxButtonState` hooks).
         const daemonHidden = bundle && !s.bundleDaemonReady;
-        // a11y is the one bundle graduated out of `earlyFeatures` — the
-        // chip-bar filter at `main.ts:2415` already surfaces it in basic
-        // mode, and the focus-toolbar button is the matching focus-mode
-        // entry point. Other early-features buttons (recording, export
-        // bundle, …) stay gated until those features graduate too.
-        this.el.btnA11yOverlay.hidden = daemonHidden || !s.inFocus;
+        // The accessibility overlay no longer has a focus-toolbar button —
+        // it's reachable from the always-visible bundle chip bar at the
+        // bottom (the `a11y` chip graduated out of `earlyFeatures`), which
+        // paints the same overlay boxes via the a11y bundle presenter.
         this.el.btnRecording.hidden =
             daemonHidden || !s.earlyFeatures || !s.inFocus;
         this.el.recordingFormat.hidden =
@@ -195,8 +183,12 @@ export class FocusToolbarController {
                     " other live · click to make this one live too · " +
                     "Shift+click to add without unsubscribing the rest"
                   : "Enter live mode (stream renders) · Shift+click to add to multi-stream";
+        // While live the button doubles as the cancel/stop control, so it
+        // flips to a stop glyph (the `live-on` class keeps it tinted red).
+        // This is the per-card stop in focus mode — the on-image corner stop
+        // is suppressed here by CSS (see `.card-live-stop-btn` in preview.css).
         this.el.btnInteractive.innerHTML = s.isLive
-            ? '<i class="codicon codicon-record" aria-hidden="true"></i>'
+            ? '<i class="codicon codicon-debug-stop" aria-hidden="true"></i>'
             : '<i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>';
     }
 
@@ -225,35 +217,6 @@ export class FocusToolbarController {
         this.el.btnRecording.innerHTML = s.isRecording
             ? '<i class="codicon codicon-debug-stop" aria-hidden="true"></i>'
             : '<i class="codicon codicon-record-keys" aria-hidden="true"></i>';
-    }
-
-    /**
-     * D2 — keep the a11y-overlay toggle in lockstep with focus-mode +
-     * the focused card identity. Outside focus mode the button hides;
-     * inside focus mode `aria-pressed` tracks whether the currently
-     * focused preview has the overlay subscription on.
-     */
-    // applyA11yOverlayButtonState applies the in-mode pressed-state +
-    // tooltip refresh; the higher-level visibility gate is owned by
-    // applyButtonVisibility above (and intentionally no longer requires
-    // earlyFeatures, since a11y is the graduated bundle).
-    applyA11yOverlayButtonState(s: A11yOverlayButtonState): void {
-        this.el.btnA11yOverlay.hidden = !s.inFocus;
-        if (!s.inFocus) {
-            this.el.btnA11yOverlay.setAttribute("aria-pressed", "false");
-            return;
-        }
-        const on =
-            s.focusedPreviewId !== null &&
-            s.focusedPreviewId === s.a11yOverlayId;
-        this.el.btnA11yOverlay.setAttribute(
-            "aria-pressed",
-            on ? "true" : "false",
-        );
-        this.el.btnA11yOverlay.title = on
-            ? "Hide accessibility overlay"
-            : "Show accessibility overlay";
-        this.el.btnA11yOverlay.classList.toggle("a11y-overlay-on", on);
     }
 
     /**

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -245,7 +245,6 @@ export class PreviewApp extends LitElement {
     @query("#btn-diff-head") private _btnDiffHead!: HTMLButtonElement;
     @query("#btn-diff-main") private _btnDiffMain!: HTMLButtonElement;
     @query("#btn-launch-device") private _btnLaunchDevice!: HTMLButtonElement;
-    @query("#btn-a11y-overlay") private _btnA11yOverlay!: HTMLButtonElement;
     @query("#btn-interactive") private _btnInteractive!: HTMLButtonElement;
     @query("#btn-stop-interactive")
     private _btnStopInteractive!: HTMLButtonElement;
@@ -344,15 +343,6 @@ export class PreviewApp extends LitElement {
                         class="codicon codicon-device-mobile"
                         aria-hidden="true"
                     ></i>
-                </button>
-                <button
-                    class="icon-button"
-                    id="btn-a11y-overlay"
-                    title="Show accessibility overlay"
-                    aria-label="Toggle accessibility overlay"
-                    aria-pressed="false"
-                >
-                    <i class="codicon codicon-eye" aria-hidden="true"></i>
                 </button>
                 <button
                     class="icon-button"
@@ -661,7 +651,6 @@ export class PreviewApp extends LitElement {
         const btnDiffHead = this._btnDiffHead;
         const btnDiffMain = this._btnDiffMain;
         const btnLaunchDevice = this._btnLaunchDevice;
-        const btnA11yOverlay = this._btnA11yOverlay;
         const btnInteractive = this._btnInteractive;
         const btnStopInteractive = this._btnStopInteractive;
         const btnRecording = this._btnRecording;
@@ -677,7 +666,6 @@ export class PreviewApp extends LitElement {
             btnDiffHead,
             btnDiffMain,
             btnLaunchDevice,
-            btnA11yOverlay,
             btnInteractive,
             btnStopInteractive,
             btnRecording,
@@ -2786,6 +2774,10 @@ export class PreviewApp extends LitElement {
             bundleDaemonReady: () => bundleDaemonReady,
             getA11yOverlayId: a11yOverlay,
             setA11yOverlayId: setA11yOverlay,
+            launcherWidgetAvailable: (previewId) =>
+                dataProductsByPreview
+                    .get(previewId)
+                    ?.has("compose/launcher-widget") ?? false,
             getFocusIndex: () => previewStore.getState().focusIndex,
             setFocusIndex: (next) =>
                 previewStore.setState({ focusIndex: next }),
@@ -2915,7 +2907,6 @@ export class PreviewApp extends LitElement {
         btnLaunchDevice.addEventListener("click", () =>
             requestLaunchOnDevice(),
         );
-        btnA11yOverlay.addEventListener("click", () => toggleA11yOverlay());
         // Shift modifier opts into the multi-stream path: keep the prior live targets, add or
         // remove just this one. Plain click keeps the single-target single-card UX casual users
         // expect.
@@ -3109,9 +3100,6 @@ export class PreviewApp extends LitElement {
         }
         function requestExportPreviewBundle(): void {
             focusController.requestExportPreviewBundle();
-        }
-        function toggleA11yOverlay(): void {
-            focusController.toggleA11yOverlay();
         }
 
         // Filter + message-banner orchestration shims — implementations live
@@ -3381,6 +3369,19 @@ export class PreviewApp extends LitElement {
                 // overlay-count threshold so noise is harmless.
                 if (matchesTarget && activeBundles.length > 0) {
                     postBundleState();
+                }
+                // The launcher-widget button gates on the focused preview
+                // surfacing a `compose/launcher-widget` payload, so refresh the
+                // focus-toolbar toggles when that payload lands for the focused
+                // card — otherwise the button wouldn't appear until the next
+                // focus navigation.
+                if (
+                    matches &&
+                    dataProducts.some(
+                        (dp) => dp.kind === "compose/launcher-widget",
+                    )
+                ) {
+                    focusController.applyFocusedToggleButtonStates();
                 }
             },
             applyFontPreviewBytes: (previewId, fontRowId, dataUri) => {


### PR DESCRIPTION
## Summary

Trims and tightens the focus-mode preview controls strip based on review feedback that "these buttons aren't the most useful":

- **Drop the accessibility-overlay (eye) button.** The a11y overlay is reachable from the always-visible bundle chip bar at the bottom, which paints the same overlay boxes via the a11y bundle presenter — so the toolbar button was a redundant entry point. Removes the button HTML, its query/wiring, and the now-dead `toggleA11yOverlay` / `applyA11yOverlayButtonState` path.
- **Live button doubles as the stop control.** While live it now flips to a stop glyph (instead of a record glyph). The on-image corner stop on the focused card is suppressed in focus mode (the toolbar button covers it); it stays in grid/flow/column layouts, where it's the per-card stop for multi-stream live previews. (Multi-stream itself is kept.)
- **Gate the interactive controls (keyboard input) button off Wear OS previews**, matching the existing soft-keyboard-band gate — there's no software keyboard on a watch surface.
- **Gate the launcher-widget cell-size button to actual widget previews.** It now shows only when the focused preview surfaces a `compose/launcher-widget` data product, instead of any module in the panel advertising the extension, so it no longer leaks onto non-widget previews (e.g. Wear). The focus toolbar is refreshed when that payload lands.
- **Hide the per-card focus button while already in focus mode.** The focus-controls bar's exit (×) button is the single exit affordance.

Touch-overlay and soft-keyboard-band buttons are unchanged.

## Test plan

- `npm test` — 1414 passing (host + webview compile, then mocha).
- `npx tsc -p tsconfig.webview.json` and `npx tsc -p ./` — clean.
- `prettier --check` on the changed files — clean.
- No unit-test, contract-harness fixture, or snapshot baseline drives the removed/changed buttons. The Playwright-based snapshot/contract harness was not run (browser download is blocked in the build environment).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NFNEf9QL2ypU6U19wud71k)_