### PR TITLE
fix(bundle): carry + resolve the tile renderer runtime for protolayout IR replay

### DIFF
--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/CoordinateResolver.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/CoordinateResolver.kt
@@ -54,7 +54,7 @@ internal object CoordinateResolver {
   ): File? {
     // Local repos AND our download cache — a jar fetched in an earlier online run must resolve
     // offline too (the network gate only governs *new* fetches, not reading what we already have).
-    val candidates = locate(coord, roots + downloadCacheDir)
+    val candidates = locate(coord, roots + downloadCacheDir, downloadCacheDir)
     val expected = coord.sha256
 
     if (expected != null) {
@@ -97,24 +97,63 @@ internal object CoordinateResolver {
     return null
   }
 
-  private fun locate(coord: ClasspathEntry.Maven, roots: List<File>): List<File> {
-    val jarName = artifactFileName(coord)
+  private fun locate(
+    coord: ClasspathEntry.Maven,
+    roots: List<File>,
+    downloadCacheDir: File,
+  ): List<File> {
     val found = mutableListOf<File>()
     for (root in roots) {
       if (!root.isDirectory) continue
-      val mavenPath = File(root, mavenRelativePath(coord))
-      if (mavenPath.isFile) found += mavenPath
-      val gradleVersionDir = File(root, "${coord.group}/${coord.artifact}/${coord.version}")
-      if (gradleVersionDir.isDirectory) {
-        gradleVersionDir
-          .listFiles()
-          ?.asSequence()
-          ?.filter { it.isDirectory }
-          ?.mapNotNull { hashDir -> File(hashDir, jarName).takeIf { it.isFile } }
-          ?.let { found += it }
+      // Coordinate's recorded type first, then `.aar` (Android deps recorded as `jar` by an older
+      // bundle, or whose `.jar` isn't published). [materialize] turns an `.aar` into its
+      // classes.jar.
+      for (fileName in candidateFileNames(coord)) {
+        val mavenPath =
+          File(
+            root,
+            "${coord.group.replace('.', '/')}/${coord.artifact}/${coord.version}/$fileName",
+          )
+        if (mavenPath.isFile) found += mavenPath
+        val gradleVersionDir = File(root, "${coord.group}/${coord.artifact}/${coord.version}")
+        if (gradleVersionDir.isDirectory) {
+          gradleVersionDir
+            .listFiles()
+            ?.asSequence()
+            ?.filter { it.isDirectory }
+            ?.mapNotNull { hashDir -> File(hashDir, fileName).takeIf { it.isFile } }
+            ?.let { found += it }
+        }
       }
     }
-    return found
+    // Materialize before returning so the hash check (and the classpath) sees real jars — an `.aar`
+    // isn't loadable and the bundle's `sha256` is of the extracted `classes.jar`.
+    return found.mapNotNull { materialize(it, downloadCacheDir) }
+  }
+
+  /**
+   * An `.aar` isn't classpath-loadable, so extract its `classes.jar` to a stable cache path under
+   * [downloadCacheDir] and return that; a `.jar` passes through. Returns null for a resource-only
+   * `.aar` (no `classes.jar`) or any extraction error — the caller then treats it as a miss.
+   */
+  private fun materialize(file: File, downloadCacheDir: File): File? {
+    if (!file.name.endsWith(".aar", ignoreCase = true)) return file
+    val dest =
+      File(
+        downloadCacheDir,
+        "extracted/${file.absolutePath.hashCode().toUInt().toString(16)}/classes.jar",
+      )
+    if (dest.isFile && dest.length() > 0) return dest
+    return try {
+      java.util.zip.ZipFile(file).use { zip ->
+        val entry = zip.getEntry("classes.jar") ?: return null
+        dest.parentFile?.mkdirs()
+        zip.getInputStream(entry).use { input -> dest.outputStream().use { input.copyTo(it) } }
+      }
+      dest.takeIf { it.length() > 0 }
+    } catch (_: Exception) {
+      null
+    }
   }
 
   /**
@@ -128,10 +167,12 @@ internal object CoordinateResolver {
     remoteRepositories: List<String>,
     downloadCacheDir: File,
   ): File? {
-    val rel = mavenRelativePath(coord)
-    val dest = File(downloadCacheDir, rel)
-    for (base in remoteRepositories) {
-      if (fetchTo(base.trimEnd('/') + "/" + rel, dest)) return dest
+    for (fileName in candidateFileNames(coord)) {
+      val rel = "${coord.group.replace('.', '/')}/${coord.artifact}/${coord.version}/$fileName"
+      val dest = File(downloadCacheDir, rel)
+      for (base in remoteRepositories) {
+        if (fetchTo(base.trimEnd('/') + "/" + rel, dest)) return materialize(dest, downloadCacheDir)
+      }
     }
     return null
   }
@@ -190,13 +231,15 @@ internal object CoordinateResolver {
   val DEFAULT_REMOTE_REPOSITORIES: List<String> =
     listOf("https://repo1.maven.org/maven2", "https://dl.google.com/dl/android/maven2")
 
-  /** `<artifact>-<version>.<type>` — `type` is `jar` (desktop) or `aar` (Android). */
-  private fun artifactFileName(coord: ClasspathEntry.Maven): String =
-    "${coord.artifact}-${coord.version}.${coord.type.ifBlank { "jar" }}"
-
-  /** `<group as path>/<artifact>/<version>/<artifact>-<version>.<type>`. */
-  private fun mavenRelativePath(coord: ClasspathEntry.Maven): String =
-    coord.group.replace('.', '/') + "/${coord.artifact}/${coord.version}/${artifactFileName(coord)}"
+  /**
+   * Candidate `<artifact>-<version>.<ext>` filenames, in order: the coordinate's recorded type
+   * (`jar` desktop / `aar` Android) first, then `.aar` as a fallback for Android deps an older
+   * bundle recorded as `jar` or whose `.jar` isn't published. De-duplicated.
+   */
+  private fun candidateFileNames(coord: ClasspathEntry.Maven): List<String> =
+    listOf(coord.type.ifBlank { "jar" }, "aar").distinct().map {
+      "${coord.artifact}-${coord.version}.$it"
+    }
 
   private fun defaultRepositoryRoots(): List<File> {
     val home = System.getProperty("user.home")?.let(::File)

--- a/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/CoordinateResolverTest.kt
+++ b/bundle-viewer/src/test/kotlin/ee/schimke/composeai/viewer/CoordinateResolverTest.kt
@@ -2,10 +2,13 @@ package ee.schimke.composeai.viewer
 
 import com.google.common.truth.Truth.assertThat
 import com.sun.net.httpserver.HttpServer
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.InetSocketAddress
 import java.nio.file.Files
 import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import org.junit.After
 import org.junit.Test
 
@@ -68,6 +71,17 @@ class CoordinateResolverTest {
 
   private fun sha256(bytes: ByteArray): String =
     MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+  /** A minimal `.aar`: a zip carrying a single `classes.jar` entry with [classesJar] bytes. */
+  private fun makeAar(classesJar: ByteArray): ByteArray {
+    val baos = ByteArrayOutputStream()
+    ZipOutputStream(baos).use { zip ->
+      zip.putNextEntry(ZipEntry("classes.jar"))
+      zip.write(classesJar)
+      zip.closeEntry()
+    }
+    return baos.toByteArray()
+  }
 
   /** Local-only resolve: network off so a miss stays hermetic. */
   private fun resolve(vararg coords: ClasspathEntry.Maven): List<File> =
@@ -160,11 +174,13 @@ class CoordinateResolverTest {
   }
 
   @Test
-  fun `aar coordinate resolves by its type extension`() {
-    val bytes = byteArrayOf(5, 0, 5)
+  fun `aar coordinate is located as aar and its classes_jar extracted`() {
+    // type=aar is looked up as `<artifact>-<version>.aar`; the resolver returns the AAR's extracted
+    // `classes.jar` (the only loadable form), which is what the bundle's sha256 is computed over.
+    val classesBytes = byteArrayOf(5, 0, 5, 9)
     val aar = File(root, "com/example/foo/widgets/1.2.3/widgets-1.2.3.aar")
     aar.parentFile.mkdirs()
-    aar.writeBytes(bytes)
+    aar.writeBytes(makeAar(classesBytes))
 
     val coord =
       ClasspathEntry.Maven(
@@ -172,12 +188,29 @@ class CoordinateResolverTest {
         artifact = "widgets",
         version = "1.2.3",
         type = "aar",
-        sha256 = sha256(bytes),
+        sha256 = sha256(classesBytes),
       )
     val out = resolve(coord)
 
-    assertThat(out.map { it.canonicalFile }).containsExactly(aar.canonicalFile)
+    assertThat(out).hasSize(1)
+    assertThat(out.single().name).isEqualTo("classes.jar")
+    assertThat(out.single().readBytes().toList()).isEqualTo(classesBytes.toList())
     assertThat(warnings).isEmpty()
+  }
+
+  @Test
+  fun `aar published dep recorded as jar still resolves via the aar fallback`() {
+    // Older bundles recorded AARs as type=jar; the resolver must still find the `.aar` and extract.
+    val classesBytes = byteArrayOf(2, 2, 2, 2)
+    val aar = File(root, "com/example/foo/widgets/1.2.3/widgets-1.2.3.aar")
+    aar.parentFile.mkdirs()
+    aar.writeBytes(makeAar(classesBytes))
+
+    // maven() defaults to type=jar, and only the .aar exists on disk.
+    val out = resolve(maven(sha = sha256(classesBytes)))
+
+    assertThat(out).hasSize(1)
+    assertThat(out.single().name).isEqualTo("classes.jar")
   }
 
   @Test

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
@@ -142,30 +142,40 @@ internal class CoordinateResolver(
    * several caches or Gradle hash dirs — [resolve] uses the hash to pick among them.
    */
   private fun locate(coord: BundleReader.ClasspathEntry.Maven): List<File> {
-    val jarName = artifactFileName(coord)
     val found = mutableListOf<File>()
     // Search the user's local repos AND our own download cache — a jar fetched during an earlier
     // online run lives in [downloadCacheDir] (Maven layout) and must resolve offline too, since the
     // network gate only governs *new* fetches, not reading what we already have.
     for (root in repositoryRoots + downloadCacheDir) {
       if (!root.isDirectory) continue
-      // Maven layout: <root>/<group as path>/<artifact>/<version>/<artifact>-<version>.jar
-      val mavenPath = File(root, mavenRelativePath(coord))
-      if (mavenPath.isFile) found += mavenPath
-      // Gradle modules-2 layout fans the jar under per-hash dirs; collect every match under
-      // <root>/<group>/<artifact>/<version>/<hash>/<jarName>. One directory level only, so a huge
-      // cache root doesn't turn this into a full filesystem scan.
-      val gradleVersionDir = File(root, "${coord.group}/${coord.artifact}/${coord.version}")
-      if (gradleVersionDir.isDirectory) {
-        gradleVersionDir
-          .listFiles()
-          ?.asSequence()
-          ?.filter { it.isDirectory }
-          ?.mapNotNull { hashDir -> File(hashDir, jarName).takeIf { it.isFile } }
-          ?.let { found += it }
+      // Try each candidate filename: the coordinate's recorded type first, then `.aar` (an Android
+      // dep may be recorded as `jar` by an older bundle, or its `.jar` simply isn't published —
+      // AndroidX libs ship `.aar`). [materialize] turns any `.aar` hit into its `classes.jar`.
+      for (fileName in candidateFileNames(coord)) {
+        // Maven layout: <root>/<group as path>/<artifact>/<version>/<artifact>-<version>.<ext>
+        val mavenPath =
+          File(
+            root,
+            "${coord.group.replace('.', '/')}/${coord.artifact}/${coord.version}/$fileName",
+          )
+        if (mavenPath.isFile) found += mavenPath
+        // Gradle modules-2 layout fans the artifact under per-hash dirs; collect every match under
+        // <root>/<group>/<artifact>/<version>/<hash>/<fileName>. One directory level only, so a
+        // huge cache root doesn't turn this into a full filesystem scan.
+        val gradleVersionDir = File(root, "${coord.group}/${coord.artifact}/${coord.version}")
+        if (gradleVersionDir.isDirectory) {
+          gradleVersionDir
+            .listFiles()
+            ?.asSequence()
+            ?.filter { it.isDirectory }
+            ?.mapNotNull { hashDir -> File(hashDir, fileName).takeIf { it.isFile } }
+            ?.let { found += it }
+        }
       }
     }
-    return found
+    // Materialize before returning so the hash check (and the caller's classpath) sees real jars:
+    // an `.aar` isn't loadable, and the bundle's `sha256` is of the extracted `classes.jar`.
+    return found.mapNotNull { materialize(it) }
   }
 
   /**
@@ -178,13 +188,44 @@ internal class CoordinateResolver(
    * bytes didn't match the bundle's hash and we want fresh bytes (which overwrite the stale copy).
    */
   private fun download(coord: BundleReader.ClasspathEntry.Maven): File? {
-    val rel = mavenRelativePath(coord)
-    val dest = File(downloadCacheDir, rel)
-    for (base in remoteRepositories) {
-      val url = base.trimEnd('/') + "/" + rel
-      if (fetchTo(url, dest)) return dest
+    // Try the recorded type, then `.aar` — same fallback as [locate], for the same reasons.
+    for (fileName in candidateFileNames(coord)) {
+      val rel = "${coord.group.replace('.', '/')}/${coord.artifact}/${coord.version}/$fileName"
+      val dest = File(downloadCacheDir, rel)
+      for (base in remoteRepositories) {
+        val url = base.trimEnd('/') + "/" + rel
+        if (fetchTo(url, dest)) return materialize(dest)
+      }
     }
     return null
+  }
+
+  /**
+   * An `.aar` isn't classpath-loadable, so extract its `classes.jar` to a stable cache path and
+   * return that; a `.jar` (or anything else) passes through unchanged. Returns null for a
+   * resource-only `.aar` with no `classes.jar` (nothing to contribute) or on any extraction error —
+   * the resolver then treats it as a miss and warns, never throws.
+   */
+  private fun materialize(file: File): File? {
+    if (!file.name.endsWith(".aar", ignoreCase = true)) return file
+    // Key the extraction dir on the source path so distinct candidates (hash disambiguation) don't
+    // collide, and a re-resolve reuses the already-extracted jar.
+    val dest =
+      File(
+        downloadCacheDir,
+        "extracted/${file.absolutePath.hashCode().toUInt().toString(16)}/classes.jar",
+      )
+    if (dest.isFile && dest.length() > 0) return dest
+    return try {
+      java.util.zip.ZipFile(file).use { zip ->
+        val entry = zip.getEntry("classes.jar") ?: return null
+        dest.parentFile?.mkdirs()
+        zip.getInputStream(entry).use { input -> dest.outputStream().use { input.copyTo(it) } }
+      }
+      dest.takeIf { it.length() > 0 }
+    } catch (_: Exception) {
+      null
+    }
   }
 
   /** GET [url] → [dest] (parent dirs created); true only on a 2xx with a non-empty body. */
@@ -233,14 +274,17 @@ internal class CoordinateResolver(
     val DEFAULT_REMOTE_REPOSITORIES: List<String> =
       listOf("https://repo1.maven.org/maven2", "https://dl.google.com/dl/android/maven2")
 
-    /** `<artifact>-<version>.<type>` — `type` is `jar` (desktop) or `aar` (Android). */
-    private fun artifactFileName(coord: BundleReader.ClasspathEntry.Maven): String =
-      "${coord.artifact}-${coord.version}.${coord.type.ifBlank { "jar" }}"
-
-    /** `<group as path>/<artifact>/<version>/<artifact>-<version>.<type>`. */
-    private fun mavenRelativePath(coord: BundleReader.ClasspathEntry.Maven): String =
-      coord.group.replace('.', '/') +
-        "/${coord.artifact}/${coord.version}/${artifactFileName(coord)}"
+    /**
+     * Candidate `<artifact>-<version>.<ext>` filenames to look for, in order: the coordinate's
+     * recorded type (`jar` desktop / `aar` Android) first, then `.aar` as a fallback. The fallback
+     * covers Android deps that an older bundle recorded as `jar`, or whose `.jar` isn't published
+     * (AndroidX libs ship `.aar`). De-duplicated, so a `jar`/`aar` coordinate yields one or two
+     * names.
+     */
+    private fun candidateFileNames(coord: BundleReader.ClasspathEntry.Maven): List<String> =
+      listOf(coord.type.ifBlank { "jar" }, "aar").distinct().map {
+        "${coord.artifact}-${coord.version}.$it"
+      }
 
     /**
      * Default local repositories searched when a caller doesn't pass its own. Honours the standard

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
@@ -1,10 +1,13 @@
 package ee.schimke.composeai.cli
 
 import com.sun.net.httpserver.HttpServer
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.InetSocketAddress
 import java.nio.file.Files
 import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -29,6 +32,14 @@ class CoordinateResolverTest {
       repositoryRoots = listOf(root),
       warn = { warnings += it },
       networkEnabled = false,
+    )
+  // Offline resolver that materializes AARs into the test cache (not the real ~/.cache).
+  private val localCacheResolver =
+    CoordinateResolver(
+      repositoryRoots = listOf(root),
+      warn = { warnings += it },
+      networkEnabled = false,
+      downloadCacheDir = cacheDir,
     )
   private var server: HttpServer? = null
 
@@ -91,6 +102,17 @@ class CoordinateResolverTest {
 
   private fun sha256(bytes: ByteArray): String =
     MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+  /** A minimal `.aar`: a zip carrying a single `classes.jar` entry with [classesJar] bytes. */
+  private fun makeAar(classesJar: ByteArray): ByteArray {
+    val baos = ByteArrayOutputStream()
+    ZipOutputStream(baos).use { zip ->
+      zip.putNextEntry(ZipEntry("classes.jar"))
+      zip.write(classesJar)
+      zip.closeEntry()
+    }
+    return baos.toByteArray()
+  }
 
   @Test
   fun `resolves from maven local layout and verifies a matching hash`() {
@@ -253,13 +275,14 @@ class CoordinateResolverTest {
   }
 
   @Test
-  fun `aar coordinate resolves by its type extension, not jar`() {
-    // An Android coordinate (type=aar) must be looked up / downloaded as
-    // `<artifact>-<version>.aar`.
-    val bytes = byteArrayOf(5, 0, 5)
+  fun `aar coordinate is located as aar and its classes_jar extracted`() {
+    // An Android coordinate (type=aar) is looked up as `<artifact>-<version>.aar`, then the
+    // resolver hands back the AAR's extracted `classes.jar` — the only classpath-loadable form. The
+    // bundle's sha256 is of that classes.jar (what the plugin hashes), so it still verifies.
+    val classesBytes = byteArrayOf(5, 0, 5, 9)
     val aar = File(root, "com/example/foo/widgets/1.2.3/widgets-1.2.3.aar")
     aar.parentFile.mkdirs()
-    aar.writeBytes(bytes)
+    aar.writeBytes(makeAar(classesBytes))
 
     val coord =
       BundleReader.ClasspathEntry.Maven(
@@ -267,18 +290,37 @@ class CoordinateResolverTest {
         artifact = "widgets",
         version = "1.2.3",
         type = "aar",
-        sha256 = sha256(bytes),
+        sha256 = sha256(classesBytes),
       )
-    val r = resolver.resolve(coord)
+    val r = localCacheResolver.resolve(coord)
 
-    assertEquals(aar.canonicalFile, r.file?.canonicalFile)
+    assertNotNullFile(r.file)
+    assertEquals("classes.jar", r.file?.name)
+    assertEquals(classesBytes.toList(), r.file?.readBytes()?.toList())
+    assertTrue(r.verified, "sha256 of the extracted classes.jar should verify: $warnings")
+  }
+
+  @Test
+  fun `aar published dep recorded as jar still resolves via the aar fallback`() {
+    // Older bundles (and the plugin before the type fix) recorded AARs as `type=jar`; the resolver
+    // must still find `<artifact>-<version>.aar` when no `.jar` exists and extract its classes.
+    val classesBytes = byteArrayOf(2, 2, 2, 2)
+    val aar = File(root, "com/example/foo/widgets/1.2.3/widgets-1.2.3.aar")
+    aar.parentFile.mkdirs()
+    aar.writeBytes(makeAar(classesBytes))
+
+    // maven() defaults to type=jar — and there is no widgets-1.2.3.jar on disk, only the .aar.
+    val r = localCacheResolver.resolve(maven(sha = sha256(classesBytes)))
+
+    assertNotNullFile(r.file)
+    assertEquals("classes.jar", r.file?.name)
     assertTrue(r.verified)
   }
 
   @Test
-  fun `aar coordinate downloads with the aar extension`() {
-    val bytes = byteArrayOf(1, 0, 0, 1)
-    val base = startRepo(body = bytes)
+  fun `aar coordinate downloads as aar and extracts classes_jar`() {
+    val classesBytes = byteArrayOf(1, 0, 0, 1, 7)
+    val base = startRepo(body = makeAar(classesBytes))
 
     val coord =
       BundleReader.ClasspathEntry.Maven(
@@ -286,15 +328,16 @@ class CoordinateResolverTest {
         artifact = "widgets",
         version = "1.2.3",
         type = "aar",
-        sha256 = sha256(bytes),
+        sha256 = sha256(classesBytes),
       )
     val r = networkResolver(base).resolve(coord)
 
     assertNotNullFile(r.file)
+    assertEquals("classes.jar", r.file?.name)
     assertTrue(r.downloaded)
-    // Cached under the aar filename, not jar.
-    val cached = File(cacheDir, "com/example/foo/widgets/1.2.3/widgets-1.2.3.aar")
-    assertTrue(cached.isFile)
+    assertTrue(r.verified)
+    // The raw aar is cached under the aar filename; the extracted jar lives under extracted/.
+    assertTrue(File(cacheDir, "com/example/foo/widgets/1.2.3/widgets-1.2.3.aar").isFile)
   }
 
   private fun assertNotNullFile(f: File?) =

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -189,7 +189,21 @@ abstract class BundlePreviewTask : DefaultTask() {
     val irByPreview: Map<String, ResolvedIr> =
       selected.mapNotNull { p -> resolvePreviewIr(p)?.let { p.id to it } }.toMap()
 
-    val depSeedFqns = selected.map { it.className }.toSet()
+    // A protolayout IR preview replays through `TileRenderer` (see renderers/android's
+    // `TileIrReplayComposable`), which no tile *preview* function references — the preview only
+    // touches the protolayout builders. So seed the dep closure from the player entry point too:
+    // the BFS then reaches `tiles-renderer` + its transitive `protolayout-renderer` / proto
+    // runtime,
+    // and since deps are kept as whole coordinates whenever any class is reachable, those renderer
+    // libs are recorded as carriage coordinates. `AndroidPreviewSupport` already injects
+    // `tiles-renderer` onto the consumer's runtime classpath, so the jar is present in the scan;
+    // without this seed it'd be pruned (reachable == 0) and the daemon replay would
+    // `NoClassDefFoundError` on `TileRenderer`. A missing entry FQN (jar absent) seeds nothing, so
+    // this is a no-op for non-tile bundles.
+    val hasProtolayoutIr = irByPreview.values.any { it.format == IR_FORMAT_PROTOLAYOUT }
+    val replayEntrySeeds = if (hasProtolayoutIr) PROTOLAYOUT_REPLAY_ENTRY_FQNS else emptySet()
+
+    val depSeedFqns = selected.map { it.className }.toSet() + replayEntrySeeds
     val packSeedFqns = selected.filter { it.id !in irByPreview }.map { it.className }.toSet()
 
     val classDirsList = moduleClassDirs.files.filter { it.exists() && it.isDirectory }
@@ -755,6 +769,15 @@ abstract class BundlePreviewTask : DefaultTask() {
       encodeDefaults = true
       classDiscriminator = "kind"
     }
+
+    /**
+     * Player entry points seeded into the dependency closure when a bundle carries protolayout IR,
+     * so the renderer runtime the daemon replays through ([TilePreviewRenderer]'s `TileRenderer`
+     * path) is carried as coordinates even though no tile preview references it. `TileRenderer`
+     * pulls `protolayout-renderer` + the proto runtime transitively, and whole coordinates are kept
+     * when any class is reachable, so this single entry carries the lot.
+     */
+    val PROTOLAYOUT_REPLAY_ENTRY_FQNS = setOf("androidx.wear.tiles.renderer.TileRenderer")
 
     /**
      * Soft size ceiling above which an embed-deps pack warns. 25 MB is comfortably above a normal

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -244,10 +244,23 @@ internal object ComposePreviewTasks {
     val depJarView =
       depConfig?.incoming?.artifactView { attributes.attribute(artifactTypeAttr, "jar") }
     val depJarFiles = depJarView?.files
+    // The `artifactType=jar` view extracts every AAR to its `classes.jar`, erasing the aar/jar
+    // distinction — but the player's `CoordinateResolver` needs the real packaging to find the
+    // artifact (`<artifact>-<version>.aar`) in a Maven/Gradle cache and unpack its classes. So read
+    // the *untransformed* artifacts too and key each component's packaging off its file extension
+    // (Android deps resolve to `.aar`, JVM deps to `.jar`), then stamp it into the coordinate
+    // below.
+    val typeByComponent: Provider<Map<String, String>> =
+      depConfig?.incoming?.artifacts?.resolvedArtifacts?.map { artifacts ->
+        artifacts.associate { artifact ->
+          artifact.id.componentIdentifier.displayName to
+            if (artifact.file.name.endsWith(".aar", ignoreCase = true)) "aar" else "jar"
+        }
+      } ?: project.providers.provider { emptyMap<String, String>() }
     // Map each resolved dependency jar to a coordinate string the task action can fold into
     // `bundle.json`'s `classpath`:
-    // - `maven:<group>:<artifact>:<version>:jar` for Maven-resolved deps (the player resolves at
-    //   open time — small bundle, no inlined jars).
+    // - `maven:<group>:<artifact>:<version>:<aar|jar>` for Maven-resolved deps (the player resolves
+    //   at open time — small bundle, no inlined jars).
     // - `project:<gradle path>` for project-local deps (the task inlines those into the bundle
     //   since they can't be re-resolved from Maven).
     //
@@ -255,13 +268,14 @@ internal object ComposePreviewTasks {
     // transformed artifact keeps its original `componentIdentifier` (the Maven module / project),
     // so coordinates resolve correctly even though `.file` points at the extracted classes.jar.
     val coordMapProvider: Provider<Map<String, String>> =
-      depJarView?.artifacts?.resolvedArtifacts?.map { artifacts ->
+      depJarView?.artifacts?.resolvedArtifacts?.zip(typeByComponent) { artifacts, typeByComponentMap
+        ->
         artifacts.associate { artifact ->
           val id = artifact.id.componentIdentifier
           val value =
             when (id) {
               is org.gradle.api.artifacts.component.ModuleComponentIdentifier ->
-                "maven:${id.group}:${id.module}:${id.version}:jar"
+                "maven:${id.group}:${id.module}:${id.version}:${typeByComponentMap[id.displayName] ?: "jar"}"
               is org.gradle.api.artifacts.component.ProjectComponentIdentifier ->
                 "project:${id.projectPath}"
               else -> "unknown:${id.displayName}"


### PR DESCRIPTION
## Goal

Make a protolayout IR bundle actually replayable through `TileRenderer` (#1666) in the **default coordinate mode**. Two coupled fixes, the second from Codex's review on this PR:

1. **Carriage** — the bundle wasn't *recording* the renderer libs.
2. **Resolution** — even once recorded, Android AAR deps couldn't be *fetched* by the daemon's resolver.

## 1. Carry the renderer runtime

Tile IR replay inflates through `TileRenderer`, but the tile *preview* only references the protolayout builders — never the renderer. So the closure left `tiles-renderer`/`protolayout-renderer` at `reachable == 0` and `buildDepDecisions` pruned them, even though `AndroidPreviewSupport` injects `tiles-renderer` onto the consumer's runtime classpath. `renderer-android` takes both `compileOnly`, so the daemon can't supply them either ⇒ replay would `NoClassDefFoundError`.

**Fix:** when the bundle carries protolayout IR, seed the dependency closure from the player entry point (`TileRenderer`). The BFS reaches `tiles-renderer` + transitive `protolayout-renderer`/proto runtime, and since deps are kept as **whole coordinates** when any class is reachable, that single seed carries the lot. No-op for non-tile / non-IR bundles.

## 2. Resolve Android AAR coordinates (Codex P1)

The coordinate `type` was hardcoded `jar` for **every** dep, so AAR deps (the seeded renderer libs *and* all the others) resolved to a nonexistent `<artifact>-<version>.jar` and were dropped — the replay classpath stayed incomplete in coordinate mode.

**Fix:**
- **`ComposePreviewTasks`** records the real artifact type. The `artifactType=jar` view extracts AARs to `classes.jar` (erasing aar/jar), so it reads the *untransformed* artifacts and keys packaging off the file extension, stamping `aar`/`jar` into the coordinate.
- **Both `CoordinateResolver`s** (`:cli` daemon path + `:bundle-viewer`) try the recorded type then `.aar`, and **materialize** any `.aar` into its extracted `classes.jar` (the only classpath-loadable form) *before* hashing — the bundle's `sha256` is of the `classes.jar`. The `.aar` fallback also rescues older bundles that recorded AARs as `jar`. Misses still warn, never throw.

## Tests

- Both resolver suites: updated the AAR cases to the extract-`classes.jar` behaviour + added a recorded-as-`jar` fallback case (real `.aar` zips with a `classes.jar` entry, materialized into a temp cache). **These run in CI** (`:cli:test`, `:bundle-viewer:test`) and are the runnable verification of the resolver half.

> ⚠️ **Verification note** — the Android e2e still can't run in my sandbox (Gradle wrapper/`build-logic` mismatch). The resolver logic is now covered by the updated unit tests; the plugin type-detection and the closure seed are static-verified. The end-to-end proof remains: a `:samples:wear` tile bundle whose `bundle.json` lists `tiles-renderer` + `protolayout-renderer` as `:aar` coords, and a `bundle daemon` replay that renders the tile with no `NoClassDefFoundError`.

## Test plan

- [ ] `:cli:test` + `:bundle-viewer:test` — resolver AAR extraction + fallback.
- [ ] `:gradle-plugin:test` / `:functionalTest` — non-IR bundles unchanged; coords now carry real `aar`/`jar` type.
- [ ] Pack a `:samples:wear` tile bundle → `bundle.json` lists the renderer libs as `:aar`; `bundle daemon` renders the tile from IR.

https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt