### PR TITLE
feat(vscode): disable live mode for non-interactive preview kinds

### DIFF
--- a/vscode-extension/src/test/cardData.test.ts
+++ b/vscode-extension/src/test/cardData.test.ts
@@ -4,6 +4,7 @@ import {
     buildVariantLabel,
     isAnimatedPreview,
     isWearPreview,
+    kindSupportsLiveMode,
     mimeFor,
     parseBounds,
     sanitizeId,
@@ -270,5 +271,37 @@ describe("parseBounds", () => {
         assert.strictEqual(parseBounds(""), null);
         assert.strictEqual(parseBounds(null), null);
         assert.strictEqual(parseBounds(undefined), null);
+    });
+});
+
+describe("kindSupportsLiveMode", () => {
+    const withKind = (kind: string | null) =>
+        preview({ params: { ...baseParams, kind } });
+
+    it("supports the default Compose path (explicit and absent kind)", () => {
+        assert.strictEqual(kindSupportsLiveMode(withKind("COMPOSE")), true);
+        assert.strictEqual(kindSupportsLiveMode(withKind(null)), true);
+        // params with no `kind` field at all (older manifests) → Compose.
+        assert.strictEqual(kindSupportsLiveMode(preview()), true);
+    });
+
+    it("keeps tiles live (kept by request — Wear tiles carry clickables)", () => {
+        assert.strictEqual(kindSupportsLiveMode(withKind("TILE")), true);
+    });
+
+    it("disables live for non-interactive surfaces", () => {
+        assert.strictEqual(
+            kindSupportsLiveMode(withKind("NOTIFICATION")),
+            false,
+        );
+        assert.strictEqual(
+            kindSupportsLiveMode(withKind("GLANCE_APPWIDGET")),
+            false,
+        );
+    });
+
+    it("treats a missing preview as supported (no spurious greying)", () => {
+        assert.strictEqual(kindSupportsLiveMode(undefined), true);
+        assert.strictEqual(kindSupportsLiveMode(null), true);
     });
 });

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -21,6 +21,16 @@ export interface PreviewParams {
      */
     previewParameterProviderClassName?: string | null;
     previewParameterLimit?: number | null;
+    /**
+     * Preview flavour, mirroring the gradle plugin's `PreviewKind`
+     * (`"COMPOSE"` / `"TILE"` / `"NOTIFICATION"` / `"GLANCE_APPWIDGET"`).
+     * Read straight off `previews.json`'s `params` block. `null`/absent ⇔
+     * `"COMPOSE"`. The webview uses this to gate the LIVE control — surfaces
+     * with no interactive Compose tree (notification / Glance) can't react to
+     * pointer input, so live mode is disabled for them (see
+     * `kindSupportsLiveMode` in `webview/preview/cardData.ts`).
+     */
+    kind?: string | null;
 }
 
 /**

--- a/vscode-extension/src/webview/preview/cardData.ts
+++ b/vscode-extension/src/webview/preview/cardData.ts
@@ -47,6 +47,32 @@ export function isAnimatedPreview(p: PreviewInfo): boolean {
 }
 
 /**
+ * Preview kinds whose rendered surface is an inflated platform View, not a
+ * live Compose tree — they can't take pointer/keyboard input, so live mode
+ * would do nothing useful and only confuses the toolbar. We disable the LIVE
+ * control for these. Compose previews (interactive) and tiles (kept live by
+ * request — Wear tiles carry clickable actions) are intentionally excluded.
+ */
+export const LIVE_UNSUPPORTED_KINDS: ReadonlySet<string> = new Set([
+    "NOTIFICATION",
+    "GLANCE_APPWIDGET",
+]);
+
+/**
+ * Whether live mode should be offered for [p]. `true` for the default Compose
+ * path (and `null`/absent kind, treated as Compose) and for tiles; `false` for
+ * the non-interactive surfaces in [LIVE_UNSUPPORTED_KINDS]. A missing preview
+ * is treated as supported so a transient lookup miss never wrongly greys the
+ * button mid-navigation.
+ */
+export function kindSupportsLiveMode(
+    p: PreviewInfo | undefined | null,
+): boolean {
+    const kind = p?.params?.kind ?? null;
+    return kind == null || !LIVE_UNSUPPORTED_KINDS.has(kind);
+}
+
+/**
  * Compact one-line label shown as the variant badge on each card.
  * Longer-form info still lives in the hover tooltip ([buildTooltip])
  * — here we only surface what distinguishes siblings: name / group /

--- a/vscode-extension/src/webview/preview/focusController.ts
+++ b/vscode-extension/src/webview/preview/focusController.ts
@@ -24,6 +24,7 @@ import {
 import type { LiveStateController } from "./liveState";
 import type { FilterToolbar } from "./components/FilterToolbar";
 import { previewStore } from "./previewStore";
+import { kindSupportsLiveMode } from "./cardData";
 import type { PreviewGrid } from "./components/PreviewGrid";
 import type { DiffMode } from "../shared/diffModeBar";
 import type { VsCodeApi } from "../shared/vscode";
@@ -148,6 +149,11 @@ export class FocusController {
             : null;
         const previewId = card?.dataset.previewId ?? null;
         const isLive = !!previewId && this.config.liveState.isLive(previewId);
+        const focusedPreview = previewId
+            ? previewStore
+                  .getState()
+                  .allPreviews.find((p) => p.id === previewId)
+            : null;
         this.config.focusToolbar.applyInteractiveButtonState({
             inFocus,
             focusedPreviewId: previewId,
@@ -161,6 +167,7 @@ export class FocusController {
                 this.config.liveState.getModuleDaemonReady(),
                 this.config.liveState.getModuleInteractiveSupported(),
             ),
+            kindSupportsLive: kindSupportsLiveMode(focusedPreview),
         });
     }
 

--- a/vscode-extension/src/webview/preview/focusToolbar.ts
+++ b/vscode-extension/src/webview/preview/focusToolbar.ts
@@ -74,6 +74,11 @@ export interface InteractiveButtonState {
     /** Whether the focused module supports v2 live mode (vs the v1
      *  fallback where renders refresh but pointer state is lost). */
     interactiveSupported: boolean;
+    /** Whether the focused preview's KIND can be driven live at all. `false`
+     *  for non-interactive surfaces (notification / Glance) — see
+     *  `kindSupportsLiveMode`. Hard-disables the button regardless of daemon
+     *  capability, since there's no interactive Compose tree to stream. */
+    kindSupportsLive: boolean;
 }
 
 export interface RecordingButtonState {
@@ -174,6 +179,22 @@ export class FocusToolbarController {
             this.el.btnInteractive.setAttribute("aria-pressed", "false");
             this.el.btnInteractive.title =
                 "Daemon not ready — live mode unavailable";
+            this.el.btnInteractive.innerHTML =
+                '<i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>';
+            return;
+        }
+        // Kind gate — notification / Glance previews render an inflated View,
+        // not a live Compose tree, so there's nothing to stream or interact
+        // with. Hard-disable the LIVE button with an explanatory tooltip,
+        // ahead of the daemon-capability checks below. (Skipped when the card
+        // is somehow already live so the user can always toggle back off.)
+        if (!s.kindSupportsLive && !s.isLive) {
+            this.el.btnInteractive.disabled = true;
+            this.el.btnInteractive.setAttribute("aria-pressed", "false");
+            this.el.btnInteractive.classList.remove("live-on");
+            this.el.btnInteractive.title =
+                "Live mode isn't available for this preview — " +
+                "notification and Glance previews have no interactive surface to stream";
             this.el.btnInteractive.innerHTML =
                 '<i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>';
             return;

--- a/vscode-extension/src/webview/preview/liveState.ts
+++ b/vscode-extension/src/webview/preview/liveState.ts
@@ -45,8 +45,10 @@ import type {
     PreviewOverrides,
 } from "../../daemon/daemonProtocol";
 import { liveToggleCommand } from "../../daemon/liveCommand";
+import { kindSupportsLiveMode } from "./cardData";
 import { planFollowFocusTeardown } from "./followFocus";
 import { attachInteractiveInputHandlers } from "./interactiveInput";
+import { previewStore } from "./previewStore";
 import type { InteractiveInputConfig } from "./interactiveInput";
 import { stampLiveBadgesOnGrid } from "./liveBadge";
 import { ensureLiveCardControls } from "./liveCardControls";
@@ -627,6 +629,19 @@ export class LiveStateController {
     setInteractiveForCard(card: HTMLElement, shift: boolean): void {
         const previewId = card.dataset.previewId;
         if (!previewId) return;
+        // Kind gate — refuse to ENTER live mode for non-interactive surfaces
+        // (notification / Glance): their rendered output is an inflated View
+        // with no Compose tree to stream or drive. The toolbar already disables
+        // the button, but this also blocks the in-card click and any
+        // auto-enter path (e.g. an interactive-only data extension). Toggling a
+        // card that's somehow already live back OFF stays allowed so a stream
+        // can never be stranded.
+        if (!this.interactivePreviewIds.has(previewId)) {
+            const preview = previewStore
+                .getState()
+                .allPreviews.find((p) => p.id === previewId);
+            if (!kindSupportsLiveMode(preview)) return;
+        }
         const plan = planLiveToggle(
             this.interactivePreviewIds,
             previewId,


### PR DESCRIPTION
## Summary

Live mode now stays usable for the previews it was built for, and is **disabled for the kinds that have no interactive surface**.

Notification and Glance previews render an inflated platform `View` (RemoteViews), not a live Compose tree — there's nothing to stream or drive, so the LIVE control just dangles. This gates it by preview `kind`.

`params.kind` already rides `previews.json` (the gradle plugin's `PreviewParams`), and the extension reads that manifest directly — so this is **extension-only**, no daemon/protocol change:

- Type `kind` on `PreviewParams`.
- `focusToolbar` hard-disables the LIVE button (with an explanatory tooltip) when the focused preview's kind is `NOTIFICATION` or `GLANCE_APPWIDGET`.
- `liveState.setInteractiveForCard` refuses to **enter** live for those kinds at the single chokepoint both the toolbar button and the in-card click funnel through (toggling an already-live card back **off** stays allowed, so a stream can never be stranded).

`COMPOSE` (interactive) and `TILE` are intentionally **kept live** — tiles carry clickable actions, and you can always try a regular preview live. The disabled-kinds set is a single constant (`LIVE_UNSUPPORTED_KINDS` in `cardData.ts`) so it's trivial to adjust later.

## Test plan
- `npm run compile` (host + webview) — clean.
- `npm test` — 1418 passing, incl. new `kindSupportsLiveMode` block (Compose/absent → live; TILE → live; NOTIFICATION/GLANCE → disabled; missing preview → supported, no spurious greying).
- `npm run format:check` — clean.

## Notes
Follow-up to #1667 (the blank-on-live fix). With both: live no longer blanks any kind, and it's only *offered* where it does something.