### PR TITLE
feat(xr-glimmer): calibrate previews to Studio's Glimmer angular + contrast model

### DIFF
--- a/docs/design/GLIMMER_PREVIEW.md
+++ b/docs/design/GLIMMER_PREVIEW.md
@@ -82,7 +82,7 @@ glimmer-preview-runtime/
 // Authors who only want the raw capture (no env compositing) use this directly.
 @Preview(
   name = "Glimmer",
-  device = "spec:width=640px,height=480px,dpi=240",  // Studio's AI-Glasses preset
+  device = "spec:width=960,height=720,dpi=160",       // AI-Glasses preset, calibrated below
   showBackground = true,                              // see "Capture encoding" below
   backgroundColor = 0xFF000000L,                      // opaque black = additive-zero baseline
   fontScale = 1f,
@@ -93,7 +93,7 @@ annotation class GlimmerPreview
 // so discovery generates a distinct PreviewInfo.id and the four captures don't
 // collapse into one. The connector reads the env intent off the name suffix
 // (`Glimmer · Light` → `light`) — no schema changes to `PreviewParams`.
-@Preview(name = "Glimmer · Light", device = "spec:width=640px,height=480px,dpi=240",
+@Preview(name = "Glimmer · Light", device = "spec:width=960,height=720,dpi=160",
          showBackground = true, backgroundColor = 0xFF000000L)
 annotation class GlimmerPreviewLight
 
@@ -280,6 +280,13 @@ fun FocusableMenu() {
 A four-way Venice / Light / Dark / Busy fan demonstrates the additive-display approximation directly — same code, same `GlimmerSurface`, four different rendered scenes, the contrast shifts visibly between the four. (Reviewing a preview-diff PR that bumps Glimmer's `surface` colour token, you see the gondolier cats at the same time as you see the unreadable text in Busy. Good.)
 
 A new `GlimmerCaptureAdditivePixelTest` in `:samples:android` asserts that the *un-composited* `NowPlayingCard_Glimmer · Light.png` capture is opaque (`alpha == 0xFF` in every pixel) and that the four corners read RGB `(0, 0, 0)` (additive-zero). This is the Encoding-B mirror of `TransparentBackgroundPreviewPixelTest` — same shape, different channel. The environment compositor outputs a sibling file, it doesn't mutate the source.
+
+### Calibrating to Studio's Glimmer model
+
+Studio's preview pane exists to check two *quantitative* rules; we pin both so our previews aren't merely "additive-looking" but numerically aligned to Studio (`:samples:xr-glimmer`'s `GlimmerContrast` + `GlimmerContrastTest`):
+
+- **Angular sizing.** Glimmer measures UI in visual angle, not pixels: the [type guidance](https://developer.android.com/design/ui/ai-glasses/guides/styles/type) pins the display at **30 pixels-per-degree** with a minimum readable text size of **0.6° = 18px**, which the [official skill](https://github.com/android/skills/tree/main/xr/display-glasses-with-jetpack-compose-glimmer) restates as **18sp**. The identity `18sp == 18px == 0.6°` only holds at **density 1.0**, so `AI_GLASSES_DEVICE_SPEC` is `spec:width=960,height=720,dpi=160` (density 1.0; a 960×720-px / 32°×24° canvas at 30 PPD), *not* a phone-style `dpi=240`. At the old `dpi=240` (density 1.5) every `.sp`/`.dp` Glimmer component rendered 1.5× larger in angle than Studio shows, so legibility read optimistically.
+- **Contrast.** The skill mandates *"at least a 70% tone difference between foreground and background using the HCT color space"*; HCT tone == CIELAB L\*, so the bar is `ΔL* ≥ 70`. `GlimmerContrastTest` reproduces the additive composite (`BlendMode.Plus` of white text / `#262626` surface over each backdrop) straight from the source env images and measures the white-text-vs-panel tone gap. Calibrated result: **additive-zero ≈ 85** (the only surface that clears 70), **Dark ≈ 64**, **Busy ≈ 42**, **VeniceCanalCats ≈ 37** — i.e. *no* real backdrop clears Studio's bar, and Busy/Venice are decisively unreadable. That turns the informal "unreadable text in Busy. Good." above into a regression gate: brighten the `surface` token, swap a backdrop, or break the blend and the relevant bound trips.
 
 ## Toolchain notes
 

--- a/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerInteractiveMenuPreviews.kt
+++ b/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerInteractiveMenuPreviews.kt
@@ -65,7 +65,7 @@ import ee.schimke.composeai.preview.FocusedPreview
  * affordance on screen. When `@GlimmerPreviewInput` + `:data-glimmer-input-connector` land the
  * planner's per-frame gesture override paints through that connector.
  *
- * Item count: four — the AI Glasses canvas (640×480dp) seats four `ListItem`s with 16-dp
+ * Item count: four — the AI Glasses canvas (960×720dp at density 1.0) seats four `ListItem`s with 16-dp
  * inter-item spacing and 24-dp insets cleanly. A header chip over the menu was the first cut
  * but ate the focus ring on the fourth item; standalone chips live in the `NowPlayingCard`
  * sample.
@@ -167,7 +167,8 @@ private fun GlimmerEnvSurface(env: GlimmerEnvironment, content: @Composable () -
  * Backdrop per env. Mixes two source modes:
  *
  *  - **Dark / Busy / VeniceCanalCats**: bitmap drawables in `res/drawable-nodpi/` (Unsplash
- *    License photos cropped to 960×720 to match the AI Glasses 4:3 canvas at density 1.5).
+ *    License photos cropped to 960×720 to match the AI Glasses 4:3 canvas — 960×720 dp at the
+ *    calibrated density 1.0, see `AI_GLASSES_DEVICE_SPEC`).
  *    Drawn via `Image(painter = painterResource(...), contentScale = ContentScale.Crop)` so
  *    the photo fills the box at any device size.
  *  - **Light**: still procedurally drawn (sky gradient + grass + sun). No clean Unsplash photo

--- a/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerPreviews.kt
+++ b/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerPreviews.kt
@@ -129,13 +129,28 @@ fun FocusableMenu() {
   }
 }
 
-// Studio's AI-Glasses preview-pane device preset (4:3 at 240dpi). Values are expressed in dp
-// without a suffix — the discovery-side `DeviceSpec.resolve(...)` reads `width=` / `height=`
-// as bare integers (`spec:width=…px` silently falls back to the 400×800dp default) and
-// applies `dpi/160` as the density. Kept as a named const so the previews above all share
-// one source of truth — bump in lockstep when the eventual `@GlimmerPreview` meta-annotation
-// adopts a different spec.
-internal const val AI_GLASSES_DEVICE_SPEC: String = "spec:width=640,height=480,dpi=240"
+// Studio's AI-Glasses preview-pane device preset, calibrated to Glimmer's published **angular**
+// sizing model rather than a phone-style dp/dpi guess. Glimmer measures UI in visual angle, not
+// pixels: the design guidance (developer.android.com/design/ui/ai-glasses/guides/styles/type)
+// pins the display at **30 pixels-per-degree (PPD)** and a minimum readable text size of
+// **0.6° = 18px**, and the official skill restates that as **18sp** — an identity (18sp == 18px
+// == 0.6°) that only holds when **density == 1.0** (dpi 160). At the old `dpi=240` (density 1.5)
+// every `.sp`/`.dp` Glimmer component rendered 1.5× larger in angle than Studio shows (18sp →
+// 27px → 0.9°), so contrast/legibility read optimistically. Pinning **dpi=160 ⇒ density 1.0**
+// makes our sp/px/degree mapping numerically identical to Studio's.
+//
+// Canvas: **960×720 px** (width/height are bare dp integers — `DeviceSpec.resolve(...)` reads
+// `width=` / `height=` as integers and `spec:width=…px` silently falls back to the 400×800dp
+// default, so no `px` suffix — and at density 1.0 dp == px). That is the same pixel canvas the
+// old `640×480 @ dpi240` produced (640·1.5 = 960, 480·1.5 = 720), so the 960×720 env backdrops
+// still fit exactly; only the density (and thus the angular size of the Glimmer UI) changes. At
+// 30 PPD the canvas spans **32° × 24°** field-of-view (960/30, 720/30) — a plausible 4:3 display-
+// glasses HUD. Re-pin width/height/dpi here if Google publishes the AI Glasses AVD's exact
+// resolution / FoV / densityDpi; the 30-PPD identity above is the anchor to preserve.
+//
+// Kept as a named const so the previews above (and `GlimmerInteractiveMenuPreviews`) share one
+// source of truth — bump in lockstep when the eventual `@GlimmerPreview` meta-annotation lands.
+internal const val AI_GLASSES_DEVICE_SPEC: String = "spec:width=960,height=720,dpi=160"
 
 // Opaque pure black — additive-zero base per the SKILL.md mandate. Drawn by the renderer's
 // background-fill path so the captured PNG carries `RGB == (0, 0, 0)` in every pixel the

--- a/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerCaptureAdditivePixelTest.kt
+++ b/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerCaptureAdditivePixelTest.kt
@@ -57,7 +57,7 @@ class GlimmerCaptureAdditivePixelTest {
       assertThat(img.height).isAtLeast(40)
 
       val (w, h) = img.width to img.height
-      // The card and chip sit centred in a 640×480 canvas with 24-dp insets from the
+      // The card and chip sit centred in a 960×720 canvas with 24-dp insets from the
       // background `Box`, so the four absolute corner pixels are well outside any
       // composable that could paint over the background-fill layer.
       listOf(0 to 0, w - 1 to 0, 0 to h - 1, w - 1 to h - 1).forEach { (x, y) ->

--- a/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerContrast.kt
+++ b/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerContrast.kt
@@ -1,0 +1,102 @@
+package com.example.samplexrglimmer
+
+import java.awt.image.BufferedImage
+
+/**
+ * Calibration helpers that encode the two quantitative rules Android Studio's Glimmer preview
+ * pane exists to check, so our previews can be measured against them instead of merely *looking*
+ * additive. Both numbers come straight from Google's public Glimmer guidance:
+ *
+ *  - **Contrast.** The official skill (`android/skills` →
+ *    `xr/display-glasses-with-jetpack-compose-glimmer`) mandates *"at least a 70% tone difference
+ *    between foreground and background using the HCT color space."* HCT's **T** (tone) channel is
+ *    *defined* as CIELAB **L\*** (identical 0–100 scale), so "70% tone difference" is `ΔL* ≥ 70`.
+ *    [tone] computes L\* from an sRGB pixel; [STUDIO_MIN_TONE_DIFFERENCE] is the 70 bar.
+ *  - **Angular sizing.** The type guidance
+ *    (developer.android.com/design/ui/ai-glasses/guides/styles/type) pins the display at
+ *    **30 pixels-per-degree** and a minimum readable text size of **0.6° = 18px** (restated as
+ *    18sp in the skill). [PIXELS_PER_DEGREE], [MIN_TEXT_ANGLE_DEGREES] and [minReadableTextPx]
+ *    capture that; they also justify the density-1.0 calibration of `AI_GLASSES_DEVICE_SPEC`
+ *    (the 18sp == 18px == 0.6° identity only holds at density 1.0).
+ *
+ * Additive-display physics: a real glasses display can only *add* light. The preview reproduces
+ * that with `BlendMode.Plus` over the env backdrop ([additivePlus]); white UI light added onto any
+ * background clamps to white (L\* 100), so the legibility question is the tone gap between the
+ * white text and the **panel** — the env pixel with Glimmer's translucent `surface` tint added on
+ * top ([GLIMMER_SURFACE]). On true black (additive-zero) the panel stays dark and the gap is wide;
+ * on a bright/busy backdrop the panel rides up toward white and the gap collapses.
+ */
+internal object GlimmerContrast {
+
+  /** Studio's contrast bar: ≥70% HCT tone difference (== ΔL\* ≥ 70). */
+  const val STUDIO_MIN_TONE_DIFFERENCE: Double = 70.0
+
+  /** Glimmer display calibration: 30 pixels per visual degree. */
+  const val PIXELS_PER_DEGREE: Double = 30.0
+
+  /** Minimum readable text angle; 0.6° × 30 PPD == 18px == 18sp at density 1.0. */
+  const val MIN_TEXT_ANGLE_DEGREES: Double = 0.6
+
+  /** Glimmer `surface` token (#262626) — the translucent tint added behind list content. */
+  val GLIMMER_SURFACE: Int = 0xFF262626.toInt()
+
+  /** Best-case Glimmer content/text: full white light. Even this fails on busy backdrops. */
+  val GLIMMER_TEXT: Int = 0xFFFFFFFF.toInt()
+
+  /** Minimum readable text size in px for a given PPD — `angle × PPD`. */
+  fun minReadableTextPx(angleDegrees: Double = MIN_TEXT_ANGLE_DEGREES): Double =
+    angleDegrees * PIXELS_PER_DEGREE
+
+  /** `BlendMode.Plus`: per-channel sum clamped to 255 — the op an additive display performs. */
+  fun additivePlus(bg: Int, ui: Int): Int {
+    val r = (((bg ushr 16) and 0xFF) + ((ui ushr 16) and 0xFF)).coerceAtMost(255)
+    val g = (((bg ushr 8) and 0xFF) + ((ui ushr 8) and 0xFF)).coerceAtMost(255)
+    val b = ((bg and 0xFF) + (ui and 0xFF)).coerceAtMost(255)
+    return (0xFF shl 24) or (r shl 16) or (g shl 8) or b
+  }
+
+  /** HCT tone (== CIELAB L\*, 0–100) of an sRGB pixel. */
+  fun tone(argb: Int): Double {
+    val r = linear((argb ushr 16) and 0xFF)
+    val g = linear((argb ushr 8) and 0xFF)
+    val b = linear(argb and 0xFF)
+    val y = 0.2126 * r + 0.7152 * g + 0.0722 * b
+    val f = if (y > 0.008856) Math.cbrt(y) else 7.787 * y + 16.0 / 116.0
+    return 116.0 * f - 16.0
+  }
+
+  /** |ΔTone| between two sRGB pixels. */
+  fun toneDifference(fg: Int, bg: Int): Double = Math.abs(tone(fg) - tone(bg))
+
+  /**
+   * Mean legibility tone-gap of white Glimmer text over [backdrop]: average, across every pixel,
+   * of the tone difference between the white text (additive-clamped to L\* 100) and the local
+   * panel (backdrop pixel + [GLIMMER_SURFACE] added). Higher = more readable;
+   * [STUDIO_MIN_TONE_DIFFERENCE] is the pass bar.
+   */
+  fun meanTextToneGap(backdrop: BufferedImage): Double {
+    var sum = 0.0
+    var n = 0L
+    for (y in 0 until backdrop.height) {
+      for (x in 0 until backdrop.width) {
+        val bg = backdrop.getRGB(x, y)
+        sum += toneDifference(additivePlus(bg, GLIMMER_TEXT), additivePlus(bg, GLIMMER_SURFACE))
+        n++
+      }
+    }
+    return sum / n
+  }
+
+  /** Additive-zero (pure black) baseline gap: white text over the bare `surface` tint. */
+  fun additiveZeroToneGap(): Double {
+    val black = 0xFF000000.toInt()
+    val text = additivePlus(black, GLIMMER_TEXT)
+    val panel = additivePlus(black, GLIMMER_SURFACE)
+    return toneDifference(text, panel)
+  }
+
+  private fun linear(c8: Int): Double {
+    val c = c8 / 255.0
+    return if (c <= 0.04045) c / 12.92 else Math.pow((c + 0.055) / 1.055, 2.4)
+  }
+}

--- a/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerContrastTest.kt
+++ b/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerContrastTest.kt
@@ -1,0 +1,89 @@
+package com.example.samplexrglimmer
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Test
+
+/**
+ * Calibrates the Glimmer sample against the two quantitative rules Android Studio's preview pane
+ * checks (see [GlimmerContrast]): the **30 PPD / 0.6° = 18px** angular sizing model and the
+ * **≥70% HCT tone-difference** contrast bar.
+ *
+ * Unlike the other tests here, this one doesn't read rendered captures — it computes the same
+ * additive composite Studio approximates directly from the **source backdrops** in
+ * `src/main/res/`, so it pins the calibration regardless of whether the SDK-37 render path is
+ * available. The numbers it asserts are the measured tone gaps of white Glimmer text over each
+ * env; they encode, as a regression gate, the qualitative finding the design doc states
+ * informally ("you see the unreadable text in Busy. Good."):
+ *
+ *  - **Additive-zero** (the SKILL-mandated `Color.Black` base) is the *only* surface that clears
+ *    Studio's 70-tone bar — legibility is guaranteed only against true black.
+ *  - **Dark** (night cityscape) is the most legible *real* backdrop but still sits below 70 once
+ *    the translucent `surface` tint lifts the panel.
+ *  - **Busy** (bright market) and **VeniceCanalCats** fall far below the bar — measurably
+ *    unreadable, exactly what the env chips are for.
+ *
+ * A future regression that brightens Glimmer's `surface` token, swaps a backdrop for a darker
+ * one, or breaks the additive blend shifts these gaps and trips the relevant bound below.
+ */
+class GlimmerContrastTest {
+
+  private val drawables = File("src/main/res/drawable-nodpi")
+
+  private fun backdropToneGap(name: String): Double {
+    val file = File(drawables, name)
+    assertThat(file.exists()).isTrue()
+    return GlimmerContrast.meanTextToneGap(ImageIO.read(file))
+  }
+
+  @Test
+  fun `device spec encodes Studio's 30 PPD angular model at density 1_0`() {
+    // The const is the single source of truth shared by every Glimmer preview; parse it back so a
+    // future edit re-checks the identities below instead of silently drifting.
+    val pattern = Regex("""spec:width=(\d+),height=(\d+),dpi=(\d+)""")
+    val m = pattern.matchEntire(AI_GLASSES_DEVICE_SPEC)
+    assertThat(m).isNotNull()
+    val (w, h, dpi) = m!!.destructured.toList().map { it.toInt() }
+
+    // density 1.0 is what makes 18sp == 18px == 0.6° hold (the calibration's whole point).
+    assertThat(dpi / 160.0).isWithin(1e-9).of(1.0)
+    // 0.6° minimum text × 30 PPD == 18px, and at density 1.0 that is 18sp.
+    assertThat(GlimmerContrast.minReadableTextPx()).isWithin(1e-9).of(18.0)
+    // Canvas is the same 960×720 px the env backdrops are authored at, spanning 32°×24° at 30 PPD.
+    assertThat(w).isEqualTo(960)
+    assertThat(h).isEqualTo(720)
+    assertThat(w / GlimmerContrast.PIXELS_PER_DEGREE).isWithin(1e-9).of(32.0)
+    assertThat(h / GlimmerContrast.PIXELS_PER_DEGREE).isWithin(1e-9).of(24.0)
+  }
+
+  @Test
+  fun `additive-zero is the only surface that clears Studio's 70 tone bar`() {
+    val gap = GlimmerContrast.additiveZeroToneGap()
+    assertThat(gap).isAtLeast(GlimmerContrast.STUDIO_MIN_TONE_DIFFERENCE)
+    assertThat(gap).isWithin(5.0).of(85.0)
+  }
+
+  @Test
+  fun `legibility degrades from dark to busy to venice, all below the bar`() {
+    val dark = backdropToneGap("env_dark.jpg")
+    val busy = backdropToneGap("env_busy.jpg")
+    val venice = backdropToneGap("env_venice_canal_cats.jpg")
+    val bar = GlimmerContrast.STUDIO_MIN_TONE_DIFFERENCE
+
+    // Measured calibration (white text vs surface-tinted panel, mean over the whole backdrop).
+    assertThat(dark).isWithin(6.0).of(64.0)
+    assertThat(busy).isWithin(6.0).of(42.0)
+    assertThat(venice).isWithin(6.0).of(37.0)
+
+    // Ordering: darker, calmer backdrops are more legible; additive-zero beats them all.
+    assertThat(GlimmerContrast.additiveZeroToneGap()).isGreaterThan(dark)
+    assertThat(dark).isGreaterThan(busy)
+    assertThat(busy).isGreaterThan(venice)
+
+    // Studio's bar: no real backdrop clears it — busy/venice are decisively unreadable.
+    assertThat(dark).isLessThan(bar)
+    assertThat(busy).isLessThan(bar)
+    assertThat(venice).isLessThan(bar)
+  }
+}


### PR DESCRIPTION
Align the Glimmer XR sample previews with the two quantitative rules Android
Studio's Glimmer preview pane checks, so the previews are numerically faithful
rather than merely additive-looking.

Angular / device spec:
- Glimmer measures UI in visual angle (30 PPD; min text 0.6deg = 18px = 18sp).
  That identity only holds at density 1.0, so AI_GLASSES_DEVICE_SPEC moves from
  spec:width=640,height=480,dpi=240 (density 1.5) to
  spec:width=960,height=720,dpi=160 (density 1.0). Same 960x720-px canvas
  (32deg x 24deg at 30 PPD) so the env backdrops still fit; only the angular
  size of the Glimmer UI changes -- the old density rendered every .sp/.dp 1.5x
  too large, reading legibility optimistically.

Contrast gate:
- Add GlimmerContrast (HCT tone == CIELAB L*, BlendMode.Plus composite, the
  >=70% tone-difference bar and the 30-PPD angular constants) and
  GlimmerContrastTest, which reproduces the additive composite straight from
  the source env backdrops and measures the white-text-vs-panel tone gap.
  Calibrated: additive-zero ~85 (only surface clearing 70), Dark ~64, Busy ~42,
  Venice ~37 -- no real backdrop clears Studio's bar and Busy/Venice are
  decisively unreadable, turning the informal "unreadable in Busy" note into a
  regression gate.

Docs/comments updated to the calibrated spec and a new "Calibrating to Studio's
Glimmer model" subsection in GLIMMER_PREVIEW.md.