### PR TITLE
feat(bundle): replay Remote Compose IR in the Android daemon (Piece B, RC)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -40,6 +40,7 @@ import ee.schimke.composeai.data.render.extensions.ExtensionContextValue
 import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
 import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
 import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.loadIrReplayClass
 import ee.schimke.composeai.data.render.extensions.loadPreviewWrapperClass
 import ee.schimke.composeai.data.render.extensions.provides
 import ee.schimke.composeai.renderer.AccessibilityDataProducts
@@ -221,8 +222,22 @@ class RenderEngine(
     // errors as it did before, until its replay path lands).
     val irReplay = BundleIrReplayStore.lookup(spec.previewId)
     val isProtolayoutIr = irReplay?.format == BundleIrReplayStore.FORMAT_PROTOLAYOUT
+    // Remote Compose replays through a connector composable the daemon can't compile against (it's
+    // built on the alpha player SDK); resolve it reflectively via the IR-replay SPI. Null when the
+    // connector isn't on the classpath — then we fall through to the normal class path (which fails
+    // as before, since the IR preview's class was dropped at pack time).
+    // Resolve via the default (context) classloader, exactly as `loadPreviewWrapperClass` does for
+    // the live RC wrapper path — that's the classloader topology under which the connector links
+    // against the alpha player at runtime.
+    val rcReplayClass: Class<*>? =
+      if (irReplay?.format == BundleIrReplayStore.FORMAT_REMOTECOMPOSE)
+        runCatching { loadIrReplayClass(BundleIrReplayStore.FORMAT_REMOTECOMPOSE) }.getOrNull()
+      else null
+    // An IR-backed preview's consumer class was dropped at pack time, so skip the reflective load
+    // whenever we have a replay path for it (protolayout direct, or a resolved RC provider).
+    val isIrReplay = isProtolayoutIr || rcReplayClass != null
     val clazz =
-      if (isProtolayoutIr) null
+      if (isIrReplay) null
       else trace.section("classloader:loadPreviewClass") { Class.forName(spec.className, true, classLoader) }
     // Tile / notification previews are non-composable top-level functions returning
     // `TilePreviewData` / `android.app.Notification`; routing them through
@@ -235,7 +250,7 @@ class RenderEngine(
     // body that fails the moment a Glance composable touches the GlanceComposition applier. The
     // dedicated branches skip top-level composable resolution and paint the result through the
     // matching renderer helper in the setContent body below.
-    val nonComposableInvocation = isTile || isNotification || isGlanceAppWidget || isProtolayoutIr
+    val nonComposableInvocation = isTile || isNotification || isGlanceAppWidget || isIrReplay
     val composableMethod: ComposableMethod? =
       if (nonComposableInvocation) null
       else trace.section("compose:resolveComposable") { clazz!!.getDeclaredComposableMethod(spec.functionName) }
@@ -354,6 +369,11 @@ class RenderEngine(
                             resourcesBytes = irReplay.resourcesBytes ?: ByteArray(0),
                             label = "IR replay ${spec.previewId ?: spec.outputBaseName}",
                           )
+                        } else if (rcReplayClass != null) {
+                          // Remote Compose IR replay — render the captured RemoteDocument through
+                          // the connector's player, reached reflectively (the daemon can't compile
+                          // against the alpha SDK). See IrReplayComposableProvider.
+                          InvokeIrReplay(rcReplayClass, irReplay!!.bytes)
                         } else if (isTile) {
                           // Non-composable @Preview from `androidx.wear.tiles.tooling.preview` —
                           // mirrors the standalone renderer's `TilePreviewStrategy`. The
@@ -1154,6 +1174,23 @@ private fun InvokeWithOptionalWrapper(
     val body: @Composable () -> Unit = { InvokeComposable(composableMethod) }
     wrapMethod.invoke(currentComposer, wrapperInstance, body)
   }
+}
+
+/**
+ * Render an IR-backed preview through a connector-provided replay composable resolved by
+ * [loadIrReplayClass]. The class exposes `@Composable Replay(bytes: ByteArray)` and a no-arg ctor;
+ * we invoke it the same way [InvokeWithOptionalWrapper] invokes `PreviewWrapperProvider.Wrap` — via
+ * [getDeclaredComposableMethod], which absorbs the synthetic `Composer`/`changed` tail. Used for
+ * Remote Compose, whose player lives in the alpha connector the daemon can't compile against.
+ */
+@Composable
+private fun InvokeIrReplay(replayClass: Class<*>, bytes: ByteArray) {
+  val (method, instance) =
+    remember(replayClass) {
+      val inst = replayClass.getDeclaredConstructor().apply { isAccessible = true }.newInstance()
+      replayClass.getDeclaredComposableMethod("Replay", ByteArray::class.java) to (inst as Any)
+    }
+  method.invoke(currentComposer, instance, bytes)
 }
 
 /**

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeIrReplay.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeIrReplay.kt
@@ -1,0 +1,49 @@
+@file:Suppress("RestrictedApiAndroidX")
+
+package ee.schimke.composeai.daemon
+
+import androidx.compose.remote.player.compose.RemoteDocumentPlayer
+import androidx.compose.remote.player.core.RemoteDocument
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import ee.schimke.composeai.data.render.IrSidecarChannel
+import ee.schimke.composeai.data.render.extensions.IrReplayComposableProvider
+
+/**
+ * Replays a Remote Compose preview from a bundle's captured IR (schema v5): the serialized
+ * `RemoteDocument` bytes ([IrSidecarChannel.FORMAT_REMOTECOMPOSE], `ir/<id>.rcdoc`) that
+ * [RemoteOverridablePreview]'s capture path emitted. Reconstructs the document with
+ * `RemoteDocument(bytes)` and hands it to the same `RemoteDocumentPlayer` the live path uses — so a
+ * bundle renders with **no** reference to the `@RemoteComposable` body that produced it (its class
+ * was dropped at pack time).
+ *
+ * The daemon reaches this reflectively (it can't compile against the alpha player), so [Replay] is
+ * an instance method with a fixed `(ByteArray)` signature and the class has a no-arg constructor —
+ * matching what `RenderEngine` resolves via `getDeclaredComposableMethod`, the same shape as
+ * `PreviewWrapperProvider.Wrap`. Seeded `renderNow.overrides.remoteCompose` named values are
+ * applied through the player's `StateUpdater` via [applyConnectorOverrides], so replay honours
+ * overrides exactly like the live path (a no-op when none are seeded).
+ */
+class RemoteComposeIrReplay {
+  @Composable
+  fun Replay(bytes: ByteArray) {
+    val context = LocalContext.current
+    val displayMetrics = context.resources.displayMetrics
+    val remoteDocument = remember(bytes) { RemoteDocument(bytes) }
+    val seededOverrides = RemoteComposeController.namedValues.value
+    RemoteDocumentPlayer(
+      document = remoteDocument.document,
+      documentWidth = displayMetrics.widthPixels,
+      documentHeight = displayMetrics.heightPixels,
+      init = { player -> applyConnectorOverrides(player.stateUpdater, seededOverrides) },
+    )
+  }
+}
+
+/** Registers [RemoteComposeIrReplay] as the replay composable for `remotecompose` IR. */
+class RemoteComposeIrReplayProvider : IrReplayComposableProvider {
+  override val format: String = IrSidecarChannel.FORMAT_REMOTECOMPOSE
+
+  override fun replayClass(): Class<*> = RemoteComposeIrReplay::class.java
+}

--- a/data/remotecompose/connector/src/main/resources/META-INF/services/ee.schimke.composeai.data.render.extensions.IrReplayComposableProvider
+++ b/data/remotecompose/connector/src/main/resources/META-INF/services/ee.schimke.composeai.data.render.extensions.IrReplayComposableProvider
@@ -1,0 +1,1 @@
+ee.schimke.composeai.daemon.RemoteComposeIrReplayProvider

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/IrReplayComposableProvider.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/IrReplayComposableProvider.kt
@@ -1,0 +1,46 @@
+package ee.schimke.composeai.data.render.extensions
+
+import java.util.ServiceLoader
+
+/**
+ * SPI for replaying a bundle's captured intermediate representation (schema v5) through a
+ * connector-provided composable, when the IR's runtime can't be a compile dependency of the daemon.
+ *
+ * Protolayout/tile IR replays through `:renderer-android`'s `TileIrReplayComposable`, which the
+ * daemon compiles against directly. Remote Compose can't: its player (`RemoteDocumentPlayer`) lives
+ * in the alpha `:data-remotecompose-connector` (compiled against a higher `compileSdk` the daemon
+ * can't depend on). So the connector registers an [IrReplayComposableProvider] and the renderer
+ * reaches the replay composable reflectively — the same indirection [loadPreviewWrapperClass] uses
+ * for `@PreviewWrapper` substitution.
+ *
+ * Discovered through `ServiceLoader`; implementations register with a
+ * `META-INF/services/ee.schimke.composeai.data.render.extensions.IrReplayComposableProvider` file
+ * in the connector's resources. [replayClass] must expose a `@Composable Replay(bytes: ByteArray)`
+ * method and a public no-arg constructor, because the renderer instantiates it and invokes `Replay`
+ * via `getDeclaredComposableMethod` exactly as it does `PreviewWrapperProvider.Wrap`.
+ */
+interface IrReplayComposableProvider {
+  /**
+   * The IR format this provider replays — matches `IrSidecarChannel.FORMAT_*` (e.g.
+   * `remotecompose`).
+   */
+  val format: String
+
+  /** The class whose `@Composable Replay(bytes: ByteArray)` method renders the IR. */
+  fun replayClass(): Class<*>
+}
+
+/**
+ * Resolve the replay class registered for [format], or null when no provider is on the classpath
+ * (the common non-bundle case, and any format without a connector). The renderer then falls back to
+ * its normal class-reflection path. "First wins" in `ServiceLoader` order.
+ */
+fun loadIrReplayClass(
+  format: String,
+  classLoader: ClassLoader =
+    Thread.currentThread().contextClassLoader ?: IrReplayComposableProvider::class.java.classLoader,
+): Class<*>? =
+  ServiceLoader.load(IrReplayComposableProvider::class.java, classLoader)
+    .asSequence()
+    .firstOrNull { it.format == format }
+    ?.replayClass()

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/IrReplayComposableProviderTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/IrReplayComposableProviderTest.kt
@@ -1,0 +1,37 @@
+package ee.schimke.composeai.data.render.extensions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Verifies [loadIrReplayClass] discovers a registered [IrReplayComposableProvider] by format. The
+ * fake provider below is wired through this module's test `META-INF/services/...` resource, exactly
+ * as `:data-remotecompose-connector` registers its real one — so this exercises the same
+ * ServiceLoader path the daemon uses.
+ */
+class IrReplayComposableProviderTest {
+
+  @Test
+  fun `resolves the registered provider's class by format`() {
+    assertEquals(
+      FakeReplayComposable::class.java,
+      loadIrReplayClass("test-fmt", javaClass.classLoader),
+    )
+  }
+
+  @Test
+  fun `returns null for an unregistered format`() {
+    assertNull(loadIrReplayClass("no-such-format", javaClass.classLoader))
+  }
+}
+
+/** Registered via `src/test/resources/META-INF/services/...IrReplayComposableProvider`. */
+class FakeReplayProvider : IrReplayComposableProvider {
+  override val format: String = "test-fmt"
+
+  override fun replayClass(): Class<*> = FakeReplayComposable::class.java
+}
+
+/** Stand-in for a connector's replay composable host — only its identity matters to the test. */
+class FakeReplayComposable

--- a/data/render/core/src/test/resources/META-INF/services/ee.schimke.composeai.data.render.extensions.IrReplayComposableProvider
+++ b/data/render/core/src/test/resources/META-INF/services/ee.schimke.composeai.data.render.extensions.IrReplayComposableProvider
@@ -1,0 +1,1 @@
+ee.schimke.composeai.data.render.extensions.FakeReplayProvider

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -189,19 +189,24 @@ abstract class BundlePreviewTask : DefaultTask() {
     val irByPreview: Map<String, ResolvedIr> =
       selected.mapNotNull { p -> resolvePreviewIr(p)?.let { p.id to it } }.toMap()
 
-    // A protolayout IR preview replays through `TileRenderer` (see renderers/android's
-    // `TileIrReplayComposable`), which no tile *preview* function references — the preview only
-    // touches the protolayout builders. So seed the dep closure from the player entry point too:
-    // the BFS then reaches `tiles-renderer` + its transitive `protolayout-renderer` / proto
-    // runtime,
-    // and since deps are kept as whole coordinates whenever any class is reachable, those renderer
-    // libs are recorded as carriage coordinates. `AndroidPreviewSupport` already injects
-    // `tiles-renderer` onto the consumer's runtime classpath, so the jar is present in the scan;
-    // without this seed it'd be pruned (reachable == 0) and the daemon replay would
-    // `NoClassDefFoundError` on `TileRenderer`. A missing entry FQN (jar absent) seeds nothing, so
-    // this is a no-op for non-tile bundles.
-    val hasProtolayoutIr = irByPreview.values.any { it.format == IR_FORMAT_PROTOLAYOUT }
-    val replayEntrySeeds = if (hasProtolayoutIr) PROTOLAYOUT_REPLAY_ENTRY_FQNS else emptySet()
+    // An IR preview replays through a *player* its own bytecode never references — a protolayout
+    // tile through `TileRenderer`, a Remote Compose doc through `RemoteDocumentPlayer` — so the
+    // preview's closure alone wouldn't keep the renderer/player libs. Seed the dep closure from
+    // each
+    // format's player entry points: the BFS then reaches those libs + their transitive runtime, and
+    // since deps are kept as whole coordinates whenever any class is reachable, they're recorded as
+    // carriage coordinates. The libs are on the consumer's runtime classpath already
+    // (`AndroidPreviewSupport` injects `tiles-renderer`; an RC consumer depends on the player), so
+    // their jars are in the scan; without these seeds they'd be pruned (reachable == 0) and the
+    // daemon replay would `NoClassDefFoundError`. A missing entry FQN (jar absent) seeds nothing,
+    // so
+    // each is a no-op unless that format's IR is actually present.
+    val replayEntrySeeds = buildSet {
+      if (irByPreview.values.any { it.format == IR_FORMAT_PROTOLAYOUT })
+        addAll(PROTOLAYOUT_REPLAY_ENTRY_FQNS)
+      if (irByPreview.values.any { it.format == IR_FORMAT_REMOTECOMPOSE })
+        addAll(REMOTECOMPOSE_REPLAY_ENTRY_FQNS)
+    }
 
     val depSeedFqns = selected.map { it.className }.toSet() + replayEntrySeeds
     val packSeedFqns = selected.filter { it.id !in irByPreview }.map { it.className }.toSet()
@@ -778,6 +783,19 @@ abstract class BundlePreviewTask : DefaultTask() {
      * when any class is reachable, so this single entry carries the lot.
      */
     val PROTOLAYOUT_REPLAY_ENTRY_FQNS = setOf("androidx.wear.tiles.renderer.TileRenderer")
+
+    /**
+     * Player entry points seeded when a bundle carries Remote Compose IR, so the alpha player the
+     * daemon replays through (`:data-remotecompose-connector`'s `RemoteComposeIrReplay`) is carried
+     * as coordinates. The RC preview's bytecode references the creation/tooling APIs, not the
+     * player; `RemoteDocument` (remote-player-core) + `RemoteDocumentPlayer`
+     * (remote-player-compose) pull the rest of the player runtime transitively.
+     */
+    val REMOTECOMPOSE_REPLAY_ENTRY_FQNS =
+      setOf(
+        "androidx.compose.remote.player.core.RemoteDocument",
+        "androidx.compose.remote.player.compose.RemoteDocumentPlayerKt",
+      )
 
     /**
      * Soft size ceiling above which an embed-deps pack warns. 25 MB is comfortably above a normal


### PR DESCRIPTION
## Goal

The final IR-replay piece: an **Remote Compose** preview now renders from its captured `RemoteDocument` bytes in the daemon, instead of the consumer class that emission + carriage dropped. This closes the loop opened in #1659 — RC bundles are now fully replayable, matching what tiles got in #1666/#1669.

## The constraint, and the seam (your call: new IR-replay SPI)

`RemoteDocumentPlayer`/`RemoteDocument` live in `:data-remotecompose-connector` (compileSdk 37, alpha deps `compileOnly`). The daemon (compileSdk 36) can't compile against them, and — unlike tiles, whose replay composable lives in `:renderer-android` — RC's player can't move to a module the daemon compiles against (it stays on Compose-compat). So the daemon reaches the player **reflectively**, via a new ServiceLoader SPI that mirrors the existing `loadPreviewWrapperClass` indirection for `@PreviewWrapper` substitution.

- **`:data-render-core` — `IrReplayComposableProvider` SPI.** Compose-free (returns the replay `Class<*>` by `format`, exactly like `PreviewWrapperSubstitutionProvider` returns a class) + `loadIrReplayClass(format)`. **Unit-tested** with a fake provider wired through test `META-INF/services` — exercises the real ServiceLoader path (`:data-render-core:test`, runs in CI).
- **`:data-remotecompose-connector` — `RemoteComposeIrReplay.Replay(bytes)`.** Rebuilds `RemoteDocument(bytes)` and renders through the **same** `RemoteDocumentPlayer` the live `RemoteOverridablePreview` uses, honouring seeded `renderNow.overrides.remoteCompose` named values via `applyConnectorOverrides`. Registered as the `remotecompose` provider via `META-INF/services`.
- **`RenderEngine`.** For an RC-IR preview: resolve the provider via the **default (context) classloader** (the topology the live wrapper path already links the alpha player under), skip `Class.forName` (class dropped), and invoke `Replay` reflectively through `getDeclaredComposableMethod` — the same shape as `InvokeWithOptionalWrapper`. The `Class.forName` skip is now generalised to any resolvable IR replay (protolayout direct, or a resolved RC provider).
- **`BundlePreviewTask` — RC carriage.** Seed the dependency closure from the RC player entry points (`RemoteDocument` / `RemoteDocumentPlayerKt`) when remotecompose IR is present, so `remote-player-*` is carried as coordinates — the same fix tiles needed (the preview's own bytecode references only the creation/tooling APIs, never the player).

## Verification

- **Runnable now (CI):** the SPI discovery test in `:data-render-core` (resolve-by-format + null-for-unknown).
- **Static / e2e only:** the reflective `Replay` invocation, the player render, and the RC carriage FQNs can't run in my sandbox (no Android SDK e2e — the Gradle/`build-logic` wrapper mismatch). I mirrored the proven live path (`RemoteOverridablePreview`) byte-for-byte on the player call and the existing `Wrap` reflective-invocation pattern, but the genuine proof is a `:samples:remotecompose` bundle daemon replay.

> ⚠️ Two specific things for review attention: (1) the RC player entry FQN `androidx.compose.remote.player.compose.RemoteDocumentPlayerKt` — the top-level-composable file-class name — should be confirmed against the alpha artifact; if it differs, the carriage seed for `remote-player-compose` misses (the resolver/embedded fallback still covers it, but worth checking). (2) the classloader choice for SPI resolution (context vs per-render) — I chose context to match the live wrapper path; if RC bundle replay can't find the connector or link the player, that's the first knob to turn.

## Test plan

- [ ] `:data-render-core:test` — SPI discovery.
- [ ] `:gradle-plugin:test` / `:functionalTest` — non-IR + non-RC bundles unchanged; RC bundle's `bundle.json` now lists `remote-player-*` coords.
- [ ] End-to-end: pack a `:samples:remotecompose` bundle → `compose-preview bundle daemon` → the RC preview renders from IR (no ClassNotFound / NoClassDefFound), matching the live render.
- [ ] `./gradlew check`

https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt)_