### PR TITLE
fix(vscode): signal daemon readiness in preview-harness so chip fixtures render

### DIFF
--- a/vscode-extension/preview-harness/scenario.html
+++ b/vscode-extension/preview-harness/scenario.html
@@ -73,6 +73,38 @@
                 for (const msg of data.messages ?? []) {
                     window.postMessage(msg, "*");
                 }
+                // Simulate the preview daemon coming up. In a real
+                // session VS Code posts `setInteractiveAvailability`
+                // once the focused module's daemon is ready; the bundle
+                // chip bar (and the focus toolbar's Interactive /
+                // Recording buttons) gate on that signal. Without it
+                // every chip paints disabled, so a fixture's chip-
+                // activation action can't fire the toggle and the data
+                // tab it would open never mounts — the snapshot then
+                // hangs on the unreachable row click. Derive the module
+                // id(s) from the replayed `setPreviews` so readiness
+                // lands on the module the manifest declared; fall back
+                // to a synthetic id for fixtures with no `moduleDir`.
+                const readyModules = new Set();
+                for (const msg of data.messages ?? []) {
+                    if (msg?.command === "setPreviews" && msg.moduleDir) {
+                        readyModules.add(msg.moduleDir);
+                    }
+                }
+                if (readyModules.size === 0) {
+                    readyModules.add("preview-harness");
+                }
+                for (const moduleId of readyModules) {
+                    window.postMessage(
+                        {
+                            command: "setInteractiveAvailability",
+                            moduleId,
+                            ready: true,
+                            interactiveSupported: true,
+                        },
+                        "*",
+                    );
+                }
                 await settle();
 
                 // After the manifest has rendered, replay user-style


### PR DESCRIPTION
The bundle chip bar greys out every chip until the focused module's
daemon reports ready (via setInteractiveAvailability). The preview
harness never sent that signal, so after the chip-disabling gate
landed, clicking a bundle chip in a fixture was a no-op: the bundle
never activated, its data tab never mounted, and the row-click action
in a11y-findings (and 7 other chip fixtures) matched no element. The
scenario then hung on the unreachable click and the snapshot timed out
with a 30s waitForFunction failure — breaking both the
vscode-preview-comment PR job and the vscode-preview-baselines push job
on main.

Replay a setInteractiveAvailability(ready) for each module the fixture
declares in setPreviews right after the manifest messages, mirroring a
real VS Code session where the daemon is up by the time bundle data is
on screen. This re-enables the chips so all 10 fixtures replay their
actions and the harness:snapshot / harness:contract runs complete.