### PR TITLE
fix(bundle): carry IR replay libs onto the daemon launch -cp

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -129,7 +129,7 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       add("-Dcomposeai.daemon.bundleSource=${file.absolutePath}")
       for (prop in launch.sysProps) add(prop)
       add("-cp")
-      add(launch.classpath)
+      add(composeDaemonClasspath(launch.classpath, libJars + resolvedJars, hasIr))
       add("ee.schimke.composeai.daemon.DaemonMain")
     }
 
@@ -484,6 +484,32 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
   }
 
   companion object {
+    /**
+     * Build the daemon launch `-cp`.
+     *
+     * For an **IR-carrying** bundle, the parent-loaded replay host (`:renderer-android`'s
+     * `TileIrReplayComposable` or the connector's `RemoteComposeIrReplay`, both shipped on the
+     * sidecar `-cp`) links the carried renderer/player libs (`androidx.wear.tiles.renderer.*`,
+     * `androidx.compose.remote.player.*`) directly. Those libs live only in
+     * `composeai.daemon.userClassDirs` — the child ([UserClassLoaderHolder]) loader — which the
+     * parent never consults, so the parent-loaded host would `NoClassDefFoundError` at replay. We
+     * therefore also append the carried deps onto the parent `-cp` here.
+     *
+     * **Appended, not prepended:** the renderer's own bundled Compose on the sidecar `-cp` must
+     * stay authoritative (a `URLClassLoader` resolves first-match), so only classes *absent* from
+     * the parent — the player / tiles-renderer APIs — become resolvable; a stale Compose carried in
+     * the bundle can't shadow the renderer's. Classic (non-IR) bundles, which never load a replay
+     * host, are left untouched. See `IrReplayClassloaderTopologyTest` for the topology
+     * characterisation.
+     */
+    internal fun composeDaemonClasspath(
+      base: String,
+      carriedDeps: List<File>,
+      hasIr: Boolean,
+    ): String =
+      if (!hasIr || carriedDeps.isEmpty()) base
+      else (listOf(base) + carriedDeps.map { it.absolutePath }).joinToString(File.pathSeparator)
+
     // Same names the gradle daemon launch path uses — kept inline so this command doesn't
     // need an extra :daemon:core dependency just for the constants.
     private const val USER_CLASS_DIRS_PROP = "composeai.daemon.userClassDirs"

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleDaemonClasspathTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleDaemonClasspathTest.kt
@@ -1,0 +1,56 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards [BundleDaemonCommand.composeDaemonClasspath] — the bundle-daemon fix for the IR-replay
+ * classloader gap characterised in `:daemon:core`'s `IrReplayClassloaderTopologyTest`. The
+ * parent-loaded replay host can only link the carried renderer/player libs if they're also on the
+ * daemon launch `-cp`; this pins that they're appended for IR bundles and the classic path is left
+ * alone.
+ */
+class BundleDaemonClasspathTest {
+
+  private val sidecar =
+    listOf("/lib/daemon.jar", "/lib/renderer.jar").joinToString(File.pathSeparator)
+  private val carried =
+    listOf(File("/work/libs/remote-player.jar"), File("/work/libs/protolayout-renderer.jar"))
+
+  @Test
+  fun `classic non-IR bundle leaves the daemon classpath untouched`() {
+    assertEquals(
+      sidecar,
+      BundleDaemonCommand.composeDaemonClasspath(sidecar, carried, hasIr = false),
+    )
+  }
+
+  @Test
+  fun `IR bundle appends carried deps so the parent-loaded replay host links them`() {
+    val cp = BundleDaemonCommand.composeDaemonClasspath(sidecar, carried, hasIr = true)
+    val entries = cp.split(File.pathSeparator)
+
+    // Sidecar entries stay first — the renderer's bundled Compose must remain authoritative.
+    assertEquals(listOf("/lib/daemon.jar", "/lib/renderer.jar"), entries.take(2))
+    // The carried player / tiles-renderer libs are present so the parent can resolve them.
+    assertTrue(
+      "carried deps must be on the parent -cp, got $entries",
+      carried.all { it.absolutePath in entries },
+    )
+    // ...and appended *after* the sidecar, never shadowing it.
+    assertTrue(
+      "carried deps must come after the sidecar jars",
+      entries.indexOf("/lib/renderer.jar") < entries.indexOf(carried.first().absolutePath),
+    )
+  }
+
+  @Test
+  fun `IR bundle with no carried deps is a no-op`() {
+    assertEquals(
+      sidecar,
+      BundleDaemonCommand.composeDaemonClasspath(sidecar, emptyList(), hasIr = true),
+    )
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleDaemonClasspathTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleDaemonClasspathTest.kt
@@ -1,9 +1,9 @@
 package ee.schimke.composeai.cli
 
 import java.io.File
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Guards [BundleDaemonCommand.composeDaemonClasspath] — the bundle-daemon fix for the IR-replay
@@ -36,13 +36,13 @@ class BundleDaemonClasspathTest {
     assertEquals(listOf("/lib/daemon.jar", "/lib/renderer.jar"), entries.take(2))
     // The carried player / tiles-renderer libs are present so the parent can resolve them.
     assertTrue(
-      "carried deps must be on the parent -cp, got $entries",
       carried.all { it.absolutePath in entries },
+      "carried deps must be on the parent -cp, got $entries",
     )
     // ...and appended *after* the sidecar, never shadowing it.
     assertTrue(
-      "carried deps must come after the sidecar jars",
       entries.indexOf("/lib/renderer.jar") < entries.indexOf(carried.first().absolutePath),
+      "carried deps must come after the sidecar jars",
     )
   }
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IrReplayClassloaderTopologyTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IrReplayClassloaderTopologyTest.kt
@@ -27,9 +27,10 @@ import org.junit.Test
  *
  * This is pure JVM classloading — no Android/Robolectric needed to pin it. The first test
  * reproduces the failure with the real [UserClassLoaderHolder] as the child; the second shows the
- * fix direction (the carried lib also on the parent `-cp`, i.e. what `BundleDaemonCommand` should
- * add) makes the same call link. The actual fix (and which entry point applies it) is a separate
- * change tracked off this harness; this only characterises the mechanism and guards the resolution.
+ * fix direction (the carried lib also on the parent `-cp`) makes the same call link. The fix that
+ * applies this in production is `BundleDaemonCommand.composeDaemonClasspath`, which appends the
+ * bundle's carried deps onto the daemon launch `-cp` for IR-carrying bundles (guarded by
+ * `BundleDaemonClasspathTest`); this test stays as the classloader-topology characterisation.
  */
 class IrReplayClassloaderTopologyTest {
 


### PR DESCRIPTION
## Goal

Fix the IR-replay classloader gap characterised by `IrReplayClassloaderTopologyTest` (#1674) and flagged in review on #1672. When `compose-preview bundle daemon` replays an IR-backed preview, the parent-loaded replay host can now actually link the carried renderer/player libs.

## The bug

The daemon replays IR through a host shipped on its **launch `-cp`** (sidecar jars): `:renderer-android`'s `TileIrReplayComposable` (protolayout) or the connector's `RemoteComposeIrReplay` (Remote Compose). Those classes are therefore defined by the daemon's **parent** classloader. The renderer/player libraries they call — `androidx.wear.tiles.renderer.*`, `androidx.compose.remote.player.*` — are carried in the bundle and land only in `composeai.daemon.userClassDirs`, the **child** (`UserClassLoaderHolder`) loader. A class resolves its references through its own defining loader and the parent never consults the child, so replay threw `NoClassDefFoundError` at link time even though the carried lib was physically present in the child.

## The fix

`BundleDaemonCommand.composeDaemonClasspath` appends the bundle's carried deps (`libJars + resolvedJars`) onto the daemon launch `-cp` **for IR-carrying bundles only**.

- **Appended, not prepended** — the renderer's own bundled Compose on the sidecar `-cp` stays authoritative (a `URLClassLoader` resolves first-match), so only classes *absent* from the parent (the player / tiles-renderer APIs) become resolvable; a stale Compose carried in a bundle can't shadow the renderer's.
- **Scoped to `hasIr`** — classic all-classes bundles never load a replay host, so their launch `-cp` is left exactly as it was.

The carried jars remain on `userClassDirs` (the child) as well, so the live preview render path is unchanged; only the parent gains the extra resolution targets the replay host needs.

## Verification

- **Runnable (CI):** `BundleDaemonClasspathTest` — non-IR untouched, IR appends carried deps after the sidecar, empty-deps no-op.
- **Topology characterisation:** `:daemon:core`'s `IrReplayClassloaderTopologyTest` (merged in #1674) pins the parent-can't-link / parent-with-lib-can-link mechanism this fix acts on; its KDoc now points at `composeDaemonClasspath` as the production fix.
- **Sandbox limit:** the full Gradle build / `bundle daemon` e2e can't run in my environment (build-logic ↔ Gradle-wrapper version mismatch). The end-to-end proof is packing a `:samples:remotecompose` (or tiles) bundle and replaying it through `compose-preview bundle daemon` with no `NoClassDefFoundError`.

## Test plan

- [ ] `:cli:test` — `BundleDaemonClasspathTest`.
- [ ] `:daemon:core:test` — `IrReplayClassloaderTopologyTest` still green.
- [ ] End-to-end: `bundle daemon` on an IR bundle replays the player/tiles preview without linkage errors.
- [ ] `./gradlew check`

https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt)_