### PR TITLE
fix(release): disable Isolated Projects for the Windows MSI viewer build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,8 +199,19 @@ jobs:
           cache-read-only: 'true'
       - name: Build the uber jar and native installer for this OS
         shell: bash
+        # On Windows the installer is an `.msi`, which Compose Multiplatform packages via the WiX
+        # toolset. The Compose Gradle plugin registers its `downloadWix` / `unzipWix` tasks on the
+        # ROOT project (`rootProject.tasks.findByName(...) ?: rootProject.tasks.register(...)`), and
+        # `:bundle-viewer`'s `packageMsi` then reads `rootProject.tasks` / `rootProject.layout` at
+        # configuration time. That cross-project access is forbidden by this repo's Isolated Projects
+        # setting (`org.gradle.unsafe.isolated-projects=true`), and `configuration-cache.problems=fail`
+        # turns it into a hard failure — but only on Windows, since `.deb`/`.dmg` need no WiX. It's a
+        # plugin-internal access we can't satisfy from our build scripts, so disable Isolated Projects
+        # for this packaging run on Windows only. Plain configuration cache stays on (the violation is
+        # IP-specific, not a plain-CC problem), and the Linux/macOS legs keep the full IP gate.
         run: |
           ./gradlew \
+            ${{ runner.os == 'Windows' && '-Dorg.gradle.unsafe.isolated-projects=false' || '' }} \
             :bundle-viewer:packageUberJarForCurrentOS \
             :bundle-viewer:packageDistributionForCurrentOS
       # Stage both artefacts into one flat dir before upload. `upload-artifact` derives the

--- a/bundle-viewer/build.gradle.kts
+++ b/bundle-viewer/build.gradle.kts
@@ -34,9 +34,14 @@ base { archivesName.set("compose-preview-viewer") }
 //   - `packageDistributionForCurrentOS` → a native installer (`.deb`/`.rpm` on Linux, `.dmg` on
 //     macOS, `.msi` on Windows) built by `jpackage`, which embeds a JDK runtime image — so a
 //     non-Java colleague installs and launches the viewer with nothing else on their machine.
-// Both stay Isolated-Projects-clean — unlike the GradleUp Shadow plugin, whose optional-property
-// lookup walks to the parent project and trips this repo's `isolated-projects=true` +
-// `configuration-cache.problems=fail` gate.
+// The uber jar stays Isolated-Projects-clean — unlike the GradleUp Shadow plugin, whose
+// optional-property lookup walks to the parent project and trips this repo's `isolated-projects=true`
+// + `configuration-cache.problems=fail` gate. The native-installer path is IP-clean on Linux/macOS
+// (`.deb`/`.dmg`), but the Windows `.msi` is NOT: Compose Multiplatform packages MSIs via the WiX
+// toolset and registers its `downloadWix` / `unzipWix` tasks on the ROOT project, so `packageMsi`
+// reads `rootProject.tasks` / `rootProject.layout` at configuration time and trips the IP gate. The
+// release workflow's viewer-packaging step disables Isolated Projects on the Windows leg only to work
+// around this plugin-internal access (see `.github/workflows/release.yml`).
 //
 // We drop the JVM `application` plugin entirely (its slim `distZip`/`distTar` is superseded by the
 // drag-around uber jar, and keeping both registers two colliding `run` tasks).


### PR DESCRIPTION
Compose Multiplatform packages the Windows .msi via the WiX toolset and
registers its downloadWix/unzipWix tasks on the root project, so
:bundle-viewer:packageMsi reads rootProject.tasks/rootProject.layout at
configuration time. That cross-project access trips this repo's Isolated
Projects gate (org.gradle.unsafe.isolated-projects=true with
configuration-cache.problems=fail), failing the release on Windows only
(.deb/.dmg need no WiX). Disable Isolated Projects for the viewer
packaging run on the Windows matrix leg; plain configuration cache stays
on and the Linux/macOS legs keep the full IP gate.