### PR TITLE
feat(cli): ship lib-daemon-android + e2e for Android bundle-daemon IR render

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,41 @@ jobs:
           name: bundle-render-functional-test-reports
           path: gradle-plugin/build/reports/tests/functionalTest/
 
+  android-bundle-daemon-e2e:
+    name: Android Bundle Daemon E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      # End-to-end for the Android path of `bundle daemon`: pack real-sample bundles (Wear tile +
+      # Remote Compose IR, plus classic Compose previews), then spawn the actual CLI binary against
+      # each and render protolayout / remotecompose / classic previews to PNG via the Robolectric
+      # daemon. Guards (1) `lib-daemon-android/` being staged into the CLI dist and (2)
+      # `BundleDaemonCommand.composeDaemonClasspath` putting the carried IR-replay libs on the
+      # daemon `-cp` (else replay dies with NoClassDefFoundError). The ubuntu-latest image ships an
+      # Android SDK (ANDROID_HOME/ANDROID_SDK_ROOT) which the daemon launch resolves android.jar
+      # from. Opt-in via `-Pbundle.daemon.android.e2e=true` — cold-starts a daemon JVM per bundle.
+      #
+      # Split into two phases for the same parallel-execution race the desktop bundle-render job
+      # documents: the included-build functionalTest can start before `:cli:installDist` finishes
+      # populating the lib dirs. Pre-building serialises the two (and is otherwise no-op).
+      - name: Pre-build CLI install + sample bundles + publish plugin
+        run: >-
+          ./gradlew :cli:installDist
+          :samples:wear:composePreviewBundle
+          :samples:remotecompose:composePreviewBundle
+          :gradle-plugin:publishToMavenLocal --stacktrace
+      - name: Android bundle daemon e2e
+        run: ./gradlew functionalTestWithAndroidBundleDaemon -Pbundle.daemon.android.e2e=true --stacktrace
+      - name: Upload functionalTest reports on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: android-bundle-daemon-functional-test-reports
+          path: gradle-plugin/build/reports/tests/functionalTest/
+
   agent-audit-samples:
     name: Agent Audit Samples
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,6 +150,30 @@ tasks.register("functionalTestWithBundleRender") {
   dependsOn(gradle.includedBuild("gradle-plugin").task(":functionalTest"))
 }
 
+tasks.register("functionalTestWithAndroidBundleDaemon") {
+  group = "verification"
+  description =
+    "Builds the compose-preview CLI install dist (now shipping `lib-daemon-android/`) plus the " +
+      "Android sample bundles (`:samples:wear` Wear-tile/Compose, `:samples:remotecompose` Remote " +
+      "Compose), then runs gradle-plugin's functionalTest with `bundle.daemon.android.e2e=true` so " +
+      "`AndroidBundleDaemonRenderFunctionalTest` drives `compose-preview bundle daemon` against " +
+      "each bundle and renders protolayout / remotecompose / classic previews to PNG. Needs a " +
+      "local Android SDK (ANDROID_HOME / ANDROID_SDK_ROOT) for android.jar + the Robolectric build."
+  // Same publish targets as the desktop e2e — running the full `functionalTest` also exercises
+  // tests that resolve the plugin (and renderer-desktop transitives) from mavenLocal.
+  bundleRenderFunctionalTestPublishTargets.forEach { dependsOn("$it:publishToMavenLocal") }
+  dependsOn(gradle.includedBuild("gradle-plugin").task(":publishToMavenLocal"))
+  // CLI install dist carries `lib-daemon-android/` (the new `stageDaemonAndroidLibs` output).
+  dependsOn(":cli:installDist")
+  // The Android sample bundles the test renders. Each `composePreviewBundle` runs the plugin's
+  // render (Robolectric) + pack against the real sample, emitting an `backend="android"` bundle
+  // with non-empty `intermediateRepresentations` (Wear tile + Remote Compose IR) alongside classic
+  // Compose previews.
+  dependsOn(":samples:wear:composePreviewBundle")
+  dependsOn(":samples:remotecompose:composePreviewBundle")
+  dependsOn(gradle.includedBuild("gradle-plugin").task(":functionalTest"))
+}
+
 // `:cli:installDist` and the included build's `functionalTest` would otherwise run in parallel
 // (Gradle's parallel scheduler doesn't serialise cross-build deps automatically). The functional
 // test invokes the CLI via `ProcessBuilder`, so it crashes with `NoClassDefFoundError` against a

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,10 +1,14 @@
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
+import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskAction
 
@@ -77,6 +81,34 @@ val composePreviewDaemonDesktop =
     isCanBeConsumed = false
   }
 
+// Sidecar configuration carrying the Android (Robolectric) daemon module (`:daemon:android`).
+// Same subprocess-only isolation as the desktop daemon above — never on the CLI's own classpath,
+// only loaded by the JVM that `compose-preview bundle daemon` spawns for an `backend="android"`
+// bundle, joined at launch time with the consumer's SDK `android.jar` (resolved from ANDROID_HOME).
+//
+// Unlike the desktop daemon, `:daemon:android` is an AGP `com.android.library`: a plain-JVM
+// consumer like `:cli` can't natively resolve its runtime (AGP exposes it as an AAR with
+// AAR-shaped transitive deps + AGP-generated R.jars). So we mirror `:daemon:harness`'s proven
+// approach instead of staging resolved artifacts directly: `:daemon:android` exposes a
+// `daemonHarnessClasspathFile` consumable configuration whose single artifact is a text file
+// listing the absolute paths of every JAR on its debug-unit-test runtime classpath. We consume
+// that descriptor here (matching attribute, zero AGP variants on the consumer side) and
+// [StageDaemonAndroidLibs] copies the listed jars into `lib-daemon-android/`.
+//
+// Resolved into `cli/build/install/compose-preview/lib-daemon-android/` and located at runtime via
+// `APP_HOME/lib-daemon-android/` (or `-Dcomposeai.cli.libDaemonAndroidDir`).
+val composePreviewDaemonAndroid =
+  configurations.create("composePreviewDaemonAndroid") {
+    isCanBeResolved = true
+    isCanBeConsumed = false
+    attributes {
+      attribute(
+        Attribute.of("ee.schimke.composeai.daemon.harness.classpath", String::class.java),
+        "android",
+      )
+    }
+  }
+
 dependencies {
   // Published wire-format DTOs (`PreviewResult`, `PreviewManifest`, the v1 a11y mirror types,
   // `ExtensionPayload`). `api` so the existing in-package imports across this module (and the
@@ -122,6 +154,12 @@ dependencies {
   // bundled here — the subprocess classpath joins `lib-daemon-desktop/*` + `lib-renderer/*`
   // at launch time, and the renderer sidecar already carries the per-OS Compose stack.
   add("composePreviewDaemonDesktop", project(":daemon:desktop"))
+
+  // `compose-preview bundle daemon` ships the Android (Robolectric) daemon in
+  // `lib-daemon-android/`. This resolves `:daemon:android`'s `daemonHarnessClasspathFile`
+  // descriptor (a text file of runtime jar paths) — see the configuration KDoc above — never the
+  // AAR itself, so no AGP variant resolution leaks onto a plain-JVM consumer.
+  add("composePreviewDaemonAndroid", project(":daemon:android"))
 
   // `:gradle-preview-driver` pulls `org.gradle:gradle-tooling-api`, whose shaded variant
   // *strictly* requires `slf4j-api:2.0.17`. Ktor 3.5.0 (and friends) pull `slf4j-api:2.0.18`
@@ -176,11 +214,54 @@ val stageDaemonDesktopLibs =
     }
   }
 
+// Stage the Android daemon's runtime jars from `:daemon:android`'s `daemonHarnessClasspathFile`
+// descriptor (a newline-separated text file of absolute jar paths, ordered module-jar →
+// testFixtures → R.jar → full test runtime → android.jar; see that module's `writeDaemonClasspath`).
+// We copy each listed jar into a build dir so the distribution wiring can fold it into
+// `lib-daemon-android/`. Two deliberate transforms:
+//   - `android.jar` is dropped: it's the SDK platform jar (redistribution-sensitive, and
+//     `BundleDaemonCommand.androidDaemonLaunch` re-adds it from the consumer's ANDROID_HOME at
+//     launch), so it must not ride along in the shipped tarball.
+//   - filenames are index-prefixed (`%04d-<name>`) to (a) keep the descriptor's classpath
+//     precedence intact under the `lib-daemon-android/*` glob the daemon launcher expands and
+//     (b) dodge basename collisions on AAR `classes.jar` / AGP-generated `R.jar`.
+abstract class StageDaemonAndroidLibs : DefaultTask() {
+  @get:InputFiles abstract val classpathDescriptor: ConfigurableFileCollection
+
+  @get:OutputDirectory abstract val destinationDir: DirectoryProperty
+
+  @TaskAction
+  fun stage() {
+    val descriptor = classpathDescriptor.singleFile
+    val dest = destinationDir.get().asFile
+    dest.deleteRecursively()
+    dest.mkdirs()
+    descriptor
+      .readLines()
+      .map { it.trim() }
+      .filter { it.isNotEmpty() }
+      .map { java.io.File(it) }
+      .filter { it.isFile && it.name.endsWith(".jar") && it.name != "android.jar" }
+      .forEachIndexed { index, jar ->
+        jar.copyTo(java.io.File(dest, "%04d-%s".format(index, jar.name)))
+      }
+  }
+}
+
+val stageDaemonAndroidLibs =
+  tasks.register<StageDaemonAndroidLibs>("stageDaemonAndroidLibs") {
+    description =
+      "Stages :daemon:android runtime jars (from its classpath descriptor) into lib-daemon-android."
+    classpathDescriptor.from(composePreviewDaemonAndroid)
+    destinationDir.set(layout.buildDirectory.dir("staged-daemon-android-libs"))
+  }
+
 distributions {
   named("main") {
     contents {
       into("lib-renderer") { from(composePreviewRenderer) }
       into("lib-daemon-desktop") { from(stageDaemonDesktopLibs) }
+      into("lib-daemon-android") { from(stageDaemonAndroidLibs) }
     }
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -223,17 +223,19 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
    * synthesized `robolectric.properties` apply to the one-shot `bundle render` path only, not the
    * daemon.
    *
-   * Still Phase 2 (only validatable in the SDK-gated Android CI chain): packaging `:daemon:android`
-   * into the CLI distribution as `lib-daemon-android/` — until then this surfaces an actionable
-   * diagnostic, and stays exercisable via `-Dcomposeai.cli.libDaemonAndroidDir=<dir>`.
+   * The `:daemon:android` runtime is shipped in the CLI distribution as `lib-daemon-android/`
+   * (staged by `:cli`'s `stageDaemonAndroidLibs` from the module's classpath descriptor), so this
+   * resolves the sidecar from `APP_HOME/lib-daemon-android/` for a normal install; the
+   * `-Dcomposeai.cli.libDaemonAndroidDir=<dir>` override stays available for IDE / `JavaExec` runs.
+   * End-to-end coverage lives in the SDK-gated `AndroidBundleDaemonRenderFunctionalTest`.
    */
   private fun androidDaemonLaunch(): DaemonLaunch {
     val daemonJars = locateSidecarJars("lib-daemon-android")
     if (daemonJars.isEmpty()) {
       System.err.println(
-        "bundle daemon: backend=android needs the Android daemon sidecar, which is not packaged in " +
-          "this CLI build yet (Phase 2). Point at a built one via " +
-          "`-Dcomposeai.cli.libDaemonAndroidDir=<dir>`. Looked in " +
+        "bundle daemon: backend=android needs the Android daemon sidecar (`lib-daemon-android/`), " +
+          "normally staged into the CLI install by `./gradlew :cli:installDist`. Point at a built " +
+          "one via `-Dcomposeai.cli.libDaemonAndroidDir=<dir>`. Looked in " +
           "`${sidecarSearchDescription("lib-daemon-android")}`."
       )
       exitProcess(1)

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -103,6 +103,27 @@ val functionalTestTask =
     // Root build's `functionalTestWithBundleRender` task flips this on.
     val bundleRenderE2E = providers.gradleProperty("bundle.render.e2e").orNull == "true"
     systemProperty("composeai.functionalTest.cliBundleRender", bundleRenderE2E.toString())
+    // Opt-in `bundle.daemon.android.e2e=true` gate for [AndroidBundleDaemonRenderFunctionalTest].
+    // Drives `compose-preview bundle daemon` against pre-built Android sample bundles and renders
+    // protolayout / remotecompose / classic previews to PNG via the Robolectric daemon — needs a
+    // local Android SDK + cold-starts a daemon JVM per bundle, so it's off by default. The root
+    // build's `functionalTestWithAndroidBundleDaemon` task flips it on after building the bundles.
+    val androidBundleDaemonE2E =
+      providers.gradleProperty("bundle.daemon.android.e2e").orNull == "true"
+    systemProperty("composeai.functionalTest.androidBundleDaemon", androidBundleDaemonE2E.toString())
+    // Paths to the Android sample bundles the test renders. Built by the root build's
+    // `:samples:wear:composePreviewBundle` / `:samples:remotecompose:composePreviewBundle`. Passed
+    // unconditionally (config-cache-safe, same rationale as `cliBinary` below); the test self-skips
+    // past the opt-in gate when a path is absent.
+    val samplesDir = rootDir.parentFile?.resolve("samples")
+    systemProperty(
+      "composeai.functionalTest.wearBundle",
+      samplesDir?.resolve("wear/build/compose-previews/bundle.png")?.absolutePath ?: "",
+    )
+    systemProperty(
+      "composeai.functionalTest.remoteComposeBundle",
+      samplesDir?.resolve("remotecompose/build/compose-previews/bundle.png")?.absolutePath ?: "",
+    )
     // Path to the compose-preview CLI binary built by `:cli:installDist`. The test invokes it
     // directly as a subprocess — that's the actual subject of the e2e. The test self-skips when
     // the binary isn't there (an `assertWithMessage(...).isFile.isTrue()` past the opt-in gate).

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AndroidBundleDaemonRenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AndroidBundleDaemonRenderFunctionalTest.kt
@@ -1,0 +1,343 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import java.io.BufferedInputStream
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.TimeUnit
+import java.util.zip.ZipFile
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end coverage for `compose-preview bundle daemon` against **Android** bundles, driven
+ * through the actual CLI binary + the Robolectric daemon.
+ *
+ * This is the test that guards the two halves of Phase 2 that unit/desktop coverage can't reach:
+ *
+ * 1. **`lib-daemon-android/` is packaged in the CLI dist.** [locateCli] asserts `:cli:installDist`
+ *    populated the sidecar (regression: the Android daemon launch dies with an "not packaged yet"
+ *    diagnostic, or `ClassNotFoundException` on a half-staged dir).
+ * 2. **`BundleDaemonCommand.composeDaemonClasspath` puts the carried IR-replay libs on the parent
+ *    `-cp`.** For an IR-backed preview the parent-loaded replay host (`:renderer-android`'s
+ *    `TileIrReplayComposable` / the connector's `RemoteComposeIrReplay`) links
+ *    `androidx.wear.tiles.renderer.*` / `androidx.compose.remote.player.*`, which live only in the
+ *    bundle's carried deps. If those aren't appended to the daemon `-cp`, replay blows up with
+ *    `NoClassDefFoundError` at render time — so we render a protolayout (Wear tile) IR preview, a
+ *    Remote Compose IR preview, and a classic (non-IR) Compose preview to PNG and assert all three
+ *    produce fresh, valid PNGs with no `NoClassDefFoundError` on the daemon's stderr.
+ *
+ * The bundles are pre-built from the real samples (`:samples:wear`, `:samples:remotecompose`) by
+ * the root build's `functionalTestWithAndroidBundleDaemon` task and handed over as paths; the test
+ * reads `bundle.json` from each to learn which preview ids are IR-backed (and their format) vs
+ * classic. Opt-in via `-Pbundle.daemon.android.e2e=true` (cold-starts a Robolectric daemon JVM and
+ * needs a local Android SDK for `android.jar`), keyed to `composeai.functionalTest.androidBundleDaemon`.
+ */
+class AndroidBundleDaemonRenderFunctionalTest {
+
+  @get:Rule val tempDir: TemporaryFolder = TemporaryFolder()
+
+  private val enabled: Boolean =
+    System.getProperty("composeai.functionalTest.androidBundleDaemon", "false") == "true"
+
+  private val cliBinary: String = System.getProperty("composeai.functionalTest.cliBinary", "")
+  private val wearBundle: String = System.getProperty("composeai.functionalTest.wearBundle", "")
+  private val remoteComposeBundle: String =
+    System.getProperty("composeai.functionalTest.remoteComposeBundle", "")
+
+  @Test
+  fun `bundle daemon renders protolayout, remotecompose and classic Android previews to PNG`() {
+    assumeTrue("Skipping: -Pbundle.daemon.android.e2e=true not set", enabled)
+
+    val cli = locateCli()
+
+    // Tracks which kinds of preview actually rendered across both bundles: protolayout (Wear
+    // tile IR), remotecompose (RC doc IR), and classic (reflected app.jar Compose preview).
+    val formatsSeen = mutableSetOf<String>()
+    renderBundle(cli, File(wearBundle), formatsSeen)
+    renderBundle(cli, File(remoteComposeBundle), formatsSeen)
+
+    assertWithMessage("expected a protolayout (Wear tile) IR preview to render. saw: $formatsSeen")
+      .that(formatsSeen)
+      .contains("protolayout")
+    assertWithMessage("expected a remotecompose IR preview to render. saw: $formatsSeen")
+      .that(formatsSeen)
+      .contains("remotecompose")
+    assertWithMessage("expected a classic (non-IR) Compose preview to render. saw: $formatsSeen")
+      .that(formatsSeen)
+      .contains("classic")
+  }
+
+  /**
+   * Drive one bundle through the daemon: pick one preview per IR format present plus one classic
+   * preview, render them via `renderNow`, and assert each produces a fresh, valid PNG. Records the
+   * rendered formats into [formatsSeen].
+   */
+  private fun renderBundle(cli: File, bundle: File, formatsSeen: MutableSet<String>) {
+    assertWithMessage(
+        "sample bundle missing: ${bundle.path} — did `:samples:…:composePreviewBundle` run? Use " +
+          "`./gradlew functionalTestWithAndroidBundleDaemon`"
+      )
+      .that(bundle.isFile)
+      .isTrue()
+
+    val manifest = readBundleManifest(bundle)
+    assertWithMessage("expected an android-backend bundle: ${bundle.path}")
+      .that(manifest.backend)
+      .isEqualTo("android")
+    assertThat(manifest.previewIds).isNotEmpty()
+
+    // One preview per IR format present, plus one classic (non-IR) preview if the bundle has one.
+    val selected = LinkedHashSet<String>()
+    manifest.formatById.entries
+      .groupBy({ it.value }, { it.key })
+      .forEach { (_, ids) -> ids.firstOrNull()?.let { selected.add(it) } }
+    manifest.previewIds.firstOrNull { it !in manifest.formatById.keys }?.let { selected.add(it) }
+    assertWithMessage("no renderable previews discovered in ${bundle.name}")
+      .that(selected)
+      .isNotEmpty()
+
+    val startMillis = System.currentTimeMillis()
+    val stderrFile = tempDir.newFile("daemon-stderr-${System.nanoTime()}.log")
+    val proc =
+      ProcessBuilder(cli.absolutePath, "bundle", "daemon", bundle.absolutePath, "--verbose")
+        .directory(tempDir.root)
+        .redirectError(ProcessBuilder.Redirect.to(stderrFile))
+        .start()
+    val stdin: OutputStream = proc.outputStream
+    val stdout: InputStream = BufferedInputStream(proc.inputStream)
+    val json = Json { ignoreUnknownKeys = true }
+
+    try {
+      // initialize — the Android (Robolectric) daemon cold-starts a sandbox, so be generous.
+      val initParams = buildJsonObject {
+        put("clientVersion", "android-bundle-daemon-e2e/1")
+        put("workspaceRoot", "")
+        put("moduleId", "bundle:test")
+        put("moduleProjectDir", "")
+        put("protocolVersion", 2)
+        put(
+          "capabilities",
+          buildJsonObject {
+            put("visibility", true)
+            put("metrics", true)
+          },
+        )
+      }
+      BundleDaemonStdio.writeFrame(
+        stdin,
+        BundleDaemonStdio.jsonRpcRequest(id = 1, method = "initialize", params = initParams),
+      )
+      val initResponse = BundleDaemonStdio.readFrameWithTimeoutMs(stdout, timeoutMs = 180_000)
+      val initJson = json.parseToJsonElement(initResponse).jsonObject
+      assertWithMessage("initialize returned an error: $initResponse")
+        .that(initJson["error"])
+        .isNull()
+      val capabilities = initJson["result"]?.jsonObject?.get("capabilities")?.jsonObject
+      assertWithMessage("initialize result missing capabilities: $initResponse")
+        .that(capabilities)
+        .isNotNull()
+      assertWithMessage("expected android backend daemon: $initResponse")
+        .that(capabilities!!["backend"]?.jsonPrimitive?.content)
+        .isEqualTo("android")
+
+      BundleDaemonStdio.writeFrame(
+        stdin,
+        BundleDaemonStdio.jsonRpcNotification(method = "initialized"),
+      )
+
+      // renderNow the selected previews; PNGs arrive asynchronously via `renderFinished`.
+      val renderParams = buildJsonObject {
+        put("previews", JsonArray(selected.map { JsonPrimitive(it) }))
+        put("tier", "full")
+        put("reason", "android-bundle-daemon-e2e")
+      }
+      BundleDaemonStdio.writeFrame(
+        stdin,
+        BundleDaemonStdio.jsonRpcRequest(id = 2, method = "renderNow", params = renderParams),
+      )
+
+      var queued: List<String>? = null
+      val finished = LinkedHashMap<String, String>() // previewId -> pngPath
+      val failed = LinkedHashMap<String, String>() // previewId -> error message
+      // Loop until the renderNow result has landed AND every queued preview has a terminal
+      // (finished | failed) notification. A wedged render surfaces as a per-frame read timeout.
+      while (queued == null || finished.size + failed.size < queued!!.size) {
+        val frame = BundleDaemonStdio.readFrameWithTimeoutMs(stdout, timeoutMs = 240_000)
+        val obj = json.parseToJsonElement(frame).jsonObject
+        val frameId = obj["id"]?.jsonPrimitive?.content
+        val method = obj["method"]?.jsonPrimitive?.content
+        when {
+          frameId == "2" && method == null -> {
+            assertWithMessage("renderNow returned an error: $frame").that(obj["error"]).isNull()
+            val result = obj["result"]!!.jsonObject
+            queued = result["queued"]?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
+            val rejected = result["rejected"]?.jsonArray?.map { it.toString() } ?: emptyList()
+            assertWithMessage("renderNow rejected previews in ${bundle.name}: $rejected")
+              .that(rejected)
+              .isEmpty()
+          }
+          method == "renderFinished" -> {
+            val params = obj["params"]!!.jsonObject
+            finished[params["id"]!!.jsonPrimitive.content] =
+              params["pngPath"]!!.jsonPrimitive.content
+          }
+          method == "renderFailed" -> {
+            val params = obj["params"]!!.jsonObject
+            failed[params["id"]!!.jsonPrimitive.content] =
+              params["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content ?: "(no message)"
+          }
+          else -> {
+            // renderStarted / discoveryUpdated / log notifications — not terminal, ignore.
+          }
+        }
+      }
+
+      drainShutdown(stdin, stdout)
+      proc.waitFor(30, TimeUnit.SECONDS)
+
+      val stderr = stderrFile.readTextOrEmpty()
+      assertWithMessage("renders failed for ${bundle.name}: $failed\nstderr:\n$stderr")
+        .that(failed)
+        .isEmpty()
+      assertWithMessage("not every selected preview rendered for ${bundle.name}\nstderr:\n$stderr")
+        .that(finished.keys)
+        .containsAtLeastElementsIn(selected)
+      for ((id, pngPath) in finished) {
+        val png = File(pngPath)
+        assertWithMessage("render PNG missing for $id at $pngPath (bundle=${bundle.name})")
+          .that(png.isFile)
+          .isTrue()
+        assertWithMessage("render PNG empty for $id at $pngPath")
+          .that(png.length())
+          .isGreaterThan(0L)
+        assertWithMessage("render output for $id is not a PNG: $pngPath").that(isPng(png)).isTrue()
+        assertWithMessage("render PNG for $id is stale (not produced by this run): $pngPath")
+          .that(png.lastModified())
+          .isAtLeast(startMillis - 5_000)
+        formatsSeen.add(manifest.formatById[id] ?: "classic")
+      }
+
+      // The exact failure `composeDaemonClasspath` fixes: a parent-loaded IR replay host that can't
+      // see the carried player / tiles-renderer libs trips NoClassDefFoundError at replay time.
+      assertWithMessage(
+          "daemon stderr contained NoClassDefFoundError (bundle=${bundle.name}):\n$stderr"
+        )
+        .that(stderr)
+        .doesNotContain("NoClassDefFoundError")
+    } finally {
+      if (proc.isAlive) {
+        proc.destroy()
+        proc.waitFor(5, TimeUnit.SECONDS)
+        if (proc.isAlive) proc.destroyForcibly()
+      }
+    }
+  }
+
+  /** Best-effort `shutdown` + `exit` handshake; tolerates trailing notifications still in flight. */
+  private fun drainShutdown(stdin: OutputStream, stdout: InputStream) {
+    BundleDaemonStdio.writeFrame(
+      stdin,
+      BundleDaemonStdio.jsonRpcRequest(id = 3, method = "shutdown"),
+    )
+    val json = Json { ignoreUnknownKeys = true }
+    // Drain any trailing notifications until the shutdown response (id=3) lands.
+    for (i in 0 until 10) {
+      val frame = BundleDaemonStdio.readFrameWithTimeoutMs(stdout, timeoutMs = 30_000)
+      val id = json.parseToJsonElement(frame).jsonObject["id"]?.jsonPrimitive?.content
+      if (id == "3") break
+    }
+    BundleDaemonStdio.writeFrame(stdin, BundleDaemonStdio.jsonRpcNotification(method = "exit"))
+    stdin.close()
+  }
+
+  private fun locateCli(): File {
+    assertWithMessage("CLI binary path not surfaced via system property")
+      .that(cliBinary)
+      .isNotEmpty()
+    val cli = File(cliBinary)
+    assertWithMessage(
+        "CLI binary $cliBinary missing — did `:cli:installDist` run? Use " +
+          "`./gradlew functionalTestWithAndroidBundleDaemon`"
+      )
+      .that(cli.isFile)
+      .isTrue()
+    val installRoot = cli.parentFile.parentFile
+    val libDaemonAndroid = installRoot.resolve("lib-daemon-android")
+    assertWithMessage(
+        "lib-daemon-android dir missing in CLI distribution at ${libDaemonAndroid.path} — the cli " +
+          "build didn't stage the `composePreviewDaemonAndroid` configuration (Phase 2 packaging)."
+      )
+      .that(libDaemonAndroid.isDirectory)
+      .isTrue()
+    assertWithMessage("lib-daemon-android is empty — :daemon:android runtime jars not staged")
+      .that(libDaemonAndroid.listFiles { f -> f.name.endsWith(".jar") }.orEmpty().asList())
+      .isNotEmpty()
+    return cli
+  }
+
+  /**
+   * Read the bundle's `bundle.json` — a PNG+ZIP polyglot, so [ZipFile] reads the central directory
+   * from the file's tail, ignoring the PNG prefix. Returns the backend, the full preview-id list,
+   * and a `previewId → IR format` map (`protolayout` / `remotecompose`) for the IR-backed previews.
+   */
+  private fun readBundleManifest(bundle: File): BundleManifestInfo {
+    val json = Json { ignoreUnknownKeys = true }
+    ZipFile(bundle).use { zf ->
+      val entry = zf.getEntry("bundle.json") ?: error("bundle.json missing in ${bundle.path}")
+      val text = zf.getInputStream(entry).bufferedReader(Charsets.UTF_8).use { it.readText() }
+      val root = json.parseToJsonElement(text).jsonObject
+      val backend = root["backend"]?.jsonPrimitive?.content ?: ""
+      val previewIds =
+        root["previewIds"]?.jsonArray?.map { it.jsonPrimitive.content } ?: emptyList()
+      val formatById =
+        root["intermediateRepresentations"]?.jsonArray?.associate {
+          val ir = it.jsonObject
+          ir["previewId"]!!.jsonPrimitive.content to ir["format"]!!.jsonPrimitive.content
+        } ?: emptyMap()
+      return BundleManifestInfo(backend, previewIds, formatById)
+    }
+  }
+
+  private data class BundleManifestInfo(
+    val backend: String,
+    val previewIds: List<String>,
+    val formatById: Map<String, String>,
+  )
+
+  private fun isPng(file: File): Boolean {
+    if (file.length() < PNG_MAGIC.size) return false
+    val head = ByteArray(PNG_MAGIC.size)
+    file.inputStream().use { it.read(head) }
+    return head.contentEquals(PNG_MAGIC)
+  }
+
+  private fun File.readTextOrEmpty(): String =
+    if (this.isFile) this.readText() else "(no stderr captured)"
+
+  private companion object {
+    private val PNG_MAGIC =
+      byteArrayOf(
+        0x89.toByte(),
+        'P'.code.toByte(),
+        'N'.code.toByte(),
+        'G'.code.toByte(),
+        0x0D,
+        0x0A,
+        0x1A,
+        0x0A,
+      )
+  }
+}

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleDaemonEndToEndFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleDaemonEndToEndFunctionalTest.kt
@@ -8,7 +8,6 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -89,8 +88,11 @@ class BundleDaemonEndToEndFunctionalTest {
           },
         )
       }
-      writeFrame(stdin, jsonRpcRequest(id = 1, method = "initialize", params = initParams))
-      val initResponse = readFrameWithTimeoutMs(stdout, timeoutMs = 60_000)
+      BundleDaemonStdio.writeFrame(
+        stdin,
+        BundleDaemonStdio.jsonRpcRequest(id = 1, method = "initialize", params = initParams),
+      )
+      val initResponse = BundleDaemonStdio.readFrameWithTimeoutMs(stdout, timeoutMs = 60_000)
       val initJson = json.parseToJsonElement(initResponse).jsonObject
       assertWithMessage("initialize response payload: $initResponse")
         .that(initJson["id"]?.jsonPrimitive?.content)
@@ -106,11 +108,17 @@ class BundleDaemonEndToEndFunctionalTest {
       initOk = true
 
       // 2. initialized notification → PROTOCOL.md § 3 requires this before further requests.
-      writeFrame(stdin, jsonRpcNotification(method = "initialized"))
+      BundleDaemonStdio.writeFrame(
+        stdin,
+        BundleDaemonStdio.jsonRpcNotification(method = "initialized"),
+      )
 
       // 3. shutdown request → expect a (typically null) result, then exit.
-      writeFrame(stdin, jsonRpcRequest(id = 2, method = "shutdown"))
-      val shutdownResponse = readFrameWithTimeoutMs(stdout, timeoutMs = 10_000)
+      BundleDaemonStdio.writeFrame(
+        stdin,
+        BundleDaemonStdio.jsonRpcRequest(id = 2, method = "shutdown"),
+      )
+      val shutdownResponse = BundleDaemonStdio.readFrameWithTimeoutMs(stdout, timeoutMs = 10_000)
       val shutdownJson = json.parseToJsonElement(shutdownResponse).jsonObject
       assertWithMessage("shutdown response payload: $shutdownResponse")
         .that(shutdownJson["id"]?.jsonPrimitive?.content)
@@ -120,7 +128,7 @@ class BundleDaemonEndToEndFunctionalTest {
         .isNull()
       shutdownOk = true
 
-      writeFrame(stdin, jsonRpcNotification(method = "exit"))
+      BundleDaemonStdio.writeFrame(stdin, BundleDaemonStdio.jsonRpcNotification(method = "exit"))
       stdin.close()
 
       val exited = proc.waitFor(30, TimeUnit.SECONDS)
@@ -208,100 +216,6 @@ class BundleDaemonEndToEndFunctionalTest {
     assertWithMessage("bundle missing after pack:\n$packOutput").that(bundle.isFile).isTrue()
     assertThat(bundle.length()).isGreaterThan(0L)
     return bundle
-  }
-
-  private fun jsonRpcRequest(id: Int, method: String, params: JsonObject? = null): String =
-    Json.encodeToString(
-      JsonObject.serializer(),
-      buildJsonObject {
-        put("jsonrpc", "2.0")
-        put("id", id)
-        put("method", method)
-        if (params != null) put("params", params)
-      },
-    )
-
-  private fun jsonRpcNotification(method: String, params: JsonObject? = null): String =
-    Json.encodeToString(
-      JsonObject.serializer(),
-      buildJsonObject {
-        put("jsonrpc", "2.0")
-        put("method", method)
-        if (params != null) put("params", params)
-      },
-    )
-
-  /**
-   * Write a JSON-RPC payload framed with LSP-style `Content-Length`. Mirrors the wire shape
-   * `DaemonClient` writes — kept inline so this test stays free of vscode-extension deps.
-   */
-  private fun writeFrame(stream: OutputStream, json: String) {
-    val bytes = json.toByteArray(Charsets.UTF_8)
-    val header = "Content-Length: ${bytes.size}\r\n\r\n".toByteArray(Charsets.US_ASCII)
-    stream.write(header)
-    stream.write(bytes)
-    stream.flush()
-  }
-
-  /**
-   * Read one LSP-framed JSON-RPC message from [stream]. Bound to [timeoutMs] in wall-clock — the
-   * blocking [InputStream.read] runs on a worker thread and we wait via
-   * [java.util.concurrent.Future.get] so a wedged daemon surfaces as a deterministic timeout rather
-   * than hanging this test until Gradle's outer cancel kicks in. The daemon's cold-start can run
-   * several seconds on first request, so the initialize timeout is generous.
-   */
-  private fun readFrameWithTimeoutMs(stream: InputStream, timeoutMs: Long): String {
-    // Single-shot executor + daemon thread so a cancelled read can't keep the JVM alive past
-    // teardown — the parent kills the daemon process in `finally` either way, but cancelling
-    // the read here lets the assertion message describe the timeout rather than blocking on
-    // GC of the lingering worker.
-    val executor =
-      java.util.concurrent.Executors.newSingleThreadExecutor { runnable ->
-        Thread(runnable, "bundle-daemon-frame-reader").apply { isDaemon = true }
-      }
-    try {
-      val future = executor.submit<String> { readFrameBlocking(stream) }
-      try {
-        return future.get(timeoutMs, TimeUnit.MILLISECONDS)
-      } catch (_: java.util.concurrent.TimeoutException) {
-        future.cancel(true)
-        error("timeout (${timeoutMs}ms) reading daemon frame on stdio")
-      } catch (e: java.util.concurrent.ExecutionException) {
-        // Unwrap the worker's failure so the assertion message points at the inner
-        // `daemon stdout closed mid-header` / malformed-header diagnostic instead of an opaque
-        // `ExecutionException`.
-        throw e.cause ?: e
-      }
-    } finally {
-      executor.shutdownNow()
-    }
-  }
-
-  /**
-   * Blocking single-frame reader. Runs on a worker thread submitted by [readFrameWithTimeoutMs] —
-   * the wait there enforces the timeout, this just does the I/O. The daemon may interleave stderr
-   * (redirected to a file in the caller so it doesn't pollute this stream) or fire-and-forget log
-   * lines on stdout in future; v1 doesn't, and the framing decoder catches violations.
-   */
-  private fun readFrameBlocking(stream: InputStream): String {
-    val header = StringBuilder()
-    while (true) {
-      val ch = stream.read()
-      check(ch != -1) { "daemon stdout closed mid-header. partial=${header}" }
-      header.append(ch.toChar())
-      if (header.endsWith("\r\n\r\n")) break
-    }
-    val contentLength =
-      Regex("""(?i)Content-Length:\s*(\d+)""").find(header)?.groupValues?.get(1)?.toIntOrNull()
-        ?: error("malformed daemon frame header: $header")
-    val buf = ByteArray(contentLength)
-    var read = 0
-    while (read < contentLength) {
-      val n = stream.read(buf, read, contentLength - read)
-      check(n != -1) { "daemon stdout closed mid-body. expected=$contentLength got=$read" }
-      read += n
-    }
-    return String(buf, Charsets.UTF_8)
   }
 
   private fun File.readTextOrEmpty(): String =

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleDaemonStdio.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleDaemonStdio.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.plugin
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Shared LSP-style JSON-RPC stdio helpers for the `compose-preview bundle daemon` e2e tests
+ * ([BundleDaemonEndToEndFunctionalTest], [AndroidBundleDaemonRenderFunctionalTest]).
+ *
+ * Mirrors the wire shape the VS Code extension's `DaemonClient` writes — `Content-Length`-framed
+ * UTF-8 JSON over the daemon subprocess's stdin/stdout — kept here so the tests stay free of any
+ * vscode-extension dependency. Reads are bounded by a wall-clock timeout (the blocking
+ * [InputStream.read] runs on a daemon worker thread waited on via [java.util.concurrent.Future])
+ * so a wedged daemon surfaces as a deterministic failure rather than hanging the suite.
+ */
+internal object BundleDaemonStdio {
+
+  fun jsonRpcRequest(id: Int, method: String, params: JsonObject? = null): String =
+    Json.encodeToString(
+      JsonObject.serializer(),
+      buildJsonObject {
+        put("jsonrpc", "2.0")
+        put("id", id)
+        put("method", method)
+        if (params != null) put("params", params)
+      },
+    )
+
+  fun jsonRpcNotification(method: String, params: JsonObject? = null): String =
+    Json.encodeToString(
+      JsonObject.serializer(),
+      buildJsonObject {
+        put("jsonrpc", "2.0")
+        put("method", method)
+        if (params != null) put("params", params)
+      },
+    )
+
+  fun writeFrame(stream: OutputStream, json: String) {
+    val bytes = json.toByteArray(Charsets.UTF_8)
+    val header = "Content-Length: ${bytes.size}\r\n\r\n".toByteArray(Charsets.US_ASCII)
+    stream.write(header)
+    stream.write(bytes)
+    stream.flush()
+  }
+
+  fun readFrameWithTimeoutMs(stream: InputStream, timeoutMs: Long): String {
+    val executor =
+      Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "bundle-daemon-frame-reader").apply { isDaemon = true }
+      }
+    try {
+      val future = executor.submit<String> { readFrameBlocking(stream) }
+      try {
+        return future.get(timeoutMs, TimeUnit.MILLISECONDS)
+      } catch (_: TimeoutException) {
+        future.cancel(true)
+        error("timeout (${timeoutMs}ms) reading daemon frame on stdio")
+      } catch (e: ExecutionException) {
+        // Unwrap the worker's failure so the assertion message points at the inner
+        // `daemon stdout closed mid-header` / malformed-header diagnostic instead of an opaque
+        // `ExecutionException`.
+        throw e.cause ?: e
+      }
+    } finally {
+      executor.shutdownNow()
+    }
+  }
+
+  private fun readFrameBlocking(stream: InputStream): String {
+    val header = StringBuilder()
+    while (true) {
+      val ch = stream.read()
+      check(ch != -1) { "daemon stdout closed mid-header. partial=${header}" }
+      header.append(ch.toChar())
+      if (header.endsWith("\r\n\r\n")) break
+    }
+    val contentLength =
+      Regex("""(?i)Content-Length:\s*(\d+)""").find(header)?.groupValues?.get(1)?.toIntOrNull()
+        ?: error("malformed daemon frame header: $header")
+    val buf = ByteArray(contentLength)
+    var read = 0
+    while (read < contentLength) {
+      val n = stream.read(buf, read, contentLength - read)
+      check(n != -1) { "daemon stdout closed mid-body. expected=$contentLength got=$read" }
+      read += n
+    }
+    return String(buf, Charsets.UTF_8)
+  }
+}


### PR DESCRIPTION
## Summary

The `composeDaemonClasspath` fix (appending a bundle's carried IR-replay libs onto the daemon launch `-cp`) is already on `main`, but it had **no end-to-end guard for the Android path** and the Android daemon sidecar wasn't actually packaged in the CLI. This PR closes both gaps.

**1. Ship `lib-daemon-android/` in the CLI dist (Phase 2 packaging).**
`compose-preview bundle daemon` can now launch an `backend="android"` bundle from a normal install. Because `:daemon:android` is an AGP `com.android.library`, `:cli` (plain JVM) can't stage its runtime the way the desktop daemon is staged. Instead a new `stageDaemonAndroidLibs` task consumes the module's existing `daemonHarnessClasspathFile` descriptor (the same text-file-of-jar-paths mechanism `:daemon:harness` uses), and copies the listed jars into `lib-daemon-android/`:
- drops `android.jar` (SDK platform jar — redistribution-sensitive; `BundleDaemonCommand` re-adds it from the consumer's `ANDROID_HOME` at launch);
- index-prefixes filenames (`%04d-<name>`) to preserve the descriptor's classpath precedence under the `lib-daemon-android/*` glob and dodge `classes.jar` / generated `R.jar` basename collisions.

The `composePreviewDaemonAndroid` configuration lives outside `runtimeClasspath`, so the `CheckCliDaemonLibraryBoundary` invariant still holds.

**2. `AndroidBundleDaemonRenderFunctionalTest` — the e2e that guards the fix.**
Packs real-sample bundles (`:samples:wear` Wear-tile + Compose, `:samples:remotecompose` Remote Compose), spawns the actual CLI binary against each, reads `bundle.json` to learn which preview ids are IR-backed vs classic, and drives `renderNow` over stdio JSON-RPC to render one of **each type to PNG**:
- a `protolayout` (Wear tile) IR preview,
- a `remotecompose` IR preview,
- a classic (non-IR) Compose preview.

It asserts each produces a **fresh, valid PNG** (magic-byte check) and that the daemon stderr contains **no `NoClassDefFoundError`** — the exact failure `composeDaemonClasspath` fixes (a parent-loaded replay host that can't see the carried player / tiles-renderer libs).

Stdio framing helpers are extracted to `BundleDaemonStdio` and shared with the existing desktop daemon e2e (dedup).

**3. Wiring.** New root task `functionalTestWithAndroidBundleDaemon` (builds the CLI install + sample bundles, then runs the gated test) and a `Android Bundle Daemon E2E` CI job. Opt-in via `-Pbundle.daemon.android.e2e=true`. The ubuntu-latest runner already ships an Android SDK, which the Robolectric daemon resolves `android.jar` from.

## Tradeoff

`:cli:installDist` / `:cli:build` now depend on building `:daemon:android`, so they require a local **Android SDK** (CI's ubuntu-latest already has one). Desktop-only contributors building `:cli` locally will now need an SDK.

## Test plan

- New CI job **Android Bundle Daemon E2E** runs the full path: pack → `bundle daemon` → render each preview type to PNG.
- Existing `Bundle Render E2E` (desktop) unaffected; its daemon e2e was refactored onto the shared `BundleDaemonStdio` (no behavior change).

> **Note for reviewers:** ktfmt could not be run in the authoring environment (no JDK 17 toolchain available to Gradle), so formatting was verified by hand. Please run `./gradlew ktfmtFormatAll` if the format check flags anything.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt)_