### PR TITLE
feat(vscode): open Android preview bundles in the bundle viewer

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -208,6 +208,12 @@
                     "scope": "machine-overridable",
                     "markdownDescription": "Absolute path to the `compose-preview` CLI launcher used by `Compose Preview: Open Preview Bundle…`. Empty (default) falls back to `$COMPOSE_PREVIEW_CLI` and then `compose-preview` on PATH (the install script's default landing spot is `~/.local/bin/compose-preview`)."
                 },
+                "composePreview.androidSdkPath": {
+                    "type": "string",
+                    "default": "",
+                    "scope": "machine-overridable",
+                    "markdownDescription": "Absolute path to a local Android SDK, used when opening an **Android** preview bundle (Wear tiles / Remote Compose / Robolectric). The bundle daemon needs `android.jar` from this SDK. Empty (default) falls back to `$ANDROID_HOME`, then `$ANDROID_SDK_ROOT`, then the workspace `local.properties` `sdk.dir`. Set this when VS Code is launched from the GUI (so it doesn't inherit your shell's `ANDROID_HOME`)."
+                },
                 "composePreview.logging.level": {
                     "type": "string",
                     "enum": [

--- a/vscode-extension/src/androidSdk.ts
+++ b/vscode-extension/src/androidSdk.ts
@@ -1,0 +1,127 @@
+// Android SDK resolution for the bundle viewer's daemon launch.
+//
+// An `backend="android"` bundle launches the Robolectric daemon, which needs
+// `android.jar` resolved from a local Android SDK (see the CLI's
+// `BundleDaemonCommand.androidDaemonLaunch`). When VS Code is launched from the
+// GUI (Finder/Dock on macOS, the Start menu on Windows) the spawned daemon does
+// NOT inherit the shell's `ANDROID_HOME`, so the launch fails with an opaque
+// error. We resolve an SDK path here and forward it into the daemon's env.
+//
+// Pure module (no `vscode` import) so the precedence logic is unit-testable; the
+// panel reads the `composePreview.androidSdkPath` setting + workspace root and
+// hands them in.
+//
+// Distinct from `launchOnDevice.ts`'s `findAndroidSdkRoot` on purpose: this adds
+// the `composePreview.androidSdkPath` setting at the top, takes an injectable
+// `env` (so the precedence is testable without mutating `process.env`), and
+// deliberately mirrors the CLI's resolution contract exactly (setting → env →
+// local.properties, no `~/.../Android/sdk` probing) so the env we forward to the
+// daemon matches what the daemon would resolve on its own.
+
+import * as fs from "fs";
+import * as path from "path";
+
+export type AndroidSdkSource =
+    | "setting"
+    | "ANDROID_HOME"
+    | "ANDROID_SDK_ROOT"
+    | "local.properties";
+
+export interface AndroidSdkResolution {
+    /** Absolute path to the Android SDK root (an existing directory). */
+    sdkDir: string;
+    /** Where the path came from — surfaced in the extension log. */
+    source: AndroidSdkSource;
+}
+
+export interface ResolveAndroidSdkOptions {
+    /** Value of the `composePreview.androidSdkPath` setting (may be empty). */
+    settingPath?: string;
+    /** Environment to read `ANDROID_HOME` / `ANDROID_SDK_ROOT` from. Defaults to `process.env`. */
+    env?: NodeJS.ProcessEnv;
+    /** Workspace root to look for `local.properties` (`sdk.dir`). */
+    workspaceRoot?: string;
+}
+
+/**
+ * Resolve an Android SDK location for the bundle daemon. Mirrors the precedence
+ * the CLI uses (`ANDROID_HOME` → `ANDROID_SDK_ROOT` → `local.properties`) but
+ * adds the `composePreview.androidSdkPath` setting at the top so users can point
+ * the panel at an SDK without touching their shell env. Each candidate must
+ * resolve to an existing directory; the first that does wins. Returns
+ * `undefined` when none resolves.
+ */
+export function resolveAndroidSdk(
+    opts: ResolveAndroidSdkOptions = {},
+): AndroidSdkResolution | undefined {
+    const env = opts.env ?? process.env;
+    const candidates: Array<{
+        value: string | undefined;
+        source: AndroidSdkSource;
+    }> = [
+        { value: opts.settingPath, source: "setting" },
+        { value: env.ANDROID_HOME, source: "ANDROID_HOME" },
+        { value: env.ANDROID_SDK_ROOT, source: "ANDROID_SDK_ROOT" },
+        {
+            value: readLocalPropertiesSdkDir(opts.workspaceRoot),
+            source: "local.properties",
+        },
+    ];
+    for (const candidate of candidates) {
+        const trimmed = candidate.value?.trim();
+        if (trimmed && isDirectory(trimmed)) {
+            return { sdkDir: trimmed, source: candidate.source };
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Env overrides handed to the daemon subprocess so its `android.jar` resolution
+ * finds [resolution]. Sets both `ANDROID_HOME` and `ANDROID_SDK_ROOT` since the
+ * CLI checks them in that order.
+ */
+export function androidSdkEnv(
+    resolution: AndroidSdkResolution,
+): Record<string, string> {
+    return {
+        ANDROID_HOME: resolution.sdkDir,
+        ANDROID_SDK_ROOT: resolution.sdkDir,
+    };
+}
+
+function isDirectory(candidate: string): boolean {
+    try {
+        return fs.statSync(candidate).isDirectory();
+    } catch {
+        return false;
+    }
+}
+
+function readLocalPropertiesSdkDir(workspaceRoot?: string): string | undefined {
+    if (!workspaceRoot) return undefined;
+    let text: string;
+    try {
+        text = fs.readFileSync(
+            path.join(workspaceRoot, "local.properties"),
+            "utf-8",
+        );
+    } catch {
+        return undefined;
+    }
+    for (const raw of text.split(/\r?\n/)) {
+        const line = raw.trim();
+        if (line.startsWith("#") || line.startsWith("!")) continue;
+        if (!line.startsWith("sdk.dir")) continue;
+        const eq = line.indexOf("=");
+        if (eq < 0) continue;
+        // Java `.properties` escapes `:` and `\` as `\:` / `\\` — common in a
+        // Windows `sdk.dir=C\:\\Users\\…`. Unescape so the path is usable.
+        const value = line
+            .slice(eq + 1)
+            .trim()
+            .replace(/\\(.)/g, "$1");
+        if (value) return value;
+    }
+    return undefined;
+}

--- a/vscode-extension/src/bundleDaemonHost.ts
+++ b/vscode-extension/src/bundleDaemonHost.ts
@@ -34,6 +34,11 @@ export interface BundleDaemonOptions {
      *  panel's value so the daemon's compatibility check passes
      *  identically. */
     clientVersion: string;
+    /** Extra environment merged onto `process.env` for the spawned daemon.
+     *  The panel populates this with `ANDROID_HOME` / `ANDROID_SDK_ROOT` for
+     *  an `backend="android"` bundle so the Robolectric daemon can resolve
+     *  `android.jar` even when VS Code was launched without a shell env. */
+    envOverrides?: Record<string, string>;
 }
 
 export interface BundleDaemonHandle {
@@ -79,6 +84,9 @@ export async function spawnBundleDaemon(
         {
             stdio: ["pipe", "pipe", "pipe"],
             windowsHide: true,
+            // Merge onto the inherited env (don't replace it) so PATH / JAVA_HOME
+            // stay intact while the panel can inject ANDROID_HOME for an android bundle.
+            env: { ...process.env, ...(opts.envOverrides ?? {}) },
         },
     );
     if (!child.stdin || !child.stdout || !child.stderr) {
@@ -88,12 +96,18 @@ export async function spawnBundleDaemon(
     }
     // The CLI emits a leading `[bundle-daemon] launching: …` block on
     // stderr before exec-ing the JVM; surface it (and subsequent daemon
-    // stderr) into the extension log so spawn failures are debuggable.
+    // stderr) into the extension log so spawn failures are debuggable. We
+    // also keep a short tail so an early death can quote the CLI's own
+    // actionable diagnostic (e.g. "backend=android needs android.jar — set
+    // ANDROID_HOME …") in the thrown error instead of just an exit code.
+    const stderrTail: string[] = [];
     child.stderr.setEncoding("utf-8");
     child.stderr.on("data", (chunk: string) => {
         for (const line of chunk.split(/\r?\n/)) {
             if (line.length === 0) continue;
             opts.logger?.appendLine(`[bundle-daemon] ${line}`);
+            stderrTail.push(line);
+            if (stderrTail.length > 20) stderrTail.shift();
         }
     });
 
@@ -111,9 +125,11 @@ export async function spawnBundleDaemon(
     // malformed beyond the manifest-read pre-flight.
     const earlyDeath = new Promise<never>((_, reject) => {
         child.once("exit", (code) => {
+            const tail =
+                stderrTail.length > 0 ? `\n${stderrTail.join("\n")}` : "";
             reject(
                 new BundleDaemonSpawnError(
-                    `bundle daemon exited before initialize (code=${code})`,
+                    `bundle daemon exited before initialize (code=${code})${tail}`,
                 ),
             );
         });

--- a/vscode-extension/src/bundleViewerPanel.ts
+++ b/vscode-extension/src/bundleViewerPanel.ts
@@ -321,8 +321,15 @@ export class BundleViewerPanel {
         const settingPath = vscode.workspace
             .getConfiguration("composePreview")
             .get<string>("androidSdkPath", "");
-        const workspaceRoot =
-            vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        // Prefer the workspace folder that actually contains the opened bundle so
+        // its `local.properties`/`sdk.dir` is consulted in a multi-root window;
+        // fall back to the first folder when the bundle lives outside any folder.
+        const bundleFolder = vscode.workspace.getWorkspaceFolder(
+            vscode.Uri.file(this.bundlePath),
+        );
+        const workspaceRoot = (
+            bundleFolder ?? vscode.workspace.workspaceFolders?.[0]
+        )?.uri.fsPath;
         const resolution = resolveAndroidSdk({ settingPath, workspaceRoot });
         if (!resolution) {
             this.deps.logLine(

--- a/vscode-extension/src/bundleViewerPanel.ts
+++ b/vscode-extension/src/bundleViewerPanel.ts
@@ -23,6 +23,7 @@ import {
     BundleFormatError,
     readBundleContents,
 } from "./bundleFormat";
+import { androidSdkEnv, resolveAndroidSdk } from "./androidSdk";
 import { BundleCliNotFoundError, locateBundleCli } from "./bundleRender";
 import {
     A11Y_DATA_KINDS,
@@ -308,6 +309,56 @@ export class BundleViewerPanel {
         void this.spawnDaemonAndSeed();
     }
 
+    /**
+     * Env overrides for the daemon subprocess. Only an `backend="android"`
+     * bundle needs them: it launches the Robolectric daemon, which resolves
+     * `android.jar` from the SDK. Returns `undefined` for desktop bundles, or
+     * when no SDK resolves (the daemon then falls back to its inherited env and
+     * surfaces an actionable error if that has none either).
+     */
+    private resolveAndroidDaemonEnv(): Record<string, string> | undefined {
+        if (this.contents.manifest?.backend !== "android") return undefined;
+        const settingPath = vscode.workspace
+            .getConfiguration("composePreview")
+            .get<string>("androidSdkPath", "");
+        const workspaceRoot =
+            vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        const resolution = resolveAndroidSdk({ settingPath, workspaceRoot });
+        if (!resolution) {
+            this.deps.logLine(
+                `${CHANNEL} android bundle: no Android SDK resolved (composePreview.androidSdkPath / ` +
+                    `ANDROID_HOME / ANDROID_SDK_ROOT / local.properties); relying on inherited env.`,
+            );
+            return undefined;
+        }
+        this.deps.logLine(
+            `${CHANNEL} android bundle: Android SDK from ${resolution.source}: ${resolution.sdkDir}`,
+        );
+        return androidSdkEnv(resolution);
+    }
+
+    /**
+     * Tack an actionable hint onto an android daemon launch failure whose
+     * message points at a missing SDK / sidecar, so the panel error tells the
+     * user how to fix it rather than just quoting the exit code.
+     */
+    private augmentSpawnError(message: string): string {
+        const isAndroid = this.contents.manifest?.backend === "android";
+        if (
+            isAndroid &&
+            /android\.jar|ANDROID_HOME|ANDROID_SDK_ROOT|lib-daemon-android/i.test(
+                message,
+            )
+        ) {
+            return (
+                `${message}\n\nThis is an Android bundle. Set the SDK location via the ` +
+                `\`composePreview.androidSdkPath\` setting (or export ANDROID_HOME before ` +
+                `launching VS Code), and ensure the compose-preview CLI ships the Android daemon.`
+            );
+        }
+        return message;
+    }
+
     private async spawnDaemonAndSeed(): Promise<void> {
         let cliPath: string;
         try {
@@ -324,6 +375,12 @@ export class BundleViewerPanel {
             );
             return;
         }
+        // An android bundle launches the Robolectric daemon, which needs
+        // android.jar from a local SDK. Resolve one (setting → ANDROID_HOME →
+        // ANDROID_SDK_ROOT → workspace local.properties) and forward it into the
+        // daemon's env so the launch works even when VS Code was started from the
+        // GUI without a shell ANDROID_HOME.
+        const envOverrides = this.resolveAndroidDaemonEnv();
         let daemon: BundleDaemonHandle;
         try {
             daemon = await vscode.window.withProgress(
@@ -340,6 +397,7 @@ export class BundleViewerPanel {
                             appendLine: (line) => this.deps.logLine(line),
                         },
                         clientVersion: CLIENT_VERSION,
+                        envOverrides,
                         events: {
                             onRenderFinished: (params) =>
                                 void this.onRenderFinished(params),
@@ -353,7 +411,10 @@ export class BundleViewerPanel {
         } catch (err) {
             const message = (err as Error).message ?? String(err);
             this.deps.logLine(`${CHANNEL} daemon spawn failed: ${message}`);
-            this.postError("Bundle daemon failed to start", message);
+            this.postError(
+                "Bundle daemon failed to start",
+                this.augmentSpawnError(message),
+            );
             return;
         }
         this.daemon = daemon;

--- a/vscode-extension/src/test/androidSdk.test.ts
+++ b/vscode-extension/src/test/androidSdk.test.ts
@@ -1,0 +1,110 @@
+// Coverage for the Android SDK resolution used by the bundle viewer's daemon
+// launch. Pure module (no `vscode`), so we drive it with explicit inputs:
+// real temp directories for the "must be an existing dir" candidates and a
+// synthetic `local.properties`.
+
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { androidSdkEnv, resolveAndroidSdk } from "../androidSdk";
+
+function tmpDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), "compose-sdk-test-"));
+}
+
+describe("resolveAndroidSdk", () => {
+    it("prefers the setting when it points at an existing directory", () => {
+        const setting = tmpDir();
+        const home = tmpDir();
+        const result = resolveAndroidSdk({
+            settingPath: setting,
+            env: { ANDROID_HOME: home },
+        });
+        assert.deepStrictEqual(result, {
+            sdkDir: setting,
+            source: "setting",
+        });
+    });
+
+    it("falls through a setting that isn't an existing directory", () => {
+        const home = tmpDir();
+        const result = resolveAndroidSdk({
+            settingPath: path.join(os.tmpdir(), "does-not-exist-xyz"),
+            env: { ANDROID_HOME: home },
+        });
+        assert.deepStrictEqual(result, {
+            sdkDir: home,
+            source: "ANDROID_HOME",
+        });
+    });
+
+    it("treats an empty setting as unset", () => {
+        const sdkRoot = tmpDir();
+        const result = resolveAndroidSdk({
+            settingPath: "   ",
+            env: { ANDROID_SDK_ROOT: sdkRoot },
+        });
+        assert.strictEqual(result?.source, "ANDROID_SDK_ROOT");
+        assert.strictEqual(result?.sdkDir, sdkRoot);
+    });
+
+    it("prefers ANDROID_HOME over ANDROID_SDK_ROOT", () => {
+        const home = tmpDir();
+        const root = tmpDir();
+        const result = resolveAndroidSdk({
+            env: { ANDROID_HOME: home, ANDROID_SDK_ROOT: root },
+        });
+        assert.deepStrictEqual(result, {
+            sdkDir: home,
+            source: "ANDROID_HOME",
+        });
+    });
+
+    it("reads sdk.dir from the workspace local.properties when env is empty", () => {
+        const sdk = tmpDir();
+        const workspaceRoot = tmpDir();
+        fs.writeFileSync(
+            path.join(workspaceRoot, "local.properties"),
+            `# generated\nsdk.dir=${sdk}\n`,
+        );
+        const result = resolveAndroidSdk({ env: {}, workspaceRoot });
+        assert.deepStrictEqual(result, {
+            sdkDir: sdk,
+            source: "local.properties",
+        });
+    });
+
+    it("ignores a local.properties whose sdk.dir doesn't exist", () => {
+        const workspaceRoot = tmpDir();
+        fs.writeFileSync(
+            path.join(workspaceRoot, "local.properties"),
+            "sdk.dir=/nope/not/here\n",
+        );
+        const result = resolveAndroidSdk({ env: {}, workspaceRoot });
+        assert.strictEqual(result, undefined);
+    });
+
+    it("returns undefined when nothing resolves", () => {
+        const result = resolveAndroidSdk({
+            settingPath: "",
+            env: {},
+            workspaceRoot: tmpDir(), // exists, but no local.properties
+        });
+        assert.strictEqual(result, undefined);
+    });
+});
+
+describe("androidSdkEnv", () => {
+    it("sets both ANDROID_HOME and ANDROID_SDK_ROOT", () => {
+        const env = androidSdkEnv({
+            sdkDir: "/opt/android",
+            source: "setting",
+        });
+        assert.deepStrictEqual(env, {
+            ANDROID_HOME: "/opt/android",
+            ANDROID_SDK_ROOT: "/opt/android",
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Follow-up to shipping `lib-daemon-android` (#1677): the CLI already branches `bundle daemon` on backend and ships the Android daemon, but the **VS Code bundle viewer panel** never accounted for the Android (Robolectric) launch path. That path needs `android.jar` from a local SDK — and when VS Code is launched from the GUI (common on macOS), the spawned daemon doesn't inherit the shell's `ANDROID_HOME`, so Android bundles (Wear tiles / Remote Compose / classic) failed with an **opaque exit-code error**.

This wires the panel up so Android bundles open and render:

- **SDK resolution + env forwarding.** For an `backend="android"` bundle the panel resolves an SDK — new **`composePreview.androidSdkPath`** setting → `ANDROID_HOME` → `ANDROID_SDK_ROOT` → workspace `local.properties` `sdk.dir` (mirroring the CLI's own contract) — and forwards it as `ANDROID_HOME`/`ANDROID_SDK_ROOT` into the daemon subprocess env (merged onto `process.env`, so `PATH`/`JAVA_HOME` stay intact). Desktop bundles are unaffected. The resolver is a pure, unit-tested module (`androidSdk.ts`).
- **Actionable errors.** `spawnBundleDaemon` now keeps a short stderr tail and quotes it in the early-death error, so the CLI's own diagnostic (e.g. *"backend=android needs android.jar — set ANDROID_HOME …"*) surfaces in the panel instead of just an exit code. For Android launch failures the panel adds an explicit hint pointing at the new setting. (This also improves desktop spawn-failure messages.)
- **Setting.** `composePreview.androidSdkPath` (machine-overridable), documented for the GUI-launch case.

## Why standalone vs `findAndroidSdkRoot`

There's an existing `findAndroidSdkRoot` in `launchOnDevice.ts`, but it reads `process.env`/`os.homedir()` directly (not injectable) and probes default `~/.../Android/sdk` locations. Reusing it would make resolution non-deterministic in tests (any machine with an SDK installed, incl. CI) and wouldn't support the new setting. The new resolver is intentionally separate — setting-aware, injectable `env` for hermetic tests, and matching the daemon's exact resolution contract — and the header comment says so.

## Test plan

- `npm run compile` — clean.
- `npm test` (mocha) — **1426 passing**, including 8 new `androidSdk` tests covering setting precedence, env fallbacks, `local.properties`, the "nothing resolves" case, and the env builder.
- `npm run format:check` — clean.

> Note: the repo's `lint` script (`eslint --ext ts`) doesn't run under the eslint v10 installed in my environment (flat-config migration) — pre-existing and unrelated to this change; CI uses its pinned toolchain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt)_