### PR TITLE
fix(cli): make stageDaemonAndroidLibs build script compile (java.io.File shadowing)

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,3 +1,4 @@
+import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
@@ -240,10 +241,10 @@ abstract class StageDaemonAndroidLibs : DefaultTask() {
       .readLines()
       .map { it.trim() }
       .filter { it.isNotEmpty() }
-      .map { java.io.File(it) }
+      .map { File(it) }
       .filter { it.isFile && it.name.endsWith(".jar") && it.name != "android.jar" }
       .forEachIndexed { index, jar ->
-        jar.copyTo(java.io.File(dest, "%04d-%s".format(index, jar.name)))
+        jar.copyTo(File(dest, "%04d-%s".format(index, jar.name)))
       }
   }
 }


### PR DESCRIPTION
## Problem — `main` is currently red

`#1677`'s `stageDaemonAndroidLibs` task in `cli/build.gradle.kts` uses fully-qualified `java.io.File(...)`. In a Gradle Kotlin DSL build script the `java` **accessor** (added by the applied `java`/`application` plugin) shadows the `java` **package**, so `java.io.File` fails to resolve:

```
Line 246: jar.copyTo(java.io.File(dest, "%04d-%s".format(index, jar.name)))
                          ^ Unresolved reference 'io'.
Line 244: .filter { it.isFile && it.name.endsWith(".jar") && ... }
                          ^ Unresolved reference 'isFile'.   (cascades — 11 errors)
```

This breaks build-script compilation, so **every CI job that configures the build fails** (Build CLI, Build plugin + CLI, Plugin Unit/Functional Tests, Build Samples, the bundle-daemon e2es, the Daemon Harness jobs, …). It landed because #1677 merged before its **Build CLI** job finished, and I couldn't catch it locally — Gradle can't provision a JDK 17 toolchain in my authoring sandbox.

## Fix

`import java.io.File` and use the simple name `File(...)`, which doesn't go through the shadowed `java` accessor. One-line import + two call sites; no behavior change.

## Test plan

Build-script-only change; verified by inspection (Gradle unavailable in the authoring environment). CI on this PR — specifically **Build CLI** / **Build plugin + CLI** — is the real check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfaNXiHR4H1XfFMtRjWsAt)_