### PR TITLE
style(cli): ktfmt-format stageDaemonAndroidLibs build script

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -217,7 +217,8 @@ val stageDaemonDesktopLibs =
 
 // Stage the Android daemon's runtime jars from `:daemon:android`'s `daemonHarnessClasspathFile`
 // descriptor (a newline-separated text file of absolute jar paths, ordered module-jar →
-// testFixtures → R.jar → full test runtime → android.jar; see that module's `writeDaemonClasspath`).
+// testFixtures → R.jar → full test runtime → android.jar; see that module's
+// `writeDaemonClasspath`).
 // We copy each listed jar into a build dir so the distribution wiring can fold it into
 // `lib-daemon-android/`. Two deliberate transforms:
 //   - `android.jar` is dropped: it's the SDK platform jar (redistribution-sensitive, and
@@ -243,9 +244,7 @@ abstract class StageDaemonAndroidLibs : DefaultTask() {
       .filter { it.isNotEmpty() }
       .map { File(it) }
       .filter { it.isFile && it.name.endsWith(".jar") && it.name != "android.jar" }
-      .forEachIndexed { index, jar ->
-        jar.copyTo(File(dest, "%04d-%s".format(index, jar.name)))
-      }
+      .forEachIndexed { index, jar -> jar.copyTo(File(dest, "%04d-%s".format(index, jar.name))) }
   }
 }
 


### PR DESCRIPTION
## Problem — `main`'s format gate is red

#1677 left `cli/build.gradle.kts` unformatted (an over-length comment line and a `forEachIndexed` block that ktfmt wants on one line). #1680 fixed the `java.io.File` compile error but merged with its **ktfmt** check still red, so the format gate is now failing on `main`:

```
> Task :cli:ktfmtCheckScripts FAILED
[ktfmt] Invalid formatting for: cli/build.gradle.kts
```

## Fix

Apply ktfmt (`googleStyle`, the repo's configured style — plugin 0.26.0 → ktfmt core 0.62) to `cli/build.gradle.kts`. Two purely cosmetic changes: wrap the over-length comment line and collapse the `forEachIndexed` lambda onto one line. No behavior change.

## Test plan

- Formatted with the standalone ktfmt 0.62 jar (the version the `com.ncorti.ktfmt.gradle` 0.26.0 plugin resolves) using `--google-style`; re-running is idempotent (stable output).
- Gradle's own `ktfmtCheckScripts` couldn't run in the authoring environment (only JDK 21 available; the build needs an auto-provisioned JDK 17 toolchain), so CI's **ktfmt (Google style)** / **Build CLI** jobs are the real check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjYP3v8o7EsubKtFUCxmn9)_