### PR TITLE
fix(plugin): tolerate unselectable runtime deps when probing aar/jar packaging

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -110,7 +110,10 @@ val functionalTestTask =
     // build's `functionalTestWithAndroidBundleDaemon` task flips it on after building the bundles.
     val androidBundleDaemonE2E =
       providers.gradleProperty("bundle.daemon.android.e2e").orNull == "true"
-    systemProperty("composeai.functionalTest.androidBundleDaemon", androidBundleDaemonE2E.toString())
+    systemProperty(
+      "composeai.functionalTest.androidBundleDaemon",
+      androidBundleDaemonE2E.toString(),
+    )
     // Paths to the Android sample bundles the test renders. Built by the root build's
     // `:samples:wear:composePreviewBundle` / `:samples:remotecompose:composePreviewBundle`. Passed
     // unconditionally (config-cache-safe, same rationale as `cliBinary` below); the test self-skips

--- a/gradle-plugin/preview-discovery/build.gradle.kts
+++ b/gradle-plugin/preview-discovery/build.gradle.kts
@@ -72,7 +72,5 @@ composeAiMavenPublishing {
 // "CLI invocation" section in `docs/NON_GRADLE_INTEGRATION.md` for the consumer-facing
 // contract.
 tasks.named<Jar>("jar").configure {
-  manifest {
-    attributes("Main-Class" to "ee.schimke.composeai.discovery.PreviewDiscoveryCli")
-  }
+  manifest { attributes("Main-Class" to "ee.schimke.composeai.discovery.PreviewDiscoveryCli") }
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleDaemonStdio.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleDaemonStdio.kt
@@ -18,8 +18,8 @@ import kotlinx.serialization.json.put
  * Mirrors the wire shape the VS Code extension's `DaemonClient` writes — `Content-Length`-framed
  * UTF-8 JSON over the daemon subprocess's stdin/stdout — kept here so the tests stay free of any
  * vscode-extension dependency. Reads are bounded by a wall-clock timeout (the blocking
- * [InputStream.read] runs on a daemon worker thread waited on via [java.util.concurrent.Future])
- * so a wedged daemon surfaces as a deterministic failure rather than hanging the suite.
+ * [InputStream.read] runs on a daemon worker thread waited on via [java.util.concurrent.Future]) so
+ * a wedged daemon surfaces as a deterministic failure rather than hanging the suite.
  */
 internal object BundleDaemonStdio {
 
@@ -53,10 +53,9 @@ internal object BundleDaemonStdio {
   }
 
   fun readFrameWithTimeoutMs(stream: InputStream, timeoutMs: Long): String {
-    val executor =
-      Executors.newSingleThreadExecutor { runnable ->
-        Thread(runnable, "bundle-daemon-frame-reader").apply { isDaemon = true }
-      }
+    val executor = Executors.newSingleThreadExecutor { runnable ->
+      Thread(runnable, "bundle-daemon-frame-reader").apply { isDaemon = true }
+    }
     try {
       val future = executor.submit<String> { readFrameBlocking(stream) }
       try {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -250,13 +250,29 @@ internal object ComposePreviewTasks {
     // the *untransformed* artifacts too and key each component's packaging off its file extension
     // (Android deps resolve to `.aar`, JVM deps to `.jar`), then stamp it into the coordinate
     // below.
+    //
+    // This read goes through a `lenient(true)` artifactView rather than the raw
+    // `incoming.artifacts`. The raw read selects artifacts using the configuration's full runtime
+    // attributes, which a dependency exposing AGP secondary variants without the standard
+    // `org.gradle.category` / jvm-environment / `kotlin.platform.type` attributes (e.g. an Android
+    // library relying on AGP's built-in Kotlin, consumed on an app's `…RuntimeClasspath`) can't
+    // satisfy — turning packaging detection into a hard `AmbiguousArtifactsFailure` that fails the
+    // whole bundle. `lenient(true)` skips any such unselectable dep here; it simply isn't keyed in
+    // the packaging map and falls back to the `"jar"` default at the coordinate below. The
+    // `artifactType=jar` view that feeds the actual classpath/closure walk is unaffected — it
+    // selects each dep's `jar` secondary variant unambiguously.
     val typeByComponent: Provider<Map<String, String>> =
-      depConfig?.incoming?.artifacts?.resolvedArtifacts?.map { artifacts ->
-        artifacts.associate { artifact ->
-          artifact.id.componentIdentifier.displayName to
-            if (artifact.file.name.endsWith(".aar", ignoreCase = true)) "aar" else "jar"
-        }
-      } ?: project.providers.provider { emptyMap<String, String>() }
+      depConfig
+        ?.incoming
+        ?.artifactView { lenient(true) }
+        ?.artifacts
+        ?.resolvedArtifacts
+        ?.map { artifacts ->
+          artifacts.associate { artifact ->
+            artifact.id.componentIdentifier.displayName to
+              if (artifact.file.name.endsWith(".aar", ignoreCase = true)) "aar" else "jar"
+          }
+        } ?: project.providers.provider { emptyMap<String, String>() }
     // Map each resolved dependency jar to a coordinate string the task action can fold into
     // `bundle.json`'s `classpath`:
     // - `maven:<group>:<artifact>:<version>:<aar|jar>` for Maven-resolved deps (the player resolves


### PR DESCRIPTION
## Problem

The `Android Bundle Daemon E2E` job died at **configuration time**: `:samples:wear:composePreviewBundle` resolves `:samples:wear`'s `debugRuntimeClasspath` as files, and `:data-ambient-connector` (an AGP-9 built-in-Kotlin Android library, the first such module consumed directly by an Android *app* bundle) exposes runtime artifact variants that the consumer can't disambiguate → `ArtifactSelectionException` ("cannot choose between variants … doesn't say anything about component category / java environment / kotlin.platform.type"). `:daemon:android` dodges this only because it's consumed through a custom `artifactType=jar` artifactView.

## Fix

Resolve that runtime classpath through the same disambiguating `artifactView` the rest of `AndroidPreviewSupport.kt` already uses (the `lenient`-tolerant probe), so an unselectable Android-library variant no longer aborts the packaging probe.

Result, confirmed by CI: the E2E goes from **dying at config time (0 useful work)** to **490 tasks executed, bundles packed, daemon started, 50 of 51 tests passing**.

Also folds in pre-existing **ktfmt** debt from #1677 that was masking behind itself in the gradle-plugin included build (merged red there): `BundleDaemonStdio.kt`, `gradle-plugin/build.gradle.kts`, `preview-discovery/build.gradle.kts`. `ktfmt (Google style)` is now green.

## Scope / status

- ✅ All checks green **except** `Android Bundle Daemon E2E`.
- ⏳ The one remaining E2E failure is a **separate, pre-existing render-path bug** — the daemon emits `renderFinished` with a `pngPath` that isn't on disk (`AndroidBundleDaemonRenderFunctionalTest.kt:223`, 1/51). It's unrelated to this resolution fix and tracked in **#1687**. This test never passed on `main` (the E2E shipped in #1677, which merged red), so this PR is a strict improvement that gets the job running for the first time.

## Test plan

- CI: `Android Bundle Daemon E2E` now builds + runs the suite (50/51); all other jobs green incl. ktfmt, Build CLI, Plugin Functional/Unit Tests, Bundle Render E2E, sample integrations.
- The resolution change can't be exercised in the authoring sandbox (no Android SDK / Robolectric); CI is the verification.