### PR TITLE
fix(daemon): Android bundle-daemon E2E render-path bug (#1687)

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -74,6 +74,16 @@ val functionalTestTask =
     classpath = functionalTest.runtimeClasspath
     useJUnit()
 
+    // Surface the full failure message + stack trace for failed functional tests on the console.
+    // Without this Gradle prints only `<Exception> at <File>:<line>`, which hides the assertion
+    // message — and these E2Es (Robolectric daemon, CLI subprocess) carry their diagnostic context
+    // in the message (e.g. the missing PNG path, daemon stderr tail), invisible in CI logs
+    // otherwise.
+    testLogging {
+      exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+      events("failed")
+    }
+
     // `CliA11yEndToEndFunctionalTest` (and any future Android-flavour functional test) requires
     // a `publishToMavenLocal` pre-step so its synthetic `com.android.library` project can
     // resolve the renderer AAR closure from `~/.m2`. The `mustRunAfter` ensures the publish

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AndroidBundleDaemonRenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AndroidBundleDaemonRenderFunctionalTest.kt
@@ -218,9 +218,22 @@ class AndroidBundleDaemonRenderFunctionalTest {
         .containsAtLeastElementsIn(selected)
       for ((id, pngPath) in finished) {
         val png = File(pngPath)
-        assertWithMessage("render PNG missing for $id at $pngPath (bundle=${bundle.name})")
-          .that(png.isFile)
-          .isTrue()
+        // Rich diagnostics for the "daemon reported renderFinished but the PNG isn't there" failure
+        // (see #1687): the reported path, the preview's IR format, what the daemon actually wrote
+        // into the output dir, and the daemon stderr tail (which logs each render's pngPath).
+        val parent = png.parentFile
+        val dirListing =
+          parent
+            ?.listFiles()
+            ?.sortedBy { it.name }
+            ?.joinToString("\n") { "    ${it.name} (${it.length()} bytes)" }
+            ?: "    (output dir does not exist: $parent)"
+        val missingDiagnostics =
+          "render PNG missing for $id at $pngPath (bundle=${bundle.name})\n" +
+            "  format=${manifest.formatById[id] ?: "classic"}\n" +
+            "  output dir $parent contents:\n$dirListing\n" +
+            "  daemon stderr (tail):\n${stderr.takeLast(4000)}"
+        assertWithMessage(missingDiagnostics).that(png.isFile).isTrue()
         assertWithMessage("render PNG empty for $id at $pngPath")
           .that(png.length())
           .isGreaterThan(0L)


### PR DESCRIPTION
Investigates and fixes #1687 — the Android Bundle Daemon E2E reports `renderFinished` with a `pngPath` that isn't on disk (1/51, `AndroidBundleDaemonRenderFunctionalTest.kt:223`).

## Status: investigating (diagnostics first)

The bug isn't obvious from a static read — both IR-replay branches (protolayout `TileIrReplayComposable`, remotecompose `InvokeIrReplay`) render inside `setContent { }` and flow through the same `captureRoboImage(file = outputFile)` as classic previews, and all `pngPath` emission sites report `outputFile.absolutePath`. I also can't reproduce locally (no Android SDK / Robolectric in the authoring sandbox) or read the run's report artifact.

So this first commit makes the failure **self-diagnosing on the CI console**, which it wasn't:
- `testLogging { exceptionFormat = FULL; events("failed") }` on the gradle-plugin `functionalTest` task (it previously printed only `<Exception> at File:line`, hiding the message).
- The missing-PNG assertion now embeds the preview's IR **format**, the actual **output-dir listing**, and the **daemon stderr tail** (which logs each render's `pngPath`).

Once CI surfaces which preview/path/format fails and what the daemon actually wrote, I'll push the real fix to this branch (and switch this description to `Closes #1687`). Both diagnostic changes are worth keeping regardless.

## Test plan
- CI's `Android Bundle Daemon E2E` is the subject; the enriched failure output drives the fix.
- ktfmt verified on the two changed gradle-plugin files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjYP3v8o7EsubKtFUCxmn9)_