### PR TITLE
fix: render Android bundle-daemon classic previews end-to-end (#1685 wiring + #1687)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,26 @@ jobs:
       # Split into two phases for the same parallel-execution race the desktop bundle-render job
       # documents: the included-build functionalTest can start before `:cli:installDist` finishes
       # populating the lib dirs. Pre-building serialises the two (and is otherwise no-op).
+      #
+      # Render the samples FIRST, in their own invocation, exactly as the desktop bundle-render job
+      # does (preview-bundle-ascii.yml): `composePreviewBundle` deliberately does NOT depend on
+      # `composePreviewRender` (packing without a render is a valid stub-cover flow) — it only
+      # `mustRunAfter`s it. So the IR sidecars (`<stem>.tilelayout`/`.tileresources`/`.rcdoc`) the
+      # render step writes beside each PNG have to already exist on disk before the bundle task's
+      # first execution to be baked into `intermediateRepresentations`. Without this step the packed
+      # bundles carry no IR and every preview falls back to classic, so the protolayout/remotecompose
+      # assertions below can never pass. `composePreviewBundle` tracks the renders dir as an input
+      # (`renderFiles`), so the fresh renders are picked up — no `--rerun-tasks` needed.
+      # `missingRenders=warn` rather than the default `fail`: these samples render here for the first
+      # time, and the E2E only needs at least one protolayout + one remotecompose IR to land — a
+      # single stubborn preview shouldn't fail the whole job (its `.error.json` still surfaces).
+      - name: Render sample previews (captures Wear tile + Remote Compose IR sidecars)
+        run: >-
+          ./gradlew
+          :samples:wear:composePreviewRenderAll
+          :samples:remotecompose:composePreviewRenderAll
+          -PcomposePreview.missingRenders=warn
+          --stacktrace
       - name: Pre-build CLI install + sample bundles + publish plugin
         run: >-
           ./gradlew :cli:installDist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,9 @@ jobs:
       # End-to-end for the Android path of `bundle daemon`: pack real-sample bundles (Wear tile +
       # Remote Compose IR, plus classic Compose previews), then spawn the actual CLI binary against
       # each and render protolayout / remotecompose / classic previews to PNG via the Robolectric
-      # daemon. Guards (1) `lib-daemon-android/` being staged into the CLI dist and (2)
+      # daemon. Guards (1) the Android daemon runtime being staged by `:cli:stageDaemonAndroidLibs`
+      # (post-#1685 it ships as a standalone archive, not inside the CLI dist; the test points the
+      # CLI at the staged dir via `-Dcomposeai.cli.libDaemonAndroidDir`) and (2)
       # `BundleDaemonCommand.composeDaemonClasspath` putting the carried IR-replay libs on the
       # daemon `-cp` (else replay dies with NoClassDefFoundError). The ubuntu-latest image ships an
       # Android SDK (ANDROID_HOME/ANDROID_SDK_ROOT) which the daemon launch resolves android.jar
@@ -196,6 +198,7 @@ jobs:
       - name: Pre-build CLI install + sample bundles + publish plugin
         run: >-
           ./gradlew :cli:installDist
+          :cli:stageDaemonAndroidLibs
           :samples:wear:composePreviewBundle
           :samples:remotecompose:composePreviewBundle
           :gradle-plugin:publishToMavenLocal --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -163,8 +163,12 @@ tasks.register("functionalTestWithAndroidBundleDaemon") {
   // tests that resolve the plugin (and renderer-desktop transitives) from mavenLocal.
   bundleRenderFunctionalTestPublishTargets.forEach { dependsOn("$it:publishToMavenLocal") }
   dependsOn(gradle.includedBuild("gradle-plugin").task(":publishToMavenLocal"))
-  // CLI install dist carries `lib-daemon-android/` (the new `stageDaemonAndroidLibs` output).
+  // The CLI install dist provides the `compose-preview` binary; #1685 moved the Android daemon
+  // runtime OUT of it into a standalone archive, so those jars now come from the staged dir
+  // produced by `:cli:stageDaemonAndroidLibs`. The test points the CLI at that dir via
+  // `-Dcomposeai.cli.libDaemonAndroidDir`.
   dependsOn(":cli:installDist")
+  dependsOn(":cli:stageDaemonAndroidLibs")
   // The Android sample bundles the test renders. Each `composePreviewBundle` runs the plugin's
   // render (Robolectric) + pack against the real sample, emitting an `backend="android"` bundle
   // with non-empty `intermediateRepresentations` (Wear tile + Remote Compose IR) alongside classic

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -629,7 +629,18 @@ open class RobolectricHost(
     require(request !is RenderRequest.Shutdown) {
       "Use shutdown() to stop the host, not submit(Shutdown)."
     }
-    val typed = request as RenderRequest.Render
+    val inbound = request as RenderRequest.Render
+    // #1687 — `JsonRpcServer.encodeRenderPayload` only knows the protocol-level `previewId=<id>`
+    // (it can't name the class/function), so a plain (non-router) host would fall through to
+    // `renderStub` for every classic renderNow. Resolve the id to a spec payload here, on the host
+    // thread, before the request crosses into the sandbox — the Android analogue of
+    // `DesktopHost.specFromPreviewIdPayload`. No-op (same instance) when the payload is already a
+    // spec payload, no resolver is wired, or the id is unknown — see [reshapeRenderPayload].
+    val typed =
+      reshapeRenderPayload(inbound.payload).let { reshaped ->
+        if (reshaped === inbound.payload) inbound
+        else RenderRequest.Render(id = inbound.id, payload = reshaped)
+      }
     // SANDBOX-POOL.md — slot dispatch. Hash the **previewId** to a slot so the same preview always
     // lands on the same sandbox; Compose snapshot caches and Robolectric shadow caches accumulate
     // per-sandbox and pay off on repeat renders. Falls back to the request id when the payload
@@ -707,6 +718,91 @@ open class RobolectricHost(
       }
     }
     return null
+  }
+
+  /**
+   * Host-side reshape of a core-issued `renderNow` payload (#1687).
+   * [JsonRpcServer.encodeRenderPayload] emits only the protocol-level `previewId=<id>` (plus any
+   * [PreviewOverrides] tokens); it can't name the class/function. When a [previewSpecResolver] is
+   * wired — production [DaemonMain] backs it with the bundle's `previews.json` — we resolve the id
+   * to a [RenderSpec] on the host thread and rewrite the payload into the parseable
+   * `className=…;functionName=…` shape the sandbox's [SandboxRunner.dispatchRender] expects.
+   * Mirrors [DesktopHost.specFromPreviewIdPayload] and the [PreviewManifestRouter]; inbound
+   * override tokens win over the spec's per-preview defaults.
+   *
+   * Returns [payload] unchanged (same instance) when it already carries `className=` (router output
+   * or a direct spec-payload caller), when no resolver is wired (in-process unit tests), or when
+   * the resolver doesn't know the id — in those cases [dispatchRender] keeps its existing behaviour
+   * (parse the spec, or fall through to [renderStub] for legacy `render-N` payloads). Without this,
+   * the Android bundle daemon (which never mounts a [PreviewManifestRouter]) stubbed every classic
+   * preview, emitting a `renderFinished` with a `daemon-stub-<id>.png` path that was never written.
+   */
+  internal fun reshapeRenderPayload(payload: String): String {
+    if (payload.contains("className=")) return payload
+    val resolver = previewSpecResolver ?: return payload
+    val inbound = parsePayloadMap(payload)
+    val previewId = inbound["previewId"]?.takeIf { it.isNotBlank() } ?: return payload
+    val base = resolver(previewId) ?: return payload
+    return buildString {
+      append("previewId=").append(previewId).append(';')
+      append("className=").append(base.className).append(';')
+      append("functionName=").append(base.functionName).append(';')
+      // Inbound explicit override wins over the spec's per-preview default. `device=` overrides are
+      // pre-resolved into widthPx/heightPx/density by `JsonRpcServer.encodeRenderPayload`.
+      append("widthPx=").append(inbound["widthPx"] ?: base.widthPx).append(';')
+      append("heightPx=").append(inbound["heightPx"] ?: base.heightPx).append(';')
+      append("density=").append(inbound["density"] ?: base.density).append(';')
+      append("showBackground=").append(base.showBackground).append(';')
+      if (base.backgroundColor != 0L) {
+        append("backgroundColor=").append(base.backgroundColor).append(';')
+      }
+      // The raw device string is forwarded so the render body's round-Wear crop heuristic sees it.
+      (inbound["device"]?.takeIf { it.isNotBlank() } ?: base.device)
+        ?.takeIf { it.isNotBlank() }
+        ?.let { append("device=").append(it).append(';') }
+      (inbound["localeTag"] ?: base.localeTag)
+        ?.takeIf { it.isNotBlank() }
+        ?.let { append("localeTag=").append(it).append(';') }
+      (inbound["fontScale"] ?: base.fontScale?.toString())?.let {
+        append("fontScale=").append(it).append(';')
+      }
+      (inbound["uiMode"] ?: base.uiMode?.name?.lowercase())?.let {
+        append("uiMode=").append(it).append(';')
+      }
+      (inbound["orientation"] ?: base.orientation?.name?.lowercase())?.let {
+        append("orientation=").append(it).append(';')
+      }
+      inbound["captureAdvanceMs"]?.let { append("captureAdvanceMs=").append(it).append(';') }
+      (inbound["inspectionMode"] ?: base.inspectionMode?.toString())?.let {
+        append("inspectionMode=").append(it).append(';')
+      }
+      inbound["overrides"]?.let { append("overrides=").append(it).append(';') }
+      inbound["mode"]?.let { append("mode=").append(it).append(';') }
+      (inbound["kind"]?.takeIf { it.isNotBlank() } ?: base.kind)
+        ?.takeIf { it.isNotBlank() }
+        ?.let { append("kind=").append(it).append(';') }
+      base.wrapperClassName
+        ?.takeIf { it.isNotBlank() }
+        ?.let { append("wrapperClassName=").append(it).append(';') }
+      // Key the output PNG on the (unique) previewId, like [PreviewManifestRouter]; the default
+      // `className-functionName` stem would collide for the multiple `@Preview` / @WearPreview*
+      // variants that share one function, overwriting each other's render.
+      append("outputBaseName=").append(previewId)
+    }
+  }
+
+  /** Parses a `;`-delimited `key=value` payload into a map; mirrors [PreviewManifestRouter]. */
+  private fun parsePayloadMap(payload: String): Map<String, String> {
+    val map = mutableMapOf<String, String>()
+    for (entry in payload.split(';')) {
+      val trimmed = entry.trim()
+      if (trimmed.isEmpty()) continue
+      val eq = trimmed.indexOf('=')
+      if (eq <= 0) continue
+      val v = trimmed.substring(eq + 1).trim()
+      if (v.isNotEmpty()) map[trimmed.substring(0, eq).trim()] = v
+    }
+    return map
   }
 
   private fun copyResultAcrossClassloaders(raw: Any): RenderResult {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -124,6 +124,14 @@ val functionalTestTask =
       "composeai.functionalTest.androidBundleDaemon",
       androidBundleDaemonE2E.toString(),
     )
+    // #1685 moved the Android daemon runtime out of the CLI install dist into a standalone archive,
+    // so the e2e points the CLI at the staged jars dir (`:cli:stageDaemonAndroidLibs` output) via
+    // `-Dcomposeai.cli.libDaemonAndroidDir`. Passed unconditionally (config-cache-safe, same
+    // rationale as `cliBinary` below); the test asserts it exists past the opt-in gate.
+    systemProperty(
+      "composeai.functionalTest.libDaemonAndroidDir",
+      rootDir.parentFile?.resolve("cli/build/staged-daemon-android-libs")?.absolutePath ?: "",
+    )
     // Paths to the Android sample bundles the test renders. Built by the root build's
     // `:samples:wear:composePreviewBundle` / `:samples:remotecompose:composePreviewBundle`. Passed
     // unconditionally (config-cache-safe, same rationale as `cliBinary` below); the test self-skips

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AndroidBundleDaemonRenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AndroidBundleDaemonRenderFunctionalTest.kt
@@ -75,13 +75,21 @@ class AndroidBundleDaemonRenderFunctionalTest {
     // Tracks which kinds of preview actually rendered across both bundles: protolayout (Wear
     // tile IR), remotecompose (RC doc IR), and classic (reflected app.jar Compose preview).
     val formatsSeen = mutableSetOf<String>()
-    renderBundle(cli, File(wearBundle), formatsSeen)
-    renderBundle(cli, File(remoteComposeBundle), formatsSeen)
+    // TEMP diagnostic (remove before merge): the IR breakdown of each bundle, surfaced in the
+    // assertion message so a green-but-classic-only run still prints why no IR preview was
+    // exercised (empty `intermediateRepresentations` in bundle.json vs a parse/selection mismatch).
+    val diagnostics = StringBuilder()
+    renderBundle(cli, File(wearBundle), formatsSeen, diagnostics)
+    renderBundle(cli, File(remoteComposeBundle), formatsSeen, diagnostics)
 
-    assertWithMessage("expected a protolayout (Wear tile) IR preview to render. saw: $formatsSeen")
+    assertWithMessage(
+        "expected a protolayout (Wear tile) IR preview to render. saw: $formatsSeen\n$diagnostics"
+      )
       .that(formatsSeen)
       .contains("protolayout")
-    assertWithMessage("expected a remotecompose IR preview to render. saw: $formatsSeen")
+    assertWithMessage(
+        "expected a remotecompose IR preview to render. saw: $formatsSeen\n$diagnostics"
+      )
       .that(formatsSeen)
       .contains("remotecompose")
     assertWithMessage("expected a classic (non-IR) Compose preview to render. saw: $formatsSeen")
@@ -94,7 +102,12 @@ class AndroidBundleDaemonRenderFunctionalTest {
    * preview, render them via `renderNow`, and assert each produces a fresh, valid PNG. Records the
    * rendered formats into [formatsSeen].
    */
-  private fun renderBundle(cli: File, bundle: File, formatsSeen: MutableSet<String>) {
+  private fun renderBundle(
+    cli: File,
+    bundle: File,
+    formatsSeen: MutableSet<String>,
+    diagnostics: StringBuilder,
+  ) {
     assertWithMessage(
         "sample bundle missing: ${bundle.path} — did `:samples:…:composePreviewBundle` run? Use " +
           "`./gradlew functionalTestWithAndroidBundleDaemon`"
@@ -258,6 +271,16 @@ class AndroidBundleDaemonRenderFunctionalTest {
         formatsSeen.add(manifest.formatById[id] ?: "classic")
       }
 
+      // TEMP diagnostic (remove before merge): per-bundle IR breakdown, appended to the buffer the
+      // top-level `formatsSeen` assertion prints. Confirms (or refutes) that the CI-built bundle
+      // carries no IR, which would explain why only classic previews are ever selected/rendered.
+      diagnostics.append("\n[${bundle.name}] backend=${manifest.backend}")
+      diagnostics.append(" previewIds(${manifest.previewIds.size})=${manifest.previewIds}")
+      diagnostics.append("\n  intermediateRepresentations(raw)=${manifest.rawIr}")
+      diagnostics.append("\n  formatById=${manifest.formatById}")
+      diagnostics.append("\n  selected=$selected")
+      diagnostics.append("\n  finished=${finished.keys}")
+
       // The exact failure `composeDaemonClasspath` fixes: a parent-loaded IR replay host that can't
       // see the carried player / tiles-renderer libs trips NoClassDefFoundError at replay time.
       assertWithMessage(
@@ -345,7 +368,10 @@ class AndroidBundleDaemonRenderFunctionalTest {
           val ir = it.jsonObject
           ir["previewId"]!!.jsonPrimitive.content to ir["format"]!!.jsonPrimitive.content
         } ?: emptyMap()
-      return BundleManifestInfo(backend, previewIds, formatById)
+      // TEMP diagnostic (remove before merge): the raw IR array as the bundle writer emitted it, so
+      // CI shows whether `intermediateRepresentations` is genuinely empty vs a parse mismatch.
+      val rawIr = root["intermediateRepresentations"]?.toString() ?: "(key absent)"
+      return BundleManifestInfo(backend, previewIds, formatById, rawIr)
     }
   }
 
@@ -353,6 +379,7 @@ class AndroidBundleDaemonRenderFunctionalTest {
     val backend: String,
     val previewIds: List<String>,
     val formatById: Map<String, String>,
+    val rawIr: String,
   )
 
   private fun isPng(file: File): Boolean {

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AndroidBundleDaemonRenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AndroidBundleDaemonRenderFunctionalTest.kt
@@ -58,6 +58,14 @@ class AndroidBundleDaemonRenderFunctionalTest {
   private val remoteComposeBundle: String =
     System.getProperty("composeai.functionalTest.remoteComposeBundle", "")
 
+  // #1685 moved the Android (Robolectric) daemon runtime OUT of the CLI install dist (it ballooned
+  // the tarball to ~382 MB) into a standalone `packageAndroidDaemon` archive. The runtime now comes
+  // from `:cli:stageDaemonAndroidLibs`'s staged jars dir, which this e2e points the CLI at via the
+  // documented `-Dcomposeai.cli.libDaemonAndroidDir` override (set as JAVA_OPTS on the daemon
+  // subprocess below) — the same shape the eventual on-demand download unpacks to.
+  private val libDaemonAndroidDir: String =
+    System.getProperty("composeai.functionalTest.libDaemonAndroidDir", "")
+
   @Test
   fun `bundle daemon renders protolayout, remotecompose and classic Android previews to PNG`() {
     assumeTrue("Skipping: -Pbundle.daemon.android.e2e=true not set", enabled)
@@ -112,11 +120,17 @@ class AndroidBundleDaemonRenderFunctionalTest {
 
     val startMillis = System.currentTimeMillis()
     val stderrFile = tempDir.newFile("daemon-stderr-${System.nanoTime()}.log")
-    val proc =
+    val processBuilder =
       ProcessBuilder(cli.absolutePath, "bundle", "daemon", bundle.absolutePath, "--verbose")
         .directory(tempDir.root)
         .redirectError(ProcessBuilder.Redirect.to(stderrFile))
-        .start()
+    // #1685 ships the Android daemon runtime as a standalone archive rather than inside the CLI
+    // install, so point the CLI at the staged jars dir via the documented override. The Gradle
+    // application start script forwards `JAVA_OPTS` to the CLI JVM, where `locateSidecarJars` reads
+    // `composeai.cli.libDaemonAndroidDir` to assemble the Android daemon `-cp`.
+    processBuilder.environment()["JAVA_OPTS"] =
+      "-Dcomposeai.cli.libDaemonAndroidDir=$libDaemonAndroidDir"
+    val proc = processBuilder.start()
     val stdin: OutputStream = proc.outputStream
     val stdout: InputStream = BufferedInputStream(proc.inputStream)
     val json = Json { ignoreUnknownKeys = true }
@@ -290,11 +304,19 @@ class AndroidBundleDaemonRenderFunctionalTest {
       )
       .that(cli.isFile)
       .isTrue()
-    val installRoot = cli.parentFile.parentFile
-    val libDaemonAndroid = installRoot.resolve("lib-daemon-android")
+    // Post-#1685 the Android daemon runtime lives in the staged jars dir
+    // (`:cli:stageDaemonAndroidLibs` output), not under `$installRoot/lib-daemon-android`. The CLI
+    // is pointed at it via `-Dcomposeai.cli.libDaemonAndroidDir` (JAVA_OPTS, set in renderBundle).
     assertWithMessage(
-        "lib-daemon-android dir missing in CLI distribution at ${libDaemonAndroid.path} — the cli " +
-          "build didn't stage the `composePreviewDaemonAndroid` configuration (Phase 2 packaging)."
+        "lib-daemon-android jars dir not surfaced via system property — did " +
+          "`:cli:stageDaemonAndroidLibs` run? Use `./gradlew functionalTestWithAndroidBundleDaemon`"
+      )
+      .that(libDaemonAndroidDir)
+      .isNotEmpty()
+    val libDaemonAndroid = File(libDaemonAndroidDir)
+    assertWithMessage(
+        "lib-daemon-android jars dir missing at ${libDaemonAndroid.path} — the cli build didn't " +
+          "stage the `composePreviewDaemonAndroid` configuration (`:cli:stageDaemonAndroidLibs`)."
       )
       .that(libDaemonAndroid.isDirectory)
       .isTrue()


### PR DESCRIPTION
Two commits that together get the `Android Bundle Daemon E2E` from red to actually rendering. Closes #1687.

## Commit 1 — wire the E2E to #1685's standalone daemon archive

The job was failing at `AndroidBundleDaemonRenderFunctionalTest.locateCli`, **not** the render path: #1685 ("ship the Android daemon runtime as a separate on-demand archive") removed `into("lib-daemon-android") { … }` from the CLI `installDist`, but the E2E + CI still asserted the old `$installRoot/lib-daemon-android` layout, so it bailed before rendering.

- **Test**: read the staged jars dir (`:cli:stageDaemonAndroidLibs` output) from a new system property and assert *that*; forward `-Dcomposeai.cli.libDaemonAndroidDir=<dir>` to the daemon subprocess via `JAVA_OPTS` so the CLI's `locateSidecarJars` finds the Android daemon `-cp`.
- **gradle-plugin / root task / CI**: surface the staged dir, and build `:cli:stageDaemonAndroidLibs` in `functionalTestWithAndroidBundleDaemon` + the CI pre-build step. Refreshed stale comments.

This unblocked the E2E so the real #1687 bug became reachable again (CI then failed at the render assertion — diagnostics from #1688 confirmed it).

## Commit 2 — fix #1687: Android host stubbed classic `renderNow` previews

With the E2E rendering, the `Ambient body — interactive` preview (a plain classic `@Preview`) came back with a `renderFinished` pointing at `.compose-preview-history/daemon-stub-1.png`, which doesn't exist — and the timeline showed it "rendered" in **+24ms**, i.e. it never actually rendered.

Root cause: `JsonRpcServer.encodeRenderPayload` sends `renderNow` payloads as just `previewId=<id>` (it can't name the class/function) and relies on the host to resolve the spec.
- **Desktop** `DesktopHost.dispatchRender` does this via `specFromPreviewIdPayload` → the wired `previewSpecResolver`. ✅
- **Android** `RobolectricHost.dispatchRender` did **not** — no `className=` → `renderStub` (null `pngPath`); the resolver was only consulted for interactive/recording sessions. ❌
- It only worked in the Gradle-plugin production path, which sets `composeai.harness.previewsManifest` and mounts `PreviewManifestRouter`. The CLI `bundle daemon` never sets it, so every classic preview stubbed.

Fix (per the chosen approach — mirror desktop in the Android host): in `RobolectricHost.submit` (host thread, before the sandbox boundary), resolve `previewId=`-only payloads via the already-wired `previewSpecResolver` and rewrite them into the parseable `className=…;functionName=…` shape. Inbound override tokens win over spec defaults; output PNG keyed on the previewId (like the router) so multi-variant-per-function Wear previews don't collide. No-op when the payload already has `className=`, no resolver is wired, or the id is unknown — so the router path, direct spec-payload callers, and the legacy `render-N` stub tests are unaffected.

## Test plan
- CI's `Android Bundle Daemon E2E` is the subject end-to-end (Robolectric + Android SDK aren't available locally — and this sandbox also lacks the JDK 17 toolchain, so the module can't be compiled here either).
- Verified no existing `:daemon:android` test submits a `previewId=`-only render expecting a stub (they all build full `className=` payloads, which this leaves untouched).
- ktfmt verified on the changed `:daemon:android` / `:gradle-plugin` files; root `build.gradle.kts` is intentionally not ktfmt-managed.