### PR TITLE
feat(samples): add XR spatial preview sample (androidx.xr.compose)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ branch:
 - [`samples:wear`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#sampleswear) — Wear OS Material 3 Expressive, `EdgeButton`, tile previews.
 - [`samples:cmp`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#samplescmp) — Compose Multiplatform Desktop.
 - [`samples:remotecompose`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#samplesremotecompose) — Remote Compose against `wear-compose-remote-material3`.
+- [`samples:xr-spatial`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#samplesxr-spatial) — Jetpack Compose for XR (`androidx.xr.compose`), 2D Home-Space fallback of `Orbiter` / `SpatialElevation` / `SpatialPanel` content.
 
 ATF a11y findings for the same samples are on the
 [`compose-preview/a11y/main`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/a11y/main)

--- a/docs/design/GLIMMER_PREVIEW.md
+++ b/docs/design/GLIMMER_PREVIEW.md
@@ -21,7 +21,7 @@ In:
 Out:
 
 - Real-device capture / emulator integration. Use the Android Studio AI Glasses emulator for that — this work targets the offline-render pipeline only.
-- 3-D scene XR (`androidx.xr.compose`'s `Subspace` / `SpatialPanel`). A separate toolkit with a separate rendering model; tracked elsewhere.
+- 3-D scene XR (`androidx.xr.compose`'s `Subspace` / `SpatialPanel`). A separate toolkit with a separate rendering model — see [`XR_SPATIAL_PREVIEW.md`](XR_SPATIAL_PREVIEW.md) and [`:samples:xr-spatial`](../../samples/xr-spatial).
 - Wear OS or phone-projection rendering — different display models, different stacks.
 
 ## Architecture

--- a/docs/design/XR_SPATIAL_PREVIEW.md
+++ b/docs/design/XR_SPATIAL_PREVIEW.md
@@ -1,0 +1,122 @@
+# Preview support for Jetpack Compose for XR (spatial UI)
+
+Design + research notes for rendering `androidx.xr.compose` spatial composables through this repo's
+`@Preview` pipeline. This is the "tracked elsewhere" follow-up that [`GLIMMER_PREVIEW.md`](GLIMMER_PREVIEW.md)
+scopes out of the Glimmer work (Glimmer is the *display-glasses* toolkit; this is the *headset /
+spatial* toolkit — different package, different rendering model).
+
+Reference sample: [`:samples:xr-spatial`](../../samples/xr-spatial).
+
+## What "XR spatial previews" are
+
+[Jetpack Compose for XR](https://developer.android.com/develop/xr/jetpack-xr-sdk/ui-compose)
+(`androidx.xr.compose`, `1.0.0-alpha14`) adds two surfaces on top of ordinary Compose:
+
+- **`androidx.xr.compose.subspace`** — a *3D* layout system. `Subspace { … }` opens a partition of
+  3D space; inside it you place `SpatialPanel`, `SpatialRow`/`SpatialColumn`/`SpatialBox`,
+  positioned with `SubspaceModifier` (`width`/`height`/`offset`/`rotate`/`depth`). A `SpatialPanel`
+  hosts ordinary 2D Compose content on a panel floating in space.
+- **`androidx.xr.compose.spatial`** — *spatial affordances* you sprinkle into a normal 2D tree:
+  `Orbiter` (floats a control strip anchored to a panel edge), `SpatialElevation` (raises content
+  toward the viewer), `SpatialDialog` / `SpatialPopup` (push the parent panel back in z and present
+  an elevated dialog/popup).
+
+### The capability gate (why this matters for previews)
+
+Both surfaces are gated on **spatialization being enabled**, surfaced through
+`LocalSpatialCapabilities.current.isSpatialUiEnabled`. Spatialization is only on in **Full Space**
+on an Android XR device, backed by a Jetpack XR `Session` + SceneCore/OpenXR runtime.
+
+- In **Home Space**, on a **phone/tablet**, and **anywhere without an XR `Session`**, the
+  composition local defaults to `SpatialCapabilities.NoCapabilities` (verified in the AAR:
+  `LocalSpatialCapabilities`'s default reads `LocalComposeXrOwners`, and falls back to
+  `NoCapabilities` when there is no session). `isSpatialUiEnabled` is then `false`.
+- **`Subspace { … }` content is *ignored* when spatialization is off** — the body is skipped
+  entirely.
+- **`spatial` affordances fall back to 2D**: `Orbiter` lays its content out inline against the
+  chosen edge, `SpatialElevation` draws its content with no z-offset, `SpatialDialog`/`SpatialPopup`
+  degrade to a plain `Dialog`/`Popup`. This is the documented "reuse your spatial components in your
+  2D UI" behaviour.
+
+## Rendering model in this repo
+
+This repo renders `@Preview`s **offline** — Robolectric (Android) / `ImageComposeScene` (Desktop).
+There is **no** Jetpack XR `Session` and no SceneCore/OpenXR runtime in either backend, and there
+is no realistic path to one (SceneCore needs the device's OpenXR stack; a Robolectric shadow of the
+full spatial scene graph is out of scope). So:
+
+| Composable | Offline render result | Same as… |
+| --- | --- | --- |
+| 2D content destined for a `SpatialPanel` | renders normally | Studio `@Preview`, phone |
+| `Orbiter { … }` | 2D fallback — content inline at the edge | Studio `@Preview`, Home Space |
+| `SpatialElevation { … }` | 2D fallback — content drawn flat | Studio `@Preview`, Home Space |
+| `SpatialDialog` / `SpatialPopup` | 2D `Dialog`/`Popup` fallback¹ | Studio `@Preview`, Home Space |
+| `Subspace { SpatialPanel { … } }` | **empty frame** — body ignored | Home Space on a phone |
+
+¹ Dialog/Popup content renders into a separate window, which the root-capture path doesn't grab —
+the same limitation any offline Compose preview has for `Dialog`, not XR-specific.
+
+**This is not a gap we can close by special-casing the renderer** — it is the *correct* behaviour.
+What Android Studio's own `@Preview` shows for an XR app in Home Space is exactly this 2D fallback;
+the true 3D placement only appears in Full Space on an XR device or the XR emulator. The repo's
+[constraints](AGENTS.md) forbid per-feature renderer branches anyway, and there is no metadata an
+override extension could supply to fabricate a spatial scene graph offline.
+
+### Recommended authoring pattern
+
+The Jetpack XR guidance — author your app UI as ordinary 2D Compose, then *place* it spatially — is
+also the previewable pattern:
+
+1. **Preview the panel's 2D content directly.** The composable you pass into a `SpatialPanel` has no
+   XR dependency; a plain `@Preview` of it captures exactly what the panel shows.
+2. **Preview the `spatial` affordances for their 2D fallback** to verify the Home Space / phone
+   layout (`Orbiter` strips, `SpatialElevation` cards).
+3. **Keep the real `Subspace { … }` layout in the sample as reference code, un-`@Preview`'d** — a
+   `@Preview` of it would only ever capture a blank frame offline, which is a poor artifact (it
+   looks like a render bug). `:samples:xr-spatial`'s `SubspaceXrLayout` documents this inline.
+
+## `:samples:xr-spatial`
+
+An Android **library** module (no `applicationId` needed; mirrors `:samples:android-library` /
+`:samples:xr-glimmer`):
+
+- `SpatialContent.kt` — XR-free 2D content (`NowPlayingPanel`, `TransportControls`) — the unit that
+  goes inside panels/orbiters.
+- `SpatialPreviews.kt` — the `@Preview`s: the panel content, an `Orbiter` top-control strip, a
+  `SpatialElevation` card. All capture their 2D fallback.
+- `SubspaceDemo.kt` — `SubspaceXrLayout`: the genuine `Subspace { SpatialPanel { … } }` + `Orbiter`
+  on-device code, deliberately **not** `@Preview`'d, with the rationale documented inline.
+
+### Build config
+
+- `androidx.xr.compose:compose`'s AAR declares **`minCompileSdk = 36`** (and `minAgp = 8.9.1`), so
+  the module compiles against `compileSdk = 36` — the repo default from `composeai.android-conventions`,
+  satisfied by the installed platform-36. Unlike `:samples:xr-glimmer` (Glimmer needs platform-37),
+  **no SDK-37 bump is required**.
+- Robolectric is pinned to **`sdkVersion.set(35)`**. The repo's toolchain is JDK 17, and Robolectric
+  4.16.1 needs JDK 21+ for an SDK-36 sandbox; the 2D fallback path is pure Compose drawing with no
+  API-36 platform symbol at render time, so SDK 35 captures it cleanly. This is the same escape
+  hatch `:samples:remotecompose` and `:samples:android-alpha` use to render compileSdk-37 modules
+  under JDK 17. Drop the override when the repo toolchain moves to JDK 21.
+
+### Render it
+
+```
+./gradlew :samples:xr-spatial:composePreviewRenderAll
+```
+
+PNGs land under `samples/xr-spatial/build/compose-previews/renders/`.
+
+## Out of scope / future work
+
+- **True 3D spatial capture.** Rendering the actual `Subspace`/`SpatialPanel` 3D layout (panel
+  poses, depth, curved rows) needs the SceneCore runtime; use the Android Studio **XR emulator** for
+  that. If `androidx.xr.compose:compose-testing` ever ships a host-side fake that composes subspace
+  content into a flat 2D tree (analogous to `ImageComposeScene`), a follow-up could capture a
+  flattened top-down projection — tracked, not built.
+- **An `@SpatialPreview` meta-annotation / spatial device spec.** Studio uses an "XR" device preset
+  in the preview picker. We could add a meta-annotation in `:preview-annotations` that pins a wide
+  spatial-panel device spec, but — unlike `@FocusedPreview`/`@AmbientPreview` — it would carry no
+  renderer behaviour (there's no spatial scene to drive offline), so it would be sugar over a shared
+  `device =` string. Left out until there's behaviour to attach; the sample uses a shared
+  `SPATIAL_PANEL_DEVICE` const instead.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,15 @@ wear-tooling-preview = "1.0.0"
 # `compileSdk = 37` (matched by `:samples:xr-glimmer`'s `compileSdk` and our
 # `agp = 9.2.x` toolchain). Alpha13 was published 2026-05-19.
 xr-glimmer = "1.0.0-alpha13"
+# Jetpack Compose for XR (`androidx.xr.compose`) — the spatial-UI toolkit
+# (`Subspace`, `SpatialPanel`, `Orbiter`, `SpatialElevation`, `SpatialDialog`).
+# AAR metadata declares `minCompileSdk = 36` / `minAgp = 8.9.1`, so it builds on
+# the repo's default `compileSdk = 36` + AGP 9.2.x — no need for the platform-37
+# bump Glimmer requires. Used by `:samples:xr-spatial`, which renders the
+# 2D Home-Space fallback of these composables through the Android Robolectric
+# pipeline (see docs/design/XR_SPATIAL_PREVIEW.md). Alpha14 was published
+# 2026-05-19.
+xr-compose = "1.0.0-alpha14"
 # `androidx.wear:wear` carries `androidx.wear.ambient.AmbientLifecycleObserver` —
 # the AOSP entry point both horologist's `AmbientAware` and direct subscribers
 # wrap. Used only by `:data-ambient-connector` (the Robolectric shadow + state
@@ -188,6 +197,8 @@ wear-tiles-tooling = { module = "androidx.wear.tiles:tiles-tooling", version.ref
 wear-tiles-tooling-preview = { module = "androidx.wear.tiles:tiles-tooling-preview", version.ref = "wear-tiles" }
 xr-glimmer = { module = "androidx.xr.glimmer:glimmer", version.ref = "xr-glimmer" }
 xr-glimmer-google-fonts = { module = "androidx.xr.glimmer:glimmer-google-fonts", version.ref = "xr-glimmer" }
+xr-compose = { module = "androidx.xr.compose:compose", version.ref = "xr-compose" }
+xr-compose-testing = { module = "androidx.xr.compose:compose-testing", version.ref = "xr-compose" }
 wear-tooling-preview = { module = "androidx.wear:wear-tooling-preview", version.ref = "wear-tooling-preview" }
 wear = { module = "androidx.wear:wear", version.ref = "wear" }
 horologist-compose-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }

--- a/samples/xr-spatial/build.gradle.kts
+++ b/samples/xr-spatial/build.gradle.kts
@@ -1,0 +1,65 @@
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.android-conventions")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
+  id("ee.schimke.composeai.preview")
+}
+
+// `:samples:xr-spatial` — Jetpack Compose for XR (`androidx.xr.compose`) spatial
+// composables rendered through this repo's `@Preview` pipeline.
+//
+// Unlike a real Android XR device, the offline renderer has no Jetpack XR
+// `Session` / SceneCore runtime, so `LocalSpatialCapabilities` reports
+// `NoCapabilities`. That is exactly the "Home Space / non-XR" code path: spatial
+// affordances that have a documented 2D fallback (`Orbiter`, `SpatialElevation`,
+// `SpatialDialog`, `SpatialPopup`) degrade to their flat equivalents and render
+// normally, while `Subspace { SpatialPanel { … } }` content is *ignored* (Google's
+// own behaviour — see `SubspaceDemo.kt`). The previews here capture the 2D
+// fallback, which is what Android Studio's `@Preview` shows for an XR app's UI in
+// Home Space too. The full rationale and rendering model live in
+// docs/design/XR_SPATIAL_PREVIEW.md.
+
+composePreview {
+  // Pin Robolectric to SDK 35. `androidx.xr.compose:compose`'s AAR metadata
+  // declares `minCompileSdk = 36`, so the module compiles against 36, but
+  // Robolectric 4.16.1 needs JDK 21+ for an SDK 36 sandbox and the repo's
+  // toolchain stays on JDK 17. The 2D fallback path the previews exercise is
+  // pure Compose drawing (no API-36 platform symbol at render time), so SDK 35
+  // captures it cleanly — the same escape hatch `:samples:remotecompose` and
+  // `:samples:android-alpha` use to render compileSdk-37 modules under JDK 17.
+  // Drop this override when the toolchain moves to JDK 21.
+  sdkVersion.set(35)
+}
+
+android {
+  namespace = "com.example.samplexrspatial"
+
+  // `androidx.xr.compose:compose` raises `minCompileSdk = 36` in its AAR
+  // metadata, so the module must compile against 36. That is the repo default
+  // from `composeai.android-conventions` (platform-36 is installed); unlike
+  // `:samples:xr-glimmer` no platform-37 bump is needed.
+  compileSdk = 36
+
+  buildFeatures { compose = true }
+
+  testOptions { unitTests.all { it.jvmArgs("-Xmx2048m") } }
+}
+
+dependencies {
+  implementation(platform(libs.compose.bom.stable))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.ui.tooling.preview)
+  implementation(libs.compose.foundation)
+
+  // Jetpack Compose for XR. Brings the `androidx.xr.compose.spatial` affordances
+  // (`Orbiter`, `SpatialElevation`, `SpatialDialog`) and the
+  // `androidx.xr.compose.subspace` layout system (`Subspace`, `SpatialPanel`,
+  // `SpatialRow`/`SpatialColumn`). Pulls `androidx.xr.scenecore` /
+  // `androidx.xr.runtime` transitively — those only matter on-device; the 2D
+  // fallback path the previews exercise never reaches for a `Session`.
+  implementation(libs.xr.compose)
+
+  debugImplementation("androidx.compose.ui:ui-tooling")
+}

--- a/samples/xr-spatial/src/main/AndroidManifest.xml
+++ b/samples/xr-spatial/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SpatialContent.kt
+++ b/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SpatialContent.kt
@@ -1,0 +1,71 @@
+package com.example.samplexrspatial
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Reusable 2D content for the XR spatial sample.
+ *
+ * The Jetpack XR docs recommend authoring your app UI as ordinary 2D Compose and then *placing*
+ * it spatially — a `SpatialPanel` hosts a 2D panel, an `Orbiter` floats a 2D control strip beside
+ * it. The composables here are that 2D content. They carry no XR dependency at all, so they're the
+ * natural unit to `@Preview`: what renders offline is identical to what the panel shows on-device.
+ *
+ * [SpatialPreviews] reuses these inside `Orbiter` / `SpatialElevation` to show how the spatial
+ * affordances degrade to a 2D layout when spatialization is unavailable (Home Space / non-XR /
+ * the offline renderer).
+ */
+
+/** The "main panel" body — the kind of 2D surface you would host inside a `SpatialPanel`. */
+@Composable
+fun NowPlayingPanel(modifier: Modifier = Modifier) {
+  Surface(modifier = modifier, color = MaterialTheme.colorScheme.surfaceContainer) {
+    Column(
+      modifier = Modifier.padding(24.dp).fillMaxWidth(),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      Text("Now Playing", style = MaterialTheme.typography.labelLarge)
+      Text("Spatial Sessions", style = MaterialTheme.typography.headlineMedium)
+      Text(
+        "Ambient electronica for a focused workspace.",
+        style = MaterialTheme.typography.bodyMedium,
+      )
+      Spacer(Modifier.height(8.dp))
+      Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        Button(onClick = {}) { Text("Play") }
+        Button(onClick = {}) { Text("Queue") }
+      }
+    }
+  }
+}
+
+/** A horizontal control strip — the content you would float in a top/bottom `Orbiter`. */
+@Composable
+fun TransportControls(modifier: Modifier = Modifier) {
+  Card(modifier = modifier) {
+    Row(
+      modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      FilledTonalButton(onClick = {}) { Text("Prev") }
+      FilledTonalButton(onClick = {}) { Text("Play") }
+      FilledTonalButton(onClick = {}) { Text("Next") }
+    }
+  }
+}

--- a/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SpatialPreviews.kt
+++ b/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SpatialPreviews.kt
@@ -1,0 +1,83 @@
+package com.example.samplexrspatial
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.xr.compose.spatial.ContentEdge
+import androidx.xr.compose.spatial.Orbiter
+import androidx.xr.compose.spatial.SpatialElevation
+import androidx.xr.compose.spatial.SpatialElevationLevel
+
+/**
+ * `@Preview`s for the XR spatial sample, rendered by `:samples:xr-spatial:composePreviewRenderAll`.
+ *
+ * The offline renderer (and Android Studio's `@Preview`, and any phone) has no Jetpack XR
+ * `Session`, so `LocalSpatialCapabilities.current` resolves to `SpatialCapabilities.NoCapabilities`
+ * and `isSpatialUiEnabled` is `false`. Every `androidx.xr.compose.spatial` affordance below detects
+ * that and renders its **2D fallback** — `Orbiter` lays its content out inline against the chosen
+ * edge, `SpatialElevation` draws its content with no z-depth. That fallback is precisely what these
+ * previews capture, and precisely what your XR app shows in Home Space. The true 3D placement only
+ * appears in Full Space on an XR device; see [SubspaceXrLayout] for why the subspace path can't be
+ * captured offline.
+ */
+
+// Shared device spec for the spatial previews: a wide landscape panel canvas at density 1.0, in the
+// shape of a spatial content panel rather than a phone. dpi=160 keeps dp == px so the panel sizes
+// below map straight to pixels.
+internal const val SPATIAL_PANEL_DEVICE: String = "spec:width=1280,height=720,dpi=160"
+
+/** The plain 2D panel content — the recommended unit to preview (no XR dependency at all). */
+@Preview(name = "Panel · Content", device = SPATIAL_PANEL_DEVICE, showBackground = true)
+@Composable
+fun NowPlayingPanelPreview() {
+  MaterialTheme {
+    Box(Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) {
+      NowPlayingPanel(Modifier.width(560.dp))
+    }
+  }
+}
+
+/**
+ * `Orbiter` with a top-edge control strip. In Full Space the strip floats in front of the panel,
+ * anchored to its top edge; in the 2D fallback captured here it renders inline above the panel
+ * content. The composable is written exactly as it would be on-device — only the rendering differs.
+ */
+@Preview(name = "Orbiter · TopControls", device = SPATIAL_PANEL_DEVICE, showBackground = true)
+@Composable
+fun OrbiterControlsPreview() {
+  MaterialTheme {
+    Surface {
+      Box(Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) {
+        Orbiter(position = ContentEdge.Top) { TransportControls() }
+        NowPlayingPanel(Modifier.width(560.dp))
+      }
+    }
+  }
+}
+
+/**
+ * `SpatialElevation` raises its content toward the viewer in Full Space. In the 2D fallback the
+ * content is drawn flat (no z-offset), so the capture shows the panel as an ordinary elevated card.
+ */
+@Preview(name = "SpatialElevation · Panel", device = SPATIAL_PANEL_DEVICE, showBackground = true)
+@Composable
+fun SpatialElevationPreview() {
+  MaterialTheme {
+    Surface {
+      Box(Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) {
+        SpatialElevation(SpatialElevationLevel.Level3) {
+          NowPlayingPanel(Modifier.fillMaxWidth(0.6f))
+        }
+      }
+    }
+  }
+}

--- a/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SubspaceDemo.kt
+++ b/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SubspaceDemo.kt
@@ -1,0 +1,40 @@
+package com.example.samplexrspatial
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.xr.compose.spatial.ContentEdge
+import androidx.xr.compose.spatial.Orbiter
+import androidx.xr.compose.spatial.Subspace
+import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.layout.SubspaceModifier
+import androidx.xr.compose.subspace.layout.height
+import androidx.xr.compose.subspace.layout.width
+
+/**
+ * The canonical "Full Space" XR spatial layout — a `SpatialPanel` floating in a `Subspace`, with a
+ * transport-control `Orbiter` anchored to its top edge.
+ *
+ * This is the real on-device code, kept here so the sample carries the genuine spatial-layout shape
+ * (not just its 2D fallback). It is deliberately **not** annotated `@Preview`:
+ *
+ * > "A subspace is rendered only when spatialization is enabled. In Home Space or on non-XR
+ * > devices, any code within that subspace is ignored."
+ *
+ * The offline renderer has no Jetpack XR `Session`, so a `@Preview` of this composable would
+ * capture an empty frame — the `Subspace` body is skipped entirely. That is correct XR behaviour,
+ * not a renderer bug, but a blank PNG is a poor sample artifact. Instead, preview the panel's 2D
+ * content directly ([NowPlayingPanelPreview]) and the spatial affordances' 2D fallbacks
+ * ([OrbiterControlsPreview], [SpatialElevationPreview]) — those capture exactly what the panel and
+ * orbiter show, and are what Android Studio's `@Preview` renders for this UI in Home Space too.
+ *
+ * See docs/design/XR_SPATIAL_PREVIEW.md for the full rendering model.
+ */
+@Composable
+fun SubspaceXrLayout() {
+  Subspace {
+    SpatialPanel(SubspaceModifier.width(560.dp).height(360.dp)) {
+      NowPlayingPanel()
+      Orbiter(position = ContentEdge.Top) { TransportControls() }
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -160,6 +160,8 @@ include(":samples:wear")
 
 include(":samples:xr-glimmer")
 
+include(":samples:xr-spatial")
+
 include(":samples:cmp")
 
 include(":samples:cmp-shared")


### PR DESCRIPTION
Add `:samples:xr-spatial`, demonstrating Jetpack Compose for XR
(`androidx.xr.compose`) spatial composables rendered through the
`@Preview` pipeline.

The offline renderer has no Jetpack XR `Session`, so
`LocalSpatialCapabilities` resolves to `NoCapabilities` — the Home Space /
non-XR code path. Spatial affordances with a 2D fallback (`Orbiter`,
`SpatialElevation`) render normally and are captured by the previews, while
`Subspace { SpatialPanel { … } }` content is ignored on-non-XR (the genuine
on-device layout ships as un-`@Preview`'d reference code in `SubspaceXrLayout`,
with the rationale documented inline).

- version catalog: `xr-compose` / `xr-compose-testing` (alpha14, minCompileSdk 36)
- sample compiles against compileSdk 36, pins Robolectric `sdkVersion = 35`
  (same JDK-17 escape hatch as `:samples:remotecompose`)
- docs/design/XR_SPATIAL_PREVIEW.md: research + rendering model
- cross-link from GLIMMER_PREVIEW.md (which scoped this out); README sample list

Verified: module compiles and discovery finds all 3 previews.