### PR TITLE
feat(bundle): carry Android resources for protolayout tile replay (schema v6)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleLaunch.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleLaunch.kt
@@ -15,9 +15,13 @@ import java.util.Properties
  * none of it is runnable without an Android SDK + Robolectric runtime):
  * - packaging `:renderer-android` / `:daemon:android` into the CLI distribution (today only the
  *   desktop sidecars ship — see `cli/build.gradle.kts`), and
- * - the bundle-side packing of Android-merged resources, and
  * - recording the consumer's `compileSdk` in the bundle manifest (we default + allow an override
  *   until then).
+ *
+ * Bundle-side packing of Android-merged resources now exists for the **daemon** path (schema v6,
+ * [ee.schimke.composeai.plugin.BundleAndroidResources]): a protolayout-IR bundle carries the merged
+ * resource APK + manifest + generated R classes, and [BundleDaemonCommand] rebuilds the Robolectric
+ * `test_config.properties` from them so the tile renderer resolves its theme on a detached daemon.
  *
  * The constants below MUST stay in lockstep with the Gradle plugin's
  * [ee.schimke.composeai.plugin.AndroidPreviewClasspath] (`buildJvmArgs`, `buildSystemProperties`)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -378,6 +378,24 @@ internal object BundleReader {
      * than by re-running their consumer bytecode. Empty for a classic all-classes bundle.
      */
     val intermediateRepresentations: List<BundleIr> = emptyList(),
+    /**
+     * v6+: Android resource carriage for protolayout (Wear tile) IR replay — the merged resource
+     * APK + manifest + generated R classes under `android/`. Null for desktop / non-protolayout
+     * bundles. See `BundleAndroidResources` in `PreviewBundleFormat.kt`.
+     */
+    val androidResources: AndroidResources? = null,
+  )
+
+  /** v6+ mirror of `BundleAndroidResources` in `PreviewBundleFormat.kt`. */
+  @Serializable
+  data class AndroidResources(
+    val resourceApkPath: String,
+    val mergedManifestPath: String,
+    val rClassesJarPath: String? = null,
+    /**
+     * Consumer application package; written as `android_custom_package` in the synthesized config.
+     */
+    val applicationPackage: String? = null,
   )
 
   /** v5+ mirror of `BundleIr` in `PreviewBundleFormat.kt`. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -96,6 +96,29 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       extractIrArtifacts(zipBytes, irDir!!, bundleManifestFile!!, file)
     }
 
+    // v6 Android resource carriage: a protolayout (Wear tile) IR replays through `TileRenderer`,
+    // which resolves a library theme resource via `getResources()` and links the non-final library
+    // `R$style` class. A detached daemon has neither the merged resource table (no AGP build) nor
+    // those generated R classes (an AAR's published classes.jar omits them), so an android bundle
+    // carrying protolayout IR also carries the merged resource APK + manifest + R classes under
+    // `android/`. Extract them, synthesize the Robolectric
+    // `com/android/tools/test_config.properties`
+    // the daemon's RobolectricTestRunner auto-reads from the classpath (exactly how the in-Gradle
+    // render path gets resources), and expose the R classes to the parent (renderer) classloader.
+    // The synthesized-config dir and the R jar both ride the IR-carriage `-cp` seam below. Absent
+    // for desktop / classic / Remote-Compose-only bundles.
+    val androidReplayClasspath = mutableListOf<File>()
+    if (manifest.backend == "android" && hasIr) {
+      val androidDir = workDir.resolve("android").apply { mkdirs() }
+      val res = extractAndroidResources(zipBytes, androidDir)
+      if (res != null) {
+        val testConfigDir = workDir.resolve("test-config")
+        writeAndroidTestConfig(testConfigDir, res.resourceApk, res.mergedManifest)
+        androidReplayClasspath += testConfigDir
+        res.rClassesJar?.let { androidReplayClasspath += it }
+      }
+    }
+
     // Branch on the bundle's backend, exactly as `bundle render` does: a desktop bundle launches
     // the CMP/Skiko daemon (lib-daemon-desktop + lib-renderer); an android bundle launches the
     // Robolectric daemon (lib-daemon-android + android.jar), reusing the Phase 1
@@ -129,7 +152,13 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       add("-Dcomposeai.daemon.bundleSource=${file.absolutePath}")
       for (prop in launch.sysProps) add(prop)
       add("-cp")
-      add(composeDaemonClasspath(launch.classpath, libJars + resolvedJars, hasIr))
+      add(
+        composeDaemonClasspath(
+          launch.classpath,
+          libJars + resolvedJars + androidReplayClasspath,
+          hasIr,
+        )
+      )
       add("ee.schimke.composeai.daemon.DaemonMain")
     }
 
@@ -145,6 +174,11 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       if (hasIr) {
         System.err.println(
           "[bundle-daemon] IR previews: ${manifest.intermediateRepresentations.size} → ${irDir?.absolutePath}"
+        )
+      }
+      if (androidReplayClasspath.isNotEmpty()) {
+        System.err.println(
+          "[bundle-daemon] android resource carriage: ${androidReplayClasspath.joinToString(", ") { it.name }}"
         )
       }
       System.err.println("[bundle-daemon] launching: ${command.joinToString(" ")}")
@@ -348,6 +382,74 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
     require(sawManifest) {
       "bundle daemon: bundle.json missing in ${bundleFile.path} — cannot resolve IR descriptors"
     }
+  }
+
+  /** The extracted v6 `android/` resource carriage (see [extractAndroidResources]). */
+  private data class AndroidReplayResources(
+    val resourceApk: File,
+    val mergedManifest: File,
+    val rClassesJar: File?,
+  )
+
+  /**
+   * Extract the v6 `android/` resource carriage from [zipBytes] into [androidDir]: the merged
+   * resource APK and manifest (both required) plus the generated R-class jar (optional). Returns
+   * null when the bundle carries no resource APK — a protolayout bundle from a pre-v6 producer, or
+   * one whose pack couldn't locate AGP's merged resources — in which case the daemon falls back to
+   * its pre-v6 (failing) tile-replay path. Each destination is verified to live inside [androidDir]
+   * (Zip Slip guard), same shape as [extractIrArtifacts].
+   */
+  private fun extractAndroidResources(
+    zipBytes: ByteArray,
+    androidDir: File,
+  ): AndroidReplayResources? {
+    val canonical = androidDir.canonicalFile
+    var apk: File? = null
+    var mergedManifest: File? = null
+    var rJar: File? = null
+    ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
+      while (true) {
+        val entry = zin.nextEntry ?: break
+        val name = entry.name
+        if (!entry.isDirectory && name.startsWith("android/")) {
+          val dest = File(androidDir, File(name).name).canonicalFile
+          if (dest.path.startsWith(canonical.path + File.separator)) {
+            dest.outputStream().use { sink -> zin.copyTo(sink) }
+            when (name) {
+              "android/resources.ap_" -> apk = dest
+              "android/AndroidManifest.xml" -> mergedManifest = dest
+              "android/r-classes.jar" -> rJar = dest
+            }
+          }
+        }
+        zin.closeEntry()
+      }
+    }
+    val resolvedApk = apk
+    val resolvedManifest = mergedManifest
+    return if (resolvedApk != null && resolvedManifest != null)
+      AndroidReplayResources(resolvedApk, resolvedManifest, rJar)
+    else null
+  }
+
+  /**
+   * Write the Robolectric `com/android/tools/test_config.properties` the daemon's
+   * RobolectricTestRunner reads from the classpath — the same file AGP generates for the in-Gradle
+   * render path — pointing at the extracted merged resource APK + manifest. Returns [root], which
+   * the caller puts on the daemon `-cp` so the resource resolves. Binary-resources mode:
+   * `android_resource_apk` carries the resource table; package + theme come from
+   * `android_merged_manifest`.
+   */
+  private fun writeAndroidTestConfig(root: File, resourceApk: File, mergedManifest: File): File {
+    val dir = File(root, "com/android/tools").apply { mkdirs() }
+    File(dir, "test_config.properties")
+      .writeText(
+        buildString {
+          appendLine("android_resource_apk=${resourceApk.absolutePath}")
+          appendLine("android_merged_manifest=${mergedManifest.absolutePath}")
+        }
+      )
+    return root
   }
 
   private fun expandAppJarAndManifest(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -113,7 +113,12 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
       val res = extractAndroidResources(zipBytes, androidDir)
       if (res != null) {
         val testConfigDir = workDir.resolve("test-config")
-        writeAndroidTestConfig(testConfigDir, res.resourceApk, res.mergedManifest)
+        writeAndroidTestConfig(
+          testConfigDir,
+          res.resourceApk,
+          res.mergedManifest,
+          manifest.androidResources?.applicationPackage,
+        )
         androidReplayClasspath += testConfigDir
         res.rClassesJar?.let { androidReplayClasspath += it }
       }
@@ -438,15 +443,26 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
    * render path — pointing at the extracted merged resource APK + manifest. Returns [root], which
    * the caller puts on the daemon `-cp` so the resource resolves. Binary-resources mode:
    * `android_resource_apk` carries the resource table; package + theme come from
-   * `android_merged_manifest`.
+   * `android_merged_manifest`. [applicationPackage] (when the pack step recorded it) is written as
+   * `android_custom_package` — the package Robolectric/AGP use for the final R class; without it,
+   * for projects whose namespace isn't recoverable from the merged manifest alone, the final R
+   * would resolve against the wrong/default package and tile replay could miss its resources.
    */
-  private fun writeAndroidTestConfig(root: File, resourceApk: File, mergedManifest: File): File {
+  private fun writeAndroidTestConfig(
+    root: File,
+    resourceApk: File,
+    mergedManifest: File,
+    applicationPackage: String?,
+  ): File {
     val dir = File(root, "com/android/tools").apply { mkdirs() }
     File(dir, "test_config.properties")
       .writeText(
         buildString {
           appendLine("android_resource_apk=${resourceApk.absolutePath}")
           appendLine("android_merged_manifest=${mergedManifest.absolutePath}")
+          if (!applicationPackage.isNullOrBlank()) {
+            appendLine("android_custom_package=$applicationPackage")
+          }
         }
       )
     return root

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1734,21 +1734,16 @@ internal object AndroidPreviewSupport {
           variant.artifacts.get(SingleArtifact.MERGED_MANIFEST),
         ),
       // The generated library R classes the tile renderer links
-      // (`androidx.wear.protolayout.renderer.R$style`)
-      // are generated only into the unit-test merged R.jar (a raw file dep on this classpath with
-      // no
-      // `artifactType=jar` attribute, so the bundle's `dependencyJars` view drops it). Resolve it
-      // through a LENIENT artifactView so AGP's `AmbiguousArtifactsFailure` on project deps
-      // exposing
-      // secondary variants (e.g. `:data-ambient-connector`) is skipped rather than fatal — the same
-      // pattern this file uses for `typeByComponent`. Raw file deps (the R.jar) are included by any
-      // view regardless of attributes.
-      androidUnitTestRuntimeClasspath =
-        project.configurations
-          .findByName("${variantName}UnitTestRuntimeClasspath")
-          ?.incoming
-          ?.artifactView { lenient(true) }
-          ?.files,
+      // (`androidx.wear.protolayout.renderer.R$style`) are generated only into the unit-test merged
+      // R.jar. That jar lives on AGP's `test<Variant>UnitTest` task classpath (a raw file dep added
+      // without the `artifactType=jar` attribute, so the bundle's filtered `dependencyJars` view —
+      // and a configuration `artifactView` — drop it). Source it from the Test task's *resolved*
+      // classpath, the SAME collection `composePreviewRender` links it from (so it resolves cleanly
+      // without the `AmbiguousArtifactsFailure` a raw configuration read hits). Supplied lazily and
+      // invoked inside the bundle task's config lambda, by which point the unit-test task exists.
+      androidUnitTestRuntimeClasspath = {
+        (project.tasks.findByName("test${capVariant}UnitTest") as? Test)?.classpath
+      },
     )
 
     // Phase 1, Stream A — preview daemon bootstrap descriptor. Registered

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1719,13 +1719,22 @@ internal object AndroidPreviewSupport {
       resolveDependencyConfigName = { dependencyConfigName },
       discoverTaskName = "composePreviewDiscover",
       backendId = "android",
-      // (v6) Feed the same AGP artefacts the render path links its resources + library R classes
-      // from, so a protolayout-IR bundle carries the merged resource APK + manifest
-      // (`unitTestConfigDir`'s `test_config.properties` points at them) and the generated R classes
-      // (`${variant}UnitTestRuntimeClasspath`) for tile replay on a detached daemon.
-      androidUnitTestConfigDir = unitTestConfigDir,
-      androidUnitTestRuntimeClasspath =
-        project.configurations.findByName("${variantName}UnitTestRuntimeClasspath"),
+      // (v6) Feed the AGP artefacts a protolayout-IR bundle carries for tile replay on a detached
+      // daemon: `unitTestConfigDir`'s `test_config.properties` names the merged resource APK +
+      // manifest, and the pack action reads those by absolute path — so union the artefacts they
+      // point at (the `apk_for_local_test` output dir + the merged manifest) into the tracked
+      // `@InputFiles` so the cacheable task re-packs when their content changes even if the paths
+      // don't. (The library R classes are scanned from the existing `dependencyJars` view inside
+      // the task — no unit-test-classpath input, which would trip AGP's
+      // `AmbiguousArtifactsFailure`.)
+      androidUnitTestConfigFiles =
+        project.files(
+          unitTestConfigDir,
+          project.layout.buildDirectory.dir(
+            "intermediates/apk_for_local_test/${variantName}UnitTest"
+          ),
+          variant.artifacts.get(SingleArtifact.MERGED_MANIFEST),
+        ),
     )
 
     // Phase 1, Stream A — preview daemon bootstrap descriptor. Registered

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1719,6 +1719,13 @@ internal object AndroidPreviewSupport {
       resolveDependencyConfigName = { dependencyConfigName },
       discoverTaskName = "composePreviewDiscover",
       backendId = "android",
+      // (v6) Feed the same AGP artefacts the render path links its resources + library R classes
+      // from, so a protolayout-IR bundle carries the merged resource APK + manifest
+      // (`unitTestConfigDir`'s `test_config.properties` points at them) and the generated R classes
+      // (`${variant}UnitTestRuntimeClasspath`) for tile replay on a detached daemon.
+      androidUnitTestConfigDir = unitTestConfigDir,
+      androidUnitTestRuntimeClasspath =
+        project.configurations.findByName("${variantName}UnitTestRuntimeClasspath"),
     )
 
     // Phase 1, Stream A — preview daemon bootstrap descriptor. Registered

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1724,9 +1724,7 @@ internal object AndroidPreviewSupport {
       // manifest, and the pack action reads those by absolute path — so union the artefacts they
       // point at (the `apk_for_local_test` output dir + the merged manifest) into the tracked
       // `@InputFiles` so the cacheable task re-packs when their content changes even if the paths
-      // don't. (The library R classes are scanned from the existing `dependencyJars` view inside
-      // the task — no unit-test-classpath input, which would trip AGP's
-      // `AmbiguousArtifactsFailure`.)
+      // don't.
       androidUnitTestConfigFiles =
         project.files(
           unitTestConfigDir,
@@ -1735,6 +1733,22 @@ internal object AndroidPreviewSupport {
           ),
           variant.artifacts.get(SingleArtifact.MERGED_MANIFEST),
         ),
+      // The generated library R classes the tile renderer links
+      // (`androidx.wear.protolayout.renderer.R$style`)
+      // are generated only into the unit-test merged R.jar (a raw file dep on this classpath with
+      // no
+      // `artifactType=jar` attribute, so the bundle's `dependencyJars` view drops it). Resolve it
+      // through a LENIENT artifactView so AGP's `AmbiguousArtifactsFailure` on project deps
+      // exposing
+      // secondary variants (e.g. `:data-ambient-connector`) is skipped rather than fatal — the same
+      // pattern this file uses for `typeByComponent`. Raw file deps (the R.jar) are included by any
+      // view regardless of attributes.
+      androidUnitTestRuntimeClasspath =
+        project.configurations
+          .findByName("${variantName}UnitTestRuntimeClasspath")
+          ?.incoming
+          ?.artifactView { lenient(true) }
+          ?.files,
     )
 
     // Phase 1, Stream A — preview daemon bootstrap descriptor. Registered

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -124,16 +124,6 @@ abstract class BundlePreviewTask : DefaultTask() {
   abstract val androidUnitTestConfig: ConfigurableFileCollection
 
   /**
-   * (v6 Android) The variant's `${variant}UnitTestRuntimeClasspath`. Scanned at pack time **only
-   * when protolayout IR is present** for the generated library R classes (`…/R.class`,
-   * `…/R$*.class` — the non-final library R fields the tile renderer links as real class
-   * references) that an AAR's published `classes.jar` omits. The collected R classes are repacked
-   * under `android/r-classes.jar` so the daemon's parent (renderer) classloader can link
-   * `androidx.wear.protolayout.renderer.R$style`. Unused by the desktop path.
-   */
-  @get:Classpath abstract val androidUnitTestRuntimeClasspath: ConfigurableFileCollection
-
-  /**
    * Renders directory from the preceding `composePreviewRender` task. Each selected preview's PNG
    * is read from here: the cover is prepended to the polyglot, and every selected preview is baked
    * into `previews/<id>.png`. When missing or empty, the cover falls back to a stub gray PNG so the
@@ -546,17 +536,25 @@ abstract class BundlePreviewTask : DefaultTask() {
   }
 
   /**
-   * Collect the generated R classes from the unit-test runtime classpath and repack them into a
-   * single jar's bytes. AGP generates these (a library's R fields are non-final, so `R.style.X`
-   * compiles to a real `getstatic` on the `R$style` *class*, which an AAR's published `classes.jar`
-   * does not contain), and the same classpath is what the render path links them from. We keep
-   * every `…/R.class` and `…/R$*.class` across all jars (deduped by entry name) — R classes are
-   * tiny leaf data holders, so carrying the lot is cheaper than guessing which library the renderer
-   * needs. Returns null when none are found.
+   * Collect the generated R classes from [dependencyJars] and repack them into a single jar's
+   * bytes. AGP generates these (a library's R fields are non-final, so `R.style.X` compiles to a
+   * real `getstatic` on the `R$style` *class*, which an AAR's published `classes.jar` does not
+   * contain). For an application module — the bundle's primary Android target — AGP's
+   * `process<Variant>Resources` puts the merged R.jar (carrying every dependency library's R,
+   * including `androidx.wear.protolayout.renderer.R$style`) on the main runtime classpath, which
+   * the bundle's `artifactType=jar` view already exposes here. We keep every `…/R.class` and
+   * `…/R$*.class` across all jars (deduped by entry name) — R classes are tiny leaf data holders,
+   * so carrying the lot is cheaper than guessing which library the renderer needs. Returns null
+   * when none are found.
+   *
+   * (Scanning the main runtime classpath rather than `…UnitTestRuntimeClasspath` deliberately
+   * avoids resolving that configuration as a task input — it triggers AGP's
+   * `AmbiguousArtifactsFailure` on project deps exposing secondary variants. The trade-off: a
+   * *library*-module consumer whose R.jar lives only on the unit-test classpath wouldn't be
+   * covered, but the bundle's Android target is an application.)
    */
   private fun packAndroidRClasses(): ByteArray? {
-    val jars =
-      androidUnitTestRuntimeClasspath.files.filter { it.isFile && it.name.endsWith(".jar") }
+    val jars = dependencyJars.files.filter { it.isFile && it.name.endsWith(".jar") }
     if (jars.isEmpty()) return null
     val collected = LinkedHashMap<String, ByteArray>()
     for (jar in jars) {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -5,7 +5,9 @@ import io.github.classgraph.ClassGraph
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.util.Properties
 import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
 import javax.imageio.ImageIO
 import kotlinx.serialization.json.Json
@@ -107,6 +109,29 @@ abstract class BundlePreviewTask : DefaultTask() {
    * so the player can still load them, but the manifest entry is flagged.
    */
   @get:Input abstract val dependencyCoordinates: MapProperty<String, String>
+
+  /**
+   * (v6 Android) AGP's `unit_test_config_directory` contents — specifically
+   * `com/android/tools/test_config.properties`. Read at pack time **only when the bundle carries
+   * protolayout (Wear tile) IR** to locate the merged resource APK + manifest the tile renderer
+   * resolves its theme against on a detached daemon. Empty on desktop and on Android bundles
+   * without a prior render; absent input is treated as "no Android resource carriage". See
+   * [resolveAndroidResources].
+   */
+  @get:InputFiles
+  @get:Optional
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val androidUnitTestConfig: ConfigurableFileCollection
+
+  /**
+   * (v6 Android) The variant's `${variant}UnitTestRuntimeClasspath`. Scanned at pack time **only
+   * when protolayout IR is present** for the generated library R classes (`…/R.class`,
+   * `…/R$*.class` — the non-final library R fields the tile renderer links as real class
+   * references) that an AAR's published `classes.jar` omits. The collected R classes are repacked
+   * under `android/r-classes.jar` so the daemon's parent (renderer) classloader can link
+   * `androidx.wear.protolayout.renderer.R$style`. Unused by the desktop path.
+   */
+  @get:Classpath abstract val androidUnitTestRuntimeClasspath: ConfigurableFileCollection
 
   /**
    * Renders directory from the preceding `composePreviewRender` task. Each selected preview's PNG
@@ -265,6 +290,16 @@ abstract class BundlePreviewTask : DefaultTask() {
         )
     }
 
+    // v6 Android resource carriage: a protolayout (Wear tile) IR replays through `TileRenderer`,
+    // which resolves a library theme resource and links the non-final library `R$style` class —
+    // neither of which a detached daemon has. When the bundle carries protolayout IR, pack the
+    // AGP-built merged resource APK + manifest and the generated library R classes under `android/`
+    // (added to `irZipFiles`, written verbatim by `buildZip`). No-op for desktop / non-protolayout.
+    val androidResources =
+      if (irByPreview.values.any { it.format == IR_FORMAT_PROTOLAYOUT })
+        resolveAndroidResources(irZipFiles)
+      else null
+
     val bundle =
       BundleManifest(
         schemaVersion = BUNDLE_SCHEMA_VERSION,
@@ -277,6 +312,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         producer = PRODUCER_GRADLE,
         resolution = classpath.resolution,
         intermediateRepresentations = irEntries,
+        androidResources = androidResources,
       )
 
     // Bake one PNG per selected preview into `previews/<id>.png` so the bundle renders detached
@@ -450,6 +486,103 @@ abstract class BundlePreviewTask : DefaultTask() {
       )
     }
     return null
+  }
+
+  /**
+   * Build the v6 Android resource carriage for a protolayout-IR bundle and add its artefacts to
+   * [zipFiles] (which [buildZip] writes verbatim). Mirrors the render path's reliance on AGP's
+   * generated `com/android/tools/test_config.properties` (see `AndroidPreviewSupport`): we read it
+   * to locate the merged resource APK (`apk-for-local-test.ap_`) + merged manifest the tile
+   * renderer resolves its theme against, and pack the generated library R classes so
+   * `androidx.wear.protolayout.renderer.R$style` links on the detached daemon.
+   *
+   * Returns null (adding nothing) when the inputs aren't available — bundling without a prior
+   * render, a project that doesn't emit binary resources, etc. — so the bundle stays well-formed
+   * and the daemon simply falls back to its pre-v6 behaviour (tile replay then fails the same way
+   * it did before this carriage existed) rather than the pack crashing.
+   */
+  private fun resolveAndroidResources(
+    zipFiles: LinkedHashMap<String, ByteArray>
+  ): BundleAndroidResources? {
+    val configFile =
+      androidUnitTestConfig.files.firstOrNull { it.isFile && it.name == "test_config.properties" }
+        ?: run {
+          logger.warn(
+            "composePreviewBundle: protolayout IR present but no test_config.properties on the " +
+              "unit-test config input — tile replay on a detached daemon can't resolve resources. " +
+              "Run composePreviewRender first so AGP generates it."
+          )
+          return null
+        }
+    val props = Properties().apply { configFile.inputStream().use { load(it) } }
+    val apkPath = props.getProperty("android_resource_apk")?.trim().orEmpty()
+    val manifestPath = props.getProperty("android_merged_manifest")?.trim().orEmpty()
+    val pkg = props.getProperty("android_custom_package")?.trim()?.takeIf { it.isNotEmpty() }
+    val apkFile = apkPath.takeIf { it.isNotEmpty() }?.let { File(it) }
+    val manifestFile = manifestPath.takeIf { it.isNotEmpty() }?.let { File(it) }
+    if (apkFile == null || !apkFile.isFile || manifestFile == null || !manifestFile.isFile) {
+      logger.warn(
+        "composePreviewBundle: protolayout IR present but the merged resource APK / manifest from " +
+          "test_config.properties is missing (apk='$apkPath', manifest='$manifestPath') — tile " +
+          "replay on a detached daemon can't resolve resources."
+      )
+      return null
+    }
+    zipFiles[ANDROID_RESOURCE_APK_PATH] = apkFile.readBytes()
+    zipFiles[ANDROID_MERGED_MANIFEST_PATH] = manifestFile.readBytes()
+    val rClassesJar = packAndroidRClasses()
+    if (rClassesJar != null) zipFiles[ANDROID_R_CLASSES_JAR_PATH] = rClassesJar
+    logger.lifecycle(
+      "composePreviewBundle — carried Android resources for protolayout replay " +
+        "(apk=${apkFile.length()}B, manifest=${manifestFile.length()}B, " +
+        "rClasses=${if (rClassesJar != null) "${rClassesJar.size}B" else "none"})"
+    )
+    return BundleAndroidResources(
+      resourceApkPath = ANDROID_RESOURCE_APK_PATH,
+      mergedManifestPath = ANDROID_MERGED_MANIFEST_PATH,
+      rClassesJarPath = if (rClassesJar != null) ANDROID_R_CLASSES_JAR_PATH else null,
+      applicationPackage = pkg,
+    )
+  }
+
+  /**
+   * Collect the generated R classes from the unit-test runtime classpath and repack them into a
+   * single jar's bytes. AGP generates these (a library's R fields are non-final, so `R.style.X`
+   * compiles to a real `getstatic` on the `R$style` *class*, which an AAR's published `classes.jar`
+   * does not contain), and the same classpath is what the render path links them from. We keep
+   * every `…/R.class` and `…/R$*.class` across all jars (deduped by entry name) — R classes are
+   * tiny leaf data holders, so carrying the lot is cheaper than guessing which library the renderer
+   * needs. Returns null when none are found.
+   */
+  private fun packAndroidRClasses(): ByteArray? {
+    val jars =
+      androidUnitTestRuntimeClasspath.files.filter { it.isFile && it.name.endsWith(".jar") }
+    if (jars.isEmpty()) return null
+    val collected = LinkedHashMap<String, ByteArray>()
+    for (jar in jars) {
+      try {
+        ZipInputStream(jar.inputStream().buffered()).use { zin ->
+          while (true) {
+            val entry = zin.nextEntry ?: break
+            val name = entry.name
+            val leaf = name.substringAfterLast('/')
+            val isR = leaf == "R.class" || (leaf.startsWith("R$") && leaf.endsWith(".class"))
+            if (!entry.isDirectory && isR && name !in collected) {
+              collected[name] = zin.readBytes()
+            }
+            zin.closeEntry()
+          }
+        }
+      } catch (e: Exception) {
+        logger.warn("composePreviewBundle: couldn't scan $jar for R classes: ${e.message}")
+      }
+    }
+    if (collected.isEmpty()) return null
+    val baos = ByteArrayOutputStream()
+    ZipOutputStream(baos).use { zip ->
+      collected.forEach { (name, bytes) -> zip.writeFile(name, bytes) }
+    }
+    return baos.toByteArray()
   }
 
   private fun packModuleClasses(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -124,6 +124,19 @@ abstract class BundlePreviewTask : DefaultTask() {
   abstract val androidUnitTestConfig: ConfigurableFileCollection
 
   /**
+   * (v6 Android) The variant's `${variant}UnitTestRuntimeClasspath`, resolved through a **lenient**
+   * `artifactView` (so AGP's `AmbiguousArtifactsFailure` on project deps exposing secondary
+   * variants is skipped rather than fatal). Scanned at pack time **only when protolayout IR is
+   * present** for the generated library R classes (`…/R.class`, `…/R$*.class`). With non-transitive
+   * R classes, the tile renderer's `androidx.wear.protolayout.renderer.R$style` is generated only
+   * into the unit-test **merged** R.jar — added to this classpath as a raw file dep *without* the
+   * `artifactType=jar` attribute, so the bundle's `dependencyJars` (attribute-filtered) view drops
+   * it. The collected R classes are repacked under `android/r-classes.jar` so the daemon's parent
+   * (renderer) classloader can link them. Unused by the desktop path.
+   */
+  @get:Classpath abstract val androidUnitTestRuntimeClasspath: ConfigurableFileCollection
+
+  /**
    * Renders directory from the preceding `composePreviewRender` task. Each selected preview's PNG
    * is read from here: the cover is prepended to the polyglot, and every selected preview is baked
    * into `previews/<id>.png`. When missing or empty, the cover falls back to a stub gray PNG so the
@@ -536,25 +549,23 @@ abstract class BundlePreviewTask : DefaultTask() {
   }
 
   /**
-   * Collect the generated R classes from [dependencyJars] and repack them into a single jar's
-   * bytes. AGP generates these (a library's R fields are non-final, so `R.style.X` compiles to a
-   * real `getstatic` on the `R$style` *class*, which an AAR's published `classes.jar` does not
-   * contain). For an application module — the bundle's primary Android target — AGP's
-   * `process<Variant>Resources` puts the merged R.jar (carrying every dependency library's R,
-   * including `androidx.wear.protolayout.renderer.R$style`) on the main runtime classpath, which
-   * the bundle's `artifactType=jar` view already exposes here. We keep every `…/R.class` and
-   * `…/R$*.class` across all jars (deduped by entry name) — R classes are tiny leaf data holders,
-   * so carrying the lot is cheaper than guessing which library the renderer needs. Returns null
-   * when none are found.
-   *
-   * (Scanning the main runtime classpath rather than `…UnitTestRuntimeClasspath` deliberately
-   * avoids resolving that configuration as a task input — it triggers AGP's
-   * `AmbiguousArtifactsFailure` on project deps exposing secondary variants. The trade-off: a
-   * *library*-module consumer whose R.jar lives only on the unit-test classpath wouldn't be
-   * covered, but the bundle's Android target is an application.)
+   * Collect the generated R classes from the unit-test runtime classpath (+ [dependencyJars]) and
+   * repack them into a single jar's bytes. AGP generates these (a library's R fields are non-final,
+   * so `R.style.X` compiles to a real `getstatic` on the `R$style` *class*, which an AAR's
+   * published `classes.jar` does not contain). With non-transitive R classes the tile renderer's
+   * `androidx.wear.protolayout.renderer.R$style` is generated only into the unit-test **merged**
+   * R.jar — a raw file dep on `…UnitTestRuntimeClasspath` *without* the `artifactType=jar`
+   * attribute, so the attribute-filtered [dependencyJars] view drops it; hence we also scan
+   * [androidUnitTestRuntimeClasspath] (resolved leniently to dodge AGP's
+   * `AmbiguousArtifactsFailure`). We keep every `…/R.class` and `…/R$*.class` across all jars
+   * (deduped by entry name) — R classes are tiny leaf data holders, so carrying the lot is cheaper
+   * than guessing which library the renderer needs. Returns null when none are found.
    */
   private fun packAndroidRClasses(): ByteArray? {
-    val jars = dependencyJars.files.filter { it.isFile && it.name.endsWith(".jar") }
+    val jars =
+      (androidUnitTestRuntimeClasspath.files + dependencyJars.files)
+        .filter { it.isFile && it.name.endsWith(".jar") }
+        .distinct()
     if (jars.isEmpty()) return null
     val collected = LinkedHashMap<String, ByteArray>()
     for (jar in jars) {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -217,12 +217,20 @@ internal object ComposePreviewTasks {
     // path (AndroidPreviewSupport) passes "android" so players know which renderer the bundle was
     // packed for. Packing itself is backend-agnostic — the closure walk only sees JVM bytecode.
     backendId: String = "desktop",
-    // (v6 Android) AGP's `unit_test_config_directory` (carrying `test_config.properties`) and the
-    // variant's `${variant}UnitTestRuntimeClasspath`. Wired only on the Android path so a
-    // protolayout-IR bundle can carry the merged resource APK + manifest + generated R classes the
-    // tile renderer needs on a detached daemon. Null on desktop — no Android resource carriage.
-    androidUnitTestConfigDir: Provider<Directory>? = null,
-    androidUnitTestRuntimeClasspath: FileCollection? = null,
+    // (v6 Android) Wired only on the Android path so a protolayout-IR bundle can carry the merged
+    // resource APK + manifest + generated R classes the tile renderer needs on a detached daemon.
+    // Null on desktop — no Android resource carriage.
+    //
+    // `androidUnitTestConfigFiles` is AGP's `unit_test_config_directory` (carrying
+    // `test_config.properties`) UNIONED with the merged resource APK + merged manifest those
+    // properties point at. The pack action reads the APK/manifest by the absolute paths in
+    // `test_config.properties`, so they must also be declared here as tracked `@InputFiles`
+    // content — otherwise the cacheable task could restore a stale bundle when those generated
+    // files change while their paths stay the same. (The generated library R classes the tile
+    // renderer needs are scanned straight from the bundle's existing `dependencyJars` view — for an
+    // application module AGP puts the merged R.jar on the main runtime classpath — so no separate
+    // unit-test-classpath input is wired, avoiding AGP's `AmbiguousArtifactsFailure`.)
+    androidUnitTestConfigFiles: FileCollection? = null,
   ) {
     val previewIdsProperty: Provider<List<String>> =
       project.providers.gradleProperty("bundlePreviewIds").map { raw ->
@@ -334,8 +342,7 @@ internal object ComposePreviewTasks {
       depJarFiles?.let { dependencyJars.from(it) }
       dependencyCoordinates.set(coordMapProvider)
       // (v6 Android) Inputs for protolayout resource carriage; null on desktop (no-op).
-      androidUnitTestConfigDir?.let { androidUnitTestConfig.from(it) }
-      androidUnitTestRuntimeClasspath?.let { this.androidUnitTestRuntimeClasspath.from(it) }
+      androidUnitTestConfigFiles?.let { androidUnitTestConfig.from(it) }
       // Renders dir is wired conditionally — when composePreviewRender has run, the dir exists and
       // contains PNGs. Use orNull semantics: missing dir = stub cover. `rendersDir` is the
       // @Internal

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -226,13 +226,14 @@ internal object ComposePreviewTasks {
     // properties point at. The pack action reads the APK/manifest by the absolute paths in
     // `test_config.properties`, so they must also be declared here as tracked `@InputFiles`
     // content — otherwise the cacheable task could restore a stale bundle when those generated
-    // files change while their paths stay the same. `androidUnitTestRuntimeClasspath` is the
-    // variant's `${variant}UnitTestRuntimeClasspath` (resolved leniently by the caller), scanned
-    // for the generated library R classes — with non-transitive R, the tile renderer's `R$style`
-    // is only on that classpath's merged R.jar, which the `artifactType=jar` `dependencyJars` view
-    // drops.
+    // files change while their paths stay the same. `androidUnitTestRuntimeClasspath` is a lazy
+    // supplier of the AGP unit-test `Test` task's classpath (the SAME source the render path links
+    // its resources + library R classes from) — invoked inside the task-config lambda so the
+    // `test<Variant>UnitTest` task exists by then. With non-transitive R, the tile renderer's
+    // `R$style` is generated only into that classpath's merged R.jar — a raw file dep without the
+    // `artifactType=jar` attribute, so the bundle's filtered `dependencyJars` view drops it.
     androidUnitTestConfigFiles: FileCollection? = null,
-    androidUnitTestRuntimeClasspath: FileCollection? = null,
+    androidUnitTestRuntimeClasspath: (() -> FileCollection?)? = null,
   ) {
     val previewIdsProperty: Provider<List<String>> =
       project.providers.gradleProperty("bundlePreviewIds").map { raw ->
@@ -343,9 +344,13 @@ internal object ComposePreviewTasks {
       moduleResourcesDir.set(moduleResourcesDirProvider)
       depJarFiles?.let { dependencyJars.from(it) }
       dependencyCoordinates.set(coordMapProvider)
-      // (v6 Android) Inputs for protolayout resource carriage; null on desktop (no-op).
+      // (v6 Android) Inputs for protolayout resource carriage; null on desktop (no-op). The
+      // unit-test classpath supplier is invoked here (inside the task-config lambda) so AGP's
+      // `test<Variant>UnitTest` task is registered by the time we query its classpath.
       androidUnitTestConfigFiles?.let { androidUnitTestConfig.from(it) }
-      androidUnitTestRuntimeClasspath?.let { this.androidUnitTestRuntimeClasspath.from(it) }
+      androidUnitTestRuntimeClasspath?.invoke()?.let {
+        this.androidUnitTestRuntimeClasspath.from(it)
+      }
       // Renders dir is wired conditionally — when composePreviewRender has run, the dir exists and
       // contains PNGs. Use orNull semantics: missing dir = stub cover. `rendersDir` is the
       // @Internal

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -226,11 +226,13 @@ internal object ComposePreviewTasks {
     // properties point at. The pack action reads the APK/manifest by the absolute paths in
     // `test_config.properties`, so they must also be declared here as tracked `@InputFiles`
     // content — otherwise the cacheable task could restore a stale bundle when those generated
-    // files change while their paths stay the same. (The generated library R classes the tile
-    // renderer needs are scanned straight from the bundle's existing `dependencyJars` view — for an
-    // application module AGP puts the merged R.jar on the main runtime classpath — so no separate
-    // unit-test-classpath input is wired, avoiding AGP's `AmbiguousArtifactsFailure`.)
+    // files change while their paths stay the same. `androidUnitTestRuntimeClasspath` is the
+    // variant's `${variant}UnitTestRuntimeClasspath` (resolved leniently by the caller), scanned
+    // for the generated library R classes — with non-transitive R, the tile renderer's `R$style`
+    // is only on that classpath's merged R.jar, which the `artifactType=jar` `dependencyJars` view
+    // drops.
     androidUnitTestConfigFiles: FileCollection? = null,
+    androidUnitTestRuntimeClasspath: FileCollection? = null,
   ) {
     val previewIdsProperty: Provider<List<String>> =
       project.providers.gradleProperty("bundlePreviewIds").map { raw ->
@@ -343,6 +345,7 @@ internal object ComposePreviewTasks {
       dependencyCoordinates.set(coordMapProvider)
       // (v6 Android) Inputs for protolayout resource carriage; null on desktop (no-op).
       androidUnitTestConfigFiles?.let { androidUnitTestConfig.from(it) }
+      androidUnitTestRuntimeClasspath?.let { this.androidUnitTestRuntimeClasspath.from(it) }
       // Renders dir is wired conditionally — when composePreviewRender has run, the dir exists and
       // contains PNGs. Use orNull semantics: missing dir = stub cover. `rendersDir` is the
       // @Internal

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -217,6 +217,12 @@ internal object ComposePreviewTasks {
     // path (AndroidPreviewSupport) passes "android" so players know which renderer the bundle was
     // packed for. Packing itself is backend-agnostic — the closure walk only sees JVM bytecode.
     backendId: String = "desktop",
+    // (v6 Android) AGP's `unit_test_config_directory` (carrying `test_config.properties`) and the
+    // variant's `${variant}UnitTestRuntimeClasspath`. Wired only on the Android path so a
+    // protolayout-IR bundle can carry the merged resource APK + manifest + generated R classes the
+    // tile renderer needs on a detached daemon. Null on desktop — no Android resource carriage.
+    androidUnitTestConfigDir: Provider<Directory>? = null,
+    androidUnitTestRuntimeClasspath: FileCollection? = null,
   ) {
     val previewIdsProperty: Provider<List<String>> =
       project.providers.gradleProperty("bundlePreviewIds").map { raw ->
@@ -327,6 +333,9 @@ internal object ComposePreviewTasks {
       moduleResourcesDir.set(moduleResourcesDirProvider)
       depJarFiles?.let { dependencyJars.from(it) }
       dependencyCoordinates.set(coordMapProvider)
+      // (v6 Android) Inputs for protolayout resource carriage; null on desktop (no-op).
+      androidUnitTestConfigDir?.let { androidUnitTestConfig.from(it) }
+      androidUnitTestRuntimeClasspath?.let { this.androidUnitTestRuntimeClasspath.from(it) }
       // Renders dir is wired conditionally — when composePreviewRender has run, the dir exists and
       // contains PNGs. Use orNull semantics: missing dir = stub cover. `rendersDir` is the
       // @Internal

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -142,6 +142,45 @@ data class BundleManifest(
    * correctly. See the "Intermediate-representation previews" section above.
    */
   val intermediateRepresentations: List<BundleIr> = emptyList(),
+  /**
+   * (v6) Android resource carriage for IR replay. Present only when the bundle carries protolayout
+   * (Wear tile) IR: replaying a tile drives `TileRenderer`, which resolves the library theme
+   * `androidx.wear.protolayout.renderer.R.style.ProtoLayoutBaseTheme` through `getResources()` and
+   * links the non-final library `R$style` *class*. A detached daemon has neither the merged
+   * resource table (no AGP build) nor the generated R classes (an AAR's published `classes.jar`
+   * omits them), so without this carriage tile replay dies with `NoClassDefFoundError` on `R$style`
+   * and then `Unknown resource value type 0`. The record points at the AGP-built merged resource
+   * APK + manifest and the generated R classes packed under `android/`; the player rebuilds a
+   * Robolectric `com/android/tools/test_config.properties` from them. `null` for desktop bundles
+   * and for Android bundles with no protolayout IR (classic / Remote-Compose-only previews need
+   * none). Additive — a pre-v6 reader ignores the field and the `android/` entries.
+   */
+  val androidResources: BundleAndroidResources? = null,
+)
+
+/**
+ * (v6) Android resource artefacts carried for protolayout IR replay. See
+ * [BundleManifest.androidResources]. All paths are posix zip paths inside the bundle.
+ */
+@Serializable
+data class BundleAndroidResources(
+  /**
+   * Zip path of the merged resource APK (AAPT2 `apk-for-local-test.ap_`), e.g.
+   * `android/resources.ap_`.
+   */
+  val resourceApkPath: String,
+  /** Zip path of the merged `AndroidManifest.xml` Robolectric reads the package + theme from. */
+  val mergedManifestPath: String,
+  /**
+   * Zip path of the jar holding the generated library R classes (`androidx.wear.protolayout.*.R$*`
+   * etc.) the tile renderer links against, e.g. `android/r-classes.jar`. `null` when no R classes
+   * were found to carry (the renderer then relies on whatever is already reachable).
+   */
+  val rClassesJarPath: String? = null,
+  /**
+   * Consumer application package (`android_custom_package`), recorded for the synthesized config.
+   */
+  val applicationPackage: String? = null,
 )
 
 /**
@@ -272,6 +311,18 @@ const val IR_EXT_PROTOLAYOUT_LAYOUT: String = "tilelayout"
 /** File extension for the companion protolayout `Resources` proto. */
 const val IR_EXT_PROTOLAYOUT_RESOURCES: String = "tileresources"
 
+/** Well-known directory inside the bundle zip holding Android resource carriage (v6). */
+const val BUNDLE_ANDROID_DIR: String = "android"
+
+/** Zip path of the carried merged resource APK (v6). See [BundleAndroidResources]. */
+const val ANDROID_RESOURCE_APK_PATH: String = "android/resources.ap_"
+
+/** Zip path of the carried merged `AndroidManifest.xml` (v6). */
+const val ANDROID_MERGED_MANIFEST_PATH: String = "android/AndroidManifest.xml"
+
+/** Zip path of the carried generated R-class jar (v6). */
+const val ANDROID_R_CLASSES_JAR_PATH: String = "android/r-classes.jar"
+
 /**
  * Schema version stamped into [BundleManifest.schemaVersion].
  * - v1 — `bundle.json` + `previews.json` + `classes/app.jar` + `report.json`, cover PNG as the
@@ -298,8 +349,14 @@ const val IR_EXT_PROTOLAYOUT_RESOURCES: String = "tileresources"
  *   dropped from `classes/app.jar`. Additive — the field defaults to empty and `ignoreUnknownKeys`
  *   readers skip the `ir/` entries, so a v4 reader opening a v5 *classpath* bundle still works;
  *   only the IR previews need a v5-aware player.
+ * - v6 — adds [BundleManifest.androidResources] and the `android/` directory: an Android bundle
+ *   carrying protolayout (Wear tile) IR also carries the AGP-built merged resource APK + manifest
+ *   and the generated library R classes, so a detached daemon can resolve the tile renderer's theme
+ *   resource and link its `R$style` class on replay. Additive — the field defaults to null and
+ *   `ignoreUnknownKeys` readers skip the `android/` entries, so a v5 reader opening a v6 bundle
+ *   still works; only protolayout IR replay on a detached Android daemon needs a v6-aware player.
  */
-const val BUNDLE_SCHEMA_VERSION: Int = 5
+const val BUNDLE_SCHEMA_VERSION: Int = 6
 
 /**
  * Well-known directory inside the bundle zip holding one rendered PNG per selected preview, keyed

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
@@ -23,8 +23,8 @@ class PreviewBundleFormatTest {
   }
 
   @Test
-  fun `current schema version is 5`() {
-    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(5)
+  fun `current schema version is 6`() {
+    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(6)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Follow-up to #1689. That PR fixed IR *capture* (the bundles now carry protolayout + Remote Compose IR, and RC + classic previews replay end-to-end on the detached daemon). It left one failing test — `AndroidBundleDaemonRenderFunctionalTest` — because replaying a **Wear tile (protolayout)** IR exposed a latent gap:

```
HelloTilePreview_Large Round → NoClassDefFoundError: androidx/wear/protolayout/renderer/R$style
```

`TileRenderer` resolves the library theme `androidx.wear.protolayout.renderer.R.style.ProtoLayoutBaseTheme` via `getResources()` and links the **non-final library `R$style` class**. A detached daemon has neither the merged resource table (it runs outside AGP) nor those generated R classes (an AAR's published `classes.jar` omits them). Classic previews never hit this (an app's own R fields are `final`, so inlined), and Remote Compose replay needs no Android resources — so this is protolayout-only.

## Approach

Mirror the in-Gradle render path, which gets resources via AGP's generated `com/android/tools/test_config.properties` on the Robolectric classpath:

- **Pack (schema v6):** when a bundle carries protolayout IR, read AGP's `test_config.properties` to locate the merged resource APK + manifest and carry them under `android/`, plus the generated library R classes (collected from the unit-test runtime classpath) as `android/r-classes.jar`. Recorded in a new optional `BundleManifest.androidResources` field — additive, so `ignoreUnknownKeys` readers ignore it.
- **Launch (CLI):** extract `android/`, synthesize the Robolectric `test_config.properties` pointing at the extracted APK + manifest, and put it plus the R-class jar on the daemon `-cp` (the parent/renderer loader, where `TileRenderer` links `R$style`) via the existing IR-carriage seam.
- **Daemon:** unchanged — `RobolectricTestRunner` auto-reads `test_config.properties`.

Gated strictly on protolayout IR being present, so desktop, classic, and Remote-Compose-only bundles are unaffected.

## Test plan

- [ ] **Android Bundle Daemon E2E** (the previously-failing test) goes green — this is the real validation; it can't be exercised locally without an Android SDK + Robolectric.
- [ ] Other CI jobs stay green (the change is additive and protolayout-gated).
- Once E2E is confirmed green, strip the temporary IR-coverage diagnostic that landed via #1689's `d1105a78`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SjYP3v8o7EsubKtFUCxmn9)_