### PR TITLE
test(xr-spatial): recover real subspace panel poses offline (fake XR runtime)

### DIFF
--- a/docs/design/XR_SPATIAL_PREVIEW.md
+++ b/docs/design/XR_SPATIAL_PREVIEW.md
@@ -107,13 +107,56 @@ An Android **library** module (no `applicationId` needed; mirrors `:samples:andr
 
 PNGs land under `samples/xr-spatial/build/compose-previews/renders/`.
 
-## Out of scope / future work
+## Recovering the real layout offline — it works (`SubspaceLayoutPoseTest`)
 
-- **True 3D spatial capture.** Rendering the actual `Subspace`/`SpatialPanel` 3D layout (panel
-  poses, depth, curved rows) needs the SceneCore runtime; use the Android Studio **XR emulator** for
-  that. If `androidx.xr.compose:compose-testing` ever ships a host-side fake that composes subspace
-  content into a flat 2D tree (analogous to `ImageComposeScene`), a follow-up could capture a
-  flattened top-down projection — tracked, not built.
+The interesting question is whether the *real* subspace layout (panel poses/sizes computed by the
+framework) can be harvested offline and projected to 2D ourselves — geometry-true previews without
+reimplementing the layout. **It can**, with no headset, no OpenXR, and no SceneCore native code. The
+proof-of-concept is [`SubspaceLayoutPoseTest`](../../samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/SubspaceLayoutPoseTest.kt);
+the recipe is entirely public API plus **one Robolectric shadow**:
+
+1. **Fake runtime off-device.** `androidx.xr.runtime:runtime-testing` +
+   `androidx.xr.scenecore:scenecore-testing` provide `FakeSceneRuntimeFactory` /
+   `FakeRenderingRuntimeFactory`. Register them for `ServiceLoader` (a `META-INF/services/` file per
+   `SceneRuntimeFactory` / `RenderingRuntimeFactory` interface) and `Session.create(activity)`
+   returns `SessionCreateSuccess` on a plain JVM under Robolectric. `FakeSceneRuntime` defaults to
+   `SpatialCapabilities(63)` = all capabilities.
+2. **Flip the one gate.** `Subspace` only takes its spatial path when
+   `packageManager.hasSystemFeature("android.software.xr.api.spatial")` (`ManifestFeature
+   .FEATURE_XR_API_SPATIAL`) is true — Robolectric reports `false`, so shadow it on with
+   `shadowOf(pm).setSystemFeature(…, true)`. **That was the whole blocker.** The session and
+   `LocalComposeXrOwners` then auto-wire from the activity (the `LocalComposeXrOwners` default
+   computes `getOrCreateXrOwnerLocals(activity)` from `LocalContext`), so no internal/reflection
+   session-injection is needed — an earlier dead end that probed the locals *above* `Subspace` (where
+   the host hasn't installed them) mis-diagnosed this as internal-only.
+3. **Read the public spatial-semantics tree.** `onSubspaceNodeWithTag(tag).fetchSemanticsNode()` →
+   `SubspaceSemanticsInfo.poseInRoot` (`Pose`, dp) + `.size` (`IntVolumeSize`, dp) + children.
+
+For a `SpatialColumn` of a 200dp panel over a 160dp panel the test recovers, offline:
+
+```
+column: poseInRoot=(0, 0, 0)    size=(560 x 360)
+top:    poseInRoot=(0, 80, 0)   size=(560 x 200)
+bottom: poseInRoot=(0, -100, 0) size=(560 x 160)
+```
+
+i.e. the genuine framework-computed stack (top above bottom, column = sum of children).
+
+**Verdict / path forward:** a real **subspace-layout projector** is feasible — render each panel's
+2D content (Robolectric, as the committed `@Preview`s already do), then composite the panels at
+their recovered `poseInRoot`/`size` through a chosen preview camera. That is a future renderer
+feature, not built here; `SubspaceLayoutPoseTest` proves the geometry is recoverable and stands as
+the **canary** that flags when the alpha XR testing stack shifts. **Fragility mitigation** (the
+honest cost of leaning on alpha `*-testing` libs + a private system-feature string): the canary test
+fails loudly on a stack change, and a future `compose-preview doctor` check can assert the fake
+runtime still loads and `Subspace` still composes before any projector feature relies on it.
+
+- **True 3D spatial capture.** Rendering the actual `Subspace`/`SpatialPanel` 3D layout with real
+  shading/compositing needs the SceneCore renderer. The Android Studio **XR emulator** runs the real
+  SceneCore/Compose-XR stack on a desktop GPU, but it is **not** an OpenXR host (Google: "OpenXR is
+  not supported on the emulator"), is **Canary-channel + GPU-mandatory**, and exposes no documented
+  spatial frame-capture / head-pose-injection hook — so it's a manual dev aid, not a deterministic CI
+  capture path.
 - **An `@SpatialPreview` meta-annotation / spatial device spec.** Studio uses an "XR" device preset
   in the preview picker. We could add a meta-annotation in `:preview-annotations` that pins a wide
   spatial-panel device spec, but — unlike `@FocusedPreview`/`@AmbientPreview` — it would carry no

--- a/samples/xr-spatial/build.gradle.kts
+++ b/samples/xr-spatial/build.gradle.kts
@@ -62,4 +62,20 @@ dependencies {
   implementation(libs.xr.compose)
 
   debugImplementation("androidx.compose.ui:ui-tooling")
+
+  // `SubspaceLayoutPoseTest` recovers the real subspace panel poses offline by driving the fake XR
+  // runtime under Robolectric (no headset / OpenXR / SceneCore native). It needs the XR `*-testing`
+  // artifacts plus Compose UI test + Robolectric. The fake `SceneRuntimeFactory` /
+  // `RenderingRuntimeFactory` are registered for `ServiceLoader` in
+  // `src/test/resources/META-INF/services/`. Versions are pinned literally (rather than via the
+  // catalog) because these alpha test artifacts move on their own cadence and only this sample's
+  // canary test consumes them; bump alongside `xr-compose` in libs.versions.toml.
+  testImplementation(libs.robolectric)
+  testImplementation("androidx.compose.ui:ui-test-junit4")
+  testImplementation("androidx.compose.ui:ui-test-manifest")
+  testImplementation(libs.xr.compose.testing)
+  testImplementation("androidx.xr.runtime:runtime-testing:1.0.0-alpha14")
+  testImplementation("androidx.xr.scenecore:scenecore-testing:1.0.0-alpha15")
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
 }

--- a/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/SubspaceLayoutPoseTest.kt
+++ b/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/SubspaceLayoutPoseTest.kt
@@ -1,0 +1,109 @@
+package com.example.samplexrspatial
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import androidx.xr.compose.platform.LocalSpatialCapabilities
+import androidx.xr.compose.spatial.Subspace
+import androidx.xr.compose.subspace.SpatialColumn
+import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.layout.SubspaceModifier
+import androidx.xr.compose.subspace.layout.height
+import androidx.xr.compose.subspace.layout.width
+import androidx.xr.compose.subspace.semantics.testTag
+import androidx.xr.compose.testing.onSubspaceNodeWithTag
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Recovers the *real* subspace layout — panel poses and sizes computed by `androidx.xr.compose` —
+ * offline, with no headset, no OpenXR, and no SceneCore native code.
+ *
+ * This is the proof-of-concept behind the "harvest poses → project to 2D" path discussed in
+ * [docs/design/XR_SPATIAL_PREVIEW.md](../../../../../../../docs/design/XR_SPATIAL_PREVIEW.md). It
+ * also doubles as the **canary** for the alpha XR testing stack: if a future
+ * `androidx.xr.*:…-testing` release changes how the fake runtime is discovered, how spatial UI is
+ * gated, or the subspace semantics surface, this test fails loudly instead of the capability
+ * silently regressing.
+ *
+ * How it works — entirely public API plus one Robolectric shadow:
+ *  1. `FakeSceneRuntimeFactory` / `FakeRenderingRuntimeFactory` (from `scenecore-testing`) are
+ *     registered for `ServiceLoader` via `src/test/resources/META-INF/services/…`, so
+ *     `Session.create(activity)` yields a fake, JVM-only XR session.
+ *  2. `Subspace` only takes its spatial path when
+ *     `packageManager.hasSystemFeature("android.software.xr.api.spatial")` is true. Robolectric
+ *     reports `false`, so we shadow it on with [ShadowPackageManager.setSystemFeature]. The
+ *     session and `LocalComposeXrOwners` then auto-wire from the activity.
+ *  3. The panel transforms are read from the public spatial-semantics tree
+ *     (`onSubspaceNodeWithTag(tag).fetchSemanticsNode().poseInRoot` / `.size`).
+ *
+ * Poses/sizes are in dp. A `SpatialColumn` of a 200dp-tall panel over a 160dp-tall panel resolves
+ * to a 360dp-tall column with the top panel above the bottom one — which is what we assert.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SubspaceLayoutPoseTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun recoversSubspacePanelPosesOffline() {
+    // Gate that selects `Subspace`'s spatial path over its 2D fallback.
+    val pm = ApplicationProvider.getApplicationContext<Context>().packageManager
+    shadowOf(pm).setSystemFeature("android.software.xr.api.spatial", true)
+
+    var spatialUiEnabled = false
+    rule.setContent {
+      val caps = LocalSpatialCapabilities.current
+      SideEffect { spatialUiEnabled = caps.isSpatialUiEnabled }
+      Subspace {
+        SpatialColumn(SubspaceModifier.testTag("column")) {
+          SpatialPanel(SubspaceModifier.testTag("top").width(560.dp).height(200.dp)) {
+            NowPlayingPanel()
+          }
+          SpatialPanel(SubspaceModifier.testTag("bottom").width(560.dp).height(160.dp)) {
+            TransportControls()
+          }
+        }
+      }
+    }
+    rule.waitForIdle()
+
+    // The fake session reached the composition and spatialization is on.
+    assertThat(spatialUiEnabled).isTrue()
+
+    val column = rule.onSubspaceNodeWithTag("column").fetchSemanticsNode("no 'column' node")
+    val top = rule.onSubspaceNodeWithTag("top").fetchSemanticsNode("no 'top' node")
+    val bottom = rule.onSubspaceNodeWithTag("bottom").fetchSemanticsNode("no 'bottom' node")
+
+    // Sizes are the layout output (dp). Panels keep their requested size; the column is their sum.
+    assertThat(top.size.width).isEqualTo(560)
+    assertThat(top.size.height).isEqualTo(200)
+    assertThat(bottom.size.height).isEqualTo(160)
+    assertThat(column.size.height).isEqualTo(360)
+
+    // Real 3D placement: the column stacks the top panel above the bottom one (+y is up).
+    assertThat(top.poseInRoot.translation.y).isGreaterThan(bottom.poseInRoot.translation.y)
+
+    println(
+      buildString {
+        appendLine("Recovered subspace layout (offline, fake runtime):")
+        for (n in listOf("column" to column, "top" to top, "bottom" to bottom)) {
+          val p = n.second.poseInRoot.translation
+          val s = n.second.size
+          appendLine(
+            "  ${n.first}: poseInRoot=(${p.x}, ${p.y}, ${p.z}) size=(${s.width} x ${s.height})"
+          )
+        }
+      }
+    )
+  }
+}

--- a/samples/xr-spatial/src/test/resources/META-INF/services/androidx.xr.runtime.internal.RenderingRuntimeFactory
+++ b/samples/xr-spatial/src/test/resources/META-INF/services/androidx.xr.runtime.internal.RenderingRuntimeFactory
@@ -1,0 +1,1 @@
+androidx.xr.scenecore.testing.FakeRenderingRuntimeFactory

--- a/samples/xr-spatial/src/test/resources/META-INF/services/androidx.xr.runtime.internal.SceneRuntimeFactory
+++ b/samples/xr-spatial/src/test/resources/META-INF/services/androidx.xr.runtime.internal.SceneRuntimeFactory
@@ -1,0 +1,1 @@
+androidx.xr.scenecore.testing.FakeSceneRuntimeFactory


### PR DESCRIPTION
Follow-up to the XR spatial sample (#1690).

`SubspaceLayoutPoseTest` proves that the spatial layout `androidx.xr.compose` computes can be harvested **off-device** — no headset, no OpenXR, no SceneCore native code — and doubles as a **canary** for the alpha XR testing stack (it fails loudly if discovery, the capability gate, or the subspace semantics surface shifts).

## How it works (public API + one Robolectric shadow)

1. Register `FakeSceneRuntimeFactory` / `FakeRenderingRuntimeFactory` (from `scenecore-testing`) for `ServiceLoader` via `src/test/resources/META-INF/services/…`, so `Session.create(activity)` returns a fake JVM session.
2. Shadow the `android.software.xr.api.spatial` system feature on (`ShadowPackageManager.setSystemFeature`). That's the **only** gate selecting `Subspace`'s spatial path over the 2D fallback; the session and `LocalComposeXrOwners` then auto-wire from the activity — no internal/reflection injection needed.
3. Read poses/sizes from the public spatial-semantics tree (`onSubspaceNodeWithTag(tag).fetchSemanticsNode().poseInRoot` / `.size`).

A `SpatialColumn` of a 200dp panel over a 160dp panel resolves offline to the genuine framework stack:

```
column: poseInRoot=(0, 0, 0)    size=(560 x 360)
top:    poseInRoot=(0, 80, 0)   size=(560 x 200)
bottom: poseInRoot=(0, -100, 0) size=(560 x 160)
```

Also updates `docs/design/XR_SPATIAL_PREVIEW.md` to the working verdict (the earlier "blocked by internal wiring" diagnosis was wrong — the blocker was the shadowable system-feature gate) and records a **subspace-layout projector** (render panels → composite at recovered poses) as future work, with fragility against the alpha `*-testing` libs mitigated by this canary test + a future `doctor` check.

## Test plan

- [x] `./gradlew :samples:xr-spatial:testDebugUnitTest --tests "*SubspaceLayoutPoseTest*"` → 1 passed (recovers distinct panel poses; asserts `spatialUiEnabled`, panel sizes, and top-above-bottom stacking)
- [x] `./gradlew :samples:xr-spatial:ktfmtCheck`
- [x] Branched fresh from `main` after #1690 landed; touches only `samples/xr-spatial` + the design doc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_