### PR TITLE
docs: update plugin version and dependency requirements

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,7 @@
         ".github/actions/install/README.md",
         "vscode-extension/README.md",
         "docs/RELEASING.md",
+        "site/index.md",
         {
           "type": "generic",
           "path": ".github/actions/preview-baselines/action.yml"

--- a/site/index.md
+++ b/site/index.md
@@ -36,7 +36,7 @@ The plugin is published to
 ```kotlin
 // <module>/build.gradle.kts
 plugins {
-    id("ee.schimke.composeai.preview") version "0.10.1"
+    id("ee.schimke.composeai.preview") version "0.12.5"
 }
 ```
 <!-- x-release-please-end -->
@@ -48,8 +48,8 @@ Then:
 ./gradlew :app:composePreviewRenderAll   # render every @Preview to PNG
 ```
 
-Requires Java 17+, Gradle 9.4.1+, AGP 9.1+ (Android), Kotlin 2.2.21,
-Compose Multiplatform 1.10.3 (Desktop).
+Requires Java 17+, Gradle 8.13+, AGP 8.13.0+ (Android), Kotlin 2.0.21+,
+Compose Multiplatform 1.10.3+ (Desktop).
 
 ### VS Code extension
 


### PR DESCRIPTION
Update documentation to reflect current plugin and dependency versions.

**Changes:**
- Bump ComposeAI preview plugin version from 0.10.1 to 0.12.5 in installation instructions
- Update minimum dependency versions:
  - Gradle: 9.4.1+ → 8.13+
  - AGP (Android): 9.1+ → 8.13.0+
  - Kotlin: 2.2.21 → 2.0.21+
  - Compose Multiplatform: 1.10.3 → 1.10.3+ (clarified as minimum)
- Add `site/index.md` to release-please configuration to ensure version updates are tracked in releases

**Notes:**
The dependency version changes appear to reflect actual minimum requirements rather than upgrades, with some versions being lowered to better match the project's compatibility matrix.

https://claude.ai/code/session_01Jiyfp5QBeFXPvFJGrvBZrS