### PR TITLE
feat: publish compose-preview skills to antigravity-awesome-skills

### DIFF
--- a/.github/workflows/publish-antigravity-skills.yml
+++ b/.github/workflows/publish-antigravity-skills.yml
@@ -1,0 +1,89 @@
+name: Publish skills (antigravity-awesome-skills)
+
+# Publishes the compose-preview / compose-preview-review skill bundles to the
+# antigravity-awesome-skills registry (https://github.com/sickn33/antigravity-awesome-skills).
+#
+# Two surfaces:
+#   - validate: a no-write dry-run (clone registry, inject our SKILL.md, run the
+#     upstream strict validator). Runs on every change to the bundles so we
+#     never ship a SKILL.md that the registry would reject.
+#   - publish: the real push-to-fork + open-PR step, keyed off the SAME release
+#     tag as release.yml (called from release-please.yml). No-ops cleanly until
+#     the ANTIGRAVITY_SKILLS_TOKEN secret is configured, so the workflow can
+#     land before the cross-repo token does.
+#
+# See contrib/registries/antigravity-awesome-skills/ for the bundles + publish.sh.
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. v0.3.5).'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. v0.3.5).'
+        required: true
+        type: string
+  pull_request:
+    paths:
+      - 'contrib/registries/antigravity-awesome-skills/**'
+      - '.github/workflows/publish-antigravity-skills.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'contrib/registries/antigravity-awesome-skills/**'
+      - '.github/workflows/publish-antigravity-skills.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-antigravity-skills-${{ inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # No-write validation: prove the bundles still pass the registry's own
+  # validator. Runs on PRs/pushes that touch the bundles, and as a gate ahead
+  # of a real publish.
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pyyaml
+      - name: Validate bundles against the upstream registry
+        env:
+          DRY_RUN: '1'
+        run: contrib/registries/antigravity-awesome-skills/publish.sh
+
+  # Real publish: only on a release (workflow_call / dispatch). Opens/updates a
+  # PR on the registry from a fork we control. Skipped if the token isn't set.
+  publish:
+    needs: validate
+    if: ${{ inputs.tag != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pyyaml
+      - name: Publish to antigravity-awesome-skills
+        env:
+          TAG_NAME: ${{ inputs.tag }}
+          GH_TOKEN: ${{ secrets.ANTIGRAVITY_SKILLS_TOKEN }}
+          AAS_FORK_REPO: ${{ vars.ANTIGRAVITY_SKILLS_FORK || 'yschimke/antigravity-awesome-skills' }}
+          AAS_GIT_NAME: ${{ vars.ANTIGRAVITY_SKILLS_GIT_NAME }}
+          AAS_GIT_EMAIL: ${{ vars.ANTIGRAVITY_SKILLS_GIT_EMAIL }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::notice::ANTIGRAVITY_SKILLS_TOKEN not set — skipping the cross-repo PR. " \
+                 "Configure the secret (and a fork) to enable automated publishing." >&2
+            DRY_RUN=1 contrib/registries/antigravity-awesome-skills/publish.sh
+            exit 0
+          fi
+          contrib/registries/antigravity-awesome-skills/publish.sh

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,3 +55,16 @@ jobs:
     secrets: inherit
     permissions:
       contents: write   # needed by the called workflow's `release` job
+
+  # Publish the compose-preview / compose-preview-review skill bundles to the
+  # antigravity-awesome-skills registry off the SAME tag. Self-guards on the
+  # ANTIGRAVITY_SKILLS_TOKEN secret, so it no-ops until that's configured.
+  publish-antigravity-skills:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/publish-antigravity-skills.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit
+    permissions:
+      contents: read

--- a/contrib/registries/antigravity-awesome-skills/README.md
+++ b/contrib/registries/antigravity-awesome-skills/README.md
@@ -1,0 +1,75 @@
+# antigravity-awesome-skills publishing
+
+Automated publishing of the `compose-preview` and `compose-preview-review`
+skill bundles to the [antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills)
+registry — a 1,400+ skill, installable `SKILL.md` library with an npm installer
+that targets Claude Code, Cursor, Codex CLI, Gemini CLI, Antigravity, Copilot,
+and more.
+
+This is one of the skill-registry rows tracked in
+[issue #772](https://github.com/yschimke/compose-ai-tools/issues/772).
+
+## Why this registry
+
+Of the skill registries surveyed in #772 it is the one with a fully documented,
+schema-backed, automatable contribution path:
+
+- skills are plain `skills/<name>/SKILL.md` files validated against a
+  [published JSON schema](https://github.com/sickn33/antigravity-awesome-skills/blob/main/schemas/skills-index.v1.schema.json)
+  and a [strict validator](https://github.com/sickn33/antigravity-awesome-skills/blob/main/tools/scripts/validate_skills.py);
+- contributions are **source-only** (we ship only the two `SKILL.md` files; the
+  registry regenerates `skills_index.json`, `CATALOG.md`, etc.);
+- the installer fans the same `SKILL.md` out to every supported host
+  (`--claude`, `--cursor`, `--gemini`, …), which matches the multi-host goal of
+  #772.
+
+By contrast, Smithery has no CLI skill-publish path (install only), and
+agentskills.so / awesome-mcp-style lists are one-off submissions — so neither is
+a clean fit for *automated* publishing today.
+
+## What's here
+
+```
+skills/compose-preview/SKILL.md          # render @Preview composables to PNG
+skills/compose-preview-review/SKILL.md   # diff @Preview renders across a PR
+publish.sh                               # validate + (optionally) open the PR
+```
+
+The two `SKILL.md` bundles are the source of truth; their bodies link back to
+the canonical skills in [`yschimke/skills`](https://github.com/yschimke/skills).
+
+## How publishing runs
+
+[`.github/workflows/publish-antigravity-skills.yml`](../../../.github/workflows/publish-antigravity-skills.yml):
+
+- **validate** — on every PR/push that touches these bundles, clones the
+  registry, drops our `SKILL.md` in, and runs the upstream **strict** validator.
+  No network writes.
+- **publish** — called from
+  [`release-please.yml`](../../../.github/workflows/release-please.yml) off the
+  same release tag as the GitHub-release tarballs. It pushes the bundles to a
+  fork we control and opens a PR against the registry.
+
+The publish step self-guards on `ANTIGRAVITY_SKILLS_TOKEN`: until that secret
+exists it runs in dry-run mode, so the automation can land before the token
+does.
+
+### One-time setup to enable the live PR
+
+1. Fork `sickn33/antigravity-awesome-skills` to an account/org we control.
+2. Add repo secret `ANTIGRAVITY_SKILLS_TOKEN` — a token with push rights to the
+   fork and PR-open rights on the registry.
+3. (Optional) repo variables: `ANTIGRAVITY_SKILLS_FORK` (default
+   `yschimke/antigravity-awesome-skills`), `ANTIGRAVITY_SKILLS_GIT_NAME`,
+   `ANTIGRAVITY_SKILLS_GIT_EMAIL` (a human identity for the commit).
+
+## Run it locally
+
+```bash
+# Validate the bundles against the live registry (no writes):
+DRY_RUN=1 contrib/registries/antigravity-awesome-skills/publish.sh
+
+# Open the PR (needs GH_TOKEN + a fork you can push to):
+GH_TOKEN=... AAS_GIT_NAME='You' AAS_GIT_EMAIL='you@example.com' \
+  TAG_NAME=v0.0.0 contrib/registries/antigravity-awesome-skills/publish.sh
+```

--- a/contrib/registries/antigravity-awesome-skills/publish.sh
+++ b/contrib/registries/antigravity-awesome-skills/publish.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Publish the compose-preview / compose-preview-review skill bundles to the
+# antigravity-awesome-skills registry (https://github.com/sickn33/antigravity-awesome-skills).
+#
+# The registry is a "source-only" community repo: contributors add
+# skills/<name>/SKILL.md files and a maintainer's tooling regenerates the
+# derived artifacts (skills_index.json, CATALOG.md, ...). So this script only
+# ever ships the two SKILL.md files that live next to it under skills/.
+#
+# Modes
+# -----
+#   DRY_RUN=1   Clone the target, drop our skills in, run the upstream
+#               validator, and stop. No network writes. Safe to run anywhere,
+#               including from the compose-ai-tools CI on every push.
+#
+#   (default)   Validate, then push to a fork we control (AAS_FORK_REPO) and
+#               open a pull request against AAS_TARGET_REPO. Requires GH_TOKEN
+#               with push rights to the fork.
+#
+# Environment
+# -----------
+#   TAG_NAME         Release tag, used in the branch name + PR title. Default: dev.
+#   AAS_TARGET_REPO  Upstream registry.   Default: sickn33/antigravity-awesome-skills
+#   AAS_FORK_REPO    Fork we can push to. Default: yschimke/antigravity-awesome-skills
+#   AAS_PR_BRANCH    Branch to push.      Default: compose-preview-skills-<TAG_NAME>
+#   GH_TOKEN         Token with push to the fork + PR-open on the target (write mode).
+#   AAS_GIT_NAME     Commit author/committer name  (write mode).
+#   AAS_GIT_EMAIL    Commit author/committer email (write mode; must be a human, not a bot).
+#   DRY_RUN          "1" to validate only.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_SRC="$SCRIPT_DIR/skills"
+
+TAG_NAME="${TAG_NAME:-dev}"
+AAS_TARGET_REPO="${AAS_TARGET_REPO:-sickn33/antigravity-awesome-skills}"
+AAS_FORK_REPO="${AAS_FORK_REPO:-yschimke/antigravity-awesome-skills}"
+AAS_PR_BRANCH="${AAS_PR_BRANCH:-compose-preview-skills-${TAG_NAME}}"
+DRY_RUN="${DRY_RUN:-0}"
+
+log() { printf '==> %s\n' "$*" >&2; }
+
+# The two skills we own, derived from the directories shipped next to this script.
+SKILL_NAMES=()
+for d in "$SKILLS_SRC"/*/; do
+  [ -f "${d}SKILL.md" ] || continue
+  SKILL_NAMES+=("$(basename "$d")")
+done
+if [ "${#SKILL_NAMES[@]}" -eq 0 ]; then
+  log "no SKILL.md bundles found under $SKILLS_SRC"; exit 1
+fi
+log "skills to publish: ${SKILL_NAMES[*]}"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+CLONE="$WORKDIR/registry"
+
+log "cloning https://github.com/$AAS_TARGET_REPO (shallow)"
+git clone --depth 1 "https://github.com/$AAS_TARGET_REPO.git" "$CLONE" >/dev/null 2>&1
+
+for name in "${SKILL_NAMES[@]}"; do
+  mkdir -p "$CLONE/skills/$name"
+  cp "$SKILLS_SRC/$name/SKILL.md" "$CLONE/skills/$name/SKILL.md"
+done
+
+log "running upstream validator (strict)"
+python3 "$CLONE/tools/scripts/validate_skills.py" --strict
+
+if [ "$DRY_RUN" = "1" ]; then
+  log "DRY_RUN=1 — validated, no PR opened."
+  exit 0
+fi
+
+# ---- write mode: push to fork + open PR ----------------------------------
+: "${GH_TOKEN:?GH_TOKEN is required in write mode (set DRY_RUN=1 to validate only)}"
+: "${AAS_GIT_NAME:?AAS_GIT_NAME is required in write mode}"
+: "${AAS_GIT_EMAIL:?AAS_GIT_EMAIL is required in write mode}"
+
+cd "$CLONE"
+git config user.name  "$AAS_GIT_NAME"
+git config user.email "$AAS_GIT_EMAIL"
+git checkout -b "$AAS_PR_BRANCH"
+
+# Source-only: stage just our SKILL.md files, nothing the tooling regenerates.
+for name in "${SKILL_NAMES[@]}"; do
+  git add "skills/$name/SKILL.md"
+done
+
+if git diff --cached --quiet; then
+  log "no changes versus upstream — already published. Nothing to do."
+  exit 0
+fi
+
+git commit -m "feat: add compose-preview and compose-preview-review skills (${TAG_NAME})"
+
+log "pushing to https://github.com/$AAS_FORK_REPO ($AAS_PR_BRANCH)"
+git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${AAS_FORK_REPO}.git"
+git push --force-with-lease -u origin "$AAS_PR_BRANCH"
+
+fork_owner="${AAS_FORK_REPO%%/*}"
+title="Add compose-preview and compose-preview-review skills"
+body=$(cat <<EOF
+Adds two source-only skill bundles from https://github.com/yschimke/compose-ai-tools (release ${TAG_NAME}):
+
+- \`compose-preview\` — render Jetpack Compose / Compose Multiplatform @Preview functions to PNG.
+- \`compose-preview-review\` — diff @Preview renders across a PR's base and head.
+
+Both pass \`npm run validate\` / \`validate_skills.py --strict\`. Only the SKILL.md files are included; no generated registry artifacts.
+EOF
+)
+
+log "opening PR against $AAS_TARGET_REPO"
+curl -fsSL -X POST \
+  -H "Authorization: Bearer ${GH_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/${AAS_TARGET_REPO}/pulls" \
+  -d "$(python3 - "$title" "$fork_owner:$AAS_PR_BRANCH" "$body" <<'PY'
+import json, sys
+title, head, body = sys.argv[1], sys.argv[2], sys.argv[3]
+print(json.dumps({"title": title, "head": head, "base": "main", "body": body, "maintainer_can_modify": True}))
+PY
+)" | python3 -c "import json,sys; d=json.load(sys.stdin); print('==> PR:', d.get('html_url') or d.get('message'))"

--- a/contrib/registries/antigravity-awesome-skills/skills/compose-preview-review/SKILL.md
+++ b/contrib/registries/antigravity-awesome-skills/skills/compose-preview-review/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: compose-preview-review
+description: "Review Compose UI pull requests by rendering @Preview composables on base and head and diffing the resulting screenshots."
+category: code-quality
+risk: safe
+source: community
+source_repo: yschimke/skills
+source_type: community
+date_added: "2026-06-02"
+author: yschimke
+tags: [android, jetpack-compose, code-review, pull-request, screenshot, ui, kotlin]
+tools: [claude, cursor, gemini, codex, antigravity]
+license: "Apache-2.0"
+license_source: "https://github.com/yschimke/skills/blob/main/LICENSE"
+---
+
+# Compose Preview — Review
+
+## Overview
+
+Workflows for reviewing pull requests that touch Compose UI, authoring
+agent-opened PRs that include preview screenshots, and wiring CI to post
+before/after diffs automatically. It builds on the
+[`compose-preview`](https://github.com/yschimke/skills/tree/main/skills/compose-preview)
+skill by rendering the same `@Preview` composables on the PR's base and head
+commits, then surfacing a visual diff so a reviewer can judge the *rendered*
+change rather than reading the source diff alone. This is the canonical
+[`compose-preview-review` skill](https://github.com/yschimke/skills/tree/main/skills/compose-preview-review)
+distributed through the [compose-ai-tools](https://github.com/yschimke/compose-ai-tools)
+project.
+
+## When to Use This Skill
+
+- Use when reviewing a pull request that changes Compose UI and you want to see
+  the visual impact, not just the code.
+- Use when authoring an agent-opened PR that touches UI and should ship
+  before/after screenshots in the description.
+- Use when wiring CI to render `compose-preview/main` baselines and post diff
+  comments automatically on UI PRs.
+
+## How It Works
+
+### Step 1: Install the toolchain
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/yschimke/skills/main/scripts/install.sh | bash
+```
+
+This installs the `compose-preview` CLI used to render both sides of the diff.
+
+### Step 2: Render base and head
+
+Check out the PR's base commit, render the affected previews, then check out the
+head commit and render again. The
+[MCP review variant](https://github.com/yschimke/skills/blob/main/skills/compose-preview-review/references/mcp-review.md)
+runs both as two workspaces (base + head) under a single server so an agent can
+read either side on demand.
+
+### Step 3: Diff and report
+
+Compare the two PNG sets and attach the changed pairs to the review. For an
+automated CI flow, see the
+[ci-previews reference](https://github.com/yschimke/skills/blob/main/skills/compose-preview-review/references/ci-previews.md),
+which sets up `compose-preview/main` baselines and posts PR diff comments.
+
+## Examples
+
+### Example 1: Local before/after review of a UI PR
+
+```bash
+# Base
+git switch --detach origin/main
+compose-preview render :feature:profile --preview com.example.ProfileScreen
+# Head
+git switch -
+compose-preview render :feature:profile --preview com.example.ProfileScreen
+# Diff the two PNGs and attach the changed pair to the review.
+```
+
+### Example 2: Two-workspace review over MCP
+
+Attach the MCP server with a base and a head workspace, then read the same
+`compose-preview://` URI from each to compare renders without re-checking-out by
+hand. See the
+[MCP review reference](https://github.com/yschimke/skills/blob/main/skills/compose-preview-review/references/mcp-review.md).
+
+## Best Practices
+
+- ✅ Render the *same* preview set on both base and head so the diff is
+  apples-to-apples.
+- ✅ Attach changed before/after pairs to the PR so the human reviewer sees the
+  visual impact.
+- ✅ Wire the CI baseline + comment flow so diffs appear automatically on UI PRs.
+- ❌ Don't approve a UI change on the source diff alone — look at the render.
+- ❌ Don't diff against a stale baseline; re-render the base from the PR's actual
+  merge-base.
+
+## Limitations
+
+- This skill does not replace environment-specific validation, testing, or
+  expert review.
+- It surfaces visual differences; judging whether a difference is *correct* is
+  still a human (or reviewing-agent) decision.
+- Requires the previewed modules to apply the
+  `id("ee.schimke.composeai.preview")` Gradle plugin.
+- Stop and ask for clarification if required inputs, permissions, or safety
+  boundaries are missing.
+
+## Security & Safety Notes
+
+- The installer is fetched over HTTPS and piped to `bash`. Review the
+  [canonical installer](https://github.com/yschimke/skills/blob/main/scripts/install.sh)
+  before running it in a sensitive environment.
+
+<!-- security-allowlist: documented installer fetch for the compose-preview toolchain -->
+
+- Reviewing a PR checks out and builds untrusted contributor code to render it.
+  Run it in an authorized, sandboxed environment — treat rendering a PR like
+  building a PR.
+
+## Common Pitfalls
+
+- **Problem:** Base and head renders aren't comparable.
+  **Solution:** Render the identical preview FQNs on both sides and diff matching
+  filenames.
+- **Problem:** CI posts no diff comment.
+  **Solution:** Confirm the `compose-preview/main` baseline exists and the
+  workflow has permission to comment; see the
+  [ci-previews reference](https://github.com/yschimke/skills/blob/main/skills/compose-preview-review/references/ci-previews.md).
+
+## Related Skills
+
+- `@compose-preview` - The base skill: render `@Preview` composables to PNG. Use
+  it directly when you just need to see one preview rather than diff a PR.

--- a/contrib/registries/antigravity-awesome-skills/skills/compose-preview/SKILL.md
+++ b/contrib/registries/antigravity-awesome-skills/skills/compose-preview/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: compose-preview
+description: "Render Jetpack Compose and Compose Multiplatform @Preview functions to PNG outside Android Studio to verify, iterate on, and compare UI changes."
+category: developer-tools
+risk: safe
+source: community
+source_repo: yschimke/skills
+source_type: community
+date_added: "2026-06-02"
+author: yschimke
+tags: [android, jetpack-compose, compose-multiplatform, ui, screenshot, preview, kotlin]
+tools: [claude, cursor, gemini, codex, antigravity]
+license: "Apache-2.0"
+license_source: "https://github.com/yschimke/skills/blob/main/LICENSE"
+---
+
+# Compose Preview
+
+## Overview
+
+Render `@Preview` composables to PNG images without launching Android Studio.
+It works on both Android (Jetpack Compose via Robolectric) and Compose
+Multiplatform Desktop (via `ImageComposeScene` + Skia), so an agent can see
+exactly what a screen looks like, iterate on the code, and re-render to confirm
+the change — all from the command line. This is the canonical
+[`compose-preview` skill](https://github.com/yschimke/skills/tree/main/skills/compose-preview)
+distributed through the [compose-ai-tools](https://github.com/yschimke/compose-ai-tools)
+project.
+
+## When to Use This Skill
+
+- Use when you change a Compose `@Preview` and want to *see* the rendered UI
+  before claiming the change works.
+- Use when iterating on a layout, theme, typography, or spacing tweak and you
+  need a fast render/look/adjust loop without an emulator or device.
+- Use when comparing before/after states of a composable, or capturing a screen
+  for a PR, design review, or bug report.
+- Use when working in a headless environment (CI, a remote agent sandbox) where
+  Android Studio is not available.
+
+## How It Works
+
+### Step 1: Install the CLI and skill
+
+The canonical installer lives in `yschimke/skills` and bootstraps the
+`compose-preview` CLI plus the skill files:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/yschimke/skills/main/scripts/install.sh | bash
+```
+
+For Android targets, pass `--android-sdk` to provision the SDK in a fresh
+environment. See the
+[agent-cloud reference](https://github.com/yschimke/skills/blob/main/skills/compose-preview/references/agent-cloud.md)
+for network-allowlist and cloud-sandbox setup.
+
+### Step 2: Apply the Gradle plugin
+
+In the module that holds the previews, apply the plugin:
+
+```kotlin
+plugins {
+    id("ee.schimke.composeai.preview")
+}
+```
+
+### Step 3: Render a preview
+
+```bash
+# Render every @Preview in a module to PNGs under build/compose-previews/.
+compose-preview render :samples:cmp
+
+# Render a single preview by fully-qualified name.
+compose-preview render :samples:cmp --preview com.example.RedSquare
+```
+
+### Step 4: Iterate
+
+Edit the composable, re-run the render, and diff the PNGs. For a live,
+push-on-change render loop, attach the MCP server (see
+[references/mcp.md](https://github.com/yschimke/skills/blob/main/skills/compose-preview/references/mcp.md))
+so renders refresh automatically as you edit source files.
+
+## Examples
+
+### Example 1: Verify a spacing change on Compose Multiplatform Desktop
+
+```bash
+# 1. Render the baseline.
+compose-preview render :samples:cmp --preview com.example.ProfileCard
+# 2. Edit ProfileCard.kt (adjust padding), then re-render.
+compose-preview render :samples:cmp --preview com.example.ProfileCard
+# 3. Compare the two PNGs under build/compose-previews/.
+```
+
+### Example 2: Capture a Wear OS preview for a PR
+
+```bash
+compose-preview render :samples:wear --preview com.example.WatchFace
+```
+
+See the
+[Wear UI reference](https://github.com/yschimke/skills/blob/main/skills/compose-preview/references/wear-ui.md)
+for Material 3 Expressive guidance on Wear.
+
+## Best Practices
+
+- ✅ Render after every meaningful UI edit and actually look at the PNG before
+  declaring success.
+- ✅ Hoist state out of composables so a `@Preview` can supply deterministic
+  inputs (see
+  [state-hoisting.md](https://github.com/yschimke/skills/blob/main/skills/compose-preview/references/state-hoisting.md)).
+- ✅ Stage rendered PNGs under `build/` so they stay out of version control.
+- ❌ Don't claim a UI change works from reading the diff alone — render it.
+- ❌ Don't commit generated PNGs into the source tree.
+
+## Limitations
+
+- This skill does not replace environment-specific validation, testing, or
+  expert review.
+- Android rendering uses Robolectric, so behavior that depends on a real device
+  GPU, hardware sensors, or runtime permissions is out of scope.
+- Cold start for the Android (Robolectric) renderer is ~5–10s; the Desktop
+  renderer is ~600ms.
+- Stop and ask for clarification if the project does not apply the plugin, or if
+  required inputs, permissions, or safety boundaries are missing.
+
+## Security & Safety Notes
+
+- The installer is fetched over HTTPS and piped to `bash`. Review the
+  [canonical installer](https://github.com/yschimke/skills/blob/main/scripts/install.sh)
+  before running it in a sensitive environment.
+
+<!-- security-allowlist: documented installer fetch for the compose-preview toolchain -->
+
+- Rendering runs Gradle tasks and spawns per-module daemon JVMs against your
+  project's build output. Run it in the project you intend to build; treat it
+  like any other local Gradle invocation.
+- No network egress is required to render once the toolchain and SDK are in
+  place.
+
+## Common Pitfalls
+
+- **Problem:** `compose-preview render` reports no previews found.
+  **Solution:** Confirm the module applies `id("ee.schimke.composeai.preview")`
+  and that the `@Preview` functions are discoverable (top-level or in a class
+  the discovery task can see).
+- **Problem:** Android renders fail in a fresh cloud sandbox.
+  **Solution:** Re-run the installer with `--android-sdk` and check the
+  [agent-cloud reference](https://github.com/yschimke/skills/blob/main/skills/compose-preview/references/agent-cloud.md)
+  for the network allowlist.
+
+## Related Skills
+
+- `@compose-preview-review` - Use when reviewing a Compose UI pull request:
+  renders previews on base and head and diffs the screenshots.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -43,6 +43,15 @@ installed agent host it detects (Claude Code, Codex, Antigravity). The
 standalone `:mcp:installDist` launcher is the alternative path for embedders
 that don't ship the CLI.
 
+> **Skill registries.** The companion `compose-preview` /
+> `compose-preview-review` skill bundles are published to the
+> [antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills)
+> registry (installable across Claude Code, Cursor, Codex, Gemini CLI,
+> Antigravity, …) — see
+> [`contrib/registries/antigravity-awesome-skills/`](../contrib/registries/antigravity-awesome-skills/README.md).
+> Additional registry targets are tracked in
+> [#772](https://github.com/yschimke/compose-ai-tools/issues/772).
+
 ### Path A: via the bundled CLI (recommended)
 
 ```bash


### PR DESCRIPTION
Adds automated publishing of the `compose-preview` and `compose-preview-review` skill bundles to the [antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills) registry — a 1,400+ skill library installable across Claude Code, Cursor, Codex, Gemini CLI, Antigravity, and other agent hosts.

## Changes

- **Two skill bundles** (`contrib/registries/antigravity-awesome-skills/skills/`):
  - `compose-preview/SKILL.md` — render Jetpack Compose / Compose Multiplatform `@Preview` functions to PNG without Android Studio
  - `compose-preview-review/SKILL.md` — diff `@Preview` renders across a PR's base and head for visual code review
  - Both bundles link back to the canonical skills in [`yschimke/skills`](https://github.com/yschimke/skills) and pass the registry's strict validator

- **Publishing automation** (`contrib/registries/antigravity-awesome-skills/publish.sh`):
  - Clones the registry, injects our `SKILL.md` files, and validates against the upstream schema
  - Pushes to a fork and opens a PR against the registry (write mode)
  - Supports dry-run validation (no network writes) for CI gates

- **GitHub Actions workflow** (`.github/workflows/publish-antigravity-skills.yml`):
  - `validate` job: runs on every PR/push touching the bundles; proves they pass the registry's strict validator
  - `publish` job: called from `release-please.yml` off the same release tag; self-guards on `ANTIGRAVITY_SKILLS_TOKEN` secret so it no-ops until configured

- **Release integration** (`.github/workflows/release-please.yml`):
  - Wires the publish workflow to run automatically on release, keyed off the same tag as the GitHub-release tarballs

- **Documentation** (`contrib/registries/antigravity-awesome-skills/README.md`):
  - Explains the registry choice, publishing flow, and one-time setup steps
  - Includes local run instructions for validation and PR opening

## Implementation notes

- The bundles are **source-only**: we ship only the two `SKILL.md` files; the registry regenerates derived artifacts (`skills_index.json`, `CATALOG.md`, etc.)
- The publish step self-guards: until `ANTIGRAVITY_SKILLS_TOKEN` is configured, it runs in dry-run mode and exits cleanly, so the automation can land before the secret does
- Validation runs on every change to the bundles (PRs + pushes to main), ensuring we never ship a `SKILL.md` the registry would reject
- The workflow uses Python's `pyyaml` to validate against the registry's published JSON schema

Addresses [#772](https://github.com/yschimke/compose-ai-tools/issues/772).

https://claude.ai/code/session_017H8U1pbYSiu3vvqRJCfcUJ