### PR TITLE
fix(vscode): reject unsupported SpatialScene versions in isSpatialScene

### DIFF
--- a/vscode-extension/src/webview/shared/spatialScene.ts
+++ b/vscode-extension/src/webview/shared/spatialScene.ts
@@ -104,9 +104,11 @@ export interface SpatialScene {
 }
 
 /**
- * Minimal structural guard — enough to reject obviously-wrong payloads (wrong version, missing
- * panels) before the viewer touches them. It is intentionally shallow; the viewer should still
- * tolerate missing optional fields.
+ * Minimal structural guard — enough to reject payloads the consumer can't safely render before it
+ * touches them: a `version` other than the {@link SPATIAL_SCENE_VERSION} this build was compiled
+ * against (the version is bumped only on breaking shape changes, so a mismatch — newer *or* older —
+ * means an incompatible shape), or missing required fields. It is intentionally shallow otherwise;
+ * the viewer should still tolerate missing optional fields.
  */
 export function isSpatialScene(value: unknown): value is SpatialScene {
     if (typeof value !== "object" || value === null) {
@@ -115,7 +117,7 @@ export function isSpatialScene(value: unknown): value is SpatialScene {
     const scene = value as Partial<SpatialScene>;
     return (
         scene.units === "dp" &&
-        typeof scene.version === "number" &&
+        scene.version === SPATIAL_SCENE_VERSION &&
         Array.isArray(scene.panels) &&
         typeof scene.camera === "object" &&
         scene.camera !== null


### PR DESCRIPTION
Follow-up to the SpatialScene contract (#1697), addressing a review finding.

`isSpatialScene` only checked `typeof scene.version === "number"`, so a future breaking payload (e.g. `version: 2`) passed as valid — even though the contract bumps the version only on **breaking** shape changes. Callers using the guard to gate rendering could treat an incompatible scene as safe, contradicting the contract and the function's own doc comment.

Require an exact `scene.version === SPATIAL_SCENE_VERSION` match (a mismatch — newer *or* older — means an incompatible shape) and clarify the doc comment.

## Test plan
- [x] `npm run format:check` + `npm run compile:webview` pass
- [x] Guard behavior: `version: 1` → `true`; `version: 2` → `false`; missing `version` → `false`
- [x] Branched fresh from `main` after #1697 merged

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_