### PR TITLE
feat(preview-data-api): Kotlin SpatialScene mirror of the wire contract

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt
@@ -1,0 +1,90 @@
+package ee.schimke.composeai.xr
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Kotlin mirror of the `SpatialScene` wire contract — the format the offline renderer
+ * (`:renderer-xr`, the producer) emits and the VS Code webview's 3D spatial-layout viewer (the
+ * consumer) reads.
+ *
+ * The **authoritative** definition is the TypeScript source
+ * (`vscode-extension/src/webview/shared/spatialScene.ts`) plus the prose spec
+ * (`docs/design/SPATIAL_SCENE_CONTRACT.md`). These data classes must stay byte-compatible with it:
+ * property names are the JSON keys, so they match the TS field names exactly. `SpatialSceneTest`
+ * deserializes the committed fixture to keep the two languages locked together — if you change a
+ * shape here, change it there too (and bump [SPATIAL_SCENE_VERSION]).
+ *
+ * Conventions (see the spec): all linear quantities are **dp**; axes are right-handed (+x right, +y
+ * up, +z toward the viewer); `rotation` is a unit quaternion.
+ */
+public const val SPATIAL_SCENE_VERSION: Int = 1
+
+/** A point or vector, in dp. */
+@Serializable public data class Vec3(val x: Double, val y: Double, val z: Double)
+
+/** A unit quaternion; identity is `(0, 0, 0, 1)`. */
+@Serializable public data class Quat(val x: Double, val y: Double, val z: Double, val w: Double)
+
+/**
+ * A rigid transform in the subspace root's frame: `translation` in dp, `rotation` a unit
+ * quaternion.
+ */
+@Serializable public data class SpatialPose(val translation: Vec3, val rotation: Quat)
+
+/** Panel extent in dp (the layout output, not the texture's pixel size). */
+@Serializable public data class SizeDp(val width: Int, val height: Int)
+
+/** A spatial panel: a flat quad hosting 2D Compose content. */
+@Serializable
+public data class SpatialPanel(
+  val id: String,
+  val label: String? = null,
+  val poseInRoot: SpatialPose,
+  val sizeDp: SizeDp,
+  /** Path to the panel's 2D-content PNG, relative to the scene file (or a resolvable URI). */
+  val texture: String,
+  val parentId: String? = null,
+)
+
+/**
+ * An Orbiter affordance — a control strip anchored to a panel edge. `edge` is top/bottom/start/end.
+ */
+@Serializable
+public data class OrbiterAffordance(
+  val id: String,
+  val label: String? = null,
+  val edge: String,
+  val poseInRoot: SpatialPose,
+  val sizeDp: SizeDp,
+  val texture: String,
+)
+
+/** Default viewing camera. Only `kind = "orbit"` is defined today. */
+@Serializable
+public data class OrbitCamera(
+  val kind: String = "orbit",
+  val target: Vec3,
+  val distance: Double,
+  val yawDeg: Double,
+  val pitchDeg: Double,
+)
+
+/** Optional scene backdrop. `kind` is "color" (`#RRGGBB` in [color]) or "skybox" ([texture]). */
+@Serializable
+public data class SpatialEnvironment(
+  val kind: String,
+  val color: String? = null,
+  val texture: String? = null,
+)
+
+/** The full scene the 3D viewer renders. [version] must equal [SPATIAL_SCENE_VERSION]. */
+@Serializable
+public data class SpatialScene(
+  val version: Int = SPATIAL_SCENE_VERSION,
+  val units: String = "dp",
+  val previewId: String? = null,
+  val camera: OrbitCamera,
+  val panels: List<SpatialPanel>,
+  val orbiters: List<OrbiterAffordance> = emptyList(),
+  val environment: SpatialEnvironment? = null,
+)

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/xr/SpatialSceneTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/xr/SpatialSceneTest.kt
@@ -1,0 +1,86 @@
+package ee.schimke.composeai.xr
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+/**
+ * Locks the Kotlin [SpatialScene] mirror to the contract the TypeScript consumer uses, by reading
+ * the single committed fixture
+ * (`vscode-extension/preview-harness/fixtures/spatial-scene/scene.json`) rather than a copy. If the
+ * wire shape changes on one side without the other, this fails.
+ */
+class SpatialSceneTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun repoRoot(): File {
+    var dir = File(".").absoluteFile
+    while (dir.parentFile != null && !File(dir, "settings.gradle.kts").exists()) {
+      dir = dir.parentFile
+    }
+    return dir
+  }
+
+  private fun fixtureScene(): SpatialScene {
+    val file =
+      File(repoRoot(), "vscode-extension/preview-harness/fixtures/spatial-scene/scene.json")
+    assertTrue(file.exists(), "contract fixture missing at ${file.path}")
+    return json.decodeFromString(SpatialScene.serializer(), file.readText())
+  }
+
+  @Test
+  fun deserializesCommittedFixtureToTheContractShape() {
+    val scene = fixtureScene()
+
+    assertEquals(SPATIAL_SCENE_VERSION, scene.version)
+    assertEquals("dp", scene.units)
+    assertEquals("orbit", scene.camera.kind)
+    assertEquals(1200.0, scene.camera.distance)
+    assertEquals(2, scene.panels.size)
+
+    val top = scene.panels.single { it.id == "top" }
+    assertEquals("Now Playing", top.label)
+    assertEquals(80.0, top.poseInRoot.translation.y)
+    assertEquals(SizeDp(560, 200), top.sizeDp)
+    assertEquals("top.png", top.texture)
+
+    val bottom = scene.panels.single { it.id == "bottom" }
+    assertEquals(-100.0, bottom.poseInRoot.translation.y)
+    assertEquals(SizeDp(560, 160), bottom.sizeDp)
+
+    // The top panel sits above the bottom one — the genuine SpatialColumn stacking.
+    assertTrue(top.poseInRoot.translation.y > bottom.poseInRoot.translation.y)
+
+    assertNotNull(scene.environment)
+    assertEquals("color", scene.environment!!.kind)
+  }
+
+  @Test
+  fun roundTripsThroughJson() {
+    val scene = fixtureScene()
+    val encoded = json.encodeToString(SpatialScene.serializer(), scene)
+    val decoded = json.decodeFromString(SpatialScene.serializer(), encoded)
+    assertEquals(scene, decoded)
+  }
+
+  @Test
+  fun defaultsStampCurrentVersionAndUnits() {
+    val scene =
+      SpatialScene(
+        camera =
+          OrbitCamera(
+            target = Vec3(0.0, 0.0, 0.0),
+            distance = 1000.0,
+            yawDeg = 0.0,
+            pitchDeg = 0.0,
+          ),
+        panels = emptyList(),
+      )
+    assertEquals(SPATIAL_SCENE_VERSION, scene.version)
+    assertEquals("dp", scene.units)
+  }
+}

--- a/docs/design/SPATIAL_SCENE_CONTRACT.md
+++ b/docs/design/SPATIAL_SCENE_CONTRACT.md
@@ -73,8 +73,12 @@ When the renderer mode is built it must emit exactly this shape:
    identity) and stamp `version = SPATIAL_SCENE_VERSION`.
 4. Write `scene.json` next to the panel PNGs under the render output dir.
 
-A `@Serializable` Kotlin mirror of these types will live in `:renderer-xr`; keep its field names and
-JSON shape identical to `spatialScene.ts`.
+A `@Serializable` Kotlin mirror of these types lives in
+[`:preview-data-api`](../../api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt)
+(`ee.schimke.composeai.xr.SpatialScene`) — the wire-DTO module the renderer and other tooling
+already build on. Its field names and JSON shape are identical to `spatialScene.ts`, and
+`SpatialSceneTest` deserializes the committed fixture to keep the two languages locked; change one
+side and the other must follow.
 
 ## For the webview agent
 


### PR DESCRIPTION
Producer-side counterpart to the SpatialScene contract (#1697).

Adds `ee.schimke.composeai.xr.SpatialScene` — a `@Serializable` Kotlin mirror of the wire format — so the offline renderer (`:renderer-xr`, when built) and other tooling can emit/read the same shape the VS Code 3D viewer consumes. It lives in `:preview-data-api` alongside the other published wire DTOs (kotlinx-serialization is already set up there), which is the idiomatic home for a wire type — no new module needed yet.

## Cross-language contract lock
`SpatialSceneTest` deserializes the **single committed fixture** (`vscode-extension/preview-harness/fixtures/spatial-scene/scene.json`) rather than a copy, so the Kotlin and TypeScript shapes can't drift — change one side and the test fails until the other follows. It also round-trips through JSON and checks the `version`/`units` defaults.

Property names are the JSON keys and match `spatialScene.ts` exactly; conventions (dp, right-handed axes, quaternion rotation) match the spec.

## Test plan
- [x] `:preview-data-api:test` — 3 passed (fixture deserializes to the contract shape; JSON round-trip; default version/units)
- [x] `:preview-data-api:ktfmtCheck`
- [x] Branched fresh from `main` after #1697/#1700 merged
- Doc: `SPATIAL_SCENE_CONTRACT.md` producer note now points at the real home

Next on the producer side: the `:renderer-xr` render mode that recovers poses (per `SubspaceLayoutPoseTest`) + renders panel textures and writes a `SpatialScene` using this type.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_