### PR TITLE
chore(bundle): remove tile-replay debugging instrumentation

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -431,12 +431,6 @@ class BundleDaemonCommand(args: List<String>) : Command(args) {
               "android/resources.ap_" -> apk = dest
               "android/AndroidManifest.xml" -> mergedManifest = dest
               "android/r-classes.jar" -> rJar = dest
-              "android/diag.txt" ->
-                // Pack-time carriage diagnostic — surface it so a null carriage is explainable
-                // without the (truncated) Gradle pack console.
-                dest.readText().trim().lineSequence().forEach {
-                  System.err.println("[bundle-daemon] pack-diag: $it")
-                }
             }
           }
         }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AndroidBundleDaemonRenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AndroidBundleDaemonRenderFunctionalTest.kt
@@ -75,21 +75,13 @@ class AndroidBundleDaemonRenderFunctionalTest {
     // Tracks which kinds of preview actually rendered across both bundles: protolayout (Wear
     // tile IR), remotecompose (RC doc IR), and classic (reflected app.jar Compose preview).
     val formatsSeen = mutableSetOf<String>()
-    // TEMP diagnostic (remove before merge): the IR breakdown of each bundle, surfaced in the
-    // assertion message so a green-but-classic-only run still prints why no IR preview was
-    // exercised (empty `intermediateRepresentations` in bundle.json vs a parse/selection mismatch).
-    val diagnostics = StringBuilder()
-    renderBundle(cli, File(wearBundle), formatsSeen, diagnostics)
-    renderBundle(cli, File(remoteComposeBundle), formatsSeen, diagnostics)
+    renderBundle(cli, File(wearBundle), formatsSeen)
+    renderBundle(cli, File(remoteComposeBundle), formatsSeen)
 
-    assertWithMessage(
-        "expected a protolayout (Wear tile) IR preview to render. saw: $formatsSeen\n$diagnostics"
-      )
+    assertWithMessage("expected a protolayout (Wear tile) IR preview to render. saw: $formatsSeen")
       .that(formatsSeen)
       .contains("protolayout")
-    assertWithMessage(
-        "expected a remotecompose IR preview to render. saw: $formatsSeen\n$diagnostics"
-      )
+    assertWithMessage("expected a remotecompose IR preview to render. saw: $formatsSeen")
       .that(formatsSeen)
       .contains("remotecompose")
     assertWithMessage("expected a classic (non-IR) Compose preview to render. saw: $formatsSeen")
@@ -102,12 +94,7 @@ class AndroidBundleDaemonRenderFunctionalTest {
    * preview, render them via `renderNow`, and assert each produces a fresh, valid PNG. Records the
    * rendered formats into [formatsSeen].
    */
-  private fun renderBundle(
-    cli: File,
-    bundle: File,
-    formatsSeen: MutableSet<String>,
-    diagnostics: StringBuilder,
-  ) {
+  private fun renderBundle(cli: File, bundle: File, formatsSeen: MutableSet<String>) {
     assertWithMessage(
         "sample bundle missing: ${bundle.path} — did `:samples:…:composePreviewBundle` run? Use " +
           "`./gradlew functionalTestWithAndroidBundleDaemon`"
@@ -271,16 +258,6 @@ class AndroidBundleDaemonRenderFunctionalTest {
         formatsSeen.add(manifest.formatById[id] ?: "classic")
       }
 
-      // TEMP diagnostic (remove before merge): per-bundle IR breakdown, appended to the buffer the
-      // top-level `formatsSeen` assertion prints. Confirms (or refutes) that the CI-built bundle
-      // carries no IR, which would explain why only classic previews are ever selected/rendered.
-      diagnostics.append("\n[${bundle.name}] backend=${manifest.backend}")
-      diagnostics.append(" previewIds(${manifest.previewIds.size})=${manifest.previewIds}")
-      diagnostics.append("\n  intermediateRepresentations(raw)=${manifest.rawIr}")
-      diagnostics.append("\n  formatById=${manifest.formatById}")
-      diagnostics.append("\n  selected=$selected")
-      diagnostics.append("\n  finished=${finished.keys}")
-
       // The exact failure `composeDaemonClasspath` fixes: a parent-loaded IR replay host that can't
       // see the carried player / tiles-renderer libs trips NoClassDefFoundError at replay time.
       assertWithMessage(
@@ -368,10 +345,7 @@ class AndroidBundleDaemonRenderFunctionalTest {
           val ir = it.jsonObject
           ir["previewId"]!!.jsonPrimitive.content to ir["format"]!!.jsonPrimitive.content
         } ?: emptyMap()
-      // TEMP diagnostic (remove before merge): the raw IR array as the bundle writer emitted it, so
-      // CI shows whether `intermediateRepresentations` is genuinely empty vs a parse mismatch.
-      val rawIr = root["intermediateRepresentations"]?.toString() ?: "(key absent)"
-      return BundleManifestInfo(backend, previewIds, formatById, rawIr)
+      return BundleManifestInfo(backend, previewIds, formatById)
     }
   }
 
@@ -379,7 +353,6 @@ class AndroidBundleDaemonRenderFunctionalTest {
     val backend: String,
     val previewIds: List<String>,
     val formatById: Map<String, String>,
-    val rawIr: String,
   )
 
   private fun isPng(file: File): Boolean {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -518,37 +518,17 @@ abstract class BundlePreviewTask : DefaultTask() {
     zipFiles: LinkedHashMap<String, ByteArray>
   ): BundleAndroidResources? {
     // `com/android/tools/test_config.properties` lives nested inside AGP's unit-test config
-    // directory, so we must walk the input as a file *tree* — a plain
-    // `ConfigurableFileCollection.files`
-    // returns the registered directory entry (`…/out`), never the nested file, which silently
-    // produced an empty carriage (issue: tile replay still ClassNotFound'd `R$style`). Try the
+    // directory, so we must walk the input as a file *tree* — a plain `ConfigurableFileCollection`
+    // `.files` returns the registered directory entry (`…/out`), never the nested file. Try the
     // dedicated config input first (small), then fall back to the unit-test runtime classpath,
     // which
     // AGP also puts the config directory on and which is guaranteed built (it's a `@Classpath`
     // input with real task dependencies).
-    // Pack-time diagnostic threaded into the bundle (android/diag.txt) and surfaced by the player —
-    // the pack runs inside Gradle whose CI console is truncated, so this is the only reliable way
-    // to
-    // see WHY the carriage did or didn't happen. Records input shape + the resolved paths.
-    val diag = StringBuilder()
-    val configEntries =
-      runCatching { androidUnitTestConfig.files.map { it.name } }
-        .getOrElse { listOf("<error:${it.message}>") }
-    val runtimeCpCount = runCatching { androidUnitTestRuntimeClasspath.files.size }.getOrElse { -1 }
-    diag.appendLine("protolayout=true")
-    diag.appendLine("androidUnitTestConfig.entries=$configEntries")
-    diag.appendLine("androidUnitTestRuntimeClasspath.entryCount=$runtimeCpCount")
-    fun emitDiag() {
-      zipFiles[ANDROID_DIAG_PATH] = diag.toString().toByteArray(Charsets.UTF_8)
-    }
-
     val configFile =
       sequenceOf(androidUnitTestConfig, androidUnitTestRuntimeClasspath)
         .flatMap { it.asFileTree.files.asSequence() }
         .firstOrNull { it.isFile && it.name == "test_config.properties" }
-    diag.appendLine("testConfigFound=${configFile != null} path=${configFile?.absolutePath}")
     if (configFile == null) {
-      emitDiag()
       logger.warn(
         "composePreviewBundle: protolayout IR present but no test_config.properties on the " +
           "unit-test config / runtime-classpath inputs — tile replay on a detached daemon can't " +
@@ -563,8 +543,8 @@ abstract class BundlePreviewTask : DefaultTask() {
     // AGP writes these paths **relative to the module dir** (e.g.
     // `build/intermediates/apk_for_local_test/…`); Robolectric resolves them against the unit-test
     // working directory (the module dir). Resolve the same way — a plain `File(path)` resolves
-    // against the build's CWD and misses (the observed `exists=false`). Absolute paths (older AGP)
-    // pass through; fall back to the test_config's own module root (ancestor before `/build/`).
+    // against the build's CWD and misses. Absolute paths (older AGP) pass through; fall back to the
+    // test_config's own module root (ancestor before `/build/`).
     val baseDir =
       moduleProjectDir.asFile.orNull
         ?: configFile.absolutePath.substringBeforeLast("/build/").let(::File).takeIf {
@@ -581,16 +561,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     }
     val apkFile = resolveModulePath(apkPath)
     val manifestFile = resolveModulePath(manifestPath)
-    diag.appendLine("moduleProjectDir=${baseDir?.absolutePath}")
-    diag.appendLine(
-      "android_resource_apk='$apkPath' → ${apkFile?.absolutePath} exists=${apkFile?.isFile == true}"
-    )
-    diag.appendLine(
-      "android_merged_manifest='$manifestPath' → ${manifestFile?.absolutePath} exists=${manifestFile?.isFile == true}"
-    )
-    diag.appendLine("android_custom_package=$pkg")
     if (apkFile == null || !apkFile.isFile || manifestFile == null || !manifestFile.isFile) {
-      emitDiag()
       logger.warn(
         "composePreviewBundle: protolayout IR present but the merged resource APK / manifest from " +
           "test_config.properties is missing (apk='$apkPath', manifest='$manifestPath') — tile " +
@@ -602,8 +573,6 @@ abstract class BundlePreviewTask : DefaultTask() {
     zipFiles[ANDROID_MERGED_MANIFEST_PATH] = manifestFile.readBytes()
     val rClassesJar = packAndroidRClasses()
     if (rClassesJar != null) zipFiles[ANDROID_R_CLASSES_JAR_PATH] = rClassesJar
-    diag.appendLine("rClassesBytes=${rClassesJar?.size ?: 0}")
-    emitDiag()
     logger.lifecycle(
       "composePreviewBundle — carried Android resources for protolayout replay " +
         "(apk=${apkFile.length()}B, manifest=${manifestFile.length()}B, " +

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -324,14 +324,6 @@ const val ANDROID_MERGED_MANIFEST_PATH: String = "android/AndroidManifest.xml"
 const val ANDROID_R_CLASSES_JAR_PATH: String = "android/r-classes.jar"
 
 /**
- * Zip path of a pack-time diagnostic note for the Android resource carriage (v6). Written on every
- * protolayout-IR pack — success or failure — so a detached player/daemon can surface *why* the
- * carriage did or didn't happen (the pack runs inside Gradle whose console is often truncated in
- * CI). Purely diagnostic; never affects rendering.
- */
-const val ANDROID_DIAG_PATH: String = "android/diag.txt"
-
-/**
  * Schema version stamped into [BundleManifest.schemaVersion].
  * - v1 — `bundle.json` + `previews.json` + `classes/app.jar` + `report.json`, cover PNG as the
  *   polyglot's leading bytes only.


### PR DESCRIPTION
## Summary

Now that protolayout (Wear tile) replay works end-to-end on the detached daemon (#1692, #1694), remove the debugging scaffolding used to chase it down:

- **Test**: the temporary IR-coverage diagnostic in `AndroidBundleDaemonRenderFunctionalTest` — the `diagnostics` `StringBuilder` threaded through `renderBundle`, and the `rawIr` field on the manifest-info helper (rode in via #1689).
- **Pack**: the `android/diag.txt` carriage note (`ANDROID_DIAG_PATH` + all `diag.appendLine`/`emitDiag` writes).
- **CLI**: the `[bundle-daemon] pack-diag:` stderr dump that printed `android/diag.txt`.

Kept (intentionally): the concise `[bundle-daemon] android carriage: resourcesAp_=… rClasses=… cpEntries=…` summary line, and the pack-side `lifecycle`/`warn` logs. The carriage logic itself is unchanged.

## Test plan

- [ ] Plugin unit + functional tests stay green.
- [ ] Android Bundle Daemon E2E stays green (pure removal of diagnostics; no behaviour change to the carriage).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SjYP3v8o7EsubKtFUCxmn9)_