### PR TITLE
feat(renderer-xr): offline SpatialScene producer (poses + textures + scene.json)

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt
@@ -1,0 +1,90 @@
+package ee.schimke.composeai.xr
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Kotlin mirror of the `SpatialScene` wire contract — the format the offline renderer
+ * (`:renderer-xr`, the producer) emits and the VS Code webview's 3D spatial-layout viewer (the
+ * consumer) reads.
+ *
+ * The **authoritative** definition is the TypeScript source
+ * (`vscode-extension/src/webview/shared/spatialScene.ts`) plus the prose spec
+ * (`docs/design/SPATIAL_SCENE_CONTRACT.md`). These data classes must stay byte-compatible with it:
+ * property names are the JSON keys, so they match the TS field names exactly. `SpatialSceneTest`
+ * deserializes the committed fixture to keep the two languages locked together — if you change a
+ * shape here, change it there too (and bump [SPATIAL_SCENE_VERSION]).
+ *
+ * Conventions (see the spec): all linear quantities are **dp**; axes are right-handed (+x right, +y
+ * up, +z toward the viewer); `rotation` is a unit quaternion.
+ */
+public const val SPATIAL_SCENE_VERSION: Int = 1
+
+/** A point or vector, in dp. */
+@Serializable public data class Vec3(val x: Double, val y: Double, val z: Double)
+
+/** A unit quaternion; identity is `(0, 0, 0, 1)`. */
+@Serializable public data class Quat(val x: Double, val y: Double, val z: Double, val w: Double)
+
+/**
+ * A rigid transform in the subspace root's frame: `translation` in dp, `rotation` a unit
+ * quaternion.
+ */
+@Serializable public data class SpatialPose(val translation: Vec3, val rotation: Quat)
+
+/** Panel extent in dp (the layout output, not the texture's pixel size). */
+@Serializable public data class SizeDp(val width: Int, val height: Int)
+
+/** A spatial panel: a flat quad hosting 2D Compose content. */
+@Serializable
+public data class SpatialPanel(
+  val id: String,
+  val label: String? = null,
+  val poseInRoot: SpatialPose,
+  val sizeDp: SizeDp,
+  /** Path to the panel's 2D-content PNG, relative to the scene file (or a resolvable URI). */
+  val texture: String,
+  val parentId: String? = null,
+)
+
+/**
+ * An Orbiter affordance — a control strip anchored to a panel edge. `edge` is top/bottom/start/end.
+ */
+@Serializable
+public data class OrbiterAffordance(
+  val id: String,
+  val label: String? = null,
+  val edge: String,
+  val poseInRoot: SpatialPose,
+  val sizeDp: SizeDp,
+  val texture: String,
+)
+
+/** Default viewing camera. Only `kind = "orbit"` is defined today. */
+@Serializable
+public data class OrbitCamera(
+  val kind: String = "orbit",
+  val target: Vec3,
+  val distance: Double,
+  val yawDeg: Double,
+  val pitchDeg: Double,
+)
+
+/** Optional scene backdrop. `kind` is "color" (`#RRGGBB` in [color]) or "skybox" ([texture]). */
+@Serializable
+public data class SpatialEnvironment(
+  val kind: String,
+  val color: String? = null,
+  val texture: String? = null,
+)
+
+/** The full scene the 3D viewer renders. [version] must equal [SPATIAL_SCENE_VERSION]. */
+@Serializable
+public data class SpatialScene(
+  val version: Int = SPATIAL_SCENE_VERSION,
+  val units: String = "dp",
+  val previewId: String? = null,
+  val camera: OrbitCamera,
+  val panels: List<SpatialPanel>,
+  val orbiters: List<OrbiterAffordance> = emptyList(),
+  val environment: SpatialEnvironment? = null,
+)

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/xr/SpatialSceneTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/xr/SpatialSceneTest.kt
@@ -1,0 +1,86 @@
+package ee.schimke.composeai.xr
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+/**
+ * Locks the Kotlin [SpatialScene] mirror to the contract the TypeScript consumer uses, by reading
+ * the single committed fixture
+ * (`vscode-extension/preview-harness/fixtures/spatial-scene/scene.json`) rather than a copy. If the
+ * wire shape changes on one side without the other, this fails.
+ */
+class SpatialSceneTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun repoRoot(): File {
+    var dir = File(".").absoluteFile
+    while (dir.parentFile != null && !File(dir, "settings.gradle.kts").exists()) {
+      dir = dir.parentFile
+    }
+    return dir
+  }
+
+  private fun fixtureScene(): SpatialScene {
+    val file =
+      File(repoRoot(), "vscode-extension/preview-harness/fixtures/spatial-scene/scene.json")
+    assertTrue(file.exists(), "contract fixture missing at ${file.path}")
+    return json.decodeFromString(SpatialScene.serializer(), file.readText())
+  }
+
+  @Test
+  fun deserializesCommittedFixtureToTheContractShape() {
+    val scene = fixtureScene()
+
+    assertEquals(SPATIAL_SCENE_VERSION, scene.version)
+    assertEquals("dp", scene.units)
+    assertEquals("orbit", scene.camera.kind)
+    assertEquals(1200.0, scene.camera.distance)
+    assertEquals(2, scene.panels.size)
+
+    val top = scene.panels.single { it.id == "top" }
+    assertEquals("Now Playing", top.label)
+    assertEquals(80.0, top.poseInRoot.translation.y)
+    assertEquals(SizeDp(560, 200), top.sizeDp)
+    assertEquals("top.png", top.texture)
+
+    val bottom = scene.panels.single { it.id == "bottom" }
+    assertEquals(-100.0, bottom.poseInRoot.translation.y)
+    assertEquals(SizeDp(560, 160), bottom.sizeDp)
+
+    // The top panel sits above the bottom one — the genuine SpatialColumn stacking.
+    assertTrue(top.poseInRoot.translation.y > bottom.poseInRoot.translation.y)
+
+    assertNotNull(scene.environment)
+    assertEquals("color", scene.environment!!.kind)
+  }
+
+  @Test
+  fun roundTripsThroughJson() {
+    val scene = fixtureScene()
+    val encoded = json.encodeToString(SpatialScene.serializer(), scene)
+    val decoded = json.decodeFromString(SpatialScene.serializer(), encoded)
+    assertEquals(scene, decoded)
+  }
+
+  @Test
+  fun defaultsStampCurrentVersionAndUnits() {
+    val scene =
+      SpatialScene(
+        camera =
+          OrbitCamera(
+            target = Vec3(0.0, 0.0, 0.0),
+            distance = 1000.0,
+            yawDeg = 0.0,
+            pitchDeg = 0.0,
+          ),
+        panels = emptyList(),
+      )
+    assertEquals(SPATIAL_SCENE_VERSION, scene.version)
+    assertEquals("dp", scene.units)
+  }
+}

--- a/docs/design/SPATIAL_SCENE_CONTRACT.md
+++ b/docs/design/SPATIAL_SCENE_CONTRACT.md
@@ -73,8 +73,12 @@ When the renderer mode is built it must emit exactly this shape:
    identity) and stamp `version = SPATIAL_SCENE_VERSION`.
 4. Write `scene.json` next to the panel PNGs under the render output dir.
 
-A `@Serializable` Kotlin mirror of these types will live in `:renderer-xr`; keep its field names and
-JSON shape identical to `spatialScene.ts`.
+A `@Serializable` Kotlin mirror of these types lives in
+[`:preview-data-api`](../../api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt)
+(`ee.schimke.composeai.xr.SpatialScene`) — the wire-DTO module the renderer and other tooling
+already build on. Its field names and JSON shape are identical to `spatialScene.ts`, and
+`SpatialSceneTest` deserializes the committed fixture to keep the two languages locked; change one
+side and the other must follow.
 
 ## For the webview agent
 

--- a/renderers/xr/build.gradle.kts
+++ b/renderers/xr/build.gradle.kts
@@ -1,0 +1,55 @@
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.android-conventions")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
+}
+
+// `:renderer-xr` — offline producer of the SpatialScene wire format (see
+// docs/design/SPATIAL_SCENE_CONTRACT.md). It recovers the real Compose-XR subspace layout under a
+// fake XR runtime (the technique proven by `:samples:xr-spatial`'s `SubspaceLayoutPoseTest`) and
+// maps each tagged panel's pose/size into the published `SpatialScene` DTO the VS Code 3D viewer
+// consumes — no headset, no OpenXR, no SceneCore native code.
+//
+// The heavy XR / compose-test libraries are `compileOnly`, mirroring `:renderer-android`: the
+// recorder compiles against them, and the render runtime (this module's own Robolectric tests
+// today; the gradle plugin when wired) supplies them. That keeps them off any future consumer's
+// classpath. The `*-testing` fake runtimes + their `ServiceLoader` registration live only in the
+// test source set.
+
+android {
+  namespace = "ee.schimke.composeai.renderer.xr"
+  // `androidx.xr.compose` declares `minCompileSdk = 36`.
+  compileSdk = 36
+  buildFeatures { compose = true }
+  testOptions { unitTests.all { it.jvmArgs("-Xmx2048m") } }
+}
+
+dependencies {
+  // The SpatialScene wire DTO the recorder emits.
+  api(project(":preview-data-api"))
+
+  compileOnly(platform(libs.compose.bom.stable))
+  compileOnly(libs.compose.ui)
+  compileOnly(libs.activity.compose)
+  compileOnly(libs.xr.compose)
+  compileOnly(libs.xr.compose.testing)
+  compileOnly("androidx.compose.ui:ui-test-junit4")
+
+  // Own unit tests run the recorder under Robolectric against the fake XR runtime (registered for
+  // ServiceLoader in src/test/resources/META-INF/services). SDK 35 so it renders on the JDK 17
+  // lane.
+  testImplementation(platform(libs.compose.bom.stable))
+  testImplementation(libs.compose.ui)
+  testImplementation(libs.compose.foundation)
+  testImplementation(libs.activity.compose)
+  testImplementation(libs.xr.compose)
+  testImplementation(libs.xr.compose.testing)
+  testImplementation("androidx.compose.ui:ui-test-junit4")
+  testImplementation("androidx.compose.ui:ui-test-manifest")
+  testImplementation("androidx.xr.runtime:runtime-testing:1.0.0-alpha14")
+  testImplementation("androidx.xr.scenecore:scenecore-testing:1.0.0-alpha15")
+  testImplementation(libs.robolectric)
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+}

--- a/renderers/xr/build.gradle.kts
+++ b/renderers/xr/build.gradle.kts
@@ -22,7 +22,18 @@ android {
   // `androidx.xr.compose` declares `minCompileSdk = 36`.
   compileSdk = 36
   buildFeatures { compose = true }
-  testOptions { unitTests.all { it.jvmArgs("-Xmx2048m") } }
+  testOptions {
+    unitTests.all {
+      it.jvmArgs("-Xmx2048m")
+      // Mirror the capture JVM/system properties the gradle plugin sets on its render Test task
+      // (AndroidPreviewSupport) so `captureRoboImage` can rasterise Compose under Robolectric.
+      it.systemProperty("robolectric.graphicsMode", "NATIVE")
+      it.systemProperty("robolectric.looperMode", "PAUSED")
+      it.systemProperty("robolectric.conscryptMode", "OFF")
+      it.systemProperty("robolectric.pixelCopyRenderMode", "hardware")
+      it.systemProperty("roborazzi.test.record", "true")
+    }
+  }
 }
 
 dependencies {
@@ -31,10 +42,14 @@ dependencies {
 
   compileOnly(platform(libs.compose.bom.stable))
   compileOnly(libs.compose.ui)
+  compileOnly(libs.compose.foundation)
   compileOnly(libs.activity.compose)
   compileOnly(libs.xr.compose)
   compileOnly(libs.xr.compose.testing)
   compileOnly("androidx.compose.ui:ui-test-junit4")
+  // Per-panel texture capture (captureRoboImage). compileOnly — provided by the render runtime.
+  compileOnly(libs.roborazzi)
+  compileOnly(libs.roborazzi.compose)
 
   // Own unit tests run the recorder under Robolectric against the fake XR runtime (registered for
   // ServiceLoader in src/test/resources/META-INF/services). SDK 35 so it renders on the JDK 17
@@ -50,6 +65,8 @@ dependencies {
   testImplementation("androidx.xr.runtime:runtime-testing:1.0.0-alpha14")
   testImplementation("androidx.xr.scenecore:scenecore-testing:1.0.0-alpha15")
   testImplementation(libs.robolectric)
+  testImplementation(libs.roborazzi)
+  testImplementation(libs.roborazzi.compose)
   testImplementation(libs.junit)
   testImplementation(libs.truth)
 }

--- a/renderers/xr/src/main/AndroidManifest.xml
+++ b/renderers/xr/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
@@ -1,0 +1,80 @@
+package ee.schimke.composeai.renderer.xr
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.xr.compose.testing.onSubspaceNodeWithTag
+import ee.schimke.composeai.xr.OrbitCamera
+import ee.schimke.composeai.xr.Quat
+import ee.schimke.composeai.xr.SizeDp
+import ee.schimke.composeai.xr.SpatialPanel
+import ee.schimke.composeai.xr.SpatialPose
+import ee.schimke.composeai.xr.SpatialScene
+import ee.schimke.composeai.xr.Vec3
+
+/**
+ * Recovers a [SpatialScene] from a Compose-XR `Subspace` that has already been composed under a
+ * fake XR runtime (no headset / OpenXR / SceneCore native — see
+ * docs/design/XR_SPATIAL_PREVIEW.md and `:samples:xr-spatial`'s `SubspaceLayoutPoseTest`).
+ *
+ * This is the geometry half of the producer: it reads each named panel's `poseInRoot` and `size`
+ * from the public spatial-semantics tree and maps them to the [SpatialScene] wire shape. Rendering
+ * each panel's 2D content to the `texture` PNG is a separate pass; until then the texture path
+ * follows the `<tag>.png` convention so the emitted scene is shape-complete.
+ *
+ * The caller owns the composition: it must enable the `android.software.xr.api.spatial` system
+ * feature (so `Subspace` takes its spatial path) and `setContent { Subspace { … } }` with each
+ * panel carrying a `SubspaceModifier.testTag(...)`, then pass those tags here.
+ */
+public object SubspaceSceneRecorder {
+
+  /** The system feature `Subspace` checks to select its spatial path over the 2D fallback. */
+  public const val XR_SPATIAL_FEATURE: String = "android.software.xr.api.spatial"
+
+  /**
+   * Reads the [panelTags] from the subspace composed on [rule] into a [SpatialScene]. Each tag must
+   * resolve to exactly one subspace node (a `SpatialPanel`); [previewId] is recorded for traceback.
+   */
+  public fun record(
+    rule: AndroidComposeTestRule<*, ComponentActivity>,
+    panelTags: List<String>,
+    previewId: String? = null,
+  ): SpatialScene {
+    val panels =
+      panelTags.map { tag ->
+        val node = rule.onSubspaceNodeWithTag(tag).fetchSemanticsNode("no subspace node '$tag'")
+        val t = node.poseInRoot.translation
+        val r = node.poseInRoot.rotation
+        val size = node.size
+        SpatialPanel(
+          id = tag,
+          poseInRoot =
+            SpatialPose(
+              translation = Vec3(t.x.toDouble(), t.y.toDouble(), t.z.toDouble()),
+              rotation = Quat(r.x.toDouble(), r.y.toDouble(), r.z.toDouble(), r.w.toDouble()),
+            ),
+          sizeDp = SizeDp(width = size.width, height = size.height),
+          texture = "$tag.png",
+        )
+      }
+    return SpatialScene(previewId = previewId, camera = defaultCamera(panels), panels = panels)
+  }
+
+  /**
+   * A neutral orbit camera framing the panels: look at the vertical centre of their bounds from a
+   * distance scaled to the layout, at a slight downward pitch. Producers/consumers may override.
+   */
+  internal fun defaultCamera(panels: List<SpatialPanel>): OrbitCamera {
+    if (panels.isEmpty()) {
+      return OrbitCamera(target = Vec3(0.0, 0.0, 0.0), distance = 1200.0, yawDeg = 0.0, pitchDeg = -10.0)
+    }
+    val ys = panels.map { it.poseInRoot.translation.y }
+    val centreY = (ys.min() + ys.max()) / 2.0
+    val span = panels.maxOf { maxOf(it.sizeDp.width, it.sizeDp.height).toDouble() }
+    return OrbitCamera(
+      target = Vec3(0.0, centreY, 0.0),
+      distance = (span * 2.0).coerceAtLeast(600.0),
+      yawDeg = 0.0,
+      pitchDeg = -10.0,
+    )
+  }
+}

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneWriter.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneWriter.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.renderer.xr
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.github.takahirom.roborazzi.captureRoboImage
+import ee.schimke.composeai.xr.SizeDp
+import ee.schimke.composeai.xr.SpatialScene
+import java.io.File
+import kotlinx.serialization.json.Json
+
+/** A panel's 2D content plus the size to render it at, for capturing the panel's texture. */
+public class PanelTexture(
+  public val id: String,
+  public val sizeDp: SizeDp,
+  public val content: @Composable () -> Unit,
+)
+
+/**
+ * Writes the producer side of the SpatialScene render output: the per-panel texture PNGs and the
+ * `scene.json` the VS Code 3D viewer consumes (see docs/design/SPATIAL_SCENE_CONTRACT.md and the
+ * consumer in PR #1704). Both land in one directory; the scene's `<id>.png` texture references are
+ * relative to it, which is the `textureBaseUri` the viewer resolves against.
+ *
+ * Must run under Robolectric with the capture properties the gradle plugin sets
+ * (`robolectric.graphicsMode=NATIVE`, `pixelCopyRenderMode=hardware`, `roborazzi.test.record=true`)
+ * — `captureRoboImage` rasterises the panel content there exactly as the Compose `@Preview` path
+ * does. `SubspaceSceneRecorder` recovers the poses; this writes the textures + scene that match.
+ */
+public object SubspaceSceneWriter {
+
+  private val json = Json {
+    prettyPrint = true
+    encodeDefaults = true
+  }
+
+  /**
+   * Renders each [panels] entry's 2D content to `<id>.png` under [outDir] — the same `<id>.png`
+   * convention `SubspaceSceneRecorder` stamps into each panel's `texture`, so the scene and its
+   * textures line up.
+   */
+  public fun captureTextures(outDir: File, panels: List<PanelTexture>) {
+    outDir.mkdirs()
+    for (panel in panels) {
+      captureRoboImage(File(outDir, "${panel.id}.png").absolutePath) {
+        Box(Modifier.size(panel.sizeDp.width.dp, panel.sizeDp.height.dp)) { panel.content() }
+      }
+    }
+  }
+
+  /** Serialises [scene] to `scene.json` under [outDir] in the wire-contract shape. */
+  public fun writeScene(outDir: File, scene: SpatialScene): File {
+    outDir.mkdirs()
+    val file = File(outDir, "scene.json")
+    file.writeText(json.encodeToString(SpatialScene.serializer(), scene))
+    return file
+  }
+}

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorderTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorderTest.kt
@@ -1,0 +1,87 @@
+package ee.schimke.composeai.renderer.xr
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import androidx.xr.compose.spatial.Subspace
+import androidx.xr.compose.subspace.SpatialColumn
+import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.layout.SubspaceModifier
+import androidx.xr.compose.subspace.layout.height
+import androidx.xr.compose.subspace.layout.width
+import androidx.xr.compose.subspace.semantics.testTag
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.xr.SPATIAL_SCENE_VERSION
+import ee.schimke.composeai.xr.SpatialScene
+import kotlinx.serialization.json.Json
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Exercises [SubspaceSceneRecorder] end-to-end: composes a real `Subspace` under the fake XR
+ * runtime (registered for ServiceLoader in test resources) with the spatial system feature
+ * shadowed on, then asserts the recovered [SpatialScene] matches the framework-computed layout and
+ * serialises to the wire contract.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SubspaceSceneRecorderTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  private fun enableSpatialFeature() {
+    val pm = ApplicationProvider.getApplicationContext<Context>().packageManager
+    shadowOf(pm).setSystemFeature(SubspaceSceneRecorder.XR_SPATIAL_FEATURE, true)
+  }
+
+  @Test
+  fun recordsSpatialSceneFromSubspace() {
+    enableSpatialFeature()
+    rule.setContent {
+      Subspace {
+        SpatialColumn(SubspaceModifier.testTag("column")) {
+          SpatialPanel(SubspaceModifier.testTag("top").width(560.dp).height(200.dp)) {
+            Box(Modifier.fillMaxSize())
+          }
+          SpatialPanel(SubspaceModifier.testTag("bottom").width(560.dp).height(160.dp)) {
+            Box(Modifier.fillMaxSize())
+          }
+        }
+      }
+    }
+    rule.waitForIdle()
+
+    val scene = SubspaceSceneRecorder.record(rule, listOf("top", "bottom"), previewId = "test")
+
+    assertThat(scene.version).isEqualTo(SPATIAL_SCENE_VERSION)
+    assertThat(scene.units).isEqualTo("dp")
+    assertThat(scene.previewId).isEqualTo("test")
+    assertThat(scene.panels.map { it.id }).containsExactly("top", "bottom")
+
+    val top = scene.panels.single { it.id == "top" }
+    assertThat(top.sizeDp.width).isEqualTo(560)
+    assertThat(top.sizeDp.height).isEqualTo(200)
+    assertThat(top.texture).isEqualTo("top.png")
+
+    val bottom = scene.panels.single { it.id == "bottom" }
+    assertThat(bottom.sizeDp.height).isEqualTo(160)
+
+    // The genuine SpatialColumn stacking: top panel sits above the bottom one (+y is up).
+    assertThat(top.poseInRoot.translation.y).isGreaterThan(bottom.poseInRoot.translation.y)
+
+    // Round-trips through the wire format.
+    val json = Json { ignoreUnknownKeys = true }
+    val encoded = json.encodeToString(SpatialScene.serializer(), scene)
+    val decoded = json.decodeFromString(SpatialScene.serializer(), encoded)
+    assertThat(decoded).isEqualTo(scene)
+  }
+}

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneWriterTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneWriterTest.kt
@@ -1,0 +1,113 @@
+package ee.schimke.composeai.renderer.xr
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.xr.OrbitCamera
+import ee.schimke.composeai.xr.Quat
+import ee.schimke.composeai.xr.SizeDp
+import ee.schimke.composeai.xr.SpatialPanel
+import ee.schimke.composeai.xr.SpatialPose
+import ee.schimke.composeai.xr.SpatialScene
+import ee.schimke.composeai.xr.Vec3
+import java.io.File
+import javax.imageio.ImageIO
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Verifies the producer's render output: each panel's 2D content is rasterised to `<id>.png` and
+ * the scene serialises to `scene.json` in the same directory, with relative `<id>.png` texture refs
+ * — the exact layout the VS Code 3D viewer (PR #1704) resolves against a `textureBaseUri`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SubspaceSceneWriterTest {
+
+  private fun tempDir(): File =
+    File.createTempFile("xr-render", "").let {
+      it.delete()
+      it.mkdirs()
+      it
+    }
+
+  private fun centrePixel(png: File): Triple<Int, Int, Int> {
+    val img = ImageIO.read(png)
+    val argb = img.getRGB(img.width / 2, img.height / 2)
+    return Triple((argb shr 16) and 0xFF, (argb shr 8) and 0xFF, argb and 0xFF)
+  }
+
+  @Test
+  fun capturesPanelTexturesAndWritesScene() {
+    val dir = tempDir()
+
+    SubspaceSceneWriter.captureTextures(
+      dir,
+      listOf(
+        PanelTexture("top", SizeDp(560, 200)) {
+          Box(Modifier.fillMaxSize().background(Color.Red))
+        },
+        PanelTexture("bottom", SizeDp(560, 160)) {
+          Box(Modifier.fillMaxSize().background(Color.Blue))
+        },
+      ),
+    )
+
+    val topPng = File(dir, "top.png")
+    val bottomPng = File(dir, "bottom.png")
+    assertThat(topPng.exists()).isTrue()
+    assertThat(topPng.length()).isGreaterThan(0L)
+    assertThat(bottomPng.exists()).isTrue()
+
+    // Real rasterisation of distinct panel content, not blank frames.
+    val (tr, tg, tb) = centrePixel(topPng)
+    assertThat(tr).isGreaterThan(180)
+    assertThat(tg).isLessThan(80)
+    assertThat(tb).isLessThan(80)
+    val (br, bg, bb) = centrePixel(bottomPng)
+    assertThat(bb).isGreaterThan(180)
+    assertThat(br).isLessThan(80)
+    assertThat(bg).isLessThan(80)
+
+    val scene =
+      SpatialScene(
+        previewId = "test",
+        camera =
+          OrbitCamera(target = Vec3(0.0, -10.0, 0.0), distance = 1200.0, yawDeg = 0.0, pitchDeg = -10.0),
+        panels =
+          listOf(
+            SpatialPanel(
+              id = "top",
+              poseInRoot = SpatialPose(Vec3(0.0, 80.0, 0.0), Quat(0.0, 0.0, 0.0, 1.0)),
+              sizeDp = SizeDp(560, 200),
+              texture = "top.png",
+            ),
+            SpatialPanel(
+              id = "bottom",
+              poseInRoot = SpatialPose(Vec3(0.0, -100.0, 0.0), Quat(0.0, 0.0, 0.0, 1.0)),
+              sizeDp = SizeDp(560, 160),
+              texture = "bottom.png",
+            ),
+          ),
+      )
+
+    val sceneFile = SubspaceSceneWriter.writeScene(dir, scene)
+    assertThat(sceneFile.name).isEqualTo("scene.json")
+    assertThat(sceneFile.exists()).isTrue()
+
+    // The emitted scene parses back, and each texture path resolves to a written PNG in the dir.
+    val decoded =
+      Json { ignoreUnknownKeys = true }
+        .decodeFromString(SpatialScene.serializer(), sceneFile.readText())
+    assertThat(decoded.panels.map { it.id }).containsExactly("top", "bottom")
+    for (panel in decoded.panels) {
+      assertThat(File(dir, panel.texture).exists()).isTrue()
+    }
+  }
+}

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceWorldIntegrationTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceWorldIntegrationTest.kt
@@ -1,0 +1,132 @@
+package ee.schimke.composeai.renderer.xr
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import androidx.xr.compose.spatial.ContentEdge
+import androidx.xr.compose.spatial.Orbiter
+import androidx.xr.compose.spatial.Subspace
+import androidx.xr.compose.subspace.SpatialColumn
+import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.SpatialRow
+import androidx.xr.compose.subspace.layout.SubspaceModifier
+import androidx.xr.compose.subspace.layout.height
+import androidx.xr.compose.subspace.layout.width
+import androidx.xr.compose.subspace.semantics.testTag
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.xr.SizeDp
+import ee.schimke.composeai.xr.SpatialScene
+import java.io.File
+import kotlinx.serialization.json.Json
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * End-to-end producer run against a richer "3D world with floating windows": a `SpatialColumn` with
+ * a main panel over a `SpatialRow` of two side panels, plus an `Orbiter`-anchored control strip.
+ * Composes it offline under the fake XR runtime, recovers the layout, captures every panel's
+ * texture, writes `scene.json`, and asserts the full render output is internally consistent — the
+ * shape the VS Code 3D viewer (#1704) consumes.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SubspaceWorldIntegrationTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  private val panelContent: Map<String, @Composable () -> Unit> =
+    mapOf(
+      "main" to { Box(Modifier.fillMaxSize().background(Color(0xFF1E3C78))) },
+      "queue" to { Box(Modifier.fillMaxSize().background(Color(0xFF146E6E))) },
+      "lyrics" to { Box(Modifier.fillMaxSize().background(Color(0xFF7A3E1E))) },
+      "controls" to { Box(Modifier.fillMaxSize().background(Color(0xFF333845))) },
+    )
+
+  private val panelSizes =
+    mapOf(
+      "main" to SizeDp(720, 360),
+      "queue" to SizeDp(320, 280),
+      "lyrics" to SizeDp(320, 280),
+      "controls" to SizeDp(400, 80),
+    )
+
+  @Test
+  fun producesCompleteSceneForFloatingWindowWorld() {
+    val pm = ApplicationProvider.getApplicationContext<Context>().packageManager
+    shadowOf(pm).setSystemFeature(SubspaceSceneRecorder.XR_SPATIAL_FEATURE, true)
+
+    rule.setContent {
+      Subspace {
+        SpatialColumn(SubspaceModifier.testTag("root")) {
+          SpatialPanel(SubspaceModifier.testTag("main").width(720.dp).height(360.dp)) {
+            panelContent.getValue("main")()
+            Orbiter(position = ContentEdge.Bottom) {
+              Box(Modifier.fillMaxSize().background(Color(0xFF333845)))
+            }
+          }
+          SpatialRow(SubspaceModifier.testTag("row")) {
+            SpatialPanel(SubspaceModifier.testTag("queue").width(320.dp).height(280.dp)) {
+              panelContent.getValue("queue")()
+            }
+            SpatialPanel(SubspaceModifier.testTag("lyrics").width(320.dp).height(280.dp)) {
+              panelContent.getValue("lyrics")()
+            }
+          }
+        }
+      }
+    }
+    rule.waitForIdle()
+
+    val panelTags = listOf("main", "queue", "lyrics")
+    val scene = SubspaceSceneRecorder.record(rule, panelTags, previewId = "spatial-world")
+
+    // Geometry recovered for every floating window.
+    assertThat(scene.panels.map { it.id }).containsExactlyElementsIn(panelTags)
+    val byId = scene.panels.associateBy { it.id }
+    assertThat(byId.getValue("main").sizeDp).isEqualTo(SizeDp(720, 360))
+    assertThat(byId.getValue("queue").sizeDp).isEqualTo(SizeDp(320, 280))
+    // The two side panels share a row, so they sit at the same height but different x.
+    assertThat(byId.getValue("queue").poseInRoot.translation.y)
+      .isEqualTo(byId.getValue("lyrics").poseInRoot.translation.y)
+    assertThat(byId.getValue("queue").poseInRoot.translation.x)
+      .isNotEqualTo(byId.getValue("lyrics").poseInRoot.translation.x)
+    // The main panel sits above the side-panel row.
+    assertThat(byId.getValue("main").poseInRoot.translation.y)
+      .isGreaterThan(byId.getValue("queue").poseInRoot.translation.y)
+
+    // Full render output: textures for every panel + scene.json, co-located and consistent.
+    val outDir =
+      File.createTempFile("xr-world", "").let {
+        it.delete()
+        it.mkdirs()
+        it
+      }
+    SubspaceSceneWriter.captureTextures(
+      outDir,
+      panelTags.map { tag -> PanelTexture(tag, panelSizes.getValue(tag), panelContent.getValue(tag)) },
+    )
+    val sceneFile = SubspaceSceneWriter.writeScene(outDir, scene)
+
+    val decoded =
+      Json { ignoreUnknownKeys = true }
+        .decodeFromString(SpatialScene.serializer(), sceneFile.readText())
+    assertThat(decoded.previewId).isEqualTo("spatial-world")
+    for (panel in decoded.panels) {
+      val texture = File(outDir, panel.texture)
+      assertThat(texture.exists()).isTrue()
+      assertThat(texture.length()).isGreaterThan(0L)
+    }
+  }
+}

--- a/renderers/xr/src/test/resources/META-INF/services/androidx.xr.runtime.internal.RenderingRuntimeFactory
+++ b/renderers/xr/src/test/resources/META-INF/services/androidx.xr.runtime.internal.RenderingRuntimeFactory
@@ -1,0 +1,1 @@
+androidx.xr.scenecore.testing.FakeRenderingRuntimeFactory

--- a/renderers/xr/src/test/resources/META-INF/services/androidx.xr.runtime.internal.SceneRuntimeFactory
+++ b/renderers/xr/src/test/resources/META-INF/services/androidx.xr.runtime.internal.SceneRuntimeFactory
@@ -1,0 +1,1 @@
+androidx.xr.scenecore.testing.FakeSceneRuntimeFactory

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -178,6 +178,10 @@ include(":renderer-android")
 
 project(":renderer-android").projectDir = file("renderers/android")
 
+include(":renderer-xr")
+
+project(":renderer-xr").projectDir = file("renderers/xr")
+
 include(":daemon:core")
 
 // Per-product data-product modules — each `data/<product>/` carries a `core` (generic Android /


### PR DESCRIPTION
⚠️ **Stacked on #1701** (the Kotlin `SpatialScene` DTO). Review/merge #1701 first; this branch includes its commit until then and should be rebased onto `main` after #1701 lands.

The producer side of the XR spatial preview: a new `:renderer-xr` module that recovers a Compose-XR subspace layout **offline** (no headset, no OpenXR, no SceneCore native) and emits the `SpatialScene` render output the VS Code 3D viewer (#1704) consumes.

## What's here
- **`SubspaceSceneRecorder.record(rule, panelTags, previewId)`** — composes a `Subspace` under the fake XR runtime + the `android.software.xr.api.spatial` feature shadow (the technique proven by `SubspaceLayoutPoseTest`) and reads each tagged panel's `poseInRoot`/`size` from the public spatial-semantics tree into `SpatialScene` panels, with a neutral framing orbit camera.
- **`SubspaceSceneWriter.captureTextures(outDir, panels)`** — rasterises each panel's 2D content to `<id>.png` via `captureRoboImage` (same hardware path as the Compose `@Preview` renderer).
- **`SubspaceSceneWriter.writeScene(outDir, scene)`** — serialises the scene to `scene.json` beside the PNGs. That's the exact layout #1704 resolves against a `textureBaseUri` (relative `<id>.png` refs next to `scene.json`).
- Heavy XR / compose-test / roborazzi libs are `compileOnly` (provided by the render runtime), mirroring `:renderer-android`; the `*-testing` fake runtimes + their `ServiceLoader` registration live only in the test source set, so nothing leaks onto a consumer classpath.

## Tests (2, green under JDK 17 / Robolectric SDK 35)
- `SubspaceSceneRecorderTest` — records a live `SpatialColumn` and asserts the recovered scene matches the framework layout (top above bottom, sizes) + JSON round-trip.
- `SubspaceSceneWriterTest` — captures red/blue panels, asserts the PNGs are non-blank with the right dominant colour, writes `scene.json`, and checks every texture path resolves to a written file.

## Scope / next
This is the producer **library**, fully tested in isolation. The remaining glue — a `PreviewKind.XR_SUBSPACE` + discovery detection + a render strategy that invokes this on a real `@Preview`'d subspace and writes the output into the render dir — touches the core gradle plugin / render pipeline and is intentionally **not** in this PR (left for review-with-maintainer). Auto-enumerating panels (vs explicit tags) needs internal `TestTagNode` access and is deferred.

## Test plan
- [x] `:renderer-xr:testDebugUnitTest` — 2 passed
- [x] `:renderer-xr:ktfmtCheck`