### PR TITLE
feat(renderer-xr): auto-enumerate tagged subspace panels (recordAll)

### DIFF
--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
@@ -80,6 +80,14 @@ public object SubspaceSceneRecorder {
         val tag = node.config.getOrNull(SemanticsProperties.TestTag) ?: return@mapNotNull null
         panelFrom(node, id = tag, parentId = null)
       }
+    // The tag is the panel id and drives the `<id>.png` texture path, so duplicates would yield an
+    // ambiguous scene + colliding captures. The tag-based `record` path fails on this implicitly
+    // (onSubspaceNodeWithTag requires a unique match); make recordAll fail just as loudly.
+    val duplicates = panels.groupingBy { it.id }.eachCount().filterValues { it > 1 }.keys
+    check(duplicates.isEmpty()) {
+      "Duplicate subspace panel testTag(s) ${duplicates.sorted()}: each SpatialPanel in an " +
+        "@XrSubspacePreview must carry a unique testTag (panel ids and texture paths derive from it)."
+    }
     return SpatialScene(previewId = previewId, camera = defaultCamera(panels), panels = panels)
   }
 

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
@@ -1,7 +1,11 @@
 package ee.schimke.composeai.renderer.xr
 
 import androidx.activity.ComponentActivity
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.xr.compose.subspace.node.SubspaceSemanticsInfo
+import androidx.xr.compose.testing.SubspaceTestContext
 import androidx.xr.compose.testing.onSubspaceNodeWithTag
 import ee.schimke.composeai.xr.OrbitCamera
 import ee.schimke.composeai.xr.Quat
@@ -42,21 +46,81 @@ public object SubspaceSceneRecorder {
     val panels =
       panelTags.map { tag ->
         val node = rule.onSubspaceNodeWithTag(tag).fetchSemanticsNode("no subspace node '$tag'")
-        val t = node.poseInRoot.translation
-        val r = node.poseInRoot.rotation
-        val size = node.size
-        SpatialPanel(
-          id = tag,
-          poseInRoot =
-            SpatialPose(
-              translation = Vec3(t.x.toDouble(), t.y.toDouble(), t.z.toDouble()),
-              rotation = Quat(r.x.toDouble(), r.y.toDouble(), r.z.toDouble(), r.w.toDouble()),
-            ),
-          sizeDp = SizeDp(width = size.width, height = size.height),
-          texture = "$tag.png",
-        )
+        panelFrom(node, id = tag, parentId = null)
       }
     return SpatialScene(previewId = previewId, camera = defaultCamera(panels), panels = panels)
+  }
+
+  /**
+   * Auto-enumerates the **tagged** panels of the subspace composed on [rule] — the path the render
+   * pipeline takes for a discovered `@XrSubspacePreview`. Every node carrying a
+   * `SubspaceModifier.testTag(...)` becomes a [SpatialPanel], with the tag as its id. Authors tag
+   * the panels they want in the scene; an untagged `SpatialPanel` produces no spatial-semantics
+   * node and is therefore invisible here (and to `onSubspaceNodeWithTag`), so tagging is required
+   * either way.
+   *
+   * `poseInRoot` is absolute, so `parentId` is left null — the viewer positions panels without the
+   * hierarchy.
+   *
+   * Implementation note: the public spatial-semantics surface only exposes nodes by *unique* match,
+   * and the merged root reports no children, so there's no public way to list every node. We reach
+   * the flat node list through one reflective call into `androidx.xr.compose.testing`'s internal
+   * `SubspaceTestContext.getAllSemanticsNodes`; the nodes it returns are the public
+   * [SubspaceSemanticsInfo] type and the tag is read from the standard
+   * [SemanticsProperties.TestTag], so only the list *access* is reflective. `:samples:xr-spatial`'s
+   * `SubspaceLayoutPoseTest` (and these tests) are the canary if that internal shifts in a future
+   * `androidx.xr.compose:compose-testing`.
+   */
+  public fun recordAll(
+    rule: AndroidComposeTestRule<*, ComponentActivity>,
+    previewId: String? = null,
+  ): SpatialScene {
+    val panels =
+      allSemanticsNodes(rule).mapNotNull { node ->
+        val tag = node.config.getOrNull(SemanticsProperties.TestTag) ?: return@mapNotNull null
+        panelFrom(node, id = tag, parentId = null)
+      }
+    return SpatialScene(previewId = previewId, camera = defaultCamera(panels), panels = panels)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun allSemanticsNodes(
+    rule: AndroidComposeTestRule<*, ComponentActivity>
+  ): List<SubspaceSemanticsInfo> {
+    val context = SubspaceTestContext(rule)
+    return try {
+      val method =
+        context.javaClass.getMethod(
+          "getAllSemanticsNodes\$compose_testing",
+          Boolean::class.javaPrimitiveType,
+        )
+      method.isAccessible = true
+      (method.invoke(context, /* useUnmergedTree = */ true) as Iterable<SubspaceSemanticsInfo>)
+        .toList()
+    } catch (e: ReflectiveOperationException) {
+      throw IllegalStateException(
+        "Could not enumerate subspace nodes via androidx.xr.compose.testing internals; the " +
+          "compose-testing API may have changed (see SubspaceSceneRecorder.recordAll).",
+        e,
+      )
+    }
+  }
+
+  private fun panelFrom(node: SubspaceSemanticsInfo, id: String, parentId: String?): SpatialPanel {
+    val t = node.poseInRoot.translation
+    val r = node.poseInRoot.rotation
+    val size = node.size
+    return SpatialPanel(
+      id = id,
+      poseInRoot =
+        SpatialPose(
+          translation = Vec3(t.x.toDouble(), t.y.toDouble(), t.z.toDouble()),
+          rotation = Quat(r.x.toDouble(), r.y.toDouble(), r.z.toDouble(), r.w.toDouble()),
+        ),
+      sizeDp = SizeDp(width = size.width, height = size.height),
+      texture = "$id.png",
+      parentId = parentId,
+    )
   }
 
   /**

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorderAutoEnumTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorderAutoEnumTest.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.renderer.xr
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import androidx.xr.compose.spatial.Subspace
+import androidx.xr.compose.subspace.SpatialColumn
+import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.SpatialRow
+import androidx.xr.compose.subspace.layout.SubspaceModifier
+import androidx.xr.compose.subspace.layout.height
+import androidx.xr.compose.subspace.layout.width
+import androidx.xr.compose.subspace.semantics.testTag
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Auto-enumeration: [SubspaceSceneRecorder.recordAll] discovers every tagged panel of a `Subspace`
+ * with no tag list supplied — the path the render pipeline takes for a discovered
+ * `@XrSubspacePreview`. Tags become panel ids; the untagged layout groups are not panels.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SubspaceSceneRecorderAutoEnumTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun recordAllDiscoversTaggedPanels() {
+    val pm = ApplicationProvider.getApplicationContext<Context>().packageManager
+    shadowOf(pm).setSystemFeature(SubspaceSceneRecorder.XR_SPATIAL_FEATURE, true)
+
+    rule.setContent {
+      Subspace {
+        // Groups are intentionally untagged; only the panels carry a testTag.
+        SpatialColumn {
+          SpatialPanel(SubspaceModifier.testTag("main").width(720.dp).height(360.dp)) {
+            Box(Modifier.fillMaxSize())
+          }
+          SpatialRow {
+            SpatialPanel(SubspaceModifier.testTag("queue").width(320.dp).height(280.dp)) {
+              Box(Modifier.fillMaxSize())
+            }
+            SpatialPanel(SubspaceModifier.testTag("lyrics").width(320.dp).height(280.dp)) {
+              Box(Modifier.fillMaxSize())
+            }
+          }
+        }
+      }
+    }
+    rule.waitForIdle()
+
+    val scene = SubspaceSceneRecorder.recordAll(rule, previewId = "auto")
+
+    // All three tagged panels discovered, keyed by their tags; the column/row groups are not panels.
+    assertThat(scene.panels.map { it.id }).containsExactly("main", "queue", "lyrics")
+    assertThat(scene.panels.all { it.texture == "${it.id}.png" }).isTrue()
+    assertThat(scene.panels.all { it.parentId == null }).isTrue()
+
+    val byId = scene.panels.associateBy { it.id }
+    assertThat(byId.getValue("main").sizeDp.width).isEqualTo(720)
+    assertThat(byId.getValue("queue").sizeDp.width).isEqualTo(320)
+
+    // The two side panels share a row → same height, different x.
+    assertThat(byId.getValue("queue").poseInRoot.translation.y)
+      .isEqualTo(byId.getValue("lyrics").poseInRoot.translation.y)
+    assertThat(byId.getValue("queue").poseInRoot.translation.x)
+      .isNotEqualTo(byId.getValue("lyrics").poseInRoot.translation.x)
+    // The main panel sits above the side-panel row.
+    assertThat(byId.getValue("main").poseInRoot.translation.y)
+      .isGreaterThan(byId.getValue("queue").poseInRoot.translation.y)
+  }
+}

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorderDuplicateTagTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorderDuplicateTagTest.kt
@@ -1,0 +1,57 @@
+package ee.schimke.composeai.renderer.xr
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import androidx.xr.compose.spatial.Subspace
+import androidx.xr.compose.subspace.SpatialColumn
+import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.layout.SubspaceModifier
+import androidx.xr.compose.subspace.layout.height
+import androidx.xr.compose.subspace.layout.width
+import androidx.xr.compose.subspace.semantics.testTag
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/** `recordAll` must reject duplicate panel tags rather than emit colliding ids / texture paths. */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class SubspaceSceneRecorderDuplicateTagTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun recordAllRejectsDuplicateTags() {
+    val pm = ApplicationProvider.getApplicationContext<Context>().packageManager
+    shadowOf(pm).setSystemFeature(SubspaceSceneRecorder.XR_SPATIAL_FEATURE, true)
+
+    rule.setContent {
+      Subspace {
+        SpatialColumn {
+          SpatialPanel(SubspaceModifier.testTag("dup").width(320.dp).height(200.dp)) {
+            Box(Modifier.fillMaxSize())
+          }
+          SpatialPanel(SubspaceModifier.testTag("dup").width(320.dp).height(160.dp)) {
+            Box(Modifier.fillMaxSize())
+          }
+        }
+      }
+    }
+    rule.waitForIdle()
+
+    val error =
+      runCatching { SubspaceSceneRecorder.recordAll(rule, previewId = "dup-test") }.exceptionOrNull()
+    assertThat(error).isInstanceOf(IllegalStateException::class.java)
+    assertThat(error).hasMessageThat().contains("dup")
+  }
+}


### PR DESCRIPTION
Adds `SubspaceSceneRecorder.recordAll(rule, previewId)` — the auto-enumeration the render pipeline needs for a discovered `@XrSubspacePreview`, where the panel set isn't known ahead of time. It returns a `SpatialScene` for **every `SpatialPanel` carrying a `SubspaceModifier.testTag(...)`**, keyed by the tag.

## Why tags
This started as the geometry-only option, expected to be reflection-free. Investigation showed the public spatial-semantics surface is a dead end for listing panels: the merged root reports `children = 0`, and `onAllSubspaceNodes(...)`'s collection exposes its nodes only privately. Worse, an **untagged** `SpatialPanel` produces *no* spatial-semantics node at all (so it's invisible to `onSubspaceNodeWithTag` too) — tagging is required to recover a panel either way. So the model is a light authoring convention: tag the panels you want in the scene; tags become panel ids.

## The one reflective seam (per your "contained reflection" call)
`recordAll` reaches the flat node list through a single reflective call into `androidx.xr.compose.testing`'s internal `SubspaceTestContext.getAllSemanticsNodes`. The returned nodes are the **public** `SubspaceSemanticsInfo` type and the tag is read from the **standard** `SemanticsProperties.TestTag`, so only the list *access* is reflective — guarded, with a clear error if that internal shifts. The existing `SubspaceLayoutPoseTest` canary + these tests flag any such change.

## Test plan
- [x] `:renderer-xr:testDebugUnitTest` — 4 passed, incl. the new auto-enum test on a `SpatialColumn` + `SpatialRow` floating-windows layout (3 tagged panels discovered by tag; untagged groups excluded; row siblings share height, differ in x)
- [x] `:renderer-xr:ktfmtCheck`
- [x] Branched fresh from `main`; touches only `:renderer-xr`

## Next
The discovery + render-routing glue (`@XrSubspacePreview` annotation → `PreviewKind.XR_SUBSPACE` → a render that calls `recordAll` + writes `scene.json` into the render dir, and excludes XR previews from the Android image render). That's the core-plugin piece; this PR unblocks it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_