### PR TITLE
feat(plugin): discover @XrSubspacePreview as PreviewKind.XR_SUBSPACE

### DIFF
--- a/api/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/XrSubspacePreview.kt
+++ b/api/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/XrSubspacePreview.kt
@@ -1,0 +1,22 @@
+package ee.schimke.composeai.preview
+
+/**
+ * Marks a `@Composable` function whose body is an `androidx.xr.compose.spatial.Subspace { … }` as a
+ * renderable **XR spatial preview**. Discovered by the compose-preview Gradle plugin by FQN —
+ * consumers depend on `ee.schimke.composeai:preview-annotations` to use it.
+ *
+ * Unlike a normal `@Preview`, XR subspace previews aren't captured to a single PNG. They're
+ * rendered by a separate `:renderer-xr` Robolectric task that composes the subspace offline under a
+ * fake XR runtime (no headset / OpenXR / SceneCore native), recovers each panel's pose + size, and
+ * writes a `scene.json` (`SpatialScene`) describing the layout for the VS Code 3D spatial-layout
+ * viewer.
+ *
+ * **Tag every `SpatialPanel` you want in the scene** with
+ * `androidx.xr.compose.subspace.semantics.testTag(...)`: the tag becomes the panel's id (and its
+ * `<id>.png` texture path), and an untagged `SpatialPanel` produces no spatial-semantics node and
+ * is therefore invisible to the recorder. See docs/design/XR_SPATIAL_PREVIEW.md.
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+@MustBeDocumented
+annotation class XrSubspacePreview

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -19,6 +19,7 @@ enum class PreviewKind {
   TILE,
   NOTIFICATION,
   GLANCE_APPWIDGET,
+  XR_SUBSPACE,
 }
 
 /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -95,6 +95,7 @@ object PreviewDiscovery {
       TILE_PREVIEW_FQN,
       NOTIFICATION_PREVIEW_FQN,
       GLANCE_APPWIDGET_PREVIEW_FQN,
+      XR_SUBSPACE_PREVIEW_FQN,
     )
   private val CONTAINER_FQNS =
     setOf(
@@ -141,6 +142,13 @@ object PreviewDiscovery {
   // tile. The annotated function is a `@Composable @GlanceComposable () -> Unit` body invoked
   // from a synthetic `GlanceAppWidget.providePreview(...)` at render time.
   internal const val GLANCE_APPWIDGET_PREVIEW_FQN = "androidx.glance.preview.Preview"
+
+  // Our own opt-in for XR spatial (subspace) previews. The annotated function is a `@Composable`
+  // whose body is an `androidx.xr.compose.spatial.Subspace { … }`; it's not captured to a single
+  // PNG but rendered by a separate `:renderer-xr` Robolectric task that recovers the panel layout
+  // and writes a `scene.json`. Same FQN-match policy as the other annotations we own. See
+  // `XrSubspacePreview.kt`.
+  internal const val XR_SUBSPACE_PREVIEW_FQN = "ee.schimke.composeai.preview.XrSubspacePreview"
 
   // `@LauncherWidgetResize` — fan-out annotation that emits one capture per whole-cell stop on
   // the walk between source and target sizes. The renderer renders each stop through the same
@@ -676,10 +684,12 @@ object PreviewDiscovery {
     val isTilePreview = isAnyTilePreviewAnnotation(annotations, scanResult)
     val isNotificationPreview = isAnyNotificationPreviewAnnotation(annotations, scanResult)
     val isGlanceAppWidgetPreview = isAnyGlanceAppWidgetPreviewAnnotation(annotations, scanResult)
+    val isXrSubspacePreview = isAnyXrSubspacePreviewAnnotation(annotations, scanResult)
     val hasUnsupportedParameters =
       !isTilePreview &&
         !isNotificationPreview &&
         !isGlanceAppWidgetPreview &&
+        !isXrSubspacePreview &&
         hasUnsupportedPreviewParameters(method, previewParameter)
     if (hasUnsupportedParameters) {
       warnings.add(
@@ -817,6 +827,26 @@ object PreviewDiscovery {
     return false
   }
 
+  /**
+   * XR subspace previews (`XR_SUBSPACE_PREVIEW_FQN`) are `@Composable` functions whose JVM
+   * signature carries the compiler-added `Composer, Int` pair the standard composable-parameter
+   * check would flag. Treat them the same as tile / notification / glance so the check is skipped:
+   * they're rendered by the separate `:renderer-xr` task, not the Android image renderer. Walk
+   * direct annotations + multi-preview meta-annotations so an XR preview reached through an alias
+   * is exempted too.
+   */
+  private fun isAnyXrSubspacePreviewAnnotation(
+    annotations: List<AnnotationInfo>,
+    scanResult: ScanResult,
+  ): Boolean {
+    if (collectDirectPreviews(annotations).any { it.name == XR_SUBSPACE_PREVIEW_FQN }) return true
+    for (ann in annotations) {
+      val resolved = resolveMultiPreview(ann, scanResult, mutableSetOf())
+      if (resolved.any { it.name == XR_SUBSPACE_PREVIEW_FQN }) return true
+    }
+    return false
+  }
+
   private fun hasUnsupportedPreviewParameters(
     method: MethodInfo,
     previewParameter: Pair<String, Int>?,
@@ -902,7 +932,11 @@ object PreviewDiscovery {
     // / focus drive, no `mainClock` tick, the renderer handles the whole materialise + inflate
     // in one shot.
     val isGlanceAppWidget = ann.name == GLANCE_APPWIDGET_PREVIEW_FQN
-    val nonComposable = isTile || isNotification || isGlanceAppWidget
+    // XR subspace previews aren't captured to a single image and have no `mainClock` / scrollable /
+    // focus owner here — the `:renderer-xr` task drives the whole recover-and-write in one shot.
+    // Gate them out of every dimensional fan-out the same way as tile / notification / glance.
+    val isXrSubspace = ann.name == XR_SUBSPACE_PREVIEW_FQN
+    val nonComposable = isTile || isNotification || isGlanceAppWidget || isXrSubspace
     val effectiveTimings = if (nonComposable) emptyList() else timings
     val effectiveScrolls = if (nonComposable) emptyList() else scrolls
     // Tile / notification previews don't go through `mainClock` — there's no animation surface to
@@ -1625,7 +1659,8 @@ object PreviewDiscovery {
       if (
         params.kind == PreviewKind.TILE ||
           params.kind == PreviewKind.NOTIFICATION ||
-          params.kind == PreviewKind.GLANCE_APPWIDGET
+          params.kind == PreviewKind.GLANCE_APPWIDGET ||
+          params.kind == PreviewKind.XR_SUBSPACE
       )
         emptyList()
       else inferredTargets.value
@@ -1728,6 +1763,11 @@ object PreviewDiscovery {
         widthDp = widthDp,
         heightDp = heightDp,
       )
+    }
+    // XR subspace previews carry no device / dimension annotation params — the layout comes from
+    // the composed `Subspace`. Emit minimal params; the `:renderer-xr` task does the rest.
+    if (ann.name == XR_SUBSPACE_PREVIEW_FQN) {
+      return PreviewParams(kind = PreviewKind.XR_SUBSPACE)
     }
     val pv = ann.parameterValues
     val kind = if (ann.name == TILE_PREVIEW_FQN) PreviewKind.TILE else PreviewKind.COMPOSE

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -1621,4 +1621,66 @@ class DiscoveryFunctionalTest {
     // Target inference is skipped for non-composable kinds, so `targets` stays empty.
     assertThat(notificationPreviews.flatMap { it.targets }).isEmpty()
   }
+
+  @Test
+  fun `composePreviewDiscover tags XrSubspacePreview functions as XR_SUBSPACE`() {
+    val projectDir = createCmpTestProject()
+
+    // Stub `@XrSubspacePreview` under its real FQN — discovery is FQN-driven, so the stub exercises
+    // the same path a real consumer (depending on `:preview-annotations`) would, without dragging
+    // `androidx.xr.compose` onto the fixture's classpath.
+    val previewFqnDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+    previewFqnDir.mkdirs()
+    File(previewFqnDir, "XrSubspacePreview.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        @MustBeDocumented
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION)
+        annotation class XrSubspacePreview
+        """
+          .trimIndent()
+      )
+
+    val srcFile = File(projectDir, "src/main/kotlin/test/XrPreviews.kt")
+    srcFile.writeText(
+      """
+      package test
+
+      import androidx.compose.runtime.Composable
+      import ee.schimke.composeai.preview.XrSubspacePreview
+
+      // The body would be a `Subspace { … }` in a real consumer; discovery is annotation-driven and
+      // doesn't reflect the body, so an empty composable exercises the detection + kind assignment.
+      @XrSubspacePreview
+      @Composable
+      fun MySpatialPreview() {}
+      """
+        .trimIndent()
+    )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    // The "unsupported parameters" warning must NOT fire — XR previews bypass the composable-param
+    // check the same way tile / notification / glance do.
+    assertThat(result.output).doesNotContain("MySpatialPreview' — method has parameter(s)")
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val xrPreviews = manifest.previews.filter { it.functionName == "MySpatialPreview" }
+    assertThat(xrPreviews.map { it.functionName }).containsExactly("MySpatialPreview")
+    assertThat(xrPreviews.map { it.params.kind }.toSet()).containsExactly(PreviewKind.XR_SUBSPACE)
+    // Non-composable kind: no scroll / time / focus fan-out, no target inference.
+    assertThat(xrPreviews.map { it.captures.size }).containsExactly(1)
+    assertThat(xrPreviews.flatMap { it.targets }).isEmpty()
+  }
 }

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -8,6 +8,7 @@ enum class PreviewKind {
     TILE,
     NOTIFICATION,
     GLANCE_APPWIDGET,
+    XR_SUBSPACE,
 }
 
 /**

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -115,7 +115,13 @@ object PreviewManifestLoader {
         // (Array<Any>[entry, args]) instead of being serialised back into the
         // manifest: provider values can be arbitrary runtime objects, often
         // not JSON-representable.
-        val expanded = manifest.previews.flatMap { expandParameterProvider(it) }
+        // XR_SUBSPACE previews are rendered by the separate `:renderer-xr` Robolectric task, not by
+        // this Android image renderer (there's no `PreviewRenderStrategy` for them, by design).
+        // Drop them before any expansion so they never reach `strategyFor`.
+        val expanded =
+            manifest.previews
+                .filter { it.params.kind != PreviewKind.XR_SUBSPACE }
+                .flatMap { expandParameterProvider(it) }
         // Tier filter (set by the plugin via TierSystemPropProvider). When
         // `fast`, drop heavyweight captures and annotation-sourced data
         // products. Heavy outputs keep their previous files on disk and stay


### PR DESCRIPTION
First slice of the XR spatial render integration (the "(a) separate render task" plan): teach the plugin to **discover** `@XrSubspacePreview` and keep those previews **out of the Android image renderer**, so the follow-up `:renderer-xr` render task can own them.

## What's here
- **`@XrSubspacePreview`** in `:preview-annotations` — marks a `@Composable` Subspace function; FQN-discovered, same policy as `@NotificationPreview`.
- **`PreviewKind.XR_SUBSPACE`** in both enum mirrors (discovery `PreviewData.kt` + renderer `RenderManifest.kt` — the renderer needs the value to *deserialize* the manifest even though it won't render it).
- **Discovery** (`PreviewDiscovery.kt`): FQN constant + `PREVIEW_FQNS`, `isAnyXrSubspacePreviewAnnotation`, the composable-parameter bypass, the `buildOutputPlan` non-composable gate (no scroll/animation/focus fan-out), the `extractPreviewParams` early-return, and target-inference skip — mirroring the tile/notification/glance path.
- **Android render exclusion** (`RobolectricRenderTest.kt`): drop XR_SUBSPACE rows before expansion so `strategyFor` is never called on a kind with no registered strategy.

## What's deliberately NOT here
The `:renderer-xr` render task itself (the parallel Robolectric Test + classpath injection + the `XrSubspaceRenderTest` entry that calls `recordAll`/`writeScene`). That's the next slice; this one is the safe, well-anchored discovery foundation.

## Test plan
- [x] New `DiscoveryFunctionalTest` case — an `@XrSubspacePreview` function is tagged `XR_SUBSPACE`, no unsupported-param warning, one capture, empty targets (1 passed via `:gradle-plugin:functionalTest`)
- [x] `:gradle-plugin:preview-discovery` + `:renderer-android` compile
- [x] `ktfmtCheck` clean; branched fresh from `main`

After this lands I'll open the follow-up with the `:renderer-xr` render task so XR previews actually emit `scene.json`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_