### PR TITLE
feat(renderer-xr): render an @XrSubspacePreview to scene.json

### DIFF
--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRenderer.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRenderer.kt
@@ -1,0 +1,65 @@
+package ee.schimke.composeai.renderer.xr
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import java.io.File
+
+/**
+ * Renders one `@XrSubspacePreview` to a `scene.json` — the execution half of the XR producer that
+ * the (separate) `:renderer-xr` Robolectric render task drives per discovered preview.
+ *
+ * It reflects the preview's `@Composable` function (the same way the Compose `@Preview` renderer
+ * does — [getDeclaredComposableMethod] + invoke through the current [currentComposer]), composes its
+ * `Subspace` on [rule], then hands off to [SubspaceSceneRecorder.recordAll] + [SubspaceSceneWriter].
+ *
+ * The caller owns the Robolectric environment: it must enable the
+ * [SubspaceSceneRecorder.XR_SPATIAL_FEATURE] system feature **before** calling this (so `Subspace`
+ * takes its spatial path), exactly as the render task / the tests do. Geometry-only: panel textures
+ * aren't captured here — the emitted scene carries `<tag>.png` paths the viewer renders as
+ * placeholders until the texture pass lands.
+ */
+public object XrSubspaceRenderer {
+
+  /**
+   * Composes the `@Composable` preview [functionName] on [className], records the subspace layout,
+   * and writes `scene.json` into [outputDir]. Returns the written file.
+   */
+  public fun render(
+    rule: AndroidComposeTestRule<*, ComponentActivity>,
+    className: String,
+    functionName: String,
+    previewId: String,
+    outputDir: File,
+  ): File {
+    val clazz = Class.forName(className)
+    val method = clazz.getDeclaredComposableMethod(functionName)
+    // Kotlin `private`/`internal` previews compile to inaccessible JVM methods; open them up so the
+    // reflective invoke below succeeds (mirrors the Compose `@Preview` renderer).
+    runCatching { method.asMethod().isAccessible = true }
+    val receiver = resolveReceiver(clazz)
+
+    rule.setContent { method.invoke(currentComposer, receiver) }
+    rule.waitForIdle()
+
+    val scene = SubspaceSceneRecorder.recordAll(rule, previewId = previewId)
+    return SubspaceSceneWriter.writeScene(outputDir, scene)
+  }
+
+  /**
+   * The JVM receiver for the preview method: a Kotlin `object`'s `INSTANCE`, else a fresh
+   * nullary-ctor instance for a regular class, else `null` for a top-level function (which compiles
+   * to a static method on the file's synthetic `…Kt` class). Mirrors `ComposeViewAdapter` /
+   * the Compose `@Preview` renderer's `resolvePreviewReceiver`.
+   */
+  private fun resolveReceiver(clazz: Class<*>): Any? {
+    runCatching { clazz.getField("INSTANCE").get(null) }.getOrNull()?.let { return it }
+    return runCatching {
+        val ctor = clazz.getDeclaredConstructor()
+        ctor.isAccessible = true
+        ctor.newInstance()
+      }
+      .getOrNull()
+  }
+}

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRendererTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRendererTest.kt
@@ -1,0 +1,90 @@
+package ee.schimke.composeai.renderer.xr
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import androidx.xr.compose.spatial.Subspace
+import androidx.xr.compose.subspace.SpatialColumn
+import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.layout.SubspaceModifier
+import androidx.xr.compose.subspace.layout.height
+import androidx.xr.compose.subspace.layout.width
+import androidx.xr.compose.subspace.semantics.testTag
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.xr.SpatialScene
+import java.io.File
+import kotlinx.serialization.json.Json
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/** A stand-in `@XrSubspacePreview` — a top-level `@Composable` whose body is a tagged `Subspace`. */
+@Composable
+fun SampleSpatialPreview() {
+  Subspace {
+    SpatialColumn {
+      SpatialPanel(SubspaceModifier.testTag("now-playing").width(560.dp).height(220.dp)) {
+        Box(Modifier.fillMaxSize())
+      }
+      SpatialPanel(SubspaceModifier.testTag("controls").width(560.dp).height(120.dp)) {
+        Box(Modifier.fillMaxSize())
+      }
+    }
+  }
+}
+
+/**
+ * Drives [XrSubspaceRenderer] end-to-end the way the render task will: enable the spatial feature,
+ * reflect + compose a preview function by name, and assert the written `scene.json`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class XrSubspaceRendererTest {
+
+  @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun rendersSceneJsonFromPreviewFunction() {
+    val pm = ApplicationProvider.getApplicationContext<Context>().packageManager
+    shadowOf(pm).setSystemFeature(SubspaceSceneRecorder.XR_SPATIAL_FEATURE, true)
+
+    val outDir =
+      File.createTempFile("xr-render", "").let {
+        it.delete()
+        it.mkdirs()
+        it
+      }
+
+    val sceneFile =
+      XrSubspaceRenderer.render(
+        rule = rule,
+        className = "ee.schimke.composeai.renderer.xr.XrSubspaceRendererTestKt",
+        functionName = "SampleSpatialPreview",
+        previewId = "sample-preview",
+        outputDir = outDir,
+      )
+
+    assertThat(sceneFile.exists()).isTrue()
+    assertThat(sceneFile.name).isEqualTo("scene.json")
+
+    val scene =
+      Json { ignoreUnknownKeys = true }
+        .decodeFromString(SpatialScene.serializer(), sceneFile.readText())
+    assertThat(scene.previewId).isEqualTo("sample-preview")
+    assertThat(scene.panels.map { it.id }).containsExactly("now-playing", "controls")
+    val byId = scene.panels.associateBy { it.id }
+    assertThat(byId.getValue("now-playing").sizeDp).isEqualTo(ee.schimke.composeai.xr.SizeDp(560, 220))
+    // The recovered column stacks now-playing above controls.
+    assertThat(byId.getValue("now-playing").poseInRoot.translation.y)
+      .isGreaterThan(byId.getValue("controls").poseInRoot.translation.y)
+  }
+}


### PR DESCRIPTION
Slice 2a of the XR render integration — the **execution core**, self-contained in `:renderer-xr`, no plugin changes.

`XrSubspaceRenderer.render(rule, className, functionName, previewId, outDir)` reflects an `@XrSubspacePreview`'s `@Composable` function (`getDeclaredComposableMethod` + invoke through `currentComposer` — the same reflection path the Compose `@Preview` renderer uses), composes its `Subspace` on the rule, then runs `SubspaceSceneRecorder.recordAll` + `SubspaceSceneWriter.writeScene` → `scene.json`. The caller enables the `XR_SPATIAL_FEATURE` shadow first (as the task/tests do). Geometry-only — panel textures aren't captured here; the scene carries `<tag>.png` paths the viewer renders as placeholders.

## Test plan
- [x] `XrSubspaceRendererTest` — defines a top-level `@Composable` `Subspace` preview, renders it **by name** through the full reflect→compose→record→write path, and asserts the written `scene.json` carries both tagged panels with the recovered column stacking (passed)
- [x] `:renderer-xr:ktfmtCheck`; branched fresh from `main`

## Next (Slice 2b)
The plugin-side parallel Robolectric `Test` task: read the manifest, filter to `XR_SUBSPACE`, drive `XrSubspaceRenderer.render` per preview, and inject the XR `*-testing` fakes + `META-INF/services` into the consumer's test classpath. That's the `AndroidPreviewSupport` wiring — the last piece.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_