### PR TITLE
fix(plugin): reject parameterized @XrSubspacePreview at discovery

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -685,6 +685,19 @@ object PreviewDiscovery {
     val isNotificationPreview = isAnyNotificationPreviewAnnotation(annotations, scanResult)
     val isGlanceAppWidgetPreview = isAnyGlanceAppWidgetPreviewAnnotation(annotations, scanResult)
     val isXrSubspacePreview = isAnyXrSubspacePreviewAnnotation(annotations, scanResult)
+    // XR subspace previews are reflected + composed parameterless by the `:renderer-xr` task — it
+    // has no @PreviewParameter argument-injection path (and a parameterized subspace layout is
+    // nonsensical). Reject any @XrSubspacePreview that declares a user parameter (whether
+    // @PreviewParameter or plain) up front, so a parameterized one is skipped here rather than
+    // emitted as an XR_SUBSPACE entry that fails at render time.
+    if (isXrSubspacePreview && userPreviewParameters(method).isNotEmpty()) {
+      warnings.add(
+        "composePreview: skipping @XrSubspacePreview '${classInfo.name}.${method.name}' — " +
+          "XR subspace previews must be parameterless (@PreviewParameter / arguments aren't " +
+          "supported by the XR renderer)."
+      )
+      return
+    }
     val hasUnsupportedParameters =
       !isTilePreview &&
         !isNotificationPreview &&

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -1657,6 +1657,12 @@ class DiscoveryFunctionalTest {
       @XrSubspacePreview
       @Composable
       fun MySpatialPreview() {}
+
+      // A parameterized XR preview must be skipped — the XR renderer composes parameterless and has
+      // no @PreviewParameter injection path.
+      @XrSubspacePreview
+      @Composable
+      fun ParameterizedSpatialPreview(label: String) {}
       """
         .trimIndent()
     )
@@ -1682,5 +1688,11 @@ class DiscoveryFunctionalTest {
     // Non-composable kind: no scroll / time / focus fan-out, no target inference.
     assertThat(xrPreviews.map { it.captures.size }).containsExactly(1)
     assertThat(xrPreviews.flatMap { it.targets }).isEmpty()
+
+    // The parameterized XR preview is rejected with a clear warning and never reaches the manifest.
+    assertThat(result.output)
+      .contains("ParameterizedSpatialPreview' — XR subspace previews must be parameterless")
+    assertThat(manifest.previews.map { it.functionName })
+      .doesNotContain("ParameterizedSpatialPreview")
   }
 }


### PR DESCRIPTION
Addresses the review on #1710 (codex P2, 👍): an `@XrSubspacePreview` declaring a user parameter (`@PreviewParameter` or plain) was emitted as `XR_SUBSPACE` — XR previews bypass the unsupported-parameter check — but the XR renderer composes the function **parameterless**, so such an entry would fail at invocation.

Discovery now skips any `@XrSubspacePreview` with a user parameter (detected via `userPreviewParameters`, which excludes the compiler-added `Composer`/mask args) with a clear warning, so it never reaches the manifest.

## Test plan
- [x] XR discovery functionalTest extended with a parameterized preview — asserts the warning fires and it's absent from `previews.json` (passed via `:gradle-plugin:functionalTest`)
- [x] ktfmt clean; branched fresh from `main`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_