### PR TITLE
fix: stamp preview card id synchronously for layout sizing

### DIFF
--- a/vscode-extension/src/test/cardBuilderSizing.test.ts
+++ b/vscode-extension/src/test/cardBuilderSizing.test.ts
@@ -1,0 +1,100 @@
+// Regression test for the "tall scroll preview is long from cache, then
+// rescales once generated" bug.
+//
+// `applyRelativeSizing` resolves each card via
+// `getElementById("preview-" + sanitizeId(id))` and only then stamps the
+// `--aspect-ratio` custom property the CSS uses to pin a tall
+// `@ScrollingPreview(LONG)`/`GIF` image into the device-sized slot. The
+// `id` used to be set in `populatePreviewCard`, which runs from the
+// `<preview-card>` Lit shell's deferred `firstUpdated()` microtask — so on
+// the FIRST `setPreviews` (the cache preload) the freshly-built card had no
+// `id` yet, `getElementById` missed it, `--aspect-ratio` was never stamped,
+// and the tall image rendered at its natural height (long). A later render
+// reseeded the now-id'd card and it finally rescaled.
+//
+// The fix stamps `card.id` synchronously in `buildPreviewCard` alongside the
+// other layout-/filter-critical attributes. These tests pin both halves:
+// the synchronous `id`, and that `applyRelativeSizing` can size a
+// freshly-built card before any microtask runs.
+
+import * as assert from "assert";
+import { buildPreviewCard } from "../webview/preview/cardBuilder";
+import type { CardBuilderConfig } from "../webview/preview/cardBuilder";
+import { applyRelativeSizing } from "../webview/preview/relativeSizing";
+import { sanitizeId } from "../webview/preview/cardData";
+import type { Capture, PreviewInfo, PreviewParams } from "../types";
+
+const baseCapture: Capture = {
+    advanceTimeMillis: null,
+    scroll: null,
+    renderOutput: "x.png",
+};
+
+const baseParams: PreviewParams = {
+    name: null,
+    device: null,
+    widthDp: null,
+    heightDp: null,
+    fontScale: 1.0,
+    showSystemUi: false,
+    showBackground: false,
+    backgroundColor: 0,
+    uiMode: 0,
+    locale: null,
+    group: null,
+};
+
+function preview(
+    id: string,
+    overrides: Partial<PreviewParams> = {},
+): PreviewInfo {
+    return {
+        id,
+        functionName: "MyPreview",
+        className: "com.example.PreviewsKt",
+        sourceFile: null,
+        params: { ...baseParams, ...overrides },
+        captures: [baseCapture],
+    };
+}
+
+// buildPreviewCard only reads `p` synchronously; the imperative population
+// that consumes `config` runs from the Lit shell's deferred `firstUpdated`.
+// A cast stub is enough for the synchronous path under test.
+const configStub = {} as unknown as CardBuilderConfig;
+
+afterEach(() => {
+    document.body.innerHTML = "";
+});
+
+describe("buildPreviewCard synchronous id stamping", () => {
+    it("stamps the card id synchronously (before firstUpdated runs)", () => {
+        const p = preview("com.example.Tall", { widthDp: 412, heightDp: 800 });
+        const card = buildPreviewCard(p, configStub);
+        // No microtask has run — the id must already be present so the
+        // synchronous applyRelativeSizing in handleSetPreviews can find it.
+        assert.strictEqual(card.id, "preview-" + sanitizeId(p.id));
+        assert.strictEqual(card.dataset.previewId, p.id);
+    });
+
+    it("lets applyRelativeSizing size a freshly-built, not-yet-populated card", () => {
+        const p = preview("com.example.Scroll", {
+            widthDp: 412,
+            heightDp: 800,
+        });
+        const card = buildPreviewCard(p, configStub);
+        document.body.appendChild(card);
+
+        // Mirrors handleSetPreviews: renderPreviews inserts the card, then
+        // applyRelativeSizing runs synchronously — before any deferred
+        // populate microtask. Pre-fix this missed the card and left
+        // --aspect-ratio unset, so a tall scroll image rendered long.
+        applyRelativeSizing([p]);
+
+        assert.strictEqual(
+            card.style.getPropertyValue("--aspect-ratio"),
+            "412 / 800",
+        );
+        assert.strictEqual(card.style.getPropertyValue("--width-dp"), "412");
+    });
+});

--- a/vscode-extension/src/webview/preview/cardBuilder.ts
+++ b/vscode-extension/src/webview/preview/cardBuilder.ts
@@ -141,15 +141,22 @@ export function buildPreviewCard(
     const card = document.createElement("preview-card") as PreviewCard;
     card.preview = p;
     card.config = config;
-    // Stamp the filter-critical attributes synchronously so the
-    // `applyFilters` call that handleSetPreviews fires immediately
-    // after renderPreviews can see them — populatePreviewCard runs
-    // from Lit's `firstUpdated()` which is scheduled on a microtask,
-    // so by the time it sets these the first applyFilters has already
-    // run against an empty grid (no `.preview-card` selector match,
-    // no dataset → variant collapse silently no-ops, all cards land
-    // visible until the next manifest reseed).
+    // Stamp the filter- and layout-critical attributes synchronously so
+    // the `applyFilters` / `applyRelativeSizing` calls that
+    // handleSetPreviews fires immediately after renderPreviews can see
+    // them — populatePreviewCard runs from Lit's `firstUpdated()` which is
+    // scheduled on a microtask, so by the time it sets these the first
+    // applyFilters has already run against an empty grid (no
+    // `.preview-card` selector match, no dataset → variant collapse
+    // silently no-ops, all cards land visible until the next manifest
+    // reseed). The `id` is sizing-critical for the same reason:
+    // `applyRelativeSizing` resolves cards via `getElementById("preview-"
+    // + sanitizeId(id))`, so without it the first setPreviews (cache
+    // preload) never stamps `--aspect-ratio` and a tall `@ScrollingPreview`
+    // image renders at its natural height — looking long until a later
+    // render reseeds the (now id'd) card.
     card.classList.add("preview-card");
+    card.id = "preview-" + sanitizeId(p.id);
     card.dataset.previewId = p.id;
     card.dataset.function = p.functionName;
     card.dataset.group = p.params.group || "";


### PR DESCRIPTION
## Summary
Fix a regression where tall scrolling preview images rendered at their natural height on initial cache load, then rescaled after a re-render. The root cause was that `applyRelativeSizing` couldn't find freshly-built cards because their `id` attribute wasn't set until a deferred microtask ran.

## Changes
- **cardBuilder.ts**: Move `card.id` stamping from the deferred `populatePreviewCard` (Lit's `firstUpdated()` microtask) to the synchronous `buildPreviewCard` function, alongside other layout-critical attributes like `classList` and `dataset`.
- **cardBuilderSizing.test.ts** (new): Add regression tests that verify:
  1. The card `id` is stamped synchronously before any microtask runs
  2. `applyRelativeSizing` can size a freshly-built card immediately after insertion, before population completes

## Implementation Details
The `id` is now stamped synchronously in `buildPreviewCard` so that the synchronous `applyRelativeSizing` call in `handleSetPreviews` (which runs immediately after `renderPreviews` inserts cards) can locate cards via `getElementById("preview-" + sanitizeId(id))` and apply the `--aspect-ratio` custom property. This ensures tall images are constrained to device dimensions on the first render, not just after a re-render.

https://claude.ai/code/session_01RcThLx9qGLvZr17z5i2iKq