### PR TITLE
feat(renderer-xr): manifest-driven XR render entry (XrSubspaceRenderTest)

### DIFF
--- a/renderers/xr/build.gradle.kts
+++ b/renderers/xr/build.gradle.kts
@@ -47,6 +47,11 @@ dependencies {
   compileOnly(libs.xr.compose)
   compileOnly(libs.xr.compose.testing)
   compileOnly("androidx.compose.ui:ui-test-junit4")
+  // `XrSubspaceRenderTest` (the render entry the plugin's task runs) references Robolectric's
+  // parameterised runner + shadows and JUnit annotations; both are provided at render time by the
+  // task classpath (same model as `:renderer-android`'s `RobolectricRenderTest`).
+  compileOnly(libs.robolectric)
+  compileOnly(libs.junit)
   // Per-panel texture capture (captureRoboImage). compileOnly — provided by the render runtime.
   compileOnly(libs.roborazzi)
   compileOnly(libs.roborazzi.compose)

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/XrManifestReader.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/XrManifestReader.kt
@@ -1,0 +1,34 @@
+package ee.schimke.composeai.renderer.xr
+
+import java.io.File
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Reads the `XR_SUBSPACE` entries out of the plugin's `previews.json` manifest. Parsed via the
+ * `JsonElement` tree (not `@Serializable` classes) so `:renderer-xr` doesn't have to mirror the full
+ * manifest schema or apply the serialization compiler plugin — it only needs the class/function/id
+ * of each XR preview to reflect + render it.
+ */
+public object XrManifestReader {
+
+  /** The fields the XR render entry needs from one manifest preview. */
+  public data class XrPreview(val id: String, val className: String, val functionName: String)
+
+  /** Returns the `XR_SUBSPACE`-kind previews in [manifestFile], in manifest order. */
+  public fun xrPreviews(manifestFile: File): List<XrPreview> {
+    val root = Json.parseToJsonElement(manifestFile.readText()).jsonObject
+    val previews = root["previews"]?.jsonArray ?: return emptyList()
+    return previews.mapNotNull { element ->
+      val obj = element.jsonObject
+      val kind = obj["params"]?.jsonObject?.get("kind")?.jsonPrimitive?.content
+      if (kind != "XR_SUBSPACE") return@mapNotNull null
+      val id = obj["id"]?.jsonPrimitive?.content ?: return@mapNotNull null
+      val className = obj["className"]?.jsonPrimitive?.content ?: return@mapNotNull null
+      val functionName = obj["functionName"]?.jsonPrimitive?.content ?: return@mapNotNull null
+      XrPreview(id = id, className = className, functionName = functionName)
+    }
+  }
+}

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRenderTest.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRenderTest.kt
@@ -1,0 +1,64 @@
+package ee.schimke.composeai.renderer.xr
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import java.io.File
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * The render entry the plugin's `composePreviewRenderXr` `Test` task runs: one parameterised case
+ * per `XR_SUBSPACE` preview in the manifest. Each composes the preview's `Subspace` under the fake
+ * XR runtime (via [XrSubspaceRenderer]) and writes `scene.json` into a per-preview subdirectory of
+ * the render output dir.
+ *
+ * Lives in `src/main` (shipped in the jar) like `:renderer-android`'s `RobolectricRenderTest`, so
+ * the plugin can run it against the consumer's test classpath; it is NOT part of `:renderer-xr`'s
+ * own unit-test run (those exercise the recorder/writer/reader directly). The Robolectric SDK comes
+ * from the `robolectric.properties` the plugin generates; the manifest + output dir from the system
+ * properties it sets (`composeai.render.manifest` / `composeai.render.outputDir`).
+ */
+@RunWith(ParameterizedRobolectricTestRunner::class)
+public class XrSubspaceRenderTest(private val preview: XrManifestReader.XrPreview) {
+
+  @get:Rule public val rule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  public fun renderScene() {
+    // `Subspace` only takes its spatial path when the XR feature is present; the offline runtime
+    // reports none, so shadow it on (mirrors the recorder tests).
+    shadowOf(rule.activity.packageManager)
+      .setSystemFeature(SubspaceSceneRecorder.XR_SPATIAL_FEATURE, true)
+
+    val rendersDir =
+      File(
+        requireNotNull(System.getProperty(OUTPUT_DIR_PROP)) { "$OUTPUT_DIR_PROP system property not set" }
+      )
+    val outputDir = File(rendersDir, sanitize(preview.id)).apply { mkdirs() }
+    XrSubspaceRenderer.render(
+      rule = rule,
+      className = preview.className,
+      functionName = preview.functionName,
+      previewId = preview.id,
+      outputDir = outputDir,
+    )
+  }
+
+  public companion object {
+    private const val MANIFEST_PROP = "composeai.render.manifest"
+    private const val OUTPUT_DIR_PROP = "composeai.render.outputDir"
+
+    @JvmStatic
+    @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
+    public fun previews(): List<XrManifestReader.XrPreview> {
+      val manifest = System.getProperty(MANIFEST_PROP) ?: return emptyList()
+      return XrManifestReader.xrPreviews(File(manifest))
+    }
+
+    /** Make a preview id safe to use as a directory name. */
+    private fun sanitize(id: String): String = id.replace(Regex("[^A-Za-z0-9._-]"), "_")
+  }
+}

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/XrManifestReaderTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/XrManifestReaderTest.kt
@@ -1,0 +1,50 @@
+package ee.schimke.composeai.renderer.xr
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/** [XrManifestReader] keeps only `XR_SUBSPACE` previews and pulls out class/function/id. */
+class XrManifestReaderTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private fun manifest(json: String): File =
+    File(tempDir.root, "previews.json").apply { writeText(json) }
+
+  @Test
+  fun filtersToXrSubspacePreviews() {
+    val file =
+      manifest(
+        """
+        {
+          "module": "demo",
+          "variant": "debug",
+          "previews": [
+            { "id": "a", "functionName": "ComposeOne", "className": "test.AKt",
+              "params": { "kind": "COMPOSE" } },
+            { "id": "spatial-1", "functionName": "MySpatial", "className": "test.XrKt",
+              "params": { "kind": "XR_SUBSPACE" }, "captures": [ { "renderOutput": "x.png" } ] },
+            { "id": "tile", "functionName": "ATile", "className": "test.TileKt",
+              "params": { "kind": "TILE" } }
+          ]
+        }
+        """
+          .trimIndent()
+      )
+
+    val xr = XrManifestReader.xrPreviews(file)
+
+    assertThat(xr).hasSize(1)
+    assertThat(xr.single())
+      .isEqualTo(XrManifestReader.XrPreview("spatial-1", "test.XrKt", "MySpatial"))
+  }
+
+  @Test
+  fun returnsEmptyWhenNoPreviews() {
+    val file = manifest("""{ "module": "demo", "variant": "debug", "previews": [] }""")
+    assertThat(XrManifestReader.xrPreviews(file)).isEmpty()
+  }
+}


### PR DESCRIPTION
The renderer half of Slice 2b — the entry the plugin's `composePreviewRenderXr` task will run. Self-contained in `:renderer-xr` (compiles + the reader is unit-tested), so it lands safely ahead of the plugin task wiring.

- **`XrManifestReader`** — pulls the `XR_SUBSPACE` previews (id / className / functionName) out of `previews.json` via the `JsonElement` tree, so `:renderer-xr` needn't mirror the full manifest schema or apply the serialization compiler plugin. Unit-tested.
- **`XrSubspaceRenderTest`** — a `ParameterizedRobolectricTestRunner` entry in `src/main` (shipped in the jar like `:renderer-android`'s `RobolectricRenderTest`; **not** part of this module's own unit-test run, so the empty-manifest case is moot). Reads `composeai.render.manifest` / `composeai.render.outputDir`, shadows the XR feature on, and drives `XrSubspaceRenderer.render` per preview into a per-preview subdir. Robolectric + JUnit are `compileOnly` (provided by the render task's classpath).

## Test plan
- [x] `:renderer-xr:compileDebugKotlin` (validates the render-entry API usage)
- [x] `XrManifestReaderTest` — filters to `XR_SUBSPACE`, pulls class/function/id (passed)
- [x] `:renderer-xr:ktfmtCheck`; branched fresh from `main`

## Next (the last piece)
The plugin task: register `composePreviewRenderXr` mirroring `composePreviewRender` (`AndroidPreviewSupport.kt:1436`) — a parallel renderer configuration pointing at `:renderer-xr` + the XR `*-testing` fakes, `include("**/XrSubspaceRenderTest.class")`, the same system-prop/robolectric wiring, aggregated into `composePreviewRenderAll` — plus an end-to-end functionalTest asserting `scene.json` lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_