### PR TITLE
build: replace deprecated compose.* plugin accessors with explicit coordinates

### DIFF
--- a/bundle-viewer/build.gradle.kts
+++ b/bundle-viewer/build.gradle.kts
@@ -90,13 +90,13 @@ dependencies {
   // on the parent classloader. Bundle's classes load via a child URLClassLoader (see
   // `BundleLoader.kt`); parent-loader Compose wins on every shared symbol.
   implementation(compose.desktop.currentOs)
-  implementation(compose.runtime)
-  implementation(compose.ui)
-  implementation(compose.foundation)
-  implementation(compose.material3)
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.ui)
+  implementation(libs.jetbrains.compose.foundation)
+  implementation(libs.jetbrains.compose.material3)
   // `androidx.compose.ui.tooling.preview.Preview` lives here. Bundles compiled against the
   // standard Compose `@Preview` annotation only resolve when this artifact is on the classpath.
-  implementation(compose.components.uiToolingPreview)
+  implementation(libs.jetbrains.compose.components.ui.tooling.preview)
 
   implementation(libs.kotlinx.serialization.json)
 

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -130,11 +130,11 @@ dependencies {
   // `getDeclaredComposableMethod`, and a few Modifier / layout helpers.
   // Platform-agnostic surface; resolves to `*-desktop` variants on JVM
   // consumers via Compose Multiplatform's variant selection.
-  implementation(compose.runtime)
-  implementation(compose.foundation)
-  implementation(compose.ui)
-  implementation(compose.material3)
-  implementation(compose.components.uiToolingPreview)
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.foundation)
+  implementation(libs.jetbrains.compose.ui)
+  implementation(libs.jetbrains.compose.material3)
+  implementation(libs.jetbrains.compose.components.ui.tooling.preview)
 
   // `compose.desktop.currentOs` bakes the *build host's* Skiko platform into
   // the published POM (e.g. `desktop-jvm-linux-x64` when CI builds on Linux),
@@ -177,11 +177,11 @@ dependencies {
   // Tests declare a small fixture composable + drive RenderEngine against it,
   // so the test classpath needs the same Compose Multiplatform stack.
   testImplementation(compose.desktop.currentOs)
-  testImplementation(compose.runtime)
-  testImplementation(compose.foundation)
-  testImplementation(compose.ui)
-  testImplementation(compose.material3)
-  testImplementation(compose.components.uiToolingPreview)
+  testImplementation(libs.jetbrains.compose.runtime)
+  testImplementation(libs.jetbrains.compose.foundation)
+  testImplementation(libs.jetbrains.compose.ui)
+  testImplementation(libs.jetbrains.compose.material3)
+  testImplementation(libs.jetbrains.compose.components.ui.tooling.preview)
 
   // testFixtures source set holds `RedFixturePreviews.kt` so its `RedSquare` composable can be
   // consumed by `:daemon:harness`'s real-mode S1 (D-harness.v1.5a) without requiring that
@@ -198,10 +198,10 @@ dependencies {
   // resolution path. testFixtures variants are skipped from the publishable component (see the
   // `afterEvaluate` block below), so this stays out of `daemon-desktop`'s POM either way.
   "testFixturesImplementation"(compose.desktop.currentOs)
-  "testFixturesImplementation"(compose.runtime)
-  "testFixturesImplementation"(compose.foundation)
-  "testFixturesImplementation"(compose.ui)
-  "testFixturesImplementation"(compose.material3)
+  "testFixturesImplementation"(libs.jetbrains.compose.runtime)
+  "testFixturesImplementation"(libs.jetbrains.compose.foundation)
+  "testFixturesImplementation"(libs.jetbrains.compose.ui)
+  "testFixturesImplementation"(libs.jetbrains.compose.material3)
 }
 
 // Convenience task — equivalent to `java -cp $(runtimeClasspath) ee.schimke.composeai.daemon

--- a/data/focus/connector-desktop/build.gradle.kts
+++ b/data/focus/connector-desktop/build.gradle.kts
@@ -36,8 +36,8 @@ dependencies {
   api(project(":daemon:core"))
   api(project(":data-render-compose"))
 
-  implementation(compose.runtime)
-  implementation(compose.ui)
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.ui)
 
   testImplementation(libs.junit)
 }

--- a/data/keyboard/connector-desktop/build.gradle.kts
+++ b/data/keyboard/connector-desktop/build.gradle.kts
@@ -25,9 +25,9 @@ dependencies {
   api(project(":daemon:core"))
   api(project(":data-render-compose"))
 
-  implementation(compose.runtime)
-  implementation(compose.ui)
-  implementation(compose.foundation)
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.ui)
+  implementation(libs.jetbrains.compose.foundation)
 
   testImplementation(libs.junit)
 }

--- a/data/launcher-widget/connector/build.gradle.kts
+++ b/data/launcher-widget/connector/build.gradle.kts
@@ -18,9 +18,9 @@ dependencies {
   api(project(":data-render-core"))
   api(project(":data-render-compose"))
 
-  implementation(compose.runtime)
-  implementation(compose.ui)
-  implementation(compose.foundation)
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.ui)
+  implementation(libs.jetbrains.compose.foundation)
 
   testImplementation(libs.junit)
 }

--- a/data/layoutinspector/connector/build.gradle.kts
+++ b/data/layoutinspector/connector/build.gradle.kts
@@ -26,8 +26,8 @@ dependencies {
   // and to the desktop/skiko variant on JVM consumers via Gradle variant attributes. `compileOnly`
   // keeps it out of the published POM — the consumer (`:daemon:android` / `:daemon:desktop`)
   // supplies its own at runtime, same shape as the pre-migration `compileOnly(libs.compose.ui)`.
-  compileOnly(compose.ui)
-  testImplementation(compose.ui)
+  compileOnly(libs.jetbrains.compose.ui)
+  testImplementation(libs.jetbrains.compose.ui)
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.serialization.json)
 }

--- a/data/pseudolocale/connector-desktop/build.gradle.kts
+++ b/data/pseudolocale/connector-desktop/build.gradle.kts
@@ -32,13 +32,13 @@ dependencies {
   api(project(":data-pseudolocale-core"))
   api(project(":daemon:core"))
   api(project(":data-render-compose"))
-  implementation(compose.runtime)
-  implementation(compose.ui)
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.ui)
   // `org.jetbrains.compose.resources.LocalResourceReader` — the byte-level interceptor we wrap so
   // every `stringResource(...)` lookup on desktop returns the pseudolocalised form. The `internal`
   // env-swap path (`LocalComposeEnvironment` / `ComposeEnvironment`) isn't reachable from outside
   // the resources module at CMP 1.10.x, so this is the published handle that actually works.
-  implementation(compose.components.resources)
+  implementation(libs.jetbrains.compose.components.resources)
 
   testImplementation(libs.junit)
 }

--- a/data/recomposition/connector/build.gradle.kts
+++ b/data/recomposition/connector/build.gradle.kts
@@ -13,8 +13,8 @@ dependencies {
   api(project(":daemon:core"))
   api(project(":data-render-compose"))
   api(project(":data-recomposition-core"))
-  implementation(compose.runtime)
-  implementation(compose.ui)
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.ui)
   testImplementation(libs.junit)
 }
 

--- a/data/strings/connector/build.gradle.kts
+++ b/data/strings/connector/build.gradle.kts
@@ -17,8 +17,8 @@ dependencies {
   api(project(":data-strings-core"))
   api(project(":daemon:core"))
   api(project(":data-layoutinspector-core"))
-  compileOnly(compose.ui)
-  testImplementation(compose.ui)
+  compileOnly(libs.jetbrains.compose.ui)
+  testImplementation(libs.jetbrains.compose.ui)
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.serialization.json)
 }

--- a/data/theme/connector/build.gradle.kts
+++ b/data/theme/connector/build.gradle.kts
@@ -13,15 +13,15 @@ dependencies {
   api(project(":daemon:core"))
   api(project(":data-render-compose"))
   api(project(":data-theme-core"))
-  implementation(compose.runtime)
-  implementation(compose.ui)
-  implementation(compose.material3)
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.ui)
+  implementation(libs.jetbrains.compose.material3)
   testImplementation(libs.junit)
   testImplementation(compose.desktop.currentOs)
-  testImplementation(compose.runtime)
-  testImplementation(compose.ui)
-  testImplementation(compose.foundation)
-  testImplementation(compose.material3)
+  testImplementation(libs.jetbrains.compose.runtime)
+  testImplementation(libs.jetbrains.compose.ui)
+  testImplementation(libs.jetbrains.compose.foundation)
+  testImplementation(libs.jetbrains.compose.material3)
 }
 
 composeAiMavenPublishing {

--- a/data/touch-overlay/connector/build.gradle.kts
+++ b/data/touch-overlay/connector/build.gradle.kts
@@ -23,9 +23,9 @@ dependencies {
   api(project(":data-render-core"))
   api(project(":data-render-compose"))
 
-  implementation(compose.runtime)
-  implementation(compose.ui)
-  implementation(compose.foundation)
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.ui)
+  implementation(libs.jetbrains.compose.foundation)
 
   testImplementation(libs.junit)
 }

--- a/data/wallpaper/connector/build.gradle.kts
+++ b/data/wallpaper/connector/build.gradle.kts
@@ -13,9 +13,9 @@ dependencies {
   api(project(":daemon:core"))
   api(project(":data-render-compose"))
   api(project(":data-wallpaper-core"))
-  implementation(compose.runtime)
-  implementation(compose.ui)
-  implementation(compose.material3)
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.ui)
+  implementation(libs.jetbrains.compose.material3)
   // KMP port of Material Color Utilities — `dynamicColorScheme(seed, isDark, style, contrast)`
   // returns the canonical Material 3 dynamic ColorScheme from a single seed color, matching what
   // Android's wallpaper-derived theming produces.
@@ -26,10 +26,10 @@ dependencies {
   }
   testImplementation(libs.junit)
   testImplementation(compose.desktop.currentOs)
-  testImplementation(compose.runtime)
-  testImplementation(compose.ui)
-  testImplementation(compose.foundation)
-  testImplementation(compose.material3)
+  testImplementation(libs.jetbrains.compose.runtime)
+  testImplementation(libs.jetbrains.compose.ui)
+  testImplementation(libs.jetbrains.compose.foundation)
+  testImplementation(libs.jetbrains.compose.material3)
 }
 
 composeAiMavenPublishing {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,12 @@ compose-bom-stable = "2026.05.01"
 # raising the supported-Compose-minimum is a manual decision.
 compose-bom-compat = "2025.11.01"
 compose-multiplatform = "1.10.3"
+# JetBrains Compose Multiplatform material3 tracks its own line: the
+# `org.jetbrains.compose` 1.10.3 plugin pins `compose.material3` to 1.9.0
+# (material3 multiplatform 1.10.x is still alpha), so the explicit coordinate
+# must use this version rather than `compose-multiplatform`. Mirrors what the
+# deprecated `compose.material3` accessor resolved to.
+compose-multiplatform-material3 = "1.9.0"
 activity-compose = "1.13.0"
 # `androidx.navigation:navigation-compose` — used only by the
 # `:samples:android` NavHost preview that exercises the daemon's
@@ -184,6 +190,11 @@ compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing" 
 jetbrains-compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
 jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
 jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multiplatform" }
+jetbrains-compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose-multiplatform" }
+jetbrains-compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose-multiplatform" }
+jetbrains-compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose-multiplatform-material3" }
+jetbrains-compose-components-ui-tooling-preview = { module = "org.jetbrains.compose.components:components-ui-tooling-preview", version.ref = "compose-multiplatform" }
+jetbrains-compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose-multiplatform" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation-compose" }
 glance-appwidget = { module = "androidx.glance:glance-appwidget", version.ref = "glance-appwidget" }

--- a/renderers/desktop/build.gradle.kts
+++ b/renderers/desktop/build.gradle.kts
@@ -11,18 +11,18 @@ plugins {
 
 dependencies {
   implementation(compose.desktop.currentOs)
-  implementation(compose.ui)
-  implementation(compose.foundation)
-  implementation(compose.material3)
-  implementation(compose.runtime)
-  implementation(compose.components.uiToolingPreview)
+  implementation(libs.jetbrains.compose.ui)
+  implementation(libs.jetbrains.compose.foundation)
+  implementation(libs.jetbrains.compose.material3)
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.components.ui.tooling.preview)
   // JetBrains Compose UI Test — gives the renderer `runComposeUiTest { ... }`, the desktop
   // equivalent of Android's `AndroidComposeTestRule`. Used by `DesktopRendererMain.renderScroll`
   // to drive `@ScrollingPreview` LONG / GIF modes: setContent, mainClock for animation control,
   // semantic queries for finding the scrollable, captureToImage for per-frame PNGs. NOT a test
   // dependency — invoked from production main code (the function name is misleading; it's an
   // entry-point for the test API, not a JUnit-only construct).
-  implementation(compose.uiTest)
+  implementation(libs.jetbrains.compose.ui.test)
   // Pure-JVM scroll primitives: `ScrollAxis` enum, `ScrollLongFramePlan` /
   // `ScrollGifFramePlan` planners, `ScrollSliceStitcher.stitchSlices`, `ScrollGifEncoder.encode`,
   // plus the `buildGifScrollScript` shape function. The Android driver

--- a/samples/cmp/build.gradle.kts
+++ b/samples/cmp/build.gradle.kts
@@ -11,11 +11,11 @@ plugins {
 
 dependencies {
   implementation(compose.desktop.currentOs)
-  implementation(compose.material3)
-  implementation(compose.foundation)
-  implementation(compose.ui)
-  implementation(compose.uiTooling)
-  implementation(compose.components.uiToolingPreview)
+  implementation(libs.jetbrains.compose.material3)
+  implementation(libs.jetbrains.compose.foundation)
+  implementation(libs.jetbrains.compose.ui)
+  implementation(libs.jetbrains.compose.ui.tooling)
+  implementation(libs.jetbrains.compose.components.ui.tooling.preview)
   // `@ScrollingPreview(modes = [LONG, GIF])` — drives the desktop renderer's scroll path. The
   // gradle plugin's discovery picks up the annotation by FQN even without it on the consumer's
   // compile classpath, but the sample composable references the annotation directly so the

--- a/samples/desktop-daemon-bench/build.gradle.kts
+++ b/samples/desktop-daemon-bench/build.gradle.kts
@@ -31,10 +31,10 @@ plugins {
 
 dependencies {
   implementation(compose.desktop.currentOs)
-  implementation(compose.material3)
-  implementation(compose.foundation)
-  implementation(compose.ui)
-  implementation(compose.components.uiToolingPreview)
+  implementation(libs.jetbrains.compose.material3)
+  implementation(libs.jetbrains.compose.foundation)
+  implementation(libs.jetbrains.compose.ui)
+  implementation(libs.jetbrains.compose.components.ui.tooling.preview)
 }
 
 // --- Bench task ---------------------------------------------------------


### PR DESCRIPTION
Compose Multiplatform 1.10 deprecated the Gradle plugin dependency aliases
(compose.runtime, compose.ui, compose.foundation, compose.material3,
compose.uiTooling, compose.uiTest, compose.components.*), which spammed
'is deprecated. Specify dependency directly.' warnings on every configure.

Migrate the JVM modules that used the bare accessors to explicit
org.jetbrains.compose coordinates via the version catalog, matching the
existing libs.jetbrains.compose.* pattern in data/render/*. Each new
coordinate is exactly what the 1.10.3 plugin injected (verified against the
plugin's ComposeBuildConfig), so resolution -- including the Android/desktop
variant selection the connectors rely on -- is unchanged:

  compose.runtime/ui/foundation -> 1.10.3
  compose.material3             -> 1.9.0 (material3 multiplatform tracks its
                                   own line; 1.10.x is still alpha)
  compose.uiTooling/uiTest      -> 1.10.3
  compose.components.*          -> 1.10.3

The KMP samples/cmp-shared already suppresses the warning deliberately and
is left as-is.