### PR TITLE
fix(daemon): re-render on save when the manifest cache was invalidated

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2751,6 +2751,9 @@ function invalidateModuleCache(filePath: string): void {
     if (module) {
         gradleService.invalidateCache(module);
         moduleManifestCache.delete(module.modulePath);
+        logLine(
+            `[daemon] invalidateModuleCache cleared manifest cache for ${module.modulePath} (file=${path.basename(filePath)})`,
+        );
     }
 }
 
@@ -3403,18 +3406,27 @@ async function reconcilePreviewManifest(
     }
     gradleService.invalidateCache(module);
     moduleManifestCache.delete(module.modulePath);
+    logLine(
+        `[daemon] reconcile: cleared manifest cache for ${module.modulePath} (discovering…)`,
+    );
     let manifest;
     try {
         manifest = await gradleService.composePreviewDiscover(module);
     } catch (err) {
         logLine(
-            `[daemon] silent discover failed for ${module.modulePath}: ${(err as Error).message}`,
+            `[daemon] silent discover failed for ${module.modulePath}: ${(err as Error).message} — manifest cache left cleared`,
         );
         return null;
     }
     if (!manifest) {
+        logLine(
+            `[daemon] reconcile: discover returned null for ${module.modulePath} — manifest cache left cleared`,
+        );
         return null;
     }
+    logLine(
+        `[daemon] reconcile: discover returned ${manifest.previews.length} preview(s) for ${module.modulePath}`,
+    );
 
     const fresh = manifest.previews;
     const moduleKey = module.modulePath;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2878,18 +2878,32 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
     // own; the caller just shouldn't escalate to a Gradle render in that
     // case (the panel will repopulate via discover + the daemon's
     // discoveryUpdated push).
-    const manifest = moduleManifestCache.get(moduleKey) ?? [];
+    let manifest = moduleManifestCache.get(moduleKey) ?? [];
+    const repaintFile =
+        editorScope.file &&
+        gradleService.resolveModule(editorScope.file)?.modulePath === moduleKey
+            ? editorScope.file
+            : undefined;
+    // The manifest cache is wiped by `invalidateModuleCache` on every save and
+    // file-change, and is only repopulated asynchronously (the daemon's
+    // `discoveryUpdated` push, or a Gradle refresh). An identity-only edit (e.g.
+    // tweaking a colour) keeps the daemon quiet — no `discoveryUpdated` — so the
+    // cache stays empty after the wipe. Without recovering here we'd derive
+    // `renderIds=0` and the save would render nothing: previews silently stop
+    // updating after the first invalidation. `sourceMayHaveDroppedCachedPreviews`
+    // can't cover this (it returns false for an empty preview list), so an empty
+    // cache must trigger a discover to recover the render ids.
+    if (manifest.length === 0) {
+        const fresh = await reconcilePreviewManifest(module, repaintFile);
+        if (fresh) {
+            manifest = fresh;
+        }
+    }
     let filePreviews = previewsForFile(manifest, module, filePath);
     if (await sourceMayHaveDroppedCachedPreviews(filePath, filePreviews)) {
         logLine(
             `daemon: preview declarations changed in ${path.basename(filePath)}; reconciling before render`,
         );
-        const repaintFile =
-            editorScope.file &&
-            gradleService.resolveModule(editorScope.file)?.modulePath ===
-                moduleKey
-                ? editorScope.file
-                : undefined;
         const fresh = await reconcilePreviewManifest(module, repaintFile);
         filePreviews = fresh
             ? previewsForFile(fresh, module, filePath)

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -583,8 +583,20 @@ export interface ComposePreviewTestApi {
      * live daemon. Resolves to whether the daemon ended up ready. Used by
      * the wear a11y e2e — the regular `triggerRefresh` only drives the
      * Gradle-task render path and never touches the daemon gate.
+     *
+     * `refreshAfterReady` mirrors the production view-open warm
+     * (`refreshOrchestrator` passes it `true`): once the daemon is ready it
+     * runs a post-warm `composePreviewDiscover`, which writes `previews.json`
+     * and populates the daemon's `PreviewIndex`. Without it the daemon comes
+     * up with an empty index, so a later `renderNow(ids)` from the save path
+     * has no previews to resolve and silently renders nothing. Tests that go
+     * on to drive daemon saves must pass `true`; defaults to `false` to keep
+     * the lean warm the chip-toggle/wear tests rely on.
      */
-    triggerWarmDaemon(filePath: string): Promise<boolean>;
+    triggerWarmDaemon(
+        filePath: string,
+        refreshAfterReady?: boolean,
+    ): Promise<boolean>;
     /**
      * Drive `composePreviewApplied` against the currently-wired
      * `gradleService` and await completion, so subsequent
@@ -2354,8 +2366,11 @@ export async function activate(
                     bundleId,
                 });
             },
-            triggerWarmDaemon(filePath: string): Promise<boolean> {
-                return warmDaemonForFile(filePath);
+            triggerWarmDaemon(
+                filePath: string,
+                refreshAfterReady = false,
+            ): Promise<boolean> {
+                return warmDaemonForFile(filePath, { refreshAfterReady });
             },
             async triggerBootstrapAppliedMarkers(): Promise<void> {
                 if (!gradleService) {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2896,6 +2896,9 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
         filePath,
         filePreviews.map((p) => p.id),
     );
+    logLine(
+        `daemon save: ${path.basename(filePath)} manifest=${manifest.length} filePreviews=${filePreviews.length} renderIds=${ids.length}`,
+    );
     if (ids.length === 0) {
         return "accepted";
     }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2751,9 +2751,6 @@ function invalidateModuleCache(filePath: string): void {
     if (module) {
         gradleService.invalidateCache(module);
         moduleManifestCache.delete(module.modulePath);
-        logLine(
-            `[daemon] invalidateModuleCache cleared manifest cache for ${module.modulePath} (file=${path.basename(filePath)})`,
-        );
     }
 }
 
@@ -3420,9 +3417,6 @@ async function reconcilePreviewManifest(
     }
     gradleService.invalidateCache(module);
     moduleManifestCache.delete(module.modulePath);
-    logLine(
-        `[daemon] reconcile: cleared manifest cache for ${module.modulePath} (discovering…)`,
-    );
     let manifest;
     try {
         manifest = await gradleService.composePreviewDiscover(module);

--- a/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
@@ -521,16 +521,26 @@ describeExternal(
                     fs.writeFileSync(kotlinFile, src);
                 }
 
-                // Land the probe in the DAEMON before the loop. The probe is a
-                // brand-new @Preview, so the daemon's PreviewIndex (seeded at
-                // warm time) doesn't know it yet; a save's renderNow can only
-                // resolve IDs the daemon already knows. A bare triggerSave or a
-                // Gradle triggerRefresh won't fix that — neither re-runs
-                // composePreviewDiscover into the daemon. Re-warming with
-                // refreshAfterReady=true does: the daemon is already up, so this
-                // just runs the post-warm discover (rewriting previews.json with
-                // the probe) and pre-renders the file's previews through the
-                // daemon, surfacing the probe's card.
+                // Land the probe in the DAEMON before the loop. Two things have
+                // to be true for a save's renderNow to render the probe (rather
+                // than emit a dropped `daemon-stub-*`):
+                //
+                //  1. previews.json must list the probe — the host resolves the
+                //     renderNow's `previewId=` to a class/function via that
+                //     manifest (RobolectricHost.reshapeRenderPayload); unknown
+                //     ids fall through to renderStub.
+                //  2. The daemon process must have LOADED that manifest. The
+                //     daemon binds its PreviewManifestRouter once at startup
+                //     (DaemonMain), and the cold-pass daemon spawned before
+                //     previews.json existed — so it's stuck in the empty-index
+                //     fallback and stubs every render for its whole lifetime.
+                //
+                // triggerWarmDaemon(refreshAfterReady=true) runs the post-warm
+                // composePreviewDiscover that satisfies (1). For (2) we then
+                // restart the daemon and warm again: the daemon's own docs call
+                // this "the next warm after discover picks up the populated
+                // manifest". restartDaemon clears the bootstrap memo, so the
+                // re-warm genuinely re-spawns against the now-written manifest.
                 api.resetMessages();
                 await api.triggerWarmDaemon(
                     kotlinFile,
@@ -553,6 +563,21 @@ describeExternal(
                                 ),
                             );
                         }),
+                );
+                // Re-spawn against the now-populated previews.json so the daemon
+                // leaves stub-render mode and resolves real specs (incl. the
+                // probe) — without this every renderNow returns a dropped
+                // daemon-stub path and no updateImage ever reaches the panel.
+                await vscode.commands.executeCommand(
+                    "composePreview.restartDaemon",
+                );
+                const rewarmed = await api.triggerWarmDaemon(
+                    kotlinFile,
+                    /* refreshAfterReady */ true,
+                );
+                assert.ok(
+                    rewarmed,
+                    "daemon must re-warm after restart so it loads the populated previews.json",
                 );
 
                 const timingsMs: number[] = [];

--- a/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
@@ -245,7 +245,12 @@ describeExternal(
             // stderr tail is already in the channel log thanks to
             // issue #1326's wrapping (`formatDaemonSpawnFailure`).
             const tWarm = phaseStart();
-            const warmed = await api.triggerWarmDaemon(kotlinFile);
+            // refreshAfterReady=true mirrors the production view-open warm: it
+            // runs a post-warm composePreviewDiscover that writes previews.json
+            // and populates the daemon's PreviewIndex. Without it the daemon
+            // comes up empty and a later save's renderNow has no previews to
+            // resolve (the daemon renders nothing).
+            const warmed = await api.triggerWarmDaemon(kotlinFile, true);
             phaseEnd("warmDaemonMs", tWarm);
             if (!warmed) {
                 // Post-mortem: surface every applied.json the workspace has on
@@ -516,16 +521,21 @@ describeExternal(
                     fs.writeFileSync(kotlinFile, src);
                 }
 
-                // Land the probe in the daemon's manifest before the loop via a
-                // full (Gradle) refresh: it discovers + renders every preview —
-                // posting setPreviews with the probe's card AND priming the
-                // daemon's manifest cache — so the first loop edit is a save where
-                // the probe is in-manifest and renders through the daemon. (A bare
-                // triggerSave doesn't suffice: a newly-added preview's image isn't
-                // rendered on the first save, and the daemon's deferred discovery
-                // only runs after a render, so the card never surfaces.)
+                // Land the probe in the DAEMON before the loop. The probe is a
+                // brand-new @Preview, so the daemon's PreviewIndex (seeded at
+                // warm time) doesn't know it yet; a save's renderNow can only
+                // resolve IDs the daemon already knows. A bare triggerSave or a
+                // Gradle triggerRefresh won't fix that — neither re-runs
+                // composePreviewDiscover into the daemon. Re-warming with
+                // refreshAfterReady=true does: the daemon is already up, so this
+                // just runs the post-warm discover (rewriting previews.json with
+                // the probe) and pre-renders the file's previews through the
+                // daemon, surfacing the probe's card.
                 api.resetMessages();
-                await api.triggerRefresh(kotlinFile, /* force */ true, "full");
+                await api.triggerWarmDaemon(
+                    kotlinFile,
+                    /* refreshAfterReady */ true,
+                );
                 await waitFor(
                     "probe discovered (card present)",
                     5 * 60_000,

--- a/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
@@ -664,25 +664,31 @@ describeExternal(
                     // what proves live mode reflects the edit instead of
                     // re-emitting a stale render. A same-bytes render would time
                     // out here and fail the test loudly.
-                    const shot = await waitFor(
-                        `edit ${i + 1} → CHANGED probe image`,
-                        // Bounded per-edit: a warm incremental edit that can't
-                        // produce a *changed* render within this window is the
-                        // stale-render bug — fail fast and loud rather than
-                        // hanging until the 30-min suite timeout.
-                        PER_EDIT_TIMEOUT_MS,
-                        100,
-                        () => {
-                            const cur = probeImageOf();
-                            if (!cur) return undefined;
-                            if (
-                                prevImage !== null &&
-                                cur.imageData === prevImage
-                            )
-                                return undefined;
-                            return cur;
-                        },
-                    );
+                    let shot: { previewId: string; imageData: string };
+                    try {
+                        shot = await waitFor(
+                            `edit ${i + 1} → CHANGED probe image`,
+                            // Bounded per-edit: a warm incremental edit that can't
+                            // produce a *changed* render within this window is the
+                            // stale-render bug — fail fast and loud rather than
+                            // hanging until the 30-min suite timeout.
+                            PER_EDIT_TIMEOUT_MS,
+                            100,
+                            () => {
+                                const cur = probeImageOf();
+                                if (!cur) return undefined;
+                                if (
+                                    prevImage !== null &&
+                                    cur.imageData === prevImage
+                                )
+                                    return undefined;
+                                return cur;
+                            },
+                        );
+                    } catch (e) {
+                        dumpDaemonDiag(`edit ${i + 1} render TIMED OUT`);
+                        throw e;
+                    }
                     const dt = Date.now() - t0;
                     timingsMs.push(dt);
 

--- a/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
@@ -557,12 +557,42 @@ describeExternal(
                 // (Codex review on #1718).
                 api.resetMessages();
                 api.triggerSave(kotlinFile);
-                const baseline = await waitFor(
-                    "probe baseline image (pre-edit render)",
-                    PER_EDIT_TIMEOUT_MS,
-                    100,
-                    () => probeImageOf() ?? undefined,
-                );
+                // Diagnostic: if the daemon never renders the probe (the save
+                // path falls back to Gradle instead of driving daemon renderNow),
+                // dump the extension's own [refresh]/daemon log tail and the
+                // panel message commands so the cause is visible in CI output
+                // rather than just a bare timeout.
+                const dumpDaemonDiag = (label: string) => {
+                    const tail = api
+                        .getOutputChannelTail(400)
+                        .filter((l) =>
+                            /daemon|render|fileChanged|disabled|focus|ensureModule|compile|manifest|discover/i.test(
+                                l,
+                            ),
+                        );
+                    console.log(
+                        `\n[editloop] ===== ${label}: output-channel tail (${tail.length} relevant lines) =====`,
+                    );
+                    for (const l of tail.slice(-120)) console.log(`  ${l}`);
+                    const cmds = (
+                        api.getPostedMessages() as PostedMessage[]
+                    ).map((m) => m.command);
+                    console.log(
+                        `[editloop] posted commands since reset: ${JSON.stringify(cmds)}`,
+                    );
+                };
+                let baseline: { previewId: string; imageData: string };
+                try {
+                    baseline = await waitFor(
+                        "probe baseline image (pre-edit render)",
+                        PER_EDIT_TIMEOUT_MS,
+                        100,
+                        () => probeImageOf() ?? undefined,
+                    );
+                } catch (e) {
+                    dumpDaemonDiag("baseline render TIMED OUT");
+                    throw e;
+                }
                 let prevImage: string | null = baseline.imageData;
                 {
                     const buf = Buffer.from(baseline.imageData, "base64");

--- a/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eExternal.test.ts
@@ -582,16 +582,18 @@ describeExternal(
 
                 const timingsMs: number[] = [];
                 const imageHashes: string[] = [];
-                // Seed prevImage with the probe's BASELINE render (its current,
-                // pre-edit colour) so edit 1 must produce a *changed* image. A
-                // save with no source change renders the baseline; capturing it
-                // here means a baseline `updateImage` that arrives late (from the
-                // prime / first daemon render) can't be accepted by edit 1 as if
-                // it were edit 1's own render — which would mask a stale edit-1
-                // render even while the later edits still produce distinct images
-                // (Codex review on #1718).
-                api.resetMessages();
-                api.triggerSave(kotlinFile);
+                // Seed prevImage with the probe's BASELINE render — the pink
+                // pre-edit image the post-restart re-warm just rendered through
+                // the daemon (warmShownPreviews). Capturing that render, rather
+                // than forcing a fresh no-change save, matters twice over:
+                //   - it gives edit 1 a real baseline to differ from, so a stale
+                //     edit-1 render can't slip through (Codex review on #1718);
+                //   - a no-change save renders byte-identical pink, which the
+                //     daemon's frame-dedup reports as `unchanged` and the host
+                //     drops (no updateImage) — so the baseline has to come from
+                //     the re-warm's render, not a redundant save.
+                // No resetMessages here: that render's updateImage is exactly
+                // what we're capturing.
                 // Diagnostic: if the daemon never renders the probe (the save
                 // path falls back to Gradle instead of driving daemon renderNow),
                 // dump the extension's own [refresh]/daemon log tail and the


### PR DESCRIPTION
## Summary

The daemon live-preview **save path could silently stop updating previews**. After the extension's `moduleManifestCache` is invalidated — which happens on every save / file-change via `invalidateModuleCache` — a subsequent save derived `renderIds=0` and dispatched **no render**. For identity-only edits (e.g. tweaking a colour) the daemon stays quiet (`discoveryDiffEmpty`), so nothing repopulates the cache, and every following save renders nothing. This is the "first edit shows, second edit doesn't" class of stale-preview bug.

## Fix

`notifyDaemonOfSave` now repopulates the manifest via `composePreviewDiscover` when the cache is empty, **before** deriving render ids — so a save landing on an invalidated cache re-discovers and renders instead of no-op'ing. (`sourceMayHaveDroppedCachedPreviews` can't cover this: it returns `false` for an empty preview list.)

## How it was found

I brought the warm edit-loop e2e (gated `COMPOSE_PREVIEW_E2E_EDITLOOP=1`) up against Confetti's `:androidApp` and made it actually drive the daemon save→render path. That surfaced a chain of issues, each fixed/worked-around so the next was visible:

1. **Test warmed the daemon without `refreshAfterReady`** → `composePreviewDiscover` never ran, the daemon's `PreviewIndex` stayed empty, `renderNow` had nothing to resolve. Exposed `triggerWarmDaemon(filePath, refreshAfterReady)` so the test mirrors the production view-open warm.
2. **The daemon's first spawn races ahead of `previews.json`** (comes up at stub-render stage) → the e2e restarts the daemon once after discover so it re-spawns against the written manifest.
3. **A no-change baseline save is frame-deduped** (`unchanged`) and dropped → capture the baseline from the re-warm render instead of a redundant save.
4. **The cache-invalidation bug above** — the actual product fix.

## e2e result (Confetti `:androidApp`, daemon under VSCodium + xvfb)

```
baseline pink → edit1 green → edit2 blue → edit3 orange → edit4 purple
5 distinct image SHAs; per-edit 8–11s; no stale renders; 2 passing, exit 0
```

Before the fix the loop timed out on the 2nd edit (`manifest=0 renderIds=0`, daemon idle).

## Notes / follow-ups

- **Perf:** the fix runs a `composePreviewDiscover` on saves that land on an empty cache. Because the cache is wiped on every save and the daemon stays quiet for identity-only edits, repeated colour tweaks pay a discover each. The better follow-up is to **not wipe the render-id list on identity-only saves** (the daemon's `discoveryUpdated` already updates the set when it genuinely changes), so `renderNow` reuses cached ids without a Gradle discover. Tracking separately; this PR prioritises correctness (previews update again).
- Kept two level-gated save-path diagnostics (`renderIds=` and the reconcile discover outcome) that made this debuggable; dropped the noisy per-clear lines.
- Pairs with the `COMPOSE_PREVIEW_DAEMON_STDERR_FILE` seam (from #1718) — the daemon's `[render] loaderId/classFile` fingerprint is what proved the recompiled `.class` was/wasn't being rendered.

## Test plan
- [x] Confetti `:androidApp` warm edit-loop e2e: 4 consecutive edits each produce a **distinct** daemon render (was: 2nd edit stale → timeout)
- [x] `npm run compile` + prettier/ktfmt clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5pRHUtK6BaARmtRjvu5sW)_