### PR TITLE
perf(daemon): keep the manifest snapshot across identity saves

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -58,7 +58,10 @@ import {
     GradleOnlyDaemonGate,
     LiveDaemonGate,
 } from "./daemon/daemonGate";
-import { DataProductAttachment } from "./daemon/daemonProtocol";
+import {
+    DataProductAttachment,
+    DiscoveryUpdatedParams,
+} from "./daemon/daemonProtocol";
 import {
     A11Y_OVERLAY_KINDS,
     DaemonScheduler,
@@ -2784,21 +2787,16 @@ function invalidateModuleCache(filePath: string): void {
  */
 async function applyDiscoveryDiff(
     moduleId: string,
-    params: {
-        added: unknown[];
-        removed: string[];
-        changed: unknown[];
-        totalPreviews: number;
-    },
+    params: DiscoveryUpdatedParams,
 ): Promise<void> {
     if (!gradleService || !panel) {
         return;
     }
 
     const removedIds = params.removed ?? [];
-    const addedCount = params.added?.length ?? 0;
+    const added = params.added ?? [];
     const changedCount = params.changed?.length ?? 0;
-    if (removedIds.length === 0 && addedCount === 0 && changedCount === 0) {
+    if (removedIds.length === 0 && added.length === 0 && changedCount === 0) {
         return;
     }
 
@@ -2815,7 +2813,34 @@ async function applyDiscoveryDiff(
         gradleService.resolveModule(editorScope.file)?.modulePath === moduleId
             ? editorScope.file
             : undefined;
-    await reconcilePreviewManifest(module, repaintFile);
+    const fresh = await reconcilePreviewManifest(module, repaintFile);
+
+    // reconcilePreviewManifest only reshapes the panel (setPreviews) — it does
+    // not render. A newly-added @Preview would otherwise show as a card with no
+    // PNG until the next save: notifyDaemonOfSave derives its renderNow ids from
+    // the pre-add snapshot (we keep moduleManifestCache across identity saves for
+    // perf), and the daemon defers this discoveryUpdated until after the save's
+    // render. This is the first point we know the added ids, so render them now.
+    if (fresh && added.length > 0) {
+        const renderable = new Set(fresh.map((p) => p.id));
+        const addedIds = added
+            .map((p) => p.id)
+            .filter((id) => renderable.has(id));
+        if (addedIds.length > 0) {
+            try {
+                await dispatchDaemonRender(
+                    module,
+                    addedIds,
+                    "discovery-added",
+                    "discovery-added-heavy-opt-in",
+                );
+            } catch (err) {
+                logLine(
+                    `daemon: render for added previews failed: ${String((err as Error).message ?? err)}`,
+                );
+            }
+        }
+    }
 }
 
 /**
@@ -2924,40 +2949,61 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
         return "accepted";
     }
     try {
-        await daemonScheduler.setFocus(module, ids);
-        const fullIds = heavyOptInsFor(module.modulePath, ids);
-        const fastIds =
-            fullIds.length === 0
-                ? ids
-                : ids.filter((id) => !fullIds.includes(id));
-
-        if (fastIds.length > 0) {
-            const ok = await daemonScheduler.renderNow(
-                module,
-                fastIds,
-                "fast",
-                "save",
-            );
-            if (!ok) {
-                return "failed";
-            }
-        }
-        if (fullIds.length > 0) {
-            const ok = await daemonScheduler.renderNow(
-                module,
-                fullIds,
-                "full",
-                "save-heavy-opt-in",
-            );
-            if (!ok) {
-                return "failed";
-            }
-        }
-        return "accepted";
+        const ok = await dispatchDaemonRender(
+            module,
+            ids,
+            "save",
+            "save-heavy-opt-in",
+        );
+        return ok ? "accepted" : "failed";
     } catch (err) {
         logLine(`daemon: ${String((err as Error).message ?? err)}`);
         return daemonGate.isBuildDisabled(module) ? "disabled" : "failed";
     }
+}
+
+/**
+ * Focus `ids` and dispatch a daemon render, split across the fast/full tiers by
+ * heavy-capture opt-in. Returns false if a renderNow was rejected, true
+ * otherwise (including an empty id set, which is a no-op). Shared by the save
+ * path and the discoveryUpdated handler so both render through the same tiering.
+ */
+async function dispatchDaemonRender(
+    module: ModuleInfo,
+    ids: string[],
+    fastReason: string,
+    fullReason: string,
+): Promise<boolean> {
+    if (!daemonScheduler || ids.length === 0) {
+        return true;
+    }
+    await daemonScheduler.setFocus(module, ids);
+    const fullIds = heavyOptInsFor(module.modulePath, ids);
+    const fastIds =
+        fullIds.length === 0 ? ids : ids.filter((id) => !fullIds.includes(id));
+    if (fastIds.length > 0) {
+        const ok = await daemonScheduler.renderNow(
+            module,
+            fastIds,
+            "fast",
+            fastReason,
+        );
+        if (!ok) {
+            return false;
+        }
+    }
+    if (fullIds.length > 0) {
+        const ok = await daemonScheduler.renderNow(
+            module,
+            fullIds,
+            "full",
+            fullReason,
+        );
+        if (!ok) {
+            return false;
+        }
+    }
+    return true;
 }
 
 function prioritizeEditedPreview(filePath: string, ids: string[]): string[] {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2749,8 +2749,16 @@ function invalidateModuleCache(filePath: string): void {
     }
     const module = gradleService.resolveModule(filePath);
     if (module) {
+        // Invalidate Gradle's discover/compile cache so the next discover
+        // recompiles against the edited sources. Deliberately KEEP
+        // moduleManifestCache (the render-id snapshot): an identity-only edit
+        // doesn't change the preview set, so the daemon save path reuses the
+        // cached ids and dispatches renderNow without paying a Gradle
+        // composePreviewDiscover on every keystroke. Set changes still refresh
+        // the snapshot — drops via sourceMayHaveDroppedCachedPreviews on the
+        // save, adds via the daemon's discoveryUpdated push — both of which call
+        // reconcilePreviewManifest.
         gradleService.invalidateCache(module);
-        moduleManifestCache.delete(module.modulePath);
     }
 }
 
@@ -2881,15 +2889,14 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
         gradleService.resolveModule(editorScope.file)?.modulePath === moduleKey
             ? editorScope.file
             : undefined;
-    // The manifest cache is wiped by `invalidateModuleCache` on every save and
-    // file-change, and is only repopulated asynchronously (the daemon's
-    // `discoveryUpdated` push, or a Gradle refresh). An identity-only edit (e.g.
-    // tweaking a colour) keeps the daemon quiet — no `discoveryUpdated` — so the
-    // cache stays empty after the wipe. Without recovering here we'd derive
-    // `renderIds=0` and the save would render nothing: previews silently stop
-    // updating after the first invalidation. `sourceMayHaveDroppedCachedPreviews`
-    // can't cover this (it returns false for an empty preview list), so an empty
-    // cache must trigger a discover to recover the render ids.
+    // The manifest snapshot persists across identity edits, but it can be empty
+    // on a cold save: the first save before any discover ran, or right after an
+    // explicit refresh cleared it. An empty snapshot would derive renderIds=0
+    // and render nothing — and an identity edit keeps the daemon quiet, so no
+    // `discoveryUpdated` would repopulate it. Recover by discovering once here.
+    // (`sourceMayHaveDroppedCachedPreviews` can't cover this — it returns false
+    // for an empty preview list.) Once populated, subsequent identity saves skip
+    // this and reuse the snapshot.
     if (manifest.length === 0) {
         const fresh = await reconcilePreviewManifest(module, repaintFile);
         if (fresh) {


### PR DESCRIPTION
## Summary

Follow-up to #1723. That PR made the daemon save path *correct* — a save landing on an empty `moduleManifestCache` re-discovers so previews keep updating. But the cache is wiped by `invalidateModuleCache` on **every** save, so an identity-only edit (colour/padding tweak — the common live-preview loop) lands on an empty snapshot every time and pays a full Gradle `composePreviewDiscover` (the ClassGraph dependency walk the daemon save path was explicitly built to avoid) just to recover the render ids.

This PR keeps the render-id snapshot across identity edits: `invalidateModuleCache` still invalidates Gradle's discover/compile cache, but no longer deletes `moduleManifestCache`. The save path reuses the cached ids and dispatches `renderNow` without a discover. The #1723 empty-cache discover stays as a cold-start fallback (first save before any discover; right after an explicit refresh).

## Correctness — set changes still reconcile *and render*

Identity edits don't change the preview set, so reusing the snapshot is safe. Set changes still refresh the snapshot and render:
- **Removing/renaming** a `@Preview` → `sourceMayHaveDroppedCachedPreviews` trips on the save → `reconcilePreviewManifest` re-discovers.
- **Adding** a `@Preview` → the daemon emits `discoveryUpdated` → `applyDiscoveryDiff` re-discovers **and now renders the added ids** (f4fc00d), so the new card arrives with a PNG — a beat after the save's render rather than inline. Extracted the save path's focus + tiered `renderNow` into a shared `dispatchDaemonRender` helper so both paths use the same fast/full tiering.

(f4fc00d addresses the Codex P2: previously `applyDiscoveryDiff` only reshaped the panel via `setPreviews`, leaving an added preview's card without a PNG until the next save — which was also the long-standing pre-#1723 baseline.)

## Measurement (Confetti `:androidApp`, warm edit loop, same container, back-to-back)

4 consecutive colour edits, each requiring a *distinct* daemon render:

| | `composePreviewDiscover` | `composePreviewCompile` | per-edit ms (steady-state 2–4) | median |
|---|---|---|---|---|
| **before** (`main`) | 6 | 6 | 6342 / 7417 / 7448 | **7417** |
| **after** (this PR) | 3 | 6 | 5481 / 4773 / 4893 | **~4.9k** |

- Per-edit discovers eliminated (the 3 remaining are setup: initial warm + the e2e's restart-rewarm). Compile still runs every save — required for the new bytecode.
- Steady-state warm-edit latency down from ~6.3–7.4s to ~4.8–5.5s. (Edit 1 varies with Gradle-daemon cold start; steady-state is the signal.)
- Green on every run (`2 passing`, all 4 image SHAs distinct).

## Test plan
- [x] Confetti `:androidApp` warm edit-loop e2e green (`COMPOSE_PREVIEW_E2E_EDITLOOP=1`); per-edit discovers = 3 (down from 6)
- [x] before/after measured back-to-back in the same container (table above)
- [x] full extension unit suite green (1454 passing) after extracting `dispatchDaemonRender`
- [x] `npm run compile` + prettier/ktfmt clean