### PR TITLE
ci: build xr-composite binaries for linux/mac/windows

### DIFF
--- a/.github/actions/build-xr-composite/action.yml
+++ b/.github/actions/build-xr-composite/action.yml
@@ -1,0 +1,116 @@
+name: Build xr-composite
+description: >
+  Build the native xr-composite tool (renderers/xr-composite) against the pinned
+  Filament desktop SDK for the current runner OS and stage the binary + compiled
+  materials into a flat dist/ directory. Build-only (no rendering), so no Xvfb /
+  Mesa needed. Shared by the CI build workflow and the release asset job so the
+  per-platform build logic lives in one place.
+
+inputs:
+  platform:
+    description: Filament SDK platform tarball flavor — linux | mac | windows.
+    required: true
+  filament-version:
+    description: Filament release tag to build against.
+    required: false
+    default: v1.71.5
+
+runs:
+  using: composite
+  steps:
+    # Linux: Filament's release libs are built against libc++, so we build the
+    # tool with clang + libc++ to match the ABI. macOS (AppleClang) and Windows
+    # (MSVC) ship their toolchains preinstalled on the runner images.
+    - name: Install clang + libc++ (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          clang libc++-dev libc++abi-dev ninja-build
+
+    - name: Install Ninja (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew install ninja
+
+    # Cache the unpacked SDK keyed on version + platform so repeat runs skip the
+    # ~50-730 MB download. The download step below is a no-op on a cache hit.
+    - name: Cache Filament SDK
+      id: cache-sdk
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: filament-sdk
+        key: filament-${{ inputs.filament-version }}-${{ inputs.platform }}
+
+    - name: Download Filament SDK
+      if: steps.cache-sdk.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p filament-sdk
+        tgz="filament-${{ inputs.filament-version }}-${{ inputs.platform }}.tgz"
+        url="https://github.com/google/filament/releases/download/${{ inputs.filament-version }}/${tgz}"
+        echo "Downloading ${url}"
+        curl -fL --retry 4 --retry-delay 2 -o "${tgz}" "${url}"
+        tar xzf "${tgz}" -C filament-sdk
+        rm -f "${tgz}"
+
+    # Locate the SDK root (the dir holding include/filament/Engine.h) and export
+    # it. Runs on both cache-hit and fresh-download, and copes with the tarball's
+    # top-level layout differing per platform. On Windows we hand CMake (a native
+    # binary) a Windows-style path (C:/...) rather than the Git-bash MSYS path
+    # (/d/a/...), which it cannot resolve.
+    - name: Resolve Filament SDK root
+      shell: bash
+      run: |
+        set -euo pipefail
+        engine="$(find "$PWD/filament-sdk" -path '*/include/filament/Engine.h' -print -quit)"
+        if [ -z "$engine" ]; then
+          echo "::error::could not find include/filament/Engine.h under filament-sdk/"
+          find "$PWD/filament-sdk" -maxdepth 2 -type d | sort
+          exit 1
+        fi
+        sdk="${engine%/include/filament/Engine.h}"
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          sdk="$(cygpath -m "$sdk")"
+        fi
+        echo "FILAMENT_SDK=${sdk}" >> "$GITHUB_ENV"
+        echo "Resolved FILAMENT_SDK=${sdk}"
+
+    - name: Configure
+      shell: bash
+      run: |
+        set -euo pipefail
+        common=(-S renderers/xr-composite -B renderers/xr-composite/build
+                -DCMAKE_BUILD_TYPE=Release "-DFILAMENT_SDK=${FILAMENT_SDK}")
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          # MSVC multi-config generator; CMakeLists pins the static /MT runtime.
+          cmake "${common[@]}" -G "Visual Studio 17 2022" -A x64
+        else
+          cmake "${common[@]}" -G Ninja \
+            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+        fi
+
+    - name: Build
+      shell: bash
+      run: cmake --build renderers/xr-composite/build --config Release
+
+    # The Visual Studio generator nests outputs under a per-config subdir; Ninja
+    # writes them at the build root. Stage both the binary and materials/ into a
+    # flat dist/ so the layout is identical across platforms.
+    - name: Stage dist/
+      shell: bash
+      run: |
+        set -euo pipefail
+        build=renderers/xr-composite/build
+        dist=dist
+        rm -rf "$dist"
+        mkdir -p "$dist"
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          cp "$build/Release/xr-composite.exe" "$dist/"
+        else
+          cp "$build/xr-composite" "$dist/"
+        fi
+        cp -r "$build/materials" "$dist/materials"
+        ls -lR "$dist"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,6 +279,61 @@ jobs:
           path: vscode-extension/*.vsix
           retention-days: 1
 
+  # Native xr-composite binaries shipped on each GitHub Release — one per desktop
+  # platform, each a `.tar.gz` of the binary + compiled materials. Built against
+  # the pinned Filament SDK via the shared `build-xr-composite` composite action
+  # (the same one the `xr-composite build` CI workflow uses). Unlike the JVM
+  # artefacts these aren't published to Maven Central, and `release` (not
+  # `publish-gradle-plugin`) is the only job that needs them — they're pure
+  # GitHub Release assets. The `.tar.gz` naming carries platform + arch + version
+  # so the three matrix legs never collide once merged into `artifacts/`, and the
+  # `release` job's existing `artifacts/*.tar.gz` glob uploads them with no extra
+  # wiring.
+  build-xr-composite:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            asset: linux-x86_64
+          - os: macos-14
+            platform: mac
+            asset: macos-arm64
+          - os: windows-2022
+            platform: windows
+            asset: windows-x86_64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.TAG_NAME }}
+          persist-credentials: false
+      - name: Derive plugin version from tag
+        shell: bash
+        run: echo "PLUGIN_VERSION=${TAG_NAME#v}" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/build-xr-composite
+        with:
+          platform: ${{ matrix.platform }}
+      # Pack the staged dist/ (binary + materials/) into one versioned tarball.
+      # `staged-artifacts/*` keeps the upload-artifact LCA at staged-artifacts/,
+      # so after the release job's `merge-multiple` the `.tar.gz` lands flat under
+      # `artifacts/` for the `artifacts/*.tar.gz` upload glob.
+      - name: Package versioned tarball
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p staged-artifacts
+          tar -C dist -czf \
+            "staged-artifacts/xr-composite-${{ matrix.asset }}-${PLUGIN_VERSION}.tar.gz" .
+          ls -l staged-artifacts
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: xr-composite-${{ matrix.asset }}
+          path: staged-artifacts/*
+          if-no-files-found: error
+          retention-days: 1
+
   # Publish the prebuilt VSIX to both marketplaces. Runs alongside the
   # `release` job (not gating it) so a marketplace outage can't block the
   # `.vsix` landing on the GitHub Release. On workflow_dispatch re-runs for
@@ -341,10 +396,12 @@ jobs:
     # irreversible (Central won't overwrite a published version), so it's gated behind every build
     # job for safety; but the GitHub assets don't need to wait behind that publish. Listing the three
     # build jobs directly lets this job run in parallel with the Maven publish, so the `.zip`/`.tar.gz`
-    # /`.jar`/installer/`.vsix` files land on the Release as soon as the builds finish instead of after
-    # Central wraps up. The build jobs still gate the Maven publish independently, so decoupling here
-    # doesn't weaken the irreversible-publish safety gate.
-    needs: [build-applications, build-viewer-artifacts, build-vscode-extension]
+    # /`.jar`/installer/`.vsix` files (including the per-OS `xr-composite-*.tar.gz` binaries) land on the
+    # Release as soon as the builds finish instead of after Central wraps up. The build jobs still gate
+    # the Maven publish independently, so decoupling here doesn't weaken the irreversible-publish safety
+    # gate. (xr-composite is in `release`'s needs but deliberately NOT in `publish-gradle-plugin`'s — the
+    # native binaries are GitHub Release assets, not Maven artifacts.)
+    needs: [build-applications, build-viewer-artifacts, build-vscode-extension, build-xr-composite]
     runs-on: ubuntu-latest
     permissions:
       contents: write   # update the release, upload assets

--- a/.github/workflows/xr-composite-build.yml
+++ b/.github/workflows/xr-composite-build.yml
@@ -93,20 +93,34 @@ jobs:
           tar xzf "${tgz}" -C filament-sdk
           rm -f "${tgz}"
 
-      # filament-sdk/filament/ is the unpacked SDK root (include/, lib/, bin/).
+      # Locate the SDK root (the dir holding include/filament/Engine.h) and export
+      # it. This runs on both cache-hit and fresh-download, and copes with the
+      # tarball's top-level layout differing per platform. On Windows we hand
+      # CMake (a native binary) a Windows-style path (C:/...) rather than the
+      # Git-bash MSYS path (/d/a/...), which it cannot resolve.
+      - name: Resolve Filament SDK root
+        shell: bash
+        run: |
+          set -euo pipefail
+          engine="$(find "$PWD/filament-sdk" -path '*/include/filament/Engine.h' -print -quit)"
+          if [ -z "$engine" ]; then
+            echo "::error::could not find include/filament/Engine.h under filament-sdk/"
+            find "$PWD/filament-sdk" -maxdepth 2 -type d | sort
+            exit 1
+          fi
+          sdk="${engine%/include/filament/Engine.h}"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            sdk="$(cygpath -m "$sdk")"
+          fi
+          echo "FILAMENT_SDK=${sdk}" >> "$GITHUB_ENV"
+          echo "Resolved FILAMENT_SDK=${sdk}"
+
       - name: Configure
         shell: bash
         run: |
           set -euo pipefail
-          sdk="$PWD/filament-sdk/filament"
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            # CMake here is a native Windows binary; hand it a Windows-style path
-            # (C:/...) rather than the Git-bash MSYS path (/d/a/...) so the SDK
-            # EXISTS check in CMakeLists resolves.
-            sdk="$(cygpath -m "$sdk")"
-          fi
           common=(-S renderers/xr-composite -B renderers/xr-composite/build
-                  -DCMAKE_BUILD_TYPE=Release "-DFILAMENT_SDK=${sdk}")
+                  -DCMAKE_BUILD_TYPE=Release "-DFILAMENT_SDK=${FILAMENT_SDK}")
           if [ "$RUNNER_OS" = "Windows" ]; then
             # MSVC multi-config generator; CMakeLists pins the static /MT runtime.
             cmake "${common[@]}" -G "Visual Studio 17 2022" -A x64

--- a/.github/workflows/xr-composite-build.yml
+++ b/.github/workflows/xr-composite-build.yml
@@ -55,102 +55,12 @@ jobs:
         with:
           persist-credentials: false
 
-      # Linux: Filament's release libs are built against libc++, so we build the
-      # tool with clang + libc++ to match the ABI. macOS (AppleClang) and Windows
-      # (MSVC) ship their toolchains preinstalled on the runner images.
-      - name: Install clang + libc++ (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            clang libc++-dev libc++abi-dev ninja-build
-        shell: bash
-
-      - name: Install Ninja (macOS)
-        if: runner.os == 'macOS'
-        run: brew install ninja
-        shell: bash
-
-      # Cache the unpacked SDK keyed on version + platform so repeat runs skip the
-      # ~50-730 MB download. The download step below is a no-op on a cache hit.
-      - name: Cache Filament SDK
-        id: cache-sdk
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      # Build + stage into dist/ via the shared composite action (also used by
+      # the release asset job in release.yml).
+      - uses: ./.github/actions/build-xr-composite
         with:
-          path: filament-sdk
-          key: filament-${{ env.FILAMENT_VERSION }}-${{ matrix.platform }}
-
-      - name: Download Filament SDK
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p filament-sdk
-          tgz="filament-${FILAMENT_VERSION}-${{ matrix.platform }}.tgz"
-          url="https://github.com/google/filament/releases/download/${FILAMENT_VERSION}/${tgz}"
-          echo "Downloading ${url}"
-          curl -fL --retry 4 --retry-delay 2 -o "${tgz}" "${url}"
-          tar xzf "${tgz}" -C filament-sdk
-          rm -f "${tgz}"
-
-      # Locate the SDK root (the dir holding include/filament/Engine.h) and export
-      # it. This runs on both cache-hit and fresh-download, and copes with the
-      # tarball's top-level layout differing per platform. On Windows we hand
-      # CMake (a native binary) a Windows-style path (C:/...) rather than the
-      # Git-bash MSYS path (/d/a/...), which it cannot resolve.
-      - name: Resolve Filament SDK root
-        shell: bash
-        run: |
-          set -euo pipefail
-          engine="$(find "$PWD/filament-sdk" -path '*/include/filament/Engine.h' -print -quit)"
-          if [ -z "$engine" ]; then
-            echo "::error::could not find include/filament/Engine.h under filament-sdk/"
-            find "$PWD/filament-sdk" -maxdepth 2 -type d | sort
-            exit 1
-          fi
-          sdk="${engine%/include/filament/Engine.h}"
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            sdk="$(cygpath -m "$sdk")"
-          fi
-          echo "FILAMENT_SDK=${sdk}" >> "$GITHUB_ENV"
-          echo "Resolved FILAMENT_SDK=${sdk}"
-
-      - name: Configure
-        shell: bash
-        run: |
-          set -euo pipefail
-          common=(-S renderers/xr-composite -B renderers/xr-composite/build
-                  -DCMAKE_BUILD_TYPE=Release "-DFILAMENT_SDK=${FILAMENT_SDK}")
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            # MSVC multi-config generator; CMakeLists pins the static /MT runtime.
-            cmake "${common[@]}" -G "Visual Studio 17 2022" -A x64
-          else
-            cmake "${common[@]}" -G Ninja \
-              -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
-          fi
-
-      - name: Build
-        shell: bash
-        run: cmake --build renderers/xr-composite/build --config Release
-
-      # The Visual Studio generator nests outputs under a per-config subdir; Ninja
-      # writes them at the build root. Stage both the binary and materials/ into a
-      # flat dist/ so the artifact layout is identical across platforms.
-      - name: Stage artifact
-        shell: bash
-        run: |
-          set -euo pipefail
-          build=renderers/xr-composite/build
-          dist=dist
-          rm -rf "$dist"
-          mkdir -p "$dist"
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            cp "$build/Release/xr-composite.exe" "$dist/"
-          else
-            cp "$build/xr-composite" "$dist/"
-          fi
-          cp -r "$build/materials" "$dist/materials"
-          ls -lR "$dist"
+          platform: ${{ matrix.platform }}
+          filament-version: ${{ env.FILAMENT_VERSION }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/xr-composite-build.yml
+++ b/.github/workflows/xr-composite-build.yml
@@ -1,0 +1,139 @@
+name: xr-composite build
+
+# Build the native xr-composite tool (renderers/xr-composite) against the pinned
+# Filament desktop SDK on Linux x86_64, macOS arm64, and Windows x86_64, and
+# upload each platform's binary + compiled materials as a CI artifact. Build-only:
+# no rendering, so no Xvfb / Mesa needed. Path-scoped so it never runs on
+# unrelated PRs.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'renderers/xr-composite/**'
+      - '.github/workflows/xr-composite-build.yml'
+  pull_request:
+    paths:
+      - 'renderers/xr-composite/**'
+      - '.github/workflows/xr-composite-build.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Per-PR group so concurrent PRs don't cancel each other; push + dispatch
+  # share one slot per ref.
+  group: xr-composite-build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FILAMENT_VERSION: v1.71.5
+
+jobs:
+  build:
+    name: build (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-x86_64
+            platform: linux
+            artifact: xr-composite-linux-x86_64
+          - os: macos-14
+            label: macos-arm64
+            platform: mac
+            artifact: xr-composite-macos-arm64
+          - os: windows-2022
+            label: windows-x86_64
+            platform: windows
+            artifact: xr-composite-windows-x86_64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Linux: Filament's release libs are built against libc++, so we build the
+      # tool with clang + libc++ to match the ABI. macOS (AppleClang) and Windows
+      # (MSVC) ship their toolchains preinstalled on the runner images.
+      - name: Install clang + libc++ (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            clang libc++-dev libc++abi-dev ninja-build
+        shell: bash
+
+      - name: Install Ninja (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ninja
+        shell: bash
+
+      # Cache the unpacked SDK keyed on version + platform so repeat runs skip the
+      # ~50-730 MB download. The download step below is a no-op on a cache hit.
+      - name: Cache Filament SDK
+        id: cache-sdk
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: filament-sdk
+          key: filament-${{ env.FILAMENT_VERSION }}-${{ matrix.platform }}
+
+      - name: Download Filament SDK
+        if: steps.cache-sdk.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p filament-sdk
+          tgz="filament-${FILAMENT_VERSION}-${{ matrix.platform }}.tgz"
+          url="https://github.com/google/filament/releases/download/${FILAMENT_VERSION}/${tgz}"
+          echo "Downloading ${url}"
+          curl -fL --retry 4 --retry-delay 2 -o "${tgz}" "${url}"
+          tar xzf "${tgz}" -C filament-sdk
+          rm -f "${tgz}"
+
+      # filament-sdk/filament/ is the unpacked SDK root (include/, lib/, bin/).
+      - name: Configure
+        shell: bash
+        run: |
+          set -euo pipefail
+          sdk="$PWD/filament-sdk/filament"
+          common=(-S renderers/xr-composite -B renderers/xr-composite/build
+                  -DCMAKE_BUILD_TYPE=Release "-DFILAMENT_SDK=${sdk}")
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            # MSVC multi-config generator; CMakeLists pins the static /MT runtime.
+            cmake "${common[@]}" -G "Visual Studio 17 2022" -A x64
+          else
+            cmake "${common[@]}" -G Ninja \
+              -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+          fi
+
+      - name: Build
+        shell: bash
+        run: cmake --build renderers/xr-composite/build --config Release
+
+      # The Visual Studio generator nests outputs under a per-config subdir; Ninja
+      # writes them at the build root. Stage both the binary and materials/ into a
+      # flat dist/ so the artifact layout is identical across platforms.
+      - name: Stage artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          build=renderers/xr-composite/build
+          dist=dist
+          rm -rf "$dist"
+          mkdir -p "$dist"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            cp "$build/Release/xr-composite.exe" "$dist/"
+          else
+            cp "$build/xr-composite" "$dist/"
+          fi
+          cp -r "$build/materials" "$dist/materials"
+          ls -lR "$dist"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/
+          if-no-files-found: error

--- a/.github/workflows/xr-composite-build.yml
+++ b/.github/workflows/xr-composite-build.yml
@@ -99,6 +99,12 @@ jobs:
         run: |
           set -euo pipefail
           sdk="$PWD/filament-sdk/filament"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            # CMake here is a native Windows binary; hand it a Windows-style path
+            # (C:/...) rather than the Git-bash MSYS path (/d/a/...) so the SDK
+            # EXISTS check in CMakeLists resolves.
+            sdk="$(cygpath -m "$sdk")"
+          fi
           common=(-S renderers/xr-composite -B renderers/xr-composite/build
                   -DCMAKE_BUILD_TYPE=Release "-DFILAMENT_SDK=${sdk}")
           if [ "$RUNNER_OS" = "Windows" ]; then

--- a/renderers/xr-composite/CMakeLists.txt
+++ b/renderers/xr-composite/CMakeLists.txt
@@ -80,8 +80,11 @@ target_link_directories(xr-composite PRIVATE "${FILAMENT_LIB_DIR}")
 target_link_libraries(xr-composite PRIVATE
   filament backend bluegl bluevk filabridge filaflat utils geometry smol-v ibl abseil zstd)
 if(APPLE)
+  # QuartzCore provides CAMetalLayer (referenced by Filament's Metal backend);
+  # Foundation backs the Objective-C runtime the .mm objects pull in.
   target_link_libraries(xr-composite PRIVATE
-    "-framework Cocoa" "-framework Metal" "-framework CoreVideo")
+    "-framework Cocoa" "-framework Metal" "-framework CoreVideo"
+    "-framework QuartzCore" "-framework Foundation")
 elseif(WIN32)
   # Per Filament's SDK README Windows recipe: the OpenGL backend needs the GDI,
   # user, and OpenGL system libs.

--- a/renderers/xr-composite/CMakeLists.txt
+++ b/renderers/xr-composite/CMakeLists.txt
@@ -18,17 +18,31 @@ if(NOT FILAMENT_SDK OR NOT EXISTS "${FILAMENT_SDK}/include/filament/Engine.h")
 endif()
 message(STATUS "Using Filament SDK: ${FILAMENT_SDK}")
 
-# Filament ships per-arch static libs under lib/<arch>/.
+# Filament ships per-arch static libs under lib/<arch>/. On Apple Silicon the
+# (universal) macOS tarball reports CMAKE_SYSTEM_PROCESSOR=arm64 -> lib/arm64,
+# which holds the arm64 slice.
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
   set(FILAMENT_ARCH "aarch64")
 else()
   set(FILAMENT_ARCH "x86_64")
 endif()
-set(FILAMENT_LIB_DIR "${FILAMENT_SDK}/lib/${FILAMENT_ARCH}")
+if(WIN32)
+  # Filament's Windows libs carry CRT-variant subdirs (mt/md/mtd/mdd); we link
+  # the static-CRT (/MT) variant, so the libs live under lib/<arch>/mt/.
+  set(FILAMENT_LIB_DIR "${FILAMENT_SDK}/lib/${FILAMENT_ARCH}/mt")
+else()
+  set(FILAMENT_LIB_DIR "${FILAMENT_SDK}/lib/${FILAMENT_ARCH}")
+endif()
+# CMake appends the platform tool suffix (.exe on Windows) when the command runs.
 set(MATC "${FILAMENT_SDK}/bin/matc")
 
-# Filament's Linux/macOS release libs are built against libc++; match the ABI.
-if(NOT APPLE)
+if(WIN32)
+  # MSVC uses its own C++ runtime (no -stdlib=libc++). Select the static CRT
+  # (/MT, /MTd for Debug) to match Filament's `mt` library variant; CMake's MSVC
+  # runtime abstraction (CMP0091) applies it to every target in the build.
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+elseif(NOT APPLE)
+  # Filament's Linux release libs are built against libc++; match the ABI.
   add_compile_options(-stdlib=libc++)
   add_link_options(-stdlib=libc++)
 endif()
@@ -58,11 +72,16 @@ target_include_directories(xr-composite PRIVATE
 target_link_directories(xr-composite PRIVATE "${FILAMENT_LIB_DIR}")
 
 # Link list extends the SDK README's recipe: + zstd (material shader decompression).
+# CMake resolves these names to lib<name>.a on Unix and <name>.lib on Windows.
 target_link_libraries(xr-composite PRIVATE
   filament backend bluegl bluevk filabridge filaflat utils geometry smol-v ibl abseil zstd)
 if(APPLE)
   target_link_libraries(xr-composite PRIVATE
     "-framework Cocoa" "-framework Metal" "-framework CoreVideo")
+elseif(WIN32)
+  # Per Filament's SDK README Windows recipe: the OpenGL backend needs the GDI,
+  # user, and OpenGL system libs.
+  target_link_libraries(xr-composite PRIVATE gdi32 user32 opengl32)
 else()
   target_link_libraries(xr-composite PRIVATE pthread c++ c++abi dl)
 endif()

--- a/renderers/xr-composite/CMakeLists.txt
+++ b/renderers/xr-composite/CMakeLists.txt
@@ -18,11 +18,15 @@ if(NOT FILAMENT_SDK OR NOT EXISTS "${FILAMENT_SDK}/include/filament/Engine.h")
 endif()
 message(STATUS "Using Filament SDK: ${FILAMENT_SDK}")
 
-# Filament ships per-arch static libs under lib/<arch>/. On Apple Silicon the
-# (universal) macOS tarball reports CMAKE_SYSTEM_PROCESSOR=arm64 -> lib/arm64,
-# which holds the arm64 slice.
+# Filament ships per-arch static libs under lib/<arch>/, but the 64-bit ARM dir
+# is spelled differently per platform: the macOS tarball uses lib/arm64 while
+# the Linux ARM tarball uses lib/aarch64. x86_64 is consistent everywhere.
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
-  set(FILAMENT_ARCH "aarch64")
+  if(APPLE)
+    set(FILAMENT_ARCH "arm64")
+  else()
+    set(FILAMENT_ARCH "aarch64")
+  endif()
 else()
   set(FILAMENT_ARCH "x86_64")
 endif()

--- a/renderers/xr-composite/src/main.cpp
+++ b/renderers/xr-composite/src/main.cpp
@@ -46,13 +46,16 @@
 #include <sstream>
 #include <string>
 #include <vector>
-#include <unistd.h>
 
 using namespace filament;
 using namespace filament::math;
 using json = nlohmann::json;
 
 namespace {
+
+// MSVC's <cmath> only defines M_PI when _USE_MATH_DEFINES is set before the
+// include; a local constant keeps the source portable across compilers.
+constexpr double kPi = 3.14159265358979323846;
 
 struct Args {
   std::string sceneDir;
@@ -243,8 +246,8 @@ int main(int argc, char** argv) {
   float3 target = {cam["target"].value("x", 0.0f), cam["target"].value("y", 0.0f),
                    cam["target"].value("z", 0.0f)};
   double distance = cam.value("distance", 1200.0);
-  double yaw = cam.value("yawDeg", 0.0) * M_PI / 180.0;
-  double pitch = cam.value("pitchDeg", -10.0) * M_PI / 180.0;
+  double yaw = cam.value("yawDeg", 0.0) * kPi / 180.0;
+  double pitch = cam.value("pitchDeg", -10.0) * kPi / 180.0;
   float3 dir = {(float)(std::cos(pitch) * std::sin(yaw)), (float)std::sin(pitch),
                 (float)(std::cos(pitch) * std::cos(yaw))};
   float3 eye = target + dir * (float)distance;
@@ -285,5 +288,7 @@ int main(int argc, char** argv) {
 
   // Spike: skip explicit Filament teardown (asserts on destroy order); the process exits here.
   fflush(stderr);
-  _exit(0);
+  // std::_Exit terminates without running destructors/atexit (portable equivalent
+  // of POSIX _exit); avoids Filament's teardown-order asserts on all platforms.
+  std::_Exit(0);
 }


### PR DESCRIPTION
## Summary

Adds a path-scoped GitHub Actions workflow that builds the native `xr-composite` tool (`renderers/xr-composite/`) against the pinned Filament desktop SDK (`v1.71.5`) on three targets and uploads each as a CI artifact:

- **Linux x86_64** — `ubuntu-latest`, clang + libc++ (matches Filament's release ABI)
- **macOS arm64** — `macos-14`, AppleClang, picks `lib/arm64` from the universal tarball
- **Windows x86_64** — `windows-2022`, MSVC, static `/MT` CRT

Build-only (no rendering), so no Xvfb/Mesa. The SDK download is cached per version+platform. Triggers on `push` to `main`, `pull_request`, and `workflow_dispatch`, all scoped to `renderers/xr-composite/**` and the workflow file.

Also makes the source portable to Windows/MSVC (it was written Linux-first):

- `src/main.cpp`: drop the `unistd.h` include / `_exit(0)` in favour of `std::_Exit(0)` from `cstdlib`; replace `M_PI` (undefined on MSVC without `_USE_MATH_DEFINES`) with a local `constexpr kPi`.
- `CMakeLists.txt`: add a Windows/MSVC branch — link Filament libs from `lib/<arch>/mt/`, select the static `/MT` CRT via `CMAKE_MSVC_RUNTIME_LIBRARY`, and link `gdi32`/`user32`/`opengl32` per the SDK README's Windows recipe. Linux libc++ and macOS framework branches unchanged.

## Test plan

- [x] Linux build verified locally in-container (clang 18 / cmake / ninja), Filament `v1.71.5` SDK downloaded and linked, binary + `materials/*.filamat` produced.
- [x] CMake reconfigure + rebuild after the Windows branch was added — Linux still green.
- [ ] CI matrix green on all three OSes (linux x86_64 / macos arm64 / windows x86_64), each uploading its `xr-composite[.exe]` + `materials/` artifact.