### PR TITLE
feat(plugin): show XR subspace composites in the preview manifest

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -71,6 +71,12 @@ data class Capture(
   val advanceTimeMillis: Long? = null,
   val scroll: ScrollCapture? = null,
   val renderOutput: String = "",
+  /**
+   * `true` → best-effort capture: displayed if present, but not required by the missing-render gate
+   * (e.g. the XR subspace composite still baked by the native `xr-composite` tool, which may be
+   * absent when the binary / display / software GL isn't available). Defaults to `false`.
+   */
+  val optional: Boolean = false,
 )
 
 @Serializable

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -378,6 +378,14 @@ data class Capture(
   /** Module-relative PNG path, e.g. `renders/<preview id>_TIME_500ms.png`. */
   val renderOutput: String = "",
   /**
+   * `true` → best-effort capture: displayed if its file exists, but NOT required by
+   * `composePreviewRenderAll`'s missing-render gate. Used for artefacts produced by an optional,
+   * out-of-band tool that may be absent (no binary / display / software GL) — for example the XR
+   * subspace composite still baked by the native `xr-composite` renderer. Defaults to `false` so
+   * existing captures stay required and older manifests are unchanged.
+   */
+  val optional: Boolean = false,
+  /**
    * Estimated render cost, normalised so a static `@Preview` is `1.0`. See the cost catalogue at
    * the top of this file ([STATIC_COST], [SCROLL_LONG_COST], [ANIMATION_COST], …) for the figures
    * the discovery task stamps in. Defaults to `1.0` so older manifests (pre-cost field) parse as

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -949,16 +949,26 @@ object PreviewDiscovery {
     // focus owner here — the `:renderer-xr` task drives the whole recover-and-write in one shot.
     // Gate them out of every dimensional fan-out the same way as tile / notification / glance.
     val isXrSubspace = ann.name == XR_SUBSPACE_PREVIEW_FQN
-    // XR subspace previews don't render a PNG — the opt-in `composePreviewRenderXr` task writes a
-    // `scene.json` (keyed off the preview's id/class/function, not these outputs). Emit NO captures
-    // and NO data products so `composePreviewRenderAll`'s missing-render validation expects neither
-    // a
-    // PNG (which is never produced) nor a scene.json (which isn't produced at all when a consumer
-    // declares `@XrSubspacePreview` but leaves `enableXrPreviews` off). The XR render is validated
-    // by
-    // `:renderer-xr`'s own tests + the sample run, not by the standard render gate.
+    // XR subspace previews don't render a PNG through the Robolectric path — the opt-in
+    // `composePreviewRenderXr` task writes a `scene.json` (+ one `<panelId>.png` texture per panel)
+    // into `renders/<sanitizedId>/`, and the optional `composePreviewCompositeXr` task bakes a
+    // single `composite.png` still from that scene via the native `xr-composite` tool. Emit ONE
+    // optional capture pointing at that composite so it shows up in the preview listing when
+    // present, but is NOT required by `composePreviewRenderAll`'s missing-render gate — the
+    // composite is best-effort (it's absent when the binary / display / software GL isn't
+    // available, or when a consumer declares `@XrSubspacePreview` but leaves `enableXrPreviews`
+    // off). The subdir uses the SAME sanitisation as `XrSubspaceRenderTest.sanitize`
+    // (`[^A-Za-z0-9._-]` → `_`, keeping dots) so the path matches the render subdir on disk.
+    // `normalizeRenderOutputs`/`rewriteRenderStem` only rewrite the leaf when it starts with the
+    // preview's stem; the leaf here is the literal `composite.png`, so the per-preview subdir path
+    // stays stable. No data products.
     if (isXrSubspace) {
-      return PreviewOutputPlan(captures = emptyList(), dataProducts = emptyList())
+      val sanitizedId = previewId.replace(Regex("[^A-Za-z0-9._-]"), "_")
+      return PreviewOutputPlan(
+        captures =
+          listOf(Capture(renderOutput = "renders/$sanitizedId/composite.png", optional = true)),
+        dataProducts = emptyList(),
+      )
     }
     val nonComposable = isTile || isNotification || isGlanceAppWidget || isXrSubspace
     val effectiveTimings = if (nonComposable) emptyList() else timings

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -1685,10 +1685,16 @@ class DiscoveryFunctionalTest {
     val xrPreviews = manifest.previews.filter { it.functionName == "MySpatialPreview" }
     assertThat(xrPreviews.map { it.functionName }).containsExactly("MySpatialPreview")
     assertThat(xrPreviews.map { it.params.kind }.toSet()).containsExactly(PreviewKind.XR_SUBSPACE)
-    // XR subspace previews emit NO PNG capture (and no data product) — their output is the
-    // scene.json written by composePreviewRenderXr, so composePreviewRenderAll's missing-render
-    // gate must expect nothing for them. Also no target inference (non-composable kind).
-    assertThat(xrPreviews.single().captures).isEmpty()
+    // XR subspace previews emit a SINGLE optional composite capture (and no data product). The
+    // composite.png is baked out-of-band by `composePreviewCompositeXr` from the scene.json
+    // `composePreviewRenderXr` writes; marking it `optional = true` means it shows in the listing
+    // when present but composePreviewRenderAll's missing-render gate never requires it. The subdir
+    // uses the same `[^A-Za-z0-9._-]` → `_` sanitisation as the render task. Also no target
+    // inference (non-composable kind).
+    val xrCapture = xrPreviews.single().captures.single()
+    val sanitizedId = xrPreviews.single().id.replace(Regex("[^A-Za-z0-9._-]"), "_")
+    assertThat(xrCapture.renderOutput).isEqualTo("renders/$sanitizedId/composite.png")
+    assertThat(xrCapture.optional).isTrue()
     assertThat(xrPreviews.single().dataProducts).isEmpty()
     assertThat(xrPreviews.flatMap { it.targets }).isEmpty()
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1450,6 +1450,26 @@ internal object AndroidPreviewSupport {
     val dataProductsDirectory = previewOutputDir.map { it.dir("data") }
     val rendersDir = rendersDirectory.map { it.asFile.absolutePath }
 
+    // Resolve the optional `xr-composite` native tool location at CONFIG time (Isolated Projects is
+    // on / the configuration cache is strict — the task action must not touch `project.*`). The
+    // binary comes from the `composePreview.xrCompositeBinary` Gradle property or the
+    // `XR_COMPOSITE_BIN` env var; the materials dir from `composePreview.xrCompositeMaterials` or,
+    // by default, `<binaryDir>/materials` (where `build.sh` emits it next to the binary). All three
+    // providers may be absent — the task degrades gracefully (logs + skips) when the binary isn't
+    // configured / found.
+    val xrCompositeBinary =
+      project.providers
+        .gradleProperty("composePreview.xrCompositeBinary")
+        .orElse(project.providers.environmentVariable("XR_COMPOSITE_BIN"))
+    val xrCompositeMaterials =
+      project.providers
+        .gradleProperty("composePreview.xrCompositeMaterials")
+        .orElse(
+          xrCompositeBinary.map {
+            java.io.File(it).absoluteFile.parentFile.resolve("materials").path
+          }
+        )
+
     // ATF / hierarchy data products are produced only by the daemon path
     // (`:daemon:android`'s RenderEngine). The standalone Robolectric `composePreviewRender` Test
     // task
@@ -1818,6 +1838,116 @@ internal object AndroidPreviewSupport {
         )
       }
 
+    // Bake the XR subspace scenes into composite stills via the native `xr-composite` tool. Runs
+    // after `composePreviewRenderXr` (which writes each `renders/<dir>/scene.json` + panel
+    // textures) and BEFORE the renderAll validation/clean step so the gate sees the produced
+    // composites and `cleanStaleRenders` keeps them (they're referenced by the manifest's optional
+    // capture). Degrades gracefully: a missing / unconfigured binary, or no display + no
+    // `xvfb-run`,
+    // logs at lifecycle level and returns without failing — the optional capture simply has no
+    // file.
+    if (xrPreviewsEnabled)
+      project.tasks.register("composePreviewCompositeXr", org.gradle.api.DefaultTask::class.java) {
+        group = "compose preview"
+        description = "Bake XR subspace scene.json files into composite.png stills via xr-composite"
+        // Captured as providers at config time — the doLast body never touches `project.*` (IP /
+        // strict configuration cache).
+        val binaryProvider = xrCompositeBinary
+        val materialsProvider = xrCompositeMaterials
+        val rendersDirProvider = rendersDirectory
+        // The render dir is shared with `composePreviewRender` (PNGs) and `composePreviewRenderXr`
+        // (scene.json + panel textures). This task both reads it (scene.json) and writes into it
+        // (composite.png), so declaring it as a tracked input/output would clash with those
+        // producers' outputs and with this task's own writes. Instead we stay untracked and order
+        // explicitly: depend on the XR render (our real producer) and run after the PNG render
+        // (the other writer to the shared dir). Best-effort + native-shell-out means there's no
+        // useful up-to-date / caching story to gain from tracking anyway.
+        dependsOn("composePreviewRenderXr")
+        mustRunAfter("composePreviewRender")
+        doLast {
+          val binaryPath = binaryProvider.orNull
+          val rendersRoot = rendersDirProvider.get().asFile
+          if (binaryPath.isNullOrBlank()) {
+            logger.lifecycle("xr-composite binary not found; skipping XR composite stills")
+            return@doLast
+          }
+          val binary = java.io.File(binaryPath)
+          if (!binary.isFile) {
+            logger.lifecycle(
+              "xr-composite binary not found at $binaryPath; skipping XR composite stills"
+            )
+            return@doLast
+          }
+          if (!rendersRoot.isDirectory) {
+            logger.lifecycle("no XR renders dir at $rendersRoot; skipping XR composite stills")
+            return@doLast
+          }
+          // `xr-composite` is an OpenGL/Filament tool — it needs a display. When `DISPLAY` is unset
+          // we wrap the invocation in `xvfb-run -a` if available; otherwise we skip gracefully
+          // rather than failing the build (the composite is best-effort).
+          val hasDisplay = !System.getenv("DISPLAY").isNullOrBlank()
+          val xvfbRun =
+            if (hasDisplay) null
+            else
+              sequenceOf("/usr/bin/xvfb-run", "/usr/local/bin/xvfb-run")
+                .map { java.io.File(it) }
+                .firstOrNull { it.isFile }
+                ?.path
+                ?: run {
+                  if (
+                    ProcessBuilder("which", "xvfb-run")
+                      .redirectErrorStream(true)
+                      .start()
+                      .waitFor() == 0
+                  )
+                    "xvfb-run"
+                  else null
+                }
+          if (!hasDisplay && xvfbRun == null) {
+            logger.lifecycle(
+              "DISPLAY unset and xvfb-run not available; skipping XR composite stills"
+            )
+            return@doLast
+          }
+          val materialsDir = materialsProvider.orNull
+          val scenes =
+            rendersRoot
+              .listFiles()
+              ?.filter { it.isDirectory }
+              ?.map { java.io.File(it, "scene.json") }
+              ?.filter { it.isFile }
+              .orEmpty()
+          if (scenes.isEmpty()) {
+            logger.lifecycle("no XR scene.json files under $rendersRoot; nothing to composite")
+            return@doLast
+          }
+          var baked = 0
+          for (scene in scenes) {
+            val outFile = java.io.File(scene.parentFile, "composite.png")
+            val cmd = mutableListOf<String>()
+            if (xvfbRun != null) {
+              cmd += xvfbRun
+              cmd += "-a"
+            }
+            cmd += binary.absolutePath
+            cmd += listOf("--scene", scene.absolutePath, "--out", outFile.absolutePath)
+            if (!materialsDir.isNullOrBlank()) cmd += listOf("--materials", materialsDir)
+            cmd += listOf("--width", "1280", "--height", "800")
+            val process = ProcessBuilder(cmd).redirectErrorStream(true).start()
+            val output = process.inputStream.bufferedReader().readText()
+            val code = process.waitFor()
+            if (code != 0 || !outFile.isFile) {
+              logger.lifecycle(
+                "xr-composite failed for ${scene.parentFile.name} (exit $code); skipping. Output:\n$output"
+              )
+            } else {
+              baked++
+            }
+          }
+          logger.lifecycle("xr-composite baked $baked of ${scenes.size} XR composite still(s)")
+        }
+      }
+
     // `aggregateAccessibility` was the rollup task that turned per-preview ATF sidecars into a
     // top-level `accessibility.json`. With a11y now produced exclusively by the daemon (which
     // streams findings on demand via `data/fetch`), nothing on the standalone Gradle path
@@ -1825,11 +1955,15 @@ internal object AndroidPreviewSupport {
     // registered.
 
     ComposePreviewTasks.registerRenderAllPreviews(project, extension, renderTask, previewOutputDir)
-    // Fold the XR render into the user-facing aggregate so `composePreviewRenderAll` produces
-    // scene.json alongside the PNGs (only when the XR path is enabled / the task exists).
+    // Fold the XR render + composite into the user-facing aggregate so `composePreviewRenderAll`
+    // produces scene.json alongside the PNGs, then bakes the composite stills (only when the XR
+    // path is enabled / the tasks exist). `composePreviewCompositeXr` itself `dependsOn`
+    // `composePreviewRenderXr`, so both run before the renderAll `doLast` validation/clean — the
+    // gate sees the produced composites and `cleanStaleRenders` keeps them.
     if (xrPreviewsEnabled) {
       project.tasks.named("composePreviewRenderAll").configure {
         dependsOn("composePreviewRenderXr")
+        dependsOn("composePreviewCompositeXr")
       }
     }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1243,6 +1243,10 @@ internal object ComposePreviewTasks {
       .filter { p ->
         val captureMissing =
           p.captures.any { c ->
+            // Optional captures are best-effort (e.g. the XR composite still baked out-of-band by
+            // the native `xr-composite` tool): shown when present, never required — so a missing
+            // one is not flagged.
+            if (c.optional) return@any false
             if (isFastTier && isHeavyCost(c.cost)) return@any false
             val rel = c.renderOutput.ifEmpty { "renders/${p.id}.png" }
             outputMissing(

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
@@ -110,4 +110,37 @@ class CleanStaleRendersTest {
     assertThat(ComposePreviewTasks.missingPreviewOutputIds(manifest, outDir, isFastTier = true))
       .isEmpty()
   }
+
+  @Test
+  fun `optional capture never counted as missing`() {
+    val outDir = tempDir.root.resolve("build/compose-previews")
+    // The XR composite is an `optional = true` capture: best-effort, baked out-of-band by the
+    // native `xr-composite` tool. When the file is absent (no binary / display / software GL) the
+    // missing-render gate must not flag it — same graceful degradation as before the capture
+    // existed.
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews =
+          listOf(
+            PreviewInfo(
+              id = "com.example.PreviewsKt.SpatialPreview",
+              functionName = "SpatialPreview",
+              className = "com.example.PreviewsKt",
+              params = PreviewParams(kind = PreviewKind.XR_SUBSPACE),
+              captures =
+                listOf(
+                  Capture(
+                    renderOutput = "renders/com.example.PreviewsKt.SpatialPreview/composite.png",
+                    optional = true,
+                  )
+                ),
+            )
+          ),
+      )
+
+    assertThat(ComposePreviewTasks.missingPreviewOutputIds(manifest, outDir, isFastTier = false))
+      .isEmpty()
+  }
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -5177,9 +5177,13 @@ async function refresh(
                                     captureIndex: idx,
                                     imageData,
                                 });
-                            } else if (forceRender) {
+                            } else if (forceRender && !capture.optional) {
                                 // Render task completed but produced no PNG for this
-                                // capture. Look for the per-preview error sidecar
+                                // capture. (Optional captures — e.g. the XR composite,
+                                // baked only when the native xr-composite binary + display
+                                // are available — are best-effort: a missing one is expected,
+                                // never a render failure, so don't surface an error for it.)
+                                // Look for the per-preview error sidecar
                                 // the renderer drops next to the would-be PNG; if
                                 // found, surface the structured exception detail
                                 // (class, message, top app frame). Falls back to

--- a/vscode-extension/src/previewConsistency.ts
+++ b/vscode-extension/src/previewConsistency.ts
@@ -136,6 +136,10 @@ export function manifestExpectedFilesMissing(
     for (const preview of manifest.previews) {
         for (const capture of preview.captures) {
             if (!capture.renderOutput) continue;
+            // Optional captures (e.g. the XR `composite.png`, baked only when the native
+            // xr-composite binary + display are available) are best-effort: their absence is
+            // expected, not drift, so it must not escalate a discover-only pass to a full render.
+            if (capture.optional) continue;
             if (!hasOutputOrSidecar(capture.renderOutput)) return true;
         }
         for (const product of preview.dataProducts ?? []) {

--- a/vscode-extension/src/test/previewConsistency.test.ts
+++ b/vscode-extension/src/test/previewConsistency.test.ts
@@ -537,6 +537,33 @@ describe("manifestExpectedFilesMissing", () => {
         );
     });
 
+    it("returns false when only an optional capture is missing", () => {
+        // The XR composite is an optional, best-effort capture — baked only when the native
+        // xr-composite binary + display are available — so its absence must not read as drift
+        // and escalate a discover-only pass into a full render.
+        const p = {
+            ...preview("com.example.XrPreview", "renders/XrPreview.png"),
+            captures: [
+                {
+                    advanceTimeMillis: null,
+                    scroll: null,
+                    renderOutput: "renders/XrPreview/composite.png",
+                    optional: true,
+                },
+            ],
+        } as unknown as PreviewInfo;
+        const disk = new Set<string>(); // composite.png absent on disk
+        assert.strictEqual(
+            manifestExpectedFilesMissing(
+                "/ws",
+                module,
+                { previews: [p] } as PreviewManifest,
+                (path) => disk.has(path),
+            ),
+            false,
+        );
+    });
+
     it("returns true when a data-product output is missing even if the static capture exists", () => {
         // The scenario from the original drift report: discover returned a manifest with new-
         // shape data-product paths under `data/render-scroll-long/`, but the renderer never

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -70,6 +70,14 @@ export interface Capture {
     advanceTimeMillis: number | null;
     scroll: ScrollCapture | null;
     renderOutput: string;
+    /**
+     * `true` → best-effort capture: displayed if its file exists, but not
+     * required by the missing-render gate (e.g. the XR subspace composite
+     * still baked by the native `xr-composite` tool, which may be absent
+     * when the binary / display / software GL isn't available). Missing
+     * (older manifests) is treated as `false`.
+     */
+    optional?: boolean;
     /** Human-readable summary of this capture's non-null dimensions —
      *  e.g. `'500ms'`, `'scrolled end'`, `'500ms · scrolled end'`, or `''`
      *  for a plain static preview. Populated extension-side (see


### PR DESCRIPTION
## Summary

Make `@XrSubspacePreview` previews show a baked composite still in the normal preview listing/manifest, produced by running the native `xr-composite` tool after the XR scene render — degrading gracefully when the binary / display / software-GL isn't available.

- Add a best-effort `Capture.optional` flag (default `false`) to the discovery model, `:preview-data-api`, and the VS Code `types.ts` mirror. An optional capture is displayed when its file exists but is never required by the missing-render gate.
- Discovery now emits a single optional capture for XR subspace previews, `renders/{sanitizedId}/composite.png`, where the subdir uses the same `[^A-Za-z0-9._-]` → `_` sanitisation as `XrSubspaceRenderTest`, instead of emitting no captures. `rewriteRenderStem` only rewrites the leaf when it starts with the preview stem, so the per-preview subdir path stays stable. No data products.
- The missing-render gate (`missingPreviewOutputIds`) skips optional captures, so an absent composite is never flagged — same graceful behavior as before. `cleanStaleRenders` already keeps the composite when present (it's referenced by the manifest).
- New `composePreviewCompositeXr` task (gated on `enableXrPreviews`, `dependsOn composePreviewRenderXr`, `mustRunAfter composePreviewRender`): resolves the binary from `composePreview.xrCompositeBinary` / `XR_COMPOSITE_BIN` and materials from `composePreview.xrCompositeMaterials` / `{binaryDir}/materials` as config-time providers (IP / strict config cache safe). For each `renders/{dir}/scene.json` it invokes the binary via `ProcessBuilder` to write `composite.png`, wrapping in `xvfb-run -a` when `DISPLAY` is unset. Missing/unconfigured binary or no display + no xvfb-run logs at lifecycle and returns without failing. Folded into `composePreviewRenderAll` ahead of its validation/clean step.
- Updated `DiscoveryFunctionalTest` to expect the optional composite capture, and added a `CleanStaleRendersTest` case asserting an optional capture is never counted as missing.

## Test plan

- `:gradle-plugin:test --tests CleanStaleRendersTest` and `:gradle-plugin:functionalTest --tests DiscoveryFunctionalTest` — green.
- `:renderer-xr:test` — green.
- Built the binary in-container (`FILAMENT_VERSION=v1.71.5 ./renderers/xr-composite/build.sh`).
- **Positive path:** `LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe ./gradlew :samples:xr-spatial:composePreviewRenderAll -PcomposePreview.xrCompositeBinary=$PWD/renderers/xr-composite/build/xr-composite` — build green, task logged `xr-composite baked 1 of 1 XR composite still(s)`, produced a valid 1280x800 RGBA PNG at `samples/xr-spatial/build/compose-previews/renders/com.example.samplexrspatial.XrSubspacePreviewsKt.NowPlayingSpatialPreview/composite.png`, and `previews.json` lists the XR preview's optional capture `renders/.../composite.png` with `optional: true`.
- **Graceful path:** `./gradlew :samples:xr-spatial:composePreviewRenderAll` without the binary property — build green, composite absent, gate did not fail, task logged `xr-composite binary not found; skipping XR composite stills`. A previously-baked composite is preserved across a no-binary run (referenced by the manifest).