### PR TITLE
ci: bake the xr-spatial composite end-to-end on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,68 @@ jobs:
       - name: Build CLI
         run: ./gradlew :cli:build
 
+  # End-to-end gate for the XR composite still: build the native xr-composite binary, then run
+  # the xr-spatial sample's full render so composePreviewRenderXr writes scene.json + panel
+  # textures and composePreviewCompositeXr bakes composite.png from them — headless, no GPU.
+  # This is otherwise only exercised by hand, so without a gate the binary↔plugin contract
+  # (CLI flags, sanitised composite path, the optional capture in previews.json) can silently
+  # rot. The graceful no-binary path is covered by the plugin unit/functional tests.
+  render-xr-composite:
+    name: Render XR composite (sample)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      # Build the compositor (clang + libc++ against the pinned Filament SDK) and its compiled
+      # materials into dist/ — the same composite action the build/release workflows use.
+      - uses: ./.github/actions/build-xr-composite
+        with:
+          platform: linux
+      # The prebuilt Filament Linux backend is GLX-only, so headless rendering needs a virtual
+      # X display (Xvfb) routed to Mesa's llvmpipe software rasteriser — no GPU required.
+      - name: Install Xvfb + Mesa software GL
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xvfb libgl1-mesa-dri libglx-mesa0
+      # Run the whole render under Xvfb (so DISPLAY is set) with --no-daemon (so the composite
+      # task's subprocess inherits the software-GL env from this step rather than a stale daemon).
+      - name: Render xr-spatial sample (bake composite)
+        shell: bash
+        env:
+          LIBGL_ALWAYS_SOFTWARE: '1'
+          GALLIUM_DRIVER: llvmpipe
+        run: |
+          xvfb-run -a -s "-screen 0 2000x1400x24" \
+            ./gradlew --no-daemon :samples:xr-spatial:composePreviewRenderAll \
+              -PcomposePreview.xrCompositeBinary="$PWD/dist/xr-composite" \
+              -PcomposePreview.xrCompositeMaterials="$PWD/dist/materials" \
+              --stacktrace
+      - name: Assert composite baked + referenced in the manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          base=samples/xr-spatial/build/compose-previews
+          png="$(find "$base/renders" -name composite.png -print -quit)"
+          if [ -z "$png" ] || [ ! -s "$png" ]; then
+            echo "::error::no non-empty composite.png under $base/renders"
+            find "$base/renders" -maxdepth 2 -type f | sort || true
+            exit 1
+          fi
+          file "$png" | grep -q 'PNG image data' || { echo "::error::$png is not a PNG"; exit 1; }
+          grep -q 'composite.png' "$base/previews.json" \
+            || { echo "::error::previews.json has no composite capture"; exit 1; }
+          echo "OK: baked $png ($(du -h "$png" | cut -f1)), referenced in previews.json"
+      - name: Upload XR composite
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: xr-spatial-composite
+          path: samples/xr-spatial/build/compose-previews/renders/**/composite.png
+          if-no-files-found: warn
+
   bundle-render:
     name: Bundle Render E2E
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a **continuous end-to-end gate** for the XR composite still — the first thing that actually *runs* the `xr-composite` binary against the real pipeline (until now it was only exercised by hand).

New `Render XR composite (sample)` job in `ci.yml`:
1. Builds the native binary + compiled materials via the shared `./.github/actions/build-xr-composite` action (clang + libc++ against the pinned Filament SDK).
2. Provisions **Xvfb + Mesa llvmpipe** (the prebuilt Filament Linux backend is GLX-only → needs a virtual display routed to software GL; no GPU).
3. Runs `:samples:xr-spatial:composePreviewRenderAll` with `-PcomposePreview.xrCompositeBinary`/`xrCompositeMaterials`, under `xvfb-run` + `--no-daemon` so the composite task's subprocess inherits the software-GL env.
4. Asserts a non-empty `composite.png` under `renders/` **and** a `composite.png` capture in `previews.json`; uploads the still as an artifact.

This guards the binary↔plugin contract (CLI flags, the sanitised composite path, the optional capture in the manifest) against silent rot. The graceful no-binary path stays covered by the plugin unit/functional tests.

## Why

Per the post-merge review of the panels feature: the plugin logic and the published binaries both shipped, but **nothing continuously verified the actual render path**. This closes that gap on Linux. (macOS/Windows binaries still compile-only / runtime-unverified — a separate follow-up; headless software GL there isn't a given on CI runners.)

## Test plan

- [x] `ci.yml` parses; job mirrors existing sample-render jobs + the build-xr-composite action.
- [ ] CI green on this PR (the new job builds the binary, bakes the sample composite under Xvfb+llvmpipe, and asserts the PNG + manifest entry) — watching.