### PR TITLE
feat(cli): auto-provision the xr-composite binary from releases

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -349,6 +349,45 @@ abstract class Command(
   }
 
   /**
+   * Auto-provision the native `xr-composite` binary into the shared cache the plugin's
+   * `composePreviewCompositeXr` task discovers, but ONLY when there's XR work to do. Runs
+   * `composePreviewDiscover` first (cheap + UP-TO-DATE on warm builds) so we can read each module's
+   * `previews.json` and gate the network fetch on the presence of an `XR_SUBSPACE` preview — a
+   * non-XR render never touches the network. On any failure (offline, no Release asset for a
+   * `-SNAPSHOT`, 404) the provisioner logs a concise note and returns without failing, so the
+   * render proceeds exactly as before (the composite still is best-effort, like the plugin's
+   * graceful skip).
+   *
+   * Returns the extra Gradle arguments the render should carry —
+   * `-PcomposePreview.xrCompositeBinary =<path>` when a binary was provisioned (so the render uses
+   * it explicitly even if cache discovery misfires), else empty. Discovery via the cache path is
+   * the general mechanism; passing the property is a belt-and-braces handoff.
+   */
+  protected fun provisionXrCompositeArgs(
+    gradle: GradleConnection,
+    modules: List<PreviewModule>,
+    silenceStdout: Boolean,
+  ): List<String> {
+    if (modules.isEmpty()) return emptyList()
+    // Discover first so previews.json exists; renderAll depends on discover anyway, so on a warm
+    // build this is a no-op UP-TO-DATE pass. A discovery failure isn't fatal here — the subsequent
+    // render will surface it; we just can't gate, so we skip provisioning.
+    val discoverOk =
+      withGradleStdout(silenceStdout) {
+        val tasks = modules.map { ":${it.gradlePath}:composePreviewDiscover" }.toTypedArray()
+        runGradle(gradle, *tasks)
+      }
+    if (!discoverOk) return emptyList()
+    val hasXr =
+      readAllManifests(modules).any { (_, manifest) ->
+        manifest.previews.any { it.params.kind == XrCompositeProvision.XR_SUBSPACE_KIND }
+      }
+    if (!hasXr) return emptyList()
+    val binary = XrCompositeProvision.ensureCached(BUNDLE_VERSION) ?: return emptyList()
+    return listOf("-PcomposePreview.xrCompositeBinary=${binary.absolutePath}")
+  }
+
+  /**
    * Outcome of [renderAllModules] — the full result of "discover preview modules, run their
    * `:composePreviewRenderAll` tasks, read each module's manifest, and build the merged
    * [PreviewResult] list." Each subcommand decides what to do with this (filter, format, exit code)
@@ -401,10 +440,11 @@ abstract class Command(
       val buildOk =
         if (modules.isEmpty()) true
         else {
+          val xrArgs = provisionXrCompositeArgs(gradle, modules, silenceStdout)
           val tasks = modules.map(taskFor).toTypedArray()
           val ok =
             withGradleStdout(silenceStdout) {
-              runGradle(gradle, *tasks, arguments = gradleArguments)
+              runGradle(gradle, *tasks, arguments = gradleArguments + xrArgs)
             }
           if (!ok) reportRenderFailures(gradle)
           ok
@@ -883,8 +923,11 @@ class RenderCommand(args: List<String>) : Command(args) {
   override fun run() {
     withGradle { gradle ->
       val modules = resolveModules(gradle)
+      val xrArgs = provisionXrCompositeArgs(gradle, modules, silenceStdout = false)
       val tasks = previewTasksFor(modules.map { it.gradlePath }).toTypedArray()
-      if (!runGradle(gradle, *tasks, arguments = gradleArgsWithForce(bundleGradleArgs()))) {
+      if (
+        !runGradle(gradle, *tasks, arguments = gradleArgsWithForce(bundleGradleArgs()) + xrArgs)
+      ) {
         reportRenderFailures(gradle)
         exitProcess(2)
       }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/XrCompositeProvision.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/XrCompositeProvision.kt
@@ -1,0 +1,212 @@
+package ee.schimke.composeai.cli
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.copyTo
+import java.io.File
+import java.util.UUID
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Auto-provisions the native `xr-composite` binary so XR "panels-in-previews" composites bake with
+ * zero manual setup after a release. The CLI is the *writer* of a well-known cache that the Gradle
+ * plugin's `composePreviewCompositeXr` task *reads* (see
+ * `AndroidPreviewSupport.xrCompositeCacheBinaryPath` for the matching reader-side path derivation —
+ * the two must stay in sync, exactly like the `BUNDLE_VERSION` / `PluginVersion` split across the
+ * includeBuild boundary).
+ *
+ * Flow, driven from the render commands before they invoke `composePreviewRenderAll`:
+ * 1. Gate on XR work — only fetch when a discovered preview is `kind == "XR_SUBSPACE"` (the CLI
+ *    learns this from `previews.json` after discovery). A non-XR render never touches the network.
+ * 2. If the version+platform binary is already cached, do nothing (idempotent — the common case
+ *    after the first run).
+ * 3. Otherwise download the per-OS Release tarball, unpack it into the cache (binary +
+ *    `materials/`) and continue.
+ *
+ * Best-effort by contract: ANY failure (offline, 404 for a `-SNAPSHOT` with no published asset,
+ * unsupported platform, corrupt archive) logs a concise note to stderr and returns without failing
+ * the render — mirroring the plugin task's graceful skip. The composite still is an optional
+ * capture.
+ *
+ * The daemon path does NOT auto-provision yet; that's a follow-up tied to the daemon actually
+ * producing composites (the renderer-service RFC). Today only the CLI→Gradle path bakes composites.
+ */
+object XrCompositeProvision {
+  /** `params.kind` value discovery stamps onto XR subspace previews in `previews.json`. */
+  internal const val XR_SUBSPACE_KIND = "XR_SUBSPACE"
+
+  /**
+   * Pure platform token derivation from JVM `os.name` / `os.arch`, matching the Release asset
+   * matrix in `.github/workflows/release.yml` (`build-xr-composite`):
+   * - linux + x86_64/amd64 → `linux-x86_64`
+   * - mac + aarch64/arm64 → `macos-arm64`
+   * - windows + amd64/x86_64 → `windows-x86_64`
+   *
+   * Returns `null` for any other combination (e.g. linux-arm64, mac-x86_64) — no asset is published
+   * for it, so the caller skips provisioning rather than fetching a 404. Kept pure (params, not
+   * `System.getProperty`) so unit tests can exercise every matrix cell.
+   */
+  internal fun platformToken(osName: String, osArch: String): String? {
+    val os = osName.lowercase()
+    val arch = osArch.lowercase()
+    return when {
+      os.contains("linux") && (arch == "x86_64" || arch == "amd64") -> "linux-x86_64"
+      (os.contains("mac") || os.contains("darwin")) && (arch == "aarch64" || arch == "arm64") ->
+        "macos-arm64"
+      os.contains("windows") && (arch == "amd64" || arch == "x86_64") -> "windows-x86_64"
+      else -> null
+    }
+  }
+
+  /** Current host's platform token, or `null` when no Release asset targets it. */
+  internal fun currentPlatformToken(): String? =
+    platformToken(System.getProperty("os.name") ?: "", System.getProperty("os.arch") ?: "")
+
+  /**
+   * Release asset filename for a version + platform — `xr-composite-<platform>-<version>.tar.gz`.
+   * Exactly the name `release.yml` packs (`xr-composite-${asset}-${PLUGIN_VERSION}.tar.gz`).
+   */
+  internal fun assetName(version: String, platform: String): String =
+    "xr-composite-$platform-$version.tar.gz"
+
+  /**
+   * Download URL on the GitHub Release tagged `v<version>`. SNAPSHOT versions have no published
+   * release, so this 404s and the caller falls through to a graceful skip.
+   */
+  internal fun assetUrl(version: String, platform: String): String =
+    "https://github.com/$REPO/releases/download/v$version/${assetName(version, platform)}"
+
+  /**
+   * Root of the shared, well-known cache: `${XDG_CACHE_HOME:-~/.cache}/composeai/xr-composite`.
+   * Honours `XDG_CACHE_HOME` (Linux/BSD), else `~/.cache` per the XDG default — the same convention
+   * the plugin-side reader derives. [env]/[userHome] are injectable for tests.
+   */
+  internal fun cacheRoot(
+    env: (String) -> String? = System::getenv,
+    userHome: String = System.getProperty("user.home") ?: ".",
+  ): File {
+    val xdg = env("XDG_CACHE_HOME")?.takeIf { it.isNotBlank() }
+    val base = if (xdg != null) File(xdg) else File(userHome, ".cache")
+    return File(base, "composeai/xr-composite")
+  }
+
+  /** Per-version+platform cache directory: `<cacheRoot>/<version>/<platform>`. */
+  internal fun cacheDir(
+    version: String,
+    platform: String,
+    env: (String) -> String? = System::getenv,
+    userHome: String = System.getProperty("user.home") ?: ".",
+  ): File = File(File(cacheRoot(env, userHome), version), platform)
+
+  /**
+   * Cached binary path: `<cacheDir>/xr-composite` (`xr-composite.exe` on Windows). The plugin reads
+   * the exact same path — see the reader-side derivation.
+   */
+  internal fun cacheBinary(
+    version: String,
+    platform: String,
+    env: (String) -> String? = System::getenv,
+    userHome: String = System.getProperty("user.home") ?: ".",
+  ): File {
+    val name = if (platform.startsWith("windows")) "xr-composite.exe" else "xr-composite"
+    return File(cacheDir(version, platform, env, userHome), name)
+  }
+
+  /**
+   * Fetch + unpack seam, injectable so tests exercise the "already cached" / "download failure"
+   * branches without hitting GitHub. [fetchTo] downloads [url] to a destination file, throwing on a
+   * non-2xx / network error.
+   */
+  fun interface Fetcher {
+    fun fetchTo(url: String, dest: File)
+  }
+
+  /** Default fetcher: Ktor over OkHttp (follows redirects), streaming the body to disk. */
+  internal val defaultFetcher = Fetcher { url, dest ->
+    HttpClient(OkHttp).use { client ->
+      runBlocking {
+        client.prepareGet(url).execute { response ->
+          if (!response.status.isSuccess()) {
+            error("HTTP ${response.status.value}")
+          }
+          dest.outputStream().use { out -> response.bodyAsChannel().copyTo(out) }
+        }
+      }
+    }
+  }
+
+  /**
+   * Ensure the cache holds the [version]+host-platform binary, fetching the Release tarball when
+   * absent. Best-effort: returns the cached binary [File] on success, or `null` on any skip/failure
+   * (and logs a one-line note). Never throws — the render proceeds regardless.
+   *
+   * @param version the CLI's own released version ([BUNDLE_VERSION]); the binary ships from the
+   *   same tag.
+   * @param log sink for the concise status/skip note (stderr by default).
+   */
+  fun ensureCached(
+    version: String,
+    fetcher: Fetcher = defaultFetcher,
+    env: (String) -> String? = System::getenv,
+    userHome: String = System.getProperty("user.home") ?: ".",
+    log: (String) -> Unit = { System.err.println(it) },
+  ): File? {
+    val platform =
+      currentPlatformToken()
+        ?: run {
+          log(
+            "xr-composite: no published binary for this platform " +
+              "(${System.getProperty("os.name")}/${System.getProperty("os.arch")}); " +
+              "skipping XR composite provisioning"
+          )
+          return null
+        }
+    val binary = cacheBinary(version, platform, env, userHome)
+    if (binary.isFile) return binary // already provisioned — the common case after first run.
+
+    val url = assetUrl(version, platform)
+    val dir = cacheDir(version, platform, env, userHome)
+    val tmp = File(dir.parentFile, ".${dir.name}.dl-${UUID.randomUUID()}.tar.gz")
+    return try {
+      dir.parentFile?.mkdirs()
+      fetcher.fetchTo(url, tmp)
+      unpackTarGz(tmp, dir)
+      if (binary.isFile) {
+        binary.setExecutable(true, false)
+        log("xr-composite: provisioned $version/$platform into ${binary.parentFile}")
+        binary
+      } else {
+        log("xr-composite: tarball $url unpacked but no binary at ${binary.name}; skipping")
+        null
+      }
+    } catch (e: Exception) {
+      // Offline / 404 (SNAPSHOT or missing asset) / corrupt archive — all best-effort skips.
+      log("xr-composite: could not provision from $url (${e.message}); skipping composite stills")
+      null
+    } finally {
+      tmp.delete()
+    }
+  }
+
+  /**
+   * Unpack a `.tar.gz` into [destDir] (created if absent) by shelling out to the system `tar`. The
+   * Release tarball is `tar -C dist` of `xr-composite[.exe]` + `materials/`, so `tar -xzf <tgz> -C
+   * <destDir>` restores that layout (including the binary's executable bit) verbatim. `tar` is
+   * present on Linux/macOS and ships as `bsdtar` on Windows 10+; if it's missing or fails, the
+   * thrown exception bubbles to [ensureCached]'s best-effort catch. Kept as a shell-out rather than
+   * pulling in a new archive dependency for one call site.
+   */
+  internal fun unpackTarGz(tarGz: File, destDir: File) {
+    destDir.mkdirs()
+    val proc =
+      ProcessBuilder("tar", "-xzf", tarGz.absolutePath, "-C", destDir.absolutePath)
+        .redirectErrorStream(true)
+        .start()
+    val output = proc.inputStream.bufferedReader().readText()
+    val code = proc.waitFor()
+    if (code != 0) error("tar exited $code: ${output.trim().takeLast(300)}")
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/XrCompositeProvisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/XrCompositeProvisionTest.kt
@@ -1,0 +1,176 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit coverage for [XrCompositeProvision] — the CLI's auto-provisioner for the native
+ * `xr-composite` binary. No real network: the fetch seam is faked. Verifies the version+platform →
+ * asset-name / URL / cache-path derivation, the "already cached → no download" short-circuit, and
+ * the "download failure → graceful continue (null, no throw)" branch.
+ */
+class XrCompositeProvisionTest {
+
+  private val tmp = Files.createTempDirectory("xr-provision-test-").toFile()
+
+  @AfterTest
+  fun cleanup() {
+    tmp.deleteRecursively()
+  }
+
+  @Test
+  fun `platform token maps the published release matrix`() {
+    assertEquals("linux-x86_64", XrCompositeProvision.platformToken("Linux", "amd64"))
+    assertEquals("linux-x86_64", XrCompositeProvision.platformToken("Linux", "x86_64"))
+    assertEquals("macos-arm64", XrCompositeProvision.platformToken("Mac OS X", "aarch64"))
+    assertEquals("macos-arm64", XrCompositeProvision.platformToken("Mac OS X", "arm64"))
+    assertEquals("windows-x86_64", XrCompositeProvision.platformToken("Windows 11", "amd64"))
+  }
+
+  @Test
+  fun `platform token is null for unpublished combos`() {
+    assertNull(XrCompositeProvision.platformToken("Linux", "aarch64"))
+    assertNull(XrCompositeProvision.platformToken("Mac OS X", "x86_64"))
+    assertNull(XrCompositeProvision.platformToken("FreeBSD", "amd64"))
+  }
+
+  @Test
+  fun `asset name and url match the release packaging`() {
+    assertEquals(
+      "xr-composite-linux-x86_64-0.13.1.tar.gz",
+      XrCompositeProvision.assetName("0.13.1", "linux-x86_64"),
+    )
+    assertEquals(
+      "https://github.com/yschimke/compose-ai-tools/releases/download/" +
+        "v0.13.1/xr-composite-macos-arm64-0.13.1.tar.gz",
+      XrCompositeProvision.assetUrl("0.13.1", "macos-arm64"),
+    )
+  }
+
+  @Test
+  fun `cache path honours XDG_CACHE_HOME and falls back to home cache`() {
+    val xdg =
+      XrCompositeProvision.cacheBinary(
+        version = "0.13.1",
+        platform = "linux-x86_64",
+        env = { if (it == "XDG_CACHE_HOME") "/xdg" else null },
+        userHome = "/home/u",
+      )
+    assertEquals(File("/xdg/composeai/xr-composite/0.13.1/linux-x86_64/xr-composite"), xdg)
+
+    val home =
+      XrCompositeProvision.cacheBinary(
+        version = "0.13.1",
+        platform = "windows-x86_64",
+        env = { null },
+        userHome = "/home/u",
+      )
+    assertEquals(
+      File("/home/u/.cache/composeai/xr-composite/0.13.1/windows-x86_64/xr-composite.exe"),
+      home,
+    )
+  }
+
+  /**
+   * Build a real `.tar.gz` of `xr-composite` + `materials/m.txt` via system tar (round-trips
+   * unpack).
+   */
+  private fun makeTarball(dest: File) {
+    val staging = File(tmp, "stage-${dest.name}")
+    File(staging, "materials").mkdirs()
+    File(staging, "xr-composite").writeText("#!/bin/sh\necho fake\n")
+    File(staging, "materials/m.txt").writeText("mat")
+    val p =
+      ProcessBuilder("tar", "-czf", dest.absolutePath, "-C", staging.absolutePath, ".")
+        .redirectErrorStream(true)
+        .start()
+    check(p.waitFor() == 0) { "tar pack failed" }
+  }
+
+  @Test
+  fun `ensureCached downloads unpacks and reports the binary`() {
+    val logs = mutableListOf<String>()
+    var fetches = 0
+    val binary =
+      XrCompositeProvision.ensureCached(
+        version = "0.13.1",
+        fetcher = { _, dst ->
+          fetches++
+          makeTarball(dst)
+        },
+        env = { if (it == "XDG_CACHE_HOME") tmp.absolutePath else null },
+        userHome = tmp.absolutePath,
+        log = { logs.add(it) },
+      )
+    // Only assert the unpack/report contract when the host platform has a published asset.
+    if (XrCompositeProvision.currentPlatformToken() == null) {
+      assertNull(binary)
+      return
+    }
+    assertEquals(1, fetches)
+    assertTrue(binary != null && binary.isFile, "binary should be unpacked: $logs")
+    assertTrue(File(binary!!.parentFile, "materials/m.txt").isFile, "materials should unpack")
+  }
+
+  @Test
+  fun `ensureCached is idempotent — second call does not re-download`() {
+    if (XrCompositeProvision.currentPlatformToken() == null) return
+    var fetches = 0
+    val fetcher = XrCompositeProvision.Fetcher { _, dst ->
+      fetches++
+      makeTarball(dst)
+    }
+    val first =
+      XrCompositeProvision.ensureCached(
+        version = "0.13.1",
+        fetcher = fetcher,
+        env = { if (it == "XDG_CACHE_HOME") tmp.absolutePath else null },
+        userHome = tmp.absolutePath,
+        log = {},
+      )
+    val second =
+      XrCompositeProvision.ensureCached(
+        version = "0.13.1",
+        fetcher = fetcher,
+        env = { if (it == "XDG_CACHE_HOME") tmp.absolutePath else null },
+        userHome = tmp.absolutePath,
+        log = {},
+      )
+    assertEquals(1, fetches, "second call must hit the cache, not re-download")
+    assertEquals(first, second)
+  }
+
+  @Test
+  fun `ensureCached swallows download failure and returns null`() {
+    if (XrCompositeProvision.currentPlatformToken() == null) return
+    val logs = mutableListOf<String>()
+    val binary =
+      XrCompositeProvision.ensureCached(
+        version = "0.13.1",
+        fetcher = { _, _ -> error("HTTP 404") },
+        env = { if (it == "XDG_CACHE_HOME") tmp.absolutePath else null },
+        userHome = tmp.absolutePath,
+        log = { logs.add(it) },
+      )
+    assertNull(binary, "a 404 must not throw — it skips gracefully")
+    assertTrue(
+      logs.any { it.contains("could not provision") },
+      "should log a concise skip note: $logs",
+    )
+    // No binary left behind in the cache.
+    val expected =
+      XrCompositeProvision.cacheBinary(
+        version = "0.13.1",
+        platform = XrCompositeProvision.currentPlatformToken()!!,
+        env = { if (it == "XDG_CACHE_HOME") tmp.absolutePath else null },
+        userHome = tmp.absolutePath,
+      )
+    assertFalse(expected.isFile)
+  }
+}

--- a/docs/design/xr-spatial/COMPOSITOR.md
+++ b/docs/design/xr-spatial/COMPOSITOR.md
@@ -55,14 +55,28 @@ Implementation gotchas (buffer lifetime, alpha premultiply, readPixels
 orientation) are documented in the tool's
 [README](../../../renderers/xr-composite/README.md#implementation-notes--gotchas).
 
+## Consumer flow (distribution)
+
+Consumers never build the tool. Per-OS Release tarballs
+(`xr-composite-<platform>-<version>.tar.gz`) are **auto-provisioned by the CLI**: when
+`compose-preview` drives a render and sees an `XR_SUBSPACE` preview, it fetches the binary matching
+its own release into a shared cache
+(`${XDG_CACHE_HOME:-~/.cache}/composeai/xr-composite/<version>/<platform>/`), and the Gradle plugin's
+`composePreviewCompositeXr` task reads it from there (after the
+`composePreview.xrCompositeBinary` / `XR_COMPOSITE_BIN` overrides). The plugin only reads; the CLI is
+the writer, so raw `./gradlew` stays explicit. Any fetch failure (offline, no asset for a
+`-SNAPSHOT`, unsupported platform) is a graceful skip. Full notes in the tool
+[README](../../../renderers/xr-composite/README.md#consumer-flow--auto-provisioned-by-the-cli);
+daemon-side auto-provisioning is a follow-up (see [`RENDERER_SERVICE.md`](RENDERER_SERVICE.md)
+decision #6).
+
 ## What's not done yet
 
 This is the renderer half. Still open: visual parity with the WebGL viewer
-(grid / axes / labels), self-contained material embedding (`resgen`), wiring the
-composite into the render pipeline + preview manifest with graceful degradation
-when the binary / display / software GL is unavailable, and macOS/Windows builds
-plus a distribution/bootstrap story. Those are the real remaining cost — the
-GPU-free rendering itself is solved.
+(grid / axes / labels), self-contained material embedding (`resgen`). Wiring the
+composite into the render pipeline + preview manifest (with graceful degradation when the binary /
+display / software GL is unavailable), the macOS/Windows builds, and the distribution/provisioning
+story are now done (see "Consumer flow" above). The GPU-free rendering itself is solved.
 
 The longer-term direction — turning this one-shot CLI into a long-lived,
 extensible, multi-session render *service* behind the daemon (live panel/pose

--- a/docs/design/xr-spatial/RENDERER_SERVICE.md
+++ b/docs/design/xr-spatial/RENDERER_SERVICE.md
@@ -162,7 +162,15 @@ panels-in-previews increment.
    Kotlin↔TS approach. Moving to a single-source IDL with codegen (e.g. protobuf) is tracked as
    follow-up in [#1729](https://github.com/yschimke/compose-ai-tools/issues/1729) — worthwhile once
    the third (C++) mirror actually exists.
-6. **Distribution — fetch the per-OS Release tarballs.** Reuse the
-   `xr-composite-<platform>-<ver>.tar.gz` binaries now published on each GitHub Release (see
-   `.github/workflows/release.yml`), gated/cached like the existing `install.sh --android-sdk` SDK
-   bootstrap, rather than a bespoke bundling scheme.
+6. **Distribution — auto-provisioned by the CLI (daemon to follow).** The
+   `xr-composite-<platform>-<ver>.tar.gz` binaries published on each GitHub Release (see
+   `.github/workflows/release.yml`) are fetched automatically by the CLI into a shared, well-known
+   cache (`${XDG_CACHE_HOME:-~/.cache}/composeai/xr-composite/<version>/<platform>/`) the first time
+   it drives an XR render — no manual install step. The Gradle plugin's `composePreviewCompositeXr`
+   task only *reads* that cache (after the `composePreview.xrCompositeBinary` property /
+   `XR_COMPOSITE_BIN` env overrides); the CLI is the writer. Both sides derive the identical path
+   from the release version + host platform, so the fetch and the read meet with no runtime
+   handshake. Implemented in `XrCompositeProvision` (`:cli`) +
+   `AndroidPreviewSupport.xrCompositeCacheBinaryPath` (`:gradle-plugin`). Daemon-side
+   auto-provisioning is a follow-up tied to the daemon actually producing composites (this RFC) —
+   today only the CLI→Gradle path bakes composites.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -38,6 +38,72 @@ internal object AndroidPreviewSupport {
   internal const val RENDERER_COMPOSE_FLOOR_VERSION: String = "1.9.5"
 
   /**
+   * Platform token for the auto-provisioned `xr-composite` cache, matching the Release asset matrix
+   * in `.github/workflows/release.yml` and the CLI writer's `XrCompositeProvision.platformToken`.
+   * `null` for any OS/arch combination that has no published asset (e.g. linux-arm64) — the cache
+   * tier then contributes nothing and the task falls through to its graceful skip. Kept pure
+   * (params rather than `System.getProperty`) so it's unit-testable.
+   */
+  internal fun xrCompositePlatformToken(osName: String, osArch: String): String? {
+    val os = osName.lowercase()
+    val arch = osArch.lowercase()
+    return when {
+      os.contains("linux") && (arch == "x86_64" || arch == "amd64") -> "linux-x86_64"
+      (os.contains("mac") || os.contains("darwin")) && (arch == "aarch64" || arch == "arm64") ->
+        "macos-arm64"
+      os.contains("windows") && (arch == "amd64" || arch == "x86_64") -> "windows-x86_64"
+      else -> null
+    }
+  }
+
+  /**
+   * Config-time provider for the shared auto-provision cache binary path:
+   * `${XDG_CACHE_HOME:-~/.cache}/composeai/xr-composite/<version>/<platform>/xr-composite`
+   * (`xr-composite.exe` on Windows). This is the WELL-KNOWN PATH CONVENTION shared with the CLI
+   * writer ([XrCompositeProvision.cacheBinary] in `:cli`) — the two derive the identical path from
+   * the same release [version] + host platform, which is how the CLI's fetch and the plugin's read
+   * meet without a runtime handshake. Built entirely from injected providers so it stays IP- and
+   * configuration-cache-safe (no `project.*` / `System.getProperty` at task-action time).
+   *
+   * Returns an absent provider when the host platform has no published asset, when `user.home`
+   * resolves empty and no `XDG_CACHE_HOME` is set — anything that would make the path meaningless —
+   * so the binary chain falls through to the graceful skip.
+   */
+  internal fun xrCompositeCacheBinaryPath(
+    version: String,
+    xdgCacheHome: Provider<String>,
+    userHome: Provider<String>,
+    osName: Provider<String>,
+    osArch: Provider<String>,
+  ): Provider<String> {
+    val platform = osName.zip(osArch) { n, a -> xrCompositePlatformToken(n, a) ?: "" }
+    // Cache root: XDG_CACHE_HOME if set, else <user.home>/.cache. `orElse("")` keeps the chain
+    // resolvable so we can detect "neither available" and drop out.
+    val cacheRoot =
+      xdgCacheHome.orElse("").zip(userHome.orElse("")) { xdg, home ->
+        when {
+          xdg.isNotBlank() -> xdg
+          home.isNotBlank() -> "$home/.cache"
+          else -> ""
+        }
+      }
+    return cacheRoot.zip(platform) { root, plat ->
+      if (root.isBlank() || plat.isBlank()) {
+        null
+      } else {
+        val binName = if (plat.startsWith("windows")) "xr-composite.exe" else "xr-composite"
+        java.io
+          .File(root)
+          .resolve("composeai/xr-composite")
+          .resolve(version)
+          .resolve(plat)
+          .resolve(binName)
+          .path
+      }
+    }
+  }
+
+  /**
    * Modules within `androidx.wear.tiles` whose presence in a consumer's declared deps signals "this
    * project writes Tile previews." When any match, [configure] injects `wear.tiles:tiles-renderer`
    * into the consumer's variant `implementation` so AGP generates R classes for
@@ -1452,15 +1518,34 @@ internal object AndroidPreviewSupport {
 
     // Resolve the optional `xr-composite` native tool location at CONFIG time (Isolated Projects is
     // on / the configuration cache is strict — the task action must not touch `project.*`). The
-    // binary comes from the `composePreview.xrCompositeBinary` Gradle property or the
-    // `XR_COMPOSITE_BIN` env var; the materials dir from `composePreview.xrCompositeMaterials` or,
-    // by default, `<binaryDir>/materials` (where `build.sh` emits it next to the binary). All three
-    // providers may be absent — the task degrades gracefully (logs + skips) when the binary isn't
-    // configured / found.
+    // binary comes, in order, from:
+    //   (a) the `composePreview.xrCompositeBinary` Gradle property (explicit override),
+    //   (b) the `XR_COMPOSITE_BIN` env var,
+    //   (c) the shared auto-provision cache for THIS plugin version + the host platform — the path
+    //       the CLI writes when it fetches the per-OS Release tarball (see
+    //       [xrCompositeCacheBinaryPath] / `XrCompositeProvision` in `:cli`). The plugin only READS
+    //       this cache; it never downloads. Raw `./gradlew` therefore stays
+    // override-or-prepopulated
+    //       — only the CLI populates the cache.
+    // The materials dir comes from `composePreview.xrCompositeMaterials` or, by default,
+    // `<binaryDir>/materials` (where `build.sh` and the Release tarball emit it next to the
+    // binary).
+    // Every tier may be absent — the task degrades gracefully (logs + skips) when the binary isn't
+    // configured / found, and the cache-tier path is only USED when the file actually exists (the
+    // task action's `isFile` check), so an empty cache falls through to the same skip.
+    val xrCompositeCachePath =
+      xrCompositeCacheBinaryPath(
+        version = PluginVersion.value,
+        xdgCacheHome = project.providers.environmentVariable("XDG_CACHE_HOME"),
+        userHome = project.providers.systemProperty("user.home"),
+        osName = project.providers.systemProperty("os.name"),
+        osArch = project.providers.systemProperty("os.arch"),
+      )
     val xrCompositeBinary =
       project.providers
         .gradleProperty("composePreview.xrCompositeBinary")
         .orElse(project.providers.environmentVariable("XR_COMPOSITE_BIN"))
+        .orElse(xrCompositeCachePath)
     val xrCompositeMaterials =
       project.providers
         .gradleProperty("composePreview.xrCompositeMaterials")

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/XrCompositeCachePathTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/XrCompositeCachePathTest.kt
@@ -1,0 +1,79 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+/**
+ * Pins the plugin-side reader half of the auto-provision contract: the platform token and the
+ * well-known cache binary path that [AndroidPreviewSupport] feeds into the
+ * `composePreviewCompositeXr` binary-resolution chain. The CLI writer (`XrCompositeProvision` in
+ * `:cli`) derives the identical path from the same release version + host platform, so both sides
+ * are unit-tested independently and must agree.
+ */
+class XrCompositeCachePathTest {
+
+  private val providers: ProviderFactory = ProjectBuilder.builder().build().providers
+
+  private fun of(value: String?) =
+    if (value == null) providers.provider { null as String? } else providers.provider { value }
+
+  @Test
+  fun `platform token maps the published release matrix`() {
+    assertThat(AndroidPreviewSupport.xrCompositePlatformToken("Linux", "amd64"))
+      .isEqualTo("linux-x86_64")
+    assertThat(AndroidPreviewSupport.xrCompositePlatformToken("Linux", "x86_64"))
+      .isEqualTo("linux-x86_64")
+    assertThat(AndroidPreviewSupport.xrCompositePlatformToken("Mac OS X", "aarch64"))
+      .isEqualTo("macos-arm64")
+    assertThat(AndroidPreviewSupport.xrCompositePlatformToken("Windows 11", "amd64"))
+      .isEqualTo("windows-x86_64")
+    assertThat(AndroidPreviewSupport.xrCompositePlatformToken("Linux", "aarch64")).isNull()
+    assertThat(AndroidPreviewSupport.xrCompositePlatformToken("Mac OS X", "x86_64")).isNull()
+  }
+
+  @Test
+  fun `cache path honours XDG_CACHE_HOME`() {
+    val path =
+      AndroidPreviewSupport.xrCompositeCacheBinaryPath(
+        version = "0.13.1",
+        xdgCacheHome = of("/xdg"),
+        userHome = of("/home/u"),
+        osName = of("Linux"),
+        osArch = of("amd64"),
+      )
+    assertThat(path.get())
+      .isEqualTo(File("/xdg/composeai/xr-composite/0.13.1/linux-x86_64/xr-composite").path)
+  }
+
+  @Test
+  fun `cache path falls back to home dot-cache and uses exe on windows`() {
+    val path =
+      AndroidPreviewSupport.xrCompositeCacheBinaryPath(
+        version = "0.13.1",
+        xdgCacheHome = of(null),
+        userHome = of("/home/u"),
+        osName = of("Windows 11"),
+        osArch = of("amd64"),
+      )
+    assertThat(path.get())
+      .isEqualTo(
+        File("/home/u/.cache/composeai/xr-composite/0.13.1/windows-x86_64/xr-composite.exe").path
+      )
+  }
+
+  @Test
+  fun `cache path is absent for unpublished platforms`() {
+    val path =
+      AndroidPreviewSupport.xrCompositeCacheBinaryPath(
+        version = "0.13.1",
+        xdgCacheHome = of("/xdg"),
+        userHome = of("/home/u"),
+        osName = of("Linux"),
+        osArch = of("aarch64"),
+      )
+    assertThat(path.isPresent).isFalse()
+  }
+}

--- a/renderers/xr-composite/README.md
+++ b/renderers/xr-composite/README.md
@@ -64,6 +64,28 @@ Rasterization" section.)
 | `--materials <dir>` | directory with the compiled `.filamat` blobs | `.` |
 | `--width` / `--height` | output size in px | `1280` × `800` |
 
+## Consumer flow — auto-provisioned by the CLI
+
+Consumers do **not** build this tool or run an install step. On each GitHub Release the binary +
+compiled `materials/` are published per OS as `xr-composite-<platform>-<version>.tar.gz`
+(`linux-x86_64` / `macos-arm64` / `windows-x86_64`, see `.github/workflows/release.yml`). When the
+`compose-preview` CLI drives a render and discovers an `XR_SUBSPACE` preview, it **auto-fetches** the
+tarball matching its own released version into a shared, well-known cache:
+
+```
+${XDG_CACHE_HOME:-~/.cache}/composeai/xr-composite/<version>/<platform>/xr-composite   (+ materials/)
+```
+
+The Gradle plugin's `composePreviewCompositeXr` task then *reads* that cache (resolution order:
+`composePreview.xrCompositeBinary` property → `XR_COMPOSITE_BIN` env → the cache path for the
+plugin's version + host platform). The CLI is the only writer; the plugin never downloads, so a raw
+`./gradlew composePreviewRenderAll` stays explicit (set the property/env or pre-populate the cache).
+
+Everything is best-effort: an offline machine, a missing asset for a local `-SNAPSHOT` build (no
+published release → 404), or an unsupported platform logs a concise note and the composite still is
+simply absent — the render is never failed. Daemon-side auto-provisioning is a follow-up (see
+`docs/design/xr-spatial/RENDERER_SERVICE.md` decision #6).
+
 ## Implementation notes / gotchas
 
 These tripped up the initial implementation and are load-bearing:
@@ -87,4 +109,5 @@ These tripped up the initial implementation and are load-bearing:
 - Embed materials via `resgen` so the binary is self-contained (drop `--materials`).
 - Wire into the render pipeline and fold the composite into the preview manifest;
   degrade gracefully when the binary / display / software GL is unavailable.
-- macOS and Windows builds + a distribution/bootstrap story.
+- ~~macOS and Windows builds + a distribution/bootstrap story.~~ Done: per-OS Release tarballs,
+  CLI auto-provisioning into a shared cache (see "Consumer flow" above).


### PR DESCRIPTION
## Summary

Makes the native `xr-composite` tool **auto-provisioned by the CLI**, so XR "panels-in-previews" composites bake with zero manual setup after a release — no install step.

- **Shared cache + path convention.** The binary lives at a deterministic path derived from version + platform: `${XDG_CACHE_HOME:-~/.cache}/composeai/xr-composite/{version}/{platform}/xr-composite` (+ `materials/` alongside). `{platform}` is one of `linux-x86_64` (linux + x86_64/amd64), `macos-arm64` (mac + aarch64/arm64), `windows-x86_64` (windows + amd64/x86_64) — matching the Release asset matrix. The CLI is the only **writer**; the plugin only **reads**.
- **Plugin discovers the cache.** `composePreviewCompositeXr`'s binary resolution is now: (a) `composePreview.xrCompositeBinary` property, then (b) `XR_COMPOSITE_BIN` env, then (c) the cache path for the plugin's own version + host platform. Built from config-time providers (`XDG_CACHE_HOME` / `user.home` / `os.name` / `os.arch`), so it stays Isolated-Projects and config-cache safe. The plugin never downloads; an empty cache falls through to today's graceful skip. Raw `./gradlew` therefore stays override-or-prepopulated.
- **CLI auto-provisions, gated to XR-only.** Before driving `composePreviewRenderAll`, the render commands run `composePreviewDiscover`, read `previews.json`, and fetch **only when an `XR_SUBSPACE` preview is present** — a non-XR render never touches the network. The fetch pulls the per-OS Release tarball for the CLI's **own** released version (`BUNDLE_VERSION`), unpacks it idempotently into the cache, and hands the binary to the render via `-PcomposePreview.xrCompositeBinary` (the plugin also discovers the same path on its own — discovery is the general mechanism, the property is a belt-and-braces handoff).
- **Best-effort.** Any failure — offline, a local `-SNAPSHOT` with no published asset (404), an unsupported platform — logs a concise note and continues without failing the render, mirroring the plugin's graceful skip. The composite still is an optional capture.
- **No published checksum.** The release currently ships only the tarball (no `.sha256`), so there's nothing to verify against; the code is structured so a checksum step can slot in if one is published later.

### Cache-path + asset-name derivation

| input | value |
|-------|-------|
| asset name | `xr-composite-{platform}-{version}.tar.gz` |
| download URL | `https://github.com/yschimke/compose-ai-tools/releases/download/v{version}/{asset}` |
| cache binary | `${XDG_CACHE_HOME:-~/.cache}/composeai/xr-composite/{version}/{platform}/xr-composite` (`.exe` on Windows) |
| version source | the CLI's own `BUNDLE_VERSION` (writer) / `PluginVersion.value` (reader) |

CLI hook point: `Command.provisionXrCompositeArgs(...)`, called from the shared `renderModules(...)` pipeline (`show` / `a11y`) and from `RenderCommand.run`.

## Daemon follow-up

Daemon-side auto-provisioning is **out of scope** here and noted as a follow-up tied to the daemon actually producing composites (the renderer-service RFC). Today only the CLI to Gradle path bakes composites.

## yschimke/skills note

The consumer-facing skill docs live in the separate **`yschimke/skills`** repo and need a matching update (the "you don't install xr-composite; the CLI fetches it" flow) — **out of scope for this PR**, flagging for a follow-up there.

## Test plan

- `./gradlew :cli:test :gradle-plugin:test :gradle-plugin:functionalTest` — green.
- New unit tests:
  - `XrCompositeProvisionTest` (CLI): version+platform to asset-name / URL / cache-path derivation; "already cached, no re-download" (idempotent); "download failure, graceful continue (null, no throw)" — fetch seam faked, no real network.
  - `XrCompositeCachePathTest` (plugin): platform-token matrix + cache-path provider (XDG vs `~/.cache`, `.exe` on Windows, absent for unpublished platforms).
- Non-XR gate confirmed by construction: the network fetch is reached only when a discovered preview has `kind == "XR_SUBSPACE"`.
- `ktfmtFormat` / `ktfmtCheck` clean on both modules.

### Deviation: no Android functional test for the composite task

`composePreviewCompositeXr` is registered only on the Android path (needs AGP + the Android SDK + a display/xvfb + a real Filament binary to actually bake a PNG). This environment has no Android SDK, and standing one up for a single resolution check is disproportionate. The binary-**resolution** logic (the only thing this PR adds to the task) is the provider chain property to env to cache-path, which is unit-tested on both the writer and reader sides, plus the task action's existing `isFile` graceful-skip. The CMP functional path doesn't register the XR task, so a functional test there wouldn't exercise it either.