### PR TITLE
fix(cli): re-provision partial xr-composite caches instead of trusting them

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/XrCompositeProvision.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/XrCompositeProvision.kt
@@ -7,6 +7,8 @@ import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.jvm.javaio.copyTo
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.UUID
 import kotlinx.coroutines.runBlocking
 
@@ -116,6 +118,21 @@ object XrCompositeProvision {
   }
 
   /**
+   * Whether [dir] holds a *complete* provisioned layout — the [binaryName] executable AND a
+   * non-empty `materials/` directory (the `.filamat` blobs the binary loads, and which the plugin
+   * task passes as the sibling `--materials` dir). A partial extraction (binary written but
+   * `materials/` missing/empty — e.g. an interrupted or failed `tar`) is deliberately NOT complete,
+   * so it is re-provisioned rather than trusted forever. Without this, a partial cache would short-
+   * circuit every future run and make composites fail until the user manually wiped the cache.
+   */
+  internal fun isComplete(dir: File, binaryName: String): Boolean {
+    val materials = File(dir, "materials")
+    return File(dir, binaryName).isFile &&
+      materials.isDirectory &&
+      (materials.listFiles()?.isNotEmpty() == true)
+  }
+
+  /**
    * Fetch + unpack seam, injectable so tests exercise the "already cached" / "download failure"
    * branches without hitting GitHub. [fetchTo] downloads [url] to a destination file, throwing on a
    * non-2xx / network error.
@@ -164,30 +181,50 @@ object XrCompositeProvision {
           )
           return null
         }
-    val binary = cacheBinary(version, platform, env, userHome)
-    if (binary.isFile) return binary // already provisioned — the common case after first run.
+    val binaryName = if (platform.startsWith("windows")) "xr-composite.exe" else "xr-composite"
+    val dir = cacheDir(version, platform, env, userHome)
+    val binary = File(dir, binaryName)
+    // Fast path: only short-circuit on a COMPLETE cache. A partial layout (e.g. an earlier
+    // interrupted unpack that left the binary but no materials/) falls through and re-provisions.
+    if (isComplete(dir, binaryName)) return binary
 
     val url = assetUrl(version, platform)
-    val dir = cacheDir(version, platform, env, userHome)
-    val tmp = File(dir.parentFile, ".${dir.name}.dl-${UUID.randomUUID()}.tar.gz")
+    val parent = dir.parentFile
+    val tmp = File(parent, ".${dir.name}.dl-${UUID.randomUUID()}.tar.gz")
+    // Unpack into a staging dir and only swap it into place once validated, so the live cache path
+    // is never observed half-written — readers see either a complete layout or nothing.
+    val stage = File(parent, ".${dir.name}.stage-${UUID.randomUUID()}")
     return try {
-      dir.parentFile?.mkdirs()
+      parent?.mkdirs()
       fetcher.fetchTo(url, tmp)
-      unpackTarGz(tmp, dir)
-      if (binary.isFile) {
-        binary.setExecutable(true, false)
-        log("xr-composite: provisioned $version/$platform into ${binary.parentFile}")
-        binary
-      } else {
-        log("xr-composite: tarball $url unpacked but no binary at ${binary.name}; skipping")
-        null
+      stage.deleteRecursively()
+      unpackTarGz(tmp, stage)
+      if (!isComplete(stage, binaryName)) {
+        log(
+          "xr-composite: tarball $url unpacked but layout incomplete (binary or materials/ missing); skipping"
+        )
+        return null
       }
+      File(stage, binaryName).setExecutable(true, false)
+      // Atomically replace any prior (incomplete) cache dir with the validated staging dir. We only
+      // get here when `dir` wasn't complete, so removing it first is safe; the move is atomic on
+      // the
+      // shared cache filesystem so a concurrent reader never sees a partial swap.
+      dir.deleteRecursively()
+      try {
+        Files.move(stage.toPath(), dir.toPath(), StandardCopyOption.ATOMIC_MOVE)
+      } catch (_: Exception) {
+        Files.move(stage.toPath(), dir.toPath()) // fall back to a non-atomic move if unsupported
+      }
+      log("xr-composite: provisioned $version/$platform into $dir")
+      binary
     } catch (e: Exception) {
       // Offline / 404 (SNAPSHOT or missing asset) / corrupt archive — all best-effort skips.
       log("xr-composite: could not provision from $url (${e.message}); skipping composite stills")
       null
     } finally {
       tmp.delete()
+      stage.deleteRecursively()
     }
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/XrCompositeProvisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/XrCompositeProvisionTest.kt
@@ -173,4 +173,65 @@ class XrCompositeProvisionTest {
       )
     assertFalse(expected.isFile)
   }
+
+  /** A `.tar.gz` with ONLY `xr-composite` (no `materials/`) — simulates an interrupted unpack. */
+  private fun makeBinaryOnlyTarball(dest: File) {
+    val staging = File(tmp, "stage-bin-${dest.name}").apply { mkdirs() }
+    File(staging, "xr-composite").writeText("#!/bin/sh\necho fake\n")
+    val p =
+      ProcessBuilder("tar", "-czf", dest.absolutePath, "-C", staging.absolutePath, ".")
+        .redirectErrorStream(true)
+        .start()
+    check(p.waitFor() == 0) { "tar pack failed" }
+  }
+
+  @Test
+  fun `ensureCached re-provisions a partial cache instead of trusting it`() {
+    if (XrCompositeProvision.currentPlatformToken() == null) return
+    val platform = XrCompositeProvision.currentPlatformToken()!!
+    val env: (String) -> String? = { if (it == "XDG_CACHE_HOME") tmp.absolutePath else null }
+    // Pre-seed a partial cache: the binary, but no materials/ (an earlier interrupted unpack).
+    val binary = XrCompositeProvision.cacheBinary("0.13.1", platform, env, tmp.absolutePath)
+    binary.parentFile.mkdirs()
+    binary.writeText("stale partial")
+    var fetches = 0
+    val result =
+      XrCompositeProvision.ensureCached(
+        version = "0.13.1",
+        fetcher = { _, dst ->
+          fetches++
+          makeTarball(dst)
+        },
+        env = env,
+        userHome = tmp.absolutePath,
+        log = {},
+      )
+    assertEquals(1, fetches, "a partial cache must NOT short-circuit — it re-provisions")
+    assertTrue(result != null && result.isFile)
+    assertTrue(File(result!!.parentFile, "materials").isDirectory, "materials/ is now present")
+  }
+
+  @Test
+  fun `ensureCached leaves no partial cache when the unpack is incomplete`() {
+    if (XrCompositeProvision.currentPlatformToken() == null) return
+    val platform = XrCompositeProvision.currentPlatformToken()!!
+    val env: (String) -> String? = { if (it == "XDG_CACHE_HOME") tmp.absolutePath else null }
+    val logs = mutableListOf<String>()
+    val result =
+      XrCompositeProvision.ensureCached(
+        version = "0.13.1",
+        fetcher = { _, dst -> makeBinaryOnlyTarball(dst) }, // no materials/ → incomplete layout
+        env = env,
+        userHome = tmp.absolutePath,
+        log = { logs.add(it) },
+      )
+    assertNull(result, "an incomplete unpack must not report a usable binary")
+    assertTrue(
+      logs.any { it.contains("incomplete") },
+      "should log the incomplete-layout skip: $logs",
+    )
+    // The live cache path must NOT be left half-populated for the next run to trust.
+    val cached = XrCompositeProvision.cacheBinary("0.13.1", platform, env, tmp.absolutePath)
+    assertFalse(cached.isFile, "no partial binary should remain in the live cache path")
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1732 — addresses the Codex review point that landed unfixed (the fix was committed just as #1732 merged, so it missed the squash).

`XrCompositeProvision.ensureCached` short-circuited on the **binary file alone**, so an interrupted or failed unpack that wrote `xr-composite` but not `materials/` was treated as a valid cache **forever**. Because the plugin's `composePreviewCompositeXr` passes the sibling `materials/` path, every XR composite would then fail until the user manually wiped the cache.

Fix:
- **Validate the full layout before short-circuiting** — the fast path now requires the binary *and* a non-empty `materials/` (`isComplete(...)`). A partial cache falls through and re-provisions instead of being trusted.
- **Stage + atomic move** — unpack into a staging dir and only `Files.move(..., ATOMIC_MOVE)` it into the live cache path once validated (non-atomic fallback if unsupported). The live cache path is never observed half-written, and any pre-existing partial dir is replaced rather than appended to.

## Test plan

- `:cli:test --tests XrCompositeProvisionTest` — green. New cases:
  - **partial cache re-provisions** — a pre-seeded binary-without-`materials/` cache does NOT short-circuit; it re-fetches and ends complete.
  - **incomplete unpack leaves nothing** — a tarball with only the binary (no `materials/`) returns null, logs the incomplete-layout skip, and leaves no partial binary in the live cache path.
  - Existing derivation / idempotent / download-failure cases still pass.
- `ktfmtFormat` clean.