### PR TITLE
fix(xr-composite): statically link libc++ so the Linux binary is self-contained

### DIFF
--- a/renderers/xr-composite/CMakeLists.txt
+++ b/renderers/xr-composite/CMakeLists.txt
@@ -46,9 +46,14 @@ if(WIN32)
   # runtime abstraction (CMP0091) applies it to every target in the build.
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 elseif(NOT APPLE)
-  # Filament's Linux release libs are built against libc++; match the ABI.
+  # Filament's Linux release libs are built against libc++; match the ABI. Link libc++ + libc++abi
+  # STATICALLY so the shipped binary is self-contained — a downloaded release artifact runs on a
+  # stock machine with no libc++ runtime installed (libc++.so.1 is not present by default on most
+  # distros / CI runners, and the CLI auto-provision can't apt-install system libs). The release
+  # smoke caught the dynamic-libc++ dependency failing with "libc++.so.1: cannot open shared object
+  # file" on a clean runner.
   add_compile_options(-stdlib=libc++)
-  add_link_options(-stdlib=libc++)
+  add_link_options(-stdlib=libc++ -static-libstdc++)
 endif()
 
 # ---- Compile materials with matc (CPU tool; no GPU needed) ----
@@ -90,5 +95,7 @@ elseif(WIN32)
   # user, and OpenGL system libs.
   target_link_libraries(xr-composite PRIVATE gdi32 user32 opengl32)
 else()
-  target_link_libraries(xr-composite PRIVATE pthread c++ c++abi dl)
+  # No explicit -lc++ / -lc++abi here: `-static-libstdc++` (with -stdlib=libc++, set above) links the
+  # static libc++ + libc++abi archives, so the binary carries no libc++.so.1 dependency.
+  target_link_libraries(xr-composite PRIVATE pthread dl)
 endif()


### PR DESCRIPTION
## Summary

**Release-blocker caught by the release-path smoke (#1735).** The smoke built + published the Linux tarball fine, but the `verify` step — which downloads the published binary onto a *clean* runner and runs it — failed at load time:

```
got/xr-composite: error while loading shared libraries: libc++.so.1: cannot open shared object file
```

Filament's libs are libc++-built and we linked `-lc++ -lc++abi` as **shared**, so the shipped artifact depended on a libc++ runtime that **isn't present by default** on most distros / CI runners — and the CLI auto-provision can't `apt install` system libs. The existing `Render XR composite (sample)` bake job only passed because it builds + runs in the same job that installed `libc++-dev`; a real consumer downloading the binary would hit this and composites would never bake.

Fix: link libc++ + libc++abi **statically** on Linux (`-stdlib=libc++ -static-libstdc++`, drop the explicit shared `-lc++`/`-lc++abi`). macOS (system libc++) and Windows (`/MT`) are unaffected.

## Test plan

- [x] Rebuilt via `build.sh`; **`ldd` shows only `libm`/`libgcc_s`/`libc`/`ld-linux` — no `libc++.so.1`** (self-contained).
- [x] The statically-linked binary still bakes a valid 1280×800 PNG headless on Xvfb+llvmpipe (committed spatial-scene fixture).
- [ ] Re-run the release smoke (#1735 workflow) after merge to confirm the full publish→fetch→bake chain is now green end-to-end.