### PR TITLE
refactor: migrate to builder API for Kotlin compilation operations

### DIFF
--- a/daemon/bta-host/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompiler.kt
+++ b/daemon/bta-host/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompiler.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.buildtools.api.arguments.JvmCompilerArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.enums.JvmTarget
 import org.jetbrains.kotlin.buildtools.api.getToolchain
 import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain
-import org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationConfiguration
 import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperation
 
 /**
@@ -81,9 +80,14 @@ class BtaCompiler(
     outputDir.toFile().mkdirs()
     val jvm = toolchains.getToolchain<JvmPlatformToolchain>()
     toolchains.createBuildSession().use { session ->
-      val op = jvm.createJvmCompilationOperation(sources, outputDir)
-      configureCompilerArgs(op, compileClasspath, compilerPlugins, moduleName)
-      executeOrThrow(session, op)
+      val builder = jvm.jvmCompilationOperationBuilder(sources, outputDir)
+      configureCompilerArgs(
+        builder.compilerArguments,
+        compileClasspath,
+        compilerPlugins,
+        moduleName,
+      )
+      executeOrThrow(session, builder.build())
     }
     return collectClassFiles(outputDir)
   }
@@ -134,7 +138,7 @@ class BtaCompiler(
       val snapshotFiles = compileClasspath.map { jar ->
         val cached = cpSnapshotsDir.resolve("${sha1(jar.toString())}.bin")
         if (!cached.exists()) {
-          val snapshottingOp = jvm.createClasspathSnapshottingOperation(jar)
+          val snapshottingOp = jvm.classpathSnapshottingOperationBuilder(jar).build()
           val snapshot = session.executeOperation(snapshottingOp)
           snapshot.saveSnapshot(cached)
         }
@@ -142,32 +146,36 @@ class BtaCompiler(
       }
 
       // 2 + 3. Build the IC config and attach it to the compile op.
-      val op = jvm.createJvmCompilationOperation(sources, outputDir)
-      val icOptions = op.createSnapshotBasedIcOptions()
+      val builder = jvm.jvmCompilationOperationBuilder(sources, outputDir)
       val icConfig =
-        JvmSnapshotBasedIncrementalCompilationConfiguration(
-          icWorkingDir,
-          sourcesChanges,
-          snapshotFiles,
-          shrunkClasspathSnapshot,
-          icOptions,
-        )
-      op.set(JvmCompilationOperation.INCREMENTAL_COMPILATION, icConfig)
-      configureCompilerArgs(op, compileClasspath, compilerPlugins, moduleName)
+        builder
+          .snapshotBasedIcConfigurationBuilder(
+            icWorkingDir,
+            sourcesChanges,
+            snapshotFiles,
+            shrunkClasspathSnapshot,
+          )
+          .build()
+      builder.set(JvmCompilationOperation.INCREMENTAL_COMPILATION, icConfig)
+      configureCompilerArgs(
+        builder.compilerArguments,
+        compileClasspath,
+        compilerPlugins,
+        moduleName,
+      )
 
       // 4. Execute.
-      executeOrThrow(session, op)
+      executeOrThrow(session, builder.build())
     }
     return collectClassFiles(outputDir)
   }
 
   private fun configureCompilerArgs(
-    op: JvmCompilationOperation,
+    args: JvmCompilerArguments.Builder,
     compileClasspath: List<Path>,
     compilerPlugins: List<CompilerPlugin>,
     moduleName: String,
   ) {
-    val args = op.compilerArguments
     args.set(
       JvmCompilerArguments.CLASSPATH,
       compileClasspath.joinToString(separator = java.io.File.pathSeparator) { it.toString() },

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompileSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompileSession.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.buildtools.api.arguments.JvmCompilerArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.enums.JvmTarget
 import org.jetbrains.kotlin.buildtools.api.getToolchain
 import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain
-import org.jetbrains.kotlin.buildtools.api.jvm.JvmSnapshotBasedIncrementalCompilationConfiguration
 import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperation
 
 /**
@@ -85,9 +84,9 @@ class BtaCompileSession(
     outputDir.toFile().mkdirs()
     val jvm = toolchains.getToolchain<JvmPlatformToolchain>()
     toolchains.createBuildSession().use { session ->
-      val op = jvm.createJvmCompilationOperation(sources, outputDir)
-      configureCompilerArgs(op, compileClasspath, compilerPlugins)
-      executeOrThrow(session, op)
+      val builder = jvm.jvmCompilationOperationBuilder(sources, outputDir)
+      configureCompilerArgs(builder.compilerArguments, compileClasspath, compilerPlugins)
+      executeOrThrow(session, builder.build())
     }
     return collectClassFiles(outputDir)
   }
@@ -132,36 +131,35 @@ class BtaCompileSession(
         val sha = sha256OfFile(jar)
         val cached = cpSnapshotsDir.resolve("$sha.bin")
         if (!cached.exists()) {
-          val snapshotOp = jvm.createClasspathSnapshottingOperation(jar)
+          val snapshotOp = jvm.classpathSnapshottingOperationBuilder(jar).build()
           val snapshot = session.executeOperation(snapshotOp)
           snapshot.saveSnapshot(cached)
         }
         cached
       }
 
-      val op = jvm.createJvmCompilationOperation(sources, outputDir)
-      val icOptions = op.createSnapshotBasedIcOptions()
+      val builder = jvm.jvmCompilationOperationBuilder(sources, outputDir)
       val icConfig =
-        JvmSnapshotBasedIncrementalCompilationConfiguration(
-          icDir,
-          sourcesChanges,
-          snapshotFiles,
-          shrunkClasspathSnapshot,
-          icOptions,
-        )
-      op.set(JvmCompilationOperation.INCREMENTAL_COMPILATION, icConfig)
-      configureCompilerArgs(op, compileClasspath, compilerPlugins)
-      executeOrThrow(session, op, diagnosticListener ?: logger)
+        builder
+          .snapshotBasedIcConfigurationBuilder(
+            icDir,
+            sourcesChanges,
+            snapshotFiles,
+            shrunkClasspathSnapshot,
+          )
+          .build()
+      builder.set(JvmCompilationOperation.INCREMENTAL_COMPILATION, icConfig)
+      configureCompilerArgs(builder.compilerArguments, compileClasspath, compilerPlugins)
+      executeOrThrow(session, builder.build(), diagnosticListener ?: logger)
     }
     return collectClassFiles(outputDir)
   }
 
   private fun configureCompilerArgs(
-    op: JvmCompilationOperation,
+    args: JvmCompilerArguments.Builder,
     compileClasspath: List<Path>,
     compilerPlugins: List<CompilerPlugin>,
   ) {
-    val args = op.compilerArguments
     args.set(
       JvmCompilerArguments.CLASSPATH,
       compileClasspath.joinToString(separator = java.io.File.pathSeparator) { it.toString() },

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
@@ -307,7 +307,7 @@ class S3_5RecompileSaveLoopRealModeTest {
     val reader = ClassReader(sourceBytes)
     val writer = ClassWriter(reader, ClassWriter.COMPUTE_MAXS or ClassWriter.COMPUTE_FRAMES)
     val remapper =
-      object : Remapper() {
+      object : Remapper(Opcodes.ASM9) {
         override fun map(internalName: String): String =
           if (internalName == sourceInternal) targetInternal else super.map(internalName)
       }

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRenderTest.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRenderTest.kt
@@ -24,6 +24,9 @@ import org.robolectric.Shadows.shadowOf
 @RunWith(ParameterizedRobolectricTestRunner::class)
 public class XrSubspaceRenderTest(private val preview: XrManifestReader.XrPreview) {
 
+  // v2 rule API (StandardTestDispatcher) is not on the compat compile classpath yet;
+  // suppress until the floor moves up. See renderer-android RobolectricRenderTest.
+  @Suppress("DEPRECATION")
   @get:Rule public val rule = createAndroidComposeRule<ComponentActivity>()
 
   @Test

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorderAutoEnumTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorderAutoEnumTest.kt
@@ -33,6 +33,9 @@ import org.robolectric.annotation.Config
 @Config(sdk = [35])
 class SubspaceSceneRecorderAutoEnumTest {
 
+  // v2 rule API (StandardTestDispatcher) is not on the compat compile classpath yet;
+  // suppress until the floor moves up. See renderer-android RobolectricRenderTest.
+  @Suppress("DEPRECATION")
   @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
 
   @Test

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorderDuplicateTagTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorderDuplicateTagTest.kt
@@ -28,6 +28,9 @@ import org.robolectric.annotation.Config
 @Config(sdk = [35])
 class SubspaceSceneRecorderDuplicateTagTest {
 
+  // v2 rule API (StandardTestDispatcher) is not on the compat compile classpath yet;
+  // suppress until the floor moves up. See renderer-android RobolectricRenderTest.
+  @Suppress("DEPRECATION")
   @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
 
   @Test

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorderTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorderTest.kt
@@ -36,6 +36,9 @@ import org.robolectric.annotation.Config
 @Config(sdk = [35])
 class SubspaceSceneRecorderTest {
 
+  // v2 rule API (StandardTestDispatcher) is not on the compat compile classpath yet;
+  // suppress until the floor moves up. See renderer-android RobolectricRenderTest.
+  @Suppress("DEPRECATION")
   @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
 
   private fun enableSpatialFeature() {

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneWriterTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneWriterTest.kt
@@ -35,6 +35,9 @@ class SubspaceSceneWriterTest {
 
   // roborazzi's standalone view capture re-parents the view into its Activity, so the view must be
   // created with an Activity context (real panels are). The compose rule supplies one.
+  // v2 rule API (StandardTestDispatcher) is not on the compat compile classpath yet;
+  // suppress until the floor moves up. See renderer-android RobolectricRenderTest.
+  @Suppress("DEPRECATION")
   @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
 
   private fun tempDir(): File =

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceWorldIntegrationTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/SubspaceWorldIntegrationTest.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.unit.dp
 import androidx.test.core.app.ApplicationProvider
-import androidx.xr.compose.spatial.ContentEdge
 import androidx.xr.compose.spatial.Orbiter
+import androidx.xr.compose.spatial.OrbiterAnchorPoint
 import androidx.xr.compose.spatial.Subspace
 import androidx.xr.compose.subspace.SpatialColumn
 import androidx.xr.compose.subspace.SpatialPanel
@@ -43,6 +43,9 @@ import org.robolectric.annotation.Config
 @Config(sdk = [35])
 class SubspaceWorldIntegrationTest {
 
+  // v2 rule API (StandardTestDispatcher) is not on the compat compile classpath yet;
+  // suppress until the floor moves up. See renderer-android RobolectricRenderTest.
+  @Suppress("DEPRECATION")
   @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
 
   @Test
@@ -55,7 +58,7 @@ class SubspaceWorldIntegrationTest {
         SpatialColumn {
           SpatialPanel(SubspaceModifier.testTag("main").width(720.dp).height(360.dp)) {
             Box(Modifier.fillMaxSize().background(Color(0xFF1E3C78)))
-            Orbiter(position = ContentEdge.Bottom) {
+            Orbiter(OrbiterAnchorPoint.Bottom) {
               Box(Modifier.fillMaxSize().background(Color(0xFF333845)))
             }
           }

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/XrRenderPipelineE2eTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/XrRenderPipelineE2eTest.kt
@@ -52,6 +52,9 @@ fun PipelineSpatialPreview() {
 @Config(sdk = [35])
 class XrRenderPipelineE2eTest {
 
+  // v2 rule API (StandardTestDispatcher) is not on the compat compile classpath yet;
+  // suppress until the floor moves up. See renderer-android RobolectricRenderTest.
+  @Suppress("DEPRECATION")
   @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
 
   @Test

--- a/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRendererTest.kt
+++ b/renderers/xr/src/test/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRendererTest.kt
@@ -53,6 +53,9 @@ fun SampleSpatialPreview() {
 @Config(sdk = [35])
 class XrSubspaceRendererTest {
 
+  // v2 rule API (StandardTestDispatcher) is not on the compat compile classpath yet;
+  // suppress until the floor moves up. See renderer-android RobolectricRenderTest.
+  @Suppress("DEPRECATION")
   @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
 
   @Test

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationStyleGallery.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/NotificationStyleGallery.kt
@@ -163,6 +163,10 @@ fun BigPictureStylePreview() {
  * skip the session — the layout draws identically with or without it because the inflater pulls
  * title / text / icon from the notification's own fields.
  */
+// androidx.media's MediaStyle is deprecated in favour of the media3 MediaSession helper; this
+// sample deliberately demonstrates the legacy androidx.media surface without a MediaSession, so we
+// suppress rather than pull in media3.
+@Suppress("DEPRECATION")
 @Preview(name = "Media style")
 @Composable
 fun MediaStylePreview() {

--- a/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SpatialPreviews.kt
+++ b/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SpatialPreviews.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.xr.compose.spatial.ContentEdge
+import androidx.xr.compose.spatial.OrbiterAnchorPoint
 import androidx.xr.compose.spatial.Orbiter
 import androidx.xr.compose.spatial.SpatialElevation
 import androidx.xr.compose.spatial.SpatialElevationLevel
@@ -57,7 +57,7 @@ fun OrbiterControlsPreview() {
   MaterialTheme {
     Surface {
       Box(Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) {
-        Orbiter(position = ContentEdge.Top) { TransportControls() }
+        Orbiter(OrbiterAnchorPoint.Top) { TransportControls() }
         NowPlayingPanel(Modifier.width(560.dp))
       }
     }

--- a/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SubspaceDemo.kt
+++ b/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SubspaceDemo.kt
@@ -2,8 +2,8 @@ package com.example.samplexrspatial
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
-import androidx.xr.compose.spatial.ContentEdge
 import androidx.xr.compose.spatial.Orbiter
+import androidx.xr.compose.spatial.OrbiterAnchorPoint
 import androidx.xr.compose.spatial.Subspace
 import androidx.xr.compose.subspace.SpatialPanel
 import androidx.xr.compose.subspace.layout.SubspaceModifier
@@ -34,7 +34,7 @@ fun SubspaceXrLayout() {
   Subspace {
     SpatialPanel(SubspaceModifier.width(560.dp).height(360.dp)) {
       NowPlayingPanel()
-      Orbiter(position = ContentEdge.Top) { TransportControls() }
+      Orbiter(OrbiterAnchorPoint.Top) { TransportControls() }
     }
   }
 }

--- a/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/SubspaceLayoutPoseTest.kt
+++ b/samples/xr-spatial/src/test/kotlin/com/example/samplexrspatial/SubspaceLayoutPoseTest.kt
@@ -52,6 +52,9 @@ import org.robolectric.annotation.Config
 @Config(sdk = [35])
 class SubspaceLayoutPoseTest {
 
+  // v2 rule API (StandardTestDispatcher) is not on the compat compile classpath yet;
+  // suppress until the floor moves up. See renderer-android RobolectricRenderTest.
+  @Suppress("DEPRECATION")
   @get:Rule val rule = createAndroidComposeRule<ComponentActivity>()
 
   @Test


### PR DESCRIPTION
## Summary
Migrate from direct operation instantiation to the builder API for Kotlin JVM compilation operations, and update XR Compose imports to use the new `OrbiterAnchorPoint` enum.

## Key Changes

### Compiler API Migration
- **BtaCompiler & BtaCompileSession**: Replaced `createJvmCompilationOperation()` with `jvmCompilationOperationBuilder()` pattern
  - Changed from passing operation object to `configureCompilerArgs()` to passing `builder.compilerArguments` directly
  - Updated incremental compilation config to use `builder.snapshotBasedIcConfigurationBuilder()` instead of direct `JvmSnapshotBasedIncrementalCompilationConfiguration` instantiation
  - Replaced `createClasspathSnapshottingOperation()` with `classpathSnapshottingOperationBuilder().build()`
  - Removed unused import of `JvmSnapshotBasedIncrementalCompilationConfiguration`

### XR Compose API Updates
- **Import changes**: Replaced deprecated `ContentEdge` with `OrbiterAnchorPoint` across multiple files
  - `SubspaceWorldIntegrationTest.kt`: `ContentEdge.Bottom` → `OrbiterAnchorPoint.Bottom`
  - `SpatialPreviews.kt`: `ContentEdge.Top` → `OrbiterAnchorPoint.Top`
  - `SubspaceDemo.kt`: `ContentEdge.Top` → `OrbiterAnchorPoint.Top`

### Deprecation Suppressions
- Added `@Suppress("DEPRECATION")` annotations to test rule declarations in XR renderer and sample tests (11 files) with explanatory comments about v2 rule API compatibility
- Added `@Suppress("DEPRECATION")` to `MediaStylePreview()` in `NotificationStyleGallery.kt` with rationale for using legacy androidx.media surface

### Minor Fix
- Updated `Remapper` instantiation in `S3_5RecompileSaveLoopRealModeTest.kt` to pass `Opcodes.ASM9` parameter

## Implementation Details
The builder pattern migration improves API ergonomics by allowing fluent configuration before operation execution. The incremental compilation configuration now uses a builder chain rather than direct constructor instantiation, making the code more maintainable and aligned with modern Kotlin API design patterns.

https://claude.ai/code/session_01BbbToXLaPWzEuKEdnuAU1j