### PR TITLE
fix(daemon): render private @Preview composables via setAccessible

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -254,6 +254,13 @@ class RenderEngine(
     val composableMethod: ComposableMethod? =
       if (nonComposableInvocation) null
       else trace.section("compose:resolveComposable") { clazz!!.getDeclaredComposableMethod(spec.functionName) }
+    // Kotlin `private fun` previews compile to JVM-private methods. `getDeclaredComposableMethod`
+    // still resolves them (it scans `declaredMethods`), but the reflective `invoke` in
+    // [InvokeComposable] would throw IllegalAccessException, so open the method up first — mirrors
+    // `:renderer-android`'s ComposePreviewStrategy. Guarded with `runCatching`: a SecurityManager
+    // or strong module encapsulation can refuse, in which case we still attempt the invoke
+    // (which succeeds for public/internal previews) rather than failing resolution outright.
+    composableMethod?.let { runCatching { it.asMethod().isAccessible = true } }
 
     // Self-diagnostic — surfaces in the VS Code extension's output channel as `[daemon stderr] …`.
     // Pairs with `[classloader] swap requested` / `allocate child loader` lines from

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -124,6 +124,48 @@ class RenderEngineTest {
   }
 
   @Test
+  fun privateComposableRendersToValidPng() {
+    // Regression: Kotlin `private fun` previews compile to JVM-private static methods. The daemon
+    // resolves them via `getDeclaredComposableMethod` but the reflective `invoke` threw
+    // `IllegalAccessException: … cannot access a member … with modifiers "private static final"`
+    // until [RenderEngine] started calling `asMethod().isAccessible = true` after resolution. The
+    // `samples/android/.../Previews.kt`'s `RedBoxPreview` ships such a preview on purpose, so a
+    // regression here blanks one render and fails the whole baseline pipeline (MISSING_RENDERS=fail).
+    val outputDir = tempFolder.newFolder("renders-private")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      val request =
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=PrivateRedSquare;" +
+              "widthPx=64;heightPx=64;density=1.0;" +
+              "showBackground=true;" +
+              "outputBaseName=private-red-square"
+        )
+      val result = host.submit(request, timeoutMs = 120_000)
+
+      assertNotNull("private @Composable must render a PNG, not blank", result.pngPath)
+      val pngFile = File(result.pngPath!!)
+      assertTrue("rendered PNG must exist on disk: ${pngFile.absolutePath}", pngFile.exists())
+      assertTrue("rendered PNG must be non-empty", pngFile.length() > 0)
+
+      val img = ByteArrayInputStream(pngFile.readBytes()).use { ImageIO.read(it) }
+      assertNotNull("PNG must decode via javax.imageio", img)
+      val matchPct = pixelMatchPct(img!!, 0xEF5350, perChannelTolerance = 8)
+      assertTrue(
+        "expected >= 95% of pixels close to #EF5350; got ${"%.2f".format(matchPct * 100)}%",
+        matchPct >= 0.95,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
   fun serifTextWritesFontsUsedDataProduct() {
     val outputDir = tempFolder.newFolder("renders-fonts")
     System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -58,6 +58,21 @@ fun BlueSquare() {
   Box(modifier = Modifier.fillMaxSize().background(Color(0xFF42A5F5)))
 }
 
+/**
+ * Identical fill to [RedSquare] but declared `private`, so it compiles to a JVM-private static
+ * method on `RedFixturePreviewsKt`. Kotlin `private fun` previews are a real, supported shape
+ * (`samples/android/.../Previews.kt`'s `RedBoxPreview` ships one on purpose). The daemon's
+ * [RenderEngine] resolves it via `getDeclaredComposableMethod` — which scans `declaredMethods` and
+ * finds private members — but the reflective `invoke` throws `IllegalAccessException` unless the
+ * method is opened with `setAccessible(true)` first. Used by
+ * [RenderEngineTest.privateComposableRendersToValidPng] to lock that in.
+ */
+@Suppress("unused") // invoked reflectively by the daemon's RenderEngine, not from Kotlin
+@Composable
+private fun PrivateRedSquare() {
+  Box(modifier = Modifier.fillMaxSize().background(Color(0xFFEF5350)))
+}
+
 @Composable
 fun ThemedPrimarySquare() {
   MaterialTheme(colorScheme = lightColorScheme(primary = Color(0xFF123456))) {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -184,6 +184,13 @@ class RenderEngine(
 
     val clazz = Class.forName(spec.className, true, classLoader)
     val composableMethod: ComposableMethod = clazz.getDeclaredComposableMethod(spec.functionName)
+    // Kotlin `private fun` previews compile to JVM-private methods. `getDeclaredComposableMethod`
+    // still resolves them (it scans `declaredMethods`), but the reflective `invoke` in
+    // [InvokeComposable] would throw IllegalAccessException, so open the method up first — mirrors
+    // `:renderer-android`'s ComposePreviewStrategy. Guarded with `runCatching`: a SecurityManager
+    // or strong module encapsulation can refuse, in which case we still attempt the invoke
+    // (which succeeds for public/internal previews) rather than failing resolution outright.
+    runCatching { composableMethod.asMethod().isAccessible = true }
 
     // Self-diagnostic — surfaces in the VS Code extension's output channel as `[daemon stderr] …`.
     // Pairs with `[classloader] swap requested` / `allocate child loader` lines from

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -90,6 +90,50 @@ class RenderEngineTest {
   }
 
   @Test
+  fun privateComposableRendersToValidPng() {
+    // Regression: Kotlin `private fun` previews compile to JVM-private static methods. The daemon
+    // resolves them via `getDeclaredComposableMethod` but the reflective `invoke` threw
+    // `IllegalAccessException: … cannot access a member … with modifiers "private static final"`
+    // until [RenderEngine] started calling `asMethod().isAccessible = true` after resolution. The
+    // `samples/android/.../Previews.kt`'s `RedBoxPreview` ships such a preview on purpose.
+    val outputDir = tempFolder.newFolder("renders-private")
+    val engine = RenderEngine(outputDir = outputDir)
+    val host = DesktopHost(engine = engine)
+    host.start()
+    try {
+      val request =
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=PrivateRedSquare;" +
+              "widthPx=64;heightPx=64;density=1.0;" +
+              "showBackground=true;" +
+              "outputBaseName=private-red-square"
+        )
+      val result = host.submit(request, timeoutMs = 60_000)
+
+      assertNotNull("private @Composable must render a PNG, not blank", result.pngPath)
+      val pngFile = File(result.pngPath!!)
+      assertTrue("rendered PNG must exist on disk: ${pngFile.absolutePath}", pngFile.exists())
+      assertTrue("rendered PNG must be non-empty", pngFile.length() > 0)
+
+      val img = ByteArrayInputStream(pngFile.readBytes()).use { ImageIO.read(it) }
+      assertNotNull("PNG must decode via javax.imageio", img)
+      val matchPct = pixelMatchPct(img!!, 0xEF5350, perChannelTolerance = 8)
+      assertTrue(
+        "expected ≥ 95% of pixels close to #EF5350; got ${"%.2f".format(matchPct * 100)}%",
+        matchPct >= 0.95,
+      )
+    } finally {
+      host.shutdown()
+    }
+    assertFalse(
+      "render thread must not observe an InterruptedException",
+      host.renderThreadInterrupted,
+    )
+  }
+
+  @Test
   fun tenSequentialRendersExposeWarmRuntime() {
     val outputDir = tempFolder.newFolder("renders-warmup")
     val engine = RenderEngine(outputDir = outputDir)

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -43,6 +43,20 @@ fun BlueSquare() {
   Box(modifier = Modifier.fillMaxSize().background(Color(0xFF42A5F5)))
 }
 
+/**
+ * Identical fill to [RedSquare] but declared `private`, so it compiles to a JVM-private static
+ * method on `RedFixturePreviewsKt`. Kotlin `private fun` previews are a real, supported shape
+ * (`samples/android/.../Previews.kt`'s `RedBoxPreview` ships one on purpose). [RenderEngine]
+ * resolves it via `getDeclaredComposableMethod` — which scans `declaredMethods` and finds private
+ * members — but the reflective `invoke` throws `IllegalAccessException` unless the method is opened
+ * with `setAccessible(true)` first. Used by [RenderEngineTest.privateComposableRendersToValidPng].
+ */
+@Suppress("unused") // invoked reflectively by the daemon's RenderEngine, not from Kotlin
+@Composable
+private fun PrivateRedSquare() {
+  Box(modifier = Modifier.fillMaxSize().background(Color(0xFFEF5350)))
+}
+
 @Composable
 fun ThemedPrimarySquare() {
   MaterialTheme(colorScheme = lightColorScheme(primary = Color(0xFF123456))) {


### PR DESCRIPTION
## Summary

Private `@Preview` composables fail to render through the daemon. The preview-generation workflow exited non-zero (`rc=2`) because the baseline pipeline reported "no PNG for 1 of 154 preview(s)" under `MISSING_RENDERS=fail`, and the a11y pipeline blew up with:

```
IllegalAccessException: class androidx.compose.runtime.reflect.ComposableMethod
cannot access a member of class com.example.sampleandroid.PreviewsKt
with modifiers "private static final"
  at androidx.compose.runtime.reflect.ComposableMethod.invoke(...)
  at ee.schimke.composeai.daemon.RenderEngineKt.InvokeComposable(RenderEngine.kt:1133)
```

The daemon's `RenderEngine` resolves previews with `getDeclaredComposableMethod` — which scans `declaredMethods` and *finds* private members — but then invokes them without opening the method up first. Kotlin `private fun` previews compile to JVM-private static methods, so the reflective `invoke` throws `IllegalAccessException`.

This is not a dependency regression — invoking a private method via reflection has always required `setAccessible(true)` on every JDK, and `ComposableMethod.invoke` has never done it for you. The standalone `:renderer-android` already compensates:

```kotlin
// renderers/android/.../PreviewRenderStrategy.kt
runCatching { composableMethod.asMethod().isAccessible = true }
```

The daemon's render body is a hand-duplicated copy of the standalone renderer (per its own KDoc), and this one line was never ported over. `samples/android`'s `RedBoxPreview` is intentionally `private` to exercise this path, so the gap became a hard pipeline failure.

## Changes

- Call `composableMethod.asMethod().isAccessible = true` after resolution in both the Android and desktop daemon `RenderEngine`s, guarded with `runCatching` so a SecurityManager / strong module encapsulation can't break public/internal resolution.
- Add a `PrivateRedSquare` test fixture + `RenderEngineTest` regression on both backends.

## Test plan

- `./gradlew :daemon:desktop:test --tests "ee.schimke.composeai.daemon.RenderEngineTest"` — green with the fix.
- Verified the new desktop regression test fails with the exact `IllegalAccessException` when the fix line is removed, and passes with it restored.
- Android equivalent is symmetric to desktop; not runnable in the dev container (no Android SDK) — CI validates it.
- `ktfmtCheck` passes on both daemon modules.


---
_Generated by [Claude Code](https://claude.ai/code/session_014Qa9jtoEd2jFUFD7kASrbf)_