### PR TITLE
feat(samples): showcase spatial Compose previews + gradient composite backdrop

### DIFF
--- a/renderers/xr-composite/src/main.cpp
+++ b/renderers/xr-composite/src/main.cpp
@@ -37,7 +37,9 @@
 #include <math/vec3.h>
 #include <math/vec4.h>
 #include <math/quat.h>
+#include <math/half.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -87,6 +89,78 @@ float3 hexToLinear(const std::string& hex) {
 }
 
 struct Vertex { float x, y, z, u, v; };
+
+// GLSL-style smoothstep on a single scalar (Filament's math headers don't export one for floats).
+float smoothstep01(float x) {
+  x = std::clamp(x, 0.0f, 1.0f);
+  return x * x * (3.0f - 2.0f * x);
+}
+
+// Direction (unnormalized) for a cubemap texel. `face` follows Filament's FaceOffsets order
+// (+X,-X,+Y,-Y,+Z,-Z); (u,v) are in [-1,1] across the face. Matches the standard GL cubemap
+// convention so the +Y face points straight up (dir.y == 1).
+float3 cubeDir(int face, float u, float v) {
+  switch (face) {
+    case 0: return { 1.0f,  -v,   -u};  // +X
+    case 1: return {-1.0f,  -v,    u};  // -X
+    case 2: return {  u,  1.0f,    v};  // +Y
+    case 3: return {  u, -1.0f,   -v};  // -Y
+    case 4: return {  u,   -v,  1.0f};  // +Z
+    default:return { -u,   -v, -1.0f};  // -Z
+  }
+}
+
+// Build a vertical-gradient environment cubemap emulating an HDRI sky/horizon, and install it as the
+// scene's skybox. `sky` is the colour straight up, `horizon` the colour at eye level; a soft glow
+// band brightens the horizon to read as atmospheric haze. RGBA16F (half) texels, one face at a time
+// via Texture::FaceOffsets. The texel buffer is heap-allocated and freed in the PixelBufferDescriptor
+// callback — Filament reads it on the driver thread during flushAndWait, so it must outlive this call
+// (same idiom as the panel textures below).
+Skybox* buildGradientSkybox(Engine& engine, float3 sky, float3 horizon) {
+  constexpr uint32_t kFace = 128;
+  constexpr uint32_t kTexelsPerFace = kFace * kFace;
+  constexpr uint32_t kChannels = 4;
+  const size_t faceBytes = (size_t)kTexelsPerFace * kChannels * sizeof(half);
+  // 6 faces packed back-to-back; FaceOffsets(faceBytes/elem≈) indexes by element count below.
+  auto* texels = new half[(size_t)kTexelsPerFace * kChannels * 6];
+
+  for (int face = 0; face < 6; ++face) {
+    half* dst = texels + (size_t)face * kTexelsPerFace * kChannels;
+    for (uint32_t y = 0; y < kFace; ++y) {
+      for (uint32_t x = 0; x < kFace; ++x) {
+        // texel centre in [-1, 1]
+        float u = ((x + 0.5f) / kFace) * 2.0f - 1.0f;
+        float v = ((y + 0.5f) / kFace) * 2.0f - 1.0f;
+        float3 dir = normalize(cubeDir(face, u, v));
+        float t = smoothstep01(dir.y * 0.5f + 0.5f);
+        float3 c = mix(horizon, sky, t);
+        // Soft horizon glow: a gentle band centred on dir.y == 0, fading above and below.
+        float glow = std::exp(-(dir.y * dir.y) / (2.0f * 0.06f * 0.06f));
+        c = c + horizon * (glow * 0.35f);
+        size_t i = ((size_t)y * kFace + x) * kChannels;
+        dst[i + 0] = half(c.r);
+        dst[i + 1] = half(c.g);
+        dst[i + 2] = half(c.b);
+        dst[i + 3] = half(1.0f);
+      }
+    }
+  }
+
+  Texture* cube = Texture::Builder()
+      .width(kFace).height(kFace).levels(1)
+      .format(Texture::InternalFormat::RGBA16F)
+      .sampler(Texture::Sampler::SAMPLER_CUBEMAP)
+      .build(engine);
+
+  Texture::FaceOffsets offsets(faceBytes);  // per-face offset in bytes, +X,-X,+Y,-Y,+Z,-Z
+  Texture::PixelBufferDescriptor pbd(
+      texels, (size_t)kTexelsPerFace * kChannels * 6 * sizeof(half),
+      Texture::Format::RGBA, Texture::Type::HALF,
+      [](void* buf, size_t, void*) { delete[] (half*)buf; }, nullptr);
+  cube->setImage(engine, 0, std::move(pbd), offsets);
+
+  return Skybox::Builder().environment(cube).showSun(false).build(engine);
+}
 
 }  // namespace
 
@@ -142,13 +216,36 @@ int main(int argc, char** argv) {
   }
 
   // ---- background ----
-  float3 bg = {0.06f, 0.06f, 0.08f};
+  // Default: a tasteful dark vertical-gradient environment cubemap (HDRI-style sky/horizon) so the
+  // light Material panels pop. `environment.kind=="color"` keeps the legacy flat skybox; an explicit
+  // `kind=="gradient"` may override the `sky`/`horizon` hex defaults. `bg` doubles as the clear
+  // colour for the readback path, so we always pick a sensible solid even in gradient mode.
+  std::string envKind = "gradient";
+  float3 gradSky = hexToLinear("#05070d");
+  float3 gradHorizon = hexToLinear("#1a1f2b");
   if (scene.contains("environment") && scene["environment"].is_object()) {
     auto& env = scene["environment"];
-    if (env.value("kind", "") == "color" && env.contains("color"))
-      bg = hexToLinear(env["color"].get<std::string>());
+    envKind = env.value("kind", "gradient");
+    if (env.contains("sky")) gradSky = hexToLinear(env["sky"].get<std::string>());
+    if (env.contains("horizon")) gradHorizon = hexToLinear(env["horizon"].get<std::string>());
   }
-  Skybox* skybox = Skybox::Builder().color({bg.r, bg.g, bg.b, 1.0f}).build(*engine);
+
+  float3 bg = {0.06f, 0.06f, 0.08f};
+  Skybox* skybox = nullptr;
+  if (envKind == "color") {
+    if (scene.contains("environment") && scene["environment"].contains("color"))
+      bg = hexToLinear(scene["environment"]["color"].get<std::string>());
+    skybox = Skybox::Builder().color({bg.r, bg.g, bg.b, 1.0f}).build(*engine);
+  } else {
+    // Clear colour mirrors the horizon so any uncovered edge blends with the gradient.
+    bg = gradHorizon;
+    skybox = buildGradientSkybox(*engine, gradSky, gradHorizon);
+    if (!skybox) {
+      // Fall back to a flat horizon-coloured skybox if the cubemap couldn't be built.
+      fprintf(stderr, "gradient skybox build failed; falling back to solid\n");
+      skybox = Skybox::Builder().color({bg.r, bg.g, bg.b, 1.0f}).build(*engine);
+    }
+  }
   fscene->setSkybox(skybox);
 
   // ---- material ----

--- a/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SpatialContent.kt
+++ b/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SpatialContent.kt
@@ -1,21 +1,38 @@
 package com.example.samplexrspatial
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 /**
@@ -67,5 +84,170 @@ fun TransportControls(modifier: Modifier = Modifier) {
       FilledTonalButton(onClick = {}) { Text("Play") }
       FilledTonalButton(onClick = {}) { Text("Next") }
     }
+  }
+}
+
+// The composables below give the showcase spatial previews (SpatialShowcasePreviews.kt) visually
+// distinct panel bodies, so the baked composite stills read as a real multi-panel app rather than
+// the same card repeated. All ordinary Material3 — no XR dependency.
+
+/** A grid of album tiles — the kind of 2D content you'd host in a "library" panel. */
+@Composable
+fun LibraryGrid(modifier: Modifier = Modifier) {
+  val albums =
+    listOf(
+      "Aurora" to Color(0xFF6750A4),
+      "Drift" to Color(0xFF1E88E5),
+      "Lumen" to Color(0xFF00897B),
+      "Pulse" to Color(0xFFD81B60),
+      "Halcyon" to Color(0xFFF4511E),
+      "Vesper" to Color(0xFF5E35B1),
+    )
+  Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+    Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+      Text("Library", style = MaterialTheme.typography.titleLarge)
+      LazyVerticalGrid(
+        columns = GridCells.Fixed(2),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+      ) {
+        items(albums) { (title, color) ->
+          Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Box(
+              Modifier.fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(12.dp))
+                .background(Brush.linearGradient(listOf(color, color.copy(alpha = 0.55f))))
+            )
+            Text(
+              title,
+              style = MaterialTheme.typography.labelLarge,
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis,
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+/** A scrollable track list — the kind of 2D content you'd host in a "queue" panel. */
+@Composable
+fun QueueList(modifier: Modifier = Modifier) {
+  val tracks =
+    listOf(
+      "Slow Light" to "Aurora",
+      "Tidal" to "Drift",
+      "Glass Fields" to "Lumen",
+      "Resonance" to "Pulse",
+      "Soft Static" to "Halcyon",
+      "Nightfall" to "Vesper",
+      "Undertow" to "Drift",
+      "Embers" to "Pulse",
+    )
+  Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surfaceContainerLow) {
+    Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+      Text("Up Next", style = MaterialTheme.typography.titleLarge)
+      LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        items(tracks) { (title, artist) ->
+          Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Box(
+              Modifier.size(36.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.primaryContainer)
+            )
+            Column(Modifier.weight(1f)) {
+              Text(
+                title,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+              )
+              Text(
+                artist,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+/** A large album-art card with a gradient cover — the "detail"/foreground panel body. */
+@Composable
+fun AlbumArtCard(modifier: Modifier = Modifier) {
+  Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surfaceContainerHigh) {
+    Column(
+      Modifier.padding(20.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      Box(
+        Modifier.fillMaxWidth()
+          .aspectRatio(1f)
+          .clip(RoundedCornerShape(16.dp))
+          .background(
+            Brush.linearGradient(listOf(Color(0xFF6750A4), Color(0xFF1E88E5), Color(0xFF00897B)))
+          )
+      )
+      Text("Aurora", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+      Text(
+        "Spatial Sessions",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+  }
+}
+
+/** A search bar — the content you'd float in a top `Orbiter`. */
+@Composable
+fun SearchBar(modifier: Modifier = Modifier) {
+  Card(modifier = modifier) {
+    Row(
+      Modifier.padding(horizontal = 20.dp, vertical = 14.dp).fillMaxWidth(),
+      horizontalArrangement = Arrangement.spacedBy(12.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Box(
+        Modifier.size(20.dp)
+          .clip(RoundedCornerShape(50))
+          .background(MaterialTheme.colorScheme.primary)
+      )
+      Text(
+        "Search your library",
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+  }
+}
+
+/** A small equalizer / settings card with sliders — a distinct "controls" panel body. */
+@Composable
+fun EqualizerCard(modifier: Modifier = Modifier) {
+  Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surfaceContainerHigh) {
+    Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+      Text("Equalizer", style = MaterialTheme.typography.titleLarge)
+      EqBand("Bass", 0.75f)
+      EqBand("Mid", 0.45f)
+      EqBand("Treble", 0.6f)
+    }
+  }
+}
+
+@Composable
+private fun EqBand(label: String, value: Float) {
+  Column {
+    Text(label, style = MaterialTheme.typography.labelMedium)
+    Slider(value = value, onValueChange = {})
   }
 }

--- a/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SpatialShowcasePreviews.kt
+++ b/samples/xr-spatial/src/main/kotlin/com/example/samplexrspatial/SpatialShowcasePreviews.kt
@@ -1,0 +1,179 @@
+package com.example.samplexrspatial
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.xr.compose.spatial.ContentEdge
+import androidx.xr.compose.spatial.Orbiter
+import androidx.xr.compose.spatial.Subspace
+import androidx.xr.compose.subspace.SpatialBox
+import androidx.xr.compose.subspace.SpatialColumn
+import androidx.xr.compose.subspace.SpatialCurvedRow
+import androidx.xr.compose.subspace.SpatialPanel
+import androidx.xr.compose.subspace.SpatialRow
+import androidx.xr.compose.subspace.layout.SpatialAlignment
+import androidx.xr.compose.subspace.layout.SpatialArrangement
+import androidx.xr.compose.subspace.layout.SubspaceModifier
+import androidx.xr.compose.subspace.layout.height
+import androidx.xr.compose.subspace.layout.offset
+import androidx.xr.compose.subspace.layout.width
+import androidx.xr.compose.subspace.semantics.testTag
+import ee.schimke.composeai.preview.XrSubspacePreview
+
+/**
+ * `@XrSubspacePreview`s that showcase the main spatial-Compose layout patterns from
+ * `androidx.xr.compose`. Each composes a real `Subspace { … }` arrangement under the fake XR runtime
+ * driven by `composePreviewRenderXr`, which recovers the panel poses/sizes into a `scene.json` (and
+ * one `<testTag>.png` texture per panel) for the offline `xr-composite` compositor to bake.
+ *
+ * Real Android XR apps don't `@Preview` the spatial arrangement itself — only the 2D panel content
+ * — because a plain `@Preview` of a `Subspace` captures an empty Home-Space frame (the subspace body
+ * is skipped when spatialization is off). These previews exist precisely to exercise the offline
+ * subspace render path, so the spatial layout is genuinely measured and laid out rather than
+ * fallen-back-to-2D.
+ *
+ * Invariant: **every `SpatialPanel` carries a unique `SubspaceModifier.testTag("<id>")`.** The tag
+ * becomes the panel id in `scene.json` and the `<id>.png` texture filename; a duplicate or missing
+ * tag breaks the scene. The 2D bodies live in [SpatialContent.kt][NowPlayingPanel] and friends.
+ */
+
+/**
+ * `SpatialRow` — three side-by-side panels (library | now-playing | queue) with even spacing. The
+ * flat multi-panel layout you'd reach for first when spreading an app across a workspace.
+ */
+@XrSubspacePreview
+@Composable
+fun SpatialRowPreview() {
+  Subspace {
+    SpatialRow(horizontalArrangement = SpatialArrangement.spacedBy(24.dp)) {
+      SpatialPanel(SubspaceModifier.testTag("row-library").width(360.dp).height(440.dp)) {
+        LibraryGrid()
+      }
+      SpatialPanel(SubspaceModifier.testTag("row-now-playing").width(480.dp).height(440.dp)) {
+        NowPlayingPanel()
+      }
+      SpatialPanel(SubspaceModifier.testTag("row-queue").width(360.dp).height(440.dp)) { QueueList() }
+    }
+  }
+}
+
+/**
+ * `SpatialCurvedRow(curveRadius = 825.dp)` — the signature "cockpit" arc. Five panels wrap around
+ * the viewer along a fixed-radius curve, the most visually distinctive spatial arrangement.
+ */
+@XrSubspacePreview
+@Composable
+fun SpatialCurvedRowPreview() {
+  Subspace {
+    SpatialCurvedRow(
+      curveRadius = 825.dp,
+      horizontalArrangement = SpatialArrangement.spacedBy(16.dp),
+    ) {
+      SpatialPanel(SubspaceModifier.testTag("curve-library").width(300.dp).height(380.dp)) {
+        LibraryGrid()
+      }
+      SpatialPanel(SubspaceModifier.testTag("curve-search").width(300.dp).height(380.dp)) {
+        SearchBar()
+      }
+      SpatialPanel(SubspaceModifier.testTag("curve-now-playing").width(360.dp).height(380.dp)) {
+        NowPlayingPanel()
+      }
+      SpatialPanel(SubspaceModifier.testTag("curve-queue").width(300.dp).height(380.dp)) {
+        QueueList()
+      }
+      SpatialPanel(SubspaceModifier.testTag("curve-equalizer").width(300.dp).height(380.dp)) {
+        EqualizerCard()
+      }
+    }
+  }
+}
+
+/**
+ * Depth — a foreground panel raised toward the viewer in front of a background panel, via a
+ * `SpatialBox` whose children carry different z `offset`s. Shows how spatial panels stack along the
+ * depth axis rather than only across a plane.
+ */
+@XrSubspacePreview
+@Composable
+fun SpatialDepthPreview() {
+  Subspace {
+    SpatialBox {
+      SpatialPanel(
+        SubspaceModifier.testTag("depth-background")
+          .width(640.dp)
+          .height(420.dp)
+          .offset(z = (-120).dp)
+      ) {
+        LibraryGrid()
+      }
+      SpatialPanel(
+        SubspaceModifier.testTag("depth-foreground")
+          .width(420.dp)
+          .height(180.dp)
+          .offset(z = 120.dp)
+      ) {
+        AlbumArtCard()
+      }
+    }
+  }
+}
+
+/**
+ * `Orbiter`s on two edges of a main `SpatialPanel` — a search/title strip floating at
+ * [ContentEdge.Top] and the transport controls at [ContentEdge.Bottom]. Orbiters host 2D control
+ * strips anchored to a panel's edges in Full Space.
+ */
+@XrSubspacePreview
+@Composable
+fun OrbiterPanelPreview() {
+  Subspace {
+    SpatialPanel(SubspaceModifier.testTag("orbiter-main").width(560.dp).height(360.dp)) {
+      NowPlayingPanel()
+      Orbiter(position = ContentEdge.Top) { SearchBar() }
+      Orbiter(position = ContentEdge.Bottom) { TransportControls() }
+    }
+  }
+}
+
+/**
+ * Master-detail — an asymmetric `SpatialRow` using `weight` so a wide master panel takes twice the
+ * width of the narrow detail panel. The common list+inspector split, placed spatially.
+ */
+@XrSubspacePreview
+@Composable
+fun MasterDetailPreview() {
+  Subspace {
+    SpatialRow(horizontalArrangement = SpatialArrangement.spacedBy(24.dp)) {
+      SpatialPanel(SubspaceModifier.testTag("md-master").weight(2f).height(460.dp)) { QueueList() }
+      SpatialPanel(SubspaceModifier.testTag("md-detail").weight(1f).height(460.dp)) {
+        AlbumArtCard()
+      }
+    }
+  }
+}
+
+/**
+ * Nested layout — a `SpatialColumn` of stacked controls nested inside a `SpatialRow` beside a wide
+ * now-playing panel. Demonstrates composing the row/column primitives into a richer arrangement.
+ */
+@XrSubspacePreview
+@Composable
+fun NestedColumnInRowPreview() {
+  Subspace {
+    SpatialRow(
+      verticalAlignment = SpatialAlignment.CenterVertically,
+      horizontalArrangement = SpatialArrangement.spacedBy(24.dp),
+    ) {
+      SpatialPanel(SubspaceModifier.testTag("nested-now-playing").width(520.dp).height(420.dp)) {
+        NowPlayingPanel()
+      }
+      SpatialColumn(verticalArrangement = SpatialArrangement.spacedBy(16.dp)) {
+        SpatialPanel(SubspaceModifier.testTag("nested-search").width(320.dp).height(120.dp)) {
+          SearchBar()
+        }
+        SpatialPanel(SubspaceModifier.testTag("nested-equalizer").width(320.dp).height(280.dp)) {
+          EqualizerCard()
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a set of showcase `@XrSubspacePreview`s to `:samples:xr-spatial` demonstrating the main spatial-Compose layout patterns from the real `androidx.xr.compose` APIs, and replaces the offline compositor's flat solid-color skybox with a tasteful HDRI-style vertical-gradient backdrop so the light Material panels pop.

Real Android XR apps don't `@Preview` the spatial arrangement itself (a plain `@Preview` of a `Subspace` captures an empty Home-Space frame); these previews exist to exercise the offline subspace render path, where the spatial layout is genuinely measured and laid out by `composePreviewRenderXr` into a `scene.json` + per-panel textures, then baked by the native `xr-composite` compositor.

### New showcase previews (`SpatialShowcasePreviews.kt`)

All compiled and rendered against `androidx.xr.compose:1.0.0-alpha14`:

- **SpatialRowPreview** — `SpatialRow` of three side-by-side panels (library | now-playing | queue) with spacing.
- **SpatialCurvedRowPreview** — `SpatialCurvedRow(curveRadius = 825.dp)` of five panels, the signature "cockpit" arc (panels rotate + recede in z).
- **SpatialDepthPreview** — `SpatialBox` with foreground/background panels at opposite z `offset`s to show depth.
- **OrbiterPanelPreview** — a main `SpatialPanel` with `Orbiter`s on its top (search) and bottom (transport) edges.
- **MasterDetailPreview** — asymmetric `SpatialRow` via `weight(2f)` / `weight(1f)`.
- **NestedColumnInRowPreview** — a `SpatialColumn` nested inside a `SpatialRow`.

Every `SpatialPanel` carries a unique `SubspaceModifier.testTag` (becomes the scene panel id + `.png` texture path). The existing `NowPlayingSpatialPreview` is kept.

New distinct 2D panel bodies in `SpatialContent.kt` (`LibraryGrid`, `QueueList`, `AlbumArtCard`, `SearchBar`, `EqualizerCard`) — ordinary Material3, no XR dependency — so the panels read as a real multi-panel app.

All six showcase preview patterns from the spec compiled against alpha14; none were dropped. The deprecated edge-based `Orbiter(position = …)` overload is used (consistent with the existing `SubspaceDemo.kt` / `SpatialPreviews.kt`).

### Gradient backdrop (`renderers/xr-composite/src/main.cpp`)

Replaces `Skybox::Builder().color(...)` with a 128² RGBA16F environment cubemap (Filament `FaceOffsets` face order): per-texel sample direction → `smoothstep(dir.y*0.5+0.5)` lerp from horizon to sky + a soft horizon glow band; built via `Skybox::Builder().environment(cube).showSun(false)`. The texel buffer is heap-allocated and freed in the `PixelBufferDescriptor` callback (mirrors the panel-texture lifetime idiom).

Backward compatible: `environment.kind=="color"` keeps the solid skybox; default (no `environment`, or `kind=="gradient"` with optional `sky`/`horizon` hex) uses the gradient, with dark defaults (sky `#05070d`, horizon `#1a1f2b`). Falls back to a solid horizon-coloured skybox if the cubemap build fails.

## Test plan

- [x] `./gradlew :samples:xr-spatial:compileDebugKotlin` — clean
- [x] `./gradlew :samples:xr-spatial:ktfmtCheck` — clean
- [x] `FILAMENT_SDK=… ./renderers/xr-composite/build.sh` — builds; `ldd` shows no dynamic `libc++`/`libstdc++` (static libc++ holds)
- [x] `./gradlew :samples:xr-spatial:composePreviewRenderXr` — produces `scene.json` + per-panel textures for all 7 previews; curved-row scene shows real curvature (panel rotation + z recession), depth scene shows z-offset stacking
- [x] Baked every render dir to `composite.png` via `xr-composite` under `xvfb-run` + llvmpipe — gradient backdrop renders correctly behind the spatial panels