### PR TITLE
fix(samples): pin android-alpha activity-compose >= 1.11 for navigationevent

### DIFF
--- a/samples/android-alpha/build.gradle.kts
+++ b/samples/android-alpha/build.gradle.kts
@@ -56,6 +56,15 @@ dependencies {
   implementation(libs.compose.ui)
   implementation(libs.compose.ui.tooling.preview)
   implementation(libs.compose.foundation)
+  // material3 1.5.0-alphaNN drags activity 1.11+ onto the test classpath, which
+  // transitively pulls androidx.navigationevent:1.0.0. AGP builds the merged
+  // test resource APK from the *main* variant, so unless the main variant also
+  // resolves activity >= 1.11 the `androidx.navigationevent.R$id.*` resources
+  // never get merged and previews crash at render time with
+  // `NoClassDefFoundError: androidx/navigationevent/R$id`. This is the
+  // `activity-vs-navigationevent` finding `compose-preview doctor` reports;
+  // pinning activity-compose here keeps the main variant ahead of the floor.
+  implementation(libs.activity.compose)
   // `@AnimatedPreview` and `@FocusedPreview` live here — source-retained
   // metadata read by `DiscoverPreviewsTask` at FQN.
   implementation(project(":preview-annotations"))


### PR DESCRIPTION
## Summary

The `Apply compose-preview` workflow on `main` failed with `rc=2`
([run 26916629446](https://github.com/yschimke/compose-ai-tools/actions/runs/26916629446/job/79407749732)).
The `compose` pipeline reported *"produced no PNG for 1 of 154 preview(s)"*, and
because the apply action runs `compose-preview show --missing-renders fail`, that
single missing render fails the whole job.

The root cause is the one `error` the run's `compose-preview doctor` block flagged:

```
✗ :samples:android-alpha — navigationevent on test classpath but main variant activity is too old
    → Upgrade main-variant activity-compose to >= 1.11.0, or avoid transitively pulling navigationevent into tests.
```

`:samples:android-alpha` pins `material3:1.5.0-alpha20`, which transitively drags
`activity` 1.11+ (and `androidx.navigationevent:1.0.0`) onto the unit-test
classpath. AGP builds the merged test resource APK from the **main** variant, so
with the main variant resolving an older `activity` the
`androidx.navigationevent.R$id.*` resources never get merged. A preview that
touches them crashes at render time with
`NoClassDefFoundError: androidx/navigationevent/R$id` → no PNG → `rc=2`.

The fix is the doctor's own remediation: declare `activity-compose` on the main
variant (catalog version 1.13.0, comfortably above the 1.11 floor) so the
`navigationevent` resources merge and the preview renders.

This also clears the doctor's sole `✗` for the module.

## Test plan

- [ ] `:samples:android-alpha:composePreviewDoctor` no longer reports the
      `activity-vs-navigationevent` finding.
- [ ] `compose-preview show --missing-renders fail` renders all android-alpha
      previews (no `[no PNG]`), so the apply workflow's `compose` pipeline exits 0.

> Note: this environment has no Android SDK, so the change was verified by static
> analysis of the doctor output and `CompatRules`, not by running the render
> locally. CI on this PR exercises the real render path.


---
_Generated by [Claude Code](https://claude.ai/code/session_016JsGWTqqt77xGAc9LQEgnK)_