### PR TITLE
feat(xr-composite): rounded panels, soft shadow, edge rim + tighter framing

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/xr/SpatialScene.kt
@@ -69,12 +69,33 @@ public data class OrbitCamera(
   val pitchDeg: Double,
 )
 
-/** Optional scene backdrop. `kind` is "color" (`#RRGGBB` in [color]) or "skybox" ([texture]). */
+/**
+ * Optional scene backdrop. `kind` is "color" (`#RRGGBB` in [color]) or "skybox" ([texture]).
+ *
+ * For gradient backdrops (any `kind` other than "color"), the offline compositor supports **named
+ * presets** ([preset], e.g. `"warm-room"` — the default — or `"studio-dark"`) plus explicit
+ * gradient stops that **override** the chosen preset: [sky] (straight up), [horizon] (eye level),
+ * and [floor] (straight down; its presence turns the 2-stop gradient into a 3-stop, room-like one).
+ * These knobs are optional; omit them to take the compositor's default `warm-room` backdrop. The
+ * compositor's `--environment` CLI flag overrides whatever the scene specifies.
+ */
 @Serializable
 public data class SpatialEnvironment(
   val kind: String,
   val color: String? = null,
   val texture: String? = null,
+  /**
+   * Named gradient preset (e.g. `"warm-room"`, `"studio-dark"`); ignored when `kind == "color"`.
+   */
+  val preset: String? = null,
+  /** Gradient colour straight up (`#RRGGBB`); overrides the preset. */
+  val sky: String? = null,
+  /**
+   * Gradient colour at eye level (`#RRGGBB`); overrides the preset. Doubles as the clear colour.
+   */
+  val horizon: String? = null,
+  /** Gradient colour straight down (`#RRGGBB`); overrides the preset and enables a 3-stop floor. */
+  val floor: String? = null,
 )
 
 /** The full scene the 3D viewer renders. [version] must equal [SPATIAL_SCENE_VERSION]. */

--- a/docs/design/SPATIAL_SCENE_CONTRACT.md
+++ b/docs/design/SPATIAL_SCENE_CONTRACT.md
@@ -60,9 +60,26 @@ See `spatialScene.ts` for the authoritative types. In brief:
         },
     ],
     "orbiters": [], // optional: edge-anchored control strips (same shape + "edge")
-    "environment": { "kind": "color", "color": "#101014" }, // optional backdrop
+    "environment": { "kind": "gradient", "preset": "warm-room" }, // optional backdrop (see below)
 }
 ```
+
+## Environment (backdrop)
+
+The optional `environment` selects the scene backdrop and is **swappable**:
+
+- `kind: "color"` — a flat solid skybox using `color` (`#RRGGBB`).
+- `kind: "skybox"` — an image-based skybox from `texture` (consumer-defined).
+- otherwise (e.g. `kind: "gradient"`, the default) — a **vertical-gradient, room-like** backdrop.
+  An optional `preset` names a built-in look; the offline compositor ships `"warm-room"` (the
+  default: a softly-lit warm passthrough room) and `"studio-dark"` (the legacy cold gradient).
+  Explicit `sky` (straight up), `horizon` (eye level), and `floor` (straight down — its presence
+  upgrades the 2-stop gradient to a 3-stop, room-like one) **override** the chosen preset, giving a
+  custom gradient. Omit `environment` entirely to take the compositor's default `warm-room`.
+
+The compositor also accepts a `--environment <preset | color:#RRGGBB>` CLI flag that **overrides**
+whatever the scene specifies (see the [compositor](xr-spatial/COMPOSITOR.md) and its
+[README](../../renderers/xr-composite/README.md)).
 
 ## Producer mapping (`:renderer-xr`, Phase A)
 

--- a/docs/design/xr-spatial/COMPOSITOR.md
+++ b/docs/design/xr-spatial/COMPOSITOR.md
@@ -49,7 +49,12 @@ convention, so the transform is essentially identity.
   black, and a `LinearToneMapper` so colors stay faithful.
 - `camera` (orbit) → eye = `target + distance · dir(yaw, pitch)`, `lookAt`,
   45° vertical FoV.
-- `environment.color` → skybox / clear color (defaults to a neutral dark).
+- `environment` → a **swappable** backdrop. `kind=="color"` → a flat skybox / clear
+  color (`color`). Otherwise a **vertical-gradient, room-like** backdrop chosen by a
+  named **preset** (`warm-room`, the softly-lit warm default, or `studio-dark`, the
+  legacy cold look), with optional explicit `sky`/`horizon`/`floor` stops overriding
+  the preset. The `--environment <preset|color:#RRGGBB>` CLI flag overrides the scene's
+  choice; the default is `warm-room`. The horizon doubles as the readback clear color.
 
 Implementation gotchas (buffer lifetime, alpha premultiply, readPixels
 orientation) are documented in the tool's

--- a/renderers/xr-composite/CMakeLists.txt
+++ b/renderers/xr-composite/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 set(MATERIALS_OUT "${CMAKE_BINARY_DIR}/materials")
 file(MAKE_DIRECTORY "${MATERIALS_OUT}")
 set(MATERIAL_BLOBS "")
-foreach(mat unlit_texture flat_color)
+foreach(mat unlit_texture flat_color panel_shadow)
   set(src "${CMAKE_CURRENT_SOURCE_DIR}/materials/${mat}.mat")
   set(out "${MATERIALS_OUT}/${mat}.filamat")
   add_custom_command(

--- a/renderers/xr-composite/README.md
+++ b/renderers/xr-composite/README.md
@@ -118,6 +118,14 @@ These tripped up the initial implementation and are load-bearing:
   written without a vertical flip and textures are loaded top-down (no stb flip).
 - **Color:** panel textures are `SRGB8_A8`; the view uses a `LinearToneMapper`
   (no filmic curve) so panel colors stay faithful.
+- **Floating-panel fidelity:** to match Android XR's floating glass panels, each
+  panel quad rounds its corners and adds a faint edge rim in `unlit_texture.mat`
+  (a rounded-rect SDF drives the alpha mask + rim), and a separate soft
+  rounded-rect **shadow quad** (`panel_shadow.mat`) is composited behind/below it.
+  Corner radius / rim / shadow are computed in an **aspect-corrected rect space**
+  (half-extents `(aspect,1)` or `(1,1/aspect)`) so corners stay circular on wide
+  panels. Real Filament shadow maps are unstable/expensive on llvmpipe, so the
+  contact shadow is a baked transparent quad — deterministic and GPU-cheap.
 
 ## Roadmap
 

--- a/renderers/xr-composite/README.md
+++ b/renderers/xr-composite/README.md
@@ -80,6 +80,40 @@ never fails and the interactive viewer + `scene.json` are unaffected.
 | `--out <path>` | output PNG | `composite.png` |
 | `--materials <dir>` | directory with the compiled `.filamat` blobs | `.` |
 | `--width` / `--height` | output size in px | `1280` × `800` |
+| `--environment <preset\|color:#RRGGBB>` | backdrop override (see "Background"): a named preset, or `color:#RRGGBB` for a flat skybox. Overrides the scene's `environment`. | `warm-room` |
+
+## Background (swappable presets)
+
+The backdrop is a **vertical-gradient, room-like environment cubemap** (an HDRI-style
+ceiling / wall / floor) so the light Material panels pop. It is **swappable** via named
+presets:
+
+| preset | look |
+|--------|------|
+| `warm-room` *(default)* | a softly-lit, muted warm passthrough room — warm-taupe ceiling (`#332e27`), a warm wall at the horizon with a gentle glow (`#5a4d40`), and a deep warm-brown floor (`#1e1a16`). Echoes a real Android XR room while staying mid-dark so panels read clearly. |
+| `studio-dark` | the legacy cold gradient — sky `#05070d` → horizon `#1a1f2b`, no floor (2-stop), preserved byte-for-byte. |
+
+The gradient is built as a cubemap: the upper hemisphere interpolates horizon → sky, the
+lower hemisphere interpolates horizon → floor (when the preset has one), with a soft glow
+band on the horizon. The horizon colour also doubles as the readback **clear colour**.
+
+**How to swap.** Selection precedence, most → least specific:
+
+1. **CLI** `--environment <name>` picks a preset; `--environment color:#RRGGBB` forces a
+   flat-colour skybox. This overrides whatever the scene says.
+2. **`scene.json` `environment`**: `kind:"color"` → flat colour (`color`); otherwise a
+   `preset` field selects a named preset, and explicit `sky` / `horizon` / `floor`
+   fields override the preset's stops (a custom gradient). Legacy scenes with
+   `kind:"gradient"` + `sky`/`horizon` still render (a custom-gradient override on the
+   default). A `floor` enables the 3-stop room look.
+3. **Built-in default** = `warm-room`.
+
+```sh
+# swap to the legacy cold look:
+./build/xr-composite --scene scene.json --out studio.png --environment studio-dark
+# force a flat backdrop:
+./build/xr-composite --scene scene.json --out flat.png   --environment color:#101014
+```
 
 ## Consumer flow — auto-provisioned by the CLI
 

--- a/renderers/xr-composite/materials/panel_shadow.mat
+++ b/renderers/xr-composite/materials/panel_shadow.mat
@@ -1,0 +1,38 @@
+material {
+    name : panelShadow,
+    shadingModel : unlit,
+    blending : transparent,
+    culling : none,
+    parameters : [
+        // A soft, rounded contact shadow cast behind/below a panel so it reads as floating. The
+        // shadow quad is larger than the panel (the host inflates it by `blur`); the shader fills a
+        // rounded rect matching the panel's silhouette and feathers its edge across `blur`.
+        // All extents are in the same aspect-corrected rect space the panel material uses.
+        { type : float2, name : halfSize },     // panel half-extents (aspect-corrected)
+        { type : float,  name : cornerRadius }, // panel corner radius
+        { type : float,  name : blur },         // feather distance of the shadow edge
+        { type : float4, name : color }         // straight-alpha shadow colour (rgb, peak alpha)
+    ],
+    requires : [ uv0 ]
+}
+fragment {
+    float roundedBoxSdf(vec2 p, vec2 halfSize, float radius) {
+        vec2 q = abs(p) - halfSize + vec2(radius);
+        return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - radius;
+    }
+
+    void material(inout MaterialInputs material) {
+        prepareMaterial(material);
+        // The shadow quad spans the inflated rect; remap UV to the inflated half-extents.
+        float blur = max(materialParams.blur, 1e-4);
+        vec2 outerHalf = materialParams.halfSize + vec2(blur);
+        vec2 p = (getUV0() - 0.5) * 2.0 * outerHalf;
+        float dist = roundedBoxSdf(p, materialParams.halfSize, materialParams.cornerRadius);
+        // Solid (alpha=1) inside the panel silhouette, feathering to 0 across `blur` outside it.
+        float fall = 1.0 - smoothstep(0.0, blur, dist);
+        // Square the falloff for a softer, more gaussian-looking penumbra.
+        fall = fall * fall;
+        float a = materialParams.color.a * fall;
+        material.baseColor = vec4(materialParams.color.rgb * a, a);
+    }
+}

--- a/renderers/xr-composite/materials/unlit_texture.mat
+++ b/renderers/xr-composite/materials/unlit_texture.mat
@@ -4,15 +4,52 @@ material {
     blending : transparent,
     culling : none,
     parameters : [
-        { type : sampler2d, name : albedo }
+        { type : sampler2d, name : albedo },
+        // Corner rounding + edge rim are evaluated in an aspect-corrected "rect space" where the
+        // panel is centred on the origin and its half-extents are `halfSize`. The host scales by the
+        // panel aspect so the rounded corners stay circular (not stretched) on a wide panel:
+        // (aspect, 1.0) for w>=h, (1.0, 1/aspect) otherwise. `cornerRadius`, `rimWidth` and
+        // `edgeSoftness` are in those same aspect-corrected units.
+        { type : float2, name : halfSize },
+        { type : float,  name : cornerRadius },
+        { type : float,  name : rimWidth },
+        { type : float,  name : rimStrength },
+        { type : float,  name : edgeSoftness }
     ],
     requires : [ uv0 ]
 }
 fragment {
+    // Signed distance to a rounded rectangle centred at the origin (negative inside).
+    float roundedBoxSdf(vec2 p, vec2 halfSize, float radius) {
+        vec2 q = abs(p) - halfSize + vec2(radius);
+        return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - radius;
+    }
+
     void material(inout MaterialInputs material) {
         prepareMaterial(material);
         vec4 c = texture(materialParams_albedo, getUV0());
-        // straight alpha from the PNG -> premultiplied for Filament's transparent blending
-        material.baseColor = vec4(c.rgb * c.a, c.a);
+
+        // Map UV (0..1) into aspect-corrected rect space centred on the origin.
+        vec2 p = (getUV0() - 0.5) * 2.0 * materialParams.halfSize;
+        float dist = roundedBoxSdf(p, materialParams.halfSize, materialParams.cornerRadius);
+
+        // Rounded-corner alpha mask: 1 inside, fading to 0 across `edgeSoftness` at the boundary.
+        float soft = max(materialParams.edgeSoftness, 1e-4);
+        float mask = 1.0 - smoothstep(-soft, soft, dist);
+
+        // Faint bright rim just inside the edge so the panel reads as floating glass. Peaks a touch
+        // inboard of the boundary and fades toward the centre; never a hard border.
+        float rim = 0.0;
+        if (materialParams.rimWidth > 0.0) {
+            float inset = -dist; // distance inside the panel (>=0 inside)
+            rim = (1.0 - smoothstep(0.0, materialParams.rimWidth, inset))
+                  * smoothstep(0.0, soft, inset)
+                  * materialParams.rimStrength;
+        }
+        vec3 rgb = c.rgb + vec3(rim);
+
+        float a = c.a * mask;
+        // straight alpha -> premultiplied for Filament's transparent blending
+        material.baseColor = vec4(rgb * a, a);
     }
 }

--- a/renderers/xr-composite/src/main.cpp
+++ b/renderers/xr-composite/src/main.cpp
@@ -252,10 +252,49 @@ int main(int argc, char** argv) {
   auto unlitPkg = readFile(args.materialsDir + "/unlit_texture.filamat");
   Material* unlit = Material::Builder().package(unlitPkg.data(), unlitPkg.size()).build(*engine);
 
+  // Soft contact shadow behind each panel — a separate transparent quad that feathers a rounded-rect
+  // silhouette. Real Filament shadows are unstable / expensive on llvmpipe, so we composite a baked
+  // soft shadow quad instead (deterministic, no shadow map, no GPU shadow pass).
+  auto shadowPkg = readFile(args.materialsDir + "/panel_shadow.filamat");
+  Material* shadowMat =
+      Material::Builder().package(shadowPkg.data(), shadowPkg.size()).build(*engine);
+
   TextureSampler sampler(TextureSampler::MinFilter::LINEAR_MIPMAP_LINEAR,
                          TextureSampler::MagFilter::LINEAR);
 
   auto& tcm = engine->getTransformManager();
+
+  // Build a textured/coloured quad renderable spanning [-hw,hw] x [-hh,hh] in the XY plane, UV0
+  // running (0,0) bottom-left to (1,1) top-right. Heap-allocates the vertex/index buffers and frees
+  // them in the descriptor callbacks (Filament reads them on the driver thread during flushAndWait).
+  auto buildQuad = [&](float hw, float hh, MaterialInstance* mi) -> utils::Entity {
+    auto* verts = new Vertex[4]{
+        {-hw, -hh, 0, 0, 0},
+        { hw, -hh, 0, 1, 0},
+        { hw,  hh, 0, 1, 1},
+        {-hw,  hh, 0, 0, 1},
+    };
+    auto* idx = new uint16_t[6]{0, 1, 2, 0, 2, 3};
+    VertexBuffer* vb = VertexBuffer::Builder()
+        .vertexCount(4).bufferCount(1)
+        .attribute(VertexAttribute::POSITION, 0, VertexBuffer::AttributeType::FLOAT3, 0, sizeof(Vertex))
+        .attribute(VertexAttribute::UV0, 0, VertexBuffer::AttributeType::FLOAT2, offsetof(Vertex, u), sizeof(Vertex))
+        .build(*engine);
+    vb->setBufferAt(*engine, 0, VertexBuffer::BufferDescriptor(
+        verts, sizeof(Vertex) * 4, [](void* p, size_t, void*) { delete[] (Vertex*)p; }));
+    IndexBuffer* ib = IndexBuffer::Builder()
+        .indexCount(6).bufferType(IndexBuffer::IndexType::USHORT).build(*engine);
+    ib->setBuffer(*engine, IndexBuffer::BufferDescriptor(
+        idx, sizeof(uint16_t) * 6, [](void* p, size_t, void*) { delete[] (uint16_t*)p; }));
+    utils::Entity e = utils::EntityManager::get().create();
+    RenderableManager::Builder(1)
+        .boundingBox({{-hw, -hh, -1.0f}, {hw, hh, 1.0f}})
+        .material(0, mi)
+        .geometry(0, RenderableManager::PrimitiveType::TRIANGLES, vb, ib, 0, 6)
+        .culling(false).castShadows(false).receiveShadows(false)
+        .build(*engine, e);
+    return e;
+  };
 
   // ---- panels ----
   int placed = 0;
@@ -285,50 +324,66 @@ int main(int argc, char** argv) {
     tex->setImage(*engine, 0, std::move(pbd));
     tex->generateMipmaps(*engine);
 
-    MaterialInstance* mi = unlit->createInstance();
-    mi->setParameter("albedo", tex, sampler);
-
     float wDp = p["sizeDp"].value("width", 100);
     float hDp = p["sizeDp"].value("height", 100);
     float hw = wDp * 0.5f, hh = hDp * 0.5f;
 
-    // Heap-allocate: Filament reads the BufferDescriptor pointer on the driver thread during
-    // flushAndWait (after this loop), so the data must outlive the iteration — free in the callback.
-    auto* verts = new Vertex[4]{
-        {-hw, -hh, 0, 0, 0},
-        { hw, -hh, 0, 1, 0},
-        { hw,  hh, 0, 1, 1},
-        {-hw,  hh, 0, 0, 1},
-    };
-    auto* idx = new uint16_t[6]{0, 1, 2, 0, 2, 3};
+    // Fidelity params evaluated in an aspect-corrected "rect space" where the panel spans
+    // [-halfSize, halfSize] and rounded corners stay circular regardless of aspect (see the .mat).
+    // For w>=h: halfSize=(aspect,1); else (1,1/aspect). Radius/rim/softness are fractions of the
+    // shorter half-extent (always 1.0), so they read consistently across panel shapes.
+    float aspect = (hDp > 0.0f) ? (wDp / hDp) : 1.0f;
+    float2 halfSize = (wDp >= hDp) ? float2{aspect, 1.0f} : float2{1.0f, 1.0f / aspect};
+    // ~24-32dp corner radius on a typical ~320dp-tall panel ≈ 0.16-0.20 of the half-extent.
+    const float kCornerRadius = 0.18f;
+    const float kRimWidth = 0.06f;     // rim band width inside the edge
+    const float kRimStrength = 0.10f;  // subtle additive highlight
+    const float kEdgeSoftness = 0.012f;  // AA feather of the rounded edge
 
-    VertexBuffer* vb = VertexBuffer::Builder()
-        .vertexCount(4).bufferCount(1)
-        .attribute(VertexAttribute::POSITION, 0, VertexBuffer::AttributeType::FLOAT3, 0, sizeof(Vertex))
-        .attribute(VertexAttribute::UV0, 0, VertexBuffer::AttributeType::FLOAT2, offsetof(Vertex, u), sizeof(Vertex))
-        .build(*engine);
-    vb->setBufferAt(*engine, 0, VertexBuffer::BufferDescriptor(
-        verts, sizeof(Vertex) * 4, [](void* p, size_t, void*) { delete[] (Vertex*)p; }));
-
-    IndexBuffer* ib = IndexBuffer::Builder()
-        .indexCount(6).bufferType(IndexBuffer::IndexType::USHORT).build(*engine);
-    ib->setBuffer(*engine, IndexBuffer::BufferDescriptor(
-        idx, sizeof(uint16_t) * 6, [](void* p, size_t, void*) { delete[] (uint16_t*)p; }));
-
-    utils::Entity re = utils::EntityManager::get().create();
-    RenderableManager::Builder(1)
-        .boundingBox({{-hw, -hh, -1.0f}, {hw, hh, 1.0f}})
-        .material(0, mi)
-        .geometry(0, RenderableManager::PrimitiveType::TRIANGLES, vb, ib, 0, 6)
-        .culling(false).castShadows(false).receiveShadows(false)
-        .build(*engine, re);
+    MaterialInstance* mi = unlit->createInstance();
+    mi->setParameter("albedo", tex, sampler);
+    mi->setParameter("halfSize", halfSize);
+    mi->setParameter("cornerRadius", kCornerRadius);
+    mi->setParameter("rimWidth", kRimWidth);
+    mi->setParameter("rimStrength", kRimStrength);
+    mi->setParameter("edgeSoftness", kEdgeSoftness);
 
     // transform: translate * rotate(quat)
     auto& T = p["poseInRoot"]["translation"];
     auto& R = p["poseInRoot"]["rotation"];
     float3 t = {T.value("x", 0.0f), T.value("y", 0.0f), T.value("z", 0.0f)};
     quatf q = {R.value("w", 1.0f), R.value("x", 0.0f), R.value("y", 0.0f), R.value("z", 0.0f)};
-    mat4f model = mat4f::translation(t) * mat4f(q);
+    mat4f rot(q);
+
+    // ---- soft drop/contact shadow behind+below the panel ----
+    // Mirror the panel's rect-space metrics so the shadow silhouette matches the rounded panel, then
+    // map the aspect-corrected units back to dp via the per-axis dp-per-unit scale. The shadow quad
+    // is inflated by `blur` so its feathered penumbra has room; it sits slightly behind the panel
+    // (toward -Z in panel-local space) and is offset down a touch for a grounded, floating look.
+    {
+      float dpPerUnitX = hw / halfSize.x;   // == hh / halfSize.y
+      float blurUnits = 0.22f;              // penumbra width in rect-space units
+      float2 outerHalf = halfSize + float2{blurUnits, blurUnits};
+      float shw = outerHalf.x * dpPerUnitX;
+      float shh = outerHalf.y * dpPerUnitX;
+
+      MaterialInstance* smi = shadowMat->createInstance();
+      smi->setParameter("halfSize", halfSize);
+      smi->setParameter("cornerRadius", kCornerRadius);
+      smi->setParameter("blur", blurUnits);
+      // Soft near-black shadow; peak alpha kept subtle so it reads as a contact shadow, not a slab.
+      smi->setParameter("color", float4{0.0f, 0.0f, 0.0f, 0.42f});
+
+      utils::Entity se = buildQuad(shw, shh, smi);
+      // Offset: down by ~6% of panel height and back behind the panel so it never z-fights the quad.
+      float3 shadowOffset = {0.0f, -0.06f * hDp, -2.0f};
+      mat4f shadowModel = mat4f::translation(t) * rot * mat4f::translation(shadowOffset);
+      tcm.setTransform(tcm.getInstance(se), shadowModel);
+      fscene->addEntity(se);
+    }
+
+    utils::Entity re = buildQuad(hw, hh, mi);
+    mat4f model = mat4f::translation(t) * rot;
     tcm.setTransform(tcm.getInstance(re), model);
 
     fscene->addEntity(re);

--- a/renderers/xr-composite/src/main.cpp
+++ b/renderers/xr-composite/src/main.cpp
@@ -66,6 +66,7 @@ struct Args {
   std::string materialsDir;
   uint32_t width = 1280;
   uint32_t height = 800;
+  std::string environment;  // CLI override: a preset name, or "color:#RRGGBB"
 };
 
 std::vector<uint8_t> readFile(const std::string& path) {
@@ -112,11 +113,15 @@ float3 cubeDir(int face, float u, float v) {
 
 // Build a vertical-gradient environment cubemap emulating an HDRI sky/horizon, and install it as the
 // scene's skybox. `sky` is the colour straight up, `horizon` the colour at eye level; a soft glow
-// band brightens the horizon to read as atmospheric haze. RGBA16F (half) texels, one face at a time
-// via Texture::FaceOffsets. The texel buffer is heap-allocated and freed in the PixelBufferDescriptor
-// callback — Filament reads it on the driver thread during flushAndWait, so it must outlive this call
-// (same idiom as the panel textures below).
-Skybox* buildGradientSkybox(Engine& engine, float3 sky, float3 horizon) {
+// band brightens the horizon to read as atmospheric haze. `floor` (when set, i.e. `hasFloor`) colours
+// the lower hemisphere (dir.y < 0), turning the 2-stop gradient into a 3-stop room-like environment
+// with a ceiling, wall, and floor; when unset the lower hemisphere mirrors the original 2-stop
+// horizon→sky interpolation so the legacy look is byte-for-byte preserved. `glow` scales the horizon
+// glow band. RGBA16F (half) texels, one face at a time via Texture::FaceOffsets. The texel buffer is
+// heap-allocated and freed in the PixelBufferDescriptor callback — Filament reads it on the driver
+// thread during flushAndWait, so it must outlive this call (same idiom as the panel textures below).
+Skybox* buildGradientSkybox(Engine& engine, float3 sky, float3 horizon, float3 floor, bool hasFloor,
+                            float glow) {
   constexpr uint32_t kFace = 128;
   constexpr uint32_t kTexelsPerFace = kFace * kFace;
   constexpr uint32_t kChannels = 4;
@@ -132,11 +137,19 @@ Skybox* buildGradientSkybox(Engine& engine, float3 sky, float3 horizon) {
         float u = ((x + 0.5f) / kFace) * 2.0f - 1.0f;
         float v = ((y + 0.5f) / kFace) * 2.0f - 1.0f;
         float3 dir = normalize(cubeDir(face, u, v));
-        float t = smoothstep01(dir.y * 0.5f + 0.5f);
-        float3 c = mix(horizon, sky, t);
+        float3 c;
+        if (hasFloor && dir.y < 0.0f) {
+          // Lower hemisphere: interpolate horizon (at the wall) → floor (straight down).
+          float t = smoothstep01(-dir.y);  // 0 at horizon, 1 straight down
+          c = mix(horizon, floor, t);
+        } else {
+          // Upper hemisphere (and the whole sphere in legacy 2-stop mode): horizon → sky.
+          float t = smoothstep01(dir.y * 0.5f + 0.5f);
+          c = mix(horizon, sky, t);
+        }
         // Soft horizon glow: a gentle band centred on dir.y == 0, fading above and below.
-        float glow = std::exp(-(dir.y * dir.y) / (2.0f * 0.06f * 0.06f));
-        c = c + horizon * (glow * 0.35f);
+        float glowBand = std::exp(-(dir.y * dir.y) / (2.0f * 0.06f * 0.06f));
+        c = c + horizon * (glowBand * glow);
         size_t i = ((size_t)y * kFace + x) * kChannels;
         dst[i + 0] = half(c.r);
         dst[i + 1] = half(c.g);
@@ -162,6 +175,33 @@ Skybox* buildGradientSkybox(Engine& engine, float3 sky, float3 horizon) {
   return Skybox::Builder().environment(cube).showSun(false).build(engine);
 }
 
+// A named gradient-skybox preset. `floor` is only used when `hasFloor` is true (a 3-stop, room-like
+// environment); otherwise the lower hemisphere mirrors the upper one (the classic 2-stop look).
+struct GradientPreset {
+  const char* name;
+  const char* sky;      // colour straight up (#RRGGBB)
+  const char* horizon;  // colour at eye level (#RRGGBB)
+  const char* floor;    // colour straight down (#RRGGBB); ignored unless hasFloor
+  bool hasFloor;
+  float glow;  // horizon glow-band strength
+};
+
+// Built-in backdrops. `warm-room` is the default: a softly-lit, muted warm passthrough room
+// (warm-taupe ceiling, warm wall at the horizon with a gentle glow, deep warm-brown floor) tuned to
+// echo real Android XR rooms while keeping the light panel surfaces popping. `studio-dark` preserves
+// the original cold 2-stop gradient byte-for-byte (no floor, glow 0.35).
+constexpr GradientPreset kPresets[] = {
+    {"warm-room", "#332e27", "#5a4d40", "#1e1a16", true, 0.30f},
+    {"studio-dark", "#05070d", "#1a1f2b", "", false, 0.35f},
+};
+constexpr const char* kDefaultPreset = "warm-room";
+
+const GradientPreset* findPreset(const std::string& name) {
+  for (const auto& p : kPresets)
+    if (name == p.name) return &p;
+  return nullptr;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -174,6 +214,7 @@ int main(int argc, char** argv) {
     else if (a == "--materials") args.materialsDir = next();
     else if (a == "--width") args.width = std::stoul(next());
     else if (a == "--height") args.height = std::stoul(next());
+    else if (a == "--environment") args.environment = next();
   }
   if (args.scenePath.empty()) { fprintf(stderr, "usage: --scene scene.json --out out.png\n"); return 2; }
   // A bare filename (no '/') means the scene lives in the current directory; find_last_of
@@ -216,30 +257,87 @@ int main(int argc, char** argv) {
   }
 
   // ---- background ----
-  // Default: a tasteful dark vertical-gradient environment cubemap (HDRI-style sky/horizon) so the
-  // light Material panels pop. `environment.kind=="color"` keeps the legacy flat skybox; an explicit
-  // `kind=="gradient"` may override the `sky`/`horizon` hex defaults. `bg` doubles as the clear
-  // colour for the readback path, so we always pick a sensible solid even in gradient mode.
-  std::string envKind = "gradient";
-  float3 gradSky = hexToLinear("#05070d");
-  float3 gradHorizon = hexToLinear("#1a1f2b");
+  // The backdrop is a swappable, room-like vertical-gradient environment cubemap (HDRI-style
+  // ceiling/wall/floor) so the light Material panels pop. Selection precedence, most → least
+  // specific:
+  //   1. CLI `--environment <name>`     → a named preset (see kPresets)
+  //      CLI `--environment color:#RRGGBB` → a flat-colour skybox
+  //   2. scene.json `environment`:
+  //        kind=="color"                 → flat colour (uses `color`)
+  //        else                          → `preset` selects a named preset; explicit
+  //                                        `sky`/`horizon`/`floor`/`glow` OVERRIDE its values
+  //        (legacy scenes with kind=="gradient" + sky/horizon still render: a custom-gradient
+  //         override on top of the default preset)
+  //   3. Built-in default = `warm-room`.
+  // `bg` doubles as the clear colour for the readback path: it mirrors the horizon in gradient mode
+  // and the colour in colour mode, so any uncovered edge blends with the backdrop.
+  bool wantColor = false;       // resolved as a flat-colour skybox?
+  float3 colorBg = {0.06f, 0.06f, 0.08f};
+
+  // Start from the default preset, then layer overrides on top.
+  const GradientPreset* preset = findPreset(kDefaultPreset);
+  float3 gradSky = hexToLinear(preset->sky);
+  float3 gradHorizon = hexToLinear(preset->horizon);
+  float3 gradFloor = hexToLinear(preset->floor);
+  bool gradHasFloor = preset->hasFloor;
+  float gradGlow = preset->glow;
+
+  // Applies a named preset's params over the current gradient state.
+  auto applyPreset = [&](const GradientPreset* p) {
+    gradSky = hexToLinear(p->sky);
+    gradHorizon = hexToLinear(p->horizon);
+    gradFloor = hexToLinear(p->floor);
+    gradHasFloor = p->hasFloor;
+    gradGlow = p->glow;
+  };
+
+  // (2) scene.json environment.
   if (scene.contains("environment") && scene["environment"].is_object()) {
     auto& env = scene["environment"];
-    envKind = env.value("kind", "gradient");
-    if (env.contains("sky")) gradSky = hexToLinear(env["sky"].get<std::string>());
-    if (env.contains("horizon")) gradHorizon = hexToLinear(env["horizon"].get<std::string>());
+    std::string kind = env.value("kind", "gradient");
+    if (kind == "color") {
+      wantColor = true;
+      if (env.contains("color")) colorBg = hexToLinear(env["color"].get<std::string>());
+    } else {
+      if (env.contains("preset")) {
+        if (const GradientPreset* p = findPreset(env["preset"].get<std::string>())) applyPreset(p);
+        else fprintf(stderr, "unknown environment preset '%s'; using default\n",
+                     env["preset"].get<std::string>().c_str());
+      }
+      // Explicit fields override the chosen preset (custom gradient).
+      if (env.contains("sky")) gradSky = hexToLinear(env["sky"].get<std::string>());
+      if (env.contains("horizon")) gradHorizon = hexToLinear(env["horizon"].get<std::string>());
+      if (env.contains("floor")) {
+        gradFloor = hexToLinear(env["floor"].get<std::string>());
+        gradHasFloor = true;
+      }
+      if (env.contains("glow")) gradGlow = env["glow"].get<float>();
+    }
   }
 
-  float3 bg = {0.06f, 0.06f, 0.08f};
+  // (1) CLI override — highest precedence, wins over scene.json.
+  if (!args.environment.empty()) {
+    const std::string& e = args.environment;
+    if (e.rfind("color:", 0) == 0) {
+      wantColor = true;
+      colorBg = hexToLinear(e.substr(6));
+    } else if (const GradientPreset* p = findPreset(e)) {
+      wantColor = false;
+      applyPreset(p);
+    } else {
+      fprintf(stderr, "unknown --environment '%s'; using scene/default backdrop\n", e.c_str());
+    }
+  }
+
+  float3 bg;
   Skybox* skybox = nullptr;
-  if (envKind == "color") {
-    if (scene.contains("environment") && scene["environment"].contains("color"))
-      bg = hexToLinear(scene["environment"]["color"].get<std::string>());
+  if (wantColor) {
+    bg = colorBg;
     skybox = Skybox::Builder().color({bg.r, bg.g, bg.b, 1.0f}).build(*engine);
   } else {
     // Clear colour mirrors the horizon so any uncovered edge blends with the gradient.
     bg = gradHorizon;
-    skybox = buildGradientSkybox(*engine, gradSky, gradHorizon);
+    skybox = buildGradientSkybox(*engine, gradSky, gradHorizon, gradFloor, gradHasFloor, gradGlow);
     if (!skybox) {
       // Fall back to a flat horizon-coloured skybox if the cubemap couldn't be built.
       fprintf(stderr, "gradient skybox build failed; falling back to solid\n");

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
@@ -173,21 +173,57 @@ public object SubspaceSceneRecorder {
   }
 
   /**
-   * A neutral orbit camera framing the panels: look at the vertical centre of their bounds from a
-   * distance scaled to the layout, at a slight downward pitch. Producers/consumers may override.
+   * A neutral orbit camera framing the panels near head-on: look at the centre of their combined
+   * bounds from the distance that makes the layout fill most of the frame, at a gentle downward
+   * pitch. Producers/consumers may override.
+   *
+   * Framing matches the Android XR reference shots, where a panel sits large and roughly head-on
+   * rather than small in a sea of void. We fit the layout's full XY bounds (not just one panel's
+   * largest side) into the compositor's 45° vertical / 16:10 (1280x800) frame, leave a small margin
+   * so corners and the soft shadow aren't clipped, and clamp the distance so a tiny single panel
+   * doesn't pull the camera implausibly close. Generic across one panel and a multi-panel row.
    */
   internal fun defaultCamera(panels: List<SpatialPanel>): OrbitCamera {
     if (panels.isEmpty()) {
-      return OrbitCamera(target = Vec3(0.0, 0.0, 0.0), distance = 1200.0, yawDeg = 0.0, pitchDeg = -10.0)
+      return OrbitCamera(target = Vec3(0.0, 0.0, 0.0), distance = 1200.0, yawDeg = 0.0, pitchDeg = -6.0)
     }
-    val ys = panels.map { it.poseInRoot.translation.y }
+    // Combined axis-aligned bounds of every panel (centre ± half-size on each axis).
+    val xs = panels.flatMap { listOf(it.poseInRoot.translation.x - it.sizeDp.width / 2.0, it.poseInRoot.translation.x + it.sizeDp.width / 2.0) }
+    val ys = panels.flatMap { listOf(it.poseInRoot.translation.y - it.sizeDp.height / 2.0, it.poseInRoot.translation.y + it.sizeDp.height / 2.0) }
+    val boundsW = xs.max() - xs.min()
+    val boundsH = ys.max() - ys.min()
+    val centreX = (xs.min() + xs.max()) / 2.0
     val centreY = (ys.min() + ys.max()) / 2.0
-    val span = panels.maxOf { maxOf(it.sizeDp.width, it.sizeDp.height).toDouble() }
+
+    // Compositor frame: 45° vertical FOV, 1280x800 (aspect 1.6). Distance to fit a given extent:
+    //   verticalFit  -> halfH / tan(vFov/2)
+    //   horizontalFit-> halfW / (tan(vFov/2) * aspect)
+    // Take the larger so the whole layout fits, then divide by FILL so it occupies ~FILL of the
+    // frame (margin for rounded corners + soft shadow).
+    val vFovRad = Math.toRadians(VERTICAL_FOV_DEG)
+    val aspect = COMPOSITE_WIDTH.toDouble() / COMPOSITE_HEIGHT.toDouble()
+    val tanHalf = Math.tan(vFovRad / 2.0)
+    val distForHeight = (boundsH / 2.0) / tanHalf
+    val distForWidth = (boundsW / 2.0) / (tanHalf * aspect)
+    val fit = maxOf(distForHeight, distForWidth)
+    val distance = (fit / FRAME_FILL).coerceAtLeast(MIN_DISTANCE)
+
     return OrbitCamera(
-      target = Vec3(0.0, centreY, 0.0),
-      distance = (span * 2.0).coerceAtLeast(600.0),
+      target = Vec3(centreX, centreY, 0.0),
+      distance = distance,
       yawDeg = 0.0,
-      pitchDeg = -10.0,
+      // Near head-on, with just a hint of downward tilt so panels read as floating in front of you.
+      pitchDeg = -6.0,
     )
   }
+
+  // Compositor framing constants — kept in sync with renderers/xr-composite (45° vertical FOV) and
+  // the bake size the Gradle `composePreviewCompositeXr` task passes (--width 1280 --height 800).
+  private const val VERTICAL_FOV_DEG = 45.0
+  private const val COMPOSITE_WIDTH = 1280
+  private const val COMPOSITE_HEIGHT = 800
+  // Fraction of the frame the layout should fill (the rest is margin for corners + shadow).
+  private const val FRAME_FILL = 0.82
+  // Don't let a single small panel pull the camera implausibly close.
+  private const val MIN_DISTANCE = 600.0
 }

--- a/vscode-extension/src/webview/shared/spatialScene.ts
+++ b/vscode-extension/src/webview/shared/spatialScene.ts
@@ -80,13 +80,30 @@ export interface OrbitCamera {
     pitchDeg: number;
 }
 
-/** Optional scene backdrop. */
+/**
+ * Optional scene backdrop.
+ *
+ * For gradient backdrops (any `kind` other than `"color"`), the offline compositor supports named
+ * `preset`s (e.g. `"warm-room"` — the default — or `"studio-dark"`) plus explicit gradient stops
+ * that override the chosen preset: `sky` (straight up), `horizon` (eye level), and `floor`
+ * (straight down; its presence turns the 2-stop gradient into a 3-stop, room-like one). All are
+ * optional; omit them to take the compositor's default `warm-room` backdrop. The compositor's
+ * `--environment` CLI flag overrides whatever the scene specifies.
+ */
 export interface SpatialEnvironment {
-    kind: "color" | "skybox";
+    kind: "color" | "skybox" | "gradient";
     /** `#RRGGBB` for `kind: "color"`. */
     color?: string;
     /** Texture path/URI for `kind: "skybox"`. */
     texture?: string;
+    /** Named gradient preset (e.g. `"warm-room"`, `"studio-dark"`); ignored when `kind: "color"`. */
+    preset?: string;
+    /** Gradient colour straight up (`#RRGGBB`); overrides the preset. */
+    sky?: string;
+    /** Gradient colour at eye level (`#RRGGBB`); overrides the preset. Doubles as the clear colour. */
+    horizon?: string;
+    /** Gradient colour straight down (`#RRGGBB`); overrides the preset and enables a 3-stop floor. */
+    floor?: string;
 }
 
 /** The full scene the 3D viewer renders. */


### PR DESCRIPTION
## Summary

Makes the offline XR composite renderer read like real Android XR floating panels instead of flat squares in a void.

- **`materials/unlit_texture.mat`** — rounded corners via a rounded-rect SDF alpha mask (~24–32 dp-equivalent radius, anti-aliased) plus a faint additive edge rim just inside the border, so panels read as floating glass. Panel content is sampled unchanged.
- **`materials/panel_shadow.mat`** (new) — soft contact/drop shadow: a feathered rounded-rect quad matching the panel silhouette with squared (gaussian-ish) falloff and a subtle near-black peak alpha. Deterministic baked quad rather than a Filament shadow map (shadow maps are unstable/expensive on llvmpipe — see README).
- **`src/main.cpp`** — loads the shadow material, factors quad-building into a `buildQuad` lambda, sets per-panel fidelity params (aspect-corrected `halfSize`, radius, rim, softness), and renders a shadow quad behind (−Z) and slightly below each panel. Aspect-corrected rect space keeps corners circular on wide panels.
- **`SubspaceSceneRecorder.defaultCamera`** — fits the layout's full XY bounds into the compositor's 45°/16:10 frame at ~82% fill with a gentle −6° pitch (was small-in-void at distance `max(w,h)*2`, −10°). NowPlaying distance 1120→612; SpatialRow→1148. Generic for single- and multi-panel rows.
- **`CMakeLists.txt`** — compiles `panel_shadow.mat`.
- **`README.md`** — documents the floating-panel fidelity approach and why the shadow is a baked quad.

## Test plan

- Build: `FILAMENT_SDK=… ./renderers/xr-composite/build.sh` — clean (only the pre-existing `setImage` deprecation warning).
- Bake: re-ran `:samples:xr-spatial:composePreviewRenderXr` then `composePreviewCompositeXr` under xvfb/llvmpipe — **7/7 composites baked**.
- `:renderer-xr:test` and `:samples:xr-spatial:testDebugUnitTest` green; `:renderer-xr:ktfmtCheck` green.
- No xr-composite golden PNGs exist to break; the committed smoke fixture (`vscode-extension/.../spatial-scene/scene.json`) bakes fine with the new binary.

Baked composite PNGs live under gitignored `build/`, so they are not committed — re-bake locally to view.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUMD4xmJ9LUtL5dBsqPU2S)_